### PR TITLE
Fix compilation problems related to the Interop project

### DIFF
--- a/src/common/common-md-flag/common-md-flag.vcxproj
+++ b/src/common/common-md-flag/common-md-flag.vcxproj
@@ -59,6 +59,7 @@
       <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Microsoft.PowerToys.Settings.UI.csproj
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Microsoft.PowerToys.Settings.UI.csproj
@@ -40,7 +40,7 @@
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ErrorReport>prompt</ErrorReport>
     <Prefer32Bit>true</Prefer32Bit>
-    <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
+    <UseDotNetNativeToolchain>false</UseDotNetNativeToolchain>
   </PropertyGroup>
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>

--- a/src/core/Microsoft.PowerToys.Settings.UnitTest/Microsoft.PowerToys.Settings.UnitTest.csproj
+++ b/src/core/Microsoft.PowerToys.Settings.UnitTest/Microsoft.PowerToys.Settings.UnitTest.csproj
@@ -110,7 +110,7 @@
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <ErrorReport>prompt</ErrorReport>
     <Prefer32Bit>true</Prefer32Bit>
-    <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
+    <UseDotNetNativeToolchain>false</UseDotNetNativeToolchain>
   </PropertyGroup>
   <PropertyGroup>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>


### PR DESCRIPTION

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
* Added missing c++17 compile flag to common-md-flag
* Removed .Net Native compilation from Release config in Settings.UI and Settings.UnitTests
* This was necessary because .Net Native does not support mixed assemblies, like PowerToysInterop.
* We can restore this flag in the future by preventing Settings.UI from using PowerToysInterop through Settings.Lib, and instead separate the UWP Interop in its own Windows Runtime Component.
