### PR TITLE
Fixed telemetry calls for Image Resizer

### DIFF
--- a/src/modules/imageresizer/dll/ContextMenuHandler.cpp
+++ b/src/modules/imageresizer/dll/ContextMenuHandler.cpp
@@ -147,6 +147,7 @@ HRESULT CContextMenuHandler::QueryContextMenu(_In_ HMENU hmenu, UINT indexMenu, 
         if (!InsertMenuItem(hmenu, indexMenu, TRUE, &mii))
         {
             hr = HRESULT_FROM_WIN32(GetLastError());
+            Trace::QueryContextMenuError(hr);
         }
         else
         {
@@ -220,12 +221,12 @@ HRESULT CContextMenuHandler::ResizePictures(CMINVOKECOMMANDINFO* pici, IShellIte
     HRESULT hr = E_FAIL;
     if (!CreatePipe(&hReadPipe, &hWritePipe, &sa, 0))
     {
-        Trace::InvokedRet(hr);
+        hr = HRESULT_FROM_WIN32(GetLastError());
         return hr;
     }
     if (!SetHandleInformation(hWritePipe, HANDLE_FLAG_INHERIT, 0))
     {
-        Trace::InvokedRet(hr);
+        hr = HRESULT_FROM_WIN32(GetLastError());
         return hr;
     }
     CAtlFile writePipe(hWritePipe);
@@ -277,12 +278,12 @@ HRESULT CContextMenuHandler::ResizePictures(CMINVOKECOMMANDINFO* pici, IShellIte
     delete[] lpszCommandLine;
     if (!CloseHandle(processInformation.hProcess))
     {
-        Trace::InvokedRet(hr);
+        hr = HRESULT_FROM_WIN32(GetLastError());
         return hr;
     }
     if (!CloseHandle(processInformation.hThread))
     {
-        Trace::InvokedRet(hr);
+        hr = HRESULT_FROM_WIN32(GetLastError());
         return hr;
     }
 
@@ -322,7 +323,6 @@ HRESULT CContextMenuHandler::ResizePictures(CMINVOKECOMMANDINFO* pici, IShellIte
 
     writePipe.Close();
     hr = S_OK;
-    Trace::InvokedRet(hr);
     return hr;
 }
 

--- a/src/modules/imageresizer/dll/trace.cpp
+++ b/src/modules/imageresizer/dll/trace.cpp
@@ -47,3 +47,13 @@ void Trace::InvokedRet(_In_ HRESULT hr) noexcept
         TraceLoggingHResult(hr),
         TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));
 }
+
+void Trace::QueryContextMenuError(_In_ HRESULT hr) noexcept
+{
+    TraceLoggingWrite(
+        g_hProvider,
+        "ImageResizer_QueryContextMenuError",
+        ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
+        TraceLoggingHResult(hr),
+        TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));
+}

--- a/src/modules/imageresizer/dll/trace.h
+++ b/src/modules/imageresizer/dll/trace.h
@@ -8,4 +8,5 @@ public:
     static void EnableImageResizer(_In_ bool enabled) noexcept;
     static void Invoked() noexcept;
     static void InvokedRet(_In_ HRESULT hr) noexcept;
+    static void QueryContextMenuError(_In_ HRESULT hr) noexcept;
 };


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR removes the duplicate calls to Trace::InvokedRet. Now if the Invoke function is returns then Trace::Invoke and Trace::InvokeRet are called exactly once.
Also added Trace:QueryContextMenuError which gets called when InsertMenuItem fails.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Applies to #1981 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
