### PR TITLE
window walker: changed info text in search box

### DIFF
--- a/src/modules/windowwalker/app/Window Walker/ViewModels/WindowWalkerViewModel.cs
+++ b/src/modules/windowwalker/app/Window Walker/ViewModels/WindowWalkerViewModel.cs
@@ -17,7 +17,7 @@ namespace WindowWalker.ViewModels
         private readonly HotKeyHandler _hotKeyHandler;
         private readonly List<string> _hints = new List<string>()
         {
-            "search for running processes ...",
+            "search for running processes or windows...",
             // "you can reinvoke this app using CTRL + WIN",
         };
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
I have changed the info text in search box to indicate the user also can search for windows.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
* nothing
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #1916
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* <strike>[] Requires documentation to be updated</strike>
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #1916

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
At the moment users see the text `Search for running processes...` which indicates the user to enter a process name. We coul add the string `or windows` so the user knows that he also can search for window titles.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
* nothing