### PR TITLE
fancyzones unity3d crash fix

### DIFF
--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -353,7 +353,7 @@ IFACEMETHODIMP ZoneWindow::MoveSizeEnter(HWND window, bool dragEnabled) noexcept
         draggedWindow = window;
         SetWindowLong(window,
                       GWL_EXSTYLE,
-                      GetWindowLong(window, GWL_EXSTYLE) | WS_EX_LAYERED);
+                      draggedWindowExstyle | WS_EX_LAYERED);
 
         GetLayeredWindowAttributes(window, &draggedWindowCrKey, &draggedWindowInitialAlpha, &draggedWindowDwFlags);
 

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -260,10 +260,10 @@ private:
     static const UINT m_flashDuration = 700; // ms
 
     HWND draggedWindow = nullptr;
-    long draggedWindowExstyle;
-    COLORREF draggedWindowCrKey;
-    DWORD draggedWindowDwFlags;
-    BYTE draggedWindowInitialAlpha;
+    long draggedWindowExstyle = 0;
+    COLORREF draggedWindowCrKey = RGB(0, 0, 0);
+    DWORD draggedWindowDwFlags = 0;
+    BYTE draggedWindowInitialAlpha = 0;
 
     ULONG_PTR gdiplusToken;
 };
@@ -746,7 +746,9 @@ void ZoneWindow::FlashZones() noexcept
 {
     // "Turning FLASHING_ZONE option off"
     if (true)
+    {
         return;
+    }
 
     m_flashMode = true;
 

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -259,8 +259,12 @@ private:
     static const UINT m_showAnimationDuration = 200; // ms
     static const UINT m_flashDuration = 700; // ms
 
-    HWND draggedWindow;
+    HWND draggedWindow = nullptr;
+    long draggedWindowExstyle;
+    COLORREF draggedWindowCrKey;
+    DWORD draggedWindowDwFlags;
     BYTE draggedWindowInitialAlpha;
+
     ULONG_PTR gdiplusToken;
 };
 
@@ -335,20 +339,25 @@ bool ZoneWindow::Init(IZoneWindowHost* host, HINSTANCE hinstance, HMONITOR monit
 
 IFACEMETHODIMP ZoneWindow::MoveSizeEnter(HWND window, bool dragEnabled) noexcept
 {
+    if (m_windowMoveSize)
+    {
+        return E_INVALIDARG;
+    }
+
     if (m_host->isMakeDraggedWindowTransparentActive())
     {
+        RestoreOrginalTransparency();
+
+        draggedWindowExstyle = GetWindowLong(window, GWL_EXSTYLE);
+
         draggedWindow = window;
         SetWindowLong(window,
                       GWL_EXSTYLE,
                       GetWindowLong(window, GWL_EXSTYLE) | WS_EX_LAYERED);
 
-        GetLayeredWindowAttributes(window, 0, &draggedWindowInitialAlpha, 0);
+        GetLayeredWindowAttributes(window, &draggedWindowCrKey, &draggedWindowInitialAlpha, &draggedWindowDwFlags);
 
         SetLayeredWindowAttributes(window, 0, (255 * 50) / 100, LWA_ALPHA);
-    }
-    if (m_windowMoveSize)
-    {
-        return E_INVALIDARG;
     }
 
     m_dragEnabled = dragEnabled;
@@ -415,10 +424,8 @@ ZoneWindow::RestoreOrginalTransparency() noexcept
 {
     if (m_host->isMakeDraggedWindowTransparentActive() && draggedWindow != nullptr)
     {
-        SetLayeredWindowAttributes(draggedWindow,
-                                   0,
-                                   draggedWindowInitialAlpha == 0 ? 255 : draggedWindowInitialAlpha,
-                                   LWA_ALPHA);
+        SetLayeredWindowAttributes(draggedWindow, draggedWindowCrKey, draggedWindowInitialAlpha, draggedWindowDwFlags);
+        SetWindowLong(draggedWindow, GWL_EXSTYLE, draggedWindowExstyle);
         draggedWindow = nullptr;
     }
 }
@@ -738,7 +745,8 @@ void ZoneWindow::CycleActiveZoneSetInternal(DWORD wparam, Trace::ZoneWindow::Inp
 void ZoneWindow::FlashZones() noexcept
 {
     // "Turning FLASHING_ZONE option off"
-    if(true) return;
+    if (true)
+        return;
 
     m_flashMode = true;
 


### PR DESCRIPTION
## PR Checklist
* [x] Applies to #1873 

## PR description
Option "make dragged window transparent" didn't full restored dragged window properties that causes some specific application eg. Unity3d to crash while moving them.
Changes were made to ensure all properties were restored to dragged window once it is dropped.

## Validation Steps Performed
Tested on unity3D

## Note

Unity3D still will crush if you grab it by 2 pixels thick application bar that is vertical resize and powertoys treats as move.
It will be fixed with #1420