### PR TITLE
Secure acces from multiple threads to JSONHelpers (add missing lock)

### DIFF
--- a/src/modules/fancyzones/lib/JsonHelpers.cpp
+++ b/src/modules/fancyzones/lib/JsonHelpers.cpp
@@ -186,6 +186,7 @@ namespace JSONHelpers
 
     bool FancyZonesData::RemoveDevicesByVirtualDesktopId(const std::wstring& virtualDesktopId)
     {
+        std::scoped_lock lock{ dataLock };
         if (virtualDesktopId == DEFAULT_GUID)
         {
             return false;


### PR DESCRIPTION
Improvement: We were missing mutex guard inside `RemoveDevicesByVirtualDesktopId`.