### PR TITLE
Fixes cursor jumping around issue.

### DIFF
--- a/src/modules/launcher/Plugins/Wox.Plugin.Folder/Main.cs
+++ b/src/modules/launcher/Plugins/Wox.Plugin.Folder/Main.cs
@@ -112,9 +112,9 @@ namespace Wox.Plugin.Folder
                     }
 
                     string changeTo = path.EndsWith("\\") ? path : path + "\\";
-                    _context.API.ChangeQuery(string.IsNullOrEmpty(query.ActionKeyword) ?
-                        changeTo :
-                        query.ActionKeyword + " " + changeTo);
+                    changeTo = string.IsNullOrEmpty(query.ActionKeyword) ? changeTo : query.ActionKeyword + " " + changeTo;
+                    bool requery = true;
+                    _context.API.ChangeQuery(changeTo, requery);
                     return false;
                 },
                 ContextData = new SearchResult { Type = ResultType.Folder, FullPath = path }

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -344,21 +344,25 @@ namespace PowerLauncher
 
         private void QueryTextBox_TextChanged(object sender, Windows.UI.Xaml.Controls.TextChangedEventArgs e)
         {
-            var latestTimeOfTyping = DateTime.Now;
             var text = ((Windows.UI.Xaml.Controls.TextBox)sender).Text;
-            Task.Run(() => DelayedCheck(latestTimeOfTyping, text));
-            s_lastTimeOfTyping = latestTimeOfTyping;
-
             //To clear the auto-suggest immediately instead of waiting for selection changed
-            if(text == String.Empty)
+            if (text == String.Empty)
             {
                 _launcher.AutoCompleteTextBox.PlaceholderText = String.Empty;
             }
 
-            if (_viewModel.QueryTextCursorMovedToEnd)
+            if (_viewModel.QueryTextUpdateBySystem)
             {
                 _launcher.TextBox.SelectionStart = _launcher.TextBox.Text.Length;
-                _viewModel.QueryTextCursorMovedToEnd = false;
+                _viewModel.QueryTextUpdateBySystem = false;
+            }
+            else
+            {
+                _viewModel.QueryText = text;
+                var latestTimeOfTyping = DateTime.Now;
+
+                Task.Run(() => DelayedCheck(latestTimeOfTyping, text));
+                s_lastTimeOfTyping = latestTimeOfTyping;
             }
         }
 
@@ -369,7 +373,7 @@ namespace PowerLauncher
             {
                 await System.Windows.Application.Current.Dispatcher.BeginInvoke(new Action(() =>
                  {
-                     _viewModel.QueryText = text;
+                     _viewModel.Query();
                  }));               
             }
         }

--- a/src/modules/launcher/Wox/MainWindow.xaml.cs
+++ b/src/modules/launcher/Wox/MainWindow.xaml.cs
@@ -235,16 +235,9 @@ namespace Wox
                 e.Handled = true;
             }
         }
-
         private void OnTextChanged(object sender, TextChangedEventArgs e)
         {
-            if (_viewModel.QueryTextCursorMovedToEnd)
-            {
-                QueryTextBox.CaretIndex = QueryTextBox.Text.Length;
-                _viewModel.QueryTextCursorMovedToEnd = false;
-            }
+           
         }
-
-
     }
 }

--- a/src/modules/launcher/Wox/PublicAPIInstance.cs
+++ b/src/modules/launcher/Wox/PublicAPIInstance.cs
@@ -38,12 +38,12 @@ namespace Wox
 
         public void ChangeQuery(string query, bool requery = false)
         {
-            _mainVM.ChangeQueryText(query);
+            _mainVM.ChangeQueryText(query, requery);
         }
 
         public void ChangeQueryText(string query, bool selectAll = false)
         {
-            _mainVM.ChangeQueryText(query);
+            _mainVM.ChangeQueryText(query, false);
         }
 
         [Obsolete]

--- a/src/modules/launcher/Wox/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/Wox/ViewModel/MainViewModel.cs
@@ -51,7 +51,6 @@ namespace Wox.ViewModel
         {
             _saved = false;
             _queryTextBeforeLeaveResults = "";
-            _queryText = "";
             _lastQuery = new Query();
 
             _settings = settings;
@@ -223,29 +222,30 @@ namespace Wox.ViewModel
         public ResultsViewModel ContextMenu { get; private set; }
         public ResultsViewModel History { get; private set; }
 
-        private string _queryText;
-        public string QueryText
-        {
-            get { return _queryText; }
-            set
-            {
-                _queryText = value;
-                Query();
-            }
-        }
+        public string SystemQueryText { get; set; }
+
+        public string QueryText { get; set; }
+      
 
         /// <summary>
         /// we need move cursor to end when we manually changed query
-        /// but we don't want to move cursor to end when query is updated from TextBox
+        /// but we don't want to move cursor to end when query is updated from TextBox. 
+        /// Also we don't want to force the results to change unless explicity told to.
         /// </summary>
         /// <param name="queryText"></param>
-        public void ChangeQueryText(string queryText)
+        /// <param name="requery">Optional Parameter that if true, will automatically execute a query against the updated text</param>
+        public void ChangeQueryText(string queryText, bool requery=false)
         {
-            QueryTextCursorMovedToEnd = true;
+            QueryTextUpdateBySystem = true;
             QueryText = queryText;
+
+            if(requery)
+            {
+               Query();
+            }
         }
         public bool LastQuerySelected { get; set; }
-        public bool QueryTextCursorMovedToEnd { get; set; }
+        public bool QueryTextUpdateBySystem { get; set; }
 
         private ResultsViewModel _selectedResults;
         private ResultsViewModel SelectedResults


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This issue fixes the cursor jumping around.  

The root cause was that due to a delay there was a disconnect between the text that was in the textbox, and what was being queried.   As a result the cursor was being set to a position that didn't match what was being queried.

PR Checklist
- [x] Applies to #2378

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
- Separating the ability to set the text from initiating a query.
- Plugins have to explicitly request the query be updated.
- Updating Folder plugin to explicitly update the query on folder selection.
- Removing unused changes from 'Wox' that don't compile.
- Don't set delay on system updated query text.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
1. Manually typed long queries and watched out for cursor changing position. 
2. Validated that the folder plugin still behaves the same as before. 