### PR TITLE
Improve multi monitor DeviceID assignment logic

### DIFF
--- a/src/common/common.vcxproj
+++ b/src/common/common.vcxproj
@@ -67,6 +67,9 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
+    <Lib>
+      <AdditionalDependencies>wbemuuid.lib;comsuppw.lib;</AdditionalDependencies>
+    </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -89,6 +92,9 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
+    <Lib>
+      <AdditionalDependencies>wbemuuid.lib;comsuppw.lib;</AdditionalDependencies>
+    </Lib>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="animation.h" />
@@ -108,8 +114,10 @@
     <ClInclude Include="Telemetry\ProjectTelemetry.h" />
     <ClInclude Include="Telemetry\TraceLoggingDefines.h" />
     <ClInclude Include="two_way_pipe_message_ipc.h" />
+    <ClInclude Include="utils\traits.h" />
     <ClInclude Include="version.h" />
     <ClInclude Include="windows_colors.h" />
+    <ClInclude Include="wmi_query.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="animation.cpp" />
@@ -129,6 +137,7 @@
     <ClCompile Include="tasklist_positions.cpp" />
     <ClCompile Include="common.cpp" />
     <ClCompile Include="windows_colors.cpp" />
+    <ClCompile Include="wmi_query.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\deps\cpprestsdk\cpprestsdk.vcxproj">

--- a/src/common/common.vcxproj.filters
+++ b/src/common/common.vcxproj.filters
@@ -72,6 +72,12 @@
     <ClInclude Include="on_thread_executor.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="wmi_query.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
+    <ClInclude Include="utils\traits.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="d2d_svg.cpp">
@@ -112,6 +118,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="on_thread_executor.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="wmi_query.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/common/utils/traits.h
+++ b/src/common/utils/traits.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <memory>
+
+template <typename T>
+inline void default_delete(T * p) noexcept
+{
+  delete p;
+}
+
+template <typename T>
+using pimpl_t = std::unique_ptr<T, decltype(&default_delete<T>)>;

