### PR TITLE
Move markdown parsing logic outside control thread

### DIFF
--- a/src/modules/previewpane/MarkdownPreviewHandler/MarkdownPreviewHandlerControl.cs
+++ b/src/modules/previewpane/MarkdownPreviewHandler/MarkdownPreviewHandlerControl.cs
@@ -78,7 +78,7 @@ namespace MarkdownPreviewHandler
                 {
                     throw new ArgumentException($"{nameof(dataSource)} for {nameof(MarkdownPreviewHandler)} must be a string but was a '{typeof(T)}'");
                 }
-            
+
                 string fileText = File.ReadAllText(filePath);
                 Regex imageTagRegex = new Regex(@"<[ ]*img.*>");
                 if (imageTagRegex.IsMatch(fileText))

--- a/src/modules/previewpane/MarkdownPreviewHandler/MarkdownPreviewHandlerControl.cs
+++ b/src/modules/previewpane/MarkdownPreviewHandler/MarkdownPreviewHandlerControl.cs
@@ -70,15 +70,15 @@ namespace MarkdownPreviewHandler
         /// <param name="dataSource">Path to the file.</param>
         public override void DoPreview<T>(T dataSource)
         {
-            if (!(dataSource is string filePath))
-            {
-                throw new ArgumentException($"{nameof(dataSource)} for {nameof(MarkdownPreviewHandler)} must be a string but was a '{typeof(T)}'");
-            }
-
             this.infoBarDisplayed = false;
 
             try
             {
+                if (!(dataSource is string filePath))
+                {
+                    throw new ArgumentException($"{nameof(dataSource)} for {nameof(MarkdownPreviewHandler)} must be a string but was a '{typeof(T)}'");
+                }
+            
                 string fileText = File.ReadAllText(filePath);
                 Regex imageTagRegex = new Regex(@"<[ ]*img.*>");
                 if (imageTagRegex.IsMatch(fileText))

--- a/src/modules/previewpane/MarkdownPreviewHandler/MarkdownPreviewHandlerControl.cs
+++ b/src/modules/previewpane/MarkdownPreviewHandler/MarkdownPreviewHandlerControl.cs
@@ -3,11 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics;
 using System.Drawing;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using Common;
@@ -73,28 +70,29 @@ namespace MarkdownPreviewHandler
         /// <param name="dataSource">Path to the file.</param>
         public override void DoPreview<T>(T dataSource)
         {
-            this.InvokeOnControlThread(() =>
+            if (!(dataSource is string filePath))
             {
-                try
+                throw new ArgumentException($"{nameof(dataSource)} for {nameof(MarkdownPreviewHandler)} must be a string but was a '{typeof(T)}'");
+            }
+
+            this.infoBarDisplayed = false;
+
+            try
+            {
+                string fileText = File.ReadAllText(filePath);
+                Regex imageTagRegex = new Regex(@"<[ ]*img.*>");
+                if (imageTagRegex.IsMatch(fileText))
                 {
-                    this.infoBarDisplayed = false;
+                    this.infoBarDisplayed = true;
+                }
 
-                    StringBuilder sb = new StringBuilder();
-                    string filePath = dataSource as string;
-                    string fileText = File.ReadAllText(filePath);
-                    this.extension.BaseUrl = Path.GetDirectoryName(filePath);
+                this.extension.BaseUrl = Path.GetDirectoryName(filePath);
+                MarkdownPipeline pipeline = this.pipelineBuilder.Build();
+                string parsedMarkdown = Markdown.ToHtml(fileText, pipeline);
+                string markdownHTML = $"{this.htmlHeader}{parsedMarkdown}{this.htmlFooter}";
 
-                    Regex rgx = new Regex(@"<[ ]*img.*>");
-                    if (rgx.IsMatch(fileText))
-                    {
-                        this.infoBarDisplayed = true;
-                    }
-
-                    MarkdownPipeline pipeline = this.pipelineBuilder.Build();
-                    string parsedMarkdown = Markdown.ToHtml(fileText, pipeline);
-                    sb.AppendFormat("{0}{1}{2}", this.htmlHeader, parsedMarkdown, this.htmlFooter);
-                    string markdownHTML = sb.ToString();
-
+                this.InvokeOnControlThread(() =>
+                {
                     this.browser = new WebBrowserExt
                     {
                         DocumentText = markdownHTML,
@@ -109,24 +107,30 @@ namespace MarkdownPreviewHandler
                     if (this.infoBarDisplayed)
                     {
                         this.infoBar = this.GetTextBoxControl(Resources.BlockedImageInfoText);
+                        this.Resize += this.FormResized;
                         this.Controls.Add(this.infoBar);
                     }
+                });
 
-                    this.Resize += this.FormResized;
-                    base.DoPreview(dataSource);
-                    MarkdownTelemetry.Log.MarkdownFilePreviewed();
-                }
-                catch (Exception e)
+                MarkdownTelemetry.Log.MarkdownFilePreviewed();
+            }
+            catch (Exception e)
+            {
+                MarkdownTelemetry.Log.MarkdownFilePreviewError(e.Message);
+
+                this.InvokeOnControlThread(() =>
                 {
-                    MarkdownTelemetry.Log.MarkdownFilePreviewError(e.Message);
+                    this.Controls.Clear();
                     this.infoBarDisplayed = true;
                     this.infoBar = this.GetTextBoxControl(Resources.MarkdownNotPreviewedError);
                     this.Resize += this.FormResized;
-                    this.Controls.Clear();
                     this.Controls.Add(this.infoBar);
-                    base.DoPreview(dataSource);
-                }
-            });
+                });
+            }
+            finally
+            {
+                base.DoPreview(dataSource);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary of the Pull Request
Move the majority of the markdown preview handler processing logic outside of the UI thread to avoid hangs when processing larger markdown files.

## PR Checklist
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [X] Tests added/passed - N/A no change in functionality.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. 

## Detailed Description of the Pull Request / Additional comments
Original implementation of the Markdown preview pane handler did all the loading and processing of the markdown document on the UI thread.  With a larger document, or some potential issue that caused a delay, this could cause hangs by temporarily blocking the UI thread.  This move any code that doesn't require direct access to the UI thread out.  In general the logic of the rendering function has not been changed.  

I wanted to take a look at the power toys code and understand how the previewers were implemented and deployed.  I noticed an opportunity for an optimization to the markdown handler and wanted to try out deploying and debugging a custom build of a preview pane handler.  I took this as chance to do that.

## Validation Steps Performed
Added delays (`Task.Sleep`) inside the UI thread portion and outside the UI thread and anecdotally verified that the UI seemed snappier when the delays were outside the UI thread.  Updated the registry entries for the handler to point to my updated binaries and reloaded the `prevhost.exe` process and validated the previews loaded as expected.

Udit: Created an issue to track the work #2111 