### PR TITLE
Migrate power rename MRU lists from registry to JSON

### DIFF
--- a/src/modules/powerrename/dll/dllmain.cpp
+++ b/src/modules/powerrename/dll/dllmain.cpp
@@ -250,7 +250,7 @@ public:
             CSettingsInstance().SetMaxMRUSize(values.get_int_value(L"int_max_mru_size").value());
             CSettingsInstance().SetShowIconOnMenu(values.get_bool_value(L"bool_show_icon_on_menu").value());
             CSettingsInstance().SetExtendedContextMenuOnly(values.get_bool_value(L"bool_show_extended_menu").value());
-            CSettingsInstance().SavePowerRenameData();
+            CSettingsInstance().Save();
 
             Trace::SettingsChanged();
         }
@@ -283,7 +283,6 @@ public:
 
     void init_settings()
     {
-        CSettingsInstance().LoadPowerRenameData();
         m_enabled = CSettingsInstance().GetEnabled();
         Trace::EnablePowerRename(m_enabled);
     }
@@ -291,7 +290,7 @@ public:
     void save_settings()
     {
         CSettingsInstance().SetEnabled(m_enabled);
-        CSettingsInstance().SavePowerRenameData();
+        CSettingsInstance().Save();
         Trace::EnablePowerRename(m_enabled);
     }
 

--- a/src/modules/powerrename/lib/Settings.cpp
+++ b/src/modules/powerrename/lib/Settings.cpp
@@ -5,14 +5,17 @@
 
 #include <filesystem>
 #include <commctrl.h>
