### PR TITLE
Fix crash when saving any module settings while module being disabled

### DIFF
--- a/src/modules/fancyzones/dll/dllmain.cpp
+++ b/src/modules/fancyzones/dll/dllmain.cpp
@@ -60,20 +60,14 @@ public:
     // This is called when the user hits Save on the settings page.
     virtual void set_config(PCWSTR config) override
     {
-        if (m_app)
-        {
-            m_settings->SetConfig(config);
-        }
+        m_settings->SetConfig(config);
     }
 
     // Signal from the Settings editor to call a custom action.
     // This can be used to spawn more complex editors.
     virtual void call_custom_action(const wchar_t* action) override
     {
-        if (m_app)
-        {
-            m_settings->CallCustomAction(action);
-        }
+        m_settings->CallCustomAction(action);
     }
 
     // Enable the powertoy
@@ -150,6 +144,7 @@ private:
             }
             m_app->Destroy();
             m_app = nullptr;
+            m_settings->ResetCallback();
         }
     }
 

--- a/src/modules/fancyzones/dll/dllmain.cpp
+++ b/src/modules/fancyzones/dll/dllmain.cpp
@@ -60,14 +60,20 @@ public:
     // This is called when the user hits Save on the settings page.
     virtual void set_config(PCWSTR config) override
     {
-        m_settings->SetConfig(config);
+        if (m_app)
+        {
+            m_settings->SetConfig(config);
+        }
     }
 
     // Signal from the Settings editor to call a custom action.
     // This can be used to spawn more complex editors.
     virtual void call_custom_action(const wchar_t* action) override
     {
-        m_settings->CallCustomAction(action);
+        if (m_app)
+        {
+            m_settings->CallCustomAction(action);
+        }
     }
 
     // Enable the powertoy

--- a/src/modules/fancyzones/lib/Settings.cpp
+++ b/src/modules/fancyzones/lib/Settings.cpp
@@ -15,6 +15,7 @@ public:
     }
     
     IFACEMETHODIMP_(void) SetCallback(IFancyZonesCallback* callback) { m_callback = callback; }
+    IFACEMETHOD_(void, ResetCallback)() { m_callback = nullptr; }
     IFACEMETHODIMP_(bool) GetConfig(_Out_ PWSTR buffer, _Out_ int *buffer_sizeg) noexcept;
     IFACEMETHODIMP_(void) SetConfig(PCWSTR config) noexcept;
     IFACEMETHODIMP_(void) CallCustomAction(PCWSTR action) noexcept;

--- a/src/modules/fancyzones/lib/Settings.cpp
+++ b/src/modules/fancyzones/lib/Settings.cpp
@@ -15,7 +15,7 @@ public:
     }
     
     IFACEMETHODIMP_(void) SetCallback(IFancyZonesCallback* callback) { m_callback = callback; }
-    IFACEMETHOD_(void, ResetCallback)() { m_callback = nullptr; }
+    IFACEMETHODIMP_(void) ResetCallback() { m_callback = nullptr; }
     IFACEMETHODIMP_(bool) GetConfig(_Out_ PWSTR buffer, _Out_ int *buffer_sizeg) noexcept;
     IFACEMETHODIMP_(void) SetConfig(PCWSTR config) noexcept;
     IFACEMETHODIMP_(void) CallCustomAction(PCWSTR action) noexcept;

