### PR TITLE
Don't show the tasklist arrows when taskbar is autohide

### DIFF
--- a/src/modules/shortcut_guide/overlay_window.cpp
+++ b/src/modules/shortcut_guide/overlay_window.cpp
@@ -228,10 +228,15 @@ void D2DOverlayWindow::show(HWND active_window) {
   lock.unlock();
   D2DWindow::show(primary_screen.left(), primary_screen.top(), primary_screen.width(), primary_screen.height());
   key_pressed.clear();
-  tasklist_cv_mutex.lock();
-  tasklist_update = true;
-  tasklist_cv_mutex.unlock();
-  tasklist_cv.notify_one();
+  // Check if taskbar is auto-hidden. If so, don't display the number arrows
+  APPBARDATA param = {};
+  param.cbSize = sizeof(APPBARDATA);
+  if ((UINT)SHAppBarMessage(ABM_GETSTATE, &param) != ABS_AUTOHIDE) {
+    tasklist_cv_mutex.lock();
+    tasklist_update = true;
+    tasklist_cv_mutex.unlock();
+    tasklist_cv.notify_one();
+  }
   Trace::EventShow();
 }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
When the taskbar is set to autohide do not display the arrows with numbers. This partially fixes #291.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
https://github.com/microsoft/PowerToys/issues/291

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
