### PR TITLE
Customize system menu items through dedicated API

### DIFF
--- a/PowerToys.sln
+++ b/PowerToys.sln
@@ -23,6 +23,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "interface", "interface", "{
 	ProjectSection(SolutionItems) = preProject
 		src\modules\interface\lowlevel_keyboard_event_data.h = src\modules\interface\lowlevel_keyboard_event_data.h
 		src\modules\interface\powertoy_module_interface.h = src\modules\interface\powertoy_module_interface.h
+		src\modules\interface\powertoy_system_menu.h = src\modules\interface\powertoy_system_menu.h
 		src\modules\interface\win_hook_event_data.h = src\modules\interface\win_hook_event_data.h
 	EndProjectSection
 EndProject

--- a/src/modules/example_powertoy/dllmain.cpp
+++ b/src/modules/example_powertoy/dllmain.cpp
@@ -214,6 +214,9 @@ public:
     }
     return 0;
   }
+
+  virtual void register_system_menu_helper(PowertoySystemMenuIface* helper) override { }
+  virtual void signal_system_menu_action(const wchar_t* name) override { }
 };
 
 // Load the settings file.

--- a/src/modules/fancyzones/dll/dllmain.cpp
+++ b/src/modules/fancyzones/dll/dllmain.cpp
@@ -183,7 +183,7 @@ public:
     }
 
     virtual void register_system_menu_helper(PowertoySystemMenuIface* helper) override { }
-    virtual void signal_system_menu_action  (const wchar_t* name) override { }
+    virtual void signal_system_menu_action(const wchar_t* name) override { }
 
     // Destroy the powertoy and free memory
     virtual void destroy() override

--- a/src/modules/fancyzones/dll/dllmain.cpp
+++ b/src/modules/fancyzones/dll/dllmain.cpp
@@ -182,6 +182,9 @@ public:
         return 0;
     }
 