--- a/src/modules/fancyzones/lib/Settings.h
+++ b/src/modules/fancyzones/lib/Settings.h
@@ -24,6 +24,7 @@ struct Settings
 interface __declspec(uuid("{BA4E77C4-6F44-4C5D-93D3-CBDE880495C2}")) IFancyZonesSettings : public IUnknown
 {
     IFACEMETHOD_(void, SetCallback)(interface IFancyZonesCallback* callback) = 0;
+    IFACEMETHOD_(void, ResetCallback)() = 0;
     IFACEMETHOD_(bool, GetConfig)(_Out_ PWSTR buffer, _Out_ int *buffer_size) = 0;
     IFACEMETHOD_(void, SetConfig)(PCWSTR serializedPowerToysSettingsJson) = 0;
     IFACEMETHOD_(void, CallCustomAction)(PCWSTR action) = 0;

--- a/src/modules/powerrename/dll/dllmain.cpp
+++ b/src/modules/powerrename/dll/dllmain.cpp
@@ -246,21 +246,24 @@ public:
     // This is called when the user hits Save on the settings page.
     virtual void set_config(PCWSTR config) override
     {
-        try
+        if (m_enabled)
         {
-            // Parse the input JSON string.
-            PowerToysSettings::PowerToyValues values =
-                PowerToysSettings::PowerToyValues::from_json_string(config);
+            try
+            {
+                // Parse the input JSON string.
+                PowerToysSettings::PowerToyValues values =
+                    PowerToysSettings::PowerToyValues::from_json_string(config);
 
-            CSettings::SetPersistState(values.get_bool_value(L"bool_persist_input").value());
-            CSettings::SetMRUEnabled(values.get_bool_value(L"bool_mru_enabled").value());
-            CSettings::SetMaxMRUSize(values.get_int_value(L"int_max_mru_size").value());
-            CSettings::SetShowIconOnMenu(values.get_bool_value(L"bool_show_icon_on_menu").value());
-            CSettings::SetExtendedContextMenuOnly(values.get_bool_value(L"bool_show_extended_menu").value());
-        }
-        catch (std::exception)
-        {
-            // Improper JSON.
+                CSettings::SetPersistState(values.get_bool_value(L"bool_persist_input").value());
+                CSettings::SetMRUEnabled(values.get_bool_value(L"bool_mru_enabled").value());
+                CSettings::SetMaxMRUSize(values.get_int_value(L"int_max_mru_size").value());
+                CSettings::SetShowIconOnMenu(values.get_bool_value(L"bool_show_icon_on_menu").value());
+                CSettings::SetExtendedContextMenuOnly(values.get_bool_value(L"bool_show_extended_menu").value());
+            }
+            catch (std::exception)
+            {
+                // Improper JSON.
+            }
         }
     }
 

--- a/src/modules/powerrename/dll/dllmain.cpp
+++ b/src/modules/powerrename/dll/dllmain.cpp
@@ -246,24 +246,21 @@ public:
     // This is called when the user hits Save on the settings page.
     virtual void set_config(PCWSTR config) override
     {
-        if (m_enabled)
+        try
         {
-            try
-            {
-                // Parse the input JSON string.
-                PowerToysSettings::PowerToyValues values =
-                    PowerToysSettings::PowerToyValues::from_json_string(config);
+            // Parse the input JSON string.
+            PowerToysSettings::PowerToyValues values =
+                PowerToysSettings::PowerToyValues::from_json_string(config);
 
-                CSettings::SetPersistState(values.get_bool_value(L"bool_persist_input").value());
-                CSettings::SetMRUEnabled(values.get_bool_value(L"bool_mru_enabled").value());
-                CSettings::SetMaxMRUSize(values.get_int_value(L"int_max_mru_size").value());
-                CSettings::SetShowIconOnMenu(values.get_bool_value(L"bool_show_icon_on_menu").value());
-                CSettings::SetExtendedContextMenuOnly(values.get_bool_value(L"bool_show_extended_menu").value());
-            }
-            catch (std::exception)
-            {
-                // Improper JSON.
-            }
+            CSettings::SetPersistState(values.get_bool_value(L"bool_persist_input").value());
+            CSettings::SetMRUEnabled(values.get_bool_value(L"bool_mru_enabled").value());
+            CSettings::SetMaxMRUSize(values.get_int_value(L"int_max_mru_size").value());
+            CSettings::SetShowIconOnMenu(values.get_bool_value(L"bool_show_icon_on_menu").value());
+            CSettings::SetExtendedContextMenuOnly(values.get_bool_value(L"bool_show_extended_menu").value());
+        }
+        catch (std::exception)
+        {
+            // Improper JSON.
         }
     }
 

--- a/src/modules/shortcut_guide/shortcut_guide.cpp
+++ b/src/modules/shortcut_guide/shortcut_guide.cpp
@@ -104,7 +104,6 @@ void OverlayWindow::set_config(const wchar_t* config)
     catch (...)
     {
         // Improper JSON. TODO: handle the error.
-        return;
     }
 }
 

--- a/src/modules/shortcut_guide/shortcut_guide.cpp
+++ b/src/modules/shortcut_guide/shortcut_guide.cpp
@@ -64,12 +64,17 @@ bool OverlayWindow::get_config(wchar_t* buffer, int* buffer_size)
 
 void OverlayWindow::set_config(const wchar_t* config)
 {
-    if (_enabled)
+    try
     {
-        try
+        // save configuration
+        PowerToysSettings::PowerToyValues _values =
+            PowerToysSettings::PowerToyValues::from_json_string(config);
+        _values.save_to_settings_file();
+        Trace::SettingsChanged(pressTime.value, overlayOpacity.value, theme.value);
+
+        // apply new settings if powertoy is enabled
+        if (_enabled)
         {
-            PowerToysSettings::PowerToyValues _values =
-                PowerToysSettings::PowerToyValues::from_json_string(config);
             if (const auto press_delay_time = _values.get_int_value(pressTime.name))
             {
                 pressTime.value = *press_delay_time;
@@ -94,13 +99,12 @@ void OverlayWindow::set_config(const wchar_t* config)
                     winkey_popup->set_theme(theme.value);
                 }
             }
-            _values.save_to_settings_file();
-            Trace::SettingsChanged(pressTime.value, overlayOpacity.value, theme.value);
         }
-        catch (...)
-        {
-            // Improper JSON. TODO: handle the error.
-        }
+    }
+    catch (...)
+    {
+        // Improper JSON. TODO: handle the error.
+        return;
     }
 }
 

--- a/src/modules/shortcut_guide/shortcut_guide.cpp
+++ b/src/modules/shortcut_guide/shortcut_guide.cpp
@@ -87,7 +87,10 @@ void OverlayWindow::set_config(const wchar_t* config)
         if (auto val = _values.get_string_value(theme.name))
         {
             theme.value = std::move(*val);
-            winkey_popup->set_theme(theme.value);
+            if (winkey_popup)
+            {
+                winkey_popup->set_theme(theme.value);
+            }
         }
         _values.save_to_settings_file();
         Trace::SettingsChanged(pressTime.value, overlayOpacity.value, theme.value);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
After powertoy module is disabled we need to make sure that no crash occurs when user tries to change settings of disabled powertoy.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #1250

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
1. Disable any of the available powertoys.
2. Change settings of disabled powertoy.

Expected result: Nothing happens (no crash occurs).