### PR TITLE
Launching explorer instead of the UWP application

### DIFF
--- a/src/modules/launcher/Plugins/Wox.Plugin.Program/Programs/UWP.cs
+++ b/src/modules/launcher/Plugins/Wox.Plugin.Program/Programs/UWP.cs
@@ -326,7 +326,7 @@ namespace Wox.Plugin.Program.Programs
                         AcceleratorModifiers = "Control,Shift",
                         Action = _ =>
                         {
-                            Main.StartProcess(Process.Start, new ProcessStartInfo(Package.Location));
+                            Main.StartProcess(Process.Start, new ProcessStartInfo("explorer", Package.Location));
 
                             return true;
                         }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
The UWP code for the program was trying to launch the folder location instead of "explorer" at the program location.  This was throwing an access denied exception. 

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
-> Search for 'Microsoft Store' 
-> Press Ctrl - Shift - E to open the file location. 
-> Validated that explorer opens up at the correct folder location for the uwp executable