### PR TITLE
Make Edit Shortcut/Single Key window scrollable

### DIFF
--- a/src/modules/keyboardmanager/ui/EditKeyboardWindow.cpp
+++ b/src/modules/keyboardmanager/ui/EditKeyboardWindow.cpp
@@ -293,18 +293,26 @@ void createEditKeyboardWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMan
         SingleKeyRemapControl::AddNewControlKeyRemapRow(keyRemapTable, keyboardRemapControlObjects);
     });
 
-    // Creating the Xaml content. xamlContainer is the parent UI element
-    Windows::UI::Xaml::Controls::StackPanel xamlContainer;
-    xamlContainer.Children().Append(header);
-    xamlContainer.Children().Append(keyRemapInfoHeader);
-    xamlContainer.Children().Append(keyRemapTable);
-    xamlContainer.Children().Append(addRemapKey);
+    StackPanel mappingsPanel;
+    mappingsPanel.Children().Append(keyRemapInfoHeader);
+    mappingsPanel.Children().Append(keyRemapTable);
+    mappingsPanel.Children().Append(addRemapKey);
 
     ScrollViewer scrollViewer;
-    scrollViewer.Content(xamlContainer);
+    scrollViewer.Content(mappingsPanel);
 
-    scrollViewer.UpdateLayout();
-    desktopSource.Content(scrollViewer);
+    // Creating the Xaml content. xamlContainer is the parent UI element
+    RelativePanel xamlContainer;
+    xamlContainer.SetBelow(scrollViewer, header);
+    xamlContainer.SetAlignLeftWithPanel(header, true);
+    xamlContainer.SetAlignRightWithPanel(header, true);
+    xamlContainer.SetAlignLeftWithPanel(scrollViewer, true);
+    xamlContainer.SetAlignRightWithPanel(scrollViewer, true);
+    xamlContainer.Children().Append(header);
+    xamlContainer.Children().Append(scrollViewer);
+
+    xamlContainer.UpdateLayout();
+    desktopSource.Content(xamlContainer);
 
     ////End XAML Island section
     if (_hWndEditKeyboardWindow)

--- a/src/modules/keyboardmanager/ui/EditKeyboardWindow.cpp
+++ b/src/modules/keyboardmanager/ui/EditKeyboardWindow.cpp
@@ -288,7 +288,7 @@ void createEditKeyboardWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMan
     plusSymbol.FontFamily(Xaml::Media::FontFamily(L"Segoe MDL2 Assets"));
     plusSymbol.Glyph(L"\xE109");
     addRemapKey.Content(plusSymbol);
-    addRemapKey.Margin({ 10 });
+    addRemapKey.Margin({ 10, 0, 0, 25 });
     addRemapKey.Click([&](winrt::Windows::Foundation::IInspectable const& sender, RoutedEventArgs const&) {
         SingleKeyRemapControl::AddNewControlKeyRemapRow(keyRemapTable, keyboardRemapControlObjects);
     });

--- a/src/modules/keyboardmanager/ui/EditKeyboardWindow.cpp
+++ b/src/modules/keyboardmanager/ui/EditKeyboardWindow.cpp
@@ -73,9 +73,6 @@ void createEditKeyboardWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMan
     // Update the xaml island window size becuase initially is 0,0
     SetWindowPos(hWndXamlIslandEditKeyboardWindow, 0, 0, 0, 400, 400, SWP_SHOWWINDOW);
 
-    // Creating the Xaml content. xamlContainer is the parent UI element
-    Windows::UI::Xaml::Controls::StackPanel xamlContainer;
-
     // Header for the window
     Windows::UI::Xaml::Controls::RelativePanel header;
     header.Margin({ 10, 10, 10, 30 });
@@ -296,12 +293,18 @@ void createEditKeyboardWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMan
         SingleKeyRemapControl::AddNewControlKeyRemapRow(keyRemapTable, keyboardRemapControlObjects);
     });
 
+    // Creating the Xaml content. xamlContainer is the parent UI element
+    Windows::UI::Xaml::Controls::StackPanel xamlContainer;
     xamlContainer.Children().Append(header);
     xamlContainer.Children().Append(keyRemapInfoHeader);
     xamlContainer.Children().Append(keyRemapTable);
     xamlContainer.Children().Append(addRemapKey);
-    xamlContainer.UpdateLayout();
-    desktopSource.Content(xamlContainer);
+
+    ScrollViewer scrollViewer;
+    scrollViewer.Content(xamlContainer);
+
+    scrollViewer.UpdateLayout();
+    desktopSource.Content(scrollViewer);
 
     ////End XAML Island section
     if (_hWndEditKeyboardWindow)

