### PR TITLE
Add ImageResizer to MSIX installer and make the code MSIX-compatible

### DIFF
--- a/installer/MSIX/PackagingLayout.xml
+++ b/installer/MSIX/PackagingLayout.xml
@@ -16,6 +16,12 @@
         <File DestinationPath="modules\PowerRenameExt.dll" SourcePath="..\..\x64\Release\modules\PowerRenameExt.dll"/>
         <File DestinationPath="modules\shortcut_guide.dll" SourcePath="..\..\x64\Release\modules\shortcut_guide.dll"/>
         <File DestinationPath="modules\PowerRenameUWPUI.exe" SourcePath="..\..\x64\Release\PowerRenameUWPUI.exe"/>
+        <File DestinationPath="modules\ImageResizer.exe" SourcePath="..\..\x64\Release\ImageResizer.exe"/>
+        <File DestinationPath="modules\ImageResizerExt.dll" SourcePath="..\..\x64\Release\modules\ImageResizerExt.dll"/>
+        <File DestinationPath="modules\GalaSoft.MvvmLight.dll" SourcePath="..\..\x64\Release\GalaSoft.MvvmLight.dll"/>
+        <File DestinationPath="modules\GalaSoft.MvvmLight.Platform.dll" SourcePath="..\..\x64\Release\GalaSoft.MvvmLight.Platform.dll"/>
+        <File DestinationPath="modules\GalaSoft.MvvmLight.Extras.dll" SourcePath="..\..\x64\Release\GalaSoft.MvvmLight.Extras.dll"/>
+        <File DestinationPath="modules\System.Windows.Interactivity.dll" SourcePath="..\..\x64\Release\System.Windows.Interactivity.dll"/>
 
         <File DestinationPath="svgs\*" SourcePath="..\..\x64\Release\svgs\*"/>
         <File DestinationPath="settings-html\**" SourcePath="..\..\x64\Release\settings-html\**"/>

--- a/installer/MSIX/appxmanifest.xml
+++ b/installer/MSIX/appxmanifest.xml
@@ -36,6 +36,9 @@
             <com:ExeServer Executable="modules\PowerRenameUWPUI.exe" DisplayName="PowerRenameUWPUI">
               <com:Class Id="0440049F-D1DC-4E46-B27B-98393D79486B"/>
             </com:ExeServer>
+            <com:SurrogateServer AppId="51B4D7E5-7568-4234-B4BB-47FB3C016A69" DisplayName="ImageResizerExt">
+              <com:Class Id="51B4D7E5-7568-4234-B4BB-47FB3C016A69" Path="modules\ImageResizerExt.dll" ThreadingModel="STA"/>
+            </com:SurrogateServer>
           </com:ComServer>
         </com:Extension>
         <desktop4:Extension Category="windows.fileExplorerContextMenus">
@@ -46,6 +49,45 @@
             <desktop5:ItemType Type="Directory">
               <desktop5:Verb Id="DirectoryPowerRename" Clsid="0440049F-D1DC-4E46-B27B-98393D79486B" />
             </desktop5:ItemType>
