### PR TITLE
[FancyZones] Send message from VirtualDesktopUpdates thread to FZ thread when update happens

### DIFF
--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -215,10 +215,10 @@ private:
     OnThreadExecutor m_dpiUnawareThread;
     OnThreadExecutor m_virtualDesktopTrackerThread;
 
-    static UINT WM_PRIV_VD_INIT; // Message to get back to the UI thread when FancyZones are initialized
-    static UINT WM_PRIV_VD_SWITCH; // Message to get back on to the UI thread when virtual desktop changes
-    static UINT WM_PRIV_VD_UPDATE; // Message to get back on the UI thread on virtual desktops update
-    static UINT WM_PRIV_EDITOR; // Message to get back on to the UI thread when the editor exits
+    static UINT WM_PRIV_VD_INIT; // Message to get back to the UI thread when FancyZones is initialized
+    static UINT WM_PRIV_VD_SWITCH; // Message to get back to the UI thread when virtual desktop switch occurs
+    static UINT WM_PRIV_VD_UPDATE; // Message to get back to the UI thread on virtual desktops update (creation/deletion)
+    static UINT WM_PRIV_EDITOR; // Message to get back to the UI thread when the editor exits
 
     // Did we terminate the editor or was it closed cleanly?
     enum class EditorExitKind : byte

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -219,6 +219,7 @@ private:
     static UINT WM_PRIV_VDCHANGED; // Message to get back on to the UI thread when virtual desktop changes
     static UINT WM_PRIV_VDINIT; // Message to get back to the UI thread when FancyZones are initialized
     static UINT WM_PRIV_EDITOR; // Message to get back on to the UI thread when the editor exits
+    static UINT WM_PRIV_VDUPDATE; // Message to get back on the UI thread on virtual desktops update
 
     // Did we terminate the editor or was it closed cleanly?
     enum class EditorExitKind : byte
@@ -231,6 +232,7 @@ private:
 UINT FancyZones::WM_PRIV_VDCHANGED = RegisterWindowMessage(L"{128c2cb0-6bdf-493e-abbe-f8705e04aa95}");
 UINT FancyZones::WM_PRIV_VDINIT = RegisterWindowMessage(L"{469818a8-00fa-4069-b867-a1da484fcd9a}");
 UINT FancyZones::WM_PRIV_EDITOR = RegisterWindowMessage(L"{87543824-7080-4e91-9d9c-0404642fc7b6}");
+UINT FancyZones::WM_PRIV_VDUPDATE = RegisterWindowMessage(L"{b8b72b46-f42f-4c26-9e20-29336cf2f22e}");
 
 // IFancyZones
 IFACEMETHODIMP_(void)
@@ -580,6 +582,14 @@ LRESULT FancyZones::WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lpa
                 m_terminateEditorEvent.release();
             }
         }
+        else if (message == WM_PRIV_VDUPDATE)
+        {
+            std::vector<GUID> ids{};
+            if (VirtualDesktopUtils::GetVirtualDekstopIds(ids))
+            {
+                std::unordered_set<GUID> idSet(std::begin(ids), std::end(ids));
+            }
+        }
         else
         {
             return DefWindowProc(window, message, wparam, lparam);
@@ -829,6 +839,7 @@ void FancyZones::HandleVirtualDesktopUpdates(HANDLE fancyZonesDestroyedEvent) no
             // if fancyZonesDestroyedEvent is signalized or WaitForMultipleObjects failed, terminate thread execution
             return;
         }
+        PostMessage(m_window, WM_PRIV_VDUPDATE, 0, 0);
         std::vector<GUID> ids{};
         if (VirtualDesktopUtils::GetVirtualDekstopIds(ids))
         {

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -284,7 +284,6 @@ FancyZones::Destroy() noexcept
     {
         SetEvent(m_terminateVirtualDesktopTrackerEvent.get());
     }
-    VirtualDesktopUtils::CloseVirtualDesktopsRegKey();
 }
 
 // IFancyZonesCallback
@@ -832,15 +831,16 @@ void FancyZones::HandleVirtualDesktopUpdates(HANDLE fancyZonesDestroyedEvent) no
     {
         if (RegNotifyChangeKeyValue(virtualDesktopsRegKey, TRUE, REG_NOTIFY_CHANGE_LAST_SET, regKeyEvent, TRUE) != ERROR_SUCCESS)
         {
-            return;
+            break;
         }
         if (WaitForMultipleObjects(2, events, FALSE, INFINITE) != (WAIT_OBJECT_0 + 0))
         {
             // if fancyZonesDestroyedEvent is signalized or WaitForMultipleObjects failed, terminate thread execution
-            return;
+            break;
         }
         PostMessage(m_window, WM_PRIV_VDUPDATE, 0, 0);
     }
