### PR TITLE
Telemetry events

### DIFF
--- a/src/common/common.cpp
+++ b/src/common/common.cpp
@@ -295,6 +295,8 @@ std::wstring get_process_path(HWND window) noexcept {
 std::wstring get_product_version() {
   static std::wstring version = std::to_wstring(VERSION_MAJOR) +
     L"." + std::to_wstring(VERSION_MINOR) +
-    L"." + std::to_wstring(VERSION_REVISION);
+    L"." + std::to_wstring(VERSION_REVISION) +
+    L"." + std::to_wstring(VERSION_BUILD);
+
   return version;
 }

--- a/src/modules/fancyzones/dll/dllmain.cpp
+++ b/src/modules/fancyzones/dll/dllmain.cpp
@@ -154,12 +154,7 @@ public:
     // Disable the powertoy
     virtual void disable()
     {
-        if (m_app)
-        {
-            Trace::FancyZones::EnableFancyZones(false);
-            m_app->Destroy();
-            m_app = nullptr;
-        }
+        Disable(true);
     }
 
     // Returns if the powertoy is enabled
@@ -190,7 +185,7 @@ public:
     // Destroy the powertoy and free memory
     virtual void destroy() override
     {
-        disable();
+        Disable(false);
         delete this;
     }
 
@@ -205,6 +200,18 @@ private:
         auto style = GetWindowLongPtr(window, GWL_STYLE);
         auto exStyle = GetWindowLongPtr(window, GWL_EXSTYLE);
         return WI_IsFlagSet(style, WS_MAXIMIZEBOX) && WI_IsFlagClear(style, WS_CHILD) && WI_IsFlagClear(exStyle, WS_EX_TOOLWINDOW);
+    }
+
+    void Disable(bool const traceEvent)
+    {
+        if (m_app) {
+            if (traceEvent) 
+            {
+                Trace::FancyZones::EnableFancyZones(false);
+            }
+            m_app->Destroy();
+            m_app = nullptr;
+        }
     }
 
     intptr_t HandleKeyboardHookEvent(LowlevelKeyboardEvent* data) noexcept;

--- a/src/modules/fancyzones/lib/trace.cpp
+++ b/src/modules/fancyzones/lib/trace.cpp
@@ -82,13 +82,13 @@ void Trace::SettingsChanged(const Settings& settings) noexcept
         "FancyZones::Event::SettingsChanged",
         ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
         TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE),
-        TraceLoggingBoolean(settings.shiftDrag, "Shift drag"),
-        TraceLoggingBoolean(settings.displayChange_moveWindows, "Move Windows On Display Change"),
-        TraceLoggingBoolean(settings.virtualDesktopChange_moveWindows, "Move Windows On Virtual Desktop Change"),
-        TraceLoggingBoolean(settings.zoneSetChange_flashZones, "Flash zones On Zone Set Change"),
-        TraceLoggingBoolean(settings.zoneSetChange_moveWindows, "Move Windows On Zone Set Change"),
-        TraceLoggingBoolean(settings.overrideSnapHotkeys, "Override snap hot keys"),
-        TraceLoggingWideString(settings.zoneHightlightColor.c_str(), "Zone highlight color"));
+        TraceLoggingBoolean(settings.shiftDrag, "ShiftDrag"),
+        TraceLoggingBoolean(settings.displayChange_moveWindows, "MoveWindowsOnDisplayChange"),
+        TraceLoggingBoolean(settings.virtualDesktopChange_moveWindows, "MoveWindowsOnVirtualDesktopChange"),
+        TraceLoggingBoolean(settings.zoneSetChange_flashZones, "FlashZonesOnZoneSetChange"),
+        TraceLoggingBoolean(settings.zoneSetChange_moveWindows, "MoveWindowsOnZoneSetChange"),
+        TraceLoggingBoolean(settings.overrideSnapHotkeys, "OverrideSnapHotKeys"),
+        TraceLoggingWideString(settings.zoneHightlightColor.c_str(), "ZoneHighlightColor"));
 }
 
 void Trace::VirtualDesktopChanged() noexcept
@@ -107,8 +107,8 @@ void Trace::ZoneWindow::KeyUp(WPARAM wParam, bool isEditorMode) noexcept
         "FancyZones::Event::ZoneWindowKeyUp",
         ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
         TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE),
-        TraceLoggingValue(wParam, "Keyboard value"),
-        TraceLoggingBoolean(isEditorMode, "Editor Mode"));
+        TraceLoggingValue(wParam, "KeyboardValue"),
+        TraceLoggingBoolean(isEditorMode, "EditorMode"));
 }
 
 void Trace::ZoneWindow::MoveSizeEnd(_In_opt_ winrt::com_ptr<IZoneSet> activeSet) noexcept
