### PR TITLE
Convert ImageResizer to a PowerToy

### DIFF
--- a/src/modules/imageresizer/ShellExtensions/ContextMenuHandler.cpp
+++ b/src/modules/imageresizer/ShellExtensions/ContextMenuHandler.cpp
@@ -53,7 +53,9 @@ HRESULT CContextMenuHandler::QueryContextMenu(_In_ HMENU hmenu, UINT indexMenu, 
         return S_OK;
     }
     if (!CSettings::GetEnabled())
+    {
         return E_FAIL;
+    }
     // NB: We just check the first item. We could iterate through more if the first one doesn't meet the criteria
     HDropIterator i(m_pdtobj);
     i.First();

--- a/src/modules/imageresizer/ShellExtensions/ContextMenuHandler.cpp
+++ b/src/modules/imageresizer/ShellExtensions/ContextMenuHandler.cpp
@@ -3,6 +3,7 @@
 #include "stdafx.h"
 #include "ContextMenuHandler.h"
 #include "HDropIterator.h"
+#include "Settings.h"
 
 CContextMenuHandler::CContextMenuHandler()
 {
@@ -51,7 +52,8 @@ HRESULT CContextMenuHandler::QueryContextMenu(_In_ HMENU hmenu, UINT indexMenu, 
     {
         return S_OK;
     }
-
+    if (!CSettings::GetEnabled())
+        return E_FAIL;
     // NB: We just check the first item. We could iterate through more if the first one doesn't meet the criteria
     HDropIterator i(m_pdtobj);
     i.First();

--- a/src/modules/imageresizer/ShellExtensions/Settings.cpp
+++ b/src/modules/imageresizer/ShellExtensions/Settings.cpp
@@ -1,0 +1,3 @@
+#include "stdafx.h"
+#include "Settings.h"
+

--- a/src/modules/imageresizer/ShellExtensions/Settings.cpp
+++ b/src/modules/imageresizer/ShellExtensions/Settings.cpp
@@ -1,3 +1,66 @@
 #include "stdafx.h"
+#include <commctrl.h>
 #include "Settings.h"
 
+const wchar_t c_rootRegPath[] = L"Software\\Microsoft\\ImageResizer";
+const wchar_t c_enabled[] = L"Enabled";
+const bool c_enabledDefault = true;
+
+bool CSettings::GetEnabled()
+{
+    return GetRegBoolValue(c_enabled, c_enabledDefault);
+}
+
+bool CSettings::SetEnabled(_In_ bool enabled)
+{
+    return SetRegBoolValue(c_enabled, enabled);
+}
+
+bool CSettings::SetRegBoolValue(_In_ PCWSTR valueName, _In_ bool value)
+{
+    DWORD dwValue = value ? 1 : 0;
+    return SetRegDWORDValue(valueName, dwValue);
+}
+
+bool CSettings::GetRegBoolValue(_In_ PCWSTR valueName, _In_ bool defaultValue)
+{
+    DWORD value = GetRegDWORDValue(valueName, (defaultValue == 0) ? false : true);
+    return (value == 0) ? false : true;
+}
+
+bool CSettings::SetRegDWORDValue(_In_ PCWSTR valueName, _In_ DWORD value)
+{
+    return (SUCCEEDED(HRESULT_FROM_WIN32(SHSetValue(HKEY_CURRENT_USER, c_rootRegPath, valueName, REG_DWORD, &value, sizeof(value)))));
+}
+
+DWORD CSettings::GetRegDWORDValue(_In_ PCWSTR valueName, _In_ DWORD defaultValue)
+{
+    DWORD retVal = defaultValue;
+    DWORD type = REG_DWORD;
+    DWORD dwEnabled = 0;
+    DWORD cb = sizeof(dwEnabled);
+    if (SHGetValue(HKEY_CURRENT_USER, c_rootRegPath, valueName, &type, &dwEnabled, &cb) == ERROR_SUCCESS)
+    {
+        retVal = dwEnabled;
+    }
+
+    return retVal;
+}
+
+bool CSettings::SetRegStringValue(_In_ PCWSTR valueName, _In_ PCWSTR value)
+{
+    ULONG cb = (DWORD)((wcslen(value) + 1) * sizeof(*value));
+    return (SUCCEEDED(HRESULT_FROM_WIN32(SHSetValue(HKEY_CURRENT_USER, c_rootRegPath, valueName, REG_SZ, (const BYTE*)value, cb))));
+}
+
+bool CSettings::GetRegStringValue(_In_ PCWSTR valueName, __out_ecount(cchBuf) PWSTR value, DWORD cchBuf)
+{
+    if (cchBuf > 0)
+    {
+        value[0] = L'\0';
+    }
+
+    DWORD type = REG_SZ;
+    ULONG cb = cchBuf * sizeof(*value);
+    return (SUCCEEDED(HRESULT_FROM_WIN32(SHGetValue(HKEY_CURRENT_USER, c_rootRegPath, valueName, &type, value, &cb) == ERROR_SUCCESS)));
+}

--- a/src/modules/imageresizer/ShellExtensions/Settings.h
+++ b/src/modules/imageresizer/ShellExtensions/Settings.h
@@ -1,0 +1,9 @@
+#pragma once
+
+class Settings
+{
+public:
+    bool GetEnabled();
+private:
+    bool enabled;
+};

--- a/src/modules/imageresizer/ShellExtensions/Settings.h
+++ b/src/modules/imageresizer/ShellExtensions/Settings.h
@@ -1,9 +1,16 @@
 #pragma once
 
-class Settings
+class CSettings
 {
 public:
-    bool GetEnabled();
+    static bool GetEnabled();
+    static bool SetEnabled(_In_ bool enabled);
+
 private:
-    bool enabled;
+    static bool GetRegBoolValue(_In_ PCWSTR valueName, _In_ bool defaultValue);
+    static bool SetRegBoolValue(_In_ PCWSTR valueName, _In_ bool value);
+    static bool SetRegDWORDValue(_In_ PCWSTR valueName, _In_ DWORD value);
+    static DWORD GetRegDWORDValue(_In_ PCWSTR valueName, _In_ DWORD defaultValue);
+    static bool SetRegStringValue(_In_ PCWSTR valueName, _In_ PCWSTR value);
+    static bool GetRegStringValue(_In_ PCWSTR valueName, __out_ecount(cchBuf) PWSTR value, DWORD cchBuf);
 };

--- a/src/modules/imageresizer/ShellExtensions/ShellExtensions.vcxproj
+++ b/src/modules/imageresizer/ShellExtensions/ShellExtensions.vcxproj
@@ -266,6 +266,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
       </PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="Settings.cpp" />
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
@@ -277,6 +278,7 @@
     <ClInclude Include="ContextMenuHandler.h" />
     <ClInclude Include="HDropIterator.h" />
     <ClInclude Include="dllmain.h" />
+    <ClInclude Include="Settings.h" />
     <ClInclude Include="Resource.h" />
     <ClInclude Include="ShellExtensions_i.h" />
     <ClInclude Include="stdafx.h" />

--- a/src/modules/imageresizer/ShellExtensions/ShellExtensions.vcxproj
+++ b/src/modules/imageresizer/ShellExtensions/ShellExtensions.vcxproj
@@ -71,18 +71,22 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <IgnoreImportLibrary>true</IgnoreImportLibrary>
     <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\modules\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <IgnoreImportLibrary>true</IgnoreImportLibrary>
     <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\modules\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <IgnoreImportLibrary>true</IgnoreImportLibrary>
     <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\modules\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <IgnoreImportLibrary>true</IgnoreImportLibrary>
     <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\modules\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -92,6 +96,8 @@
       <PreprocessorDefinitions>WIN32;_WINDOWS;_DEBUG;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <AdditionalIncludeDirectories>..\..\..\common\inc;..\..\..\common\Telemetry;..\..\;..\..\..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <Midl>
       <MkTypLibCompatible>false</MkTypLibCompatible>
@@ -126,6 +132,8 @@
       <PreprocessorDefinitions>_WINDOWS;_DEBUG;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <AdditionalIncludeDirectories>..\..\..\common\inc;..\..\..\common\Telemetry;..\..\;..\..\..\;..\..\..\..\deps\cpprestsdk\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <Midl>
       <MkTypLibCompatible>false</MkTypLibCompatible>
@@ -159,6 +167,8 @@
       <PreprocessorDefinitions>WIN32;_WINDOWS;NDEBUG;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <AdditionalIncludeDirectories>..\..\..\common\inc;..\..\..\common\Telemetry;..\..\;..\..\..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <Midl>
       <MkTypLibCompatible>false</MkTypLibCompatible>
@@ -195,6 +205,8 @@
       <PreprocessorDefinitions>_WINDOWS;NDEBUG;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <AdditionalIncludeDirectories>..\..\..\common\inc;..\..\..\common\Telemetry;..\..\;..\..\..\;..\..\..\..\deps\cpprestsdk\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <Midl>
       <MkTypLibCompatible>false</MkTypLibCompatible>
@@ -280,6 +292,11 @@
   </ItemGroup>
   <ItemGroup>
     <Midl Include="ShellExtensions.idl" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\common\common.vcxproj">
+      <Project>{74485049-c722-400f-abe5-86ac52d929b3}</Project>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/src/modules/imageresizer/ShellExtensions/ShellExtensions.vcxproj.filters
+++ b/src/modules/imageresizer/ShellExtensions/ShellExtensions.vcxproj.filters
@@ -37,6 +37,9 @@
     <ClCompile Include="HDropIterator.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="Settings.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="stdafx.h">
@@ -58,6 +61,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="HDropIterator.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Settings.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/modules/imageresizer/ShellExtensions/dllmain.cpp
+++ b/src/modules/imageresizer/ShellExtensions/dllmain.cpp
@@ -2,7 +2,6 @@
 #include "resource.h"
 #include "ShellExtensions_i.h"
 #include "dllmain.h"
-#include <common/common.h>
 #include <interface/powertoy_module_interface.h>
 #include <common/settings_objects.h>
 

--- a/src/modules/imageresizer/ShellExtensions/dllmain.cpp
+++ b/src/modules/imageresizer/ShellExtensions/dllmain.cpp
@@ -4,6 +4,7 @@
 #include "dllmain.h"
 #include <interface/powertoy_module_interface.h>
 #include <common/settings_objects.h>
+#include "Settings.h"
 
 CShellExtensionsModule _AtlModule;
 
@@ -117,12 +118,14 @@ public:
     virtual void enable()
     {
         m_enabled = true;
+        CSettings::SetEnabled(m_enabled);
     }
 
     // Disable the powertoy
     virtual void disable()
     {
         m_enabled = false;
+        CSettings::SetEnabled(m_enabled);
     }
 
     // Returns if the powertoys is enabled

--- a/src/modules/imageresizer/ShellExtensions/dllmain.cpp
+++ b/src/modules/imageresizer/ShellExtensions/dllmain.cpp
@@ -170,3 +170,8 @@ void ImageResizerModule::init_settings()
         // Error while loading from the settings file. Let default values stay as they are.
     }
 }
