### PR TITLE
Update Web browser control for Markdown Previewer

### DIFF
--- a/src/modules/previewpane/MarkdownPreviewHandler/MarkdownPreviewHandlerControl.cs
+++ b/src/modules/previewpane/MarkdownPreviewHandler/MarkdownPreviewHandlerControl.cs
@@ -12,6 +12,7 @@ using System.Windows.Forms;
 using Common;
 using Markdig;
 using MarkdownPreviewHandler.Properties;
+using PreviewHandlerCommon;
 
 namespace MarkdownPreviewHandler
 {
@@ -46,7 +47,7 @@ namespace MarkdownPreviewHandler
         private RichTextBox infoBar;
 
         /// <summary>
-        /// WebBrowser control to display markdown html.
+        /// Extended Browser Control to display markdown html.
         /// </summary>
         private WebBrowser browser;
 
@@ -85,7 +86,7 @@ namespace MarkdownPreviewHandler
                     MarkdownPipeline pipeline = this.pipelineBuilder.Build();
                     string parsedMarkdown = Markdown.ToHtml(fileText, pipeline);
                     sb.AppendFormat("{0}{1}{2}", this.htmlHeader, parsedMarkdown, this.htmlFooter);
-                    string markdownHTML = this.RemoveScriptFromHTML(sb.ToString());
+                    string markdownHTML = sb.ToString();
 
                     this.browser = new WebBrowser
                     {
@@ -119,23 +120,6 @@ namespace MarkdownPreviewHandler
                     base.DoPreview(dataSource);
                 }
             });
-        }
-
-        /// <summary>
-        /// Removes script tag from html string.
-        /// </summary>
-        /// <param name="html">html string.</param>
-        /// <returns>HTML string without script tag.</returns>
-        public string RemoveScriptFromHTML(string html)
-        {
-            HtmlAgilityPack.HtmlDocument doc = new HtmlAgilityPack.HtmlDocument();
-            doc.LoadHtml(html);
-
-            doc.DocumentNode.Descendants()
-                            .Where(n => n.Name == "script")
-                            .ToList()
-                            .ForEach(n => n.Remove());
-            return doc.DocumentNode.InnerHtml;
         }
 
         /// <summary>

--- a/src/modules/previewpane/MarkdownPreviewHandler/MarkdownPreviewHandlerControl.cs
+++ b/src/modules/previewpane/MarkdownPreviewHandler/MarkdownPreviewHandlerControl.cs
@@ -49,7 +49,7 @@ namespace MarkdownPreviewHandler
         /// <summary>
         /// Extended Browser Control to display markdown html.
         /// </summary>
-        private WebBrowser browser;
+        private WebBrowserExt browser;
 
         /// <summary>
         /// True if external image is blocked, false otherwise.
@@ -88,15 +88,15 @@ namespace MarkdownPreviewHandler
                     sb.AppendFormat("{0}{1}{2}", this.htmlHeader, parsedMarkdown, this.htmlFooter);
                     string markdownHTML = sb.ToString();
 
-                    this.browser = new WebBrowser
+                    this.browser = new WebBrowserExt
                     {
                         DocumentText = markdownHTML,
                         Dock = DockStyle.Fill,
                         IsWebBrowserContextMenuEnabled = false,
                         ScriptErrorsSuppressed = true,
                         ScrollBarsEnabled = true,
+                        AllowNavigation = false,
                     };
-                    this.browser.Navigating += this.WebBrowserNavigating;
                     this.Controls.Add(this.browser);
 
                     if (this.infoBarDisplayed)
@@ -174,17 +174,6 @@ namespace MarkdownPreviewHandler
         private void ImagesBlockedCallBack()
         {
             this.infoBarDisplayed = true;
-        }
-
-        /// <summary>
-        /// Callback when link tag is clicked in html.
-        /// </summary>
-        /// <param name="sender">Reference to resized control.</param>
-        /// <param name="e">Provides data for the WebBrowserNavigatingEventArgs event.</param>
-        private void WebBrowserNavigating(object sender, WebBrowserNavigatingEventArgs e)
-        {
-            e.Cancel = true;
-            Process.Start(e.Url.ToString());
         }
     }
 }

--- a/src/modules/previewpane/PreviewPaneUnitTests/MarkdownPreviewHandlerTest.cs
+++ b/src/modules/previewpane/PreviewPaneUnitTests/MarkdownPreviewHandlerTest.cs
@@ -7,6 +7,7 @@ using System.Xml.Linq;
 using Markdig;
 using MarkdownPreviewHandler;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PreviewHandlerCommon;
 
 namespace PreviewPaneUnitTests
 {
@@ -24,7 +25,7 @@ namespace PreviewPaneUnitTests
 
             // Assert
             Assert.AreEqual(markdownPreviewHandlerControl.Controls.Count, 2);
-            Assert.IsInstanceOfType(markdownPreviewHandlerControl.Controls[0], typeof(WebBrowser));
+            Assert.IsInstanceOfType(markdownPreviewHandlerControl.Controls[0], typeof(WebBrowserExt));
         }
 
         [TestMethod]
@@ -52,7 +53,7 @@ namespace PreviewPaneUnitTests
 
             // Assert
             Assert.AreEqual(markdownPreviewHandlerControl.Controls.Count, 1);
