### PR TITLE
[FancyZones][UnitTests] Fixing TestDeviceId, and TestUniqueId.

### DIFF
--- a/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
@@ -5,8 +5,24 @@ using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
 namespace FancyZonesUnitTests
 {
+    struct MockZoneWindowHost : public winrt::implements<MockZoneWindowHost, IZoneWindowHost>
+    {
+        IFACEMETHODIMP_(void) MoveWindowsOnActiveZoneSetChange() noexcept {};
+        IFACEMETHODIMP_(COLORREF) GetZoneHighlightColor() noexcept
+        {
+            return RGB(0xFF, 0xFF, 0xFF);
+        }
+        IFACEMETHODIMP_(GUID) GetCurrentMonitorZoneSetId(HMONITOR monitor) noexcept
+        {
+            return m_guid;
+        }
+
+        GUID m_guid;
+    };
+
     TEST_CLASS(ZoneWindowUnitTests){
         public:
+
             TEST_METHOD(TestCreateZoneWindow){
                 winrt::com_ptr<IZoneWindow> zoneWindow = MakeZoneWindow(nullptr, Mocks::Instance(), Mocks::Monitor(), L"DeviceId", L"MyVirtualDesktopId", false);
     Assert::IsNotNull(zoneWindow.get());
@@ -15,10 +31,12 @@ namespace FancyZonesUnitTests
 TEST_METHOD(TestDeviceId)
 {
     // Window initialization requires a valid HMONITOR - just use the primary for now.
-    HMONITOR pimaryMonitor = MonitorFromWindow(nullptr, MONITOR_DEFAULTTOPRIMARY);
-    winrt::com_ptr<IZoneWindow> zoneWindow = MakeZoneWindow(nullptr, Mocks::Instance(), pimaryMonitor, L"SomeRandomValue", L"MyVirtualDesktopId", false);
-    // We have no way to test the correctness, just do our best and check its not an empty string.
-    Assert::IsTrue(zoneWindow->DeviceId().size() > 0);
+	HMONITOR pimaryMonitor = MonitorFromWindow(HWND(), MONITOR_DEFAULTTOPRIMARY);
+    MockZoneWindowHost host;
+    std::wstring expectedDeviceId = L"SomeRandomValue";
+    winrt::com_ptr<IZoneWindow> zoneWindow = MakeZoneWindow(dynamic_cast<IZoneWindowHost*>(&host), Mocks::Instance(), pimaryMonitor, expectedDeviceId.c_str(), L"MyVirtualDesktopId", false);
+
+    Assert::AreEqual(expectedDeviceId, zoneWindow->DeviceId());
 }
 
 TEST_METHOD(TestUniqueId)
@@ -27,7 +45,7 @@ TEST_METHOD(TestUniqueId)
     // Example: "DELA026#5&10a58c63&0&UID16777488_1024_768_MyVirtualDesktopId"
     std::wstring deviceId(L"\\\\?\\DISPLAY#DELA026#5&10a58c63&0&UID16777488#{e6f07b5f-ee97-4a90-b076-33f57bf4eaa7}");
     // Window initialization requires a valid HMONITOR - just use the primary for now.
-    HMONITOR pimaryMonitor = MonitorFromWindow(nullptr, MONITOR_DEFAULTTOPRIMARY);
+    HMONITOR pimaryMonitor = MonitorFromWindow(HWND(), MONITOR_DEFAULTTOPRIMARY);
     MONITORINFO info;
     info.cbSize = sizeof(info);
     Assert::IsTrue(GetMonitorInfo(pimaryMonitor, &info));
@@ -36,7 +54,8 @@ TEST_METHOD(TestUniqueId)
     std::wstringstream ss;
     ss << L"DELA026#5&10a58c63&0&UID16777488_" << monitorRect.width() << "_" << monitorRect.height() << "_MyVirtualDesktopId";
 
-    winrt::com_ptr<IZoneWindow> zoneWindow = MakeZoneWindow(nullptr, Mocks::Instance(), pimaryMonitor, deviceId.c_str(), L"MyVirtualDesktopId", false);
+	MockZoneWindowHost host;
+    winrt::com_ptr<IZoneWindow> zoneWindow = MakeZoneWindow(dynamic_cast<IZoneWindowHost*>(&host), Mocks::Instance(), pimaryMonitor, deviceId.c_str(), L"MyVirtualDesktopId", false);
     Assert::AreEqual(zoneWindow->UniqueId().compare(ss.str()), 0);
 }
 }

--- a/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
@@ -7,12 +7,15 @@ namespace FancyZonesUnitTests
 {
     struct MockZoneWindowHost : public winrt::implements<MockZoneWindowHost, IZoneWindowHost>
     {
-        IFACEMETHODIMP_(void) MoveWindowsOnActiveZoneSetChange() noexcept {};
-        IFACEMETHODIMP_(COLORREF) GetZoneHighlightColor() noexcept
+        IFACEMETHODIMP_(void)
+        MoveWindowsOnActiveZoneSetChange() noexcept {};
+        IFACEMETHODIMP_(COLORREF)
+        GetZoneHighlightColor() noexcept
         {
             return RGB(0xFF, 0xFF, 0xFF);
         }
-        IFACEMETHODIMP_(GUID) GetCurrentMonitorZoneSetId(HMONITOR monitor) noexcept
+        IFACEMETHODIMP_(GUID)
+        GetCurrentMonitorZoneSetId(HMONITOR monitor) noexcept
         {
             return m_guid;
         }
@@ -31,7 +34,7 @@ namespace FancyZonesUnitTests
 TEST_METHOD(TestDeviceId)
 {
     // Window initialization requires a valid HMONITOR - just use the primary for now.
-	HMONITOR pimaryMonitor = MonitorFromWindow(HWND(), MONITOR_DEFAULTTOPRIMARY);
+    HMONITOR pimaryMonitor = MonitorFromWindow(HWND(), MONITOR_DEFAULTTOPRIMARY);
     MockZoneWindowHost host;
     std::wstring expectedDeviceId = L"SomeRandomValue";
     winrt::com_ptr<IZoneWindow> zoneWindow = MakeZoneWindow(dynamic_cast<IZoneWindowHost*>(&host), Mocks::Instance(), pimaryMonitor, expectedDeviceId.c_str(), L"MyVirtualDesktopId", false);
@@ -54,7 +57,7 @@ TEST_METHOD(TestUniqueId)
     std::wstringstream ss;
     ss << L"DELA026#5&10a58c63&0&UID16777488_" << monitorRect.width() << "_" << monitorRect.height() << "_MyVirtualDesktopId";
 
-	MockZoneWindowHost host;
+    MockZoneWindowHost host;
     winrt::com_ptr<IZoneWindow> zoneWindow = MakeZoneWindow(dynamic_cast<IZoneWindowHost*>(&host), Mocks::Instance(), pimaryMonitor, deviceId.c_str(), L"MyVirtualDesktopId", false);
     Assert::AreEqual(zoneWindow->UniqueId().compare(ss.str()), 0);
 }


### PR DESCRIPTION
Just attempting to get the remainder of the unit tests green, as I onboard to the codebase. 

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

1. Creating a mock ZoneWindowHost.   Previously creating a ZoneWindow would throw an exception if the ZoneWindowHost is null.
2. Passing in HWND() instead of null to get rig of SAL annotation warnings.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #918
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [] Requires documentation to be updated
* [] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manually ran unit tests. 

![image](https://user-images.githubusercontent.com/56318517/70583291-23427100-1b72-11ea-85e7-6860b1866963.png)

