### PR TITLE
Add support for shortcuts with >2 keys (dev/keyboardManager)

### DIFF
--- a/src/modules/keyboardmanager/dll/dllmain.cpp
+++ b/src/modules/keyboardmanager/dll/dllmain.cpp
@@ -76,7 +76,7 @@ public:
     {
         //// If mapped to 0x0 then key is disabled.
         //keyboardManagerState.singleKeyReMap[0x41] = 0x42;
-        //keyboardManagerState.singleKeyReMap[0x42] = 0x43;
+        //keyboardManagerState.singleKeyReMap[0x42] = 0x41;
         //keyboardManagerState.singleKeyReMap[0x43] = 0x41;
         //keyboardManagerState.singleKeyReMap[VK_LWIN] = VK_LCONTROL;
         //keyboardManagerState.singleKeyReMap[VK_LCONTROL] = VK_LWIN;
@@ -85,11 +85,11 @@ public:
         //keyboardManagerState.singleKeyToggleToMod[VK_CAPITAL] = false;
 
         //// OS-level shortcut remappings
-        //keyboardManagerState.osLevelShortcutReMap[std::vector<DWORD>({ VK_LMENU, 0x44 })] = std::make_pair(std::vector<WORD>({ VK_LCONTROL, 0x56 }), false);
+        //keyboardManagerState.osLevelShortcutReMap[std::vector<DWORD>({ VK_MENU, 0x56 })] = std::make_pair(std::vector<WORD>({ VK_LCONTROL, 0x56 }), false);
         //keyboardManagerState.osLevelShortcutReMap[std::vector<DWORD>({ VK_LMENU, 0x45 })] = std::make_pair(std::vector<WORD>({ VK_LCONTROL, 0x58 }), false);
         //keyboardManagerState.osLevelShortcutReMap[std::vector<DWORD>({ VK_LWIN, 0x46 })] = std::make_pair(std::vector<WORD>({ VK_LWIN, 0x53 }), false);
         //keyboardManagerState.osLevelShortcutReMap[std::vector<DWORD>({ VK_LWIN, 0x41 })] = std::make_pair(std::vector<WORD>({ VK_LCONTROL, 0x58 }), false);
-        //keyboardManagerState.osLevelShortcutReMap[std::vector<DWORD>({ VK_LCONTROL, 0x58 })] = std::make_pair(std::vector<WORD>({ VK_LWIN, 0x41 }), false);
+        //keyboardManagerState.osLevelShortcutReMap[std::vector<DWORD>({ VK_LCONTROL, 0x56 })] = std::make_pair(std::vector<WORD>({ VK_MENU, 0x56 }), false);
 
         //keyboardManagerState.osLevelShortcutReMap[std::vector<DWORD>({ VK_LWIN, 0x41 })] = std::make_pair(std::vector<WORD>({ VK_LCONTROL, 0x58 }), false);
         //keyboardManagerState.osLevelShortcutReMap[std::vector<DWORD>({ VK_LCONTROL, 0x58 })] = std::make_pair(std::vector<WORD>({ VK_LMENU, 0x44 }), false);
@@ -322,7 +322,7 @@ public:
                 {
                     return 1;
                 }
-
+ 
                 int key_count = 1;
                 LPINPUT keyEventList = new INPUT[size_t(key_count)]();
                 memset(keyEventList, 0, sizeof(keyEventList));
@@ -398,6 +398,11 @@ public:
         bool isIgnore = false;
         for (int keyVal = 0; keyVal < 0x100; keyVal++)
         {
+            // Skip mouse buttons. Keeping this could cause a remapping to fail if a mouse button is also pressed at the same time
+            if (keyVal == VK_LBUTTON || keyVal == VK_RBUTTON || keyVal == VK_MBUTTON || keyVal == VK_XBUTTON1 || keyVal == VK_XBUTTON2)
+            {
+                continue;
+            }
             // Check state of the key
             if (GetAsyncKeyState(keyVal) & 0x8000)
             {

--- a/src/modules/keyboardmanager/dll/dllmain.cpp
+++ b/src/modules/keyboardmanager/dll/dllmain.cpp
@@ -395,13 +395,61 @@ public:
     // Function to check if any keys are pressed down except those passed in the argument
     bool IsKeyboardStateClearExceptArgs(const std::vector<DWORD>& args)
     {
+        bool isIgnore = false;
         for (int keyVal = 0; keyVal < 0x100; keyVal++)
         {
             // Check state of the key
             if (GetAsyncKeyState(keyVal) & 0x8000)
             {
+                isIgnore = false;
                 // If the key is not part of the argument then the keyboard state is not clear
-                if (std::find(args.begin(), args.end(), keyVal) == args.end())
+                for (int i = 0; i < args.size(); i++)
+                {
+                    // If the key matches one of the args, ignore
+                    if (args[i] == keyVal)
+                    {
+                        isIgnore = true;
+                        break;
+                    }
+                    // If the key is Control and either of the args is L/R Control, ignore
+                    else if ((args[i] == VK_LCONTROL || args[i] == VK_RCONTROL) && keyVal == VK_CONTROL)
+                    {
+                        isIgnore = true;
+                        break;
+                    }
+                    // If the key is Alt and either of the args is L/R Alt, ignore
+                    else if ((args[i] == VK_LMENU || args[i] == VK_RMENU) && keyVal == VK_MENU)
+                    {
+                        isIgnore = true;
+                        break;
+                    }
+                    // If the key is Shift and either of the args is L/R Shift, ignore
+                    else if ((args[i] == VK_LSHIFT || args[i] == VK_RSHIFT) && keyVal == VK_SHIFT)
+                    {
+                        isIgnore = true;
+                        break;
+                    }
+                    // If the key is L/R Control and either of the args is Control, ignore
+                    else if ((keyVal == VK_LCONTROL || keyVal == VK_RCONTROL) && args[i] == VK_CONTROL)
+                    {
+                        isIgnore = true;
+                        break;
+                    }
+                    // If the key is L/R Alt and either of the args is Alt, ignore
+                    else if ((keyVal == VK_LMENU || keyVal == VK_RMENU) && args[i] == VK_MENU)
+                    {
+                        isIgnore = true;
+                        break;
+                    }
+                    // If the key is L/R Shift and either of the args is Shift, ignore
+                    else if ((keyVal == VK_LSHIFT || keyVal == VK_RSHIFT) && args[i] == VK_SHIFT)
+                    {
+                        isIgnore = true;
+                        break;
+                    }
+                }
+
+                if (!isIgnore)
                 {
                     return false;
                 }
@@ -425,6 +473,7 @@ public:
             {
                 if (data->lParam->vkCode == src_2 && (data->wParam == WM_KEYDOWN || data->wParam == WM_SYSKEYDOWN))
                 {
+                    // Check if any other keys have been pressed apart from the shortcut
                     if (!IsKeyboardStateClearExceptArgs(it.first))
                     {
                         return 0;

--- a/src/modules/keyboardmanager/dll/dllmain.cpp
+++ b/src/modules/keyboardmanager/dll/dllmain.cpp
@@ -76,20 +76,20 @@ public:
     {
         //// If mapped to 0x0 then key is disabled.
         //keyboardManagerState.singleKeyReMap[0x41] = 0x42;
-        //keyboardManagerState.singleKeyReMap[0x42] = 0x41;
+        //keyboardManagerState.singleKeyReMap[0x42] = 0x43;
         //keyboardManagerState.singleKeyReMap[0x43] = 0x41;
         //keyboardManagerState.singleKeyReMap[VK_LWIN] = VK_LCONTROL;
         //keyboardManagerState.singleKeyReMap[VK_LCONTROL] = VK_LWIN;
-        //keyboardManagerState.singleKeyReMap[VK_CAPITAL] = 0x41;
-        //keyboardManagerState.singleKeyReMap[0x41] = VK_CAPITAL;
+        //keyboardManagerState.singleKeyReMap[VK_CAPITAL] = 0x0;
+        //keyboardManagerState.singleKeyReMap[VK_LSHIFT] = VK_CAPITAL;
         //keyboardManagerState.singleKeyToggleToMod[VK_CAPITAL] = false;
 
         //// OS-level shortcut remappings
-        //keyboardManagerState.osLevelShortcutReMap[std::vector<DWORD>({ VK_MENU, 0x56 })] = std::make_pair(std::vector<WORD>({ VK_LCONTROL, 0x56 }), false);
+        //keyboardManagerState.osLevelShortcutReMap[std::vector<DWORD>({ VK_MENU, 0x44 })] = std::make_pair(std::vector<WORD>({ VK_LCONTROL, 0x56 }), false);
         //keyboardManagerState.osLevelShortcutReMap[std::vector<DWORD>({ VK_LMENU, 0x45 })] = std::make_pair(std::vector<WORD>({ VK_LCONTROL, 0x58 }), false);
         //keyboardManagerState.osLevelShortcutReMap[std::vector<DWORD>({ VK_LWIN, 0x46 })] = std::make_pair(std::vector<WORD>({ VK_LWIN, 0x53 }), false);
         //keyboardManagerState.osLevelShortcutReMap[std::vector<DWORD>({ VK_LWIN, 0x41 })] = std::make_pair(std::vector<WORD>({ VK_LCONTROL, 0x58 }), false);
-        //keyboardManagerState.osLevelShortcutReMap[std::vector<DWORD>({ VK_LCONTROL, 0x56 })] = std::make_pair(std::vector<WORD>({ VK_MENU, 0x56 }), false);
+        //keyboardManagerState.osLevelShortcutReMap[std::vector<DWORD>({ VK_LCONTROL, 0x58 })] = std::make_pair(std::vector<WORD>({ VK_LWIN, 0x41 }), false);
 
         //keyboardManagerState.osLevelShortcutReMap[std::vector<DWORD>({ VK_LWIN, 0x41 })] = std::make_pair(std::vector<WORD>({ VK_LCONTROL, 0x58 }), false);
         //keyboardManagerState.osLevelShortcutReMap[std::vector<DWORD>({ VK_LCONTROL, 0x58 })] = std::make_pair(std::vector<WORD>({ VK_LMENU, 0x44 }), false);

--- a/src/modules/keyboardmanager/dll/dllmain.cpp
+++ b/src/modules/keyboardmanager/dll/dllmain.cpp
@@ -392,6 +392,25 @@ public:
         return 0;
     }
 
+    // Function to check if any keys are pressed down except those passed in the argument
+    bool IsKeyboardStateClearExceptArgs(const std::vector<DWORD>& args)
+    {
+        for (int keyVal = 0; keyVal < 0x100; keyVal++)
+        {
+            // Check state of the key
+            if (GetAsyncKeyState(keyVal) & 0x8000)
+            {
+                // If the key is not part of the argument then the keyboard state is not clear
+                if (std::find(args.begin(), args.end(), keyVal) == args.end())
+                {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
     // Function to a handle a shortcut remap
     intptr_t HandleShortcutRemapEvent(LowlevelKeyboardEvent* data, std::map<std::vector<DWORD>, std::pair<std::vector<WORD>, bool>>& reMap) noexcept
     {
@@ -406,6 +425,10 @@ public:
             {
                 if (data->lParam->vkCode == src_2 && (data->wParam == WM_KEYDOWN || data->wParam == WM_SYSKEYDOWN))
                 {
+                    if (!IsKeyboardStateClearExceptArgs(it.first))
+                    {
+                        return 0;
+                    }
                     int key_count = 4;
                     LPINPUT keyEventList = new INPUT[size_t(key_count)]();
                     memset(keyEventList, 0, sizeof(keyEventList));

--- a/src/modules/keyboardmanager/dll/dllmain.cpp
+++ b/src/modules/keyboardmanager/dll/dllmain.cpp
@@ -85,7 +85,7 @@ public:
         //keyboardManagerState.singleKeyToggleToMod[VK_CAPITAL] = false;
 
         //// OS-level shortcut remappings
-        //keyboardManagerState.osLevelShortcutReMap[std::vector<DWORD>({ VK_MENU, 0x44 })] = std::make_pair(std::vector<WORD>({ VK_LCONTROL, 0x56 }), false);
+        //keyboardManagerState.osLevelShortcutReMap[std::vector<DWORD>({ VK_LMENU, 0x44 })] = std::make_pair(std::vector<WORD>({ VK_LCONTROL, 0x56 }), false);
         //keyboardManagerState.osLevelShortcutReMap[std::vector<DWORD>({ VK_LMENU, 0x45 })] = std::make_pair(std::vector<WORD>({ VK_LCONTROL, 0x58 }), false);
         //keyboardManagerState.osLevelShortcutReMap[std::vector<DWORD>({ VK_LWIN, 0x46 })] = std::make_pair(std::vector<WORD>({ VK_LWIN, 0x53 }), false);
         //keyboardManagerState.osLevelShortcutReMap[std::vector<DWORD>({ VK_LWIN, 0x41 })] = std::make_pair(std::vector<WORD>({ VK_LCONTROL, 0x58 }), false);

--- a/src/modules/keyboardmanager/ui/EditShortcutsWindow.cpp
+++ b/src/modules/keyboardmanager/ui/EditShortcutsWindow.cpp
@@ -140,8 +140,8 @@ void createEditShortcutsWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMa
                 std::vector<DWORD> originalKeys = convertWStringVectorToIntegerVector<DWORD>(splitwstring(originalShortcut.c_str(), L' '));
                 std::vector<WORD> newKeys = convertWStringVectorToIntegerVector<WORD>(splitwstring(newShortcut.c_str(), L' '));
 
-                // Check if number of keys is two since only that is currently implemented
-                if (originalKeys.size() == 2 && newKeys.size() == 2)
+                // Shortcut should consist of atleast two keys
+                if (originalKeys.size() > 1 && newKeys.size() > 1)
                 {
                     keyboardManagerState.AddOSLevelShortcut(originalKeys, newKeys);
                 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR adds support for shortcut remapping when shortcuts have more than 2 keys. The shortcut remapping will now also work with the On-Screen Keyboard.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Applies to #6 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [X] Tests passed

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
- Generalized the shortcut code to work for shortcuts greater than 2 keys
- Removed the "Shortcut must be exactly 2 keys" constraint on the Edit Shortcuts UI. The only constraint as of now is that the shortcut must be atleast 2 keys.
- Added a function in the shortcut code to check if any other keys are pressed apart from the shortcut. This was required because in the previous version of the code, if the user remaps Ctrl+C to Ctrl+V and the user pressed Ctrl+Shift+C the system would get Ctrl+Shift+V, whereas Ctrl+Shift+C is actually a different shortcut. By checking that no other keys are pressed when Ctrl+C is pressed we can ensure to remap the exact shortcut instead of all shortcuts which contain it.
- Summary of the remap algorithm (also present in comments across the code):
    - Check for the last key in the original shortcut. If all the modifier keys are also pressed down **and** no other keys are pressed, then clear out all the original shortcut keys and set the new shortcut keys as pressed down.
    - There are 4 cases to be handled if the shortcut has been pressed down
      1. The user lets go of one of the modifier keys - reset the keyboard back to the state of the keys actually being pressed down (original shortcut keys except the one which was released)
      2. The user keeps the shortcut pressed - the shortcut is repeated (for example you could hold down Ctrl+V and it will keep pasting)
      3. The user lets go of the last key - reset the keyboard back to the state of the keys actually being pressed down (original shortcut except the last key)
      4. The user presses another key while holding the shortcut down - the system now sees all the new shortcut keys and this extra key pressed at the end. Not handled as resetting the state would trigger the original shortcut once more
- **Note:** In all the steps above, an extra check has been added to avoid resetting the state and resending key events for keys which are common between the two shortcuts. The code would still work fine without this, but to minimize latency the lesser the number of SendInput events the better.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Build and run the project. At the Edit Shortcuts UI type any shortcut with any number of keys, but ensure the non-modifier key is the last one to be pressed. Apply the shortcut remap and it will work on any application.