### PR TITLE
FZ editor: Splitted zones positioning

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
@@ -416,7 +416,7 @@ namespace FancyZonesEditor
 
                         newRowPercents[row] = model.RowPercents[sourceRow];
                     }
-                    
+
                     sourceRow++;
                 }
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation
+// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -222,7 +222,7 @@ namespace FancyZonesEditor
             int newChildIndex = AddZone();
 
             double offset = e.Offset;
-            double thickness = e.Thickness;
+            double space = e.Space;
 
             if (e.Orientation == Orientation.Vertical)
             {
@@ -295,25 +295,28 @@ namespace FancyZonesEditor
                 model.CellChildMap = newCellChildMap;
 
                 sourceCol = 0;
+                double newTotalExtent = ActualWidth - (space * (cols + 1));
                 for (int col = 0; col < cols; col++)
                 {
                     if (col == foundCol)
                     {
-                        RowColInfo[] split = _colInfo[col].Split(offset, thickness);
+                        RowColInfo[] split = _colInfo[col].Split(offset, space);
                         newColInfo[col] = split[0];
                         newColPercents[col] = split[0].Percent;
                         col++;
 
                         newColInfo[col] = split[1];
                         newColPercents[col] = split[1].Percent;
-                        sourceCol++;
                     }
                     else
                     {
                         newColInfo[col] = _colInfo[sourceCol];
+                        newColInfo[col].RecalculatePercent(newTotalExtent);
+
                         newColPercents[col] = model.ColumnPercents[sourceCol];
-                        sourceCol++;
                     }
+
+                    sourceCol++;
                 }
 
                 _colInfo = newColInfo;
@@ -393,25 +396,28 @@ namespace FancyZonesEditor
                 model.CellChildMap = newCellChildMap;
 
                 sourceRow = 0;
+                double newTotalExtent = ActualHeight - (space * (rows + 1));
                 for (int row = 0; row < rows; row++)
                 {
                     if (row == foundRow)
                     {
-                        RowColInfo[] split = _rowInfo[row].Split(offset, thickness);
+                        RowColInfo[] split = _rowInfo[row].Split(offset, space);
                         newRowInfo[row] = split[0];
                         newRowPercents[row] = split[0].Percent;
                         row++;
 
                         newRowInfo[row] = split[1];
                         newRowPercents[row] = split[1].Percent;
-                        sourceRow++;
                     }
                     else
                     {
                         newRowInfo[row] = _rowInfo[sourceRow];
+                        newRowInfo[row].RecalculatePercent(newTotalExtent);
+
                         newRowPercents[row] = model.RowPercents[sourceRow];
-                        sourceRow++;
                     }
+                    
+                    sourceRow++;
                 }
 
                 _rowInfo = newRowInfo;

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
@@ -222,6 +222,7 @@ namespace FancyZonesEditor
             int newChildIndex = AddZone();
 
             double offset = e.Offset;
+            double thickness = e.Thickness;
 
             if (e.Orientation == Orientation.Vertical)
             {
@@ -298,17 +299,20 @@ namespace FancyZonesEditor
                 {
                     if (col == foundCol)
                     {
-                        RowColInfo[] split = _colInfo[col].Split(offset);
+                        RowColInfo[] split = _colInfo[col].Split(offset, thickness);
+                        newColInfo[col] = split[0];
                         newColPercents[col] = split[0].Percent;
-                        newColInfo[col++] = split[0];
-                        newColPercents[col] = split[1].Percent;
+                        col++;
+
                         newColInfo[col] = split[1];
+                        newColPercents[col] = split[1].Percent;
                         sourceCol++;
                     }
                     else
                     {
+                        newColInfo[col] = _colInfo[sourceCol];
                         newColPercents[col] = model.ColumnPercents[sourceCol];
-                        newColInfo[col] = _colInfo[sourceCol++];
+                        sourceCol++;
                     }
                 }
 
@@ -393,17 +397,20 @@ namespace FancyZonesEditor
                 {
                     if (row == foundRow)
                     {
-                        RowColInfo[] split = _rowInfo[row].Split(offset);
+                        RowColInfo[] split = _rowInfo[row].Split(offset, thickness);
+                        newRowInfo[row] = split[0];
                         newRowPercents[row] = split[0].Percent;
-                        newRowInfo[row++] = split[0];
-                        newRowPercents[row] = split[1].Percent;
+                        row++;
+
                         newRowInfo[row] = split[1];
+                        newRowPercents[row] = split[1].Percent;
                         sourceRow++;
                     }
                     else
                     {
+                        newRowInfo[row] = _rowInfo[sourceRow];
                         newRowPercents[row] = model.RowPercents[sourceRow];
-                        newRowInfo[row] = _rowInfo[sourceRow++];
+                        sourceRow++;
                     }
                 }
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridZone.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridZone.xaml.cs
@@ -277,7 +277,14 @@ namespace FancyZonesEditor
 
         private void DoSplit(Orientation orientation, double offset)
         {
-            Split?.Invoke(this, new SplitEventArgs(orientation, offset, SplitterThickness));
+            int spacing = 0;
+            Settings settings = ((App)Application.Current).ZoneSettings;
+            if (settings.ShowSpacing)
+            {
+                spacing = settings.Spacing;
+            }
+
+            Split?.Invoke(this, new SplitEventArgs(orientation, offset, spacing));
         }
 
         private void FullSplit_Click(object sender, RoutedEventArgs e)

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridZone.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridZone.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation
+// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -277,7 +277,7 @@ namespace FancyZonesEditor
 
         private void DoSplit(Orientation orientation, double offset)
         {
-            Split?.Invoke(this, new SplitEventArgs(orientation, offset));
+            Split?.Invoke(this, new SplitEventArgs(orientation, offset, SplitterThickness));
         }
 
         private void FullSplit_Click(object sender, RoutedEventArgs e)

--- a/src/modules/fancyzones/editor/FancyZonesEditor/RowColInfo.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/RowColInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation
+// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -34,13 +34,18 @@ namespace FancyZonesEditor
             return Extent;
         }
 
-        public RowColInfo[] Split(double offset)
+        public RowColInfo[] Split(double offset, double thickness)
         {
             RowColInfo[] info = new RowColInfo[2];
 
-            int newPercent = (int)(Percent * offset / Extent);
+            double totalExtent = Extent * _multiplier / Percent;
+            totalExtent -= thickness;
+
+            int newPercent = (int)(offset * _multiplier / totalExtent);
+
             info[0] = new RowColInfo(newPercent);
             info[1] = new RowColInfo(Percent - newPercent);
+
             return info;
         }
     }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/RowColInfo.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/RowColInfo.cs
