### PR TITLE
When spacing is set to 0 or turned off display 1px border so user can  distinguish zone edges

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
@@ -557,8 +557,9 @@ namespace FancyZonesEditor
             }
 
             Settings settings = ((App)Application.Current).ZoneSettings;
-            int spacing = settings.Spacing;
-            int gutter = settings.Spacing;
+
+            int spacing, gutter;
+            spacing = gutter = settings.ShowSpacing ? settings.Spacing : 0;
 
             int cols = model.Columns;
             int rows = model.Rows;

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridZone.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridZone.xaml
@@ -6,6 +6,8 @@
              xmlns:local="clr-namespace:FancyZonesEditor"
              mc:Ignorable="d" 
             Background="LightGray"
+            BorderThickness="1"
+            BorderBrush="SlateGray"
               Opacity="0.5"
              d:DesignHeight="450" d:DesignWidth="800">
     <Grid x:Name="Frame" Visibility="Collapsed">


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Spacing was added to the zones after editing custom layout based on value written for spacing, no matter if flag `Show space around zones` is on or off. Use spacing 0 if `Show space around zones` is disabled. When the spacing is off, user should still distinguish between zone edges, so 1px border is added in that case (only in UI, spacing 0 will be applied to the zone layout).

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #752

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
1. Open FancyZones editor.
2. Switch off Show space around zones. Set Space Around Zones to some positive value.
3. Select any layout and click Edit Selected Layout.
4. Apply and save changes.

Expected Behavior: If flag Show space around zones is disabled, no space should be when layout is applied.