### PR TITLE
[Window Walker] Set focus on text box control on hotkey invoke

### DIFF
--- a/src/modules/windowwalker/app/Window Walker/MainWindow.xaml
+++ b/src/modules/windowwalker/app/Window Walker/MainWindow.xaml
@@ -21,7 +21,8 @@
         TextElement.FontSize="14"
         FontFamily="pack://application:,,,/MaterialDesignThemes.Wpf;component/Resources/Roboto/#Roboto"
         Deactivated="Window_Deactivated"
-        ShowInTaskbar="false">
+        ShowInTaskbar="false"
+        GotFocus="Window_GotFocus">
     
     <Window.Resources>
         <ResourceDictionary>    

--- a/src/modules/windowwalker/app/Window Walker/MainWindow.xaml.cs
+++ b/src/modules/windowwalker/app/Window Walker/MainWindow.xaml.cs
@@ -114,5 +114,10 @@ namespace WindowWalker
                 viewModel.WindowHideCommand.Execute(null);
             }
         }
+
+        private void Window_GotFocus(object sender, RoutedEventArgs e)
+        {
+            this.searchBox.Focus();
+        }
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request

If the user selects an item from the result windows in Window Walker using the mouse, the next invocation does not have the text box selected by default. This change sets the focus on the text box every time the window gets focus.

While this fixes a specific issue, it will also hopefully fix the general bug reported in #1800.

## PR Checklist
* [X] Applies to #xxx
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* ~~[] Tests added/passed~~
* [X] Requires documentation to be updated
* [X] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #1800

## Validation Steps Performed

Tried out the scenario of mouse clicking and checking for focus and it works fine.