### PR TITLE
Push program execution to background thread

### DIFF
--- a/src/modules/launcher/Wox/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/Wox/ViewModel/MainViewModel.cs
@@ -158,17 +158,18 @@ namespace Wox.ViewModel
                 if (!didExecuteContextButton)
                 {
                     var result = results.SelectedItem?.Result;
-                    if (result != null) // SelectedItem returns null if selection is empty.
+                    if (result != null && result.Action != null) // SelectedItem returns null if selection is empty.
                     {
-                        bool hideWindow = result.Action != null && result.Action(new ActionContext
-                        {
-                            SpecialKeyState = GlobalHotkey.Instance.CheckModifiers()
-                        });
 
-                        if (hideWindow)
+                        MainWindowVisibility = Visibility.Collapsed;
+
+                        Task.Run(() =>
                         {
-                            MainWindowVisibility = Visibility.Collapsed;
-                        }
+                            result.Action(new ActionContext
+                            {
+                                SpecialKeyState = GlobalHotkey.Instance.CheckModifiers()
+                            });
+                        });
 
                         if (SelectedIsFromQueryResults())
                         {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Push program execution to a background thread.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2338 #2367 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests Added/Passed

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Whenever a search result was executed through Enter/click, `Process.start` was freezing the UI thread till it's completion. This PR pushes this operation to a background thread and hides the launcher window. 

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Validated that the launcher hides without waiting for process to start.
- Manually validated working of all plugins.