### PR TITLE
Fixed multi-monitor scaling bug

### DIFF
--- a/src/modules/fancyzones/lib/Zone.cpp
+++ b/src/modules/fancyzones/lib/Zone.cpp
@@ -115,6 +115,9 @@ void Zone::SizeWindowToZone(HWND window, HWND zoneWindow) noexcept
         placement.showCmd = SW_RESTORE | SW_SHOWNA;
     }
     ::SetWindowPlacement(window, &placement);
+    // Do it again, allowing Windows to resize the window and set correct scaling
+    // This fixes Issue #365
+    ::SetWindowPlacement(window, &placement);
 }
 
 void Zone::StampZone(HWND window, bool stamp) noexcept


### PR DESCRIPTION
Fixed an issue (#365) where a window gets resized after it gets dropped into a zone.

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This was tested manually in the same scenario described in the issue.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [] Applies to #365 
* [] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [] Tests added/passed
* [] Requires documentation to be updated
* [] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Tested manually and compared to the version without this commit. I verified that calling the API twice doesn't have side effects on regular windows that snap correctly the first time.
