### PR TITLE
[FancyZones] Outlook new message restore placement bug

### DIFF
--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -372,7 +372,7 @@ FancyZones::WindowCreated(HWND window) noexcept
                         !fancyZonesData.IsAnotherWindowOfApplicationInstanceZoned(window))
                     {
                         m_windowMoveHandler.MoveWindowIntoZoneByIndexSet(window, monitor, zoneIndexSet, m_zoneWindowMap);
-                        fancyZonesData.UpdateHandle(window);
+                        fancyZonesData.UpdateProcessIdToHandleMap(window);
                         break;
                     }
                 }

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -940,14 +940,14 @@ bool FancyZones::IsNewWorkArea(GUID virtualDesktopId, HMONITOR monitor) noexcept
 
 bool FancyZones::IsSplashScreen(HWND window)
 {
-    wchar_t splashString[] = L"MsoSplash";
+    wchar_t splashClassName[] = L"MsoSplash"; // shouldn't be localized
     wchar_t className[MAX_PATH];
     if (GetClassName(window, className, MAX_PATH) == 0)
     {
         return false;
     }
 
-    return wcscmp(splashString, className) == 0;
+    return wcscmp(splashClassName, className) == 0;
 }
 
 void FancyZones::OnEditorExitEvent() noexcept

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -60,13 +60,13 @@ public:
         std::unique_lock writeLock(m_lock);
         m_windowMoveHandler.MoveSizeStart(window, monitor, ptScreen, m_zoneWindowMap);
     }
-    
+
     void MoveSizeUpdate(HMONITOR monitor, POINT const& ptScreen) noexcept
     {
         std::unique_lock writeLock(m_lock);
         m_windowMoveHandler.MoveSizeUpdate(monitor, ptScreen, m_zoneWindowMap);
     }
-    
+
     void MoveSizeEnd(HWND window, POINT const& ptScreen) noexcept
     {
         std::unique_lock writeLock(m_lock);
@@ -114,7 +114,7 @@ public:
     ToggleEditor() noexcept;
     IFACEMETHODIMP_(void)
     SettingsChanged() noexcept;
-    
+
     void WindowCreated(HWND window) noexcept;
 
     // IZoneWindowHost
@@ -669,7 +669,6 @@ LRESULT FancyZones::WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lpa
     return 0;
 }
 
-
 void FancyZones::OnDisplayChange(DisplayChangeType changeType) noexcept
 {
     if (changeType == DisplayChangeType::VirtualDesktop ||
@@ -941,9 +940,12 @@ bool FancyZones::IsNewWorkArea(GUID virtualDesktopId, HMONITOR monitor) noexcept
 
 bool FancyZones::IsSplashScreen(HWND window)
 {
-    TCHAR splashString[] = L"MsoSplash";
-    TCHAR className[MAX_PATH];
-    GetClassName(window, className, _countof(className));
+    wchar_t splashString[] = L"MsoSplash";
+    wchar_t className[MAX_PATH];
+    if (GetClassName(window, className, wcslen(className)) == 0)
+    {
+        return false;
+    }
 
     return wcscmp(splashString, className) == 0;
 }

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -221,10 +221,7 @@ private:
     void CycleActiveZoneSet(DWORD vkCode) noexcept;
     bool OnSnapHotkey(DWORD vkCode) noexcept;
 
-
     void RegisterVirtualDesktopUpdates(std::vector<GUID>& ids) noexcept;
-    void HandleVirtualDesktopUpdates(HANDLE fancyZonesDestroyedEvent) noexcept;
-    void RegisterVirtualDesktopUpdates(std::unordered_set<GUID>& currentVirtualDesktopIds) noexcept;
 
     void RegisterNewWorkArea(GUID virtualDesktopId, HMONITOR monitor) noexcept;
     bool IsNewWorkArea(GUID virtualDesktopId, HMONITOR monitor) noexcept;

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -369,7 +369,7 @@ FancyZones::WindowCreated(HWND window) noexcept
                     std::vector<int> zoneIndexSet = fancyZonesData.GetAppLastZoneIndexSet(window, zoneWindow->UniqueId(), guidString.get());
                     if (zoneIndexSet.size() &&
                         !IsSplashScreen(window) &&
-                        !fancyZonesData.IsAnotherWindowOfApplicationInstancePlaced(window))
+                        !fancyZonesData.IsAnotherWindowOfApplicationInstanceZoned(window))
                     {
                         m_windowMoveHandler.MoveWindowIntoZoneByIndexSet(window, monitor, zoneIndexSet, m_zoneWindowMap);
                         fancyZonesData.UpdateHandle(window);

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -942,7 +942,7 @@ bool FancyZones::IsSplashScreen(HWND window)
 {
     wchar_t splashString[] = L"MsoSplash";
     wchar_t className[MAX_PATH];
-    if (GetClassName(window, className, wcslen(className)) == 0)
+    if (GetClassName(window, className, MAX_PATH) == 0)
     {
         return false;
     }

--- a/src/modules/fancyzones/lib/JsonHelpers.cpp
+++ b/src/modules/fancyzones/lib/JsonHelpers.cpp
@@ -410,7 +410,7 @@ namespace JSONHelpers
         return false;
     }
 
-    void FancyZonesData::UpdateHandle(HWND window)
+    void FancyZonesData::UpdateProcessIdToHandleMap(HWND window)
     {
         std::scoped_lock lock{ dataLock };
         auto processPath = get_process_path(window);

--- a/src/modules/fancyzones/lib/JsonHelpers.cpp
+++ b/src/modules/fancyzones/lib/JsonHelpers.cpp
@@ -382,7 +382,7 @@ namespace JSONHelpers
         SaveFancyZonesData();
     }
 
-    bool FancyZonesData::IsAnotherWindowOfApplicationInstancePlaced(HWND window) const
+    bool FancyZonesData::IsAnotherWindowOfApplicationInstanceZoned(HWND window) const
     {
         std::scoped_lock lock{ dataLock };
         auto processPath = get_process_path(window);
@@ -457,7 +457,7 @@ namespace JSONHelpers
                 auto& data = history->second;
                 if (data.zoneSetUuid == zoneSetId && data.deviceId == deviceId)
                 {
-                    if (!IsAnotherWindowOfApplicationInstancePlaced(window))
+                    if (!IsAnotherWindowOfApplicationInstanceZoned(window))
                     {
                         DWORD processId = 0;
                         GetWindowThreadProcessId(window, &processId);
@@ -488,7 +488,7 @@ namespace JSONHelpers
     {
         std::scoped_lock lock{ dataLock };
 
-        if (IsAnotherWindowOfApplicationInstancePlaced(window))
+        if (IsAnotherWindowOfApplicationInstanceZoned(window))
         {
             return false;
         }

--- a/src/modules/fancyzones/lib/JsonHelpers.cpp
+++ b/src/modules/fancyzones/lib/JsonHelpers.cpp
@@ -501,9 +501,25 @@ namespace JSONHelpers
             return false;
         }
 
-        auto windowMap = appZoneHistoryMap[processPath].processIdToHandleMap;
         DWORD processId = 0;
         GetWindowThreadProcessId(window, &processId);
+
+        auto history = appZoneHistoryMap.find(processPath);
+
+        if (history != appZoneHistoryMap.end())
+        {
+            auto& data = history->second;
+
+            for (auto placedWindow : data.processIdToHandleMap)
+            {
+                if (IsWindow(placedWindow.second) && processId != placedWindow.first)
+                {
+                    return false;
+                }
+            }
+        }
+
+        auto windowMap = appZoneHistoryMap[processPath].processIdToHandleMap;
         windowMap[processId] = window;
         appZoneHistoryMap[processPath] = AppZoneHistoryData{ .processIdToHandleMap = windowMap, .zoneSetUuid = zoneSetId, .deviceId = deviceId, .zoneIndexSet = zoneIndexSet };
         SaveFancyZonesData();

--- a/src/modules/fancyzones/lib/JsonHelpers.cpp
+++ b/src/modules/fancyzones/lib/JsonHelpers.cpp
@@ -394,11 +394,13 @@ namespace JSONHelpers
                 DWORD processId = 0;
                 GetWindowThreadProcessId(window, &processId);
 
-                if (history->second.processIdToHandleMap.find(processId) == history->second.processIdToHandleMap.end())
+                auto processIdIt = history->second.processIdToHandleMap.find(processId);
+
+                if (processIdIt == history->second.processIdToHandleMap.end())
                 {
                     return false;
                 }
-                else if (history->second.processIdToHandleMap.at(processId) != window && IsWindow(history->second.processIdToHandleMap.at(processId)))
+                else if (processIdIt->second != window && IsWindow(processIdIt->second))
                 {
                     return true;
                 }

--- a/src/modules/fancyzones/lib/JsonHelpers.cpp
+++ b/src/modules/fancyzones/lib/JsonHelpers.cpp
@@ -382,6 +382,49 @@ namespace JSONHelpers
         SaveFancyZonesData();
     }
 
+    bool FancyZonesData::IsAnotherWindowOfApplicationInstancePlaced(HWND window) const
+    {
+        std::scoped_lock lock{ dataLock };
+        auto processPath = get_process_path(window);
+        if (!processPath.empty())
+        {
+            auto history = appZoneHistoryMap.find(processPath);
+            if (history != appZoneHistoryMap.end())
+            {
+                DWORD processId = 0;
+                GetWindowThreadProcessId(window, &processId);
+
+                if (history->second.processIdToHandleMap.find(processId) == history->second.processIdToHandleMap.end())
+                {
+                    return false;
+                }
+                else if (history->second.processIdToHandleMap.at(processId) != window && IsWindow(history->second.processIdToHandleMap.at(processId)))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    void FancyZonesData::UpdateHandle(HWND window)
+    {
+        std::scoped_lock lock{ dataLock };
+        auto processPath = get_process_path(window);
+        if (!processPath.empty())
+        {
+            auto history = appZoneHistoryMap.find(processPath);
+            if (history != appZoneHistoryMap.end())
+            {
+                DWORD processId = 0;
+                GetWindowThreadProcessId(window, &processId);
+
+                history->second.processIdToHandleMap[processId] = window;
+            }
+        }
+    }
+
     std::vector<int> FancyZonesData::GetAppLastZoneIndexSet(HWND window, const std::wstring_view& deviceId, const std::wstring_view& zoneSetId) const
     {
         std::scoped_lock lock{ dataLock };
@@ -411,9 +454,26 @@ namespace JSONHelpers
             auto history = appZoneHistoryMap.find(processPath);
             if (history != appZoneHistoryMap.end())
             {
-                const auto& data = history->second;
+                auto& data = history->second;
                 if (data.zoneSetUuid == zoneSetId && data.deviceId == deviceId)
                 {
+                    if (!IsAnotherWindowOfApplicationInstancePlaced(window))
+                    {
+                        DWORD processId = 0;
+                        GetWindowThreadProcessId(window, &processId);
+
+                        data.processIdToHandleMap.erase(processId);
+                    }
+
+                    // if there is another instance placed don't erase history
+                    for (auto placedWindow : data.processIdToHandleMap)
+                    {
+                        if (IsWindow(placedWindow.second))
+                        {
+                            return false;
+                        }
+                    }
+
                     appZoneHistoryMap.erase(processPath);
                     SaveFancyZonesData();
                     return true;
@@ -427,13 +487,23 @@ namespace JSONHelpers
     bool FancyZonesData::SetAppLastZones(HWND window, const std::wstring& deviceId, const std::wstring& zoneSetId, const std::vector<int>& zoneIndexSet)
     {
         std::scoped_lock lock{ dataLock };
+
+        if (IsAnotherWindowOfApplicationInstancePlaced(window))
+        {
+            return false;
+        }
+
         auto processPath = get_process_path(window);
         if (processPath.empty())
         {
             return false;
         }
 
-        appZoneHistoryMap[processPath] = AppZoneHistoryData{ .zoneSetUuid = zoneSetId, .deviceId = deviceId, .zoneIndexSet = zoneIndexSet };
+        auto windowMap = appZoneHistoryMap[processPath].processIdToHandleMap;
+        DWORD processId = 0;
+        GetWindowThreadProcessId(window, &processId);
+        windowMap[processId] = window;
+        appZoneHistoryMap[processPath] = AppZoneHistoryData{ .processIdToHandleMap = windowMap, .zoneSetUuid = zoneSetId, .deviceId = deviceId, .zoneIndexSet = zoneIndexSet };
         SaveFancyZonesData();
         return true;
     }
@@ -735,18 +805,19 @@ namespace JSONHelpers
 
                 switch (zoneSetData.type)
                 {
-                case CustomLayoutType::Grid: {
+                case CustomLayoutType::Grid:
+                {
                     int j = 5;
                     GridLayoutInfo zoneSetInfo(GridLayoutInfo::Minimal{ .rows = data[j++], .columns = data[j++] });
 
-                    for (int row = 0; row < zoneSetInfo.rows(); row++, j+=2)
+                    for (int row = 0; row < zoneSetInfo.rows(); row++, j += 2)
                     {
-                        zoneSetInfo.rowsPercents()[row] = data[j] * 256 + data[j+1];
+                        zoneSetInfo.rowsPercents()[row] = data[j] * 256 + data[j + 1];
                     }
 
-                    for (int col = 0; col < zoneSetInfo.columns(); col++, j+=2)
+                    for (int col = 0; col < zoneSetInfo.columns(); col++, j += 2)
                     {
-                        zoneSetInfo.columnsPercents()[col] = data[j] * 256 + data[j+1];
+                        zoneSetInfo.columnsPercents()[col] = data[j] * 256 + data[j + 1];
                     }
 
                     for (int row = 0; row < zoneSetInfo.rows(); row++)
@@ -759,7 +830,8 @@ namespace JSONHelpers
                     zoneSetData.info = zoneSetInfo;
                     break;
                 }
-                case CustomLayoutType::Canvas: {
+                case CustomLayoutType::Canvas:
+                {
                     CanvasLayoutInfo info;
 
                     int j = 5;
@@ -1071,7 +1143,8 @@ namespace JSONHelpers
         result.SetNamedValue(L"name", json::value(customZoneSet.data.name));
         switch (customZoneSet.data.type)
         {
-        case CustomLayoutType::Canvas: {
+        case CustomLayoutType::Canvas:
+        {
             result.SetNamedValue(L"type", json::value(L"canvas"));
 
             CanvasLayoutInfo info = std::get<CanvasLayoutInfo>(customZoneSet.data.info);
@@ -1079,7 +1152,8 @@ namespace JSONHelpers
 
             break;
         }
-        case CustomLayoutType::Grid: {
+        case CustomLayoutType::Grid:
+        {
             result.SetNamedValue(L"type", json::value(L"grid"));
 
             GridLayoutInfo gridInfo = std::get<GridLayoutInfo>(customZoneSet.data.info);
@@ -1103,7 +1177,7 @@ namespace JSONHelpers
             {
                 return std::nullopt;
             }
-            
+
             result.data.name = customZoneSet.GetNamedString(L"name");
 
             json::JsonObject infoJson = customZoneSet.GetNamedObject(L"info");

--- a/src/modules/fancyzones/lib/JsonHelpers.h
+++ b/src/modules/fancyzones/lib/JsonHelpers.h
@@ -132,6 +132,8 @@ namespace JSONHelpers
 
     struct AppZoneHistoryData
     {
+        std::map<DWORD, HWND> processIdToHandleMap;
+
         std::wstring zoneSetUuid;
         std::wstring deviceId;
         std::vector<int> zoneIndexSet;
@@ -242,6 +244,8 @@ namespace JSONHelpers
         void UpdatePrimaryDesktopData(const std::wstring& desktopId);
         void RemoveDeletedDesktops(const std::vector<std::wstring>& activeDesktops);
 
+        bool IsAnotherWindowOfApplicationInstancePlaced(HWND window) const;
+        void UpdateHandle(HWND window);
         std::vector<int> GetAppLastZoneIndexSet(HWND window, const std::wstring_view& deviceId, const std::wstring_view& zoneSetId) const;
         bool RemoveAppLastZone(HWND window, const std::wstring_view& deviceId, const std::wstring_view& zoneSetId);
         bool SetAppLastZones(HWND window, const std::wstring& deviceId, const std::wstring& zoneSetId, const std::vector<int>& zoneIndexSet);

--- a/src/modules/fancyzones/lib/JsonHelpers.h
+++ b/src/modules/fancyzones/lib/JsonHelpers.h
@@ -132,7 +132,7 @@ namespace JSONHelpers
 
     struct AppZoneHistoryData
     {
-        std::map<DWORD, HWND> processIdToHandleMap;
+        std::map<DWORD, HWND> processIdToHandleMap; // Maps process id(DWORD) of application to zoned window handle(HWND)
 
         std::wstring zoneSetUuid;
         std::wstring deviceId;
@@ -245,7 +245,7 @@ namespace JSONHelpers
         void RemoveDeletedDesktops(const std::vector<std::wstring>& activeDesktops);
 
         bool IsAnotherWindowOfApplicationInstanceZoned(HWND window) const;
-        void UpdateHandle(HWND window);
+        void UpdateProcessIdToHandleMap(HWND window);
         std::vector<int> GetAppLastZoneIndexSet(HWND window, const std::wstring_view& deviceId, const std::wstring_view& zoneSetId) const;
         bool RemoveAppLastZone(HWND window, const std::wstring_view& deviceId, const std::wstring_view& zoneSetId);
         bool SetAppLastZones(HWND window, const std::wstring& deviceId, const std::wstring& zoneSetId, const std::vector<int>& zoneIndexSet);

--- a/src/modules/fancyzones/lib/JsonHelpers.h
+++ b/src/modules/fancyzones/lib/JsonHelpers.h
@@ -244,7 +244,7 @@ namespace JSONHelpers
         void UpdatePrimaryDesktopData(const std::wstring& desktopId);
         void RemoveDeletedDesktops(const std::vector<std::wstring>& activeDesktops);
 
-        bool IsAnotherWindowOfApplicationInstancePlaced(HWND window) const;
+        bool IsAnotherWindowOfApplicationInstanceZoned(HWND window) const;
         void UpdateHandle(HWND window);
         std::vector<int> GetAppLastZoneIndexSet(HWND window, const std::wstring_view& deviceId, const std::wstring_view& zoneSetId) const;
         bool RemoveAppLastZone(HWND window, const std::wstring_view& deviceId, const std::wstring_view& zoneSetId);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Some application like outlook uses multiple windows. If application was zoned "Move newly created window to zone" all other windows were moved to the zone also.
After changes only one window of same application will be zoned on creation, rest will not be moved by fancy zones.
When one window of same application window is zoned, zoning other window can be zoned, but it will not be saved in zone-settings.json.

Edit: Now multiple instances of same application will be zoned based on process id. First window of aplication instance will be zoned, rest will be unzoned while starting app

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #1192

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Manual testing
- Unit tests passed
