### PR TITLE
Move reusable functions from PowerRenameLib Helpers.h to Common

### DIFF
--- a/src/common/common.vcxproj
+++ b/src/common/common.vcxproj
@@ -97,6 +97,8 @@
     <ClInclude Include="d2d_text.h" />
     <ClInclude Include="d2d_window.h" />
     <ClInclude Include="dpi_aware.h" />
+    <ClInclude Include="window_helpers.h" />
+    <ClInclude Include="icon_helpers.h" />
     <ClInclude Include="hwnd_data_cache.h" />
     <ClInclude Include="json.h" />
     <ClInclude Include="monitors.h" />
@@ -130,10 +132,12 @@
     </ClCompile>
     <ClCompile Include="settings_helpers.cpp" />
     <ClCompile Include="settings_objects.cpp" />
+    <ClCompile Include="icon_helpers.cpp" />
     <ClCompile Include="start_visible.cpp" />
     <ClCompile Include="tasklist_positions.cpp" />
     <ClCompile Include="common.cpp" />
     <ClCompile Include="windows_colors.cpp" />
+    <ClCompile Include="window_helpers.cpp" />
     <ClCompile Include="winstore.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/src/common/common.vcxproj.filters
+++ b/src/common/common.vcxproj.filters
@@ -81,6 +81,12 @@
     <ClInclude Include="winstore.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="icon_helpers.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="window_helpers.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="d2d_svg.cpp">
@@ -130,6 +136,12 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="winstore.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="icon_helpers.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="window_helpers.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/common/icon_helpers.cpp
+++ b/src/common/icon_helpers.cpp
@@ -1,0 +1,90 @@
+#include "icon_helpers.h"
+#include "pch.h"
+
+HRESULT GetIconIndexFromPath(_In_ PCWSTR path, _Out_ int* index)
+{
+    *index = 0;
+
+    HRESULT hr = E_FAIL;
+
+    SHFILEINFO shFileInfo = { 0 };
+
+    if (!PathIsRelative(path))
+    {
+        DWORD attrib = GetFileAttributes(path);
+        HIMAGELIST himl = (HIMAGELIST)SHGetFileInfo(path, attrib, &shFileInfo, sizeof(shFileInfo), (SHGFI_SYSICONINDEX | SHGFI_SMALLICON | SHGFI_USEFILEATTRIBUTES));
+        if (himl)
+        {
+            *index = shFileInfo.iIcon;
+            // We shouldn't free the HIMAGELIST.
+            hr = S_OK;
+        }
+    }
+
+    return hr;
+}
+
+HBITMAP CreateBitmapFromIcon(_In_ HICON hIcon, _In_opt_ UINT width, _In_opt_ UINT height)
+{
+    HBITMAP hBitmapResult = NULL;
+
+    // Create compatible DC
+    HDC hDC = CreateCompatibleDC(NULL);
+    if (hDC != NULL)
+    {
+        // Get bitmap rectangle size
+        RECT rc = { 0 };
+        rc.left = 0;
+        rc.right = (width != 0) ? width : GetSystemMetrics(SM_CXSMICON);
+        rc.top = 0;
+        rc.bottom = (height != 0) ? height : GetSystemMetrics(SM_CYSMICON);
+
+        // Create bitmap compatible with DC
+        BITMAPINFO BitmapInfo;
+        ZeroMemory(&BitmapInfo, sizeof(BITMAPINFO));
+
+        BitmapInfo.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+        BitmapInfo.bmiHeader.biWidth = rc.right;
+        BitmapInfo.bmiHeader.biHeight = rc.bottom;
+        BitmapInfo.bmiHeader.biPlanes = 1;
+        BitmapInfo.bmiHeader.biBitCount = 32;
+        BitmapInfo.bmiHeader.biCompression = BI_RGB;
+
+        HDC hDCBitmap = GetDC(NULL);
+
+        HBITMAP hBitmap = CreateDIBSection(hDCBitmap, &BitmapInfo, DIB_RGB_COLORS, NULL, NULL, 0);
+
+        ReleaseDC(NULL, hDCBitmap);
+
+        if (hBitmap != NULL)
+        {
+            // Select bitmap into DC
+            HBITMAP hBitmapOld = (HBITMAP)SelectObject(hDC, hBitmap);
+            if (hBitmapOld != NULL)
+            {
+                // Draw icon into DC
+                if (DrawIconEx(hDC, 0, 0, hIcon, rc.right, rc.bottom, 0, NULL, DI_NORMAL))
+                {
+                    // Restore original bitmap in DC
+                    hBitmapResult = (HBITMAP)SelectObject(hDC, hBitmapOld);
+                    hBitmapOld = NULL;
+                    hBitmap = NULL;
+                }
+
+                if (hBitmapOld != NULL)
+                {
+                    SelectObject(hDC, hBitmapOld);
+                }
+            }
+
+            if (hBitmap != NULL)
+            {
+                DeleteObject(hBitmap);
+            }
+        }
+
+        DeleteDC(hDC);
+    }
+
+    return hBitmapResult;
+}

