### PR TITLE
Tab Selection 

### DIFF
--- a/src/modules/launcher/PowerLauncher.UI/ResultList.xaml
+++ b/src/modules/launcher/PowerLauncher.UI/ResultList.xaml
@@ -63,7 +63,7 @@
                                    Grid.Column="1" 
                                    ItemsSource="{Binding ContextMenuItems}" 
                                    SelectionMode="Single"
-                                   SelectedIndex="{Binding SelectedIndex}">
+                                   SelectedIndex="{Binding ContextMenuSelectedIndex}">
                             <ListView.ItemsPanel>
                                 <ItemsPanelTemplate>
                                     <StackPanel Orientation="Horizontal"/>

--- a/src/modules/launcher/PowerLauncher.UI/ResultList.xaml
+++ b/src/modules/launcher/PowerLauncher.UI/ResultList.xaml
@@ -25,7 +25,7 @@
             Margin="{ThemeResource AutoSuggestListMargin}"
             Padding="{ThemeResource AutoSuggestListPadding}"
             ItemsSource="{Binding Results.Results, Mode=OneWay}"
-            SelectionMode="Single"          
+            SelectionMode="Single"
             SelectedIndex="{Binding Results.SelectedIndex, Mode=TwoWay}"
             >
             <ListView.ItemTemplate>
@@ -57,7 +57,13 @@
                         <Image x:Name="AppIcon" Height="36" Margin="8,0,0,0" Grid.RowSpan="2" HorizontalAlignment="Left" Source="{Binding Image}" />
                         <TextBlock x:Name="Title" Grid.Column="1" Text="{Binding Result.Title}" FontWeight="SemiBold" FontSize="20" VerticalAlignment="Bottom"/>
                         <TextBlock x:Name="Path" Grid.Column="1" Text= "{Binding Result.SubTitle}" Grid.Row="1" Opacity="0.6" VerticalAlignment="Top"/>
-                        <ListView  Opacity="0" HorizontalAlignment="Right" Grid.RowSpan="2" Grid.Column="1" ItemsSource="{Binding ContextMenuItems}">
+                        <ListView  Opacity="0" 
+                                   HorizontalAlignment="Right" 
+                                   Grid.RowSpan="2" 
+                                   Grid.Column="1" 
+                                   ItemsSource="{Binding ContextMenuItems}" 
+                                   SelectionMode="Single"
+                                   SelectedIndex="{Binding SelectedIndex}">
                             <ListView.ItemsPanel>
                                 <ItemsPanelTemplate>
                                     <StackPanel Orientation="Horizontal"/>

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -237,12 +237,12 @@ namespace PowerLauncher
         {
             if (e.Key == VirtualKey.Tab && IsKeyDown(VirtualKey.Shift))
             {
-                _viewModel.SelectPrevItemCommand.Execute(null);
+                _viewModel.SelectPrevTabItemCommand.Execute(null);
                 e.Handled = true;
             }
             else if (e.Key == VirtualKey.Tab)
             {
-                _viewModel.SelectNextItemCommand.Execute(null);
+                    _viewModel.SelectNextTabItemCommand.Execute(null);
                 e.Handled = true;
             }
             else if (e.Key == VirtualKey.Down)

--- a/src/modules/launcher/Wox/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/Wox/ViewModel/MainViewModel.cs
@@ -116,6 +116,16 @@ namespace Wox.ViewModel
                 SelectedResults.SelectPrevResult();
             });
 
