### PR TITLE
Flash zones only when new virtual desktop is created

### DIFF
--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -787,6 +787,7 @@ void FancyZones::HandleVirtualDesktopUpdates(HANDLE fancyZonesDestroyedEvent) no
         }
         const int guidSize = sizeof(GUID);
         std::unordered_map<GUID, bool> temp;
+        temp.reserve(bufferCapacity / guidSize);
         for (int i = 0; i < bufferCapacity; i += guidSize) {
             GUID *guid = reinterpret_cast<GUID*>(buffer.get() + i);
             temp[*guid] = true;

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -756,10 +756,12 @@ void FancyZones::HandleVirtualDesktopUpdates(HANDLE event) noexcept
         DWORD bufferCapacity;
         const WCHAR* key = L"VirtualDesktopIDs";
         const int guidSize = sizeof(GUID);
+        // request regkey binary buffer capacity only
         if (RegQueryValueExW(m_virtualDesktopsRegKey, key, 0, nullptr, NULL, &bufferCapacity) != ERROR_SUCCESS) {
             return;
         }
         BYTE* buffer = (BYTE*)malloc(bufferCapacity);
+        // request regkey binary content
         if (RegQueryValueExW(m_virtualDesktopsRegKey, key, 0, nullptr, buffer, &bufferCapacity) != ERROR_SUCCESS) {
             free(buffer);
             return;
@@ -775,13 +777,14 @@ void FancyZones::HandleVirtualDesktopUpdates(HANDLE event) noexcept
         free(buffer);
         for (auto it = begin(m_virtualDesktopIds); it != end(m_virtualDesktopIds);) {
             if (auto iter = temp.find(it->first); iter == temp.end()) {
-                it = m_virtualDesktopIds.erase(it);
+                it = m_virtualDesktopIds.erase(it); // virtual desktop closed, remove it from map
             }
             else {
-                temp.erase(it->first);
+                temp.erase(it->first); // virtual desktop already in map, skip it
                 ++it;
             }
         }
+        // register new virtual desktops, if any
         m_virtualDesktopIds.insert(begin(temp), end(temp));
     }
 }

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -2,6 +2,7 @@
 #include "common/dpi_aware.h"
 #include "common/on_thread_executor.h"
 
+#include <unordered_set>
 #include <functional>
 
 namespace std
@@ -14,6 +15,53 @@ namespace std
             return ::UuidHash(&const_cast<GUID&>(Value), &status);
         }
     };
+}
+
+namespace
+{
+    std::mutex gLock;
+
+    std::unordered_set<GUID> gVirtualDesktopIDs;
+
+    void VirtualDesktopTracker(HANDLE fancyZonesDestroyedEvent) noexcept
+    {
+        HKEY virtualDesktopsRegKey{ nullptr };
+        if (RegOpenKeyEx(HKEY_CURRENT_USER, L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\VirtualDesktops", 0, KEY_ALL_ACCESS, &virtualDesktopsRegKey) != ERROR_SUCCESS) {
+            return;
+        }
+        HANDLE regKeyEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+        HANDLE events[2] = { regKeyEvent, fancyZonesDestroyedEvent };
+        while (1) {
+            if (RegNotifyChangeKeyValue(HKEY_CURRENT_USER, TRUE, REG_NOTIFY_CHANGE_LAST_SET, regKeyEvent, TRUE) != ERROR_SUCCESS) {
+                return;
+            }
+            if (WaitForMultipleObjects(2, events, FALSE, INFINITE) != (WAIT_OBJECT_0 + 0)) {
+                // if fancyZonesDestroyedEvent is signalized or WaitForMultipleObjects failed, terminate thread execution
+                return;
+            }
+            DWORD bufferCapacity;
+            const WCHAR* key = L"VirtualDesktopIDs";
+            // request regkey binary buffer capacity only
+            if (RegQueryValueExW(virtualDesktopsRegKey, key, 0, nullptr, nullptr, &bufferCapacity) != ERROR_SUCCESS) {
+                return;
+            }
+            std::unique_ptr<BYTE[]> buffer = std::make_unique<BYTE[]>(bufferCapacity);
+            // request regkey binary content
+            if (RegQueryValueExW(virtualDesktopsRegKey, key, 0, nullptr, buffer.get(), &bufferCapacity) != ERROR_SUCCESS) {
+                return;
+            }
+            const int guidSize = sizeof(GUID);
+
+            gLock.lock();
+            gVirtualDesktopIDs.clear();
+            for (int i = 0; i < bufferCapacity; i += guidSize) {
+                GUID* guid = reinterpret_cast<GUID*>(buffer.get() + i);
+                gVirtualDesktopIDs.insert(*guid);
+            }
+            gLock.unlock();
+        }
+        RegCloseKey(virtualDesktopsRegKey);
+    }
 }
 
 struct FancyZones : public winrt::implements<FancyZones, IFancyZones, IFancyZonesCallback, IZoneWindowHost>
@@ -86,11 +134,9 @@ private:
     void MoveSizeStartInternal(HWND window, HMONITOR monitor, POINT const& ptScreen, require_write_lock) noexcept;
     void MoveSizeEndInternal(HWND window, POINT const& ptScreen, require_write_lock) noexcept;
     void MoveSizeUpdateInternal(HMONITOR monitor, POINT const& ptScreen, require_write_lock) noexcept;
-    void HandleVirtualDesktopUpdates(HANDLE fancyZonesDestroyedEvent) noexcept;
+    void UpdateVirtualDesktopIDs() noexcept;
 
     const HINSTANCE m_hinstance{};
-
-    HKEY m_virtualDesktopsRegKey;
 
     mutable std::shared_mutex m_lock;
     HWND m_window{};
@@ -103,7 +149,7 @@ private:
     GUID m_currentVirtualDesktopId{}; // UUID of the current virtual desktop. Is GUID_NULL until first VD switch per session.
     std::unordered_map<GUID, bool> m_virtualDesktopIds;
     wil::unique_handle m_terminateEditorEvent; // Handle of FancyZonesEditor.exe we launch and wait on
-    wil::unique_handle m_fancyZonesDestroyedEvent;
+    wil::unique_handle m_terminateVirtualDesktopTrackerEvent;
 
     OnThreadExecutor m_dpiUnawareThread;
     OnThreadExecutor m_virtualDesktopTrackerThread;
@@ -148,13 +194,9 @@ IFACEMETHODIMP_(void) FancyZones::Run() noexcept
         SetThreadDpiHostingBehavior(DPI_HOSTING_BEHAVIOR_MIXED);
     }}).wait();
 
