### PR TITLE
Fix for issue 448

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -11,7 +11,7 @@
         Background="White"
         ResizeMode="NoResize"
         WindowStartupLocation="CenterScreen"
-        Loaded="OnLoaded"
+        Initialized="InitializedEventHandler"
         Closed="OnClosed">
     <Window.Resources>
         <local:BooleanToBrushConverter x:Key="BooleanToBrushConverter" />
@@ -222,7 +222,7 @@
 
                     </StackPanel>
                     <StackPanel Orientation="Horizontal" Margin="0,12,0,16">
-                        <Button x:Name="EditTemplateBUtton" Padding="8" Content="Edit selected layout" Style="{StaticResource secondaryButton}" Click="EditLayout_Click"/>
+                        <Button x:Name="EditTemplateButton" Padding="8" Content="Edit selected layout" Style="{StaticResource secondaryButton}" Click="EditLayout_Click"/>
                         <Button x:Name="ApplyTemplateButton" Padding="8" Content="Apply" Style="{StaticResource primaryButton}" Click="Apply_Click"/>
                     </StackPanel>
                 </StackPanel>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -78,17 +78,15 @@ namespace FancyZonesEditor
 
         private void EditLayout_Click(object sender, RoutedEventArgs e)
         {
-            _editing = true;
-            this.Close();
-
             EditorOverlay mainEditor = EditorOverlay.Current;
             LayoutModel model = mainEditor.DataContext as LayoutModel;
             if (model == null)
             {
-                mainEditor.Close();
                 return;
             }
             model.IsSelected = false;
+            _editing = true;
+            this.Close();
 
             bool isPredefinedLayout = Settings.IsPredefinedLayout(model);
 
@@ -150,9 +148,8 @@ namespace FancyZonesEditor
                 {
                     model.Apply((model as CanvasLayoutModel).Zones.ToArray());
                 }
+                this.Close();
             }
-
-            this.Close();
         }
 
         private void OnClosed(object sender, EventArgs e)
@@ -163,13 +160,18 @@ namespace FancyZonesEditor
             }
         }
 
-        private void OnLoaded(object sender, RoutedEventArgs e)
+        private void InitializedEventHandler(object sender, EventArgs e)
         {
-            foreach(LayoutModel model in _settings.CustomModels)
+            SetSelectedItem();
+        }
+
+        private void SetSelectedItem()
+        {
+            foreach (LayoutModel model in _settings.CustomModels)
             {
                 if (model.IsSelected)
                 {
-                    TemplateTab.SelectedIndex = 1;
+                    TemplateTab.SelectedItem = model;
                     return;
                 }
             }
@@ -180,7 +182,7 @@ namespace FancyZonesEditor
             LayoutModel model = ((FrameworkElement)sender).DataContext as LayoutModel;
             if (model.IsSelected)
             {
-                OnLoaded(null, null);
+                SetSelectedItem();
             }
             model.Delete();
         }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Don't quit the FZ editor if no layout is selected when clicking on the "Edit selected layout".
Don't exit when clicking on "Apply" if no layout is selected.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #448

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Credit to @AlexR3 for the fix. Alex provided a more extensive fix that disables the button when no layout  is selected, but it requires more changes to the XAML and we preferred to avoid that now.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manual test.