### PR TITLE
Change key mappings according to Keyboard Layout

### DIFF
--- a/src/modules/keyboardmanager/common/KeyboardManagerCommon.vcxproj
+++ b/src/modules/keyboardmanager/common/KeyboardManagerCommon.vcxproj
@@ -89,6 +89,7 @@
   <ItemGroup>
     <ClCompile Include="Helpers.cpp" />
     <ClCompile Include="KeyboardManagerState.cpp" />
+    <ClCompile Include="LayoutMap.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
@@ -99,6 +100,7 @@
   <ItemGroup>
     <ClInclude Include="Helpers.h" />
     <ClInclude Include="KeyboardManagerState.h" />
+    <ClInclude Include="LayoutMap.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="RemapShortcut.h" />
     <ClInclude Include="Shortcut.h" />

--- a/src/modules/keyboardmanager/common/KeyboardManagerCommon.vcxproj.filters
+++ b/src/modules/keyboardmanager/common/KeyboardManagerCommon.vcxproj.filters
@@ -24,6 +24,9 @@
     <ClCompile Include="pch.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="LayoutMap.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="Shortcut.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -39,6 +42,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="pch.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="LayoutMap.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Shortcut.h">

--- a/src/modules/keyboardmanager/common/KeyboardManagerState.cpp
+++ b/src/modules/keyboardmanager/common/KeyboardManagerState.cpp
@@ -166,12 +166,12 @@ void KeyboardManagerState::UpdateDetectShortcutUI()
     // Save the latest displayed shortcut
     currentShortcut = detectedShortcut;
     currentShortcut_lock.unlock();
-    std::vector<hstring> shortcut = detectedShortcut.GetKeyVector(keyboardMap);
-    
     detectedShortcut_lock.unlock();
 
     // Since this function is invoked from the back-end thread, in order to update the UI the dispatcher must be used.
