### PR TITLE
Adding MSI Installation for Preview Handler

### DIFF
--- a/installer/PowerToysSetup/Product.wxs
+++ b/installer/PowerToysSetup/Product.wxs
@@ -254,6 +254,75 @@
             <RegistryValue Type="string" Value="{0440049F-D1DC-4E46-B27B-98393D79486B}"/>
         </RegistryKey>
       </Component>
+      <Component Id="Module_PowerPreview" Guid="FF1700D5-1B07-4E07-9A62-4D206645EEA9" Win64="yes">
+        <File Source="$(var.BinX64Dir)\modules\powerpreview.dll" KeyPath="yes" />
+        <File Source="$(var.BinX64Dir)\modules\PreviewHandlerCommon.dll" />
+        <File Id="Svg_PreviewHandler_Dll" Source="$(var.BinX64Dir)\modules\SvgPreviewHandler.dll" />
+        <File Id="Md_PreviewHandler_Dll" Source="$(var.BinX64Dir)\modules\MarkdownPreviewHandler.dll" />
+        <File Source="$(var.BinX64Dir)\modules\Markdig.Signed.dll" />
+        <File Source="$(var.BinX64Dir)\modules\HtmlAgilityPack.dll" />
+      </Component>
+      <Component Id="Module_PowerPreview_PerUserRegistry" Guid="CD90ADC0-7CD5-4A62-B0AF-23545C1E6DD3" Win64="yes">
+        <!-- Added a separate component for Per-User registry changes -->
+        <!-- Registry Key for Class Registration of Svg Preview Handler -->
+        <RegistryKey Root="HKCU" Key="Software\Classes\CLSID\{ddee2b8a-6807-48a6-bb20-2338174ff779}">
+          <RegistryValue Type="string" Value="SvgPreviewHandler.SvgPreviewHandler" />
+          <RegistryValue Type="string" Name="DisplayName" Value="Svg Preview Handler" />
+          <RegistryValue Type="string" Name="AppID" Value="{CF142243-F059-45AF-8842-DBBE9783DB14}" />
+          <RegistryValue Type="string" Key="Implemented Categories\{62C8FE65-4EBB-45e7-B440-6E39B2CDBF29}" Value=""/>
+          <RegistryValue Type="string" Key="InprocServer32" Value="mscoree.dll" />
+          <RegistryValue Type="string" Key="InprocServer32" Name="Assembly" Value="SvgPreviewHandler, Version=1.0.0.0, Culture=neutral, PublicKeyToken=9bdcf6dae174efd3" />
+          <RegistryValue Type="string" Key="InprocServer32" Name="Class" Value="SvgPreviewHandler.SvgPreviewHandler" />
+          <RegistryValue Type="string" Key="InprocServer32" Name="RuntimeVersion" Value="v4.0.30319" />
+          <RegistryValue Type="string" Key="InprocServer32" Name="ThreadingModel" Value="Both" />
+          <RegistryValue Type="string" Key="InprocServer32" Name="CodeBase" Value="file:///[#Svg_PreviewHandler_Dll]" />
+          <RegistryValue Type="string" Key="InprocServer32\1.0.0.0" Name="Assembly" Value="SvgPreviewHandler, Version=1.0.0.0, Culture=neutral, PublicKeyToken=9bdcf6dae174efd3" />
+          <RegistryValue Type="string" Key="InprocServer32\1.0.0.0" Name="Class" Value="SvgPreviewHandler.SvgPreviewHandler" />
+          <RegistryValue Type="string" Key="InprocServer32\1.0.0.0" Name="RuntimeVersion" Value="v4.0.30319" />
+          <RegistryValue Type="string" Key="InprocServer32\1.0.0.0" Name="CodeBase" Value="file:///[#Svg_PreviewHandler_Dll]" />
+        </RegistryKey>
+        <!-- Registry Key for Class Registration of Markdown Preview Handler -->
+        <RegistryKey Root="HKCU" Key="Software\Classes\CLSID\{45769bcc-e8fd-42d0-947e-02beef77a1f5}">
+          <RegistryValue Type="string" Value="MarkdownPreviewHandler.MarkdownPreviewHandler" />
+          <RegistryValue Type="string" Name="DisplayName" Value="Markdown Preview Handler" />
+          <RegistryValue Type="string" Name="AppID" Value="{CF142243-F059-45AF-8842-DBBE9783DB14}" />
+          <RegistryValue Type="string" Key="Implemented Categories\{62C8FE65-4EBB-45e7-B440-6E39B2CDBF29}" Value="" />
+          <RegistryValue Type="string" Key="InprocServer32" Value="mscoree.dll" />
+          <RegistryValue Type="string" Key="InprocServer32" Name="Assembly" Value="MarkdownPreviewHandler, Version=1.0.0.0, Culture=neutral, PublicKeyToken=201d23296ab86a5a" />
+          <RegistryValue Type="string" Key="InprocServer32" Name="Class" Value="MarkdownPreviewHandler.MarkdownPreviewHandler" />
+          <RegistryValue Type="string" Key="InprocServer32" Name="RuntimeVersion" Value="v4.0.30319" />
+          <RegistryValue Type="string" Key="InprocServer32" Name="ThreadingModel" Value="Both" />
+          <RegistryValue Type="string" Key="InprocServer32" Name="CodeBase" Value="file:///[#Md_PreviewHandler_Dll]" />
+          <RegistryValue Type="string" Key="InprocServer32\1.0.0.0" Name="Assembly" Value="MarkdownPreviewHandler, Version=1.0.0.0, Culture=neutral, PublicKeyToken=201d23296ab86a5a" />
+          <RegistryValue Type="string" Key="InprocServer32\1.0.0.0" Name="Class" Value="MarkdownPreviewHandler.MarkdownPreviewHandler" />
+          <RegistryValue Type="string" Key="InprocServer32\1.0.0.0" Name="RuntimeVersion" Value="v4.0.30319" />
+          <RegistryValue Type="string" Key="InprocServer32\1.0.0.0" Name="CodeBase" Value="file:///[#Md_PreviewHandler_Dll]" />
+        </RegistryKey>
+        <!-- Registry Key for AppID registration -->
+        <RegistryKey Root="HKCU" Key="Software\Classes\AppID\{CF142243-F059-45AF-8842-DBBE9783DB14}">
+          <RegistryValue Type="expandable" Name="DllSurrogate" Value="%SystemRoot%\system32\prevhost.exe" />
+        </RegistryKey>
+        <!-- Add Svg preview handler to preview handlers list -->
+        <RegistryKey Root="HKCU" Key="SOFTWARE\Microsoft\Windows\CurrentVersion\PreviewHandlers">
+          <RegistryValue Type="string" Name="{ddee2b8a-6807-48a6-bb20-2338174ff779}" Value="Svg Preview Handler" />
+        </RegistryKey>
+        <!-- Add Markdown preview handler to preview handlers list -->
+        <RegistryKey Root="HKCU" Key="SOFTWARE\Microsoft\Windows\CurrentVersion\PreviewHandlers">
+          <RegistryValue Type="string" Name="{45769bcc-e8fd-42d0-947e-02beef77a1f5}" Value="Markdown Preview Handler" />
+        </RegistryKey>
+        <!-- Add file type association for Svg Preview Handler -->
+        <RegistryKey Root="HKCU" Key="Software\Classes\.svg\shellex">
+          <RegistryValue Type="string" Key="{8895b1c6-b41f-4c1c-a562-0d564250836f}" Value="{ddee2b8a-6807-48a6-bb20-2338174ff779}" />
+        </RegistryKey>
+        <!-- Add file type association for Markdown Preview Handler -->
+        <RegistryKey Root="HKCU" Key="Software\Classes\.md\shellex">
+          <RegistryValue Type="string" Key="{8895b1c6-b41f-4c1c-a562-0d564250836f}" Value="{45769bcc-e8fd-42d0-947e-02beef77a1f5}" />
+        </RegistryKey>
+        <!-- Update Key to use IE11 for prevhost.exe -->
+        <RegistryKey Root="HKCU" Key="Software\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_BROWSER_EMULATION">
+          <RegistryValue Type="integer" Name="prevhost.exe" Value="11000" />
+        </RegistryKey>
+      </Component>
     </DirectoryRef>
     <DirectoryRef Id="SettingsHtmlInstallFolder" FileSource="$(var.RepoDir)\settings\settings-html\">
       <Component Id="settings_html" Guid="87881A99-E917-4B0D-B1D8-5C6EB9709F96" Win64="yes">
