### PR TITLE
Fix for #195 - Fancy Zones new editor needs to support multiple monitors

### DIFF
--- a/src/modules/fancyzones/dll/dllmain.cpp
+++ b/src/modules/fancyzones/dll/dllmain.cpp
@@ -1,6 +1,5 @@
 #include "pch.h"
 #include <common/settings_objects.h>
-#include <common/dpi_aware.h>
 #include <interface/powertoy_module_interface.h>
 #include <interface/lowlevel_keyboard_event_data.h>
 #include <interface/win_hook_event_data.h>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/App.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/App.xaml.cs
@@ -20,7 +20,6 @@ namespace FancyZonesEditor
         private ushort _idInitial = 0;
         public App()
         {
-            //init settings
             _settings = new Settings();
         }
 
@@ -64,8 +63,7 @@ namespace FancyZonesEditor
             }
 
             foundModel.IsSelected = true;
-            // TODO: multimon
-            // Pass in the correct args to show on the desired monitor
+
             EditorOverlay overlay = new EditorOverlay();
             overlay.Show();
             overlay.DataContext = foundModel;

--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml.cs
@@ -41,7 +41,7 @@ namespace FancyZonesEditor
             }
             else if (xDelta > 0)
             {
-                xDelta = Math.Min(xDelta, c_workArea.Width - rect.Width - rect.X);
+                xDelta = Math.Min(xDelta, _settings.WorkArea.Width - rect.Width - rect.X);
             }
 
             if (yDelta < 0)
@@ -50,7 +50,7 @@ namespace FancyZonesEditor
             }
             else if (yDelta > 0)
             {
-                yDelta = Math.Min(yDelta, c_workArea.Height - rect.Height - rect.Y);
+                yDelta = Math.Min(yDelta, _settings.WorkArea.Height - rect.Height - rect.Y);
             }
 
             rect.X += (int) xDelta;
@@ -69,13 +69,13 @@ namespace FancyZonesEditor
             {
                 int newWidth = rect.Width + (int) xDelta;
 
-                if (newWidth < 48)
+                if (newWidth < c_minZoneSize)
                 {
-                    newWidth = 48;
+                    newWidth = c_minZoneSize;
                 }
-                else if (newWidth > (c_workArea.Width - rect.X))
+                else if (newWidth > (_settings.WorkArea.Width - rect.X))
                 {
-                    newWidth = (int) c_workArea.Width - rect.X;
+                    newWidth = (int) _settings.WorkArea.Width - rect.X;
                 }
                 MinWidth = rect.Width = newWidth;
             }
@@ -84,13 +84,13 @@ namespace FancyZonesEditor
             {
                 int newHeight = rect.Height + (int)yDelta;
 
-                if (newHeight < 48)
+                if (newHeight < c_minZoneSize)
                 {
-                    newHeight = 48;
+                    newHeight = c_minZoneSize;
                 }
-                else if (newHeight > (c_workArea.Height - rect.Y))
+                else if (newHeight > (_settings.WorkArea.Height - rect.Y))
                 {
-                    newHeight = (int)c_workArea.Height - rect.Y;
+                    newHeight = (int)_settings.WorkArea.Height - rect.Y;
                 }
                 MinHeight = rect.Height = newHeight;
             }
@@ -98,10 +98,7 @@ namespace FancyZonesEditor
         }
 
         private static int c_zIndex = 0;
-
-        // TODO: multimon
-        // This needs to be the work area of the monitor we get launched on
-        private static Rect c_workArea = System.Windows.SystemParameters.WorkArea;
+        private static int c_minZoneSize = 48;
 
         protected override void OnPreviewMouseDown(MouseButtonEventArgs e)
         {
@@ -163,5 +160,7 @@ namespace FancyZonesEditor
             ((Panel)Parent).Children.Remove(this);
             Model.RemoveZoneAt(ZoneIndex);
         }
+
+        private Settings _settings = ((App)Application.Current).ZoneSettings;
     }
 }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/EditorOverlay.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/EditorOverlay.xaml.cs
@@ -94,6 +94,7 @@ namespace FancyZonesEditor
 
             MainWindow window = new MainWindow();
             window.Owner = this;
+            window.ShowActivated = true;
             window.Show();
         }
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/EditorOverlay.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/EditorOverlay.xaml.cs
@@ -71,14 +71,10 @@ namespace FancyZonesEditor
             InitializeComponent();
             Current = this;
 
