### PR TITLE
Fix for program executing when there is no query text in search box

### DIFF
--- a/src/modules/launcher/Wox/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/Wox/ViewModel/MainViewModel.cs
@@ -155,11 +155,11 @@ namespace Wox.ViewModel
                 if(results.SelectedItem != null)
                 {
                     //If there is a context button selected fire the action for that button before the main command. 
-                    bool didExecuteContextButton = results.SelectedItem?.ExecuteSelectedContextButton() ?? false;
+                    bool didExecuteContextButton = results.SelectedItem.ExecuteSelectedContextButton();
 
                     if (!didExecuteContextButton)
                     {
-                        var result = results.SelectedItem?.Result;
+                        var result = results.SelectedItem.Result;
                         if (result != null) // SelectedItem returns null if selection is empty.
                         {
                             bool hideWindow = result.Action != null && result.Action(new ActionContext

--- a/src/modules/launcher/Wox/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/Wox/ViewModel/MainViewModel.cs
@@ -152,35 +152,38 @@ namespace Wox.ViewModel
                     results.SelectedIndex = int.Parse(index.ToString());
                 }
 
-                //If there is a context button selected fire the action for that button before the main command. 
-                bool didExecuteContextButton = results.SelectedItem?.ExecuteSelectedContextButton() ?? false;
-
-                if (!didExecuteContextButton)
+                if(results.SelectedItem != null)
                 {
-                    var result = results.SelectedItem?.Result;
-                    if (result != null) // SelectedItem returns null if selection is empty.
+                    //If there is a context button selected fire the action for that button before the main command. 
+                    bool didExecuteContextButton = results.SelectedItem?.ExecuteSelectedContextButton() ?? false;
+
+                    if (!didExecuteContextButton)
                     {
-                        bool hideWindow = result.Action != null && result.Action(new ActionContext
+                        var result = results.SelectedItem?.Result;
+                        if (result != null) // SelectedItem returns null if selection is empty.
                         {
-                            SpecialKeyState = GlobalHotkey.Instance.CheckModifiers()
-                        });
+                            bool hideWindow = result.Action != null && result.Action(new ActionContext
+                            {
+                                SpecialKeyState = GlobalHotkey.Instance.CheckModifiers()
+                            });
 
-                        if (hideWindow)
-                        {
-                            MainWindowVisibility = Visibility.Collapsed;
-                        }
+                            if (hideWindow)
+                            {
+                                MainWindowVisibility = Visibility.Collapsed;
+                            }
 
-                        if (SelectedIsFromQueryResults())
-                        {
-                            _userSelectedRecord.Add(result);
-                            _history.Add(result.OriginQuery.RawQuery);
-                        }
-                        else
-                        {
-                            SelectedResults = Results;
+                            if (SelectedIsFromQueryResults())
+                            {
+                                _userSelectedRecord.Add(result);
+                                _history.Add(result.OriginQuery.RawQuery);
+                            }
+                            else
+                            {
+                                SelectedResults = Results;
+                            }
                         }
                     }
-                }
+                }              
             });
 
             LoadContextMenuCommand = new RelayCommand(_ =>
@@ -419,7 +422,8 @@ namespace Wox.ViewModel
             }
             else
             {
-                Results.Clear();
+                Results.SelectedItem = null;
+                Results.Clear();                
                 Results.Visbility = Visibility.Collapsed;
             }
         }

--- a/src/modules/launcher/Wox/ViewModel/ResultsViewModel.cs
+++ b/src/modules/launcher/Wox/ViewModel/ResultsViewModel.cs
@@ -68,6 +68,10 @@ namespace Wox.ViewModel
                     _selectedItem.EnableContextMenu();
                     _selectedItem.IsSelected = true;
                 }
+                else
+                {
+                    _selectedItem = value;
+                }
             }
         }
 


### PR DESCRIPTION
<!--_ Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Fix for program executing when there is no query text in search box and `Enter` is pressed. 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Verified that last selected program is not executed again if we press `Enter` in empty search box.
- Manually validated the working of plugins.