### PR TITLE
Enabling key accelerators on context buttons.

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/ContextMenuLoader.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/ContextMenuLoader.cs
@@ -24,9 +24,9 @@ namespace Microsoft.Plugin.Indexer
             _context = context;
         }
 
-        public List<Result> LoadContextMenus(Result selectedResult)
+        public List<ContextMenuResult> LoadContextMenus(Result selectedResult)
         {
-            var contextMenus = new List<Result>();
+            var contextMenus = new List<ContextMenuResult>();
             if (selectedResult.ContextData is SearchResult record)
             {
                 ResultType type = Path.HasExtension(record.Path) ? ResultType.File : ResultType.Folder;
@@ -37,12 +37,15 @@ namespace Microsoft.Plugin.Indexer
                 }
 
                 var fileOrFolder = (type == ResultType.File) ? "file" : "folder";
-                contextMenus.Add(new Result
+                contextMenus.Add(new ContextMenuResult
                 {
                     Title = "Copy path",
                     Glyph = "\xE8C8",
                     FontFamily = "Segoe MDL2 Assets",
                     SubTitle = $"Copy the current {fileOrFolder} path to clipboard",
+                    AcceleratorKey = "C", 
+                    AcceleratorModifiers = "Control",
+
                     Action = (context) =>
                     {
                         try
@@ -64,13 +67,15 @@ namespace Microsoft.Plugin.Indexer
             return contextMenus;
         }
 
-        private Result CreateOpenContainingFolderResult(SearchResult record)
+        private ContextMenuResult CreateOpenContainingFolderResult(SearchResult record)
         {
-            return new Result
+            return new ContextMenuResult
             {
                 Title = "Open containing folder",
                 Glyph = "\xE838",
                 FontFamily = "Segoe MDL2 Assets",
+                AcceleratorKey = "E",
+                AcceleratorModifiers = "Control,Shift",
                 Action = _ =>
                 {
                     try

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Main.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Plugin.Indexer
             return "Returns files and folders";
         }
 
-        public List<Result> LoadContextMenus(Result selectedResult)
+        public List<ContextMenuResult> LoadContextMenus(Result selectedResult)
         {
             return _contextMenuLoader.LoadContextMenus(selectedResult);
         }

--- a/src/modules/launcher/Plugins/Wox.Plugin.Folder/ContextMenuLoader.cs
+++ b/src/modules/launcher/Plugins/Wox.Plugin.Folder/ContextMenuLoader.cs
@@ -19,9 +19,9 @@ namespace Wox.Plugin.Folder
             _context = context;
         }
 
-        public List<Result> LoadContextMenus(Result selectedResult)
+        public List<ContextMenuResult> LoadContextMenus(Result selectedResult)
         {
-            var contextMenus = new List<Result>();
+            var contextMenus = new List<ContextMenuResult>();
             if (selectedResult.ContextData is SearchResult record)
             {
                 if (record.Type == ResultType.File)
@@ -31,12 +31,14 @@ namespace Wox.Plugin.Folder
 
                 var icoPath = (record.Type == ResultType.File) ? Main.FileImagePath : Main.FolderImagePath;
                 var fileOrFolder = (record.Type == ResultType.File) ? "file" : "folder";
-                contextMenus.Add(new Result
+                contextMenus.Add(new ContextMenuResult
                 {
                     Title = "Copy path",
                     Glyph = "\xE8C8",
                     FontFamily = "Segoe MDL2 Assets",
                     SubTitle = $"Copy the current {fileOrFolder} path to clipboard",
+                    AcceleratorKey = "C",
+                    AcceleratorModifiers = "Control",
                     Action = (context) =>
                     {
                         try
@@ -51,21 +53,22 @@ namespace Wox.Plugin.Folder
                             _context.API.ShowMsg(message);
                             return false;
                         }
-                    },
-                    IcoPath = Main.CopyImagePath
+                    }
                 });
             }
 
             return contextMenus;
         }
 
-        private Result CreateOpenContainingFolderResult(SearchResult record)
+        private ContextMenuResult CreateOpenContainingFolderResult(SearchResult record)
         {
-            return new Result
+            return new ContextMenuResult
             {
                 Title = "Open containing folder",
                 Glyph = "\xE838",
                 FontFamily = "Segoe MDL2 Assets",
+                AcceleratorKey = "E",
+                AcceleratorModifiers = "Control,Shift",
                 Action = _ =>
                 {
                     try
@@ -81,8 +84,7 @@ namespace Wox.Plugin.Folder
                     }
 
                     return true;
-                },
-                IcoPath = Main.FolderImagePath
+                }
             };
         }
 

--- a/src/modules/launcher/Plugins/Wox.Plugin.Folder/Main.cs
+++ b/src/modules/launcher/Plugins/Wox.Plugin.Folder/Main.cs
@@ -302,7 +302,7 @@ namespace Wox.Plugin.Folder
             return _context.API.GetTranslation("wox_plugin_folder_plugin_description");
         }
 
-        public List<Result> LoadContextMenus(Result selectedResult)
+        public List<ContextMenuResult> LoadContextMenus(Result selectedResult)
         {
             return _contextMenuLoader.LoadContextMenus(selectedResult);
         }

--- a/src/modules/launcher/Plugins/Wox.Plugin.Program/Main.cs
+++ b/src/modules/launcher/Plugins/Wox.Plugin.Program/Main.cs
@@ -141,9 +141,9 @@ namespace Wox.Plugin.Program
             return _context.API.GetTranslation("wox_plugin_program_plugin_description");
         }
 
