### PR TITLE
Fix PowerToysSetup project for debug config

### DIFF
--- a/installer/PowerToysSetup/PowerToysSetup.wixproj
+++ b/installer/PowerToysSetup/PowerToysSetup.wixproj
@@ -15,7 +15,6 @@
     </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
-    <DefineConstants>Debug</DefineConstants>
     <OutputPath>$(Platform)\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>obj\$(Platform)\$(Configuration)\</IntermediateOutputPath>
   </PropertyGroup>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
PowerToysSetup.wixproj is failing to build in Debug configuration. With error: Undefined preprocessor variable $(var.Version)

The error is in importing the version.props it's not able to override `DefineConstants` if there are already `DefaultConstants` present.
Removed the `DefaultConstants` from the `Debug` configuration.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ x ] Applies to #1548

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Build the project in Debug configuration and validate the output msi.