### PR TITLE
Small bugs fixes to PowerRename

### DIFF
--- a/src/modules/powerrename/dll/PowerRenameExt.cpp
+++ b/src/modules/powerrename/dll/PowerRenameExt.cpp
@@ -91,7 +91,7 @@ HRESULT CPowerRenameMenu::InvokeCommand(_In_ LPCMINVOKECOMMANDINFO pici)
 {
     HRESULT hr = E_FAIL;
 
-    if (IsEnabled() &
+    if (IsEnabled() &&
         (IS_INTRESOURCE(pici->lpVerb)) &&
         (LOWORD(pici->lpVerb) == 0))
     {

--- a/src/modules/powerrename/ui/PowerRenameUI.cpp
+++ b/src/modules/powerrename/ui/PowerRenameUI.cpp
@@ -216,7 +216,7 @@ IFACEMETHODIMP CPowerRenameUI::OnRenameCompleted()
     EnableWindow(m_hwnd, TRUE);
 
     // Close the window
-    _OnCloseDlg();
+    PostMessage(m_hwnd, WM_CLOSE, (WPARAM)0, (LPARAM)0);
     return S_OK;
 }
 


### PR DESCRIPTION
A noticed a deadlock that can occur on close of the power rename dialog with a recent change that is not in a release yet.  Also fixed typo in CPowerRenameMenu::InvokeCommand