@@ -119,7 +119,7 @@ void Trace::ZoneWindow::MoveSizeEnd(_In_opt_ winrt::com_ptr<IZoneSet> activeSet)
         "FancyZones::Event::MoveSizeEnd",
         ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
         TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE),
-        TraceLoggingValue(reinterpret_cast<void*>(activeSet.get()), "Active Set"),
+        TraceLoggingValue(reinterpret_cast<void*>(activeSet.get()), "ActiveSet"),
         TraceLoggingValue(zoneInfo.NumberOfZones, "NumberOfZones"),
         TraceLoggingValue(zoneInfo.NumberOfWindows, "NumberOfWindows"),
         TraceLoggingValue(static_cast<int>(zoneInfo.Layout), "LayoutKind"));
@@ -133,7 +133,7 @@ void Trace::ZoneWindow::CycleActiveZoneSet(_In_opt_ winrt::com_ptr<IZoneSet> act
         "FancyZones::Event::CycleActiveZoneSet",
         ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
         TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE),
-        TraceLoggingValue(reinterpret_cast<void*>(activeSet.get()), "Active Set"),
+        TraceLoggingValue(reinterpret_cast<void*>(activeSet.get()), "ActiveSet"),
         TraceLoggingValue(zoneInfo.NumberOfZones, "NumberOfZones"),
         TraceLoggingValue(zoneInfo.NumberOfWindows, "NumberOfWindows"),
         TraceLoggingValue(static_cast<int>(zoneInfo.Layout), "LayoutKind"),
@@ -156,7 +156,7 @@ void Trace::ZoneWindow::EditorModeActivity::Stop(_In_opt_ winrt::com_ptr<IZoneSe
         m_activity.value(),
         "FancyZones::Activity::EditorMode",
         ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
-        TraceLoggingValue(reinterpret_cast<void*>(activeSet.get()), "Active Set"),
+        TraceLoggingValue(reinterpret_cast<void*>(activeSet.get()), "ActiveSet"),
         TraceLoggingValue(zoneInfo.NumberOfZones, "NumberOfZones"),
         TraceLoggingValue(zoneInfo.NumberOfWindows, "NumberOfWindows"),
         TraceLoggingValue(static_cast<int>(zoneInfo.Layout), "LayoutKind"));

--- a/src/modules/interface/powertoy_module_interface.h
+++ b/src/modules/interface/powertoy_module_interface.h
@@ -24,7 +24,6 @@
     - signal_event() to send an event the PowerToy registered to.
 
   When terminating, the runner will:
-    - call disable(),
     - call destroy() which should free all the memory and delete the PowerToy object,
     - unload the DLL.
  */

--- a/src/modules/shortcut_guide/overlay_window.cpp
+++ b/src/modules/shortcut_guide/overlay_window.cpp
@@ -350,7 +350,11 @@ void D2DOverlayWindow::on_hide() {
     DwmUnregisterThumbnail(thumbnail);
   }
   std::chrono::steady_clock::time_point shown_end_time = std::chrono::steady_clock::now();
-  Trace::EventHide(std::chrono::duration_cast<std::chrono::milliseconds>(shown_end_time - shown_start_time).count(), key_pressed);
+  // Trace the event only if the overaly window was visible.
+  if (shown_start_time.time_since_epoch().count() > 0) {
+    Trace::EventHide(std::chrono::duration_cast<std::chrono::milliseconds>(shown_end_time - shown_start_time).count(), key_pressed);
+    shown_start_time = {};
+  }
   key_pressed.clear();
 }
 

--- a/src/modules/shortcut_guide/overlay_window.cpp
+++ b/src/modules/shortcut_guide/overlay_window.cpp
@@ -240,7 +240,6 @@ void D2DOverlayWindow::show(HWND active_window) {
     tasklist_cv_mutex.unlock();
     tasklist_cv.notify_one();
   }
