### PR TITLE
Use same zone set initially for new virtual desktops of same monitor

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/Settings.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/Settings.cs
@@ -36,7 +36,7 @@ namespace FancyZonesEditor
                 return false;
             }
         }
-        
+
         public Settings()
         {
             ParseCommandLineArgs();
@@ -64,9 +64,9 @@ namespace FancyZonesEditor
 
             _blankCustomModel = new CanvasLayoutModel("Create new custom", c_blankCustomModelId, (int)_workArea.Width, (int)_workArea.Height);
 
-            _zoneCount = (int)Registry.GetValue(_uniqueRegistryPath, "ZoneCount", 3);
-            _spacing = (int)Registry.GetValue(_uniqueRegistryPath, "Spacing", 16);
-            _showSpacing = (int)Registry.GetValue(_uniqueRegistryPath, "ShowSpacing", 1) == 1;
+            _zoneCount = ReadRegistryInt("ZoneCount", 3);
+            _spacing = ReadRegistryInt("Spacing", 16);
+            _showSpacing = ReadRegistryInt("ShowSpacing", 1) == 1;
 
             UpdateLayoutModels();
         }
@@ -180,6 +180,12 @@ namespace FancyZonesEditor
             get { return _dpi; }
         }
         private static float _dpi;
+
+        private int ReadRegistryInt(string valueName, int defaultValue)
+        {
+            object obj = Registry.GetValue(_uniqueRegistryPath, valueName, defaultValue);
+            return (obj != null) ? (int)obj : defaultValue;
+        }
 
         // UpdateLayoutModels
         //  Update the five default layouts based on the new ZoneCount

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -39,9 +39,16 @@ public:
         const auto nB = (tmp & 0xFF);
         return RGB(nR, nG, nB);
     }
+    IFACEMETHODIMP_(GUID) GetCurrentMonitorZoneSetId(HMONITOR monitor) noexcept
+    {
+        if (auto it = m_zoneWindowMap.find(monitor); it != m_zoneWindowMap.end()) {
+            return it->second->ActiveZoneSet()->Id();
+        }
+        return GUID_NULL;
+    }
 
     LRESULT WndProc(HWND, UINT, WPARAM, LPARAM) noexcept;
-    void OnDisplayChange(HWND window, DisplayChangeType changeType) noexcept;
+    void OnDisplayChange(DisplayChangeType changeType) noexcept;
     void AddZoneWindow(HMONITOR monitor, PCWSTR deviceId) noexcept;
     void MoveWindowIntoZoneByIndex(HWND window, int index) noexcept;
 
@@ -382,14 +389,14 @@ LRESULT FancyZones::WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lpa
     {
         if (wparam == SPI_SETWORKAREA)
         {
-            OnDisplayChange(window, DisplayChangeType::WorkArea);
+            OnDisplayChange(DisplayChangeType::WorkArea);
         }
     }
     break;
 
     case WM_DISPLAYCHANGE:
     {
-        OnDisplayChange(window, DisplayChangeType::DisplayChange);
+        OnDisplayChange(DisplayChangeType::DisplayChange);
     }
     break;
 
