### PR TITLE
FancyZones editor magnetic snapping effect

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditor.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditor.xaml.cs
@@ -63,8 +63,8 @@ namespace FancyZonesEditor
                 zone.ZoneIndex = i;
                 Canvas.SetLeft(zone, rect.X);
                 Canvas.SetTop(zone, rect.Y);
-                zone.MinHeight = rect.Height;
-                zone.MinWidth = rect.Width;
+                zone.Height = rect.Height;
+                zone.Width = rect.Width;
             }
         }
     }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml
@@ -24,19 +24,19 @@
             <ColumnDefinition Width="16"/>
             <ColumnDefinition Width="8"/>
         </Grid.ColumnDefinitions>
-        <Thumb x:Name="NWResize" Cursor="SizeNWSE" Background="Black" Grid.Row="0" Grid.Column="0" Grid.RowSpan="2" Grid.ColumnSpan="2" DragDelta="NWResize_DragDelta"/>
-        <Thumb x:Name="NEResize" Cursor="SizeNESW" Background="Black" Grid.Row="0" Grid.Column="3" Grid.RowSpan="2" Grid.ColumnSpan="2" DragDelta="NEResize_DragDelta"/>
-        <Thumb x:Name="SWResize" Cursor="SizeNESW" Background="Black" Grid.Row="4" Grid.Column="0" Grid.RowSpan="2" Grid.ColumnSpan="2" DragDelta="SWResize_DragDelta"/>
-        <Thumb x:Name="SEResize" Cursor="SizeNWSE" Background="Black" Grid.Row="4" Grid.Column="3" Grid.RowSpan="2" Grid.ColumnSpan="2" DragDelta="SEResize_DragDelta"/>
-        <Thumb x:Name="NResize" Cursor="SizeNS" Background="Black" Margin="1,0,1,0" Grid.Row="0" Grid.Column="2" DragDelta="NResize_DragDelta"/>
-        <Thumb x:Name="SResize" Cursor="SizeNS" Background="Black" Margin="1,0,1,0" Grid.Row="5" Grid.Column="2" DragDelta="SResize_DragDelta"/>
-        <Thumb x:Name="WResize" Cursor="SizeWE" Background="Black" Margin="0,1,0,1" Grid.Row="2" Grid.Column="0" Grid.RowSpan="2" DragDelta="WResize_DragDelta"/>
-        <Thumb x:Name="EResize" Cursor="SizeWE" Background="Black" Margin="0,1,0,1" Grid.Row="2" Grid.Column="4" Grid.RowSpan="2" DragDelta="EResize_DragDelta"/>
+        <Thumb x:Name="NWResize" Cursor="SizeNWSE" Background="Black" Grid.Row="0" Grid.Column="0" Grid.RowSpan="2" Grid.ColumnSpan="2" DragDelta="UniversalDragDelta" DragStarted="NWResize_DragStarted"/>
+        <Thumb x:Name="NEResize" Cursor="SizeNESW" Background="Black" Grid.Row="0" Grid.Column="3" Grid.RowSpan="2" Grid.ColumnSpan="2" DragDelta="UniversalDragDelta" DragStarted="NEResize_DragStarted"/>
+        <Thumb x:Name="SWResize" Cursor="SizeNESW" Background="Black" Grid.Row="4" Grid.Column="0" Grid.RowSpan="2" Grid.ColumnSpan="2" DragDelta="UniversalDragDelta" DragStarted="SWResize_DragStarted"/>
+        <Thumb x:Name="SEResize" Cursor="SizeNWSE" Background="Black" Grid.Row="4" Grid.Column="3" Grid.RowSpan="2" Grid.ColumnSpan="2" DragDelta="UniversalDragDelta" DragStarted="SEResize_DragStarted"/>
+        <Thumb x:Name="NResize" Cursor="SizeNS" Background="Black" Margin="1,0,1,0" Grid.Row="0" Grid.Column="2" DragDelta="UniversalDragDelta" DragStarted="NResize_DragStarted"/>
+        <Thumb x:Name="SResize" Cursor="SizeNS" Background="Black" Margin="1,0,1,0" Grid.Row="5" Grid.Column="2" DragDelta="UniversalDragDelta" DragStarted="SResize_DragStarted"/>
+        <Thumb x:Name="WResize" Cursor="SizeWE" Background="Black" Margin="0,1,0,1" Grid.Row="2" Grid.Column="0" Grid.RowSpan="2" DragDelta="UniversalDragDelta" DragStarted="WResize_DragStarted"/>
+        <Thumb x:Name="EResize" Cursor="SizeWE" Background="Black" Margin="0,1,0,1" Grid.Row="2" Grid.Column="4" Grid.RowSpan="2" DragDelta="UniversalDragDelta" DragStarted="EResize_DragStarted"/>
         <DockPanel Grid.Row="1" Grid.Column="1" Grid.RowSpan="2" Grid.ColumnSpan="3">
             <Button DockPanel.Dock="Right" Padding="8,0" Click="OnClose">
                 <Image Source="images/ChromeClose.png" Height="24" Width="24" />
             </Button>
