### PR TITLE
Fix for indexer symbol error

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Main.cs
@@ -13,6 +13,7 @@ using Microsoft.Search.Interop;
 using Microsoft.PowerToys.Settings.UI.Lib;
 using System.Windows.Controls;
 using Wox.Infrastructure.Logger;
+using System.Text.RegularExpressions;
 
 namespace Microsoft.Plugin.Indexer
 {
@@ -30,6 +31,9 @@ namespace Microsoft.Plugin.Indexer
 
         // To access Windows Search functionalities
         private readonly WindowsSearchAPI _api = new WindowsSearchAPI();
+
+        // Reserved keywords in oleDB
+        private string ReservedStringPattern = @"^[\/\\\$\%]+$";
 
         private IContextMenu _contextMenuLoader;
 
@@ -51,63 +55,68 @@ namespace Microsoft.Plugin.Indexer
                     _settings.MaxSearchCount = 50;
                 }
 
-                try
+                var regexMatch = Regex.Match(searchQuery, ReservedStringPattern);
+
+                if (!regexMatch.Success)
                 {
-                    var searchResultsList = _api.Search(searchQuery, maxCount: _settings.MaxSearchCount).ToList();
-                    foreach (var searchResult in searchResultsList)
+                    try
                     {
-                        var path = searchResult.Path;
-
-                        string workingDir = null;
-                        if (_settings.UseLocationAsWorkingDir)
-                            workingDir = Path.GetDirectoryName(path);
-
-                        Result r = new Result();
-                        r.Title = searchResult.Title;
-                        r.SubTitle = "Search: " + path;
-                        r.IcoPath = path;
-                        r.Action = c =>
+                        var searchResultsList = _api.Search(searchQuery, maxCount: _settings.MaxSearchCount).ToList();
+                        foreach (var searchResult in searchResultsList)
                         {
-                            bool hide;
-                            try
+                            var path = searchResult.Path;
+
+                            string workingDir = null;
+                            if (_settings.UseLocationAsWorkingDir)
+                                workingDir = Path.GetDirectoryName(path);
+
+                            Result r = new Result();
+                            r.Title = searchResult.Title;
+                            r.SubTitle = "Search: " + path;
+                            r.IcoPath = path;
+                            r.Action = c =>
                             {
-                                Process.Start(new ProcessStartInfo
+                                bool hide;
+                                try
                                 {
-                                    FileName = path,
-                                    UseShellExecute = true,
-                                    WorkingDirectory = workingDir
-                                });
-                                hide = true;
-                            }
-                            catch (Win32Exception)
+                                    Process.Start(new ProcessStartInfo
+                                    {
+                                        FileName = path,
+                                        UseShellExecute = true,
+                                        WorkingDirectory = workingDir
+                                    });
+                                    hide = true;
+                                }
+                                catch (Win32Exception)
+                                {
+                                    var name = $"Plugin: {_context.CurrentPluginMetadata.Name}";
+                                    var msg = "Can't Open this file";
+                                    _context.API.ShowMsg(name, msg, string.Empty);
+                                    hide = false;
+                                }
+                                return hide;
+                            };
+                            r.ContextData = searchResult;
+
+                            //If the result is a directory, then it's display should show a directory.
+                            if (Directory.Exists(path))
                             {
-                                var name = $"Plugin: {_context.CurrentPluginMetadata.Name}";
-                                var msg = "Can't Open this file";
-                                _context.API.ShowMsg(name, msg, string.Empty);
-                                hide = false;
+                                r.QueryTextDisplay = path;
                             }
-                            return hide;
-                        };
-                        r.ContextData = searchResult;
 
-                        //If the result is a directory, then it's display should show a directory.
-                        if(Directory.Exists(path))
-                        {
-                            r.QueryTextDisplay = path;
+                            results.Add(r);
                         }
-
-                        results.Add(r);
                     }
-                }
-                catch(InvalidOperationException)
-                {
-                    //The connection has closed, internal error of ExecuteReader()
-                    //Not showing this exception to the users
-                }
-                catch (Exception ex)
-                {              
-                    Log.Info(ex.ToString());
-                }
+                    catch (InvalidOperationException)
+                    {
+                        //The connection has closed, internal error of ExecuteReader()
+                        //Not showing this exception to the users
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Info(ex.ToString());
+                    }
+                }               
             }
 
             return results;

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Main.cs
@@ -12,6 +12,7 @@ using Microsoft.Plugin.Indexer.SearchHelper;
 using Microsoft.Search.Interop;
 using Microsoft.PowerToys.Settings.UI.Lib;
 using System.Windows.Controls;
+using Wox.Infrastructure.Logger;
 
 namespace Microsoft.Plugin.Indexer
 {
@@ -104,12 +105,8 @@ namespace Microsoft.Plugin.Indexer
                     //Not showing this exception to the users
                 }
                 catch (Exception ex)
-                {
-                    results.Add(new Result
-                    {
-                        Title = ex.ToString(),
-                        IcoPath = "Images\\WindowsIndexerImg.bmp"
-                    });
+                {              
+                    Log.Info(ex.ToString());
                 }
             }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Fix for indexer throwing error in results when symbols are given as input.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2557 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
This PR  prevents querying database with strings that contain symbols and result in error. It also removes adding error messages in indexer results.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manually validated that Index doesn't throw error when symbols are given as input. 