### PR TITLE
Fix ImageResizer startup location to center of the screen (dev/imageResizer)

### DIFF
--- a/src/modules/imageresizer/ui/Views/AdvancedWindow.xaml
+++ b/src/modules/imageresizer/ui/Views/AdvancedWindow.xaml
@@ -12,7 +12,8 @@
         ResizeMode="NoResize"
         SizeToContent="WidthAndHeight"
         Title="{x:Static p:Resources.Advanced_Title}"
-        WindowStyle="ToolWindow">
+        WindowStyle="ToolWindow"
+        WindowStartupLocation="CenterScreen">
 
     <Window.Resources>
         <ObjectDataProvider x:Key="PngInterlaceOptionValues"

--- a/src/modules/imageresizer/ui/Views/MainWindow.xaml
+++ b/src/modules/imageresizer/ui/Views/MainWindow.xaml
@@ -10,7 +10,8 @@
         Name="_this"
         ResizeMode="NoResize"
         SizeToContent="WidthAndHeight"
-        Title="{x:Static p:Resources.ImageResizer}">
+        Title="{x:Static p:Resources.ImageResizer}"
+        WindowStartupLocation="CenterScreen">
 
     <Window.Resources>
         <DataTemplate DataType="{x:Type vm:InputViewModel}">


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Set the WindowStartupLocation flag for both the Main Window and the settings window to CenterScreen. This also fixed the MSIX issue of launching only on the primary monitor (#1096) as [CenterScreen](https://docs.microsoft.com/en-us/dotnet/api/system.windows.windowstartuplocation?redirectedfrom=MSDN&view=netframework-4.8) sets the location to center of the screen which contains the mouse cursor. 

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
- https://stackoverflow.com/questions/1545258/changing-the-start-up-location-of-a-wpf-window

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Applies to #1435 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [X] Tests passed

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Installed and verified with MSIX and MSI.
