### PR TITLE
Fix - issue 2301 buttons showing inconsistently

### DIFF
--- a/src/modules/launcher/PowerLauncher.UI/ResultList.xaml
+++ b/src/modules/launcher/PowerLauncher.UI/ResultList.xaml
@@ -17,7 +17,6 @@
     <Grid 
         x:Name="PowerBar"
         Background="{ThemeResource BackdropAcrylicBrush}"        
-        Translation="0,0,16" 
         VerticalAlignment="Top">
         <ListView 
             x:Name="SuggestionsList"
@@ -26,7 +25,7 @@
             MinHeight="{Binding Results.MaxHeight}"
             AllowFocusOnInteraction="False"
             IsItemClickEnabled="True"
-            Margin="{ThemeResource AutoSuggestListMargin}"
+            Margin="0"
             Padding="{ThemeResource AutoSuggestListPadding}"
             ItemsSource="{Binding Results.Results, Mode=OneWay}"
             SelectionMode="Single"

--- a/src/modules/launcher/PowerLauncher.UI/ResultList.xaml
+++ b/src/modules/launcher/PowerLauncher.UI/ResultList.xaml
@@ -8,11 +8,16 @@
     xmlns:ToolkitBehaviors="using:Microsoft.Toolkit.Uwp.UI.Animations.Behaviors"
     xmlns:Core="using:Microsoft.Xaml.Interactions.Core"
     xmlns:Interactivity="using:Microsoft.Xaml.Interactivity"
+    xmlns:converters="using:Microsoft.Toolkit.Uwp.UI.Converters"
     d:DesignHeight="300"
     d:DesignWidth="720">
+    <UserControl.Resources>
+        <converters:BoolToObjectConverter x:Key="BoolToVisibilityConverter" TrueValue="Visible" FalseValue="Collapsed"/>
+    </UserControl.Resources>
     <Grid 
-        x:Name="PowerBar" 
+        x:Name="PowerBar"
         Background="{ThemeResource BackdropAcrylicBrush}"        
+        Translation="0,0,16" 
         VerticalAlignment="Top">
         <ListView 
             x:Name="SuggestionsList"
@@ -21,28 +26,22 @@
             MinHeight="{Binding Results.MaxHeight}"
             AllowFocusOnInteraction="False"
             IsItemClickEnabled="True"
-            Margin="0"
+            Margin="{ThemeResource AutoSuggestListMargin}"
             Padding="{ThemeResource AutoSuggestListPadding}"
             ItemsSource="{Binding Results.Results, Mode=OneWay}"
             SelectionMode="Single"
             SelectedIndex="{Binding Results.SelectedIndex, Mode=TwoWay}"
-            Style="{StaticResource ListViewNoAnimations}">
+            Style="{StaticResource ListViewNoAnimations}"
+            >
             <ListView.ItemTemplate>
                 <DataTemplate >
                     <Grid Height="72" Width="690" Background="Transparent" RowSpacing="0">
                         <Interactivity:Interaction.Behaviors>
-                            <Core:DataTriggerBehavior Binding="{Binding IsSelected}" ComparisonCondition="Equal" Value="true" >
-                                <Core:CallMethodAction TargetObject="{Binding ElementName=ShowActionButtons}" MethodName="StartAnimation"/>
-                            </Core:DataTriggerBehavior>
-                            <Core:DataTriggerBehavior Binding="{Binding IsSelected}" ComparisonCondition="Equal" Value="false">
-                                <Core:CallMethodAction TargetObject="{Binding ElementName=HideActionsButtons}" MethodName="StartAnimation"/>
-                            </Core:DataTriggerBehavior>
                             <Core:EventTriggerBehavior EventName="PointerEntered">
-                                <Core:CallMethodAction TargetObject="{Binding ElementName=ShowActionButtons}" MethodName="StartAnimation"/>
-                                <Core:InvokeCommandAction Command="{Binding LoadContextMenuCommand}"/>
+                                <Core:InvokeCommandAction Command="{Binding ActivateContextButtonsHoverCommand}"/>
                             </Core:EventTriggerBehavior>
                             <Core:EventTriggerBehavior EventName="PointerExited">
-                                <Core:CallMethodAction TargetObject="{Binding ElementName=HideActionsButtons}" MethodName="StartAnimation"/>
+                                <Core:InvokeCommandAction Command="{Binding DeactivateContextButtonsHoverCommand}"/>
                             </Core:EventTriggerBehavior>
                         </Interactivity:Interaction.Behaviors>
                         <Grid.ColumnDefinitions>
