### PR TITLE
Version helper compare operator fix

### DIFF
--- a/src/common/UnitTests-CommonLib/UnitTestsVersionHelper.cpp
+++ b/src/common/UnitTests-CommonLib/UnitTestsVersionHelper.cpp
@@ -50,45 +50,51 @@ namespace UnitTestsVersionHelper
         }
         TEST_METHOD (whenMajorVersionIsGreaterComparationOperatorShouldReturnProperValue)
         {
-            VersionHelper rhs(MAJOR_VERSION_0, MINOR_VERSION_12, REVISION_VERSION_0);
             VersionHelper lhs(MAJOR_VERSION_0 + 1, MINOR_VERSION_12, REVISION_VERSION_0);
+            VersionHelper rhs(MAJOR_VERSION_0, MINOR_VERSION_12, REVISION_VERSION_0);
 
             Assert::IsTrue(lhs > rhs);
         }
         TEST_METHOD (whenMajorVersionIsLesserComparationOperatorShouldReturnProperValue)
         {
-            VersionHelper rhs(MAJOR_VERSION_0 + 1, MINOR_VERSION_12, REVISION_VERSION_0);
             VersionHelper lhs(MAJOR_VERSION_0, MINOR_VERSION_12, REVISION_VERSION_0);
+            VersionHelper rhs(MAJOR_VERSION_0 + 1, MINOR_VERSION_12, REVISION_VERSION_0);
 
             Assert::IsFalse(lhs > rhs);
         }
         TEST_METHOD (whenMajorVersionIsEqualComparationOperatorShouldCompareMinorVersionValue)
         {
-            VersionHelper rhs(MAJOR_VERSION_0, MINOR_VERSION_12 - 1, REVISION_VERSION_0);
-
             VersionHelper lhs(MAJOR_VERSION_0, MINOR_VERSION_12, REVISION_VERSION_0);
+            VersionHelper rhs(MAJOR_VERSION_0, MINOR_VERSION_12 - 1, REVISION_VERSION_0);
 
             Assert::IsTrue(lhs > rhs);
         }
         TEST_METHOD (whenMajorVersionIsEqualComparationOperatorShouldCompareMinorVersionValue2)
         {
-            VersionHelper rhs(MAJOR_VERSION_0, MINOR_VERSION_12, REVISION_VERSION_0);
             VersionHelper lhs(MAJOR_VERSION_0, MINOR_VERSION_12 - 1, REVISION_VERSION_0);
+            VersionHelper rhs(MAJOR_VERSION_0, MINOR_VERSION_12, REVISION_VERSION_0);
 
             Assert::IsFalse(lhs > rhs);
         }
 
         TEST_METHOD (whenMajorAndMinorVersionIsEqualComparationOperatorShouldCompareRevisionValue)
         {
-            VersionHelper rhs(MAJOR_VERSION_0, MINOR_VERSION_12, REVISION_VERSION_0);
             VersionHelper lhs(MAJOR_VERSION_0, MINOR_VERSION_12, REVISION_VERSION_0 + 1);
+            VersionHelper rhs(MAJOR_VERSION_0, MINOR_VERSION_12, REVISION_VERSION_0);
 
             Assert::IsTrue(lhs > rhs);
         }
         TEST_METHOD (whenMajorAndMinorVersionIsEqualComparationOperatorShouldCompareRevisionValue2)
         {
-            VersionHelper rhs(MAJOR_VERSION_0, MINOR_VERSION_12, REVISION_VERSION_0 + 1);
             VersionHelper lhs(MAJOR_VERSION_0, MINOR_VERSION_12, REVISION_VERSION_0);
+            VersionHelper rhs(MAJOR_VERSION_0, MINOR_VERSION_12, REVISION_VERSION_0 + 1);
+
+            Assert::IsFalse(lhs > rhs);
+        }
+        TEST_METHOD (whenMajorMinorAndRevisionIsEqualGreaterThanOperatorShouldReturnFalse)
+        {
+            VersionHelper lhs(MAJOR_VERSION_0, MINOR_VERSION_12, REVISION_VERSION_0);
+            VersionHelper rhs(MAJOR_VERSION_0, MINOR_VERSION_12, REVISION_VERSION_0);
 
             Assert::IsFalse(lhs > rhs);
         }

