### PR TITLE
"Unhooked" the Shortcut guide module from the PT event dispatcher

### DIFF
--- a/src/modules/shortcut_guide/shortcut_guide.cpp
+++ b/src/modules/shortcut_guide/shortcut_guide.cpp
@@ -13,7 +13,7 @@ OverlayWindow* instance = nullptr;
 
 namespace
 {
-    LRESULT CALLBACK lowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam)
+    LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam)
     {
         LowlevelKeyboardEvent event;
         if (nCode == HC_ACTION)
@@ -134,7 +134,11 @@ void OverlayWindow::enable()
         winkey_popup->set_theme(theme.value);
         target_state = std::make_unique<TargetState>(pressTime.value);
         winkey_popup->initialize();
-        hook_handle = SetWindowsHookEx(WH_KEYBOARD_LL, lowLevelKeyboardProc, GetModuleHandle(NULL), NULL);
+        hook_handle = SetWindowsHookEx(WH_KEYBOARD_LL, LowLevelKeyboardProc, GetModuleHandle(NULL), NULL);
+        if (!hook_handle)
+        {
+            MessageBoxW(NULL, L"Cannot install keyboard listener.", L"PowerToys - Shortcut Guide", MB_OK | MB_ICONERROR);
+        }
     }
     _enabled = true;
 }

--- a/src/modules/shortcut_guide/shortcut_guide.cpp
+++ b/src/modules/shortcut_guide/shortcut_guide.cpp
@@ -201,6 +201,10 @@ intptr_t OverlayWindow::signal_event(LowlevelKeyboardEvent* event)
             event->wParam == WM_KEYDOWN || event->wParam == WM_SYSKEYDOWN);
         return suppress ? 1 : 0;
     }
+    else
+    {
+        return 0;
+    }
 }
 
 void OverlayWindow::on_held()

--- a/src/modules/shortcut_guide/shortcut_guide.cpp
+++ b/src/modules/shortcut_guide/shortcut_guide.cpp
@@ -11,6 +11,24 @@ extern "C" IMAGE_DOS_HEADER __ImageBase;
 
 OverlayWindow* instance = nullptr;
 
+namespace
+{
+    LRESULT CALLBACK hookProc(int nCode, WPARAM wParam, LPARAM lParam)
+    {
+        LowlevelKeyboardEvent event;
+        if (nCode == HC_ACTION)
+        {
+            event.lParam = reinterpret_cast<KBDLLHOOKSTRUCT*>(lParam);
+            event.wParam = wParam;
+            if (instance->signal_event(&event) != 0)
+            {
+                return 1;
+            }
+        }
+        return CallNextHookEx(NULL, nCode, wParam, lParam);
+    }
+}
+
 OverlayWindow::OverlayWindow()
 {
     app_name = GET_RESOURCE_STRING(IDS_SHORTCUT_GUIDE);
@@ -24,8 +42,7 @@ const wchar_t* OverlayWindow::get_name()
 
 const wchar_t** OverlayWindow::get_events()
 {
-    static const wchar_t* events[2] = { ll_keyboard, 0 };
-    return events;
+    return nullptr;
 }
 
 bool OverlayWindow::get_config(wchar_t* buffer, int* buffer_size)
@@ -117,6 +134,12 @@ void OverlayWindow::enable()
         winkey_popup->set_theme(theme.value);
         target_state = std::make_unique<TargetState>(pressTime.value);
         winkey_popup->initialize();
+
+        hook_handle = SetWindowsHookEx(WH_KEYBOARD_LL, hookProc, GetModuleHandle(NULL), NULL);
+        if (!hook_handle)
+        {
+            throw std::runtime_error("Cannot install keyboard listener");
+        }
     }
     _enabled = true;
 }
@@ -134,6 +157,16 @@ void OverlayWindow::disable(bool trace_event)
         target_state->exit();
         target_state.reset();
         winkey_popup.reset();