+    virtual void register_system_menu_helper(PowertoySystemMenuIface* helper) override { }
+    virtual void signal_system_menu_action  (const wchar_t* name) override { }
+
     // Destroy the powertoy and free memory
     virtual void destroy() override
     {

--- a/src/modules/interface/powertoy_module_interface.h
+++ b/src/modules/interface/powertoy_module_interface.h
@@ -28,6 +28,8 @@
     - unload the DLL.
  */
 
+class PowertoySystemMenuIface;
+
 class PowertoyModuleIface {
 public:
   /* Returns the name of the PowerToy, this will be cached by the runner. */
@@ -63,6 +65,12 @@ public:
        * win_hook_event: see win_hook_event_data.h
   */
   virtual intptr_t signal_event(const wchar_t* name, intptr_t data) = 0;
+
+  /* Register helper class to handle system menu items related actions. */
+  virtual void register_system_menu_helper(PowertoySystemMenuIface* helper) = 0;
+  /* Handle action on system menu item. */
+  virtual void signal_system_menu_action(const wchar_t* name) = 0;
+
   /* Destroy the PowerToy and free all memory. */
   virtual void destroy() = 0;
 };

--- a/src/modules/interface/powertoy_module_interface.h
+++ b/src/modules/interface/powertoy_module_interface.h
@@ -32,7 +32,7 @@ class PowertoySystemMenuIface;
 
 class PowertoyModuleIface {
 public:
-  // Returns the name of the PowerToy, this will be cached by the runner.
+  /* Returns the name of the PowerToy, this will be cached by the runner. */
   virtual const wchar_t* get_name() = 0;
   /* Returns a null-terminated table of the names of the events the PowerToy wants to 
      subscribe to. Available events:
@@ -49,15 +49,15 @@ public:
    * Returns true if successful.
    */
   virtual bool get_config(wchar_t* buffer, int *buffer_size) = 0;
-  // Sets the configuration values.
+  /* Sets the configuration values. */
   virtual void set_config(const wchar_t* config) = 0;
-  // Call custom action from settings screen.
+  /* Call custom action from settings screen. */
   virtual void call_custom_action(const wchar_t* action) {};
-  // Enables the PowerToy.
+  /* Enables the PowerToy. */
   virtual void enable() = 0;
-  // Disables the PowerToy, should free as much memory as possible.
+  /* Disables the PowerToy, should free as much memory as possible. */
   virtual void disable() = 0;
-  // Should return if the PowerToys is enabled or disabled.
+  /* Should return if the PowerToys is enabled or disabled. */
   virtual bool is_enabled() = 0;
   /* Handle event. Only the events the PowerToy subscribed to will be signaled.
      The data argument and return value meaning are event-specific:
@@ -66,12 +66,12 @@ public:
   */
   virtual intptr_t signal_event(const wchar_t* name, intptr_t data) = 0;
 
-  // Register helper class to handle system menu items related actions.
+  /* Register helper class to handle system menu items related actions. */
   virtual void register_system_menu_helper(PowertoySystemMenuIface* helper) = 0;
-  // Handle action on system menu item.
+  /* Handle action on system menu item. */
   virtual void signal_system_menu_action(const wchar_t* name) = 0;
 
-  // Destroy the PowerToy and free all memory.
+  /* Destroy the PowerToy and free all memory. */
   virtual void destroy() = 0;
 };
 

--- a/src/modules/interface/powertoy_module_interface.h
+++ b/src/modules/interface/powertoy_module_interface.h
@@ -32,7 +32,7 @@ class PowertoySystemMenuIface;
 
 class PowertoyModuleIface {
 public:
-  /* Returns the name of the PowerToy, this will be cached by the runner. */
+  // Returns the name of the PowerToy, this will be cached by the runner.
   virtual const wchar_t* get_name() = 0;
   /* Returns a null-terminated table of the names of the events the PowerToy wants to 
      subscribe to. Available events:
@@ -49,15 +49,15 @@ public:
    * Returns true if successful.
    */
   virtual bool get_config(wchar_t* buffer, int *buffer_size) = 0;
-  /* Sets the configuration values. */
+  // Sets the configuration values.
   virtual void set_config(const wchar_t* config) = 0;
-  /* Call custom action from settings screen. */
+  // Call custom action from settings screen.
   virtual void call_custom_action(const wchar_t* action) {};
-  /* Enables the PowerToy. */
+  // Enables the PowerToy.
   virtual void enable() = 0;
-  /* Disables the PowerToy, should free as much memory as possible. */
+  // Disables the PowerToy, should free as much memory as possible.
   virtual void disable() = 0;
-  /* Should return if the PowerToys is enabled or disabled. */
+  // Should return if the PowerToys is enabled or disabled.
   virtual bool is_enabled() = 0;
   /* Handle event. Only the events the PowerToy subscribed to will be signaled.
      The data argument and return value meaning are event-specific:
@@ -66,12 +66,12 @@ public:
   */
   virtual intptr_t signal_event(const wchar_t* name, intptr_t data) = 0;
 
-  /* Register helper class to handle system menu items related actions. */
+  // Register helper class to handle system menu items related actions.
   virtual void register_system_menu_helper(PowertoySystemMenuIface* helper) = 0;
-  /* Handle action on system menu item. */
+  // Handle action on system menu item.
   virtual void signal_system_menu_action(const wchar_t* name) = 0;
 
-  /* Destroy the PowerToy and free all memory. */
+  // Destroy the PowerToy and free all memory.
   virtual void destroy() = 0;
 };
 

--- a/src/modules/interface/powertoy_system_menu.h
+++ b/src/modules/interface/powertoy_system_menu.h
@@ -7,13 +7,18 @@ class PowertoyModuleIface;
 class PowertoySystemMenuIface
 {
 public:
+  struct ItemInfo {
+    std::wstring name{};
+    bool enable{ false };
+    bool checkBox{ false };
+  };
   /* 
    * Set configuration of system menu items for specific powertoy module. Configuration
    * parameters such as item name (and hotkey), item status at creation (enabled/disabled)
    * and whether check box will appear next to item name when action is taken, are passed
    * as JSON formatted string.
    */
-  virtual void SetConfiguration(PowertoyModuleIface* module, const wchar_t* config) = 0;
-  /* Register action on specific system menu item. */
-  virtual void RegisterAction(PowertoyModuleIface* module, HWND window, const wchar_t* name) = 0;
+  virtual void SetConfiguration(PowertoyModuleIface* module, std::vector<ItemInfo>& config) = 0;
+  // Process action on specific system menu item.
+  virtual void ProcessSelectedItem(PowertoyModuleIface* module, HWND window, const wchar_t* itemName) = 0;
 };

--- a/src/modules/interface/powertoy_system_menu.h
+++ b/src/modules/interface/powertoy_system_menu.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <string>
+
+class PowertoyModuleIface;
+
+class PowertoySystemMenuIface
+{
+public:
+  /* 
+   * Set configuration of system menu items for specific powertoy module. Configuration
+   * parameters such as item name (and hotkey), item status at creation (enabled/disabled)
+   * and whether check box will appear next to item name when action is taken, are passed
+   * as JSON formatted string.
+   */
+  virtual void SetConfiguration(PowertoyModuleIface* module, const wchar_t* config) = 0;
+  /* Register action on specific system menu item. */
+  virtual void RegisterAction(PowertoyModuleIface* module, HWND window, const wchar_t* name) = 0;
+};

--- a/src/modules/interface/powertoy_system_menu.h
+++ b/src/modules/interface/powertoy_system_menu.h
@@ -16,7 +16,7 @@ public:
    * parameters include item name (and hotkey), item status at creation (enabled/disabled)
    * and whether check box will appear next to item name when action is taken.
    */
-  virtual void SetConfiguration(PowertoyModuleIface* module, std::vector<ItemInfo>& config) = 0;
+  virtual void SetConfiguration(PowertoyModuleIface* module, const std::vector<ItemInfo>& config) = 0;
   /* Process action on specific system menu item. */
   virtual void ProcessSelectedItem(PowertoyModuleIface* module, HWND window, const wchar_t* itemName) = 0;
 };

