### PR TITLE
Fix for different per-monitor scaling

### DIFF
--- a/src/common/common.vcxproj
+++ b/src/common/common.vcxproj
@@ -98,6 +98,7 @@
     <ClInclude Include="d2d_window.h" />
     <ClInclude Include="dpi_aware.h" />
     <ClInclude Include="monitors.h" />
+    <ClInclude Include="on_thread_executor.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="settings_helpers.h" />
     <ClInclude Include="settings_objects.h" />
@@ -117,6 +118,7 @@
     <ClCompile Include="d2d_window.cpp" />
     <ClCompile Include="dpi_aware.cpp" />
     <ClCompile Include="monitors.cpp" />
+    <ClCompile Include="on_thread_executor.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>

--- a/src/common/common.vcxproj.filters
+++ b/src/common/common.vcxproj.filters
@@ -69,6 +69,9 @@
     <ClInclude Include="version.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="on_thread_executor.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="d2d_svg.cpp">
@@ -106,6 +109,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="dpi_aware.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="on_thread_executor.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/common/dpi_aware.cpp
+++ b/src/common/dpi_aware.cpp
@@ -38,3 +38,8 @@ void DPIAware::Convert(HMONITOR monitor_handle, int &width, int &height) {
     height = height * dpi_y / DEFAULT_DPI;
   }
 }
+
+void DPIAware::EnableDPIAwarenessForThisThread()
+{
+  SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+}

--- a/src/common/dpi_aware.cpp
+++ b/src/common/dpi_aware.cpp
@@ -39,7 +39,6 @@ void DPIAware::Convert(HMONITOR monitor_handle, int &width, int &height) {
   }
 }
 
-void DPIAware::EnableDPIAwarenessForThisProcess()
-{
-  SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+void DPIAware::EnableDPIAwarenessForThisProcess() {
+    SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
 }

--- a/src/common/dpi_aware.cpp
+++ b/src/common/dpi_aware.cpp
@@ -39,7 +39,7 @@ void DPIAware::Convert(HMONITOR monitor_handle, int &width, int &height) {
   }
 }
 
-void DPIAware::EnableDPIAwarenessForThisThread()
+void DPIAware::EnableDPIAwarenessForThisProcess()
 {
   SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
 }

--- a/src/common/dpi_aware.h
+++ b/src/common/dpi_aware.h
@@ -7,4 +7,5 @@ struct DPIAware {
   static HRESULT GetScreenDPIForWindow(HWND hwnd, UINT & dpi_x, UINT & dpi_y);
   static HRESULT GetScreenDPIForPoint(POINT p, UINT& dpi_x, UINT& dpi_y);
   static void Convert(HMONITOR monitor_handle, int &width, int &height);
+  static void EnableDPIAwarenessForThisThread();
 };

--- a/src/common/dpi_aware.h
+++ b/src/common/dpi_aware.h
@@ -1,11 +1,9 @@
 #pragma once
 #include "windef.h"
 