-            <Thumb x:Name="Caption" Cursor="SizeAll" Background="DarkGray" DragDelta="Caption_DragDelta"/>
+            <Thumb x:Name="Caption" Cursor="SizeAll" Background="DarkGray" DragDelta="UniversalDragDelta" DragStarted="Caption_DragStarted"/>
         </DockPanel>
         <Rectangle Fill="LightGray" Grid.Row="3" Grid.Column="1" Grid.RowSpan="2" Grid.ColumnSpan="3"/>
         <Canvas x:Name="Body" />

--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml.cs
@@ -73,14 +73,14 @@ namespace FancyZonesEditor
                 {
                     if (i != zoneIndex)
                     {
-                        int curr_p = isX ? zones[i].X : zones[i].Y;
-                        int curr_w = isX ? zones[i].Width : zones[i].Height;
-                        key_positions.Add(curr_p);
-                        key_positions.Add(curr_p + curr_w);
+                        int ith_zone_position = isX ? zones[i].X : zones[i].Y;
+                        int ith_zone_axis_size = isX ? zones[i].Width : zones[i].Height;
+                        key_positions.Add(ith_zone_position);
+                        key_positions.Add(ith_zone_position + ith_zone_axis_size);
                         if (mode == ResizeMode.BothEdges)
                         {
-                            key_positions.Add(curr_p - zone_axis_size);
-                            key_positions.Add(curr_p + curr_w - zone_axis_size);
+                            key_positions.Add(ith_zone_position - zone_axis_size);
+                            key_positions.Add(ith_zone_position + ith_zone_axis_size - zone_axis_size);
                         }
                     }
                 }
@@ -106,12 +106,12 @@ namespace FancyZonesEditor
                         // We're dragging the low edge, don't go below zero
                         MinValue = 0;
 
-                        // It can't make the zone smaller than min_w
+                        // It can't make the zone smaller than min_axis_size
                         MaxValue = zone_position + zone_axis_size - min_axis_size;
                         Position = zone_position;
                         break;
                     case ResizeMode.TopEdge:
-                        // We're dragging the high edge, don't make the zone smaller than min_w
+                        // We're dragging the high edge, don't make the zone smaller than min_axis_size
                         MinValue = zone_position + min_axis_size;
 
                         // Don't go off the screen

