### PR TITLE
fix for crash when tabbing with no selected item

### DIFF
--- a/src/modules/launcher/Wox/ViewModel/ResultsViewModel.cs
+++ b/src/modules/launcher/Wox/ViewModel/ResultsViewModel.cs
@@ -165,7 +165,8 @@ namespace Wox.ViewModel
 
         public void SelectNextTabItem()
         {
-            if(!SelectedItem.SelectNextContextButton())
+            //Do nothing if there is no selected item or we've selected the next context button
+            if(!SelectedItem?.SelectNextContextButton() ?? true)
             {
                 SelectNextResult();
             }
@@ -173,7 +174,8 @@ namespace Wox.ViewModel
 
         public void SelectPrevTabItem()
         {
-            if (!SelectedItem.SelectPrevContextButton())
+            //Do nothing if there is no selected item or we've selected the previous context button
+            if (!SelectedItem?.SelectPrevContextButton() ?? true)
             {
                 //Tabbing backwards should highlight the last item of the previous row
                 SelectPrevResult();


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
I noticed a crash when pressing tab if there is no selected item. 

I put in a guard that prevents us from attempting to select the next context menu item if there is no selected item in the results. 

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [] Applies to #xxx
* [] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [] Tests added/passed
* [] Requires documentation to be updated
* [] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
- Steps to reproduce (Prior to this change).
- Type a string that will return no results such as 'asdfghjkl'. 
- Press 'Tab'.  
- Observe the crash. 


<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Performed the above steps and verified that there was no longer a crash. 
- Also verified that the expected tabbing behavior was executed going forward and backwards. 