-            // TODO: multimon
-            // Need to set Left and Top to the correct monitor based on the
-            // foreground window passed in the command line arguments
-            Rect workArea = System.Windows.SystemParameters.WorkArea;
-            Left = workArea.Left;
-            Top = workArea.Top;
-            Width = workArea.Width;
-            Height = workArea.Height;
+            Left = _settings.WorkArea.Left;
+            Top = _settings.WorkArea.Top;
+            Width = _settings.WorkArea.Width;
+            Height = _settings.WorkArea.Height;
         }
 
         void onLoad(object sender, RoutedEventArgs e)

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
@@ -186,14 +186,12 @@ namespace FancyZonesEditor.Models
             // Scale all the zones to the DPI and then pack them up to be marshalled.
             int zoneCount = zones.Length;
             var zoneArray = new int[zoneCount * 4];
-            var graphics = System.Drawing.Graphics.FromHwnd(IntPtr.Zero);
-            float dpi = graphics.DpiX / 96;
             for (int i = 0; i < zones.Length; i++)
             {
-                var left = (int)(zones[i].X * dpi);
-                var top = (int)(zones[i].Y * dpi);
-                var right = left + (int)(zones[i].Width * dpi);
-                var bottom = top + (int)(zones[i].Height * dpi);
+                var left = (int)(zones[i].X * Settings.Dpi);
+                var top = (int)(zones[i].Y * Settings.Dpi);
+                var right = left + (int)(zones[i].Width * Settings.Dpi);
+                var bottom = top + (int)(zones[i].Height * Settings.Dpi);
 
                 var index = i * 4;
                 zoneArray[index] = left;
@@ -202,19 +200,8 @@ namespace FancyZonesEditor.Models
                 zoneArray[index+3] = bottom;
             }
 
-            string[] args = Environment.GetCommandLineArgs();
-            if (args.Length > 1)
-            {
-                string uniqueId = args[1];
-                uint monitor = 0;
-                if (args.Length > 3)
-                {
-                    monitor = uint.Parse(args[4]);
-                }
-
-                var persistZoneSet = Marshal.GetDelegateForFunctionPointer<Native.PersistZoneSet>(pfn);
-                persistZoneSet(uniqueId, monitor, _id, zoneCount, zoneArray);
-            }
+            var persistZoneSet = Marshal.GetDelegateForFunctionPointer<Native.PersistZoneSet>(pfn);
+            persistZoneSet(Settings.UniqueKey, Settings.Monitor, _id, zoneCount, zoneArray);
         }
 
         private static readonly string c_registryPath = Settings.RegistryPath + "\\Layouts";

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
@@ -155,7 +155,7 @@ namespace FancyZonesEditor.Models
 
             internal delegate int PersistZoneSet(
                 [MarshalAs(UnmanagedType.LPWStr)] string activeKey,
-                [MarshalAs(UnmanagedType.LPWStr)] string key,
+                uint monitor,
                 ushort layoutId,
                 int zoneCount,
                 [MarshalAs(UnmanagedType.LPArray)] int[] zoneArray);
@@ -205,18 +205,15 @@ namespace FancyZonesEditor.Models
             string[] args = Environment.GetCommandLineArgs();
             if (args.Length > 1)
             {
-                // args[1] = registry key value of currently active ZoneSet
-                // args[2] = id of layout to load at startup
-
                 string uniqueId = args[1];
-
-                // TODO: multimon
-                double height = System.Windows.Forms.Screen.PrimaryScreen.Bounds.Height;
-                double width = System.Windows.Forms.Screen.PrimaryScreen.Bounds.Width;
-                var key = width.ToString() + "_" + height.ToString();
+                uint monitor = 0;
+                if (args.Length > 3)
+                {
+                    monitor = uint.Parse(args[4]);
+                }
 
                 var persistZoneSet = Marshal.GetDelegateForFunctionPointer<Native.PersistZoneSet>(pfn);
-                persistZoneSet(uniqueId, key, _id, zoneCount, zoneArray);
+                persistZoneSet(uniqueId, monitor, _id, zoneCount, zoneArray);
             }
         }
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
@@ -155,6 +155,7 @@ namespace FancyZonesEditor.Models
 
             internal delegate int PersistZoneSet(
                 [MarshalAs(UnmanagedType.LPWStr)] string activeKey,
+                [MarshalAs(UnmanagedType.LPWStr)] string resolutionKey,
                 uint monitor,
                 ushort layoutId,
                 int zoneCount,
@@ -201,7 +202,7 @@ namespace FancyZonesEditor.Models
             }
 
             var persistZoneSet = Marshal.GetDelegateForFunctionPointer<Native.PersistZoneSet>(pfn);