-            Assert.IsInstanceOfType(markdownPreviewHandlerControl.Controls[0], typeof(WebBrowser));
+            Assert.IsInstanceOfType(markdownPreviewHandlerControl.Controls[0], typeof(WebBrowserExt));
         }
 
         [TestMethod]
@@ -65,7 +66,7 @@ namespace PreviewPaneUnitTests
             markdownPreviewHandlerControl.DoPreview<string>("HelperFiles/MarkdownWithExternalImage.txt");
 
             // Assert
-            Assert.IsInstanceOfType(markdownPreviewHandlerControl.Controls[0], typeof(WebBrowser));
+            Assert.IsInstanceOfType(markdownPreviewHandlerControl.Controls[0], typeof(WebBrowserExt));
             Assert.IsNotNull(((WebBrowser)markdownPreviewHandlerControl.Controls[0]).DocumentText);
             Assert.AreEqual(((WebBrowser)markdownPreviewHandlerControl.Controls[0]).Dock, DockStyle.Fill);
             Assert.AreEqual(((WebBrowser)markdownPreviewHandlerControl.Controls[0]).IsWebBrowserContextMenuEnabled, false);
@@ -89,20 +90,6 @@ namespace PreviewPaneUnitTests
             Assert.AreEqual(((RichTextBox)markdownPreviewHandlerControl.Controls[1]).BorderStyle, BorderStyle.None);
             Assert.AreEqual(((RichTextBox)markdownPreviewHandlerControl.Controls[1]).BackColor, Color.LightYellow);
             Assert.AreEqual(((RichTextBox)markdownPreviewHandlerControl.Controls[1]).Multiline, true);
-        }
-
-        [TestMethod]
-        public void MarkdownPreviewHandlerControl_RemovesScriptTags_RemoveScriptFromHTMLIsCalled()
-        {
-            // Arrange
-            MarkdownPreviewHandlerControl markdownPreviewHandlerControl = new MarkdownPreviewHandlerControl();
-            string html = "<html><style></style><script>alert(\"hello\");</script><script></script></html>";
-
-            // Act
-            string parsedHTML = markdownPreviewHandlerControl.RemoveScriptFromHTML(html);
-
-            // Assert
-            Assert.AreEqual(parsedHTML, "<html>\r\n  <style></style>\r\n</html>");
         }
     }
 }

--- a/src/modules/previewpane/PreviewPaneUnitTests/MarkdownPreviewHandlerTest.cs
+++ b/src/modules/previewpane/PreviewPaneUnitTests/MarkdownPreviewHandlerTest.cs
@@ -72,6 +72,7 @@ namespace PreviewPaneUnitTests
             Assert.AreEqual(((WebBrowser)markdownPreviewHandlerControl.Controls[0]).IsWebBrowserContextMenuEnabled, false);
             Assert.AreEqual(((WebBrowser)markdownPreviewHandlerControl.Controls[0]).ScriptErrorsSuppressed, true);
             Assert.AreEqual(((WebBrowser)markdownPreviewHandlerControl.Controls[0]).ScrollBarsEnabled, true);
+            Assert.AreEqual(((WebBrowser)markdownPreviewHandlerControl.Controls[0]).AllowNavigation, false);
         }
 
         [TestMethod]

--- a/src/modules/previewpane/SvgPreviewHandler/SvgPreviewControl.cs
+++ b/src/modules/previewpane/SvgPreviewHandler/SvgPreviewControl.cs
@@ -110,6 +110,7 @@ namespace SvgPreviewHandler
             this.browser.IsWebBrowserContextMenuEnabled = false;
             this.browser.ScriptErrorsSuppressed = true;
             this.browser.ScrollBarsEnabled = true;
+            this.browser.AllowNavigation = false;
             this.Controls.Add(this.browser);
         }
 

--- a/src/modules/previewpane/UnitTests-SvgPreviewHandler/SvgPreviewControlTests.cs
+++ b/src/modules/previewpane/UnitTests-SvgPreviewHandler/SvgPreviewControlTests.cs
@@ -95,6 +95,19 @@ namespace UnitTests_SvgPreviewHandler
         }
 
         [TestMethod]
+        public void SvgPreviewControl_ShouldDisableAllowNavigation_WhenDoPreviewCalled()
+        {
+            // Arrange
+            var svgPreviewControl = new SvgPreviewControl();
+
+            // Act
+            svgPreviewControl.DoPreview(GetMockStream("<svg></svg>"));
+
+            // Assert
+            Assert.AreEqual(((WebBrowser)svgPreviewControl.Controls[0]).AllowNavigation, false);
+        }
+
+        [TestMethod]
         public void SvgPreviewControl_ShouldAddValidInfoBar_IfSvgPreviewThrows()
         {
             // Arrange


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Update the Markdown previewer to use `WebBrowserExt` which is implementing in this [PR](https://github.com/microsoft/PowerToys/pull/1368). To block external content to load and run on the `WebBrowser` Control itself. 

Additional Changes:
1. Disabled AllowNavigation option to prevent user to navigate to other pages within the Preview Pane for Markdown and Svg Previewer.
2. Removed the logic to launch default browser on clicking on the link. It's failing with `Access Denied` for the `prevhost.exe` to launch browser Application which is causing the web browser control to open the web page inside the preview pane itself.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #914 

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Validated Unit tests and test the preview handlers on dev machine to block external content and not opening the urls.
