### PR TITLE
Remove unused check for pClassFactory

### DIFF
--- a/src/modules/powerrename/dll/dllmain.cpp
+++ b/src/modules/powerrename/dll/dllmain.cpp
@@ -123,9 +123,8 @@ STDAPI DllCanUnloadNow(void)
 STDAPI DllGetClassObject(_In_ REFCLSID clsid, _In_ REFIID riid, _Outptr_ void** ppv)
 {
     *ppv = NULL;
-    HRESULT hr = E_OUTOFMEMORY;
     CPowerRenameClassFactory* pClassFactory = new CPowerRenameClassFactory(clsid);
-    hr = pClassFactory->QueryInterface(riid, ppv);
+    HRESULT hr = pClassFactory->QueryInterface(riid, ppv);
     pClassFactory->Release();
     return hr;
 }

--- a/src/modules/powerrename/dll/dllmain.cpp
+++ b/src/modules/powerrename/dll/dllmain.cpp
@@ -59,16 +59,13 @@ public:
         {
             hr = CLASS_E_NOAGGREGATION;
         }
+        else if (m_clsid == CLSID_PowerRenameMenu)
+        {
+            hr = CPowerRenameMenu::s_CreateInstance(punkOuter, riid, ppv);
+        }
         else
         {
-            if (m_clsid == CLSID_PowerRenameMenu)
-            {
-                hr = CPowerRenameMenu::s_CreateInstance(punkOuter, riid, ppv);
-            }
-            else
-            {
-                hr = CLASS_E_CLASSNOTAVAILABLE;
-            }
+            hr = CLASS_E_CLASSNOTAVAILABLE;
         }
         return hr;
     }
@@ -128,11 +125,8 @@ STDAPI DllGetClassObject(_In_ REFCLSID clsid, _In_ REFIID riid, _Outptr_ void** 
     *ppv = NULL;
     HRESULT hr = E_OUTOFMEMORY;
     CPowerRenameClassFactory* pClassFactory = new CPowerRenameClassFactory(clsid);
-    if (pClassFactory)
-    {
-        hr = pClassFactory->QueryInterface(riid, ppv);
-        pClassFactory->Release();
-    }
+    hr = pClassFactory->QueryInterface(riid, ppv);
+    pClassFactory->Release();
     return hr;
 }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
pClassFactory is always created as per the "new" statement in C++. Why are we checking for the object then?

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Removed unneeded check

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manual
Automated