### PR TITLE
MoveWindowIntoZoneByIndexWithInvalidIndex failing TC fix

### DIFF
--- a/src/modules/fancyzones/tests/UnitTests/ZoneSet.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/ZoneSet.Spec.cpp
@@ -339,7 +339,7 @@ namespace FancyZonesUnitTests
 
                 HWND window = Mocks::Window();
                 m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 100);
-                Assert::IsTrue(zone1->ContainsWindow(window));
+                Assert::IsFalse(zone1->ContainsWindow(window));
                 Assert::IsFalse(zone2->ContainsWindow(window));
                 Assert::IsFalse(zone3->ContainsWindow(window));
             }


### PR DESCRIPTION

## Summary of the Pull Request
- Fixed one testcase that was failing on master

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [] Applies to #1977