### PR TITLE
[FancyZones] Only process windows located on currently active work area when moving them

### DIFF
--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -22,7 +22,6 @@ enum class DisplayChangeType
     WorkArea,
     DisplayChange,
     VirtualDesktop,
-    Editor,
     Initialization
 };
 
@@ -621,7 +620,14 @@ LRESULT FancyZones::WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lpa
             if (lparam == static_cast<LPARAM>(EditorExitKind::Exit))
             {
                 OnEditorExitEvent();
-                OnDisplayChange(DisplayChangeType::Editor);
+                for (auto& [monitor, zoneWindow] : m_zoneWindowMap)
+                {
+                    zoneWindow->UpdateActiveZoneSet();
+                }
+                if (m_settings->GetSettings()->zoneSetChange_moveWindows)
+                {
+                    MoveWindowsOnDisplayChange();
+                }
             }
 
             {
@@ -699,13 +705,6 @@ void FancyZones::OnDisplayChange(DisplayChangeType changeType) noexcept
     else if (changeType == DisplayChangeType::VirtualDesktop)
     {
         if (m_settings->GetSettings()->virtualDesktopChange_moveWindows)
-        {
-            MoveWindowsOnDisplayChange();
-        }
-    }
-    else if (changeType == DisplayChangeType::Editor)
-    {
-        if (m_settings->GetSettings()->zoneSetChange_moveWindows)
         {
             MoveWindowsOnDisplayChange();
         }

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -218,7 +218,7 @@ private:
     };
 
     void UpdateZoneWindows() noexcept;
-    void MoveWindowsOnDisplayChange() noexcept;
+    void UpdateWindowsPositions() noexcept;
     void CycleActiveZoneSet(DWORD vkCode) noexcept;
     bool OnSnapHotkey(DWORD vkCode) noexcept;
 
@@ -558,7 +558,7 @@ FancyZones::MoveWindowsOnActiveZoneSetChange() noexcept
 {
     if (m_settings->GetSettings()->zoneSetChange_moveWindows)
     {
-        MoveWindowsOnDisplayChange();
+        UpdateWindowsPositions();
     }
 }
 
@@ -620,14 +620,6 @@ LRESULT FancyZones::WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lpa
             if (lparam == static_cast<LPARAM>(EditorExitKind::Exit))
             {
                 OnEditorExitEvent();
-                for (auto& [monitor, zoneWindow] : m_zoneWindowMap)
-                {
-                    zoneWindow->UpdateActiveZoneSet();
-                }
-                if (m_settings->GetSettings()->zoneSetChange_moveWindows)
-                {
-                    MoveWindowsOnDisplayChange();
-                }
             }
 
             {
@@ -699,14 +691,14 @@ void FancyZones::OnDisplayChange(DisplayChangeType changeType) noexcept
     {
         if (m_settings->GetSettings()->displayChange_moveWindows)
         {
-            MoveWindowsOnDisplayChange();
+            UpdateWindowsPositions();
         }
     }
     else if (changeType == DisplayChangeType::VirtualDesktop)
     {
         if (m_settings->GetSettings()->virtualDesktopChange_moveWindows)
         {
-            MoveWindowsOnDisplayChange();
+            UpdateWindowsPositions();
         }
     }
 }
@@ -795,7 +787,7 @@ void FancyZones::UpdateZoneWindows() noexcept
     EnumDisplayMonitors(nullptr, nullptr, callback, reinterpret_cast<LPARAM>(this));
 }
 
