### PR TITLE
Auto completion feature for text box

### DIFF
--- a/src/modules/launcher/PowerLauncher.UI/LauncherControl.xaml
+++ b/src/modules/launcher/PowerLauncher.UI/LauncherControl.xaml
@@ -416,6 +416,21 @@
         Translation="0,0,16" 
         VerticalAlignment="Top">
         <TextBox
+            x:Name="AutoCompleteTextBox"
+            x:FieldModifier="public"
+            Style="{StaticResource CustomAutoSuggestBoxTextBoxStyle}"
+            PlaceholderText="{Binding AutoCompleteText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+            Height="72"
+            IsReadOnly="True"
+            AllowFocusOnInteraction="False"
+            ScrollViewer.BringIntoViewOnFocusChange="False"
+            Canvas.ZIndex="0"
+            Margin="0" 
+            VerticalAlignment="Center"
+            FontSize="24"
+            DesiredCandidateWindowAlignment="BottomEdge" />
+        
+        <TextBox
             x:Name="TextBox"
             x:FieldModifier="public"
             Style="{StaticResource CustomAutoSuggestBoxTextBoxStyle}"

--- a/src/modules/launcher/PowerLauncher.UI/LauncherControl.xaml
+++ b/src/modules/launcher/PowerLauncher.UI/LauncherControl.xaml
@@ -419,7 +419,7 @@
             x:Name="AutoCompleteTextBox"
             x:FieldModifier="public"
             Style="{StaticResource CustomAutoSuggestBoxTextBoxStyle}"
-            PlaceholderText="{Binding AutoCompleteText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+            PlaceholderText="{Binding AutoCompleteText, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
             Height="72"
             IsReadOnly="True"
             AllowFocusOnInteraction="False"

--- a/src/modules/launcher/PowerLauncher.UI/LauncherControl.xaml
+++ b/src/modules/launcher/PowerLauncher.UI/LauncherControl.xaml
@@ -419,7 +419,6 @@
             x:Name="AutoCompleteTextBox"
             x:FieldModifier="public"
             Style="{StaticResource CustomAutoSuggestBoxTextBoxStyle}"
-            PlaceholderText="{Binding AutoCompleteText, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}"
             Height="72"
             IsReadOnly="True"
             AllowFocusOnInteraction="False"

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -286,6 +286,7 @@ namespace PowerLauncher
             // To populate the AutoCompleteTextBox as soon as the selection is changed or set.
             // Setting it here instead of when the text is changed as there is a delay in executing the query and populating the result
             _launcher.AutoCompleteTextBox.PlaceholderText = ListView_FirstItem(_viewModel.QueryText);
+
         }
 
         private void ResultsList_ItemClick(object sender, ItemClickEventArgs e)
@@ -332,6 +333,7 @@ namespace PowerLauncher
 
             return String.Empty;
         }
+
 
         private void QueryTextBox_TextChanged(object sender, Windows.UI.Xaml.Controls.TextChangedEventArgs e)
         {

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -239,6 +239,7 @@ namespace PowerLauncher
             _resultList.SuggestionsList.SelectionChanged += SuggestionsList_SelectionChanged;
         }
 
+
         private void _launcher_KeyDown(object sender, KeyRoutedEventArgs e)
         {
             if (e.Key == VirtualKey.Down)
@@ -281,6 +282,10 @@ namespace PowerLauncher
             {
                 listview.ScrollIntoView(e.AddedItems[0]);
             }
+
+            // To populate the AutoCompleteTextBox as soon as the selection is changed or set.
+            // Setting it here instead of when the text is changed as there is a delay in executing the query and populating the result
+            _launcher.AutoCompleteTextBox.PlaceholderText = ListView_FirstItem(_viewModel.QueryText);
         }
 
         private void ResultsList_ItemClick(object sender, ItemClickEventArgs e)
@@ -309,12 +314,37 @@ namespace PowerLauncher
         private const int millisecondsToWait = 200;
         private static DateTime s_lastTimeOfTyping;
 
+        private string ListView_FirstItem(String input)
+        {
+            string s = input;
+            if (s.Length > 0)
+            {
+                String selectedItem = _viewModel.Results?.SelectedItem?.ToString();
+                int selectedIndex = _viewModel.Results.SelectedIndex;
+                if (selectedItem != null)
+                {
+                    if (selectedItem.IndexOf(input) == 0)
+                    {
+                        return selectedItem;
+                    }
+                }
+            }
+
+            return String.Empty;
+        }
+
         private void QueryTextBox_TextChanged(object sender, Windows.UI.Xaml.Controls.TextChangedEventArgs e)
         {
             var latestTimeOfTyping = DateTime.Now;
             var text = ((Windows.UI.Xaml.Controls.TextBox)sender).Text;
             Task.Run(() => DelayedCheck(latestTimeOfTyping, text));
             s_lastTimeOfTyping = latestTimeOfTyping;
+
+            //To clear the auto-suggest immediately instead of waiting for selection changed
+            if(text == String.Empty)
+            {
+                _launcher.AutoCompleteTextBox.PlaceholderText = String.Empty;
+            }
         }
 
         private async Task DelayedCheck(DateTime latestTimeOfTyping, string text)

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -322,7 +322,7 @@ namespace PowerLauncher
             {
                 String selectedItem = _viewModel.Results?.SelectedItem?.ToString();
                 int selectedIndex = _viewModel.Results.SelectedIndex;
-                if (selectedItem != null)
+                if (selectedItem != null && selectedIndex == 0)
                 {
                     if (selectedItem.IndexOf(input) == 0)
                     {

--- a/src/modules/launcher/PowerLauncher/ResultListBox.xaml
+++ b/src/modules/launcher/PowerLauncher/ResultListBox.xaml
@@ -1,5 +1,4 @@
 ﻿<ListBox x:Class="PowerLauncher.ResultListBox"
-         x:Name="ListBox"
          xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
          xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
          xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"

--- a/src/modules/launcher/PowerLauncher/ResultListBox.xaml
+++ b/src/modules/launcher/PowerLauncher/ResultListBox.xaml
@@ -1,4 +1,5 @@
 ﻿<ListBox x:Class="PowerLauncher.ResultListBox"
+         x:Name="ListBox"
          xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
          xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
          xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
* The text box now has the auto-complete feature.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
* The auto-completion text is set as soon as the selection is set to the first item.
* The auto-completion is removed as soon as there is no more text in the Search box.

However, as there is a slight delay in the dropdown being produced and the first item to show up, the auto-complete text stays a bit longer when changing from one to another. The following GIF explains this scenario. However, that is the earliest point in which we get the event that the list has been modified. 

We are artificially inducing a 200 ms delay in populating executing and obtaining the results. It seems like a high value and I can notice a visible change in the results showing up between 20 and 200 ms delay (on my system). 

When there is a 200 ms delay -
![autocomplete_delay](https://user-images.githubusercontent.com/28739210/79626586-13b9d280-80e6-11ea-9e1c-61d902998a90.gif)

When there is a 20 ms delay - 
![autocomplete_nodelay](https://user-images.githubusercontent.com/28739210/79626706-07824500-80e7-11ea-880c-c6554c558d0c.gif)

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
* Manually tested its working.