### PR TITLE
Advertise shortcuts

### DIFF
--- a/installer/PowerToysSetup/CustomDialogs/PTInstallDirDlg.wxs
+++ b/installer/PowerToysSetup/CustomDialogs/PTInstallDirDlg.wxs
@@ -21,9 +21,8 @@
                 <Control Id="FolderLabel" Type="Text" X="20" Y="60" Width="290" Height="30" NoPrefix="yes" Text="!(loc.InstallDirDlgFolderLabel)" />
                 <Control Id="Folder" Type="PathEdit" X="20" Y="100" Width="320" Height="18" Property="WIXUI_INSTALLDIR" Indirect="yes" />
                 <Control Id="ChangeFolder" Type="PushButton" X="20" Y="120" Width="56" Height="17" Text="!(loc.InstallDirDlgChange)" />
-                <Control Id="StartMenuShortcutCheckBox" Type="CheckBox" X="20" Y="160" Width="290" Height="17" Property="INSTALLSTARTMENUSHORTCUT" CheckBoxValue="1" Text="Create a shortcut for [ProductName] in the start menu." />
-                <Control Id="DesktopShortcutCheckBox" Type="CheckBox" X="20" Y="180" Width="290" Height="17" Property="INSTALLDESKTOPSHORTCUT" CheckBoxValue="1" Text="Create a shortcut for [ProductName] in the desktop." />
-                <Control Id="ScheduledTaskCheckBox" Type="CheckBox" X="20" Y="200" Width="330" Height="17" Property="CREATESCHEDULEDTASK" CheckBoxValue="1" Text="Automatically start [ProductName] at logon." />
+                <Control Id="DesktopShortcutCheckBox" Type="CheckBox" X="20" Y="160" Width="290" Height="17" Property="INSTALLDESKTOPSHORTCUT" CheckBoxValue="1" Text="Create a shortcut for [ProductName] in the desktop." />
+                <Control Id="ScheduledTaskCheckBox" Type="CheckBox" X="20" Y="180" Width="330" Height="17" Property="CREATESCHEDULEDTASK" CheckBoxValue="1" Text="Automatically start [ProductName] at logon." />
             </Dialog>
         </UI>
     </Fragment>

--- a/installer/PowerToysSetup/CustomDialogs/WixUI_PTInstallDir.wxs
+++ b/installer/PowerToysSetup/CustomDialogs/WixUI_PTInstallDir.wxs
@@ -59,21 +59,24 @@ Patch dialog sequence:
             <Publish Dialog="PTInstallDirDlg" Control="Next" Event="SetTargetPath" Value="[WIXUI_INSTALLDIR]" Order="1">1</Publish>
             <Publish Dialog="PTInstallDirDlg" Control="Next" Event="DoAction" Value="WixUIValidatePath" Order="2">NOT WIXUI_DONTVALIDATEPATH</Publish>
             <Publish Dialog="PTInstallDirDlg" Control="Next" Event="SpawnDialog" Value="InvalidDirDlg" Order="3"><![CDATA[NOT WIXUI_DONTVALIDATEPATH AND WIXUI_INSTALLDIR_VALID<>"1"]]></Publish>
-            <Publish Dialog="PTInstallDirDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="4">WIXUI_DONTVALIDATEPATH OR WIXUI_INSTALLDIR_VALID="1"</Publish>
+            <Publish Dialog="PTInstallDirDlg" Control="Next" Event="NewDialog" Value="CustomizeDlg" Order="4">WIXUI_DONTVALIDATEPATH OR WIXUI_INSTALLDIR_VALID="1"</Publish>
             <Publish Dialog="PTInstallDirDlg" Control="ChangeFolder" Property="_BrowseProperty" Value="[WIXUI_INSTALLDIR]" Order="1">1</Publish>
             <Publish Dialog="PTInstallDirDlg" Control="ChangeFolder" Event="SpawnDialog" Value="BrowseDlg" Order="2">1</Publish>
