### PR TITLE
Select text whenever launcher is set to visible after being hidden

### DIFF
--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -169,6 +169,12 @@ namespace PowerLauncher
                         {
                             _viewModel.LastQuerySelected = true;
                         }          
+                        
+                        // to select the text so that the user can continue to type
+                        if(!String.IsNullOrEmpty(_launcher.TextBox.Text))
+                        {
+                            _launcher.TextBox.SelectAll();
+                        }
                     }
                 }
             };           


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
* This PR selects the text whenever visibility of launcher is set to visible after being hidden.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2269 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
* Text is selected every time the window is made visible.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
* Manually validated it.
![text_selection](https://user-images.githubusercontent.com/28739210/79934851-66f29480-8408-11ea-83bb-606acd26dfa2.gif)
