### PR TITLE
Issue 2383 update folder and selection behavior

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Main.cs
@@ -86,6 +86,13 @@ namespace Microsoft.Plugin.Indexer
                             return hide;
                         };
                         r.ContextData = searchResult;
+
+                        //If the result is a directory, then it's display should show a directory.
+                        if(Directory.Exists(path))
+                        {
+                            r.QueryTextDisplay = path;
+                        }
+
                         results.Add(r);
                     }
                 }

--- a/src/modules/launcher/Plugins/Wox.Plugin.Folder/Main.cs
+++ b/src/modules/launcher/Plugins/Wox.Plugin.Folder/Main.cs
@@ -96,7 +96,12 @@ namespace Wox.Plugin.Folder
                 SubTitle = subtitle,
                 QueryTextDisplay = path,
                 TitleHighlightData = StringMatcher.FuzzySearch(query.Search, title).MatchData,
-                ContextData = new SearchResult { Type = ResultType.Folder, FullPath = path }
+                ContextData = new SearchResult { Type = ResultType.Folder, FullPath = path },
+                Action = c =>
+                {
+                    Process.Start(_fileExplorerProgramName, path);
+                    return true;
+                }
             };
         }
 

--- a/src/modules/launcher/Plugins/Wox.Plugin.Folder/Main.cs
+++ b/src/modules/launcher/Plugins/Wox.Plugin.Folder/Main.cs
@@ -94,29 +94,8 @@ namespace Wox.Plugin.Folder
                 Title = title,
                 IcoPath = path,
                 SubTitle = subtitle,
+                QueryTextDisplay = path,
                 TitleHighlightData = StringMatcher.FuzzySearch(query.Search, title).MatchData,
-                Action = c =>
-                {
-                    if (c.SpecialKeyState.CtrlPressed)
-                    {
-                        try
-                        {
-                            Process.Start(_fileExplorerProgramName, path);
-                            return true;
-                        }
-                        catch (Exception ex)
-                        {
-                            MessageBox.Show(ex.Message, "Could not start " + path);
-                            return false;
-                        }
-                    }
-
-                    string changeTo = path.EndsWith("\\") ? path : path + "\\";
-                    changeTo = string.IsNullOrEmpty(query.ActionKeyword) ? changeTo : query.ActionKeyword + " " + changeTo;
-                    bool requery = true;
-                    _context.API.ChangeQuery(changeTo, requery);
-                    return false;
-                },
                 ContextData = new SearchResult { Type = ResultType.Folder, FullPath = path }
             };
         }

--- a/src/modules/launcher/Plugins/Wox.Plugin.Folder/Main.cs
+++ b/src/modules/launcher/Plugins/Wox.Plugin.Folder/Main.cs
@@ -257,6 +257,7 @@ namespace Wox.Plugin.Folder
             return new Result
             {
                 Title = firstResult,
+                QueryTextDisplay = search,
                 SubTitle = $"Use > to search within the directory. Use * to search for file extensions. Or use both >*.",
                 IcoPath = search,
                 Score = 500,

--- a/src/modules/launcher/PowerLauncher.UI/LauncherControl.xaml
+++ b/src/modules/launcher/PowerLauncher.UI/LauncherControl.xaml
@@ -375,7 +375,6 @@
             x:FieldModifier="public"
             Style="{StaticResource CustomAutoSuggestBoxTextBoxStyle}"
             PlaceholderText="Start typing"
-            Text="{Binding QueryText}"
             Height="60"
             ScrollViewer.BringIntoViewOnFocusChange="False"
             Canvas.ZIndex="0"

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -239,21 +239,25 @@ namespace PowerLauncher
             if (e.Key == VirtualKey.Tab && IsKeyDown(VirtualKey.Shift))
             {
                 _viewModel.SelectPrevTabItemCommand.Execute(null);
+                UpdateTextBoxToSelectedItem();
                 e.Handled = true;
             }
             else if (e.Key == VirtualKey.Tab)
             {
-                    _viewModel.SelectNextTabItemCommand.Execute(null);
+                _viewModel.SelectNextTabItemCommand.Execute(null);
+                UpdateTextBoxToSelectedItem();
                 e.Handled = true;
             }
             else if (e.Key == VirtualKey.Down)
             {
                 _viewModel.SelectNextItemCommand.Execute(null);
+                UpdateTextBoxToSelectedItem();
                 e.Handled = true;
             }
             else if (e.Key == VirtualKey.Up)
             {
                 _viewModel.SelectPrevItemCommand.Execute(null);
+                UpdateTextBoxToSelectedItem();
                 e.Handled = true;
             }
             else if (e.Key == VirtualKey.PageDown)
@@ -265,6 +269,15 @@ namespace PowerLauncher
             {
                 _viewModel.SelectPrevPageCommand.Execute(null);
                 e.Handled = true;
+            }
+        }
+
+        private void UpdateTextBoxToSelectedItem()
+        {
+            var itemText = _viewModel?.Results?.SelectedItem?.ToString() ?? null;
+            if (!String.IsNullOrEmpty(itemText))
+            {
+                _viewModel.ChangeQueryText(itemText);
             }
         }
 

