### PR TITLE
Updating Button positioning and adding background

### DIFF
--- a/src/modules/launcher/PowerLauncher.UI/ResultList.xaml
+++ b/src/modules/launcher/PowerLauncher.UI/ResultList.xaml
@@ -57,25 +57,26 @@
                         <Image x:Name="AppIcon" Height="36" Margin="8,0,0,0" Grid.RowSpan="2" HorizontalAlignment="Left" Source="{Binding Image}" />
                         <TextBlock x:Name="Title" Grid.Column="1" Text="{Binding Result.Title}" FontWeight="SemiBold" FontSize="20" VerticalAlignment="Bottom"/>
                         <TextBlock x:Name="Path" Grid.Column="1" Text= "{Binding Result.SubTitle}" Grid.Row="1" Opacity="0.6" VerticalAlignment="Top"/>
-                        <ListView  Opacity="0" 
+                        <GridView 
                                    HorizontalAlignment="Right" 
+                                   VerticalAlignment="Center"
+                                   CornerRadius="4"
                                    Grid.RowSpan="2" 
-                                   Grid.Column="1" 
+                                   Grid.Column="1"
+                                   Margin="0,0,42,0"
+                                   Height="46"
+                                   ScrollViewer.IsVerticalRailEnabled="False"
                                    ItemsSource="{Binding ContextMenuItems}" 
                                    SelectionMode="Single"
                                    SelectedIndex="{Binding ContextMenuSelectedIndex}">
-                            <ListView.ItemsPanel>
-                                <ItemsPanelTemplate>
-                                    <StackPanel Orientation="Horizontal"/>
-                                </ItemsPanelTemplate>
-                            </ListView.ItemsPanel>
+
                             <Interactivity:Interaction.Behaviors>
                                 <ToolkitBehaviors:Fade x:Name="ShowActionButtons" Duration="250" Delay="0" AutomaticallyStart="False" Value="1" />
                                 <ToolkitBehaviors:Fade x:Name="HideActionsButtons" Duration="250" Delay="0" AutomaticallyStart="False" Value="0" />
                             </Interactivity:Interaction.Behaviors>
-                            <ListView.ItemTemplate>
+                            <GridView.ItemTemplate>
                                 <DataTemplate>
-                                    <Button Command="{Binding Command}" Background="Transparent" Height="42" Width="42" BorderThickness="1" Style="{ThemeResource ButtonRevealStyle}">
+                                    <Button Command="{Binding Command}" VerticalAlignment="Center" CornerRadius="4" Height="42" Width="42" BorderThickness="1" Style="{ThemeResource ButtonRevealStyle}">
                                         <ToolTipService.ToolTip>
                                             <TextBlock Text="{Binding Title}"/>
                                         </ToolTipService.ToolTip>
@@ -91,8 +92,8 @@
                                         </Button.KeyboardAccelerators>
                                     </Button>
                                 </DataTemplate>
-                            </ListView.ItemTemplate>
-                        </ListView>
+                            </GridView.ItemTemplate>
+                        </GridView>
                     </Grid>
                 </DataTemplate>
             </ListView.ItemTemplate>

--- a/src/modules/launcher/PowerLauncher.UI/ResultList.xaml
+++ b/src/modules/launcher/PowerLauncher.UI/ResultList.xaml
@@ -65,7 +65,8 @@
                                    Grid.Column="1"
                                    Margin="0,0,42,0"
                                    Height="46"
-                                   ScrollViewer.IsVerticalRailEnabled="False"
+                                   ScrollViewer.VerticalScrollBarVisibility="Disabled"
+                                   ScrollViewer.HorizontalScrollBarVisibility="Disabled"                       
                                    ItemsSource="{Binding ContextMenuItems}" 
                                    SelectionMode="Single"
                                    SelectedIndex="{Binding ContextMenuSelectedIndex}">


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
- Switching ListView to GridView for horizontal layout.  This fixes the issue of the ListViewItem having being stretched horizontally. 
- Adding a right margin to the gridview so buttons don't push up against the edge. 
- Setting the height to 46.  (I don't really understand this).  The grid view items also add a bit of padding veritcally.  46 is a value that adds some buffer to the height of the buttons but includes enough room for margins).  It's a bit of a magic number that I would love to make pixel perfect, but this will likely get re-styled anyway. 
- Adding background to buttons. 

* [] Applies to #2261 

## Detailed Description of the Pull Request / Additional comments
![ButtonPositioning](https://user-images.githubusercontent.com/56318517/79895632-0a698800-83bc-11ea-9caa-de5c0036b366.gif)

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manually Validated