### PR TITLE
Update settings logic for file explorer preview

### DIFF
--- a/src/modules/previewpane/powerpreview/powerpreview.cpp
+++ b/src/modules/previewpane/powerpreview/powerpreview.cpp
@@ -113,10 +113,7 @@ void PowerPreviewModule::disable()
 {
     for (auto previewHandler : this->m_previewHandlers)
     {
-        if (previewHandler->GetToggleSettingState())
-        {
-            previewHandler->DisablePreview();
-        }
+        previewHandler->DisablePreview();
     }
 
     this->m_enabled = false;

--- a/src/modules/previewpane/powerpreview/powerpreview.cpp
+++ b/src/modules/previewpane/powerpreview/powerpreview.cpp
@@ -99,6 +99,10 @@ void PowerPreviewModule::enable()
             // Enable all the previews with intial state set as true.
             previewHandler->EnablePreview();
         }
+        else
+        {
+            previewHandler->DisablePreview();
+        }
     }
 
     this->m_enabled = true;

--- a/src/modules/previewpane/powerpreview/powerpreview.cpp
+++ b/src/modules/previewpane/powerpreview/powerpreview.cpp
@@ -16,7 +16,7 @@ void PowerPreviewModule::destroy()
     {
         if (previewHandler != NULL)
         {
-            // Stop all the active previews handlers.
+            // Disable all the active preview handlers.
             if (this->m_enabled && previewHandler->GetToggleSettingState())
             {
                 previewHandler->DisablePreview();

--- a/src/modules/previewpane/powerpreview/powerpreview.cpp
+++ b/src/modules/previewpane/powerpreview/powerpreview.cpp
@@ -105,6 +105,11 @@ void PowerPreviewModule::enable()
         }
     }
 
+    if (!this->m_enabled)
+    {
+        Trace::EnabledPowerPreview(true);
+    }
+
     this->m_enabled = true;
 }
 
@@ -114,6 +119,11 @@ void PowerPreviewModule::disable()
     for (auto previewHandler : this->m_previewHandlers)
     {
         previewHandler->DisablePreview();
+    }
+
+    if (this->m_enabled)
+    {
+        Trace::EnabledPowerPreview(false);
     }
 
     this->m_enabled = false;

