### PR TITLE
[launcher] - Improve Indexer results and resolve issues causing exceptions

### DIFF
--- a/src/modules/launcher/Wox.Test/Plugins/WindowsIndexerTest.cs
+++ b/src/modules/launcher/Wox.Test/Plugins/WindowsIndexerTest.cs
@@ -29,99 +29,73 @@ namespace Wox.Test.Plugins
         }
 
         [Test]
-        public void ModifyQueryHelper_ShouldSetQueryHelper_WhenPatternIsAsterisk()
+        public void ModifySearchQuery_ShouldNotAddAsterisk_ForAllSpaceSeparatedStrings()
         {
             // Arrange
-            ISearchQueryHelper queryHelper;
-            String pattern = "*";
-            _api.InitQueryHelper(out queryHelper, 10);
+            string query1 = "*";
+            string query2 = " *";
+            string query3 = "* ";
+            string query4 = "**";
+            string query5 = "*  ** *** ";
 
             // Act
-            _api.ModifyQueryHelper(ref queryHelper, pattern);
+            query1 = _api.ModifySearchQuery(query1);
+            query2 = _api.ModifySearchQuery(query2);
+            query3 = _api.ModifySearchQuery(query3);
+            query4 = _api.ModifySearchQuery(query4);
+            query5 = _api.ModifySearchQuery(query5);
 
             // Assert
-            Assert.IsFalse(queryHelper.QueryWhereRestrictions.Contains("LIKE"));
-            Assert.IsFalse(queryHelper.QueryWhereRestrictions.Contains("Contains"));
+            Assert.AreEqual(query1, "*");
+            Assert.AreEqual(query2, "*");
+            Assert.AreEqual(query3, "*");
+            Assert.AreEqual(query4, "*");
+            Assert.AreEqual(query5, "*");
+
         }
 
         [Test]
-        public void ModifyQueryHelper_ShouldSetQueryHelper_WhenPatternContainsAsterisk()
+        public void ModifySearchQuery_ShouldAddAsterisk_ForAllSpaceSeparatedStrings()
         {
             // Arrange
-            ISearchQueryHelper queryHelper;
-            String pattern = "tt*^&)";
-            _api.InitQueryHelper(out queryHelper, 10);
+            string query1 = "test";
+            string query2 = "*test";
+            string query3 = " **test";
+            string query4 = " *test** *";
+            string query5 = "* ** test* ** ";
 
             // Act
-            _api.ModifyQueryHelper(ref queryHelper, pattern);
+            query1 = _api.ModifySearchQuery(query1);
+            query2 = _api.ModifySearchQuery(query2);
+            query3 = _api.ModifySearchQuery(query3);
+            query4 = _api.ModifySearchQuery(query4);
+            query5 = _api.ModifySearchQuery(query5);
 
             // Assert
-            Assert.IsTrue(queryHelper.QueryWhereRestrictions.Contains("LIKE"));
-            Assert.IsFalse(queryHelper.QueryWhereRestrictions.Contains("Contains"));
+            Assert.AreEqual(query1, "*test");
+            Assert.AreEqual(query2, "*test");
+            Assert.AreEqual(query3, "*test");
+            Assert.AreEqual(query4, "*test");
+            Assert.AreEqual(query5, "*test");
         }
 
         [Test]
