### PR TITLE
Fix migrating never applied custom zonesets

### DIFF
--- a/src/modules/fancyzones/lib/JsonHelpers.cpp
+++ b/src/modules/fancyzones/lib/JsonHelpers.cpp
@@ -626,6 +626,21 @@ namespace JSONHelpers
                 {
                     it->second.uuid = uuid = it->first;
                 }
+                else
+                {
+                    GUID guid;
+                    auto result = CoCreateGuid(&guid);
+                    if (result != S_OK)
+                    {
+                        return;
+                    }
+                    wil::unique_cotaskmem_string guidString;
+                    if (SUCCEEDED_LOG(StringFromCLSID(guid, &guidString)))
+                    {
+                        it->second.uuid = uuid = guidString.get();
+                    }
+                }
+
                 switch (zoneSetData.type)
                 {
                 case CustomLayoutType::Grid: {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
This fixes migration of never applied custom layout from registry (e.g. custom layout with 0 zones)


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [] Applies to #1422 
