### PR TITLE
Fix migration of rows and columns percents from registry

### DIFF
--- a/src/modules/fancyzones/lib/JsonHelpers.cpp
+++ b/src/modules/fancyzones/lib/JsonHelpers.cpp
@@ -714,14 +714,14 @@ namespace JSONHelpers
                     int j = 5;
                     GridLayoutInfo zoneSetInfo(GridLayoutInfo::Minimal{ .rows = data[j++], .columns = data[j++] });
 
-                    for (int row = 0; row < zoneSetInfo.rows(); row++)
+                    for (int row = 0; row < zoneSetInfo.rows(); row++, j+=2)
                     {
-                        zoneSetInfo.rowsPercents()[row] = data[j++] * 256 + data[j++];
+                        zoneSetInfo.rowsPercents()[row] = data[j] * 256 + data[j+1];
                     }
 
-                    for (int col = 0; col < zoneSetInfo.columns(); col++)
+                    for (int col = 0; col < zoneSetInfo.columns(); col++, j+=2)
                     {
-                        zoneSetInfo.columnsPercents()[col] = data[j++] * 256 + data[j++];
+                        zoneSetInfo.columnsPercents()[col] = data[j] * 256 + data[j+1];
                     }
 
                     for (int row = 0; row < zoneSetInfo.rows(); row++)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
**Modifying same variable in an expression twice can cause undefined behavior.** Performing post increment to counter twice in single expression here causes faulty behavior, we are reading same value twice, and only after that we have counter incremented twice.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #1526 