### PR TITLE
MSIX: add a dedicated .rc for UWPUI which joins both UI and DLL .rc's

### DIFF
--- a/src/modules/powerrename/UWPui/PowerRenameUWPUI.rc
+++ b/src/modules/powerrename/UWPui/PowerRenameUWPUI.rc
@@ -1,0 +1,64 @@
+// Microsoft Visual C++ generated resource script.
+//
+#include "resource.h"
+
+// We need both DLL and UI resource files for UWP UI.
+#include "..\dll\PowerRenameExt.rc"
+#undef IDC_STATIC
+#include "..\ui\PowerRenameUI.rc"
+
+#define APSTUDIO_READONLY_SYMBOLS
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 2 resource.
+//
+#include "winres.h"
+
+/////////////////////////////////////////////////////////////////////////////
+#undef APSTUDIO_READONLY_SYMBOLS
+
+/////////////////////////////////////////////////////////////////////////////
+// English (United States) resources
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
+LANGUAGE 9, 1
+
+#ifdef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// TEXTINCLUDE
+//
+
+1 TEXTINCLUDE  
+BEGIN
+    "resource.h\0"
+END
+
+2 TEXTINCLUDE  
+BEGIN
+    "#include ""winres.h""\r\n"
+    "\0"
+END
+
+3 TEXTINCLUDE  
+BEGIN
+    "\r\n"
+    "\0"
+END
+
+#endif    // APSTUDIO_INVOKED
+
+#endif    // English (United States) resources
+/////////////////////////////////////////////////////////////////////////////
+
+
+
+#ifndef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 3 resource.
+//
+
+
+/////////////////////////////////////////////////////////////////////////////
+#endif    // not APSTUDIO_INVOKED

--- a/src/modules/powerrename/UWPui/PowerRenameUWPUI.vcxproj
+++ b/src/modules/powerrename/UWPui/PowerRenameUWPUI.vcxproj
@@ -117,7 +117,7 @@
     <Image Include="..\ui\PowerRename.ico" />
   </ItemGroup>
   <ItemGroup>
-    <ResourceCompile Include="..\ui\PowerRenameUI.rc" />
+    <ResourceCompile Include="PowerRenameUWPUI.rc" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/src/modules/powerrename/UWPui/PowerRenameUWPUI.vcxproj.filters
+++ b/src/modules/powerrename/UWPui/PowerRenameUWPUI.vcxproj.filters
@@ -42,7 +42,7 @@
     </Image>
   </ItemGroup>
   <ItemGroup>
-    <ResourceCompile Include="..\ui\PowerRenameUI.rc">
+    <ResourceCompile Include="PowerRenameUWPUI.rc">
       <Filter>Resource Files</Filter>
     </ResourceCompile>
   </ItemGroup>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
We need both of those .rc's for localization and dialog boxes to work. I've kept the boilerplate generated by VS's resource editor, so it doesn't get added automatically in the future etc.

The issue was caused by PowerRenameUWPUI using external resource file - `PowerRenameUI.rc`. It doesn't contain the `IDS_POWERRENAME` string which is responsible for the menu item title (see `CPowerRenameMenu::GetTitle`). 

We cannot just simply use `PowerRenameExt.rc` instead which contains `IDS_POWERRENAME`, because we also need `IDD_MAIN` for the UI dialog, which is contained in the former file.

Therefore, I've created a new resource file for UWPUI project, which simply `#include`s both files mentioned above.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #1136

## Validation Steps Performed
Launched the PowerRename from the MSIX