### PR TITLE
runner: autoupdate improvements

### DIFF
--- a/src/common/VersionHelper.cpp
+++ b/src/common/VersionHelper.cpp
@@ -28,7 +28,7 @@ VersionHelper::VersionHelper(int major, int minor, int revision) :
 {
 }
 
-std::wstring VersionHelper::to_string() const
+std::wstring VersionHelper::toWstring() const
 {
     std::wstring result{ L"v" };
     result += std::to_wstring(major);

--- a/src/common/VersionHelper.cpp
+++ b/src/common/VersionHelper.cpp
@@ -27,3 +27,14 @@ VersionHelper::VersionHelper(int major, int minor, int revision) :
     revision(revision)
 {
 }
+
+std::wstring VersionHelper::to_string() const
+{
+    std::wstring result{ L"v" };
+    result += std::to_wstring(major);
+    result += L'.';
+    result += std::to_wstring(minor);
+    result += L'.';
+    result += std::to_wstring(revision);
+    return result;
+}

--- a/src/common/VersionHelper.h
+++ b/src/common/VersionHelper.h
@@ -13,4 +13,6 @@ struct VersionHelper
     int major;
     int minor;
     int revision;
+
+    std::wstring to_string() const;
 };

--- a/src/common/VersionHelper.h
+++ b/src/common/VersionHelper.h
@@ -14,5 +14,5 @@ struct VersionHelper
     int minor;
     int revision;
 
-    std::wstring to_string() const;
+    std::wstring toWstring() const;
 };

--- a/src/common/notifications.cpp
+++ b/src/common/notifications.cpp
@@ -33,6 +33,11 @@ namespace
     constexpr std::wstring_view WIN32_AUMID = L"Microsoft.PowerToysWin32";
 }
 
+namespace localized_strings 
+{
+    constexpr std::wstring_view SNOOZE_BUTTON = L"Snooze";
+}
+
 static DWORD loop_thread_id()
 {
     static const DWORD thread_id = GetCurrentThreadId();
@@ -276,7 +281,9 @@ void notifications::show_toast_with_activations(std::wstring message, std::wstri
                                toast_xml += selection_id;
                                toast_xml += '"';
                            }
-                           toast_xml += LR"( content="" />)";
+                           toast_xml += LR"( content=")";
+                           toast_xml += localized_strings::SNOOZE_BUTTON;
+                           toast_xml += LR"(" />)";
                        } },
                    actions[i]);
     }

--- a/src/common/notifications.cpp
+++ b/src/common/notifications.cpp
@@ -213,7 +213,14 @@ void notifications::show_toast_with_activations(std::wstring message, std::wstri
                                toast_xml += selection_id;
                                toast_xml += LR"(" type="selection" defaultInput=")";
                                toast_xml += std::to_wstring(b.durations[0].minutes);
-                               toast_xml += LR"(">)";
+                               toast_xml += L'"';
+                               if (!b.snooze_title.empty())
+                               {
+                                   toast_xml += LR"( title=")";
+                                   toast_xml += b.snooze_title;
+                                   toast_xml += L'"';
+                               }
+                               toast_xml += L'>';
                                for (const auto& duration : b.durations)
                                {
                                    toast_xml += LR"(<selection id=")";

--- a/src/common/notifications.h
+++ b/src/common/notifications.h
@@ -22,6 +22,7 @@ namespace notifications
 
     struct snooze_button
     {
+        std::wstring snooze_title;
         std::vector<snooze_duration> durations;
     };
 

--- a/src/common/updating/updating.cpp
+++ b/src/common/updating/updating.cpp
@@ -48,7 +48,7 @@ namespace localized_strings
 
     const wchar_t GITHUB_NEW_VERSION_AVAILABLE_OFFER_VISIT[] = L"An update to PowerToys is available. Visit our GitHub page to update.\n";
     const wchar_t GITHUB_NEW_VERSION_AGREE[] = L"Visit";
-    const wchar_t GITHUB_NEW_VERSION_SNOOZE_TITLE[] = L"You can snooze it to be reminded in:";
+    const wchar_t GITHUB_NEW_VERSION_SNOOZE_TITLE[] = L"Click Snooze to be reminded in:";
     const wchar_t GITHUB_NEW_VERSION_UPDATE_SNOOZE_1D[] = L"1 day";
     const wchar_t GITHUB_NEW_VERSION_UPDATE_SNOOZE_5D[] = L"5 days";
 }