--- a/src/modules/previewpane/powerpreview/powerpreview.h
+++ b/src/modules/previewpane/powerpreview/powerpreview.h
@@ -24,7 +24,7 @@ public:
         m_previewHandlers(
             { // SVG Preview Hanlder settings object.
               new FileExplorerPreviewSettings(
-                  false,
+                  true,
                   GET_RESOURCE_STRING(IDS_PREVPANE_SVG_BOOL_TOGGLE_CONTROLL),
                   GET_RESOURCE_STRING(IDS_PREVPANE_SVG_SETTINGS_DESCRIPTION),
                   L"{ddee2b8a-6807-48a6-bb20-2338174ff779}",
@@ -33,7 +33,7 @@ public:
 
               // MarkDown Preview Handler Settings Object.
               new FileExplorerPreviewSettings(
-                  false,
+                  true,
                   GET_RESOURCE_STRING(IDS_PREVPANE_MD_BOOL_TOGGLE_CONTROLL),
                   GET_RESOURCE_STRING(IDS_PREVPANE_MD_SETTINGS_DESCRIPTION),
                   L"{45769bcc-e8fd-42d0-947e-02beef77a1f5}",

--- a/src/modules/previewpane/powerpreview/powerpreview.h
+++ b/src/modules/previewpane/powerpreview/powerpreview.h
@@ -25,19 +25,19 @@ public:
             { // SVG Preview Hanlder settings object.
               new FileExplorerPreviewSettings(
                   true,
-                  GET_RESOURCE_STRING(IDS_PREVPANE_SVG_BOOL_TOGGLE_CONTROLL),
+                  L"svg-previewer-toggle-setting",
                   GET_RESOURCE_STRING(IDS_PREVPANE_SVG_SETTINGS_DESCRIPTION),
                   L"{ddee2b8a-6807-48a6-bb20-2338174ff779}",
-                  GET_RESOURCE_STRING(IDS_PREVPANE_SVG_SETTINGS_DISPLAYNAME),
+                  L"SVG Preview Handler",
                   new RegistryWrapper()),
 
               // MarkDown Preview Handler Settings Object.
               new FileExplorerPreviewSettings(
                   true,
-                  GET_RESOURCE_STRING(IDS_PREVPANE_MD_BOOL_TOGGLE_CONTROLL),
+                  L"md-previewer-toggle-setting",
                   GET_RESOURCE_STRING(IDS_PREVPANE_MD_SETTINGS_DESCRIPTION),
                   L"{45769bcc-e8fd-42d0-947e-02beef77a1f5}",
-                  GET_RESOURCE_STRING(IDS_PREVPANE_MD_SETTINGS_DISPLAYNAME),
+                  L"Markdown Preview Handler",
                   new RegistryWrapper())
             })
     {

--- a/src/modules/previewpane/powerpreview/powerpreview.vcxproj
+++ b/src/modules/previewpane/powerpreview/powerpreview.vcxproj
@@ -116,7 +116,7 @@
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|x64'">pch.h</PrecompiledHeaderFile>
     </ClCompile>
     <ClCompile Include="powerpreview.cpp" />
-    <ClCompile Include="powerpreview.h" />
+    <ClInclude Include="powerpreview.h" />
     <ClCompile Include="registry_wrapper.cpp" />
     <ClCompile Include="settings.cpp" />
     <ClCompile Include="trace.cpp" />

--- a/src/modules/previewpane/powerpreview/powerpreview.vcxproj.filters
+++ b/src/modules/previewpane/powerpreview/powerpreview.vcxproj.filters
@@ -5,7 +5,6 @@
     <ClCompile Include="dllmain.cpp" />
     <ClCompile Include="trace.cpp" />
     <ClCompile Include="settings.cpp" />
-    <ClCompile Include="powerpreview.h" />
     <ClCompile Include="powerpreview.cpp" />
     <ClCompile Include="registry_wrapper.cpp" />
   </ItemGroup>
@@ -17,6 +16,7 @@
     <ClInclude Include="CLSID.h" />
     <ClInclude Include="registry_wrapper.h" />
     <ClInclude Include="registry_wrapper_interface.h" />
+    <ClInclude Include="powerpreview.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="powerpreview.rc" />

--- a/src/modules/previewpane/powerpreview/settings.cpp
+++ b/src/modules/previewpane/powerpreview/settings.cpp
@@ -43,35 +43,6 @@ namespace PowerPreviewSettings
         this->m_isPreviewEnabled = state;
     }
 
-    void FileExplorerPreviewSettings::LoadState(PowerToysSettings::PowerToyValues& settings)
-    {
-        auto toggle = settings.get_bool_value(this->GetName());
-        if (toggle != std::nullopt)
-        {
-            this->m_isPreviewEnabled = toggle.value();
-        }
-    }
-
-    void FileExplorerPreviewSettings::UpdateState(PowerToysSettings::PowerToyValues& values)
-    {
-        auto toggle = values.get_bool_value(this->GetName());
-        if (toggle != std::nullopt)
-        {
-            if (toggle.value())
-            {
-                this->EnablePreview();
-            }
-            else
-            {
-                this->DisablePreview();
-            }
-        }
-        else
-        {
-            Trace::PowerPreviewSettingsUpDateFailed(this->GetName().c_str());
-        }
-    }
-
     std::wstring FileExplorerPreviewSettings::GetName() const
     {
         return this->m_name;
@@ -119,7 +90,6 @@ namespace PowerPreviewSettings
 
         if (err == ERROR_SUCCESS)
         {
-            this->SetState(true);
             Trace::PreviewHandlerEnabled(true, this->GetDisplayName().c_str());
         }
         else
@@ -135,12 +105,11 @@ namespace PowerPreviewSettings
 
         if (err == ERROR_SUCCESS)
         {
-            this->SetState(false);
             Trace::PreviewHandlerEnabled(false, this->GetDisplayName().c_str());
         }
         else
         {
             Trace::PowerPreviewSettingsUpDateFailed(this->GetName().c_str());
-        }    
+        }  
     }
 }

--- a/src/modules/previewpane/powerpreview/settings.cpp
+++ b/src/modules/previewpane/powerpreview/settings.cpp
@@ -63,14 +63,13 @@ namespace PowerPreviewSettings
         return this->m_registryValueData;
     }
 
-
     // Load intital state of the Preview Handler. If no inital state present initialize setting with default value.
     void FileExplorerPreviewSettings::LoadState(PowerToysSettings::PowerToyValues& settings)
     {
         auto toggle = settings.get_bool_value(this->GetToggleSettingName());
         if (toggle)
         {
-            // If no exisiting setting found leave the default intitialization value i.e: true
+            // If no exisiting setting found leave the default intitialization value.
             this->UpdateToggleSettingState(*toggle);
         }
     }

--- a/src/modules/previewpane/powerpreview/settings.cpp
+++ b/src/modules/previewpane/powerpreview/settings.cpp
@@ -15,12 +15,12 @@ namespace PowerPreviewSettings
     static LPCWSTR preview_handlers_subkey = L"Software\\Microsoft\\Windows\\CurrentVersion\\PreviewHandlers";
 
     // Base Settinngs Class Implementation