@@ -298,6 +367,8 @@
       <ComponentRef Id="Module_FancyZones" />
       <ComponentRef Id="DesktopShortcut" />
       <ComponentRef Id="Module_PowerRename" />
+      <ComponentRef Id="Module_PowerPreview" />
+      <ComponentRef Id="Module_PowerPreview_PerUserRegistry" />
       <ComponentRef Id="settings_exe" />
       <ComponentRef Id="settings_html" />
       <ComponentRef Id="settings_dark_html" />

--- a/installer/PowerToysSetup/Product.wxs
+++ b/installer/PowerToysSetup/Product.wxs
@@ -265,7 +265,7 @@
       <Component Id="Module_PowerPreview_PerUserRegistry" Guid="CD90ADC0-7CD5-4A62-B0AF-23545C1E6DD3" Win64="yes">
         <!-- Added a separate component for Per-User registry changes -->
         <!-- Registry Key for Class Registration of Svg Preview Handler -->
-        <RegistryKey Root="HKCU" Key="Software\Classes\CLSID\{ddee2b8a-6807-48a6-bb20-2338174ff779}">
+        <RegistryKey Root="HKCU" Key="SOFTWARE\Classes\CLSID\{ddee2b8a-6807-48a6-bb20-2338174ff779}">
           <RegistryValue Type="string" Value="SvgPreviewHandler.SvgPreviewHandler" />
           <RegistryValue Type="string" Name="DisplayName" Value="Svg Preview Handler" />
           <RegistryValue Type="string" Name="AppID" Value="{CF142243-F059-45AF-8842-DBBE9783DB14}" />