--- a/src/modules/launcher/Wox.Plugin/Result.cs
+++ b/src/modules/launcher/Wox.Plugin/Result.cs
@@ -18,6 +18,11 @@ namespace Wox.Plugin
 
         public string FontFamily { get; set; }
 
+        /// <summary>
+        /// The text that will get displayed in the Search text box, when this item is selected in the result list.
+        /// </summary>
+        public string QueryTextDisplay { get; set; }
+
         public string IcoPath
         {
             get { return _icoPath; }

--- a/src/modules/launcher/Wox/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/Wox/ViewModel/MainViewModel.cs
@@ -236,16 +236,15 @@ namespace Wox.ViewModel
         /// <param name="requery">Optional Parameter that if true, will automatically execute a query against the updated text</param>
         public void ChangeQueryText(string queryText, bool requery=false)
         {
-            QueryTextUpdateBySystem = true;
-            QueryText = queryText;
-
+            SystemQueryText = queryText;
+            
             if(requery)
             {
-               Query();
+                QueryText = queryText;
+                Query();
             }
         }
         public bool LastQuerySelected { get; set; }
-        public bool QueryTextUpdateBySystem { get; set; }
 
         private ResultsViewModel _selectedResults;
         private ResultsViewModel SelectedResults

--- a/src/modules/launcher/Wox/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/Wox/ViewModel/MainViewModel.cs
@@ -222,9 +222,9 @@ namespace Wox.ViewModel
         public ResultsViewModel ContextMenu { get; private set; }
         public ResultsViewModel History { get; private set; }
 
-        public string SystemQueryText { get; set; }
+        public string SystemQueryText { get; set; } = String.Empty;
 
-        public string QueryText { get; set; }
+        public string QueryText { get; set; } = String.Empty;
       
 
         /// <summary>

--- a/src/modules/launcher/Wox/ViewModel/ResultViewModel.cs
+++ b/src/modules/launcher/Wox/ViewModel/ResultViewModel.cs
@@ -255,7 +255,8 @@ namespace Wox.ViewModel
 
         public override string ToString()
         {
-            return Result.Title.ToString();
+            var display = String.IsNullOrEmpty(Result.QueryTextDisplay) ? Result.Title : Result.QueryTextDisplay;
+            return display;
         }
     }
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This change makes the directory navigation behave more like search and the runner. 
- Arrow keys or tab to select will update the query text to the path of the folder. 
- Enter on the folder will launch explorer

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2383
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments. 
1.  It became apparent when using the arrow keys to update the query text programatically, that there were holes in the logic to prevent updating the query when we change the text.  To fix this it was broken into to TextChanged event handlers one to deal with programatic input and the other to deal with user text changes.  Because the property changed event and the text changed are on different dispatchers, we can't check the boolean flag inside the event handler. 

![SelectDirectory_PathComplete](https://user-images.githubusercontent.com/56318517/80286646-73653e80-86e1-11ea-9d4e-cf32e3d6b155.gif)

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manually tested. 
- Navigating to a folder from the folder plugin.
- Navigating to a folder from the search indexer plugin.
- Actioning on a folder from the folder plugin. 
- Actioning on a folder from the search indexer plugin.
- holding arrow keys to validate that a query doesn't get updated upon selecting a new item.