### PR TITLE
Display keys in Shorcut modal as buttons

### DIFF
--- a/src/modules/keyboardmanager/common/KeyboardManagerState.cpp
+++ b/src/modules/keyboardmanager/common/KeyboardManagerState.cpp
@@ -156,11 +156,10 @@ void KeyboardManagerState::UpdateDetectShortcutUI()
         return;
     }
 
-    std::vector<hstring> shortcut;
     
     std::unique_lock<std::mutex> detectedShortcut_lock(detectedShortcut_mutex);
     
-    detectedShortcut.GetKeyVector(shortcut);
+    std::vector<hstring> shortcut = detectedShortcut.GetKeyVector();
     
     detectedShortcut_lock.unlock();
 

--- a/src/modules/keyboardmanager/common/KeyboardManagerState.cpp
+++ b/src/modules/keyboardmanager/common/KeyboardManagerState.cpp
@@ -115,17 +115,36 @@ bool KeyboardManagerState::AddSingleKeyRemap(const DWORD& originalKey, const DWO
 }
 
 // Function to set the textblock of the detect shortcut UI so that it can be accessed by the hook
-void KeyboardManagerState::ConfigureDetectShortcutUI(const TextBlock& textBlock)
+void KeyboardManagerState::ConfigureDetectShortcutUI(const StackPanel& textBlock)
 {
     std::lock_guard<std::mutex> lock(currentShortcutTextBlock_mutex);
     currentShortcutTextBlock = textBlock;
 }
 
 // Function to set the textblock of the detect remap key UI so that it can be accessed by the hook
-void KeyboardManagerState::ConfigureDetectSingleKeyRemapUI(const TextBlock& textBlock)
+void KeyboardManagerState::ConfigureDetectSingleKeyRemapUI(const StackPanel& textBlock)
 {
     std::lock_guard<std::mutex> lock(currentSingleKeyRemapTextBlock_mutex);
     currentSingleKeyRemapTextBlock = textBlock;
+}
+
+
+void KeyboardManagerState::AddKeyToLayout(const StackPanel& panel, const hstring& key)
+{
+    // Textblock to display the detected key
+    TextBlock remapKey;
+    Border border;
+
+    border.Padding({ 20, 10, 20, 10 });
+    border.Margin({0, 0, 10, 0 });
+    border.Background(Windows::UI::Xaml::Media::SolidColorBrush{ Windows::UI::Colors::LightGray() });
+    remapKey.Foreground(Windows::UI::Xaml::Media::SolidColorBrush{ Windows::UI::Colors::Black() });
+    remapKey.FontSize(20);
+    border.HorizontalAlignment(HorizontalAlignment::Left);
+    border.Child(remapKey);
+
+    remapKey.Text(key);
+    panel.Children().Append(border);
 }
 
 // Function to update the detect shortcut UI based on the entered keys
@@ -137,13 +156,22 @@ void KeyboardManagerState::UpdateDetectShortcutUI()
         return;
     }
 
+    std::vector<hstring> shortcut;
+    
     std::unique_lock<std::mutex> detectedShortcut_lock(detectedShortcut_mutex);
-    hstring shortcutString = detectedShortcut.ToHstring();
+    
+    detectedShortcut.GetKeyVector(shortcut);
+    
     detectedShortcut_lock.unlock();
 
     // Since this function is invoked from the back-end thread, in order to update the UI the dispatcher must be used.
-    currentShortcutTextBlock.Dispatcher().RunAsync(Windows::UI::Core::CoreDispatcherPriority::Normal, [=]() {
-        currentShortcutTextBlock.Text(shortcutString);
+    currentShortcutTextBlock.Dispatcher().RunAsync(Windows::UI::Core::CoreDispatcherPriority::Normal, [this, shortcut]() {
+        currentShortcutTextBlock.Children().Clear();
+        for (auto& key : shortcut)
+        {
+            AddKeyToLayout(currentShortcutTextBlock, key);
+        }
+        currentShortcutTextBlock.UpdateLayout();
     });
 }
 
@@ -157,12 +185,14 @@ void KeyboardManagerState::UpdateDetectSingleKeyRemapUI()
     }
 
     std::unique_lock<std::mutex> detectedRemapKey_lock(detectedRemapKey_mutex);
