### PR TITLE
Fix for broken unit test in power rename using regular expressions and wildcard. 

### DIFF
--- a/src/modules/powerrename/unittests/PowerRenameRegExTests.cpp
+++ b/src/modules/powerrename/unittests/PowerRenameRegExTests.cpp
@@ -275,26 +275,60 @@ TEST_METHOD(VerifyMatchAllWildcardUseRegEx)
     }
 }
 
-TEST_METHOD(VerifyReplaceFirstWildcardUseRegEx)
+void VerifyReplaceFirstWildcard(SearchReplaceExpected sreTable[], int tableSize, DWORD flags)
 {
     CComPtr<IPowerRenameRegEx> renameRegEx;
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
-    DWORD flags = UseRegularExpressions;
     Assert::IsTrue(renameRegEx->put_flags(flags) == S_OK);
 
-    SearchReplaceExpected sreTable[] = {
-        { L".*", L"Foo", L"AAAAAA", L"FooAAAA" },
-    };
-
-    for (int i = 0; i < ARRAYSIZE(sreTable); i++)
+    for (int i = 0; i < tableSize; i++)
     {
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->put_searchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->put_replaceTerm(sreTable[i].replace) == S_OK);
         Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
-        Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
+        Assert::AreEqual(sreTable[i].expected, result);
         CoTaskMemFree(result);
     }
+}
+
+TEST_METHOD(VerifyReplaceFirstWildCardUseRegex)
+{
+    SearchReplaceExpected sreTable[] = {
+        //search, replace, test, result
+        { L".*", L"Foo", L"AAAAAA", L"Foo" },
+    };
+    VerifyReplaceFirstWildcard(sreTable, ARRAYSIZE(sreTable), UseRegularExpressions);
+}
+
+TEST_METHOD(VerifyReplaceFirstWildCardUseRegexMatchAllOccurances)
+{
+    SearchReplaceExpected sreTable[] = {
+        //search, replace, test, result
+        { L".*", L"Foo", L"AAAAAA", L"Foo" },
+    };
+    VerifyReplaceFirstWildcard(sreTable, ARRAYSIZE(sreTable), UseRegularExpressions | MatchAllOccurences);
+}
+
+TEST_METHOD(VerifyReplaceFirstWildCardMatchAllOccurances)
+{
+    SearchReplaceExpected sreTable[] = {
+        //search, replace, test, result
+        { L".*", L"Foo", L"AAAAAA", L"AAAAAA" },
+        { L".*", L"Foo", L".*", L"Foo" },
+        { L".*", L"Foo", L".*Bar.*", L"FooBarFoo" },
+    };
+    VerifyReplaceFirstWildcard(sreTable, ARRAYSIZE(sreTable), MatchAllOccurences);
+}
+
+TEST_METHOD(VerifyReplaceFirstWildNoFlags)
+{
+    SearchReplaceExpected sreTable[] = {
+        //search, replace, test, result
+        { L".*", L"Foo", L"AAAAAA", L"AAAAAA" },
+        { L".*", L"Foo", L".*", L"Foo" },
+    };
+    VerifyReplaceFirstWildcard(sreTable, ARRAYSIZE(sreTable), 0);
 }
 
 TEST_METHOD(VerifyEventsFire)


### PR DESCRIPTION




<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This test brake was introduced in the following fix:
https://github.com/microsoft/PowerToys/pull/647/commits/1efe5bff9fcf8216814e12a1045df2668beb1709

It looks to me like the test cases just was also wrong and just wasn't updated with the fix.

I've modified some of the test cases to verify the expected behavior:
1) Slight refactor of the tests to pass in the SearchReplaceExpected and flags for the tests.
2) Using Assert::AreEqual instead of Assert::IsTrue for better error meesaging when failed.
3) Verifying that the behavior is the same with or without match all occurances when using *.
4) Verifying that without the `UseRegularExpressionsFlag` the `.*` characters get replaced, including when MatchAllOccurances is set.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [] Applies to #904 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [X] Tests added/passed
* [] Requires documentation to be updated
* [] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Ran updated unit tests


Note:  The clang format change is making this diff very difficult to read in github.  Here is a screenshot(s) of the main changes in beyond compare. 

Edit: 
![image](https://user-images.githubusercontent.com/56318517/70499779-bd50dd80-1ace-11ea-8895-fafaeb4f056a.png)

Added Methods: 
![image](https://user-images.githubusercontent.com/56318517/70499868-f5f0b700-1ace-11ea-9fd3-7620d0ae5e6f.png)

![image](https://user-images.githubusercontent.com/56318517/70499890-00ab4c00-1acf-11ea-9951-fc52605e7adb.png)


