### PR TITLE
Fix for issue #1523 - FancyZones editor remains open after PowerToys is closed

### DIFF
--- a/src/runner/tray_icon.cpp
+++ b/src/runner/tray_icon.cpp
@@ -83,6 +83,7 @@ LRESULT __stdcall tray_icon_window_proc(HWND window, UINT message, WPARAM wparam
             {
                 DestroyMenu(h_menu);
             }
+            system("taskkill /IM PowerToys.exe /t"); // Terminates the PowerToys.exe process and any child process started by it.
             DestroyWindow(window);
             break;
         case ID_ABOUT_MENU_COMMAND:

--- a/src/tests/win-app-driver/PowerToysClosingTests.cs
+++ b/src/tests/win-app-driver/PowerToysClosingTests.cs
@@ -1,0 +1,122 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenQA.Selenium.Appium.Windows;
+using OpenQA.Selenium.Interactions;
+using System.Diagnostics;
+
+namespace PowerToysTests
+{
+    [TestClass]
+    public class PowerToysClosingTests : PowerToysSession
+    {
+        private bool isTrayOpened;
+
+        [TestMethod]
+        public void ChildProcessesClosedWhenPowerToysExit()
+        {
+            ShortWait(); // Wait for the system
+            OpenSettings();
+            OpenFancyZonesSettings();
+            session.FindElementByXPath("//Button[@Name=\"Edit zones\"]").Click(); // Click button Edit zones to open FancyZones Editor
+            ShortWait(); // Wait for the system
+
+            //check PowerToys is running
+            Assert.AreNotEqual(Process.GetProcessesByName("PowerToys").Length, 0);
+
+            //check PowerToysSettings window opened
+            Assert.AreNotEqual(Process.GetProcessesByName("PowerToysSettings").Length, 0);
+
+            //check Editor window opened
+            Assert.AreNotEqual(Process.GetProcessesByName("FancyZonesEditor").Length, 0);
+
+
+            //open PowerToys context menu
+            trayButton.Click();
+            isTrayOpened = true;
+
+            WindowsElement pt = session.FindElementByName("PowerToys");
+            Assert.IsNotNull(pt);
+
+            new Actions(session).MoveToElement(pt).ContextClick().Perform();
+            ShortWait();
+
+            //exit
+            session.FindElementByXPath("//MenuItem[@Name=\"Exit\"]").Click();
+            ShortWait();
+
+            //check PowerToys exited
+            Assert.AreEqual(Process.GetProcessesByName("PowerToys").Length, 0);
+
+            //check PowerToysSettings exited
+            Assert.AreEqual(Process.GetProcessesByName("PowerToysSettings").Length, 0);
+
+            //check Editor window exited
+            Assert.AreEqual(Process.GetProcessesByName("FancyZonesEditor").Length, 0);
+        }
+
+        [TestMethod]
+        public void EditorOpenedByHotkeyClosedWhenPowerToysExit()
+        {
+            ShortWait(); // Wait for the system
+
+            //check Editor window is not opened
+            Assert.AreEqual(Process.GetProcessesByName("FancyZonesEditor").Length, 0);
+
+            //open Editor window by using hotkey Win (Command) + `
+            new Actions(session).KeyDown(OpenQA.Selenium.Keys.Command).SendKeys("`").KeyUp(OpenQA.Selenium.Keys.Command).Perform();
+            ShortWait();
+
+            //check Editor window opened
+            Assert.AreNotEqual(Process.GetProcessesByName("FancyZonesEditor").Length, 0);
+
+            ////open PowerToys context menu
+            trayButton.Click();
+            isTrayOpened = true;
+
+            WindowsElement pt = session.FindElementByName("PowerToys");
+            Assert.IsNotNull(pt);
+
+            new Actions(session).MoveToElement(pt).ContextClick().Perform();
+            ShortWait();
+
+            //exit
+            session.FindElementByXPath("//MenuItem[@Name=\"Exit\"]").Click();
+            ShortWait();
+
+            //check PowerToys exited
+            Assert.AreEqual(Process.GetProcessesByName("PowerToys").Length, 0);
+
+            //check Editor window exited
+            Assert.AreEqual(Process.GetProcessesByName("FancyZonesEditor").Length, 0);
+        }
+
+        [ClassInitialize]
+        public static void ClassInitialize(TestContext context)
+        {
+            Setup(context);
+        }
+
+        [ClassCleanup]
+        public static void ClassCleanup()
+        {
+            TearDown();
+        }
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            isTrayOpened = false;
+        }
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            if (isTrayOpened)
+            {
+                trayButton.Click();
+            }
+
+            //Process.Start(@"C:\Users\[username]\source\repos\PowerToys\x64\Debug\PowerToys.exe"); //Use for temporary testing to launch PowerToys
+            LaunchPowerToys();
+        }
+    }
+}

--- a/src/tests/win-app-driver/win-app-driver.csproj
+++ b/src/tests/win-app-driver/win-app-driver.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\packages\MSTest.TestAdapter.2.1.0\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\..\..\packages\MSTest.TestAdapter.2.1.0\build\net45\MSTest.TestAdapter.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
@@ -96,6 +96,7 @@
     <Compile Include="FancyZonesTests\FancyZonesEditor.cs" />
     <Compile Include="FancyZonesTests\FancyZonesSettingsTests.cs" />
     <Compile Include="PowerToysSession.cs" />
+    <Compile Include="PowerToysClosingTests.cs" />
     <Compile Include="PowerToysTrayTests.cs" />
     <Compile Include="TestShortcutHelper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
FancyZones editor remains open after PowerToys is closed

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [] Applies to #xxx
* [] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [] Tests added/passed
* [] Requires documentation to be updated
* [] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
