### PR TITLE
[Settings] Workaround for Settings ViewModel tests

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/GeneralSettings.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/GeneralSettings.cs
@@ -59,7 +59,15 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
             this.AutoDownloadUpdates = false;
             this.Theme = "system";
             this.SystemTheme = "light";
-            this.PowertoysVersion = interop.CommonManaged.GetProductVersion();
+            try
+            {
+                this.PowertoysVersion = DefaultPowertoysVersion();
+            }
+            catch
+            {
+                this.PowertoysVersion = "v0.0.0";
+            }
+
             this.Enabled = new EnabledModules();
             this.CustomActionName = string.Empty;
         }
@@ -68,6 +76,11 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
         public string ToJsonString()
         {
             return JsonSerializer.Serialize(this);
+        }
+
+        private string DefaultPowertoysVersion()
+        {
+            return interop.CommonManaged.GetProductVersion();
         }
     }
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This is a work around fix for the Settings UnitTests failing caused by #2601 

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Tests were failing because GeneralSettings uses the `interop` library to get version information. `interop` is a C++/CLI project, and can't be called by an UWP app. This is not a problem in the Settings.UI exe because we are using XamlIslands, but thats not so in the UnitTests.
The current fix is just to handle the exception, which solves the crashes that happened in the UnitTest project.
A more permanent solution could be to set up the UnitTest project in a similar fashion to the Main application, that is, by having a .NET Core runner invoking a XamlIsland. 


<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list  manual validation steps taken as well -->
## Validation Steps Performed
* Microsoft.PowerToys.Settings.UnitTest pass.
* The version number in the GeneralSettings page is displayed properly