### PR TITLE
Removing restore orignal trasparecny from zone window destructor

### DIFF
--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -294,8 +294,6 @@ ZoneWindow::ZoneWindow(HINSTANCE hinstance)
 
 ZoneWindow::~ZoneWindow()
 {
-    RestoreOrginalTransparency();
-
     Gdiplus::GdiplusShutdown(m_gdiplusToken);
 }
 

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -365,8 +365,6 @@ IFACEMETHODIMP ZoneWindow::MoveSizeEnter(HWND window, bool dragEnabled) noexcept
         decltype(m_draggedWindowInitialAlpha) draggedWindowInitialAlpha;
         decltype(m_draggedWindowDwFlags) draggedWindowDwFlags;
 
-        RestoreOrginalTransparency();
-
         draggedWindowExstyle = GetWindowLong(window, GWL_EXSTYLE);
 
         draggedWindow = window;


### PR DESCRIPTION
## Summary of the Pull Request
- Removed call of RestoreOrginalTransparency from ZoneWindow destructor and MoveSizeEnter. This call causes some multi-threaded problems.


## Validation Steps Performed
- Manual testing
