### PR TITLE
WebView fixes

### DIFF
--- a/src/common/common.cpp
+++ b/src/common/common.cpp
@@ -3,7 +3,7 @@
 #include <dwmapi.h>
 #pragma comment(lib, "dwmapi.lib")
 #include <strsafe.h>
-
+#include <sddl.h>
 
 std::optional<RECT> get_button_pos(HWND hwnd) {
   RECT button;
@@ -37,17 +37,21 @@ HWND get_filtered_active_window() {
   static auto shell = GetShellWindow();
   auto active_window = GetForegroundWindow();
   active_window = GetAncestor(active_window, GA_ROOT);
+
   if (active_window == desktop || active_window == shell) {
     return nullptr;
   }
+  
   auto window_styles = GetWindowLong(active_window, GWL_STYLE);
   if ((window_styles & WS_CHILD) || (window_styles & WS_DISABLED)) {
     return nullptr;
   }
+  
   window_styles = GetWindowLong(active_window, GWL_EXSTYLE);
   if ((window_styles & WS_EX_TOOLWINDOW) ||(window_styles & WS_EX_NOACTIVATE)) {
     return nullptr;
   }
+  
   char class_name[256] = "";
   GetClassNameA(active_window, class_name, 256);
   if (strcmp(class_name, "SysListView32") == 0 ||
@@ -86,12 +90,14 @@ RECT keep_rect_inside_rect(const RECT& small_rect, const RECT& big_rect) {
       result.left -= result.right-big_rect.right;
       result.right -= result.right-big_rect.right;
     }
+
     if (result.left < big_rect.left) {
       // move the rect right.
       result.right += big_rect.left-result.left;
       result.left += big_rect.left-result.left;
     }
   }
+
   if ((result.bottom - result.top) > (big_rect.bottom - big_rect.top)) {
     // small_rect is too big vertically. resize it.
     result.bottom = big_rect.bottom;
@@ -102,6 +108,7 @@ RECT keep_rect_inside_rect(const RECT& small_rect, const RECT& big_rect) {
       result.top -= result.bottom-big_rect.bottom;
       result.bottom -= result.bottom-big_rect.bottom;
     }
+
     if (result.top < big_rect.top) {
       // move the rect down.
       result.bottom += big_rect.top-result.top;
@@ -148,19 +155,24 @@ void show_last_error_message(LPCWSTR lpszFunction, DWORD dw) {
 WindowState get_window_state(HWND hwnd) {
   WINDOWPLACEMENT placement;
   placement.length = sizeof(WINDOWPLACEMENT);
+
   if (GetWindowPlacement(hwnd, &placement) == 0) {
     return UNKNONW;
   }
+  
   if (placement.showCmd == SW_MINIMIZE || placement.showCmd == SW_SHOWMINIMIZED || IsIconic(hwnd)) {
     return MINIMIZED;
   }
+  
   if (placement.showCmd == SW_MAXIMIZE || placement.showCmd == SW_SHOWMAXIMIZED) {
     return MAXIMIZED;
   }
+  
   auto rectp = get_window_pos(hwnd);
   if (!rectp) {
     return UNKNONW;
   }
+  
   auto rect = *rectp;
   MONITORINFO monitor;
   monitor.cbSize = sizeof(MONITORINFO);
@@ -170,11 +182,56 @@ WindowState get_window_state(HWND hwnd) {
   bool bottom_left = monitor.rcWork.bottom == rect.bottom && monitor.rcWork.left == rect.left;
   bool top_right = monitor.rcWork.top == rect.top && monitor.rcWork.right == rect.right;
   bool bottom_right = monitor.rcWork.bottom == rect.bottom && monitor.rcWork.right == rect.right;
+  
   if (top_left && bottom_left) return SNAPED_LEFT;
   if (top_left) return SNAPED_TOP_LEFT;
   if (bottom_left) return SNAPED_BOTTOM_LEFT;
   if (top_right && bottom_right) return SNAPED_RIGHT;
   if (top_right) return SNAPED_TOP_RIGHT;
   if (bottom_right) return SNAPED_BOTTOM_RIGHT;
+  
   return RESTORED;
+}
+
+bool is_process_elevated() {
+  HANDLE token = nullptr;
+  bool elevated = false;
+
+  if (OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &token)) {
+    TOKEN_ELEVATION elevation;
+    DWORD size;
+    if (GetTokenInformation(token, TokenElevation, &elevation, sizeof(elevation), &size)) {
+      elevated = (elevation.TokenIsElevated != 0);
+    }
+  }
+
+  if (token) {
+    CloseHandle(token);
+  }
+
+  return elevated;
+}
+
+bool drop_elevated_privileges() {
+  HANDLE token = nullptr;
+  LPCTSTR lpszPrivilege = SE_SECURITY_NAME;
+  if (!OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_DEFAULT | WRITE_OWNER, &token)) {
+    return false;
+  }
+
+  PSID medium_sid = NULL;
+  if (!::ConvertStringSidToSid(SDDL_ML_MEDIUM, &medium_sid)) {
+    return false;
+  }
+
+  TOKEN_MANDATORY_LABEL label = { 0 };
+  label.Label.Attributes = SE_GROUP_INTEGRITY;
+  label.Label.Sid = medium_sid;
+  DWORD size = (DWORD)sizeof(TOKEN_MANDATORY_LABEL) + ::GetLengthSid(medium_sid);
+
+  BOOL result = SetTokenInformation(token, TokenIntegrityLevel, &label, size);
+  LocalFree(medium_sid);
+  CloseHandle(token);
+
+  return result;
 }

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -37,3 +37,9 @@ enum WindowState {
   RESTORED
 };
 WindowState get_window_state(HWND hwnd);
+
+// Returns true if the current process is running with elevated privileges
+bool is_process_elevated();
+
+// Drops the elevated privilages if present
+bool drop_elevated_privileges();

--- a/src/editor/main.cpp
+++ b/src/editor/main.cpp
@@ -60,10 +60,16 @@ void NavigateToLocalhostReactServer() {
   webview_control.Navigate(Uri(hstring(L"http://localhost:8080")));
 }
 #endif
-void NavigateToUri(_In_ LPCWSTR uri_as_string) {
-  Uri url = webview_control.BuildLocalStreamUri(hstring(L"settings-html"), hstring(uri_as_string));
-  webview_control.NavigateToLocalStreamUri(url, local_uri_resolver);
 
+const std::wstring uriContentId = L"\\settings-html";
+
+void NavigateToUri(_In_ LPCWSTR uri_as_string) {
+  // initialize the base_path for the html content relative to the executable.
+  GetModuleFileName(NULL, local_uri_resolver.base_path, MAX_PATH);
+  PathRemoveFileSpec(local_uri_resolver.base_path);
+  wcscat_s(local_uri_resolver.base_path, uriContentId.c_str());
+  Uri url = webview_control.BuildLocalStreamUri(hstring(uriContentId), hstring(uri_as_string));
+  webview_control.NavigateToLocalStreamUri(url, local_uri_resolver);
 }
 
 Rect hwnd_client_rect_to_bounds_rect(_In_ HWND hwnd) {
@@ -197,14 +203,6 @@ void receive_message_from_webview(const std::wstring& msg) {
 }
 
 void initialize_win32_webview(HWND hwnd, int nCmdShow) {
-  
-  // initialize the base_path for the html content relative to the executable.
-  WCHAR executable_path[MAX_PATH];
-  GetModuleFileName(NULL, executable_path, MAX_PATH);
-  PathRemoveFileSpec(executable_path);
-  wcscat_s(executable_path, L"\\settings-html");
-  wcscpy_s(local_uri_resolver.base_path, executable_path);
-  
   try {
     if (!webview_process) {
       webview_process = WebViewControlProcess();

--- a/src/editor/main.cpp
+++ b/src/editor/main.cpp
@@ -49,7 +49,7 @@ UINT wm_destroy_window = 0;
 // mutex for checking if the window has already been created.
 std::mutex m_window_created_mutex;
 
-TwoWayPipeMessageIPC* current_settings_ipc = NULL;
+TwoWayPipeMessageIPC* current_settings_ipc = nullptr;
 
 // Set to true if waiting for webview confirmation before closing the Window.
 bool m_waiting_for_close_confirmation = false;
@@ -65,7 +65,7 @@ const std::wstring uriContentId = L"\\settings-html";
 
 void NavigateToUri(_In_ LPCWSTR uri_as_string) {
   // initialize the base_path for the html content relative to the executable.
-  GetModuleFileName(NULL, local_uri_resolver.base_path, MAX_PATH);
+  GetModuleFileName(nullptr, local_uri_resolver.base_path, MAX_PATH);
   PathRemoveFileSpec(local_uri_resolver.base_path);
   wcscat_s(local_uri_resolver.base_path, uriContentId.c_str());
   Uri url = webview_control.BuildLocalStreamUri(hstring(uriContentId), hstring(uri_as_string));
@@ -97,7 +97,7 @@ void resize_web_view() {
 #define SEND_TO_WEBVIEW_MSG 1
 
 void send_message_to_webview(const std::wstring& msg) {
-  if (g_main_wnd != NULL && wm_data_for_webview != 0) {
+  if (g_main_wnd != nullptr && wm_data_for_webview != 0) {
     // Allocate the COPYDATASTRUCT and message to pass to the Webview.
     // This is needed in order to use PostMessage, since COM calls to
     // webview_control.InvokeScriptAsync can't be made from 
@@ -115,7 +115,7 @@ void send_message_to_webview(const std::wstring& msg) {
 }
 
 void send_message_to_powertoys_runner(const std::wstring& msg) {
-  if (current_settings_ipc != NULL) {
+  if (current_settings_ipc != nullptr) {
     current_settings_ipc->send(msg);
   } else {
     // For Debug purposes, in case the webview is being run alone.
@@ -218,7 +218,7 @@ void initialize_webview(HWND hwnd, int nCmdShow) {
       
       webview_control.NewWindowRequested([=](IWebViewControl sender_requester, WebViewControlNewWindowRequestedEventArgs args ) {
         // Open the requested link in the default browser registered in the Shell
-        ShellExecute(NULL, L"open", args.Uri().AbsoluteUri().c_str(), NULL, NULL, SW_SHOWNORMAL);
+        ShellExecute(nullptr, L"open", args.Uri().AbsoluteUri().c_str(), nullptr, nullptr, SW_SHOWNORMAL);
       });
 
       webview_control.DOMContentLoaded([=](IWebViewControl sender_loaded, WebViewControlDOMContentLoadedEventArgs const& args_loaded) {
@@ -263,7 +263,7 @@ LRESULT CALLBACK wnd_proc_static(HWND hWnd, UINT message, WPARAM wParam, LPARAM 
     } else {
       // Allow user to confirm exit in the WebView in case there's possible data loss.
       m_waiting_for_close_confirmation = true;
-      if (webview_control != NULL) {
+      if (webview_control != nullptr) {
         const auto _ = webview_control.InvokeScriptAsync(hstring(L"exit_settings_app"), {});
       } else {
         break;
@@ -288,7 +288,7 @@ LRESULT CALLBACK wnd_proc_static(HWND hWnd, UINT message, WPARAM wParam, LPARAM 
       // Resize the window using the suggested rect
       RECT* const prcNewWindow = (RECT*)lParam;
       SetWindowPos(hWnd,
-        NULL,
+        nullptr,
         prcNewWindow->left,
         prcNewWindow->top,
         prcNewWindow->right - prcNewWindow->left,
@@ -307,7 +307,7 @@ LRESULT CALLBACK wnd_proc_static(HWND hWnd, UINT message, WPARAM wParam, LPARAM 
       PCOPYDATASTRUCT msg = (PCOPYDATASTRUCT)lParam;
       if (msg->dwData == SEND_TO_WEBVIEW_MSG) {
         wchar_t* json_message = (wchar_t*)(msg->lpData);
-        if (webview_control != NULL) {
+        if (webview_control != nullptr) {
           const auto _ = webview_control.InvokeScriptAsync(hstring(L"receive_from_settings_app"), { hstring(json_message) });
         }
         delete[] json_message;
@@ -352,7 +352,7 @@ int init_instance(HINSTANCE hInstance, int nCmdShow) {
 
   int wind_width = 1024;
   int wind_height = 700;
-  DPIAware::Convert(NULL, wind_width, wind_height);
+  DPIAware::Convert(nullptr, wind_width, wind_height);
   
   g_main_wnd = CreateWindowW(
     L"PTSettingsClass",
@@ -375,7 +375,7 @@ int init_instance(HINSTANCE hInstance, int nCmdShow) {
 
 void wait_on_parent_process_thread(DWORD pid) {
   HANDLE process = OpenProcess(SYNCHRONIZE, FALSE, pid);
-  if (process != NULL) {
+  if (process != nullptr) {
     if (WaitForSingleObject(process, INFINITE) == WAIT_OBJECT_0) {
       // If it's possible to detect when the PowerToys process terminates, message the main window.
       CloseHandle(process);
@@ -407,11 +407,11 @@ void read_arguments() {
   argument_list = CommandLineToArgvW(GetCommandLineW(), &n_args);
   if (n_args > 3) {
     current_settings_ipc = new TwoWayPipeMessageIPC(std::wstring(argument_list[2]), std::wstring(argument_list[1]), send_message_to_webview);
-    current_settings_ipc->start(NULL);
+    current_settings_ipc->start(nullptr);
     quit_when_parent_terminates(std::wstring(argument_list[3]));
   } else {
 #ifndef _DEBUG
-    MessageBox(NULL, L"This executable isn't supposed to be called as a stand-alone process", L"Error running settings", MB_OK);
+    MessageBox(nullptr, L"This executable isn't supposed to be called as a stand-alone process", L"Error running settings", MB_OK);
     exit(1);
 #endif
   }

--- a/src/editor/main.cpp
+++ b/src/editor/main.cpp
@@ -10,11 +10,6 @@
 #pragma comment(lib, "shlwapi.lib")
 #pragma comment(lib, "shcore.lib")
 #pragma comment(lib, "windowsapp")
-#pragma comment(lib, "dxgi")
-#pragma comment(lib, "d3d11")
-#pragma comment(lib, "d2d1")
-#pragma comment(lib, "dcomp")
-#pragma comment(lib, "dwmapi")
 
 #ifdef _DEBUG
 #define _DEBUG_WITH_LOCALHOST 0

--- a/src/editor/main.cpp
+++ b/src/editor/main.cpp
@@ -49,7 +49,8 @@ UINT wm_destroy_window = 0;
 // Mutex for checking if the window has already been created.
 std::mutex g_window_created;
 
-TwoWayPipeMessageIPC* current_settings_ipc = nullptr;
+// Message pipe to send/receive messages to/from the Powertoys runner.
+TwoWayPipeMessageIPC* g_message_pipe = nullptr;
 
 // Set to true if waiting for webview confirmation before closing the Window.
 bool g_waiting_for_close_confirmation = false;
@@ -117,8 +118,8 @@ void send_message_to_webview(const std::wstring& msg) {
 }
 
 void send_message_to_powertoys_runner(const std::wstring& msg) {
-  if (current_settings_ipc != nullptr) {
-    current_settings_ipc->send(msg);
+  if (g_message_pipe != nullptr) {
+    g_message_pipe->send(msg);
   } else {
     // For Debug purposes, in case the webview is being run alone.
 #ifdef _DEBUG
@@ -422,8 +423,8 @@ void read_arguments() {
 
   argument_list = CommandLineToArgvW(GetCommandLineW(), &n_args);
   if (n_args > 3) {
-    current_settings_ipc = new TwoWayPipeMessageIPC(std::wstring(argument_list[2]), std::wstring(argument_list[1]), send_message_to_webview);
-    current_settings_ipc->start(nullptr);
+    g_message_pipe = new TwoWayPipeMessageIPC(std::wstring(argument_list[2]), std::wstring(argument_list[1]), send_message_to_webview);
+    g_message_pipe->start(nullptr);
     quit_when_parent_terminates(std::wstring(argument_list[3]));
   } else {
 #ifndef _DEBUG

--- a/src/editor/main.cpp
+++ b/src/editor/main.cpp
@@ -36,7 +36,6 @@ HWND g_main_wnd = nullptr;
 
 WebViewControl webview_control = nullptr;
 WebViewControlProcess webview_process = nullptr;
-WebViewControlProcessOptions webview_process_options = nullptr;
 StreamUriResolverFromFile local_uri_resolver;
 
 // Windows message for receiving copied data to send to the webview.
@@ -207,12 +206,8 @@ void initialize_win32_webview(HWND hwnd, int nCmdShow) {
   wcscpy_s(local_uri_resolver.base_path, executable_path);
   
   try {
-    if (!webview_process_options) {
-      webview_process_options = WebViewControlProcessOptions();
-    }
-
     if (!webview_process) {
-      webview_process = WebViewControlProcess(webview_process_options);
+      webview_process = WebViewControlProcess();
     }
     auto asyncwebview = webview_process.CreateWebViewControlAsync((int64_t)g_main_wnd, hwnd_client_rect_to_bounds_rect(g_main_wnd));
     asyncwebview.Completed([=](IAsyncOperation<WebViewControl> const& sender, AsyncStatus args) {

--- a/src/editor/main.cpp
+++ b/src/editor/main.cpp
@@ -343,7 +343,7 @@ void register_classes(HINSTANCE hInstance) {
   RegisterClassExW(&wcex);
 }
 
-int init_instance(HINSTANCE hInstance, int nCmdShow) {
+int init_instance(HINSTANCE hInstance, int nShowCmd) {
   g_hinst = hInstance;
 
   RECT desktopRect;
@@ -367,7 +367,7 @@ int init_instance(HINSTANCE hInstance, int nCmdShow) {
     hInstance,
     nullptr);
 
-  initialize_webview(g_main_wnd, nCmdShow);
+  initialize_webview(g_main_wnd, nShowCmd);
   UpdateWindow(g_main_wnd);
 
   return TRUE;
@@ -418,12 +418,12 @@ void read_arguments() {
   LocalFree(argument_list);
 }
 
-int start_webview_window(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow) {
+int start_webview_window(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nShowCmd) {
   // To be unlocked after the Window has finished being created.
   m_window_created_mutex.lock();
   read_arguments();
   register_classes(hInstance);
-  init_instance(hInstance, nCmdShow);
+  init_instance(hInstance, nShowCmd);
   MSG msg;
   // Main message loop:
   while (GetMessage(&msg, nullptr, 0, 0)) {
@@ -434,7 +434,7 @@ int start_webview_window(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpC
   return (int)msg.wParam;
 }
 
-int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow) {
+int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _In_ LPSTR lpCmdLine, _In_ int nShowCmd) {
   CoInitialize(nullptr);
-  return start_webview_window(hInstance, hPrevInstance, lpCmdLine, nCmdShow);
+  return start_webview_window(hInstance, hPrevInstance, lpCmdLine, nShowCmd);
 }

--- a/src/editor/main.cpp
+++ b/src/editor/main.cpp
@@ -6,6 +6,7 @@
 #include <ShellScalingApi.h>
 #include "resource.h"
 #include <common/dpi_aware.h>
+#include <common/common.h>
 
 #pragma comment(lib, "shlwapi.lib")
 #pragma comment(lib, "shcore.lib")
@@ -424,12 +425,21 @@ void initialize_message_pipe() {
 int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _In_ LPSTR lpCmdLine, _In_ int nShowCmd) {
   CoInitialize(nullptr);
 
+  if (is_process_elevated()) {
+    if (!drop_elevated_privileges()) {
+      MessageBox(NULL, L"Failed to drop admin privileges.\nPlease report the bug to https://github.com/microsoft/PowerToys/issues.", L"PowerToys Settings Error", MB_OK);
+    }
+  }
+
   g_hinst = hInstance;
   initialize_message_pipe();
   register_classes(hInstance);
   g_main_wnd = create_main_window(hInstance);
+  if (g_main_wnd == nullptr) {
+    MessageBox(NULL, L"Failed to create main window.\nPlease report the bug to https://github.com/microsoft/PowerToys/issues.", L"PowerToys Settings Error", MB_OK);
+  }
   initialize_webview();
-  WINRT_VERIFY(ShowWindow(g_main_wnd, nShowCmd));
+  ShowWindow(g_main_wnd, nShowCmd);
 
   // Main message loop.
   MSG msg;

--- a/src/editor/main.cpp
+++ b/src/editor/main.cpp
@@ -32,9 +32,9 @@ using namespace winrt::Windows::Web::UI;
 using namespace winrt::Windows::Web::UI::Interop;
 using namespace winrt::Windows::System;
 
-winrt::Windows::Web::UI::Interop::WebViewControl webview_control = nullptr;
-winrt::Windows::Web::UI::Interop::WebViewControlProcess webview_process = nullptr;
-winrt::Windows::Web::UI::Interop::WebViewControlProcessOptions webview_process_options = nullptr;
+WebViewControl webview_control = nullptr;
+WebViewControlProcess webview_process = nullptr;
+WebViewControlProcessOptions webview_process_options = nullptr;
 StreamUriResolverFromFile local_uri_resolver;
 
 // Windows message for receiving copied data to send to the webview.
@@ -82,7 +82,7 @@ Rect hwnd_client_rect_to_bounds_rect(_In_ HWND hwnd) {
 
 void resize_web_view() {
   Rect bounds = hwnd_client_rect_to_bounds_rect(main_window_handler);
-  winrt::Windows::Web::UI::Interop::IWebViewControlSite webViewControlSite = (winrt::Windows::Web::UI::Interop::IWebViewControlSite) webview_control;
+  IWebViewControlSite webViewControlSite = (IWebViewControlSite) webview_control;
   webViewControlSite.Bounds(bounds);
 
 }
@@ -206,11 +206,11 @@ void initialize_win32_webview(HWND hwnd, int nCmdShow) {
   
   try {
     if (!webview_process_options) {
-      webview_process_options = winrt::Windows::Web::UI::Interop::WebViewControlProcessOptions();
+      webview_process_options = WebViewControlProcessOptions();
     }
 
     if (!webview_process) {
-      webview_process = winrt::Windows::Web::UI::Interop::WebViewControlProcess(webview_process_options);
+      webview_process = WebViewControlProcess(webview_process_options);
     }
     auto asyncwebview = webview_process.CreateWebViewControlAsync((int64_t)main_window_handler, hwnd_client_rect_to_bounds_rect(main_window_handler));
     asyncwebview.Completed([=](IAsyncOperation<WebViewControl> const& sender, AsyncStatus args) {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR fixes the blank Settings window when the PowerToysSettings.exe is running elevated.
Improved error handling for the WebView control initialization.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Solves one of the two bugs that are reported in https://github.com/microsoft/PowerToys/issues/243
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
At startup, checks if PowerToysSettings.exe is running elevated and in that case drop the access token admin privileges.
If a fatal error occur during the WebView initialization, shows an error message instead of showing a blank window.
Code refactoring for easier integration of the upcoming WebView2 support.
Fix some warnings.
Coding style.

**Note for the reviewers**: I made several small commits to isolate the important changes from the code refactoring/variables and functions renaming.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manual test.