--- a/src/common/wmi_query.cpp
+++ b/src/common/wmi_query.cpp
@@ -1,0 +1,120 @@
+#include "pch.h"
+
+#include "wmi_query.h"
+
+#include <Wbemidl.h>
+#include <comutil.h>
+
+#include <wil/com.h>
+
+#include <xmllite.h>
+
+#include <winrt/Windows.Data.Xml.Dom.h>
+
+struct wmi_connection::impl
+{
+  wil::com_ptr_t<IWbemServices> _services;
+  wil::com_ptr_t<IWbemLocator>  _locator;
+  wil::com_ptr_t<IWbemContext>  _context;
+};
+
+wil::com_ptr_t<IWbemContext> setup_wmi_context()
+{
+  auto context = wil::CoCreateInstance<WbemContext, IWbemContext>(CLSCTX_INPROC_SERVER);
+  _variant_t option;
+
+  option.vt = VT_BOOL;
+  option.boolVal = VARIANT_FALSE;
+  context->SetValue(L"IncludeQualifiers", 0, &option);
+  option.Clear();
+
+  option.vt = VT_I4;
+  option.lVal = 0;
+  context->SetValue(L"PathLevel", 0, &option);
+  option.Clear();
+
+  option.vt = VT_BOOL;
+  option.boolVal = VARIANT_TRUE;
+  context->SetValue(L"ExcludeSystemProperties", 0, &option);
+  option.Clear();
+
+  option.vt = VT_BOOL;
+  option.lVal = VARIANT_FALSE;
+  context->SetValue(L"LocalOnly", 0, &option);
+  option.Clear();
+
+  return context;
+}
+
+wmi_connection::wmi_connection()
+  :_impl{new impl{}, &default_delete<impl>}
+{
+}
+
+wmi_connection wmi_connection::initialize()
+{
+  wmi_connection con;
+  con._impl->_locator = wil::CoCreateInstance<WbemLocator, IWbemLocator>(CLSCTX_INPROC_SERVER);
+  con._impl->_context = setup_wmi_context();
+
+  if(FAILED(con._impl->_locator->ConnectServer(
+    bstr_t("ROOT\\wmi"),
+    nullptr,
+    nullptr,
+    nullptr,
+    0,
+    nullptr,
+    nullptr,
+    &con._impl->_services)))
+  {
+    throw std::runtime_error("cannot initialize WMI!");
+  }
+
+  if(FAILED(CoSetProxyBlanket(
+    con._impl->_services.get(),
+    RPC_C_AUTHN_WINNT,
+    RPC_C_AUTHZ_NONE,
+    nullptr,
+    RPC_C_AUTHN_LEVEL_CALL,
+    RPC_C_IMP_LEVEL_IMPERSONATE,
+    nullptr,
+    EOAC_NONE
+  )))
+  {
+    throw std::runtime_error("cannot initialize WMI!");
+  }
+  return con;
+}
+
+void wmi_connection::select_all(const wchar_t * statement, std::function<void(std::wstring_view)> callback)
+{
+  bstr_t query_string{"select * from "};
+  query_string += statement;
+  wil::com_ptr<IEnumWbemClassObject> enum_class_obj;
+  if(FAILED(_impl->_services->ExecQuery(
+    bstr_t("WQL"),
+    query_string,
+    WBEM_FLAG_FORWARD_ONLY | WBEM_FLAG_RETURN_IMMEDIATELY,
+    nullptr,
+    &enum_class_obj)))
+  {
+    throw std::runtime_error("WMI query error!");
+  }
+  wil::com_ptr_t<IWbemClassObject> class_obj;
+  ULONG got_next{};
+  while(!FAILED(enum_class_obj->Next(WBEM_INFINITE, 1, &class_obj, &got_next)) && got_next)
+  {
+    auto obj_text_src = wil::CoCreateInstance<WbemObjectTextSrc, IWbemObjectTextSrc>(CLSCTX_INPROC_SERVER);
+    _bstr_t obj_text;
+    if(FAILED(obj_text_src->GetText(0,
+      class_obj.get(),
+      WMI_OBJ_TEXT_CIM_DTD_2_0,
+      _impl->_context.get(),
+      obj_text.GetAddress())))
+    {
+      throw std::runtime_error("WMI query error!");
+    }
+    callback({static_cast<const wchar_t *>(obj_text), obj_text.length()});
+  }
+}
+

--- a/src/common/wmi_query.h
+++ b/src/common/wmi_query.h
@@ -1,0 +1,18 @@
+#pragma once
+#include "common.h"
+#include "utils/traits.h"
+
+#include <functional>
+#include <string_view>
+
+class wmi_connection
+{
+  struct impl;
+  pimpl_t<impl> _impl;
+  
+  wmi_connection();
+public:
+  static wmi_connection initialize();
+
+  void select_all(const wchar_t * statement, std::function<void(std::wstring_view)> callback);
+};

