### PR TITLE
Detect Shortcut: Hold Esc/Enter to Cancel/Accept

### DIFF
--- a/src/modules/keyboardmanager/common/KeyDelay.cpp
+++ b/src/modules/keyboardmanager/common/KeyDelay.cpp
@@ -1,0 +1,167 @@
+#include "pch.h"
+#include "KeyDelay.h"
+
+#define LONG_PRESS_DELAY_MILLIS 900
+#define ON_HOLD_WAIT_TIMEOUT_MILLIS 50
+
+KeyDelay::~KeyDelay()
+{
+    _quit = true;
+    _cv.notify_all();
+    _delayThread.join();
+}
+
+void KeyDelay::KeyEvent(LowlevelKeyboardEvent* ev)
+{
+    std::lock_guard guard(_queueMutex);
+    _queue.push({ ev->lParam->time, ev->wParam });
+    _cv.notify_all();
+}
+
+KeyTimedEvent KeyDelay::NextEvent()
+{
+    auto ev = _queue.front();
+    _queue.pop();
+    return ev;
+}
+
+bool KeyDelay::CheckIfMillisHaveElapsed(DWORD first, DWORD last, DWORD duration)
+{
+    if (first < last && first <= first + duration) 
+    {
+        return first + duration < last;
+    }
+    else
+    {
+        first += ULONG_MAX / 2;
+        last += ULONG_MAX / 2;
+        return first + duration < last;
+    }
+}
+
+bool KeyDelay::HasNextEvent()
+{
+    return !_queue.empty();
+}
+
+bool KeyDelay::HandleRelease()
+{
+    while (HasNextEvent())
+    {
+        auto ev = NextEvent();
+        switch (ev.message)
+        {
+        case WM_KEYDOWN:
+        case WM_SYSKEYDOWN:
+            _state = KeyDelayState::ON_HOLD;
+            _initialHoldKeyDown = ev.time;
+            return false;
+        case WM_KEYUP:
+        case WM_SYSKEYUP:
+            break;
+        }
+    }
+
+    return true;
+}
+
+bool KeyDelay::HandleOnHold(std::unique_lock<std::mutex>& cvLock)
+{
+    while (HasNextEvent())
+    {
+        auto ev = NextEvent();
+        switch (ev.message)
+        {
+        case WM_KEYDOWN:
+        case WM_SYSKEYDOWN:
+            break;
+        case WM_KEYUP:
+        case WM_SYSKEYUP:
+            if (CheckIfMillisHaveElapsed(_initialHoldKeyDown, ev.time, LONG_PRESS_DELAY_MILLIS))
+            {
+                if (_onLongPressDetected != nullptr)
+                {
+                    _onLongPressDetected(_key);
+                }
+                if (_onLongPressReleased != nullptr)
+                {
+                    _onLongPressReleased(_key);
+                }
+            }
+            else
+            {
+                if (_onShortPress != nullptr)
+                {
+                    _onShortPress(_key);
+                }
+            }
+            _state = KeyDelayState::RELEASED;
+           return false;
+        }
+    }
+
+    if (CheckIfMillisHaveElapsed(_initialHoldKeyDown, GetTickCount(), LONG_PRESS_DELAY_MILLIS))
+    {
+        if (_onLongPressDetected != nullptr)
+        {
+            _onLongPressDetected(_key);   
+        }
+        _state = KeyDelayState::ON_HOLD_TIMEOUT;
+    }
+    else 
+    {
+        _cv.wait_for(cvLock, std::chrono::milliseconds(ON_HOLD_WAIT_TIMEOUT_MILLIS));
+    }
+    return false;
+}
+
+bool KeyDelay::HandleOnHoldTimeout()
+{
+    while (HasNextEvent())
+    {
+        auto ev = NextEvent();
+        switch (ev.message)
+        {
+        case WM_KEYDOWN:
+        case WM_SYSKEYDOWN:
+            break;
+        case WM_KEYUP:
+        case WM_SYSKEYUP:
+            if (_onLongPressReleased != nullptr)
+            {
+                _onLongPressReleased(_key);
+            }
+            _state = KeyDelayState::RELEASED;
+            return false;
+        }
+    }
+
+    return true;
+}
+
+void KeyDelay::DelayThread()
+{
+    std::unique_lock<std::mutex> qLock(_queueMutex);
+    bool shouldWait = true;
+
+    while (!_quit)
+    {
+        if (shouldWait)
+        {
+            _cv.wait(qLock);
+        }
+
+        switch (_state)
+        {
+        case KeyDelayState::RELEASED:
+            shouldWait = HandleRelease();
+            break;
+        case KeyDelayState::ON_HOLD:
+            shouldWait = HandleOnHold(qLock);
+            break;
+        case KeyDelayState::ON_HOLD_TIMEOUT:
+            shouldWait = HandleOnHoldTimeout();
+            break;
+        }
+    }
+}