+            <desktop4:ItemType Type=".bmp">
+              <desktop4:Verb Id="BMPImageResizer" Clsid="51B4D7E5-7568-4234-B4BB-47FB3C016A69" />
+            </desktop4:ItemType>
+            <desktop4:ItemType Type=".dib">
+              <desktop4:Verb Id="DIBImageResizer" Clsid="51B4D7E5-7568-4234-B4BB-47FB3C016A69" />
+            </desktop4:ItemType>
+            <desktop4:ItemType Type=".gif">
+              <desktop4:Verb Id="GIFImageResizer" Clsid="51B4D7E5-7568-4234-B4BB-47FB3C016A69" />
+            </desktop4:ItemType>
+            <desktop4:ItemType Type=".jfif">
+              <desktop4:Verb Id="JFIFImageResizer" Clsid="51B4D7E5-7568-4234-B4BB-47FB3C016A69" />
+            </desktop4:ItemType>
+            <desktop4:ItemType Type=".jpe">
+              <desktop4:Verb Id="JPEImageResizer" Clsid="51B4D7E5-7568-4234-B4BB-47FB3C016A69" />
+            </desktop4:ItemType>
+            <desktop4:ItemType Type=".jpeg">
+              <desktop4:Verb Id="JPEGImageResizer" Clsid="51B4D7E5-7568-4234-B4BB-47FB3C016A69" />
+            </desktop4:ItemType>
+            <desktop4:ItemType Type=".jpg">
+              <desktop4:Verb Id="JPGImageResizer" Clsid="51B4D7E5-7568-4234-B4BB-47FB3C016A69" />
+            </desktop4:ItemType>
+            <desktop4:ItemType Type=".jxr">
+              <desktop4:Verb Id="JXRImageResizer" Clsid="51B4D7E5-7568-4234-B4BB-47FB3C016A69" />
+            </desktop4:ItemType>
+            <desktop4:ItemType Type=".png">
+              <desktop4:Verb Id="PNGImageResizer" Clsid="51B4D7E5-7568-4234-B4BB-47FB3C016A69" />
+            </desktop4:ItemType>
+            <desktop4:ItemType Type=".rle">
+              <desktop4:Verb Id="RLEImageResizer" Clsid="51B4D7E5-7568-4234-B4BB-47FB3C016A69" />
+            </desktop4:ItemType>
+            <desktop4:ItemType Type=".tif">
+              <desktop4:Verb Id="TIFImageResizer" Clsid="51B4D7E5-7568-4234-B4BB-47FB3C016A69" />
+            </desktop4:ItemType>
+            <desktop4:ItemType Type=".tiff">
+              <desktop4:Verb Id="TIFFImageResizer" Clsid="51B4D7E5-7568-4234-B4BB-47FB3C016A69" />
+            </desktop4:ItemType>
+            <desktop4:ItemType Type=".wdp">
+              <desktop4:Verb Id="WDPImageResizer" Clsid="51B4D7E5-7568-4234-B4BB-47FB3C016A69" />
+            </desktop4:ItemType>
           </desktop4:FileExplorerContextMenus>
         </desktop4:Extension>
       </Extensions>

--- a/installer/MSIX/appxmanifest.xml
+++ b/installer/MSIX/appxmanifest.xml
@@ -36,7 +36,7 @@
             <com:ExeServer Executable="modules\PowerRenameUWPUI.exe" DisplayName="PowerRenameUWPUI">
               <com:Class Id="0440049F-D1DC-4E46-B27B-98393D79486B"/>
             </com:ExeServer>
-            <com:SurrogateServer AppId="51B4D7E5-7568-4234-B4BB-47FB3C016A69" DisplayName="ImageResizerExt">
+            <com:SurrogateServer DisplayName="ImageResizerExt">
               <com:Class Id="51B4D7E5-7568-4234-B4BB-47FB3C016A69" Path="modules\ImageResizerExt.dll" ThreadingModel="STA"/>
             </com:SurrogateServer>
           </com:ComServer>

--- a/installer/MSIX/appxmanifest.xml
+++ b/installer/MSIX/appxmanifest.xml
@@ -49,6 +49,7 @@
             <desktop5:ItemType Type="Directory">
               <desktop5:Verb Id="DirectoryPowerRename" Clsid="0440049F-D1DC-4E46-B27B-98393D79486B" />
             </desktop5:ItemType>
+            <!-- Image Resizer context menu handler for each of the following image formats: bmp, dib, gif, jfif, jpe, jpeg, jpg, jxr, png, rle, tif, tiff, wdp  -->
             <desktop4:ItemType Type=".bmp">
               <desktop4:Verb Id="BMPImageResizer" Clsid="51B4D7E5-7568-4234-B4BB-47FB3C016A69" />
             </desktop4:ItemType>

--- a/installer/MSIX/appxmanifest.xml
+++ b/installer/MSIX/appxmanifest.xml
@@ -49,45 +49,8 @@
             <desktop5:ItemType Type="Directory">
               <desktop5:Verb Id="DirectoryPowerRename" Clsid="0440049F-D1DC-4E46-B27B-98393D79486B" />
             </desktop5:ItemType>
