### PR TITLE
FancyZones Editor fix: Save data after layout deletion immediately

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -193,6 +193,7 @@ namespace FancyZonesEditor
             }
 
             model.Delete();
+            LayoutModel.SerializeDeletedCustomZoneSets();
         }
     }
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Saving data right after user clicks delete button

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #1754 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

Fixed scenarios:
1. Delete Custom layout A. create and apply Custom layout B. 
2. Delete Custom layout A, select custom Layout B, click "edit selected Layout", click "Save and Apply".

Both layout were saved in settings file in these scenarios, though only layout A expected to be saved.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Tests now pass:
https://github.com/microsoft/PowerToys/blob/90a228619e6f9e66124ea86635d6d007dca5bbcd/src/tests/win-app-driver/FancyZonesTests/EditorCustomLayoutsTests.cs#L228
https://github.com/microsoft/PowerToys/blob/90a228619e6f9e66124ea86635d6d007dca5bbcd/src/tests/win-app-driver/FancyZonesTests/EditorCustomLayoutsTests.cs#L198