### PR TITLE
Display infobar for blocked relative image path

### DIFF
--- a/src/modules/previewpane/MarkDownPreviewHandler/HTMLParsingExtension.cs
+++ b/src/modules/previewpane/MarkDownPreviewHandler/HTMLParsingExtension.cs
@@ -91,23 +91,9 @@ namespace MarkdownPreviewHandler
                     {
                         if (link.IsImage)
                         {
+                            link.Url = "#";
                             link.GetAttributes().AddClass("img-fluid");
-                        }
-
-                        if (!Uri.TryCreate(link.Url, UriKind.Absolute, out _))
-                        {
-                            link.Url = link.Url.TrimStart('/', '\\');
-                            this.BaseUrl = this.BaseUrl.TrimEnd('/', '\\');
-                            Uri uriLink = new Uri(Path.Combine(this.BaseUrl, link.Url));
-                            link.Url = uriLink.ToString();
-                        }
-                        else
-                        {
-                            if (link.IsImage)
-                            {
-                                link.Url = "#";
-                                this.imagesBlockedCallBack();
-                            }
+                            this.imagesBlockedCallBack();
                         }
                     }
                 }

--- a/src/modules/previewpane/MarkdownPreviewHandler/MarkdownPreviewHandlerControl.cs
+++ b/src/modules/previewpane/MarkdownPreviewHandler/MarkdownPreviewHandlerControl.cs
@@ -8,6 +8,7 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using Common;
 using Markdig;
@@ -82,6 +83,12 @@ namespace MarkdownPreviewHandler
                     string filePath = dataSource as string;
                     string fileText = File.ReadAllText(filePath);
                     this.extension.BaseUrl = Path.GetDirectoryName(filePath);
+
+                    Regex rgx = new Regex(@"<[ ]*img.*>");
+                    if (rgx.IsMatch(fileText))
+                    {
+                        this.infoBarDisplayed = true;
+                    }
 
                     MarkdownPipeline pipeline = this.pipelineBuilder.Build();
                     string parsedMarkdown = Markdown.ToHtml(fileText, pipeline);

--- a/src/modules/previewpane/PreviewPaneUnitTests/HTMLParsingExtensionTest.cs
+++ b/src/modules/previewpane/PreviewPaneUnitTests/HTMLParsingExtensionTest.cs
@@ -47,7 +47,7 @@ namespace PreviewPaneUnitTests
         }
 
         [TestMethod]
-        public void Extension_UpdatesFigureClassAndRelativeUrltoAbsolute_WhenUsed()
+        public void Extension_UpdatesFigureClassAndBlocksRelativeUrl_WhenUsed()
         {
             // arrange 
             String mdString = "![text](a.jpg \"Figure\")";
@@ -58,37 +58,7 @@ namespace PreviewPaneUnitTests
             String html = Markdown.ToHtml(mdString, markdownPipeline);
 
             // Assert
-            Assert.AreEqual(html, "<p><img src=\"file:///C:/Users/a.jpg\" class=\"img-fluid\" alt=\"text\" title=\"Figure\" /></p>\n");
-        }
-
-        [TestMethod]
-        public void Extension_CreatesCorrectAbsoluteLinkByTrimmingForwardSlash_WhenUsed()
-        {
-            // arrange 
-            String mdString = "![text](\\document\\a.jpg \"Figure\")";
-            HTMLParsingExtension htmlParsingExtension = new HTMLParsingExtension(() => { }, "C:\\Users\\");
-            MarkdownPipeline markdownPipeline = BuidPipeline(htmlParsingExtension);
-
-            // Act
-            String html = Markdown.ToHtml(mdString, markdownPipeline);
-
-            // Assert
-            Assert.AreEqual(html, "<p><img src=\"file:///C:/Users/document/a.jpg\" class=\"img-fluid\" alt=\"text\" title=\"Figure\" /></p>\n");
-        }
-
-        [TestMethod]
-        public void Extension_CreatesCorrectAbsoluteLinkByTrimmingBackwardSlash_WhenUsed()
-        {
-            // arrange 
-            String mdString = "![text](/document/a.jpg \"Figure\")";
-            HTMLParsingExtension htmlParsingExtension = new HTMLParsingExtension(() => { }, "C:/Users/");
-            MarkdownPipeline markdownPipeline = BuidPipeline(htmlParsingExtension);
-
-            // Act
-            String html = Markdown.ToHtml(mdString, markdownPipeline);
-
-            // Assert
-            Assert.AreEqual(html, "<p><img src=\"file:///C:/Users/document/a.jpg\" class=\"img-fluid\" alt=\"text\" title=\"Figure\" /></p>\n");
+            Assert.AreEqual(html, "<p><img src=\"#\" class=\"img-fluid\" alt=\"text\" title=\"Figure\" /></p>\n");
         }
 
         [TestMethod]

--- a/src/modules/previewpane/PreviewPaneUnitTests/HelperFiles/MarkdownWithHTMLImageTag.txt
+++ b/src/modules/previewpane/PreviewPaneUnitTests/HelperFiles/MarkdownWithHTMLImageTag.txt
@@ -1,0 +1,2 @@
+﻿## Something
+<img src="./a.jpg" \>

--- a/src/modules/previewpane/PreviewPaneUnitTests/MarkdownPreviewHandlerTest.cs
+++ b/src/modules/previewpane/PreviewPaneUnitTests/MarkdownPreviewHandlerTest.cs
@@ -43,6 +43,20 @@ namespace PreviewPaneUnitTests
         }
 
         [TestMethod]
+        public void MarkdownPreviewHandlerControl__AddsInfoBarToFormIfHTMLImageTagIsPresent_WhenDoPreviewIsCalled()
+        {
+            // Arrange 
+            MarkdownPreviewHandlerControl markdownPreviewHandlerControl = new MarkdownPreviewHandlerControl();
+
+            // Act
+            markdownPreviewHandlerControl.DoPreview<string>("HelperFiles/MarkdownWithHTMLImageTag.txt");
+
+            // Assert
+            Assert.AreEqual(markdownPreviewHandlerControl.Controls.Count, 2);
+            Assert.IsInstanceOfType(markdownPreviewHandlerControl.Controls[1], typeof(RichTextBox));
+        }
+
+        [TestMethod]
         public void MarkdownPreviewHandlerControl__DoesNotAddInfoBarToFormIfExternalImageLinkNotPresent_WhenDoPreviewIsCalled()
         {
             // Arrange 

--- a/src/modules/previewpane/PreviewPaneUnitTests/UnitTests-MarkdownPreviewHandler.csproj
+++ b/src/modules/previewpane/PreviewPaneUnitTests/UnitTests-MarkdownPreviewHandler.csproj
@@ -116,6 +116,9 @@
     <Content Include="HelperFiles\MarkdownWithExternalImage.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="HelperFiles\MarkdownWithHTMLImageTag.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="HelperFiles\MarkdownWithscript.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Updated HTML parsing extension in markdown preview pane to display infobar for blocked relative image URL's.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #1677 
* [x] Tests added/passed

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manually validated desired functionality and ensured that tests are passing