--- a/src/modules/fancyzones/dll/FancyZonesModule.vcxproj
+++ b/src/modules/fancyzones/dll/FancyZonesModule.vcxproj
@@ -70,7 +70,7 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
-      <AdditionalDependencies>gdiplus.lib;dwmapi.lib;shlwapi.lib;uxtheme.lib;shcore.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>gdiplus.lib;dwmapi.lib;shlwapi.lib;uxtheme.lib;shcore.lib;wbemuuid.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>fancyzones.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
@@ -95,7 +95,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
-      <AdditionalDependencies>gdiplus.lib;dwmapi.lib;shlwapi.lib;uxtheme.lib;shcore.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>gdiplus.lib;dwmapi.lib;shlwapi.lib;uxtheme.lib;shcore.lib;wbemuuid.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>fancyzones.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -576,60 +576,66 @@ void FancyZones::UpdateZoneWindows() noexcept
     {
         MONITORINFOEX mi;
         mi.cbSize = sizeof(mi);
-        if (GetMonitorInfo(monitor, &mi))
+        if (GetMonitorInfo(monitor, &mi) == FALSE)
         {
-            DISPLAY_DEVICE displayDevice = { sizeof(displayDevice) };
-            PCWSTR deviceId = nullptr;
+          return TRUE;
+        }
+        DISPLAY_DEVICE displayDevice = { sizeof(displayDevice) };
+        PCWSTR deviceId = nullptr;
 
-            bool validMonitor = true;
-            if (EnumDisplayDevices(mi.szDevice, 0, &displayDevice, 1))
+        bool validMonitor = true;
+        if (EnumDisplayDevices(mi.szDevice, 0, &displayDevice, 1))
+        {
+            if (WI_IsFlagSet(displayDevice.StateFlags, DISPLAY_DEVICE_MIRRORING_DRIVER))
             {
-                if (WI_IsFlagSet(displayDevice.StateFlags, DISPLAY_DEVICE_MIRRORING_DRIVER))
-                {
-                    validMonitor = FALSE;
-                }
-                else if (displayDevice.DeviceID[0] != L'\0')
-                {
-                    deviceId = displayDevice.DeviceID;
-                }
+                validMonitor = FALSE;
             }
-
-            if (validMonitor)
+            else if (displayDevice.DeviceID[0] != L'\0')
             {
-                auto strongThis = reinterpret_cast<FancyZones*>(data);
-                
-                std::wstring wmiHWID;
-                if (deviceId)
-                {
-                  wchar_t parsedId[256]{};
-                  ParseDeviceId(deviceId, parsedId, 256);
-                  WmiMonitorID displayWmiInfo;
-                  std::wstring query{L"WmiMonitorID where InstanceName like \"%"};
-                  std::wstring_view instanceNameSearchKey{parsedId};
-                  instanceNameSearchKey = instanceNameSearchKey.substr(instanceNameSearchKey.find(L'#') + 1);
-                  (query += instanceNameSearchKey) += L"%\"";
-                  try
-                  {
-                    strongThis->m_wmiConnection.select_all(query.c_str(), [&](std::wstring_view xml_obj){
-                        displayWmiInfo = parse_monitorID_from_dtd(xml_obj);
-                    });
-                    wmiHWID = displayWmiInfo._friendly_name + L"_" + displayWmiInfo._serial_number_id;
-                  }
-                  catch(...)
-                  {
-                    // WMI query failed => using a backup deviceID instead(warn: could be identical for 2 devices
-                    // of the same model
-                  }
-                }
-                else
-                {
-                    deviceId = GetSystemMetrics(SM_REMOTESESSION) ?
-                        L"\\\\?\\DISPLAY#REMOTEDISPLAY#" :
-                        L"\\\\?\\DISPLAY#LOCALDISPLAY#";
-                }
-                strongThis->AddZoneWindow(monitor, wmiHWID.empty() ? deviceId : wmiHWID.c_str());
+                deviceId = displayDevice.DeviceID;
             }
         }
+
+        if (!validMonitor)
+        {
+          return TRUE;
+        }
+        auto strongThis = reinterpret_cast<FancyZones*>(data);
+                
+        std::wstring wmiHWID;
+        wchar_t parsedId[256]{};
+
+        if (deviceId)
+        {
+            ParseDeviceId(deviceId, parsedId, 256);
+            WmiMonitorID displayWmiInfo;
+            std::wstring query{L"WmiMonitorID where InstanceName like \"%"};
+            std::wstring_view instanceNameSearchKey{parsedId};
+            instanceNameSearchKey = instanceNameSearchKey.substr(instanceNameSearchKey.find(L'#') + 1);
+            (query += instanceNameSearchKey) += L"%\"";
+            try
+            {
+              strongThis->m_wmiConnection.select_all(query.c_str(), [&](std::wstring_view xml_obj){
+                  displayWmiInfo = parse_monitorID_from_dtd(xml_obj);
+              });
+              if (!displayWmiInfo._serial_number_id.empty())
+              {
+                  wmiHWID = displayWmiInfo._friendly_name + L"_" + displayWmiInfo._serial_number_id;
+              }
+            }
+          catch(...)
+          {
+            // WMI query failed => using a backup deviceID instead(warn: could be identical for 2 devices
+            // of the same model
+          }
+        }
+        else
+        {
+            deviceId = GetSystemMetrics(SM_REMOTESESSION) ?
+                L"\\\\?\\DISPLAY#REMOTEDISPLAY#" :
+                L"\\\\?\\DISPLAY#LOCALDISPLAY#";
+        }
+        strongThis->AddZoneWindow(monitor, wmiHWID.empty() ? parsedId : wmiHWID.c_str());
         return TRUE;
     };
 