+
+extern "C" __declspec(dllexport) PowertoyModuleIface* __cdecl powertoy_create()
+{
+    return new ImageResizerModule();
+}

--- a/src/modules/imageresizer/ShellExtensions/dllmain.cpp
+++ b/src/modules/imageresizer/ShellExtensions/dllmain.cpp
@@ -76,26 +76,7 @@ public:
 
     // Signal from the Settings editor to call a custom action.
     // This can be used to spawn more complex editors.
-    virtual void call_custom_action(const wchar_t* action) override
-    {
-        static UINT custom_action_num_calls = 0;
-        try
-        {
-            // Parse the action values, including name.
-            PowerToysSettings::CustomActionObject action_object =
-                PowerToysSettings::CustomActionObject::from_json_string(action);
-
-            /*
-      if (action_object.get_name() == L"custom_action_id") {
-        // Execute your custom action
-      }
-      */
-        }
-        catch (std::exception ex)
-        {
-            // Improper JSON.
-        }
-    }
+    virtual void call_custom_action(const wchar_t* action) override {}
 
     // Called by the runner to pass the updated settings values as a serialized JSON.
     virtual void set_config(const wchar_t* config) override

--- a/src/modules/imageresizer/ShellExtensions/dllmain.cpp
+++ b/src/modules/imageresizer/ShellExtensions/dllmain.cpp
@@ -17,22 +17,6 @@ const static wchar_t* MODULE_NAME = L"ImageResizer";
 // Add a description that will we shown in the module settings page.
 const static wchar_t* MODULE_DESC = L"<no description>";
 
