### PR TITLE
Remove list view animation

### DIFF
--- a/src/modules/launcher/PowerLauncher.UI/App.xaml
+++ b/src/modules/launcher/PowerLauncher.UI/App.xaml
@@ -32,6 +32,14 @@
                 </ResourceDictionary>
             </ResourceDictionary.ThemeDictionaries>
 
+            <Style x:Key="ListViewNoAnimations" TargetType="ListView">
+                <Setter Property="ItemContainerTransitions">
+                    <Setter.Value>
+                        <TransitionCollection/>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+
             <Style x:Key="IconOnlyButton" TargetType="Button">
                 <Setter Property="Background" Value="{ThemeResource ButtonRevealBackground}" />
                 <Setter Property="Foreground" Value="{ThemeResource PrimaryTextColor}" />

--- a/src/modules/launcher/PowerLauncher.UI/ResultList.xaml
+++ b/src/modules/launcher/PowerLauncher.UI/ResultList.xaml
@@ -27,6 +27,7 @@
             ItemsSource="{Binding Results.Results, Mode=OneWay}"
             SelectionMode="Single"
             SelectedIndex="{Binding Results.SelectedIndex, Mode=TwoWay}"
+            Style="{StaticResource ListViewNoAnimations}"
             >
             <ListView.ItemTemplate>
                 <DataTemplate >


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR removes default transitions from UWP Listview control.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2267 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manually validated that list view animation is no longer triggered.
Example repro : Type `Maps` and change it to `Ma`. The fly in effect should not be present. 

![capt1](https://user-images.githubusercontent.com/10995909/79832784-03605c80-835f-11ea-97be-f8e45a28bc43.gif)