+            SelectNextTabItemCommand = new RelayCommand(_ =>
+            {
+                SelectedResults.SelectNextTabItem(); 
+            });
+
+            SelectPrevTabItemCommand = new RelayCommand(_ =>
+            {
+                SelectedResults.SelectPrevTabItem();
+            });
+
             SelectNextPageCommand = new RelayCommand(_ =>
             {
                 SelectedResults.SelectNextPage();
@@ -142,27 +152,33 @@ namespace Wox.ViewModel
                     results.SelectedIndex = int.Parse(index.ToString());
                 }
 
-                var result = results.SelectedItem?.Result;
-                if (result != null) // SelectedItem returns null if selection is empty.
+                //If there is a context button selected fire the action for that button before the main command. 
+                bool didExecuteContextButton = results.SelectedItem?.ExecuteSelectedContextButton() ?? false;
+
+                if (!didExecuteContextButton)
                 {
-                    bool hideWindow = result.Action != null && result.Action(new ActionContext
+                    var result = results.SelectedItem?.Result;
+                    if (result != null) // SelectedItem returns null if selection is empty.
                     {
-                        SpecialKeyState = GlobalHotkey.Instance.CheckModifiers()
-                    });
+                        bool hideWindow = result.Action != null && result.Action(new ActionContext
+                        {
+                            SpecialKeyState = GlobalHotkey.Instance.CheckModifiers()
+                        });
 
-                    if (hideWindow)
-                    {
-                        MainWindowVisibility = Visibility.Collapsed;
-                    }
+                        if (hideWindow)
+                        {
+                            MainWindowVisibility = Visibility.Collapsed;
+                        }
 
-                    if (SelectedIsFromQueryResults())
-                    {
-                        _userSelectedRecord.Add(result);
-                        _history.Add(result.OriginQuery.RawQuery);
-                    }
-                    else
-                    {
-                        SelectedResults = Results;
+                        if (SelectedIsFromQueryResults())
+                        {
+                            _userSelectedRecord.Add(result);
+                            _history.Add(result.OriginQuery.RawQuery);
+                        }
+                        else
+                        {
+                            SelectedResults = Results;
+                        }
                     }
                 }
             });
@@ -271,6 +287,10 @@ namespace Wox.ViewModel
         public ICommand EscCommand { get; set; }
         public ICommand SelectNextItemCommand { get; set; }
         public ICommand SelectPrevItemCommand { get; set; }
+
+        public ICommand SelectNextTabItemCommand { get; set; }
+        public ICommand SelectPrevTabItemCommand { get; set; }
+
         public ICommand SelectNextPageCommand { get; set; }
         public ICommand SelectPrevPageCommand { get; set; }
         public ICommand SelectFirstResultCommand { get; set; }

--- a/src/modules/launcher/Wox/ViewModel/ResultViewModel.cs
+++ b/src/modules/launcher/Wox/ViewModel/ResultViewModel.cs
@@ -23,12 +23,17 @@ namespace Wox.ViewModel
 
         public bool IsSelected { get; set; }
 
+        public int SelectedIndex { get; set; }
+
+        const int NoSelectionIndex = -1;
+
         public ResultViewModel(Result result)
         {
             if (result != null)
             {
                 Result = result;
             }
+            SelectedIndex = NoSelectionIndex;
             LoadContextMenuCommand = new RelayCommand(LoadContextMenu);
         }
         public void LoadContextMenu(object sender=null)
@@ -82,6 +87,57 @@ namespace Wox.ViewModel
                 // will get here either when icoPath has value\icon delegate is null\when had exception in delegate
                 return ImageLoader.Load(imagePath);
             }
+        }
+
+        //Returns false if we've already reached the last item.
+        public bool SelectNextContextButton()
+        {
+            if(SelectedIndex == (ContextMenuItems.Count -1))
+            {
+                SelectedIndex = NoSelectionIndex;
+                return false; 
+            }
+
+            SelectedIndex++;
+            return true;
+        }
+
+        //Returns false if we've already reached the first item.
+        public bool SelectPrevContextButton()
+        {
+            if (SelectedIndex == NoSelectionIndex)
+            {
+                return false;
+            }
+
+            SelectedIndex--;
+            return true;
+        }
+
+        public void SelectLastContextButton()
+        {
+            SelectedIndex = ContextMenuItems.Count - 1;
+        }
+
+        public bool HasSelectedContextButton()
+        {
+            var isContextSelected = (SelectedIndex != NoSelectionIndex);
+            return isContextSelected;
+        }
+
+        /// <summary>
+        ///  Triggers the action on the selected context button
+        /// </summary>
+        /// <returns>False if there is nothing selected, oherwise true</returns>
+        public bool ExecuteSelectedContextButton()
+        {
+            if (HasSelectedContextButton())
+            {
+                ContextMenuItems[SelectedIndex].Command.Execute(null);
+                return true;
+            }
+
+            return false;
         }
 
         public Result Result { get; }

