### PR TITLE
FancyZones now does its own event processing

### DIFF
--- a/src/modules/fancyzones/dll/dllmain.cpp
+++ b/src/modules/fancyzones/dll/dllmain.cpp
@@ -146,8 +146,7 @@ private:
 
             if (s_llKeyboardHook)
             {
-                bool success = UnhookWindowsHookEx(s_llKeyboardHook);
-                if (success)
+                if (UnhookWindowsHookEx(s_llKeyboardHook))
                 {
                     s_llKeyboardHook = nullptr;
                 }
@@ -155,8 +154,7 @@ private:
 
             if (s_winEventHook)
             {
-                bool success = UnhookWinEvent(s_winEventHook);
-                if (success)
+                if (UnhookWinEvent(s_winEventHook))
                 {
                     s_winEventHook = nullptr;
                 }

--- a/src/modules/fancyzones/dll/dllmain.cpp
+++ b/src/modules/fancyzones/dll/dllmain.cpp
@@ -45,8 +45,7 @@ public:
     // nullptr as the last element of the array. Nullptr can also be retured for empty list.
     virtual PCWSTR* get_events() override
     {
-        static PCWSTR events[] = { ll_keyboard, win_hook_event, nullptr };
-        return events;
+        return nullptr;
     }
 
     // Return JSON with the configuration options.
@@ -77,6 +76,19 @@ public:
         {
             Trace::FancyZones::EnableFancyZones(true);
             m_app = MakeFancyZones(reinterpret_cast<HINSTANCE>(&__ImageBase), m_settings);
+
+            s_llKeyboardHook = SetWindowsHookEx(WH_KEYBOARD_LL, LowLevelKeyboardProc, GetModuleHandle(NULL), NULL);
+            if (!s_llKeyboardHook)
+            {
+                MessageBoxW(NULL, L"Cannot install keyboard listener.", L"PowerToys - FancyZones", MB_OK | MB_ICONERROR);
+            }
+
+            s_winEventHook = SetWinEventHook(EVENT_MIN, EVENT_MAX, nullptr, WinHookProc, 0, 0, WINEVENT_OUTOFCONTEXT | WINEVENT_SKIPOWNPROCESS);
+            if (!s_winEventHook)
+            {
+                MessageBoxW(NULL, L"Cannot install Windows event listener.", L"PowerToys - FancyZones", MB_OK | MB_ICONERROR);
+            }
+
             if (m_app)
             {
                 m_app->Run();
@@ -96,22 +108,9 @@ public:
         return (m_app != nullptr);
     }
 
-    // Handle incoming event, data is event-specific
+    // PowertoyModuleIface method, unused
     virtual intptr_t signal_event(const wchar_t* name, intptr_t data) override
     {
-        if (m_app)
-        {
-            if (wcscmp(name, ll_keyboard) == 0)
-            {
-                // Return 1 if the keypress is to be suppressed (not forwarded to Windows), otherwise return 0.
-                return HandleKeyboardHookEvent(reinterpret_cast<LowlevelKeyboardEvent*>(data));
-            }
-            else if (wcscmp(name, win_hook_event) == 0)
-            {
-                // Return value is ignored
-                HandleWinHookEvent(reinterpret_cast<WinHookEvent*>(data));
-            }
-        }
         return 0;
     }
 
@@ -130,6 +129,7 @@ public:
         app_name = GET_RESOURCE_STRING(IDS_FANCYZONES);
         m_settings = MakeFancyZonesSettings(reinterpret_cast<HINSTANCE>(&__ImageBase), FancyZonesModule::get_name());
         JSONHelpers::FancyZonesDataInstance().LoadFancyZonesData();
+        s_instance = this;
     }
 
 private:
@@ -143,6 +143,24 @@ private:
             m_app->Destroy();
             m_app = nullptr;
             m_settings->ResetCallback();
+
+            if (s_llKeyboardHook)
+            {
+                bool success = UnhookWindowsHookEx(s_llKeyboardHook);
+                if (success)
+                {
+                    s_llKeyboardHook = nullptr;
+                }
+            }
+
+            if (s_winEventHook)
+            {
+                bool success = UnhookWinEvent(s_winEventHook);
+                if (success)
+                {
+                    s_winEventHook = nullptr;
+                }
+            }
         }
     }
 
@@ -155,6 +173,35 @@ private:
     winrt::com_ptr<IFancyZones> m_app;
     winrt::com_ptr<IFancyZonesSettings> m_settings;
     std::wstring app_name;
+
+    static inline FancyZonesModule* s_instance;
+    static inline HHOOK s_llKeyboardHook;
+    static inline HWINEVENTHOOK s_winEventHook;
+
+    static LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam)
+    {
+        LowlevelKeyboardEvent event;
+        if (nCode == HC_ACTION)
+        {
+            event.lParam = reinterpret_cast<KBDLLHOOKSTRUCT*>(lParam);
+            event.wParam = wParam;
+            if (s_instance)
+            {
+                return s_instance->HandleKeyboardHookEvent(&event);
+            }
+        }
+        return CallNextHookEx(NULL, nCode, wParam, lParam);
+    }
+
+    static void CALLBACK WinHookProc(HWINEVENTHOOK winEventHook, DWORD event, HWND window, LONG object,
+        LONG child, DWORD eventThread, DWORD eventTime)
+    {
+        WinHookEvent data{ event, window, object, child, eventThread, eventTime };
+        if (s_instance)
+        {
+            s_instance->HandleWinHookEvent(&data);
+        }
+    }
 };
 
 intptr_t FancyZonesModule::HandleKeyboardHookEvent(LowlevelKeyboardEvent* data) noexcept
@@ -245,7 +292,5 @@ void FancyZonesModule::MoveSizeUpdate(POINT const& ptScreen) noexcept
 
 extern "C" __declspec(dllexport) PowertoyModuleIface*  __cdecl powertoy_create()
 {
-  return new FancyZonesModule();
+    return new FancyZonesModule();
 }
-
-


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This PR moves the code which creates and uses WinHooks used in FancyZones from PowerToys to the FancyZones module, without affecting other modules.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

Relevant issue: #961

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #961
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Manually tested the FancyZones module, also tried disabling it and then enabling it again.