### PR TITLE
[FancyZones] zone settings: update virtual desktop data on app start

### DIFF
--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -195,6 +195,7 @@ private:
     void RegisterVirtualDesktopUpdates(std::unordered_set<GUID>& currentVirtualDesktopIds) noexcept;
     void RegisterNewWorkArea(GUID virtualDesktopId, HMONITOR monitor) noexcept;
     bool IsNewWorkArea(GUID virtualDesktopId, HMONITOR monitor) noexcept;
+    void LoadWorkAreas();
 
     void OnEditorExitEvent() noexcept;
 
@@ -266,6 +267,9 @@ FancyZones::Run() noexcept
                           SetThreadDpiHostingBehavior(DPI_HOSTING_BEHAVIOR_MIXED);
                       } })
         .wait();
+
+
+    LoadWorkAreas();
 
     if (RegOpenKeyEx(HKEY_CURRENT_USER, L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\VirtualDesktops", 0, KEY_ALL_ACCESS, &m_virtualDesktopsRegKey) == ERROR_SUCCESS)
     {
@@ -1200,6 +1204,16 @@ bool FancyZones::IsNewWorkArea(GUID virtualDesktopId, HMONITOR monitor) noexcept
         return std::find(it->second.begin(), it->second.end(), monitor) == it->second.end();
     }
     return true;
+}
+
+void FancyZones::LoadWorkAreas()
+{
+    const auto& fancyZonesData = JSONHelpers::FancyZonesDataInstance();
+    const auto usedVirtualDesktops = fancyZonesData.GetVirtualDeslktopIds();
+    for (auto id : usedVirtualDesktops)
+    {
+        m_processedWorkAreas[id] = std::vector<HMONITOR>();
+    }
 }
 
 void FancyZones::OnEditorExitEvent() noexcept

--- a/src/modules/fancyzones/lib/JsonHelpers.cpp
+++ b/src/modules/fancyzones/lib/JsonHelpers.cpp
@@ -276,6 +276,21 @@ namespace JSONHelpers
         }
     }
 
+    std::vector<GUID> FancyZonesData::GetVirtualDeslktopIds() const
+    {
+        std::vector<GUID> ids;
+        for (auto it = deviceInfoMap.begin(); it != deviceInfoMap.end(); ++it)
+        {
+            const std::wstring& idStr = ExtractVirtualDesktopId(it->first);
+            GUID id;
+            if (SUCCEEDED_LOG(CLSIDFromString(idStr.c_str(), &id)))
+            {
+                ids.push_back(id);    
+            }
+        }
+        return ids;
+    }
+
     bool FancyZonesData::RemoveDevicesByVirtualDesktopId(const std::wstring& virtualDesktopId)
     {
         std::scoped_lock lock{ dataLock };

--- a/src/modules/fancyzones/lib/JsonHelpers.cpp
+++ b/src/modules/fancyzones/lib/JsonHelpers.cpp
@@ -279,13 +279,13 @@ namespace JSONHelpers
     std::vector<GUID> FancyZonesData::GetVirtualDeslktopIds() const
     {
         std::vector<GUID> ids;
-        for (auto it = deviceInfoMap.begin(); it != deviceInfoMap.end(); ++it)
+        for (const auto& [id, info] : deviceInfoMap)
         {
-            const std::wstring& idStr = ExtractVirtualDesktopId(it->first);
-            GUID id;
-            if (SUCCEEDED_LOG(CLSIDFromString(idStr.c_str(), &id)))
+            const std::wstring& idStr = ExtractVirtualDesktopId(id);
+            GUID guid;
+            if (SUCCEEDED_LOG(CLSIDFromString(idStr.c_str(), &guid)))
             {
-                ids.push_back(id);    
+                ids.push_back(guid);    
             }
         }
         return ids;

--- a/src/modules/fancyzones/lib/JsonHelpers.h
+++ b/src/modules/fancyzones/lib/JsonHelpers.h
@@ -231,6 +231,7 @@ namespace JSONHelpers
         }
 
         void AddDevice(const std::wstring& deviceId);
+        std::vector<GUID> GetVirtualDeslktopIds() const;
         bool RemoveDevicesByVirtualDesktopId(const std::wstring& virtualDesktopId);
         void CloneDeviceInfo(const std::wstring& source, const std::wstring& destination);
 

--- a/src/modules/fancyzones/tests/UnitTests/JsonHelpers.Tests.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/JsonHelpers.Tests.cpp
@@ -962,14 +962,14 @@ namespace FancyZonesUnitTests
                 }
             }
 
-            TEST_METHOD (FancyZonesDataDeviceInfoMap)
+            TEST_METHOD (DeviceInfoMap)
             {
                 FancyZonesData data;
                 const auto actual = data.GetDeviceInfoMap();
                 Assert::IsTrue(actual.empty());
             }
 
