### PR TITLE
Swallow shift keyboard event when dragging window

### DIFF
--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -374,6 +374,10 @@ FancyZones::OnKeyDown(PKBDLLHOOKSTRUCT info) noexcept
         CycleActiveZoneSet(info->vkCode);
         return false;
     }
+    if (m_dragEnabled && shift)
+    {
+        return true;
+    }
     return false;
 }
 
@@ -654,6 +658,7 @@ void FancyZones::AddZoneWindow(HMONITOR monitor, PCWSTR deviceId) noexcept
         {
             m_zoneWindowMap[monitor] = std::move(zoneWindow);
         }
+
         if (newWorkArea)
         {
             RegisterNewWorkArea(m_currentVirtualDesktopId, monitor);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Don't pass SHIFT keyboard press to other applications in chain when dragging window (and shift+drag option enabled in PowerToys).

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #1141

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
1. Turn on FancyZones setting: _Hold Shift key or any non-primary mouse button to enable zones while dragging_
2. Open Google Chrome.
3. Press shift key and drag on of the opened tabs outside of main window.

Expected result: Zone hints are displayed and tab can be taken out of the main window and put to certain zone.