--- a/src/modules/keyboardmanager/common/KeyDelay.cpp
+++ b/src/modules/keyboardmanager/common/KeyDelay.cpp
@@ -1,9 +1,6 @@
 #include "pch.h"
 #include "KeyDelay.h"
 
-#define LONG_PRESS_DELAY_MILLIS 900
-#define ON_HOLD_WAIT_TIMEOUT_MILLIS 50
-
 KeyDelay::~KeyDelay()
 {
     std::unique_lock<std::mutex> l(_queueMutex);
@@ -29,7 +26,7 @@ KeyTimedEvent KeyDelay::NextEvent()
 
 bool KeyDelay::CheckIfMillisHaveElapsed(DWORD first, DWORD last, DWORD duration)
 {
-    if (first < last && first <= first + duration) 
+    if (first < last && first <= first + duration)
     {
         return first + duration < last;
     }
@@ -98,7 +95,7 @@ void KeyDelay::HandleOnHold(std::unique_lock<std::mutex>& cvLock)
                 }
             }
             _state = KeyDelayState::RELEASED;
-           return;
+            return;
         }
     }
 
@@ -106,11 +103,11 @@ void KeyDelay::HandleOnHold(std::unique_lock<std::mutex>& cvLock)
     {
         if (_onLongPressDetected != nullptr)
         {
-            _onLongPressDetected(_key);   
+            _onLongPressDetected(_key);
         }
         _state = KeyDelayState::ON_HOLD_TIMEOUT;
     }
-    else 
+    else
     {
         _cv.wait_for(cvLock, std::chrono::milliseconds(ON_HOLD_WAIT_TIMEOUT_MILLIS));
     }

--- a/src/modules/keyboardmanager/common/KeyDelay.h
+++ b/src/modules/keyboardmanager/common/KeyDelay.h
@@ -1,0 +1,66 @@
+#pragma once
+#include <interface/lowlevel_keyboard_event_data.h>
+#include <functional>
+#include <thread>
+#include <queue>
+#include <mutex>
+#include <chrono>
+
+enum class KeyDelayState 
+{
+    RELEASED,
+    ON_HOLD,
+    ON_HOLD_TIMEOUT,
+};
+
+struct KeyTimedEvent
+{
+    DWORD time;
+    WPARAM message;
+};
+
+class KeyDelay
+{
+public:
+    KeyDelay(
+        DWORD key,
+        std::function<void(DWORD)> onShortPress,
+        std::function<void(DWORD)> onLongPressDetected,
+        std::function<void(DWORD)> onLongPressReleased
+    ) :
+        _quit(false), 
+        _state(KeyDelayState::RELEASED),
+        _initialHoldKeyDown(0),
+        _key(key),
+        _onShortPress(onShortPress),
+        _onLongPressDetected(onLongPressDetected),
+        _onLongPressReleased(onLongPressReleased),
+        _delayThread(&KeyDelay::DelayThread, this)
+    {};
+
+    void KeyEvent(LowlevelKeyboardEvent* ev);
+    ~KeyDelay();
+
+private:
+    void DelayThread();
+    bool HandleRelease();
+    bool HandleOnHold(std::unique_lock<std::mutex>& cvLock);
+    bool HandleOnHoldTimeout();
+    KeyTimedEvent NextEvent();
+    bool HasNextEvent();
+    bool CheckIfMillisHaveElapsed(DWORD first, DWORD last, DWORD duration);
+
+    std::thread _delayThread;
+    bool _quit;
+    KeyDelayState _state;
+    std::function<void(DWORD)> _onLongPressDetected;
+    std::function<void(DWORD)> _onLongPressReleased;
+    std::function<void(DWORD)> _onShortPress;
+    std::queue<KeyTimedEvent> _queue;
+    std::mutex _queueMutex;
+    std::condition_variable _cv;
+    DWORD _initialHoldKeyDown;
+    DWORD _key;
+};
+
+