+    VirtualDesktopUtils::CloseVirtualDesktopsRegKey();
 }
 
 void FancyZones::RegisterVirtualDesktopUpdates(std::vector<GUID>& ids) noexcept

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -604,10 +604,6 @@ void FancyZones::OnDisplayChange(DisplayChangeType changeType) noexcept
     if (changeType == DisplayChangeType::VirtualDesktop ||
         changeType == DisplayChangeType::Initialization)
     {
-        // Explorer persists this value to the registry on a per session basis but only after
-        // the first virtual desktop switch happens. If the user hasn't switched virtual desktops in this session
-        // then this value will be empty. This means loading the first virtual desktop's configuration can be
-        // funky the first time we load up at boot since the user will not have switched virtual desktops yet.
         GUID currentVirtualDesktopId{};
         if (VirtualDesktopUtils::GetCurrentVirtualDesktopId(&currentVirtualDesktopId))
         {

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -381,7 +381,6 @@ FancyZones::OnKeyDown(PKBDLLHOOKSTRUCT info) noexcept
     //    return false;
     //}
 
-    std::shared_lock readLock(m_lock);
     if (m_windowMoveHandler.IsDragEnabled() && shift)
     {
         return true;

--- a/src/modules/fancyzones/lib/VirtualDesktopUtils.cpp
+++ b/src/modules/fancyzones/lib/VirtualDesktopUtils.cpp
@@ -9,6 +9,7 @@ namespace VirtualDesktopUtils
 
     const wchar_t RegCurrentVirtualDesktop[] = L"CurrentVirtualDesktop";
     const wchar_t RegVirtualDesktopIds[] = L"VirtualDesktopIDs";
+    const wchar_t RegKeyVirtualDesktops[] = L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\VirtualDesktops";
 
     IServiceProvider* GetServiceProvider()
     {
@@ -50,7 +51,7 @@ namespace VirtualDesktopUtils
         return SUCCEEDED(CLSIDFromString(virtualDesktopId.c_str(), desktopId));
     }
 
-    bool GetCurrentVirtualDesktopId(GUID* desktopId)
+    bool GetDesktopIdFromCurrentSession(GUID* desktopId)
     {
         DWORD sessionId;
         ProcessIdToSessionId(GetCurrentProcessId(), &sessionId);
@@ -77,8 +78,30 @@ namespace VirtualDesktopUtils
         return false;
     }
 
+    bool GetCurrentVirtualDesktopId(GUID* desktopId)
+    {
+        if (!GetDesktopIdFromCurrentSession(desktopId))
+        {
+            // Explorer persists current virtual desktop identifier to registry on a per session basis,
+            // but only after first virtual desktop switch happens. If the user hasn't switched virtual
+            // desktops (only primary desktop) in this session value in registry will be empty.
+            // If this value is empty take first element from array of virtual desktops (not kept per session).
+            std::vector<GUID> ids{};
+            if (!GetVirtualDekstopIds(ids) || ids.empty())
+            {
+                return false;
+            }
+            *desktopId = ids[0];
+        }
+        return true;
+    }
+
     bool GetVirtualDekstopIds(HKEY hKey, std::vector<GUID>& ids)
     {
+        if (!hKey)
+        {
+            return false;
+        }
         DWORD bufferCapacity;
         // request regkey binary buffer capacity only
         if (RegQueryValueExW(hKey, RegVirtualDesktopIds, 0, nullptr, nullptr, &bufferCapacity) != ERROR_SUCCESS)
@@ -101,5 +124,35 @@ namespace VirtualDesktopUtils
         }
         ids = std::move(temp);
         return true;
+    }
+
+    bool GetVirtualDekstopIds(std::vector<GUID>& ids)
+    {
+        return GetVirtualDekstopIds(GetVirtualDesktopsRegKey(), ids);
+    }
+
+    HKEY OpenVirtualDesktopsRegKey()
+    {
+        HKEY hKey{ nullptr };
+        if (RegOpenKeyEx(HKEY_CURRENT_USER, RegKeyVirtualDesktops, 0, KEY_ALL_ACCESS, &hKey) == ERROR_SUCCESS)
+        {
+            return hKey;
+        }
+        return nullptr;
+    }
+
+    HKEY GetVirtualDesktopsRegKey()
+    {
+        static HKEY virtualDesktopsKey = OpenVirtualDesktopsRegKey();
+        return virtualDesktopsKey;
+    }
+
+    void CloseVirtualDesktopsRegKey()
+    {
+        HKEY hKey = GetVirtualDesktopsRegKey();
+        if (hKey)
+        {
+            RegCloseKey(hKey);
+        }
     }
 }

--- a/src/modules/fancyzones/lib/VirtualDesktopUtils.h
+++ b/src/modules/fancyzones/lib/VirtualDesktopUtils.h
@@ -7,5 +7,7 @@ namespace VirtualDesktopUtils
     bool GetWindowDesktopId(HWND topLevelWindow, GUID* desktopId);
     bool GetZoneWindowDesktopId(IZoneWindow* zoneWindow, GUID* desktopId);
     bool GetCurrentVirtualDesktopId(GUID* desktopId);
-    bool GetVirtualDekstopIds(HKEY hKey, std::vector<GUID>& ids);
+    bool GetVirtualDekstopIds(std::vector<GUID>& ids);
+    HKEY GetVirtualDesktopsRegKey();
+    void CloseVirtualDesktopsRegKey();
 }

--- a/src/modules/fancyzones/lib/VirtualDesktopUtils.h
+++ b/src/modules/fancyzones/lib/VirtualDesktopUtils.h
@@ -9,5 +9,5 @@ namespace VirtualDesktopUtils
     bool GetCurrentVirtualDesktopId(GUID* desktopId);
     bool GetVirtualDekstopIds(std::vector<GUID>& ids);
     HKEY GetVirtualDesktopsRegKey();
-    void CloseVirtualDesktopsRegKey();
+    void HandleVirtualDesktopUpdates(HWND window, UINT message, HANDLE terminateEvent);
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
After we detect changes in virtual desktops (creation / deletion) send windows message to FancyZones thread and do the handling there, instead of accessing private FancyZones members from VirtualDesktopUpdates thread. Move some virtual desktops related logic to VirtualDesktopUtils namespace.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2528 & https://github.com/microsoft/PowerToys/issues/2437