--- a/src/modules/fancyzones/lib/FancyZonesLib.vcxproj
+++ b/src/modules/fancyzones/lib/FancyZonesLib.vcxproj
@@ -98,6 +98,7 @@
     <ClInclude Include="Settings.h" />
     <ClInclude Include="trace.h" />
     <ClInclude Include="util.h" />
+    <ClInclude Include="WmiHelpers.h" />
     <ClInclude Include="Zone.h" />
     <ClInclude Include="ZoneSet.h" />
     <ClInclude Include="ZoneWindow.h" />
@@ -110,6 +111,7 @@
     </ClCompile>
     <ClCompile Include="Settings.cpp" />
     <ClCompile Include="trace.cpp" />
+    <ClCompile Include="WmiHelpers.cpp" />
     <ClCompile Include="Zone.cpp" />
     <ClCompile Include="ZoneSet.cpp" />
     <ClCompile Include="ZoneWindow.cpp" />

--- a/src/modules/fancyzones/lib/FancyZonesLib.vcxproj.filters
+++ b/src/modules/fancyzones/lib/FancyZonesLib.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
@@ -45,6 +45,9 @@
     <ClInclude Include="trace.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="WmiHelpers.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp">
@@ -66,6 +69,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="trace.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="WmiHelpers.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/modules/fancyzones/lib/WmiHelpers.cpp
+++ b/src/modules/fancyzones/lib/WmiHelpers.cpp
@@ -35,6 +35,23 @@ WmiMonitorID parse_monitorID_from_dtd(std::wstring_view xml)
   
   WmiMonitorID result;
 
