### PR TITLE
MSIX: Fix for foreground issue for ImageResizer

### DIFF
--- a/src/modules/imageresizer/ui/App.xaml.cs
+++ b/src/modules/imageresizer/ui/App.xaml.cs
@@ -8,6 +8,7 @@ using System.Windows;
 using GalaSoft.MvvmLight.Threading;
 using ImageResizer.Models;
 using ImageResizer.Properties;
+using ImageResizer.Utilities;
 using ImageResizer.ViewModels;
 using ImageResizer.Views;
 
@@ -26,7 +27,19 @@ namespace ImageResizer
             var batch = ResizeBatch.FromCommandLine(Console.In, e.Args);
 
             // TODO: Add command-line parameters that can be used in lieu of the input page (issue #14)
-            new MainWindow(new MainViewModel(batch, Settings.Default)).Show();
+            var mainWindow = new MainWindow(new MainViewModel(batch, Settings.Default));
+            mainWindow.Show();
+
+            // Temporary workaround for issue #1273
+            BecomeForegroundWindow(new System.Windows.Interop.WindowInteropHelper(mainWindow).Handle);
+        }
+
+        private void BecomeForegroundWindow(IntPtr hWnd)
+        {
+            Win32Helpers.INPUT input = new Win32Helpers.INPUT { type = Win32Helpers.INPUTTYPE.INPUT_MOUSE, data = { } };
+            Win32Helpers.INPUT[] inputs = new Win32Helpers.INPUT[] { input };
+            Win32Helpers.SendInput(1, inputs, Win32Helpers.INPUT.Size);
+            Win32Helpers.SetForegroundWindow(hWnd);
         }
     }
 }

--- a/src/modules/imageresizer/ui/ImageResizerUI.csproj
+++ b/src/modules/imageresizer/ui/ImageResizerUI.csproj
@@ -71,6 +71,7 @@
     <Compile Include="Models\ResizeSize.cs" />
     <Compile Include="Models\ResizeUnit.cs" />
     <Compile Include="Utilities\MathHelpers.cs" />
+    <Compile Include="Utilities\Win32Helpers.cs" />
     <Compile Include="ViewModels\AdvancedViewModel.cs" />
     <Compile Include="ViewModels\InputViewModel.cs" />
     <Compile Include="ViewModels\ITabViewModel.cs" />

--- a/src/modules/imageresizer/ui/Utilities/Win32Helpers.cs
+++ b/src/modules/imageresizer/ui/Utilities/Win32Helpers.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+[module: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1636:FileHeaderCopyrightTextMustMatch", Justification = "File created under PowerToys.")]
+
+namespace ImageResizer.Utilities
+{
+    // Win32 functions required for temporary workaround for issue #1273
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1307:Accessible fields should begin with upper-case letter", Justification = "Naming used in Win32 dll")]
+    internal class Win32Helpers
+    {
+        [DllImport("user32.dll")]
+        internal static extern bool SetForegroundWindow(IntPtr hWnd);
+
+        [DllImport("user32.dll")]
+        internal static extern uint SendInput(uint nInputs, INPUT[] pInputs, int cbSize);
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct INPUT
+        {
+            internal INPUTTYPE type;
+            internal InputUnion data;
+
+            internal static int Size
+            {
+                get { return Marshal.SizeOf(typeof(INPUT)); }
+            }
+        }
+
+        [StructLayout(LayoutKind.Explicit)]
+        internal struct InputUnion
+        {
+            [FieldOffset(0)]
+            internal MOUSEINPUT mi;
+            [FieldOffset(0)]
+            internal KEYBDINPUT ki;
+            [FieldOffset(0)]
+            internal HARDWAREINPUT hi;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct MOUSEINPUT
+        {
+            internal int dx;
+            internal int dy;
+            internal int mouseData;
+            internal uint dwFlags;
+            internal uint time;
+            internal UIntPtr dwExtraInfo;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct KEYBDINPUT
+        {
+            internal short wVk;
+            internal short wScan;
+            internal uint dwFlags;
+            internal int time;
+            internal UIntPtr dwExtraInfo;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct HARDWAREINPUT
+        {
+            internal int uMsg;
+            internal short wParamL;
+            internal short wParamH;
+        }
+
+        internal enum INPUTTYPE : uint
+        {
+            INPUT_MOUSE = 0,
+            INPUT_KEYBOARD = 1,
+            INPUT_HARDWARE = 2,
+        }
+    }
+}


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Implemented the fix for the foreground issue (#1273) using the same approach that @yuyoyuppe used in #1282, however in case of ImageResizer the UI is in WPF so it required using the Win32 functions from user32.dll. For this a Win32Helpers.cs file was added which contains the win32 functions required for this fix.
Also added a comment to cross reference the code with this issue so that it can be removed later once resolved externally.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Applies to #1273 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [X] Tests passed

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Build Release x64 and install the MSIX build.
- It was harder to verify that the fix works for ImageResizer as earlier the issue what happen sometimes but not always like how PowerRename did. This was probably because ImageResizer was launched in a separate process using its executable from the Shell Extension. 
- I tried right-click launching resize pictures >10 times and all those times it was in the foreground. The best case which can be used to reproduce the issue in the original code is to open a file explorer window across two monitors with a larger part in the second monitor (so it appears in the taskbar of the second monitor) and then open the context menu. This had a higher chance of replicating the issue.
