### PR TITLE
[Window Walker] Handle UWP process names

### DIFF
--- a/src/modules/windowwalker/app/Window Walker/Components/InteropAndHelpers.cs
+++ b/src/modules/windowwalker/app/Window Walker/Components/InteropAndHelpers.cs
@@ -776,6 +776,9 @@ namespace WindowWalker.Components
         public static extern int GetWindowLong(IntPtr hWnd, int nIndex);
 
         [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+        public static extern int EnumChildWindows(IntPtr hWnd, CallBackPtr callPtr, int lPar);
+
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
         public static extern int GetWindowText(IntPtr hWnd, StringBuilder strText, int maxCount);
 
         [DllImport("user32.dll", CharSet = CharSet.Unicode)]

--- a/src/modules/windowwalker/app/Window Walker/Components/Window.cs
+++ b/src/modules/windowwalker/app/Window Walker/Components/Window.cs
@@ -365,6 +365,11 @@ namespace WindowWalker.Components
             Unknown,
         }
 
+        /// <summary>
+        /// Gets the name of the process using the window handle
+        /// </summary>
+        /// <param name="hwnd">The handle to the window</param>
+        /// <returns>A string representing the process name or an empty string if the function fails</returns>
         private string GetProcessNameFromWindowHandle(IntPtr hwnd)
         {
             uint processId = GetProcessIDFromWindowHandle(hwnd);
@@ -382,6 +387,11 @@ namespace WindowWalker.Components
             }
         }
 
+        /// <summary>
+        /// Gets the process ID for the Window handle
+        /// </summary>
+        /// <param name="hwnd">The handle to the window</param>
+        /// <returns>The process ID</returns>
         private uint GetProcessIDFromWindowHandle(IntPtr hwnd)
         {
             InteropAndHelpers.GetWindowThreadProcessId(hwnd, out uint processId);

--- a/src/modules/windowwalker/app/Window Walker/Components/Window.cs
+++ b/src/modules/windowwalker/app/Window Walker/Components/Window.cs
@@ -91,12 +91,9 @@ namespace WindowWalker.Components
 
                     if (!_handlesToProcessCache.ContainsKey(Hwnd))
                     {
-                        InteropAndHelpers.GetWindowThreadProcessId(Hwnd, out uint processId);
-                        ProcessID = processId;
-                        IntPtr processHandle = InteropAndHelpers.OpenProcess(InteropAndHelpers.ProcessAccessFlags.AllAccess, true, (int)processId);
-                        StringBuilder processName = new StringBuilder(MaximumFileNameLength);
+                        var processName = GetProcessNameFromWindowHandle(Hwnd);
 
-                        if (InteropAndHelpers.GetProcessImageFileName(processHandle, processName, MaximumFileNameLength) != 0)
+                        if (processName.Length != 0)
                         {
                             _handlesToProcessCache.Add(
                                 Hwnd,


### PR DESCRIPTION
## Summary of the Pull Request

UWP apps only showed the hosting process `ApplicationFrameHost.exe` for the process name. Following the code sample referenced in #1766, this should now correctly show the process names.

## PR Checklist
* [X] Applies to #1766 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* ~~[] Tests added/passed~~
* ~~[] Requires documentation to be updated~~
* [X] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #1766

## Detailed Description of the Pull Request / Additional comments

There were 3 options that were helpfully outlined by @arjunbalgovind and @enricogior provided a working C++ code sample I was able to translate. Its worth mentioning that @arjunbalgovind suggested using method 3 as more reliable and better documented but for now, this solution should be fine.

## Validation Steps Performed

Searching for UWP apps works as expected (both title and process names are reasonable). Performance also seems fine since the child enumeration happens on a child thread.
