### PR TITLE
Fixed WW disable not working as expected after relaunch

### DIFF
--- a/src/modules/windowwalker/dll/dllmain.cpp
+++ b/src/modules/windowwalker/dll/dllmain.cpp
@@ -40,7 +40,7 @@ class WindowWalker : public PowertoyModuleIface
 {
 private:
     // The PowerToy state.
-    bool m_enabled = true;
+    bool m_enabled = false;
 
     // Load initial settings from the persisted values.
     void init_settings();


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
The `m_enabled` variable was defaulted to `true` instead of `false`. This resulted in the settings window showing enabled irrespective of the value in settings.json after every relaunch.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Applies to #1749 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Built Debugx64 and installed with MSI. Checked both cases were settings.json does not exist - Window Walker should be enabled by default, and once it exists then it should follow the value in the json on every launch.