### PR TITLE
Fix dll loading at runtime 

### DIFF
--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -210,8 +210,14 @@ namespace PowerLauncher
             _resultList = (UI.ResultList)host.Child;
             _resultList.DataContext = _viewModel;
             _resultList.Tapped += SuggestionsList_Tapped;
+            _resultList.SuggestionsList.Loaded += SuggestionsList_Loaded;
             _resultList.SuggestionsList.SelectionChanged += SuggestionsList_SelectionChanged;
             _resultList.SuggestionsList.ContainerContentChanging += SuggestionList_UpdateListSize;
+        }
+
+        private void SuggestionsList_Loaded(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        {
+            _viewModel.ColdStartFix();
         }
 
         private bool IsKeyDown(VirtualKey key)

--- a/src/modules/launcher/Wox/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/Wox/ViewModel/MainViewModel.cs
@@ -609,6 +609,32 @@ namespace Wox.ViewModel
             }
         }
 
+        public void ColdStartFix()
+        {
+            // Fix Cold start for List view xaml island
+            List<Result> list = new List<Result>();
+            Result r = new Result
+            {
+                Title = "hello"
+            };
+            list.Add(r);
+            Results.AddResults(list, "0");
+            Results.Clear();
+            MainWindowVisibility = System.Windows.Visibility.Collapsed;
+
+            // Fix Cold start for plugins
+            string s = "m";
+            var query = QueryBuilder.Build(s.Trim(), PluginManager.NonGlobalPlugins);
+            var plugins = PluginManager.ValidPluginsForQuery(query);
+            foreach (PluginPair plugin in plugins)
+            {
+                if (!plugin.Metadata.Disabled && plugin.Metadata.Name != "Window Walker")
+                {
+                    var _ = PluginManager.QueryForPlugin(plugin, query);
+                }
+            };
+        }
+
         #endregion
     }
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR fixes dll's being loaded when first query is made.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2283 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
**Dll's loaded when plugin is queried for first time :** 
1. Microsoft.Search.Interop.dll
2. System.Data.OleDb.dll.
3. System.Transactions.Local.dll
4. System.Diagnostics.PerformanceCounter.dll

**Dll's loaded when the List view is populated for the first time :** 
1. Windows.ApplicationModel.winmd
2. System.Globalization.dll
3. System.Reflection.dll
4. System.Reflection.Extensions.dll
5. Windows.Storage.winmd


<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manually validated that dll's are loaded before first query.
Steps to compare : 
1. Run in debug mode as the difference can be easily compared. 
2. Open current 'dev/powerlauncher' and when the searchbox is visible for first time type one single letter. 
3. Repeat step 2 with this PR. 