-  Trace::EventShow();
 }
 
 void D2DOverlayWindow::animate(int vk_code) {

--- a/src/modules/shortcut_guide/shortcut_guide.cpp
+++ b/src/modules/shortcut_guide/shortcut_guide.cpp
@@ -88,6 +88,7 @@ void OverlayWindow::set_config(const wchar_t * config) {
 
 void OverlayWindow::enable() {
   if (!_enabled) {
+    Trace::EnableShortcutGuide(true);
     winkey_popup = new D2DOverlayWindow();
     winkey_popup->apply_overlay_opacity(((float)overlayOpacity.value)/100.0f);
     winkey_popup->set_theme(theme.value);
@@ -97,8 +98,11 @@ void OverlayWindow::enable() {
   _enabled = true;
 }
 
-void OverlayWindow::disable() {
+void OverlayWindow::disable(bool trace_event) {
   if (_enabled) {
+    if (trace_event) {
+      Trace::EnableShortcutGuide(false);
+    }
     winkey_popup->hide();
     target_state->exit();
     delete target_state;
@@ -107,6 +111,10 @@ void OverlayWindow::disable() {
     winkey_popup = nullptr;
   }
   _enabled = false;
+}
+
+void OverlayWindow::disable() {
+  this->disable(true);
 }
 
 bool OverlayWindow::is_enabled() {
@@ -142,6 +150,7 @@ void OverlayWindow::was_hidden() {
 }
 
 void OverlayWindow::destroy() {
+  this->disable(false);
   delete this;
   instance = nullptr;
 }

--- a/src/modules/shortcut_guide/shortcut_guide.h
+++ b/src/modules/shortcut_guide/shortcut_guide.h
@@ -26,12 +26,14 @@ public:
   void was_hidden();
 
   virtual void destroy() override;
+
 private:
   TargetState* target_state;
   D2DOverlayWindow *winkey_popup;
   bool _enabled = false;
 
   void init_settings();
+  void disable(bool trace_event);
 
   struct PressTime {
     PCWSTR name = L"press_time";

--- a/src/modules/shortcut_guide/trace.cpp
+++ b/src/modules/shortcut_guide/trace.cpp
@@ -8,15 +8,15 @@ TRACELOGGING_DEFINE_PROVIDER(
   (0x38e8889b, 0x9731, 0x53f5, 0xe9, 0x01, 0xe8, 0xa7, 0xc1, 0x75, 0x30, 0x74),
   TraceLoggingOptionProjectTelemetry());
 
-void Trace::RegisterProvider() {
+void Trace::RegisterProvider() noexcept {
   TraceLoggingRegister(g_hProvider);
 }
 
-void Trace::UnregisterProvider() {
+void Trace::UnregisterProvider() noexcept {
   TraceLoggingUnregister(g_hProvider);
 }
 
-void Trace::EventShow() {
+void Trace::EventShow() noexcept {
   TraceLoggingWrite(
     g_hProvider,
     "ShortcutGuide::Event::ShowGuide",
@@ -25,7 +25,7 @@ void Trace::EventShow() {
     TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));
 }
 
-void Trace::EventHide(const __int64 duration_ms, std::vector<int> &key_pressed) {
+void Trace::EventHide(const __int64 duration_ms, std::vector<int> &key_pressed) noexcept {
   std::string vk_codes;
   std::vector<int>::iterator it;
   for (it = key_pressed.begin(); it != key_pressed.end(); ) {
@@ -41,6 +41,16 @@ void Trace::EventHide(const __int64 duration_ms, std::vector<int> &key_pressed) 
     TraceLoggingInt64(duration_ms, "Duration in ms"),
     TraceLoggingInt64(key_pressed.size(), "# of key pressed"),
     TraceLoggingString(vk_codes.c_str(), "list of key pressed"),
+    ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
+    TraceLoggingBoolean(TRUE, "UTCReplace_AppSessionGuid"),
+    TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));
+}
+
+void Trace::EnableShortcutGuide(bool enabled) noexcept {
+  TraceLoggingWrite(
+    g_hProvider,
+    "ShortcutGuide::Event::EnableGuide",
+    TraceLoggingBoolean(enabled, "Enabled"),
     ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
     TraceLoggingBoolean(TRUE, "UTCReplace_AppSessionGuid"),
     TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));

--- a/src/modules/shortcut_guide/trace.cpp
+++ b/src/modules/shortcut_guide/trace.cpp
@@ -16,15 +16,6 @@ void Trace::UnregisterProvider() noexcept {
   TraceLoggingUnregister(g_hProvider);
 }
 
-void Trace::EventShow() noexcept {
-  TraceLoggingWrite(
-    g_hProvider,
-    "ShortcutGuide::Event::ShowGuide",
-    ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
-    TraceLoggingBoolean(TRUE, "UTCReplace_AppSessionGuid"),
-    TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));
-}
-
 void Trace::EventHide(const __int64 duration_ms, std::vector<int> &key_pressed) noexcept {
   std::string vk_codes;
   std::vector<int>::iterator it;
@@ -38,9 +29,9 @@ void Trace::EventHide(const __int64 duration_ms, std::vector<int> &key_pressed) 
   TraceLoggingWrite(
     g_hProvider,
     "ShortcutGuide::Event::HideGuide",
-    TraceLoggingInt64(duration_ms, "Duration in ms"),
-    TraceLoggingInt64(key_pressed.size(), "# of key pressed"),
-    TraceLoggingString(vk_codes.c_str(), "list of key pressed"),
+    TraceLoggingInt64(duration_ms, "DurationInMs"),
+    TraceLoggingInt64(key_pressed.size(), "NumberOfKeysPressed"),
+    TraceLoggingString(vk_codes.c_str(), "ListOfKeysPressed"),
     ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
     TraceLoggingBoolean(TRUE, "UTCReplace_AppSessionGuid"),
     TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));

--- a/src/modules/shortcut_guide/trace.h
+++ b/src/modules/shortcut_guide/trace.h
@@ -2,8 +2,9 @@
 
 class Trace {
 public:
-  static void RegisterProvider();
-  static void UnregisterProvider();
-  static void EventShow();
-  static void EventHide(const __int64 duration_ms, std::vector<int> &key_pressed);
+  static void RegisterProvider() noexcept;
+  static void UnregisterProvider() noexcept;
+  static void EventShow() noexcept;
+  static void EventHide(const __int64 duration_ms, std::vector<int> &key_pressed) noexcept;
+  static void EnableShortcutGuide(bool enabled) noexcept;
 };

--- a/src/modules/shortcut_guide/trace.h
+++ b/src/modules/shortcut_guide/trace.h
@@ -4,7 +4,6 @@ class Trace {
 public:
   static void RegisterProvider() noexcept;
   static void UnregisterProvider() noexcept;
-  static void EventShow() noexcept;
   static void EventHide(const __int64 duration_ms, std::vector<int> &key_pressed) noexcept;
   static void EnableShortcutGuide(bool enabled) noexcept;
 };

--- a/src/runner/powertoy_module.h
+++ b/src/runner/powertoy_module.h
@@ -13,7 +13,6 @@ struct PowertoyModuleDeleter {
   void operator()(PowertoyModuleIface* module) const {
     if (module) {
       powertoys_events().unregister_receiver(module);
-      module->disable();
       module->destroy();
     }
   }
@@ -26,12 +25,12 @@ struct PowertoyModuleDLLDeleter {
   }
 };
 
-
 class PowertoyModule {
 public:
   PowertoyModule(PowertoyModuleIface* module, HMODULE  handle) : handle(handle), module(module) {
-    if (!module)
+    if (!module) {
       throw std::runtime_error("Module not initialized");
+    }
     name = module->get_name();
     auto want_signals = module->get_events();
     if (want_signals) {
@@ -40,9 +39,11 @@ public:
       }
     }
   }
+
   const std::wstring& get_name() const {
     return name;
   }
+  
   const std::wstring get_config() const {
     std::wstring result;
     int size = 0;
@@ -54,30 +55,36 @@ public:
     delete[] buffer;
     return result;
   }
+
   void set_config(const std::wstring& config) {
     module->set_config(config.c_str());
   }
+  
   void call_custom_action(const std::wstring& action) {
     module->call_custom_action(action.c_str());
   }
+  
   intptr_t signal_event(const std::wstring& signal_event, intptr_t data) {
     return module->signal_event(signal_event.c_str(), data);
   }
+
   bool is_enabled() {
     return module->is_enabled();
   }
+  
   void enable() {
     module->enable();
   }
+  
   void disable() {
     module->disable();
   }
+
 private:
   std::unique_ptr<HMODULE, PowertoyModuleDLLDeleter> handle;
   std::unique_ptr<PowertoyModuleIface, PowertoyModuleDeleter> module;
   std::wstring name;
 };
-
 
 PowertoyModule load_powertoy(const std::wstring& filename);
 std::unordered_map<std::wstring, PowertoyModule>& modules();

--- a/src/runner/trace.cpp
+++ b/src/runner/trace.cpp
@@ -20,7 +20,7 @@ void Trace::EventLaunch(const std::wstring& versionNumber) {
   TraceLoggingWrite(
     g_hProvider,
     "Runner::Event::Launch",
-    TraceLoggingWideString(versionNumber.c_str(), "version"),
+    TraceLoggingWideString(versionNumber.c_str(), "Version"),
     ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
     TraceLoggingBoolean(TRUE, "UTCReplace_AppSessionGuid"),
     TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Fix trace events when turning modules on/off.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] I've discussed this with core contributors already.

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
The runner was calling `module->disable();` before calling `module->destroy();`, that was preventing a module to distinguish between being turned off and PowerToys exiting and therefore misfiring the `off` trace event.
Added the on/off trace events to ShortcutGuide.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manual test.