### PR TITLE
Send undefined keystroke instead of Ctrl to suppress the start menu.

### DIFF
--- a/src/modules/shortcut_guide/target_state.cpp
+++ b/src/modules/shortcut_guide/target_state.cpp
@@ -22,11 +22,15 @@ bool TargetState::signal_event(unsigned vk_code, bool key_down) {
   lock.unlock();
   cv.notify_one();
   if (supress) {
+    // Send a fake key-stroke to prevent the start menu from appearing.
+    // We use 0x07 VK code, which is undefined. It still prevents the
+    // start menu from appearing, but should not interfere with any
+    // keyboard shortcuts.
     INPUT input[3] = { {},{},{} };
     input[0].type = INPUT_KEYBOARD;
-    input[0].ki.wVk = VK_CONTROL;
+    input[0].ki.wVk = 0x07;
     input[1].type = INPUT_KEYBOARD;
-    input[1].ki.wVk = VK_CONTROL;
+    input[1].ki.wVk = 0x07;
     input[1].ki.dwFlags = KEYEVENTF_KEYUP;
     input[2].type = INPUT_KEYBOARD;
     input[2].ki.wVk = VK_LWIN;


### PR DESCRIPTION
Send a fake key-stroke to prevent the start menu from appearing.. We use `0x07` VK code, which is undefined. It still prevents the start menu from appearing, but should not interfere with any keyboard shortcuts.

## PR Checklist
* [x] Closes #375
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

## Validation Steps Performed
Manual