### PR TITLE
FancyZones: subscribe only to handled WinHook events

### DIFF
--- a/src/modules/fancyzones/dll/dllmain.cpp
+++ b/src/modules/fancyzones/dll/dllmain.cpp
@@ -252,7 +252,13 @@ void FancyZonesModule::HandleWinHookEvent(WinHookEvent* data) noexcept
         MoveSizeStart(data->hwnd, ptScreen);
         if (!m_objectLocationWinEventHook)
         {
-            m_objectLocationWinEventHook = SetWinEventHook(EVENT_OBJECT_LOCATIONCHANGE, EVENT_OBJECT_LOCATIONCHANGE, nullptr, WinHookProc, 0, 0, WINEVENT_OUTOFCONTEXT | WINEVENT_SKIPOWNPROCESS);
+            m_objectLocationWinEventHook = SetWinEventHook(EVENT_OBJECT_LOCATIONCHANGE,
+                                                           EVENT_OBJECT_LOCATIONCHANGE,
+                                                           nullptr,
+                                                           WinHookProc,
+                                                           0,
+                                                           0,
+                                                           WINEVENT_OUTOFCONTEXT | WINEVENT_SKIPOWNPROCESS);
         }
     }
     break;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
- subscribe only to handled WinHook events
- (un)hook `EVENT_OBJECT_LOCATIONCHANGE` handler only when required


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #1264

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- moved windows in FZ with various options turned off and on