### PR TITLE
Prevent Window Walker from having multiple running instances

### DIFF
--- a/src/modules/windowwalker/app/Window Walker/App.xaml.cs
+++ b/src/modules/windowwalker/app/Window Walker/App.xaml.cs
@@ -17,7 +17,7 @@ namespace WindowWalker
         public App()
         {
             // Check if there is already a running instance
-            _appMutex = new Mutex(false, "Global\\" + Guid);
+            _appMutex = new Mutex(false, Guid);
             if (!_appMutex.WaitOne(0, false))
             {
                 Shutdown();

--- a/src/modules/windowwalker/app/Window Walker/App.xaml.cs
+++ b/src/modules/windowwalker/app/Window Walker/App.xaml.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.  Code forked from Betsegaw Tadele's https://github.com/betsegaw/windowwalker/
 
+using System.Threading;
 using System.Windows;
 
 namespace WindowWalker
@@ -11,5 +12,18 @@ namespace WindowWalker
     /// </summary>
     public partial class App : Application
     {
+        private Mutex _appMutex;
+
+        public App()
+        {
+            // Check if there is already a running instance
+            _appMutex = new Mutex(false, "Global\\" + Guid);
+            if (!_appMutex.WaitOne(0, false))
+            {
+                Shutdown();
+            }
+        }
+
+        private static readonly string Guid = "5dedb2a2-690f-45db-9ef7-07605223a70a";
     }
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This PR implements a check in Window Walker which should prevent it from having multiple running instances - #1691. This is done at C#/App level, so it should even work when users start the module manually.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #1691
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Manually tested by running multiple instances from Explorer, and also by quitting/restarting PowerToys. There's still going to be an issue with Window Walker persisting after quitting PowerToys.