--- a/src/common/updating/updating.cpp
+++ b/src/common/updating/updating.cpp
@@ -48,7 +48,7 @@ namespace localized_strings
 
     const wchar_t GITHUB_NEW_VERSION_AVAILABLE_OFFER_VISIT[] = L"An update to PowerToys is available. Visit our GitHub page to update.\n";
     const wchar_t GITHUB_NEW_VERSION_AGREE[] = L"Visit";
-    const wchar_t GITHUB_NEW_VERSION_SNOOZE_TITLE[] = L"Click Snooze to be reminded in:";
+    const wchar_t GITHUB_NEW_VERSION_SNOOZE_TITLE[] = L"You can snooze it to be reminded in:";
     const wchar_t GITHUB_NEW_VERSION_UPDATE_SNOOZE_1D[] = L"1 day";
     const wchar_t GITHUB_NEW_VERSION_UPDATE_SNOOZE_5D[] = L"5 days";
 }

--- a/src/common/updating/updating.cpp
+++ b/src/common/updating/updating.cpp
@@ -237,9 +237,9 @@ namespace updating
         {
             auto installer_download_dst = get_pending_updates_path();
             std::error_code _;
+            std::filesystem::create_directories(installer_download_dst, _);
             installer_download_dst /= new_version->msi_filename;
 
-            std::filesystem::create_directories(installer_download_dst, _);
 
             bool download_success = false;
             for (size_t i = 0; i < MAX_DOWNLOAD_ATTEMPTS; ++i)

--- a/src/common/updating/updating.cpp
+++ b/src/common/updating/updating.cpp
@@ -240,7 +240,6 @@ namespace updating
             std::filesystem::create_directories(installer_download_dst, _);
             installer_download_dst /= new_version->msi_filename;
 
-
             bool download_success = false;
             for (size_t i = 0; i < MAX_DOWNLOAD_ATTEMPTS; ++i)
             {
@@ -270,7 +269,12 @@ namespace updating
             std::wstring new_version_ready{ GITHUB_NEW_VERSION_READY_TO_INSTALL };
             new_version_ready += current_version_to_next_version;
 
-            notifications::show_toast_with_activations(std::move(new_version_ready), {}, { notifications::link_button{ GITHUB_NEW_VERSION_UPDATE_NOW, L"powertoys://update_now/" }, notifications::link_button{ GITHUB_NEW_VERSION_UPDATE_AFTER_RESTART, L"powertoys://schedule_update/" }, notifications::snooze_button{ GITHUB_NEW_VERSION_SNOOZE_TITLE, { { GITHUB_NEW_VERSION_UPDATE_SNOOZE_1D, 24 * 60 }, { GITHUB_NEW_VERSION_UPDATE_SNOOZE_5D, 120 * 60 } } } }, std::move(toast_params));
+            notifications::show_toast_with_activations(std::move(new_version_ready),
+                                                       {},
+                                                       { notifications::link_button{ GITHUB_NEW_VERSION_UPDATE_NOW, L"powertoys://update_now/" },
+                                                         notifications::link_button{ GITHUB_NEW_VERSION_UPDATE_AFTER_RESTART, L"powertoys://schedule_update/" },
+                                                         notifications::snooze_button{ GITHUB_NEW_VERSION_SNOOZE_TITLE, { { GITHUB_NEW_VERSION_UPDATE_SNOOZE_1D, 24 * 60 }, { GITHUB_NEW_VERSION_UPDATE_SNOOZE_5D, 120 * 60 } } } },
+                                                       std::move(toast_params));
         }
         else
         {

--- a/src/common/updating/updating.cpp
+++ b/src/common/updating/updating.cpp
@@ -48,6 +48,7 @@ namespace localized_strings
 
     const wchar_t GITHUB_NEW_VERSION_AVAILABLE_OFFER_VISIT[] = L"An update to PowerToys is available. Visit our GitHub page to update.\n";
     const wchar_t GITHUB_NEW_VERSION_AGREE[] = L"Visit";
+    const wchar_t GITHUB_NEW_VERSION_SNOOZE_TITLE[] = L"Click Snooze to be reminded in:";
     const wchar_t GITHUB_NEW_VERSION_UPDATE_SNOOZE_1D[] = L"1 day";
     const wchar_t GITHUB_NEW_VERSION_UPDATE_SNOOZE_5D[] = L"5 days";
 }
@@ -268,7 +269,8 @@ namespace updating
             notifications::toast_params toast_params{ UPDATE_READY_TOAST_TAG, false };
             std::wstring new_version_ready{ GITHUB_NEW_VERSION_READY_TO_INSTALL };
             new_version_ready += current_version_to_next_version;
-            notifications::show_toast_with_activations(std::move(new_version_ready), {}, { notifications::link_button{ GITHUB_NEW_VERSION_UPDATE_NOW, L"powertoys://update_now/" }, notifications::link_button{ GITHUB_NEW_VERSION_UPDATE_AFTER_RESTART, L"powertoys://schedule_update/" }, notifications::snooze_button{ { { GITHUB_NEW_VERSION_UPDATE_SNOOZE_1D, 24 * 60 }, { GITHUB_NEW_VERSION_UPDATE_SNOOZE_5D, 120 * 60 } } } }, std::move(toast_params));
+
+            notifications::show_toast_with_activations(std::move(new_version_ready), {}, { notifications::link_button{ GITHUB_NEW_VERSION_UPDATE_NOW, L"powertoys://update_now/" }, notifications::link_button{ GITHUB_NEW_VERSION_UPDATE_AFTER_RESTART, L"powertoys://schedule_update/" }, notifications::snooze_button{ GITHUB_NEW_VERSION_SNOOZE_TITLE, { { GITHUB_NEW_VERSION_UPDATE_SNOOZE_1D, 24 * 60 }, { GITHUB_NEW_VERSION_UPDATE_SNOOZE_5D, 120 * 60 } } } }, std::move(toast_params));
         }
         else
         {

--- a/src/common/updating/updating.cpp
+++ b/src/common/updating/updating.cpp
@@ -41,12 +41,12 @@ namespace localized_strings
     const wchar_t UNINSTALLATION_SUCCESS[] = L"Previous version of PowerToys was uninstalled successfully.";
     const wchar_t UNINSTALLATION_UNKNOWN_ERROR[] = L"Error: please uninstall the previous version of PowerToys manually.";
 
-    const wchar_t GITHUB_NEW_VERSION_READY_TO_INSTALL[] = L"An update to PowerToys is ready to install. ";
-    const wchar_t GITHUB_NEW_VERSION_DOWNLOAD_INSTALL_ERROR[] = L"Error: couldn't download PowerToys installer. Visit our GitHub page to update ";
+    const wchar_t GITHUB_NEW_VERSION_READY_TO_INSTALL[] = L"An update to PowerToys is ready to install.\n";
+    const wchar_t GITHUB_NEW_VERSION_DOWNLOAD_INSTALL_ERROR[] = L"Error: couldn't download PowerToys installer. Visit our GitHub page to update.\n";
     const wchar_t GITHUB_NEW_VERSION_UPDATE_NOW[] = L"Update now";
     const wchar_t GITHUB_NEW_VERSION_UPDATE_AFTER_RESTART[] = L"At next launch";
 
-    const wchar_t GITHUB_NEW_VERSION_AVAILABLE_OFFER_VISIT[] = L"An update to PowerToys is available. Visit our GitHub page to update ";
+    const wchar_t GITHUB_NEW_VERSION_AVAILABLE_OFFER_VISIT[] = L"An update to PowerToys is available. Visit our GitHub page to update.\n";
     const wchar_t GITHUB_NEW_VERSION_AGREE[] = L"Visit";
     const wchar_t GITHUB_NEW_VERSION_UPDATE_SNOOZE_1D[] = L"1 day";
     const wchar_t GITHUB_NEW_VERSION_UPDATE_SNOOZE_5D[] = L"5 days";
@@ -231,7 +231,6 @@ namespace updating
         auto current_version_to_next_version = VersionHelper{ VERSION_MAJOR, VERSION_MINOR, VERSION_REVISION }.to_string();
         current_version_to_next_version += L" -> ";
         current_version_to_next_version += new_version->version_string;
-        current_version_to_next_version += L'.';
 
         if (download_updates_automatically && !could_be_costly_connection())
         {

--- a/src/common/updating/updating.cpp
+++ b/src/common/updating/updating.cpp
@@ -229,7 +229,7 @@ namespace updating
             co_return;
         }
         using namespace localized_strings;
-        auto current_version_to_next_version = VersionHelper{ VERSION_MAJOR, VERSION_MINOR, VERSION_REVISION }.to_string();
+        auto current_version_to_next_version = VersionHelper{ VERSION_MAJOR, VERSION_MINOR, VERSION_REVISION }.toWstring();
         current_version_to_next_version += L" -> ";
         current_version_to_next_version += new_version->version_string;
 

--- a/src/common/updating/updating.cpp
+++ b/src/common/updating/updating.cpp
@@ -28,6 +28,10 @@ namespace
     const wchar_t LATEST_RELEASE_ENDPOINT[] = L"https://api.github.com/repos/microsoft/PowerToys/releases/latest";
     const wchar_t MSIX_PACKAGE_NAME[] = L"Microsoft.PowerToys";
     const wchar_t MSIX_PACKAGE_PUBLISHER[] = L"CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US";
+
+    const wchar_t UPDATE_NOTIFY_TOAST_TAG[] = L"PTUpdateNotifyTag";
+    const wchar_t UPDATE_READY_TOAST_TAG[] = L"PTUpdateReadyTag";
+    const size_t MAX_DOWNLOAD_ATTEMPTS = 3;
 }
 
 namespace localized_strings