--- a/src/common/VersionHelper.cpp
+++ b/src/common/VersionHelper.cpp
@@ -30,34 +30,5 @@ VersionHelper::VersionHelper(int major, int minor, int revision) :
 
 bool VersionHelper::operator>(const VersionHelper& rhs)
 {
-    if (major > rhs.major)
-    {
-        return true;
-    }
-    else if (major < rhs.major)
-    {
-        return false;
-    }
-    else
-    {
-        if (minor > rhs.minor)
-        {
-            return true;
-        }
-        else if (minor < rhs.minor)
-        {
-            return false;
-        }
-        else
-        {
-            if (revision > rhs.revision)
-            {
-                return true;
-            }
-            else
-            {
-                return false;
-            }
-        }
-    }
+    return std::tie(major, minor, revision) > std::tie(rhs.major, rhs.minor, rhs.revision);
 }

--- a/src/common/VersionHelper.cpp
+++ b/src/common/VersionHelper.cpp
@@ -30,33 +30,33 @@ VersionHelper::VersionHelper(int major, int minor, int revision) :
 
 bool VersionHelper::operator>(const VersionHelper& rhs)
 {
-    if (major < rhs.major)
-    {
-        return false;
-    }
-    else if (major > rhs.major)
+    if (major > rhs.major)
     {
         return true;
     }
+    else if (major < rhs.major)
+    {
+        return false;
+    }
     else
     {
-        if (minor < rhs.minor)
-        {
-            return false;
-        }
-        else if (minor > rhs.minor)
+        if (minor > rhs.minor)
         {
             return true;
         }
+        else if (minor < rhs.minor)
+        {
+            return false;
+        }
         else
         {
-            if (revision < rhs.revision)
+            if (revision > rhs.revision)
             {
-                return false;
+                return true;
             }
             else
             {
-                return true;
+                return false;
             }
         }
     }

--- a/src/common/msi_to_msix_upgrade_lib/msi_to_msix_upgrade.cpp
+++ b/src/common/msi_to_msix_upgrade_lib/msi_to_msix_upgrade.cpp
@@ -113,13 +113,13 @@ std::future<std::optional<new_version_download_info>> check_for_new_github_relea
 
         VersionHelper current_version(VERSION_MAJOR, VERSION_MINOR, VERSION_REVISION);
 
-        if (current_version > github_version)
+        if (github_version > current_version)
         {
-            co_return std::nullopt;
+            co_return new_version_download_info{ std::move(release_page_uri), new_version.c_str() };
         }
         else
         {
-            co_return new_version_download_info{ std::move(release_page_uri), new_version.c_str() };
+            co_return std::nullopt;
         }
     }
     catch (...)

--- a/src/common/msi_to_msix_upgrade_lib/msi_to_msix_upgrade.cpp
+++ b/src/common/msi_to_msix_upgrade_lib/msi_to_msix_upgrade.cpp
@@ -110,7 +110,6 @@ std::future<std::optional<new_version_download_info>> check_for_new_github_relea
         winrt::Windows::Foundation::Uri release_page_uri{ json_body.GetNamedString(L"html_url") };
 
         VersionHelper github_version(winrt::to_string(new_version));
-
         VersionHelper current_version(VERSION_MAJOR, VERSION_MINOR, VERSION_REVISION);
 
         if (github_version > current_version)


### PR DESCRIPTION
* [x] Applies to #1770

To test change:
- main.cpp:144 to 
std::this_thread::sleep_for(std::chrono::seconds(1));
- msi_to_msix_upgrade.cpp:114  
VersionHelper current_version(VERSION_MAJOR , VERSION_MINOR, VERSION_REVISION);
Set different major, minor and revision