-            <!-- Image Resizer context menu handler for each of the following image formats: bmp, dib, gif, jfif, jpe, jpeg, jpg, jxr, png, rle, tif, tiff, wdp  -->
-            <desktop4:ItemType Type=".bmp">
-              <desktop4:Verb Id="BMPImageResizer" Clsid="51B4D7E5-7568-4234-B4BB-47FB3C016A69" />
-            </desktop4:ItemType>
-            <desktop4:ItemType Type=".dib">
-              <desktop4:Verb Id="DIBImageResizer" Clsid="51B4D7E5-7568-4234-B4BB-47FB3C016A69" />
-            </desktop4:ItemType>
-            <desktop4:ItemType Type=".gif">
-              <desktop4:Verb Id="GIFImageResizer" Clsid="51B4D7E5-7568-4234-B4BB-47FB3C016A69" />
-            </desktop4:ItemType>
-            <desktop4:ItemType Type=".jfif">
-              <desktop4:Verb Id="JFIFImageResizer" Clsid="51B4D7E5-7568-4234-B4BB-47FB3C016A69" />
-            </desktop4:ItemType>
-            <desktop4:ItemType Type=".jpe">
-              <desktop4:Verb Id="JPEImageResizer" Clsid="51B4D7E5-7568-4234-B4BB-47FB3C016A69" />
-            </desktop4:ItemType>
-            <desktop4:ItemType Type=".jpeg">
-              <desktop4:Verb Id="JPEGImageResizer" Clsid="51B4D7E5-7568-4234-B4BB-47FB3C016A69" />
-            </desktop4:ItemType>
-            <desktop4:ItemType Type=".jpg">
-              <desktop4:Verb Id="JPGImageResizer" Clsid="51B4D7E5-7568-4234-B4BB-47FB3C016A69" />
-            </desktop4:ItemType>
-            <desktop4:ItemType Type=".jxr">
-              <desktop4:Verb Id="JXRImageResizer" Clsid="51B4D7E5-7568-4234-B4BB-47FB3C016A69" />
-            </desktop4:ItemType>
-            <desktop4:ItemType Type=".png">
-              <desktop4:Verb Id="PNGImageResizer" Clsid="51B4D7E5-7568-4234-B4BB-47FB3C016A69" />
-            </desktop4:ItemType>
-            <desktop4:ItemType Type=".rle">
-              <desktop4:Verb Id="RLEImageResizer" Clsid="51B4D7E5-7568-4234-B4BB-47FB3C016A69" />
-            </desktop4:ItemType>
-            <desktop4:ItemType Type=".tif">
-              <desktop4:Verb Id="TIFImageResizer" Clsid="51B4D7E5-7568-4234-B4BB-47FB3C016A69" />
-            </desktop4:ItemType>
-            <desktop4:ItemType Type=".tiff">
-              <desktop4:Verb Id="TIFFImageResizer" Clsid="51B4D7E5-7568-4234-B4BB-47FB3C016A69" />
-            </desktop4:ItemType>
-            <desktop4:ItemType Type=".wdp">
-              <desktop4:Verb Id="WDPImageResizer" Clsid="51B4D7E5-7568-4234-B4BB-47FB3C016A69" />
+            <desktop4:ItemType Type="*">
+              <desktop4:Verb Id="ImageResizer" Clsid="51B4D7E5-7568-4234-B4BB-47FB3C016A69" />
             </desktop4:ItemType>
           </desktop4:FileExplorerContextMenus>
         </desktop4:Extension>

--- a/installer/PowerToysSetup/Product.wxs
+++ b/installer/PowerToysSetup/Product.wxs
@@ -261,7 +261,6 @@
         <File Source="$(var.BinX64Dir)\modules\ImageResizer.exe">
           <netfx:NativeImage Id="ImageResizer.exe" Platform="all" Priority="0" />
         </File>
-        <RegistryValue Root="HKLM" Key="Software\Microsoft\ImageResizer" Value="[ModulesInstallFolder]ImageResizer.exe" Type="string"/>
         <File Source="$(var.BinX64Dir)\modules\GalaSoft.MvvmLight.dll" />
         <File Source="$(var.BinX64Dir)\modules\GalaSoft.MvvmLight.Platform.dll" />
         <File Source="$(var.BinX64Dir)\modules\GalaSoft.MvvmLight.Extras.dll" />