@@ -64,16 +63,12 @@
                                    Grid.Column="1"
                                    Margin="0,0,42,0"
                                    Height="46"
+                                   Visibility="{Binding AreContextButtonsActive, Converter={StaticResource BoolToVisibilityConverter}}"
                                    ScrollViewer.VerticalScrollBarVisibility="Disabled"
                                    ScrollViewer.HorizontalScrollBarVisibility="Disabled"                       
                                    ItemsSource="{Binding ContextMenuItems}" 
                                    SelectionMode="Single"
                                    SelectedIndex="{Binding ContextMenuSelectedIndex}">
-
-                            <Interactivity:Interaction.Behaviors>
-                                <ToolkitBehaviors:Fade x:Name="ShowActionButtons" Duration="250" Delay="0" AutomaticallyStart="False" Value="1" />
-                                <ToolkitBehaviors:Fade x:Name="HideActionsButtons" Duration="250" Delay="0" AutomaticallyStart="False" Value="0" />
-                            </Interactivity:Interaction.Behaviors>
                             <GridView.ItemTemplate>
                                 <DataTemplate>
                                     <Button Command="{Binding Command}" VerticalAlignment="Center" CornerRadius="4" Height="42" Width="42" BorderThickness="1" Style="{ThemeResource ButtonRevealStyle}">
@@ -87,7 +82,7 @@
                                             <KeyboardAccelerator
                                                 Key="{Binding AcceleratorKey}"
                                                 Modifiers="{Binding AcceleratorModifiers}"
-                                                IsEnabled="{Binding IsEnabled}"
+                                                IsEnabled="{Binding IsAcceleratorKeyEnabled}"
                                             />
                                         </Button.KeyboardAccelerators>
                                     </Button>

--- a/src/modules/launcher/Wox/ViewModel/ContextMenuItemViewModel.cs
+++ b/src/modules/launcher/Wox/ViewModel/ContextMenuItemViewModel.cs
@@ -12,6 +12,6 @@ namespace Wox.ViewModel
         public ICommand Command { get; set; }
         public string AcceleratorKey { get; set; }
         public string AcceleratorModifiers { get; set; }
-        public bool IsEnabled { get; set; }
+        public bool IsAcceleratorKeyEnabled { get; set; }
     }
 }

--- a/src/modules/launcher/Wox/ViewModel/ResultViewModel.cs
+++ b/src/modules/launcher/Wox/ViewModel/ResultViewModel.cs
@@ -33,6 +33,8 @@ namespace Wox.ViewModel
 
         public bool IsSelected { get; set; }
 
+        public bool IsHovered { get; set; }
+
         public bool AreContextButtonsActive { get; set; }
 
         public int ContextMenuSelectedIndex { get; set; }
@@ -76,6 +78,10 @@ namespace Wox.ViewModel
                 IsSelected = true;
                 EnableContextMenuAcceleratorKeys();
             }
+            else if(activationType == ActivationType.Hover)
+            {
+                IsHovered = true;
+            }
         }
 
 
@@ -91,13 +97,17 @@ namespace Wox.ViewModel
 
         public void DeactivateContextButtons(ActivationType activationType)
         {
-            AreContextButtonsActive = false;
-
             if (activationType == ActivationType.Selection)
             {
                 IsSelected = false;
                 DisableContextMenuAcceleratorkeys();
             }
+            else if (activationType == ActivationType.Hover)
+            {
+                IsHovered = false;
+            }
+
+            AreContextButtonsActive = IsSelected || IsHovered;
         }
 
 

--- a/src/modules/launcher/Wox/ViewModel/ResultViewModel.cs
+++ b/src/modules/launcher/Wox/ViewModel/ResultViewModel.cs
@@ -17,11 +17,23 @@ namespace Wox.ViewModel
 {
     public class ResultViewModel : BaseModel
     {
+        public enum ActivationType
+        {
+            Selection,
+            Hover
+        };
+
         public List<ContextMenuItemViewModel> ContextMenuItems { get; set; }
 
-        public ICommand LoadContextMenuCommand { get; set; }
+        public ICommand ActivateContextButtonsHoverCommand { get; set; }
+        public ICommand ActivateContextButtonsSelectionCommand { get; set; }
+        public ICommand DeactivateContextButtonsHoverCommand { get; set; }
+
+        public ICommand DeactivateContextButtonsSelectionCommand { get; set; }
 
         public bool IsSelected { get; set; }
+
+        public bool AreContextButtonsActive { get; set; }
 
         public int ContextMenuSelectedIndex { get; set; }
 
@@ -34,9 +46,62 @@ namespace Wox.ViewModel
                 Result = result;
             }
             ContextMenuSelectedIndex = NoSelectionIndex;
-            LoadContextMenuCommand = new RelayCommand(LoadContextMenu);
+            ActivateContextButtonsHoverCommand = new RelayCommand(ActivateContextButtonsHoverAction);
+            ActivateContextButtonsSelectionCommand = new RelayCommand(ActivateContextButtonsSelectionAction);
+            DeactivateContextButtonsHoverCommand = new RelayCommand(DeactivateContextButtonsHoverAction);
+            DeactivateContextButtonsSelectionCommand = new RelayCommand(DeactivateContextButtonsSelectionAction);
         }
