### PR TITLE
[Settings V2] Release notes link + minor styling fixes

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml
@@ -44,7 +44,7 @@
 
             <ToggleSwitch Header="Run at startup" x:Name="ToggleSwitch_RunAtStartUp"  Margin="{StaticResource SmallTopMargin}" Toggled="ToggleSwitch_RunAtStartUp_Toggled" />
 
-            <muxc:RadioButtons Header="Theme" Margin="{StaticResource SmallTopMargin}">
+            <muxc:RadioButtons Header="Theme" Margin="{StaticResource MediumTopMargin}">
                 <RadioButton x:Name="Radio_Theme_Dark" Content="Dark" Tag="Dark" Checked="Theme_Changed"/>
                 <RadioButton x:Name="Radio_Theme_Light"  Content="Light" Tag="Light" Checked="Theme_Changed"/>
                 <RadioButton x:Name="Radio_Theme_Default"  Content="System default" Tag="System" Checked="Theme_Changed"/>
@@ -58,7 +58,7 @@
 
             <Button 
                 Content="Restart as admin" 
-                Margin="{StaticResource SmallTopMargin}" 
+                Margin="{StaticResource MediumTopMargin}" 
                 Style="{StaticResource AccentButtonStyle}" 
                 Click="Restart_Elevated" />
 

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml
@@ -89,16 +89,18 @@
                 Text="Version 0.15.2" 
                 FontWeight="Bold"
                 Margin="{StaticResource SmallTopMargin}" />
+            <HyperlinkButton 
+                Content="Release notes" 
+                NavigateUri="https://github.com/microsoft/PowerToys/releases"  />
             <Button 
                 Content="Check for updates" 
                 Margin="{StaticResource SmallTopMargin}" 
                 Style="{StaticResource AccentButtonStyle}" 
                 Click="CheckForUpdates_Click" />
-
             <HyperlinkButton 
                 Content="Report a bug" 
                 NavigateUri="https://github.com/microsoft/PowerToys/issues" 
-                Margin="{StaticResource SmallTopMargin}" />
+                Margin="{StaticResource MediumTopMargin}" />
             <HyperlinkButton 
                 Content="Request a feature"  
                 NavigateUri="https://github.com/microsoft/PowerToys/issues"/>


### PR DESCRIPTION
## Summary of the Pull Request
- Increased the vertical margins between the 3 settings since they are not related to each other.
- Added a Release notes link.

![image](https://user-images.githubusercontent.com/9866362/79507362-deef4200-8037-11ea-86cc-0672a6492ff2.png)


## References
#2138 #889 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Applies to #2138 #889 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