--- a/src/common/icon_helpers.h
+++ b/src/common/icon_helpers.h
@@ -1,0 +1,5 @@
+#pragma once
+#include "common.h"
+
+HRESULT GetIconIndexFromPath(_In_ PCWSTR path, _Out_ int* index);
+HBITMAP CreateBitmapFromIcon(_In_ HICON hIcon, _In_opt_ UINT width = 0, _In_opt_ UINT height = 0);

--- a/src/common/window_helpers.cpp
+++ b/src/common/window_helpers.cpp
@@ -1,0 +1,30 @@
+#include "window_helpers.h"
+#include "pch.h"
+
+HWND CreateMsgWindow(_In_ HINSTANCE hInst, _In_ WNDPROC pfnWndProc, _In_ void* p)
+{
+    WNDCLASS wc = { 0 };
+    
+    PCWSTR wndClassName = L"MsgWindow";
+
+    wc.lpfnWndProc = DefWindowProc;
+    wc.cbWndExtra = sizeof(void*);
+    wc.hInstance = hInst;
+    wc.hbrBackground = (HBRUSH)(COLOR_BTNFACE + 1);
+    wc.lpszClassName = wndClassName;
+
+    RegisterClass(&wc);
+
+    HWND hwnd = CreateWindowEx(
+        0, wndClassName, nullptr, 0, 0, 0, 0, 0, HWND_MESSAGE, 0, hInst, nullptr);
+    if (hwnd)
+    {
+        SetWindowLongPtr(hwnd, 0, (LONG_PTR)p);
+        if (pfnWndProc)
+        {
+            SetWindowLongPtr(hwnd, GWLP_WNDPROC, (LONG_PTR)pfnWndProc);
+        }
+    }
+
+    return hwnd;
+}

--- a/src/common/window_helpers.h
+++ b/src/common/window_helpers.h
@@ -1,0 +1,4 @@
+#pragma once
+#include "common.h"
+
+HWND CreateMsgWindow(_In_ HINSTANCE hInst, _In_ WNDPROC pfnWndProc, _In_ void* p);

--- a/src/modules/powerrename/dll/PowerRenameExt.cpp
+++ b/src/modules/powerrename/dll/PowerRenameExt.cpp
@@ -5,6 +5,7 @@
 #include <PowerRenameManager.h>
 #include <trace.h>
 #include <Helpers.h>
+#include <icon_helpers.h>
 #include <Settings.h>
 #include "resource.h"
 

--- a/src/modules/powerrename/lib/Helpers.cpp
+++ b/src/modules/powerrename/lib/Helpers.cpp
@@ -2,94 +2,6 @@
 #include "Helpers.h"
 #include <ShlGuid.h>
 