--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml.cs
@@ -65,37 +65,37 @@ namespace FancyZonesEditor
             /// <param name="screenAxisSize"> The size of the screen in this (X or Y) dimension</param>
             public SnappyHelperBase(IList<Int32Rect> zones, int zoneIndex, bool isX, ResizeMode mode, int screenAxisSize)
             {
-                int zone_position = isX ? zones[zoneIndex].X : zones[zoneIndex].Y;
-                int zone_axis_size = isX ? zones[zoneIndex].Width : zones[zoneIndex].Height;
-                int min_axis_size = isX ? MinZoneWidth : MinZoneHeight;
-                List<int> key_positions = new List<int>();
+                int zonePosition = isX ? zones[zoneIndex].X : zones[zoneIndex].Y;
+                int zoneAxisSize = isX ? zones[zoneIndex].Width : zones[zoneIndex].Height;
+                int minAxisSize = isX ? MinZoneWidth : MinZoneHeight;
+                List<int> keyPositions = new List<int>();
                 for (int i = 0; i < zones.Count; ++i)
                 {
                     if (i != zoneIndex)
                     {
-                        int ith_zone_position = isX ? zones[i].X : zones[i].Y;
-                        int ith_zone_axis_size = isX ? zones[i].Width : zones[i].Height;
-                        key_positions.Add(ith_zone_position);
-                        key_positions.Add(ith_zone_position + ith_zone_axis_size);
+                        int ithZonePosition = isX ? zones[i].X : zones[i].Y;
+                        int ithZoneAxisSize = isX ? zones[i].Width : zones[i].Height;
+                        keyPositions.Add(ithZonePosition);
+                        keyPositions.Add(ithZonePosition + ithZoneAxisSize);
                         if (mode == ResizeMode.BothEdges)
                         {
-                            key_positions.Add(ith_zone_position - zone_axis_size);
-                            key_positions.Add(ith_zone_position + ith_zone_axis_size - zone_axis_size);
+                            keyPositions.Add(ithZonePosition - zoneAxisSize);
+                            keyPositions.Add(ithZonePosition + ithZoneAxisSize - zoneAxisSize);
                         }
                     }
                 }
 
                 // Remove duplicates and sort
-                key_positions.Sort();
+                keyPositions.Sort();
                 Snaps = new List<int>();
-                if (key_positions.Count > 0)
+                if (keyPositions.Count > 0)
                 {
-                    Snaps.Add(key_positions[0]);
-                    for (int i = 1; i < key_positions.Count; ++i)
+                    Snaps.Add(keyPositions[0]);
+                    for (int i = 1; i < keyPositions.Count; ++i)
                     {
-                        if (key_positions[i] != key_positions[i - 1])
+                        if (keyPositions[i] != keyPositions[i - 1])
                         {
-                            Snaps.Add(key_positions[i]);
+                            Snaps.Add(keyPositions[i]);
                         }
                     }
                 }
@@ -106,25 +106,25 @@ namespace FancyZonesEditor
                         // We're dragging the low edge, don't go below zero
                         MinValue = 0;
 
-                        // It can't make the zone smaller than min_axis_size
-                        MaxValue = zone_position + zone_axis_size - min_axis_size;
-                        Position = zone_position;
+                        // It can't make the zone smaller than minAxisSize
+                        MaxValue = zonePosition + zoneAxisSize - minAxisSize;
+                        Position = zonePosition;
                         break;
                     case ResizeMode.TopEdge:
-                        // We're dragging the high edge, don't make the zone smaller than min_axis_size
-                        MinValue = zone_position + min_axis_size;
+                        // We're dragging the high edge, don't make the zone smaller than minAxisSize
+                        MinValue = zonePosition + minAxisSize;
 
                         // Don't go off the screen
                         MaxValue = screenAxisSize;
-                        Position = zone_position + zone_axis_size;
+                        Position = zonePosition + zoneAxisSize;
                         break;
                     case ResizeMode.BothEdges:
                         // We're moving the window, don't move it below zero
                         MinValue = 0;
 
                         // Don't go off the screen (this time the lower edge is tracked)
-                        MaxValue = screenAxisSize - zone_axis_size;
-                        Position = zone_position;
+                        MaxValue = screenAxisSize - zoneAxisSize;
+                        Position = zonePosition;
                         break;
                 }
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml.cs
@@ -23,9 +23,9 @@ namespace FancyZonesEditor
             Canvas.SetZIndex(this, zIndex++);
         }
 
