### PR TITLE
Make Start menu not appear if Shortcut Guide fade-in animation completes

### DIFF
--- a/src/modules/shortcut_guide/target_state.cpp
+++ b/src/modules/shortcut_guide/target_state.cpp
@@ -14,7 +14,7 @@ bool TargetState::signal_event(unsigned vk_code, bool key_down) {
   bool supress = false;
   if (!key_down && (vk_code == VK_LWIN || vk_code == VK_RWIN) &&
     state == Shown &&
-    std::chrono::system_clock::now() - singnal_timestamp > std::chrono::seconds(1) &&
+    std::chrono::system_clock::now() - singnal_timestamp > std::chrono::milliseconds(300) &&
     !key_was_pressed) {
     supress = true;
   }


### PR DESCRIPTION
The issue reported in https://github.com/microsoft/PowerToys/issues/375#issuecomment-543353524. Animation time should be refactored to a global setting after https://github.com/microsoft/PowerToys/pull/521 lands.

## PR Checklist
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

## Validation Steps Performed
Manual