### PR TITLE
[settings] loading powerpreview module from subfolder

### DIFF
--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -123,6 +123,9 @@ int runner(bool isProcessElevated)
         chdir_current_executable();
         // Load Powertyos DLLS
         // For now only load known DLLs
+        
+        std::wstring baseModuleFolder = L"modules/";
+
         std::unordered_set<std::wstring> known_dlls = {
             L"shortcut_guide.dll",
             L"fancyzones.dll",
@@ -132,19 +135,28 @@ int runner(bool isProcessElevated)
             L"powerpreview.dll",
             L"KeyboardManager.dll"
         };
-        for (auto& file : std::filesystem::directory_iterator(L"modules/"))
+
+        std::unordered_set<std::wstring> module_folders = {
+            L"",
+            L"FileExplorerPreview/",
+        };
+
+        for (std::wstring subfolderName : module_folders)
         {
-            if (file.path().extension() != L".dll")
-                continue;
-            if (known_dlls.find(file.path().filename()) == known_dlls.end())
-                continue;
-            try
+            for (auto& file : std::filesystem::directory_iterator(baseModuleFolder + subfolderName))
             {
-                auto module = load_powertoy(file.path().wstring());
-                modules().emplace(module->get_name(), std::move(module));
-            }
-            catch (...)
-            {
+                if (file.path().extension() != L".dll")
+                    continue;
+                if (known_dlls.find(file.path().filename()) == known_dlls.end())
+                    continue;
+                try
+                {
+                    auto module = load_powertoy(file.path().wstring());
+                    modules().emplace(module->get_name(), std::move(module));
+                }
+                catch (...)
+                {
+                }
             }
         }
         // Start initial powertoys

--- a/src/runner/settings_window.cpp
+++ b/src/runner/settings_window.cpp
@@ -288,7 +288,7 @@ void run_settings_window()
 
     // Arg 4: settings theme.
     const std::wstring settings_theme_setting{ get_general_settings().theme };
-    std::wstring settings_theme = L"system";
+    std::wstring settings_theme;
     if (settings_theme_setting == L"dark" || (settings_theme_setting == L"system" && WindowsColors::is_dark_mode()))
     {
         settings_theme = L"dark";

--- a/src/runner/settings_window.cpp
+++ b/src/runner/settings_window.cpp
@@ -288,7 +288,7 @@ void run_settings_window()
 
     // Arg 4: settings theme.
     const std::wstring settings_theme_setting{ get_general_settings().theme };
-    std::wstring settings_theme;
+    std::wstring settings_theme = L"system";
     if (settings_theme_setting == L"dark" || (settings_theme_setting == L"system" && WindowsColors::is_dark_mode()))
     {
         settings_theme = L"dark";


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
- Powerpreview.dll output path changed. this PR loads the dll from the updated output folder.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2761
* [] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [x] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #2761

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- verified changes in the son file and loading of modules from specified folders.

