### PR TITLE
Making Shell plugin behave more like Win+R

### DIFF
--- a/src/modules/launcher/Plugins/Wox.Plugin.Shell/Main.cs
+++ b/src/modules/launcher/Plugins/Wox.Plugin.Shell/Main.cs
@@ -174,7 +174,7 @@ namespace Wox.Plugin.Shell
             if (_settings.Shell == Shell.Cmd)
             {
                 var arguments = _settings.LeaveShellOpen ? $"/k \"{command}\"" : $"/c \"{command}\" & pause";
-                
+
                 info = ShellCommand.SetProcessStartInfo("cmd.exe", workingDirectory, arguments, runAsAdministratorArg);
             }
             else if (_settings.Shell == Shell.Powershell)
@@ -193,23 +193,31 @@ namespace Wox.Plugin.Shell
             }
             else if (_settings.Shell == Shell.RunCommand)
             {
-                var parts = command.Split(new[] { ' ' }, 2);
-                if (parts.Length == 2)
+                //Open explorer if the path is a file or directory
+                if(Directory.Exists(command) || File.Exists(command))
                 {
-                    var filename = parts[0];
-                    if (ExistInPath(filename))
+                    info = ShellCommand.SetProcessStartInfo("explorer.exe", arguments: command, verb: runAsAdministratorArg);
+                }
+                else
+                {
+                    var parts = command.Split(new[] { ' ' }, 2);
+                    if (parts.Length == 2)
                     {
-                        var arguments = parts[1];
-                        info = ShellCommand.SetProcessStartInfo(filename, workingDirectory, arguments, runAsAdministratorArg);
+                        var filename = parts[0];
+                        if (ExistInPath(filename))
+                        {
+                            var arguments = parts[1];
+                            info = ShellCommand.SetProcessStartInfo(filename, workingDirectory, arguments, runAsAdministratorArg);
+                        }
+                        else
+                        {
+                            info = ShellCommand.SetProcessStartInfo(command, verb: runAsAdministratorArg);
+                        }
                     }
                     else
                     {
                         info = ShellCommand.SetProcessStartInfo(command, verb: runAsAdministratorArg);
                     }
-                }
-                else
-                {
-                    info = ShellCommand.SetProcessStartInfo(command, verb: runAsAdministratorArg);
                 }
             }
             else

--- a/src/modules/launcher/Plugins/Wox.Plugin.Shell/Settings.cs
+++ b/src/modules/launcher/Plugins/Wox.Plugin.Shell/Settings.cs
@@ -4,10 +4,10 @@ namespace Wox.Plugin.Shell
 {
     public class Settings
     {
-        public Shell Shell { get; set; } = Shell.Cmd;
+        public Shell Shell { get; set; } = Shell.RunCommand;
         public bool ReplaceWinR { get; set; } = true;
         public bool LeaveShellOpen { get; set; }
-        public bool RunAsAdministrator { get; set; } = true;
+        public bool RunAsAdministrator { get; set; } = false;
 
         public Dictionary<string, int> Count = new Dictionary<string, int>();
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
- Run as admin is off by default
- Process.Start will get called by the name of the exectuble. 
- If the user types in a file or directory path, we will launch explorer at that location

**NOTE: Settings are cached under %AppData%\PowerLauncher\Settings\Plugins\Wox.Plugin.Shell**.  You will need to delete these setting to see the change. 

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2270 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #2270 

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Validated locally -- see screenshots below: 

### Open C:\ ###
![Shell_Open_C](https://user-images.githubusercontent.com/56318517/80048222-6a4b5600-84c4-11ea-9c49-e55782a111c3.gif)
### Launch Terminal ###
![Shell_Launch_Terminal](https://user-images.githubusercontent.com/56318517/80048228-6d464680-84c4-11ea-81ce-840ef8fedb0f.gif)
### CMD w/ Arguments ###
![Shell_Launch_Cmd_w_args](https://user-images.githubusercontent.com/56318517/80048232-6f100a00-84c4-11ea-99a7-b8ddde1a3fc3.gif)

### Resolving Environment Variables ###
![Shell_Resolving_Env_Variable](https://user-images.githubusercontent.com/56318517/80048830-25c0ba00-84c6-11ea-837b-6622eb0a51e0.gif)

