### PR TITLE
Save the zone when window is moved by hotkeys

### DIFF
--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -294,6 +294,7 @@ IFACEMETHODIMP_(void) ZoneWindow::MoveWindowIntoZoneByDirection(HWND window, DWO
     if (m_activeZoneSet)
     {
         m_activeZoneSet->MoveWindowIntoZoneByDirection(window, m_window.get(), vkCode);
+        SaveWindowProcessToZoneIndex(window);
     }
 }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Right now window-to-zone assignment is only saved if the window was snapped to a zone using the mouse. This PR makes snapping a window to a zone using WinKey+Left/Right also save the assigned zone to the registry.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manual