### PR TITLE
[FancyZones] Clean up resources taken by closed virtual desktops on module startup

### DIFF
--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -609,9 +609,28 @@ void FancyZones::OnDisplayChange(DisplayChangeType changeType) noexcept
             m_currentVirtualDesktopId = currentVirtualDesktopId;
             wil::unique_cotaskmem_string id;
             if (changeType == DisplayChangeType::Initialization &&
-                SUCCEEDED_LOG(StringFromCLSID(m_currentVirtualDesktopId, &id)))
+                SUCCEEDED(StringFromCLSID(m_currentVirtualDesktopId, &id)))
             {
                 JSONHelpers::FancyZonesDataInstance().UpdatePrimaryDesktopData(id.get());
+            }
+        }
+        if (changeType == DisplayChangeType::Initialization)
+        {
+            // Get currenty active desktops and clean data from persisted storage for all closed desktops.
+            std::vector<GUID> ids{};
+            if (VirtualDesktopUtils::GetVirtualDekstopIds(ids))
+            {
+                std::vector<std::wstring> strIds{};
+                strIds.reserve(ids.size());
+                for (auto& id : ids)
+                {
+                    wil::unique_cotaskmem_string strId;
+                    if (SUCCEEDED(StringFromCLSID(id, &strId)))
+                    {
+                        strIds.push_back(strId.get());
+                    }
+                }
+                JSONHelpers::FancyZonesDataInstance().CleanResourcesFromClosedDesktops(strIds);
             }
         }
     }

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -606,21 +606,14 @@ void FancyZones::OnDisplayChange(DisplayChangeType changeType) noexcept
         GUID currentVirtualDesktopId{};
         if (VirtualDesktopUtils::GetCurrentVirtualDesktopId(&currentVirtualDesktopId))
         {
-            std::unique_lock writeLock(m_lock);
             m_currentVirtualDesktopId = currentVirtualDesktopId;
-            wil::unique_cotaskmem_string id;
-            if (changeType == DisplayChangeType::Initialization &&
-                SUCCEEDED(StringFromCLSID(m_currentVirtualDesktopId, &id)))
-            {
-                JSONHelpers::FancyZonesDataInstance().UpdatePrimaryDesktopData(id.get());
-            }
         }
         if (changeType == DisplayChangeType::Initialization)
         {
-            // Get currenty active desktops and clean data from persisted storage for all closed desktops.
             std::vector<std::wstring> ids{};
-            if (VirtualDesktopUtils::GetVirtualDesktopIds(ids))
+            if (VirtualDesktopUtils::GetVirtualDesktopIds(ids) && !ids.empty())
             {
+                JSONHelpers::FancyZonesDataInstance().UpdatePrimaryDesktopData(ids[0]);
                 JSONHelpers::FancyZonesDataInstance().RemoveDeletedDesktops(ids);
             }
         }

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -568,7 +568,7 @@ LRESULT FancyZones::WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lpa
         else if (message == WM_PRIV_VD_UPDATE)
         {
             std::vector<GUID> ids{};
-            if (VirtualDesktopUtils::GetVirtualDekstopIds(ids))
+            if (VirtualDesktopUtils::GetVirtualDesktopIds(ids))
             {
                 RegisterVirtualDesktopUpdates(ids);
             }
@@ -597,6 +597,7 @@ LRESULT FancyZones::WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lpa
     return 0;
 }
 
+
 void FancyZones::OnDisplayChange(DisplayChangeType changeType) noexcept
 {
     if (changeType == DisplayChangeType::VirtualDesktop ||
@@ -617,20 +618,10 @@ void FancyZones::OnDisplayChange(DisplayChangeType changeType) noexcept
         if (changeType == DisplayChangeType::Initialization)
         {
             // Get currenty active desktops and clean data from persisted storage for all closed desktops.
-            std::vector<GUID> ids{};
-            if (VirtualDesktopUtils::GetVirtualDekstopIds(ids))
+            std::vector<std::wstring> ids{};
+            if (VirtualDesktopUtils::GetVirtualDesktopIds(ids))
             {
-                std::vector<std::wstring> strIds{};
-                strIds.reserve(ids.size());
-                for (auto& id : ids)
-                {
-                    wil::unique_cotaskmem_string strId;
-                    if (SUCCEEDED(StringFromCLSID(id, &strId)))
-                    {
-                        strIds.push_back(strId.get());
-                    }
-                }
-                JSONHelpers::FancyZonesDataInstance().CleanResourcesFromClosedDesktops(strIds);
+                JSONHelpers::FancyZonesDataInstance().RemoveDeletedDesktops(ids);
             }
         }
     }

--- a/src/modules/fancyzones/lib/JsonHelpers.cpp
+++ b/src/modules/fancyzones/lib/JsonHelpers.cpp
@@ -349,7 +349,7 @@ namespace JSONHelpers
         SaveFancyZonesData();
     }
 