-    currentShortcutUI.Dispatcher().RunAsync(Windows::UI::Core::CoreDispatcherPriority::Normal, [this, shortcut]() {
+    currentShortcutUI.Dispatcher().RunAsync(Windows::UI::Core::CoreDispatcherPriority::Normal, [this]() {
+
+        std::vector<hstring> shortcut = detectedShortcut.GetKeyVector(keyboardMap);
         currentShortcutUI.Children().Clear();
         for (auto& key : shortcut)
         {
@@ -190,13 +190,10 @@ void KeyboardManagerState::UpdateDetectSingleKeyRemapUI()
         return;
     }
 
-    std::unique_lock<std::mutex> detectedRemapKey_lock(detectedRemapKey_mutex);
-    hstring key = winrt::to_hstring(keyboardMap.GetKeyName(detectedRemapKey).c_str());
-    detectedRemapKey_lock.unlock();
-
     // Since this function is invoked from the back-end thread, in order to update the UI the dispatcher must be used.
-    currentSingleKeyUI.Dispatcher().RunAsync(Windows::UI::Core::CoreDispatcherPriority::Normal, [this, key]() {
+    currentSingleKeyUI.Dispatcher().RunAsync(Windows::UI::Core::CoreDispatcherPriority::Normal, [this]() {
         currentSingleKeyUI.Children().Clear();
+        hstring key = winrt::to_hstring(keyboardMap.GetKeyName(detectedRemapKey).c_str());
         AddKeyToLayout(currentSingleKeyUI, key);
         currentSingleKeyUI.UpdateLayout();
     });

--- a/src/modules/keyboardmanager/common/KeyboardManagerState.h
+++ b/src/modules/keyboardmanager/common/KeyboardManagerState.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "Helpers.h"
+#include "LayoutMap.h"
 #include "Shortcut.h"
 #include "RemapShortcut.h"
 #include <interface/lowlevel_keyboard_event_data.h>
@@ -30,9 +31,13 @@ private:
     HWND currentUIWindow;
     std::mutex currentUIWindow_mutex;
 
-    // Object to store the shortcut detected in the detect shortcut UI window. This is used in both the backend and the UI.
+    // Object to store the shortcut detected in the detect shortcut UI window. Gets cleared on releasing keys. This is used in both the backend and the UI.
     Shortcut detectedShortcut;
     std::mutex detectedShortcut_mutex;
+
+    // Object to store the shortcut state displayed in the UI window. Always stores last displayed shortcut irrespective of releasing keys. This is used in both the backend and the UI.
+    Shortcut currentShortcut;
+    std::mutex currentShortcut_mutex;
 
     // Store detected remap key in the remap UI window. This is used in both the backend and the UI.
     DWORD detectedRemapKey;
@@ -66,6 +71,9 @@ public:
     // Stores the app-specific shortcut remappings. Maps application name to the shortcut map
     std::map<std::wstring, std::map<Shortcut, RemapShortcut>> appSpecificShortcutReMap;
     std::mutex appSpecificShortcutReMap_mutex;
+
+    // Stores the keyboard layout
+    LayoutMap keyboardMap;
 
     // Constructor
     KeyboardManagerState();

--- a/src/modules/keyboardmanager/common/LayoutMap.cpp
+++ b/src/modules/keyboardmanager/common/LayoutMap.cpp
@@ -1,0 +1,14 @@
+#include "pch.h"
+#include "LayoutMap.h"
+
+std::wstring LayoutMap::GetKeyName(DWORD key)
+{
+    std::wstring result = L"Undefined";
+    std::lock_guard<std::mutex> lock(keyboardLayoutMap_mutex);
+    auto it = keyboardLayoutMap.find(key);
+    if (it != keyboardLayoutMap.end())
+    {
+        result = it->second;
+    }
+    return result;
+}

--- a/src/modules/keyboardmanager/common/LayoutMap.cpp
+++ b/src/modules/keyboardmanager/common/LayoutMap.cpp
@@ -5,10 +5,153 @@ std::wstring LayoutMap::GetKeyName(DWORD key)
 {
     std::wstring result = L"Undefined";
     std::lock_guard<std::mutex> lock(keyboardLayoutMap_mutex);
+    UpdateLayout();
+
     auto it = keyboardLayoutMap.find(key);
     if (it != keyboardLayoutMap.end())
     {
         result = it->second;
     }
     return result;
+}
+
+void LayoutMap::UpdateLayout()
+{
+    // Get keyboard layout for current thread
+    HKL layout = GetKeyboardLayout(0);
+    if (layout == previousLayout) {
+        return;
+    }
+    previousLayout = layout;
+
+    unsigned char btKeys[256] = { 0 };
+    GetKeyboardState(btKeys);
+
+    // Iterate over all the virtual key codes
+    for (int i = 0; i < 256; i++)
+    {
+        // Get the scan code from the virtual key code
+        UINT scanCode = MapVirtualKeyExW(i, MAPVK_VK_TO_VSC, layout);
+        // Get the unicode representation from the virtual key code and scan code pair to 
+        wchar_t szBuffer[3] = { 0 };
+        int result = ToUnicodeEx(i, scanCode, (BYTE*)btKeys, szBuffer, 3, 0, layout);
+        // If a representation is returned
+        if (result > 0)
+        {
+            keyboardLayoutMap[i] = szBuffer;
+        }
+        else
+        {
+            // Store the virtual key code as string
+            std::wstring vk = L"VK ";
+            vk += std::to_wstring(i);
+            keyboardLayoutMap[i] = vk;
+        }
+    }
+
+    // Override special key names like Shift, Ctrl etc because they don't have unicode mappings and key names like Enter, Space as they appear as "\r", " "
+    // To do: localization
+    keyboardLayoutMap[VK_CANCEL] = L"Break";
+    keyboardLayoutMap[VK_BACK] = L"Backspace";
+    keyboardLayoutMap[VK_TAB] = L"Tab";
+    keyboardLayoutMap[VK_CLEAR] = L"Clear";
+    keyboardLayoutMap[VK_RETURN] = L"Enter";
+    keyboardLayoutMap[VK_SHIFT] = L"Shift";
+    keyboardLayoutMap[VK_CONTROL] = L"Ctrl";
+    keyboardLayoutMap[VK_MENU] = L"Alt";
+    keyboardLayoutMap[VK_PAUSE] = L"Pause";
+    keyboardLayoutMap[VK_CAPITAL] = L"Caps Lock";
+    keyboardLayoutMap[VK_ESCAPE] = L"Esc";
+    keyboardLayoutMap[VK_SPACE] = L"Space";
+    keyboardLayoutMap[VK_PRIOR] = L"PgUp";
+    keyboardLayoutMap[VK_NEXT] = L"PgDn";
+    keyboardLayoutMap[VK_END] = L"End";
+    keyboardLayoutMap[VK_HOME] = L"Home";
+    keyboardLayoutMap[VK_LEFT] = L"Left";
+    keyboardLayoutMap[VK_UP] = L"Up";
+    keyboardLayoutMap[VK_RIGHT] = L"Right";
+    keyboardLayoutMap[VK_DOWN] = L"Down";
+    keyboardLayoutMap[VK_SELECT] = L"Select";
+    keyboardLayoutMap[VK_PRINT] = L"Print";
+    keyboardLayoutMap[VK_EXECUTE] = L"Execute";
+    keyboardLayoutMap[VK_SNAPSHOT] = L"Print Screen";
+    keyboardLayoutMap[VK_INSERT] = L"Insert";
+    keyboardLayoutMap[VK_DELETE] = L"Delete";
+    keyboardLayoutMap[VK_HELP] = L"Help";
+    keyboardLayoutMap[VK_LWIN] = L"LWin";
+    keyboardLayoutMap[VK_RWIN] = L"RWin";
+    keyboardLayoutMap[VK_APPS] = L"Menu";
+    keyboardLayoutMap[VK_SLEEP] = L"Sleep";
+    keyboardLayoutMap[VK_NUMPAD0] = L"NumPad 0";
+    keyboardLayoutMap[VK_NUMPAD1] = L"NumPad 1";
+    keyboardLayoutMap[VK_NUMPAD2] = L"NumPad 2";
+    keyboardLayoutMap[VK_NUMPAD3] = L"NumPad 3";
+    keyboardLayoutMap[VK_NUMPAD4] = L"NumPad 4";
+    keyboardLayoutMap[VK_NUMPAD5] = L"NumPad 5";
+    keyboardLayoutMap[VK_NUMPAD6] = L"NumPad 6";
+    keyboardLayoutMap[VK_NUMPAD7] = L"NumPad 7";
+    keyboardLayoutMap[VK_NUMPAD8] = L"NumPad 8";
+    keyboardLayoutMap[VK_NUMPAD9] = L"NumPad 9";
+    keyboardLayoutMap[VK_SEPARATOR] = L"Separator";
+    keyboardLayoutMap[VK_F1] = L"F1";
+    keyboardLayoutMap[VK_F2] = L"F2";
+    keyboardLayoutMap[VK_F3] = L"F3";
+    keyboardLayoutMap[VK_F4] = L"F4";
+    keyboardLayoutMap[VK_F5] = L"F5";
+    keyboardLayoutMap[VK_F6] = L"F6";
+    keyboardLayoutMap[VK_F7] = L"F7";
+    keyboardLayoutMap[VK_F8] = L"F8";
+    keyboardLayoutMap[VK_F9] = L"F9";
+    keyboardLayoutMap[VK_F10] = L"F10";
+    keyboardLayoutMap[VK_F11] = L"F11";
+    keyboardLayoutMap[VK_F12] = L"F12";
+    keyboardLayoutMap[VK_F13] = L"F13";
+    keyboardLayoutMap[VK_F14] = L"F14";
+    keyboardLayoutMap[VK_F15] = L"F15";
+    keyboardLayoutMap[VK_F16] = L"F16";
+    keyboardLayoutMap[VK_F17] = L"F17";
+    keyboardLayoutMap[VK_F18] = L"F18";
+    keyboardLayoutMap[VK_F19] = L"F19";
+    keyboardLayoutMap[VK_F20] = L"F20";
+    keyboardLayoutMap[VK_F21] = L"F21";
+    keyboardLayoutMap[VK_F22] = L"F22";
+    keyboardLayoutMap[VK_F23] = L"F23";
+    keyboardLayoutMap[VK_F24] = L"F24";
+    keyboardLayoutMap[VK_NUMLOCK] = L"Num Lock";
+    keyboardLayoutMap[VK_SCROLL] = L"Scroll Lock";
+    keyboardLayoutMap[VK_LSHIFT] = L"LShift";
+    keyboardLayoutMap[VK_RSHIFT] = L"RShift";
+    keyboardLayoutMap[VK_LCONTROL] = L"LCtrl";
+    keyboardLayoutMap[VK_RCONTROL] = L"RCtrl";
+    keyboardLayoutMap[VK_LMENU] = L"LAlt";
+    keyboardLayoutMap[VK_RMENU] = L"RAlt";
+    keyboardLayoutMap[VK_BROWSER_BACK] = L"Browser Back";
+    keyboardLayoutMap[VK_BROWSER_FORWARD] = L"Browser Forward";
+    keyboardLayoutMap[VK_BROWSER_REFRESH] = L"Browser Refresh";
+    keyboardLayoutMap[VK_BROWSER_STOP] = L"Browser Stop";
+    keyboardLayoutMap[VK_BROWSER_SEARCH] = L"Browser Search";
+    keyboardLayoutMap[VK_BROWSER_FAVORITES] = L"Browser Favorites";
+    keyboardLayoutMap[VK_BROWSER_HOME] = L"Browser Start & Home";
+    keyboardLayoutMap[VK_VOLUME_MUTE] = L"Volume Mute";
+    keyboardLayoutMap[VK_VOLUME_DOWN] = L"Volume Down";
+    keyboardLayoutMap[VK_VOLUME_UP] = L"Volume Up";
+    keyboardLayoutMap[VK_MEDIA_NEXT_TRACK] = L"Next Track";
+    keyboardLayoutMap[VK_MEDIA_PREV_TRACK] = L"Previous Track";
+    keyboardLayoutMap[VK_MEDIA_STOP] = L"Stop Media";
+    keyboardLayoutMap[VK_MEDIA_PLAY_PAUSE] = L"Play/Pause Media";
+    keyboardLayoutMap[VK_LAUNCH_MAIL] = L"Start Mail";
+    keyboardLayoutMap[VK_LAUNCH_MEDIA_SELECT] = L"Select Media";
+    keyboardLayoutMap[VK_LAUNCH_APP1] = L"Start Application 1";
+    keyboardLayoutMap[VK_LAUNCH_APP2] = L"Start Application 2";
+    keyboardLayoutMap[VK_PACKET] = L"Packet";
+    keyboardLayoutMap[VK_ATTN] = L"Attn";
+    keyboardLayoutMap[VK_CRSEL] = L"CrSel";
+    keyboardLayoutMap[VK_EXSEL] = L"ExSel";
+    keyboardLayoutMap[VK_EREOF] = L"Erase EOF";
+    keyboardLayoutMap[VK_PLAY] = L"Play";
+    keyboardLayoutMap[VK_ZOOM] = L"Zoom";
+    keyboardLayoutMap[VK_PA1] = L"PA1";
+    keyboardLayoutMap[VK_OEM_CLEAR] = L"Clear";
+    keyboardLayoutMap[0xFF] = L"Undefined";
+    // To do: Add IME key names
 }

--- a/src/modules/keyboardmanager/common/LayoutMap.h
+++ b/src/modules/keyboardmanager/common/LayoutMap.h
@@ -1,0 +1,152 @@
+#pragma once
+#include <interface/lowlevel_keyboard_event_data.h>
+#include <string>
+#include <map>
+#include <mutex>
+
+// Wrapper class to handle keyboard layout
+class LayoutMap
+{
+private:
+    // Stores mappings for all the virtual key codes to the name of the key
+    std::map<DWORD, std::wstring> keyboardLayoutMap;
+    std::mutex keyboardLayoutMap_mutex;
+
+public:
+    LayoutMap()
+    {
+        // Get keyboard layout for current thread
+        HKL layout = GetKeyboardLayout(0);
+        unsigned char btKeys[256] = { 0 };
+        GetKeyboardState(btKeys);
+
+        // Iterate over all the virtual key codes
+        for (int i = 0; i < 256; i++)
+        {
+            // Get the scan code from the virtual key code
+            UINT scanCode = MapVirtualKeyExW(i, MAPVK_VK_TO_VSC, layout);
+            // Get the unicode representation from the virtual key code and scan code pair to 
+            wchar_t szBuffer[3] = { 0 };
+            int result = ToUnicodeEx(i, scanCode, (BYTE*)btKeys, szBuffer, 3, 0, layout);
+            // If a representation is returned
+            if (result > 0)
+            {
+                keyboardLayoutMap[i] = szBuffer;
+            }
+            else
+            {
+                // Store the virtual key code as string
+                keyboardLayoutMap[i] = L"VK " + std::to_wstring(i);
+            }
+        }
+
+        // Override special key names like Shift, Ctrl etc because they don't have unicode mappings and key names like Enter, Space as they appear as "\r", " "
+        // To do: localization
+        keyboardLayoutMap[VK_CANCEL] = L"Break";
+        keyboardLayoutMap[VK_BACK] = L"Backspace";
+        keyboardLayoutMap[VK_TAB] = L"Tab";
+        keyboardLayoutMap[VK_CLEAR] = L"Clear";
+        keyboardLayoutMap[VK_RETURN] = L"Enter";
+        keyboardLayoutMap[VK_SHIFT] = L"Shift";
+        keyboardLayoutMap[VK_CONTROL] = L"Ctrl";
+        keyboardLayoutMap[VK_MENU] = L"Alt";
+        keyboardLayoutMap[VK_PAUSE] = L"Pause";
+        keyboardLayoutMap[VK_CAPITAL] = L"Caps Lock";
+        keyboardLayoutMap[VK_ESCAPE] = L"Esc";
+        keyboardLayoutMap[VK_SPACE] = L"Space";
+        keyboardLayoutMap[VK_PRIOR] = L"PgUp";
+        keyboardLayoutMap[VK_NEXT] = L"PgDn";
+        keyboardLayoutMap[VK_END] = L"End";
+        keyboardLayoutMap[VK_HOME] = L"Home";
+        keyboardLayoutMap[VK_LEFT] = L"Left";
+        keyboardLayoutMap[VK_UP] = L"Up";
+        keyboardLayoutMap[VK_RIGHT] = L"Right";
+        keyboardLayoutMap[VK_DOWN] = L"Down";
+        keyboardLayoutMap[VK_SELECT] = L"Select";
+        keyboardLayoutMap[VK_PRINT] = L"Print";
+        keyboardLayoutMap[VK_EXECUTE] = L"Execute";
+        keyboardLayoutMap[VK_SNAPSHOT] = L"Print Screen";
+        keyboardLayoutMap[VK_INSERT] = L"Insert";
+        keyboardLayoutMap[VK_DELETE] = L"Delete";
+        keyboardLayoutMap[VK_HELP] = L"Help";
+        keyboardLayoutMap[VK_LWIN] = L"LWin";
+        keyboardLayoutMap[VK_RWIN] = L"RWin";
+        keyboardLayoutMap[VK_APPS] = L"Menu";
+        keyboardLayoutMap[VK_SLEEP] = L"Sleep";
+        keyboardLayoutMap[VK_NUMPAD0] = L"NumPad 0";
+        keyboardLayoutMap[VK_NUMPAD1] = L"NumPad 1";
+        keyboardLayoutMap[VK_NUMPAD2] = L"NumPad 2";
+        keyboardLayoutMap[VK_NUMPAD3] = L"NumPad 3";
+        keyboardLayoutMap[VK_NUMPAD4] = L"NumPad 4";
+        keyboardLayoutMap[VK_NUMPAD5] = L"NumPad 5";
+        keyboardLayoutMap[VK_NUMPAD6] = L"NumPad 6";
+        keyboardLayoutMap[VK_NUMPAD7] = L"NumPad 7";
+        keyboardLayoutMap[VK_NUMPAD8] = L"NumPad 8";
+        keyboardLayoutMap[VK_NUMPAD9] = L"NumPad 9";
+        keyboardLayoutMap[VK_SEPARATOR] = L"Separator";
+        keyboardLayoutMap[VK_F1] = L"F1";
+        keyboardLayoutMap[VK_F2] = L"F2";
+        keyboardLayoutMap[VK_F3] = L"F3";
+        keyboardLayoutMap[VK_F4] = L"F4";
+        keyboardLayoutMap[VK_F5] = L"F5";
+        keyboardLayoutMap[VK_F6] = L"F6";
+        keyboardLayoutMap[VK_F7] = L"F7";
+        keyboardLayoutMap[VK_F8] = L"F8";
+        keyboardLayoutMap[VK_F9] = L"F9";
+        keyboardLayoutMap[VK_F10] = L"F10";
+        keyboardLayoutMap[VK_F11] = L"F11";
+        keyboardLayoutMap[VK_F12] = L"F12";
+        keyboardLayoutMap[VK_F13] = L"F13";
+        keyboardLayoutMap[VK_F14] = L"F14";
+        keyboardLayoutMap[VK_F15] = L"F15";
+        keyboardLayoutMap[VK_F16] = L"F16";
+        keyboardLayoutMap[VK_F17] = L"F17";
+        keyboardLayoutMap[VK_F18] = L"F18";
+        keyboardLayoutMap[VK_F19] = L"F19";
+        keyboardLayoutMap[VK_F20] = L"F20";
+        keyboardLayoutMap[VK_F21] = L"F21";
+        keyboardLayoutMap[VK_F22] = L"F22";
+        keyboardLayoutMap[VK_F23] = L"F23";
+        keyboardLayoutMap[VK_F24] = L"F24";
+        keyboardLayoutMap[VK_NUMLOCK] = L"Num Lock";
+        keyboardLayoutMap[VK_SCROLL] = L"Scroll Lock";
+        keyboardLayoutMap[VK_LSHIFT] = L"LShift";
+        keyboardLayoutMap[VK_RSHIFT] = L"RShift";
+        keyboardLayoutMap[VK_LCONTROL] = L"LCtrl";
+        keyboardLayoutMap[VK_RCONTROL] = L"RCtrl";
+        keyboardLayoutMap[VK_LMENU] = L"LAlt";
+        keyboardLayoutMap[VK_RMENU] = L"RAlt";
+        keyboardLayoutMap[VK_BROWSER_BACK] = L"Browser Back";
+        keyboardLayoutMap[VK_BROWSER_FORWARD] = L"Browser Forward";
+        keyboardLayoutMap[VK_BROWSER_REFRESH] = L"Browser Refresh";
+        keyboardLayoutMap[VK_BROWSER_STOP] = L"Browser Stop";
+        keyboardLayoutMap[VK_BROWSER_SEARCH] = L"Browser Search";
+        keyboardLayoutMap[VK_BROWSER_FAVORITES] = L"Browser Favorites";
+        keyboardLayoutMap[VK_BROWSER_HOME] = L"Browser Start & Home";
+        keyboardLayoutMap[VK_VOLUME_MUTE] = L"Volume Mute";
+        keyboardLayoutMap[VK_VOLUME_DOWN] = L"Volume Down";
+        keyboardLayoutMap[VK_VOLUME_UP] = L"Volume Up";
+        keyboardLayoutMap[VK_MEDIA_NEXT_TRACK] = L"Next Track";
+        keyboardLayoutMap[VK_MEDIA_PREV_TRACK] = L"Previous Track";
+        keyboardLayoutMap[VK_MEDIA_STOP] = L"Stop Media";
+        keyboardLayoutMap[VK_MEDIA_PLAY_PAUSE] = L"Play/Pause Media";
+        keyboardLayoutMap[VK_LAUNCH_MAIL] = L"Start Mail";
+        keyboardLayoutMap[VK_LAUNCH_MEDIA_SELECT] = L"Select Media";
+        keyboardLayoutMap[VK_LAUNCH_APP1] = L"Start Application 1";
+        keyboardLayoutMap[VK_LAUNCH_APP2] = L"Start Application 2";
+        keyboardLayoutMap[VK_PACKET] = L"Packet";
+        keyboardLayoutMap[VK_ATTN] = L"Attn";
+        keyboardLayoutMap[VK_CRSEL] = L"CrSel";
+        keyboardLayoutMap[VK_EXSEL] = L"ExSel";
+        keyboardLayoutMap[VK_EREOF] = L"Erase EOF";
+        keyboardLayoutMap[VK_PLAY] = L"Play";
+        keyboardLayoutMap[VK_ZOOM] = L"Zoom";
+        keyboardLayoutMap[VK_PA1] = L"PA1";
+        keyboardLayoutMap[VK_OEM_CLEAR] = L"Clear";
+        keyboardLayoutMap[0xFF] = L"Undefined";
+        // To do: Add IME key names
+    }
+
+    // Function to return the unicode string name of the key
+    std::wstring GetKeyName(DWORD key);
+};

--- a/src/modules/keyboardmanager/common/LayoutMap.h
+++ b/src/modules/keyboardmanager/common/LayoutMap.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <map>
 #include <mutex>
+#include <windows.h>
 
 // Wrapper class to handle keyboard layout
 class LayoutMap
@@ -11,142 +12,18 @@ private:
     // Stores mappings for all the virtual key codes to the name of the key
     std::map<DWORD, std::wstring> keyboardLayoutMap;
     std::mutex keyboardLayoutMap_mutex;
+    HKL previousLayout = 0;
 
 public:
+    // Update Keyboard layout according to input locale identifier
+    void UpdateLayout();
+
     LayoutMap()
     {
-        // Get keyboard layout for current thread
-        HKL layout = GetKeyboardLayout(0);
-        unsigned char btKeys[256] = { 0 };
-        GetKeyboardState(btKeys);
-
-        // Iterate over all the virtual key codes
-        for (int i = 0; i < 256; i++)
-        {
-            // Get the scan code from the virtual key code
-            UINT scanCode = MapVirtualKeyExW(i, MAPVK_VK_TO_VSC, layout);
-            // Get the unicode representation from the virtual key code and scan code pair to 
-            wchar_t szBuffer[3] = { 0 };
-            int result = ToUnicodeEx(i, scanCode, (BYTE*)btKeys, szBuffer, 3, 0, layout);
-            // If a representation is returned
-            if (result > 0)
-            {
-                keyboardLayoutMap[i] = szBuffer;
-            }
-            else
-            {
-                // Store the virtual key code as string
-                keyboardLayoutMap[i] = L"VK " + std::to_wstring(i);
-            }
-        }
-
-        // Override special key names like Shift, Ctrl etc because they don't have unicode mappings and key names like Enter, Space as they appear as "\r", " "
-        // To do: localization
-        keyboardLayoutMap[VK_CANCEL] = L"Break";
-        keyboardLayoutMap[VK_BACK] = L"Backspace";
-        keyboardLayoutMap[VK_TAB] = L"Tab";
-        keyboardLayoutMap[VK_CLEAR] = L"Clear";
-        keyboardLayoutMap[VK_RETURN] = L"Enter";
-        keyboardLayoutMap[VK_SHIFT] = L"Shift";
-        keyboardLayoutMap[VK_CONTROL] = L"Ctrl";
-        keyboardLayoutMap[VK_MENU] = L"Alt";
-        keyboardLayoutMap[VK_PAUSE] = L"Pause";
-        keyboardLayoutMap[VK_CAPITAL] = L"Caps Lock";
-        keyboardLayoutMap[VK_ESCAPE] = L"Esc";
-        keyboardLayoutMap[VK_SPACE] = L"Space";
-        keyboardLayoutMap[VK_PRIOR] = L"PgUp";
-        keyboardLayoutMap[VK_NEXT] = L"PgDn";
-        keyboardLayoutMap[VK_END] = L"End";
-        keyboardLayoutMap[VK_HOME] = L"Home";
-        keyboardLayoutMap[VK_LEFT] = L"Left";
-        keyboardLayoutMap[VK_UP] = L"Up";
-        keyboardLayoutMap[VK_RIGHT] = L"Right";
-        keyboardLayoutMap[VK_DOWN] = L"Down";
-        keyboardLayoutMap[VK_SELECT] = L"Select";
-        keyboardLayoutMap[VK_PRINT] = L"Print";
-        keyboardLayoutMap[VK_EXECUTE] = L"Execute";
-        keyboardLayoutMap[VK_SNAPSHOT] = L"Print Screen";
-        keyboardLayoutMap[VK_INSERT] = L"Insert";
-        keyboardLayoutMap[VK_DELETE] = L"Delete";
-        keyboardLayoutMap[VK_HELP] = L"Help";
-        keyboardLayoutMap[VK_LWIN] = L"LWin";
-        keyboardLayoutMap[VK_RWIN] = L"RWin";
-        keyboardLayoutMap[VK_APPS] = L"Menu";
-        keyboardLayoutMap[VK_SLEEP] = L"Sleep";
-        keyboardLayoutMap[VK_NUMPAD0] = L"NumPad 0";
-        keyboardLayoutMap[VK_NUMPAD1] = L"NumPad 1";
-        keyboardLayoutMap[VK_NUMPAD2] = L"NumPad 2";
-        keyboardLayoutMap[VK_NUMPAD3] = L"NumPad 3";
-        keyboardLayoutMap[VK_NUMPAD4] = L"NumPad 4";
-        keyboardLayoutMap[VK_NUMPAD5] = L"NumPad 5";
-        keyboardLayoutMap[VK_NUMPAD6] = L"NumPad 6";
-        keyboardLayoutMap[VK_NUMPAD7] = L"NumPad 7";
-        keyboardLayoutMap[VK_NUMPAD8] = L"NumPad 8";
-        keyboardLayoutMap[VK_NUMPAD9] = L"NumPad 9";
-        keyboardLayoutMap[VK_SEPARATOR] = L"Separator";
-        keyboardLayoutMap[VK_F1] = L"F1";
-        keyboardLayoutMap[VK_F2] = L"F2";
-        keyboardLayoutMap[VK_F3] = L"F3";
-        keyboardLayoutMap[VK_F4] = L"F4";
-        keyboardLayoutMap[VK_F5] = L"F5";
-        keyboardLayoutMap[VK_F6] = L"F6";
-        keyboardLayoutMap[VK_F7] = L"F7";
-        keyboardLayoutMap[VK_F8] = L"F8";
-        keyboardLayoutMap[VK_F9] = L"F9";
-        keyboardLayoutMap[VK_F10] = L"F10";
-        keyboardLayoutMap[VK_F11] = L"F11";
-        keyboardLayoutMap[VK_F12] = L"F12";
-        keyboardLayoutMap[VK_F13] = L"F13";
-        keyboardLayoutMap[VK_F14] = L"F14";
-        keyboardLayoutMap[VK_F15] = L"F15";
-        keyboardLayoutMap[VK_F16] = L"F16";
-        keyboardLayoutMap[VK_F17] = L"F17";
-        keyboardLayoutMap[VK_F18] = L"F18";
-        keyboardLayoutMap[VK_F19] = L"F19";
-        keyboardLayoutMap[VK_F20] = L"F20";
-        keyboardLayoutMap[VK_F21] = L"F21";
-        keyboardLayoutMap[VK_F22] = L"F22";
-        keyboardLayoutMap[VK_F23] = L"F23";
-        keyboardLayoutMap[VK_F24] = L"F24";
-        keyboardLayoutMap[VK_NUMLOCK] = L"Num Lock";
-        keyboardLayoutMap[VK_SCROLL] = L"Scroll Lock";
-        keyboardLayoutMap[VK_LSHIFT] = L"LShift";
-        keyboardLayoutMap[VK_RSHIFT] = L"RShift";
-        keyboardLayoutMap[VK_LCONTROL] = L"LCtrl";
-        keyboardLayoutMap[VK_RCONTROL] = L"RCtrl";
-        keyboardLayoutMap[VK_LMENU] = L"LAlt";
-        keyboardLayoutMap[VK_RMENU] = L"RAlt";
-        keyboardLayoutMap[VK_BROWSER_BACK] = L"Browser Back";
-        keyboardLayoutMap[VK_BROWSER_FORWARD] = L"Browser Forward";
-        keyboardLayoutMap[VK_BROWSER_REFRESH] = L"Browser Refresh";
-        keyboardLayoutMap[VK_BROWSER_STOP] = L"Browser Stop";
-        keyboardLayoutMap[VK_BROWSER_SEARCH] = L"Browser Search";
-        keyboardLayoutMap[VK_BROWSER_FAVORITES] = L"Browser Favorites";
-        keyboardLayoutMap[VK_BROWSER_HOME] = L"Browser Start & Home";
-        keyboardLayoutMap[VK_VOLUME_MUTE] = L"Volume Mute";
-        keyboardLayoutMap[VK_VOLUME_DOWN] = L"Volume Down";
-        keyboardLayoutMap[VK_VOLUME_UP] = L"Volume Up";
-        keyboardLayoutMap[VK_MEDIA_NEXT_TRACK] = L"Next Track";
-        keyboardLayoutMap[VK_MEDIA_PREV_TRACK] = L"Previous Track";
-        keyboardLayoutMap[VK_MEDIA_STOP] = L"Stop Media";
-        keyboardLayoutMap[VK_MEDIA_PLAY_PAUSE] = L"Play/Pause Media";
-        keyboardLayoutMap[VK_LAUNCH_MAIL] = L"Start Mail";
-        keyboardLayoutMap[VK_LAUNCH_MEDIA_SELECT] = L"Select Media";
-        keyboardLayoutMap[VK_LAUNCH_APP1] = L"Start Application 1";
-        keyboardLayoutMap[VK_LAUNCH_APP2] = L"Start Application 2";
-        keyboardLayoutMap[VK_PACKET] = L"Packet";
-        keyboardLayoutMap[VK_ATTN] = L"Attn";
-        keyboardLayoutMap[VK_CRSEL] = L"CrSel";
-        keyboardLayoutMap[VK_EXSEL] = L"ExSel";
-        keyboardLayoutMap[VK_EREOF] = L"Erase EOF";
-        keyboardLayoutMap[VK_PLAY] = L"Play";
-        keyboardLayoutMap[VK_ZOOM] = L"Zoom";
-        keyboardLayoutMap[VK_PA1] = L"PA1";
-        keyboardLayoutMap[VK_OEM_CLEAR] = L"Clear";
-        keyboardLayoutMap[0xFF] = L"Undefined";
-        // To do: Add IME key names
+        UpdateLayout();
     }
 
     // Function to return the unicode string name of the key
     std::wstring GetKeyName(DWORD key);
+
 };

--- a/src/modules/keyboardmanager/common/Shortcut.cpp
+++ b/src/modules/keyboardmanager/common/Shortcut.cpp
@@ -99,7 +99,6 @@ DWORD Shortcut::GetWinKey(const ModifierKey& input) const
             //return VK_LWIN by default
             return VK_LWIN;
         }
-
     }
 }
 
@@ -393,10 +392,10 @@ void Shortcut::ResetKey(const DWORD& input, const bool& isWinBoth)
 }
 
 // Function to return the string representation of the shortcut
-winrt::hstring Shortcut::ToHstring() const
+winrt::hstring Shortcut::ToHstring(LayoutMap& keyboardMap)
 {
-    std::vector<winrt::hstring> keys = GetKeyVector();
-    
+    std::vector<winrt::hstring> keys = GetKeyVector(keyboardMap);
+
     winrt::hstring output;
     for (auto& key : keys)
     {
@@ -404,7 +403,7 @@ winrt::hstring Shortcut::ToHstring() const
     }
     if (keys.size() > 1)
     {
-        return winrt::hstring(output.c_str(), output.size() - 1);   
+        return winrt::hstring(output.c_str(), output.size() - 1);
     }
     else
     {
@@ -412,28 +411,28 @@ winrt::hstring Shortcut::ToHstring() const
     }
 }
 
-std::vector<winrt::hstring> Shortcut::GetKeyVector() const
+std::vector<winrt::hstring> Shortcut::GetKeyVector(LayoutMap& keyboardMap)
 {
     std::vector<winrt::hstring> keys;
     if (winKey != ModifierKey::Disabled)
     {
-        keys.push_back(ModifierKeyNameWithSide(winKey, L"Win"));
+        keys.push_back(winrt::to_hstring(keyboardMap.GetKeyName(GetWinKey(ModifierKey::Left)).c_str()));
     }
     if (ctrlKey != ModifierKey::Disabled)
     {
-        keys.push_back(ModifierKeyNameWithSide(ctrlKey, L"Ctrl"));
+        keys.push_back(winrt::to_hstring(keyboardMap.GetKeyName(GetCtrlKey()).c_str()));
     }
     if (altKey != ModifierKey::Disabled)
     {
-        keys.push_back(ModifierKeyNameWithSide(altKey, L"Alt"));
+        keys.push_back(winrt::to_hstring(keyboardMap.GetKeyName(GetAltKey()).c_str()));
     }
     if (shiftKey != ModifierKey::Disabled)
     {
-        keys.push_back(ModifierKeyNameWithSide(shiftKey, L"Shift"));
+        keys.push_back(winrt::to_hstring(keyboardMap.GetKeyName(GetShiftKey()).c_str()));
     }
     if (actionKey != NULL)
     {
-        keys.push_back(winrt::to_hstring((unsigned int)actionKey));
+        keys.push_back(winrt::to_hstring(keyboardMap.GetKeyName(actionKey).c_str()));
     }
     return keys;
 }
@@ -709,102 +708,4 @@ int Shortcut::GetCommonModifiersCount(const Shortcut& input) const
     }
 
     return commonElements;
