### PR TITLE
Wix installer: kill explorer if shellext is detected

### DIFF
--- a/installer/PowerToysSetup/Product.wxs
+++ b/installer/PowerToysSetup/Product.wxs
@@ -62,6 +62,10 @@
     <Property Id="WixShellExecTarget" Value="[#PowerToys.exe]" />
     <CustomAction Id="LaunchApplication" BinaryKey="WixCA" DllEntry="WixShellExec" Impersonate="yes" />
 
+    <Property Id ="EXISTINGPOWERRENAMEEXTPATH">
+      <RegistrySearch Id="ExistingExtPath" Root="HKCR" Key="CLSID\{0440049F-D1DC-4E46-B27B-98393D79486B}\InprocServer32" Type="raw"/>
+    </Property>
+
     <InstallExecuteSequence>
       <Custom Action="SetRegisterPowerToysSchTaskParam" Before="RegisterPowerToysSchTask" />
       <Custom Action="RegisterPowerToysSchTask" After="InstallFiles">
@@ -156,6 +160,10 @@
 
     <!-- Close 'PowerToys.exe' before uninstall-->
     <Property Id="MSIRESTARTMANAGERCONTROL" Value="Disable" />
+    <!-- Restart explorer.exe if we detect existing powerrenameext.dll installation -->
+    <util:CloseApplication Target="explorer.exe" RebootPrompt="no" TerminateProcess="0">
+      EXISTINGPOWERRENAMEEXTPATH
+    </util:CloseApplication>
     <util:CloseApplication CloseMessage="yes" Target="PowerToys.exe" ElevatedCloseMessage="yes" RebootPrompt="no" TerminateProcess="0" />
   </Product>
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
There's no standard API to tell `explorer` to unload a shell extension, so we need to restart it.

[`RestartResource`](https://wixtoolset.org/documentation/manual/v3/xsd/util/restartresource.html), which is a wrapper for [Restart Manager API](https://docs.microsoft.com/en-us/windows/win32/rstmgr/using-restart-manager-with-a-primary-installer), isn't able to cleanly restart `explorer` since we [got the API disabled](https://github.com/microsoft/PowerToys/blob/ee1a1fd61446b25a2e03522da7560875005c2f50/installer/PowerToysSetup/Product.wxs#L158), although enabling it produces other issues.

[`CloseApplication`](https://wixtoolset.org/documentation/manual/v3/xsd/util/closeapplication.html) does the trick though. It's also conditioned not to close `explorer` if a user doesn't have an existing `PowerRenameExt.dll` shell extension installed.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #785 

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Performed clean and upgrade from 0.13 installation of compiled msi on desktop and VM.