-        private CanvasLayoutModel model;
-
         private readonly Settings _settings = ((App)Application.Current).ZoneSettings;
+
+        private CanvasLayoutModel model;
 
         private int zoneIndex;
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml.cs
@@ -25,6 +25,8 @@ namespace FancyZonesEditor
 
         private CanvasLayoutModel model;
 
+        private readonly Settings _settings = ((App)Application.Current).ZoneSettings;
+
         private int zoneIndex;
 
         public enum ResizeMode
@@ -287,8 +289,8 @@ namespace FancyZonesEditor
         // Corner dragging
         private void Caption_DragStarted(object sender, System.Windows.Controls.Primitives.DragStartedEventArgs e)
         {
-            snappyX = NewDefaultSnappyHelper(true, ResizeMode.BothEdges, Model.ReferenceWidth);
-            snappyY = NewDefaultSnappyHelper(false, ResizeMode.BothEdges, Model.ReferenceHeight);
+            snappyX = NewDefaultSnappyHelper(true, ResizeMode.BothEdges, (int)_settings.WorkArea.Width);
+            snappyY = NewDefaultSnappyHelper(false, ResizeMode.BothEdges, (int)_settings.WorkArea.Height);
         }
 
         public CanvasLayoutModel Model { get => model; set => model = value; }
@@ -297,50 +299,50 @@ namespace FancyZonesEditor
 
         private void NWResize_DragStarted(object sender, System.Windows.Controls.Primitives.DragStartedEventArgs e)
         {
-            snappyX = NewDefaultSnappyHelper(true, ResizeMode.BottomEdge, Model.ReferenceWidth);
-            snappyY = NewDefaultSnappyHelper(false, ResizeMode.BottomEdge, Model.ReferenceHeight);
+            snappyX = NewDefaultSnappyHelper(true, ResizeMode.BottomEdge, (int)_settings.WorkArea.Width);
+            snappyY = NewDefaultSnappyHelper(false, ResizeMode.BottomEdge, (int)_settings.WorkArea.Height);
         }
 
         private void NEResize_DragStarted(object sender, System.Windows.Controls.Primitives.DragStartedEventArgs e)
         {
-            snappyX = NewDefaultSnappyHelper(true, ResizeMode.TopEdge, Model.ReferenceWidth);
-            snappyY = NewDefaultSnappyHelper(false, ResizeMode.BottomEdge, Model.ReferenceHeight);
+            snappyX = NewDefaultSnappyHelper(true, ResizeMode.TopEdge, (int)_settings.WorkArea.Width);
+            snappyY = NewDefaultSnappyHelper(false, ResizeMode.BottomEdge, (int)_settings.WorkArea.Height);
         }
 
         private void SWResize_DragStarted(object sender, System.Windows.Controls.Primitives.DragStartedEventArgs e)
         {
-            snappyX = NewDefaultSnappyHelper(true, ResizeMode.BottomEdge, Model.ReferenceWidth);
-            snappyY = NewDefaultSnappyHelper(false, ResizeMode.TopEdge, Model.ReferenceHeight);
+            snappyX = NewDefaultSnappyHelper(true, ResizeMode.BottomEdge, (int)_settings.WorkArea.Width);
+            snappyY = NewDefaultSnappyHelper(false, ResizeMode.TopEdge, (int)_settings.WorkArea.Height);
         }
 
         private void SEResize_DragStarted(object sender, System.Windows.Controls.Primitives.DragStartedEventArgs e)
         {
-            snappyX = NewDefaultSnappyHelper(true, ResizeMode.TopEdge, Model.ReferenceWidth);
-            snappyY = NewDefaultSnappyHelper(false, ResizeMode.TopEdge, Model.ReferenceHeight);
+            snappyX = NewDefaultSnappyHelper(true, ResizeMode.TopEdge, (int)_settings.WorkArea.Width);
+            snappyY = NewDefaultSnappyHelper(false, ResizeMode.TopEdge, (int)_settings.WorkArea.Height);
         }
 
         // Edge dragging
         private void NResize_DragStarted(object sender, System.Windows.Controls.Primitives.DragStartedEventArgs e)
         {
             snappyX = null;
-            snappyY = NewDefaultSnappyHelper(false, ResizeMode.BottomEdge, Model.ReferenceHeight);
+            snappyY = NewDefaultSnappyHelper(false, ResizeMode.BottomEdge, (int)_settings.WorkArea.Height);
         }
 
         private void SResize_DragStarted(object sender, System.Windows.Controls.Primitives.DragStartedEventArgs e)
         {
             snappyX = null;
-            snappyY = NewDefaultSnappyHelper(false, ResizeMode.TopEdge, Model.ReferenceHeight);
+            snappyY = NewDefaultSnappyHelper(false, ResizeMode.TopEdge, (int)_settings.WorkArea.Height);
         }
 
         private void WResize_DragStarted(object sender, System.Windows.Controls.Primitives.DragStartedEventArgs e)
         {
-            snappyX = NewDefaultSnappyHelper(true, ResizeMode.BottomEdge, Model.ReferenceWidth);
+            snappyX = NewDefaultSnappyHelper(true, ResizeMode.BottomEdge, (int)_settings.WorkArea.Width);
             snappyY = null;
         }
 
         private void EResize_DragStarted(object sender, System.Windows.Controls.Primitives.DragStartedEventArgs e)
         {
-            snappyX = NewDefaultSnappyHelper(true, ResizeMode.TopEdge, Model.ReferenceWidth);
+            snappyX = NewDefaultSnappyHelper(true, ResizeMode.TopEdge, (int)_settings.WorkArea.Width);
             snappyY = null;
         }
     }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml.cs
