### PR TITLE
PowerRename: bring the rename dialog to foreground

### DIFF
--- a/src/modules/powerrename/ui/PowerRenameUI.cpp
+++ b/src/modules/powerrename/ui/PowerRenameUI.cpp
@@ -519,6 +519,11 @@ HRESULT CPowerRenameUI::_DoModeless(__in_opt HWND hwnd)
     if (NULL != CreateDialogParam(g_hInst, MAKEINTRESOURCE(IDD_MAIN), hwnd, s_DlgProc, (LPARAM)this))
     {
         ShowWindow(m_hwnd, SW_SHOWNORMAL);
+        if (SetForegroundWindow(m_hwnd) == FALSE)
+        {
+            SetWindowPos(m_hwnd, HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
+        }
+        
         MSG msg;
         while (GetMessage(&msg, NULL, 0, 0))
         {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
We try to bring the dialog using `SetForegroundWindow`, which sometimes fail in cases like a user immediately pressing alt+tab after executing rename command and before the dialog was initialized. We use `SetWindowPos` in that case.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #1039

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Launched PowerRename dialog multiple times.