### PR TITLE
Make sure FancyZones Editor window is on top of PowerToys settings window

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/EditorOverlay.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/EditorOverlay.xaml.cs
@@ -95,7 +95,12 @@ namespace FancyZonesEditor
             MainWindow window = new MainWindow();
             window.Owner = this;
             window.ShowActivated = true;
+            window.Topmost = true;
             window.Show();
+
+            // window is set to topmost to make sure it shows on top of PowerToys settings page
+            // we can reset topmost flag now
+            window.Topmost = false;
         }
 
         // These event handlers are used to track the current state of the Shift and Ctrl keys on the keyboard


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Sometimes `FancyZones` editor is displayed behind `PowerToys` general settings window.


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #832 

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
1. Open `PowerToys` general settings page.
2. Go to `FancyZones` and start editor (`Edit zones` button).

Expected behavior: `FancyZones` editor is displayed in front of `PowerToys` settings window.
