### PR TITLE
Settings: fix default theme selected option

### DIFF
--- a/src/runner/general_settings.cpp
+++ b/src/runner/general_settings.cpp
@@ -7,7 +7,7 @@
 
 using namespace web;
 
-static std::wstring settings_theme;
+static std::wstring settings_theme = L"system";
 
 web::json::value load_general_settings() {
   auto loaded = PTSettingsHelper::load_general_settings();


### PR DESCRIPTION
The call to `load_general_settings` will throw an exception if the `settings.json` file for the general settings is not present. This leaves `settings_theme` variable uninitialized, resulting in no value selected in the general settings screen for users that did not make any changes to the general settings. This fixes this issue by initializing the value with a "system" default value.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #560
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

## Validation Steps Performed
Manual. Delete `%LOCALAPPDATA%\Microsoft\PowerToys\settings.json` to reproduce the issue without the fix.
