### PR TITLE
we shouldn't be overriding key in multiple areas

### DIFF
--- a/src/modules/launcher/Plugins/Wox.Plugin.Shell/Main.cs
+++ b/src/modules/launcher/Plugins/Wox.Plugin.Shell/Main.cs
@@ -289,6 +289,9 @@ namespace Wox.Plugin.Shell
 
         bool API_GlobalKeyboardEvent(int keyevent, int vkcode, SpecialKeyState state)
         {
+            // not overriding Win+R 
+            // crutkas we need to earn the right for Win+R override
+
             if (_settings.ReplaceWinR)
             {
                 if (keyevent == (int)KeyEvent.WM_KEYDOWN && vkcode == (int)Keys.R && state.WinPressed)

--- a/src/modules/launcher/Plugins/Wox.Plugin.Shell/Settings.cs
+++ b/src/modules/launcher/Plugins/Wox.Plugin.Shell/Settings.cs
@@ -5,7 +5,10 @@ namespace Wox.Plugin.Shell
     public class Settings
     {
         public Shell Shell { get; set; } = Shell.RunCommand;
-        public bool ReplaceWinR { get; set; } = true;
+
+        // not overriding Win+R 
+        // crutkas we need to earn the right for Win+R override
+        public bool ReplaceWinR { get; set; } = false;
         public bool LeaveShellOpen { get; set; }
         public bool RunAsAdministrator { get; set; } = false;
 


### PR DESCRIPTION
Disabling Win+R Override in shell plugin.  We should also have a single way to do key overrides, this and how the main code base override differently