-    if (RegOpenKeyEx(HKEY_CURRENT_USER, L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\VirtualDesktops", 0, KEY_ALL_ACCESS, &m_virtualDesktopsRegKey) != ERROR_SUCCESS) {
-        return;
-    }
-    
-    m_fancyZonesDestroyedEvent.reset(CreateEvent(NULL, FALSE, FALSE, NULL));
+    m_terminateVirtualDesktopTrackerEvent.reset(CreateEvent(nullptr, FALSE, FALSE, nullptr));
     m_virtualDesktopTrackerThread.submit(
-        OnThreadExecutor::task_t{ std::bind(&FancyZones::HandleVirtualDesktopUpdates, this, m_fancyZonesDestroyedEvent.get()) });
+        OnThreadExecutor::task_t{ std::bind(VirtualDesktopTracker, m_terminateVirtualDesktopTrackerEvent.get()) });
 }
 
 // IFancyZones
@@ -168,10 +210,9 @@ IFACEMETHODIMP_(void) FancyZones::Destroy() noexcept
         DestroyWindow(m_window);
         m_window = nullptr;
     }
-    if (m_fancyZonesDestroyedEvent) {
-        SetEvent(m_fancyZonesDestroyedEvent.get());
+    if (m_terminateVirtualDesktopTrackerEvent) {
+        SetEvent(m_terminateVirtualDesktopTrackerEvent.get());
     }
-    RegCloseKey(m_virtualDesktopsRegKey);
 }
 
 // IFancyZonesCallback