--- a/src/modules/interface/powertoy_system_menu.h
+++ b/src/modules/interface/powertoy_system_menu.h
@@ -14,9 +14,8 @@ public:
   };
   /* 
    * Set configuration of system menu items for specific powertoy module. Configuration
-   * parameters such as item name (and hotkey), item status at creation (enabled/disabled)
-   * and whether check box will appear next to item name when action is taken, are passed
-   * as JSON formatted string.
+   * parameters include item name (and hotkey), item status at creation (enabled/disabled)
+   * and whether check box will appear next to item name when action is taken.
    */
   virtual void SetConfiguration(PowertoyModuleIface* module, std::vector<ItemInfo>& config) = 0;
   // Process action on specific system menu item.

--- a/src/modules/interface/powertoy_system_menu.h
+++ b/src/modules/interface/powertoy_system_menu.h
@@ -4,8 +4,7 @@
 
 class PowertoyModuleIface;
 
-class PowertoySystemMenuIface
-{
+class PowertoySystemMenuIface {
 public:
   struct ItemInfo {
     std::wstring name{};
@@ -18,6 +17,6 @@ public:
    * and whether check box will appear next to item name when action is taken.
    */
   virtual void SetConfiguration(PowertoyModuleIface* module, std::vector<ItemInfo>& config) = 0;
-  // Process action on specific system menu item.
+  /* Process action on specific system menu item. */
   virtual void ProcessSelectedItem(PowertoyModuleIface* module, HWND window, const wchar_t* itemName) = 0;
 };

--- a/src/modules/powerrename/dll/dllmain.cpp
+++ b/src/modules/powerrename/dll/dllmain.cpp
@@ -225,7 +225,7 @@ public:
     }
 
     virtual void register_system_menu_helper(PowertoySystemMenuIface* helper) override { }
-    virtual void signal_system_menu_action  (const wchar_t* name) override { }
+    virtual void signal_system_menu_action(const wchar_t* name) override { }
 
     // Destroy the powertoy and free memory
     virtual void destroy() override

--- a/src/modules/powerrename/dll/dllmain.cpp
+++ b/src/modules/powerrename/dll/dllmain.cpp
@@ -224,6 +224,9 @@ public:
         return 0;
     }
 
+    virtual void register_system_menu_helper(PowertoySystemMenuIface* helper) override { }
+    virtual void signal_system_menu_action  (const wchar_t* name) override { }
+
     // Destroy the powertoy and free memory
     virtual void destroy() override
     {

--- a/src/modules/shortcut_guide/shortcut_guide.h
+++ b/src/modules/shortcut_guide/shortcut_guide.h
@@ -21,6 +21,9 @@ public:
   virtual bool is_enabled() override;
   virtual intptr_t signal_event(const wchar_t* name, intptr_t data)  override;
 
+  virtual void register_system_menu_helper(PowertoySystemMenuIface* helper) override { }
+  virtual void signal_system_menu_action  (const wchar_t* name) override { }
+
   void on_held();
   void on_held_press(DWORD vkCode);
   void was_hidden();

--- a/src/modules/shortcut_guide/shortcut_guide.h
+++ b/src/modules/shortcut_guide/shortcut_guide.h
@@ -22,7 +22,7 @@ public:
   virtual intptr_t signal_event(const wchar_t* name, intptr_t data)  override;
 
   virtual void register_system_menu_helper(PowertoySystemMenuIface* helper) override { }
-  virtual void signal_system_menu_action  (const wchar_t* name) override { }
+  virtual void signal_system_menu_action(const wchar_t* name) override { }
 
   void on_held();
   void on_held_press(DWORD vkCode);

--- a/src/runner/pch.h
+++ b/src/runner/pch.h
@@ -24,4 +24,3 @@
 #include <string>
 #include <common/common.h>
 #include <ProjectTelemetry.h>
-#include <cpprest/json.h>

--- a/src/runner/pch.h
+++ b/src/runner/pch.h
@@ -24,3 +24,4 @@
 #include <string>
 #include <common/common.h>
 #include <ProjectTelemetry.h>
+#include <cpprest/json.h>

--- a/src/runner/powertoy_module.cpp
+++ b/src/runner/powertoy_module.cpp
@@ -20,5 +20,6 @@ PowertoyModule load_powertoy(const std::wstring& filename) {
     FreeLibrary(handle);
     winrt::throw_last_error();
   }
+  module->register_system_menu_helper(&SystemMenuHelperInstace());
   return PowertoyModule(module, handle);
 }

--- a/src/runner/powertoy_module.h
+++ b/src/runner/powertoy_module.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "powertoys_events.h"
+#include "system_menu_helper.h"
 #include <interface/powertoy_module_interface.h>
 #include <string>
 #include <memory>
