### PR TITLE
Fix for msi not loading on visual studio

### DIFF
--- a/installer/PowerToysSetup/PowerToysSetup.wixproj
+++ b/installer/PowerToysSetup/PowerToysSetup.wixproj
@@ -58,7 +58,11 @@
   <ItemGroup>
     <Content Include="packages.config" />
   </ItemGroup>
-  <Import Project="$(WixTargetsPath)" />
+  <Import Project="$(WixTargetsPath)" Condition=" '$(WixTargetsPath)' != '' " />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets" Condition=" '$(WixTargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets') " />
+  <Target Name="EnsureWixToolsetInstalled" Condition=" '$(WixTargetsImported)' != 'true' ">
+    <Error Text="The WiX Toolset v3 build tools must be installed to build this project. To download the WiX Toolset, see http://wixtoolset.org/releases/" />
+  </Target>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>

--- a/installer/PowerToysSetup/Product.wxs
+++ b/installer/PowerToysSetup/Product.wxs
@@ -202,7 +202,7 @@
       <Component Id="powertoys_exe" Guid="A2C66D91-3485-4D00-B04D-91844E6B345B" Win64="yes">
         <File Id="PowerToys.exe" KeyPath="yes" Checksum="yes">
           <Shortcut Id="ApplicationStartMenuShortcut"
-                    Name="PowerToys"
+                    Name="PowerToys (Preview)"
                     Description="PowerToys - Windows system utilities to maximize productivity"
                     Directory="ApplicationProgramsFolder"
                     WorkingDirectory="INSTALLFOLDER"
@@ -292,7 +292,7 @@
                         Value="1"
                         KeyPath="yes"/>
         <Shortcut Id="DesktopShortcutId"
-                  Name="PowerToys"
+                  Name="PowerToys (Preview)"
                   Description="PowerToys - Windows system utilities to maximize productivity"
                   Target="[!PowerToys.exe]"
                   WorkingDirectory="INSTALLFOLDER"


### PR DESCRIPTION
couldn't get it to load, based on an email from @enricogior and @betsegaw this seemed to fix it

note this is for 0.16