### PR TITLE
Fancyzones: unify window filtering

### DIFF
--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -97,6 +97,7 @@ private:
         require_write_lock(const std::unique_lock<T>& lock) { lock; }
     };
 
+    bool IsInterestingWindow(HWND window) noexcept;
     void UpdateZoneWindows() noexcept;
     void MoveWindowsOnDisplayChange() noexcept;
     void UpdateDragState(require_write_lock) noexcept;
@@ -199,8 +200,11 @@ IFACEMETHODIMP_(void) FancyZones::Destroy() noexcept
 // IFancyZonesCallback
 IFACEMETHODIMP_(void) FancyZones::MoveSizeStart(HWND window, HMONITOR monitor, POINT const& ptScreen) noexcept
 {
-    std::unique_lock writeLock(m_lock);
-    MoveSizeStartInternal(window, monitor, ptScreen, writeLock);
+    if (IsInterestingWindow(window))
+    {
+        std::unique_lock writeLock(m_lock);
+        MoveSizeStartInternal(window, monitor, ptScreen, writeLock);
+    }
 }
 
 // IFancyZonesCallback
@@ -213,8 +217,11 @@ IFACEMETHODIMP_(void) FancyZones::MoveSizeUpdate(HMONITOR monitor, POINT const& 
 // IFancyZonesCallback
 IFACEMETHODIMP_(void) FancyZones::MoveSizeEnd(HWND window, POINT const& ptScreen) noexcept
 {
-    std::unique_lock writeLock(m_lock);
-    MoveSizeEndInternal(window, ptScreen, writeLock);
+    if (IsInterestingWindow(window) || window == m_windowMoveSize)
+    {
+        std::unique_lock writeLock(m_lock);
+        MoveSizeEndInternal(window, ptScreen, writeLock);
+    }
 }
 
 // IFancyZonesCallback
@@ -234,7 +241,7 @@ IFACEMETHODIMP_(void) FancyZones::VirtualDesktopInitialize() noexcept
 // IFancyZonesCallback
 IFACEMETHODIMP_(void) FancyZones::WindowCreated(HWND window) noexcept
 {
-    if (m_settings->GetSettings().appLastZone_moveWindows)
+    if (IsInterestingWindow(window) && m_settings->GetSettings().appLastZone_moveWindows)
     {
         auto processPath = get_process_path(window);
         if (!processPath.empty()) 
@@ -586,6 +593,41 @@ LRESULT CALLBACK FancyZones::s_WndProc(HWND window, UINT message, WPARAM wparam,
         DefWindowProc(window, message, wparam, lparam);
 }
 
+bool FancyZones::IsInterestingWindow(HWND window) noexcept
+{
+    auto style = GetWindowLongPtr(window, GWL_STYLE);
+    auto exStyle = GetWindowLongPtr(window, GWL_EXSTYLE);
+    // Ignore:
+    if (GetAncestor(window, GA_ROOT) != window || // windows that are not top-level
+        GetWindow(window, GW_OWNER) != nullptr || // windows that have an owner - like Save As dialogs
+        (style & WS_CHILD) != 0 || // windows that are child elements of other windows - like buttons
+        (style & WS_DISABLED) != 0 || // windows that are disabled
+        (exStyle & WS_EX_TOOLWINDOW) != 0 || // toolbar windows
+        !IsWindowVisible(window)) // invisible windows
+    {
+        return false;
+    }
+    // Filter some windows like the Start menu or Cortana
+    auto windowAndPath = get_filtered_base_window_and_path(window);
+    if (windowAndPath.hwnd == nullptr)
+    {
+        return false;
+    }
+    // Filter out user specified apps
+    CharUpperBuffW(windowAndPath.process_path.data(), (DWORD)windowAndPath.process_path.length());
+    if (m_settings)
+    {
+        for (const auto& excluded : m_settings->GetSettings().excludedAppsArray)
+        {
+            if (windowAndPath.process_path.find(excluded) != std::wstring::npos)
+            {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
 void FancyZones::UpdateZoneWindows() noexcept
 {
     auto callback = [](HMONITOR monitor, HDC, RECT *, LPARAM data) -> BOOL
@@ -678,12 +720,9 @@ void FancyZones::UpdateDragState(require_write_lock) noexcept
 
 void FancyZones::CycleActiveZoneSet(DWORD vkCode) noexcept
 {
-    if (const HWND window = get_filtered_active_window())
+    auto window = GetForegroundWindow();
+    if (IsInterestingWindow(window))
     {
-        if (GetWindow(window, GW_OWNER) != nullptr)
-        {
-            return;
-        }
         if (const HMONITOR monitor = MonitorFromWindow(window, MONITOR_DEFAULTTONULL))
         {
             std::shared_lock readLock(m_lock);
@@ -698,12 +737,9 @@ void FancyZones::CycleActiveZoneSet(DWORD vkCode) noexcept
 
 void FancyZones::OnSnapHotkey(DWORD vkCode) noexcept
 {
-    if (const HWND window = get_filtered_active_window())
+    auto window = GetForegroundWindow();
+    if (IsInterestingWindow(window))
     {
-        if (GetWindow(window, GW_OWNER) != nullptr)
-        {
-            return;
-        }
         if (const HMONITOR monitor = MonitorFromWindow(window, MONITOR_DEFAULTTONULL))
         {
             std::shared_lock readLock(m_lock);

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -217,7 +217,7 @@ IFACEMETHODIMP_(void) FancyZones::MoveSizeUpdate(HMONITOR monitor, POINT const& 
 // IFancyZonesCallback
 IFACEMETHODIMP_(void) FancyZones::MoveSizeEnd(HWND window, POINT const& ptScreen) noexcept
 {
-    if (IsInterestingWindow(window) || window == m_windowMoveSize)
+    if (window == m_windowMoveSize || IsInterestingWindow(window))
     {
         std::unique_lock writeLock(m_lock);
         MoveSizeEndInternal(window, ptScreen, writeLock);
@@ -241,7 +241,7 @@ IFACEMETHODIMP_(void) FancyZones::VirtualDesktopInitialize() noexcept
 // IFancyZonesCallback
 IFACEMETHODIMP_(void) FancyZones::WindowCreated(HWND window) noexcept
 {
-    if (IsInterestingWindow(window) && m_settings->GetSettings().appLastZone_moveWindows)
+    if (m_settings->GetSettings().appLastZone_moveWindows && IsInterestingWindow(window))
     {
         auto processPath = get_process_path(window);
         if (!processPath.empty()) 


### PR DESCRIPTION
## Summary of the Pull Request
Makes FancyZone use the same code for filtering windows when windows are being dragged and when moved by WinKey + arrows.

This is mostly a code refactor, but it also solves one issue.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies (partly) to #1182 
* [x] CLA signed.
* [x] Tests added/passed
## Detailed Description of the Pull Request / Additional comments
 - The `IsInterestingWindow` method is moved "as is" to the `FancyZones.cpp`.
 - 3 `IsInterestingWindow` calls were moved to the `FancyZones.cpp` in appropriate places
 - In 2 places in `FancyZones.cpp` where we used `get_filtered_active_window()` and `GetWindow(window, GW_OWNER)` calls, we now use `IsInteresetingWindow`.
 - The `m_movedWindow` is removed. It fixed an issue when a Chrom tab is dragged into another Chrome instance, the style would change so that the window would become uninteresting. FancyZones would be stuck in "window is dragged mode", so we kept a reference to the dragged window to make sure we disengage the display of the zones. In the `FancyZones.cpp` the reference is already kept in `m_windowMoveSize`, we will reuse it.
 - For #1182 we should probably not swallow the keyboard events. Excluded apps should probably be able to use regular Windows snapping.
## Validation Steps Performed
Unit tests
Manual tests with Notepad, Git Extensions and Chrome