### PR TITLE
FancyZones: remove dialog boxes filtering

### DIFF
--- a/src/common/hwnd_data_cache.h
+++ b/src/common/hwnd_data_cache.h
@@ -26,10 +26,7 @@ private:
   // List of HWNDs that are not interesting - like desktop, cortana, etc
   std::vector<HWND> invalid_hwnds = { GetDesktopWindow(), GetShellWindow() };
   // List of invalid window basic styles
-  std::vector<LONG> invalid_basic_styles = { WS_CHILD, WS_DISABLED, DS_ABSALIGN, DS_SYSMODAL, DS_LOCALEDIT,
-                                             DS_SETFONT, DS_MODALFRAME, DS_NOIDLEMSG, DS_SETFOREGROUND, DS_3DLOOK,
-                                             DS_FIXEDSYS, DS_NOFAILCREATE, DS_CONTROL, DS_CENTER, DS_CENTERMOUSE,
-                                             DS_CONTEXTHELP, DS_SHELLFONT };
+  std::vector<LONG> invalid_basic_styles = { WS_CHILD, WS_DISABLED };
   // List of invalid window extended styles
   std::vector<LONG> invalid_ext_styles = { WS_EX_TOOLWINDOW, WS_EX_NOACTIVATE };
   // List of invalid window classes - things like start menu, etc.

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -680,6 +680,10 @@ void FancyZones::CycleActiveZoneSet(DWORD vkCode) noexcept
 {
     if (const HWND window = get_filtered_active_window())
     {
+        if (GetWindow(window, GW_OWNER) != nullptr)
+        {
+            return;
+        }
         if (const HMONITOR monitor = MonitorFromWindow(window, MONITOR_DEFAULTTONULL))
         {
             std::shared_lock readLock(m_lock);
@@ -696,6 +700,10 @@ void FancyZones::OnSnapHotkey(DWORD vkCode) noexcept
 {
     if (const HWND window = get_filtered_active_window())
     {
+        if (GetWindow(window, GW_OWNER) != nullptr)
+        {
+            return;
+        }
         if (const HMONITOR monitor = MonitorFromWindow(window, MONITOR_DEFAULTTONULL))
         {
             std::shared_lock readLock(m_lock);


### PR DESCRIPTION
## Summary of the Pull Request
We added the dialog box styles to the "not zonable window" filter, to prevent Save As.. and similar dialogs to be assigned to a zone. This caused a lot of apps that use dialog styles to not work with FancyZones. This PR removes those dialog box styles, since the "window has no owner" rule makes the actual dialog boxes not zonable.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #970 #908 #531 #209 
* [x] CLA signed

## Validation Steps Performed
Manual

--
Edit: affected issues