### PR TITLE
Add Window Walker to module list

### DIFF
--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -188,7 +188,8 @@ int runner(bool isProcessElevated)
             L"fancyzones.dll",
             L"PowerRenameExt.dll",
             L"ImageResizerExt.dll",
-            L"powerpreview.dll"
+            L"powerpreview.dll",
+            L"WindowWalker.dll"
         };
         for (auto& file : std::filesystem::directory_iterator(L"modules/"))
         {


### PR DESCRIPTION
This enables the Window Walker app (Alt-tab alternative) within Power Toys.
## PR Checklist
* [X] Applies to #861 and continues work from #1177
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* ~~Tests added/passed~~
* ~~Requires documentation to be updated~~
* [X] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx


## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Compiled locally and verified that Window Walker actually launches. Disabled it from settings and verified that it doesn't run. Enabled again and verified that it runs again.
