### PR TITLE
MSIX: keep PowerRename local COM server in memory

### DIFF
--- a/src/modules/powerrename/UWPui/PowerRenameUWPUI.cpp
+++ b/src/modules/powerrename/UWPui/PowerRenameUWPUI.cpp
@@ -18,7 +18,8 @@ void ModuleRelease()
 {
     if (--g_dwModuleRefCount == 0)
     {
-        PostThreadMessage(main_thread_id, WM_QUIT, 0, 0);
+        // Do nothing and keep the COM server in memory forever. We might want to introduce delayed shutdown and/or
+        // periodic polling whether a user has disabled us in settings. Tracking this in #1217
     }
 }
 HINSTANCE g_hInst = 0;
@@ -95,9 +96,9 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
     main_thread_id = GetCurrentThreadId();
     winrt::init_apartment();
     g_hInst = hInstance;
-    auto factory = std::make_unique<CPowerRenameClassLocalFactory>(CLSID_PowerRenameMenu);
+    CPowerRenameClassLocalFactory factory{CLSID_PowerRenameMenu};
     DWORD token;
-    if (!SUCCEEDED(CoRegisterClassObject(CLSID_PowerRenameMenu, factory.get(), CLSCTX_LOCAL_SERVER, REGCLS_MULTIPLEUSE, &token)))
+    if (!SUCCEEDED(CoRegisterClassObject(CLSID_PowerRenameMenu, &factory, CLSCTX_LOCAL_SERVER, REGCLS_MULTIPLEUSE, &token)))
     {
         return 1;
     }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Don't send WM_QUIT message for PowerRename local COM server to prevent its shutdown. Detailed discussion is in the issue. Also avoid unnecessary dynamic allocation during the server start to reduce the first time lag.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #1197

## Validation Steps Performed
- PowerRename GUI window is functional
- no lag is observed except for the first time the COM server is loaded (hard to avoid)