### PR TITLE
Fix license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-The MIT License (MIT)
+The MIT License
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 


### PR DESCRIPTION
By removing `(MIT)` from the `LICENSE` file, the license type is displayed on the PowerToys start page.