@@ -37,11 +41,12 @@ namespace localized_strings
     const wchar_t UNINSTALLATION_SUCCESS[] = L"Previous version of PowerToys was uninstalled successfully.";
     const wchar_t UNINSTALLATION_UNKNOWN_ERROR[] = L"Error: please uninstall the previous version of PowerToys manually.";
 
-    const wchar_t GITHUB_NEW_VERSION_READY_TO_INSTALL[] = L"An update to PowerToys is ready to install.";
+    const wchar_t GITHUB_NEW_VERSION_READY_TO_INSTALL[] = L"An update to PowerToys is ready to install. ";
+    const wchar_t GITHUB_NEW_VERSION_DOWNLOAD_INSTALL_ERROR[] = L"Error: couldn't download PowerToys installer. Visit our GitHub page to update ";
     const wchar_t GITHUB_NEW_VERSION_UPDATE_NOW[] = L"Update now";
     const wchar_t GITHUB_NEW_VERSION_UPDATE_AFTER_RESTART[] = L"At next launch";
 
-    const wchar_t GITHUB_NEW_VERSION_AVAILABLE_OFFER_VISIT[] = L"An update to PowerToys is available. Visit our GitHub page to get ";
+    const wchar_t GITHUB_NEW_VERSION_AVAILABLE_OFFER_VISIT[] = L"An update to PowerToys is available. Visit our GitHub page to update ";
     const wchar_t GITHUB_NEW_VERSION_AGREE[] = L"Visit";
     const wchar_t GITHUB_NEW_VERSION_UPDATE_SNOOZE_1D[] = L"1 day";
     const wchar_t GITHUB_NEW_VERSION_UPDATE_SNOOZE_5D[] = L"5 days";
