### PR TITLE
Prevent ShortcutGuide from crashing when it is being disabled while shown.

### DIFF
--- a/src/modules/shortcut_guide/shortcut_guide.cpp
+++ b/src/modules/shortcut_guide/shortcut_guide.cpp
@@ -101,6 +101,7 @@ void OverlayWindow::enable() {
 
 void OverlayWindow::disable(bool trace_event) {
   if (_enabled) {
+    _enabled = false;
     if (trace_event) {
       Trace::EnableShortcutGuide(false);
     }
@@ -111,7 +112,6 @@ void OverlayWindow::disable(bool trace_event) {
     target_state = nullptr;
     winkey_popup = nullptr;
   }
-  _enabled = false;
 }
 
 void OverlayWindow::disable() {


### PR DESCRIPTION
## Summary of the Pull Request
The keyboard event handler in the ShortcutGuide was disabled (`_enabled = false`) after the handling object was destroyed (`delete target_state`). This caused a segfault when TargetState tried to process incoming events. This changes the order, disabling the event handler before deleting the object.

## PR Checklist
* [x] Applies to https://github.com/microsoft/PowerToys/issues/780
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

## Validation Steps Performed
Manual.