+#include <algorithm>
 
 namespace
 {
     const wchar_t c_powerRenameDataFilePath[] = L"power-rename-settings.json";
+    const wchar_t c_searchMRUListFilePath[] = L"search-mru.json";
+    const wchar_t c_replaceMRUListFilePath[] = L"replace-mru.json";
 
     const wchar_t c_rootRegPath[] = L"Software\\Microsoft\\PowerRename";
-    const wchar_t c_mruSearchRegPath[] = L"SearchMRU";
-    const wchar_t c_mruReplaceRegPath[] = L"ReplaceMRU";
+    const wchar_t c_mruSearchRegPath[] = L"\\SearchMRU";
+    const wchar_t c_mruReplaceRegPath[] = L"\\ReplaceMRU";
 
     const wchar_t c_enabled[] = L"Enabled";
     const wchar_t c_showIconOnMenu[] = L"ShowIcon";
@@ -23,6 +26,8 @@ namespace
     const wchar_t c_searchText[] = L"SearchText";
     const wchar_t c_replaceText[] = L"ReplaceText";
     const wchar_t c_mruEnabled[] = L"MRUEnabled";
+    const wchar_t c_mruList[] = L"MRUList";
+    const wchar_t c_insertionIdx[] = L"InsertionIdx";
 
     long GetRegNumber(const std::wstring& valueName, long defaultValue)
     {
@@ -52,34 +57,180 @@ namespace
         SetRegNumber(valueName, value ? 1 : 0);
     }
 
-    std::wstring GetRegString(const std::wstring& valueName) {
+    std::wstring GetRegString(const std::wstring& valueName,const std::wstring& subPath)
+    {
         wchar_t value[CSettings::MAX_INPUT_STRING_LEN];
         value[0] = L'\0';
         DWORD type = REG_SZ;
         DWORD size = CSettings::MAX_INPUT_STRING_LEN * sizeof(wchar_t);
-        if (SUCCEEDED(HRESULT_FROM_WIN32(SHGetValue(HKEY_CURRENT_USER, c_rootRegPath, valueName.c_str(), &type, value, &size) == ERROR_SUCCESS)))
-        {
-            return std::wstring(value);
-        }
-        return std::wstring{};
+        std::wstring completePath = std::wstring(c_rootRegPath) + subPath;
+        SHGetValue(HKEY_CURRENT_USER, completePath.c_str(), valueName.c_str(), &type, value, &size);
+        return std::wstring(value);
     }
 }
 
-typedef int (CALLBACK* MRUCMPPROC)(LPCWSTR, LPCWSTR);
+class MRUListHandler
+{
+public:
+    MRUListHandler(int size, const std::wstring& path) :
+        pushIdx(0),
+        nextIdx(1),
+        size(size)
+    {
+        items.resize(size);
+        std::wstring result = PTSettingsHelper::get_module_save_folder_location(L"PowerRename");
+        jsonFilePath = result + L"\\" + path;
+        Load();
+    }
 
-typedef struct {
-    DWORD      cbSize;
-    UINT       uMax;
-    UINT       fFlags;
-    HKEY       hKey;
-    LPCTSTR    lpszSubKey;
-    MRUCMPPROC lpfnCompare;
-} MRUINFO;
+    void Push(const std::wstring& data);
+    bool Next(std::wstring& data);
 
-typedef HANDLE (*CreateMRUListFn)(MRUINFO* pmi);
-typedef int (*AddMRUStringFn)(HANDLE hMRU, LPCWSTR data);
-typedef int (*EnumMRUListFn)(HANDLE hMRU, int nItem, void* lpData, UINT uLen);
-typedef int (*FreeMRUListFn)(HANDLE hMRU);
+    void Reset();
+
+private:
+    void Load();
+    void Save();
+    void MigrateFromRegistry();
+    json::JsonArray Serialize();
+    void ParseJson();
+
+    bool Exists(const std::wstring& data);
+
+    std::vector<std::wstring> items;
+    long pushIdx;
+    long nextIdx;
+    long size;
+    std::wstring jsonFilePath;
+};
+
+
+void MRUListHandler::Push(const std::wstring& data)
+{
+    if (Exists(data))
+    {
+        // TODO: Already existing item should be put on top of MRU list.
+        return;
+    }
+    items[pushIdx] = data;
+    pushIdx = (pushIdx + 1) % size;
+    Save();
+}
+
+bool MRUListHandler::Next(std::wstring& data)
+{
+    if (nextIdx == size + 1)
+    {
+        Reset();
+        return false;
+    }
+    // Go backwards to consume latest items first.
+    long idx = (pushIdx + size - nextIdx) % size;
+    if (items[idx].empty())
+    {
+        Reset();
+        return false;
+    }
+    data = items[idx];
+    ++nextIdx;
+    return true;
+}
+
+void MRUListHandler::Reset()
+{
+    nextIdx = 1;
+}
+
+void MRUListHandler::Load()
+{
+    if (!std::filesystem::exists(jsonFilePath))
+    {
+        MigrateFromRegistry();
+
+        Save();
+    }
+    else
+    {
+        ParseJson();
+    }
+}
+
+void MRUListHandler::Save()
+{
+    json::JsonObject jsonData;
+
+    jsonData.SetNamedValue(c_maxMRUSize, json::value(size));
+    jsonData.SetNamedValue(c_mruList, Serialize());
+    jsonData.SetNamedValue(c_insertionIdx, json::value(pushIdx));
+
+    json::to_file(jsonFilePath, jsonData);
+}
+
+json::JsonArray MRUListHandler::Serialize()
+{
+    json::JsonArray searchMRU{};
+
+    std::wstring data{};
+    while (Next(data))
+    {
+        searchMRU.Append(json::value(data));
+    }
+    Reset();
+
+    return searchMRU;
+}
+
+void MRUListHandler::MigrateFromRegistry()
+{
+    std::wstring searchListKeys = GetRegString(c_mruList, c_mruSearchRegPath);
+    std::sort(std::begin(searchListKeys), std::end(searchListKeys));
+    for (const wchar_t& key : searchListKeys)
+    {
+        Push(GetRegString(std::wstring(1, key), c_mruSearchRegPath));
+    }
+}
+
+void MRUListHandler::ParseJson()
+{
+    auto json = json::from_file(jsonFilePath);
+    if (json)
+    {
+        const json::JsonObject& jsonObject = json.value();
+        try
+        {
+            if (json::has(jsonObject, c_mruList, json::JsonValueType::Array))
+            {
+                auto searchList = jsonObject.GetNamedArray(c_mruList);
+                for (uint32_t i = 0; i < searchList.Size(); ++i)
+                {
+                    Push(std::wstring(searchList.GetStringAt(i)));
+                }
+            }
+            if (json::has(jsonObject, c_maxMRUSize, json::JsonValueType::Number))
+            {
+                long oldSize = (long)jsonObject.GetNamedNumber(c_maxMRUSize);
+                if (oldSize == size)
+                {
+                    // Load insertion index if size remained the same.
+                    if (json::has(jsonObject, c_insertionIdx, json::JsonValueType::Number))
+                    {
+                        pushIdx = (long)jsonObject.GetNamedNumber(c_insertionIdx);
+                    }
+                }
+                else
+                {
+                    Save();
+                }
+            }
+        }
+        catch (const winrt::hresult_error&) { }
+    }
+}
+
+bool MRUListHandler::Exists(const std::wstring& data)
+{
+    return std::find(std::begin(items), std::end(items), data) != std::end(items);
+}
 
 class CRenameMRU :
     public IEnumString,
@@ -100,65 +251,33 @@ public:
     // IPowerRenameMRU
     IFACEMETHODIMP AddMRUString(_In_ PCWSTR entry);
 
-    static HRESULT CreateInstance(_In_ PCWSTR regPathMRU, _In_ ULONG maxMRUSize, _Outptr_ IUnknown** ppUnk);
+    static HRESULT CreateInstance(_In_ const std::wstring& path, _Outptr_ IUnknown** ppUnk);
 
 private:
-    CRenameMRU();
-    ~CRenameMRU();
+    CRenameMRU(int size, const std::wstring& path);
 
-    HRESULT _Initialize(_In_ PCWSTR regPathMRU, __in ULONG maxMRUSize);
-    HRESULT _CreateMRUList(_In_ MRUINFO* pmi);
-    int _AddMRUString(_In_ PCWSTR data);
-    int _EnumMRUList(_In_ int nItem, _Out_ void* lpData, _In_ UINT uLen);
-    void _FreeMRUList();
-
-    long   m_refCount = 0;
-    HKEY   m_hKey = NULL;
-    ULONG  m_maxMRUSize = 0;
-    ULONG  m_mruIndex = 0;
-    ULONG  m_mruSize = 0;
-    HANDLE m_mruHandle = NULL;
-    HMODULE m_hComctl32Dll = NULL;
-    PWSTR  m_regPath = nullptr;
+    std::unique_ptr<MRUListHandler> mruList;
+    long refCount = 0;
 };
 
