### PR TITLE
Stop Window Walker on exit

### DIFF
--- a/src/modules/windowwalker/dll/dllmain.cpp
+++ b/src/modules/windowwalker/dll/dllmain.cpp
@@ -58,6 +58,11 @@ public:
     // Destroy the powertoy and free memory
     virtual void destroy() override
     {
+        if (m_enabled)
+        {
+            TerminateProcess(m_hProcess, 1);
+        }
+
         delete this;
     }
 


### PR DESCRIPTION
## Summary of the Pull Request
Stop the Window Walker process on exit of PowerToys

Before this change, the launched Window walker keeps sitting in the background when PowerToys exits. This makes sure that the module stops the process on PowerToys exit.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #1691
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] ~~Tests added/passed~~
* [x] ~~Requires documentation to be updated~~
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Validation Steps Performed

Ran it and verified that when exiting PowerToys using the exit menu, Window Walker is also stopped.