-class DPIAware {
-private:
-  static const int DEFAULT_DPI = 96;
+struct DPIAware {
+  static constexpr int DEFAULT_DPI = 96;
 
-public:
   static HRESULT GetScreenDPIForWindow(HWND hwnd, UINT & dpi_x, UINT & dpi_y);
   static HRESULT GetScreenDPIForPoint(POINT p, UINT& dpi_x, UINT& dpi_y);
   static void Convert(HMONITOR monitor_handle, int &width, int &height);

--- a/src/common/dpi_aware.h
+++ b/src/common/dpi_aware.h
@@ -7,5 +7,5 @@ struct DPIAware {
   static HRESULT GetScreenDPIForWindow(HWND hwnd, UINT & dpi_x, UINT & dpi_y);
   static HRESULT GetScreenDPIForPoint(POINT p, UINT& dpi_x, UINT& dpi_y);
   static void Convert(HMONITOR monitor_handle, int &width, int &height);
-  static void EnableDPIAwarenessForThisThread();
+  static void EnableDPIAwarenessForThisProcess();
 };

--- a/src/common/on_thread_executor.cpp
+++ b/src/common/on_thread_executor.cpp
@@ -1,0 +1,39 @@
+#include "pch.h"
+
+#include "on_thread_executor.h"
+
+OnThreadExecutor::OnThreadExecutor()
+  :_worker_thread{[this]() { worker_thread(); }}
+{}
+
+std::future<void> OnThreadExecutor::submit(task_t task) {
+  
+  auto future = task.get_future();
+  std::lock_guard lock{_task_mutex};
+  _task_queue.emplace(std::move(task));
+  _task_cv.notify_one();
+  return future;
+}
+
+void OnThreadExecutor::worker_thread() {
+  while(_active)
+  {
+    task_t task;
+    {
+      std::unique_lock task_lock{_task_mutex};
+      _task_cv.wait(task_lock, [this] { return !_task_queue.empty() || !_active; });
+      if(!_active)
+        break;
+      task = std::move(_task_queue.front());
+      _task_queue.pop();
+    }
+    task();
+  }
+}
+
+OnThreadExecutor::~OnThreadExecutor() {
+  _active = false;
+  _task_cv.notify_one();
+  _worker_thread.join();
+}
+

--- a/src/common/on_thread_executor.cpp
+++ b/src/common/on_thread_executor.cpp
@@ -23,7 +23,9 @@ void OnThreadExecutor::worker_thread() {
       std::unique_lock task_lock{_task_mutex};
       _task_cv.wait(task_lock, [this] { return !_task_queue.empty() || !_active; });
       if(!_active)
+      {
         break;
+      }
       task = std::move(_task_queue.front());
       _task_queue.pop();
     }

--- a/src/common/on_thread_executor.cpp
+++ b/src/common/on_thread_executor.cpp
@@ -7,7 +7,6 @@ OnThreadExecutor::OnThreadExecutor()
 {}
 
 std::future<void> OnThreadExecutor::submit(task_t task) {
-  
   auto future = task.get_future();
   std::lock_guard lock{_task_mutex};
   _task_queue.emplace(std::move(task));
@@ -16,14 +15,12 @@ std::future<void> OnThreadExecutor::submit(task_t task) {
 }
 
 void OnThreadExecutor::worker_thread() {
-  while(_active)
-  {
+  while(_active) {
     task_t task;
     {
       std::unique_lock task_lock{_task_mutex};
       _task_cv.wait(task_lock, [this] { return !_task_queue.empty() || !_active; });
-      if(!_active)
-      {
+      if(!_active) {
         break;
       }
       task = std::move(_task_queue.front());

--- a/src/common/on_thread_executor.h
+++ b/src/common/on_thread_executor.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <future>
+#include <thread>
+#include <functional>
+#include <queue>
+#include <atomic>
+
+class OnThreadExecutor final {
+public:
+  using task_t = std::packaged_task<void()>;
+
+  OnThreadExecutor();
+  ~OnThreadExecutor();
+  std::future<void> submit(task_t task);
+
+private:
+  void worker_thread();
+
+  std::thread _worker_thread;
+
+  std::mutex _task_mutex;
+  std::condition_variable _task_cv;
+  std::atomic_bool _active;
+  std::queue<std::packaged_task<void()>> _task_queue;
+};

--- a/src/common/on_thread_executor.h
+++ b/src/common/on_thread_executor.h
@@ -6,6 +6,10 @@
 #include <queue>
 #include <atomic>
 
+// OnThreadExecutor allows its caller to off-load some work to a persistently running background thread.
+// This might come in handy if you use the API which sets thread-wide global state and the state needs
+// to be isolated.
+
 class OnThreadExecutor final {
 public:
   using task_t = std::packaged_task<void()>;

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -23,6 +23,9 @@ namespace FancyZonesEditor
     /// </summary>
     public partial class MainWindow : MetroWindow
     {
+        // TODO: share the constants b/w C# Editor and FancyZoneLib
+        public static int MAX_ZONES = 40;
+        
         public MainWindow()
         {
             InitializeComponent();
@@ -57,7 +60,7 @@ namespace FancyZonesEditor
 
         private void IncrementZones_Click(object sender, RoutedEventArgs e)
         {
-            if (_settings.ZoneCount < 40)
+            if (_settings.ZoneCount < MAX_ZONES)
             {
                 _settings.ZoneCount++;
             }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/Settings.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/Settings.cs
@@ -279,7 +279,7 @@ namespace FancyZonesEditor
                 // 1 = unique key for per-monitor settings
                 // 2 = layoutid used to generate current layout (used to pick the default layout to show)
                 // 3 = handle to monitor (passed back to engine to persist data)
-                // 4 = X_Y_Width_Height (where EditorOverlay shows up)
+                // 4 = X_Y_Width_Height in a dpi-scaled-but-unaware coords (where EditorOverlay shows up)
                 // 5 = resolution key (passed back to engine to persist data)
                 // 6 = monitor DPI (float)
 

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -239,8 +239,8 @@ void FancyZones::ToggleEditor() noexcept
     }
 
     HMONITOR monitor{};
-    UINT dpi_x = 96;
-    UINT dpi_y = 96;
+    UINT dpi_x = DPIAware::DEFAULT_DPI;
+    UINT dpi_y = DPIAware::DEFAULT_DPI;
 
     if (m_settings->GetSettings().use_cursorpos_editor_startupscreen)
     {
@@ -278,15 +278,17 @@ void FancyZones::ToggleEditor() noexcept
     // From there, we need to scale the difference between the monitor and workarea rects to get the
     // appropriate offset where the overlay should appear.
     // This covers the cases where the taskbar is not at the bottom of the screen.
-    const auto x = mi.rcMonitor.left + MulDiv(mi.rcWork.left - mi.rcMonitor.left, 96, dpi_x);
-    const auto y = mi.rcMonitor.top + MulDiv(mi.rcWork.top - mi.rcMonitor.top, 96, dpi_y);
+    const auto taskbar_x_offset = MulDiv(mi.rcWork.left - mi.rcMonitor.left, DPIAware::DEFAULT_DPI, dpi_x);
+    const auto taskbar_y_offset = MulDiv(mi.rcWork.top - mi.rcMonitor.top, DPIAware::DEFAULT_DPI, dpi_y);
+    const auto x = mi.rcMonitor.left + taskbar_x_offset;
+    const auto y = mi.rcMonitor.top + taskbar_y_offset;
 
     // Location that the editor should occupy, scaled by DPI
-    std::wstring editorLocation = 
+    const std::wstring editorLocation = 
         std::to_wstring(x) + L"_" +
         std::to_wstring(y) + L"_" +
-        std::to_wstring(MulDiv(mi.rcWork.right - mi.rcWork.left, 96, dpi_x)) + L"_" +
-        std::to_wstring(MulDiv(mi.rcWork.bottom - mi.rcWork.top, 96, dpi_y));
+        std::to_wstring(MulDiv(mi.rcWork.right - mi.rcWork.left, DPIAware::DEFAULT_DPI, dpi_x)) + L"_" +
+        std::to_wstring(MulDiv(mi.rcWork.bottom - mi.rcWork.top, DPIAware::DEFAULT_DPI, dpi_y));
 
     const std::wstring params =
         iter->second->UniqueId() + L" " +
@@ -294,7 +296,7 @@ void FancyZones::ToggleEditor() noexcept
         std::to_wstring(reinterpret_cast<UINT_PTR>(monitor)) + L" " +
         editorLocation + L" " +
         iter->second->WorkAreaKey() + L" " +
-        std::to_wstring(static_cast<float>(dpi_x) / 96.0f);
+        std::to_wstring(static_cast<float>(dpi_x) / DPIAware::DEFAULT_DPI);
 
     SHELLEXECUTEINFO sei{ sizeof(sei) };
     sei.fMask = { SEE_MASK_NOCLOSEPROCESS | SEE_MASK_FLAG_NO_UI };

--- a/src/modules/fancyzones/lib/ZoneSet.h
+++ b/src/modules/fancyzones/lib/ZoneSet.h
@@ -34,13 +34,15 @@ interface __declspec(uuid("{E4839EB7-669D-49CF-84A9-71A2DFD851A3}")) IZoneSet : 
 #define VERSION_PERSISTEDDATA 0x0000F00D
 struct ZoneSetPersistedData
 {
+    static constexpr inline size_t MAX_ZONES = 40;
+
     DWORD Version{VERSION_PERSISTEDDATA};
     WORD LayoutId{};
     DWORD ZoneCount{};
     ZoneSetLayout Layout{};
     DWORD PaddingInner{};
     DWORD PaddingOuter{};
-    RECT Zones[40]{};
+    RECT Zones[MAX_ZONES]{};
 };
 
 struct ZoneSetConfig

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -1,4 +1,6 @@
 #include "pch.h"
+#include <common/dpi_aware.h>
+
 #include <ShellScalingApi.h>
 
 struct ZoneWindow : public winrt::implements<ZoneWindow, IZoneWindow>
@@ -1284,7 +1286,7 @@ UINT ZoneWindow::GetDpiForMonitor() noexcept
         }
     }
 
-    return (dpi == 0) ? 96 : dpi;
+    return (dpi == 0) ? DPIAware::DEFAULT_DPI : dpi;
 }
 #pragma endregion
 

--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -34,7 +34,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     return 0;
   }
 
-  DPIAware::EnableDPIAwarenessForThisThread();
+  DPIAware::EnableDPIAwarenessForThisProcess();
   
   #if _DEBUG && _WIN64
   //Global error handlers to diagnose errors.

--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -8,6 +8,8 @@
 #include "trace.h"
 #include "general_settings.h"
 
+#include <common/dpi_aware.h>
+
 #if _DEBUG && _WIN64
 #include "unhandled_exception_handler.h"
 #endif
@@ -31,6 +33,8 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     // The app is already running
     return 0;
   }
+
+  DPIAware::EnableDPIAwarenessForThisThread();
   
   #if _DEBUG && _WIN64
   //Global error handlers to diagnose errors.

--- a/src/runner/runner.vcxproj
+++ b/src/runner/runner.vcxproj
@@ -67,7 +67,7 @@
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
     </Link>
     <Manifest>
-      <EnableDpiAwareness>PerMonitorHighDPIAware</EnableDpiAwareness>
+      <EnableDpiAwareness>false</EnableDpiAwareness>
     </Manifest>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -92,7 +92,7 @@
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
     </Link>
     <Manifest>
-      <EnableDpiAwareness>PerMonitorHighDPIAware</EnableDpiAwareness>
+      <EnableDpiAwareness>false</EnableDpiAwareness>
     </Manifest>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/src/settings/settings.vcxproj
+++ b/src/settings/settings.vcxproj
@@ -60,6 +60,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <AdditionalIncludeDirectories>..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalOptions>/Zm150 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <CustomBuildStep>
       <Command>
@@ -88,6 +89,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <AdditionalIncludeDirectories>..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalOptions>/Zm150 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
- Changes `EnableDpiAwareness` manifest setting in a `runner` project so the DPI-unaware API return valid data.
- Adds `DEFAULT_DPI` usage for easier code navigation.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
- Supersedes #520 
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Closes #564 

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
I was able to test some cases of #564 with a following triple display desktop setup: 
```
[fullHD]   [2K]     [fullHD]
   1     2(primary)    3
```
Bug occurs even if I launch the layout window on [1], but [3] has a different scale from the others. That happens because `GetMonitorInfo` and `GetDpiForWindow` do not depend on the scale setting of [3], but we pass those to FancyZonesEditor'. They're treated differently though, since the returned coords are virtual and not truly DPI-aware. 
Since the `runner` process doesn't draw any UI itself except for the tray dialog menu and uses only DPI-unaware calls, we need to disable "Per Monitor V2 DPI" in an app manifest.