### PR TITLE
Call GC on preview unloading

### DIFF
--- a/src/modules/previewpane/common/controls/FormHandlerControl.cs
+++ b/src/modules/previewpane/common/controls/FormHandlerControl.cs
@@ -115,6 +115,7 @@ namespace Common
             // Call garbage collection at the time of unloading of Preview. This is to mitigate issue with WebBrowser Control not able to dispose properly.
             // Which is preventing prevhost.exe to exit at the time of closing File explorer.
             // Preview Handlers run in a separate process from PowerToys. This will not affect the performance of other modules.
+            // Mitigate the following Github issue: https://github.com/microsoft/PowerToys/issues/1468
             GC.Collect();
         }
 

--- a/src/modules/previewpane/common/controls/FormHandlerControl.cs
+++ b/src/modules/previewpane/common/controls/FormHandlerControl.cs
@@ -111,6 +111,11 @@ namespace Common
 
                 this.Controls.Clear();
             });
+
+            // Call garbage collection at the time of unloading of Preview. This is to mitigate issue with WebBrowser Control not able to dispose properly.
+            // Which is preventing prevhost.exe to exit at the time of closing File explorer.
+            // Preview Handlers run in a separate process from PowerToys. This will not affect the performance of other modules.
+            GC.Collect();
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Updated logic to call Garbage Collection on unloading of the preview to mitigate the issue with Web browser control not disposing properly and the `prevhost.exe` is not exiting on closing the File explorer.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #963 
* [x] Applies to #1468  

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Validated the PreviewHandlers with MSI installation. There are no significant effect on performance of loading a new preview. 