-CRenameMRU::CRenameMRU() :
-    m_refCount(1)
-{}
-
-CRenameMRU::~CRenameMRU()
+CRenameMRU::CRenameMRU(int size, const std::wstring& path) :
+    refCount(1)
 {
-    if (m_hKey)
-    {
-        RegCloseKey(m_hKey);
-    }
-
-    _FreeMRUList();
-
-    if (m_hComctl32Dll)
-    {
-        FreeLibrary(m_hComctl32Dll);
-    }
-
-    CoTaskMemFree(m_regPath);
+    mruList = std::make_unique<MRUListHandler>(size, path);
 }
 
-HRESULT CRenameMRU::CreateInstance(_In_ PCWSTR regPathMRU, _In_ ULONG maxMRUSize, _Outptr_ IUnknown** ppUnk)
+HRESULT CRenameMRU::CreateInstance(_In_ const std::wstring& path, _Outptr_ IUnknown** ppUnk)
 {
     *ppUnk = nullptr;
-    HRESULT hr = (regPathMRU && maxMRUSize > 0) ? S_OK : E_FAIL;
+    long maxMRUSize = CSettingsInstance().GetMaxMRUSize();
+    HRESULT hr = maxMRUSize > 0 ? S_OK : E_FAIL;
     if (SUCCEEDED(hr))
     {
-        CRenameMRU* renameMRU = new CRenameMRU();
+        CRenameMRU* renameMRU = new CRenameMRU(maxMRUSize, path);
         hr = renameMRU ? S_OK : E_OUTOFMEMORY;
         if (SUCCEEDED(hr))
         {
-            hr = renameMRU->_Initialize(regPathMRU, maxMRUSize);
-            if (SUCCEEDED(hr))
-            {
-                hr = renameMRU->QueryInterface(IID_PPV_ARGS(ppUnk));
-            }
-
+            renameMRU->QueryInterface(IID_PPV_ARGS(ppUnk));
             renameMRU->Release();
         }
     }
@@ -166,21 +285,20 @@ HRESULT CRenameMRU::CreateInstance(_In_ PCWSTR regPathMRU, _In_ ULONG maxMRUSize
     return hr;
 }
 
-// IUnknown
 IFACEMETHODIMP_(ULONG) CRenameMRU::AddRef()
 {
-    return InterlockedIncrement(&m_refCount);
+    return InterlockedIncrement(&refCount);
 }
 
 IFACEMETHODIMP_(ULONG) CRenameMRU::Release()
 {
-    long refCount = InterlockedDecrement(&m_refCount);
+    long cnt = InterlockedDecrement(&refCount);
 
-    if (refCount == 0)
+    if (cnt == 0)
     {
         delete this;
     }
-    return refCount;
+    return cnt;
 }
 
 IFACEMETHODIMP CRenameMRU::QueryInterface(_In_ REFIID riid, _Outptr_ void** ppv)
@@ -193,57 +311,8 @@ IFACEMETHODIMP CRenameMRU::QueryInterface(_In_ REFIID riid, _Outptr_ void** ppv)
     return QISearch(this, qit, riid, ppv);
 }
 