-}
-
-// Function to return the name of the key with L or R prefix depending on the first argument. Second argument should be the name of the key without any prefix (ex: Win, Ctrl)
-winrt::hstring Shortcut::ModifierKeyNameWithSide(const ModifierKey& key, const std::wstring& keyName) const
-{
-    if (key == ModifierKey::Left)
-    {
-        return winrt::to_hstring(L"L") + winrt::to_hstring(keyName.c_str());
-    }
-    else if (key == ModifierKey::Right)
-    {
-        return winrt::to_hstring(L"R") + winrt::to_hstring(keyName.c_str());
-    }
-    else if (key == ModifierKey::Both)
-    {
-        return winrt::to_hstring(keyName.c_str());
-    }
-
-    return winrt::hstring();
-}
-
-// Function to return the virtual key code from the name of the key
-DWORD Shortcut::DecodeKey(const std::wstring& keyName)
-{
-    if (keyName == L"LWin")
-    {
-        return VK_LWIN;
-    }
-    else if (keyName == L"RWin")
-    {
-        return VK_RWIN;
-    }
-    else if (keyName == L"LCtrl")
-    {
-        return VK_LCONTROL;
-    }
-    else if (keyName == L"RCtrl")
-    {
-        return VK_RCONTROL;
-    }
-    else if (keyName == L"Ctrl")
-    {
-        return VK_CONTROL;
-    }
-    else if (keyName == L"LAlt")
-    {
-        return VK_LMENU;
-    }
-    else if (keyName == L"RAlt")
-    {
-        return VK_RMENU;
-    }
-    else if (keyName == L"Alt")
-    {
-        return VK_MENU;
-    }
-    else if (keyName == L"LShift")
-    {
-        return VK_LSHIFT;
-    }
-    else if (keyName == L"RShift")
-    {
-        return VK_RSHIFT;
-    }
-    else if (keyName == L"Shift")
-    {
-        return VK_SHIFT;
-    }
-    else
-    {
-        return std::stoi(keyName);
-    }
-}
-
-// Function to create a shortcut object from its string representation
-Shortcut Shortcut::CreateShortcut(const std::vector<winrt::hstring>& keys)
-{
-    Shortcut newShortcut;
-    for (int i = 0; i < keys.size(); i++)
-    {
-        if (keys[i] == L"Win")
-        {
-            newShortcut.SetKey(NULL, true);
-        }
-        else
-        {
-            DWORD keyCode = DecodeKey(keys[i].c_str());
-            newShortcut.SetKey(keyCode);
-        }
-    }
-
-    return newShortcut;
-}
-
-Shortcut Shortcut::CreateShortcut(const winrt::hstring& input)
-{
-    std::vector<std::wstring> shortcut = splitwstring(input.c_str(), L' ');
-    return CreateShortcut(std::vector<winrt::hstring>(shortcut.begin(), shortcut.end()));
 }

