### PR TITLE
Make Alt-F4 always close the settings window

### DIFF
--- a/src/editor/main.cpp
+++ b/src/editor/main.cpp
@@ -239,6 +239,12 @@ void initialize_win32_webview(HWND hwnd, int nCmdShow) {
         std::wstring message_sent = args_script_notify.Value().c_str();
         receive_message_from_webview(message_sent);
       });
+      webview_control.AcceleratorKeyPressed([&](IWebViewControl sender, WebViewControlAcceleratorKeyPressedEventArgs const& args) {
+        if (args.VirtualKey() == winrt::Windows::System::VirtualKey::F4) {
+          // WebView swallows key-events. Detect Alt-F4 one and close the window manually.
+          webview_control.InvokeScriptAsync(hstring(L"exit_settings_app"), {});
+        }
+      });
       resize_web_view();
 #if defined(_DEBUG) && _DEBUG_WITH_LOCALHOST
       // navigates to localhost:8080


### PR DESCRIPTION
## Summary of the Pull Request
WebView swallows key-events. Detect Alt-F4 one and close the window manually.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #289
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

## Validation Steps Performed
Manual