### PR TITLE
[FancyZonesEditor] Make transforming struct field names to dash case region invariant

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/StringUtils.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/StringUtils.cs
@@ -16,7 +16,7 @@ namespace FancyZonesEditor.Utils
                 return str;
             }
 
-            return string.Concat(str.Select((x, i) => i > 0 && char.IsUpper(x) ? "-" + x.ToString() : x.ToString())).ToLower();
+            return string.Concat(str.Select((x, i) => i > 0 && char.IsUpper(x) ? "-" + x.ToString() : x.ToString())).ToLowerInvariant();
         }
     }
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Region settings were affecting (escaping unicode) json tag created by transforming struct field name to dash case. After that, FZ could not match json tags. `ToLowerInvariant()` method prevents that.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2594 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Changed region settings as described in issue and back to default. Applying several different layouts for each of the regions set.