-    FileExplorerPreviewSettings::FileExplorerPreviewSettings(bool enabled, const std::wstring& name, const std::wstring& description, LPCWSTR clsid, const std::wstring& displayname, RegistryWrapperIface * registryWrapper) :
-        m_isPreviewEnabled(enabled),
-        m_name(name),
-        m_description(description),
+    FileExplorerPreviewSettings::FileExplorerPreviewSettings(bool toggleSettingEnabled, const std::wstring& toggleSettingName, const std::wstring& toggleSettingDescription, LPCWSTR clsid, const std::wstring& registryValueData, RegistryWrapperIface* registryWrapper) :
+        m_toggleSettingEnabled(toggleSettingEnabled),
+        m_toggleSettingName(toggleSettingName),
+        m_toggleSettingDescription(toggleSettingDescription),
         m_clsid(clsid),
-        m_displayName(displayname),
+        m_registryValueData(registryValueData),
         m_registryWrapper(registryWrapper)
     {
     }
@@ -33,39 +33,24 @@ namespace PowerPreviewSettings
         }
     }
 
-    bool FileExplorerPreviewSettings::GetState() const
+    bool FileExplorerPreviewSettings::GetToggleSettingState() const
     {
-        return this->m_isPreviewEnabled;
+        return this->m_toggleSettingEnabled;
     }
 
-    void FileExplorerPreviewSettings::SetState(bool state)
+    void FileExplorerPreviewSettings::UpdateToggleSettingState(bool state)
     {
-        this->m_isPreviewEnabled = state;
+        this->m_toggleSettingEnabled = state;
     }
 
-    std::wstring FileExplorerPreviewSettings::GetName() const
+    std::wstring FileExplorerPreviewSettings::GetToggleSettingName() const
     {
-        return this->m_name;
+        return this->m_toggleSettingName;
     }
 
-    void FileExplorerPreviewSettings::SetName(const std::wstring& name)
+    std::wstring FileExplorerPreviewSettings::GetToggleSettingDescription() const
     {
-        this->m_name = name;
-    }
-
-    std::wstring FileExplorerPreviewSettings::GetDescription() const
-    {
-        return this->m_description;
-    }
-
-    void FileExplorerPreviewSettings::SetDescription(const std::wstring& description)
-    {
-        this->m_description = description;
-    }
-
-    LPCWSTR FileExplorerPreviewSettings::GetSubKey() const
-    {
-        return preview_handlers_subkey;
+        return this->m_toggleSettingDescription;
     }
 
     LPCWSTR FileExplorerPreviewSettings::GetCLSID() const
@@ -73,43 +58,77 @@ namespace PowerPreviewSettings
         return this->m_clsid;
     }
 
-    std::wstring FileExplorerPreviewSettings::GetDisplayName() const
+    std::wstring FileExplorerPreviewSettings::GetRegistryValueData() const
     {
-        return this->m_displayName;
+        return this->m_registryValueData;
     }
 
