### PR TITLE
[PowerRename] Split general module settings and UI flags to separate files.

### DIFF
--- a/src/modules/powerrename/lib/Settings.cpp
+++ b/src/modules/powerrename/lib/Settings.cpp
@@ -6,10 +6,12 @@
 #include <filesystem>
 #include <commctrl.h>
 #include <algorithm>
+#include <fstream>
 
 namespace
 {
     const wchar_t c_powerRenameDataFilePath[] = L"\\power-rename-settings.json";
+    const wchar_t c_powerRenameUIFlagsFilePath[] = L"\\power-rename-ui-flags";
     const wchar_t c_searchMRUListFilePath[] = L"\\search-mru.json";
     const wchar_t c_replaceMRUListFilePath[] = L"\\replace-mru.json";
 
@@ -395,6 +397,7 @@ CSettings::CSettings()
 {
     std::wstring result = PTSettingsHelper::get_module_save_folder_location(L"PowerRename");
     jsonFilePath = result + std::wstring(c_powerRenameDataFilePath);
+    UIFlagsFilePath = result + std::wstring(c_powerRenameUIFlagsFilePath);
     Load();
 }
 
@@ -408,11 +411,11 @@ void CSettings::Save()
     jsonData.SetNamedValue(c_persistState,            json::value(settings.persistState));
     jsonData.SetNamedValue(c_mruEnabled,              json::value(settings.MRUEnabled));
     jsonData.SetNamedValue(c_maxMRUSize,              json::value(settings.maxMRUSize));
-    jsonData.SetNamedValue(c_flags,                   json::value(settings.flags));
     jsonData.SetNamedValue(c_searchText,              json::value(settings.searchText));
     jsonData.SetNamedValue(c_replaceText,             json::value(settings.replaceText));
 
     json::to_file(jsonFilePath, jsonData);
+    GetSystemTimeAsFileTime(&lastLoadedTime);
 }
 
 void CSettings::Load()
@@ -422,12 +425,13 @@ void CSettings::Load()
         MigrateFromRegistry();
 
         Save();
+        WriteFlags();
     }
     else
     {
         ParseJson();
+        ReadFlags();
     }
-    GetSystemTimeAsFileTime(&lastLoadedTime);
 }
 
 void CSettings::Reload()
@@ -487,10 +491,6 @@ void CSettings::ParseJson()
             {
                 settings.maxMRUSize = (unsigned int)jsonSettings.GetNamedNumber(c_maxMRUSize);
             }
-            if (json::has(jsonSettings, c_flags, json::JsonValueType::Number))
-            {
-                settings.flags = (unsigned int)jsonSettings.GetNamedNumber(c_flags);
-            }
             if (json::has(jsonSettings, c_searchText, json::JsonValueType::String))
             {
                 settings.searchText = jsonSettings.GetNamedString(c_searchText);
@@ -501,6 +501,25 @@ void CSettings::ParseJson()
             }
         }
         catch (const winrt::hresult_error&) { }
+    }
+    GetSystemTimeAsFileTime(&lastLoadedTime);
+}
+
+void CSettings::ReadFlags()
+{
+    std::ifstream file(UIFlagsFilePath, std::ios::binary);
+    if (file.is_open())
+    {
+        file >> settings.flags;
+    }
+}
+
+void CSettings::WriteFlags()
+{
+    std::ofstream file(UIFlagsFilePath, std::ios::binary);
+    if (file.is_open())
+    {
+        file << settings.flags;
     }
 }
 

--- a/src/modules/powerrename/lib/Settings.h
+++ b/src/modules/powerrename/lib/Settings.h
@@ -79,7 +79,7 @@ public:
     inline void SetFlags(unsigned int flags)
     {
         settings.flags = flags;
-        Save();
+        WriteFlags();
     }
 
     inline const std::wstring& GetSearchText() const
@@ -125,8 +125,12 @@ private:
     void MigrateFromRegistry();
     void ParseJson();
 
+    void ReadFlags();
+    void WriteFlags();
+
     Settings settings;
     std::wstring jsonFilePath;
+    std::wstring UIFlagsFilePath;
     FILETIME lastLoadedTime;
 };
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Reason for this PR is that file with PowerRename settings is accessed from different processes (PowerToys settings application and PowerRename application itself) which is not safe and can lead to data race.
Keep general module settings as it is, and introduce new binary file for UI flags (encoded as bits in integer indicating on/off for certain flags). Support migration from registry directly to new file for UI flags. Migration from current json formatted file to new file with flags is not supported.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2612