@@ -12,6 +13,7 @@ class PowertoyModule;
 struct PowertoyModuleDeleter {
   void operator()(PowertoyModuleIface* module) const {
     if (module) {
+      powertoys_events().unregister_system_menu_action(module);
       powertoys_events().unregister_receiver(module);
       module->destroy();
     }
@@ -37,6 +39,9 @@ public:
       for (; *want_signals; ++want_signals) {
         powertoys_events().register_receiver(*want_signals, module);
       }
+    }
+    if (SystemMenuHelperInstace().HasCustomConfig(module)) {
+      powertoys_events().register_system_menu_action(module);
     }
   }
 

--- a/src/runner/powertoys_events.cpp
+++ b/src/runner/powertoys_events.cpp
@@ -44,21 +44,21 @@ void PowertoysEvents::unregister_receiver(PowertoyModuleIface* module) {
 
 void PowertoysEvents::register_system_menu_action(PowertoyModuleIface* module) {
   std::unique_lock lock(mutex);
-  systemMenuUsers.insert(module);
+  systemMenuReceivers.insert(module);
 }
 
 void PowertoysEvents::unregister_system_menu_action(PowertoyModuleIface* module) {
   std::unique_lock lock(mutex);
-  auto it = systemMenuUsers.find(module);
-  if (it != systemMenuUsers.end()) {
+  auto it = systemMenuReceivers.find(module);
+  if (it != systemMenuReceivers.end()) {
     SystemMenuHelperInstace().Reset(module);
-    systemMenuUsers.erase(it);
+    systemMenuReceivers.erase(it);
   }
 }
 
 void PowertoysEvents::handle_system_menu_action(const WinHookEvent& data) {
   if (data.event == EVENT_SYSTEM_MENUSTART) {
-    for (auto& module : systemMenuUsers) {
+    for (auto& module : systemMenuReceivers) {
       SystemMenuHelperInstace().Customize(module, data.hwnd);
     }
   }

--- a/src/runner/powertoys_events.cpp
+++ b/src/runner/powertoys_events.cpp
@@ -44,21 +44,21 @@ void PowertoysEvents::unregister_receiver(PowertoyModuleIface* module) {
 
 void PowertoysEvents::register_system_menu_action(PowertoyModuleIface* module) {
   std::unique_lock lock(mutex);
-  systemMenuReceivers.insert(module);
+  system_menu_receivers.insert(module);
 }
 
 void PowertoysEvents::unregister_system_menu_action(PowertoyModuleIface* module) {
   std::unique_lock lock(mutex);
-  auto it = systemMenuReceivers.find(module);
-  if (it != systemMenuReceivers.end()) {
+  auto it = system_menu_receivers.find(module);
+  if (it != system_menu_receivers.end()) {
     SystemMenuHelperInstace().Reset(module);
-    systemMenuReceivers.erase(it);
+    system_menu_receivers.erase(it);
   }
 }
 
 void PowertoysEvents::handle_system_menu_action(const WinHookEvent& data) {
   if (data.event == EVENT_SYSTEM_MENUSTART) {
-    for (auto& module : systemMenuReceivers) {
+    for (auto& module : system_menu_receivers) {
       SystemMenuHelperInstace().Customize(module, data.hwnd);
     }
   }

--- a/src/runner/powertoys_events.cpp
+++ b/src/runner/powertoys_events.cpp
@@ -2,6 +2,7 @@
 #include "powertoys_events.h"
 #include "lowlevel_keyboard_event.h"
 #include "win_hook_event.h"
+#include "system_menu_helper.h"
 
 void first_subscribed(const std::wstring& event) {
   if (event == ll_keyboard)
@@ -37,6 +38,42 @@ void PowertoysEvents::unregister_receiver(PowertoyModuleIface* module) {
     subscribers.erase(remove(begin(subscribers), end(subscribers), module), end(subscribers));
     if (subscribers.empty()) {
       last_unsubscribed(event);
+    }
+  }
+}
+
+void PowertoysEvents::register_system_menu_action(PowertoyModuleIface* module)
+{
+  std::unique_lock lock(mutex);
+  systemMenuUsers.insert(module);
+}
+
+void PowertoysEvents::unregister_system_menu_action(PowertoyModuleIface* module)
+{
+  std::unique_lock lock(mutex);
+  auto it = systemMenuUsers.find(module);
+  if (it != systemMenuUsers.end()) {
+    SystemMenuHelperInstace().Reset(module);
+    systemMenuUsers.erase(it);
+  }
+}
+
+void PowertoysEvents::handle_system_menu_action(const WinHookEvent& data)
+{
+  if (data.event == EVENT_SYSTEM_MENUSTART) {
+    for (auto& module : systemMenuUsers) {
+      SystemMenuHelperInstace().Customize(module, data.hwnd);
+    }
+  }
+  else if (data.event == EVENT_OBJECT_INVOKED)
+  {
+    if (PowertoyModuleIface* module{ SystemMenuHelperInstace().ModuleFromItemId(data.idChild) }) {
+      std::wstring name = SystemMenuHelperInstace().ItemNameFromItemId(data.idChild);
+
+      // Process event on specified system menu item by responsible module.
+      module->signal_system_menu_action(name.c_str());
+      // Process event on specified system menu item by system menu helper (check/uncheck if needed).
+      SystemMenuHelperInstace().RegisterAction(module, GetForegroundWindow(), name.c_str());
     }
   }
 }

--- a/src/runner/powertoys_events.cpp
+++ b/src/runner/powertoys_events.cpp
@@ -42,14 +42,12 @@ void PowertoysEvents::unregister_receiver(PowertoyModuleIface* module) {
   }
 }
 
-void PowertoysEvents::register_system_menu_action(PowertoyModuleIface* module)
-{
+void PowertoysEvents::register_system_menu_action(PowertoyModuleIface* module) {
   std::unique_lock lock(mutex);
   systemMenuUsers.insert(module);
 }
 
-void PowertoysEvents::unregister_system_menu_action(PowertoyModuleIface* module)
-{
+void PowertoysEvents::unregister_system_menu_action(PowertoyModuleIface* module) {
   std::unique_lock lock(mutex);
   auto it = systemMenuUsers.find(module);
   if (it != systemMenuUsers.end()) {
@@ -58,22 +56,19 @@ void PowertoysEvents::unregister_system_menu_action(PowertoyModuleIface* module)
   }
 }
 
-void PowertoysEvents::handle_system_menu_action(const WinHookEvent& data)
-{
+void PowertoysEvents::handle_system_menu_action(const WinHookEvent& data) {
   if (data.event == EVENT_SYSTEM_MENUSTART) {
     for (auto& module : systemMenuUsers) {
       SystemMenuHelperInstace().Customize(module, data.hwnd);
     }
   }
-  else if (data.event == EVENT_OBJECT_INVOKED)
-  {
+  else if (data.event == EVENT_OBJECT_INVOKED) {
     if (PowertoyModuleIface* module{ SystemMenuHelperInstace().ModuleFromItemId(data.idChild) }) {
-      std::wstring name = SystemMenuHelperInstace().ItemNameFromItemId(data.idChild);
-
+      std::wstring itemName = SystemMenuHelperInstace().ItemNameFromItemId(data.idChild);
       // Process event on specified system menu item by responsible module.
-      module->signal_system_menu_action(name.c_str());
+      module->signal_system_menu_action(itemName.c_str());
       // Process event on specified system menu item by system menu helper (check/uncheck if needed).
-      SystemMenuHelperInstace().RegisterAction(module, GetForegroundWindow(), name.c_str());
+      SystemMenuHelperInstace().ProcessSelectedItem(module, GetForegroundWindow(), itemName.c_str());
     }
   }
 }

--- a/src/runner/powertoys_events.h
+++ b/src/runner/powertoys_events.h
@@ -17,7 +17,7 @@ public:
 private:
   std::shared_mutex mutex;
   std::unordered_map<std::wstring, std::vector<PowertoyModuleIface*>> receivers;
-  std::unordered_set<PowertoyModuleIface*> systemMenuUsers;
+  std::unordered_set<PowertoyModuleIface*> systemMenuReceivers;
 };
 
 PowertoysEvents& powertoys_events();

--- a/src/runner/powertoys_events.h
+++ b/src/runner/powertoys_events.h
@@ -17,7 +17,7 @@ public:
 private:
   std::shared_mutex mutex;
   std::unordered_map<std::wstring, std::vector<PowertoyModuleIface*>> receivers;
-  std::unordered_set<PowertoyModuleIface*> systemMenuReceivers;
+  std::unordered_set<PowertoyModuleIface*> system_menu_receivers;
 };
 
 PowertoysEvents& powertoys_events();

--- a/src/runner/powertoys_events.h
+++ b/src/runner/powertoys_events.h
@@ -1,15 +1,23 @@
 #pragma once
+
 #include <interface/powertoy_module_interface.h>
+#include <interface/win_hook_event_data.h>
 #include <string>
 
 class PowertoysEvents {
 public:
   void register_receiver(const std::wstring& event, PowertoyModuleIface* module);
   void unregister_receiver(PowertoyModuleIface* module);
+
+  void register_system_menu_action  (PowertoyModuleIface* module);
+  void unregister_system_menu_action(PowertoyModuleIface* module);
+  void handle_system_menu_action    (const WinHookEvent& data);
+
   intptr_t signal_event(const std::wstring& event, intptr_t data);
 private:
   std::shared_mutex mutex;
   std::unordered_map<std::wstring, std::vector<PowertoyModuleIface*>> receivers;
+  std::unordered_set<PowertoyModuleIface*> systemMenuUsers;
 };
 
 PowertoysEvents& powertoys_events();

--- a/src/runner/powertoys_events.h
+++ b/src/runner/powertoys_events.h
@@ -9,9 +9,9 @@ public:
   void register_receiver(const std::wstring& event, PowertoyModuleIface* module);
   void unregister_receiver(PowertoyModuleIface* module);
 
-  void register_system_menu_action  (PowertoyModuleIface* module);
+  void register_system_menu_action(PowertoyModuleIface* module);
   void unregister_system_menu_action(PowertoyModuleIface* module);
-  void handle_system_menu_action    (const WinHookEvent& data);
+  void handle_system_menu_action(const WinHookEvent& data);
 
   intptr_t signal_event(const std::wstring& event, intptr_t data);
 private:

--- a/src/runner/runner.vcxproj
+++ b/src/runner/runner.vcxproj
@@ -107,6 +107,7 @@
     <ClCompile Include="powertoy_module.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="settings_window.cpp" />
+    <ClCompile Include="system_menu_helper.cpp" />
     <ClCompile Include="trace.cpp" />
     <ClCompile Include="tray_icon.cpp" />
     <ClCompile Include="unhandled_exception_handler.cpp" />
@@ -121,6 +122,7 @@
     <ClInclude Include="powertoy_module.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="settings_window.h" />
+    <ClInclude Include="system_menu_helper.h" />
     <ClInclude Include="trace.h" />
     <ClInclude Include="tray_icon.h" />
     <ClInclude Include="unhandled_exception_handler.h" />

--- a/src/runner/runner.vcxproj.filters
+++ b/src/runner/runner.vcxproj.filters
@@ -33,6 +33,9 @@
     <ClCompile Include="win_hook_event.cpp">
       <Filter>Events</Filter>
     </ClCompile>
+    <ClCompile Include="system_menu_helper.cpp">
+      <Filter>Utils</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
@@ -66,6 +69,9 @@
     </ClInclude>
     <ClInclude Include="win_hook_event.h">
       <Filter>Events</Filter>
+    </ClInclude>
+    <ClInclude Include="system_menu_helper.h">
+      <Filter>Utils</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/runner/system_menu_helper.cpp
+++ b/src/runner/system_menu_helper.cpp
@@ -1,0 +1,155 @@
+#include "pch.h"
+#include "system_menu_helper.h"
+
+#include <interface/powertoy_module_interface.h>
+
+namespace {
+  constexpr int KSeparatorPos = 1;
+  constexpr int KNewItemPos = 2;
+
+  int GenerateItemId() {
+    static int generator = 0xDEADBEEF;
+    return ++generator;
+  }
+}
+
+SystemMenuHelper& SystemMenuHelperInstace()
+{
+  static SystemMenuHelper instance;
+  return instance;
+}
+
+void SystemMenuHelper::SetConfiguration(PowertoyModuleIface* module, const wchar_t* config)
+{
+  Reset(module);
+  std::vector<ItemInfo> info;
+  ParseConfiguration(std::wstring(config), info);
+  Configurations[module] = info;
+  for (auto& [window, modules] : ProcessedWindows) {
+    // Unregister module. After system menu is openned again, new configuration will be applied.
+    modules.erase(std::remove(std::begin(modules), std::end(modules), module), std::end(modules));
+  }
+}
+
+void SystemMenuHelper::RegisterAction(PowertoyModuleIface* module, HWND window, const wchar_t* name)
+{
+  for (auto& item : Configurations[module]) {
+    if (!wcscmp(name, item.name.c_str()) && item.check) {
+      // Handle check/uncheck action only if specified by module configuration.
+      for (auto& [id, data] : IdMappings) {
+        if (data.second == name) {
+          HMENU systemMenu = GetSystemMenu(window, false);
+          int state = (GetMenuState(systemMenu, id, MF_BYCOMMAND) == MF_CHECKED) ? MF_UNCHECKED : MF_CHECKED;
+          CheckMenuItem(systemMenu, id, MF_BYCOMMAND | state);
+          break;
+        }
+      }
+      break;
+    }
+  }
+}
+
+bool SystemMenuHelper::Customize(PowertoyModuleIface* module, HWND window)
+{
+  for (const auto& m : ProcessedWindows[window]) {
+    if (module == m) {
+      return false;
+    }
+  }
+  AddSeparator(module, window);
+  for (const auto& info : Configurations[module]) {
+    AddItem(module, window, info.name, info.enable);
+  }
+  ProcessedWindows[window].push_back(module);
+  return true;
+}
+
+void SystemMenuHelper::Reset(PowertoyModuleIface* module)
+{
+  for (auto& [window, modules] : ProcessedWindows) {
+    for (auto& [id, data] : IdMappings) {
+      HMENU sysMenu{ nullptr };
+      if (data.first == module && (sysMenu = GetSystemMenu(window, false))) {
+        DeleteMenu(GetSystemMenu(window, false), id, MF_BYCOMMAND);
+      }
+    }
+  }
+}
+
+bool SystemMenuHelper::HasCustomConfig(PowertoyModuleIface* module)
+{
+  return (Configurations.find(module) != Configurations.end());
+}
+
+bool SystemMenuHelper::AddItem(PowertoyModuleIface* module, HWND window, const std::wstring& name, const bool enable)
+{
+  if (HMENU systemMenu{ GetSystemMenu(window, false) }) {
+    MENUITEMINFO item;
+    item.cbSize     = sizeof(item);
+    item.fMask      = MIIM_ID | MIIM_STRING | MIIM_STATE;
+    item.fState     = MF_UNCHECKED | MF_DISABLED; // Item is disabled by default.
+    item.wID        = GenerateItemId();
+    item.dwTypeData = const_cast<WCHAR*>(name.c_str());
+    item.cch        = name.size() + 1;
+
+    if (InsertMenuItem(systemMenu, GetMenuItemCount(systemMenu) - KNewItemPos, true, &item)) {
+      IdMappings[item.wID] = { module, name };
+      if (enable) {
+        EnableMenuItem(systemMenu, item.wID, MF_BYCOMMAND | MF_ENABLED);
+      }
+      return true;
+    }
+  }
+  return false;
+}
+
+bool SystemMenuHelper::AddSeparator(PowertoyModuleIface* module, HWND window)
+{
+  if (HMENU systemMenu{ GetSystemMenu(window, false) }) {
+    MENUITEMINFO separator;
+    separator.cbSize = sizeof(separator);
+    separator.fMask  = MIIM_ID | MIIM_FTYPE;
+    separator.fType  = MFT_SEPARATOR;
+    separator.wID    = GenerateItemId();
+
+    if (InsertMenuItem(systemMenu, GetMenuItemCount(systemMenu) - KSeparatorPos, true, &separator)) {
+      IdMappings[separator.wID] = { module, L"sepparator_dummy_name" };
+      return true;
+    }
+  }
+  return false;
+}
+
+void SystemMenuHelper::ParseConfiguration(const std::wstring& config, std::vector<SystemMenuHelper::ItemInfo>& out)
+{
+  using namespace web::json;
+  if (!config.empty()) {
+    value json_config = value::parse(config);
+    array json_array = json_config.at(U("custom_items")).as_array();
+    for (auto item : json_array) {
+      ItemInfo info{};
+      info.name   = item[L"name"].as_string();
+      info.enable = item[L"enable"].as_bool();
+      info.check  = item[L"check"].as_bool();
+      out.push_back(info);
+    }
+  }
+}
+
+PowertoyModuleIface* SystemMenuHelper::ModuleFromItemId(const int& id)
+{
+  auto it = IdMappings.find(id);
+  if (it != IdMappings.end()) {
+    return it->second.first;
+  }
+  return nullptr;
+}
+
+const std::wstring SystemMenuHelper::ItemNameFromItemId(const int& id)
+{
+  auto itemIt = IdMappings.find(id);
+  if (itemIt != IdMappings.end()) {
+    return itemIt->second.second;
+  }
+  return std::wstring{};
+}

--- a/src/runner/system_menu_helper.cpp
+++ b/src/runner/system_menu_helper.cpp
@@ -69,8 +69,7 @@ void SystemMenuHelper::Reset(PowertoyModuleIface* module) {
   }
 }
 
-bool SystemMenuHelper::HasCustomConfig(PowertoyModuleIface* module)
-{
+bool SystemMenuHelper::HasCustomConfig(PowertoyModuleIface* module) {
   return (Configurations.find(module) != Configurations.end());
 }
 

--- a/src/runner/system_menu_helper.h
+++ b/src/runner/system_menu_helper.h
@@ -28,7 +28,7 @@ private:
   bool AddItem(PowertoyModuleIface* module, HWND window, const std::wstring& name, const bool enable);
   bool AddSeparator(PowertoyModuleIface* module, HWND window);
 
-  // Store processed windows to avoid handling it multiple times.
+  // Store processed modules per window to avoid handling it multiple times.
   std::unordered_map<HWND, std::vector<PowertoyModuleIface*>> ProcessedModules{};
 
   // Keep mappings form item id to the module who created it and item name for faster processing later.

--- a/src/runner/system_menu_helper.h
+++ b/src/runner/system_menu_helper.h
@@ -13,7 +13,7 @@ class PowertoyModuleIface;
 class SystemMenuHelper : public PowertoySystemMenuIface {
 public:
   // PowertoySystemMenuIface
-  virtual void SetConfiguration(PowertoyModuleIface* module, std::vector<ItemInfo>& config) override;
+  virtual void SetConfiguration(PowertoyModuleIface* module, const std::vector<ItemInfo>& config) override;
   virtual void ProcessSelectedItem(PowertoyModuleIface* module, HWND window, const wchar_t* itemName) override;
 
   bool Customize(PowertoyModuleIface* module, HWND window);

--- a/src/runner/system_menu_helper.h
+++ b/src/runner/system_menu_helper.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#pragma once
+
+#include <interface/powertoy_system_menu.h>
+#include <windows.h>
+#include <string>
+#include <vector>
+#include <unordered_map>
+
+class PowertoyModuleIface;
+
+class SystemMenuHelper : public PowertoySystemMenuIface
+{
+public:
+  // PowertoySystemMenuIface
+  virtual void SetConfiguration(PowertoyModuleIface* module, const wchar_t* config) override;
+  virtual void RegisterAction  (PowertoyModuleIface* module, HWND window, const wchar_t* name) override;
+
+  bool Customize(PowertoyModuleIface* module, HWND window);
+  void Reset    (PowertoyModuleIface* module);
+
+  bool HasCustomConfig(PowertoyModuleIface* module);
+
+  PowertoyModuleIface* ModuleFromItemId(const int& id);
+  const std::wstring   ItemNameFromItemId(const int& id);
+private:
+
+  /* Data parsed from JSON configuration suplied by module itself. */
+  struct ItemInfo {
+    std::wstring name{};
+    bool         enable{ false };
+    bool         check{ false };
+  };
+
+  bool AddItem(PowertoyModuleIface* module, HWND window, const std::wstring& name, const bool enable);
+  bool AddSeparator(PowertoyModuleIface* module, HWND window);
+  void ParseConfiguration(const std::wstring& config, std::vector<ItemInfo>& out);
+
+  /* Store processed windows to avoid handling it multiple times. */
+  std::unordered_map<HWND, std::vector<PowertoyModuleIface*>>            ProcessedWindows{};
+  /* 
+   * Keep mappings form item id to the module who created it and item name for faster
+   * processing later.
+   */
+  std::unordered_map<int, std::pair<PowertoyModuleIface*, std::wstring>> IdMappings{};
+  /* 
+   * Store configurations provided by module. This will be used to create custom
+   * system menu items and to handle updates.
+   */
+  std::unordered_map<PowertoyModuleIface*, std::vector<ItemInfo>>        Configurations{};
+};
+
+SystemMenuHelper& SystemMenuHelperInstace();

--- a/src/runner/system_menu_helper.h
+++ b/src/runner/system_menu_helper.h
@@ -10,45 +10,33 @@
 
 class PowertoyModuleIface;
 
-class SystemMenuHelper : public PowertoySystemMenuIface
-{
+class SystemMenuHelper : public PowertoySystemMenuIface {
 public:
   // PowertoySystemMenuIface
-  virtual void SetConfiguration(PowertoyModuleIface* module, const wchar_t* config) override;
-  virtual void RegisterAction  (PowertoyModuleIface* module, HWND window, const wchar_t* name) override;
+  virtual void SetConfiguration(PowertoyModuleIface* module, std::vector<ItemInfo>& config) override;
+  virtual void ProcessSelectedItem(PowertoyModuleIface* module, HWND window, const wchar_t* itemName) override;
 
   bool Customize(PowertoyModuleIface* module, HWND window);
-  void Reset    (PowertoyModuleIface* module);
+  void Reset(PowertoyModuleIface* module);
 
   bool HasCustomConfig(PowertoyModuleIface* module);
 
   PowertoyModuleIface* ModuleFromItemId(const int& id);
-  const std::wstring   ItemNameFromItemId(const int& id);
+  const std::wstring ItemNameFromItemId(const int& id);
+
 private:
-
-  /* Data parsed from JSON configuration suplied by module itself. */
-  struct ItemInfo {
-    std::wstring name{};
-    bool         enable{ false };
-    bool         check{ false };
-  };
-
   bool AddItem(PowertoyModuleIface* module, HWND window, const std::wstring& name, const bool enable);
   bool AddSeparator(PowertoyModuleIface* module, HWND window);
-  void ParseConfiguration(const std::wstring& config, std::vector<ItemInfo>& out);
 
-  /* Store processed windows to avoid handling it multiple times. */
-  std::unordered_map<HWND, std::vector<PowertoyModuleIface*>>            ProcessedWindows{};
-  /* 
-   * Keep mappings form item id to the module who created it and item name for faster
-   * processing later.
-   */
+  // Store processed windows to avoid handling it multiple times.
+  std::unordered_map<HWND, std::vector<PowertoyModuleIface*>> ProcessedModules{};
+
+  // Keep mappings form item id to the module who created it and item name for faster processing later.
   std::unordered_map<int, std::pair<PowertoyModuleIface*, std::wstring>> IdMappings{};
-  /* 
-   * Store configurations provided by module. This will be used to create custom
-   * system menu items and to handle updates.
-   */
-  std::unordered_map<PowertoyModuleIface*, std::vector<ItemInfo>>        Configurations{};
+
+  // Store configurations provided by module.
+  // This will be used to create custom system menu items and to handle updates.
+  std::unordered_map<PowertoyModuleIface*, std::vector<ItemInfo>> Configurations{};
 };
 
 SystemMenuHelper& SystemMenuHelperInstace();


### PR DESCRIPTION
Expose API for handling customized system menu per window. Allow modules to create system menu items, specify hotkey for them, specify default item state after creation (enabled/disabled) and specify whether checkbox will appear left to the menu item (checked/unchecked).

Each module registers helper class and pass configuration to it. Afterwards, when action is registered on custom system menu item, module will be triggered to process it accordingly.

All handling of custom system menu items is centralized and located inside runner project. This implementation ensures that no conflicts can occur in between modules.
