### PR TITLE
Make FancyZones not zone invisible, child and tool windows

### DIFF
--- a/src/common/hwnd_data_cache.cpp
+++ b/src/common/hwnd_data_cache.cpp
@@ -18,9 +18,10 @@ HWND HWNDDataCache::get_window(HWND hwnd) {
 WindowAndProcPath* HWNDDataCache::get_internal(HWND hwnd) {
   auto root = GetAncestor(hwnd, GA_ROOT);
   // Filter the fast and easy cases
-  if (is_invalid_hwnd(root) ||
-    is_invalid_class(root) ||
-    is_invalid_style(root)) {
+  if (!IsWindowVisible(root) ||
+      is_invalid_hwnd(root) ||
+      is_invalid_class(root) ||
+      is_invalid_style(root)) {
     return nullptr;
   }
   // Get the HWND process path from the cache

--- a/src/modules/fancyzones/dll/dllmain.cpp
+++ b/src/modules/fancyzones/dll/dllmain.cpp
@@ -215,7 +215,9 @@ private:
                 }
             }
         }
-        return true;
+        // Don't zone child windows and tool window
+        return (GetWindowLongPtr(window, GWL_STYLE) & WS_CHILD) == 0 &&
+               (GetWindowLongPtr(window, GWL_EXSTYLE) & WS_EX_TOOLWINDOW) == 0;
     }
 
     void Disable(bool const traceEvent)


### PR DESCRIPTION

## Summary of the Pull Request

Fixes "Move newly created windows to their last known zone"
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #830 and #840
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

## Validation Steps Performed
Manual