-    hstring remapKeyString = winrt::to_hstring((unsigned int)detectedRemapKey);
+    hstring key = winrt::to_hstring((unsigned int)detectedRemapKey);
     detectedRemapKey_lock.unlock();
 
     // Since this function is invoked from the back-end thread, in order to update the UI the dispatcher must be used.
-    currentSingleKeyRemapTextBlock.Dispatcher().RunAsync(Windows::UI::Core::CoreDispatcherPriority::Normal, [=]() {
-        currentSingleKeyRemapTextBlock.Text(remapKeyString);
+    currentSingleKeyRemapTextBlock.Dispatcher().RunAsync(Windows::UI::Core::CoreDispatcherPriority::Normal, [this, key]() {
+        currentSingleKeyRemapTextBlock.Children().Clear();
+        AddKeyToLayout(currentSingleKeyRemapTextBlock, key);
+        currentSingleKeyRemapTextBlock.UpdateLayout();
     });
 }
 
@@ -170,26 +200,36 @@ void KeyboardManagerState::UpdateDetectSingleKeyRemapUI()
 Shortcut KeyboardManagerState::GetDetectedShortcut()
 {
     std::unique_lock<std::mutex> lock(currentShortcutTextBlock_mutex);
-    hstring detectedShortcutString = currentShortcutTextBlock.Text();
+
+    std::vector<winrt::hstring> keys;
+    if (currentShortcutTextBlock.Children().Size() > 0)
+    {
+        for (auto border : currentShortcutTextBlock.Children())
+        {
+            auto keyString = border.as<Border>().Child().as<TextBlock>().Text();
+            keys.push_back(keyString);
+        }    
+    }
+
     lock.unlock();
-    return Shortcut::CreateShortcut(detectedShortcutString);
+    return Shortcut::CreateShortcut(keys);
 }
 
 // Function to return the currently detected remap key which is displayed on the UI
 DWORD KeyboardManagerState::GetDetectedSingleRemapKey()
 {
     std::unique_lock<std::mutex> lock(currentSingleKeyRemapTextBlock_mutex);
-    hstring remapKeyString = currentSingleKeyRemapTextBlock.Text();
-    lock.unlock();
-
-    std::wstring remapKeyWString = remapKeyString.c_str();
-    DWORD remapKey = NULL;
-    if (!remapKeyString.empty())
+    DWORD key = 0;
+    if (currentSingleKeyRemapTextBlock.Children().Size() > 0)
     {
-        remapKey = std::stoul(remapKeyWString);
+        auto border = currentSingleKeyRemapTextBlock.Children().GetAt(0);
+        auto keyString = border.as<Border>().Child().as<TextBlock>().Text();
+        key = std::stoul(keyString.c_str());
     }
 
-    return remapKey;
+    lock.unlock();
+
+    return key;
 }
 
 // Function which can be used in HandleKeyboardHookEvent before the single key remap event to use the UI and suppress events while the remap window is active.

--- a/src/modules/keyboardmanager/common/KeyboardManagerState.h
+++ b/src/modules/keyboardmanager/common/KeyboardManagerState.h
@@ -39,13 +39,15 @@ private:
     std::mutex detectedRemapKey_mutex;
 
     // Stores the UI element which is to be updated based on the remap key entered.
-    TextBlock currentSingleKeyRemapTextBlock;
+    StackPanel currentSingleKeyRemapTextBlock;
     std::mutex currentSingleKeyRemapTextBlock_mutex;
 
     // Stores the UI element which is to be updated based on the shortcut entered
-    TextBlock currentShortcutTextBlock;
+    StackPanel currentShortcutTextBlock;
     std::mutex currentShortcutTextBlock_mutex;
 
+    // Display a key by appending a border Control as a child of the panel.
+    void AddKeyToLayout(const StackPanel& panel, const winrt::hstring& key);
 public:
     // The map members and their mutexes are left as public since the maps are used extensively in dllmain.cpp.
     // Maps which store the remappings for each of the features. The bool fields should be initalised to false. They are used to check the current state of the shortcut (i.e is that particular shortcut currently pressed down or not).
@@ -93,10 +95,10 @@ public:
     bool AddOSLevelShortcut(const Shortcut& originalSC, const Shortcut& newSC);
 
     // Function to set the textblock of the detect shortcut UI so that it can be accessed by the hook
-    void ConfigureDetectShortcutUI(const TextBlock& textBlock);
+    void ConfigureDetectShortcutUI(const StackPanel& textBlock);
 
     // Function to set the textblock of the detect remap key UI so that it can be accessed by the hook
-    void ConfigureDetectSingleKeyRemapUI(const TextBlock& textBlock);
+    void ConfigureDetectSingleKeyRemapUI(const StackPanel& textBlock);
 
     // Function to update the detect shortcut UI based on the entered keys
     void UpdateDetectShortcutUI();

--- a/src/modules/keyboardmanager/common/KeyboardManagerState.h
+++ b/src/modules/keyboardmanager/common/KeyboardManagerState.h
@@ -39,12 +39,12 @@ private:
     std::mutex detectedRemapKey_mutex;
 
     // Stores the UI element which is to be updated based on the remap key entered.
-    StackPanel currentSingleKeyRemapTextBlock;
-    std::mutex currentSingleKeyRemapTextBlock_mutex;
+    StackPanel currentSingleKeyUI;
+    std::mutex currentSingleKeyUI_mutex;
 
     // Stores the UI element which is to be updated based on the shortcut entered
-    StackPanel currentShortcutTextBlock;
-    std::mutex currentShortcutTextBlock_mutex;
+    StackPanel currentShortcutUI;
+    std::mutex currentShortcutUI_mutex;
 
     // Display a key by appending a border Control as a child of the panel.
     void AddKeyToLayout(const StackPanel& panel, const winrt::hstring& key);

--- a/src/modules/keyboardmanager/common/Shortcut.cpp
+++ b/src/modules/keyboardmanager/common/Shortcut.cpp
@@ -395,8 +395,7 @@ void Shortcut::ResetKey(const DWORD& input, const bool& isWinBoth)
 // Function to return the string representation of the shortcut
 winrt::hstring Shortcut::ToHstring() const
 {
-    std::vector<winrt::hstring> keys;
-    GetKeyVector(keys);
+    std::vector<winrt::hstring> keys = GetKeyVector();
     
     winrt::hstring output;
     for (auto& key : keys)
@@ -413,8 +412,9 @@ winrt::hstring Shortcut::ToHstring() const
     }
 }
 
