### PR TITLE
Fancy zones on all monitors - when dragging window to another monitor sometimes zone stays marked as active on previous fix

### DIFF
--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -1052,9 +1052,12 @@ void FancyZones::MoveSizeUpdateInternal(HMONITOR monitor, POINT const& ptScreen,
                             m_zoneWindowMoveSize->HideZoneWindow();
                         }
                         m_zoneWindowMoveSize = iter->second;
-                        m_zoneWindowMoveSize->MoveSizeEnter(m_windowMoveSize, m_zoneWindowMoveSize->IsDragEnabled());
                     }
-                    m_zoneWindowMoveSize->MoveSizeUpdate(ptScreen, m_dragEnabled);
+
+                    for (auto [keyMonitor, zoneWindow] : m_zoneWindowMap)
+                    {
+                        zoneWindow->MoveSizeUpdate(ptScreen, m_dragEnabled);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary of the Pull Request
## PR Checklist
* [x] Applies to #1704

# Steps to reproduce fixed bug
- turn off "show spaces around zones" on two monitors and have grids or other configuration on both
- drag window from one monitor to another 
# Expected behavior
- zone on new monitor is marked as active
- all zones on previous are marked as inactive
# Actual behavior
- zone on new monitor is marked as active
- zone on previous is marked as active
