### PR TITLE
[KBM] Constrain the buttons such that only one of the windows can be opened

### DIFF
--- a/src/modules/keyboardmanager/dll/dllmain.cpp
+++ b/src/modules/keyboardmanager/dll/dllmain.cpp
@@ -225,14 +225,14 @@ public:
 
             if (action_object.get_name() == L"RemapKeyboard")
             {
-                if (!CheckEditKeyboardWindowActive())
+                if (!CheckEditKeyboardWindowActive() && !CheckEditShortcutsWindowActive())
                 {
                     std::thread(createEditKeyboardWindow, hInstance, std::ref(keyboardManagerState)).detach();
                 }
             }
             else if (action_object.get_name() == L"EditShortcut")
             {
-                if (!CheckEditShortcutsWindowActive())
+                if (!CheckEditKeyboardWindowActive() && !CheckEditShortcutsWindowActive())
                 {
                     std::thread(createEditShortcutsWindow, hInstance, std::ref(keyboardManagerState)).detach();
                 }

--- a/src/modules/keyboardmanager/ui/EditKeyboardWindow.cpp
+++ b/src/modules/keyboardmanager/ui/EditKeyboardWindow.cpp
@@ -318,7 +318,10 @@ void createEditKeyboardWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMan
     {
         ShowWindow(_hWndEditKeyboardWindow, SW_SHOW);
         UpdateWindow(_hWndEditKeyboardWindow);
+        SetForegroundWindow(_hWndEditKeyboardWindow);
     }
+
+    SetFocus(hWndXamlIslandEditKeyboardWindow);
 
     // Message loop:
     xamlBridge.MessageLoop();
@@ -344,6 +347,12 @@ LRESULT CALLBACK EditKeyboardWindowProc(HWND hWnd, UINT messageCode, WPARAM wPar
         GetClientRect(hWnd, &rcClient);
         SetWindowPos(hWndXamlIslandEditKeyboardWindow, 0, rcClient.left, rcClient.top, rcClient.right, rcClient.bottom, SWP_SHOWWINDOW);
         break;
+    case WM_SETFOCUS:
+        if (hWndXamlIslandEditKeyboardWindow != 0)
+        {
+            SetFocus(hWndXamlIslandEditKeyboardWindow);
+        }
+        return DefWindowProc(hWnd, messageCode, wParam, lParam);
     default:
         // If the Xaml Bridge object exists, then use it's message handler to handle keyboard focus operations
         if (xamlBridgePtr != nullptr)

--- a/src/modules/keyboardmanager/ui/EditKeyboardWindow.cpp
+++ b/src/modules/keyboardmanager/ui/EditKeyboardWindow.cpp
@@ -318,10 +318,7 @@ void createEditKeyboardWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMan
     {
         ShowWindow(_hWndEditKeyboardWindow, SW_SHOW);
         UpdateWindow(_hWndEditKeyboardWindow);
-        SetForegroundWindow(_hWndEditKeyboardWindow);
     }
-
-    SetFocus(hWndXamlIslandEditKeyboardWindow);
 
     // Message loop:
     xamlBridge.MessageLoop();
@@ -347,12 +344,6 @@ LRESULT CALLBACK EditKeyboardWindowProc(HWND hWnd, UINT messageCode, WPARAM wPar
         GetClientRect(hWnd, &rcClient);
         SetWindowPos(hWndXamlIslandEditKeyboardWindow, 0, rcClient.left, rcClient.top, rcClient.right, rcClient.bottom, SWP_SHOWWINDOW);
         break;
-    case WM_SETFOCUS:
-        if (hWndXamlIslandEditKeyboardWindow != 0)
-        {
-            SetFocus(hWndXamlIslandEditKeyboardWindow);
-        }
-        return DefWindowProc(hWnd, messageCode, wParam, lParam);
     default:
         // If the Xaml Bridge object exists, then use it's message handler to handle keyboard focus operations
         if (xamlBridgePtr != nullptr)

--- a/src/modules/keyboardmanager/ui/EditKeyboardWindow.cpp
+++ b/src/modules/keyboardmanager/ui/EditKeyboardWindow.cpp
@@ -350,7 +350,7 @@ LRESULT CALLBACK EditKeyboardWindowProc(HWND hWnd, UINT messageCode, WPARAM wPar
         {
             return xamlBridgePtr->MessageHandler(messageCode, wParam, lParam);
         }
-        else if (messageCode == WM_DESTROY)
+        else if (messageCode == WM_NCDESTROY)
         {
             PostQuitMessage(0);
             break;

--- a/src/modules/keyboardmanager/ui/EditShortcutsWindow.cpp
+++ b/src/modules/keyboardmanager/ui/EditShortcutsWindow.cpp
@@ -242,7 +242,10 @@ void createEditShortcutsWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMa
     {
         ShowWindow(_hWndEditShortcutsWindow, SW_SHOW);
         UpdateWindow(_hWndEditShortcutsWindow);
+        SetForegroundWindow(_hWndEditShortcutsWindow);
     }
+
+    SetFocus(hWndXamlIslandEditShortcutsWindow);
 
     // Message loop:
     xamlBridge.MessageLoop();
@@ -268,6 +271,12 @@ LRESULT CALLBACK EditShortcutsWindowProc(HWND hWnd, UINT messageCode, WPARAM wPa
         GetClientRect(hWnd, &rcClient);
         SetWindowPos(hWndXamlIslandEditShortcutsWindow, 0, rcClient.left, rcClient.top, rcClient.right, rcClient.bottom, SWP_SHOWWINDOW);
         break;
+    case WM_SETFOCUS:
+        if (hWndXamlIslandEditShortcutsWindow != 0)
+        {
+            SetFocus(hWndXamlIslandEditShortcutsWindow);
+        }
+        return DefWindowProc(hWnd, messageCode, wParam, lParam);
     default:
         // If the Xaml Bridge object exists, then use it's message handler to handle keyboard focus operations
         if (xamlBridgePtr != nullptr)

--- a/src/modules/keyboardmanager/ui/EditShortcutsWindow.cpp
+++ b/src/modules/keyboardmanager/ui/EditShortcutsWindow.cpp
@@ -242,10 +242,7 @@ void createEditShortcutsWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMa
     {
         ShowWindow(_hWndEditShortcutsWindow, SW_SHOW);
         UpdateWindow(_hWndEditShortcutsWindow);
-        SetForegroundWindow(_hWndEditShortcutsWindow);
     }
-
-    SetFocus(hWndXamlIslandEditShortcutsWindow);
 
     // Message loop:
     xamlBridge.MessageLoop();
@@ -271,12 +268,6 @@ LRESULT CALLBACK EditShortcutsWindowProc(HWND hWnd, UINT messageCode, WPARAM wPa
         GetClientRect(hWnd, &rcClient);
         SetWindowPos(hWndXamlIslandEditShortcutsWindow, 0, rcClient.left, rcClient.top, rcClient.right, rcClient.bottom, SWP_SHOWWINDOW);
         break;
-    case WM_SETFOCUS:
-        if (hWndXamlIslandEditShortcutsWindow != 0)
-        {
-            SetFocus(hWndXamlIslandEditShortcutsWindow);
-        }
-        return DefWindowProc(hWnd, messageCode, wParam, lParam);
     default:
         // If the Xaml Bridge object exists, then use it's message handler to handle keyboard focus operations
         if (xamlBridgePtr != nullptr)

--- a/src/modules/keyboardmanager/ui/EditShortcutsWindow.cpp
+++ b/src/modules/keyboardmanager/ui/EditShortcutsWindow.cpp
@@ -274,7 +274,7 @@ LRESULT CALLBACK EditShortcutsWindowProc(HWND hWnd, UINT messageCode, WPARAM wPa
         {
             return xamlBridgePtr->MessageHandler(messageCode, wParam, lParam);
         }
-        else if (messageCode == WM_DESTROY)
+        else if (messageCode == WM_NCDESTROY)
         {
             PostQuitMessage(0);
             break;

--- a/src/modules/keyboardmanager/ui/XamlBridge.cpp
+++ b/src/modules/keyboardmanager/ui/XamlBridge.cpp
@@ -289,7 +289,7 @@ LRESULT XamlBridge::MessageHandler(UINT const message, WPARAM const wParam, LPAR
 {
     switch (message)
     {
-        HANDLE_MSG(parentWindow, WM_DESTROY, OnDestroy);
+        HANDLE_MSG(parentWindow, WM_NCDESTROY, OnDestroy);
         HANDLE_MSG(parentWindow, WM_ACTIVATE, OnActivate);
         HANDLE_MSG(parentWindow, WM_SETFOCUS, OnSetFocus);
     }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
The crash mentioned in the linked issue was happening because we use a single KeyboardManagerState variable for both of the windows, so when one of the windows is closed there is most likely something getting set to `nullptr` while a window is still open. The way the code was written was considering only one window open, so the best way to solve this with minimal changes is to ensure only one window can be opened at a time.
The PR changes the behavior of the buttons, such that when clicking either of the buttons - if Edit keyboard or edit shortcut either of them are open, it will bring that window in focus. Earlier if Edit keyboard was open and you clicked the same button again, it would just bring that to focus. By this change we ensure that only one window is open at a time, and by bring that in focus the user should also notice the window lying open.
This is a first step for #2466 . The pending work for the modal dialog is to prevent the user from being able to access the Settings window while this dialog box is up.

This also adds a fix where the remap button would stop working if you closed KBM from the taskbar (the runner would not crash though).

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Applies to #2469, #2569 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Tried closing and reopening the windows with both the buttons multiple times.