-HRESULT CRenameMRU::_Initialize(_In_ PCWSTR regPathMRU, __in ULONG maxMRUSize)
-{
-    m_maxMRUSize = maxMRUSize;
-
-    wchar_t regPath[MAX_PATH] = { 0 };
-    HRESULT hr = StringCchPrintf(regPath, ARRAYSIZE(regPath), L"%s\\%s", c_rootRegPath, regPathMRU);
-    if (SUCCEEDED(hr))
-    {
-        hr = SHStrDup(regPathMRU, &m_regPath);
-
-        if (SUCCEEDED(hr))
-        {
-            MRUINFO mi = {
-                sizeof(MRUINFO),
-                maxMRUSize,
-                0,
-                HKEY_CURRENT_USER,
-                regPath,
-                nullptr
-            };
-
-            hr = _CreateMRUList(&mi);
-            if (SUCCEEDED(hr))
-            {
-                m_mruSize = _EnumMRUList(-1, NULL, 0);
-            }
-            else
-            {
-                hr = E_FAIL;
-            }
-        }
-    }
-
-    return hr;
-}
-
-// IEnumString
-IFACEMETHODIMP CRenameMRU::Reset()
-{
-    m_mruIndex = 0;
-    return S_OK;
-}
-
-#define MAX_ENTRY_STRING 1024
-
 IFACEMETHODIMP CRenameMRU::Next(__in ULONG celt, __out_ecount_part(celt, *pceltFetched) LPOLESTR* rgelt, __out_opt ULONG* pceltFetched)
 {
-    HRESULT hr = S_OK;
-    WCHAR mruEntry[MAX_ENTRY_STRING];
-    mruEntry[0] = L'\0';
-
     if (pceltFetched)
     {
         *pceltFetched = 0;
@@ -259,10 +328,10 @@ IFACEMETHODIMP CRenameMRU::Next(__in ULONG celt, __out_ecount_part(celt, *pceltF
         return S_FALSE;
     }
 
-    hr = S_FALSE;
-    if (m_mruIndex <= m_mruSize && _EnumMRUList(m_mruIndex++, (void*)mruEntry, ARRAYSIZE(mruEntry)) > 0)
+    HRESULT hr = S_FALSE;
+    if (std::wstring data{}; mruList->Next(data))
     {
-        hr = SHStrDup(mruEntry, rgelt);
+        hr = SHStrDup(data.c_str(), rgelt);
         if (SUCCEEDED(hr) && pceltFetched != nullptr)
         {
             *pceltFetched = 1;
@@ -272,137 +341,49 @@ IFACEMETHODIMP CRenameMRU::Next(__in ULONG celt, __out_ecount_part(celt, *pceltF
     return hr;
 }
 
+IFACEMETHODIMP CRenameMRU::Reset()
+{
+    mruList->Reset();
+    return S_OK;
+}
+
 IFACEMETHODIMP CRenameMRU::AddMRUString(_In_ PCWSTR entry)
 {
-    return (_AddMRUString(entry) < 0) ? E_FAIL : S_OK;
-}
-
-HRESULT CRenameMRU::_CreateMRUList(_In_ MRUINFO* pmi)
-{
-    if (m_mruHandle != NULL)
-    {
-        _FreeMRUList();
-    }
-
-    if (m_hComctl32Dll == NULL)
-    {
-        m_hComctl32Dll = LoadLibraryEx(L"comctl32.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
-    }
-
-    if (m_hComctl32Dll != nullptr)
-    {
-        CreateMRUListFn pfnCreateMRUList = reinterpret_cast<CreateMRUListFn>(GetProcAddress(m_hComctl32Dll, (LPCSTR)MAKEINTRESOURCE(400)));
-        if (pfnCreateMRUList != nullptr)
-        {
-            m_mruHandle = pfnCreateMRUList(pmi);
-        }
-    }
-
-    return (m_mruHandle != NULL) ? S_OK : E_FAIL;
-}
-
-int CRenameMRU::_AddMRUString(_In_ PCWSTR data)
-{
-    int retVal = -1;
-    if (m_mruHandle != NULL)
-    {
-        if (m_hComctl32Dll == NULL)
-        {
-            m_hComctl32Dll = LoadLibraryEx(L"comctl32.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
-        }
-
-        if (m_hComctl32Dll != nullptr)
-        {
-            AddMRUStringFn pfnAddMRUString = reinterpret_cast<AddMRUStringFn>(GetProcAddress(m_hComctl32Dll, (LPCSTR)MAKEINTRESOURCE(401)));
-            if (pfnAddMRUString != nullptr)
-            {
-                retVal = pfnAddMRUString(m_mruHandle, data);
-            }
-        }
-    }
-
-    return retVal;
-}
-
-int CRenameMRU::_EnumMRUList(_In_ int nItem, _Out_ void* lpData, _In_ UINT uLen)
-{
-    int retVal = -1;
-    if (m_mruHandle != NULL)
-    {
-        if (m_hComctl32Dll == NULL)
-        {
-            m_hComctl32Dll = LoadLibraryEx(L"comctl32.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
-        }
-
-        if (m_hComctl32Dll != nullptr)
-        {
-            EnumMRUListFn pfnEnumMRUList = reinterpret_cast<EnumMRUListFn>(GetProcAddress(m_hComctl32Dll, (LPCSTR)MAKEINTRESOURCE(403)));
-            if (pfnEnumMRUList != nullptr)
-            {
-                retVal = pfnEnumMRUList(m_mruHandle, nItem, lpData, uLen);
-            }
-        }
-    }
-
-    return retVal;
-}
-
-void CRenameMRU::_FreeMRUList()
-{
-    if (m_mruHandle != NULL)
-    {
-        if (m_hComctl32Dll == NULL)
-        {
-            m_hComctl32Dll = LoadLibraryEx(L"comctl32.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
-        }
-
-        if (m_hComctl32Dll != nullptr)
-        {
-            FreeMRUListFn pfnFreeMRUList = reinterpret_cast<FreeMRUListFn>(GetProcAddress(m_hComctl32Dll, (LPCSTR)MAKEINTRESOURCE(152)));
-            if (pfnFreeMRUList != nullptr)
-            {
-                pfnFreeMRUList(m_mruHandle);
-            }
-            
-        }
-        m_mruHandle = NULL;
-    }
+    mruList->Push(entry);
+    return S_OK;
 }
 
 CSettings::CSettings()
 {
     std::wstring result = PTSettingsHelper::get_module_save_folder_location(L"PowerRename");
     jsonFilePath = result + L"\\" + std::wstring(c_powerRenameDataFilePath);
+    Load();
 }
 
-bool CSettings::GetEnabled()
-{
-    return GetRegBoolean(c_enabled, true);
-}
-
-void CSettings::SetEnabled(bool enabled)
-{
-    SetRegBoolean(c_enabled, enabled);
-}
-
-void CSettings::LoadPowerRenameData()
+void CSettings::Load()
 {
     if (!std::filesystem::exists(jsonFilePath))
     {
-        MigrateSettingsFromRegistry();
+        MigrateFromRegistry();
 
-        SavePowerRenameData();
+        Save();
     }
     else
     {
-        ParseJsonSettings();
+        ParseJson();
     }
 }
 
-void CSettings::SavePowerRenameData() const
+void CSettings::Reload()
+{
+    Load();
+}
+
+void CSettings::Save()
 {
     json::JsonObject jsonData;
 
+    jsonData.SetNamedValue(c_enabled,                 json::value(settings.enabled));
     jsonData.SetNamedValue(c_showIconOnMenu,          json::value(settings.showIconOnMenu));
     jsonData.SetNamedValue(c_extendedContextMenuOnly, json::value(settings.extendedContextMenuOnly));
     jsonData.SetNamedValue(c_persistState,            json::value(settings.persistState));
@@ -415,19 +396,20 @@ void CSettings::SavePowerRenameData() const
     json::to_file(jsonFilePath, jsonData);
 }
 
-void CSettings::MigrateSettingsFromRegistry()
+void CSettings::MigrateFromRegistry()
 {
+    settings.enabled                 = GetRegBoolean(c_enabled, true);
     settings.showIconOnMenu          = GetRegBoolean(c_showIconOnMenu, true);
     settings.extendedContextMenuOnly = GetRegBoolean(c_extendedContextMenuOnly, false); // Disabled by default.
     settings.persistState            = GetRegBoolean(c_persistState, true);
     settings.MRUEnabled              = GetRegBoolean(c_mruEnabled, true);
     settings.maxMRUSize              = GetRegNumber(c_maxMRUSize, 10);
     settings.flags                   = GetRegNumber(c_flags, 0);
-    settings.searchText              = GetRegString(c_searchText);
-    settings.replaceText             = GetRegString(c_replaceText);
+    settings.searchText              = GetRegString(c_searchText, L"");
+    settings.replaceText             = GetRegString(c_replaceText, L"");
 }
 
-void CSettings::ParseJsonSettings()
+void CSettings::ParseJson()
 {
     auto json = json::from_file(jsonFilePath);
     if (json)
@@ -435,6 +417,10 @@ void CSettings::ParseJsonSettings()
         const json::JsonObject& jsonSettings = json.value();
         try
         {
+            if (json::has(jsonSettings, c_enabled, json::JsonValueType::Boolean))
+            {
+                settings.enabled = jsonSettings.GetNamedBoolean(c_enabled);
+            }
             if (json::has(jsonSettings, c_showIconOnMenu, json::JsonValueType::Boolean))
             {
                 settings.showIconOnMenu = jsonSettings.GetNamedBoolean(c_showIconOnMenu);
@@ -480,10 +466,11 @@ CSettings& CSettingsInstance()
 
 HRESULT CRenameMRUSearch_CreateInstance(_Outptr_ IUnknown** ppUnk)
 {
-    return CRenameMRU::CreateInstance(c_mruSearchRegPath, CSettingsInstance().GetMaxMRUSize(), ppUnk);
+    return CRenameMRU::CreateInstance(c_searchMRUListFilePath, ppUnk);
 }
 
 HRESULT CRenameMRUReplace_CreateInstance(_Outptr_ IUnknown** ppUnk)
 {
-    return CRenameMRU::CreateInstance(c_mruReplaceRegPath, CSettingsInstance().GetMaxMRUSize(), ppUnk);
+    return CRenameMRU::CreateInstance(c_replaceMRUListFilePath, ppUnk);
 }
+

--- a/src/modules/powerrename/lib/Settings.cpp
+++ b/src/modules/powerrename/lib/Settings.cpp
@@ -238,7 +238,7 @@ void MRUListHandler::ParseJson()
                     if (size > oldSize)
                     {
                         std::reverse(std::begin(temp), std::end(temp));
-                        pushIdx = temp.size();
+                        pushIdx = (long)temp.size();
                         temp.resize(size);
                     }
                     else
@@ -388,6 +388,23 @@ CSettings::CSettings()
     Load();
 }
 
+void CSettings::Save()
+{
+    json::JsonObject jsonData;
+
+    jsonData.SetNamedValue(c_enabled,                 json::value(settings.enabled));
+    jsonData.SetNamedValue(c_showIconOnMenu,          json::value(settings.showIconOnMenu));
+    jsonData.SetNamedValue(c_extendedContextMenuOnly, json::value(settings.extendedContextMenuOnly));
+    jsonData.SetNamedValue(c_persistState,            json::value(settings.persistState));
+    jsonData.SetNamedValue(c_mruEnabled,              json::value(settings.MRUEnabled));
+    jsonData.SetNamedValue(c_maxMRUSize,              json::value(settings.maxMRUSize));
+    jsonData.SetNamedValue(c_flags,                   json::value(settings.flags));
+    jsonData.SetNamedValue(c_searchText,              json::value(settings.searchText));
+    jsonData.SetNamedValue(c_replaceText,             json::value(settings.replaceText));
+
+    json::to_file(jsonFilePath, jsonData);
+}
+
 void CSettings::Load()
 {
     if (!std::filesystem::exists(jsonFilePath))
@@ -413,22 +430,6 @@ void CSettings::Reload()
     }
 }
 
-void CSettings::Save()
-{
-    json::JsonObject jsonData;
-
-    jsonData.SetNamedValue(c_enabled,                 json::value(settings.enabled));
-    jsonData.SetNamedValue(c_showIconOnMenu,          json::value(settings.showIconOnMenu));
-    jsonData.SetNamedValue(c_extendedContextMenuOnly, json::value(settings.extendedContextMenuOnly));
-    jsonData.SetNamedValue(c_persistState,            json::value(settings.persistState));
-    jsonData.SetNamedValue(c_mruEnabled,              json::value(settings.MRUEnabled));
-    jsonData.SetNamedValue(c_maxMRUSize,              json::value(settings.maxMRUSize));
-    jsonData.SetNamedValue(c_flags,                   json::value(settings.flags));
-    jsonData.SetNamedValue(c_searchText,              json::value(settings.searchText));
-    jsonData.SetNamedValue(c_replaceText,             json::value(settings.replaceText));
-
-    json::to_file(jsonFilePath, jsonData);
-}
 
 void CSettings::MigrateFromRegistry()
 {

--- a/src/modules/powerrename/lib/Settings.cpp
+++ b/src/modules/powerrename/lib/Settings.cpp
@@ -64,8 +64,11 @@ namespace
         DWORD type = REG_SZ;
         DWORD size = CSettings::MAX_INPUT_STRING_LEN * sizeof(wchar_t);
         std::wstring completePath = std::wstring(c_rootRegPath) + subPath;
-        SHGetValue(HKEY_CURRENT_USER, completePath.c_str(), valueName.c_str(), &type, value, &size);
-        return std::wstring(value);
+        if (SHGetValue(HKEY_CURRENT_USER, completePath.c_str(), valueName.c_str(), &type, value, &size) == ERROR_SUCCESS)
+        {
+            return std::wstring(value);
+        }
+        return std::wstring{};
     }
 
     bool LastModifiedTime(const std::wstring& filePath, FILETIME* lpFileTime)

--- a/src/modules/powerrename/lib/Settings.h
+++ b/src/modules/powerrename/lib/Settings.h
@@ -18,11 +18,11 @@ public:
     inline void SetEnabled(bool enabled)
     {
         settings.enabled = enabled;
+        Save();
     }
 
     inline bool GetShowIconOnMenu()
     {
-        Reload();
         return settings.showIconOnMenu;
     }
 
@@ -33,7 +33,6 @@ public:
 
     inline bool GetExtendedContextMenuOnly()
     {
-        Reload();
         return settings.extendedContextMenuOnly;
     }
 
@@ -44,7 +43,6 @@ public:
 
     inline bool GetPersistState()
     {
-        Reload();
         return settings.persistState;
     }
 
@@ -55,7 +53,6 @@ public:
 
     inline bool GetMRUEnabled()
     {
-        Reload();
         return settings.MRUEnabled;
     }
 
@@ -66,7 +63,6 @@ public:
 
     inline long GetMaxMRUSize()
     {
-        Reload();
         return settings.maxMRUSize;
     }
 
@@ -77,7 +73,6 @@ public:
 
     inline long GetFlags()
     {
-        Reload();
         return settings.flags;
     }
 
@@ -89,7 +84,6 @@ public:
 
     inline const std::wstring& GetSearchText()
     {
-        Reload();
         return settings.searchText;
     }
 
@@ -101,7 +95,6 @@ public:
 
     inline const std::wstring& GetReplaceText()
     {
-        Reload();
         return settings.replaceText;
     }
 
@@ -112,6 +105,7 @@ public:
     }
 
     void Save();
+    void Load();
 
 private:
     struct Settings
@@ -127,7 +121,6 @@ private:
         std::wstring replaceText{};
     };
 
-    void Load();
     void Reload();
     void MigrateFromRegistry();
     void ParseJson();

--- a/src/modules/powerrename/lib/Settings.h
+++ b/src/modules/powerrename/lib/Settings.h
@@ -134,6 +134,7 @@ private:
 
     Settings settings;
     std::wstring jsonFilePath;
+    FILETIME lastLoadedTime;
 };
 
 CSettings& CSettingsInstance();

--- a/src/modules/powerrename/lib/Settings.h
+++ b/src/modules/powerrename/lib/Settings.h
@@ -21,7 +21,7 @@ public:
         Save();
     }
 
-    inline bool GetShowIconOnMenu()
+    inline bool GetShowIconOnMenu() const
     {
         return settings.showIconOnMenu;
     }
@@ -31,7 +31,7 @@ public:
         settings.showIconOnMenu = show;
     }
 
-    inline bool GetExtendedContextMenuOnly()
+    inline bool GetExtendedContextMenuOnly() const
     {
         return settings.extendedContextMenuOnly;
     }
@@ -41,7 +41,7 @@ public:
         settings.extendedContextMenuOnly = extendedOnly;
     }
 
-    inline bool GetPersistState()
+    inline bool GetPersistState() const
     {
         return settings.persistState;
     }
@@ -51,7 +51,7 @@ public:
         settings.persistState = persistState;
     }
 
-    inline bool GetMRUEnabled()
+    inline bool GetMRUEnabled() const
     {
         return settings.MRUEnabled;
     }
@@ -61,7 +61,7 @@ public:
         settings.MRUEnabled = MRUEnabled;
     }
 
-    inline long GetMaxMRUSize()
+    inline long GetMaxMRUSize() const
     {
         return settings.maxMRUSize;
     }
@@ -71,7 +71,7 @@ public:
         settings.maxMRUSize = maxMRUSize;
     }
 
-    inline long GetFlags()
+    inline long GetFlags() const
     {
         return settings.flags;
     }
@@ -82,7 +82,7 @@ public:
         Save();
     }
 
-    inline const std::wstring& GetSearchText()
+    inline const std::wstring& GetSearchText() const
     {
         return settings.searchText;
     }
@@ -93,7 +93,7 @@ public:
         Save();
     }
 
