### PR TITLE
Fancy zones preserve size of non-resizable windows

### DIFF
--- a/src/modules/fancyzones/lib/Zone.cpp
+++ b/src/modules/fancyzones/lib/Zone.cpp
@@ -121,13 +121,14 @@ void Zone::SizeWindowToZone(HWND window, HWND zoneWindow) noexcept
         ::GetWindowPlacement(window, &placement);
     }
 
-    placement.rcNormalPosition = newWindowRect;
-    placement.flags |= WPF_ASYNCWINDOWPLACEMENT;
     // Do not restore minimized windows. We change their placement though so they restore to the correct zone.
     if ((placement.showCmd & SW_SHOWMINIMIZED) == 0)
     {
         placement.showCmd = SW_RESTORE | SW_SHOWNA;
     }
+
+    placement.rcNormalPosition = newWindowRect;
+    placement.flags |= WPF_ASYNCWINDOWPLACEMENT;
 
     ::SetWindowPlacement(window, &placement);
     // Do it again, allowing Windows to resize the window and set correct scaling

--- a/src/modules/fancyzones/lib/Zone.cpp
+++ b/src/modules/fancyzones/lib/Zone.cpp
@@ -105,7 +105,7 @@ void Zone::SizeWindowToZone(HWND window, HWND zoneWindow) noexcept
         }
     }
 
-    if ((::GetWindowLong(window, GWL_EXSTYLE) & SWP_NOSIZE) != 0)
+    if ((::GetWindowLong(window, GWL_STYLE) & WS_SIZEBOX) == 0)
     {
         newWindowRect.right = newWindowRect.left + (windowRect.right - windowRect.left);
         newWindowRect.bottom = newWindowRect.top + (windowRect.bottom - windowRect.top);

--- a/src/modules/fancyzones/lib/Zone.cpp
+++ b/src/modules/fancyzones/lib/Zone.cpp
@@ -66,9 +66,9 @@ void Zone::SizeWindowToZone(HWND window, HWND zoneWindow) noexcept
     {
         return;
     }
-  
+
     // Take care of 1px border
-    RECT zoneRect = m_zoneRect;
+    RECT newWindowRect = m_zoneRect;
 
     RECT windowRect{};
     ::GetWindowRect(window, &windowRect);
@@ -82,27 +82,33 @@ void Zone::SizeWindowToZone(HWND window, HWND zoneWindow) noexcept
         const auto left_margin = frameRect.left - windowRect.left;
         const auto right_margin = frameRect.right - windowRect.right;
         const auto bottom_margin = frameRect.bottom - windowRect.bottom;
-        zoneRect.left -= left_margin;
-        zoneRect.right -= right_margin;
-        zoneRect.bottom -= bottom_margin;
+        newWindowRect.left -= left_margin;
+        newWindowRect.right -= right_margin;
+        newWindowRect.bottom -= bottom_margin;
     }
 
     // Map to screen coords
-    MapWindowRect(zoneWindow, nullptr, &zoneRect);
+    MapWindowRect(zoneWindow, nullptr, &newWindowRect);
 
-    MONITORINFO mi{sizeof(mi)};
+    MONITORINFO mi{ sizeof(mi) };
     if (GetMonitorInfoW(MonitorFromWindow(zoneWindow, MONITOR_DEFAULTTONEAREST), &mi))
     {
         const auto taskbar_left_size = std::abs(mi.rcMonitor.left - mi.rcWork.left);
         const auto taskbar_top_size = std::abs(mi.rcMonitor.top - mi.rcWork.top);
-        OffsetRect(&zoneRect, -taskbar_left_size, -taskbar_top_size);
+        OffsetRect(&newWindowRect, -taskbar_left_size, -taskbar_top_size);
         if (accountForUnawareness)
         {
-            zoneRect.left = max(mi.rcMonitor.left, zoneRect.left);
-            zoneRect.right = min(mi.rcMonitor.right - taskbar_left_size, zoneRect.right);
-            zoneRect.top = max(mi.rcMonitor.top, zoneRect.top);
-            zoneRect.bottom = min(mi.rcMonitor.bottom - taskbar_top_size, zoneRect.bottom);
+            newWindowRect.left = max(mi.rcMonitor.left, newWindowRect.left);
+            newWindowRect.right = min(mi.rcMonitor.right - taskbar_left_size, newWindowRect.right);
+            newWindowRect.top = max(mi.rcMonitor.top, newWindowRect.top);
+            newWindowRect.bottom = min(mi.rcMonitor.bottom - taskbar_top_size, newWindowRect.bottom);
         }
+    }
+
+    if ((::GetWindowLong(window, GWL_EXSTYLE) & SWP_NOSIZE) != 0)
+    {
+        newWindowRect.right = newWindowRect.left + (windowRect.right - windowRect.left);
+        newWindowRect.bottom = newWindowRect.top + (windowRect.bottom - windowRect.top);
     }
 
     WINDOWPLACEMENT placement{};
@@ -115,14 +121,13 @@ void Zone::SizeWindowToZone(HWND window, HWND zoneWindow) noexcept
         ::GetWindowPlacement(window, &placement);
     }
 
+    placement.rcNormalPosition = newWindowRect;
+    placement.flags |= WPF_ASYNCWINDOWPLACEMENT;
     // Do not restore minimized windows. We change their placement though so they restore to the correct zone.
     if ((placement.showCmd & SW_SHOWMINIMIZED) == 0)
     {
         placement.showCmd = SW_RESTORE | SW_SHOWNA;
     }
-
-    placement.rcNormalPosition = zoneRect;
-    placement.flags |= WPF_ASYNCWINDOWPLACEMENT;
 
     ::SetWindowPlacement(window, &placement);
     // Do it again, allowing Windows to resize the window and set correct scaling


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Fancy zones is now taking into consideration that window could be non-resizable.
In that case it will place the window into zone without resizing it
## PR Checklist
* [x] Applies to #1883

