### PR TITLE
MSIX: reinstall script uses bundle instead of .msi to be able to reinstall in all cases

### DIFF
--- a/installer/MSIX/msix_reinstall.ps1
+++ b/installer/MSIX/msix_reinstall.ps1
@@ -6,6 +6,6 @@ Get-AppxPackage -Name 'PowerToys' | select -ExpandProperty "PackageFullName" | R
 signtool sign /debug /a /fd SHA256 /f PowerToys_TemporaryKey.pfx /p 12345 bin\PowerToys-x64.msix
 signtool sign /debug /a /fd SHA256 /f PowerToys_TemporaryKey.pfx /p 12345 bin\PowerToys.msixbundle
 
-Add-AppxPackage .\bin\PowerToys-x64.msix
+Add-AppxPackage .\bin\PowerToys.msixbundle
 
 start $Env:windir\explorer.exe


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
The problem description is in the issue #1147.

## PR Checklist
* [x] Applies to #1147
