### PR TITLE
Order PowerToys aplhabetically Settings

### DIFF
--- a/src/runner/general_settings.h
+++ b/src/runner/general_settings.h
@@ -7,7 +7,7 @@ struct GeneralSettings
     bool isPackaged;
     bool isStartupEnabled;
     std::wstring startupDisabledReason;
-    std::unordered_map<std::wstring, bool> isModulesEnabledMap;
+    std::map<std::wstring, bool> isModulesEnabledMap;
     bool isElevated;
     bool isRunElevated;
     bool isAdmin;

--- a/src/runner/pch.h
+++ b/src/runner/pch.h
@@ -20,7 +20,6 @@
 #include <condition_variable>
 #include <stdexcept>
 #include <tuple>
-#include <set>
 #include <unordered_set>
 #include <string>
 #include <ProjectTelemetry.h>

--- a/src/runner/pch.h
+++ b/src/runner/pch.h
@@ -20,6 +20,7 @@
 #include <condition_variable>
 #include <stdexcept>
 #include <tuple>
+#include <set>
 #include <unordered_set>
 #include <string>
 #include <ProjectTelemetry.h>

--- a/src/runner/powertoy_module.cpp
+++ b/src/runner/powertoy_module.cpp
@@ -3,9 +3,9 @@
 #include "lowlevel_keyboard_event.h"
 #include <algorithm>
 
-std::unordered_map<std::wstring, PowertoyModule>& modules()
+std::map<std::wstring, PowertoyModule>& modules()
 {
-    static std::unordered_map<std::wstring, PowertoyModule> modules;
+    static std::map<std::wstring, PowertoyModule> modules;
     return modules;
 }
 

--- a/src/runner/powertoy_module.h
+++ b/src/runner/powertoy_module.h
@@ -50,4 +50,4 @@ private:
 };
 
 PowertoyModule load_powertoy(const std::wstring& filename);
-std::unordered_map<std::wstring, PowertoyModule>& modules();
+std::map<std::wstring, PowertoyModule>& modules();


### PR DESCRIPTION

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Order of PowerToys was random in both Settings list and in General Settings enable's list. Now it's in alphabetical order.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [] Applies to #1687 
* [] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [] Tests added/passed
* [] Requires documentation to be updated
* [] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Before:
![old](https://user-images.githubusercontent.com/57057282/77637366-d8e4d480-6f55-11ea-8fcd-89e4323bfbe8.png)

Now:
![nnew](https://user-images.githubusercontent.com/57057282/77637523-13e70800-6f56-11ea-9444-a866870d9f5c.png)

