### PR TITLE
[Settings] Close Settings Window on runner exit

### DIFF
--- a/src/runner/settings_window.cpp
+++ b/src/runner/settings_window.cpp
@@ -359,3 +359,15 @@ void open_settings_window()
         std::thread(run_settings_window).detach();
     }
 }
+
+void close_settings_window()
+{
+    if (g_settings_process_id != 0)
+    {
+        HANDLE proc = OpenProcess(PROCESS_TERMINATE, false, g_settings_process_id);
+        if (proc != INVALID_HANDLE_VALUE)
+        {
+            TerminateProcess(proc, 0);
+        }
+    }
+}

--- a/src/runner/settings_window.h
+++ b/src/runner/settings_window.h
@@ -1,2 +1,3 @@
 #pragma once
 void open_settings_window();
+void close_settings_window();

--- a/src/runner/tray_icon.cpp
+++ b/src/runner/tray_icon.cpp
@@ -67,6 +67,7 @@ LRESULT __stdcall tray_icon_window_proc(HWND window, UINT message, WPARAM wparam
             Shell_NotifyIcon(NIM_DELETE, &tray_icon_data);
             tray_icon_created = false;
         }
+        close_settings_window();
         PostQuitMessage(0);
         break;
     case WM_CLOSE:


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Settings Window gets closed whenever the user clicks Exit on the PowerToys system tray menu.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
The settings window used to outlast the Runner executable. This fixes this by killing the Settings proecess when the runner window gets destroyed.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
* Start PowerToys.
* Click on the Runner. A Settings window should show up.
* Right click on the system tray icon, then select exit.
* Both the Settings window and the runner should exit at the same time.
