### PR TITLE
Fix for issue #1830 - [FancyZones Settings] Fancy Zones Editor was closed when clicking on Edit zones button

### DIFF
--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -424,7 +424,8 @@ void FancyZones::ToggleEditor() noexcept
         std::shared_lock readLock(m_lock);
         if (m_terminateEditorEvent)
         {
-            SetEvent(m_terminateEditorEvent.get());
+            MessageBox(nullptr, L"Fancy Zones Editor is already running.", L"Fancy Zones Editor", MB_ICONINFORMATION); // Show a notification to users
+            //SetEvent(m_terminateEditorEvent.get()); // Stop terminating event
             return;
         }
     }

--- a/src/tests/win-app-driver/FancyZonesTests/EditorOpeningTwiceTest.cs
+++ b/src/tests/win-app-driver/FancyZonesTests/EditorOpeningTwiceTest.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Appium.Windows;
+using OpenQA.Selenium.Interactions;
+
+namespace PowerToysTests
+{
+    [TestClass]
+    public class FancyZonesEditorOpeningTwiceTest : PowerToysSession
+    {
+        [TestMethod]
+        public void OpenEditorTwiceBySettingsButton()
+        {
+            ShortWait(); // Wait for the system
+            OpenSettings();
+            OpenFancyZonesSettings();
+            session.FindElementByXPath("//Button[@Name=\"Edit zones\"]").Click(); // Click button Edit zones to open FancyZones Editor
+            ShortWait(); // Wait for the system
+            Assert.IsNotNull(session.FindElementByName("FancyZones Editor")); // Check the FancyZones Editor is running
+
+            // Click button Edit zones while FancyZones Editor is running
+            OpenSettings();
+            session.FindElementByXPath("//Button[@Name=\"Edit zones\"]").Click(); // Click button Edit zones to open FancyZones Editor
+            ShortWait(); // Wait for the system
+            Assert.IsNotNull(session.FindElementByName("FancyZones Editor")); // Check the FancyZones Editor is running
+            Assert.IsNotNull(session.FindElementByName("Fancy Zones Editor")); // Check the notification is running
+            CloseWindow("Fancy Zones Editor"); // Close the notification
+            OpenSettings();
+            CloseWindow("FancyZones Editor"); // Close FancyZones Editor
+
+            // Click button Edit zones while FancyZones Editor is not running
+            session.FindElementByXPath("//Button[@Name=\"Edit zones\"]").Click(); // Click button Edit zones to open FancyZones Editor
+            ShortWait(); // Wait for the system
+            Assert.IsNotNull(session.FindElementByName("FancyZones Editor")); // Check the FancyZones Editor is running
+            CloseWindow("FancyZones Editor"); // Close FancyZones Editor
+            CloseSettings();
+        }
+
+        [TestMethod]
+        public void OpenEditorTwiceByHotkey()
+        {
+            ShortWait(); // Wait for the system
+            new Actions(session).KeyDown(Keys.Command).SendKeys("`").KeyUp(Keys.Command).Perform(); // Hold Win (Command) and press ` -> Open editor by hotkey
+            ShortWait(); // Wait for the system
+            Assert.IsNotNull(session.FindElementByName("FancyZones Editor")); // Check the FancyZones Editor is running
+
+            // Open Edit zones while FancyZones Editor is running
+            new Actions(session).KeyDown(Keys.Command).SendKeys("`").KeyUp(Keys.Command).Perform(); // Hold Win (Command) and press ` -> Open editor by hotkey
+            ShortWait(); // Wait for the system
+            Assert.IsNotNull(session.FindElementByName("FancyZones Editor")); // Check the FancyZones Editor is running
+            Assert.IsNotNull(session.FindElementByName("Fancy Zones Editor")); // Check the notification is running
+            CloseWindow("Fancy Zones Editor"); // Close the notification
+            CloseWindow("FancyZones Editor"); // Close FancyZones Editor
+
+            // Open Edit zones while FancyZones Editor is not running
+            new Actions(session).KeyDown(Keys.Command).SendKeys("`").KeyUp(Keys.Command).Perform(); // Hold Win (Command) and press ` -> Open editor by hotkey
+            ShortWait(); // Wait for the system
+            Assert.IsNotNull(session.FindElementByName("FancyZones Editor")); // Check the FancyZones Editor is running
+            CloseWindow("FancyZones Editor"); // Close FancyZones Editor
+        }
+
+        [ClassInitialize]
+        public static void ClassInitialize(TestContext context)
+        {
+            Setup(context);
+        }
+
+        [ClassCleanup]
+        public static void ClassCleanup()
+        {
+            TearDown();
+        }
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+
+        }
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+
+        }
+    }
+}

--- a/src/tests/win-app-driver/PowerToysSession.cs
+++ b/src/tests/win-app-driver/PowerToysSession.cs
@@ -176,6 +176,23 @@ namespace PowerToysTests
             }
         }
 
+        // Close window by using FindElementByName
+        public static void CloseWindow(string windowName)
+        {
+            try
+            {
+                WindowsElement window = session.FindElementByName(windowName);
+                if (window != null)
+                {
+                    window.SendKeys(Keys.Alt + Keys.F4);
+                }
+            }
+            catch (Exception)
+            {
+
+            }
+        }
+
         private static bool CheckPowerToysLaunched()        
         {
             trayButton.Click();

--- a/src/tests/win-app-driver/win-app-driver.csproj
+++ b/src/tests/win-app-driver/win-app-driver.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\packages\MSTest.TestAdapter.2.1.0\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\..\..\packages\MSTest.TestAdapter.2.1.0\build\net45\MSTest.TestAdapter.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
@@ -90,6 +90,7 @@
     <Compile Include="FancyZonesTests\EditorCustomLayoutsTests.cs" />
     <Compile Include="FancyZonesTests\EditorGridZoneResizeTests.cs" />
     <Compile Include="FancyZonesTests\EditorOpeningTests.cs" />
+    <Compile Include="FancyZonesTests\EditorOpeningTwiceTest.cs" />
     <Compile Include="FancyZonesTests\EditorSettingsTests.cs" />
     <Compile Include="FancyZonesTests\EditorTemplatesApplyTests.cs" />
     <Compile Include="FancyZonesTests\EditorTemplatesEditTests.cs" />


### PR DESCRIPTION
[FancyZones Settings] Fancy Zones Editor was closed when clicking on Edit zones button

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [] Applies to #xxx
* [] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [] Tests added/passed
* [] Requires documentation to be updated
* [] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
