### PR TITLE
FancyZones: filter out WM_POPUP windows if they dont have maximize/minimize button or a resizable frame

### DIFF
--- a/src/common/hwnd_data_cache.cpp
+++ b/src/common/hwnd_data_cache.cpp
@@ -80,6 +80,14 @@ bool HWNDDataCache::is_invalid_class(HWND hwnd) const {
 }
 bool HWNDDataCache::is_invalid_style(HWND hwnd) const {
   auto style = GetWindowLong(hwnd, GWL_STYLE);
+  // WS_POPUP need to have a border or minimize/maximize buttons,
+  // otherwise the window is "not interesting"
+  if ((style & WS_POPUP) == WS_POPUP &&
+      (style & WS_THICKFRAME) == 0 &&
+      (style & WS_MINIMIZEBOX) == 0 &&
+      (style & WS_MAXIMIZEBOX) == 0) {
+    return true;
+  }
   for (auto invalid : invalid_basic_styles) {
     if ((invalid & style) != 0) {
       return true;


### PR DESCRIPTION
## Summary of the Pull Request
This filters out TaskView and Win32 menus.

## PR Checklist
* [x] Applies to #1159 
* [x] CLA signed.

## Validation Steps Performed
Manual using PaswordSafe, 1Password, TortoiseSVN, GOG Galaxy beta, GlassWire, VS Code and Battle.net launcher