### PR TITLE
fix FZ editor bug in multi monitor scenario

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml.cs
@@ -66,9 +66,9 @@ namespace FancyZonesEditor
             Int32Rect rect = Model.Zones[ZoneIndex];
             if (xDelta < 0)
             {
-                if ((rect.X + xDelta) < _settings.WorkArea.X)
+                if ((rect.X + xDelta) < 0)
                 {
-                    xDelta = _settings.WorkArea.X - rect.X;
+                    xDelta = -rect.X;
                 }
             }
             else if (xDelta > 0)
@@ -81,9 +81,9 @@ namespace FancyZonesEditor
 
             if (yDelta < 0)
             {
-                if ((rect.Y + yDelta) < _settings.WorkArea.Y)
+                if ((rect.Y + yDelta) < 0)
                 {
-                    yDelta = _settings.WorkArea.Y - rect.Y;
+                    yDelta = -rect.Y;
                 }
             }
             else if (yDelta > 0)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Fix for crashing bug when resizing a zone in multi monitor configuration.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
The bug was introduced in this commit https://github.com/microsoft/PowerToys/commit/c8039828fa301783aca4588c8e2c2091403c92d1

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
The bug effects only multi monitor case where a monitor `WorkArea` coordinates may be different from {0,0}.
Since the zone `rect.X` and `rect.Y` coordinates are relative to the current monitor, the boundary check should be made using `X=0` and `Y=0` as coordinates of the current monitor regardless the absolute value of `WorkArea.X` and `WorkArea.Y`.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manual tests.
Verified the fix works when the taskbar is on the left edge of the screen.