### PR TITLE
Fix deleting custom layouts when closing on SaveApply

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/EditorWindow.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/EditorWindow.cs
@@ -30,6 +30,8 @@ namespace FancyZonesEditor
             {
                 EditorOverlay.Current.ShowLayoutPicker();
             }
+
+            LayoutModel.SerializeDeletedCustomZoneSets();
         }
 
         protected void OnCancel(object sender, RoutedEventArgs e)

--- a/src/modules/fancyzones/editor/FancyZonesEditor/EditorWindow.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/EditorWindow.cs
@@ -19,6 +19,8 @@ namespace FancyZonesEditor
                 model.Persist();
             }
 
+            LayoutModel.SerializeDeletedCustomZoneSets();
+
             _choosing = true;
             Close();
             EditorOverlay.Current.Close();
@@ -30,8 +32,6 @@ namespace FancyZonesEditor
             {
                 EditorOverlay.Current.ShowLayoutPicker();
             }
-
-            LayoutModel.SerializeDeletedCustomZoneSets();
         }
 
         protected void OnCancel(object sender, RoutedEventArgs e)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
Deleted custom layouts were not serialized to tmp JSON file when Editor was closed via Save and Apply button form EditorWidnow

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [] Applies to #1509
