### PR TITLE
Change Windows Store to Microsoft Store in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The latest release of PowerToys can be downloaded currently a few different ways
 The preview of these utilities can be installed from the [PowerToys GitHub releases page](https://github.com/Microsoft/powertoys/releases). Click on `Assets` to show the files available in the release and then click on `PowerToysSetup.msi` to download the PowerToys installer. <br />
 PDB symbols for the release are available in a separate zip file `PDB symbols.zip`.
 
-### Windows Store
+### Microsoft Store
 
 On backlog, [Issue #413](https://github.com/microsoft/PowerToys/issues/413) 
 


### PR DESCRIPTION
## Summary of the Pull Request
The Windows Store was renamed to the Microsoft Store back in 2017, best to keep things up-to-date to avoid potential confusion.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] CLA signed.
