### PR TITLE
FancyZones: do not zone windows on startup

### DIFF
--- a/src/modules/fancyzones/lib/FancyZones.h
+++ b/src/modules/fancyzones/lib/FancyZones.h
@@ -8,7 +8,8 @@ enum class DisplayChangeType
     WorkArea,
     DisplayChange,
     VirtualDesktop,
-    Editor
+    Editor,
+    Initialization
 };
 
 interface __declspec(uuid("{50D3F0F5-736E-4186-BDF4-3D6BEE150C3A}")) IFancyZones : public IUnknown


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
FancyZones won't zone windows when starting.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #967
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

## Validation Steps Performed
Manual