### PR TITLE
MSIX: Fix for Heap Corruption bug in ImageResizer

### DIFF
--- a/src/modules/imageresizer/dll/ContextMenuHandler.cpp
+++ b/src/modules/imageresizer/dll/ContextMenuHandler.cpp
@@ -376,7 +376,7 @@ HRESULT __stdcall CContextMenuHandler::GetState(IShellItemArray* psiItemArray, B
     // TODO: Instead, detect whether there's a WIC codec installed that can handle this file
     AssocGetPerceivedType(pszExt, &type, &flag, NULL);
 
-    free(pszPath);
+    CoTaskMemFree(pszPath);
     // If selected file is an image...
     if (type == PERCEIVED_TYPE_IMAGE)
     {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Fix for #1566. A free was being used for a string created by [IShellItem::GetDisplayName](https://docs.microsoft.com/en-us/windows/win32/api/shobjidl_core/nf-shobjidl_core-ishellitem-getdisplayname) instead of [CoTaskMemFree](https://docs.microsoft.com/en-us/windows/win32/api/combaseapi/nf-combaseapi-cotaskmemfree).

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Applies to #1566
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA