### PR TITLE
Dpi unaware placement bug

### DIFF
--- a/src/common/monitors.cpp
+++ b/src/common/monitors.cpp
@@ -38,6 +38,11 @@ std::vector<MonitorInfo> MonitorInfo::GetMonitors(bool include_toolbar)
     return monitors;
 }
 
+int MonitorInfo::GetMonitorsCount()
+{
+    return GetMonitors(true).size();
+}
+
 static BOOL CALLBACK get_primary_display_enum_cb(HMONITOR monitor, HDC hdc, LPRECT rect, LPARAM data)
 {
     MONITORINFOEX monitor_info;

--- a/src/common/monitors.h
+++ b/src/common/monitors.h
@@ -32,6 +32,7 @@ struct MonitorInfo : ScreenSize
 
     // Returns monitor rects ordered from left to right
     static std::vector<MonitorInfo> GetMonitors(bool include_toolbar);
+    static int GetMonitorsCount();
     // Return primary display
     static MonitorInfo GetPrimaryMonitor();
     // Return monitor on which hwnd window is displayed

--- a/src/modules/fancyzones/lib/Zone.cpp
+++ b/src/modules/fancyzones/lib/Zone.cpp
@@ -77,14 +77,19 @@ void Zone::SizeWindowToZone(HWND window, HWND zoneWindow) noexcept
 
     const auto level = DPIAware::GetAwarenessLevel(GetWindowDpiAwarenessContext(window));
     const bool accountForUnawareness = level < DPIAware::PER_MONITOR_AWARE;
+
+    LONG leftMargin = 0;
+    LONG rightMargin = 0;
+    LONG bottomMargin = 0;
+
     if (SUCCEEDED(DwmGetWindowAttribute(window, DWMWA_EXTENDED_FRAME_BOUNDS, &frameRect, sizeof(frameRect))))
     {
-        const auto left_margin = frameRect.left - windowRect.left;
-        const auto right_margin = frameRect.right - windowRect.right;
-        const auto bottom_margin = frameRect.bottom - windowRect.bottom;
-        newWindowRect.left -= left_margin;
-        newWindowRect.right -= right_margin;
-        newWindowRect.bottom -= bottom_margin;
+        leftMargin = frameRect.left - windowRect.left;
+        rightMargin = frameRect.right - windowRect.right;
+        bottomMargin = frameRect.bottom - windowRect.bottom;
+        newWindowRect.left -= leftMargin;
+        newWindowRect.right -= rightMargin;
+        newWindowRect.bottom -= bottomMargin;
     }
 
     // Map to screen coords
@@ -98,8 +103,8 @@ void Zone::SizeWindowToZone(HWND window, HWND zoneWindow) noexcept
         OffsetRect(&newWindowRect, -taskbar_left_size, -taskbar_top_size);
         if (accountForUnawareness)
         {
-            newWindowRect.left = max(mi.rcMonitor.left, newWindowRect.left);
-            newWindowRect.right = min(mi.rcMonitor.right - taskbar_left_size, newWindowRect.right);
+            newWindowRect.left = max(mi.rcMonitor.left - leftMargin, newWindowRect.left);
+            newWindowRect.right = min(mi.rcMonitor.right - taskbar_left_size - rightMargin, newWindowRect.right);
             newWindowRect.top = max(mi.rcMonitor.top, newWindowRect.top);
             newWindowRect.bottom = min(mi.rcMonitor.bottom - taskbar_top_size, newWindowRect.bottom);
         }

--- a/src/modules/fancyzones/lib/Zone.cpp
+++ b/src/modules/fancyzones/lib/Zone.cpp
@@ -5,6 +5,8 @@
 #include "Zone.h"
 #include "Settings.h"
 
+#include "common/monitors.h"
+
 struct Zone : winrt::implements<Zone, IZone>
 {
 public:
@@ -101,10 +103,12 @@ void Zone::SizeWindowToZone(HWND window, HWND zoneWindow) noexcept
         const auto taskbar_left_size = std::abs(mi.rcMonitor.left - mi.rcWork.left);
         const auto taskbar_top_size = std::abs(mi.rcMonitor.top - mi.rcWork.top);
         OffsetRect(&newWindowRect, -taskbar_left_size, -taskbar_top_size);
-        if (accountForUnawareness)
+
+        int monitorCount = MonitorInfo::GetMonitors(true).size();
+        if (accountForUnawareness && monitorCount  > 1)
         {
-            newWindowRect.left = max(mi.rcMonitor.left - leftMargin, newWindowRect.left);
-            newWindowRect.right = min(mi.rcMonitor.right - taskbar_left_size - rightMargin, newWindowRect.right);
+            newWindowRect.left = max(mi.rcMonitor.left, newWindowRect.left);
+            newWindowRect.right = min(mi.rcMonitor.right - taskbar_left_size, newWindowRect.right);
             newWindowRect.top = max(mi.rcMonitor.top, newWindowRect.top);
             newWindowRect.bottom = min(mi.rcMonitor.bottom - taskbar_top_size, newWindowRect.bottom);
         }

--- a/src/modules/fancyzones/lib/Zone.cpp
+++ b/src/modules/fancyzones/lib/Zone.cpp
@@ -80,15 +80,11 @@ void Zone::SizeWindowToZone(HWND window, HWND zoneWindow) noexcept
     const auto level = DPIAware::GetAwarenessLevel(GetWindowDpiAwarenessContext(window));
     const bool accountForUnawareness = level < DPIAware::PER_MONITOR_AWARE;
 
-    LONG leftMargin = 0;
-    LONG rightMargin = 0;
-    LONG bottomMargin = 0;
-
     if (SUCCEEDED(DwmGetWindowAttribute(window, DWMWA_EXTENDED_FRAME_BOUNDS, &frameRect, sizeof(frameRect))))
     {
-        leftMargin = frameRect.left - windowRect.left;
-        rightMargin = frameRect.right - windowRect.right;
-        bottomMargin = frameRect.bottom - windowRect.bottom;
+        LONG leftMargin = frameRect.left - windowRect.left;
+        LONG rightMargin = frameRect.right - windowRect.right;
+        LONG bottomMargin = frameRect.bottom - windowRect.bottom;
         newWindowRect.left -= leftMargin;
         newWindowRect.right -= rightMargin;
         newWindowRect.bottom -= bottomMargin;

--- a/src/modules/fancyzones/lib/Zone.cpp
+++ b/src/modules/fancyzones/lib/Zone.cpp
@@ -100,8 +100,7 @@ void Zone::SizeWindowToZone(HWND window, HWND zoneWindow) noexcept
         const auto taskbar_top_size = std::abs(mi.rcMonitor.top - mi.rcWork.top);
         OffsetRect(&newWindowRect, -taskbar_left_size, -taskbar_top_size);
 
-        int monitorCount = MonitorInfo::GetMonitors(true).size();
-        if (accountForUnawareness && monitorCount  > 1)
+        if (accountForUnawareness && MonitorInfo::GetMonitorsCount() > 1)
         {
             newWindowRect.left = max(mi.rcMonitor.left, newWindowRect.left);
             newWindowRect.right = min(mi.rcMonitor.right - taskbar_left_size, newWindowRect.right);

--- a/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
@@ -650,5 +650,30 @@ namespace FancyZonesUnitTests
             const auto actual = m_fancyZonesData.GetAppZoneHistoryMap().at(processPath).zoneIndex;
             Assert::AreEqual(expected, actual);
         }
+
+        TEST_METHOD (TestNew)
+        {
+            m_zoneWindow = InitZoneWindowWithActiveZoneSet();
+            Assert::IsNotNull(m_zoneWindow->ActiveZoneSet());
+
+            auto window = Mocks::WindowCreate(m_hInst);
+
+            int orginalWidth = 450;
+            int orginalHeight = 550;
+
+            SetWindowPos(window, nullptr, 150, 150, orginalWidth, orginalHeight, SWP_SHOWWINDOW);
+           /* SetProcessDPIAware(window, DPI_AWARENESS_SYSTEM_AWARE);*/
+            ShowWindow(window, SW_SHOW);
+
+            auto zone = MakeZone(RECT{ 0, 0, 300, 300 });
+            m_zoneWindow->ActiveZoneSet()->AddZone(zone);
+
+            m_zoneWindow->MoveWindowIntoZoneByDirection(window, VK_LEFT, true);
+
+            RECT inZoneRect;
+            GetWindowRect(window, &inZoneRect);
+            Assert::AreEqual(orginalWidth, (int)inZoneRect.right - (int)inZoneRect.left);
+            Assert::AreEqual(orginalHeight, (int)inZoneRect.bottom - (int)inZoneRect.top);
+        }
     };
 }

--- a/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
@@ -650,40 +650,5 @@ namespace FancyZonesUnitTests
             const auto actual = m_fancyZonesData.GetAppZoneHistoryMap().at(processPath).zoneIndex;
             Assert::AreEqual(expected, actual);
         }
-
-        TEST_METHOD (WhenPlacingDpiUnawareWindowIntoTheZoneItRectShouldBeExtendedToFitTargetZone)
-        {
-            m_zoneWindow = InitZoneWindowWithActiveZoneSet();
-            Assert::IsNotNull(m_zoneWindow->ActiveZoneSet());
-
-            auto window = Mocks::WindowCreate(m_hInst);
-
-            SetWindowPos(window, nullptr, 150, 150, 450, 550, SWP_SHOWWINDOW);
-            Assert::IsTrue(AreDpiAwarenessContextsEqual(DPI_AWARENESS_CONTEXT_UNAWARE, GetWindowDpiAwarenessContext(window)));
-
-            RECT nonExtendedWindowRect{};
-            ::GetWindowRect(window, &nonExtendedWindowRect);
-
-            RECT extendedFrameRect{};
-            Assert::IsTrue(SUCCEEDED(DwmGetWindowAttribute(window, DWMWA_EXTENDED_FRAME_BOUNDS, &extendedFrameRect, sizeof(extendedFrameRect))));
-
-            int leftMargin = extendedFrameRect.left - nonExtendedWindowRect.left;
-            int rightMargin = extendedFrameRect.right - nonExtendedWindowRect.right;
-            int bottomMargin = extendedFrameRect.bottom - nonExtendedWindowRect.bottom;
-            ShowWindow(window, SW_SHOW);
-
-            RECT zoneRect{ 0, 0, 250, 350 };
-            auto zone = MakeZone(zoneRect);
-            m_zoneWindow->ActiveZoneSet()->AddZone(zone);
-
-            m_zoneWindow->MoveWindowIntoZoneByDirection(window, VK_LEFT, true);
-
-            RECT inZoneRect;
-            GetWindowRect(window, &inZoneRect);
-            Assert::AreEqual(-leftMargin, (int)inZoneRect.left);
-            Assert::AreEqual((int)zoneRect.right - rightMargin, (int)inZoneRect.right);
-            Assert::AreEqual((int)zoneRect.bottom - bottomMargin, (int)inZoneRect.bottom);
-            Assert::AreEqual(0, (int)inZoneRect.top);
-        }
     };
 }

--- a/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
@@ -651,18 +651,15 @@ namespace FancyZonesUnitTests
             Assert::AreEqual(expected, actual);
         }
 
-        TEST_METHOD (TestNew)
+        TEST_METHOD (TestNesdsdw)
         {
             m_zoneWindow = InitZoneWindowWithActiveZoneSet();
             Assert::IsNotNull(m_zoneWindow->ActiveZoneSet());
 
             auto window = Mocks::WindowCreate(m_hInst);
 
-            int orginalWidth = 450;
-            int orginalHeight = 550;
-
-            SetWindowPos(window, nullptr, 150, 150, orginalWidth, orginalHeight, SWP_SHOWWINDOW);
-           /* SetProcessDPIAware(window, DPI_AWARENESS_SYSTEM_AWARE);*/
+            SetWindowPos(window, nullptr, 150, 150, 450, 550, SWP_SHOWWINDOW);
+            Assert::IsTrue(AreDpiAwarenessContextsEqual(DPI_AWARENESS_CONTEXT_UNAWARE, GetWindowDpiAwarenessContext(window)));
             ShowWindow(window, SW_SHOW);
 
             auto zone = MakeZone(RECT{ 0, 0, 300, 300 });
@@ -672,8 +669,8 @@ namespace FancyZonesUnitTests
 
             RECT inZoneRect;
             GetWindowRect(window, &inZoneRect);
-            Assert::AreEqual(orginalWidth, (int)inZoneRect.right - (int)inZoneRect.left);
-            Assert::AreEqual(orginalHeight, (int)inZoneRect.bottom - (int)inZoneRect.top);
+            Assert::AreEqual(0, (int)inZoneRect.left);
+            Assert::AreEqual(0, (int)inZoneRect.bottom - (int)inZoneRect.top);
         }
     };
 }


### PR DESCRIPTION
## Summary of the Pull Request
Fix for bug when placing dpi unaware window such as Notepad++ in left of right part of monitor. In that application gap of about 7px was left or right.
 This fixes only single-monitor scenario 
It skips correction for dpi unaware window that leaves a gap
## PR Checklist
* [x] Applies to ##1967

## Validation Steps Performed
- manual testing ( notepad++, git extensions, emacs)
- added unit test that passes