--- a/src/modules/keyboardmanager/common/KeyDelay.h
+++ b/src/modules/keyboardmanager/common/KeyDelay.h
@@ -6,7 +6,7 @@
 #include <mutex>
 
 // Available states for the KeyDelay state machine.
-enum class KeyDelayState 
+enum class KeyDelayState
 {
     RELEASED,
     ON_HOLD,
@@ -30,17 +30,15 @@ public:
         DWORD key,
         std::function<void(DWORD)> onShortPress,
         std::function<void(DWORD)> onLongPressDetected,
-        std::function<void(DWORD)> onLongPressReleased
-    ) :
-        _quit(false), 
+        std::function<void(DWORD)> onLongPressReleased) :
+        _quit(false),
         _state(KeyDelayState::RELEASED),
         _initialHoldKeyDown(0),
         _key(key),
         _onShortPress(onShortPress),
         _onLongPressDetected(onLongPressDetected),
         _onLongPressReleased(onLongPressReleased),
-        _delayThread(&KeyDelay::DelayThread, this)
-    {};
+        _delayThread(&KeyDelay::DelayThread, this){};
 
     // Enque new KeyTimedEvent and notify the condition variable.
     void KeyEvent(LowlevelKeyboardEvent* ev);
@@ -74,7 +72,7 @@ private:
     std::function<void(DWORD)> _onLongPressReleased;
     std::function<void(DWORD)> _onShortPress;
 
-    // Queue holding key events that are not processed yet. Should be kept synchronized 
+    // Queue holding key events that are not processed yet. Should be kept synchronized
     // using _queueMutex
     std::queue<KeyTimedEvent> _queue;
     std::mutex _queueMutex;
@@ -87,6 +85,7 @@ private:
 
     // Virtual Key provided in the constructor. Passed to callback functions.
     DWORD _key;
+
+    static const DWORD LONG_PRESS_DELAY_MILLIS = 900;
+    static const DWORD ON_HOLD_WAIT_TIMEOUT_MILLIS = 50;
 };
-
-

--- a/src/modules/keyboardmanager/common/KeyDelay.h
+++ b/src/modules/keyboardmanager/common/KeyDelay.h
@@ -51,9 +51,9 @@ private:
 
     // Manage state transitions and trigger callbacks on certain events.
     // Returns whether or not the thread should wait on new events.
-    void HandleRelease();
-    void HandleOnHold(std::unique_lock<std::mutex>& cvLock);
-    void HandleOnHoldTimeout();
+    bool HandleRelease();
+    bool HandleOnHold(std::unique_lock<std::mutex>& cvLock);
+    bool HandleOnHoldTimeout();
 
     // Get next key event in queue.
     KeyTimedEvent NextEvent();

--- a/src/modules/keyboardmanager/common/KeyboardManagerCommon.vcxproj
+++ b/src/modules/keyboardmanager/common/KeyboardManagerCommon.vcxproj
@@ -89,6 +89,7 @@
   <ItemGroup>
     <ClCompile Include="Helpers.cpp" />
     <ClCompile Include="KeyboardManagerState.cpp" />
+    <ClCompile Include="KeyDelay.cpp" />
     <ClCompile Include="LayoutMap.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
@@ -100,6 +101,7 @@
   <ItemGroup>
     <ClInclude Include="Helpers.h" />
     <ClInclude Include="KeyboardManagerState.h" />
+    <ClInclude Include="KeyDelay.h" />
     <ClInclude Include="LayoutMap.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="RemapShortcut.h" />

--- a/src/modules/keyboardmanager/common/KeyboardManagerCommon.vcxproj.filters
+++ b/src/modules/keyboardmanager/common/KeyboardManagerCommon.vcxproj.filters
@@ -33,6 +33,9 @@
     <ClCompile Include="RemapShortcut.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="KeyDelay.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="KeyboardManagerState.h">
@@ -51,6 +54,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="RemapShortcut.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="KeyDelay.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/modules/keyboardmanager/common/KeyboardManagerState.cpp
+++ b/src/modules/keyboardmanager/common/KeyboardManagerState.cpp
@@ -132,7 +132,6 @@ void KeyboardManagerState::ConfigureDetectSingleKeyRemapUI(const StackPanel& tex
     currentSingleKeyUI = textBlock;
 }
 
-
 void KeyboardManagerState::AddKeyToLayout(const StackPanel& panel, const hstring& key)
 {
     // Textblock to display the detected key
@@ -140,7 +139,7 @@ void KeyboardManagerState::AddKeyToLayout(const StackPanel& panel, const hstring
     Border border;
 
     border.Padding({ 20, 10, 20, 10 });
-    border.Margin({0, 0, 10, 0 });
+    border.Margin({ 0, 0, 10, 0 });
     border.Background(Windows::UI::Xaml::Media::SolidColorBrush{ Windows::UI::Colors::LightGray() });
     remapKey.Foreground(Windows::UI::Xaml::Media::SolidColorBrush{ Windows::UI::Colors::Black() });
     remapKey.FontSize(20);
@@ -323,7 +322,8 @@ void KeyboardManagerState::UnregisterKeyDelay(DWORD key)
     std::lock_guard l(keyDelays_mutex);
 
     auto deleted = keyDelays.erase(key);
-    if (deleted == 0) {
+    if (deleted == 0)
+    {
         throw std::invalid_argument("The key was not previously registered.");
     }
 }

--- a/src/modules/keyboardmanager/common/KeyboardManagerState.h
+++ b/src/modules/keyboardmanager/common/KeyboardManagerState.h
@@ -3,6 +3,7 @@
 #include "LayoutMap.h"
 #include "Shortcut.h"
 #include "RemapShortcut.h"
+#include "KeyDelay.h"
 #include <interface/lowlevel_keyboard_event_data.h>
 #include <mutex>
 #include <winrt/Windows.UI.Xaml.Controls.h>
@@ -50,6 +51,10 @@ private:
     // Stores the UI element which is to be updated based on the shortcut entered
     StackPanel currentShortcutUI;
     std::mutex currentShortcutUI_mutex;
+
+    // Registered KeyDelay objects, used to notify delayed key events.
+    std::map<DWORD, std::unique_ptr<KeyDelay>> keyDelays;
+    std::mutex keyDelays_mutex;
 
     // Display a key by appending a border Control as a child of the panel.
     void AddKeyToLayout(const StackPanel& panel, const winrt::hstring& key);
@@ -125,4 +130,19 @@ public:
 
     // Function which can be used in HandleKeyboardHookEvent before the os level shortcut remap event to use the UI and suppress events while the remap window is active.
     bool DetectShortcutUIBackend(LowlevelKeyboardEvent* data);
+
+    void RegisterKeyDelay(
+        DWORD key, 
+        std::function<void(DWORD)> onShortPress, 
+        std::function<void(DWORD)> onLongPressDetected, 
+        std::function<void(DWORD)> onLongPressReleased
+    );
+    
+    void UnregisterKeyDelay(DWORD key);
+
+    bool HandleKeyDelayEvent(LowlevelKeyboardEvent* ev);
+
+    void SelectDetectedRemapKey(DWORD key);
+  
+    void SelectDetectedShortcut(DWORD key);
 };

--- a/src/modules/keyboardmanager/common/KeyboardManagerState.h
+++ b/src/modules/keyboardmanager/common/KeyboardManagerState.h
@@ -58,6 +58,7 @@ private:
 
     // Display a key by appending a border Control as a child of the panel.
     void AddKeyToLayout(const StackPanel& panel, const winrt::hstring& key);
+
 public:
     // The map members and their mutexes are left as public since the maps are used extensively in dllmain.cpp.
     // Maps which store the remappings for each of the features. The bool fields should be initalised to false. They are used to check the current state of the shortcut (i.e is that particular shortcut currently pressed down or not).
@@ -132,18 +133,17 @@ public:
     bool DetectShortcutUIBackend(LowlevelKeyboardEvent* data);
 
     void RegisterKeyDelay(
-        DWORD key, 
-        std::function<void(DWORD)> onShortPress, 
-        std::function<void(DWORD)> onLongPressDetected, 
-        std::function<void(DWORD)> onLongPressReleased
-    );
-    
+        DWORD key,
+        std::function<void(DWORD)> onShortPress,
+        std::function<void(DWORD)> onLongPressDetected,
+        std::function<void(DWORD)> onLongPressReleased);
+
     void UnregisterKeyDelay(DWORD key);
 
     bool HandleKeyDelayEvent(LowlevelKeyboardEvent* ev);
 
     void SelectDetectedRemapKey(DWORD key);
