### PR TITLE
Ensure we are not leaking a bitmap in the context menu

### DIFF
--- a/src/modules/powerrename/dll/PowerRenameExt.cpp
+++ b/src/modules/powerrename/dll/PowerRenameExt.cpp
@@ -24,6 +24,7 @@ CPowerRenameMenu::CPowerRenameMenu()
 CPowerRenameMenu::~CPowerRenameMenu()
 {
     m_spdo = nullptr;
+    DeleteObject(m_hbmpIcon);
     DllRelease();
 }
 
@@ -83,7 +84,11 @@ HRESULT CPowerRenameMenu::QueryContextMenu(HMENU hMenu, UINT index, UINT uIDFirs
             if (hIcon)
             {
                 mii.fMask |= MIIM_BITMAP;
-                mii.hbmpItem = CreateBitmapFromIcon(hIcon);
+                if (m_hbmpIcon == NULL)
+                {
+                    m_hbmpIcon = CreateBitmapFromIcon(hIcon);
+                }
+                mii.hbmpItem = m_hbmpIcon;
                 DestroyIcon(hIcon);
             }
         }

--- a/src/modules/powerrename/dll/PowerRenameExt.h
+++ b/src/modules/powerrename/dll/PowerRenameExt.h
@@ -56,6 +56,7 @@ private:
     ~CPowerRenameMenu();
 
     long m_refCount = 1;
+    HBITMAP m_hbmpIcon = NULL;
     CComPtr<IDataObject> m_spdo;
 };
 


### PR DESCRIPTION
I noticed we are leaking the bitmap passed to the context menu.  This change caches the bitmap for the lifetime of the CSmartRenameMenu and then destroys it in its destructor.