-            
+
+            <Publish Dialog="CustomizeDlg" Control="Back" Event="NewDialog" Value="MaintenanceTypeDlg" Order="1">Installed</Publish>
+            <Publish Dialog="CustomizeDlg" Control="Back" Event="NewDialog" Value="PTInstallDirDlg" Order="2">NOT Installed</Publish>
+            <Publish Dialog="CustomizeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
+
             <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="PTInstallDirDlg" Order="1">NOT Installed</Publish>
             <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="MaintenanceTypeDlg" Order="2">Installed AND NOT PATCH</Publish>
             <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2">Installed AND PATCH</Publish>
 
             <Publish Dialog="MaintenanceWelcomeDlg" Control="Next" Event="NewDialog" Value="MaintenanceTypeDlg">1</Publish>
 
+            <Publish Dialog="MaintenanceTypeDlg" Control="ChangeButton" Event="NewDialog" Value="CustomizeDlg">1</Publish>
             <Publish Dialog="MaintenanceTypeDlg" Control="RepairButton" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
             <Publish Dialog="MaintenanceTypeDlg" Control="RemoveButton" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
             <Publish Dialog="MaintenanceTypeDlg" Control="Back" Event="NewDialog" Value="MaintenanceWelcomeDlg">1</Publish>
-
-            <Property Id="ARPNOMODIFY" Value="1" />
         </UI>
 
         <UIRef Id="WixUI_Common" />

--- a/installer/PowerToysSetup/CustomDialogs/WixUI_PTInstallDir.wxs
+++ b/installer/PowerToysSetup/CustomDialogs/WixUI_PTInstallDir.wxs
@@ -62,20 +62,12 @@ Patch dialog sequence:
             <Publish Dialog="PTInstallDirDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="4">WIXUI_DONTVALIDATEPATH OR WIXUI_INSTALLDIR_VALID="1"</Publish>
             <Publish Dialog="PTInstallDirDlg" Control="ChangeFolder" Property="_BrowseProperty" Value="[WIXUI_INSTALLDIR]" Order="1">1</Publish>
             <Publish Dialog="PTInstallDirDlg" Control="ChangeFolder" Event="SpawnDialog" Value="BrowseDlg" Order="2">1</Publish>
-
-            <!--
-            <Publish Dialog="CustomizeDlg" Control="Back" Event="NewDialog" Value="MaintenanceTypeDlg" Order="1">Installed</Publish>
-            <Publish Dialog="CustomizeDlg" Control="Back" Event="NewDialog" Value="PTInstallDirDlg" Order="2">NOT Installed</Publish>
-            <Publish Dialog="CustomizeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
-            -->
-
             <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="PTInstallDirDlg" Order="1">NOT Installed</Publish>
             <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="MaintenanceTypeDlg" Order="2">Installed AND NOT PATCH</Publish>
             <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2">Installed AND PATCH</Publish>
 
             <Publish Dialog="MaintenanceWelcomeDlg" Control="Next" Event="NewDialog" Value="MaintenanceTypeDlg">1</Publish>
 
-            <!--<Publish Dialog="MaintenanceTypeDlg" Control="ChangeButton" Event="NewDialog" Value="CustomizeDlg">1</Publish>-->
             <Publish Dialog="MaintenanceTypeDlg" Control="RepairButton" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
             <Publish Dialog="MaintenanceTypeDlg" Control="RemoveButton" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
             <Publish Dialog="MaintenanceTypeDlg" Control="Back" Event="NewDialog" Value="MaintenanceWelcomeDlg">1</Publish>

--- a/installer/PowerToysSetup/CustomDialogs/WixUI_PTInstallDir.wxs
+++ b/installer/PowerToysSetup/CustomDialogs/WixUI_PTInstallDir.wxs
@@ -59,13 +59,15 @@ Patch dialog sequence:
             <Publish Dialog="PTInstallDirDlg" Control="Next" Event="SetTargetPath" Value="[WIXUI_INSTALLDIR]" Order="1">1</Publish>
             <Publish Dialog="PTInstallDirDlg" Control="Next" Event="DoAction" Value="WixUIValidatePath" Order="2">NOT WIXUI_DONTVALIDATEPATH</Publish>
             <Publish Dialog="PTInstallDirDlg" Control="Next" Event="SpawnDialog" Value="InvalidDirDlg" Order="3"><![CDATA[NOT WIXUI_DONTVALIDATEPATH AND WIXUI_INSTALLDIR_VALID<>"1"]]></Publish>
