### PR TITLE
Update MSIX Readme with sideloading steps

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -15,6 +15,9 @@ For the first-time installation, you'll need to generate a self-signed certifica
 1. Open `Developer PowerShell for VS` as admin
 2. Run `Set-ExecutionPolicy -executionPolicy Unrestricted`
 
+### Allow Sideloaded apps
+In order to install the MSIX package without using the Microsoft Store, sideloading apps needs to be enabled. This can be done by enabling `Developer Options > Sideload apps` or `Developer Options > Developer mode`. 
+
 ## To Build MSIX
 1. Make sure you've built the `Release` configuration of `powertoys.sln`
 2. Open `Developer PowerShell for VS`


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
The MSIX installer Readme is missing the step of enabling sideloaded apps under the Developer Options. Adding this to the Readme so that the steps can be followed without any errors.

Failing to enable Sideload apps/Developer mode results in this error:

    Add-AppxPackage : Deployment failed with HRESULT: 0x80073CFF, To install this application you need either a Windowsdeveloper license or a sideloading-enabled system.
    Deployment of package Microsoft.PowerToys_0.15.0.0_x64__8wekyb3d8bbwe with package origin Unknown failed because no valid license or sideloading policy could be applied. A developer license (http://go.microsoft.com/fwlink/?LinkId=233074) or enterprise sideloading configuration (http://go.microsoft.com/fwlink/?LinkId=231020) may be required.
    NOTE: For additional information, look for [ActivityId] 93449567-d863-0006-1e2f-529363d8d501 in the Event Log or use the command line Get-AppPackageLog -ActivityID 93449567-d863-0006-1e2f-529363d8d501

    At E:\Power_toys\PowerToys_master\installer\MSIX\msix_reinstall.ps1:9 char:1
    + Add-AppxPackage .\bin\PowerToys.msixbundle
    + ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (E:\Power_toys\P...Toys.msixbundle:String) [Add-AppxPackage], Exception
    + FullyQualifiedErrorId : DeploymentError,Microsoft.Windows.Appx.PackageManager.Commands.AddAppxPackageCommand"