+  for(const auto & node : xml_doc.GetElementsByTagName(L"PROPERTY"))
+  {
+    for(const auto & attr : node.Attributes())
+    {
+      if(attr.NodeName() != L"NAME")
+      {
+        continue;
+      }
+      const auto property_name = attr.InnerText();
+
+      if(property_name == L"InstanceName")
+      {
+        result._instance_name = node.FirstChild().InnerText();
+      }
+    }
+  }
+
   for(const auto & node : xml_doc.GetElementsByTagName(L"PROPERTY.ARRAY"))
   {
     for(const auto & attr : node.Attributes())

--- a/src/modules/fancyzones/lib/WmiHelpers.cpp
+++ b/src/modules/fancyzones/lib/WmiHelpers.cpp
@@ -1,0 +1,59 @@
+#include "pch.h"
+#include "WmiHelpers.h"
+
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Data.Xml.Dom.h>
+#include <xmllite.h>
+
+std::wstring parse_utf16_value_array(const winrt::Windows::Data::Xml::Dom::IXmlNode & value_array_node)
+{
+  std::wstring result;
+  for(auto char_node = value_array_node.FirstChild(); char_node; char_node = char_node.NextSibling())
+  {
+    uint16_t char_code;
+    std::wistringstream{std::wstring{char_node.InnerText()}} >> char_code;
+    if(char_code)
+    {
+      result += char_code;
+    }
+    else
+    {
+      return result;
+    }
+  }
+  return result;
+}
+
+WmiMonitorID parse_monitorID_from_dtd(std::wstring_view xml)
+{
+  winrt::Windows::Data::Xml::Dom::XmlDocument xml_doc;
+  winrt::Windows::Data::Xml::Dom::XmlLoadSettings load_settings;
+  load_settings.ValidateOnParse(false);
+  load_settings.ElementContentWhiteSpace(false);
+  xml_doc.LoadXml(xml, load_settings);
+  xml_doc.Normalize();
+  
+  WmiMonitorID result;
+
+  for(const auto & node : xml_doc.GetElementsByTagName(L"PROPERTY.ARRAY"))
+  {
+    for(const auto & attr : node.Attributes())
+    {
+      if(attr.NodeName() != L"NAME")
+      {
+        continue;
+      }
+      const auto property_name = attr.InnerText();
+
+      if(property_name == L"UserFriendlyName")
+      {
+        result._friendly_name = parse_utf16_value_array(node.FirstChild());
+      }
+      else if(property_name == L"SerialNumberID")
+      {
+        result._serial_number_id = parse_utf16_value_array(node.FirstChild());
+      }
+    }
+  }
+  return result;
+}

--- a/src/modules/fancyzones/lib/WmiHelpers.h
+++ b/src/modules/fancyzones/lib/WmiHelpers.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <string_view>
+
+struct WmiMonitorID
+{
+  std::wstring _friendly_name;
+  std::wstring _serial_number_id;
+};
+
+WmiMonitorID parse_monitorID_from_dtd(std::wstring_view xml);

--- a/src/modules/fancyzones/lib/WmiHelpers.h
+++ b/src/modules/fancyzones/lib/WmiHelpers.h
@@ -4,8 +4,14 @@
 
 struct WmiMonitorID
 {
+  std::wstring _instance_name;
   std::wstring _friendly_name;
   std::wstring _serial_number_id;
+
+  inline std::wstring hardware_id() const
+  {
+    return _friendly_name + L"_" + _serial_number_id;
+  }
 };
 
 WmiMonitorID parse_monitorID_from_dtd(std::wstring_view xml);

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -37,7 +37,7 @@ private:
         int thickness{};
     };
 
-    void InitializeId(PCWSTR deviceId, PCWSTR virtualDesktopId) noexcept;
+    void InitializeId(PCWSTR hardwareDeviceID, PCWSTR virtualDesktopId) noexcept;
     void LoadSettings() noexcept;
     void InitializeZoneSets() noexcept;
     void LoadZoneSetsFromRegistry() noexcept;
@@ -316,20 +316,17 @@ IFACEMETHODIMP_(void) ZoneWindow::CycleActiveZoneSet(DWORD wparam) noexcept
 }
 
 #pragma region private
-void ZoneWindow::InitializeId(PCWSTR deviceId, PCWSTR virtualDesktopId) noexcept
+void ZoneWindow::InitializeId(PCWSTR hardwareDeviceID, PCWSTR virtualDesktopId) noexcept
 {
-    SHStrDup(deviceId, &m_deviceId);
+    SHStrDup(hardwareDeviceID, &m_deviceId);
 
     MONITORINFOEXW mi;
     mi.cbSize = sizeof(mi);
     if (GetMonitorInfo(m_monitor, &mi))
     {
-        wchar_t parsedId[256]{};
-        ParseDeviceId(m_deviceId.get(), parsedId, 256);
-
         Rect const monitorRect(mi.rcMonitor);
         StringCchPrintf(m_uniqueId, ARRAYSIZE(m_uniqueId), L"%s_%d_%d_%s",
-            parsedId, monitorRect.width(), monitorRect.height(), virtualDesktopId);
+          hardwareDeviceID, monitorRect.width(), monitorRect.height(), virtualDesktopId);
     }
 }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
- handles remote(RDC) case somewhat
- workaround for EnumDisplayMonitors bug 
- uses WMI data when possible
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #611
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Debug/Release full registry clean launch on a desktop machine VM, VM-RDC, VM-RDC multimonitor.