@@ -397,14 +404,14 @@ LRESULT FancyZones::WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lpa
     {
         if (message == WM_PRIV_VDCHANGED)
         {
-            OnDisplayChange(window, DisplayChangeType::VirtualDesktop);
+            OnDisplayChange(DisplayChangeType::VirtualDesktop);
         }
         else if (message == WM_PRIV_EDITOR)
         {
             if (lparam == static_cast<LPARAM>(EditorExitKind::Exit))
             {
                 // Don't reload settings if we terminated the editor
-                OnDisplayChange(window, DisplayChangeType::Editor);
+                OnDisplayChange(DisplayChangeType::Editor);
             }
 
             {
@@ -423,11 +430,8 @@ LRESULT FancyZones::WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lpa
     return 0;
 }
 
-void FancyZones::OnDisplayChange(HWND window, DisplayChangeType changeType) noexcept
+void FancyZones::OnDisplayChange(DisplayChangeType changeType) noexcept
 {
-    HMONITOR monitor{ MonitorFromWindow(window, MONITOR_DEFAULTTONULL) };
-    GUID activeZoneSetId{};
-
     if (changeType == DisplayChangeType::VirtualDesktop)
     {
         // Explorer persists this value to the registry on a per session basis but only after
@@ -445,20 +449,9 @@ void FancyZones::OnDisplayChange(HWND window, DisplayChangeType changeType) noex
             // TODO: Use the previous "Desktop 1" fallback
             // Need to maintain a map of desktop name to virtual desktop uuid
         }
-
-        // Save active zone set id, so it can be used on other virtual desktops of the same monitor.
-        if (auto it = m_zoneWindowMap.find(monitor); it != m_zoneWindowMap.end()) {
-            activeZoneSetId = it->second->ActiveZoneSet()->Id();
-        }
     }
 
     UpdateZoneWindows();
-
-    if (changeType == DisplayChangeType::VirtualDesktop) {
-        if (auto it = m_zoneWindowMap.find(monitor); it != m_zoneWindowMap.end()) {
-            it->second->UpdateActiveZoneSet(activeZoneSetId);
-        }
-    }
 
     if ((changeType == DisplayChangeType::WorkArea) || (changeType == DisplayChangeType::DisplayChange))
     {
@@ -567,10 +560,6 @@ void FancyZones::UpdateZoneWindows() noexcept
         return TRUE;
     };
 
-    {
-        std::unique_lock writeLock(m_lock);
-        m_zoneWindowMap.clear();
-    }
     EnumDisplayMonitors(nullptr, nullptr, callback, reinterpret_cast<LPARAM>(this));
 }
 

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -41,8 +41,9 @@ public:
     }
     IFACEMETHODIMP_(GUID) GetCurrentMonitorZoneSetId(HMONITOR monitor) noexcept
     {
-        if (auto it = m_zoneWindowMap.find(monitor); it != m_zoneWindowMap.end()) {
-            return it->second->ActiveZoneSet()->Id();
+        if (auto it = m_zoneWindowMap.find(monitor); it != m_zoneWindowMap.end() && it->second->ActiveZoneSet()) {
+            const auto activeZoneSet = it->second->ActiveZoneSet();
+            return activeZoneSet ? activeZoneSet->Id() : GUID_NULL;
         }
         return GUID_NULL;
     }
@@ -315,9 +316,12 @@ void FancyZones::ToggleEditor() noexcept
         std::to_wstring(width) + L"_" +
         std::to_wstring(height);
 
+    const auto activeZoneSet = iter->second->ActiveZoneSet();
+    const std::wstring layoutID = activeZoneSet ? std::to_wstring(activeZoneSet->LayoutId()) : L"0";
+
     const std::wstring params =
         iter->second->UniqueId() + L" " +
-        std::to_wstring(iter->second->ActiveZoneSet()->LayoutId()) + L" " +
+        layoutID + L" " +
         std::to_wstring(reinterpret_cast<UINT_PTR>(monitor)) + L" " +
         editorLocation + L" " +
         iter->second->WorkAreaKey() + L" " +

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -42,8 +42,7 @@ public:
     IFACEMETHODIMP_(GUID) GetCurrentMonitorZoneSetId(HMONITOR monitor) noexcept
     {
         if (auto it = m_zoneWindowMap.find(monitor); it != m_zoneWindowMap.end() && it->second->ActiveZoneSet()) {
-            const auto activeZoneSet = it->second->ActiveZoneSet();
-            return activeZoneSet ? activeZoneSet->Id() : GUID_NULL;
+            return it->second->ActiveZoneSet()->Id();
         }
         return GUID_NULL;
     }

--- a/src/modules/fancyzones/lib/FancyZones.h
+++ b/src/modules/fancyzones/lib/FancyZones.h
@@ -34,6 +34,7 @@ interface __declspec(uuid("{5C8D99D6-34B2-4F4A-A8E5-7483F6869775}")) IZoneWindow
 {
     IFACEMETHOD_(void, MoveWindowsOnActiveZoneSetChange)() = 0;
     IFACEMETHOD_(COLORREF, GetZoneHighlightColor)() = 0;
+    IFACEMETHOD_(GUID, GetCurrentMonitorZoneSetId)(HMONITOR monitor) = 0;
 };
 
 winrt::com_ptr<IFancyZones> MakeFancyZones(HINSTANCE hinstance, IFancyZonesSettings* settings) noexcept;

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -21,6 +21,7 @@ public:
     IFACEMETHODIMP_(std::wstring) WorkAreaKey() noexcept { return { m_workArea }; }
     IFACEMETHODIMP_(void) SaveWindowProcessToZoneIndex(HWND window) noexcept;
     IFACEMETHODIMP_(IZoneSet*) ActiveZoneSet() noexcept { return m_activeZoneSet.get(); }
+    IFACEMETHODIMP_(void) UpdateActiveZoneSet(GUID id) noexcept;
 
 protected:
     static LRESULT CALLBACK s_WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lparam) noexcept;