@@ -150,102 +150,6 @@ namespace FancyZonesEditor
             public abstract void Move(int delta);
         }
 
-        private class SnappyHelperSliding : SnappyHelperBase
-        {
-            private int MaxEnergy
-            {
-                get
-                {
-                    return (int)(0.008 * ScreenW);
-                }
-            }
-
-            /// <summary>
-            /// Initializes a new instance of the <see cref="SnappyHelperSliding"/> class.
-            ///     Just pass it the canvas arguments. Use mode
-            ///     to tell it which edges of the existing masks to use when building its list
-            ///     of snap points, and generally which edges to track. There will be two
-            ///     SnappyHelpers, one for X-coordinates and one for
-            ///     Y-coordinates, they work independently but share the same logic.
-            /// </summary>
-            /// <param name="zones">The list of rectangles describing all zones</param>
-            /// <param name="zoneIndex">The index of the zone to track</param>
-            /// <param name="isX"> Whether this is the X or Y SnappyHelper</param>
-            /// <param name="mode"> One of the three modes of operation (for example: tracking left/right/both edges)</param>
-            /// <param name="screen_w"> The size of the screen in this (X or Y) dimension</param>
-            public SnappyHelperSliding(IList<Int32Rect> zones, int zoneIndex, bool isX, int mode, int screen_w)
-                : base(zones, zoneIndex, isX, mode, screen_w)
-            {
-            }
-
-            public override void Move(int delta)
-            {
-                if (delta == 0)
-                {
-                    return;
-                }
-
-                int target_position = Position + delta;
-                if (target_position > MaxValue)
-                {
-                    Position = MaxValue;
-                    return;
-                }
-
-                if (target_position < MinValue)
-                {
-                    Position = MinValue;
-                    return;
-                }
-
-                // are we flying over a snap position?
-                int snapId = -1;
-
-                if (delta > 0)
-                {
-                    for (int i = 0; i < Snaps.Count; ++i)
-                    {
-                        if (Position <= Snaps[i] && Snaps[i] <= target_position)
-                        {
-                            snapId = i;
-                            break;
-                        }
-                    }
-                }
-                else
-                {
-                    for (int i = Snaps.Count - 1; i >= 0; --i)
-                    {
-                        if (target_position <= Snaps[i] && Snaps[i] <= Position)
-                        {
-                            snapId = i;
-                            break;
-                        }
-                    }
-                }
-
-                if (snapId == -1)
-                {
-                    Position = target_position;
-                }
-                else
-                {
-                    int energy = target_position - Snaps[snapId];
-                    Position = Snaps[snapId];
-                    if (energy > MaxEnergy)
-                    {
-                        energy = 0;
-                        Position += 1;
-                    }
-                    else if (energy < -MaxEnergy)
-                    {
-                        energy = 0;
-                        Position -= 1;
-                    }
-                }
-            }
-        }
-
         private class SnappyHelperMagnetic : SnappyHelperBase
         {
             private List<int> magnetZoneSizes;
@@ -310,7 +214,6 @@ namespace FancyZonesEditor
         private SnappyHelperBase snappyX;
         private SnappyHelperBase snappyY;
 
-        // change to SnappyHelperSliding for different behavior
         private SnappyHelperBase NewDefaultSnappyHelper(bool isX, int mode, int screen_w)
         {
             return new SnappyHelperMagnetic(Model.Zones, ZoneIndex, isX, mode, screen_w);

--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml.cs
@@ -104,52 +104,29 @@ namespace FancyZonesEditor
                     }
                 }
 
