### PR TITLE
Fix for calculator plugin not showing results

### DIFF
--- a/src/modules/launcher/Plugins/Wox.Plugin.WindowWalker/plugin.json
+++ b/src/modules/launcher/Plugins/Wox.Plugin.WindowWalker/plugin.json
@@ -1,5 +1,5 @@
 {
-    "ID":"CEA0FDFC6D3B4085823D60DC76F28855",
+    "ID":"F737A9223560B3C6833B5FFB8CDF78E5",
     "ActionKeyword":"*",
     "Name":"Window Walker",
     "Description":"Alt-Tab alternative enabling searching through your windows.",


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR fixes issue with calculator results showing up results only once.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2254 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
The plugin ID for WW and calculator was same. This caused results from calculator plugin to be overwritten with results from WW. 

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Validated that calculator plugin works as expected.