-  
+
     void SelectDetectedShortcut(DWORD key);
 
     void ResetDetectedShortcutKey(DWORD key);

--- a/src/modules/keyboardmanager/common/KeyboardManagerState.h
+++ b/src/modules/keyboardmanager/common/KeyboardManagerState.h
@@ -145,4 +145,6 @@ public:
     void SelectDetectedRemapKey(DWORD key);
   
     void SelectDetectedShortcut(DWORD key);
+
+    void ResetDetectedShortcutKey(DWORD key);
 };

--- a/src/modules/keyboardmanager/common/KeyboardManagerState.h
+++ b/src/modules/keyboardmanager/common/KeyboardManagerState.h
@@ -132,19 +132,29 @@ public:
     // Function which can be used in HandleKeyboardHookEvent before the os level shortcut remap event to use the UI and suppress events while the remap window is active.
     bool DetectShortcutUIBackend(LowlevelKeyboardEvent* data);
 
+    // Add a KeyDelay object to get delayed key presses events for a given virtual key
+    // NOTE: this will throw an exception if a virtual key is registered twice.
+    // NOTE*: the virtual key should represent the original, unmapped virtual key.
     void RegisterKeyDelay(
         DWORD key,
         std::function<void(DWORD)> onShortPress,
         std::function<void(DWORD)> onLongPressDetected,
         std::function<void(DWORD)> onLongPressReleased);
 
+    // Remove a KeyDelay.
+    // NOTE: this method will throw if the virtual key is not registered beforehand.
+    // NOTE*: the virtual key should represent the original, unmapped virtual key.
     void UnregisterKeyDelay(DWORD key);
 
+    // Handle a key event, for a delayed key.
     bool HandleKeyDelayEvent(LowlevelKeyboardEvent* ev);
 
+    // Update the currently selected single key remap
     void SelectDetectedRemapKey(DWORD key);
 
+    // Update the currently selected shortcut.
     void SelectDetectedShortcut(DWORD key);
 
+    // Reset the shortcut (backend) state after releasing a key.
     void ResetDetectedShortcutKey(DWORD key);
 };

--- a/src/modules/keyboardmanager/common/Shortcut.cpp
+++ b/src/modules/keyboardmanager/common/Shortcut.cpp
@@ -411,7 +411,7 @@ winrt::hstring Shortcut::ToHstring(LayoutMap& keyboardMap)
     }
 }
 