-    inline const std::wstring& GetReplaceText()
+    inline const std::wstring& GetReplaceText() const
     {
         return settings.replaceText;
     }

--- a/src/modules/powerrename/lib/Settings.h
+++ b/src/modules/powerrename/lib/Settings.h
@@ -2,8 +2,6 @@
 
 #include "json.h"
 
-#include <string>
-
 class CSettings
 {
 public:
@@ -11,12 +9,20 @@ public:
 
     CSettings();
 
-    bool GetEnabled();
-
-    void SetEnabled(bool enabled);
-
-    inline bool GetShowIconOnMenu() const
+    inline bool GetEnabled()
     {
+        Reload();
+        return settings.enabled;
+    }
+
+    inline void SetEnabled(bool enabled)
+    {
+        settings.enabled = enabled;
+    }
+
+    inline bool GetShowIconOnMenu()
+    {
+        Reload();
         return settings.showIconOnMenu;
     }
 
@@ -25,8 +31,9 @@ public:
         settings.showIconOnMenu = show;
     }
 
-    inline bool GetExtendedContextMenuOnly() const
+    inline bool GetExtendedContextMenuOnly()
     {
+        Reload();
         return settings.extendedContextMenuOnly;
     }
 
@@ -35,8 +42,9 @@ public:
         settings.extendedContextMenuOnly = extendedOnly;
     }
 
