### PR TITLE
Don't flash current zone setup when focused window is in full screen

### DIFF
--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -3,6 +3,8 @@
 
 #include <ShellScalingApi.h>
 
+bool IsFullscreen(HWND window);
+
 struct ZoneWindow : public winrt::implements<ZoneWindow, IZoneWindow>
 {
 public:
@@ -121,7 +123,7 @@ ZoneWindow::ZoneWindow(
     if (m_window)
     {
         MakeWindowTransparent(m_window.get());
-        if (flashZones)
+        if (flashZones && !IsFullscreen(GetForegroundWindow()))
         {
             FlashZones();
         }
@@ -761,4 +763,22 @@ winrt::com_ptr<IZoneWindow> MakeZoneWindow(IZoneWindowHost* host, HINSTANCE hins
     PCWSTR deviceId, PCWSTR virtualDesktopId, bool flashZones) noexcept
 {
     return winrt::make_self<ZoneWindow>(host, hinstance, monitor, deviceId, virtualDesktopId, flashZones);
+}
+
+
+bool IsFullscreen(HWND window)
+{
+  MONITORINFO monitorInfo;
+  monitorInfo.cbSize = sizeof(MONITORINFO);
+  RECT windowRect;
+
+  if (GetMonitorInfo(MonitorFromWindow(window, MONITOR_DEFAULTTOPRIMARY), &monitorInfo) &&
+    GetWindowRect(window, &windowRect)) {
+
+    return windowRect.left == monitorInfo.rcMonitor.left &&
+      windowRect.top == monitorInfo.rcMonitor.top &&
+      windowRect.right == monitorInfo.rcMonitor.right &&
+      windowRect.bottom == monitorInfo.rcMonitor.bottom;
+  }
+  return false;
 }

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -3,7 +3,7 @@
 
 #include <ShellScalingApi.h>
 
-bool IsFullscreen(HWND window);
+bool IsFullscreen(const MONITORINFO& monitor, HWND window);
 
 struct ZoneWindow : public winrt::implements<ZoneWindow, IZoneWindow>
 {
@@ -123,7 +123,7 @@ ZoneWindow::ZoneWindow(
     if (m_window)
     {
         MakeWindowTransparent(m_window.get());
-        if (flashZones && !IsFullscreen(GetForegroundWindow()))
+        if (flashZones && !IsFullscreen(mi, GetForegroundWindow()))
         {
             FlashZones();
         }
@@ -766,19 +766,16 @@ winrt::com_ptr<IZoneWindow> MakeZoneWindow(IZoneWindowHost* host, HINSTANCE hins
 }
 
 
-bool IsFullscreen(HWND window)
+bool IsFullscreen(const MONITORINFO& monitor, HWND window)
 {
-  MONITORINFO monitorInfo;
-  monitorInfo.cbSize = sizeof(MONITORINFO);
   RECT windowRect;
 
-  if (GetMonitorInfo(MonitorFromWindow(window, MONITOR_DEFAULTTOPRIMARY), &monitorInfo) &&
-    GetWindowRect(window, &windowRect)) {
+  if (GetWindowRect(window, &windowRect)) {
 
-    return windowRect.left == monitorInfo.rcMonitor.left &&
-      windowRect.top == monitorInfo.rcMonitor.top &&
-      windowRect.right == monitorInfo.rcMonitor.right &&
-      windowRect.bottom == monitorInfo.rcMonitor.bottom;
+    return windowRect.left == monitor.rcMonitor.left &&
+      windowRect.top == monitor.rcMonitor.top &&
+      windowRect.right == monitor.rcMonitor.right &&
+      windowRect.bottom == monitor.rcMonitor.bottom;
   }
   return false;
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
If there is a window focused in full screen don't flash current zone setup, even if that option is checked in FancyZones general settings. Window in full screen in different resolution (video game for example) would otherwise cause zones to flash since change in resolution is detected. Flashing zones would steel focus from currently active window.

Fix for: https://github.com/microsoft/PowerToys/issues/306

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

1. Start any window in full screen (in different resolution than the specified desktop resolution).
2. Turn on `Flash zones when the active FancyZones layout changes`.

Expected behavior: Window keep his focus in full screen and FancyZones layout will not be flashed.