-std::vector<winrt::hstring> Shortcut::GetKeyVector(LayoutMap& keyboardMap)
+std::vector<winrt::hstring> Shortcut::GetKeyVector(LayoutMap& keyboardMap) const
 {
     std::vector<winrt::hstring> keys;
     if (winKey != ModifierKey::Disabled)

--- a/src/modules/keyboardmanager/common/Shortcut.h
+++ b/src/modules/keyboardmanager/common/Shortcut.h
@@ -140,7 +140,7 @@ public:
     winrt::hstring ToHstring(LayoutMap& keyboardMap);
 
     // Function to return a vector of hstring for each key, in the same order as ToHstring()
-    std::vector<winrt::hstring> GetKeyVector(LayoutMap& keyboardMap);
+    std::vector<winrt::hstring> GetKeyVector(LayoutMap& keyboardMap) const;
 
     // Function to check if all the modifiers in the shortcut have been pressed down
     bool CheckModifiersKeyboardState() const;

--- a/src/modules/keyboardmanager/dll/dllmain.cpp
+++ b/src/modules/keyboardmanager/dll/dllmain.cpp
@@ -273,6 +273,12 @@ public:
     // Function called by the hook procedure to handle the events. This is the starting point function for remapping
     intptr_t HandleKeyboardHookEvent(LowlevelKeyboardEvent* data) noexcept
     {
+        // Check if there is a registered KeyDelay for this key.
+        if (keyboardManagerState.HandleKeyDelayEvent(data))
+        {
+            return 1;
+        }
+
         // If the Detect Key Window is currently activated, then suppress the keyboard event
         if (keyboardManagerState.DetectSingleRemapKeyUIBackend(data))
         {

--- a/src/modules/keyboardmanager/dll/dllmain.cpp
+++ b/src/modules/keyboardmanager/dll/dllmain.cpp
@@ -273,12 +273,6 @@ public:
     // Function called by the hook procedure to handle the events. This is the starting point function for remapping
     intptr_t HandleKeyboardHookEvent(LowlevelKeyboardEvent* data) noexcept
     {
-        // Check if there is a registered KeyDelay for this key.
-        if (keyboardManagerState.HandleKeyDelayEvent(data))
-        {
-            return 1;
-        }
-
         // If the Detect Key Window is currently activated, then suppress the keyboard event
         if (keyboardManagerState.DetectSingleRemapKeyUIBackend(data))
         {

--- a/src/modules/keyboardmanager/ui/ShortcutControl.cpp
+++ b/src/modules/keyboardmanager/ui/ShortcutControl.cpp
@@ -135,7 +135,7 @@ void ShortcutControl::createDetectShortcutWindow(IInspectable const& sender, Xam
                     primaryButton.Background(Windows::UI::Xaml::Media::SolidColorBrush{ Windows::UI::Colors::DarkGray() });
                 });
         },
-        [onAccept,detectShortcutBox](DWORD) {
+        [onAccept, detectShortcutBox](DWORD) {
             detectShortcutBox.Dispatcher().RunAsync(
                 Windows::UI::Core::CoreDispatcherPriority::Normal,
                 [onAccept] {

--- a/src/modules/keyboardmanager/ui/SingleKeyRemapControl.cpp
+++ b/src/modules/keyboardmanager/ui/SingleKeyRemapControl.cpp
@@ -68,21 +68,33 @@ void SingleKeyRemapControl::createDetectKeyWindow(IInspectable const& sender, Xa
 {
     // ContentDialog for detecting remap key. This is the parent UI element.
     ContentDialog detectRemapKeyBox;
-    
+
     // TODO: Hardcoded light theme, since the app is not theme aware ATM.
     detectRemapKeyBox.RequestedTheme(ElementTheme::Light);
     // ContentDialog requires manually setting the XamlRoot (https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.contentdialog#contentdialog-in-appwindow-or-xaml-islands)
     detectRemapKeyBox.XamlRoot(xamlRoot);
     detectRemapKeyBox.Title(box_value(L"Press a key on selected keyboard:"));
-    detectRemapKeyBox.PrimaryButtonText(to_hstring(L"OK"));
+    detectRemapKeyBox.IsPrimaryButtonEnabled(false);
     detectRemapKeyBox.IsSecondaryButtonEnabled(false);
-    detectRemapKeyBox.CloseButtonText(to_hstring(L"Cancel"));
 
     // Get the linked text block for the "Type Key" button that was clicked
     TextBlock linkedRemapText = getSiblingElement(sender).as<TextBlock>();
 
-    // OK button
-    detectRemapKeyBox.PrimaryButtonClick([=, &singleKeyRemapBuffer, &keyboardManagerState](Windows::UI::Xaml::Controls::ContentDialog const& sender, ContentDialogButtonClickEventArgs const&) {
+    auto unregisterKeys = [&keyboardManagerState]() {
+        std::thread t1(&KeyboardManagerState::UnregisterKeyDelay, &keyboardManagerState, VK_ESCAPE);
+        std::thread t2(&KeyboardManagerState::UnregisterKeyDelay, &keyboardManagerState, VK_RETURN);
+        t1.detach();
+        t2.detach();
+    };
+
+    TextBlock primaryButtonText;
+    primaryButtonText.Text(to_hstring(L"OK"));
+
+    Button primaryButton;
+    primaryButton.HorizontalAlignment(HorizontalAlignment::Stretch);
+    primaryButton.Margin({ 2, 2, 2, 2 });
+    primaryButton.Content(primaryButtonText);
+    primaryButton.Click([=, &singleKeyRemapBuffer, &keyboardManagerState](IInspectable const& sender, RoutedEventArgs const&) {
         // Save the detected key in the linked text block
         DWORD detectedKey = keyboardManagerState.GetDetectedSingleRemapKey();
 
@@ -94,13 +106,73 @@ void SingleKeyRemapControl::createDetectKeyWindow(IInspectable const& sender, Xa
 
         // Reset the keyboard manager UI state
         keyboardManagerState.ResetUIState();
+        unregisterKeys();
+        detectRemapKeyBox.Hide();
     });
 
+    keyboardManagerState.RegisterKeyDelay(
+        VK_RETURN,
+        std::bind(&KeyboardManagerState::SelectDetectedRemapKey, &keyboardManagerState, std::placeholders::_1),
+        [primaryButton, detectRemapKeyBox](DWORD) {
+            detectRemapKeyBox.Dispatcher().RunAsync(
+                Windows::UI::Core::CoreDispatcherPriority::Normal,
+                [primaryButton] {
+                    primaryButton.Background(Windows::UI::Xaml::Media::SolidColorBrush{ Windows::UI::Colors::DarkGray() });
+                });
+        },
+        [=, &singleKeyRemapBuffer, &keyboardManagerState](DWORD) {
+            DWORD detectedKey = keyboardManagerState.GetDetectedSingleRemapKey();
+
+            detectRemapKeyBox.Dispatcher().RunAsync(
+                Windows::UI::Core::CoreDispatcherPriority::Normal,
+                [detectRemapKeyBox, linkedRemapText, detectedKey, &keyboardManagerState] {
+                    detectRemapKeyBox.Hide();
+
+                    if (detectedKey != NULL)
+                    {
+                        linkedRemapText.Text(winrt::to_hstring(keyboardManagerState.keyboardMap.GetKeyName(detectedKey).c_str()));
+                    }
+                });
+
+            if (detectedKey != NULL)
+            {
+                singleKeyRemapBuffer[rowIndex][colIndex] = detectedKey;
+            }
+
+            // Reset the keyboard manager UI state
+            keyboardManagerState.ResetUIState();
+            unregisterKeys();
+        });
+
+    TextBlock cancelButtonText;
+    cancelButtonText.Text(to_hstring(L"Cancel"));
+
+    Button cancelButton;
+    cancelButton.HorizontalAlignment(HorizontalAlignment::Stretch);
+    cancelButton.Margin({ 2, 2, 2, 2 });
+    cancelButton.Content(cancelButtonText);
     // Cancel button
-    detectRemapKeyBox.CloseButtonClick([&keyboardManagerState](Windows::UI::Xaml::Controls::ContentDialog const& sender, ContentDialogButtonClickEventArgs const&) {
+    cancelButton.Click([detectRemapKeyBox, unregisterKeys, &keyboardManagerState](IInspectable const& sender, RoutedEventArgs const&) {
         // Reset the keyboard manager UI state
         keyboardManagerState.ResetUIState();
+        unregisterKeys();
+        detectRemapKeyBox.Hide();
     });
+
+    keyboardManagerState.RegisterKeyDelay(
+        VK_ESCAPE,
+        std::bind(&KeyboardManagerState::SelectDetectedRemapKey, &keyboardManagerState, std::placeholders::_1),
+        [&keyboardManagerState, detectRemapKeyBox, unregisterKeys](DWORD) {
+            detectRemapKeyBox.Dispatcher().RunAsync(
+                Windows::UI::Core::CoreDispatcherPriority::Normal,
+                [detectRemapKeyBox] {
+                    detectRemapKeyBox.Hide();
+                });
+
+            keyboardManagerState.ResetUIState();
+            unregisterKeys();
+        },
+        nullptr);
 
     // StackPanel parent for the displayed text in the dialog
     Windows::UI::Xaml::Controls::StackPanel stackPanel;
@@ -114,8 +186,36 @@ void SingleKeyRemapControl::createDetectKeyWindow(IInspectable const& sender, Xa
 
     // Target StackPanel to place the selected key
     Windows::UI::Xaml::Controls::StackPanel keyStackPanel;
-    stackPanel.Children().Append(keyStackPanel);
     keyStackPanel.Orientation(Orientation::Horizontal);
+    stackPanel.Children().Append(keyStackPanel);
+
+    TextBlock holdEscInfo;
+    holdEscInfo.Text(winrt::to_hstring("Hold Esc to discard"));
+    holdEscInfo.FontSize(12);
+    holdEscInfo.Margin({ 0, 20, 0, 0 });
+    stackPanel.Children().Append(holdEscInfo);
+
+    TextBlock holdEnterInfo;
+    holdEnterInfo.Text(winrt::to_hstring("Hold Enter to apply"));
+    holdEnterInfo.FontSize(12);
+    holdEnterInfo.Margin({ 0, 0, 0, 0 });
+    stackPanel.Children().Append(holdEnterInfo);
+
+    ColumnDefinition primaryButtonColumn;
+    ColumnDefinition cancelButtonColumn;
+
+    Grid buttonPanel;
+    buttonPanel.Margin({0, 20, 0, 0});
+    buttonPanel.HorizontalAlignment(HorizontalAlignment::Stretch);
+    buttonPanel.ColumnDefinitions().Append(primaryButtonColumn);
+    buttonPanel.ColumnDefinitions().Append(cancelButtonColumn);
+    buttonPanel.SetColumn(primaryButton, 0);
+    buttonPanel.SetColumn(cancelButton, 1);
+
+    buttonPanel.Children().Append(primaryButton);
+    buttonPanel.Children().Append(cancelButton);
+
+    stackPanel.Children().Append(buttonPanel);
     stackPanel.UpdateLayout();
 
     // Configure the keyboardManagerState to store the UI information.


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Apply/Discard changes on the Detect SingleKey/Shortcut ContentDialog by holding down Enter/Escape.
<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #6
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
* When the detect single key/shortcut content dialog is created, two KeyDelays objects are registered to track the Escape and Enter keys.
* For each KeyDelay object, three callbacks are provided, one for Short Press, and two for Long Press (when pressed initially and when released).
* Long Press triggers when the user holds the key for more that 0.9 seconds.
* When the callback function needs to close the window, the UnregisterKeyDelay code should be run from a different thread, otherwise there would be a deadlock.
* The Detect shortcut content dialog takes into account single key remapping when tracking Escape and Enter. 

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
* Holding down the Escape key has the same effect as clicking on Cancel on the content dialog.
* Holding down the Enter key has the same effect as clicking (and holding) on OK on the content dialog. 
* Pressing and releasing early either the Enter or Escape key detects the key value.