### PR TITLE
When moving window to a zone, ensure it does not remain in maximized state

### DIFF
--- a/src/modules/fancyzones/lib/Zone.cpp
+++ b/src/modules/fancyzones/lib/Zone.cpp
@@ -74,7 +74,13 @@ void Zone::SizeWindowToZone(HWND window, HWND zoneWindow) noexcept
 
     // Map to screen coords
     MapWindowRect(zoneWindow, nullptr, &zoneRect);
-    ::SetWindowPos(window, nullptr, zoneRect.left, zoneRect.top, zoneRect.right - zoneRect.left, zoneRect.bottom - zoneRect.top, SWP_NOZORDER | SWP_ASYNCWINDOWPOS | SWP_NOACTIVATE | SWP_NOSENDCHANGING);
+
+    WINDOWPLACEMENT placement;
+    ::GetWindowPlacement(window, &placement);
+    placement.rcNormalPosition = zoneRect;
+    placement.flags |= WPF_ASYNCWINDOWPLACEMENT;
+    placement.showCmd = SW_RESTORE | SW_SHOWNA;
+    ::SetWindowPlacement(window, &placement);
 }
 
 void Zone::StampZone(HWND window, bool stamp) noexcept


### PR DESCRIPTION
## Summary of the Pull Request
When moving a window to a zone, ensure it does not remain in maximized state. Fixes #388
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #388
* [x] CLA signed.

## Validation Steps Performed
Manual.