-        public List<Result> LoadContextMenus(Result selectedResult)
+        public List<ContextMenuResult> LoadContextMenus(Result selectedResult)
         {
-            var menuOptions = new List<Result>();
+            var menuOptions = new List<ContextMenuResult>();
             var program = selectedResult.ContextData as IProgram;
             if (program != null)
             {

--- a/src/modules/launcher/Plugins/Wox.Plugin.Program/Programs/IProgram.cs
+++ b/src/modules/launcher/Plugins/Wox.Plugin.Program/Programs/IProgram.cs
@@ -4,7 +4,7 @@ namespace Wox.Plugin.Program.Programs
 {
     public interface IProgram
     {
-        List<Result> ContextMenus(IPublicAPI api);
+        List<ContextMenuResult> ContextMenus(IPublicAPI api);
         Result Result(string query, IPublicAPI api);
         string UniqueIdentifier { get; set; }
         string Name { get; }

--- a/src/modules/launcher/Plugins/Wox.Plugin.Program/Programs/UWP.cs
+++ b/src/modules/launcher/Plugins/Wox.Plugin.Program/Programs/UWP.cs
@@ -18,6 +18,7 @@ using IStream = AppxPackaing.IStream;
 using Rect = System.Windows.Rect;
 using Windows.UI.Xaml.Media.Imaging;
 using Windows.UI.Xaml.Media;
+using System.Windows.Controls;
 
 namespace Wox.Plugin.Program.Programs
 {
@@ -312,23 +313,23 @@ namespace Wox.Plugin.Program.Programs
                 return result;
             }
 
-            public List<Result> ContextMenus(IPublicAPI api)
+            public List<ContextMenuResult> ContextMenus(IPublicAPI api)
             {
-                var contextMenus = new List<Result>
+                var contextMenus = new List<ContextMenuResult>
                 {
-                    new Result
+                    new ContextMenuResult
                     {
                         Title = api.GetTranslation("wox_plugin_program_open_containing_folder"),
                         Glyph = "\xE838",
                         FontFamily = "Segoe MDL2 Assets",
+                        AcceleratorKey = "E",
+                        AcceleratorModifiers = "Control,Shift",
                         Action = _ =>
                         {
                             Main.StartProcess(Process.Start, new ProcessStartInfo(Package.Location));
 
                             return true;
-                        },
-
-                        IcoPath = "Images/folder.png"
+                        }
                     }
                 };
                 return contextMenus;

--- a/src/modules/launcher/Plugins/Wox.Plugin.Program/Programs/Win32.cs
+++ b/src/modules/launcher/Plugins/Wox.Plugin.Program/Programs/Win32.cs
@@ -94,15 +94,17 @@ namespace Wox.Plugin.Program.Programs
         }
 
 
-        public List<Result> ContextMenus(IPublicAPI api)
+        public List<ContextMenuResult> ContextMenus(IPublicAPI api)
         {
-            var contextMenus = new List<Result>
+            var contextMenus = new List<ContextMenuResult>
             {
-                new Result
+                new ContextMenuResult
                 {
                     Title = api.GetTranslation("wox_plugin_program_run_as_administrator"),
                     Glyph = "\xE7EF",
                     FontFamily = "Segoe MDL2 Assets",
+                    AcceleratorKey = "Enter",
+                    AcceleratorModifiers = "Control,Shift",
                     Action = _ =>
                     {
                         var info = new ProcessStartInfo
@@ -116,14 +118,15 @@ namespace Wox.Plugin.Program.Programs
                         Task.Run(() => Main.StartProcess(Process.Start, info));
 
                         return true;
-                    },
-                    IcoPath = "Images/cmd.png"
+                    }
                 },
-                new Result
+                new ContextMenuResult
                 {
                     Title = api.GetTranslation("wox_plugin_program_open_containing_folder"),
                     Glyph = "\xE838",
                     FontFamily = "Segoe MDL2 Assets",
+                    AcceleratorKey = "E",
+                    AcceleratorModifiers = "Control,Shift",
                     Action = _ =>
                     {
 
@@ -131,8 +134,7 @@ namespace Wox.Plugin.Program.Programs
                         Main.StartProcess(Process.Start, new ProcessStartInfo("explorer", ParentDirectory));
 
                         return true;
-                    },
-                    IcoPath = "Images/folder.png"
+                    }
                 }
             };
             return contextMenus;

--- a/src/modules/launcher/Plugins/Wox.Plugin.Shell/Main.cs
+++ b/src/modules/launcher/Plugins/Wox.Plugin.Shell/Main.cs
@@ -320,21 +320,22 @@ namespace Wox.Plugin.Shell
             return _context.API.GetTranslation("wox_plugin_cmd_plugin_description");
         }
 
-        public List<Result> LoadContextMenus(Result selectedResult)
+        public List<ContextMenuResult> LoadContextMenus(Result selectedResult)
         {
-            var resultlist = new List<Result>
+            var resultlist = new List<ContextMenuResult>
             {
-                new Result
+                new ContextMenuResult
                 {
                     Title = _context.API.GetTranslation("wox_plugin_cmd_run_as_administrator"),
                     Glyph = "\xE7EF",
                     FontFamily = "Segoe MDL2 Assets",
+                    AcceleratorKey = "Enter",
+                    AcceleratorModifiers = "Control,Shift",
                     Action = c =>
                     {
                         Execute(Process.Start, PrepareProcessStartInfo(selectedResult.Title, true));
                         return true;
-                    },
-                    IcoPath = Image
+                    }
                 }
             };
 

--- a/src/modules/launcher/PowerLauncher.UI/ResultList.xaml
+++ b/src/modules/launcher/PowerLauncher.UI/ResultList.xaml
@@ -82,6 +82,13 @@
                                         <Button.Content>
                                             <FontIcon FontFamily="{Binding FontFamily}" FontSize="16" Glyph="{Binding Glyph}"/>
                                         </Button.Content>
+                                        <Button.KeyboardAccelerators>
+                                            <KeyboardAccelerator
+                                                Key="{Binding AcceleratorKey}"
+                                                Modifiers="{Binding AcceleratorModifiers}"
+                                                IsEnabled="{Binding IsEnabled}"
+                                            />
+                                        </Button.KeyboardAccelerators>
                                     </Button>
                                 </DataTemplate>
                             </ListView.ItemTemplate>

--- a/src/modules/launcher/Wox.Core/Plugin/JsonRPCPlugin.cs
+++ b/src/modules/launcher/Wox.Core/Plugin/JsonRPCPlugin.cs
@@ -45,16 +45,20 @@ namespace Wox.Core.Plugin
             }
         }
 
