### PR TITLE
Remove uneeded TmpMigrateAppliedZoneSets()

### DIFF
--- a/src/modules/fancyzones/lib/JsonHelpers.cpp
+++ b/src/modules/fancyzones/lib/JsonHelpers.cpp
@@ -579,9 +579,6 @@ namespace JSONHelpers
 
         if (!std::filesystem::exists(jsonFilePath))
         {
-            TmpMigrateAppliedZoneSetsFromRegistry();
-
-            // Custom zone sets have to be migrated after applied zone sets!
             MigrateCustomZoneSetsFromRegistry();
 
             SaveFancyZonesData();
@@ -614,56 +611,6 @@ namespace JSONHelpers
         json::to_file(jsonFilePath, root);
     }
 
-    void FancyZonesData::TmpMigrateAppliedZoneSetsFromRegistry()
-    {
-        std::wregex ex(L"^[0-9]{3,4}_[0-9]{3,4}$");
-
-        std::scoped_lock lock{ dataLock };
-        wchar_t key[256];
-        StringCchPrintf(key, ARRAYSIZE(key), L"%s", RegistryHelpers::REG_SETTINGS);
-        HKEY hkey;
-        if (RegOpenKeyExW(HKEY_CURRENT_USER, key, 0, KEY_ALL_ACCESS, &hkey) == ERROR_SUCCESS)
-        {
-            wchar_t resolutionKey[256]{};
-            DWORD resolutionKeyLength = ARRAYSIZE(resolutionKey);
-            DWORD i = 0;
-            while (RegEnumKeyW(hkey, i++, resolutionKey, resolutionKeyLength) == ERROR_SUCCESS)
-            {
-                std::wstring resolution{ resolutionKey };
-                wchar_t appliedZoneSetskey[256];
-                StringCchPrintf(appliedZoneSetskey, ARRAYSIZE(appliedZoneSetskey), L"%s\\%s", RegistryHelpers::REG_SETTINGS, resolutionKey);
-                HKEY appliedZoneSetsHkey;
-                if (std::regex_match(resolution, ex) && RegOpenKeyExW(HKEY_CURRENT_USER, appliedZoneSetskey, 0, KEY_ALL_ACCESS, &appliedZoneSetsHkey) == ERROR_SUCCESS)
-                {
-                    ZoneSetPersistedDataOLD data;
-                    DWORD dataSize = sizeof(data);
-                    wchar_t value[256]{};
-                    DWORD valueLength = ARRAYSIZE(value);
-                    DWORD i = 0;
-
-                    while (RegEnumValueW(appliedZoneSetsHkey, i++, value, &valueLength, nullptr, nullptr, reinterpret_cast<BYTE*>(&data), &dataSize) == ERROR_SUCCESS)
-                    {
-                        ZoneSetData appliedZoneSetData;
-                        appliedZoneSetData.type = TypeFromLayoutId(data.LayoutId);
-                        if (appliedZoneSetData.type != ZoneSetLayoutType::Custom)
-                        {
-                            appliedZoneSetData.uuid = std::wstring{ value };
-                        }
-                        else
-                        {
-                            // uuid is changed later to actual uuid when migrating custom zone sets
-                            appliedZoneSetData.uuid = std::to_wstring(data.LayoutId);
-                        }
-                        appliedZoneSetsMap[value] = appliedZoneSetData;
-                        dataSize = sizeof(data);
-                        valueLength = ARRAYSIZE(value);
-                    }
-                }
-                resolutionKeyLength = ARRAYSIZE(resolutionKey);
-            }
-        }
-    }
-
     void FancyZonesData::MigrateCustomZoneSetsFromRegistry()
     {
         std::scoped_lock lock{ dataLock };
@@ -684,29 +631,19 @@ namespace JSONHelpers
                 zoneSetData.type = static_cast<CustomLayoutType>(data[2]);
                 // int version =  data[0] * 256 + data[1]; - Not used anymore
 
-                std::wstring uuid = std::to_wstring(data[3] * 256 + data[4]);
-                auto it = std::find_if(appliedZoneSetsMap.cbegin(), appliedZoneSetsMap.cend(), [&uuid](std::pair<std::wstring, ZoneSetData> zoneSetMap) {
-                    return zoneSetMap.second.uuid.compare(uuid) == 0;
-                });
+                GUID guid;
+                auto result = CoCreateGuid(&guid);
+                if (result != S_OK)
+                {
+                    continue;
+                }
+                wil::unique_cotaskmem_string guidString;
+                if (!SUCCEEDED_LOG(StringFromCLSID(guid, &guidString)))
+                {
+                    continue;
+                }
 
-                if (it != appliedZoneSetsMap.cend())
-                {
-                    uuid = it->first;
-                }
-                else
-                {
-                    GUID guid;
-                    auto result = CoCreateGuid(&guid);
-                    if (result != S_OK)
-                    {
-                        return;
-                    }
-                    wil::unique_cotaskmem_string guidString;
-                    if (SUCCEEDED_LOG(StringFromCLSID(guid, &guidString)))
-                    {
-                        uuid = guidString.get();
-                    }
-                }
+                std::wstring uuid = guidString.get();
 
                 switch (zoneSetData.type)
                 {

--- a/src/modules/fancyzones/lib/JsonHelpers.h
+++ b/src/modules/fancyzones/lib/JsonHelpers.h
@@ -207,7 +207,6 @@ namespace JSONHelpers
 #if defined(UNIT_TESTS)
         inline void clear_data()
         {
-            appliedZoneSetsMap.clear();
             appZoneHistoryMap.clear();
             deviceInfoMap.clear();
             customZoneSetsMap.clear();
@@ -254,10 +253,8 @@ namespace JSONHelpers
         void SaveFancyZonesData() const;
 
     private:
-        void TmpMigrateAppliedZoneSetsFromRegistry();
         void MigrateCustomZoneSetsFromRegistry();
 
-        std::unordered_map<std::wstring, ZoneSetData> appliedZoneSetsMap{};
         std::unordered_map<std::wstring, AppZoneHistoryData> appZoneHistoryMap{};
         std::unordered_map<std::wstring, DeviceInfoData> deviceInfoMap{};
         std::unordered_map<std::wstring, CustomZoneSetData> customZoneSetsMap{};


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This was needed while we were still migrating device-info, so active layout could be migrated as well. At some point we dropped migration of device-info. Therefore, this has no valid purpose anymore.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [] Applies to #1761 
* [] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [] No automatic tests needed. Manually tested migration of custom layouts.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Tested migration of custom layouts from Windows Registry, as this removal was part of MigrateCustomZoneSets() method. Migration works as expected.