--- a/src/modules/keyboardmanager/ui/EditShortcutsWindow.cpp
+++ b/src/modules/keyboardmanager/ui/EditShortcutsWindow.cpp
@@ -213,7 +213,7 @@ void createEditShortcutsWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMa
     plusSymbol.FontFamily(Xaml::Media::FontFamily(L"Segoe MDL2 Assets"));
     plusSymbol.Glyph(L"\xE109");
     addShortcut.Content(plusSymbol);
-    addShortcut.Margin({ 10 });
+    addShortcut.Margin({ 10, 0, 0, 25 });
     addShortcut.Click([&](winrt::Windows::Foundation::IInspectable const& sender, RoutedEventArgs const&) {
         ShortcutControl::AddNewShortcutControlRow(shortcutTable, keyboardRemapControlObjects);
     });

--- a/src/modules/keyboardmanager/ui/EditShortcutsWindow.cpp
+++ b/src/modules/keyboardmanager/ui/EditShortcutsWindow.cpp
@@ -218,17 +218,24 @@ void createEditShortcutsWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMa
         ShortcutControl::AddNewShortcutControlRow(shortcutTable, keyboardRemapControlObjects);
     });
 
-    // Creating the Xaml content. xamlContainer is the parent UI element
-    Windows::UI::Xaml::Controls::StackPanel xamlContainer;
-    xamlContainer.Children().Append(header);
-    xamlContainer.Children().Append(shortcutTable);
-    xamlContainer.Children().Append(addShortcut);
-    xamlContainer.UpdateLayout();
+    StackPanel mappingsPanel;
+    mappingsPanel.Children().Append(shortcutTable);
+    mappingsPanel.Children().Append(addShortcut);
 
     ScrollViewer scrollViewer;
-    scrollViewer.Content(xamlContainer);
-    scrollViewer.UpdateLayout();
-    desktopSource.Content(scrollViewer);
+    scrollViewer.Content(mappingsPanel);
+
+    RelativePanel xamlContainer;
+    xamlContainer.SetBelow(scrollViewer, header);
+    xamlContainer.SetAlignLeftWithPanel(header, true);
+    xamlContainer.SetAlignRightWithPanel(header, true);
+    xamlContainer.SetAlignLeftWithPanel(scrollViewer, true);
+    xamlContainer.SetAlignRightWithPanel(scrollViewer, true);
+    xamlContainer.Children().Append(header);
+    xamlContainer.Children().Append(scrollViewer);
+
+    xamlContainer.UpdateLayout();
+    desktopSource.Content(xamlContainer);
 
     ////End XAML Island section
     if (_hWndEditShortcutsWindow)

--- a/src/modules/keyboardmanager/ui/EditShortcutsWindow.cpp
+++ b/src/modules/keyboardmanager/ui/EditShortcutsWindow.cpp
@@ -74,9 +74,6 @@ void createEditShortcutsWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMa
     // Update the xaml island window size becuase initially is 0,0
     SetWindowPos(hWndXamlIslandEditShortcutsWindow, 0, 0, 0, 400, 400, SWP_SHOWWINDOW);
 
-    // Creating the Xaml content. xamlContainer is the parent UI element
-    Windows::UI::Xaml::Controls::StackPanel xamlContainer;
-
     // Header for the window
     Windows::UI::Xaml::Controls::RelativePanel header;
     header.Margin({ 10, 10, 10, 30 });
@@ -221,11 +218,17 @@ void createEditShortcutsWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMa
         ShortcutControl::AddNewShortcutControlRow(shortcutTable, keyboardRemapControlObjects);
     });
 
+    // Creating the Xaml content. xamlContainer is the parent UI element
+    Windows::UI::Xaml::Controls::StackPanel xamlContainer;
     xamlContainer.Children().Append(header);
     xamlContainer.Children().Append(shortcutTable);
     xamlContainer.Children().Append(addShortcut);
     xamlContainer.UpdateLayout();
-    desktopSource.Content(xamlContainer);
+
+    ScrollViewer scrollViewer;
+    scrollViewer.Content(xamlContainer);
+    scrollViewer.UpdateLayout();
+    desktopSource.Content(scrollViewer);
 
     ////End XAML Island section
     if (_hWndEditShortcutsWindow)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2196
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
* This only adds the basic scrolling functionality, not the redesigned talked about in the follow up comments of #2196 

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Add a bunch of keyboard and shortcuts remappings, the windows are scrollable.