### PR TITLE
Fix Chrome tab move leaving zone highlighted

### DIFF
--- a/src/modules/fancyzones/dll/dllmain.cpp
+++ b/src/modules/fancyzones/dll/dllmain.cpp
@@ -220,6 +220,7 @@ private:
     void MoveSizeEnd(HWND window, POINT const& ptScreen) noexcept;
     void MoveSizeUpdate(POINT const& ptScreen) noexcept;
 
+    HANDLE m_moved_window = nullptr;
     winrt::com_ptr<IFancyZones> m_app;
     winrt::com_ptr<IFancyZonesSettings> m_settings;
 };
@@ -298,6 +299,7 @@ void FancyZonesModule::MoveSizeStart(HWND window, POINT const& ptScreen) noexcep
     {
         if (auto monitor = MonitorFromPoint(ptScreen, MONITOR_DEFAULTTONULL))
         {
+            m_moved_window = window;
             m_app.as<IFancyZonesCallback>()->MoveSizeStart(window, monitor, ptScreen);
         }
     }
@@ -305,8 +307,9 @@ void FancyZonesModule::MoveSizeStart(HWND window, POINT const& ptScreen) noexcep
 
 void FancyZonesModule::MoveSizeEnd(HWND window, POINT const& ptScreen) noexcept
 {
-    if (IsInterestingWindow(window))
+    if (IsInterestingWindow(window) || (window != nullptr && window == m_moved_window))
     {
+        m_moved_window = nullptr;
         m_app.as<IFancyZonesCallback>()->MoveSizeEnd(window, ptScreen);
     }
 }

--- a/src/modules/fancyzones/dll/dllmain.cpp
+++ b/src/modules/fancyzones/dll/dllmain.cpp
@@ -220,7 +220,7 @@ private:
     void MoveSizeEnd(HWND window, POINT const& ptScreen) noexcept;
     void MoveSizeUpdate(POINT const& ptScreen) noexcept;
 
-    HANDLE m_moved_window = nullptr;
+    HANDLE m_movedWindow = nullptr;
     winrt::com_ptr<IFancyZones> m_app;
     winrt::com_ptr<IFancyZonesSettings> m_settings;
 };
@@ -299,7 +299,7 @@ void FancyZonesModule::MoveSizeStart(HWND window, POINT const& ptScreen) noexcep
     {
         if (auto monitor = MonitorFromPoint(ptScreen, MONITOR_DEFAULTTONULL))
         {
-            m_moved_window = window;
+            m_movedWindow = window;
             m_app.as<IFancyZonesCallback>()->MoveSizeStart(window, monitor, ptScreen);
         }
     }
@@ -307,9 +307,9 @@ void FancyZonesModule::MoveSizeStart(HWND window, POINT const& ptScreen) noexcep
 
 void FancyZonesModule::MoveSizeEnd(HWND window, POINT const& ptScreen) noexcept
 {
-    if (IsInterestingWindow(window) || (window != nullptr && window == m_moved_window))
+    if (IsInterestingWindow(window) || (window != nullptr && window == m_movedWindow))
     {
-        m_moved_window = nullptr;
+        m_movedWindow = nullptr;
         m_app.as<IFancyZonesCallback>()->MoveSizeEnd(window, ptScreen);
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request
When a Chrome tab is moved, its style is changed so `IsInterestingWindow` no longer returns true. This would leave the zones highlighted. This PR stores the HWND of the window which move triggered the zones to be highlighted.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #534
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

## Validation Steps Performed
Manual