### PR TITLE
Added a General tab page with XAML layout and controls according to spec

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI/Microsoft.PowerToys.Settings.UI.csproj
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Microsoft.PowerToys.Settings.UI.csproj
@@ -133,11 +133,15 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Services\ActivationService.cs" />
     <Compile Include="Services\NavigationService.cs" />
+    <Compile Include="ViewModels\GeneralViewModel.cs" />
     <Compile Include="ViewModels\MainViewModel.cs" />
     <Compile Include="ViewModels\ShellViewModel.cs" />
     <Compile Include="ViewModels\Test1ViewModel.cs" />
     <Compile Include="ViewModels\Test2ViewModel.cs" />
     <Compile Include="ViewModels\Test3ViewModel.cs" />
+    <Compile Include="Views\GeneralPage.xaml.cs">
+      <DependentUpon>GeneralPage.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Views\MainPage.xaml.cs">
       <DependentUpon>MainPage.xaml</DependentUpon>
     </Compile>
@@ -211,6 +215,10 @@
     <Page Include="Styles\_Thickness.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Views\GeneralPage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Views\MainPage.xaml">
       <Generator>MSBuild:Compile</Generator>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -141,4 +141,8 @@
     <value>Test3</value>
     <comment>Navigation view item name for Test3</comment>
   </data>
+  <data name="Shell_General.Content" xml:space="preserve">
+    <value>General</value>
+    <comment>Navigation view item name for General</comment>
+  </data>
 </root>

--- a/src/core/Microsoft.PowerToys.Settings.UI/ViewModels/GeneralViewModel.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/ViewModels/GeneralViewModel.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+using Microsoft.PowerToys.Settings.UI.Helpers;
+
+namespace Microsoft.PowerToys.Settings.UI.ViewModels
+{
+    public class GeneralViewModel : Observable
+    {
+        public GeneralViewModel()
+        {
+        }
+    }
+}

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml
@@ -1,0 +1,45 @@
+﻿<Page
+    x:Class="Microsoft.PowerToys.Settings.UI.Views.GeneralPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Microsoft.PowerToys.Settings.UI.Views"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+        <ScrollViewer>
+            <StackPanel Orientation="Vertical" Margin="14,0,14,48">
+
+                <ToggleSwitch Header="Start at startup" IsOn="True" Margin="0,14,0,0" />
+
+                <muxc:RadioButtons Header="Theme" Margin="0, 28,0,0">
+                    <RadioButton Content="Dark"/>
+                    <RadioButton Content="Light"/>
+                    <RadioButton Content="System default" IsChecked="True"/>
+                </muxc:RadioButtons>
+
+                <ToggleSwitch Header="Disable telemetry" IsOn="True" Margin="0,14,0,0" />
+                <TextBlock Text="PowerToys currently respects the Windows data &amp; feedback setting" Opacity="0.8" Margin="0,0,0,0" />
+
+                <TextBlock Text="Default apps" Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,34,0,8"/>
+                <ComboBox Header="Shell" SelectedIndex="0" MinWidth="240" Margin="0,14,0,0">
+                    <ComboBoxItem>PowerShell</ComboBoxItem>
+                </ComboBox>
+                <ComboBox Header="Terminal" SelectedIndex="0" MinWidth="240" Margin="0,14,0,0">
+                    <ComboBoxItem>Windows Console</ComboBoxItem>
+                </ComboBox>
+                <TextBlock Text="About PowerToys" Style="{StaticResource SubtitleTextBlockStyle}" Margin="0,34,0,8"/>
+                <TextBlock FontWeight="Bold" Text="Version 0.15.1.0" Margin="0,14,0,0" />
+                <Button Background="{ThemeResource SystemAccentColor}" Content="Check for updates" Margin="0,10,0,0" Foreground="White"/>
+                <!-- TO DO: The styling of this button should be improved so the hover/pressed states are representing the SystemAccentColor -->
+
+                <HyperlinkButton Content="Report a bug" Margin="0,14,0,0" />
+                <HyperlinkButton Content="Request a feature"  />
+                <HyperlinkButton Content="Privacy statement"  />
+            </StackPanel>
+        </ScrollViewer>
+    </Grid>
+</Page>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.PowerToys.Settings.UI.ViewModels;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+
+namespace Microsoft.PowerToys.Settings.UI.Views
+{
+    public sealed partial class GeneralPage : Page
+    {
+        public GeneralViewModel ViewModel { get; } = new GeneralViewModel();
+
+        public GeneralPage()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ShellPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ShellPage.xaml
@@ -47,6 +47,11 @@
             Or to use an IconElement instead of a Symbol see https://github.com/Microsoft/WindowsTemplateStudio/blob/master/docs/projectTypes/navigationpane.md
             Edit String/en-US/Resources.resw: Add a menu item title for each page
             -->
+            <winui:NavigationViewItem x:Uid="Shell_General" helpers:NavHelper.NavigateTo="views:GeneralPage">
+                <winui:NavigationViewItem.Icon>
+                    <FontIcon Glyph="&#xE713;"/>
+                </winui:NavigationViewItem.Icon>
+            </winui:NavigationViewItem>
             <winui:NavigationViewItem x:Uid="Shell_Main" Icon="Home" helpers:NavHelper.NavigateTo="views:MainPage" />
             <winui:NavigationViewItem x:Uid="Shell_Test1" Icon="Play" helpers:NavHelper.NavigateTo="views:Test1Page" />
             <winui:NavigationViewItem x:Uid="Shell_Test2" Icon="Refresh" helpers:NavHelper.NavigateTo="views:Test2Page" />


### PR DESCRIPTION
Created a proof of concept General settings tab page with XAML layout. Fontsizes, margins and paddings are a 1:1 copy of the official Windows 10 settings app.

## Summary of the Pull Request

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [] Applies to #xxx
* [] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [] Tests added/passed
* [] Requires documentation to be updated
* [] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
