### PR TITLE
Take subset of pr 2115 for issues 2042 2039

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/SearchHelper/WindowsSearchAPI.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/SearchHelper/WindowsSearchAPI.cs
@@ -90,13 +90,13 @@ namespace Microsoft.Plugin.Indexer.SearchHelper
             queryHelper.QueryMaxResults = maxCount;
 
             // Set list of columns we want to display, getting the path presently
-            queryHelper.QuerySelectColumns = "System.ItemPathDisplay";
+            queryHelper.QuerySelectColumns = "System.ItemPathDisplay, System.FileName";
 
             // Set additional query restriction
             queryHelper.QueryWhereRestrictions = "AND scope='file:'";
 
             // To filter based on title for now
-            queryHelper.QueryContentProperties = "System.Title";
+            queryHelper.QueryContentProperties = "System.FileName";
 
             // Set sorting order 
             queryHelper.QuerySorting = "System.DateModified DESC";


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
We noticed some performance impact the the search indexer changes to query 'LIKE' instead of 'CONTAINS'.  I want to commit a subset of @alekhyareddy28 's changes in #2115, to fix the issues listed below and separately evaluate the tradeoff between the new results returned by "LIKE' queries, and the extra time the indexer is taking. 

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2042, #2039
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [] Tests added/passed
* [] Requires documentation to be updated
* [] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Here are the logs of the indexer in #2115 vs just the subset of changes. 

#2115: 
```
Debug||PluginManager.QueryForPlugin|Cost for Windows Indexer Plugin <872ms>
Debug||PluginManager.QueryForPlugin|Cost for Calculator <0ms>
Debug||PluginManager.QueryForPlugin|Cost for Folder <0ms>
Debug||PluginManager.QueryForPlugin|Cost for Program <20ms>
Debug||PluginManager.QueryForPlugin|Cost for Calculator <0ms>
Debug||PluginManager.QueryForPlugin|Cost for Folder <0ms>
Debug||PluginManager.QueryForPlugin|Cost for Windows Indexer Plugin <2260ms>
Exception thrown: 'System.OperationCanceledException' in System.Threading.Tasks.Parallel.dll
Debug||PluginManager.QueryForPlugin|Cost for Program <1813ms>
Debug||PluginManager.QueryForPlugin|Cost for Windows Indexer Plugin <3370ms>
```

This PR: 
```
Debug||PluginManager.QueryForPlugin|Cost for Shell <19ms>
Debug||PluginManager.QueryForPlugin|Cost for Calculator <0ms>
Debug||PluginManager.QueryForPlugin|Cost for Folder <0ms>
Debug||PluginManager.QueryForPlugin|Cost for Program <10ms>
Debug||PluginManager.QueryForPlugin|Cost for Windows Indexer Plugin <101ms>
Debug||PluginManager.QueryForPlugin|Cost for Calculator <0ms>
Debug||PluginManager.QueryForPlugin|Cost for Folder <0ms>
Debug||PluginManager.QueryForPlugin|Cost for Windows Indexer Plugin <66ms>
Debug||PluginManager.QueryForPlugin|Cost for Program <24ms>
Debug||PluginManager.QueryForPlugin|Cost for Calculator <0ms>
Debug||PluginManager.QueryForPlugin|Cost for Folder <0ms>
Debug||PluginManager.QueryForPlugin|Cost for Program <10ms>
Debug||PluginManager.QueryForPlugin|Cost for Windows Indexer Plugin <35ms>
```

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Tested locally. 