-    void FileExplorerPreviewSettings::SetDisplayName(const std::wstring& displayName)
+
+    // Load intital state of the Preview Handler. If no inital state present initialize setting with default value.
+    void FileExplorerPreviewSettings::LoadState(PowerToysSettings::PowerToyValues& settings)
     {
-        this->m_displayName = displayName;
+        auto toggle = settings.get_bool_value(this->GetToggleSettingName());
+        if (toggle)
+        {
+            // If no exisiting setting found leave the default intitialization value i.e: true
+            this->UpdateToggleSettingState(*toggle);
+        }
+    }
+
+    // Manage change in state of Preview Handler settings.
+    void FileExplorerPreviewSettings::UpdateState(PowerToysSettings::PowerToyValues& settings, bool enabled)
+    {
+        auto toggle = settings.get_bool_value(this->GetToggleSettingName());
+        if (toggle)
+        {
+            auto lastState = this->GetToggleSettingState();
+            if (lastState != *toggle)
+            {
+                this->UpdateToggleSettingState(*toggle);
+
+                // If global setting is enable. Add or remove the preview handler otherwise just change the UI and save the updated config.
+                if (enabled)
+                {
+                    if (lastState)
+                    {
+                        this->DisablePreview();
+                    }
+                    else
+                    {
+                        this->EnablePreview();
+                    }
+                }
+            }
+        }
     }
 
     void FileExplorerPreviewSettings::EnablePreview()
     {
         // Add registry value to enable preview.
-        LONG err = this->m_registryWrapper->SetRegistryValue(HKEY_CURRENT_USER, this->GetSubKey(), this->GetCLSID(), REG_SZ, (LPBYTE)this->GetDisplayName().c_str(), (DWORD)(this->GetDisplayName().length() * sizeof(wchar_t)));
+        LONG err = this->m_registryWrapper->SetRegistryValue(HKEY_CURRENT_USER, preview_handlers_subkey, this->GetCLSID(), REG_SZ, (LPBYTE)this->GetRegistryValueData().c_str(), (DWORD)(this->GetRegistryValueData().length() * sizeof(wchar_t)));
 
         if (err == ERROR_SUCCESS)
         {
-            Trace::PreviewHandlerEnabled(true, this->GetDisplayName().c_str());
+            Trace::PreviewHandlerEnabled(true, this->GetToggleSettingName().c_str());
         }
         else
         {
-            Trace::PowerPreviewSettingsUpDateFailed(this->GetName().c_str());
+            Trace::PowerPreviewSettingsUpDateFailed(this->GetToggleSettingName().c_str());
         }
     }
 
     void FileExplorerPreviewSettings::DisablePreview()
     {
         // Delete the registry key to disable preview.
-        LONG err = this->m_registryWrapper->DeleteRegistryValue(HKEY_CURRENT_USER, this->GetSubKey(), this->GetCLSID());
+        LONG err = this->m_registryWrapper->DeleteRegistryValue(HKEY_CURRENT_USER, preview_handlers_subkey, this->GetCLSID());
 
         if (err == ERROR_SUCCESS)
         {
-            Trace::PreviewHandlerEnabled(false, this->GetDisplayName().c_str());
+            Trace::PreviewHandlerEnabled(false, this->GetToggleSettingName().c_str());
         }
         else
         {
-            Trace::PowerPreviewSettingsUpDateFailed(this->GetName().c_str());
-        }  
+            Trace::PowerPreviewSettingsUpDateFailed(this->GetToggleSettingName().c_str());
+        }
     }
 }

--- a/src/modules/previewpane/powerpreview/settings.h
+++ b/src/modules/previewpane/powerpreview/settings.h
@@ -11,28 +11,25 @@ namespace PowerPreviewSettings
 	class FileExplorerPreviewSettings
 	{
 	private:
-		bool m_isPreviewEnabled;
-		std::wstring m_name;
-		std::wstring m_description;
-		std::wstring m_displayName;
+		bool m_toggleSettingEnabled;
+        std::wstring m_toggleSettingName;
+        std::wstring m_toggleSettingDescription;
+		std::wstring m_registryValueData;
         RegistryWrapperIface * m_registryWrapper;
 		LPCWSTR m_clsid;
-        
 
 	public:
-        FileExplorerPreviewSettings(bool enabled, const std::wstring& name, const std::wstring& description, LPCWSTR clsid, const std::wstring& displayname, RegistryWrapperIface* registryWrapper);
+        FileExplorerPreviewSettings(bool toggleSettingEnabled, const std::wstring& toggleSettingName, const std::wstring& toggleSettingDescription, LPCWSTR clsid, const std::wstring& registryValueData, RegistryWrapperIface* registryWrapper);
         ~ FileExplorerPreviewSettings();
 
-		virtual bool GetState() const;
-		virtual void SetState(bool state);
-		virtual std::wstring GetName() const;
-		virtual void SetName(const std::wstring& name);
-		virtual std::wstring GetDescription() const;
-		virtual void SetDescription(const std::wstring& description);
-		virtual void SetDisplayName(const std::wstring& displayName);
-		virtual std::wstring GetDisplayName() const;
-		virtual LPCWSTR GetCLSID() const;
-		virtual LPCWSTR GetSubKey() const;
+		virtual bool GetToggleSettingState() const;
+        virtual void UpdateToggleSettingState(bool state);
+		virtual std::wstring GetToggleSettingName() const;
+        virtual std::wstring GetToggleSettingDescription() const;
+        virtual LPCWSTR GetCLSID() const;
+        virtual std::wstring GetRegistryValueData() const;
+        virtual void LoadState(PowerToysSettings::PowerToyValues& settings);
+        virtual void UpdateState(PowerToysSettings::PowerToyValues& settings, bool enabled);
 		virtual void EnablePreview();
 		virtual void DisablePreview();
 	};

--- a/src/modules/previewpane/powerpreview/settings.h
+++ b/src/modules/previewpane/powerpreview/settings.h
@@ -30,7 +30,7 @@ namespace PowerPreviewSettings
         virtual std::wstring GetRegistryValueData() const;
         virtual void LoadState(PowerToysSettings::PowerToyValues& settings);
         virtual void UpdateState(PowerToysSettings::PowerToyValues& settings, bool enabled);
-		virtual void EnablePreview();
-		virtual void DisablePreview();
+        virtual LONG EnablePreview();
+        virtual LONG DisablePreview();
 	};
 }

