### PR TITLE
runner: only launch update threads when we know we won't be elevated …

### DIFF
--- a/src/common/common.cpp
+++ b/src/common/common.cpp
@@ -442,6 +442,7 @@ bool run_elevated(const std::wstring& file, const std::wstring& params)
     exec_info.fMask = SEE_MASK_NOCLOSEPROCESS;
     exec_info.lpDirectory = 0;
     exec_info.hInstApp = 0;
+    exec_info.nShow = SW_SHOWDEFAULT;
 
     if (ShellExecuteExW(&exec_info))
     {

--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -167,6 +167,17 @@ int runner(bool isProcessElevated)
     int result = -1;
     try
     {
+        std::thread{ [] {
+            github_update_checking_worker();
+        } }.detach();
+
+        if (winstore::running_as_packaged())
+        {
+            std::thread{ [] {
+                start_msi_uninstallation_sequence();
+            } }.detach();
+        }
+
         notifications::register_background_toast_handler();
 
         chdir_current_executable();
@@ -317,17 +328,6 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     int result = 0;
     try
     {
-        std::thread{ [] {
-            github_update_checking_worker();
-        } }.detach();
-
-        if (winstore::running_as_packaged())
-        {
-            std::thread{ [] {
-                start_msi_uninstallation_sequence();
-            } }.detach();
-        }
-
         // Singletons initialization order needs to be preserved, first events and
         // then modules to guarantee the reverse destruction order.
         SystemMenuHelperInstace();


### PR DESCRIPTION
We now only launch update threads when we know we won't be elevated (so we don't blink if we're gonna be relaunched) and show windows for the child process by using correct flags for  `ShellExecuteExW`.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #1401

## Validation Steps Performed
- restarted as admin w/o a version check logic
