### PR TITLE
Compare window desktop id with currently active work area desktop id.

### DIFF
--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -355,6 +355,8 @@ FancyZones::WindowCreated(HWND window) noexcept
     {
         for (const auto& [monitor, zoneWindow] : m_zoneWindowMap)
         {
+            // WindowCreated is also invoked when a virtual desktop switch occurs, we need a way
+            // to figure out when that happens to avoid moving windows that should not be moved.
             GUID windowDesktopId{};
             GUID zoneWindowDesktopId{};
             if (VirtualDesktopUtils::GetWindowDesktopId(window, &windowDesktopId) &&

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -360,7 +360,7 @@ FancyZones::WindowCreated(HWND window) noexcept
                 ZoneWindowUtils::GetZoneWindowDesktopId(zoneWindow.get(), &zoneWindowDesktopId) &&
                 (windowDesktopId != zoneWindowDesktopId))
             {
-                break;
+                return;
             }
             const auto activeZoneSet = zoneWindow->ActiveZoneSet();
             if (activeZoneSet)

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -9,6 +9,7 @@
 #include "lib/JsonHelpers.h"
 #include "lib/ZoneSet.h"
 #include "trace.h"
+#include "VirtualDesktopUtils.h"
 
 #include <functional>
 #include <common/common.h>
@@ -356,8 +357,8 @@ FancyZones::WindowCreated(HWND window) noexcept
         {
             GUID windowDesktopId{};
             GUID zoneWindowDesktopId{};
-            if (ZoneWindowUtils::GetWindowDesktopId(window, &windowDesktopId) &&
-                ZoneWindowUtils::GetZoneWindowDesktopId(zoneWindow.get(), &zoneWindowDesktopId) &&
+            if (VirtualDesktopUtils::GetWindowDesktopId(window, &windowDesktopId) &&
+                VirtualDesktopUtils::GetZoneWindowDesktopId(zoneWindow.get(), &zoneWindowDesktopId) &&
                 (windowDesktopId != zoneWindowDesktopId))
             {
                 return;

--- a/src/modules/fancyzones/lib/FancyZonesLib.vcxproj
+++ b/src/modules/fancyzones/lib/FancyZonesLib.vcxproj
@@ -103,6 +103,7 @@
     <ClInclude Include="Settings.h" />
     <ClInclude Include="trace.h" />
     <ClInclude Include="util.h" />
+    <ClInclude Include="VirtualDesktopUtils.h" />
     <ClInclude Include="Zone.h" />
     <ClInclude Include="ZoneSet.h" />
     <ClInclude Include="ZoneWindow.h" />
@@ -117,6 +118,7 @@
     <ClCompile Include="Settings.cpp" />
     <ClCompile Include="trace.cpp" />
     <ClCompile Include="util.cpp" />
+    <ClCompile Include="VirtualDesktopUtils.cpp" />
     <ClCompile Include="Zone.cpp" />
     <ClCompile Include="ZoneSet.cpp" />
     <ClCompile Include="ZoneWindow.cpp" />

--- a/src/modules/fancyzones/lib/FancyZonesLib.vcxproj.filters
+++ b/src/modules/fancyzones/lib/FancyZonesLib.vcxproj.filters
@@ -48,6 +48,9 @@
     <ClInclude Include="JsonHelpers.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="VirtualDesktopUtils.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp">
@@ -75,6 +78,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="util.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="VirtualDesktopUtils.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/modules/fancyzones/lib/VirtualDesktopUtils.cpp
+++ b/src/modules/fancyzones/lib/VirtualDesktopUtils.cpp
@@ -5,6 +5,7 @@
 namespace VirtualDesktopUtils
 {
     const CLSID CLSID_ImmersiveShell = { 0xC2F03A33, 0x21F5, 0x47FA, 0xB4, 0xBB, 0x15, 0x63, 0x62, 0xA2, 0xF2, 0x39 };
+    const wchar_t GUID_EmptyGUID[] = L"{00000000-0000-0000-0000-000000000000}";
 
     IServiceProvider* GetServiceProvider()
     {
@@ -39,6 +40,10 @@ namespace VirtualDesktopUtils
         // Format: <device-id>_<resolution>_<virtual-desktop-id>
         std::wstring uniqueId = zoneWindow->UniqueId();
         std::wstring virtualDesktopId = uniqueId.substr(uniqueId.rfind('_') + 1);
+        if (virtualDesktopId == GUID_EmptyGUID)
+        {
+            return false;
+        }
         return SUCCEEDED(CLSIDFromString(virtualDesktopId.c_str(), desktopId));
     }
 }

--- a/src/modules/fancyzones/lib/VirtualDesktopUtils.cpp
+++ b/src/modules/fancyzones/lib/VirtualDesktopUtils.cpp
@@ -1,0 +1,44 @@
+#include "pch.h"
+
+#include "VirtualDesktopUtils.h"
+
+namespace VirtualDesktopUtils
+{
+    const CLSID CLSID_ImmersiveShell = { 0xC2F03A33, 0x21F5, 0x47FA, 0xB4, 0xBB, 0x15, 0x63, 0x62, 0xA2, 0xF2, 0x39 };
+
+    IServiceProvider* GetServiceProvider()
+    {
+        IServiceProvider* provider{ nullptr };
+        if (FAILED(CoCreateInstance(CLSID_ImmersiveShell, nullptr, CLSCTX_LOCAL_SERVER, __uuidof(provider), (PVOID*)&provider)))
+        {
+            return nullptr;
+        }
+        return provider;
+    }
+
+    IVirtualDesktopManager* GetVirtualDesktopManager()
+    {
+        IVirtualDesktopManager* manager{ nullptr };
+        IServiceProvider* serviceProvider = GetServiceProvider();
+        if (serviceProvider == nullptr || FAILED(serviceProvider->QueryService(__uuidof(manager), &manager)))
+        {
+            return nullptr;
+        }
+        return manager;
+    }
+
+    bool GetWindowDesktopId(HWND topLevelWindow, GUID* desktopId)
+    {
+        static IVirtualDesktopManager* virtualDesktopManager = GetVirtualDesktopManager();
+        return (virtualDesktopManager != nullptr) &&
+               SUCCEEDED(virtualDesktopManager->GetWindowDesktopId(topLevelWindow, desktopId));
+    }
+
+    bool GetZoneWindowDesktopId(IZoneWindow* zoneWindow, GUID* desktopId)
+    {
+        // Format: <device-id>_<resolution>_<virtual-desktop-id>
+        std::wstring uniqueId = zoneWindow->UniqueId();
+        std::wstring virtualDesktopId = uniqueId.substr(uniqueId.rfind('_') + 1);
+        return SUCCEEDED(CLSIDFromString(virtualDesktopId.c_str(), desktopId));
+    }
+}

--- a/src/modules/fancyzones/lib/VirtualDesktopUtils.h
+++ b/src/modules/fancyzones/lib/VirtualDesktopUtils.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "ZoneWindow.h"
+
+namespace VirtualDesktopUtils
+{
+    bool GetWindowDesktopId(HWND topLevelWindow, GUID* desktopId);
+    bool GetZoneWindowDesktopId(IZoneWindow* zoneWindow, GUID* desktopId);
+}

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -86,34 +86,28 @@ namespace ZoneWindowUtils
 
     IServiceProvider* GetServiceProvider()
     {
-        static winrt::com_ptr<IServiceProvider> provider;
-        if (!provider)
+        winrt::com_ptr<IServiceProvider> provider;
+        if (FAILED(CoCreateInstance(CLSID_ImmersiveShell, nullptr, CLSCTX_LOCAL_SERVER, __uuidof(provider), provider.put_void())))
         {
-            if (FAILED(CoCreateInstance(CLSID_ImmersiveShell, nullptr, CLSCTX_LOCAL_SERVER, __uuidof(provider), provider.put_void())))
-            {
-                return nullptr;
-            }
+            return nullptr;
         }
         return provider.get();
     }
 
     IVirtualDesktopManager* GetVirtualDesktopManager()
     {
-        static winrt::com_ptr<IVirtualDesktopManager> manager;
-        if (!manager)
+        winrt::com_ptr<IVirtualDesktopManager> manager;
+        static IServiceProvider* serviceProvider = GetServiceProvider();
+        if (serviceProvider == nullptr || FAILED(serviceProvider->QueryService(__uuidof(manager), manager.put())))
         {
-            auto serviceProvider = GetServiceProvider();
-            if (serviceProvider == nullptr || FAILED(serviceProvider->QueryService(__uuidof(manager), manager.put())))
-            {
-                return nullptr;
-            }
+            return nullptr;
         }
         return manager.get();
     }
 
     bool GetWindowDesktopId(HWND topLevelWindow, GUID* desktopId)
     {
-        auto virtualDesktopManager = GetVirtualDesktopManager();
+        static IVirtualDesktopManager* virtualDesktopManager = GetVirtualDesktopManager();
         return (virtualDesktopManager != nullptr) &&
                SUCCEEDED(virtualDesktopManager->GetWindowDesktopId(topLevelWindow, desktopId));
     }

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -86,23 +86,23 @@ namespace ZoneWindowUtils
 
     IServiceProvider* GetServiceProvider()
     {
-        winrt::com_ptr<IServiceProvider> provider;
-        if (FAILED(CoCreateInstance(CLSID_ImmersiveShell, nullptr, CLSCTX_LOCAL_SERVER, __uuidof(provider), provider.put_void())))
+        IServiceProvider* provider{ nullptr };
+        if (FAILED(CoCreateInstance(CLSID_ImmersiveShell, nullptr, CLSCTX_LOCAL_SERVER, __uuidof(provider), (PVOID*)&provider)))
         {
             return nullptr;
         }
-        return provider.get();
+        return provider;
     }
 
     IVirtualDesktopManager* GetVirtualDesktopManager()
     {
-        winrt::com_ptr<IVirtualDesktopManager> manager;
+        IVirtualDesktopManager* manager{ nullptr };
         IServiceProvider* serviceProvider = GetServiceProvider();
-        if (serviceProvider == nullptr || FAILED(serviceProvider->QueryService(__uuidof(manager), manager.put())))
+        if (serviceProvider == nullptr || FAILED(serviceProvider->QueryService(__uuidof(manager), &manager)))
         {
             return nullptr;
         }
-        return manager.get();
+        return manager;
     }
 
     bool GetWindowDesktopId(HWND topLevelWindow, GUID* desktopId)

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -81,44 +81,6 @@ namespace ZoneWindowUtils
         }
         return std::wstring{ uniqueId };
     }
-
-    const CLSID CLSID_ImmersiveShell = { 0xC2F03A33, 0x21F5, 0x47FA, 0xB4, 0xBB, 0x15, 0x63, 0x62, 0xA2, 0xF2, 0x39 };
-
-    IServiceProvider* GetServiceProvider()
-    {
-        IServiceProvider* provider{ nullptr };
-        if (FAILED(CoCreateInstance(CLSID_ImmersiveShell, nullptr, CLSCTX_LOCAL_SERVER, __uuidof(provider), (PVOID*)&provider)))
-        {
-            return nullptr;
-        }
-        return provider;
-    }
-
-    IVirtualDesktopManager* GetVirtualDesktopManager()
-    {
-        IVirtualDesktopManager* manager{ nullptr };
-        IServiceProvider* serviceProvider = GetServiceProvider();
-        if (serviceProvider == nullptr || FAILED(serviceProvider->QueryService(__uuidof(manager), &manager)))
-        {
-            return nullptr;
-        }
-        return manager;
-    }
-
-    bool GetWindowDesktopId(HWND topLevelWindow, GUID* desktopId)
-    {
-        static IVirtualDesktopManager* virtualDesktopManager = GetVirtualDesktopManager();
-        return (virtualDesktopManager != nullptr) &&
-               SUCCEEDED(virtualDesktopManager->GetWindowDesktopId(topLevelWindow, desktopId));
-    }
-
-    bool GetZoneWindowDesktopId(IZoneWindow* zoneWindow, GUID* desktopId)
-    {
-        // Format: <device-id>_<resolution>_<virtual-desktop-id>
-        std::wstring uniqueId = zoneWindow->UniqueId();
-        std::wstring virtualDesktopId = uniqueId.substr(uniqueId.rfind('_') + 1);
-        return SUCCEEDED(CLSIDFromString(virtualDesktopId.c_str(), desktopId));
-    }
 }
 
 namespace ZoneWindowDrawUtils

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -97,7 +97,7 @@ namespace ZoneWindowUtils
     IVirtualDesktopManager* GetVirtualDesktopManager()
     {
         winrt::com_ptr<IVirtualDesktopManager> manager;
-        static IServiceProvider* serviceProvider = GetServiceProvider();
+        IServiceProvider* serviceProvider = GetServiceProvider();
         if (serviceProvider == nullptr || FAILED(serviceProvider->QueryService(__uuidof(manager), manager.put())))
         {
             return nullptr;

--- a/src/modules/fancyzones/lib/ZoneWindow.h
+++ b/src/modules/fancyzones/lib/ZoneWindow.h
@@ -7,7 +7,11 @@ namespace ZoneWindowUtils
     const std::wstring& GetActiveZoneSetTmpPath();
     const std::wstring& GetAppliedZoneSetTmpPath();
     const std::wstring& GetCustomZoneSetsTmpPath();
+
     std::wstring GenerateUniqueId(HMONITOR monitor, PCWSTR deviceId, PCWSTR virtualDesktopId);
+
+    bool GetWindowDesktopId(HWND topLevelWindow, GUID* desktopId);
+    bool GetZoneWindowDesktopId(IZoneWindow* zoneWindow, GUID* desktopId);
 }
 
 /**

--- a/src/modules/fancyzones/lib/ZoneWindow.h
+++ b/src/modules/fancyzones/lib/ZoneWindow.h
@@ -9,9 +9,6 @@ namespace ZoneWindowUtils
     const std::wstring& GetCustomZoneSetsTmpPath();
 
     std::wstring GenerateUniqueId(HMONITOR monitor, PCWSTR deviceId, PCWSTR virtualDesktopId);
-
-    bool GetWindowDesktopId(HWND topLevelWindow, GUID* desktopId);
-    bool GetZoneWindowDesktopId(IZoneWindow* zoneWindow, GUID* desktopId);
 }
 
 /**


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Since handling of virtual desktop switch is asynchronous, event indicating that new window is created can appear in the meantime resulting in window being assigned to invalid zone. Compare virtual desktop id on which window is created with the currently active virtual desktop id, and continue handling window created event only in case these two match.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #1236

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
1. Make sure you have `Move newly created windows to their last known zone` on.
2. Create a custom layout with two zones and apply it to both virtual desktops.
3. On first virtual desktop snap Notepad on zone 1.
4. On second virtual desktop snap Notepad on zone 2.
4. Switch back and forth between virtual desktops.

Expected result: Both windows stay assigned to their zones on different virtual desktops.