### PR TITLE
Dragging to another monitor doesn't activate fancy zone placement fix

### DIFF
--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -1078,6 +1078,7 @@ void FancyZones::MoveSizeUpdateInternal(HMONITOR monitor, POINT const& ptScreen,
                             m_zoneWindowMoveSize->HideZoneWindow();
                         }
                         m_zoneWindowMoveSize = iter->second;
+                        m_zoneWindowMoveSize->MoveSizeEnter(m_windowMoveSize, m_zoneWindowMoveSize->IsDragEnabled());
                     }
 
                     for (auto [keyMonitor, zoneWindow] : m_zoneWindowMap)


### PR DESCRIPTION
Fixes a regression introduced by https://github.com/microsoft/PowerToys/pull/1709/files

Applies to https://github.com/microsoft/PowerToys/issues/1738