### PR TITLE
Resize DPI unaware windows more precisely

### DIFF
--- a/src/common/dpi_aware.cpp
+++ b/src/common/dpi_aware.cpp
@@ -5,60 +5,71 @@
 
 namespace DPIAware
 {
-    HRESULT GetScreenDPIForWindow(HWND hwnd, UINT &dpi_x, UINT &dpi_y) {
-  auto monitor_handle = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
-  dpi_x = 0;
-  dpi_y = 0;
-  if (monitor_handle != nullptr) {
-    return GetDpiForMonitor(monitor_handle, MDT_EFFECTIVE_DPI, &dpi_x, &dpi_y);
-  } else {
-    return E_FAIL;
-  }
-}
-
-HRESULT GetScreenDPIForPoint(POINT p, UINT& dpi_x, UINT& dpi_y) {
-  auto monitor_handle = MonitorFromPoint(p, MONITOR_DEFAULTTONEAREST);
-  dpi_x = 0;
-  dpi_y = 0;
-  if (monitor_handle != nullptr) {
-    return GetDpiForMonitor(monitor_handle, MDT_EFFECTIVE_DPI, &dpi_x, &dpi_y);
-  }
-  else {
-    return E_FAIL;
-  }
-}
-
-void Convert(HMONITOR monitor_handle, int &width, int &height) {
-  if (monitor_handle == NULL) {
-    const POINT ptZero = { 0, 0 };
-    monitor_handle = MonitorFromPoint(ptZero, MONITOR_DEFAULTTOPRIMARY);
-  }
-
-  UINT dpi_x, dpi_y;
-  if (GetDpiForMonitor(monitor_handle, MDT_EFFECTIVE_DPI, &dpi_x, &dpi_y) == S_OK) {
-    width = width * dpi_x / DEFAULT_DPI;
-    height = height * dpi_y / DEFAULT_DPI;
-  }
-}
-
-void EnableDPIAwarenessForThisProcess() {
-    SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
-}
-
-AWARENESS_LEVEL GetAwarenessLevel(DPI_AWARENESS_CONTEXT system_returned_value)
-{
-    const std::array levels{ DPI_AWARENESS_CONTEXT_UNAWARE,
-                             DPI_AWARENESS_CONTEXT_SYSTEM_AWARE,
-                             DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE,
-                             DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2,
-                             DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED };
-    for(size_t i = 0; i < size(levels); ++i)
+    HRESULT GetScreenDPIForWindow(HWND hwnd, UINT& dpi_x, UINT& dpi_y)
     {
-      if(AreDpiAwarenessContextsEqual(levels[i], system_returned_value))
+        auto monitor_handle = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
+        dpi_x = 0;
+        dpi_y = 0;
+        if (monitor_handle != nullptr)
         {
-          return static_cast<AWARENESS_LEVEL>(i);
+            return GetDpiForMonitor(monitor_handle, MDT_EFFECTIVE_DPI, &dpi_x, &dpi_y);
+        }
+        else
+        {
+            return E_FAIL;
         }
     }
-    return AWARENESS_LEVEL::UNAWARE;
-}
+
+    HRESULT GetScreenDPIForPoint(POINT p, UINT& dpi_x, UINT& dpi_y)
+    {
+        auto monitor_handle = MonitorFromPoint(p, MONITOR_DEFAULTTONEAREST);
+        dpi_x = 0;
+        dpi_y = 0;
+        if (monitor_handle != nullptr)
+        {
+            return GetDpiForMonitor(monitor_handle, MDT_EFFECTIVE_DPI, &dpi_x, &dpi_y);
+        }
+        else
+        {
+            return E_FAIL;
+        }
+    }
+
+    void Convert(HMONITOR monitor_handle, int& width, int& height)
+    {
+        if (monitor_handle == NULL)
+        {
+            const POINT ptZero = { 0, 0 };
+            monitor_handle = MonitorFromPoint(ptZero, MONITOR_DEFAULTTOPRIMARY);
+        }
+
+        UINT dpi_x, dpi_y;
+        if (GetDpiForMonitor(monitor_handle, MDT_EFFECTIVE_DPI, &dpi_x, &dpi_y) == S_OK)
+        {
+            width = width * dpi_x / DEFAULT_DPI;
+            height = height * dpi_y / DEFAULT_DPI;
+        }
+    }
+
+    void EnableDPIAwarenessForThisProcess()
+    {
+        SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+    }
+
+    AWARENESS_LEVEL GetAwarenessLevel(DPI_AWARENESS_CONTEXT system_returned_value)
+    {
+        const std::array levels{ DPI_AWARENESS_CONTEXT_UNAWARE,
+                                 DPI_AWARENESS_CONTEXT_SYSTEM_AWARE,
+                                 DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE,
+                                 DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2,
+                                 DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED };
+        for (size_t i = 0; i < size(levels); ++i)
+        {
+            if (AreDpiAwarenessContextsEqual(levels[i], system_returned_value))
+            {
+                return static_cast<AWARENESS_LEVEL>(i);
+            }
+        }
+        return AWARENESS_LEVEL::UNAWARE;
+    }
 }

