### PR TITLE
Fix for issue #1849 - FancyZones: When decreasing the number of zones windows in the last zone get placed in the first zone.

### DIFF
--- a/src/modules/fancyzones/lib/ZoneSet.cpp
+++ b/src/modules/fancyzones/lib/ZoneSet.cpp
@@ -226,7 +226,7 @@ ZoneSet::MoveWindowIntoZoneByIndex(HWND window, HWND windowZone, int index) noex
 
     if (index >= int(m_zones.size()))
     {
-        index = 0;
+        return;
     }
 
     while (auto zoneDrop = ZoneFromWindow(window))


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Simple fix for https://github.com/microsoft/PowerToys/issues/1849

Prevents windows in the last zone being placed in the first zone when the zone count is decreased. Tested manually.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #1849 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #1849 

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Tested each template layout from 9 zones, placed a window into each zone. Decreased the number of zones one at a time and checked that the window in the last zone maintained its size and position, and was not sized and placed so as to be in the first zone.