--- a/src/modules/keyboardmanager/common/Shortcut.h
+++ b/src/modules/keyboardmanager/common/Shortcut.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "Helpers.h"
+#include "LayoutMap.h"
 #include <interface/lowlevel_keyboard_event_data.h>
 
 // Enum type to store different states of the win key
@@ -20,10 +21,8 @@ private:
     ModifierKey shiftKey;
     DWORD actionKey;
 
-    // Function to return the name of the key with L or R prefix depending on the first argument. Second argument should be the name of the key without any prefix (ex: Win, Ctrl)
-    winrt::hstring ModifierKeyNameWithSide(const ModifierKey& key, const std::wstring& keyName) const;
-
 public:
+
     // By default create an empty shortcut
     Shortcut() :
         winKey(ModifierKey::Disabled), ctrlKey(ModifierKey::Disabled), altKey(ModifierKey::Disabled), shiftKey(ModifierKey::Disabled), actionKey(NULL)
@@ -138,10 +137,10 @@ public:
     void ResetKey(const DWORD& input, const bool& isWinBoth = false);
 
     // Function to return the string representation of the shortcut
-    winrt::hstring ToHstring() const;
+    winrt::hstring ToHstring(LayoutMap& keyboardMap);
 
     // Function to return a vector of hstring for each key, in the same order as ToHstring()
