### PR TITLE
Handle RAlt, RCtrl and other extended keys correctly (dev/build-features)

### DIFF
--- a/src/modules/keyboardmanager/common/Helpers.cpp
+++ b/src/modules/keyboardmanager/common/Helpers.cpp
@@ -26,3 +26,19 @@ IInspectable getSiblingElement(IInspectable const& element)
     parentElement.Children().IndexOf(frameworkElement, index);
     return parentElement.Children().GetAt(index + 1);
 }
+
+// Function to return if the key is an extended key which requires the use of the extended key flag
+bool isExtendedKey(DWORD key)
+{
+    switch (key)
+    {
+    case VK_RCONTROL:
+    case VK_RMENU:
+    case VK_NUMLOCK:
+    case VK_SNAPSHOT:
+    case VK_CANCEL:
+        return true;
+    default:
+        return false;
+    }
+}

--- a/src/modules/keyboardmanager/common/Helpers.h
+++ b/src/modules/keyboardmanager/common/Helpers.h
@@ -32,3 +32,6 @@ std::vector<T> convertWStringVectorToIntegerVector(const std::vector<std::wstrin
 
     return typeVector;
 }
+
+// Function to return if the key is an extended key which requires the use of the extended key flag
+bool isExtendedKey(DWORD key);

--- a/src/modules/keyboardmanager/common/Shortcut.cpp
+++ b/src/modules/keyboardmanager/common/Shortcut.cpp
@@ -539,8 +539,8 @@ bool Shortcut::CheckModifiersKeyboardState() const
 // Function to check if any keys are pressed down except those in the shortcut
 bool Shortcut::IsKeyboardStateClearExceptShortcut() const
 {
-    // Iterate through all the virtual key codes
-    for (int keyVal = 0; keyVal < 0x100; keyVal++)
+    // Iterate through all the virtual key codes - 0xFF is set to key down because of the Num Lock
+    for (int keyVal = 0; keyVal < 0xFF; keyVal++)
     {
         // Skip mouse buttons. Keeping this could cause a remapping to fail if a mouse button is also pressed at the same time
         if (keyVal == VK_LBUTTON || keyVal == VK_RBUTTON || keyVal == VK_MBUTTON || keyVal == VK_XBUTTON1 || keyVal == VK_XBUTTON2)

--- a/src/modules/keyboardmanager/dll/dllmain.cpp
+++ b/src/modules/keyboardmanager/dll/dllmain.cpp
@@ -152,7 +152,7 @@ public:
                 PowerToysSettings::CustomActionObject::from_json_string(action);
             HINSTANCE hInstance = reinterpret_cast<HINSTANCE>(&__ImageBase);
 
-            if (action_object.get_name() == L"RemapKeyboard") 
+            if (action_object.get_name() == L"RemapKeyboard")
             {
                 if (!CheckEditKeyboardWindowActive())
                 {
@@ -325,6 +325,10 @@ public:
         keyEventArray[index].type = inputType;
         keyEventArray[index].ki.wVk = keyCode;
         keyEventArray[index].ki.dwFlags = flags;
+        if (isExtendedKey(keyCode))
+        {
+            keyEventArray[index].ki.dwFlags |= KEYEVENTF_EXTENDEDKEY;
+        }
         keyEventArray[index].ki.dwExtraInfo = extraInfo;
     }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
- This PR adds a check for extended keys which include RAlt and RCtrl. For these keys an extended key flag is included during SendInput in order to work properly. If that wasn't added you would get weird behaviour if you remapped LShift to RCtrl, held down LShift and switch to another window and then release LShift, it would act as if RCtrl was still held down.
- Another issue that was fixed was for shortcuts containing Ins, Home, Pg keys, Del, End and Arrow keys. It was observed that the shortcuts would not get remapped if Num lock was turned on. It turns out that this was because for shortcut remappings we ensure that no other key states are set to "down" but when num lock is pressed, an undocumented `0xFF` is set to down. Now we don't check the 0xFF key code.

## References
- https://docs.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes
- https://docs.microsoft.com/en-us/windows/win32/inputdev/about-keyboard-input#extended-key-flag

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Applies to #6
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

