### PR TITLE
[Launcher] Remove Win+R checkbox

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
@@ -119,8 +119,8 @@
 
             <CheckBox x:Uid="PowerLauncher_OverrideWinRKey" 
                       Margin="{StaticResource SmallTopMargin}"
-                      IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.OverrideWinRKey}"
-                      IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.EnablePowerLauncher}"
+                      IsChecked="False"
+                      IsEnabled="False"
                       />
 
             <CheckBox x:Uid="PowerLauncher_OverrideWinSKey"

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
@@ -54,7 +54,7 @@
             <TextBlock x:Uid="PowerLauncher_SearchResults"
                        Style="{StaticResource SettingsGroupTitleStyle}"/>
 
-            <ComboBox x:Uid="PowerLauncher_SearchResultPreference"
+            <!--<ComboBox x:Uid="PowerLauncher_SearchResultPreference"
                       MinWidth="320"
                       Margin="{StaticResource SmallTopMargin}"
                       ItemsSource="{x:Bind searchResultPreferencesOptions}"
@@ -72,7 +72,7 @@
                       SelectedValuePath="Item2"
                       DisplayMemberPath="Item1"
                       IsEnabled="False"
-                      />
+                      />-->
 
             <muxc:NumberBox x:Uid="PowerLauncher_MaximumNumberOfResults" 
                             Value="{x:Bind Mode=TwoWay, Path=ViewModel.MaximumNumberOfResults}"
@@ -95,7 +95,7 @@
                                           HotkeySettings="{x:Bind Path=ViewModel.OpenPowerLauncher, Mode=TwoWay}"
                                           IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.EnablePowerLauncher}"
                                         />
-            <Custom:HotkeySettingsControl x:Uid="PowerLauncher_OpenFileLocation"
+            <!--<Custom:HotkeySettingsControl x:Uid="PowerLauncher_OpenFileLocation"
                                           Width="320"
                                           HorizontalAlignment="Left"
                                           Margin="{StaticResource SmallTopMargin}"
@@ -115,19 +115,19 @@
                                           Margin="{StaticResource SmallTopMargin}"
                                           HotkeySettings="{x:Bind Path=ViewModel.OpenConsole, Mode=TwoWay}"
                                           IsEnabled="False"
-                                        />
+                                        />-->
 
-            <CheckBox x:Uid="PowerLauncher_OverrideWinRKey" 
+            <!--<CheckBox x:Uid="PowerLauncher_OverrideWinRKey" 
                       Margin="{StaticResource SmallTopMargin}"
                       IsChecked="False"
                       IsEnabled="False"
-                      />
+                      />-->
 
-            <CheckBox x:Uid="PowerLauncher_OverrideWinSKey"
+            <!--<CheckBox x:Uid="PowerLauncher_OverrideWinSKey"
                       Margin="{StaticResource SmallTopMargin}"
                       IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.OverrideWinSKey}"
                       IsEnabled="False"
-                      />
+                      />-->
         </StackPanel>
         <StackPanel
             x:Name="SidePanel"

--- a/src/core/Microsoft.PowerToys.Settings.UnitTest/ViewModelTests/PowerLauncherViewModelTest.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UnitTest/ViewModelTests/PowerLauncherViewModelTest.cs
@@ -13,15 +13,6 @@ namespace ViewModelTests
     [TestClass]
     public class PowerLauncher
     {
-        class PowerLauncherSettingsMock : PowerLauncherSettings
-        {
-            public int TimesSaved { get; set; }
-            public override void Save()
-            {
-                TimesSaved++;
-            }
-        }
-
         class SendCallbackMock
         {
             public int TimesSent { get; set; }
@@ -31,14 +22,14 @@ namespace ViewModelTests
             }
         }
         private PowerLauncherViewModel viewModel;
-        private PowerLauncherSettingsMock mockSettings;
+        private PowerLauncherSettings mockSettings;
         private SendCallbackMock sendCallbackMock;
 
 
         [TestInitialize]
         public void Initialize()
         {
-            mockSettings = new PowerLauncherSettingsMock();
+            mockSettings = new PowerLauncherSettings();
             sendCallbackMock = new SendCallbackMock();
 
             viewModel = new PowerLauncherViewModel(
@@ -54,19 +45,17 @@ namespace ViewModelTests
             viewModel.SearchTypePreference = "SearchOptionsAreNotValidated";
 
             Assert.AreEqual(sendCallbackMock.TimesSent, 2);
-            Assert.AreEqual(mockSettings.TimesSaved, 2);
-
             Assert.IsTrue(mockSettings.properties.search_result_preference == "SearchOptionsAreNotValidated");
             Assert.IsTrue(mockSettings.properties.search_type_preference == "SearchOptionsAreNotValidated");
         }
 
         public void AssertHotkeySettings(HotkeySettings setting, bool win, bool ctrl, bool alt, bool shift, int code)
         {
-            Assert.AreEqual(setting.Win, win);
-            Assert.AreEqual(setting.Ctrl, ctrl);
-            Assert.AreEqual(setting.Alt, alt);
-            Assert.AreEqual(setting.Shift, shift);
-            Assert.AreEqual(setting.Code, code);
+            Assert.AreEqual(win, setting.Win);
+            Assert.AreEqual(ctrl, setting.Ctrl);
+            Assert.AreEqual(alt, setting.Alt);
+            Assert.AreEqual(shift, setting.Shift);
+            Assert.AreEqual(code, setting.Code);
         }
 
         [TestMethod]
@@ -94,8 +83,7 @@ namespace ViewModelTests
             viewModel.OpenConsole = openConsole;
             viewModel.CopyPathLocation = copyFileLocation;
 
-            Assert.AreEqual(mockSettings.TimesSaved, 4);
-            Assert.AreEqual(sendCallbackMock.TimesSent, 4);
+            Assert.AreEqual(4, sendCallbackMock.TimesSent);
 
             AssertHotkeySettings(
                 mockSettings.properties.open_powerlauncher,
@@ -138,8 +126,7 @@ namespace ViewModelTests
             viewModel.OverrideWinSKey = false;
 
 
-            Assert.AreEqual(sendCallbackMock.TimesSent, 1);
-            Assert.AreEqual(mockSettings.TimesSaved, 1);
+            Assert.AreEqual(1, sendCallbackMock.TimesSent);
 
             Assert.IsTrue(mockSettings.properties.override_win_r_key);
             Assert.IsFalse(mockSettings.properties.override_win_s_key);

--- a/src/modules/launcher/Plugins/Wox.Plugin.Shell/Main.cs
+++ b/src/modules/launcher/Plugins/Wox.Plugin.Shell/Main.cs
@@ -293,7 +293,7 @@ namespace Wox.Plugin.Shell
         {
             // not overriding Win+R 
             // crutkas we need to earn the right for Win+R override
-
+            /*
             if (_settings.ReplaceWinR)
             {
                 if (keyevent == (int)KeyEvent.WM_KEYDOWN && vkcode == (int)Keys.R && state.WinPressed)
@@ -309,6 +309,7 @@ namespace Wox.Plugin.Shell
                     return false;
                 }
             }
+            */
             return true;
         }
 
@@ -357,7 +358,7 @@ namespace Wox.Plugin.Shell
 
         public void UpdateSettings(PowerLauncherSettings settings)
         {
-            _settings.ReplaceWinR = settings.properties.override_win_r_key;
+            //_settings.ReplaceWinR = settings.properties.override_win_r_key;
         }
     }
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Disable Win+R overriding functionality in Launcher.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2345 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