-// These are the properties shown in the Settings page.
-struct ModuleSettings
-{
-    // Add the PowerToy module properties with default values.
-    // Currently available types:
-    // - int
-    // - bool
-    // - string
-
-    //bool bool_prop = true;
-    //int int_prop = 10;
-    //std::wstring string_prop = L"The quick brown fox jumps over the lazy dog";
-    //std::wstring color_prop = L"#1212FF";
-
-} g_settings;
-
 class ImageResizerModule : public PowertoyModuleIface
 {
 private:

--- a/src/modules/imageresizer/ShellExtensions/stdafx.cpp
+++ b/src/modules/imageresizer/ShellExtensions/stdafx.cpp
@@ -1,1 +1,2 @@
 #include "stdafx.h"
+#pragma comment(lib, "windowsapp")

--- a/src/modules/imageresizer/ShellExtensions/targetver.h
+++ b/src/modules/imageresizer/ShellExtensions/targetver.h
@@ -1,7 +1,4 @@
 #pragma once
 
-#define _WIN32_WINNT _WIN32_WINNT_WINXP
-#define _WIN32_IE _WIN32_IE_XPSP2
-
 #include <winsdkver.h>
 #include <SDKDDKVer.h>

--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -52,7 +52,8 @@ int runner()
         std::unordered_set<std::wstring> known_dlls = {
             L"shortcut_guide.dll",
             L"fancyzones.dll",
-            L"PowerRenameExt.dll"
+            L"PowerRenameExt.dll",
+            L"ShellExtensions.dll"
         };
         for (auto& file : std::filesystem::directory_iterator(L"modules/"))
         {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Updated the dllmain.cpp to match the PowerToys template, and added a Settings.cpp which mimics the [settings codebase of PowerRename](https://github.com/microsoft/PowerToys/blob/master/src/modules/powerrename/lib/Settings.h).
Currently the only setting which is implemented is Enabling/Disabling the PowerToy.

There is now a working ImageResizer which can be enabled/disabled with the PowerToy settings. It can currently be "installed" by the process described in the Validation Steps Performed section.
<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## Future Changes to be made
* Include ImageResizer in the installer
* Renaming the files and projects to be consistent with other power toys code bases.
* Shift settings from registry to JSON while maintaining performance and access safety

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Applies to #53
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [X] Tests passed

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
* Implemented the PowerToyModuleIface in dllmain.cpp
* Added ShellExtensions.dll to the runner
* **Updated header files stdafx.h and targetver.h to build and mimic other power toys (if the version support was provided for WinXP as in the original image resizer code, the common/settings_objects.h cannot be used as it contains macros which aren't defined for WinXP.)**
* Added Settings.cpp and Settings.h which mimic PowerRename. A class with static methods is used and the settings are stored in registry instead of a JSON file. Since [registry operations are atomic in Windows](https://stackoverflow.com/a/706348/7995937) there is no issue of thread-safety.
* The settings implemented so far are only the Enabled/Disabled flag for the powertoy as a whole. If ImageResizer is disabled, the "Resize pictures" option is removed from the context menu.
* The changes in the vcxproj file and vcxproj.filters file are the addition of the new files(Settings.h and Settings.cpp).

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
* Since the installer has not yet been updated, the following steps can be followed for testing the power toy:
    - Build the solution. This will automatically register the ShellExtensions.dll at HKEY_CLASSES_ROOT\\*\shellex\ContextMenuHandlers\Image Resizer. The Resize pictures option will now appear on the context menu when an image is right clicked, however it will fail as the exe file hasn't been linked yet.
    - Add registry entry for the ImageResizer.exe file at HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\BriceLambson\ImageResizer with the string value as the path of the ImageResizer.exe generated from the build (src\modules\imageresizer\ImageResizer\bin\Debug\ImageResizer.exe). The Resize pictures option will work now.
    - Run PowerToys. The enable/disable ImageResizer option will work as expected.

## Screenshots
* Enabled
![ptresize](https://user-images.githubusercontent.com/32061677/72193088-caf2cf00-33bc-11ea-9bbd-eec24b6b44bb.png)
![ptresizer](https://user-images.githubusercontent.com/32061677/72193094-cfb78300-33bc-11ea-9b39-4d0b78b44077.png)
* Disabled
![ptdisable](https://user-images.githubusercontent.com/32061677/72193110-dd6d0880-33bc-11ea-8f7b-103cb19037e8.png)