-    inline bool GetPersistState() const
+    inline bool GetPersistState()
     {
+        Reload();
         return settings.persistState;
     }
 
@@ -45,8 +53,9 @@ public:
         settings.persistState = persistState;
     }
 
-    inline bool GetMRUEnabled() const
+    inline bool GetMRUEnabled()
     {
+        Reload();
         return settings.MRUEnabled;
     }
 
@@ -55,8 +64,9 @@ public:
         settings.MRUEnabled = MRUEnabled;
     }
 
-    inline long GetMaxMRUSize() const
+    inline long GetMaxMRUSize()
     {
+        Reload();
         return settings.maxMRUSize;
     }
 
@@ -65,42 +75,48 @@ public:
         settings.maxMRUSize = maxMRUSize;
     }
 
-    inline long GetFlags() const
+    inline long GetFlags()
     {
+        Reload();
         return settings.flags;
     }
 
     inline void SetFlags(long flags)
     {
         settings.flags = flags;
+        Save();
     }
 
-    inline const std::wstring& GetSearchText() const
+    inline const std::wstring& GetSearchText()
     {
+        Reload();
         return settings.searchText;
     }
 
     inline void SetSearchText(const std::wstring& text)
     {
         settings.searchText = text;
+        Save();
     }
 
-    inline const std::wstring& GetReplaceText() const
+    inline const std::wstring& GetReplaceText()
     {
+        Reload();
         return settings.replaceText;
     }
 
     inline void SetReplaceText(const std::wstring& text)
     {
         settings.replaceText = text;
+        Save();
     }
 