-size_t Shortcut::GetKeyVector(std::vector<winrt::hstring>& keys) const
+std::vector<winrt::hstring> Shortcut::GetKeyVector() const
 {
+    std::vector<winrt::hstring> keys;
     if (winKey != ModifierKey::Disabled)
     {
         keys.push_back(ModifierKeyNameWithSide(winKey, L"Win"));
@@ -435,7 +435,7 @@ size_t Shortcut::GetKeyVector(std::vector<winrt::hstring>& keys) const
     {
         keys.push_back(winrt::to_hstring((unsigned int)actionKey));
     }
-    return keys.size();
+    return keys;
 }
 
 // Function to check if all the modifiers in the shortcut have been pressed down

--- a/src/modules/keyboardmanager/common/Shortcut.h
+++ b/src/modules/keyboardmanager/common/Shortcut.h
@@ -141,7 +141,7 @@ public:
     winrt::hstring ToHstring() const;
 
     // Function to return a vector of hstring for each key, in the same order as ToHstring()
-    size_t GetKeyVector(std::vector<winrt::hstring>& keys) const;
+    std::vector<winrt::hstring> GetKeyVector() const;
 
     // Function to check if all the modifiers in the shortcut have been pressed down
     bool CheckModifiersKeyboardState() const;

--- a/src/modules/keyboardmanager/common/Shortcut.h
+++ b/src/modules/keyboardmanager/common/Shortcut.h
@@ -140,6 +140,9 @@ public:
     // Function to return the string representation of the shortcut
     winrt::hstring ToHstring() const;
 
+    // Function to return a vector of hstring for each key, in the same order as ToHstring()
+    size_t GetKeyVector(std::vector<winrt::hstring>& keys) const;
+
     // Function to check if all the modifiers in the shortcut have been pressed down
     bool CheckModifiersKeyboardState() const;
 
@@ -151,6 +154,9 @@ public:
 
     // Function to return the virtual key code from the name of the key
     static DWORD DecodeKey(const std::wstring& keyName);
+
+    // Function to create a shortcut object from its string vector representation
+    static Shortcut CreateShortcut(const std::vector<winrt::hstring>& keys);
 
     // Function to create a shortcut object from its string representation
     static Shortcut CreateShortcut(const winrt::hstring& input);

--- a/src/modules/keyboardmanager/ui/ShortcutControl.cpp
+++ b/src/modules/keyboardmanager/ui/ShortcutControl.cpp
@@ -57,13 +57,14 @@ void ShortcutControl::createDetectShortcutWindow(IInspectable const& sender, Xam
     // ContentDialog for detecting shortcuts. This is the parent UI element.
     ContentDialog detectShortcutBox;
 
+    // TODO: Hardcoded light theme, since the app is not theme aware ATM.
+    detectShortcutBox.RequestedTheme(ElementTheme::Light);
     // ContentDialog requires manually setting the XamlRoot (https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.contentdialog#contentdialog-in-appwindow-or-xaml-islands)
     detectShortcutBox.XamlRoot(xamlRoot);
     detectShortcutBox.Title(box_value(L"Press the keys in shortcut:"));
     detectShortcutBox.PrimaryButtonText(to_hstring(L"OK"));
     detectShortcutBox.IsSecondaryButtonEnabled(false);
     detectShortcutBox.CloseButtonText(to_hstring(L"Cancel"));
-    detectShortcutBox.Background(Windows::UI::Xaml::Media::SolidColorBrush{ Windows::UI::Colors::LightGray() });
 
     // Get the linked text block for the "Type shortcut" button that was clicked
     TextBlock linkedShortcutText = getSiblingElement(sender).as<TextBlock>();
@@ -86,23 +87,23 @@ void ShortcutControl::createDetectShortcutWindow(IInspectable const& sender, Xam
 
     // StackPanel parent for the displayed text in the dialog
     Windows::UI::Xaml::Controls::StackPanel stackPanel;
-    stackPanel.Background(Windows::UI::Xaml::Media::SolidColorBrush{ Windows::UI::Colors::LightGray() });
+    detectShortcutBox.Content(stackPanel);
 
     // Header textblock
     TextBlock text;
     text.Text(winrt::to_hstring("Keys Pressed:"));
     text.Margin({ 0, 0, 0, 10 });
-
-    // Textblock to display the detected shortcut
-    TextBlock shortcutKeys;
-
     stackPanel.Children().Append(text);
-    stackPanel.Children().Append(shortcutKeys);
+
+    // Target StackPanel to place the selected key
+    Windows::UI::Xaml::Controls::StackPanel keyStackPanel;
+    stackPanel.Children().Append(keyStackPanel);
+    keyStackPanel.Orientation(Orientation::Horizontal);
+
     stackPanel.UpdateLayout();
-    detectShortcutBox.Content(stackPanel);
 
     // Configure the keyboardManagerState to store the UI information.
-    keyboardManagerState.ConfigureDetectShortcutUI(shortcutKeys);
+    keyboardManagerState.ConfigureDetectShortcutUI(keyStackPanel);
 
     // Show the dialog
     detectShortcutBox.ShowAsync();

--- a/src/modules/keyboardmanager/ui/SingleKeyRemapControl.cpp
+++ b/src/modules/keyboardmanager/ui/SingleKeyRemapControl.cpp
@@ -58,15 +58,15 @@ void SingleKeyRemapControl::createDetectKeyWindow(IInspectable const& sender, Xa
 {
     // ContentDialog for detecting remap key. This is the parent UI element.
     ContentDialog detectRemapKeyBox;
-
+    
+    // TODO: Hardcoded light theme, since the app is not theme aware ATM.
+    detectRemapKeyBox.RequestedTheme(ElementTheme::Light);
     // ContentDialog requires manually setting the XamlRoot (https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.contentdialog#contentdialog-in-appwindow-or-xaml-islands)
     detectRemapKeyBox.XamlRoot(xamlRoot);
     detectRemapKeyBox.Title(box_value(L"Press a key on selected keyboard:"));
     detectRemapKeyBox.PrimaryButtonText(to_hstring(L"OK"));
     detectRemapKeyBox.IsSecondaryButtonEnabled(false);
     detectRemapKeyBox.CloseButtonText(to_hstring(L"Cancel"));
-    detectRemapKeyBox.Background(Windows::UI::Xaml::Media::SolidColorBrush{ Windows::UI::Colors::LightGray() });
-    detectRemapKeyBox.Foreground(Windows::UI::Xaml::Media::SolidColorBrush{ Windows::UI::Colors::Black() });
 
     // Get the linked text block for the "Type Key" button that was clicked
     TextBlock linkedRemapText = getSiblingElement(sender).as<TextBlock>();
@@ -92,23 +92,22 @@ void SingleKeyRemapControl::createDetectKeyWindow(IInspectable const& sender, Xa
 
     // StackPanel parent for the displayed text in the dialog
     Windows::UI::Xaml::Controls::StackPanel stackPanel;
-    stackPanel.Background(Windows::UI::Xaml::Media::SolidColorBrush{ Windows::UI::Colors::LightGray() });
+    detectRemapKeyBox.Content(stackPanel);
 
     // Header textblock
     TextBlock text;
     text.Text(winrt::to_hstring("Key Pressed:"));
     text.Margin({ 0, 0, 0, 10 });
-
-    // Textblock to display the detected key
-    TextBlock remapKey;
-
     stackPanel.Children().Append(text);
-    stackPanel.Children().Append(remapKey);
+
+    // Target StackPanel to place the selected key
+    Windows::UI::Xaml::Controls::StackPanel keyStackPanel;
+    stackPanel.Children().Append(keyStackPanel);
+    keyStackPanel.Orientation(Orientation::Horizontal);
     stackPanel.UpdateLayout();
-    detectRemapKeyBox.Content(stackPanel);
 
     // Configure the keyboardManagerState to store the UI information.
-    keyboardManagerState.ConfigureDetectSingleKeyRemapUI(remapKey);
+    keyboardManagerState.ConfigureDetectSingleKeyRemapUI(keyStackPanel);
 
     // Show the dialog
     detectRemapKeyBox.ShowAsync();


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Change displayed text in Detect key/shortcut to appear like buttons

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #6 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [] Tests added/passed
* [] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
* Keys are displayed as TextBlocks inside Border blocks to appear like buttons.
* This change is not theme ready, since the colors would not change in dark mode.
* Applies both to the shorcut modal and the single key modal.
 
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manual testing, could set up shorcuts and single key mappings.