### PR TITLE
Fix reversed order of zones in layout

### DIFF
--- a/src/modules/fancyzones/lib/ZoneSet.cpp
+++ b/src/modules/fancyzones/lib/ZoneSet.cpp
@@ -49,7 +49,7 @@ IFACEMETHODIMP_(winrt::com_ptr<IZone>) ZoneSet::ZoneFromPoint(POINT pt) noexcept
     winrt::com_ptr<IZone> smallestKnownZone = nullptr;
     // To reduce redundant calculations, we will store the last known zones area.
     int smallestKnownZoneArea = INT32_MAX;
-    for (auto iter = m_zones.begin(); iter != m_zones.end(); iter++)
+    for (auto iter = m_zones.rbegin(); iter != m_zones.rend(); iter++)
     {
         if (winrt::com_ptr<IZone> zone = iter->try_as<IZone>())
         {

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -553,7 +553,7 @@ void ZoneWindow::DrawActiveZoneSet(wil::unique_hdc& hdc, RECT const& clientRect)
         auto zones = m_activeZoneSet->GetZones();
         const size_t maxColorIndex = min(size(zones) - 1, size(colors) - 1);
         size_t colorIndex = maxColorIndex;
-        for (auto iter = zones.rbegin(); iter != zones.rend(); iter++)
+        for (auto iter = zones.begin(); iter != zones.end(); iter++)
         {
             winrt::com_ptr<IZone> zone = iter->try_as<IZone>();
             if (!zone)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
After custom or predefined zone layout is applied, zones are displayed and used in reverse order (topmost zone is displayed in the back).

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #1046

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
1. Create a custom zone layout with zones overlapping, or use `focus` predefined zone layout.
2. Apply zone set.
3. Hold shift while dragging window.

Expected result: Displayed zones are properly ordered, zone set as topmost while configuring layout is displayed at top (and all other accordingly).