### PR TITLE
activate zones for windows with custom titlebar

### DIFF
--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -594,19 +594,17 @@ void FancyZones::OnSnapHotkey(DWORD vkCode) noexcept
 
 void FancyZones::MoveSizeStartInternal(HWND window, HMONITOR monitor, POINT const& ptScreen, require_write_lock writeLock) noexcept
 {
-    // Only enter move/size if the cursor is in the titlebar.
+    // Only enter move/size if the cursor is inside the window rect by a certain padding.
     // This prevents resize from triggering zones.
     RECT windowRect{};
     ::GetWindowRect(window, &windowRect);
 
-    TITLEBARINFO titlebarInfo{ sizeof(titlebarInfo) };
-    ::GetTitleBarInfo(window, &titlebarInfo);
+    windowRect.top += 6;
+    windowRect.left += 8;
+    windowRect.right -= 8;
+    windowRect.bottom -= 6;
 
-    // Titlebar height is weird and apps can do custom drag areas.
-    // Give it half of the height of the window to make sure.
-    titlebarInfo.rcTitleBar.bottom += ((windowRect.bottom - windowRect.top) / 2);
-
-    if (PtInRect(&titlebarInfo.rcTitleBar, ptScreen))
+    if (PtInRect(&windowRect, ptScreen))
     {
         m_inMoveSize = true;
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Fix for https://github.com/microsoft/PowerToys/issues/209

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] I've discussed this with core contributors already.

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
FZ needs to determine if the received event is for a window resize or a window move.
Before this fix, we were checking if the cursor was in the titlebar, but there are apps with custom titlebar that cause our logic to fail.
Instead of calling `GetTitleBarInfo()`, use the windows rect and assume that if the cursor position is inside the windows rect by a certain padding, the eent is for a window move.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manual testing with several apps that have custom titlebars.