### PR TITLE
Indexer Plugin Context Buttons

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/ContextMenuLoader.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/ContextMenuLoader.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Windows;
+using Wox.Infrastructure.Logger;
+using Wox.Plugin;
+using Microsoft.Plugin.Indexer.SearchHelper;
+
+namespace Microsoft.Plugin.Indexer
+{
+    internal class ContextMenuLoader : IContextMenu
+    {
+        private readonly PluginInitContext _context;
+
+        public enum ResultType
+        {
+            Folder,
+            File
+        }
+
+        public ContextMenuLoader(PluginInitContext context)
+        {
+            _context = context;
+        }
+
+        public List<Result> LoadContextMenus(Result selectedResult)
+        {
+            var contextMenus = new List<Result>();
+            if (selectedResult.ContextData is SearchResult record)
+            {
+                ResultType type = Path.HasExtension(record.Path) ? ResultType.File : ResultType.Folder;
+
+                if (type == ResultType.File)
+                {
+                    contextMenus.Add(CreateOpenContainingFolderResult(record));
+                }
+
+                var fileOrFolder = (type == ResultType.File) ? "file" : "folder";
+                contextMenus.Add(new Result
+                {
+                    Title = "Copy path",
+                    Glyph = "\xE8C8",
+                    FontFamily = "Segoe MDL2 Assets",
+                    SubTitle = $"Copy the current {fileOrFolder} path to clipboard",
+                    Action = (context) =>
+                    {
+                        try
+                        {
+                            Clipboard.SetText(record.Path);
+                            return true;
+                        }
+                        catch (Exception e)
+                        {
+                            var message = "Fail to set text in clipboard";
+                            LogException(message, e);
+                            _context.API.ShowMsg(message);
+                            return false;
+                        }
+                    }
+                });
+            }
+
+            return contextMenus;
+        }
+
+        private Result CreateOpenContainingFolderResult(SearchResult record)
+        {
+            return new Result
+            {
+                Title = "Open containing folder",
+                Glyph = "\xE838",
+                FontFamily = "Segoe MDL2 Assets",
+                Action = _ =>
+                {
+                    try
+                    {
+                        Process.Start("explorer.exe", $" /select,\"{record.Path}\"");
+                    }
+                    catch(Exception e)
+                    {
+                        var message = $"Fail to open file at {record.Path}";
+                        LogException(message, e);
+                        _context.API.ShowMsg(message);
+                        return false;
+                    }
+
+                    return true;
+                },
+            };
+        }
+
+        public void LogException(string message, Exception e)
+        {
+            Log.Exception($"|Wox.Plugin.Folder.ContextMenu|{message}", e);
+        }
+    }
+
+}

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Main.cs
@@ -13,7 +13,7 @@ using Microsoft.Search.Interop;
 
 namespace Microsoft.Plugin.Indexer
 {
-    class Main : IPlugin, ISavable, IPluginI18n
+    class Main : IPlugin, ISavable, IPluginI18n, IContextMenu
     {
 
         // This variable contains metadata about the Plugin
@@ -27,6 +27,8 @@ namespace Microsoft.Plugin.Indexer
 
         // To access Windows Search functionalities
         private readonly WindowsSearchAPI _api = new WindowsSearchAPI();
+
+        private IContextMenu _contextMenuLoader;
 
         // To save the configurations of plugins
         public void Save()
@@ -109,6 +111,7 @@ namespace Microsoft.Plugin.Indexer
         {
             // initialize the context of the plugin
             _context = context;
+            _contextMenuLoader = new ContextMenuLoader(context);
             _storage = new PluginJsonStorage<Settings>();
             _settings = _storage.Load();
         }
@@ -127,6 +130,9 @@ namespace Microsoft.Plugin.Indexer
             return "Returns files and folders";
         }
 
-
+        public List<Result> LoadContextMenus(Result selectedResult)
+        {
+            return _contextMenuLoader.LoadContextMenus(selectedResult);
+        }
     }
 }


### PR DESCRIPTION
Adding context buttons to Indexer plugin.  This allows for the following:

1. [Files] Open Containing folder
2. [Folders/Files] Copy Path

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
1) This just adds `open file location` and `copy path` context buttons to the results specified by the windows search indexer plugin. 

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

![IndexerContextButtons](https://user-images.githubusercontent.com/56318517/79672372-153ad780-8186-11ea-8a77-9f34891a52ef.gif)

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Ran manually