### PR TITLE
added Fancy Zones Settings

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/EnabledModules.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/EnabledModules.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.PowerToys.Settings.UI.Lib
+{
+    public class EnabledModules
+    {
+        public EnabledModules()
+        {
+            this.FancyZones = false;
+            this.ImageResizer = false;
+            this.FileExplorerPreview = false;
+            this.PowerRename = false;
+            this.ShortcutGuide = true;
+        }
+
+        [JsonPropertyName("FancyZones")]
+        public bool FancyZones { get; set; }
+
+        [JsonPropertyName("ImageResizer")]
+        public bool ImageResizer { get; set; }
+
+        [JsonPropertyName("File Explorer Preview")]
+        public bool FileExplorerPreview { get; set; }
+
+        [JsonPropertyName("Shortcut Guide")]
+        public bool ShortcutGuide { get; set; }
+
+        public bool PowerRename { get; set; }
+    }
+}

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/FZConfigProperties.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/FZConfigProperties.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.PowerToys.Settings.UI.Lib
+{
+    public class FZConfigProperties
+    {
+        public FZConfigProperties()
+        {
+            this.FancyzonesShiftDrag = new BoolProperty();
+            this.FancyzonesOverrideSnapHotkeys = new BoolProperty();
+            this.FancyzonesZoneSetChangeFlashZones = new BoolProperty();
+            this.FancyzonesDisplayChangeMoveWindows = new BoolProperty();
+            this.FancyzonesZoneSetChangeMoveWindows = new BoolProperty();
+            this.FancyzonesVirtualDesktopChangeMoveWindows = new BoolProperty();
+            this.FancyzonesAppLastZoneMoveWindows = new BoolProperty();
+            this.UseCursorposEditorStartupscreen = new BoolProperty();
+            this.FancyzonesShowOnAllMonitors = new BoolProperty();
+            this.FancyzonesZoneHighlightColor = new StringProperty();
+            this.FancyzonesHighlightOpacity = new IntProperty();
+            this.FancyzonesEditorHotkey = new KeyBoardKeysProperty();
+            this.FancyzonesExcludedApps = new StringProperty();
+        }
+
+        [JsonPropertyName("fancyzones_shiftDrag")]
+        public BoolProperty FancyzonesShiftDrag { get; set; }
+
+        [JsonPropertyName("fancyzones_overrideSnapHotkeys")]
+        public BoolProperty FancyzonesOverrideSnapHotkeys { get; set; }
+
+        [JsonPropertyName("fancyzones_zoneSetChange_flashZones")]
+        public BoolProperty FancyzonesZoneSetChangeFlashZones { get; set; }
+
+        [JsonPropertyName("fancyzones_displayChange_moveWindows")]
+        public BoolProperty FancyzonesDisplayChangeMoveWindows { get; set; }
+
+        [JsonPropertyName("fancyzones_zoneSetChange_moveWindows")]
+        public BoolProperty FancyzonesZoneSetChangeMoveWindows { get; set; }
+
+        [JsonPropertyName("fancyzones_virtualDesktopChange_moveWindows")]
+        public BoolProperty FancyzonesVirtualDesktopChangeMoveWindows { get; set; }
+
+        [JsonPropertyName("fancyzones_appLastZone_moveWindows")]
+        public BoolProperty FancyzonesAppLastZoneMoveWindows { get; set; }
+
+        [JsonPropertyName("use_cursorpos_editor_startupscreen")]
+        public BoolProperty UseCursorposEditorStartupscreen { get; set; }
+
+        [JsonPropertyName("fancyzones_show_on_all_monitors")]
+        public BoolProperty FancyzonesShowOnAllMonitors { get; set; }
+
+        [JsonPropertyName("fancyzones_zoneHighlightColor")]
+        public StringProperty FancyzonesZoneHighlightColor { get; set; }
+
+        [JsonPropertyName("fancyzones_highlight_opacity")]
+        public IntProperty FancyzonesHighlightOpacity { get; set; }
+
+        [JsonPropertyName("fancyzones_editor_hotkey")]
+        public KeyBoardKeysProperty FancyzonesEditorHotkey { get; set; }
+
+        [JsonPropertyName("fancyzones_excluded_apps")]
+        public StringProperty FancyzonesExcludedApps { get; set; }
+    }
+}

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/FancyZonesSettings.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/FancyZonesSettings.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.PowerToys.Settings.UI.Lib
+{
+    public class FancyZonesSettings
+    {
+        public FancyZonesSettings()
+        {
+            this.Version = string.Empty;
+            this.Name = string.Empty;
+            this.Properties = new FZConfigProperties();
+        }
+
+        [JsonPropertyName("version")]
+        public string Version { get; set; }
+
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        [JsonPropertyName("properties")]
+        public FZConfigProperties Properties { get; set; }
+
+        public string ToJsonString()
+        {
+            return JsonSerializer.Serialize(this);
+        }
+    }
+}

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/GeneralSettings.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/GeneralSettings.cs
@@ -3,44 +3,57 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Microsoft.PowerToys.Settings.UI.Lib
 {
     public class GeneralSettings
     {
         // Gets or sets a value indicating whether packaged.
+        [JsonPropertyName("packaged")]
         public bool Packaged { get; set; }
 
         // Gets or sets a value indicating whether run powertoys on start-up.
-        public bool startup { get; set; }
+        [JsonPropertyName("startup")]
+        public bool Startup { get; set; }
 
         // Gets or sets a value indicating whether the powertoy elevated.
-        public bool is_elevated { get; set; }
+        [JsonPropertyName("is_elevated")]
+        public bool IsElevated { get; set; }
 
         // Gets or sets a value indicating whether powertoys should run elevated.
-        public bool run_elevated { get; set; }
+        [JsonPropertyName("run_elevated")]
+        public bool RunElevated { get; set; }
 
         // Gets or sets a value indicating whether is admin.
-        public bool is_admin { get; set; }
+        [JsonPropertyName("is_admin")]
+        public bool IsAdmin { get; set; }
 
         // Gets or sets theme Name.
-        public string theme { get; set; }
+        [JsonPropertyName("theme")]
+        public string Theme { get; set; }
 
         // Gets or sets system theme name.
-        public string system_theme { get; set; }
+        [JsonPropertyName("system_theme")]
+        public string SystemTheme { get; set; }
 
         // Gets or sets powertoys version number.
-        public string powertoys_version { get; set; }
+        [JsonPropertyName("powertoys_version")]
+        public string PowertoysVersion { get; set; }
+
+        [JsonPropertyName("enabled")]
+        public EnabledModules Enabled { get; set; }
 
         public GeneralSettings()
         {
-            Packaged = false;
-            startup = false;
-            is_admin = false;
-            is_elevated = false;
-            theme = "system";
-            system_theme = "light";
-            powertoys_version = "v0.15.3";
+            this.Packaged = false;
+            this.Startup = false;
+            this.IsAdmin = false;
+            this.IsElevated = false;
+            this.Theme = "system";
+            this.SystemTheme = "light";
+            this.PowertoysVersion = "v0.15.3";
+            this.Enabled = new EnabledModules();
         }
 
         // converts the current to a json string.

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/HotkeySettings.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/HotkeySettings.cs
@@ -3,48 +3,65 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Text;
+using System.Text.Json.Serialization;
 
 namespace Microsoft.PowerToys.Settings.UI.Lib
 {
     public class HotkeySettings
     {
-        public bool win { get; set; }
+        public HotkeySettings()
+        {
+            this.Win = false;
+            this.Ctrl = false;
+            this.Alt = false;
+            this.Shift = false;
+            this.Key = string.Empty;
+            this.Code = 0;
+        }
 
-        public bool ctrl { get; set; }
+        [JsonPropertyName("win")]
+        public bool Win { get; set; }
 
-        public bool alt { get; set; }
+        [JsonPropertyName("ctrl")]
+        public bool Ctrl { get; set; }
 
-        public bool shift { get; set; }
+        [JsonPropertyName("alt")]
+        public bool Alt { get; set; }
 
-        public string key { get; set; }
+        [JsonPropertyName("shift")]
+        public bool Shift { get; set; }
 
-        public int code { get; set; }
+        [JsonPropertyName("key")]
+        public string Key { get; set; }
+
+        [JsonPropertyName("code")]
+        public int Code { get; set; }
 
         public override string ToString()
         {
             StringBuilder output = new StringBuilder();
 
-            if (win)
+            if (Win)
             {
                 output.Append("Win + ");
             }
 
-            if (ctrl)
+            if (Ctrl)
             {
                 output.Append("Ctrl + ");
             }
 
-            if (alt)
+            if (Alt)
             {
                 output.Append("Alt + ");
             }
 
-            if (shift)
+            if (Shift)
             {
                 output.Append("Shift + ");
             }
 
-            output.Append(key);
+            output.Append(Key);
             return output.ToString();
         }
     }

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/KeyBoardKeysProperty.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/KeyBoardKeysProperty.cs
@@ -5,24 +5,18 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
-using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.PowerToys.Settings.UI.Lib
 {
-    public class BoolProperty
+    public class KeyBoardKeysProperty
     {
-        public BoolProperty()
+        public KeyBoardKeysProperty()
         {
-            this.Value = false;
+            this.Value = new HotkeySettings();
         }
 
         [JsonPropertyName("value")]
-        public bool Value { get; set; }
-
-        public override string ToString()
-        {
-            return JsonSerializer.Serialize(this);
-        }
+        public HotkeySettings Value { get; set; }
     }
 }

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/SndFancyZonesSettings.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/SndFancyZonesSettings.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.PowerToys.Settings.UI.Lib
+{
+    public class SndFancyZonesSettings
+    {
+        public FancyZonesSettings FancyZones { get; set; }
+
+        public SndFancyZonesSettings(FancyZonesSettings settings)
+        {
+            this.FancyZones = settings;
+        }
+
+        public string ToJsonString()
+        {
+            return JsonSerializer.Serialize(this);
+        }
+    }
+}

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/StringProperty.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/StringProperty.cs
@@ -2,22 +2,25 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Collections.Generic;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.PowerToys.Settings.UI.Lib
 {
-    // Represents the configuration property of the settings that store Integer type.
-    public class IntProperty
+    // Represents the configuration property of the settings that store string type.
+    public class StringProperty
     {
-        public IntProperty()
+        public StringProperty()
         {
-            this.Value = 0;
+            this.Value = string.Empty;
         }
 
         // Gets or sets the integer value of the settings configuration.
         [JsonPropertyName("value")]
-        public int Value { get; set; }
+        public string Value { get; set; }
 
         // Returns a JSON version of the class settings configuration class.
         public override string ToString()

--- a/src/core/Microsoft.PowerToys.Settings.UI/Controls/HotkeySettingsControl.xaml.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Controls/HotkeySettingsControl.xaml.cs
@@ -72,28 +72,28 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
             if (IsDown(Windows.System.VirtualKey.LeftWindows) ||
                 IsDown(Windows.System.VirtualKey.RightWindows))
             {
-                settings.win = true;
+                settings.Win = true;
             }
 
             if (IsDown(Windows.System.VirtualKey.Control))
             {
-                settings.ctrl = true;
+                settings.Ctrl = true;
             }
 
             if (IsDown(Windows.System.VirtualKey.Menu))
             {
-                settings.alt = true;
+                settings.Alt = true;
             }
 
             if (IsDown(Windows.System.VirtualKey.Shift))
             {
-                settings.shift = true;
+                settings.Shift = true;
             }
 
-            settings.key = e.Key.ToString();
+            settings.Key = e.Key.ToString();
 
             // TODO: Check that e.OriginalKey is the ScanCode. It is not clear from docs.
-            settings.code = (int)e.OriginalKey;
+            settings.Code = (int)e.OriginalKey;
             HotkeySettings = settings;
         }
     }

--- a/src/core/Microsoft.PowerToys.Settings.UI/Microsoft.PowerToys.Settings.UI.csproj
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Microsoft.PowerToys.Settings.UI.csproj
@@ -66,6 +66,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Services\ActivationService.cs" />
     <Compile Include="Services\NavigationService.cs" />
+    <Compile Include="ViewModels\Commands\ButtonClickCommand.cs" />
     <Compile Include="ViewModels\GeneralViewModel.cs" />
     <Compile Include="ViewModels\FancyZonesViewModel.cs" />
     <Compile Include="ViewModels\ImageResizerViewModel.cs" />

--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -254,4 +254,70 @@
     <value>To:</value>
     <comment>Keyboard Manager mapping keys view right header</comment>
   </data>
+  <data name="About_This_Feature.Text" xml:space="preserve">
+    <value>About this feature</value>
+  </data>
+  <data name="Appearancce_GroupSettings.Text" xml:space="preserve">
+    <value>Appearance</value>
+  </data>
+  <data name="FancyZones_Description.Text" xml:space="preserve">
+    <value>Create window layouts to help make multi-tasking easy.</value>
+  </data>
+  <data name="FancyZones_DisplayChangeMoveWindowsCheckBoxControl.Content" xml:space="preserve">
+    <value>Keep windows in their zones when the screen resolution changes</value>
+  </data>
+  <data name="FancyZones_EnableToggleControl_HeaderText.Header" xml:space="preserve">
+    <value>Enable FancyZones</value>
+  </data>
+  <data name="FancyZones_ExcludeApps.Text" xml:space="preserve">
+    <value>Excluded apps</value>
+  </data>
+  <data name="FancyZones_ExcludeApps_TextBoxControl.Header" xml:space="preserve">
+    <value>To exclude an application from snapping to zones add its name here (one per line). Excluded apps will react to the Windows Snap regardless of all other settings.</value>
+  </data>
+  <data name="FancyZones_HighlightOpacity.Header" xml:space="preserve">
+    <value>Zone highlight opacity (%)</value>
+  </data>
+  <data name="FancyZones_HokeyEditorControl_Header.Header" xml:space="preserve">
+    <value>Edit Hot Key/ Shortcut</value>
+  </data>
+  <data name="FancyZones_KeepWindowsPinned.Content" xml:space="preserve">
+    <value>Keep windows pinned to multiple desktops in the same zone when the active desktop changes</value>
+  </data>
+  <data name="FancyZones_LaunchEditorButtonControl_Header.Content" xml:space="preserve">
+    <value>Launch Zones Editor</value>
+  </data>
+  <data name="FancyZones_OverrideSnapHotkeysCheckBoxControl.Content" xml:space="preserve">
+    <value>Override Windows Snap hotkeys (Win + arrow) to move windows between zones</value>
+  </data>
+  <data name="FancyZones_SaveColorChoice.Content" xml:space="preserve">
+    <value>Save Color Choice</value>
+  </data>
+  <data name="FancyZones_ShiftDragCheckBoxControl_Header.Content" xml:space="preserve">
+    <value>Hold Shift key or any non-primary mouse button to enable zones while dragging</value>
+  </data>
+  <data name="FancyZones_UseCursorPosEditorStartupScreen.Content" xml:space="preserve">
+    <value>Follow mouse cursor instead of focus when launching editor in a multi screen environment</value>
+  </data>
+  <data name="FancyZones_VirtualDesktopChangeMoveWindows.Content" xml:space="preserve">
+    <value>Move newly created windows to their last known zone</value>
+  </data>
+  <data name="FancyZones_ZonBehaivior_GroupSettings.Text" xml:space="preserve">
+    <value>Zone behaviour</value>
+  </data>
+  <data name="FancyZones_ZoneHighlightColor.Text" xml:space="preserve">
+    <value>Zone highlight color (default: #0078D7)</value>
+  </data>
+  <data name="FancyZones_ZoneSetChangeFlashZonesCheckBoxControl.Content" xml:space="preserve">
+    <value>Flash zones when the active FancyZones layout changes</value>
+  </data>
+  <data name="FancyZones_ZoneSetChangeMoveWindows.Content" xml:space="preserve">
+    <value>During zone layout changes, windows assigned to a zone will match new size/positions</value>
+  </data>
+  <data name="Give_Feedback.Content" xml:space="preserve">
+    <value>Give feedback</value>
+  </data>
+  <data name="Module_overview.Content" xml:space="preserve">
+    <value>Module overview</value>
+  </data>
 </root>

--- a/src/core/Microsoft.PowerToys.Settings.UI/ViewModels/Commands/ButtonClickCommand.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/ViewModels/Commands/ButtonClickCommand.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Windows.Input;
+
+namespace Microsoft.PowerToys.Settings.UI.ViewModels.Commands
+{
+    public class ButtonClickCommand : ICommand
+    {
+        private readonly Action _execute;
+
+        public ButtonClickCommand(Action execute)
+        {
+            this._execute = execute;
+        }
+
+        // Occurs when changes occur that affect whether or not the command should execute.
+        public event EventHandler CanExecuteChanged;
+
+        // Defines the method that determines whether the command can execute in its current state.
+        public bool CanExecute(object parameter)
+        {
+            return true;
+        }
+
+        // Defines the method to be called when the command is invoked.
+        public void Execute(object parameter)
+        {
+            _execute();
+        }
+    }
+}

--- a/src/core/Microsoft.PowerToys.Settings.UI/ViewModels/FancyZonesViewModel.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/ViewModels/FancyZonesViewModel.cs
@@ -2,14 +2,366 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Runtime.CompilerServices;
+using System.Windows.Input;
 using Microsoft.PowerToys.Settings.UI.Helpers;
+using Microsoft.PowerToys.Settings.UI.Lib;
+using Microsoft.PowerToys.Settings.UI.ViewModels.Commands;
+using Microsoft.PowerToys.Settings.UI.Views;
+using Windows.UI;
+using Windows.UI.Popups;
 
 namespace Microsoft.PowerToys.Settings.UI.ViewModels
 {
     public class FancyZonesViewModel : Observable
     {
+        private const string ModuleName = "FancyZones";
+
+        public ButtonClickCommand LaunchEditorEventHandler { get; set; }
+
+        public ICommand SaveColorChoiceEventHandler
+        {
+            get
+            {
+                return new RelayCommand<Color>(SaveColorChoice);
+            }
+        }
+
+        private FancyZonesSettings Settings { get; set; }
+
         public FancyZonesViewModel()
         {
+            Settings = SettingsUtils.GetSettings<FancyZonesSettings>(ModuleName);
+            this.LaunchEditorEventHandler = new ButtonClickCommand(LaunchEditor);
+            // this.SaveColorChoiceEventHandler = new ButtonClickCommand(SaveColorChoice);
+
+            this._shiftDrag = Settings.Properties.FancyzonesShiftDrag.Value;
+            this._overrideSnapHotkeys = Settings.Properties.FancyzonesOverrideSnapHotkeys.Value;
+            this._flashZones = Settings.Properties.FancyzonesZoneSetChangeFlashZones.Value;
+            this._displayChangemoveWindows = Settings.Properties.FancyzonesDisplayChangeMoveWindows.Value;
+            this._zoneSetChangeMoveWindows = Settings.Properties.FancyzonesZoneSetChangeMoveWindows.Value;
+            this._virtualDesktopChangeMoveWindows = Settings.Properties.FancyzonesVirtualDesktopChangeMoveWindows.Value;
+            this._appLastZoneMoveWindows = Settings.Properties.FancyzonesAppLastZoneMoveWindows.Value;
+            this._useCursorPosEditorStartupScreen = Settings.Properties.UseCursorposEditorStartupscreen.Value;
+            this._showOnAllMonitors = Settings.Properties.FancyzonesShowOnAllMonitors.Value;
+            this._zoneHighlightColor = Settings.Properties.FancyzonesZoneHighlightColor.Value;
+            this._highlightOpacity = Settings.Properties.FancyzonesHighlightOpacity.Value;
+            this._excludedApps = Settings.Properties.FancyzonesExcludedApps.Value;
+            this._editorHotkey = Settings.Properties.FancyzonesEditorHotkey.Value;
+
+            GeneralSettings generalSettings = SettingsUtils.GetSettings<GeneralSettings>(string.Empty);
+            this._isEnabled = generalSettings.Enabled.FancyZones;
+        }
+
+        private bool _isEnabled;
+        private bool _shiftDrag;
+        private bool _overrideSnapHotkeys;
+        private bool _flashZones;
+        private bool _displayChangemoveWindows;
+        private bool _zoneSetChangeMoveWindows;
+        private bool _virtualDesktopChangeMoveWindows;
+        private bool _appLastZoneMoveWindows;
+        private bool _useCursorPosEditorStartupScreen;
+        private bool _showOnAllMonitors;
+        private string _zoneHighlightColor;
+        private int _highlightOpacity;
+        private string _excludedApps;
+        private HotkeySettings _editorHotkey;
+
+        public bool IsEnabled
+        {
+            get
+            {
+                return _isEnabled;
+            }
+
+            set
+            {
+                if (value != _isEnabled)
+                {
+                    _isEnabled = value;
+                    GeneralSettings generalSettings = SettingsUtils.GetSettings<GeneralSettings>(string.Empty);
+                    generalSettings.Enabled.FancyZones = value;
+                    OutGoingGeneralSettings snd = new OutGoingGeneralSettings(generalSettings);
+
+                    ShellPage.DefaultSndMSGCallback(snd.ToString());
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        public bool ShiftDrag
+        {
+            get
+            {
+                return _shiftDrag;
+            }
+
+            set
+            {
+                if (value != _shiftDrag)
+                {
+                    _shiftDrag = value;
+                    Settings.Properties.FancyzonesShiftDrag.Value = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        public bool OverrideSnapHotkeys
+        {
+            get
+            {
+                return _overrideSnapHotkeys;
+            }
+
+            set
+            {
+                if (value != _overrideSnapHotkeys)
+                {
+                    _overrideSnapHotkeys = value;
+                    Settings.Properties.FancyzonesOverrideSnapHotkeys.Value = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        public bool ZoneSetChangeFlashZones
+        {
+            get
+            {
+                return _flashZones;
+            }
+
+            set
+            {
+                if (value != _flashZones)
+                {
+                    _flashZones = value;
+                    Settings.Properties.FancyzonesZoneSetChangeFlashZones.Value = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        public bool DisplayChangeMoveWindows
+        {
+            get
+            {
+                return _displayChangemoveWindows;
+            }
+
+            set
+            {
+                if (value != _displayChangemoveWindows)
+                {
+                    _displayChangemoveWindows = value;
+                    Settings.Properties.FancyzonesDisplayChangeMoveWindows.Value = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        public bool ZoneSetChangeMoveWindows
+        {
+            get
+            {
+                return _zoneSetChangeMoveWindows;
+            }
+
+            set
+            {
+                if (value != _zoneSetChangeMoveWindows)
+                {
+                    _zoneSetChangeMoveWindows = value;
+                    Settings.Properties.FancyzonesZoneSetChangeMoveWindows.Value = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        public bool VirtualDesktopChangeMoveWindows
+        {
+            get
+            {
+                return _virtualDesktopChangeMoveWindows;
+            }
+
+            set
+            {
+                if (value != _virtualDesktopChangeMoveWindows)
+                {
+                    _virtualDesktopChangeMoveWindows = value;
+                    Settings.Properties.FancyzonesVirtualDesktopChangeMoveWindows.Value = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        public bool AppLastZoneMoveWindows
+        {
+            get
+            {
+                return _appLastZoneMoveWindows;
+            }
+
+            set
+            {
+                if (value != _appLastZoneMoveWindows)
+                {
+                    _appLastZoneMoveWindows = value;
+                    Settings.Properties.FancyzonesAppLastZoneMoveWindows.Value = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        public bool UseCursorPosEditorStartupScreen
+        {
+            get
+            {
+                return _useCursorPosEditorStartupScreen;
+            }
+
+            set
+            {
+                if (value != _useCursorPosEditorStartupScreen)
+                {
+                    _useCursorPosEditorStartupScreen = value;
+                    Settings.Properties.UseCursorposEditorStartupscreen.Value = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        public bool ShowOnAllMonitors
+        {
+            get
+            {
+                return _showOnAllMonitors;
+            }
+
+            set
+            {
+                if (value != _showOnAllMonitors)
+                {
+                    _showOnAllMonitors = value;
+                    Settings.Properties.FancyzonesShowOnAllMonitors.Value = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        public string ZoneHighlightColor
+        {
+            get
+            {
+                return _zoneHighlightColor;
+            }
+
+            set
+            {
+                if (value != _zoneHighlightColor)
+                {
+                    _zoneHighlightColor = value;
+                    Settings.Properties.FancyzonesZoneHighlightColor.Value = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        public int HighlightOpacity
+        {
+            get
+            {
+                return _highlightOpacity;
+            }
+
+            set
+            {
+                if (value != _highlightOpacity)
+                {
+                    _highlightOpacity = value;
+                    Settings.Properties.FancyzonesHighlightOpacity.Value = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        /*
+        public int EditorHotkey
+        {
+            get
+            {
+                return _editorHotkey;
+            }
+
+            set
+            {
+                if (value != _editorHotkey)
+                {
+                    _editorHotkey = value;
+                    Settings.Properties.FancyzonesHighlightOpacity.Value = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+        */
+
+        public HotkeySettings EditorHotkey
+        {
+            get
+            {
+                return _editorHotkey;
+            }
+
+            set
+            {
+                if (value != _editorHotkey)
+                {
+                    _editorHotkey = value;
+                    Settings.Properties.FancyzonesEditorHotkey.Value = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        public string ExcludedApps
+        {
+            get
+            {
+                return _excludedApps;
+            }
+
+            set
+            {
+                if (value != _excludedApps)
+                {
+                    _excludedApps = value;
+                    Settings.Properties.FancyzonesExcludedApps.Value = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        private void LaunchEditor()
+        {
+            // send message to launch the zones editor;
+            ShellPage.DefaultSndMSGCallback("{\"action\":{\"FancyZones\":{\"action_name\":\"ToggledFZEditor\", \"value\":\"\"}}}");
+        }
+
+        private void SaveColorChoice(Color color)
+        {
+            ZoneHighlightColor = color.ToString();
+        }
+
+        public void RaisePropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            OnPropertyChanged(propertyName);
+            SndFancyZonesSettings outsettings = new SndFancyZonesSettings(Settings);
+            SndModuleSettings<SndFancyZonesSettings> ipcMessage = new SndModuleSettings<SndFancyZonesSettings>(outsettings);
+            ShellPage.DefaultSndMSGCallback(ipcMessage.ToJsonString());
         }
     }
 }

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -5,9 +5,15 @@
     xmlns:local="using:Microsoft.PowerToys.Settings.UI.Views"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:viewModel="using:Microsoft.PowerToys.Settings.UI.ViewModels"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+    xmlns:CustomControls="using:Microsoft.PowerToys.Settings.UI.Controls"
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Page.Resources>
+        <viewModel:FancyZonesViewModel x:Key="eventViewModel"/>
+    </Page.Resources>
 
     <Grid ColumnSpacing="{StaticResource DefaultColumnSpacing}" RowSpacing="{StaticResource DefaultRowSpacing}">
         <VisualStateManager.VisualStateGroups>
@@ -41,69 +47,96 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <StackPanel Orientation="Vertical">
-            <TextBlock Text="Create window layouts to help make multi-tasking easy."
+        <StackPanel Orientation="Vertical" x:Name="FZSettingsView">
+            <TextBlock x:Uid="FancyZones_Description"
                        TextWrapping="Wrap"/>
 
-            <ToggleSwitch Header="Enable FancyZones"
-                          IsOn="True"
+            <ToggleSwitch x:Uid="FancyZones_EnableToggleControl_HeaderText"
+                          IsOn="{ Binding Mode=TwoWay, Path=IsEnabled}"
                           Margin="{StaticResource SmallTopMargin}" />
 
-            <TextBlock Text="Zone behaviour"
-                       Style="{StaticResource SettingsGroupTitleStyle}"/>
+            <TextBlock x:Uid="FancyZones_ZonBehaivior_GroupSettings"
+                       Style="{StaticResource SettingsGroupTitleStyle}"
+                       />
 
-            <CheckBox Content="Hold Shift key or any non-primary mouse button to enable zones while dragging"
-                          IsChecked="True"
-                          Margin="{StaticResource SmallTopMargin}"/>
+            <Button x:Uid="FancyZones_LaunchEditorButtonControl_Header"
+                    Margin="{StaticResource SmallTopMargin}"
+                    Style="{StaticResource AccentButtonStyle}"
+                    Command = "{Binding LaunchEditorEventHandler, Source={StaticResource eventViewModel}}"
+                    IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"
+                    />
 
-            <CheckBox Content="Override Windows Snap hotkeys (Win + arrow) to move windows between zones"
-                          IsChecked="True"
-                          Margin="{StaticResource SmallTopMargin}"/>
+            <CustomControls:HotkeySettingsControl 
+                                          x:Uid="FancyZones_HokeyEditorControl_Header"
+                                          Width="320"
+                                          HorizontalAlignment="Left"
+                                          Margin="{StaticResource SmallTopMargin}"
+                                          HotkeySettings="{x:Bind Path=ViewModel.EditorHotkey, Mode=TwoWay}"
+                                          IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"        
+                                        />
 
-            <CheckBox Content="Flash zones when the active FancyZones layout changes"
-                          IsChecked="True"
-                          Margin="{StaticResource SmallTopMargin}"/>
+            <CheckBox x:Uid="FancyZones_ShiftDragCheckBoxControl_Header"
+                      IsChecked="{ Binding Mode=TwoWay, Path=ShiftDrag}"
+                      Margin="{StaticResource SmallTopMargin}"
+                      IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"
+                      />
 
-            <CheckBox Content="Keep windows in their zones when the screen resolution changes"
-                          IsChecked="True"
-                          Margin="{StaticResource SmallTopMargin}"/>
+            <CheckBox x:Uid="FancyZones_OverrideSnapHotkeysCheckBoxControl"
+                      IsChecked="{ Binding Mode=TwoWay, Path=OverrideSnapHotkeys}"
+                      Margin="{StaticResource SmallTopMargin}"
+                      IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"/>
 
-            <CheckBox Content="During zone layout changes, windows assigned to a zone will match new size/positions"
-                          IsChecked="True"
-                          Margin="{StaticResource SmallTopMargin}"/>
+            <CheckBox x:Uid="FancyZones_ZoneSetChangeFlashZonesCheckBoxControl"
+                      IsChecked="{ Binding Mode=TwoWay, Path=ZoneSetChangeFlashZones}"
+                      Margin="{StaticResource SmallTopMargin}"
+                      IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"/>
 
-            <CheckBox Content="Keep windows pinned to multiple desktops in the same zone when the active desktop changes"
-                          IsChecked="True"
-                          Margin="{StaticResource SmallTopMargin}"/>
+            <CheckBox x:Uid="FancyZones_DisplayChangeMoveWindowsCheckBoxControl"
+                      IsChecked="{ Binding Mode=TwoWay, Path=DisplayChangeMoveWindows}"
+                      Margin="{StaticResource SmallTopMargin}"
+                      IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"
+                      />
 
-            <CheckBox Content="Move newly created windows to their last known zone"
-                          IsChecked="True"
-                          Margin="{StaticResource SmallTopMargin}"/>
+            <CheckBox x:Uid="FancyZones_ZoneSetChangeMoveWindows"
+                      IsChecked="{ Binding Mode=TwoWay, Path=ZoneSetChangeMoveWindows}"
+                      Margin="{StaticResource SmallTopMargin}"
+                      IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"/>
 
-            <CheckBox Content="Follow mouse cursor instead of focus when launching editor in a multi screen environment"
-                          IsChecked="True"
-                          Margin="{StaticResource SmallTopMargin}"/>
+            <CheckBox x:Uid="FancyZones_KeepWindowsPinned"
+                      IsChecked="{ Binding Mode=TwoWay, Path=VirtualDesktopChangeMoveWindows}"
+                      Margin="{StaticResource SmallTopMargin}"
+                      IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"/>
+
+            <CheckBox x:Uid="FancyZones_VirtualDesktopChangeMoveWindows"
+                      IsChecked="{ Binding Mode=TwoWay, Path=AppLastZoneMoveWindows}"
+                      Margin="{StaticResource SmallTopMargin}"
+                      IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"/>
+
+            <CheckBox x:Uid="FancyZones_UseCursorPosEditorStartupScreen"
+                      IsChecked="{ Binding Mode=TwoWay, Path=UseCursorPosEditorStartupScreen}"
+                      Margin="{StaticResource SmallTopMargin}"
+                      IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"/>
 
 
-
-
-            <TextBlock Text="Appearance" 
+            <TextBlock x:Uid="Appearancce_GroupSettings"
                        Style="{StaticResource SettingsGroupTitleStyle}"/>
 
             <!-- TO DO: Do we still need this numberbox? The colorpicker has an Alpha/Opacity option as well so we could use that -->
-            <muxc:NumberBox Header="Zone highlight opacity (%)"
-                            Value="90"
+            <muxc:NumberBox x:Uid="FancyZones_HighlightOpacity"
+                            Value="{ Binding Mode=TwoWay, Path=HighlightOpacity}"
                             Minimum="0"
                             Maximum="100"
                             SpinButtonPlacementMode="Inline"
                             HorizontalAlignment="Left"
-                            Margin="{StaticResource SmallTopMargin}" />
+                            Margin="{StaticResource SmallTopMargin}" 
+                            IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"/>
 
-            <TextBlock Text="Zone highlight color (default: #0078D7)" 
+            <TextBlock x:Uid="FancyZones_ZoneHighlightColor" 
                        Style="{StaticResource BodyTextBlockStyle}"
                        Margin="{StaticResource SmallTopMargin}" />
-            
-            <muxc:ColorPicker Margin="0,6,0,0"
+
+            <muxc:ColorPicker x:Name="ColorChoice"
+                              Margin="0,6,0,0"
                               HorizontalAlignment="Left"
                               IsMoreButtonVisible="True"
                               IsColorSliderVisible="True"
@@ -111,32 +144,52 @@
                               IsHexInputVisible="True"
                               IsAlphaEnabled="True"
                               IsAlphaSliderVisible="True"
-                              IsAlphaTextInputVisible="True" />
+                              IsAlphaTextInputVisible="True"
+                              Color="{Binding Path=ZoneHighlightColor, Mode=TwoWay, Source={StaticResource eventViewModel}}"
+                              IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"/>
 
-            <TextBlock Text="Excluded apps" 
+            <Button x:Uid="FancyZones_SaveColorChoice"
+                    Margin="{StaticResource SmallTopMargin}"
+                    Style="{StaticResource AccentButtonStyle}"
+                    Command = "{Binding SaveColorChoiceEventHandler, Source={StaticResource eventViewModel}}"
+                    CommandParameter="{Binding Color, ElementName=ColorChoice}"
+                    IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"/>
+
+            <TextBlock x:Uid="FancyZones_ExcludeApps"
                        Style="{StaticResource SettingsGroupTitleStyle}"/>
 
-            <TextBox Header="To exclude an application from snapping to zones add its name here (one per line). Excluded apps will react to the Windows Snap regardless of all other settings."
-                     Margin="{StaticResource SmallTopMargin}"/>
-            
-        </StackPanel>
-        
-        <StackPanel 
-            x:Name="SidePanel"
-            Orientation="Vertical"
-            HorizontalAlignment="Left"
-            Width="{StaticResource SidePanelWidth}"
-            Grid.Column="1">
+            <TextBox x:Uid="FancyZones_ExcludeApps_TextBoxControl"
+                     Margin="{StaticResource SmallTopMargin}"
+                     Text="{ Binding Mode=TwoWay, Path=ExcludedApps}"
+                     IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"/>
 
-            <TextBlock
-                Text="About this feature"
-                Style="{StaticResource SettingsGroupTitleStyle}"
-                Margin="{StaticResource XSmallBottomMargin}"/>
-            <Image 
-                Source="https://user-images.githubusercontent.com/9866362/77859136-f04ae880-7207-11ea-8a7f-4295342fe319.gif" />
-            <HyperlinkButton 
-                Content="Module overview" 
-                NavigateUri="https://github.com/microsoft/PowerToys/blob/master/src/modules/fancyzones/README.md"/>
+        </StackPanel>
+
+        <StackPanel x:Name="SidePanel"
+                    Orientation="Vertical"
+                    HorizontalAlignment="Left"
+                    Width="{StaticResource SidePanelWidth}"
+                    Grid.Column="1">
+
+            <TextBlock x:Uid="About_This_Feature"
+                       Style="{StaticResource SettingsGroupTitleStyle}"
+                       Margin="{StaticResource XSmallBottomMargin}"/>
+            
+            <Image Source="https://user-images.githubusercontent.com/9866362/77859136-f04ae880-7207-11ea-8a7f-4295342fe319.gif" />
+
+            <HyperlinkButton x:Uid="Module_overview"
+                             NavigateUri="https://github.com/microsoft/PowerToys/blob/master/src/modules/fancyzones/README.md"/>
+
+            <HyperlinkButton x:Uid="Give_Feedback" NavigateUri="https://github.com/microsoft/PowerToys/issues"/>
+
+            <!--
+            <TextBlock Text="Contributors"
+                           Style="{StaticResource SettingsGroupTitleStyle}"/>
+
+            <HyperlinkButton Content="Contributor name"/>
+            <HyperlinkButton Content="Contributor name"/>
+            <HyperlinkButton Content="Contributor name"/>
+            -->
         </StackPanel>
     </Grid>
 </Page>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml.cs
@@ -2,18 +2,33 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
 using Microsoft.PowerToys.Settings.UI.ViewModels;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
 
 namespace Microsoft.PowerToys.Settings.UI.Views
 {
     public sealed partial class FancyZonesPage : Page
     {
-        public FancyZonesViewModel ViewModel { get; } = new FancyZonesViewModel();
+        public FancyZonesViewModel ViewModel { get; set; }
 
         public FancyZonesPage()
         {
-            InitializeComponent();
+            this.InitializeComponent();
+            ViewModel = new FancyZonesViewModel();
+            this.FZSettingsView.DataContext = ViewModel;
         }
     }
 }

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml.cs
@@ -42,10 +42,10 @@ namespace Microsoft.PowerToys.Settings.UI.Views
                 settings = SettingsUtils.GetSettings<GeneralSettings>(string.Empty);
 
                 // load and apply theme settings
-                ReLoadTheme(settings.theme);
+                ReLoadTheme(settings.Theme);
 
                 // load run on start-up settings value and update the ui state.
-                ToggleSwitch_RunAtStartUp.IsOn = settings.startup;
+                ToggleSwitch_RunAtStartUp.IsOn = settings.Startup;
             }
             catch
             {
@@ -54,10 +54,10 @@ namespace Microsoft.PowerToys.Settings.UI.Views
                 SettingsUtils.SaveSettings(settings.ToJsonString(), string.Empty);
 
                 // load and apply theme settings
-                ReLoadTheme(settings.theme);
+                ReLoadTheme(settings.Theme);
 
                 // load run on start up ui settings value and update the ui state.
-                ToggleSwitch_RunAtStartUp.IsOn = settings.startup;
+                ToggleSwitch_RunAtStartUp.IsOn = settings.Startup;
             }
         }
 
@@ -96,10 +96,10 @@ namespace Microsoft.PowerToys.Settings.UI.Views
                 switch (startup)
                 {
                     case "true":
-                        settings.startup = true;
+                        settings.Startup = true;
                         break;
                     case "false":
-                        settings.startup = false;
+                        settings.Startup = false;
                         break;
                 }
 
@@ -116,7 +116,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
         private void Restart_Elevated(object sender, RoutedEventArgs e)
         {
             GeneralSettings settings = SettingsUtils.GetSettings<GeneralSettings>(string.Empty);
-            settings.run_elevated = true;
+            settings.RunElevated = true;
             OutGoingGeneralSettings outsettings = new OutGoingGeneralSettings(settings);
 
             if (ShellPage.DefaultSndMSGCallback != null)
@@ -136,7 +136,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
 
                 // update and save settings to file.
                 GeneralSettings settings = SettingsUtils.GetSettings<GeneralSettings>(string.Empty);
-                settings.theme = themeName;
+                settings.Theme = themeName;
                 SettingsUtils.SaveSettings(settings.ToJsonString(), string.Empty);
             }
         }

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerPreviewPage.xaml.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerPreviewPage.xaml.cs
@@ -29,15 +29,15 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             {
                 base.OnNavigatedTo(e);
                 settings = SettingsUtils.GetSettings<PowerPreviewSettings>(PreviewPaneKey);
-                ToggleSwitch_Preview_SVG.IsOn = settings.properties.IDS_PREVPANE_SVG_BOOL_TOGGLE_CONTROLL.value;
-                ToggleSwitch_Preview_MD.IsOn = settings.properties.PREVPANE_MD_BOOL_TOGGLE_CONTROLL_ID.value;
+                ToggleSwitch_Preview_SVG.IsOn = settings.properties.IDS_PREVPANE_SVG_BOOL_TOGGLE_CONTROLL.Value;
+                ToggleSwitch_Preview_MD.IsOn = settings.properties.PREVPANE_MD_BOOL_TOGGLE_CONTROLL_ID.Value;
             }
             catch
             {
                 settings = new PowerPreviewSettings(PreviewPaneKey);
                 SettingsUtils.SaveSettings(settings.ToJsonString(), PreviewPaneKey);
-                ToggleSwitch_Preview_SVG.IsOn = settings.properties.IDS_PREVPANE_SVG_BOOL_TOGGLE_CONTROLL.value;
-                ToggleSwitch_Preview_MD.IsOn = settings.properties.PREVPANE_MD_BOOL_TOGGLE_CONTROLL_ID.value;
+                ToggleSwitch_Preview_SVG.IsOn = settings.properties.IDS_PREVPANE_SVG_BOOL_TOGGLE_CONTROLL.Value;
+                ToggleSwitch_Preview_MD.IsOn = settings.properties.PREVPANE_MD_BOOL_TOGGLE_CONTROLL_ID.Value;
             }
         }
 
@@ -48,7 +48,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             if (swt != null)
             {
                 PowerPreviewSettings settings = SettingsUtils.GetSettings<PowerPreviewSettings>(PreviewPaneKey);
-                settings.properties.IDS_PREVPANE_SVG_BOOL_TOGGLE_CONTROLL.value = swt.IsOn;
+                settings.properties.IDS_PREVPANE_SVG_BOOL_TOGGLE_CONTROLL.Value = swt.IsOn;
 
                 if (ShellPage.DefaultSndMSGCallback != null)
                 {
@@ -66,7 +66,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             if (swt != null)
             {
                 PowerPreviewSettings settings = SettingsUtils.GetSettings<PowerPreviewSettings>(PreviewPaneKey);
-                settings.properties.PREVPANE_MD_BOOL_TOGGLE_CONTROLL_ID.value = swt.IsOn;
+                settings.properties.PREVPANE_MD_BOOL_TOGGLE_CONTROLL_ID.Value = swt.IsOn;
 
                 if (ShellPage.DefaultSndMSGCallback != null)
                 {

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerRenamePage.xaml.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerRenamePage.xaml.cs
@@ -43,11 +43,11 @@ namespace Microsoft.PowerToys.Settings.UI.Views
 
         private void UpdateView(PowerRenameSettings settings)
         {
-            Toggle_PowerRename_Enable.IsOn = settings.properties.MruEnabled.value;
-            Toggle_PowerRename_EnableOnExtendedContextMenu.IsOn = settings.properties.ShowExtendedMenu.value;
-            Toggle_PowerRename_MaxDispListNum.Value = settings.properties.MaxMruSize.value;
-            Toggle_PowerRename_EnableOnContextMenu.IsOn = settings.properties.ShowIconInMenu.value;
-            Toggle_PowerRename_RestoreFlagsOnLaunch.IsOn = settings.properties.PersistInput.value;
+            Toggle_PowerRename_Enable.IsOn = settings.properties.MruEnabled.Value;
+            Toggle_PowerRename_EnableOnExtendedContextMenu.IsOn = settings.properties.ShowExtendedMenu.Value;
+            Toggle_PowerRename_MaxDispListNum.Value = settings.properties.MaxMruSize.Value;
+            Toggle_PowerRename_EnableOnContextMenu.IsOn = settings.properties.ShowIconInMenu.Value;
+            Toggle_PowerRename_RestoreFlagsOnLaunch.IsOn = settings.properties.PersistInput.Value;
         }
 
         private void Toggle_PowerRename_Enable_Toggled(object sender, RoutedEventArgs e)
@@ -57,7 +57,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             if (swt != null)
             {
                 PowerRenameSettings settings = SettingsUtils.GetSettings<PowerRenameSettings>(POWERTOYNAME);
-                settings.properties.MruEnabled.value = swt.IsOn;
+                settings.properties.MruEnabled.Value = swt.IsOn;
 
                 if (ShellPage.DefaultSndMSGCallback != null)
                 {
@@ -75,7 +75,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             if (swt != null)
             {
                 PowerRenameSettings settings = SettingsUtils.GetSettings<PowerRenameSettings>(POWERTOYNAME);
-                settings.properties.ShowIconInMenu.value = swt.IsOn;
+                settings.properties.ShowIconInMenu.Value = swt.IsOn;
 
                 if (ShellPage.DefaultSndMSGCallback != null)
                 {
@@ -93,7 +93,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             if (swt != null)
             {
                 PowerRenameSettings settings = SettingsUtils.GetSettings<PowerRenameSettings>(POWERTOYNAME);
-                settings.properties.ShowExtendedMenu.value = swt.IsOn;
+                settings.properties.ShowExtendedMenu.Value = swt.IsOn;
 
                 if (ShellPage.DefaultSndMSGCallback != null)
                 {
@@ -111,7 +111,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             if (swt != null)
             {
                 PowerRenameSettings settings = SettingsUtils.GetSettings<PowerRenameSettings>(POWERTOYNAME);
-                settings.properties.PersistInput.value = swt.IsOn;
+                settings.properties.PersistInput.Value = swt.IsOn;
 
                 if (ShellPage.DefaultSndMSGCallback != null)
                 {
@@ -127,7 +127,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             if (sender != null)
             {
                 PowerRenameSettings settings = SettingsUtils.GetSettings<PowerRenameSettings>(POWERTOYNAME);
-                settings.properties.MaxMruSize.value = Convert.ToInt32(sender.Value);
+                settings.properties.MaxMruSize.Value = Convert.ToInt32(sender.Value);
 
                 if (ShellPage.DefaultSndMSGCallback != null)
                 {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
- Added ViewModel implementation of the FancyZones settings.
- Move Text in XAML to a localized string resource.
- Added Flag to disable UI controls when the PowerToy is disabled.

Demo: https://github.com/microsoft/PowerToys/blob/user/laius/temp/doc/images/FZ_Settings_V2_Demo_GIF.gif

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #889, #2127
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #889, #2127

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Verified changes in the JSON settings file and the UI itself. 