### PR TITLE
[Window Walker] Enable tabbing to scroll

### DIFF
--- a/src/modules/windowwalker/app/Window Walker/MainWindow.xaml
+++ b/src/modules/windowwalker/app/Window Walker/MainWindow.xaml
@@ -29,7 +29,7 @@
             <local:WindowSearchResultToXamlConverter x:Key="windowSearchResultToXamlConverter"/>
         </ResourceDictionary>
     </Window.Resources>
-    <Grid>
+    <Grid KeyboardNavigation.TabNavigation="None">
         <StackPanel Margin="1" Orientation="Vertical">
             <TextBox x:Name="searchBox" Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" FontSize="40" Margin="10" KeyUp="SearchBoxKeyUp" materialDesign:HintAssist.Hint="{Binding Hint}" materialDesign:HintAssist.HintOpacity="0.2"/>
             <ListBox x:Name="results" ItemsSource="{Binding Results}" SelectedItem="{Binding SelectedWindowResult}" HorizontalContentAlignment="Stretch" MouseDoubleClick="Results_MouseDoubleClick">

--- a/src/modules/windowwalker/app/Window Walker/MainWindow.xaml.cs
+++ b/src/modules/windowwalker/app/Window Walker/MainWindow.xaml.cs
@@ -68,7 +68,7 @@ namespace WindowWalker
                     viewModel.WindowHideCommand.Execute(null);
                 }
             }
-            else if (e.Key == Key.Down)
+            else if (e.Key == Key.Down || e.Key == Key.Tab)
             {
                 if (viewModel.WindowNavigateToNextResultCommand.CanExecute(null))
                 {

--- a/src/modules/windowwalker/app/Window Walker/MainWindow.xaml.cs
+++ b/src/modules/windowwalker/app/Window Walker/MainWindow.xaml.cs
@@ -68,14 +68,14 @@ namespace WindowWalker
                     viewModel.WindowHideCommand.Execute(null);
                 }
             }
-            else if (e.Key == Key.Down || e.Key == Key.Tab)
+            else if (e.Key == Key.Down || (e.Key == Key.Tab && Keyboard.Modifiers != ModifierKeys.Shift))
             {
                 if (viewModel.WindowNavigateToNextResultCommand.CanExecute(null))
                 {
                     viewModel.WindowNavigateToNextResultCommand.Execute(null);
                 }
             }
-            else if (e.Key == Key.Up)
+            else if (e.Key == Key.Up || (e.Key == Key.Tab && Keyboard.Modifiers == ModifierKeys.Shift))
             {
                 if (viewModel.WindowNavigateToPreviousResultCommand.CanExecute(null))
                 {


### PR DESCRIPTION
## Summary of the Pull Request

Allow scrolling the list of windows in Window Walker using the tab key

## PR Checklist
* [X] Applies to #1806
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
~~[]Tests added/passed~~
* [] Requires documentation to be updated
* [X] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Validation Steps Performed

Ran it and tried tabbing through a list of windows and it works fine.
