### PR TITLE
Enable non-ascii chars

### DIFF
--- a/src/common/json.cpp
+++ b/src/common/json.cpp
@@ -9,11 +9,12 @@ namespace json
     {
         try
         {
-            std::wifstream file(file_name.data(), std::ios::binary);
+            std::ifstream file(file_name.data(), std::ios::binary);
             if (file.is_open())
             {
-                using isbi = std::istreambuf_iterator<wchar_t>;
-                return JsonValue::Parse(std::wstring{ isbi{ file }, isbi{} }).GetObjectW();
+                using isbi = std::istreambuf_iterator<char>;
+                std::string objStr{ isbi{ file }, isbi{} };
+                return JsonValue::Parse(winrt::to_hstring(objStr)).GetObjectW();
             }
             return std::nullopt;
         }
@@ -25,6 +26,7 @@ namespace json
 
     void to_file(std::wstring_view file_name, const JsonObject& obj)
     {
-        std::wofstream{ file_name.data(), std::ios::binary } << obj.Stringify().c_str();
+        std::wstring objStr{ obj.Stringify().c_str() };
+        std::ofstream{ file_name.data(), std::ios::binary } << winrt::to_string(objStr);
     }
 }

--- a/src/common/json.cpp
+++ b/src/common/json.cpp
@@ -12,13 +12,8 @@ namespace json
             std::ifstream file(file_name.data(), std::ios::binary);
             if (file.is_open())
             {
-                file.seekg(0, file.end);
-                auto length = file.tellg();
-                file.seekg(0, file.beg);
-                std::string obj_str;
-                obj_str.resize(length);
-                file.read(obj_str.data(), length);
-                file.close();
+                using isbi = std::istreambuf_iterator<char>;
+                std::string obj_str{ isbi{ file }, isbi{} };
                 return JsonValue::Parse(winrt::to_hstring(obj_str)).GetObjectW();
             }
             return std::nullopt;
@@ -31,13 +26,7 @@ namespace json
 
     void to_file(std::wstring_view file_name, const JsonObject& obj)
     {
-        std::ofstream file{ file_name.data(), std::ios::binary };
-
-        if(file.is_open())
-        {
-            std::string obj_str{winrt::to_string(obj.Stringify())};
-            file.write(obj_str.c_str(), obj_str.size());
-            file.close();
-        }
+        std::wstring obj_str{ obj.Stringify().c_str() };
+        std::ofstream{ file_name.data(), std::ios::binary } << winrt::to_string(obj_str);
     }
 }

--- a/src/common/json.cpp
+++ b/src/common/json.cpp
@@ -18,7 +18,7 @@ namespace json
                 std::string obj_str;
                 obj_str.resize(length);
                 file.read(obj_str.data(), length);
-
+                file.close();
                 return JsonValue::Parse(winrt::to_hstring(obj_str)).GetObjectW();
             }
             return std::nullopt;
@@ -37,6 +37,7 @@ namespace json
         {
             std::string obj_str{winrt::to_string(obj.Stringify())};
             file.write(obj_str.c_str(), obj_str.size());
+            file.close();
         }
     }
 }

--- a/src/common/json.cpp
+++ b/src/common/json.cpp
@@ -12,8 +12,13 @@ namespace json
             std::ifstream file(file_name.data(), std::ios::binary);
             if (file.is_open())
             {
-                using isbi = std::istreambuf_iterator<char>;
-                std::string obj_str{ isbi{ file }, isbi{} };
+                file.seekg(0, file.end);
+                auto length = file.tellg();
+                file.seekg(0, file.beg);
+                std::string obj_str;
+                obj_str.resize(length);
+                file.read(obj_str.data(), length);
+                file.close();
                 return JsonValue::Parse(winrt::to_hstring(obj_str)).GetObjectW();
             }
             return std::nullopt;
@@ -26,7 +31,13 @@ namespace json
 
     void to_file(std::wstring_view file_name, const JsonObject& obj)
     {
-        std::wstring obj_str{ obj.Stringify().c_str() };
-        std::ofstream{ file_name.data(), std::ios::binary } << winrt::to_string(obj_str);
+        std::ofstream file{ file_name.data(), std::ios::binary };
+
+        if(file.is_open())
+        {
+            std::string obj_str{winrt::to_string(obj.Stringify())};
+            file.write(obj_str.c_str(), obj_str.size());
+            file.close();
+        }
     }
 }

--- a/src/common/json.cpp
+++ b/src/common/json.cpp
@@ -13,8 +13,8 @@ namespace json
             if (file.is_open())
             {
                 using isbi = std::istreambuf_iterator<char>;
-                std::string objStr{ isbi{ file }, isbi{} };
-                return JsonValue::Parse(winrt::to_hstring(objStr)).GetObjectW();
+                std::string obj_str{ isbi{ file }, isbi{} };
+                return JsonValue::Parse(winrt::to_hstring(obj_str)).GetObjectW();
             }
             return std::nullopt;
         }
@@ -26,7 +26,7 @@ namespace json
 
     void to_file(std::wstring_view file_name, const JsonObject& obj)
     {
-        std::wstring objStr{ obj.Stringify().c_str() };
-        std::ofstream{ file_name.data(), std::ios::binary } << winrt::to_string(objStr);
+        std::wstring obj_str{ obj.Stringify().c_str() };
+        std::ofstream{ file_name.data(), std::ios::binary } << winrt::to_string(obj_str);
     }
 }

--- a/src/common/json.cpp
+++ b/src/common/json.cpp
@@ -18,7 +18,7 @@ namespace json
                 std::string obj_str;
                 obj_str.resize(length);
                 file.read(obj_str.data(), length);
-                file.close();
+
                 return JsonValue::Parse(winrt::to_hstring(obj_str)).GetObjectW();
             }
             return std::nullopt;
@@ -37,7 +37,6 @@ namespace json
         {
             std::string obj_str{winrt::to_string(obj.Stringify())};
             file.write(obj_str.c_str(), obj_str.size());
-            file.close();
         }
     }
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Enables serializing utf8 characters to file. This was not working before out of the box and was ending up with messing with both temporary json files (causing Editor to crash) and zones-settings.json file.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #1322, #1533