### PR TITLE
FZ: disable flash zones option for 0.16

### DIFF
--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -682,7 +682,9 @@ void FancyZones::AddZoneWindow(HMONITOR monitor, PCWSTR deviceId) noexcept
         JSONHelpers::FancyZonesDataInstance().SetActiveDeviceId(uniqueId);
 
         const bool newWorkArea = IsNewWorkArea(m_currentVirtualDesktopId, monitor);
-        const bool flash = m_settings->GetSettings()->zoneSetChange_flashZones && newWorkArea;
+        // "Turning FLASHING_ZONE option off"
+        //const bool flash = m_settings->GetSettings()->zoneSetChange_flashZones && newWorkArea;
+        const bool flash = false;
 
         auto zoneWindow = MakeZoneWindow(this, m_hinstance, monitor, uniqueId, flash);
         if (zoneWindow)

--- a/src/modules/fancyzones/lib/Settings.cpp
+++ b/src/modules/fancyzones/lib/Settings.cpp
@@ -36,10 +36,11 @@ private:
         PCWSTR name;
         bool* value;
         int resourceId;
-    } m_configBools[10] = {
+    } m_configBools[9 /* 10 */] = { // "Turning FLASHING_ZONE option off"
         { L"fancyzones_shiftDrag", &m_settings.shiftDrag, IDS_SETTING_DESCRIPTION_SHIFTDRAG },
         { L"fancyzones_overrideSnapHotkeys", &m_settings.overrideSnapHotkeys, IDS_SETTING_DESCRIPTION_OVERRIDE_SNAP_HOTKEYS },
-        { L"fancyzones_zoneSetChange_flashZones", &m_settings.zoneSetChange_flashZones, IDS_SETTING_DESCRIPTION_ZONESETCHANGE_FLASHZONES },
+        // "Turning FLASHING_ZONE option off"
+        //{ L"fancyzones_zoneSetChange_flashZones", &m_settings.zoneSetChange_flashZones, IDS_SETTING_DESCRIPTION_ZONESETCHANGE_FLASHZONES },
         { L"fancyzones_displayChange_moveWindows", &m_settings.displayChange_moveWindows, IDS_SETTING_DESCRIPTION_DISPLAYCHANGE_MOVEWINDOWS },
         { L"fancyzones_zoneSetChange_moveWindows", &m_settings.zoneSetChange_moveWindows, IDS_SETTING_DESCRIPTION_ZONESETCHANGE_MOVEWINDOWS },
         { L"fancyzones_virtualDesktopChange_moveWindows", &m_settings.virtualDesktopChange_moveWindows, IDS_SETTING_DESCRIPTION_VIRTUALDESKTOPCHANGE_MOVEWINDOWS },

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -737,6 +737,9 @@ void ZoneWindow::CycleActiveZoneSetInternal(DWORD wparam, Trace::ZoneWindow::Inp
 
 void ZoneWindow::FlashZones() noexcept
 {
+    // "Turning FLASHING_ZONE option off"
+    if(true) return;
+
     m_flashMode = true;
 
     ShowWindow(m_window.get(), SW_SHOWNA);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
The option is no longer there and will be removed from settings.json as soon as there's a need to update it. Once the option is restored and turned off, it'll appear in the settings.json again (switched off by default).


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #1720
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- launched FZ, opened settings, opened settings.json