@@ -503,11 +544,16 @@ void FancyZones::OnDisplayChange(DisplayChangeType changeType) noexcept
 
 void FancyZones::AddZoneWindow(HMONITOR monitor, PCWSTR deviceId) noexcept
 {
+    UpdateVirtualDesktopIDs();
     std::unique_lock writeLock(m_lock);
     wil::unique_cotaskmem_string virtualDesktopId;
     if (SUCCEEDED_LOG(StringFromCLSID(m_currentVirtualDesktopId, &virtualDesktopId)))
     {
-        const bool newVirtualDesktop = m_virtualDesktopIds[m_currentVirtualDesktopId];
+        bool newVirtualDesktop{ true };
+        if (auto it = m_virtualDesktopIds.find(m_currentVirtualDesktopId); it != end(m_virtualDesktopIds)) {
+            newVirtualDesktop = it->second;
+        }
+
         const bool flash = m_settings->GetSettings().zoneSetChange_flashZones && newVirtualDesktop;
 
         if (auto zoneWindow = MakeZoneWindow(this, m_hinstance, monitor, deviceId, virtualDesktopId.get(), flash))
@@ -758,49 +804,23 @@ void FancyZones::MoveSizeUpdateInternal(HMONITOR monitor, POINT const& ptScreen,
     }
 }
 
-void FancyZones::HandleVirtualDesktopUpdates(HANDLE fancyZonesDestroyedEvent) noexcept
+void FancyZones::UpdateVirtualDesktopIDs() noexcept
 {
-    HANDLE regKeyEvent = CreateEvent(NULL, FALSE, FALSE, NULL);
-    HANDLE events[2] = { regKeyEvent, fancyZonesDestroyedEvent };
-    while (1) {
-        if (RegNotifyChangeKeyValue(HKEY_CURRENT_USER, TRUE, REG_NOTIFY_CHANGE_LAST_SET, regKeyEvent, TRUE) != ERROR_SUCCESS) {
-            return;
+    gLock.lock();
+    std::unordered_set<GUID> temp(gVirtualDesktopIDs);
+    gLock.unlock();
+    for (auto it = begin(m_virtualDesktopIds); it != end(m_virtualDesktopIds);) {
+        if (auto iter = temp.find(it->first); iter == end(temp)) {
+            it = m_virtualDesktopIds.erase(it); // virtual desktop closed, remove it from map
         }
-        if (WaitForMultipleObjects(2, events, FALSE, INFINITE) != (WAIT_OBJECT_0 + 0)) {
-            // if fancyZonesDestroyedEvent is signalized or WaitForMultipleObjects failed, terminate thread execution
-            return;
+        else {
+            temp.erase(iter); // virtual desktop already in map, skip it
+            ++it;
         }
-        DWORD bufferCapacity;
-        const WCHAR* key = L"VirtualDesktopIDs";
-        // request regkey binary buffer capacity only
-        if (RegQueryValueExW(m_virtualDesktopsRegKey, key, 0, nullptr, NULL, &bufferCapacity) != ERROR_SUCCESS) {
-            return;
-        }
-        BYTE* buffer = (BYTE*)malloc(bufferCapacity);
-        // request regkey binary content
-        if (RegQueryValueExW(m_virtualDesktopsRegKey, key, 0, nullptr, buffer, &bufferCapacity) != ERROR_SUCCESS) {
-            free(buffer);
-            return;
-        }
-        const int guidSize = sizeof(GUID);
-        std::unordered_map<GUID, bool> temp;
-        for (int i = 0; i < bufferCapacity; i += guidSize) {
-            GUID guid;
-            memcpy(&guid, buffer + i, guidSize);
-            temp[guid] = true;
-        }
-        free(buffer);
-        for (auto it = begin(m_virtualDesktopIds); it != end(m_virtualDesktopIds);) {
-            if (auto iter = temp.find(it->first); iter == temp.end()) {
-                it = m_virtualDesktopIds.erase(it); // virtual desktop closed, remove it from map
-            }
-            else {
-                temp.erase(it->first); // virtual desktop already in map, skip it
-                ++it;
-            }
-        }
-        // register new virtual desktops, if any
-        m_virtualDesktopIds.insert(begin(temp), end(temp));
+    }
+    // register new virtual desktops, if any
+    for (const auto& guid : temp) {
+        m_virtualDesktopIds[guid] = true;
     }
 }
 

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -766,7 +766,7 @@ void FancyZones::HandleVirtualDesktopUpdates(HANDLE fancyZonesDestroyedEvent) no
         if (RegNotifyChangeKeyValue(HKEY_CURRENT_USER, TRUE, REG_NOTIFY_CHANGE_LAST_SET, regKeyEvent, TRUE) != ERROR_SUCCESS) {
             return;
         }
-        if (DWORD result{ WaitForMultipleObjects(2, events, FALSE, INFINITE) }; result != (WAIT_OBJECT_0 + 0)) {
+        if (WaitForMultipleObjects(2, events, FALSE, INFINITE) != (WAIT_OBJECT_0 + 0)) {
             // if fancyZonesDestroyedEvent is signalized or WaitForMultipleObjects failed, terminate thread execution
             return;
         }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Do not flash fancyzones layout every time user switches between virtual desktops. Only flash current fancyzones layout when user creates new virtual desktop. Flag `Flash zones when the active FancyZones layout changes` must be turned on.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #550 

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

1. Start PowerToys application and turn on flag `Flash zones when the active FancyZones layout changes`.
2. Create several new virtual desktops.
3. Switch between virtual desktops using `CTRL + WIN + Left/Right Arrow`.

Expected behavior: Zone layout is flashed only when new virtual desktop is created. Later, during switching between virtual desktops there is no zone flashing.