-    void LoadPowerRenameData();
-    void SavePowerRenameData() const;
+    void Save();
 
 private:
     struct Settings
     {
+        bool enabled{ true };
         bool showIconOnMenu{ true };
         bool extendedContextMenuOnly{ false }; // Disabled by default.
         bool persistState{ true };
@@ -111,8 +127,10 @@ private:
         std::wstring replaceText{};
     };
 
-    void MigrateSettingsFromRegistry();
-    void ParseJsonSettings();
+    void Load();
+    void Reload();
+    void MigrateFromRegistry();
+    void ParseJson();
 
     Settings settings;
     std::wstring jsonFilePath;

--- a/src/modules/powerrename/ui/PowerRenameUI.cpp
+++ b/src/modules/powerrename/ui/PowerRenameUI.cpp
@@ -5,7 +5,6 @@
 #include <commctrl.h>
 #include <Shlobj.h>
 #include <helpers.h>
-#include <settings.h>
 #include <windowsx.h>
 #include <thread>
 #include <trace.h>

--- a/src/modules/powerrename/ui/PowerRenameUI.cpp
+++ b/src/modules/powerrename/ui/PowerRenameUI.cpp
@@ -79,6 +79,14 @@ inline int RECT_HEIGHT(RECT& r)
     return r.bottom - r.top;
 }
 
