### PR TITLE
[FancyZones] React to right Windows key

### DIFF
--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -347,7 +347,7 @@ FancyZones::OnKeyDown(PKBDLLHOOKSTRUCT info) noexcept
 {
     // Return true to swallow the keyboard event
     bool const shift = GetAsyncKeyState(VK_SHIFT) & 0x8000;
-    bool const win = GetAsyncKeyState(VK_LWIN) & 0x8000;
+    bool const win = GetAsyncKeyState(VK_LWIN) & 0x8000 || GetAsyncKeyState(VK_RWIN) & 0x8000;
     if (win && !shift)
     {
         bool const ctrl = GetAsyncKeyState(VK_CONTROL) & 0x8000;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Check the status of VK_RWIN as well as VK_LWIN, so that keyboards with (only) right-hand Windows keys or keys that send the right-hand Windows key virtual key can use Windows Snap hotkey overriding in FancyZones as expected.

Fixes #436

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #436
* [x] CLA signed.
* [x] Tests added/passed: Manually tested. I had a look in the FancyZonesTests dir and couldn't see any related to this, but please let me know if I missed them!
* [x] Requires documentation to be updated: No change required.
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx
