### PR TITLE
Fix lack of tray icon #268 by handling initial Shell_NotifyIcon failure

### DIFF
--- a/src/runner/tray_icon.cpp
+++ b/src/runner/tray_icon.cpp
@@ -7,23 +7,22 @@
 extern "C" IMAGE_DOS_HEADER __ImageBase;
 
 namespace {
-HWND tray_icon_hwnd = NULL;
+  HWND tray_icon_hwnd = NULL;
 
-// Message code that Windows will use for tray icon notifications.
-UINT wm_icon_notify = 0;
+  // Message code that Windows will use for tray icon notifications.
+  UINT wm_icon_notify = 0;
 
-// Contains the Windows Message for taskbar creation.
-UINT wm_taskbar_restart = 0;
-UINT wm_run_on_main_ui_thread = 0;
+  // Contains the Windows Message for taskbar creation.
+  UINT wm_taskbar_restart = 0;
+  UINT wm_run_on_main_ui_thread = 0;
 
-NOTIFYICONDATAW tray_icon_data;
-bool tray_icon_created = false;
+  NOTIFYICONDATAW tray_icon_data;
+  bool tray_icon_created = false;
 
-bool about_box_shown = false;
+  bool about_box_shown = false;
 
-HMENU h_menu = nullptr;
-HMENU h_sub_menu = nullptr;
-
+  HMENU h_menu = nullptr;
+  HMENU h_sub_menu = nullptr;
 }
 
 // Struct to fill with callback and the data. The window_proc is responsible for cleaning it.


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
`Shell_NotifyIcon` can fail when we invoke it during the time explorer.exe isn't present/ready to handle it. We'll also never receive `wm_taskbar_restart message` if the first call to `Shell_NotifyIcon` failed, so that changes reacts to `WM_WINDOWPOSCHANGING` which is always received on explorer startup sequence.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #268

## Validation Steps Performed
Launched PowerToys while there's/isn't explorer.exe present, restarted explorer.exe