### PR TITLE
Handle case where two windows have the same title

### DIFF
--- a/src/modules/windowwalker/app/Window Walker/Components/OpenWindows.cs
+++ b/src/modules/windowwalker/app/Window Walker/Components/OpenWindows.cs
@@ -101,7 +101,10 @@ namespace WindowWalker.Components
                     windows.Remove(windows.Where(x => x.Title == newWindow.Title).First());
                 }
 
-                return true;
+                if (windows.Select(x => x.Hwnd).Contains(newWindow.Hwnd))
+                {
+                    return true;
+                }
             }
 
             if ((newWindow.Visible && !newWindow.ProcessName.ToLower().Equals("iexplore.exe")) ||


### PR DESCRIPTION
## Summary of the Pull Request

When two windows have the same name, they are considered "duplicates" and one of them is thrown out. The proper behavior that this PR implements is to check their window handles as well to see if they are the same windows.

## PR Checklist
* [X] Applies to #1887
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [X] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #1887

## Validation Steps Performed

Duplicate window title show up as expected.