### PR TITLE
FancyZones: optimize elevation detection logic

### DIFF
--- a/src/common/common.h
+++ b/src/common/common.h
@@ -61,7 +61,7 @@ enum WindowState
 WindowState get_window_state(HWND hwnd);
 
 // Returns true if the current process is running with elevated privileges
-bool is_process_elevated();
+bool is_process_elevated(const bool use_cached_value = true);
 
 // Drops the elevated privilages if present
 bool drop_elevated_privileges();
@@ -78,7 +78,7 @@ bool run_same_elevation(const std::wstring& file, const std::wstring& params);
 // Returns true if the current process is running from administrator account
 bool check_user_is_admin();
 
-//Returns true when one or more strings from vector found in string 
+//Returns true when one or more strings from vector found in string
 bool find_app_name_in_path(const std::wstring& where, const std::vector<std::wstring>& what);
 
 // Get the executable path or module name for modern apps

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -78,7 +78,7 @@ bool run_same_elevation(const std::wstring& file, const std::wstring& params);
 // Returns true if the current process is running from administrator account
 bool check_user_is_admin();
 
-//Returns true when one or more strings from vector found in string
+// Returns true when one or more strings from vector found in string
 bool find_app_name_in_path(const std::wstring& where, const std::vector<std::wstring>& what);
 
 // Get the executable path or module name for modern apps

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -867,10 +867,8 @@ void FancyZones::UpdateDragState(HWND window, require_write_lock) noexcept
         m_dragEnabled = !(shift | mouse);
     }
 
-    const bool windowElevated = IsProcessOfWindowElevated(window);
-    static const bool meElevated = is_process_elevated();
     static bool warning_shown = false;
-    if (!meElevated && windowElevated)
+    if (!is_process_elevated() && IsProcessOfWindowElevated(window))
     {
         m_dragEnabled = false;
         if (!warning_shown && !is_cant_drag_elevated_warning_disabled())

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -870,7 +870,7 @@ void FancyZones::UpdateDragState(HWND window, require_write_lock) noexcept
     const bool windowElevated = IsProcessOfWindowElevated(window);
     static const bool meElevated = is_process_elevated();
     static bool warning_shown = false;
-    if (windowElevated && !meElevated)
+    if (!meElevated && windowElevated)
     {
         m_dragEnabled = false;
         if (!warning_shown && !is_cant_drag_elevated_warning_disabled())

--- a/src/settings/main.cpp
+++ b/src/settings/main.cpp
@@ -567,7 +567,7 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
     Trace::RegisterProvider();
     CoInitialize(nullptr);
 
-    const bool should_try_drop_privileges = !initialize_com_security_policy_for_webview() && is_process_elevated();
+    const bool should_try_drop_privileges = !initialize_com_security_policy_for_webview() && is_process_elevated(false);
 
     if (should_try_drop_privileges)
     {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #1722

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
- we use `is_process_elevated(false)` at the start of settings `main()` function, because it's the only place where we try to `drop_elevated_privileges` before using `is_process_elevated`, so it must not be cached.
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- restarted as admin, checked that it works