-    std::vector<winrt::hstring> GetKeyVector() const;
+    std::vector<winrt::hstring> GetKeyVector(LayoutMap& keyboardMap);
 
     // Function to check if all the modifiers in the shortcut have been pressed down
     bool CheckModifiersKeyboardState() const;
@@ -151,13 +150,4 @@ public:
 
     // Function to get the number of modifiers that are common between the current shortcut and the shortcut in the argument
     int GetCommonModifiersCount(const Shortcut& input) const;
-
-    // Function to return the virtual key code from the name of the key
-    static DWORD DecodeKey(const std::wstring& keyName);
-
-    // Function to create a shortcut object from its string vector representation
-    static Shortcut CreateShortcut(const std::vector<winrt::hstring>& keys);
-
-    // Function to create a shortcut object from its string representation
-    static Shortcut CreateShortcut(const winrt::hstring& input);
 };

--- a/src/modules/keyboardmanager/dll/dllmain.cpp
+++ b/src/modules/keyboardmanager/dll/dllmain.cpp
@@ -59,9 +59,6 @@ private:
     // Variable which stores all the state information to be shared between the UI and back-end
     KeyboardManagerState keyboardManagerState;
 
-    // Vector to store the detected shortcut in the detect shortcut UI. Acts as a shortcut buffer while detecting the shortcuts in the UI.
-    std::vector<DWORD> detectedShortcutKeys;
-
 public:
     // Constructor
     KeyboardManager()