-HRESULT GetIconIndexFromPath(_In_ PCWSTR path, _Out_ int* index)
-{
-    *index = 0;
-
-    HRESULT hr = E_FAIL;
-
-    SHFILEINFO shFileInfo = { 0 };
-
-    if (!PathIsRelative(path))
-    {
-        DWORD attrib = GetFileAttributes(path);
-        HIMAGELIST himl = (HIMAGELIST)SHGetFileInfo(path, attrib, &shFileInfo, sizeof(shFileInfo), (SHGFI_SYSICONINDEX | SHGFI_SMALLICON | SHGFI_USEFILEATTRIBUTES));
-        if (himl)
-        {
-            *index = shFileInfo.iIcon;
-            // We shouldn't free the HIMAGELIST.
-            hr = S_OK;
-        }
-    }
-
-    return hr;
-}
-
-HBITMAP CreateBitmapFromIcon(_In_ HICON hIcon, _In_opt_ UINT width, _In_opt_ UINT height)
-{
-    HBITMAP hBitmapResult = NULL;
-
-    // Create compatible DC
-    HDC hDC = CreateCompatibleDC(NULL);
-    if (hDC != NULL)
-    {
-        // Get bitmap rectangle size
-        RECT rc = { 0 };
-        rc.left = 0;
-        rc.right = (width != 0) ? width : GetSystemMetrics(SM_CXSMICON);
-        rc.top = 0;
-        rc.bottom = (height != 0) ? height : GetSystemMetrics(SM_CYSMICON);
-
-        // Create bitmap compatible with DC
-        BITMAPINFO BitmapInfo;
-        ZeroMemory(&BitmapInfo, sizeof(BITMAPINFO));
-
-        BitmapInfo.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
-        BitmapInfo.bmiHeader.biWidth = rc.right;
-        BitmapInfo.bmiHeader.biHeight = rc.bottom;
-        BitmapInfo.bmiHeader.biPlanes = 1;
-        BitmapInfo.bmiHeader.biBitCount = 32;
-        BitmapInfo.bmiHeader.biCompression = BI_RGB;
-
-        HDC hDCBitmap = GetDC(NULL);
-
-        HBITMAP hBitmap = CreateDIBSection(hDCBitmap, &BitmapInfo, DIB_RGB_COLORS, NULL, NULL, 0);
-
-        ReleaseDC(NULL, hDCBitmap);
-
-        if (hBitmap != NULL)
-        {
-            // Select bitmap into DC
-            HBITMAP hBitmapOld = (HBITMAP)SelectObject(hDC, hBitmap);
-            if (hBitmapOld != NULL)
-            {
-                // Draw icon into DC
-                if (DrawIconEx(hDC, 0, 0, hIcon, rc.right, rc.bottom, 0, NULL, DI_NORMAL))
-                {
-                    // Restore original bitmap in DC
-                    hBitmapResult = (HBITMAP)SelectObject(hDC, hBitmapOld);
-                    hBitmapOld = NULL;
-                    hBitmap = NULL;
-                }
-
-                if (hBitmapOld != NULL)
-                {
-                    SelectObject(hDC, hBitmapOld);
-                }
-            }
-
-            if (hBitmap != NULL)
-            {
-                DeleteObject(hBitmap);
-            }
-        }
-
-        DeleteDC(hDC);
-    }
-
-    return hBitmapResult;
-}
-
 HRESULT _ParseEnumItems(_In_ IEnumShellItems* pesi, _In_ IPowerRenameManager* psrm, _In_ int depth = 0)
 {
     HRESULT hr = E_INVALIDARG;
@@ -165,33 +77,6 @@ HRESULT EnumerateDataObject(_In_ IUnknown* dataSource, _In_ IPowerRenameManager*
     }
 
     return hr;
-}
-
-HWND CreateMsgWindow(_In_ HINSTANCE hInst, _In_ WNDPROC pfnWndProc, _In_ void* p)
-{
-    WNDCLASS wc = { 0 };
-    PWSTR wndClassName = L"MsgWindow";
-
-    wc.lpfnWndProc = DefWindowProc;
-    wc.cbWndExtra = sizeof(void*);
-    wc.hInstance = hInst;
-    wc.hbrBackground = (HBRUSH)(COLOR_BTNFACE + 1);
-    wc.lpszClassName = wndClassName;
-
-    RegisterClass(&wc);
-
-    HWND hwnd = CreateWindowEx(
-        0, wndClassName, nullptr, 0, 0, 0, 0, 0, HWND_MESSAGE, 0, hInst, nullptr);
-    if (hwnd)
-    {
-        SetWindowLongPtr(hwnd, 0, (LONG_PTR)p);
-        if (pfnWndProc)
-        {
-            SetWindowLongPtr(hwnd, GWLP_WNDPROC, (LONG_PTR)pfnWndProc);
-        }
-    }
-
-    return hwnd;
 }
 
 BOOL GetEnumeratedFileName(__out_ecount(cchMax) PWSTR pszUniqueName, UINT cchMax, __in PCWSTR pszTemplate, __in_opt PCWSTR pszDir, unsigned long ulMinLong, __inout unsigned long* pulNumUsed)

