### PR TITLE
Fix rcNormalPosition in SetWindowPlacement

### DIFF
--- a/src/modules/fancyzones/lib/Zone.cpp
+++ b/src/modules/fancyzones/lib/Zone.cpp
@@ -1,6 +1,5 @@
 #include "pch.h"
 
-
 struct Zone : winrt::implements<Zone, IZone>
 {
 public:
@@ -74,6 +73,12 @@ void Zone::SizeWindowToZone(HWND window, HWND zoneWindow) noexcept
 
     // Map to screen coords
     MapWindowRect(zoneWindow, nullptr, &zoneRect);
+
+    MONITORINFO mi{sizeof(mi)};
+    if (GetMonitorInfoW(MonitorFromWindow(zoneWindow, MONITOR_DEFAULTTONEAREST), &mi))
+    {
+        OffsetRect(&zoneRect, mi.rcMonitor.left - mi.rcWork.left, mi.rcMonitor.top - mi.rcWork.top);
+    }
 
     WINDOWPLACEMENT placement;
     ::GetWindowPlacement(window, &placement);

--- a/src/modules/fancyzones/lib/ZoneSet.cpp
+++ b/src/modules/fancyzones/lib/ZoneSet.cpp
@@ -270,10 +270,6 @@ IFACEMETHODIMP_(void) ZoneSet::MoveSizeEnd(HWND window, HWND zoneWindow, POINT p
     if (auto zone = ZoneFromPoint(ptClient))
     {
         zone->AddWindowToZone(window, zoneWindow, true);
-
-        POINT pointAdjustedScreen = ptClient;
-        MapWindowPoints(zoneWindow, nullptr, &pointAdjustedScreen, 1);
-        SetCursorPos(pointAdjustedScreen.x, pointAdjustedScreen.y);
     }
 }
 


### PR DESCRIPTION
## Summary of the Pull Request
rcNormalPosition in SetWindowPlacement is relative to the desktop work area. m_zoneRect is in absolute screen coordinates so we need to offset it by the diff between the monitor work area top/left and the monitor rect.