### PR TITLE
Giving credit to MarkDig for implementation of markdown.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ This code is based on [Chris Davis's SmartRename](https://github.com/chrdavis/Sm
 
 PowerToys will now enable two types of files to be previewed:
 
-- Markdown files (.md)
+- Markdown files (.md).  This code leverages [MarkDig](https://github.com/lunet-io/markdig) for markdown rendering. 
 - SVG (.svg)
 
 ### Image Resizer


### PR DESCRIPTION
Just calling out that we use the MarkDig open source library to implement markdown rendering in the preview pane.