--- a/src/modules/powerrename/lib/Helpers.h
+++ b/src/modules/powerrename/lib/Helpers.h
@@ -4,9 +4,6 @@
 #include <lib/PowerRenameInterfaces.h>
 
 HRESULT EnumerateDataObject(_In_ IUnknown* pdo, _In_ IPowerRenameManager* psrm);
-HRESULT GetIconIndexFromPath(_In_ PCWSTR path, _Out_ int* index);
-HBITMAP CreateBitmapFromIcon(_In_ HICON hIcon, _In_opt_ UINT width = 0, _In_opt_ UINT height = 0);
-HWND CreateMsgWindow(_In_ HINSTANCE hInst, _In_ WNDPROC pfnWndProc, _In_ void* p);
 BOOL GetEnumeratedFileName(
     __out_ecount(cchMax) PWSTR pszUniqueName,
     UINT cchMax,

--- a/src/modules/powerrename/lib/PowerRenameItem.cpp
+++ b/src/modules/powerrename/lib/PowerRenameItem.cpp
@@ -1,6 +1,6 @@
 #include "stdafx.h"
 #include "PowerRenameItem.h"
-#include "helpers.h"
+#include "icon_helpers.h"
 
 int CPowerRenameItem::s_id = 0;
 

--- a/src/modules/powerrename/lib/PowerRenameManager.cpp
+++ b/src/modules/powerrename/lib/PowerRenameManager.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <shlobj.h>
 #include "helpers.h"
+#include "window_helpers.h"
 #include <filesystem>
 #include "trace.h"
 

--- a/src/modules/powerrename/testapp/PowerRenameTest.vcxproj
+++ b/src/modules/powerrename/testapp/PowerRenameTest.vcxproj
@@ -185,6 +185,11 @@
   <ItemGroup>
     <ResourceCompile Include="PowerRenameTest.rc" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\common\common.vcxproj">
+      <Project>{74485049-c722-400f-abe5-86ac52d929b3}</Project>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/src/modules/powerrename/unittests/PowerRenameLibUnitTests.vcxproj
+++ b/src/modules/powerrename/unittests/PowerRenameLibUnitTests.vcxproj
@@ -192,6 +192,11 @@
     <ClCompile Include="PowerRenameRegExTests.cpp" />
     <ClCompile Include="TestFileHelper.cpp" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\common\common.vcxproj">
+      <Project>{74485049-c722-400f-abe5-86ac52d929b3}</Project>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Shifted some functions from PowerRenameLib/Helpers.h to Common as they could be reused. Out of the 5 functions 3 were moved as these 3 did not seem PowerRename specific. CreateBitMapFromIcon would be reused for ImageResizer (the motivation for this issue/PR).

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Applies to #1098 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [X] Tests passed

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
* Created two new header files and source files under common:
    - icon_helpers.h : Moved CreateBitmapFromIcon and GetIconIndexFromPath
    - window_helpers.h : Moved CreateMsgWindow
* Included these header files wherever they were referenced (PowerRenameLib/PowerRenameItem.cpp, PowerRenameLib/PowerRenameManager.cpp, PowerRenameExt/PowerRenameExt.cpp)
* Added Common project reference in PowerRenameTest and PowerRenameUnitTests to fix compilation linker errors

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Builds successfully in Debug/Release x64
- All test cases pass
- Used the MSI installer to install PowerToys and verify that PowerRename is working