-        public List<Result> LoadContextMenus(Result selectedResult)
+        public List<ContextMenuResult> LoadContextMenus(Result selectedResult)
         {
             string output = ExecuteContextMenu(selectedResult);
             try
             {
-                return DeserializedResult(output);
+                //This should not hit. If it does it's because Wox shares the same interface for querying context menu items as well as search results. In this case please file a bug.
+                //To my knowledge we aren't supporting this JSonRPC commands in Launcher, and am not able to repro this, but I will leave this here for the time being in case I'm proven wrong. 
+                //We should remove this, or identify and test officially supported use cases and Deserialize this properly. 
+                //return DeserializedResult(output);
+                throw new NotImplementedException();
             }
             catch (Exception e)
             {
-                Log.Exception($"|JsonRPCPlugin.LoadContextMenus|Exception on result <{selectedResult}>", e);
+                Log.Exception($"|JsonRPCPlugin.LoadContextMenus| THIS IS A BUG - Exception on result <{selectedResult}>", e);
                 return null;
             }
         }

--- a/src/modules/launcher/Wox.Core/Plugin/PluginManager.cs
+++ b/src/modules/launcher/Wox.Core/Plugin/PluginManager.cs
@@ -198,7 +198,7 @@ namespace Wox.Core.Plugin
             return AllPlugins.Where(p => p.Plugin is T);
         }
 
