### PR TITLE
Defensive check for QueryText being null

### DIFF
--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -330,8 +330,7 @@ namespace PowerLauncher
 
         private string ListView_FirstItem(String input)
         {
-            string s = input;
-            if (s.Length > 0)
+            if (!String.IsNullOrEmpty(input))
             {
                 String selectedItem = _viewModel.Results?.SelectedItem?.ToString();
                 int selectedIndex = _viewModel.Results.SelectedIndex;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This was causing an exception.  It was fixed by initializing query text in #2392, but it's better to be defensive as someone could assign null to querytext at any point.