-                // Initialize minValue
-                if (mode == ResizeMode.ModeLow)
+                switch (mode)
                 {
-                    // We're dragging the low edge, don't go below zero
-                    MinValue = 0;
-                }
-                else if (mode == ResizeMode.ModeHigh)
-                {
-                    // We're dragging the high edge, don't make the zone smaller than min_w
-                    MinValue = track_p + min_w;
-                }
-                else if (mode == ResizeMode.ModeBoth)
-                {
-                    // We're moving the window, don't move it below zero
-                    MinValue = 0;
-                }
-
-                // Initialize maxValue
-                if (mode == ResizeMode.ModeLow)
-                {
-                    // We're dragging the low edge, it can't make the zone smaller than min_w
-                    MaxValue = track_p + track_w - min_w;
-                }
-                else if (mode == ResizeMode.ModeHigh)
-                {
-                    // We're dragging the high edge, don't go off the screen
-                    MaxValue = screen_w;
-                }
-                else if (mode == ResizeMode.ModeBoth)
-                {
-                    // We're moving the window, don't go off the screen (this time the lower edge is tracked)
-                    MaxValue = screen_w - track_w;
-                }
-
-                // Initialize position
-                if (mode == ResizeMode.ModeLow)
-                {
-                    Position = track_p;
-                }
-                else if (mode == ResizeMode.ModeHigh)
-                {
-                    Position = track_p + track_w;
-                }
-                else if (mode == ResizeMode.ModeBoth)
-                {
-                    Position = track_p;
+                    case ResizeMode.ModeLow:
+                        // We're dragging the low edge, don't go below zero
+                        MinValue = 0;
+                        // It can't make the zone smaller than min_w
+                        MaxValue = track_p + track_w - min_w;
+                        Position = track_p;
+                        break;
+                    case ResizeMode.ModeHigh:
+                        // We're dragging the high edge, don't make the zone smaller than min_w
+                        MinValue = track_p + min_w;
+                        // Don't go off the screen
+                        MaxValue = screen_w;
+                        Position = track_p + track_w;
+                        break;
+                    case ResizeMode.ModeBoth:
+                        // We're moving the window, don't move it below zero
+                        MinValue = 0;
+                        // Don't go off the screen (this time the lower edge is tracked)
+                        MaxValue = screen_w - track_w;
+                        Position = track_p;
+                        break;
                 }
 
                 Mode = mode;


### PR DESCRIPTION
Implemented a solution to Issue #585: FancyZones: Alignment/Snapping/Ruler

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR implements one aspect of Issue #585. Now, windows in the Canvas zone editor will snap to each other when being moved and resized.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #585 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Closed #1277 in favor of this PR, because I messed up the history on the other branch.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manually tested the Canvas zone editor in various scenarios.