@@ -204,6 +209,17 @@ namespace updating
         return { std::move(path_str) };
     }
 
+    std::future<void> attempt_to_download_installer(const std::filesystem::path& destination, const winrt::Windows::Foundation::Uri& url)
+    {
+        namespace storage = winrt::Windows::Storage;
+
+        auto client = create_http_client();
+        auto response = co_await client.GetAsync(url);
+        (void)response.EnsureSuccessStatusCode();
+        auto msi_installer_file_stream = co_await storage::Streams::FileRandomAccessStream::OpenAsync(destination.c_str(), storage::FileAccessMode::ReadWrite, storage::StorageOpenOptions::AllowReadersAndWriters, storage::Streams::FileOpenDisposition::CreateAlways);
+        co_await response.Content().WriteToStreamAsync(msi_installer_file_stream);
+    }
+
     std::future<void> try_autoupdate(const bool download_updates_automatically)
     {
         const auto new_version = co_await get_new_github_version_info_async();
@@ -212,32 +228,54 @@ namespace updating
             co_return;
         }
         using namespace localized_strings;
-        namespace storage = winrt::Windows::Storage;
+        auto current_version_to_next_version = VersionHelper{ VERSION_MAJOR, VERSION_MINOR, VERSION_REVISION }.to_string();
+        current_version_to_next_version += L" -> ";
+        current_version_to_next_version += new_version->version_string;
+        current_version_to_next_version += L'.';
 
         if (download_updates_automatically && !could_be_costly_connection())
         {
-            auto client = create_http_client();
-            auto response = co_await client.GetAsync(new_version->msi_download_url);
-            (void)response.EnsureSuccessStatusCode();
-
-            auto download_dst = get_pending_updates_path();
+            auto installer_download_dst = get_pending_updates_path();
             std::error_code _;
-            std::filesystem::create_directories(download_dst, _);
-            download_dst /= new_version->msi_filename;
-            auto msi_installer_file_stream = co_await storage::Streams::FileRandomAccessStream::OpenAsync(download_dst.c_str(), storage::FileAccessMode::ReadWrite, storage::StorageOpenOptions::AllowReadersAndWriters, storage::Streams::FileOpenDisposition::CreateAlways);
-            co_await response.Content().WriteToStreamAsync(msi_installer_file_stream);
-            notifications::toast_params toast_params{ L"PTUpdateReadyTag", false };
+            installer_download_dst /= new_version->msi_filename;
+
+            std::filesystem::create_directories(installer_download_dst, _);
+
+            bool download_success = false;
+            for (size_t i = 0; i < MAX_DOWNLOAD_ATTEMPTS; ++i)
+            {
+                try
+                {
+                    co_await attempt_to_download_installer(installer_download_dst, new_version->msi_download_url);
+                    download_success = true;
+                    break;
+                }
+                catch (...)
+                {
+                    // reattempt to download or do nothing
+                }
+            }
+            if (!download_success)
+            {
+                notifications::toast_params toast_params{ UPDATE_NOTIFY_TOAST_TAG, false };
+                std::wstring contents = GITHUB_NEW_VERSION_DOWNLOAD_INSTALL_ERROR;
+                contents += current_version_to_next_version;
+
+                notifications::show_toast_with_activations(std::move(contents), {}, { notifications::link_button{ GITHUB_NEW_VERSION_AGREE, new_version->release_page_uri.ToString().c_str() } }, std::move(toast_params));
+
+                co_return;
+            }
+
+            notifications::toast_params toast_params{ UPDATE_READY_TOAST_TAG, false };
             std::wstring new_version_ready{ GITHUB_NEW_VERSION_READY_TO_INSTALL };
-            new_version_ready += L" ";
-            new_version_ready += new_version->version_string;
+            new_version_ready += current_version_to_next_version;
             notifications::show_toast_with_activations(std::move(new_version_ready), {}, { notifications::link_button{ GITHUB_NEW_VERSION_UPDATE_NOW, L"powertoys://update_now/" }, notifications::link_button{ GITHUB_NEW_VERSION_UPDATE_AFTER_RESTART, L"powertoys://schedule_update/" }, notifications::snooze_button{ { { GITHUB_NEW_VERSION_UPDATE_SNOOZE_1D, 24 * 60 }, { GITHUB_NEW_VERSION_UPDATE_SNOOZE_5D, 120 * 60 } } } }, std::move(toast_params));
         }
         else
         {
-            notifications::toast_params toast_params{ L"PTUpdateNotifyTag", false };
+            notifications::toast_params toast_params{ UPDATE_NOTIFY_TOAST_TAG, false };
             std::wstring contents = GITHUB_NEW_VERSION_AVAILABLE_OFFER_VISIT;
-            contents += new_version->version_string;
-            contents += L'.';
+            contents += current_version_to_next_version;
             notifications::show_toast_with_activations(std::move(contents), {}, { notifications::link_button{ GITHUB_NEW_VERSION_AGREE, new_version->release_page_uri.ToString().c_str() } }, std::move(toast_params));
         }
     }


### PR DESCRIPTION
## Summary of the Pull Request
- attempt to download the installer 3 times 
- toast cosmetic improvements

![new toasts](https://user-images.githubusercontent.com/1828123/80097237-a4276580-8573-11ea-9181-319f613f10a1.png)

The screenshot was done before I've noticed the missed dots at the end of the sentence, that's also fixed.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2337

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- installed PT with a version set to 0.15.2, update the PT