### PR TITLE
[Shortcut Guide] right Win key release fix

### DIFF
--- a/src/modules/shortcut_guide/target_state.cpp
+++ b/src/modules/shortcut_guide/target_state.cpp
@@ -46,7 +46,7 @@ bool TargetState::signal_event(unsigned vk_code, bool key_down)
         input[1].ki.wVk = 0xCF;
         input[1].ki.dwFlags = KEYEVENTF_KEYUP;
         input[2].type = INPUT_KEYBOARD;
-        input[2].ki.wVk = VK_LWIN;
+        input[2].ki.wVk = vk_code;
         input[2].ki.dwFlags = KEYEVENTF_KEYUP;
         SendInput(3, input, sizeof(INPUT));
     }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Close Shortcut Guide on right Win button release. 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2641
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [] Requires documentation to be updated
* [] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Open Shortcut Guide with right Win button and release button.
 