### PR TITLE
FancyZonesEditor: open a tab with the selected layout on startup

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -1,4 +1,4 @@
-﻿<Controls:MetroWindow x:Class="FancyZonesEditor.MainWindow"
+<Controls:MetroWindow x:Class="FancyZonesEditor.MainWindow"
         x:Name="MainWindow1"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -18,6 +18,7 @@
     <Window.Resources>
         <local:BooleanToBrushConverter x:Key="BooleanToBrushConverter" />
         <local:ModelToVisibilityConverter x:Key="ModelToVisibilityConverter" />
+        <local:BooleanToIntConverter x:Key="BooleanToIntConverter" />
 
         <Style x:Key="titleText" TargetType="TextBlock">
             <Setter Property="FontFamily" Value="Segoe UI" />
@@ -176,8 +177,8 @@
     <StackPanel>
 
         <TextBlock Name="dialog_Title" Text="Choose your layout" Style="{StaticResource titleText}"  />
-        
-        <TabControl BorderThickness="0" x:Name="TemplateTab">
+
+        <TabControl BorderThickness="0" x:Name="TemplateTab" SelectedIndex="{Binding IsCustomLayoutActive, Mode=OneWay, Converter={StaticResource BooleanToIntConverter}}">
             <TabItem Header="Templates" Template="{StaticResource myTabs}">
                 <StackPanel>
                     <StackPanel Margin="0,15,0,8" Orientation="Horizontal" HorizontalAlignment="Center">

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -243,7 +243,7 @@ namespace FancyZonesEditor
     {
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            if(value is bool)
+            if (value is bool)
             {
                 return (bool)value == true ? 1 : 0;
             }
@@ -251,7 +251,7 @@ namespace FancyZonesEditor
         }
         public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            if(value is int)
+            if (value is int)
             {
                 return (int)value == 1;
             }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -38,7 +38,8 @@ namespace FancyZonesEditor
         }
 
         private int _WrapPanelItemSize = 262;
-        public int WrapPanelItemSize {
+        public int WrapPanelItemSize
+        {
             get
             {
                 return _WrapPanelItemSize;
@@ -236,6 +237,25 @@ namespace FancyZonesEditor
         public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
             return null;
+        }
+    }
+    public class BooleanToIntConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            if(value is bool)
+            {
+                return (bool)value == true ? 1 : 0;
+            }
+            return 0;
+        }
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            if(value is int)
+            {
+                return (int)value == 1;
+            }
+            return false;
         }
     }
 }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/Settings.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/Settings.cs
@@ -22,6 +22,21 @@ namespace FancyZonesEditor
     //
     public class Settings : INotifyPropertyChanged
     {
+        public bool IsCustomLayoutActive
+        {
+            get
+            {
+                foreach(LayoutModel model in CustomModels)
+                {
+                    if(model.IsSelected)
+                    {
+                        return true;
+                    }
+                }
+                return false;
+            }
+        }
+        
         public Settings()
         {
             ParseCommandLineArgs();

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/Settings.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/Settings.cs
@@ -26,9 +26,9 @@ namespace FancyZonesEditor
         {
             get
             {
-                foreach(LayoutModel model in CustomModels)
+                foreach (LayoutModel model in CustomModels)
                 {
-                    if(model.IsSelected)
+                    if (model.IsSelected)
                     {
                         return true;
                     }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Determine if we're using custom layout currently and open a corresponding editor tab on startup.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #592

## Validation Steps Performed
Launched editor in debug&release mode