### PR TITLE
fix for #819 - use shortest distance from mouse position to zone top left corner when selecting a zone

### DIFF
--- a/src/modules/fancyzones/lib/ZoneSet.cpp
+++ b/src/modules/fancyzones/lib/ZoneSet.cpp
@@ -47,7 +47,7 @@ IFACEMETHODIMP ZoneSet::AddZone(winrt::com_ptr<IZone> zone) noexcept
 IFACEMETHODIMP_(winrt::com_ptr<IZone>) ZoneSet::ZoneFromPoint(POINT pt) noexcept
 {
     winrt::com_ptr<IZone> selectedZone = nullptr;
-    int distanceToSelectedZoneTop = 0; 
+    int distanceToSelectedZoneLeftCorner = 0; 
 
     for (auto iter = m_zones.begin(); iter != m_zones.end(); iter++)
     {
@@ -61,16 +61,16 @@ IFACEMETHODIMP_(winrt::com_ptr<IZone>) ZoneSet::ZoneFromPoint(POINT pt) noexcept
                     // This is the first zone we've found containing this point
                     selectedZone = zone;
                     RECT* r = &selectedZone->GetZoneRect();
-                    distanceToSelectedZoneTop = (pt.y - r->top);
+                    distanceToSelectedZoneLeftCorner = sqrt(pow(pt.y - r->top, 2) + pow(pt.x - r->left, 2));
                 }
                 else
                 {
                     // We found another possible zone, so need to determine if we should change the target zone to this one
-                    // Use closest distance to zone's top border to decide which zone is selected
-                    int distanceToNewZoneTop = (pt.y - zoneRect->top);
-                    if (distanceToNewZoneTop < distanceToSelectedZoneTop)
+                    // Use closest distance to zone's top left corner to decide which zone is selected
+                    int distanceToNewZoneLeftCorner = sqrt(pow(pt.y - zoneRect->top, 2) + pow(pt.x - zoneRect->left, 2));
+                    if (distanceToNewZoneLeftCorner < distanceToSelectedZoneLeftCorner)
                     {
-                        distanceToSelectedZoneTop = distanceToNewZoneTop;
+                        distanceToSelectedZoneLeftCorner = distanceToNewZoneLeftCorner;
                         selectedZone = zone;
                     }
                 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
Fix for #819 

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
Looks like there are multiple related bugs

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [] Applies to #xxx
* [] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [] Tests added/passed
* [] Requires documentation to be updated
* [] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
I've tested this change with many zone configurations including configurations where there were issues with the previous logic