### PR TITLE
Escape less-than-sign in README.md so it renders

### DIFF
--- a/src/modules/fancyzones/README.md
+++ b/src/modules/fancyzones/README.md
@@ -21,7 +21,7 @@ The backlog for the utility can be found [here](https://github.com/Microsoft/Pow
 | Shortcut      | Action |
 | ----------- | ----------- |
 | Win + ~      | Launches editor       |
-| Win+Ctrl+<Number>   | Cycles through saved layouts with the coresponding number of zones        |
+| Win+Ctrl+\<Number>   | Cycles through saved layouts with the coresponding number of zones        |
 | Win+Left/Right Arrow | Move focused window between zones (only if Override snap hotkeys setting is enabled)  |
 
 ## Settings


### PR DESCRIPTION
## Summary of the Pull Request
Escape less-than-sign in README.md so it renders

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
None

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* ~[ ] Closes #xxx~
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* ~[ ] Tests added/passed~
* ~[ ] Requires documentation to be updated~
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Without escaping this is rendered as an HTML, which is invisible. With escaping it appears as expected in the rendered copy.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Previewed the change in the Github web UI.
