### PR TITLE
[Keyboard Manager] Fix Remap buttons stop working 

### DIFF
--- a/src/modules/keyboardmanager/ui/XamlBridge.cpp
+++ b/src/modules/keyboardmanager/ui/XamlBridge.cpp
@@ -227,6 +227,8 @@ void XamlBridge::OnTakeFocusRequested(winrt::Windows::UI::Xaml::Hosting::Desktop
 HWND XamlBridge::InitDesktopWindowsXamlSource(winrt::Windows::UI::Xaml::Hosting::DesktopWindowXamlSource desktopSource)
 {
     HRESULT hr = S_OK;
+    winrt::init_apartment(apartment_type::single_threaded);
+    winxamlmanager = WindowsXamlManager::InitializeForCurrentThread();
 
     auto interop = desktopSource.as<IDesktopWindowXamlSourceNative>();
     // Parent the DesktopWindowXamlSource object to current window
@@ -258,6 +260,8 @@ void XamlBridge::ClearXamlIslands()
         xamlSource.Close();
     }
     m_xamlSources.clear();
+
+    winxamlmanager.Close();
 }
 
 // Function invoked when the window is destroyed

--- a/src/modules/keyboardmanager/ui/XamlBridge.h
+++ b/src/modules/keyboardmanager/ui/XamlBridge.h
@@ -17,7 +17,7 @@ public:
 
     // Constructor
     XamlBridge(HWND parent) :
-        parentWindow(parent), lastFocusRequestId(winrt::guid())
+        parentWindow(parent), lastFocusRequestId(winrt::guid()), winxamlmanager(nullptr)
     {
     }
 
@@ -36,6 +36,9 @@ private:
 
     // Stores the handle of the parent native window
     HWND parentWindow = nullptr;
+
+    // Window xaml manager for UI thread.
+    WindowsXamlManager winxamlmanager;
 
     // Stores the GUID of the last focus request
     winrt::guid lastFocusRequestId;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
~I got it to stop crashing by bypassing XamlBridge Window focus handling.~
It seems there was some initialization missing that was the root cause of the strange crashes in Windows Insiders.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2321 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
* ~Xaml Bridge seems to not handle focus events properly, so this fix just bypasses it by handling the WM_SETFOCUS event directly.~
* ~This also solves another not documented crash that involved minimizing the window, then closing by pressing the X button without interacting with the window content itself.~
* Solved by calling `winrt::init_apartment` and `WindowsXamlManager::InitializeForCurrentThread()` in the constructor of the XamlBridge class.
 
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
*For Windows Insiders users*
1. Click on the Remap a key button with no key remappings.
2. Close the window by pressing the X button.
3. It shouldn't crash.
4. Repeat for Redefine a shortcut.

Another crashing scenario.
1. Click on the Remap a key button.
2. Minimize the Window.
3. Click on the taskbar to show the window again.
4. Close the window by pressing the X button.
5. It shouldn't crash.