### PR TITLE
FZ editor: splitter thickness set to 1px when space around zones is zero

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridZone.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridZone.xaml.cs
@@ -101,7 +101,16 @@ namespace FancyZonesEditor
 
         private int SplitterThickness
         {
-            get { return Math.Max(((App)Application.Current).ZoneSettings.Spacing, 5); }
+            get
+            {
+                Settings settings = ((App)Application.Current).ZoneSettings;
+                if (!settings.ShowSpacing)
+                {
+                    return 1;
+                }
+
+                return Math.Max(settings.Spacing, 5);
+            }
         }
 
         private void UpdateSplitter()

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridZone.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridZone.xaml.cs
@@ -109,7 +109,7 @@ namespace FancyZonesEditor
                     return 1;
                 }
 
-                return Math.Max(settings.Spacing, 5);
+                return Math.Max(settings.Spacing, 1);
             }
         }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Check `ShowSpacing` flag in `SplitterThickness`. 

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2007
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [] Requires documentation to be updated
* [] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
![splitter](https://user-images.githubusercontent.com/8949536/78896155-b59f4680-7a78-11ea-9b1c-6bfbeb5c6775.png)