-        public void LoadContextMenu(object sender=null)
+
+        private void ActivateContextButtonsHoverAction(object sender)
+        {
+            ActivateContextButtons(ActivationType.Hover);
+        }
+
+        private void ActivateContextButtonsSelectionAction(object sender)
+        {
+            ActivateContextButtons(ActivationType.Selection);
+        }
+        public void ActivateContextButtons(ActivationType activationType)
+        {
+            
+            if (ContextMenuItems == null)
+            {
+                LoadContextMenu();
+            }
+
+            AreContextButtonsActive = true;
+
+            if (activationType == ActivationType.Selection)
+            {
+                IsSelected = true;
+                EnableContextMenuAcceleratorKeys();
+            }
+        }
+
+
+        private void DeactivateContextButtonsHoverAction(object sender)
+        {
+            DeactivateContextButtons(ActivationType.Hover);
+        }
+
+        private void DeactivateContextButtonsSelectionAction(object sender)
+        {
+            DeactivateContextButtons(ActivationType.Selection);
+        }
+
+        public void DeactivateContextButtons(ActivationType activationType)
+        {
+            AreContextButtonsActive = false;
+
+            if (activationType == ActivationType.Selection)
+            {
+                IsSelected = false;
+                DisableContextMenuAcceleratorkeys();
+            }
+        }
+
+
+        public void LoadContextMenu()
         {
             var results = PluginManager.GetContextMenusForPlugin(Result);
             var newItems = new List<ContextMenuItemViewModel>();
@@ -68,19 +133,19 @@ namespace Wox.ViewModel
             ContextMenuItems = newItems;
         }
 
-        internal void EnableContextMenu()
+        private void EnableContextMenuAcceleratorKeys()
         {
             foreach(var i in ContextMenuItems)
             {
-                i.IsEnabled = true;
+                i.IsAcceleratorKeyEnabled = true;
             }
         }
 
-        internal void DisableContextMenu()
+        private void DisableContextMenuAcceleratorkeys()
         {
             foreach (var i in ContextMenuItems)
             {
-                i.IsEnabled = false;
+                i.IsAcceleratorKeyEnabled = false;
             }
         }
 

--- a/src/modules/launcher/Wox/ViewModel/ResultsViewModel.cs
+++ b/src/modules/launcher/Wox/ViewModel/ResultsViewModel.cs
@@ -59,14 +59,11 @@ namespace Wox.ViewModel
                 {
                     if (_selectedItem != null)
                     {
-                        _selectedItem.IsSelected = false;
-                        _selectedItem.DisableContextMenu();
+                        _selectedItem.DeactivateContextButtons(ResultViewModel.ActivationType.Selection);
                     }
 
                     _selectedItem = value;
-                    _selectedItem.LoadContextMenu();
-                    _selectedItem.EnableContextMenu();
-                    _selectedItem.IsSelected = true;
+                    _selectedItem.ActivateContextButtons(ResultViewModel.ActivationType.Selection);
                 }
             }
         }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
The Fade behavior was exposed to race conditions because Pointer events were conflicting with keyboard input.  This PR does the following: 
1. Removes the fade animation, and sets visibility property. 
2. Encapsulates context button activation inside the resultviewmodel, which knows how to respond to both pointer events and keyboard input
<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2301
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
![ConsitentButtons_2301](https://user-images.githubusercontent.com/56318517/80124056-8989c800-8544-11ea-825d-c64238fa5be6.gif)

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
1.  Verified that PointerExit on the selected item doesn't hide the buttons. 
2.  Verified that accelerator keys trigger the selected result, not the result in the pointer over state.
3.  Verified that pressing the buttons initiates the context action. 
4.  Verified that each result has context menu buttons (except window walker items).