--- a/src/modules/launcher/Wox/ViewModel/ResultViewModel.cs
+++ b/src/modules/launcher/Wox/ViewModel/ResultViewModel.cs
@@ -23,7 +23,7 @@ namespace Wox.ViewModel
 
         public bool IsSelected { get; set; }
 
-        public int SelectedIndex { get; set; }
+        public int ContextMenuSelectedIndex { get; set; }
 
         const int NoSelectionIndex = -1;
 
@@ -33,7 +33,7 @@ namespace Wox.ViewModel
             {
                 Result = result;
             }
-            SelectedIndex = NoSelectionIndex;
+            ContextMenuSelectedIndex = NoSelectionIndex;
             LoadContextMenuCommand = new RelayCommand(LoadContextMenu);
         }
         public void LoadContextMenu(object sender=null)
@@ -92,36 +92,36 @@ namespace Wox.ViewModel
         //Returns false if we've already reached the last item.
         public bool SelectNextContextButton()
         {
-            if(SelectedIndex == (ContextMenuItems.Count -1))
+            if(ContextMenuSelectedIndex == (ContextMenuItems.Count -1))
             {
-                SelectedIndex = NoSelectionIndex;
+                ContextMenuSelectedIndex = NoSelectionIndex;
                 return false; 
             }
 
-            SelectedIndex++;
+            ContextMenuSelectedIndex++;
             return true;
         }
 
         //Returns false if we've already reached the first item.
         public bool SelectPrevContextButton()
         {
-            if (SelectedIndex == NoSelectionIndex)
+            if (ContextMenuSelectedIndex == NoSelectionIndex)
             {
                 return false;
             }
 
-            SelectedIndex--;
+            ContextMenuSelectedIndex--;
             return true;
         }
 
         public void SelectLastContextButton()
         {
-            SelectedIndex = ContextMenuItems.Count - 1;
+            ContextMenuSelectedIndex = ContextMenuItems.Count - 1;
         }
 
         public bool HasSelectedContextButton()
         {
-            var isContextSelected = (SelectedIndex != NoSelectionIndex);
+            var isContextSelected = (ContextMenuSelectedIndex != NoSelectionIndex);
             return isContextSelected;
         }
 
@@ -133,7 +133,7 @@ namespace Wox.ViewModel
         {
             if (HasSelectedContextButton())
             {
-                ContextMenuItems[SelectedIndex].Command.Execute(null);
+                ContextMenuItems[ContextMenuSelectedIndex].Command.Execute(null);
                 return true;
             }
 

--- a/src/modules/launcher/Wox/ViewModel/ResultsViewModel.cs
+++ b/src/modules/launcher/Wox/ViewModel/ResultsViewModel.cs
@@ -69,6 +69,8 @@ namespace Wox.ViewModel
             }
         }
 
+
+
         public Thickness Margin { get; set; }
         public Visibility Visbility { get; set; } = Visibility.Collapsed;
 
@@ -148,6 +150,24 @@ namespace Wox.ViewModel
         public void RemoveResultsFor(PluginMetadata metadata)
         {
             Results.RemoveAll(r => r.Result.PluginID == metadata.ID);
+        }
+
+        public void SelectNextTabItem()
+        {
+            if(!SelectedItem.SelectNextContextButton())
+            {
+                SelectNextResult();
+            }
+        }
+
+        public void SelectPrevTabItem()
+        {
+            if (!SelectedItem.SelectPrevContextButton())
+            {
+                //Tabbing backwards should highlight the last item of the previous row
+                SelectPrevResult();
+                SelectedItem.SelectLastContextButton();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This PR allows us to tab between the context buttons for each of the results.  This is needed to be handled manually because we want to keep the focus on the textbox while the user is tabbing or using the arrow keys.   It's not super clear to the user that the row is selected when the context buttons are unselected.  We may need a new visual treatment.

![TabToContextButtons](https://user-images.githubusercontent.com/56318517/79676929-0f51f000-81a0-11ea-87a3-56928a749350.gif)

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- [x] Made sure tabing forward navigats the buttons correct  order.
- [x] Made sure tabbing backward navigates through the buttons in reverse order. 
- [x] Made sure tabbing will also select the row itself. 
- [x] Verified hitting `enter` on the row opens the result. 
- [x] Verified hitting `enter` on the context buttons executes the expected command.
