### PR TITLE
Editor: zones offset scaling

### DIFF
--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -437,9 +437,6 @@ void FancyZones::ToggleEditor() noexcept
     HMONITOR monitor{};
     HWND foregroundWindow{};
 
-    UINT dpi_x = DPIAware::DEFAULT_DPI;
-    UINT dpi_y = DPIAware::DEFAULT_DPI;
-
     const bool use_cursorpos_editor_startupscreen = m_settings->GetSettings()->use_cursorpos_editor_startupscreen;
     POINT currentCursorPos{};
     if (use_cursorpos_editor_startupscreen)
@@ -473,24 +470,14 @@ void FancyZones::ToggleEditor() noexcept
                       } })
         .wait();
 
-    if (use_cursorpos_editor_startupscreen)
-    {
-        DPIAware::GetScreenDPIForPoint(currentCursorPos, dpi_x, dpi_y);
-    }
-    else
-    {
-        DPIAware::GetScreenDPIForWindow(foregroundWindow, dpi_x, dpi_y);
-    }
-
     auto zoneWindow = iter->second;
 
     const auto& fancyZonesData = JSONHelpers::FancyZonesDataInstance();
     fancyZonesData.CustomZoneSetsToJsonFile(ZoneWindowUtils::GetCustomZoneSetsTmpPath());
 
-    const auto taskbar_x_offset = MulDiv(mi.rcWork.left - mi.rcMonitor.left, DPIAware::DEFAULT_DPI, dpi_x);
-    const auto taskbar_y_offset = MulDiv(mi.rcWork.top - mi.rcMonitor.top, DPIAware::DEFAULT_DPI, dpi_y);
-
     // Do not scale window params by the dpi, that will be done in the editor - see LayoutModel.Apply
+    const auto taskbar_x_offset = mi.rcWork.left - mi.rcMonitor.left;
+    const auto taskbar_y_offset = mi.rcWork.top - mi.rcMonitor.top;
     const auto x = mi.rcMonitor.left + taskbar_x_offset;
     const auto y = mi.rcMonitor.top + taskbar_y_offset;
     const auto width = mi.rcWork.right - mi.rcWork.left;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Removed offset scaling on editor opening.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #1649
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Editor window coordinates depended on DPI unaware coordinates with scaled offsets. Removing offset scaling solved the problem.

Editor with scaled offsets:
![before](https://user-images.githubusercontent.com/8949536/78260714-f0e4c700-7506-11ea-8325-504345c581bc.png)

Editor with not scaled offsets:
![after](https://user-images.githubusercontent.com/8949536/78260776-0528c400-7507-11ea-9958-b3ba867b293a.PNG)

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Also checked different combinations of taskbar positions with different monitor scalings on primary and secondary monitors
![bottom1](https://user-images.githubusercontent.com/8949536/78262447-415d2400-7509-11ea-9ae4-1d133f2aeaed.PNG)
![left2](https://user-images.githubusercontent.com/8949536/78263444-a1a09580-750a-11ea-9fb0-bca7a50225a9.PNG)
![right1](https://user-images.githubusercontent.com/8949536/78263834-1f64a100-750b-11ea-92bb-bdafc599f6e3.PNG)
![top2](https://user-images.githubusercontent.com/8949536/78264657-1c1de500-750c-11ea-9532-39fe9e9e8ddb.PNG)
![top-bottom](https://user-images.githubusercontent.com/8949536/78264845-5edfbd00-750c-11ea-9133-89a5c33ff4ee.PNG)
![custom1](https://user-images.githubusercontent.com/8949536/78265173-c6960800-750c-11ea-95dc-f35c5220812f.PNG)

