### PR TITLE
Fix single regex search replace bug

### DIFF
--- a/src/modules/powerrename/lib/PowerRenameRegEx.cpp
+++ b/src/modules/powerrename/lib/PowerRenameRegEx.cpp
@@ -213,7 +213,7 @@ HRESULT CPowerRenameRegEx::Replace(_In_ PCWSTR source, _Outptr_ PWSTR* result)
                     std::wsmatch m;
                     if (std::regex_search(sourceToUse, m, pattern))
                     {
-                        res = sourceToUse.replace(m.prefix().length(), searchTerm.length(), replaceTerm);
+                        res = sourceToUse.replace(m.prefix().length(), m.length(), replaceTerm);
                     }
                 }
             }


### PR DESCRIPTION
Fix an issue where regular expression search and replace was not being done correctly when MatchAllOccurences is not specified.
