### PR TITLE
KeePass window showing from tray

### DIFF
--- a/src/modules/fancyzones/lib/Zone.cpp
+++ b/src/modules/fancyzones/lib/Zone.cpp
@@ -106,16 +106,18 @@ void Zone::SizeWindowToZone(HWND window, HWND zoneWindow) noexcept
     }
 
     WINDOWPLACEMENT placement{};
-    
+    ::GetWindowPlacement(window, &placement);
+
+    //wait if SW_SHOWMINIMIZED would be removed from window (Issue #1685)    
+    for (int i = 0; i < 5 && (placement.showCmd & SW_SHOWMINIMIZED) != 0; i++)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        ::GetWindowPlacement(window, &placement);
+    }
+
     // Do not restore minimized windows. We change their placement though so they restore to the correct zone.
     if ((placement.showCmd & SW_SHOWMINIMIZED) == 0)
     {
-        //wait if SW_SHOWMINIMIZED would be removed from window (Issue #1685)
-        for (int i = 0; i < 5; i++)
-        {
-            std::this_thread::sleep_for(std::chrono::milliseconds(100));
-            ::GetWindowPlacement(window, &placement);
-        }
         placement.showCmd = SW_RESTORE | SW_SHOWNA;
     }
 

--- a/src/modules/fancyzones/lib/Zone.cpp
+++ b/src/modules/fancyzones/lib/Zone.cpp
@@ -105,6 +105,9 @@ void Zone::SizeWindowToZone(HWND window, HWND zoneWindow) noexcept
         }
     }
 
+    //wait if SW_SHOWMINIMIZED would be removed from window (Issue #1685)
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
     WINDOWPLACEMENT placement{};
     ::GetWindowPlacement(window, &placement);
     placement.rcNormalPosition = zoneRect;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Wait for `showCmd` parameter change on moving window into zone.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #1685
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [] Requires documentation to be updated
* [] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

At the moment when windows position is changed to be applied to zone, KeePass window has SW_SHOWMINIMIZED flag. For this reason it minimizes again as expected. 

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

1. Configure KeePass to "Minimize to tray"
2. Configure FancyZones as follows:
![image](https://user-images.githubusercontent.com/8949536/78456252-3fcb6180-76ab-11ea-8ada-2818debfe4eb.png)
3. Apply layout (doesn't matter, custom or template, but the more zones it contains, the bigger chance to catch a bug)
4. Open KeePass
5. Apply KeePass to zone
6. Minimize KeePass winow
7. Restore KeePass from tray

KeePass window expected to be opened. 