--- a/src/modules/previewpane/powerpreview/settings.h
+++ b/src/modules/previewpane/powerpreview/settings.h
@@ -25,8 +25,6 @@ namespace PowerPreviewSettings
 
 		virtual bool GetState() const;
 		virtual void SetState(bool state);
-		virtual void LoadState(PowerToysSettings::PowerToyValues& settings);
-        virtual void UpdateState(PowerToysSettings::PowerToyValues& values);
 		virtual std::wstring GetName() const;
 		virtual void SetName(const std::wstring& name);
 		virtual std::wstring GetDescription() const;

--- a/src/modules/previewpane/powerpreview/trace.cpp
+++ b/src/modules/previewpane/powerpreview/trace.cpp
@@ -29,24 +29,40 @@ void Trace::UnregisterProvider()
     TraceLoggingUnregister(g_hProvider);
 }
 
-void Trace::PreviewHandlerEnabled(bool enabled, LPCWSTR previewHandlerName)
+void Trace::EnabledPowerPreview(bool enabled)
 {
     TraceLoggingWrite(
         g_hProvider,
-        "PowerPreview_TweakUISettings_Enabled",
-        TraceLoggingWideString(previewHandlerName, "PreviewHanlder_FileType"),
+        "PowerPreview_Enabled",
         TraceLoggingBoolean(enabled, "Enabled"),
         ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
         TraceLoggingBoolean(TRUE, "UTCReplace_AppSessionGuid"),
         TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));
 }
 
-void Trace::PowerPreviewSettingsUpDateFailed(LPCWSTR SettingsName)
+void Trace::PowerPreviewSettingsUpdated(LPCWSTR SettingsName, bool oldState, bool newState, bool globalState)
+{
+    TraceLoggingWrite(
+        g_hProvider,
+        "PowerPreview_TweakUISettings_SuccesfullyUpdatedSettings",
+        TraceLoggingWideString(SettingsName, "Previewer_Settings_Name"),
+        TraceLoggingBoolean(oldState, "Old_Settings_State"),
+        TraceLoggingBoolean(newState, "New_Settings_State"),
+        TraceLoggingBoolean(globalState, "Global_File_Explorer_Settings_State"),
+        ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
+        TraceLoggingBoolean(TRUE, "UTCReplace_AppSessionGuid"),
+        TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));
+}
+
+void Trace::PowerPreviewSettingsUpdateFailed(LPCWSTR SettingsName, bool oldState, bool newState, bool globalState)
 {
     TraceLoggingWrite(
         g_hProvider,
         "PowerPreview_TweakUISettings_FailedUpdatingSettings",
-        TraceLoggingWideString(SettingsName, "ExceptionMessage"),
+        TraceLoggingWideString(SettingsName, "Previewer_Settings_Name"),
+        TraceLoggingBoolean(oldState, "Old_Settings_State"),
+        TraceLoggingBoolean(newState, "New_Settings_State"),
+        TraceLoggingBoolean(globalState, "Global_File_Explorer_Settings_State"),
         ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
         TraceLoggingBoolean(TRUE, "UTCReplace_AppSessionGuid"),
         TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));

--- a/src/modules/previewpane/powerpreview/trace.h
+++ b/src/modules/previewpane/powerpreview/trace.h
@@ -7,7 +7,8 @@ public:
     static void UnregisterProvider();
     static void SetConfigInvalidJSON(const char* exceptionMessage);
     static void InitSetErrorLoadingFile(const char* exceptionMessage);
-    static void PreviewHandlerEnabled(bool enabled, LPCWSTR previewHandlerName);
-    static void PowerPreviewSettingsUpDateFailed(LPCWSTR SettingsName);
+    static void EnabledPowerPreview(bool enabled);
+    static void PowerPreviewSettingsUpdated(LPCWSTR SettingsName, bool oldState, bool newState, bool globalState);
+    static void PowerPreviewSettingsUpdateFailed(LPCWSTR SettingsName, bool oldState, bool newState, bool globalState);
     static void Destroyed();
 };