+CPowerRenameUI::CPowerRenameUI() :
+    m_refCount(1)
+{
+    CSettingsInstance().Load();
+    (void)OleInitialize(nullptr);
+    ModuleAddRef();
+}
+
 // IUnknown
 IFACEMETHODIMP CPowerRenameUI::QueryInterface(__in REFIID riid, __deref_out void** ppv)
 {

--- a/src/modules/powerrename/ui/PowerRenameUI.h
+++ b/src/modules/powerrename/ui/PowerRenameUI.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <PowerRenameInterfaces.h>
+#include <settings.h>
 #include <shldisp.h>
 
 void ModuleAddRef();
@@ -40,6 +41,7 @@ public:
     CPowerRenameUI() :
         m_refCount(1)
     {
+        CSettingsInstance().Load();
         (void)OleInitialize(nullptr);
         ModuleAddRef();
     }

--- a/src/modules/powerrename/ui/PowerRenameUI.h
+++ b/src/modules/powerrename/ui/PowerRenameUI.h
@@ -38,13 +38,7 @@ class CPowerRenameUI :
     public IPowerRenameManagerEvents
 {
 public:
-    CPowerRenameUI() :
-        m_refCount(1)
-    {
-        CSettingsInstance().Load();
-        (void)OleInitialize(nullptr);
-        ModuleAddRef();
-    }
+    CPowerRenameUI();
 
     // IUnknown
     IFACEMETHODIMP QueryInterface(__in REFIID riid, __deref_out void** ppv);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
For the autocomplete feature to work properly (while doing power-rename) we need to handle all previous search and replace items and also keep it as most recently used (MRU) list. Previously those items were kept in registry, and goal of this PR is to move them to persistent JSON data file.

- Implemented MRU list handler with persistent JSON storage. Migration from registry is supported.
- Support  on the run changes in MRU list size.
- Always check if JSON data file has changed since we loaded it last time, and do reload if needed.
- `Enabled` flag is also migrated from registry.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2011
