### PR TITLE
Added more in-depth check for zone determination when dragging around

### DIFF
--- a/src/modules/fancyzones/lib/ZoneSet.cpp
+++ b/src/modules/fancyzones/lib/ZoneSet.cpp
@@ -77,17 +77,33 @@ IFACEMETHODIMP ZoneSet::RemoveZone(winrt::com_ptr<IZone> zone) noexcept
 
 IFACEMETHODIMP_(winrt::com_ptr<IZone>) ZoneSet::ZoneFromPoint(POINT pt) noexcept
 {
+    winrt::com_ptr<IZone> smallestKnownZone = nullptr;
     for (auto iter = m_zones.begin(); iter != m_zones.end(); iter++)
     {
         if (winrt::com_ptr<IZone> zone = iter->try_as<IZone>())
         {
-            if (PtInRect(&zone->GetZoneRect(), pt))
+            RECT* newZoneRect = &zone->GetZoneRect();
+            if (PtInRect(newZoneRect, pt))
             {
-                return zone;
+                if(smallestKnownZone == nullptr)
+                {
+                    smallestKnownZone = zone;
+                }
+                else
+                {
+                    RECT* r = &smallestKnownZone->GetZoneRect();
+                    int knownZoneArea = (r->right-r->left)*(r->bottom-r->top);
+
+                    int newZoneArea = (newZoneRect->right-newZoneRect->left)*(newZoneRect->bottom-newZoneRect->top);
+
+                    if(newZoneArea<knownZoneArea)
+                        smallestKnownZone = zone;
+                }
             }
         }
     }
-    return nullptr;
+
+    return smallestKnownZone;
 }
 
 IFACEMETHODIMP_(winrt::com_ptr<IZone>) ZoneSet::ZoneFromWindow(HWND window) noexcept


### PR DESCRIPTION
the screen. Previously, it would iterate through the zones in the order
they were added and find the first one that fit the description. While
this works in most cases, if a user wants to have overlapping zones, it
is better to iterate through all of them and find the zone that the user
expects. There are cases where a zone is completely inaccessible on drag
because of the current code. To resolve this, the zone search will look
for the smallest zone possible. The reason I chose this solution is
because this guarantees that zones are at least reachable since if a
zone was bigger than another zone, then there must be a part of it
that is exposed, therefore reachable itself. Note: this solution is for
the scenario between two zones. More than that is not guaranteed. But I
feel like this covers enough scenarios to warrant its addition.

Example:
  ----------------
  - Zone1        -
  -  ----------  -
  -  - Zone2  -  -
  -  -        -  -
  -  ----------  -
  ----------------

Previously, zone2 was inaccessible since it would iterate through 1 then
2. But 1 would always be seen first when dragging a window. With this
fix it zone2 will be accessible.

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Closes #xxx
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
