### PR TITLE
Don't auto close issues referenced in PR

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,11 +6,11 @@
 
 <!-- Please review the items on the PR checklist before submitting-->
 ## PR Checklist
-* [ ] Closes #xxx
-* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
-* [ ] Tests added/passed
-* [ ] Requires documentation to be updated
-* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx
+* [] Applies to #xxx
+* [] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
+* [] Tests added/passed
+* [] Requires documentation to be updated
+* [] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx
 
 <!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
 ## Detailed Description of the Pull Request / Additional comments


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
When merging a PR is preferable to not auto-close the referenced issue(s).
Instead, manually mark them as `resolved` and close them only after a release that contains the fix has been published.
 
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Also removed the white-space for the `Checklist` check-boxes.


