### PR TITLE
Fix telemetry event names

### DIFF
--- a/src/modules/example_powertoy/trace.cpp
+++ b/src/modules/example_powertoy/trace.cpp
@@ -19,7 +19,7 @@ void Trace::UnregisterProvider() {
 void Trace::MyEvent() {
   TraceLoggingWrite(
     g_hProvider,
-    "PowerToyName::Event::MyEvent",
+    "PowerToyName_MyEvent",
     ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
     TraceLoggingBoolean(TRUE, "UTCReplace_AppSessionGuid"),
     TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));

--- a/src/modules/fancyzones/lib/trace.cpp
+++ b/src/modules/fancyzones/lib/trace.cpp
@@ -46,7 +46,7 @@ void Trace::FancyZones::EnableFancyZones(bool enabled) noexcept
 {
     TraceLoggingWrite(
         g_hProvider,
-        "FancyZones::Event::EnableFancyZones",
+        "FancyZones_EnableFancyZones",
         ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
         TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE),
         TraceLoggingBoolean(enabled, "Enabled"));
@@ -56,7 +56,7 @@ void Trace::FancyZones::ToggleZoneViewers(bool visible) noexcept
 {
     TraceLoggingWrite(
         g_hProvider,
-        "FancyZones::Event::ToggleZoneViewers",
+        "FancyZones_ToggleZoneViewers",
         ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
         TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE),
         TraceLoggingBoolean(visible, "Visible"));
@@ -66,7 +66,7 @@ void Trace::FancyZones::OnKeyDown(DWORD vkCode, bool win, bool control, bool inM
 {
     TraceLoggingWrite(
         g_hProvider,
-        "FancyZones::Event::OnKeyDown",
+        "FancyZones_OnKeyDown",
         ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
         TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE),
         TraceLoggingValue(vkCode, "Hotkey"),
@@ -79,7 +79,7 @@ void Trace::SettingsChanged(const Settings& settings) noexcept
 {
     TraceLoggingWrite(
         g_hProvider,
-        "FancyZones::Event::SettingsChanged",
+        "FancyZones_SettingsChanged",
         ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
         TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE),
         TraceLoggingBoolean(settings.shiftDrag, "ShiftDrag"),
@@ -95,7 +95,7 @@ void Trace::VirtualDesktopChanged() noexcept
 {
     TraceLoggingWrite(
         g_hProvider,
-        "FancyZones::Event::VirtualDesktopChanged",
+        "FancyZones_VirtualDesktopChanged",
         ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
         TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));
 }
@@ -104,7 +104,7 @@ void Trace::ZoneWindow::KeyUp(WPARAM wParam, bool isEditorMode) noexcept
 {
     TraceLoggingWrite(
         g_hProvider,
-        "FancyZones::Event::ZoneWindowKeyUp",
+        "FancyZones_ZoneWindowKeyUp",
         ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
         TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE),
         TraceLoggingValue(wParam, "KeyboardValue"),
@@ -116,7 +116,7 @@ void Trace::ZoneWindow::MoveSizeEnd(_In_opt_ winrt::com_ptr<IZoneSet> activeSet)
     auto const zoneInfo = GetZoneSetInfo(activeSet);
     TraceLoggingWrite(
         g_hProvider,
-        "FancyZones::Event::MoveSizeEnd",
+        "FancyZones_MoveSizeEnd",
         ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
         TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE),
         TraceLoggingValue(reinterpret_cast<void*>(activeSet.get()), "ActiveSet"),
@@ -130,7 +130,7 @@ void Trace::ZoneWindow::CycleActiveZoneSet(_In_opt_ winrt::com_ptr<IZoneSet> act
     auto const zoneInfo = GetZoneSetInfo(activeSet);
     TraceLoggingWrite(
         g_hProvider,
-        "FancyZones::Event::CycleActiveZoneSet",
+        "FancyZones_CycleActiveZoneSet",
         ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
         TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE),
         TraceLoggingValue(reinterpret_cast<void*>(activeSet.get()), "ActiveSet"),
@@ -145,7 +145,7 @@ void Trace::ZoneWindow::EditorModeActivity::Start() noexcept
     m_activity = TraceLoggingActivity<g_hProvider, PROJECT_KEYWORD_MEASURE>();
     TraceLoggingWriteStart(
         m_activity.value(),
-        "FancyZones::Activity::EditorMode",
+        "FancyZones_Activity_EditorMode",
         ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance));
 }
 
@@ -154,7 +154,7 @@ void Trace::ZoneWindow::EditorModeActivity::Stop(_In_opt_ winrt::com_ptr<IZoneSe
     auto const zoneInfo = GetZoneSetInfo(activeSet);
     TraceLoggingWriteStop(
         m_activity.value(),
-        "FancyZones::Activity::EditorMode",
+        "FancyZones_Activity_EditorMode",
         ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
         TraceLoggingValue(reinterpret_cast<void*>(activeSet.get()), "ActiveSet"),
         TraceLoggingValue(zoneInfo.NumberOfZones, "NumberOfZones"),

--- a/src/modules/shortcut_guide/overlay_window.cpp
+++ b/src/modules/shortcut_guide/overlay_window.cpp
@@ -351,7 +351,7 @@ void D2DOverlayWindow::on_hide() {
   std::chrono::steady_clock::time_point shown_end_time = std::chrono::steady_clock::now();
   // Trace the event only if the overaly window was visible.
   if (shown_start_time.time_since_epoch().count() > 0) {
-    Trace::EventHide(std::chrono::duration_cast<std::chrono::milliseconds>(shown_end_time - shown_start_time).count(), key_pressed);
+    Trace::HideGuide(std::chrono::duration_cast<std::chrono::milliseconds>(shown_end_time - shown_start_time).count(), key_pressed);
     shown_start_time = {};
   }
   key_pressed.clear();

--- a/src/modules/shortcut_guide/shortcut_guide.cpp
+++ b/src/modules/shortcut_guide/shortcut_guide.cpp
@@ -80,6 +80,7 @@ void OverlayWindow::set_config(const wchar_t * config) {
       winkey_popup->set_theme(theme.value);
     }
     _values.save_to_settings_file();
+    Trace::SettingsChanged(pressTime.value, overlayOpacity.value, theme.value);
   }
   catch (std::exception&) {
     // Improper JSON.

--- a/src/modules/shortcut_guide/trace.cpp
+++ b/src/modules/shortcut_guide/trace.cpp
@@ -16,7 +16,7 @@ void Trace::UnregisterProvider() noexcept {
   TraceLoggingUnregister(g_hProvider);
 }
 
-void Trace::EventHide(const __int64 duration_ms, std::vector<int> &key_pressed) noexcept {
+void Trace::HideGuide(const __int64 duration_ms, std::vector<int> &key_pressed) noexcept {
   std::string vk_codes;
   std::vector<int>::iterator it;
   for (it = key_pressed.begin(); it != key_pressed.end(); ) {
@@ -28,7 +28,7 @@ void Trace::EventHide(const __int64 duration_ms, std::vector<int> &key_pressed) 
 
   TraceLoggingWrite(
     g_hProvider,
-    "ShortcutGuide::Event::HideGuide",
+    "ShortcutGuide_HideGuide",
     TraceLoggingInt64(duration_ms, "DurationInMs"),
     TraceLoggingInt64(key_pressed.size(), "NumberOfKeysPressed"),
     TraceLoggingString(vk_codes.c_str(), "ListOfKeysPressed"),
@@ -37,11 +37,23 @@ void Trace::EventHide(const __int64 duration_ms, std::vector<int> &key_pressed) 
     TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));
 }
 
-void Trace::EnableShortcutGuide(bool enabled) noexcept {
+void Trace::EnableShortcutGuide(const bool enabled) noexcept {
   TraceLoggingWrite(
     g_hProvider,
-    "ShortcutGuide::Event::EnableGuide",
+    "ShortcutGuide_EnableGuide",
     TraceLoggingBoolean(enabled, "Enabled"),
+    ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
+    TraceLoggingBoolean(TRUE, "UTCReplace_AppSessionGuid"),
+    TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));
+}
+
+void Trace::SettingsChanged(const int press_delay_time, const int overlay_opacity, const std::wstring& theme) noexcept {
+  TraceLoggingWrite(
+    g_hProvider,
+    "ShortcutGuide_SettingsChanged",
+    TraceLoggingInt32(press_delay_time, "PressDelayTime"),
+    TraceLoggingInt32(overlay_opacity, "OverlayOpacity"),
+    TraceLoggingWideString(theme.c_str(), "Theme"),
     ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
     TraceLoggingBoolean(TRUE, "UTCReplace_AppSessionGuid"),
     TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));

--- a/src/modules/shortcut_guide/trace.h
+++ b/src/modules/shortcut_guide/trace.h
@@ -4,6 +4,7 @@ class Trace {
 public:
   static void RegisterProvider() noexcept;
   static void UnregisterProvider() noexcept;
-  static void EventHide(const __int64 duration_ms, std::vector<int> &key_pressed) noexcept;
-  static void EnableShortcutGuide(bool enabled) noexcept;
+  static void HideGuide(const __int64 duration_ms, std::vector<int> &key_pressed) noexcept;
+  static void EnableShortcutGuide(const bool enabled) noexcept;
+  static void SettingsChanged(const int press_delay_time, const int overlay_opacity, const std::wstring& theme) noexcept;
 };

--- a/src/runner/trace.cpp
+++ b/src/runner/trace.cpp
@@ -19,7 +19,7 @@ void Trace::UnregisterProvider() {
 void Trace::EventLaunch(const std::wstring& versionNumber) {
   TraceLoggingWrite(
     g_hProvider,
-    "Runner::Event::Launch",
+    "Runner_Launch",
     TraceLoggingWideString(versionNumber.c_str(), "Version"),
     ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
     TraceLoggingBoolean(TRUE, "UTCReplace_AppSessionGuid"),


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Event names have to follow the naming convention, regex [A-Za-z][A-Za-z0-9_]* as per https://osgwiki.com/wiki/Vortex/EventQuality#Quality_bits

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] I've discussed this with core contributors already. 

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Replaced `::Event::` substring in event names with underscore.
Replaced `::Activity::` substring with `_Activity_` because it's a different event and it may be useful to specify that in the name.
Added setting changed event for ShortcutGuide.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manual test.