--- a/src/common/dpi_aware.cpp
+++ b/src/common/dpi_aware.cpp
@@ -3,7 +3,9 @@
 #include "monitors.h"
 #include <ShellScalingApi.h>
 
-HRESULT DPIAware::GetScreenDPIForWindow(HWND hwnd, UINT &dpi_x, UINT &dpi_y) {
+namespace DPIAware
+{
+    HRESULT GetScreenDPIForWindow(HWND hwnd, UINT &dpi_x, UINT &dpi_y) {
   auto monitor_handle = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
   dpi_x = 0;
   dpi_y = 0;
@@ -14,7 +16,7 @@ HRESULT DPIAware::GetScreenDPIForWindow(HWND hwnd, UINT &dpi_x, UINT &dpi_y) {
   }
 }
 
-HRESULT DPIAware::GetScreenDPIForPoint(POINT p, UINT& dpi_x, UINT& dpi_y) {
+HRESULT GetScreenDPIForPoint(POINT p, UINT& dpi_x, UINT& dpi_y) {
   auto monitor_handle = MonitorFromPoint(p, MONITOR_DEFAULTTONEAREST);
   dpi_x = 0;
   dpi_y = 0;
@@ -26,7 +28,7 @@ HRESULT DPIAware::GetScreenDPIForPoint(POINT p, UINT& dpi_x, UINT& dpi_y) {
   }
 }
 
-void DPIAware::Convert(HMONITOR monitor_handle, int &width, int &height) {
+void Convert(HMONITOR monitor_handle, int &width, int &height) {
   if (monitor_handle == NULL) {
     const POINT ptZero = { 0, 0 };
     monitor_handle = MonitorFromPoint(ptZero, MONITOR_DEFAULTTOPRIMARY);
@@ -39,6 +41,24 @@ void DPIAware::Convert(HMONITOR monitor_handle, int &width, int &height) {
   }
 }
 
-void DPIAware::EnableDPIAwarenessForThisProcess() {
+void EnableDPIAwarenessForThisProcess() {
     SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+}
+
+AWARENESS_LEVEL GetAwarenessLevel(DPI_AWARENESS_CONTEXT system_returned_value)
+{
+    const std::array levels{ DPI_AWARENESS_CONTEXT_UNAWARE,
+                             DPI_AWARENESS_CONTEXT_SYSTEM_AWARE,
+                             DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE,
+                             DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2,
+                             DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED };
+    for(size_t i = 0; i < size(levels); ++i)
+    {
+      if(AreDpiAwarenessContextsEqual(levels[i], system_returned_value))
+        {
+          return static_cast<AWARENESS_LEVEL>(i);
+        }
+    }
+    return AWARENESS_LEVEL::UNAWARE;
+}
 }

--- a/src/common/dpi_aware.cpp
+++ b/src/common/dpi_aware.cpp
@@ -56,7 +56,7 @@ namespace DPIAware
         SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
     }
 
-    AWARENESS_LEVEL GetAwarenessLevel(DPI_AWARENESS_CONTEXT system_returned_value)
+    AwarnessLevel GetAwarenessLevel(DPI_AWARENESS_CONTEXT system_returned_value)
     {
         const std::array levels{ DPI_AWARENESS_CONTEXT_UNAWARE,
                                  DPI_AWARENESS_CONTEXT_SYSTEM_AWARE,
@@ -67,9 +67,9 @@ namespace DPIAware
         {
             if (AreDpiAwarenessContextsEqual(levels[i], system_returned_value))
             {
-                return static_cast<AWARENESS_LEVEL>(i);
+                return static_cast<AwarnessLevel>(i);
             }
         }
-        return AWARENESS_LEVEL::UNAWARE;
+        return AwarnessLevel::UNAWARE;
     }
 }

--- a/src/common/dpi_aware.h
+++ b/src/common/dpi_aware.h
@@ -1,11 +1,22 @@
 #pragma once
 #include "windef.h"
 
-struct DPIAware {
-  static constexpr int DEFAULT_DPI = 96;
+namespace DPIAware {
+  constexpr inline int DEFAULT_DPI = 96;
 
-  static HRESULT GetScreenDPIForWindow(HWND hwnd, UINT & dpi_x, UINT & dpi_y);
-  static HRESULT GetScreenDPIForPoint(POINT p, UINT& dpi_x, UINT& dpi_y);
-  static void Convert(HMONITOR monitor_handle, int &width, int &height);
-  static void EnableDPIAwarenessForThisProcess();
+  HRESULT GetScreenDPIForWindow(HWND hwnd, UINT & dpi_x, UINT & dpi_y);
+  HRESULT GetScreenDPIForPoint(POINT p, UINT& dpi_x, UINT& dpi_y);
+  void Convert(HMONITOR monitor_handle, int &width, int &height);
+  void EnableDPIAwarenessForThisProcess();
+  
+  enum class AWARENESS_LEVEL
+  {
+      UNAWARE,
+      SYSTEM_AWARE,
+      PER_MONITOR_AWARE,
+      PER_MONITOR_AWARE_V2,
+      UNAWARE_GDISCALED
+  };
+  AWARENESS_LEVEL GetAwarenessLevel(DPI_AWARENESS_CONTEXT system_returned_value);
 };
+

--- a/src/common/dpi_aware.h
+++ b/src/common/dpi_aware.h
@@ -1,22 +1,22 @@
 #pragma once
 #include "windef.h"
 
-namespace DPIAware {
-  constexpr inline int DEFAULT_DPI = 96;
+namespace DPIAware
+{
+    constexpr inline int DEFAULT_DPI = 96;
 
-  HRESULT GetScreenDPIForWindow(HWND hwnd, UINT & dpi_x, UINT & dpi_y);
-  HRESULT GetScreenDPIForPoint(POINT p, UINT& dpi_x, UINT& dpi_y);
-  void Convert(HMONITOR monitor_handle, int &width, int &height);
-  void EnableDPIAwarenessForThisProcess();
-  
-  enum class AWARENESS_LEVEL
-  {
-      UNAWARE,
-      SYSTEM_AWARE,
-      PER_MONITOR_AWARE,
-      PER_MONITOR_AWARE_V2,
-      UNAWARE_GDISCALED
-  };
-  AWARENESS_LEVEL GetAwarenessLevel(DPI_AWARENESS_CONTEXT system_returned_value);
+    HRESULT GetScreenDPIForWindow(HWND hwnd, UINT& dpi_x, UINT& dpi_y);
+    HRESULT GetScreenDPIForPoint(POINT p, UINT& dpi_x, UINT& dpi_y);
+    void Convert(HMONITOR monitor_handle, int& width, int& height);
+    void EnableDPIAwarenessForThisProcess();
+
+    enum AWARENESS_LEVEL
+    {
+        UNAWARE,
+        SYSTEM_AWARE,
+        PER_MONITOR_AWARE,
+        PER_MONITOR_AWARE_V2,
+        UNAWARE_GDISCALED
+    };
+    AWARENESS_LEVEL GetAwarenessLevel(DPI_AWARENESS_CONTEXT system_returned_value);
 };
-

--- a/src/common/dpi_aware.h
+++ b/src/common/dpi_aware.h
@@ -10,7 +10,7 @@ namespace DPIAware
     void Convert(HMONITOR monitor_handle, int& width, int& height);
     void EnableDPIAwarenessForThisProcess();
 
-    enum AWARENESS_LEVEL
+    enum AwarnessLevel
     {
         UNAWARE,
         SYSTEM_AWARE,
@@ -18,5 +18,5 @@ namespace DPIAware
         PER_MONITOR_AWARE_V2,
         UNAWARE_GDISCALED
     };
-    AWARENESS_LEVEL GetAwarenessLevel(DPI_AWARENESS_CONTEXT system_returned_value);
+    AwarnessLevel GetAwarenessLevel(DPI_AWARENESS_CONTEXT system_returned_value);
 };


### PR DESCRIPTION
## Summary of the Pull Request
Restrict DPI unaware windows horizontally to the current display to avoid unwanted automatic resize by Windows. This could introduce a small horizontal gap for those windows due to clamped `right_margin`; increasing it even by 1px triggers the bug though.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #762
* [x] Applies to #893

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Tested various horizontal/vertical combinations of column/row/custom layout with a different scaling levels and dpi-(un)aware apps.