@@ -34,17 +34,23 @@ namespace FancyZonesEditor
             return Extent;
         }
 
-        public RowColInfo[] Split(double offset, double thickness)
+        public void RecalculatePercent(double newTotalExtent)
+        {
+            Percent = (int)(Extent * _multiplier / newTotalExtent);
+        }
+
+        public RowColInfo[] Split(double offset, double space)
         {
             RowColInfo[] info = new RowColInfo[2];
 
             double totalExtent = Extent * _multiplier / Percent;
-            totalExtent -= thickness;
+            totalExtent -= space;
 
-            int newPercent = (int)(offset * _multiplier / totalExtent);
+            int percent0 = (int)(offset * _multiplier / totalExtent);
+            int percent1 = (int)((Extent - space - offset) * _multiplier / totalExtent);
 
-            info[0] = new RowColInfo(newPercent);
-            info[1] = new RowColInfo(Percent - newPercent);
+            info[0] = new RowColInfo(percent0);
+            info[1] = new RowColInfo(percent1);
 
             return info;
         }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/SplitEventArgs.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/SplitEventArgs.cs
@@ -17,14 +17,14 @@ namespace FancyZonesEditor
         {
             Orientation = orientation;
             Offset = offset;
-            Thickness = thickness;
+            Space = thickness;
         }
 
         public Orientation Orientation { get; }
 
         public double Offset { get; }
 
-        public double Thickness { get; }
+        public double Space { get; }
     }
 
     public delegate void SplitEventHandler(object sender, SplitEventArgs args);

--- a/src/modules/fancyzones/editor/FancyZonesEditor/SplitEventArgs.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/SplitEventArgs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation
+// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -13,15 +13,18 @@ namespace FancyZonesEditor
         {
         }
 
-        public SplitEventArgs(Orientation orientation, double offset)
+        public SplitEventArgs(Orientation orientation, double offset, double thickness)
         {
             Orientation = orientation;
             Offset = offset;
+            Thickness = thickness;
         }
 
         public Orientation Orientation { get; }
 
         public double Offset { get; }
+
+        public double Thickness { get; }
     }
 
     public delegate void SplitEventHandler(object sender, SplitEventArgs args);

--- a/src/tests/win-app-driver/FancyZonesTests/FancyZonesEditor.cs
+++ b/src/tests/win-app-driver/FancyZonesTests/FancyZonesEditor.cs
@@ -17,9 +17,11 @@ namespace PowerToysTests
         protected static void OpenEditor()
         {
             new Actions(session).KeyDown(OpenQA.Selenium.Keys.Command).SendKeys("`").KeyUp(OpenQA.Selenium.Keys.Command).Perform();
+            WaitSeconds(2);
             //editorWindow = WaitElementByXPath("//Window[@Name=\"FancyZones Editor\"]");
+            editorWindow = WaitElementByName("FancyZones Editor");
             //may not find editor by name in 0.16.1
-            editorWindow = WaitElementByAccessibilityId("MainWindow1");
+            //editorWindow = WaitElementByAccessibilityId("MainWindow1");
             Assert.IsNotNull(editorWindow, "Couldn't find editor window");
         }
 
@@ -57,10 +59,10 @@ namespace PowerToysTests
         protected static void OpenCreatorWindow(string tabName, string creatorWindowName, string buttonId = "EditCustomButton")
         {
             string elementXPath = "//Text[@Name=\"" + tabName + "\"]";
-            session.FindElementByXPath(elementXPath).Click();
-            session.FindElementByAccessibilityId(buttonId).Click();
+            WaitElementByXPath(elementXPath).Click();
+            WaitElementByAccessibilityId(buttonId).Click();
 
-            WindowsElement creatorWindow = session.FindElementByName(creatorWindowName);
+            WindowsElement creatorWindow = WaitElementByName(creatorWindowName);
             Assert.IsNotNull(creatorWindow, "Creator window didn't open");
         }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
FancyZones Editor: fixed splitted zones positioning in grid layouts

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2023 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [] Requires documentation to be updated
* [] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
In grid layouts zone size is represented in percentage of useful screen area (without splitters and borders). When we split zone useful area is reduced. Since it is expected that zone size shouldn't be changed, all zones percents have to be recalculated.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
* manually tested with different layouts and different display scaling
* added WinAppDriver tests