### PR TITLE
Fixed The selection highlight not visible issue

### DIFF
--- a/src/modules/launcher/PowerLauncher.UI/App.xaml
+++ b/src/modules/launcher/PowerLauncher.UI/App.xaml
@@ -13,7 +13,7 @@
             <ResourceDictionary.ThemeDictionaries>
                 <ResourceDictionary x:Key="Light">
                     <SolidColorBrush x:Key="PrimaryTextColor" Color="Black"/>
-                    <SolidColorBrush x:Key="SystemControlHighlightAccentBrush" Color="White"/>
+                    <SolidColorBrush x:Key="SystemChromeLow" Color="{ThemeResource SystemChromeLowColor}" />
                     <AcrylicBrush x:Key="BackdropAcrylicBrush" BackgroundSource="Backdrop" TintColor="White" TintOpacity="0.9" FallbackColor="White"/>
                     <AcrylicBrush x:Key="KeyboardShortcutAcrylicBrush" BackgroundSource="Backdrop" TintColor="White" TintOpacity="0.9" FallbackColor="White"/>
                     <SolidColorBrush x:Key="ItemBackgroundColor" Color="#FFFFFFFF"/>
@@ -23,7 +23,7 @@
 
                 <ResourceDictionary x:Key="Default">
                     <SolidColorBrush x:Key="PrimaryTextColor" Color="White"/>
-                    <SolidColorBrush x:Key="SystemControlHighlightAccentBrush" Color="#484848"/>
+                    <SolidColorBrush x:Key="SystemChromeLow" Color="{ThemeResource SystemChromeLowColor}" />
                     <AcrylicBrush x:Key="BackdropAcrylicBrush" BackgroundSource="Backdrop" TintColor="#88484848" TintOpacity="0.9" FallbackColor="#FF484848"/>
                     <AcrylicBrush x:Key="KeyboardShortcutAcrylicBrush" BackgroundSource="Backdrop" TintColor="Black" TintOpacity="0.9" FallbackColor="Black"/>
                     <SolidColorBrush x:Key="ItemBackgroundColor" Color="#FFFFFFFF"/>

--- a/src/modules/launcher/PowerLauncher.UI/LauncherControl.xaml.cs
+++ b/src/modules/launcher/PowerLauncher.UI/LauncherControl.xaml.cs
@@ -35,12 +35,12 @@ namespace PowerLauncher.UI
 
         private void UserControl_ActualThemeChanged(FrameworkElement sender, object args)
         {
-            SolidBorderBrush = Application.Current.Resources["SystemControlHighlightAccentBrush"] as SolidColorBrush;
+            SolidBorderBrush = Application.Current.Resources["SystemChromeLow"] as SolidColorBrush;
         }
 
         private void UserControl_Loaded(object sender, RoutedEventArgs e)
         {
-            SolidBorderBrush = Application.Current.Resources["SystemControlHighlightAccentBrush"] as SolidColorBrush;
+            SolidBorderBrush = Application.Current.Resources["SystemChromeLow"] as SolidColorBrush;
         }
 
         public event PropertyChangedEventHandler PropertyChanged;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
* The `SystemControlHighlightAccentBrush` was being set to white (in light mode) which was causing the selection highlight to also be white, therefore selecting the text was showing a white text box.
* Using the `SystemChromeLow` theme instead and setting it to the default theme resource so that nothing else in the app gets affected.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
* Light Mode - 
![image](https://user-images.githubusercontent.com/28739210/79822643-80330c80-8346-11ea-9d1f-2a346adf1818.png)

* Dark mode -
![image](https://user-images.githubusercontent.com/28739210/79822667-8e812880-8346-11ea-8341-331d9f257451.png)

