### PR TITLE
Fixed SettingsV2 crash

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI.Runner/Program.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Runner/Program.cs
@@ -26,7 +26,7 @@ namespace Microsoft.PowerToys.Settings.UI.Runner
 
                 if (args.Length > 3)
                 {
-                    if (args[4] == "true")
+                    if (args[3] == "true")
                     {
                         IsElevated = true;
                     }

--- a/src/core/Microsoft.PowerToys.Settings.UI.Runner/Program.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Runner/Program.cs
@@ -26,7 +26,7 @@ namespace Microsoft.PowerToys.Settings.UI.Runner
 
                 if (args.Length > 3)
                 {
-                    if (args[3] == "true")
+                    if (args[4] == "true")
                     {
                         IsElevated = true;
                     }

--- a/src/runner/settings_window.cpp
+++ b/src/runner/settings_window.cpp
@@ -288,7 +288,7 @@ void run_settings_window()
 
     // Arg 4: settings theme.
     const std::wstring settings_theme_setting{ get_general_settings().theme };
-    std::wstring settings_theme;
+    std::wstring settings_theme = L"system";
     if (settings_theme_setting == L"dark" || (settings_theme_setting == L"system" && WindowsColors::is_dark_mode()))
     {
         settings_theme = L"dark";


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR fixes a crash on launching Settings ~~due to an out of bound index error~~ due to an uninitialized theme string as identified by @laviusmotileng-ms. Verified the elevated argument is read on opening settings (adding in #2676 ).