+
+        bool success = UnhookWindowsHookEx(hook_handle);
+        if (success)
+        {
+            hook_handle = nullptr;
+        }
+        else
+        {
+            throw std::runtime_error("Cannot uninstall keyboard listener");
+        }
     }
 }
 
@@ -149,20 +182,25 @@ bool OverlayWindow::is_enabled()
 
 intptr_t OverlayWindow::signal_event(const wchar_t* name, intptr_t data)
 {
-    if (_enabled && wcscmp(name, ll_keyboard) == 0)
-    {
-        auto& event = *(reinterpret_cast<LowlevelKeyboardEvent*>(data));
-        if (event.wParam == WM_KEYDOWN ||
-            event.wParam == WM_SYSKEYDOWN ||
-            event.wParam == WM_KEYUP ||
-            event.wParam == WM_SYSKEYUP)
-        {
-            bool supress = target_state->signal_event(event.lParam->vkCode,
-                                                      event.wParam == WM_KEYDOWN || event.wParam == WM_SYSKEYDOWN);
-            return supress ? 1 : 0;
-        }
-    }
     return 0;
+}
+
+intptr_t OverlayWindow::signal_event(LowlevelKeyboardEvent* event)
+{
+    if (!_enabled)
+    {
+        return 0;
+    }
+
+    if (event->wParam == WM_KEYDOWN ||
+        event->wParam == WM_SYSKEYDOWN ||
+        event->wParam == WM_KEYUP ||
+        event->wParam == WM_SYSKEYUP)
+    {
+        bool suppress = target_state->signal_event(event->lParam->vkCode,
+            event->wParam == WM_KEYDOWN || event->wParam == WM_SYSKEYDOWN);
+        return suppress ? 1 : 0;
+    }
 }
 
 void OverlayWindow::on_held()

--- a/src/modules/shortcut_guide/shortcut_guide.h
+++ b/src/modules/shortcut_guide/shortcut_guide.h
@@ -34,7 +34,7 @@ public:
     void quick_hide();
     void was_hidden();
 
-    // Method called from lowLevelKeyboardProc
+    // Method called from LowLevelKeyboardProc
     intptr_t signal_event(LowlevelKeyboardEvent* event);
 
     virtual void destroy() override;

--- a/src/modules/shortcut_guide/shortcut_guide.h
+++ b/src/modules/shortcut_guide/shortcut_guide.h
@@ -22,6 +22,8 @@ public:
     virtual void enable() override;
     virtual void disable() override;
     virtual bool is_enabled() override;
+
+    // PowerToys interface method, not used
     virtual intptr_t signal_event(const wchar_t* name, intptr_t data) override;
 
     virtual void register_system_menu_helper(PowertoySystemMenuIface* helper) override {}
@@ -32,6 +34,9 @@ public:
     void quick_hide();
     void was_hidden();
 
+    // Method called from hookProc
+    intptr_t signal_event(LowlevelKeyboardEvent* event);
+
     virtual void destroy() override;
 
 private:
@@ -39,6 +44,7 @@ private:
     std::unique_ptr<TargetState> target_state;
     std::unique_ptr<D2DOverlayWindow> winkey_popup;
     bool _enabled = false;
+    HHOOK hook_handle;
 
     void init_settings();
     void disable(bool trace_event);

--- a/src/modules/shortcut_guide/shortcut_guide.h
+++ b/src/modules/shortcut_guide/shortcut_guide.h
@@ -34,7 +34,7 @@ public:
     void quick_hide();
     void was_hidden();
 
-    // Method called from hookProc
+    // Method called from lowLevelKeyboardProc
     intptr_t signal_event(LowlevelKeyboardEvent* event);
 
     virtual void destroy() override;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This PR represents the beginning of long-planned work to move the control over winhooks from the PT runner to the modules themselves. Shortcut Guide is probably the easiest module to start from.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

Relevant issue: #961

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #961
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

The naming conventions may not follow the rest of the solution, but it's in line with the module itself.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Manually tested the Shortcut guide module, also tried disabling it and then enabling it again.