--- a/src/modules/previewpane/powerpreviewTest/FileExplorerPreviewSettingsTest.cpp
+++ b/src/modules/previewpane/powerpreviewTest/FileExplorerPreviewSettingsTest.cpp
@@ -62,162 +62,141 @@ namespace PreviewHandlerSettingsTest
 	TEST_CLASS(BaseSettingsTest)
 	{
 	public:
-		TEST_METHOD(LoadState_ShouldLoadNewState_WhenSucessfull)
-		{
-			// Arrange
-            FileExplorerPreviewSettings tempSettings = GetSttingsObjects(new RegistryMock());
-			PowerToyValues values = PowerToyValues::from_json_string(GetJSONSettings(tempSettings.GetName(), L"true"));
-			tempSettings.SetState(false);
-			bool expectedState = true;
 
-			// Act
-			tempSettings.LoadState(values);
-			bool actualState = tempSettings.GetState();
-
-			// Assert
-			Assert::AreEqual(actualState, expectedState);
-		}
-
-		TEST_METHOD(UpdateState_ShouldChangeState_WhenSucessfull)
-		{
-			// Arrange
-            FileExplorerPreviewSettings tempSettings = GetSttingsObjects(new RegistryMock());
-			PowerToyValues values = PowerToyValues::from_json_string(GetJSONSettings(tempSettings.GetName(), L"true"));
-			tempSettings.SetState(false);
-			bool expectedState = true;
-
-			// Act
-			tempSettings.UpdateState(values);
-			bool actualState = tempSettings.GetState();
-
-			// Assert
-			Assert::AreEqual(actualState, expectedState);
-		}
-
-		TEST_METHOD(EnableRender_ShouldUpdateStateToTrue_WhenSuccessful)
+        TEST_METHOD (LoadState_ShouldLoadValidState_IfInitalStateIsPresent)
         {
             // Arrange
-            FileExplorerPreviewSettings tempSettings = GetSttingsObjects(new RegistryMock());
-            tempSettings.SetState(false); //preview handler initially disabled
+            bool defaultState = true;
+            RegistryMock* mockRegistryWrapper = new RegistryMock();
+            FileExplorerPreviewSettings previewSettings = GetSettingsObject(defaultState, mockRegistryWrapper);
+            auto settings = PowerToyValues::from_json_string(GetJSONSettings(previewSettings.GetToggleSettingName(), L"false"));
 
             // Act
-            tempSettings.EnablePreview();
+            previewSettings.LoadState(settings);
 
             // Assert
-            Assert::IsTrue(tempSettings.GetState());
+            Assert::IsFalse(previewSettings.GetToggleSettingState());
         }
 
-        TEST_METHOD(DisableRender_ShouldUpdateStateToFalse_WhenSuccessful)
+        TEST_METHOD (LoadState_ShouldNotChangeDefaultState_IfNoInitalStateIsPresent)
         {
             // Arrange
-            FileExplorerPreviewSettings tempSettings = GetSttingsObjects(new RegistryMock());
-            tempSettings.SetState(true); //preview handler initially enabled
+            bool defaultState = true;
+            RegistryMock* mockRegistryWrapper = new RegistryMock();
+            FileExplorerPreviewSettings previewSettings = GetSettingsObject(defaultState, mockRegistryWrapper);
+            auto settings = PowerToyValues::from_json_string(GetJSONSettings(L"", L""));
 
             // Act
-            tempSettings.DisablePreview();
+            previewSettings.LoadState(settings);
 
             // Assert
-            Assert::IsFalse(tempSettings.GetState());
+            Assert::AreEqual(previewSettings.GetToggleSettingState(), defaultState);
+        }
+
+        TEST_METHOD (UpdateState_ShouldDisablePreview_IfPreviewsAreEnabledAndNewSettingsStateIsFalse)
+        {
+            // Arrange
+            bool enabled = true;
+            RegistryMock* mockRegistryWrapper = new RegistryMock();
+            FileExplorerPreviewSettings previewSettings = GetSettingsObject(true, mockRegistryWrapper);
+            auto settings = PowerToyValues::from_json_string(GetJSONSettings(previewSettings.GetToggleSettingName(), L"false"));
+            previewSettings.UpdateToggleSettingState(true);
+
+            // Act
+            previewSettings.UpdateState(settings, enabled);
+
+            // Assert
+            Assert::IsFalse(previewSettings.GetToggleSettingState());
+            Assert::AreEqual(mockRegistryWrapper->DeleteRegistryMockProperties.NumOfCalls, 1);
+        }
+
+        TEST_METHOD (UpdateState_ShouldEnablePreview_IfPreviewsAreEnabledAndNewSettingsStateIsTrue)
+        {
+            // Arrange
+            bool enabled = true;
+            RegistryMock* mockRegistryWrapper = new RegistryMock();
+            FileExplorerPreviewSettings previewSettings = GetSettingsObject(true, mockRegistryWrapper);
+            auto settings = PowerToyValues::from_json_string(GetJSONSettings(previewSettings.GetToggleSettingName(), L"true"));
+            previewSettings.UpdateToggleSettingState(false);
+
+            // Act
+            previewSettings.UpdateState(settings, enabled);
+
+            // Assert
+            Assert::IsTrue(previewSettings.GetToggleSettingState());
+            Assert::AreEqual(mockRegistryWrapper->SetRegistryMockProperties.NumOfCalls, 1);
+        }
+
+        TEST_METHOD (UpdateState_ShouldOnlyUpdateToggleSettingState_IfPreviewsAreDisabled)
+        {
+            // Arrange
+            bool enabled = false;
+            RegistryMock* mockRegistryWrapper = new RegistryMock();
+            FileExplorerPreviewSettings previewSettings = GetSettingsObject(true, mockRegistryWrapper);
+            auto settings = PowerToyValues::from_json_string(GetJSONSettings(previewSettings.GetToggleSettingName(), L"false"));
+
+            // Act
+            previewSettings.UpdateState(settings, enabled);
+
+            // Assert
+            Assert::IsFalse(previewSettings.GetToggleSettingState());
+            Assert::AreEqual(mockRegistryWrapper->SetRegistryMockProperties.NumOfCalls, 0);
+            Assert::AreEqual(mockRegistryWrapper->DeleteRegistryMockProperties.NumOfCalls, 0);
+        }
+
+        TEST_METHOD (UpdateToggleSettingState_ShouldUpdateState_WhenCalled)
+        {
+            // Arrange
+            bool updatedState = false;
+            FileExplorerPreviewSettings previewSettings = GetSettingsObject(true, new RegistryMock());
+
+            // Act
+            previewSettings.UpdateToggleSettingState(updatedState);
+
+            // Assert
+            Assert::AreEqual(previewSettings.GetToggleSettingState(), updatedState);
         }
 
         TEST_METHOD(EnablePreview_ShouldCallSetRegistryValueWithValidArguments_WhenCalled)
         {
             // Arrange
             RegistryMock* mockRegistryWrapper = new RegistryMock();
-            FileExplorerPreviewSettings tempSettings = GetSttingsObjects(mockRegistryWrapper);
+            FileExplorerPreviewSettings previewSettings = GetSettingsObject(true, mockRegistryWrapper);
 
             // Act
-            tempSettings.EnablePreview();
+            previewSettings.EnablePreview();
 
             // Assert
             Assert::AreEqual(mockRegistryWrapper->SetRegistryMockProperties.NumOfCalls, 1);
-            Assert::AreEqual(mockRegistryWrapper->SetRegistryMockProperties.SubKey, tempSettings.GetSubKey());
-            Assert::AreEqual(mockRegistryWrapper->SetRegistryMockProperties.ValueName, tempSettings.GetCLSID());
+            Assert::AreEqual(mockRegistryWrapper->SetRegistryMockProperties.SubKey, preview_handlers_subkey);
+            Assert::AreEqual(mockRegistryWrapper->SetRegistryMockProperties.ValueName, previewSettings.GetCLSID());
             Assert::AreEqual((ULONG_PTR)(mockRegistryWrapper->SetRegistryMockProperties.Scope), (ULONG_PTR)(HKEY_CURRENT_USER));
-        }
-
-        TEST_METHOD(EnablePreview_ShouldNotSetStateToTrue_IfSetRegistryValueFailed)
-        {
-            // Arrange
-            RegistryMock* mockRegistryWrapper = new RegistryMock();
-            mockRegistryWrapper->SetRegistryMockProperties.ReturnValue = ERROR_OUTOFMEMORY;
-            FileExplorerPreviewSettings tempSettings = GetSttingsObjects(mockRegistryWrapper);
-            tempSettings.SetState(false);
-
-            // Act
-            tempSettings.EnablePreview();
-
-            // Assert
-            Assert::IsFalse(tempSettings.GetState());
-        }
-
-        TEST_METHOD(EnablePreview_ShouldSetStateToTrue_IfSetRegistryValueReturnSuccessErrorCode)
-        {
-            // Arrange
-            RegistryMock* mockRegistryWrapper = new RegistryMock();
-            FileExplorerPreviewSettings tempSettings = GetSttingsObjects(mockRegistryWrapper);
-            tempSettings.SetState(false);
-
-            // Act
-            tempSettings.EnablePreview();
-
-            // Assert
-            Assert::IsTrue(tempSettings.GetState());
         }
 
         TEST_METHOD(DisablePreview_ShouldCallDeleteRegistryValueWithValidArguments_WhenCalled)
         {
             // Arrange
             RegistryMock* mockRegistryWrapper = new RegistryMock();
-            FileExplorerPreviewSettings tempSettings = GetSttingsObjects(mockRegistryWrapper);
+            FileExplorerPreviewSettings previewSettings = GetSettingsObject(true, mockRegistryWrapper);
 
             // Act
-            tempSettings.DisablePreview();
+            previewSettings.DisablePreview();
 
             // Assert
             Assert::AreEqual(mockRegistryWrapper->DeleteRegistryMockProperties.NumOfCalls, 1);
-            Assert::AreEqual(mockRegistryWrapper->DeleteRegistryMockProperties.SubKey, tempSettings.GetSubKey());
-            Assert::AreEqual(mockRegistryWrapper->DeleteRegistryMockProperties.ValueName, tempSettings.GetCLSID());
+            Assert::AreEqual(mockRegistryWrapper->DeleteRegistryMockProperties.SubKey, preview_handlers_subkey);
+            Assert::AreEqual(mockRegistryWrapper->DeleteRegistryMockProperties.ValueName, previewSettings.GetCLSID());
             Assert::AreEqual((ULONG_PTR)(mockRegistryWrapper->DeleteRegistryMockProperties.Scope), (ULONG_PTR)(HKEY_CURRENT_USER));
         }
 
-        TEST_METHOD(DisablePreview_ShouldNotSetStateToFalse_IfDeleteRegistryValueFailed)
-        {
-            // Arrange
-            RegistryMock* mockRegistryWrapper = new RegistryMock();
-            mockRegistryWrapper->DeleteRegistryMockProperties.ReturnValue = ERROR_OUTOFMEMORY;
-            FileExplorerPreviewSettings tempSettings = GetSttingsObjects(mockRegistryWrapper);
-            tempSettings.SetState(true);
-
-            // Act
-            tempSettings.DisablePreview();
-
-            // Assert
-            Assert::IsTrue(tempSettings.GetState());
-        }
-
-        TEST_METHOD(DisablePreview_ShouldSetStateToFalse_IfDeleteRegistryValueReturnSuccessErrorCode)
-        {
-            // Arrange
-            RegistryMock* mockRegistryWrapper = new RegistryMock();
-            FileExplorerPreviewSettings tempSettings = GetSttingsObjects(mockRegistryWrapper);
-            tempSettings.SetState(true);
-
-            // Act
-            tempSettings.DisablePreview();
-
-            // Assert
-            Assert::IsFalse(tempSettings.GetState());
-        }
-
-		FileExplorerPreviewSettings GetSttingsObjects(RegistryMock * registryMock)
+		FileExplorerPreviewSettings GetSettingsObject(bool defaultState, RegistryWrapperIface* registryMock)
 		{
             return FileExplorerPreviewSettings(
-                false,
-                GET_RESOURCE_STRING(IDS_PREVPANE_MD_BOOL_TOGGLE_CONTROLL),
-                GET_RESOURCE_STRING(IDS_PREVPANE_MD_SETTINGS_DESCRIPTION),
-                L"{test-guid}",
-                TEXT("Test Handler\0"),
+                defaultState,
+                L"valid-name",
+                L"valid-description",
+                L"valid-guid",
+                L"valid-handler",
                 registryMock);
 		}
 

--- a/src/modules/previewpane/powerpreviewTest/FileExplorerPreviewSettingsTest.cpp
+++ b/src/modules/previewpane/powerpreviewTest/FileExplorerPreviewSettingsTest.cpp
@@ -19,7 +19,7 @@ namespace PreviewHandlerSettingsTest
     public:
         LONG ReturnValue = ERROR_SUCCESS;
         int NumOfCalls = 0;
-        HKEY Scope;
+        HKEY Scope = NULL;
         LPCWSTR SubKey;
         LPCWSTR ValueName;
     };
@@ -84,7 +84,7 @@ namespace PreviewHandlerSettingsTest
             bool defaultState = true;
             RegistryMock* mockRegistryWrapper = new RegistryMock();
             FileExplorerPreviewSettings previewSettings = GetSettingsObject(defaultState, mockRegistryWrapper);
-            auto settings = PowerToyValues::from_json_string(GetJSONSettings(L"", L""));
+            auto settings = PowerToyValues::from_json_string(L"{\"name\":\"Module Name\"}");
 
             // Act
             previewSettings.LoadState(settings);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Update the logic of File explorer settings. Updated the logic to pick up default value as `true` in case of no previous settings is present and make the settings persistent in case of restarting the PowerToys.

Settings logic behaviour:
1. On startup of `PowerToys` if previous settings config present used it otherwise default to enable.
2. On exit of `PowerToys` disable all the active previews handlers.
3. If the global setting `File Explorer` is disabled all the `enable` and `disable` update operation on individual Preview Handler will only be reflected on Settings UI and applied once the global settings is set to `enabled`.
4.  If the global setting `File Explorer` is enabled all the `enable` and `disable` update operation on individual Preview Handler will be reflected on Settings UI and applied.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #1630, #1652 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Validated settings with MSI installation of `PowerToys`.