### PR TITLE
Do not leak FancyZones object

### DIFF
--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -6,8 +6,8 @@ struct FancyZones : public winrt::implements<FancyZones, IFancyZones, IFancyZone
 public:
     FancyZones(HINSTANCE hinstance, IFancyZonesSettings* settings) noexcept
         : m_hinstance(hinstance)
+        , m_settings(settings)
     {
-        m_settings.attach(settings);
         m_settings->SetCallback(this);
     }
 
@@ -84,7 +84,7 @@ private:
     bool m_dragEnabled{}; // True if we should be showing zone hints while dragging
     std::map<HMONITOR, winrt::com_ptr<IZoneWindow>> m_zoneWindowMap; // Map of monitor to ZoneWindow (one per monitor)
     winrt::com_ptr<IZoneWindow> m_zoneWindowMoveSize; // "Active" ZoneWindow, where the move/size is happening. Will update as drag moves between monitors.
-    winrt::com_ptr<IFancyZonesSettings> m_settings;
+    IFancyZonesSettings* m_settings{};
     GUID m_currentVirtualDesktopId{};
     wil::unique_handle m_terminateEditorEvent;
 
@@ -126,7 +126,7 @@ IFACEMETHODIMP_(void) FancyZones::Run() noexcept
 IFACEMETHODIMP_(void) FancyZones::Destroy() noexcept
 {
     std::unique_lock writeLock(m_lock);
-
+    m_zoneWindowMap.clear();
     BufferedPaintUnInit();
     if (m_window)
     {

--- a/src/modules/fancyzones/lib/Settings.cpp
+++ b/src/modules/fancyzones/lib/Settings.cpp
@@ -11,7 +11,7 @@ public:
         LoadSettings(name, true /*fromFile*/);
     }
 
-    IFACEMETHODIMP_(void) SetCallback(IFancyZonesCallback* callback) { m_callback.attach(callback); }
+    IFACEMETHODIMP_(void) SetCallback(IFancyZonesCallback* callback) { m_callback = callback; }
     IFACEMETHODIMP_(bool) GetConfig(_Out_ PWSTR buffer, _Out_ int *buffer_sizeg) noexcept;
     IFACEMETHODIMP_(void) SetConfig(PCWSTR config) noexcept;
     IFACEMETHODIMP_(void) CallCustomAction(PCWSTR action) noexcept;
@@ -21,7 +21,7 @@ private:
     void LoadSettings(PCWSTR config, bool fromFile) noexcept;
     void SaveSettings() noexcept;
 
-    winrt::com_ptr<IFancyZonesCallback> m_callback;
+    IFancyZonesCallback* m_callback{};
     const HINSTANCE m_hinstance;
     PCWSTR m_name{};
 


### PR DESCRIPTION
## Summary of the Pull Request
Since `winrt::com_ptr` is akin to `std::shared_ptr`, it can cause memory leaks via circular references. We've had a `FancyZones::m_zoneWindowMap` field holding a reference to itself(`this`), preventing the destructor from running.

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
We never destroyed FancyZones object. The leak was happening because `FancyZones` had a field with a pointer to itself:
- [`zoneWindow` stores ref-counter pointer to a `host`, which is the actually `FancyZones` object](https://github.com/microsoft/PowerToys/blob/39cbc59c1282fc0b37a049a26e16f76b38058518/src/modules/fancyzones/lib/ZoneWindow.cpp#L115)
- [We store `zoneWindow` as part of a `FancyZones::m_zoneWindowMap`](https://github.com/microsoft/PowerToys/blob/39cbc59c1282fc0b37a049a26e16f76b38058518/src/modules/fancyzones/lib/FancyZones.cpp#L510-L513). `winrt::com_ptr::copy_from` is basically the same as `shared_ptr` copy ctor

So we need to clear the `m_zoneWindowMap` to break circularity.

I've also removed some of the `com_ptr`s fields, because now that we actually call `~FancyZones`, it will free its `FancyZones::m_settings` member. But since `FancyZones` is being destroyed, that means we're in `FancyZonesModule::destroy` which has its own `FancyZonesModule::m_settings`. However, since `FancyZones::FancyZones` didn't share a refcount to the settings and instead did a `m_settings.attach(settings);`, we would crash in `~FancyZonesModule` with a double free. 

Same problem with a `winrt::com_ptr<IFancyZonesCallback> m_callback` basically.

Initial review was done by @bzoz, and he noticed that we would later may need to call `set_config` again after `enable()` in the runner.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->

## Validation Steps Performed
- Tested FancyZones dtor invocation by turning it off and on via settings window