-            TEST_METHOD (FancyZonesDataDeviceInfoMapParseEmpty)
+            TEST_METHOD (DeviceInfoMapParseEmpty)
             {
                 FancyZonesData data;
 
@@ -980,7 +980,7 @@ namespace FancyZonesUnitTests
                 Assert::IsTrue(actual.empty());
             }
 
-            TEST_METHOD (FancyZonesDataDeviceInfoMapParseValidEmpty)
+            TEST_METHOD (DeviceInfoMapParseValidEmpty)
             {
                 FancyZonesData data;
 
@@ -994,7 +994,7 @@ namespace FancyZonesUnitTests
                 Assert::IsTrue(actual.empty());
             }
 
-            TEST_METHOD (FancyZonesDataDeviceInfoMapParseInvalid)
+            TEST_METHOD (DeviceInfoMapParseInvalid)
             {
                 json::JsonArray devices;
                 devices.Append(json::JsonObject::Parse(m_defaultCustomDeviceStr));
@@ -1009,7 +1009,7 @@ namespace FancyZonesUnitTests
                 Assert::IsFalse(actual);
             }
 
-            TEST_METHOD (FancyZonesDataDeviceInfoMapParseSingle)
+            TEST_METHOD (DeviceInfoMapParseSingle)
             {
                 json::JsonArray devices;
                 devices.Append(m_defaultCustomDeviceValue);
@@ -1023,7 +1023,7 @@ namespace FancyZonesUnitTests
                 Assert::AreEqual((size_t)1, actualMap.size());
             }
 
-            TEST_METHOD (FancyZonesDataDeviceInfoMapParseMany)
+            TEST_METHOD (DeviceInfoMapParseMany)
             {
                 json::JsonArray devices;
                 for (int i = 0; i < 10; i++)
@@ -1043,6 +1043,64 @@ namespace FancyZonesUnitTests
 
                 const auto actualMap = data.GetDeviceInfoMap();
                 Assert::AreEqual((size_t)10, actualMap.size());
+            }
+
+            TEST_METHOD(AddDevice)
+            {
+                FancyZonesData data;
+                data.AddDevice(m_defaultDeviceId);
+                const auto actual = data.GetDeviceInfoMap();
+                Assert::AreEqual((size_t)1, actual.size());
+            }
+
+            TEST_METHOD (RemoveDevicesByVirtualDesktopId)
+            {
+                FancyZonesData data;
+                data.AddDevice(m_defaultDeviceId);
+                data.RemoveDevicesByVirtualDesktopId(L"{39B25DD2-130D-4B5D-8851-4791D66B1539}");
+
+                const auto actual = data.GetDeviceInfoMap();
+                Assert::IsTrue(actual.empty());
+            }
+
+            TEST_METHOD (RemoveDevicesByVirtualDesktopIdNonexistent)
+            {
+                FancyZonesData data;
+                data.AddDevice(m_defaultDeviceId);
+                data.RemoveDevicesByVirtualDesktopId(L"{00000000-130D-4B5D-8851-4791D66B1539}");
+
+                const auto actual = data.GetDeviceInfoMap();
+                Assert::AreEqual((size_t)1, actual.size());
+            }
+
+            TEST_METHOD (RemoveDevicesByVirtualDesktopIdEmpty)
+            {
+                FancyZonesData data;
+                data.RemoveDevicesByVirtualDesktopId(L"{39B25DD2-130D-4B5D-8851-4791D66B1539}");
+
+                const auto actual = data.GetDeviceInfoMap();
+                Assert::IsTrue(actual.empty());
+            }
+
+            TEST_METHOD(GetVirtualDeslktopIds)
+            {
+                FancyZonesData data;
+                data.AddDevice(m_defaultDeviceId);
+
+                const auto actual = data.GetVirtualDeslktopIds();
+                Assert::AreEqual((size_t)1, actual.size());
+
+                GUID expected;
+                Assert::AreEqual(S_OK, CLSIDFromString(L"{39B25DD2-130D-4B5D-8851-4791D66B1539}", &expected));
+
+                Assert::IsTrue(expected == actual[0]);
+            }
+
+            TEST_METHOD (GetVirtualDeslktopIdsEmpty)
+            {
+                FancyZonesData data;
+                const auto actual = data.GetVirtualDeslktopIds();
+                Assert::IsTrue(actual.empty());
             }
 
             TEST_METHOD (FancyZonesDataSerialize)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Restore work areas on start. If virtual desktops were removed while PowerToys was off, settings would be updated. 

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #1312
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [] Requires documentation to be updated
* [] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
manually tested