### PR TITLE
MSIX: add debug configuration option for package building

### DIFF
--- a/installer/MSIX/build_msix.ps1
+++ b/installer/MSIX/build_msix.ps1
@@ -1,1 +1,13 @@
-makeappx build /v /overwrite /f PackagingLayout.xml /id "PowerToys-x64" /op bin\
+param (
+  [bool]$debug = 0
+)
+
+$PackagingLayoutFile = "PackagingLayout.xml"
+
+if ($debug) {
+  (Get-Content $PackagingLayoutFile) `
+  -replace 'x64\\Release\\', 'x64\Debug\' `
+  |  Out-File -Encoding utf8 "$env:temp\$PackagingLayoutFile"
+  $PackagingLayoutFile = "$env:temp\$PackagingLayoutFile"
+}
+makeappx build /v /overwrite /f $PackagingLayoutFile /id "PowerToys-x64" /op bin\


### PR DESCRIPTION
- MSIX: add debug configuration option for package building

Use like this:

```ps1
.\build_msix.ps1 -debug 1
```

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #1292

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- installed debug version of MSIX