### PR TITLE
Skip cloning device information from parent virtual desktop if it is deleted

### DIFF
--- a/src/modules/fancyzones/lib/JsonHelpers.cpp
+++ b/src/modules/fancyzones/lib/JsonHelpers.cpp
@@ -209,7 +209,18 @@ namespace JSONHelpers
 
     void FancyZonesData::CloneDeviceInfo(const std::wstring& source, const std::wstring& destination)
     {
+        if (source == destination)
+        {
+            return;
+        }
         std::scoped_lock lock{ dataLock };
+
+        // The source virtual desktop is deleted, simply ignore it.
+        if (!deviceInfoMap.contains(source))
+        {
+            return;
+        }
+
         // Clone information from source device if destination device is uninitialized (Blank).
         auto& destInfo = deviceInfoMap[destination];
         if (destInfo.activeZoneSet.type == ZoneSetLayoutType::Blank)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Once new virtual desktop is created, or when switching back and forth through virtual desktops, new desktop tries to inherit zone layout from his logical parent. If parent virtual desktop is deleted and it had no zone layout assigned, this could cause an issue of inheriting faulty data. Faulty data could cause that `FancyZones` Editor won't open.
We need to avoid copying data from parent virtual desktop if it's deleted in the meantime.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #1414

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
1. Multi monitor scenario.
2. Set zone layout on one monitor.
3. Create new virtual desktop.
4. Set different layout on the new virtual desktop (for monitor in step 2).
5. Delete that virtual desktop (automatically navigate back to main desktop).
6. Open `FancyZones` Editor on monitor which had no active zone layout.

Expected result: Editor opens properly, and since no there was no layout active, `Focus` with 3 zones are displayed by default.
