### PR TITLE
Persist app zone history in real time

### DIFF
--- a/src/modules/fancyzones/dll/dllmain.cpp
+++ b/src/modules/fancyzones/dll/dllmain.cpp
@@ -136,8 +136,6 @@ private:
     void Disable(bool const traceEvent)
     {
         if (m_app) {
-            const auto& fancyZonesData = JSONHelpers::FancyZonesDataInstance();
-            fancyZonesData.SaveFancyZonesData();
             if (traceEvent) 
             {
                 Trace::FancyZones::EnableFancyZones(false);

--- a/src/modules/fancyzones/lib/JsonHelpers.cpp
+++ b/src/modules/fancyzones/lib/JsonHelpers.cpp
@@ -631,7 +631,6 @@ namespace JSONHelpers
                     abort(); // TODO(stefan): Exception safety
                 }
                 customZoneSetsMap[uuid] = zoneSetData;
-                SaveFancyZonesData();
 
                 valueLength = ARRAYSIZE(value);
                 dataSize = ARRAYSIZE(data);

--- a/src/modules/fancyzones/lib/JsonHelpers.cpp
+++ b/src/modules/fancyzones/lib/JsonHelpers.cpp
@@ -207,6 +207,7 @@ namespace JSONHelpers
                 if (data.zoneSetUuid == zoneSetId && data.deviceId == deviceId)
                 {
                     appZoneHistoryMap.erase(processPath);
+                    SaveFancyZonesData();
                     return true;
                 }
             }
@@ -224,6 +225,7 @@ namespace JSONHelpers
         }
 
         appZoneHistoryMap[processPath] = AppZoneHistoryData{ .zoneSetUuid = zoneSetId, .deviceId = deviceId, .zoneIndex = zoneIndex };
+        SaveFancyZonesData();
         return true;
     }
 
@@ -538,6 +540,7 @@ namespace JSONHelpers
         if (appliedZoneSetsMap.contains(std::wstring{ activeZoneSetId }))
         {
             deviceInfoMap[deviceId] = DeviceInfoData{ appliedZoneSetsMap.at(std::wstring{ activeZoneSetId }), static_cast<bool>(showSpacing), static_cast<int>(spacing), static_cast<int>(zoneCount) };
+            SaveFancyZonesData();
         }
     }
 
@@ -628,6 +631,7 @@ namespace JSONHelpers
                     abort(); // TODO(stefan): Exception safety
                 }
                 customZoneSetsMap[uuid] = zoneSetData;
+                SaveFancyZonesData();
 
                 valueLength = ARRAYSIZE(value);
                 dataSize = ARRAYSIZE(data);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Settings with app history, device info and custom zonesets are saved every time changes are performed. 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #1253
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [] Requires documentation to be updated
* [] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
manual testing