--- a/src/modules/keyboardmanager/ui/EditKeyboardWindow.cpp
+++ b/src/modules/keyboardmanager/ui/EditKeyboardWindow.cpp
@@ -130,6 +130,21 @@ void createEditKeyboardWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMan
     // Message to display success/failure of saving settings.
     TextBlock settingsMessage;
 
+    // Store handle of edit keyboard window
+    SingleKeyRemapControl::EditKeyboardWindowHandle = _hWndEditKeyboardWindow;
+    // Store keyboard manager state
+    SingleKeyRemapControl::keyboardManagerState = &keyboardManagerState;
+    // Clear the single key remap buffer
+    SingleKeyRemapControl::singleKeyRemapBuffer.clear();
+
+    // Load existing remaps into UI
+    std::unique_lock<std::mutex> lock(keyboardManagerState.singleKeyReMap_mutex);
+    for (const auto& it : keyboardManagerState.singleKeyReMap)
+    {
+        SingleKeyRemapControl::AddNewControlKeyRemapRow(keyRemapTable, it.first, it.second);
+    }
+    lock.unlock();
+
     // Main Header Apply button
     Button applyButton;
     applyButton.Background(Windows::UI::Xaml::Media::SolidColorBrush{ Windows::UI::Colors::LightGray() });
