### PR TITLE
SendInput hack to workaround the SetForegroundWindow bug (Issue 1039 #2)

### DIFF
--- a/installer/MSIX/reinstall_msix.ps1
+++ b/installer/MSIX/reinstall_msix.ps1
@@ -1,8 +1,7 @@
-taskkill /f /im explorer.exe
+taskkill /f /im PowerRenameUWPUI.exe
 
 .\uninstall_msix.ps1
 .\build_msix.ps1
 .\sign_msix.ps1
 .\install_msix.ps1
 
-start $Env:windir\explorer.exe

--- a/src/modules/powerrename/ui/PowerRenameUI.cpp
+++ b/src/modules/powerrename/ui/PowerRenameUI.cpp
@@ -6,6 +6,7 @@
 #include <helpers.h>
 #include <settings.h>
 #include <windowsx.h>
+#include <thread>
 #include <trace.h>
 
 extern HINSTANCE g_hInst;
@@ -512,6 +513,12 @@ HRESULT CPowerRenameUI::_DoModal(__in_opt HWND hwnd)
     }
     return hr;
 }
+void CPowerRenameUI::BecomeForegroundWindow()
+{
+    static INPUT i = {INPUT_MOUSE, {}};
+    SendInput(1, &i, sizeof(i));
+    SetForegroundWindow(m_hwnd);
+}
 
 HRESULT CPowerRenameUI::_DoModeless(__in_opt HWND hwnd)
 {
@@ -520,6 +527,7 @@ HRESULT CPowerRenameUI::_DoModeless(__in_opt HWND hwnd)
     if (NULL != CreateDialogParam(g_hInst, MAKEINTRESOURCE(IDD_MAIN), hwnd, s_DlgProc, (LPARAM)this))
     {
         ShowWindow(m_hwnd, SW_SHOWNORMAL);
+        BecomeForegroundWindow();
         MSG msg;
         while (GetMessage(&msg, NULL, 0, 0))
         {

--- a/src/modules/powerrename/ui/PowerRenameUI.h
+++ b/src/modules/powerrename/ui/PowerRenameUI.h
@@ -86,6 +86,7 @@ private:
 
     HRESULT _DoModal(__in_opt HWND hwnd);
     HRESULT _DoModeless(__in_opt HWND hwnd);
+    void BecomeForegroundWindow();
 
     static INT_PTR CALLBACK s_DlgProc(HWND hdlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
     {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
- Use `AttachThreadInput` to be able to workaround the `SetForegroundWindow` bug. More info is in the issue. The same fix could be also applied to ImageResizer and other context menu tools.
- Do not kill explorer for MSIX (separate commit)
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #1039

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
[As described by Raymond Chen](https://devblogs.microsoft.com/oldnewthing/?p=94745), the main issue with attaching the input queue of another application, is that our thread could hang with the application we've attached to. To aid testing, I've developed a small test application which works in tandem with PowerRenameExt:
- it locks a named mutex when launched
- PowerRenameExt waits for this mutex to be unlocked until I've pressed a button in small application window: it stops the message pump loop (now we've "stopped responding") and unlocks the mutex. Pressing the button also brings the test app to the foreground.
- PowerRenameExt attaches itself to the foreground thread from a different thread, which is killed after 10 seconds in case of hanging.

Actually, I've observed that even though I didn't process intentionally any messages in the test app, PowerRename didn't hang. Even though, we create a separate thread just in case. In the worst case scenario, we'll just remain in the background.