### PR TITLE
Reindex UWP Apps when apps are installed or uninstalled.

### DIFF
--- a/src/modules/launcher/Plugins/Wox.Plugin.Program/Main.cs
+++ b/src/modules/launcher/Plugins/Wox.Plugin.Program/Main.cs
@@ -188,9 +188,8 @@ namespace Wox.Plugin.Program
             _watcher.Path = resolvedPath;
 
             //Filter to create and deletes of 'microsoft.system.package.metadata' directories. 
-            _watcher.NotifyFilter = NotifyFilters.DirectoryName;
+            _watcher.NotifyFilter = NotifyFilters.DirectoryName | NotifyFilters.FileName;
             _watcher.IncludeSubdirectories = true;
-            _watcher.Filter = "microsoft.system.package.metadata";
 
             // Add event handlers.
             _watcher.Created += OnChanged;

--- a/src/modules/launcher/Plugins/Wox.Plugin.Program/Main.cs
+++ b/src/modules/launcher/Plugins/Wox.Plugin.Program/Main.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Security.Permissions;
 using System.Threading.Tasks;
 using System.Timers;
 using System.Windows.Controls;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR watches for all files and directories being created and deleted out of the `Program Files` directory. This will trigger the application to reindex after a delay. 

I don't think this is a permanent solution, and we will have to put more though into how to do this in a less intrusive way. 
 
<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2398 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
This is not perfect.  We get multiple  writes on installing or uninstalling the uwp app.   The idea is an initial write will trigger a timed delay of the reindex, if another write is detected within that time span it resets the timer.   If the install has delays between file writes we will reindex multiple times (not good). 

Also there seems to be thread contention that causes stalls if we are querying for apps while the UWP apps are being reindexed.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Launch the app.  Verify no "Reindexing" is a happening. 
- Uninstall Terminal, and verify that it triggers a reindex, and that terminal no longer appears in the results. 
- Reinstall Terminal, and verify that it triggers a reindex and that the terminal will now appear in the results. 

NOTE:  There is about a 10-15 second delay after installing, for the results to be reflected in the UI.