@@ -282,7 +282,7 @@
           <RegistryValue Type="string" Key="InprocServer32\1.0.0.0" Name="CodeBase" Value="file:///[#Svg_PreviewHandler_Dll]" />
         </RegistryKey>
         <!-- Registry Key for Class Registration of Markdown Preview Handler -->
-        <RegistryKey Root="HKCU" Key="Software\Classes\CLSID\{45769bcc-e8fd-42d0-947e-02beef77a1f5}">
+        <RegistryKey Root="HKCU" Key="SOFTWARE\Classes\CLSID\{45769bcc-e8fd-42d0-947e-02beef77a1f5}">
           <RegistryValue Type="string" Value="MarkdownPreviewHandler.MarkdownPreviewHandler" />
           <RegistryValue Type="string" Name="DisplayName" Value="Markdown Preview Handler" />
           <RegistryValue Type="string" Name="AppID" Value="{CF142243-F059-45AF-8842-DBBE9783DB14}" />
@@ -299,7 +299,7 @@
           <RegistryValue Type="string" Key="InprocServer32\1.0.0.0" Name="CodeBase" Value="file:///[#Md_PreviewHandler_Dll]" />
         </RegistryKey>
         <!-- Registry Key for AppID registration -->
-        <RegistryKey Root="HKCU" Key="Software\Classes\AppID\{CF142243-F059-45AF-8842-DBBE9783DB14}">
+        <RegistryKey Root="HKCU" Key="SOFTWARE\Classes\AppID\{CF142243-F059-45AF-8842-DBBE9783DB14}">
           <RegistryValue Type="expandable" Name="DllSurrogate" Value="%SystemRoot%\system32\prevhost.exe" />
         </RegistryKey>
         <!-- Add Svg preview handler to preview handlers list -->
@@ -311,15 +311,15 @@
           <RegistryValue Type="string" Name="{45769bcc-e8fd-42d0-947e-02beef77a1f5}" Value="Markdown Preview Handler" />
         </RegistryKey>
         <!-- Add file type association for Svg Preview Handler -->
-        <RegistryKey Root="HKCU" Key="Software\Classes\.svg\shellex">
+        <RegistryKey Root="HKCU" Key="SOFTWARE\Classes\.svg\shellex">
           <RegistryValue Type="string" Key="{8895b1c6-b41f-4c1c-a562-0d564250836f}" Value="{ddee2b8a-6807-48a6-bb20-2338174ff779}" />
         </RegistryKey>
         <!-- Add file type association for Markdown Preview Handler -->