-    void FancyZonesData::CleanResourcesFromClosedDesktops(const std::vector<std::wstring>& activeDesktops)
+    void FancyZonesData::RemoveDeletedDesktops(const std::vector<std::wstring>& activeDesktops)
     {
         std::unordered_set<std::wstring> active(std::begin(activeDesktops), std::end(activeDesktops));
         std::scoped_lock lock{ dataLock };

--- a/src/modules/fancyzones/lib/JsonHelpers.cpp
+++ b/src/modules/fancyzones/lib/JsonHelpers.cpp
@@ -10,6 +10,7 @@
 #include <fstream>
 #include <regex>
 #include <sstream>
+#include <unordered_set>
 
 namespace
 {
@@ -344,6 +345,25 @@ namespace JSONHelpers
         if (activeDeviceId == DEFAULT_GUID)
         {
             activeDeviceId = replaceDesktopId(activeDeviceId);
+        }
+        SaveFancyZonesData();
+    }
+
+    void FancyZonesData::CleanResourcesFromClosedDesktops(const std::vector<std::wstring>& activeDesktops)
+    {
+        std::unordered_set<std::wstring> active(std::begin(activeDesktops), std::end(activeDesktops));
+        std::scoped_lock lock{ dataLock };
+        for (auto it = std::begin(deviceInfoMap); it != std::end(deviceInfoMap);)
+        {
+            auto foundId = active.find(ExtractVirtualDesktopId(it->first));
+            if (foundId == std::end(active))
+            {
+                it = deviceInfoMap.erase(it);
+            }
+            else
+            {
+                ++it;
+            }
         }
         SaveFancyZonesData();
     }

--- a/src/modules/fancyzones/lib/JsonHelpers.h
+++ b/src/modules/fancyzones/lib/JsonHelpers.h
@@ -234,7 +234,7 @@ namespace JSONHelpers
         bool RemoveDevicesByVirtualDesktopId(const std::wstring& virtualDesktopId);
         void CloneDeviceInfo(const std::wstring& source, const std::wstring& destination);
         void UpdatePrimaryDesktopData(const std::wstring& desktopId);
-        void CleanResourcesFromClosedDesktops(const std::vector<std::wstring>& activeDesktops);
+        void RemoveDeletedDesktops(const std::vector<std::wstring>& activeDesktops);
 
         int GetAppLastZoneIndex(HWND window, const std::wstring_view& deviceId, const std::wstring_view& zoneSetId) const;
         bool RemoveAppLastZone(HWND window, const std::wstring_view& deviceId, const std::wstring_view& zoneSetId);

--- a/src/modules/fancyzones/lib/JsonHelpers.h
+++ b/src/modules/fancyzones/lib/JsonHelpers.h
@@ -234,6 +234,7 @@ namespace JSONHelpers
         bool RemoveDevicesByVirtualDesktopId(const std::wstring& virtualDesktopId);
         void CloneDeviceInfo(const std::wstring& source, const std::wstring& destination);
         void UpdatePrimaryDesktopData(const std::wstring& desktopId);
+        void CleanResourcesFromClosedDesktops(const std::vector<std::wstring>& activeDesktops);
 
         int GetAppLastZoneIndex(HWND window, const std::wstring_view& deviceId, const std::wstring_view& zoneSetId) const;
         bool RemoveAppLastZone(HWND window, const std::wstring_view& deviceId, const std::wstring_view& zoneSetId);

--- a/src/modules/fancyzones/lib/VirtualDesktopUtils.cpp
+++ b/src/modules/fancyzones/lib/VirtualDesktopUtils.cpp
@@ -87,7 +87,7 @@ namespace VirtualDesktopUtils
             // desktops (only primary desktop) in this session value in registry will be empty.
             // If this value is empty take first element from array of virtual desktops (not kept per session).
             std::vector<GUID> ids{};
-            if (!GetVirtualDekstopIds(ids) || ids.empty())
+            if (!GetVirtualDesktopIds(ids) || ids.empty())
             {
                 return false;
             }
@@ -96,7 +96,7 @@ namespace VirtualDesktopUtils
         return true;
     }
 
-    bool GetVirtualDekstopIds(HKEY hKey, std::vector<GUID>& ids)
+    bool GetVirtualDesktopIds(HKEY hKey, std::vector<GUID>& ids)
     {
         if (!hKey)
         {
@@ -126,9 +126,27 @@ namespace VirtualDesktopUtils
         return true;
     }
 
-    bool GetVirtualDekstopIds(std::vector<GUID>& ids)
+    bool GetVirtualDesktopIds(std::vector<GUID>& ids)
     {
-        return GetVirtualDekstopIds(GetVirtualDesktopsRegKey(), ids);
+        return GetVirtualDesktopIds(GetVirtualDesktopsRegKey(), ids);
+    }
+
+    bool GetVirtualDesktopIds(std::vector<std::wstring>& ids)
+    {
+        std::vector<GUID> guids{};
+        if (GetVirtualDesktopIds(guids))
+        {
+            for (auto& guid : guids)
+            {
+                wil::unique_cotaskmem_string guidString;
+                if (SUCCEEDED(StringFromCLSID(guid, &guidString)))
+                {
+                    ids.push_back(guidString.get());
+                }
+            }
+            return true;
+        }
+        return false;
     }
 
     HKEY OpenVirtualDesktopsRegKey()

--- a/src/modules/fancyzones/lib/VirtualDesktopUtils.h
+++ b/src/modules/fancyzones/lib/VirtualDesktopUtils.h
@@ -7,7 +7,8 @@ namespace VirtualDesktopUtils
     bool GetWindowDesktopId(HWND topLevelWindow, GUID* desktopId);
     bool GetZoneWindowDesktopId(IZoneWindow* zoneWindow, GUID* desktopId);
     bool GetCurrentVirtualDesktopId(GUID* desktopId);
-    bool GetVirtualDekstopIds(std::vector<GUID>& ids);
+    bool GetVirtualDesktopIds(std::vector<GUID>& ids);
+    bool GetVirtualDesktopIds(std::vector<std::wstring>& ids);
     HKEY GetVirtualDesktopsRegKey();
     void HandleVirtualDesktopUpdates(HWND window, UINT message, HANDLE terminateEvent);
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
After FancyZones module start, get list of currently active virtual desktops and go through all persisted device information and delete those related to desktops that no longer exist.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #1312

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
1. Create several virtual desktops and zone layouts on them.
2. Close PowerToys.
3. Close all virtual desktops but primary.
4. Start PowerToys.

Check zones-settings.json file after PowerToys start. All device info related to closed virtual desktops is removed.
