### PR TITLE
Revert: Keep window in their zone after layout changes

### DIFF
--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -462,7 +462,7 @@ void FancyZones::OnDisplayChange(DisplayChangeType changeType) noexcept
     }
     else if (changeType == DisplayChangeType::Editor)
     {
-        if (!m_settings->GetSettings().zoneSetChange_moveWindows)
+        if (m_settings->GetSettings().zoneSetChange_moveWindows)
         {
             MoveWindowsOnDisplayChange();
         }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Fix for this issue revered original behavior which is not intended. Description for this `FancyZones` settings was invalid, as it didn't explained behavior of this feature in proper way. This pull request will revert original fix, and description for this setting will be updated.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #768 

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
1. Create two customs layouts.
2. Select the first layout, move a window to the zone.
3. Switch layout and verify that the window is only moved to the second zone when the flag is off.

Expected behavior: When the flag is on, the window should not move.