### PR TITLE
FancyZones settings: show proper hotkey even when wrong key was saved before

### DIFF
--- a/src/common/settings_objects.h
+++ b/src/common/settings_objects.h
@@ -166,7 +166,11 @@ namespace PowerToysSettings {
         return output.data();
       }
     }
-    HotkeyObject(web::json::value hotkey_json) : m_json(hotkey_json) {};
+    HotkeyObject(web::json::value hotkey_json) : m_json(hotkey_json) {
+      if (m_json.has_number_field(L"code")) {
+        m_json.as_object()[L"key"] = web::json::value::string(key_from_code(get_code()));
+      }
+    };
     web::json::value m_json;
   };
 


### PR DESCRIPTION
## Summary of the Pull Request

This makes the Hotkey settings object ignore the key value stored in JSON. Instead, it will be deduced from the current keyboard layout and the vk_code.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manual