-            <Publish Dialog="PTInstallDirDlg" Control="Next" Event="NewDialog" Value="CustomizeDlg" Order="4">WIXUI_DONTVALIDATEPATH OR WIXUI_INSTALLDIR_VALID="1"</Publish>
+            <Publish Dialog="PTInstallDirDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="4">WIXUI_DONTVALIDATEPATH OR WIXUI_INSTALLDIR_VALID="1"</Publish>
             <Publish Dialog="PTInstallDirDlg" Control="ChangeFolder" Property="_BrowseProperty" Value="[WIXUI_INSTALLDIR]" Order="1">1</Publish>
             <Publish Dialog="PTInstallDirDlg" Control="ChangeFolder" Event="SpawnDialog" Value="BrowseDlg" Order="2">1</Publish>
 
+            <!--
             <Publish Dialog="CustomizeDlg" Control="Back" Event="NewDialog" Value="MaintenanceTypeDlg" Order="1">Installed</Publish>
             <Publish Dialog="CustomizeDlg" Control="Back" Event="NewDialog" Value="PTInstallDirDlg" Order="2">NOT Installed</Publish>
             <Publish Dialog="CustomizeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
+            -->
 
             <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="PTInstallDirDlg" Order="1">NOT Installed</Publish>
             <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="MaintenanceTypeDlg" Order="2">Installed AND NOT PATCH</Publish>
@@ -73,7 +75,7 @@ Patch dialog sequence:
 
             <Publish Dialog="MaintenanceWelcomeDlg" Control="Next" Event="NewDialog" Value="MaintenanceTypeDlg">1</Publish>
 
-            <Publish Dialog="MaintenanceTypeDlg" Control="ChangeButton" Event="NewDialog" Value="CustomizeDlg">1</Publish>
+            <!--<Publish Dialog="MaintenanceTypeDlg" Control="ChangeButton" Event="NewDialog" Value="CustomizeDlg">1</Publish>-->
             <Publish Dialog="MaintenanceTypeDlg" Control="RepairButton" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
             <Publish Dialog="MaintenanceTypeDlg" Control="RemoveButton" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
             <Publish Dialog="MaintenanceTypeDlg" Control="Back" Event="NewDialog" Value="MaintenanceWelcomeDlg">1</Publish>

--- a/installer/PowerToysSetup/Product.wxs
+++ b/installer/PowerToysSetup/Product.wxs
@@ -25,8 +25,11 @@
 
     <Icon Id="powertoys.ico" SourceFile="$(var.BinX64Dir)\svgs\icon.ico"/>
     <Property Id="ARPPRODUCTICON" Value="powertoys.ico" />
-    <Feature Id="ProductFeature" Title="PowerToys" Level="1">
-      <ComponentGroupRef Id="ProductComponents" />
+    <Feature Id="ProductFeature" Title="PowerToys" Level="1" AllowAdvertise="no">
+      <Feature Id="CoreFeature" Title="Shortcut Guide &amp; Fancy Zones" AllowAdvertise="no" TypicalDefault="install"
+               ConfigurableDirectory="INSTALLFOLDER">
+        <ComponentGroupRef Id="CoreComponents" />
+      </Feature>
     </Feature>
     <Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER" />
     <UI>
@@ -169,7 +172,7 @@
         </Directory>
       </Directory>
       <Directory Id="ProgramMenuFolder">
-        <Directory Id ="ApplicationProgramsFolder" Name ="PowerToys"/>
+        <Directory Id="ApplicationProgramsFolder" Name="PowerToys"/>
       </Directory>
       <Directory Id="DesktopFolder" Name="Desktop"/>
     </Directory>
@@ -178,7 +181,18 @@
   <Fragment>
     <DirectoryRef Id="INSTALLFOLDER" FileSource="$(var.BinX64Dir)">
       <Component Id="powertoys_exe" Guid="A2C66D91-3485-4D00-B04D-91844E6B345B" Win64="yes">
