### PR TITLE
FancyZones: prevent WinHookEventProc reentrancy bugs by serializing e…

### DIFF
--- a/src/modules/fancyzones/dll/dllmain.cpp
+++ b/src/modules/fancyzones/dll/dllmain.cpp
@@ -75,7 +75,7 @@ public:
     {
         if (!m_app)
         {
-            initialize_winhook_event_ids();
+            InitializeWinhookEventIds();
             Trace::FancyZones::EnableFancyZones(true);
             m_app = MakeFancyZones(reinterpret_cast<HINSTANCE>(&__ImageBase), m_settings);
 
@@ -202,7 +202,7 @@ private:
     static LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam)
     {
         LowlevelKeyboardEvent event;
-        if (nCode == HC_ACTION)
+        if (nCode == HC_ACTION && wParam == WM_KEYDOWN)
         {
             event.lParam = reinterpret_cast<KBDLLHOOKSTRUCT*>(lParam);
             event.wParam = wParam;
@@ -232,11 +232,7 @@ private:
 
 intptr_t FancyZonesModule::HandleKeyboardHookEvent(LowlevelKeyboardEvent* data) noexcept
 {
-    if (data->wParam == WM_KEYDOWN)
-    {
-        return m_app.as<IFancyZonesCallback>()->OnKeyDown(data->lParam) ? 1 : 0;
-    }
-    return 0;
+    return m_app.as<IFancyZonesCallback>()->OnKeyDown(data->lParam);
 }
 
 void FancyZonesModule::HandleWinHookEvent(WinHookEvent* data) noexcept

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -1,6 +1,8 @@
 #include "pch.h"
-#include "common/dpi_aware.h"
-#include "common/on_thread_executor.h"
+
+#include <common/dpi_aware.h>
+#include <common/on_thread_executor.h>
+#include <common/window_helpers.h>
 
 #include "FancyZones.h"
 #include "lib/Settings.h"
@@ -8,13 +10,12 @@
 #include "lib/JsonHelpers.h"
 #include "lib/ZoneSet.h"
 #include "lib/WindowMoveHandler.h"
+#include "lib/FancyZonesWinHookEventIDs.h"
+#include "lib/util.h"
 #include "trace.h"
 #include "VirtualDesktopUtils.h"
 
-#include <functional>
-#include <common/window_helpers.h>
-#include <lib/util.h>
-#include <unordered_set>
+#include <interface/win_hook_event_data.h>
 
 enum class DisplayChangeType
 {
@@ -72,14 +73,46 @@ public:
     MoveSizeUpdate(HMONITOR monitor, POINT const& ptScreen) noexcept
     {
         std::unique_lock writeLock(m_lock);
-        m_windowMoveHandler.MoveSizeUpdate(monitor, ptScreen, m_zoneWindowMap);    
+        m_windowMoveHandler.MoveSizeUpdate(monitor, ptScreen, m_zoneWindowMap);
     }
     IFACEMETHODIMP_(void)
     MoveSizeEnd(HWND window, POINT const& ptScreen) noexcept
     {
         std::unique_lock writeLock(m_lock);
-        m_windowMoveHandler.MoveSizeEnd(window, ptScreen, m_zoneWindowMap);    
+        m_windowMoveHandler.MoveSizeEnd(window, ptScreen, m_zoneWindowMap);
     }
+    IFACEMETHODIMP_(void)
+    HandleWinHookEvent(const WinHookEvent* data) noexcept
+    {
+        const auto wparam = reinterpret_cast<WPARAM>(data->hwnd);
+        const LONG lparam = 0;
+        std::shared_lock readLock(m_lock);
+        switch (data->event)
+        {
+        case EVENT_SYSTEM_MOVESIZESTART:
+            PostMessageW(m_window, WM_PRIV_MOVESIZESTART, wparam, lparam);
+            break;
+        case EVENT_SYSTEM_MOVESIZEEND:
+            PostMessageW(m_window, WM_PRIV_MOVESIZEEND, wparam, lparam);
+            break;
+        case EVENT_OBJECT_LOCATIONCHANGE:
+            PostMessageW(m_window, WM_PRIV_LOCATIONCHANGE, wparam, lparam);
+            break;
+        case EVENT_OBJECT_NAMECHANGE:
+            PostMessageW(m_window, WM_PRIV_NAMECHANGE, wparam, lparam);
+            break;
+
+        case EVENT_OBJECT_UNCLOAKED:
+        case EVENT_OBJECT_SHOW:
+        case EVENT_OBJECT_CREATE:
+            if (data->idObject == OBJID_WINDOW)
+            {
+                PostMessageW(m_window, WM_PRIV_WINDOWCREATED, wparam, lparam);
+            }
+            break;
+        }
+    }
+
     IFACEMETHODIMP_(void)
     VirtualDesktopChanged() noexcept;
     IFACEMETHODIMP_(void)
@@ -189,7 +222,7 @@ private:
     void MoveWindowsOnDisplayChange() noexcept;
     void CycleActiveZoneSet(DWORD vkCode) noexcept;
     bool OnSnapHotkey(DWORD vkCode) noexcept;
-    
+
     void RegisterVirtualDesktopUpdates(std::vector<GUID>& ids) noexcept;
     void RegisterNewWorkArea(GUID virtualDesktopId, HMONITOR monitor) noexcept;
     bool IsNewWorkArea(GUID virtualDesktopId, HMONITOR monitor) noexcept;
@@ -204,7 +237,7 @@ private:
     mutable std::shared_mutex m_lock;
     HWND m_window{};
     WindowMoveHandler m_windowMoveHandler;
-    
+
     std::map<HMONITOR, winrt::com_ptr<IZoneWindow>> m_zoneWindowMap; // Map of monitor to ZoneWindow (one per monitor)
     winrt::com_ptr<IFancyZonesSettings> m_settings{};
     GUID m_currentVirtualDesktopId{}; // UUID of the current virtual desktop. Is GUID_NULL until first VD switch per session.
@@ -263,8 +296,7 @@ FancyZones::Run() noexcept
         .wait();
 
     m_terminateVirtualDesktopTrackerEvent.reset(CreateEvent(nullptr, FALSE, FALSE, nullptr));
-    m_virtualDesktopTrackerThread.submit(OnThreadExecutor::task_t{ [&] {
-        VirtualDesktopUtils::HandleVirtualDesktopUpdates(m_window, WM_PRIV_VD_UPDATE, m_terminateVirtualDesktopTrackerEvent.get()); } });
+    m_virtualDesktopTrackerThread.submit(OnThreadExecutor::task_t{ [&] { VirtualDesktopUtils::HandleVirtualDesktopUpdates(m_window, WM_PRIV_VD_UPDATE, m_terminateVirtualDesktopTrackerEvent.get()); } });
 }
 
 // IFancyZones
@@ -289,8 +321,8 @@ FancyZones::Destroy() noexcept
 IFACEMETHODIMP_(void)
 FancyZones::VirtualDesktopChanged() noexcept
 {
-    // VirtualDesktopChanged is called from another thread but results in new windows being created.
-    // Jump over to the UI thread to handle it.
+    // VirtualDesktopChanged is called from a reentrant WinHookProc function, therefore we must postpone the actual logic
+    // until we're in FancyZones::WndProc, which is not reentrant.
     std::shared_lock readLock(m_lock);
     PostMessage(m_window, WM_PRIV_VD_SWITCH, 0, 0);
 }
@@ -557,6 +589,9 @@ LRESULT FancyZones::WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lpa
 
     default:
     {
+        POINT ptScreen;
+        GetPhysicalCursorPos(&ptScreen);
+
         if (message == WM_PRIV_VD_INIT)
         {
             OnDisplayChange(DisplayChangeType::Initialization);
@@ -586,6 +621,31 @@ LRESULT FancyZones::WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lpa
                 std::unique_lock writeLock(m_lock);
                 m_terminateEditorEvent.release();
             }
+        }
+        else if (message == WM_PRIV_MOVESIZESTART)
+        {
+            auto hwnd = reinterpret_cast<HWND>(wparam);
+            if (auto monitor = MonitorFromPoint(ptScreen, MONITOR_DEFAULTTONULL))
+            {
+                MoveSizeStart(hwnd, monitor, ptScreen);
+            }
+        }
+        else if (message == WM_PRIV_MOVESIZEEND)
+        {
+            auto hwnd = reinterpret_cast<HWND>(wparam);
+            MoveSizeEnd(hwnd, ptScreen);
+        }
+        else if (message == WM_PRIV_LOCATIONCHANGE && InMoveSize())
+        {
+            if (auto monitor = MonitorFromPoint(ptScreen, MONITOR_DEFAULTTONULL))
+            {
+                MoveSizeUpdate(monitor, ptScreen);
+            }
+        }
+        else if (message == WM_PRIV_WINDOWCREATED)
+        {
+            auto hwnd = reinterpret_cast<HWND>(wparam);
+            WindowCreated(hwnd);
         }
         else
         {
@@ -668,7 +728,6 @@ void FancyZones::AddZoneWindow(HMONITOR monitor, PCWSTR deviceId) noexcept
         }
     }
 }
-
 
 LRESULT CALLBACK FancyZones::s_WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lparam) noexcept
 {

--- a/src/modules/fancyzones/lib/FancyZones.h
+++ b/src/modules/fancyzones/lib/FancyZones.h
@@ -24,35 +24,6 @@ interface __declspec(uuid("{50D3F0F5-736E-4186-BDF4-3D6BEE150C3A}")) IFancyZones
 interface __declspec(uuid("{2CB37E8F-87E6-4AEC-B4B2-E0FDC873343F}")) IFancyZonesCallback : public IUnknown
 {
     /**
-     * @returns Boolean indicating whether a move/size operation is currently active.
-     */
-    IFACEMETHOD_(bool, InMoveSize)() = 0;
-     /**
-     * A window is being moved or resized. Track down window position and give zone layout
-     * hints if dragging functionality is enabled.
-     *
-     * @param   window   Handle of window being moved or resized.
-     * @param   monitor  Handle of monitor on which windows is moving / resizing.
-     * @param   ptScreen Cursor coordinates.
-     */
-    IFACEMETHOD_(void, MoveSizeStart)(HWND window, HMONITOR monitor, POINT const& ptScreen) = 0;
-     /**
-     * A window has changed location, shape, or size. Track down window position and give zone layout
-     * hints if dragging functionality is enabled.
-     *
-     * @param   monitor  Handle of monitor on which windows is moving / resizing.
-     * @param   ptScreen Cursor coordinates.
-     */
-    IFACEMETHOD_(void, MoveSizeUpdate)(HMONITOR monitor, POINT const& ptScreen) = 0;
-    /**
-     * The movement or resizing of a window has finished. Assign window to the zone if it
-     * is dropped within zone borders.
-     *
-     * @param   window   Handle of window being moved or resized.
-     * @param   ptScreen Cursor coordinates where window is droped.
-     */
-    IFACEMETHOD_(void, MoveSizeEnd)(HWND window, POINT const& ptScreen) = 0;
-    /**
      * Inform FancyZones that user has switched between virtual desktops.
      */
     IFACEMETHOD_(void, VirtualDesktopChanged)() = 0;
@@ -61,15 +32,7 @@ interface __declspec(uuid("{2CB37E8F-87E6-4AEC-B4B2-E0FDC873343F}")) IFancyZones
      *
      * @param   data  Handle of window being moved or resized.
      */
-    IFACEMETHOD_(void, HandleWinHookEvent)(const WinHookEvent* data){};
-    /**
-     * Inform FancyZones that new window is created. FancyZones will try to assign it to the
-     * zone insde active zone layout (if information about last zone, in which window was located
-     * before being closed, is available).
-     *
-     * @param   window Handle of newly created window.
-     */
-    IFACEMETHOD_(void, WindowCreated)(HWND window) = 0;
+    IFACEMETHOD_(void, HandleWinHookEvent)(const WinHookEvent* data) = 0;
     /**
      * Process keyboard event.
      *

--- a/src/modules/fancyzones/lib/FancyZones.h
+++ b/src/modules/fancyzones/lib/FancyZones.h
@@ -4,6 +4,8 @@ interface IZoneWindow;
 interface IFancyZonesSettings;
 interface IZoneSet;
 
+struct WinHookEvent;
+
 interface __declspec(uuid("{50D3F0F5-736E-4186-BDF4-3D6BEE150C3A}")) IFancyZones : public IUnknown
 {
     /**
@@ -54,6 +56,12 @@ interface __declspec(uuid("{2CB37E8F-87E6-4AEC-B4B2-E0FDC873343F}")) IFancyZones
      * Inform FancyZones that user has switched between virtual desktops.
      */
     IFACEMETHOD_(void, VirtualDesktopChanged)() = 0;
+    /**
+     * Callback from WinEventHook to FancyZones
+     *
+     * @param   data  Handle of window being moved or resized.
+     */
+    IFACEMETHOD_(void, HandleWinHookEvent)(const WinHookEvent* data){};
     /**
      * Inform FancyZones that new window is created. FancyZones will try to assign it to the
      * zone insde active zone layout (if information about last zone, in which window was located

--- a/src/modules/fancyzones/lib/FancyZonesLib.vcxproj
+++ b/src/modules/fancyzones/lib/FancyZonesLib.vcxproj
@@ -95,6 +95,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="FancyZones.h" />
+    <ClInclude Include="FancyZonesWinHookEventIDs.h" />
     <ClInclude Include="JsonHelpers.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="resource.h" />
@@ -109,6 +110,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="FancyZones.cpp" />
+    <ClCompile Include="FancyZonesWinHookEventIDs.cpp" />
     <ClCompile Include="JsonHelpers.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>

--- a/src/modules/fancyzones/lib/FancyZonesLib.vcxproj.filters
+++ b/src/modules/fancyzones/lib/FancyZonesLib.vcxproj.filters
@@ -51,6 +51,9 @@
     <ClInclude Include="WindowMoveHandler.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="FancyZonesWinHookEventIDs.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp">
@@ -84,6 +87,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="WindowMoveHandler.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="FancyZonesWinHookEventIDs.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/modules/fancyzones/lib/FancyZonesWinHookEventIDs.cpp
+++ b/src/modules/fancyzones/lib/FancyZonesWinHookEventIDs.cpp
@@ -12,7 +12,7 @@ UINT WM_PRIV_WINDOWCREATED;
 
 std::once_flag init_flag;
 
-void initialize_winhook_event_ids()
+void InitializeWinhookEventIds()
 {
     std::call_once(init_flag, [&] {
         WM_PRIV_MOVESIZESTART = RegisterWindowMessage(L"{f48def23-df42-4c0f-a13d-3eb4a9e204d4}");

--- a/src/modules/fancyzones/lib/FancyZonesWinHookEventIDs.cpp
+++ b/src/modules/fancyzones/lib/FancyZonesWinHookEventIDs.cpp
@@ -1,0 +1,24 @@
+#include "pch.h"
+
+#include <mutex>
+
+#include "FancyZonesWinHookEventIDs.h"
+
+UINT WM_PRIV_MOVESIZESTART;
+UINT WM_PRIV_MOVESIZEEND;
+UINT WM_PRIV_LOCATIONCHANGE;
+UINT WM_PRIV_NAMECHANGE;
+UINT WM_PRIV_WINDOWCREATED;
+
+std::once_flag init_flag;
+
+void initialize_winhook_event_ids()
+{
+    std::call_once(init_flag, [&] {
+        WM_PRIV_MOVESIZESTART = RegisterWindowMessage(L"{f48def23-df42-4c0f-a13d-3eb4a9e204d4}");
+        WM_PRIV_MOVESIZEEND = RegisterWindowMessage(L"{805d643c-804d-4728-b533-907d760ebaf0}");
+        WM_PRIV_LOCATIONCHANGE = RegisterWindowMessage(L"{d56c5ee7-58e5-481c-8c4f-8844cf4d0347}");
+        WM_PRIV_NAMECHANGE = RegisterWindowMessage(L"{b7b30c61-bfa0-4d95-bcde-fc4f2cbf6d76}");
+        WM_PRIV_WINDOWCREATED = RegisterWindowMessage(L"{bdb10669-75da-480a-9ec4-eeebf09a02d7}");
+    });
+}

--- a/src/modules/fancyzones/lib/FancyZonesWinHookEventIDs.h
+++ b/src/modules/fancyzones/lib/FancyZonesWinHookEventIDs.h
@@ -6,4 +6,4 @@ extern UINT WM_PRIV_LOCATIONCHANGE;
 extern UINT WM_PRIV_NAMECHANGE;
 extern UINT WM_PRIV_WINDOWCREATED;
 
-void initialize_winhook_event_ids();
+void InitializeWinhookEventIds();

--- a/src/modules/fancyzones/lib/FancyZonesWinHookEventIDs.h
+++ b/src/modules/fancyzones/lib/FancyZonesWinHookEventIDs.h
@@ -1,0 +1,9 @@
+#pragma once
+
+extern UINT WM_PRIV_MOVESIZESTART;
+extern UINT WM_PRIV_MOVESIZEEND;
+extern UINT WM_PRIV_LOCATIONCHANGE;
+extern UINT WM_PRIV_NAMECHANGE;
+extern UINT WM_PRIV_WINDOWCREATED;
+
+void initialize_winhook_event_ids();

--- a/src/modules/fancyzones/lib/pch.h
+++ b/src/modules/fancyzones/lib/pch.h
@@ -17,6 +17,8 @@
 #include <winrt/windows.foundation.h>
 #include <psapi.h>
 #include <shared_mutex>
+#include <functional>
+#include <unordered_set>
 
 #pragma comment(lib, "windowsapp")
 

--- a/src/modules/fancyzones/tests/UnitTests/FancyZonesSettings.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/FancyZonesSettings.Spec.cpp
@@ -387,6 +387,8 @@ namespace FancyZonesUnitTests
             IFACEMETHODIMP_(void)
             MoveSizeEnd(HWND window, POINT const& ptScreen) noexcept {}
             IFACEMETHODIMP_(void)
+            HandleWinHookEvent(const WinHookEvent * data) noexcept {}
+            IFACEMETHODIMP_(void)
             VirtualDesktopChanged() noexcept {}
             IFACEMETHODIMP_(void)
             VirtualDesktopInitialize() noexcept {}


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
- postpone WinHookEvent processing until `FancyZones::WndProc` function by `PostMessage`s
- in theory, we might start removing mutexes from FancyZones class, e.g. starting by replacing it with [null_mutex](https://github.com/yuyoyuppe/ckvs/blob/dev/src/ckvs/utils/shared_null_mutex.hpp) and test if it still works

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #961, #2654

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- played with FZ with various settings turned on and off, added and removed VDs
- unit tests passed