### PR TITLE
Support device names with underscores (such as 'Default_Monitor') in JSONHelpers.isValidDeviceId 

### DIFF
--- a/src/modules/fancyzones/lib/JsonHelpers.cpp
+++ b/src/modules/fancyzones/lib/JsonHelpers.cpp
@@ -55,9 +55,34 @@ namespace JSONHelpers
 
     bool isValidDeviceId(const std::wstring& str)
     {
+        std::wstring monitorName;
         std::wstring temp;
         std::vector<std::wstring> parts;
         std::wstringstream wss(str);
+
+        /* 
+         Important fix for device info that contains a '_' in the name:
+         1. first search for '#'
+         2. Then split the remaining string by '_' 
+        */
+
+        // Step 1: parse the name until the #, then to the '_'
+        if (!std::getline(wss, temp, L'#'))
+        {
+            return false;
+        }
+        
+        monitorName = temp;
+
+        if (!std::getline(wss, temp, L'_'))
+        {
+            return false;
+        }
+
+        monitorName += L"#" + temp;
+        parts.push_back(monitorName);
+
+        // Step 2: parse the rest of the id
         while (std::getline(wss, temp, L'_'))
         {
             parts.push_back(temp);

--- a/src/modules/fancyzones/lib/JsonHelpers.cpp
+++ b/src/modules/fancyzones/lib/JsonHelpers.cpp
@@ -67,20 +67,20 @@ namespace JSONHelpers
         */
 
         // Step 1: parse the name until the #, then to the '_'
-        if (!std::getline(wss, temp, L'#'))
+        if (str.find(L'#') != std::string::npos)
         {
-            return false;
-        }
-        
-        monitorName = temp;
+            std::getline(wss, temp, L'#');
 
-        if (!std::getline(wss, temp, L'_'))
-        {
-            return false;
-        }
+            monitorName = temp;
 
-        monitorName += L"#" + temp;
-        parts.push_back(monitorName);
+            if (!std::getline(wss, temp, L'_'))
+            {
+                return false;
+            }
+
+            monitorName += L"#" + temp;
+            parts.push_back(monitorName);
+        }
 
         // Step 2: parse the rest of the id
         while (std::getline(wss, temp, L'_'))

--- a/src/modules/fancyzones/tests/UnitTests/JsonHelpers.Tests.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/JsonHelpers.Tests.cpp
@@ -84,6 +84,12 @@ namespace FancyZonesUnitTests
             Assert::IsTrue(isValidDeviceId(deviceId));
         }
 
+        TEST_METHOD (DeviceIdWithUnderscoresInName)
+        {
+            const auto deviceId = L"Default_Monitor#1&1f0c3c2f&0&UID256_5120_1440_{00000000-0000-0000-0000-000000000000}";
+            Assert::IsTrue(isValidDeviceId(deviceId));
+        }
+
         TEST_METHOD (DeviceIdInvalidFormat)
         {
             const auto deviceId = L"_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1539}";
@@ -1011,7 +1017,7 @@ namespace FancyZonesUnitTests
                 for (int i = 0; i < 10; i++)
                 {
                     json::JsonObject obj = json::JsonObject::Parse(m_defaultCustomDeviceStr);
-                    obj.SetNamedValue(L"device-id", json::JsonValue::CreateStringValue(std::to_wstring(i) + L"_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1539}"));
+                    obj.SetNamedValue(L"device-id", json::JsonValue::CreateStringValue(std::to_wstring(i) + L"#_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1539}"));
                     devices.Append(obj);
                 }
 

--- a/src/modules/fancyzones/tests/UnitTests/JsonHelpers.Tests.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/JsonHelpers.Tests.cpp
@@ -1017,7 +1017,7 @@ namespace FancyZonesUnitTests
                 for (int i = 0; i < 10; i++)
                 {
                     json::JsonObject obj = json::JsonObject::Parse(m_defaultCustomDeviceStr);
-                    obj.SetNamedValue(L"device-id", json::JsonValue::CreateStringValue(std::to_wstring(i) + L"#_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1539}"));
+                    obj.SetNamedValue(L"device-id", json::JsonValue::CreateStringValue(std::to_wstring(i) + L"_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1539}"));
                     devices.Append(obj);
                 }
 

--- a/src/modules/fancyzones/tests/UnitTests/JsonHelpers.Tests.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/JsonHelpers.Tests.cpp
@@ -84,6 +84,18 @@ namespace FancyZonesUnitTests
             Assert::IsTrue(isValidDeviceId(deviceId));
         }
 
+        TEST_METHOD (DeviceIdWithoutHashInName)
+        {
+            const auto deviceId = L"LOCALDISPLAY_5120_1440_{00000000-0000-0000-0000-000000000000}";
+            Assert::IsTrue(isValidDeviceId(deviceId));
+        }
+
+        TEST_METHOD (DeviceIdWithoutHashInNameButWithUnderscores)
+        {
+            const auto deviceId = L"LOCAL_DISPLAY_5120_1440_{00000000-0000-0000-0000-000000000000}";
+            Assert::IsFalse(isValidDeviceId(deviceId));
+        }
+
         TEST_METHOD (DeviceIdWithUnderscoresInName)
         {
             const auto deviceId = L"Default_Monitor#1&1f0c3c2f&0&UID256_5120_1440_{00000000-0000-0000-0000-000000000000}";


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Fixes #1821 

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

I think this could be related to #1807 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #1821
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #1821 

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

Fixes the JSONHelper::isValidDeviceId by splitting the first section on the '#' instead of by '_'. This allows to use underscores in monitor device names.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