@@ -140,17 +155,13 @@ void createEditKeyboardWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMan
         // Clear existing Key Remaps
         keyboardManagerState.ClearSingleKeyRemaps();
 
-        // Save the keys that are valid and report if any of them were invalid
-        for (unsigned int i = 1; i < keyRemapTable.Children().Size(); i++)
+        for (int i = 0; i < SingleKeyRemapControl::singleKeyRemapBuffer.size(); i++)
         {
-            StackPanel currentRow = keyRemapTable.Children().GetAt(i).as<StackPanel>();
-            hstring originalKeyString = currentRow.Children().GetAt(0).as<StackPanel>().Children().GetAt(1).as<TextBlock>().Text();
-            hstring newKeyString = currentRow.Children().GetAt(1).as<StackPanel>().Children().GetAt(1).as<TextBlock>().Text();
-            if (!originalKeyString.empty() && !newKeyString.empty())
-            {
-                DWORD originalKey = std::stoi(originalKeyString.c_str());
-                DWORD newKey = std::stoi(newKeyString.c_str());
+            DWORD originalKey = SingleKeyRemapControl::singleKeyRemapBuffer[i][0];
+            DWORD newKey = SingleKeyRemapControl::singleKeyRemapBuffer[i][1];
 
+            if (originalKey != NULL && newKey != NULL)
+            {
                 bool result = keyboardManagerState.AddSingleKeyRemap(originalKey, newKey);
                 if (!result)
                 {
@@ -179,19 +190,6 @@ void createEditKeyboardWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMan
     header.Children().Append(cancelButton);
     header.Children().Append(applyButton);
     header.Children().Append(settingsMessage);
-
-    // Store handle of edit keyboard window
-    SingleKeyRemapControl::EditKeyboardWindowHandle = _hWndEditKeyboardWindow;
-    // Store keyboard manager state
-    SingleKeyRemapControl::keyboardManagerState = &keyboardManagerState;
-
-    // Load existing remaps into UI
-    std::unique_lock<std::mutex> lock(keyboardManagerState.singleKeyReMap_mutex);
-    for (const auto& it : keyboardManagerState.singleKeyReMap)
-    {
-        SingleKeyRemapControl::AddNewControlKeyRemapRow(keyRemapTable, it.first, it.second);
-    }
-    lock.unlock();
 
     // Add remap key button
     Windows::UI::Xaml::Controls::Button addRemapKey;

--- a/src/modules/keyboardmanager/ui/EditKeyboardWindow.cpp
+++ b/src/modules/keyboardmanager/ui/EditKeyboardWindow.cpp
@@ -12,6 +12,7 @@ bool isEditKeyboardWindowRegistrationCompleted = false;
 // Function to create the Edit Keyboard Window
 void createEditKeyboardWindow(HINSTANCE hInst, KeyboardManagerState& keyboardManagerState)
 {
+
     // Window Registration
     const wchar_t szWindowClass[] = L"EditKeyboardWindow";
     if (!isEditKeyboardWindowRegistrationCompleted)

--- a/src/modules/keyboardmanager/ui/EditShortcutsWindow.h
+++ b/src/modules/keyboardmanager/ui/EditShortcutsWindow.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "keyboardmanager/common/KeyboardManagerState.h"
+#include "keyboardmanager/common/Shortcut.h"
 #include "keyboardmanager/common/Helpers.h"
 
 // Function to create the Edit Shortcuts Window

--- a/src/modules/keyboardmanager/ui/ShortcutControl.h
+++ b/src/modules/keyboardmanager/ui/ShortcutControl.h
@@ -20,14 +20,16 @@ public:
     static HWND EditShortcutsWindowHandle;
     // Pointer to the keyboard manager state
     static KeyboardManagerState* keyboardManagerState;
+    // Stores the current list of remappings
+    static std::vector<std::vector<Shortcut>> shortcutRemapBuffer;
 
-    ShortcutControl()
+    ShortcutControl(const int& rowIndex, const int& colIndex)
     {
         typeShortcut.Content(winrt::box_value(winrt::to_hstring("Type Shortcut")));
-        typeShortcut.Click([&](IInspectable const& sender, RoutedEventArgs const&) {
+        typeShortcut.Click([&, rowIndex, colIndex](IInspectable const& sender, RoutedEventArgs const&) {
             keyboardManagerState->SetUIState(KeyboardManagerUIState::DetectShortcutWindowActivated, EditShortcutsWindowHandle);
             // Using the XamlRoot of the typeShortcut to get the root of the XAML host
-            createDetectShortcutWindow(sender, sender.as<Button>().XamlRoot(), *keyboardManagerState);
+            createDetectShortcutWindow(sender, sender.as<Button>().XamlRoot(), shortcutRemapBuffer, *keyboardManagerState, rowIndex, colIndex);
         });
 
         shortcutControlLayout.Background(Windows::UI::Xaml::Media::SolidColorBrush{ Windows::UI::Colors::LightGray() });
@@ -39,11 +41,11 @@ public:
     }
 
     // Function to add a new row to the shortcut table. If the originalKeys and newKeys args are provided, then the displayed shortcuts are set to those values.
-    static void AddNewShortcutControlRow(StackPanel& parent, const Shortcut& originalKeys = Shortcut(), const Shortcut& newKeys = Shortcut());
+    static void AddNewShortcutControlRow(StackPanel& parent, Shortcut originalKeys = Shortcut(), Shortcut newKeys = Shortcut());
 
     // Function to return the stack panel element of the ShortcutControl. This is the externally visible UI element which can be used to add it to other layouts
     StackPanel getShortcutControl();
 
     // Function to create the detect shortcut UI window
-    void createDetectShortcutWindow(IInspectable const& sender, XamlRoot xamlRoot, KeyboardManagerState& keyboardManagerState);
+    void createDetectShortcutWindow(IInspectable const& sender, XamlRoot xamlRoot, std::vector<std::vector<Shortcut>>& shortcutRemapBuffer, KeyboardManagerState& keyboardManagerState, const int& rowIndex, const int& colIndex);
 };

--- a/src/modules/keyboardmanager/ui/SingleKeyRemapControl.cpp
+++ b/src/modules/keyboardmanager/ui/SingleKeyRemapControl.cpp
@@ -4,6 +4,8 @@
 //Both static members are initialized to null
 HWND SingleKeyRemapControl::EditKeyboardWindowHandle = nullptr;
 KeyboardManagerState* SingleKeyRemapControl::keyboardManagerState = nullptr;
+// Initialized as new vector
+std::vector<std::vector<DWORD>> SingleKeyRemapControl::singleKeyRemapBuffer;
 
 // Function to add a new row to the remap keys table. If the originalKey and newKey args are provided, then the displayed remap keys are set to those values.
 void SingleKeyRemapControl::AddNewControlKeyRemapRow(StackPanel& parent, const DWORD& originalKey, const DWORD& newKey)
@@ -15,18 +17,24 @@ void SingleKeyRemapControl::AddNewControlKeyRemapRow(StackPanel& parent, const D
     tableRow.Orientation(Windows::UI::Xaml::Controls::Orientation::Horizontal);
 
     // SingleKeyRemapControl for the original key.
-    SingleKeyRemapControl originalRemapKeyControl;
+    SingleKeyRemapControl originalRemapKeyControl(singleKeyRemapBuffer.size(), 0);
     tableRow.Children().Append(originalRemapKeyControl.getSingleKeyRemapControl());
 
     // SingleKeyRemapControl for the new remap key.
-    SingleKeyRemapControl newRemapKeyControl;
+    SingleKeyRemapControl newRemapKeyControl(singleKeyRemapBuffer.size(), 1);
     tableRow.Children().Append(newRemapKeyControl.getSingleKeyRemapControl());
 
     // Set the key text if the two keys are not null (i.e. default args)
     if (originalKey != NULL && newKey != NULL)
     {
-        originalRemapKeyControl.singleKeyRemapText.Text(winrt::to_hstring((unsigned int)originalKey));
-        newRemapKeyControl.singleKeyRemapText.Text(winrt::to_hstring((unsigned int)newKey));
+        singleKeyRemapBuffer.push_back(std::vector<DWORD>{ originalKey, newKey });
+        originalRemapKeyControl.singleKeyRemapText.Text(winrt::to_hstring(keyboardManagerState->keyboardMap.GetKeyName(originalKey).c_str()));
+        newRemapKeyControl.singleKeyRemapText.Text(winrt::to_hstring(keyboardManagerState->keyboardMap.GetKeyName(newKey).c_str()));
+    }
+    else
+    {
+        // Initialize both keys to NULL
+        singleKeyRemapBuffer.push_back(std::vector<DWORD>{ NULL, NULL });
     }
 
     // Delete row button
@@ -42,6 +50,8 @@ void SingleKeyRemapControl::AddNewControlKeyRemapRow(StackPanel& parent, const D
         uint32_t index;
         parent.Children().IndexOf(currentRow, index);
         parent.Children().RemoveAt(index);
+        // delete the row from the buffer. Since first child of the stackpanel is the header, the effective index starts from 1
+        singleKeyRemapBuffer.erase(singleKeyRemapBuffer.begin() + (index - 1));
     });
     tableRow.Children().Append(deleteRemapKeys);
     parent.Children().Append(tableRow);
@@ -54,7 +64,7 @@ StackPanel SingleKeyRemapControl::getSingleKeyRemapControl()
 }
 
 // Function to create the detect remap key UI window
-void SingleKeyRemapControl::createDetectKeyWindow(IInspectable const& sender, XamlRoot xamlRoot, KeyboardManagerState& keyboardManagerState)
+void SingleKeyRemapControl::createDetectKeyWindow(IInspectable const& sender, XamlRoot xamlRoot, std::vector<std::vector<DWORD>>& singleKeyRemapBuffer, KeyboardManagerState& keyboardManagerState, const int& rowIndex, const int& colIndex)
 {
     // ContentDialog for detecting remap key. This is the parent UI element.
     ContentDialog detectRemapKeyBox;
@@ -72,12 +82,14 @@ void SingleKeyRemapControl::createDetectKeyWindow(IInspectable const& sender, Xa
     TextBlock linkedRemapText = getSiblingElement(sender).as<TextBlock>();
 
     // OK button
-    detectRemapKeyBox.PrimaryButtonClick([=, &keyboardManagerState](Windows::UI::Xaml::Controls::ContentDialog const& sender, ContentDialogButtonClickEventArgs const&) {
+    detectRemapKeyBox.PrimaryButtonClick([=, &singleKeyRemapBuffer, &keyboardManagerState](Windows::UI::Xaml::Controls::ContentDialog const& sender, ContentDialogButtonClickEventArgs const&) {
         // Save the detected key in the linked text block
         DWORD detectedKey = keyboardManagerState.GetDetectedSingleRemapKey();
+
         if (detectedKey != NULL)
         {
-            linkedRemapText.Text(winrt::to_hstring((unsigned int)detectedKey));
+            singleKeyRemapBuffer[rowIndex][colIndex] = detectedKey;
+            linkedRemapText.Text(winrt::to_hstring(keyboardManagerState.keyboardMap.GetKeyName(detectedKey).c_str()));
         }
 
         // Reset the keyboard manager UI state

--- a/src/modules/keyboardmanager/ui/SingleKeyRemapControl.h
+++ b/src/modules/keyboardmanager/ui/SingleKeyRemapControl.h
@@ -18,16 +18,18 @@ public:
     static HWND EditKeyboardWindowHandle;
     // Pointer to the keyboard manager state
     static KeyboardManagerState* keyboardManagerState;
+    // Stores the current list of remappings
+    static std::vector<std::vector<DWORD>> singleKeyRemapBuffer;
 
-    SingleKeyRemapControl()
+    SingleKeyRemapControl(const int& rowIndex, const int& colIndex)
     {
         typeKey.Content(winrt::box_value(winrt::to_hstring("Type Key")));
         typeKey.Background(Windows::UI::Xaml::Media::SolidColorBrush{ Windows::UI::Colors::LightGray() });
         typeKey.Foreground(Windows::UI::Xaml::Media::SolidColorBrush{ Windows::UI::Colors::Black() });
-        typeKey.Click([&](IInspectable const& sender, RoutedEventArgs const&) {
+        typeKey.Click([&, rowIndex, colIndex](IInspectable const& sender, RoutedEventArgs const&) {
             keyboardManagerState->SetUIState(KeyboardManagerUIState::DetectSingleKeyRemapWindowActivated, EditKeyboardWindowHandle);
             // Using the XamlRoot of the typeKey to get the root of the XAML host
-            createDetectKeyWindow(sender, sender.as<Button>().XamlRoot(), *keyboardManagerState);
+            createDetectKeyWindow(sender, sender.as<Button>().XamlRoot(), singleKeyRemapBuffer, *keyboardManagerState, rowIndex, colIndex);
         });
 
         singleKeyRemapControlLayout.Background(Windows::UI::Xaml::Media::SolidColorBrush{ Windows::UI::Colors::LightGray() });
@@ -45,5 +47,5 @@ public:
     StackPanel getSingleKeyRemapControl();
 
     // Function to create the detect remap keys UI window
-    void createDetectKeyWindow(IInspectable const& sender, XamlRoot xamlRoot, KeyboardManagerState& keyboardManagerState);
+    void createDetectKeyWindow(IInspectable const& sender, XamlRoot xamlRoot, std::vector<std::vector<DWORD>>& singleKeyRemapBuffer, KeyboardManagerState& keyboardManagerState, const int& rowIndex, const int& colIndex);
 };


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Keyboard Layout is detected by calling `GetKeyboardLayout` on every `GetKeyName` call to check if keyboard layout changed.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #6
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [] Tests added/passed
* [] Requires documentation to be updated
* [] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
* The initial approach of handling the `WM_INPUTLANGUAGECHANGED` message did not work as intended, because the windows would stop getting the message unexpectedly after having any sort of user input in them.
* Calling `GetKeyboardLayout` repeatedly was not found to incur in a significant performance cost, after having profiled a stress test scenario (mashing keys at the Detect Key screen). 

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manually added key mappings, the Keys were displayed as intended.
