### PR TITLE
Win+R shouldn't launch WindowWalker

### DIFF
--- a/src/modules/launcher/Plugins/Wox.Plugin.Shell/Main.cs
+++ b/src/modules/launcher/Plugins/Wox.Plugin.Shell/Main.cs
@@ -292,7 +292,7 @@ namespace Wox.Plugin.Shell
                 if (keyevent == (int)KeyEvent.WM_KEYUP && _winRStroked && vkcode == (int)Keys.LWin)
                 {
                     _winRStroked = false;
-                    _keyboardSimulator.ModifiedKeyStroke(VirtualKeyCode.LWIN, VirtualKeyCode.CONTROL);
+                    _keyboardSimulator.ModifiedKeyStroke(VirtualKeyCode.LWIN, VirtualKeyCode.BACK);
                     return false;
                 }
             }


### PR DESCRIPTION

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
* This is happening because of the code in the shell plugin.
The Shell plugin has it's own code to override the Win+R key and because of the way they are creating and handling hooks, once we press Win+R, the Win key must be pressed again to release it. So basically, they're trying to simulate the Win key press, however since simulating only the win key press would pop up the start menu, they are simulating Win+Ctrl which is the same shortcut as that of ww.

To unblock us and mitigate this issue for now, I used the BackSpace keystroke instead of Control, so we would be simulating a Win+BackSpace keystroke.

**NOTE** Wox uses [`NHotkey.wpf`](https://www.nuget.org/packages/NHotkey.Wpf) nuget package for handling hotkeys and we would like the code for modifying hotkeys to be the same across all of powerToys and as that involves major code refactoring it would be done for v1.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2035 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
* Manually validated that Win+R no longer pops up WindowWalker.