### PR TITLE
Fix misaligned display of zones in layout priview and grid editor

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
@@ -558,23 +558,22 @@ namespace FancyZonesEditor
 
             Settings settings = ((App)Application.Current).ZoneSettings;
 
-            int spacing, gutter;
-            spacing = gutter = settings.ShowSpacing ? settings.Spacing : 0;
+            int spacing = settings.ShowSpacing ? settings.Spacing : 0;
 
             int cols = model.Columns;
             int rows = model.Rows;
 
-            double totalWidth = arrangeSize.Width - (gutter * 2) - (spacing * (cols - 1));
-            double totalHeight = arrangeSize.Height - (gutter * 2) - (spacing * (rows - 1));
+            double totalWidth = arrangeSize.Width - (spacing * (cols + 1));
+            double totalHeight = arrangeSize.Height - (spacing * (rows + 1));
 
-            double top = gutter;
+            double top = spacing;
             for (int row = 0; row < rows; row++)
             {
                 double cellHeight = _rowInfo[row].Recalculate(top, totalHeight);
                 top += cellHeight + spacing;
             }
 
-            double left = gutter;
+            double left = spacing;
             for (int col = 0; col < cols; col++)
             {
                 double cellWidth = _colInfo[col].Recalculate(left, totalWidth);

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridZone.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridZone.xaml
@@ -7,7 +7,7 @@
              mc:Ignorable="d" 
             Background="LightGray"
             BorderThickness="1"
-            BorderBrush="SlateGray"
+            BorderBrush="DarkGray"
               Opacity="0.5"
              d:DesignHeight="450" d:DesignWidth="800">
     <Grid x:Name="Frame" Visibility="Collapsed">

--- a/src/modules/fancyzones/editor/FancyZonesEditor/LayoutPreview.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/LayoutPreview.xaml.cs
@@ -137,27 +137,52 @@ namespace FancyZonesEditor
                         Rectangle rect = new Rectangle();
                         Grid.SetRow(rect, row);
                         Grid.SetColumn(rect, col);
-                        int span = 1;
+                        int rowSpan = 1;
                         int walk = row + 1;
                         while ((walk < grid.Rows) && grid.CellChildMap[walk, col] == childIndex)
                         {
-                            span++;
+                            rowSpan++;
                             walk++;
                         }
 
-                        Grid.SetRowSpan(rect, span);
+                        Grid.SetRowSpan(rect, rowSpan);
 
-                        span = 1;
+                        int columnSpan = 1;
                         walk = col + 1;
                         while ((walk < grid.Columns) && grid.CellChildMap[row, walk] == childIndex)
                         {
-                            span++;
+                            columnSpan++;
                             walk++;
                         }
 
-                        Grid.SetColumnSpan(rect, span);
+                        Grid.SetColumnSpan(rect, columnSpan);
 
-                        rect.Margin = margin;
+                        Thickness m = margin;
+                        if (IsActualSize)
+                        {
+                            // if we are handling zones leanning on the edges of the screen we need to increase margin by 2
+                            if (col == 0)
+                            {
+                                m.Left *= divisor;
+                            }
+
+                            if (row == 0)
+                            {
+                                m.Top *= divisor;
+                            }
+
+                            if ((col == grid.Columns - 1) || (col + columnSpan == grid.Columns))
+                            {
+                                m.Right *= divisor;
+                            }
+
+                            if ((row == grid.Rows - 1) || (row + rowSpan == grid.Rows))
+                            {
+                                m.Bottom *= divisor;
+                            }
+                        }
+
+                        rect.Margin = m;
                         rect.StrokeThickness = 1;
                         rect.Stroke = Brushes.DarkGray;
                         rect.Fill = Brushes.LightGray;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Zone layout looks different in layout priview (just going through predefined zones in main editor window) and once You actually try to edit zone by going to `Edit selected layout`. Over the edges of the screen, in layout preview zone spacing is smaller in comparisson to editing layout where we have correct spacing both between zones and between zone edges and border of the screen (monitor).

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #952 


<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
1. Open `FancyZones` editor (go to edit zones in `FancyZones` general settings).
2. Select a 4 zones grid template with 20px spacing.
3. Check one of the corners, for instance the top-left corner.
4. Click `Edit selected layout`.

Expected result: Spacing between edges of the zones and border of the screen is the same as the spacing between zones itself (both for layout preview and when editing layout).