### PR TITLE
FZ: run AnimateWindow and InvalidateRect in a dedicated thread

### DIFF
--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -499,23 +499,28 @@ ZoneWindow::SaveWindowProcessToZoneIndex(HWND window) noexcept
 IFACEMETHODIMP_(void)
 ZoneWindow::ShowZoneWindow() noexcept
 {
-    if (m_window)
+    auto window = m_window.get();
+    if (!window)
     {
-        m_flashMode = false;
-
-        UINT flags = SWP_NOSIZE | SWP_NOMOVE | SWP_NOACTIVATE;
-
-        HWND windowInsertAfter = m_windowMoveSize;
-        if (windowInsertAfter == nullptr)
-        {
-            windowInsertAfter = HWND_TOPMOST;
-        }
-
-        SetWindowPos(m_window.get(), windowInsertAfter, 0, 0, 0, 0, flags);
-
-        AnimateWindow(m_window.get(), m_showAnimationDuration, AW_BLEND);
-        InvalidateRect(m_window.get(), nullptr, true);
+        return;
     }
+
+    m_flashMode = false;
+
+    UINT flags = SWP_NOSIZE | SWP_NOMOVE | SWP_NOACTIVATE;
+
+    HWND windowInsertAfter = m_windowMoveSize;
+    if (windowInsertAfter == nullptr)
+    {
+        windowInsertAfter = HWND_TOPMOST;
+    }
+
+    SetWindowPos(window, windowInsertAfter, 0, 0, 0, 0, flags);
+
+    std::thread{ [=]() {
+        AnimateWindow(window, m_showAnimationDuration, AW_BLEND);
+        InvalidateRect(window, nullptr, true);
+    } }.detach();
 }
 
 IFACEMETHODIMP_(void)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR invokes synchronous window animation functions in a separate thread, so we don't wait for them before allowing a window to be snapped onto a zone


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2098

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- tested with "show window on all monitors" turned off and on