### PR TITLE
msi: fix icon bug due to wix quirk

### DIFF
--- a/installer/PowerToysSetup/Product.wxs
+++ b/installer/PowerToysSetup/Product.wxs
@@ -32,8 +32,8 @@
       <![CDATA[(WINDOWSBUILDNUMBER >= 17134)]]>
     </Condition>
 
-    <Icon Id="powertoys.ico" SourceFile="$(var.BinX64Dir)\svgs\icon.ico"/>
-    <Property Id="ARPPRODUCTICON" Value="powertoys.ico" />
+    <Icon Id="powertoys.exe" SourceFile="$(var.BinX64Dir)\svgs\icon.ico"/>
+    <Property Id="ARPPRODUCTICON" Value="powertoys.exe" />
     <Feature Id="CoreFeature" Title="PowerToys" AllowAdvertise="no" Absent="disallow" TypicalDefault="install"
              Description="Contains the Shortcut Guide and Fancy Zones features.">
       <ComponentGroupRef Id="CoreComponents" />
@@ -228,7 +228,7 @@
                     Description="PowerToys - Windows system utilities to maximize productivity"
                     Directory="ApplicationProgramsFolder"
                     WorkingDirectory="INSTALLFOLDER"
-                    Icon="powertoys.ico"
+                    Icon="powertoys.exe"
                     IconIndex="0"
                     Advertise="yes">
             <ShortcutProperty Key="System.AppUserModel.ID" Value="Microsoft.PowerToysWin32"/>
@@ -500,7 +500,7 @@
                   Description="PowerToys - Windows system utilities to maximize productivity"
                   Target="[!PowerToys.exe]"
                   WorkingDirectory="INSTALLFOLDER"
-                  Icon="powertoys.ico"
+                  Icon="powertoys.exe"
                   Directory="DesktopFolder"/>
       </Component>
     </DirectoryRef>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #1801

## Detailed Description of the Pull Request / Additional comments
[See `Icon` description from wix manual](https://wixtoolset.org/documentation/manual/v3/xsd/wix/shortcut.html)
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- installed with this commit: icon works
- installed w/o this commit: no icon