-            persistZoneSet(Settings.UniqueKey, Settings.Monitor, _id, zoneCount, zoneArray);
+            persistZoneSet(Settings.UniqueKey, Settings.WorkAreaKey, Settings.Monitor, _id, zoneCount, zoneArray);
         }
 
         private static readonly string c_registryPath = Settings.RegistryPath + "\\Layouts";

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/Settings.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/Settings.cs
@@ -262,25 +262,26 @@ namespace FancyZonesEditor
         {
             _workArea = System.Windows.SystemParameters.WorkArea;
             _monitor = 0;
+            _uniqueRegistryPath = FullRegistryPath;
             _uniqueKey = "";
             _dpi = 1;
 
             string[] args = Environment.GetCommandLineArgs();
-            if (args.Length == 5)
+            if (args.Length == 6)
             {
                 // 1 = unique key for per-monitor settings
                 // 2 = layoutid used to generate current layout
                 // 3 = handle to foreground window (used to figure out which monitor to show on)
                 // 4 = handle to monitor (passed back to engine to persist data)
+                // 5 = monitor DPI (float)
 
                 _uniqueKey = args[1];
-                _uniqueRegistryPath = FullRegistryPath + "\\" + _uniqueKey;
+                _uniqueRegistryPath += "\\" + _uniqueKey;
 
                 var foregroundWindow = new IntPtr(uint.Parse(args[3]));
                 var screen = System.Windows.Forms.Screen.FromHandle(foregroundWindow);
 
-                var graphics = System.Drawing.Graphics.FromHwnd(foregroundWindow);
-                _dpi = graphics.DpiX / 96;
+                _dpi = float.Parse(args[5]);
                 _workArea = new Rect(
                     screen.WorkingArea.X / _dpi,
                     screen.WorkingArea.Y / _dpi,

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/Settings.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/Settings.cs
@@ -23,11 +23,25 @@ namespace FancyZonesEditor
     {
         public Settings()
         {
-            Rect workArea = System.Windows.SystemParameters.WorkArea;
+            _workArea = System.Windows.SystemParameters.WorkArea;
+            string[] args = Environment.GetCommandLineArgs();
+            if (args.Length > 2)
+            {
+                var foregroundWindow = uint.Parse(args[3]);
+                var screen = System.Windows.Forms.Screen.FromHandle(new IntPtr(foregroundWindow));
+
+                var graphics = System.Drawing.Graphics.FromHwnd(IntPtr.Zero);
+                float dpi = graphics.DpiX / 96;
+                _workArea = new Rect(
+                    screen.WorkingArea.X / dpi,
+                    screen.WorkingArea.Y / dpi,
+                    screen.WorkingArea.Width / dpi,
+                    screen.WorkingArea.Height / dpi);
+            }
 
             // Initialize the five default layout models: Focus, Columns, Rows, Grid, and PriorityGrid
             _defaultModels = new List<LayoutModel>(5);
-            _focusModel = new CanvasLayoutModel("Focus", c_focusModelId, (int)workArea.Width, (int)workArea.Height);
+            _focusModel = new CanvasLayoutModel("Focus", c_focusModelId, (int)_workArea.Width, (int)_workArea.Height);
             _defaultModels.Add(_focusModel);
 
             _columnsModel = new GridLayoutModel("Columns", c_columnsModelId);
@@ -46,7 +60,7 @@ namespace FancyZonesEditor
             _priorityGridModel = new GridLayoutModel("Priority Grid", c_priorityGridModelId);
             _defaultModels.Add(_priorityGridModel);
 
-            _blankCustomModel = new CanvasLayoutModel("Create new custom", c_blankCustomModelId, (int)workArea.Width, (int)workArea.Height);
+            _blankCustomModel = new CanvasLayoutModel("Create new custom", c_blankCustomModelId, (int)_workArea.Width, (int)_workArea.Height);
 
             _zoneCount = (int)Registry.GetValue(FullRegistryPath, "ZoneCount", 3);
             _spacing = (int)Registry.GetValue(FullRegistryPath, "Spacing", 16);
@@ -133,6 +147,12 @@ namespace FancyZonesEditor
             }
         }
         private bool _isCtrlKeyPressed;
+
+        public Rect WorkArea
+        {
+            get { return _workArea; }
+        }
+        private Rect _workArea;
 
         // UpdateLayoutModels
         //  Update the five default layouts based on the new ZoneCount

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/Settings.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/Settings.cs
@@ -153,6 +153,12 @@ namespace FancyZonesEditor
         private static String _uniqueKey;
         private String _uniqueRegistryPath;
 
+        public static String WorkAreaKey
+        {
+            get { return _workAreaKey; }
+        }
+        private static String _workAreaKey;
+
         public static float Dpi
         {
             get { return _dpi; }
@@ -267,26 +273,27 @@ namespace FancyZonesEditor
             _dpi = 1;
 
             string[] args = Environment.GetCommandLineArgs();
-            if (args.Length == 6)
+            if (args.Length == 7)
             {
                 // 1 = unique key for per-monitor settings
-                // 2 = layoutid used to generate current layout
-                // 3 = handle to foreground window (used to figure out which monitor to show on)
-                // 4 = handle to monitor (passed back to engine to persist data)
-                // 5 = monitor DPI (float)
+                // 2 = layoutid used to generate current layout (used to pick the default layout to show)
+                // 3 = handle to monitor (passed back to engine to persist data)
+                // 4 = X_Y_Width_Height (where EditorOverlay shows up)
+                // 5 = resolution key (passed back to engine to persist data)
+                // 6 = monitor DPI (float)
 
                 _uniqueKey = args[1];
                 _uniqueRegistryPath += "\\" + _uniqueKey;
 
-                var foregroundWindow = new IntPtr(uint.Parse(args[3]));
-                var screen = System.Windows.Forms.Screen.FromHandle(foregroundWindow);
+                var parsedLocation = args[4].Split('_');
+                var x = int.Parse(parsedLocation[0]);
+                var y = int.Parse(parsedLocation[1]);
+                var width = int.Parse(parsedLocation[2]);
+                var height = int.Parse(parsedLocation[3]);
 
-                _dpi = float.Parse(args[5]);
-                _workArea = new Rect(
-                    screen.WorkingArea.X / _dpi,
-                    screen.WorkingArea.Y / _dpi,
-                    screen.WorkingArea.Width / _dpi,
-                    screen.WorkingArea.Height / _dpi);
+                _workAreaKey = args[5];
+                _dpi = float.Parse(args[6]);
+                _workArea = new Rect(x, y, width, height);
 
                 uint monitor = 0;
                 if (uint.TryParse(args[4], out monitor))

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "common/dpi_aware.h"
 
 struct FancyZones : public winrt::implements<FancyZones, IFancyZones, IFancyZonesCallback, IZoneWindowHost>
 {
@@ -244,11 +245,16 @@ void FancyZones::ToggleEditor() noexcept
         auto iter = m_zoneWindowMap.find(monitor);
         if (iter != m_zoneWindowMap.end())
         {
+            UINT dpi_x = 96;
+            UINT dpi_y = 96;
+            DPIAware::GetScreenDPIForWindow(foregroundWindow, dpi_x, dpi_y);
+
             const std::wstring params =
                 iter->second->UniqueId() + L" " +
                 std::to_wstring(iter->second->ActiveZoneSet()->LayoutId()) + L" " +
                 std::to_wstring(reinterpret_cast<UINT_PTR>(foregroundWindow)) + L" " +
-                std::to_wstring(reinterpret_cast<UINT_PTR>(monitor));
+                std::to_wstring(reinterpret_cast<UINT_PTR>(monitor)) + L" " +
+                std::to_wstring(static_cast<float>(dpi_x) / 96.0f);
 
             SHELLEXECUTEINFO sei{ sizeof(sei) };
             sei.fMask = { SEE_MASK_NOCLOSEPROCESS | SEE_MASK_FLAG_NO_UI };

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -237,7 +237,7 @@ void FancyZones::ToggleEditor() noexcept
         m_terminateEditorEvent.reset(CreateEvent(nullptr, true, false, nullptr));
     }
 
-	const HWND foregroundWindow = GetForegroundWindow();
+    const HWND foregroundWindow = GetForegroundWindow();
     if (const HMONITOR monitor = MonitorFromWindow(foregroundWindow, MONITOR_DEFAULTTOPRIMARY))
     {
         std::shared_lock readLock(m_lock);
@@ -245,10 +245,10 @@ void FancyZones::ToggleEditor() noexcept
         if (iter != m_zoneWindowMap.end())
         {
             const std::wstring params =
-				iter->second->UniqueId() + L" " +
-				std::to_wstring(iter->second->ActiveZoneSet()->LayoutId()) + L" " +
-				std::to_wstring(reinterpret_cast<UINT_PTR>(foregroundWindow)) + L" " +
-				std::to_wstring(reinterpret_cast<UINT_PTR>(monitor));
+                iter->second->UniqueId() + L" " +
+                std::to_wstring(iter->second->ActiveZoneSet()->LayoutId()) + L" " +
+                std::to_wstring(reinterpret_cast<UINT_PTR>(foregroundWindow)) + L" " +
+                std::to_wstring(reinterpret_cast<UINT_PTR>(monitor));
 
             SHELLEXECUTEINFO sei{ sizeof(sei) };
             sei.fMask = { SEE_MASK_NOCLOSEPROCESS | SEE_MASK_FLAG_NO_UI };

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -237,18 +237,19 @@ void FancyZones::ToggleEditor() noexcept
         m_terminateEditorEvent.reset(CreateEvent(nullptr, true, false, nullptr));
     }
 
-    // TODO: multimon support
-    // Pass in args so that the editor shows up on the correct monitor
-    // This can be an HWND, HMONITOR, or the X/Y/Width/Height of the monitor's work area, (whichever works best).
-    if (const HMONITOR monitor = MonitorFromWindow(nullptr, MONITOR_DEFAULTTOPRIMARY))
+	const HWND foregroundWindow = GetForegroundWindow();
+    if (const HMONITOR monitor = MonitorFromWindow(foregroundWindow, MONITOR_DEFAULTTOPRIMARY))
     {
         std::shared_lock readLock(m_lock);
         auto iter = m_zoneWindowMap.find(monitor);
         if (iter != m_zoneWindowMap.end())
         {
-            // Pass command line args to the editor to tell it which layout it should pick by default
-            auto activeZoneSet = iter->second->ActiveZoneSet();
-            std::wstring params = iter->second->UniqueId() + L" " + std::to_wstring(activeZoneSet->LayoutId());
+            const std::wstring params =
+				iter->second->UniqueId() + L" " +
+				std::to_wstring(iter->second->ActiveZoneSet()->LayoutId()) + L" " +
+				std::to_wstring(reinterpret_cast<UINT_PTR>(foregroundWindow)) + L" " +
+				std::to_wstring(reinterpret_cast<UINT_PTR>(monitor));
+
             SHELLEXECUTEINFO sei{ sizeof(sei) };
             sei.fMask = { SEE_MASK_NOCLOSEPROCESS | SEE_MASK_FLAG_NO_UI };
             sei.lpFile = L"modules\\FancyZonesEditor.exe";

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -249,11 +249,23 @@ void FancyZones::ToggleEditor() noexcept
             UINT dpi_y = 96;
             DPIAware::GetScreenDPIForWindow(foregroundWindow, dpi_x, dpi_y);
 
+            MONITORINFOEX mi;
+            mi.cbSize = sizeof(mi);
+            GetMonitorInfo(monitor, &mi);
+
+            // Location that the editor should occupy, scaled by DPI
+            std::wstring editorLocation = 
+                std::to_wstring(MulDiv(mi.rcWork.left, 96, dpi_x)) + L"_" +
+                std::to_wstring(MulDiv(mi.rcWork.top, 96, dpi_y)) + L"_" +
+                std::to_wstring(MulDiv(mi.rcWork.right - mi.rcWork.left, 96, dpi_x)) + L"_" +
+                std::to_wstring(MulDiv(mi.rcWork.bottom - mi.rcWork.top, 96, dpi_y));
+
             const std::wstring params =
                 iter->second->UniqueId() + L" " +
                 std::to_wstring(iter->second->ActiveZoneSet()->LayoutId()) + L" " +
-                std::to_wstring(reinterpret_cast<UINT_PTR>(foregroundWindow)) + L" " +
                 std::to_wstring(reinterpret_cast<UINT_PTR>(monitor)) + L" " +
+                editorLocation + L" " +
+                iter->second->WorkAreaKey() + L" " +
                 std::to_wstring(static_cast<float>(dpi_x) / 96.0f);
 
             SHELLEXECUTEINFO sei{ sizeof(sei) };

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -253,10 +253,17 @@ void FancyZones::ToggleEditor() noexcept
             mi.cbSize = sizeof(mi);
             GetMonitorInfo(monitor, &mi);
 
+			// X/Y need to start in unscaled screen coordinates to get to the proper top/left of the monitor
+			// From there, we need to scale the difference between the monitor and workarea rects to get the
+			// appropriate offset where the overlay should appear.
+			// This covers the cases where the taskbar is not at the bottom of the screen.
+			const auto x = mi.rcMonitor.left + MulDiv(mi.rcWork.left - mi.rcMonitor.left, 96, dpi_x);
+			const auto y = mi.rcMonitor.top + MulDiv(mi.rcWork.top - mi.rcMonitor.top, 96, dpi_y);
+
             // Location that the editor should occupy, scaled by DPI
             std::wstring editorLocation = 
-                std::to_wstring(MulDiv(mi.rcWork.left, 96, dpi_x)) + L"_" +
-                std::to_wstring(MulDiv(mi.rcWork.top, 96, dpi_y)) + L"_" +
+                std::to_wstring(x) + L"_" +
+                std::to_wstring(y) + L"_" +
                 std::to_wstring(MulDiv(mi.rcWork.right - mi.rcWork.left, 96, dpi_x)) + L"_" +
                 std::to_wstring(MulDiv(mi.rcWork.bottom - mi.rcWork.top, 96, dpi_y));
 

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -18,6 +18,7 @@ public:
     IFACEMETHODIMP_(void) CycleActiveZoneSet(DWORD vkCode) noexcept;
     IFACEMETHODIMP_(std::wstring) DeviceId() noexcept { return { m_deviceId.get() }; }
     IFACEMETHODIMP_(std::wstring) UniqueId() noexcept { return { m_uniqueId }; }
+    IFACEMETHODIMP_(std::wstring) WorkAreaKey() noexcept { return { m_workArea }; }
     IFACEMETHODIMP_(void) SaveWindowProcessToZoneIndex(HWND window) noexcept;
     IFACEMETHODIMP_(IZoneSet*) ActiveZoneSet() noexcept { return m_activeZoneSet.get(); }
 

--- a/src/modules/fancyzones/lib/ZoneWindow.h
+++ b/src/modules/fancyzones/lib/ZoneWindow.h
@@ -16,6 +16,7 @@ interface __declspec(uuid("{7F017528-8110-4FB3-BE41-F472969C2560}")) IZoneWindow
     IFACEMETHOD_(void, SaveWindowProcessToZoneIndex)(HWND window) = 0;
     IFACEMETHOD_(std::wstring, DeviceId)() = 0;
     IFACEMETHOD_(std::wstring, UniqueId)() = 0;
+    IFACEMETHOD_(std::wstring, WorkAreaKey)() = 0;
     IFACEMETHOD_(IZoneSet*, ActiveZoneSet)() = 0;
 };
 


### PR DESCRIPTION
## Summary of the Pull Request
This change makes the FZ editor get invoked on the monitor with the foreground window (or primary monitor if there is no foreground window). This allows the user to configure each monitor individually using the new editor.
This also fixes the issue where invoking the editor from the settings dialog does not bring the editor to the foreground

## PR Checklist
* [y] Closes #195 #292 
* [y] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [y] Tests added/passed
* [n] Requires documentation to be updated
* [y] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Detailed Description of the Pull Request / Additional comments
WPF is pretty bad at mixed DPI systems so I use the engine to pass in the appropriate size/location that the editor should use
Updated various places throughout the code that I had marked with TODO multimon tags to ensure the proper experience

## Validation Steps Performed
Manually deployed locally using monitors of various DPI to verify the editor invokes at the appropriate size and location