### PR TITLE
add (Preview) for MSI product name

### DIFF
--- a/installer/PowerToysSetup/Product.wxs
+++ b/installer/PowerToysSetup/Product.wxs
@@ -6,7 +6,7 @@
   <?define RepoDir="$(var.ProjectDir)..\..\" ?>
   <?define BinX64Dir="$(var.RepoDir)x64\$(var.Configuration)\" ?>
   <Product Id="*"
-       Name="PowerToys"
+       Name="PowerToys (Preview)"
        Language="1033"
        Version="0.15.0"
        Manufacturer="Microsoft"


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
We have "(Preview)" suffix for MSI PT icon now, but not for the application, e.g. in App & features page:
![image](https://user-images.githubusercontent.com/1828123/75526672-423ef980-5a23-11ea-821f-9a16075272ea.png).

[`Product`](https://wixtoolset.org/documentation/manual/v3/xsd/wix/product.html) element's `Name` attribute is responsible for that and should be safe to change.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #1383

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- installed v0.14 MSI, then v0.15 and verified that upgrade works

## Screenshot
![image](https://user-images.githubusercontent.com/1828123/75527168-e0cb5a80-5a23-11ea-8591-77f28072b00c.png)
