### PR TITLE
Update Product.wxs

### DIFF
--- a/installer/PowerToysSetup/Product.wxs
+++ b/installer/PowerToysSetup/Product.wxs
@@ -226,7 +226,7 @@
           <Shortcut Id="ApplicationStartMenuShortcut"
                     Name="PowerToys (Preview)"
                     Description="PowerToys - Windows system utilities to maximize productivity"
-                    Directory="ApplicationProgramsFolder"
+                    Directory="ProgramMenuFolder" 
                     WorkingDirectory="INSTALLFOLDER"
                     Icon="powertoys.ico"
                     IconIndex="0"


### PR DESCRIPTION
Changed Shortcut location on the start menu

I can the shortcut directory to the ProgramMenuFolder which is the directory for the start menu 

The change was tested by reinstalling powerToys and checking to see if the location was updated.

crutkas: xref #1494 for tracking issue