### PR TITLE
fix editor CLI parsing if comma is decimal sep in locale

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor.sln
+++ b/src/modules/fancyzones/editor/FancyZonesEditor.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27703.2042
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29326.143
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FancyZonesEditor", "FancyZonesEditor\FancyZonesEditor.csproj", "{5CCC8468-DEC8-4D36-99D4-5C891BEBD481}"
 EndProject
@@ -11,10 +11,8 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{5CCC8468-DEC8-4D36-99D4-5C891BEBD481}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{5CCC8468-DEC8-4D36-99D4-5C891BEBD481}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{5CCC8468-DEC8-4D36-99D4-5C891BEBD481}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{5CCC8468-DEC8-4D36-99D4-5C891BEBD481}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5CCC8468-DEC8-4D36-99D4-5C891BEBD481}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{5CCC8468-DEC8-4D36-99D4-5C891BEBD481}.Release|Any CPU.ActiveCfg = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/Settings.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/Settings.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using System.ComponentModel;
 using System.Collections;
 using System.Collections.ObjectModel;
+using System.Globalization;
 using FancyZonesEditor.Models;
 using System.Windows.Documents;
 using System.Windows;
@@ -292,7 +293,20 @@ namespace FancyZonesEditor
                 var height = int.Parse(parsedLocation[3]);
 
                 _workAreaKey = args[5];
-                _dpi = float.Parse(args[6]);
+
+                // Try invariant culture first, caller likely uses invariant i.e. "C" locale to construct parameters
+                foreach (var cultureInfo in new[] { CultureInfo.InvariantCulture, CultureInfo.CurrentCulture, CultureInfo.CurrentUICulture })
+                {
+                    try
+                    {
+                        _dpi = float.Parse(args[6], cultureInfo);
+                        break;
+                    }
+                    catch (FormatException)
+                    {
+                    }
+                }
+
                 _workArea = new Rect(x, y, width, height);
 
                 uint monitor = 0;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
Fix FancyZonesEditor CLI parsing of DPI on locales with comma as decimal separator.
<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
Related existing issue #449

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
Although the CLI should be constructed with C locale (C/C++, invariant in C#) by the FancyZones application, I wasn't completely certain about that, so I resorted to using a fallback mechanism of trying both invariant and current cultures for float parsing.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Tested manually by setting computer language e.g. to Finnish (comma as decimal separator) and regression tested with en-us as computer culture, as well as Finnish with forced period as decimal separator.
