### PR TITLE
runner: download_updates_automatically option is disabled by default for non-admin users

### DIFF
--- a/src/runner/general_settings.cpp
+++ b/src/runner/general_settings.cpp
@@ -67,12 +67,13 @@ json::JsonObject load_general_settings()
 
 GeneralSettings get_general_settings()
 {
+    const bool is_user_admin = check_user_is_admin();
     GeneralSettings settings{
         .isPackaged = winstore::running_as_packaged(),
         .isElevated = is_process_elevated(),
         .isRunElevated = run_as_elevated,
-        .isAdmin = check_user_is_admin(),
-        .downloadUpdatesAutomatically = download_updates_automatically,
+        .isAdmin = is_user_admin,
+        .downloadUpdatesAutomatically = download_updates_automatically && is_user_admin,
         .theme = settings_theme,
         .systemTheme = WindowsColors::is_dark_mode() ? L"dark" : L"light",
         .powerToysVersion = get_product_version()


### PR DESCRIPTION
## Summary of the Pull Request
…for non-admin users

## PR Checklist
* [x] Applies to #2354

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- installed the PT as a non-admin user and observed "Visit"-type toast notification