--- a/installer/README.md
+++ b/installer/README.md
@@ -22,7 +22,7 @@ For the first-time installation, you'll need to generate a self-signed certifica
 4. Run `.\msix_reinstall.ps1` from the devenv powershell
 
 #### What msix_reinstall.ps1 does
-`msix_reinstall.ps1` removes the current PowerToys installation, restarts explorer.exe (to update PowerRename shell extension), builds `PowerToys-x64.msix` package, signs it with a PowerToys_TemporaryKey.pfx, and finally installs it.
+`msix_reinstall.ps1` removes the current PowerToys installation, restarts explorer.exe (to update PowerRename and ImageResizer shell extension), builds `PowerToys-x64.msix` package, signs it with a PowerToys_TemporaryKey.pfx, and finally installs it.
 
 #### Removing all .msi/.msix PowerToys installations
 ```ps

--- a/src/modules/imageresizer/dll/ContextMenuHandler.cpp
+++ b/src/modules/imageresizer/dll/ContextMenuHandler.cpp
@@ -205,13 +205,9 @@ HRESULT CContextMenuHandler::InvokeCommand(_In_ CMINVOKECOMMANDINFO* pici)
 HRESULT CContextMenuHandler::ResizePictures(CMINVOKECOMMANDINFO* pici, IShellItemArray* psiItemArray)
 {
     // Set the application path based on the location of the dll
-    LPTSTR buffer = new TCHAR[MAX_PATH];
-    GetModuleFileName(g_hInst_imageResizer, buffer, MAX_PATH);
-    std::wstring::size_type pos = std::wstring(buffer).find_last_of(L"\\/");
-    std::wstring path = std::wstring(buffer).substr(0, pos);
+    std::wstring path = get_module_folderpath(g_hInst_imageResizer);
     path = path + L"\\ImageResizer.exe";
     LPTSTR lpApplicationName = (LPTSTR)path.c_str();
-    delete[] buffer;
     // Create an anonymous pipe to stream filenames
     SECURITY_ATTRIBUTES sa;
     HANDLE hReadPipe;
@@ -338,6 +334,11 @@ HRESULT __stdcall CContextMenuHandler::GetCanonicalName(GUID* pguidCommandName)
 
 HRESULT __stdcall CContextMenuHandler::GetState(IShellItemArray* psiItemArray, BOOL fOkToBeSlow, EXPCMDSTATE* pCmdState)
 {
+    if (!CSettings::GetEnabled())
+    {
+        *pCmdState = ECS_HIDDEN;
+        return S_OK;
+    }
     // Hide if the file is not an image
     *pCmdState = ECS_HIDDEN;
     // Suppressing C26812 warning as the issue is in the shtypes.h library
@@ -359,7 +360,7 @@ HRESULT __stdcall CContextMenuHandler::GetState(IShellItemArray* psiItemArray, B
     // If selected file is an image...
     if (type == PERCEIVED_TYPE_IMAGE)
     {
-        *pCmdState = CSettings::GetEnabled() ? ECS_ENABLED : ECS_HIDDEN;
+        *pCmdState = ECS_ENABLED;
     }
     return S_OK;
 }

--- a/src/modules/imageresizer/dll/ContextMenuHandler.cpp
+++ b/src/modules/imageresizer/dll/ContextMenuHandler.cpp
@@ -5,7 +5,6 @@
 #include "HDropIterator.h"
 #include "Settings.h"
 #include "common/icon_helpers.h"
-#include <fstream>
 
 extern HINSTANCE g_hInst_imageResizer;
 
@@ -291,12 +290,6 @@ HRESULT CContextMenuHandler::ResizePictures(CMINVOKECOMMANDINFO* pici, IShellIte
         DWORD fileCount = 0;
         // Gets the list of files currently selected using the IShellItemArray
         psiItemArray->GetCount(&fileCount);
-
-        std::ofstream logFile("D:\\arjunlog.txt");
-        if (logFile.is_open())
-        {
-            logFile << fileCount << std::endl;
-        }
         // Iterate over the list of files
         for (DWORD i = 0; i < fileCount; i++)
         {
@@ -309,29 +302,7 @@ HRESULT CContextMenuHandler::ResizePictures(CMINVOKECOMMANDINFO* pici, IShellIte
             fileName.Append(_T("\r\n"));
             // Write the file path into the input stream for image resizer
             writePipe.Write(fileName, fileName.GetLength() * sizeof(TCHAR));
-            LPSTR result = NULL;
-
-            int len = WideCharToMultiByte(CP_UTF8, 0, itemName, -1, NULL, 0, 0, 0);
-
-            if (len > 0)
-            {
-                result = new char[len + 1];
-                if (result)
-                {
-                    int resLen = WideCharToMultiByte(CP_UTF8, 0, itemName, -1, &result[0], len, 0, 0);
-
-                    if (resLen == len)
-                    {
-                        logFile.write(result, len);
-                    }
-
-                    delete[] result;
-                }
-            }
-            logFile << std::endl;
         }
-
-        logFile.close();
     }
 
     writePipe.Close();
@@ -346,12 +317,11 @@ HRESULT __stdcall CContextMenuHandler::GetTitle(IShellItemArray* /*psiItemArray*
 
 HRESULT __stdcall CContextMenuHandler::GetIcon(IShellItemArray* /*psiItemArray*/, LPWSTR* ppszIcon)
 {
-    /*std::wstring iconResourcePath = get_module_filename();
+    // Since ImageResizer is registered as a COM SurrogateServer the current module filename would be dllhost.exe. To get the icon we need the path of ImageResizerExt.dll, which can be obtained by passing the HINSTANCE of the dll
+    std::wstring iconResourcePath = get_module_filename(g_hInst_imageResizer);
     iconResourcePath += L",-";
     iconResourcePath += std::to_wstring(IDI_RESIZE_PICTURES);
-    return SHStrDup(iconResourcePath.c_str(), ppszIcon);*/
-    *ppszIcon = nullptr;
-    return E_NOTIMPL;
+    return SHStrDup(iconResourcePath.c_str(), ppszIcon);
 }
 
 HRESULT __stdcall CContextMenuHandler::GetToolTip(IShellItemArray* /*psiItemArray*/, LPWSTR* ppszInfotip)

--- a/src/modules/imageresizer/dll/ContextMenuHandler.h
+++ b/src/modules/imageresizer/dll/ContextMenuHandler.h
@@ -12,15 +12,17 @@
 
 using namespace ATL;
 
-class ATL_NO_VTABLE CContextMenuHandler :
+class ATL_NO_VTABLE __declspec(uuid("51B4D7E5-7568-4234-B4BB-47FB3C016A69")) CContextMenuHandler :
     public CComObjectRootEx<CComSingleThreadModel>,
     public CComCoClass<CContextMenuHandler, &CLSID_ContextMenuHandler>,
     public IShellExtInit,
-    public IContextMenu
+    public IContextMenu,
+    public IExplorerCommand
 {
     BEGIN_COM_MAP(CContextMenuHandler)
     COM_INTERFACE_ENTRY(IShellExtInit)
     COM_INTERFACE_ENTRY(IContextMenu)
+    COM_INTERFACE_ENTRY(IExplorerCommand)
     END_COM_MAP()
     DECLARE_REGISTRY_RESOURCEID(IDR_CONTEXTMENUHANDLER)
     DECLARE_NOT_AGGREGATABLE(CContextMenuHandler)
@@ -33,12 +35,23 @@ public:
     HRESULT STDMETHODCALLTYPE GetCommandString(UINT_PTR idCmd, UINT uType, _In_ UINT* pReserved, LPSTR pszName, UINT cchMax);
     HRESULT STDMETHODCALLTYPE InvokeCommand(_In_ CMINVOKECOMMANDINFO* pici);
 
+    // Inherited via IExplorerCommand
+    virtual HRESULT __stdcall GetTitle(IShellItemArray* psiItemArray, LPWSTR* ppszName) override;
+    virtual HRESULT __stdcall GetIcon(IShellItemArray* psiItemArray, LPWSTR* ppszIcon) override;
+    virtual HRESULT __stdcall GetToolTip(IShellItemArray* psiItemArray, LPWSTR* ppszInfotip) override;
+    virtual HRESULT __stdcall GetCanonicalName(GUID* pguidCommandName) override;
+    virtual HRESULT __stdcall GetState(IShellItemArray* psiItemArray, BOOL fOkToBeSlow, EXPCMDSTATE* pCmdState) override;
+    virtual HRESULT __stdcall Invoke(IShellItemArray* psiItemArray, IBindCtx* pbc) override;
+    virtual HRESULT __stdcall GetFlags(EXPCMDFLAGS* pFlags) override;
+    virtual HRESULT __stdcall EnumSubCommands(IEnumExplorerCommand** ppEnum) override;
+
 private:
     void Uninitialize();
-    HRESULT ResizePictures(CMINVOKECOMMANDINFO* pici);
+    HRESULT ResizePictures(CMINVOKECOMMANDINFO* pici, IShellItemArray* psiItemArray);
     PCIDLIST_ABSOLUTE m_pidlFolder;
     IDataObject* m_pdtobj;
     HBITMAP m_hbmpIcon = nullptr;
+    std::wstring app_name;
 };
 
 OBJECT_ENTRY_AUTO(__uuidof(ContextMenuHandler), CContextMenuHandler)

--- a/src/modules/imageresizer/dll/stdafx.h
+++ b/src/modules/imageresizer/dll/stdafx.h
@@ -12,9 +12,11 @@
 #include "targetver.h"
 #include "resource.h"
 
+#include <winrt/base.h>
 #include <atlbase.h>
 #include <atlcom.h>
 #include <atlfile.h>
 #include <atlstr.h>
+#include <windows.h>
 
 #include <ShlObj.h>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR adds ImageResizer to the MSIX package and makes code refactoring to implement the IExplorerCommand interface which is required for MSIX Context menu handlers. There is no perf issue for ImageResizer (as in #1197 ) when PowerRename is commented out in the appmanifest.xml.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Applies to #53 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [X] Tests passed

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
- Added ImageResizer files and dlls to MSIX packaging layout
- Added ImageResizerExt.dll as SurrogateServer (ExeServer can't be used as there is no C++ exe for it).
- Added a file explorer context menu entry to the appmanifest for *
- Removed the registry key which stores the ImageResizer.exe file location from the MSI installer and made changes to the code so that the location of ImageResizer.exe is identified using the location of the module ImageResizerExt.dll.
- Implemented IExplorerCommand interface methods which are required for MSIX. 
- Modified ResizePictures() method to be reusable for both MSI and MSIX builds.

## Observed issues and workarounds
- On adding the SurrogateServer, the icon failed to load. This happened because the current module in ContextMenuHandler.cpp is Dllhost.exe, and in the GetIcon function the icon was being retrieved from the current module. This was resolved by pointing to the module HINSTANCE of ImageResizerExt.dll instead.
- Adding the ImageResizer fileExplorerContextMenus handler to a particular file type like .png instead of * resulted in very weird menu entry positioning, and it caused the "Open" entry to move down for some reason. A workaround was to set it as * instead of particular file types and filter for image file types within the GetState function in the code.
**.png handler**
![fileSpecificHandler](https://user-images.githubusercontent.com/32061677/73886885-4cece100-481f-11ea-9082-71bee2dd8bb2.png)
**\* handler**
![AllFilesHandler](https://user-images.githubusercontent.com/32061677/73886891-5118fe80-481f-11ea-8328-11283efaef00.png)

# Open Issues
- The drag and drop handler does not appear on MSIX install. 
- The Resize pictures option does not appear with Rotate left/right (as in #1110 ). Unlikely to be fixable based on investigation for #1038 .

## Validation Steps Performed
- Verified with multiple MSIX install/uninstalls.
- All tests pass
- Checked the context menu with png and jpg files and non-image files.
- Checked enabling/disabling ImageResizer

## How to Validate
- Follow the instructions in the [Readme](https://github.com/microsoft/PowerToys/blob/dev/imageResizer/installer/README.md) to create the self-signed certificate and install using MSIX. Make sure to enable Sideloading Apps under the Windows Developer Options.
- Launch the PowerToys Preview from start menu to adjust any global settings.
- Right-clicking any image/group of images will provide a Resize pictures option which opens the ImageResizer executable.