### PR TITLE
Add switch to turn off keyboard hooks while debugging

### DIFF
--- a/src/runner/lowlevel_keyboard_event.cpp
+++ b/src/runner/lowlevel_keyboard_event.cpp
@@ -18,7 +18,16 @@ namespace {
   }
 }
 
+// Prevent system-wide input lagging while paused in the debugger
+//#define DISABLE_LOWLEVEL_KBHOOK_WHEN_DEBUGGED
+
 void start_lowlevel_keyboard_hook() {
+#if defined(_DEBUG) && defined(DISABLE_LOWLEVEL_KBHOOK_WHEN_DEBUGGED)
+  if(IsDebuggerPresent()) {
+    return;
+  }
+#endif
+
   if (!hook_handle) {
     hook_handle = SetWindowsHookEx(WH_KEYBOARD_LL, hook_proc, GetModuleHandle(NULL), NULL);
     hook_handle_copy = hook_handle;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
I've experienced severe system-wide keyboard input lagging when debugging a `runner` process caused by `SetWindowsHookEx`. 

This PR allows to safely and easily toggling it in a debug environment.