-        public void ModifyQueryHelper_ShouldSetQueryHelper_WhenPatternContainsPercent()
+        public void ModifySearchQuery_ShouldAddAsterisk_MultipleKeywords()
         {
             // Arrange
-            ISearchQueryHelper queryHelper;
-            String pattern = "tt%^&)";
-            _api.InitQueryHelper(out queryHelper, 10);
+            string query1 = "test1 test2";
+            string query2 = "*test1 * test2";
+            string query3 = "test1 test2 test3 test4 ";
 
             // Act
-            _api.ModifyQueryHelper(ref queryHelper, pattern);
+            query1 = _api.ModifySearchQuery(query1);
+            query2 = _api.ModifySearchQuery(query2);
+            query3 = _api.ModifySearchQuery(query3);
 
             // Assert
-            Assert.IsTrue(queryHelper.QueryWhereRestrictions.Contains("LIKE"));
-            Assert.IsFalse(queryHelper.QueryWhereRestrictions.Contains("Contains"));
-        }
-
-        [Test]
-        public void ModifyQueryHelper_ShouldSetQueryHelper_WhenPatternContainsUnderScore()
-        {
-            // Arrange
-            ISearchQueryHelper queryHelper;
-            String pattern = "tt_^&)";
-            _api.InitQueryHelper(out queryHelper, 10);
-
-            // Act
-            _api.ModifyQueryHelper(ref queryHelper, pattern);
-
-            // Assert
-            Assert.IsTrue(queryHelper.QueryWhereRestrictions.Contains("LIKE"));
-            Assert.IsFalse(queryHelper.QueryWhereRestrictions.Contains("Contains"));
-        }
-
-        [Test]
-        public void ModifyQueryHelper_ShouldSetQueryHelper_WhenPatternContainsQuestionMark()
-        {
-            // Arrange
-            ISearchQueryHelper queryHelper;
-            String pattern = "tt?^&)";
-            _api.InitQueryHelper(out queryHelper, 10);
-
-            // Act
-            _api.ModifyQueryHelper(ref queryHelper, pattern);
-
-            // Assert
-            Assert.IsTrue(queryHelper.QueryWhereRestrictions.Contains("LIKE"));
-            Assert.IsFalse(queryHelper.QueryWhereRestrictions.Contains("Contains"));
-        }
-
-        [Test]
-        public void ModifyQueryHelper_ShouldSetQueryHelper_WhenPatternDoesNotContainSplSymbols()
-        {
-            // Arrange
-            ISearchQueryHelper queryHelper;
-            String pattern = "tt^&)bc";
-            _api.InitQueryHelper(out queryHelper, 10);
-
-            // Act
-            _api.ModifyQueryHelper(ref queryHelper, pattern);
-
-            // Assert
-            Assert.IsFalse(queryHelper.QueryWhereRestrictions.Contains("LIKE"));
-            Assert.IsTrue(queryHelper.QueryWhereRestrictions.Contains("Contains"));
+            Assert.AreEqual(query1, "*test1 *test2");
+            Assert.AreEqual(query2, "*test1 *test2");
+            Assert.AreEqual(query3, "*test1 *test2 *test3 *test4");
         }
 
         [Test]
@@ -130,8 +104,8 @@ namespace Wox.Test.Plugins
             // Arrange
             ISearchQueryHelper queryHelper;
             _api.InitQueryHelper(out queryHelper, 10);
-            _api.ModifyQueryHelper(ref queryHelper, "*");
             string keyword = "test";
+            keyword = _api.ModifySearchQuery(keyword);
             bool commandDisposed = false;
             bool resultDisposed = false;
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR contains fixes for some issues such as -
* Indexer throws out of bounds exception when search keyword starts with '*'
* Unexpected search results when searching for folder/file.

It also adds a functionality for treating spaces as the logical AND operator - Reference to similar issue in WW (#1913)

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2042, #2039, #2048
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Changes made in this PR are as follows - 
1. Fix for Indexer throws out of bounds exception when search keyword starts with '*'  
Removed the reference to pattern which was adding regex search functionality and instead added an asterisk at the start of every keyword. This generates the correct SQL query programmatically using the `GenerateSQLFromUserQuery`.
2. Unexpected search results when searching for folder/file - Fixed this by using the `System.FileName` Windows Property instead of `System.Title`.
3. Spaces are treated as AND and search results quality is improved.

![search_regex_and](https://user-images.githubusercontent.com/28739210/79166667-88190c80-7d9a-11ea-8b32-dc4690af230c.gif)


<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
* Added tests for validating the new functionality.
* All Wox tests pass.
* Manually validated it as shown in the above plugin. We no longer get an exception when we search for '*'.