### PR TITLE
initialize all OnThreadExecutor fields and clarify intent further

### DIFF
--- a/src/common/on_thread_executor.cpp
+++ b/src/common/on_thread_executor.cpp
@@ -3,7 +3,8 @@
 #include "on_thread_executor.h"
 
 OnThreadExecutor::OnThreadExecutor()
-  :_worker_thread{[this]() { worker_thread(); }}
+  : _shutdown_request{false}
+  , _worker_thread{[this] { worker_thread(); }}
 {}
 
 std::future<void> OnThreadExecutor::submit(task_t task) {
@@ -15,13 +16,13 @@ std::future<void> OnThreadExecutor::submit(task_t task) {
 }
 
 void OnThreadExecutor::worker_thread() {
-  while(_active) {
+  while(!_shutdown_request) {
     task_t task;
     {
       std::unique_lock task_lock{_task_mutex};
-      _task_cv.wait(task_lock, [this] { return !_task_queue.empty() || !_active; });
-      if(!_active) {
-        break;
+      _task_cv.wait(task_lock, [this] { return !_task_queue.empty() || _shutdown_request; });
+      if(_shutdown_request) {
+        return;
       }
       task = std::move(_task_queue.front());
       _task_queue.pop();
@@ -31,7 +32,7 @@ void OnThreadExecutor::worker_thread() {
 }
 
 OnThreadExecutor::~OnThreadExecutor() {
-  _active = false;
+  _shutdown_request = true;
   _task_cv.notify_one();
   _worker_thread.join();
 }

--- a/src/common/on_thread_executor.h
+++ b/src/common/on_thread_executor.h
@@ -25,6 +25,6 @@ private:
 
   std::mutex _task_mutex;
   std::condition_variable _task_cv;
-  std::atomic_bool _active;
+  std::atomic_bool _shutdown_request;
   std::queue<std::packaged_task<void()>> _task_queue;
 };


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
- `_active` wasn't initialized, so sometimes `OnThreadExecutor` thread could exit instantly.
- renamed `_active` to `_shutdown_request` to clarify its purpose 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #699 

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Launched the app multiple times both in debug and release configurations