### PR TITLE
Folder Plugin 

### DIFF
--- a/src/modules/launcher/PowerLauncher.UI/LauncherControl.xaml
+++ b/src/modules/launcher/PowerLauncher.UI/LauncherControl.xaml
@@ -375,6 +375,7 @@
             x:FieldModifier="public"
             Style="{StaticResource CustomAutoSuggestBoxTextBoxStyle}"
             PlaceholderText="Start typing"
+            Text="{Binding QueryText}"
             Height="60"
             ScrollViewer.BringIntoViewOnFocusChange="False"
             Canvas.ZIndex="0"

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -354,6 +354,12 @@ namespace PowerLauncher
             {
                 _launcher.AutoCompleteTextBox.PlaceholderText = String.Empty;
             }
+
+            if (_viewModel.QueryTextCursorMovedToEnd)
+            {
+                _launcher.TextBox.SelectionStart = _launcher.TextBox.Text.Length;
+                _viewModel.QueryTextCursorMovedToEnd = false;
+            }
         }
 
         private async Task DelayedCheck(DateTime latestTimeOfTyping, string text)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
- This just adds the binding back to the querytext box, so that plugins can update the query text field. 
- Cursor Position is also updated to the end when plugins update the text.
- Note this also will automatically add the '> ' when pressing Win-R, however we will want to not select the '> ' when bringing it up a consecutive time. 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2371 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
![OpenDirectory_PathComplete](https://user-images.githubusercontent.com/56318517/80165968-98e33280-8591-11ea-854a-91b652675115.gif)

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
