### PR TITLE
Implement canceling edits in FZE, fix crashes related to canceling.

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditor.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditor.xaml.cs
@@ -55,6 +55,12 @@ namespace FancyZonesEditor
                 previewChildrenCount++;
             }
 
+            while (previewChildrenCount > _model.Zones.Count)
+            {
+                Preview.Children.RemoveAt(previewChildrenCount - 1);
+                previewChildrenCount--;
+            }
+
             for (int i = 0; i < previewChildrenCount; i++)
             {
                 Int32Rect rect = _model.Zones[i];

--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditorWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditorWindow.xaml.cs
@@ -16,6 +16,7 @@ namespace FancyZonesEditor
         {
             InitializeComponent();
             _model = EditorOverlay.Current.DataContext as CanvasLayoutModel;
+            _stashedModel = (CanvasLayoutModel)_model.Clone();
         }
 
         private void OnAddZone(object sender, RoutedEventArgs e)
@@ -24,7 +25,14 @@ namespace FancyZonesEditor
             _offset += 100;
         }
 
+        protected new void OnCancel(object sender, RoutedEventArgs e)
+        {
+            base.OnCancel(sender, e);
+            _stashedModel.RestoreTo(_model);
+        }
+
         private int _offset = 100;
         private CanvasLayoutModel _model;
+        private CanvasLayoutModel _stashedModel;
     }
 }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
@@ -18,11 +18,16 @@ namespace FancyZonesEditor
     {
         public static readonly DependencyProperty ModelProperty = DependencyProperty.Register("Model", typeof(GridLayoutModel), typeof(GridEditor), new PropertyMetadata(null, OnGridDimensionsChanged));
 
+        private static int gridEditorUniqueIdCounter = 0;
+
+        private int gridEditorUniqueId;
+
         public GridEditor()
         {
             InitializeComponent();
             Loaded += GridEditor_Loaded;
             ((App)Application.Current).ZoneSettings.PropertyChanged += ZoneSettings_PropertyChanged;
+            gridEditorUniqueId = ++gridEditorUniqueIdCounter;
         }
 
         private void GridEditor_Loaded(object sender, RoutedEventArgs e)
@@ -73,7 +78,9 @@ namespace FancyZonesEditor
         private void ZoneSettings_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
             Size actualSize = new Size(ActualWidth, ActualHeight);
-            if (actualSize.Width > 0)
+
+            // Only enter if this is the newest instance
+            if (actualSize.Width > 0 && gridEditorUniqueId == gridEditorUniqueIdCounter)
             {
                 ArrangeGridRects(actualSize);
             }
@@ -495,7 +502,8 @@ namespace FancyZonesEditor
 
         private void OnGridDimensionsChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
-            if ((e.PropertyName == "Rows") || (e.PropertyName == "Columns"))
+            // Only enter if this is the newest instance
+            if (((e.PropertyName == "Rows") || (e.PropertyName == "Columns")) && gridEditorUniqueId == gridEditorUniqueIdCounter)
             {
                 OnGridDimensionsChanged();
             }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditorWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditorWindow.xaml.cs
@@ -2,6 +2,9 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Windows;
+using FancyZonesEditor.Models;
+
 namespace FancyZonesEditor
 {
     /// <summary>
@@ -12,6 +15,16 @@ namespace FancyZonesEditor
         public GridEditorWindow()
         {
             InitializeComponent();
+            _stashedModel = (GridLayoutModel)(EditorOverlay.Current.DataContext as GridLayoutModel).Clone();
         }
+
+        protected new void OnCancel(object sender, RoutedEventArgs e)
+        {
+            base.OnCancel(sender, e);
+            GridLayoutModel model = EditorOverlay.Current.DataContext as GridLayoutModel;
+            _stashedModel.RestoreTo(model);
+        }
+
+        private GridLayoutModel _stashedModel;
     }
 }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/CanvasLayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/CanvasLayoutModel.cs
@@ -113,6 +113,15 @@ namespace FancyZonesEditor.Models
             return layout;
         }
 
+        public void RestoreTo(CanvasLayoutModel other)
+        {
+            other.Zones.Clear();
+            foreach (Int32Rect zone in Zones)
+            {
+                other.Zones.Add(zone);
+            }
+        }
+
         // PersistData
         // Implements the LayoutModel.PersistData abstract method
         protected override void PersistData()

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/GridLayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/GridLayoutModel.cs
@@ -131,6 +131,12 @@ namespace FancyZonesEditor.Models
         public override LayoutModel Clone()
         {
             GridLayoutModel layout = new GridLayoutModel(Name);
+            RestoreTo(layout);
+            return layout;
+        }
+
+        public void RestoreTo(GridLayoutModel layout)
+        {
             int rows = Rows;
             int cols = Columns;
 
@@ -163,8 +169,6 @@ namespace FancyZonesEditor.Models
             }
 
             layout.ColumnPercents = colPercents;
-
-            return layout;
         }
 
         // PersistData


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This PR fixes #1519 and also fixes #751.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #1519 and  #751
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

The reason for these crashes is finally known and has been mitigated in this PR. It comes down to instances of GridEditor and CanvasEditor persisting after the editor window is closed when clicking Cancel. They stay alive and are still subscribed to events happening to the currently active Model. This PR adds checks which prevents these old instances of becoming awake and crashing.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

