### PR TITLE
Fix: Creating too many zones causes a crash

### DIFF
--- a/src/modules/fancyzones/lib/ZoneSet.cpp
+++ b/src/modules/fancyzones/lib/ZoneSet.cpp
@@ -551,8 +551,8 @@ bool ZoneSet::CalculateGridZones(Rect workArea, JSONHelpers::GridLayoutInfo grid
         long Start;
         long End;
     };
-    Info rowInfo[JSONHelpers::MAX_ZONE_COUNT];
-    Info columnInfo[JSONHelpers::MAX_ZONE_COUNT];
+    std::vector<Info> rowInfo(gridLayoutInfo.rows());
+    std::vector<Info> columnInfo(gridLayoutInfo.columns());
 
     long top = spacing;
     for (int row = 0; row < gridLayoutInfo.rows(); row++)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This fixes #1336 

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [] Applies to #1336 
* [] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [] Tests added/passed
* [] Requires documentation to be updated
* [] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Tested by creating ~100 zones using the GridEditor, clicked "Apply/Save" and everything works.
