### PR TITLE
[FancyZones] Don't poll for changes in HKEY_CURRENT_USER, but only for VirtualDesktops regkey

### DIFF
--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -1123,7 +1123,7 @@ void FancyZones::HandleVirtualDesktopUpdates(HANDLE fancyZonesDestroyedEvent) no
     HANDLE events[2] = { regKeyEvent, fancyZonesDestroyedEvent };
     while (1)
     {
-        if (RegNotifyChangeKeyValue(HKEY_CURRENT_USER, TRUE, REG_NOTIFY_CHANGE_LAST_SET, regKeyEvent, TRUE) != ERROR_SUCCESS)
+        if (RegNotifyChangeKeyValue(m_virtualDesktopsRegKey, TRUE, REG_NOTIFY_CHANGE_LAST_SET, regKeyEvent, TRUE) != ERROR_SUCCESS)
         {
             return;
         }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Polling for changes in HKEY_CURRENT_USER will trigger `RegisterVirtualDesktopUpdates` function call to often, even if nothing related to virtual desktops has changed. Fix this and only register updates in `Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\VirtualDesktops` regkey.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2482