### PR TITLE
fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The first preview of these utilities can be installed from [here](https://github
 ## September Update
 The first preview release of the PowerToys utilities and source code is now live!  This release includes two preview quality utilities as well as the tools and docs to make it easy to create new PowerToys utilities.  
 
-1. [FancyZones](/src/modules/fancyzones/) - FancyZones is a window manager that makes it easy to create copmlex window layouts and quickly position windows into those layouts.  The FancyZones backlog can be found [here](https://github.com/Microsoft/PowerToys/tree/master/doc/planning/FancyZonesBacklog.md)
+1. [FancyZones](/src/modules/fancyzones/) - FancyZones is a window manager that makes it easy to create complex window layouts and quickly position windows into those layouts.  The FancyZones backlog can be found [here](https://github.com/Microsoft/PowerToys/tree/master/doc/planning/FancyZonesBacklog.md)
 
 ![FancyZones](src/modules/fancyzones/FancyZones.png)
 


### PR DESCRIPTION
## Summary of the Pull Request

Fixes a typo.

## References

## PR Checklist
* [x] Closes #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [x] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Detailed Description of the Pull Request / Additional comments

The letters "m" and "p" were, presumably, accidentally transposed in the word "complex" in the description of the FancyZones utility.

## Validation Steps Performed

I read the corrected spelling of the word, and it agreed with the spelling I was taught during my secondary level education.