-void FancyZones::MoveWindowsOnDisplayChange() noexcept
+void FancyZones::UpdateWindowsPositions() noexcept
 {
     auto callback = [](HWND window, LPARAM data) -> BOOL {
         int i = static_cast<int>(reinterpret_cast<UINT_PTR>(::GetProp(window, ZONE_STAMP)));
@@ -946,6 +938,15 @@ void FancyZones::OnEditorExitEvent() noexcept
     JSONHelpers::FancyZonesDataInstance().ParseDeletedCustomZoneSetsFromTmpFile(ZoneWindowUtils::GetCustomZoneSetsTmpPath());
     JSONHelpers::FancyZonesDataInstance().ParseCustomZoneSetFromTmpFile(ZoneWindowUtils::GetAppliedZoneSetTmpPath());
     JSONHelpers::FancyZonesDataInstance().SaveFancyZonesData();
+    // Update zone sets for currently active work areas.
+    for (auto& [monitor, zoneWindow] : m_zoneWindowMap)
+    {
+        zoneWindow->UpdateActiveZoneSet();
+    }
+    if (m_settings->GetSettings()->zoneSetChange_moveWindows)
+    {
+        UpdateWindowsPositions();
+    }
 }
 
 std::vector<HMONITOR> FancyZones::GetMonitorsSorted() noexcept

--- a/src/modules/fancyzones/lib/WindowMoveHandler.cpp
+++ b/src/modules/fancyzones/lib/WindowMoveHandler.cpp
@@ -8,6 +8,7 @@
 #include "lib/Settings.h"
 #include "lib/ZoneWindow.h"
 #include "lib/util.h"
+#include "VirtualDesktopUtils.h"
 
 extern "C" IMAGE_DOS_HEADER __ImageBase;
 
@@ -298,6 +299,15 @@ void WindowMoveHandlerPrivate::MoveWindowIntoZoneByIndexSet(HWND window, HMONITO
             if (zoneWindow != zoneWindowMap.end())
             {
                 const auto& zoneWindowPtr = zoneWindow->second;
+                // Only process windows located on currently active work area.
+                GUID windowDesktopId{};
+                GUID zoneWindowDesktopId{};
+                if (VirtualDesktopUtils::GetWindowDesktopId(window, &windowDesktopId) &&
+                    VirtualDesktopUtils::GetZoneWindowDesktopId(zoneWindowPtr.get(), &zoneWindowDesktopId) &&
+                    (windowDesktopId != zoneWindowDesktopId))
+                {
+                    return;
+                }
                 zoneWindowPtr->MoveWindowIntoZoneByIndexSet(window, indexSet);
             }
         }

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -233,6 +233,8 @@ public:
     ShowZoneWindow() noexcept;
     IFACEMETHODIMP_(void)
     HideZoneWindow() noexcept;
+    IFACEMETHODIMP_(void)
+    UpdateActiveZoneSet() noexcept;
 
 protected:
     static LRESULT CALLBACK s_WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lparam) noexcept;
@@ -534,6 +536,12 @@ ZoneWindow::HideZoneWindow() noexcept
         m_drawHints = false;
         m_highlightZone = {};
     }
+}
+
+IFACEMETHODIMP_(void)
+ZoneWindow::UpdateActiveZoneSet() noexcept
+{
+    CalculateZoneSet();
 }
 
 #pragma region private

--- a/src/modules/fancyzones/lib/ZoneWindow.h
+++ b/src/modules/fancyzones/lib/ZoneWindow.h
@@ -103,6 +103,10 @@ interface __declspec(uuid("{7F017528-8110-4FB3-BE41-F472969C2560}")) IZoneWindow
     IFACEMETHOD_(IZoneSet*, ActiveZoneSet)() = 0;
     IFACEMETHOD_(void, ShowZoneWindow)() = 0;
     IFACEMETHOD_(void, HideZoneWindow)() = 0;
+    /**
+     * Update currently active zone layout for this work area.
+     */
+    IFACEMETHOD_(void, UpdateActiveZoneSet)() = 0;
 };
 
 winrt::com_ptr<IZoneWindow> MakeZoneWindow(IZoneWindowHost* host, HINSTANCE hinstance, HMONITOR monitor,


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
When moving window into zone by index set, only move windows on currently active work area.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2690
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
1. Assign zone layout on primary desktop.
2. Assign window to certain zone in the layout.
3. Create new virtual desktop.
4. Choose different layout on new virtual desktop.
5. Switch back to primary desktop.

Expected behavior: Window assigned in zone on the primary desktop kept his position.