-        <RegistryKey Root="HKCU" Key="Software\Classes\.md\shellex">
+        <RegistryKey Root="HKCU" Key="SOFTWARE\Classes\.md\shellex">
           <RegistryValue Type="string" Key="{8895b1c6-b41f-4c1c-a562-0d564250836f}" Value="{45769bcc-e8fd-42d0-947e-02beef77a1f5}" />
         </RegistryKey>
         <!-- Update Key to use IE11 for prevhost.exe -->
-        <RegistryKey Root="HKCU" Key="Software\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_BROWSER_EMULATION">
+        <RegistryKey Root="HKCU" Key="SOFTWARE\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_BROWSER_EMULATION">
           <RegistryValue Type="integer" Name="prevhost.exe" Value="11000" />
         </RegistryKey>
       </Component>

--- a/installer/PowerToysSetup/Product.wxs
+++ b/installer/PowerToysSetup/Product.wxs
@@ -255,6 +255,7 @@
         </RegistryKey>
       </Component>
       <Component Id="Module_PowerPreview" Guid="FF1700D5-1B07-4E07-9A62-4D206645EEA9" Win64="yes">
+        <!-- Component to include PowerPreview Module Source dll's -->
         <File Source="$(var.BinX64Dir)\modules\powerpreview.dll" KeyPath="yes" />
         <File Source="$(var.BinX64Dir)\modules\PreviewHandlerCommon.dll" />
         <File Id="Svg_PreviewHandler_Dll" Source="$(var.BinX64Dir)\modules\SvgPreviewHandler.dll" />
@@ -265,7 +266,7 @@
       <Component Id="Module_PowerPreview_PerUserRegistry" Guid="CD90ADC0-7CD5-4A62-B0AF-23545C1E6DD3" Win64="yes">
         <!-- Added a separate component for Per-User registry changes -->
         <!-- Registry Key for Class Registration of Svg Preview Handler -->
-        <RegistryKey Root="HKCU" Key="SOFTWARE\Classes\CLSID\{ddee2b8a-6807-48a6-bb20-2338174ff779}">
+        <RegistryKey Root="HKCU" Key="Software\Classes\CLSID\{ddee2b8a-6807-48a6-bb20-2338174ff779}">
           <RegistryValue Type="string" Value="SvgPreviewHandler.SvgPreviewHandler" />
           <RegistryValue Type="string" Name="DisplayName" Value="Svg Preview Handler" />
           <RegistryValue Type="string" Name="AppID" Value="{CF142243-F059-45AF-8842-DBBE9783DB14}" />
@@ -282,7 +283,7 @@
           <RegistryValue Type="string" Key="InprocServer32\1.0.0.0" Name="CodeBase" Value="file:///[#Svg_PreviewHandler_Dll]" />
         </RegistryKey>
         <!-- Registry Key for Class Registration of Markdown Preview Handler -->
-        <RegistryKey Root="HKCU" Key="SOFTWARE\Classes\CLSID\{45769bcc-e8fd-42d0-947e-02beef77a1f5}">
+        <RegistryKey Root="HKCU" Key="Software\Classes\CLSID\{45769bcc-e8fd-42d0-947e-02beef77a1f5}">
           <RegistryValue Type="string" Value="MarkdownPreviewHandler.MarkdownPreviewHandler" />
           <RegistryValue Type="string" Name="DisplayName" Value="Markdown Preview Handler" />
           <RegistryValue Type="string" Name="AppID" Value="{CF142243-F059-45AF-8842-DBBE9783DB14}" />
@@ -299,27 +300,27 @@
           <RegistryValue Type="string" Key="InprocServer32\1.0.0.0" Name="CodeBase" Value="file:///[#Md_PreviewHandler_Dll]" />
         </RegistryKey>
         <!-- Registry Key for AppID registration -->
-        <RegistryKey Root="HKCU" Key="SOFTWARE\Classes\AppID\{CF142243-F059-45AF-8842-DBBE9783DB14}">
+        <RegistryKey Root="HKCU" Key="Software\Classes\AppID\{CF142243-F059-45AF-8842-DBBE9783DB14}">
           <RegistryValue Type="expandable" Name="DllSurrogate" Value="%SystemRoot%\system32\prevhost.exe" />
         </RegistryKey>
         <!-- Add Svg preview handler to preview handlers list -->
-        <RegistryKey Root="HKCU" Key="SOFTWARE\Microsoft\Windows\CurrentVersion\PreviewHandlers">
+        <RegistryKey Root="HKCU" Key="Software\Microsoft\Windows\CurrentVersion\PreviewHandlers">
           <RegistryValue Type="string" Name="{ddee2b8a-6807-48a6-bb20-2338174ff779}" Value="Svg Preview Handler" />
         </RegistryKey>
         <!-- Add Markdown preview handler to preview handlers list -->
-        <RegistryKey Root="HKCU" Key="SOFTWARE\Microsoft\Windows\CurrentVersion\PreviewHandlers">
+        <RegistryKey Root="HKCU" Key="Software\Microsoft\Windows\CurrentVersion\PreviewHandlers">
           <RegistryValue Type="string" Name="{45769bcc-e8fd-42d0-947e-02beef77a1f5}" Value="Markdown Preview Handler" />
         </RegistryKey>
         <!-- Add file type association for Svg Preview Handler -->
-        <RegistryKey Root="HKCU" Key="SOFTWARE\Classes\.svg\shellex">
+        <RegistryKey Root="HKCU" Key="Software\Classes\.svg\shellex">
           <RegistryValue Type="string" Key="{8895b1c6-b41f-4c1c-a562-0d564250836f}" Value="{ddee2b8a-6807-48a6-bb20-2338174ff779}" />
         </RegistryKey>
         <!-- Add file type association for Markdown Preview Handler -->
-        <RegistryKey Root="HKCU" Key="SOFTWARE\Classes\.md\shellex">
+        <RegistryKey Root="HKCU" Key="Software\Classes\.md\shellex">
           <RegistryValue Type="string" Key="{8895b1c6-b41f-4c1c-a562-0d564250836f}" Value="{45769bcc-e8fd-42d0-947e-02beef77a1f5}" />
         </RegistryKey>
         <!-- Update Key to use IE11 for prevhost.exe -->
-        <RegistryKey Root="HKCU" Key="SOFTWARE\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_BROWSER_EMULATION">
+        <RegistryKey Root="HKCU" Key="Software\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_BROWSER_EMULATION">
           <RegistryValue Type="integer" Name="prevhost.exe" Value="11000" />
         </RegistryKey>
       </Component>

--- a/installer/PowerToysSetup/Product.wxs
+++ b/installer/PowerToysSetup/Product.wxs
@@ -256,9 +256,13 @@
       </Component>
       <Component Id="Module_PowerPreview" Guid="FF1700D5-1B07-4E07-9A62-4D206645EEA9" Win64="yes">
         <!-- Component to include PowerPreview Module Source dll's -->
+        <!-- File to include PowerPreview Module native dll -->
         <File Source="$(var.BinX64Dir)\modules\powerpreview.dll" KeyPath="yes" />
+        <!-- File to include common library used by preview handlers -->
         <File Source="$(var.BinX64Dir)\modules\PreviewHandlerCommon.dll" />
+        <!-- File to include dll for Svg Preview Handler -->
         <File Id="Svg_PreviewHandler_Dll" Source="$(var.BinX64Dir)\modules\SvgPreviewHandler.dll" />
+        <!-- Files to include dll's for Markdown Preview Handler and it's dependencies -->
         <File Id="Md_PreviewHandler_Dll" Source="$(var.BinX64Dir)\modules\MarkdownPreviewHandler.dll" />
         <File Source="$(var.BinX64Dir)\modules\Markdig.Signed.dll" />
         <File Source="$(var.BinX64Dir)\modules\HtmlAgilityPack.dll" />


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Adding MSI installation support for Preview Handlers. Added all the registry changes required under `HKEY_CURRENT_USER`.  Used two separate `Component` for Preview Handler one for copying the dll and one for updating Registry under Current_User. Unable to do that in a single component [because of ICE57 error](https://docs.microsoft.com/en-us/windows/win32/msi/ice57).

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #963 

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
1. Installed and validated Preview Handlers with MSI.
