### PR TITLE
Fix Fancy Zones editor location calculation

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/EditorOverlay.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/EditorOverlay.xaml.cs
@@ -11,6 +11,7 @@ using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Documents;
 using System.Windows.Input;
+using System.Windows.Interop;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
@@ -71,8 +72,14 @@ namespace FancyZonesEditor
             InitializeComponent();
             Current = this;
 
-            Left = _settings.WorkArea.Left;
-            Top = _settings.WorkArea.Top;
+            Matrix matrix;
+            using (var src = new HwndSource(new HwndSourceParameters()))
+            {
+                matrix = src.CompositionTarget.TransformFromDevice;
+            }
+
+            Left = matrix.M11 * _settings.WorkArea.Left;
+            Top = matrix.M22 * _settings.WorkArea.Top;
             Width = _settings.WorkArea.Width;
             Height = _settings.WorkArea.Height;
         }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

I noticed that while the new Fancy Zones worked on my primary monitor, the editor window was halfway off the screen on the secondary one (it's to the left, Windows refers to it with negative coordinates). I've found the error in the calculations, fixed it and here we are I guess.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

This is related to Fancy Zones' multi-monitor support.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

The current code uses the unscaled top/left coordinates of the monitor, and then adds the difference between the `work area` and the `monitor rect` left/top coordinates (this is to compensate for the taskbar, since it can be on any edge). 
We should instead scale the monitor top/left coordinates as well, and then add the difference between the two areas. I added the `std::abs` calls to mark that we need to add the absolute difference there, but the calculations should always yield positive values anyway if I'm correct.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
I opened the build with the fix included, and the positioning of the editor window is now correct, and the zones work correctly.
To validate the fix you could:
 - Open the Fancy Zones tab
 - Click Edit Zones
 - See that the default zone covers the entire work area of the window (in older versions, it was offset to the left, and wouldn't be able to reach the right or bottom side).