@@ -238,6 +239,16 @@ IFACEMETHODIMP_(void) ZoneWindow::SaveWindowProcessToZoneIndex(HWND window) noex
         if (zoneIndex != -1)
         {
             RegistryHelpers::SaveAppLastZone(window, processPath.data(), zoneIndex);
+        }
+    }
+}
+
+IFACEMETHODIMP_(void) ZoneWindow::UpdateActiveZoneSet(GUID id) noexcept
+{
+    for (const auto& zoneSet : m_zoneSets) {
+        if (id == zoneSet->Id()) {
+            UpdateActiveZoneSet(zoneSet.get());
+            break;
         }
     }
 }

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -21,7 +21,6 @@ public:
     IFACEMETHODIMP_(std::wstring) WorkAreaKey() noexcept { return { m_workArea }; }
     IFACEMETHODIMP_(void) SaveWindowProcessToZoneIndex(HWND window) noexcept;
     IFACEMETHODIMP_(IZoneSet*) ActiveZoneSet() noexcept { return m_activeZoneSet.get(); }
-    IFACEMETHODIMP_(void) UpdateActiveZoneSet(GUID id) noexcept;
 
 protected:
     static LRESULT CALLBACK s_WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lparam) noexcept;
@@ -243,16 +242,6 @@ IFACEMETHODIMP_(void) ZoneWindow::SaveWindowProcessToZoneIndex(HWND window) noex
     }
 }
 
-IFACEMETHODIMP_(void) ZoneWindow::UpdateActiveZoneSet(GUID id) noexcept
-{
-    for (const auto& zoneSet : m_zoneSets) {
-        if (id == zoneSet->Id()) {
-            UpdateActiveZoneSet(zoneSet.get());
-            break;
-        }
-    }
-}
-
 #pragma region private
 void ZoneWindow::ShowZoneWindow() noexcept
 {
@@ -323,7 +312,17 @@ void ZoneWindow::InitializeZoneSets(MONITORINFO const& mi) noexcept
 
     if (!m_activeZoneSet)
     {
-        ChooseDefaultActiveZoneSet();
+        if (GUID id{ m_host->GetCurrentMonitorZoneSetId(m_monitor) }; id != GUID_NULL) {
+            for (const auto& zoneSet : m_zoneSets) {
+                if (id == zoneSet->Id()) {
+                    UpdateActiveZoneSet(zoneSet.get());
+                    break;
+                }
+            }
+        }
+        else {
+            ChooseDefaultActiveZoneSet();
+        }
     }
 }
 

--- a/src/modules/fancyzones/lib/ZoneWindow.h
+++ b/src/modules/fancyzones/lib/ZoneWindow.h
@@ -16,7 +16,6 @@ interface __declspec(uuid("{7F017528-8110-4FB3-BE41-F472969C2560}")) IZoneWindow
     IFACEMETHOD_(std::wstring, UniqueId)() = 0;
     IFACEMETHOD_(std::wstring, WorkAreaKey)() = 0;
     IFACEMETHOD_(IZoneSet*, ActiveZoneSet)() = 0;
-    IFACEMETHOD_(void, UpdateActiveZoneSet)(GUID id) = 0;
 };
 
 winrt::com_ptr<IZoneWindow> MakeZoneWindow(IZoneWindowHost* host, HINSTANCE hinstance, HMONITOR monitor,

--- a/src/modules/fancyzones/lib/ZoneWindow.h
+++ b/src/modules/fancyzones/lib/ZoneWindow.h
@@ -16,6 +16,7 @@ interface __declspec(uuid("{7F017528-8110-4FB3-BE41-F472969C2560}")) IZoneWindow
     IFACEMETHOD_(std::wstring, UniqueId)() = 0;
     IFACEMETHOD_(std::wstring, WorkAreaKey)() = 0;
     IFACEMETHOD_(IZoneSet*, ActiveZoneSet)() = 0;
+    IFACEMETHOD_(void, UpdateActiveZoneSet)(GUID id) = 0;
 };
 
 winrt::com_ptr<IZoneWindow> MakeZoneWindow(IZoneWindowHost* host, HINSTANCE hinstance, HMONITOR monitor,


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Newly created virtual desktops on same monitor should have same zone set **initially** as the virtual desktop they are created from. Currently when new virtual desktop is created, default zone set (only one zone representing work area) is used.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #383 

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
1. Start PowerToys and select zone layout in FancyZones.
2. Create one or more virtual desktops on same monitor.
3. Check how zones are configured on each of them.

Expected behavior: Virtual desktops on same monitor have same zone layout **initially** as the virtual desktop from where they are created. User can change it latter through FancyZones Editor settings.