### PR TITLE
Apply spacing only if flag ShowSpacing is set

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
@@ -540,8 +540,9 @@ namespace FancyZonesEditor
             }
 
             Settings settings = ((App)(Application.Current)).ZoneSettings;
-            int spacing = settings.Spacing;
-            int gutter = settings.Spacing;
+
+            int spacing, gutter;
+            spacing = gutter = (settings.ShowSpacing) ? settings.Spacing : 0;
 
             int cols = model.Columns;
             int rows = model.Rows;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Spacing was added to the zones after editing custom layout based on value written for spacing, no matter if flag `Show space around zones` is on or off. Use spacing 0 if `Show space around zones` is disabled.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #752

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
1. Open `FancyZones` editor.
2. Switch off `Show space around zones`. Set `Space Around Zones` to some positive value.
3. Select any layout and click `Edit Selected Layout`.
4. Apply and save changes.

Expected Behavior: If flag `Show space around zones` is disabled, no space should be when layout is applied.