-        <File Id="PowerToys.exe" KeyPath="yes" Checksum="yes" />
+        <File Id="PowerToys.exe" KeyPath="yes" Checksum="yes">
+          <Shortcut Id="ApplicationStartMenuShortcut"
+                    Name="PowerToys"
+                    Description="PowerToys - Windows system utilities to maximize productivity"
+                    Directory="ApplicationProgramsFolder"
+                    WorkingDirectory="INSTALLFOLDER"
+                    Icon="powertoys.ico"
+                    IconIndex="0"
+                    Advertise="yes" />
+        </File>
+
+        <RemoveFolder Id="DeleteShortcutFolder" Directory="ApplicationProgramsFolder" On="uninstall" />
       </Component>
       <Component Id="settings_exe" Guid="A5A461A9-7097-4CBA-9D39-3DBBB6B7B80C" Win64="yes">
         <File Id="PowerToysSettings.exe" KeyPath="yes" Checksum="yes" />
@@ -227,27 +241,6 @@
       </Component>
     </DirectoryRef>
 
-    <DirectoryRef Id="ApplicationProgramsFolder">
-      <Component Id="ApplicationShortcut" Guid="43184672-485D-4632-A16C-12D5E33B1F11">
-        <Condition>INSTALLSTARTMENUSHORTCUT</Condition>
-        <Shortcut Id="ApplicationStartMenuShortcut"
-                  Name="PowerToys"
-                  Description="PowerToys - Windows system utilities to maximize productivity"
-                  Target="[!PowerToys.exe]"
-                  WorkingDirectory="INSTALLFOLDER"
-                  Icon="powertoys.ico"
-                  IconIndex="0"/>
-        <RemoveFolder Id="RemoveApplicationProgramsFolder" Directory="ApplicationProgramsFolder" On="uninstall"/>
-        <RegistryValue Root="HKCU"
-                       Key="Software\[Manufacturer]\[ProductName]"
-                       Name="startshorcutinstalled"
-                       Type="integer"
-                       Value="1"
-                       KeyPath="yes"/>
-      </Component>
-    </DirectoryRef>
-  </Fragment>
-  <Fragment>
     <DirectoryRef Id="DesktopFolder">
       <Component Id="DesktopShortcut" Guid="87321F2B-CC48-4326-881E-9C62CC260DC8">
         <Condition>INSTALLDESKTOPSHORTCUT</Condition>
@@ -269,13 +262,12 @@
   </Fragment>
 
   <Fragment>
-    <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
+    <ComponentGroup Id="CoreComponents" Directory="INSTALLFOLDER">
       <ComponentRef Id="powertoys_exe" />
       <ComponentRef Id="License_rtf" />
       <ComponentRef Id="PowerToysSvgs" />
       <ComponentRef Id="Module_ShortcutGuide" />
       <ComponentRef Id="Module_FancyZones" />
-      <ComponentRef Id="ApplicationShortcut" />
       <ComponentRef Id="DesktopShortcut" />
       <ComponentRef Id="settings_exe" />
       <ComponentRef Id="settings_html" />

--- a/installer/PowerToysSetup/Product.wxs
+++ b/installer/PowerToysSetup/Product.wxs
@@ -25,11 +25,9 @@
 
     <Icon Id="powertoys.ico" SourceFile="$(var.BinX64Dir)\svgs\icon.ico"/>
     <Property Id="ARPPRODUCTICON" Value="powertoys.ico" />
-    <Feature Id="ProductFeature" Title="PowerToys" Level="1" AllowAdvertise="no">
-      <Feature Id="CoreFeature" Title="Shortcut Guide &amp; Fancy Zones" AllowAdvertise="no" TypicalDefault="install"
-               ConfigurableDirectory="INSTALLFOLDER">
-        <ComponentGroupRef Id="CoreComponents" />
-      </Feature>
+    <Feature Id="CoreFeature" Title="PowerToys" AllowAdvertise="no" Absent="disallow" TypicalDefault="install"
+             Description="Contains the Shortcut Guide and Fancy Zones features.">
+      <ComponentGroupRef Id="CoreComponents" />
     </Feature>
     <Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER" />
     <UI>


### PR DESCRIPTION
## Summary of the Pull Request

This PR changes the installer to use an advertised shortcut. It also enables the MSI Customize dialog, so that as we add more features to the MSI, the user can choose to install or not install the new features.

## PR Checklist

* [x] Closes #182
* [x] CLA signed.
* [x] I've discussed this with core contributors already. Issue number where discussion took place: #182.

## Validation Steps Performed

Build the PR, and run the installer. I have tested initial installation, uninstallation, Customize and Repair (from Apps & Features in Windows), as well as shortcut self-healing.