-        public static List<Result> GetContextMenusForPlugin(Result result)
+        public static List<ContextMenuResult> GetContextMenusForPlugin(Result result)
         {
             var pluginPair = _contextMenuPlugins.FirstOrDefault(o => o.Metadata.ID == result.PluginID);
             if (pluginPair != null)
@@ -209,23 +209,17 @@ namespace Wox.Core.Plugin
                 try
                 {
                     var results = plugin.LoadContextMenus(result);
-                    foreach (var r in results)
-                    {
-                        r.PluginDirectory = metadata.PluginDirectory;
-                        r.PluginID = metadata.ID;
-                        r.OriginQuery = result.OriginQuery;
-                    }
                     return results;
                 }
                 catch (Exception e)
                 {
                     Log.Exception($"|PluginManager.GetContextMenusForPlugin|Can't load context menus for plugin <{metadata.Name}>", e);
-                    return new List<Result>();
+                    return new List<ContextMenuResult>();
                 }
             }
             else
             {
-                return new List<Result>();
+                return new List<ContextMenuResult>();
             }
 
         }

--- a/src/modules/launcher/Wox.Plugin/ContextMenuResult.cs
+++ b/src/modules/launcher/Wox.Plugin/ContextMenuResult.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using Windows.UI.Xaml.Media;
+
+namespace Wox.Plugin
+{
+
+    public class ContextMenuResult
+    {
+        public string Title { get; set; }
+        public string SubTitle { get; set; }
+
+        public string Glyph { get; set; }
+
+        public string FontFamily { get; set; }
+
+        public string AcceleratorKey { get; set; }
+
+        public string AcceleratorModifiers { get; set; }
+
+        /// <summary>
+        /// return true to hide wox after select result
+        /// </summary>
+        public Func<ActionContext, bool> Action { get; set; }
+
+        public override string ToString()
+        {
+            return Title + SubTitle;
+        }
+    }
+}

--- a/src/modules/launcher/Wox.Plugin/Feature.cs
+++ b/src/modules/launcher/Wox.Plugin/Feature.cs
@@ -8,7 +8,7 @@ namespace Wox.Plugin
 
     public interface IContextMenu : IFeatures
     {
-        List<Result> LoadContextMenus(Result selectedResult);
+        List<ContextMenuResult> LoadContextMenus(Result selectedResult);
     }
 
     [Obsolete("If a plugin has a action keyword, then it is exclusive. This interface will be remove in v1.3.0")]

--- a/src/modules/launcher/Wox/ViewModel/ContextMenuItemViewModel.cs
+++ b/src/modules/launcher/Wox/ViewModel/ContextMenuItemViewModel.cs
@@ -6,13 +6,12 @@ namespace Wox.ViewModel
 {
     public class ContextMenuItemViewModel : BaseModel
     {
-
         public string Title { get; set; }
         public string Glyph { get; set; }
-
         public string FontFamily { get; set; }
-
         public ICommand Command { get; set; }
-
+        public string AcceleratorKey { get; set; }
+        public string AcceleratorModifiers { get; set; }
+        public bool IsEnabled { get; set; }
     }
 }

--- a/src/modules/launcher/Wox/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/Wox/ViewModel/MainViewModel.cs
@@ -307,41 +307,9 @@ namespace Wox.ViewModel
             {
                 QueryResults();
             }
-            else if (ContextMenuSelected())
-            {
-                QueryContextMenu();
-            }
             else if (HistorySelected())
             {
                 QueryHistory();
-            }
-        }
-
-        private void QueryContextMenu()
-        {
-            const string id = "Context Menu ID";
-            var query = QueryText.ToLower().Trim();
-            ContextMenu.Clear();
-
-            var selected = Results.SelectedItem?.Result;
-
-            if (selected != null) // SelectedItem returns null if selection is empty.
-            {
-                var results = PluginManager.GetContextMenusForPlugin(selected);
-
-                if (!string.IsNullOrEmpty(query))
-                {
-                    var filtered = results.Where
-                    (
-                        r => StringMatcher.FuzzySearch(query, r.Title).IsSearchPrecisionScoreMet()
-                            || StringMatcher.FuzzySearch(query, r.SubTitle).IsSearchPrecisionScoreMet()
-                    ).ToList();
-                    ContextMenu.AddResults(filtered, id);
-                }
-                else
-                {
-                    ContextMenu.AddResults(results, id);
-                }
             }
         }
 

--- a/src/modules/launcher/Wox/ViewModel/ResultViewModel.cs
+++ b/src/modules/launcher/Wox/ViewModel/ResultViewModel.cs
@@ -47,6 +47,8 @@ namespace Wox.ViewModel
                     Title = r.Title,
                     Glyph = r.Glyph,
                     FontFamily = r.FontFamily,
+                    AcceleratorKey = r.AcceleratorKey,
+                    AcceleratorModifiers = r.AcceleratorModifiers,
                     Command = new RelayCommand(_ =>
                     {
                         bool hideWindow = r.Action != null && r.Action(new ActionContext
@@ -64,6 +66,22 @@ namespace Wox.ViewModel
             }
 
             ContextMenuItems = newItems;
+        }
+
+        internal void EnableContextMenu()
+        {
+            foreach(var i in ContextMenuItems)
+            {
+                i.IsEnabled = true;
+            }
+        }
+
+        internal void DisableContextMenu()
+        {
+            foreach (var i in ContextMenuItems)
+            {
+                i.IsEnabled = false;
+            }
         }
 
         public ImageSource Image

--- a/src/modules/launcher/Wox/ViewModel/ResultsViewModel.cs
+++ b/src/modules/launcher/Wox/ViewModel/ResultsViewModel.cs
@@ -60,10 +60,12 @@ namespace Wox.ViewModel
                     if (_selectedItem != null)
                     {
                         _selectedItem.IsSelected = false;
+                        _selectedItem.DisableContextMenu();
                     }
 
                     _selectedItem = value;
                     _selectedItem.LoadContextMenu();
+                    _selectedItem.EnableContextMenu();
                     _selectedItem.IsSelected = true;
                 }
             }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Allows users to use shortcuts for actions specific to the selected row.  eg.  CTRL-SHIFT-ENTER = Run as Admin, Ctrl-Shift-E open folder location, etc. 

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

1. Add new object ContextMenuResult instead instead of reusing Result for both query results and context menu results.
2. Binding KeyboardAccelerator keys to contextmenuitemviewmodel
3. Enabling and disabling contextmenu items when selecting or deselecting each row.  Because we are manually maintaining selectionwe can't use ScopeOwners as the textbox is really the only item ever in focus.

@crutkas .  #1 is an explicit breaking change if we plan to support Wox plugins directly. However, I would rather be explicit with the data type, and write and adapter if we need to support existing wox plugins in the future.  The design of how these actions are executed is quite different, so I doubt wox plugins would work out of the box anyway right now. 

![AcceleratorKeys](https://user-images.githubusercontent.com/56318517/79697553-4f64b180-8238-11ea-92ff-bb32b13017dd.gif)


<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

The following items are being validated by setting breakpoints on each of the modified actions and verifying that the action triggers from the expected accelerator keys

- [x] Executed Run As Admin on a Win32 Program result. 
- [x] Executed Open File Location on a Win32 Program result
- [x]  Executed Run as Admin on a Shell Program result  -- Typed "> ping www.bing.com"
- [x] Executed Copy Path on a Indexer Plugin result. 
- [x] Executed Open File Location on Indexer Plugin result. 
- [x] Executed Copy Path on a Folder Plugin result. 
- [x] Executed Open File Location on a File plugin result. 
- [x] Verified that Actions for a previously selected row don't fire.  IOW - They are disabled.
