### PR TITLE
Fancy zones settings - Color pickers saved ARGB value fix (now saves RGB)

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI/ViewModels/FancyZonesViewModel.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/ViewModels/FancyZonesViewModel.cs
@@ -9,6 +9,7 @@ using Microsoft.PowerToys.Settings.UI.Helpers;
 using Microsoft.PowerToys.Settings.UI.Lib;
 using Microsoft.PowerToys.Settings.UI.ViewModels.Commands;
 using Microsoft.PowerToys.Settings.UI.Views;
+using Microsoft.Toolkit.Uwp.Helpers;
 using Windows.UI;
 using Windows.UI.Popups;
 
@@ -19,30 +20,6 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
         private const string ModuleName = "FancyZones";
 
         public ButtonClickCommand LaunchEditorEventHandler { get; set; }
-
-        public ICommand SaveZoneHighlightColorEventHandler
-        {
-            get
-            {
-                return new RelayCommand<Color>(SaveZoneHighlightColor);
-            }
-        }
-
-        public ICommand SaveBorderColorEventHandler
-        {
-            get
-            {
-                return new RelayCommand<Color>(SaveZoneBorderColor);
-            }
-        }
-
-        public ICommand SaveInActiveColorEventHandler
-        {
-            get
-            {
-                return new RelayCommand<Color>(SaveZoneInActiveColor);
-            }
-        }
 
         private FancyZonesSettings Settings { get; set; }
 
@@ -69,12 +46,12 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             this._appLastZoneMoveWindows = Settings.Properties.FancyzonesAppLastZoneMoveWindows.Value;
             this._useCursorPosEditorStartupScreen = Settings.Properties.UseCursorposEditorStartupscreen.Value;
             this._showOnAllMonitors = Settings.Properties.FancyzonesShowOnAllMonitors.Value;
-            this._zoneHighlightColor = Settings.Properties.FancyzonesZoneHighlightColor.Value;
             this._highlightOpacity = Settings.Properties.FancyzonesHighlightOpacity.Value;
             this._excludedApps = Settings.Properties.FancyzonesExcludedApps.Value;
             this._editorHotkey = Settings.Properties.FancyzonesEditorHotkey.Value;
-            this._zoneBorderColor = Settings.Properties.FancyzonesBorderColor.Value;
-            this._zoneInActiveColor = Settings.Properties.FancyzonesInActiveColor.Value;
+            this._zoneInActiveColor = Settings.Properties.FancyzonesInActiveColor.Value.ToColor();
+            this._zoneBorderColor = Settings.Properties.FancyzonesBorderColor.Value.ToColor();
+            this._zoneHighlightColor = Settings.Properties.FancyzonesZoneHighlightColor.Value.ToColor();
 
             GeneralSettings generalSettings;
             try
@@ -100,12 +77,13 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
         private bool _appLastZoneMoveWindows;
         private bool _useCursorPosEditorStartupScreen;
         private bool _showOnAllMonitors;
-        private string _zoneHighlightColor;
+        
         private int _highlightOpacity;
         private string _excludedApps;
         private HotkeySettings _editorHotkey;
-        private string _zoneBorderColor;
-        private string _zoneInActiveColor;
+        private Color _zoneInActiveColor;
+        private Color _zoneBorderColor;
+        private Color _zoneHighlightColor;
 
         public bool IsEnabled
         {
@@ -291,7 +269,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             }
         }
 
-        public string ZoneHighlightColor
+        public Color ZoneHighlightColor
         {
             get
             {
@@ -303,13 +281,13 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 if (value != _zoneHighlightColor)
                 {
                     _zoneHighlightColor = value;
-                    Settings.Properties.FancyzonesZoneHighlightColor.Value = value;
+                    Settings.Properties.FancyzonesZoneHighlightColor.Value = ToRGBHex(value);
                     RaisePropertyChanged();
                 }
             }
         }
 
-        public string ZoneBorderColor
+        public Color ZoneBorderColor
         {
             get
             {
@@ -321,13 +299,13 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 if (value != _zoneBorderColor)
                 {
                     _zoneBorderColor = value;
-                    Settings.Properties.FancyzonesBorderColor.Value = value;
+                    Settings.Properties.FancyzonesBorderColor.Value = ToRGBHex(value);
                     RaisePropertyChanged();
                 }
             }
         }
 
-        public string ZoneInActiveColor
+        public Color ZoneInActiveColor
         {
             get
             {
@@ -339,7 +317,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 if (value != _zoneInActiveColor)
                 {
                     _zoneInActiveColor = value;
-                    Settings.Properties.FancyzonesInActiveColor.Value = value;
+                    Settings.Properties.FancyzonesInActiveColor.Value = ToRGBHex(value);
                     RaisePropertyChanged();
                 }
             }
@@ -425,19 +403,9 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             ShellPage.DefaultSndMSGCallback("{\"action\":{\"FancyZones\":{\"action_name\":\"ToggledFZEditor\", \"value\":\"\"}}}");
         }
 
-        private void SaveZoneHighlightColor(Color color)
+        private String ToRGBHex(Color color)
         {
-            ZoneHighlightColor = color.ToString();
-        }
-
-        private void SaveZoneBorderColor(Color color)
-        {
-            ZoneBorderColor = color.ToString();
-        }
-
-        private void SaveZoneInActiveColor(Color color)
-        {
-            ZoneInActiveColor = color.ToString();
+            return "#" + color.R.ToString("X2") + color.G.ToString("X2") + color.B.ToString("X2");
         }
 
         public void RaisePropertyChanged([CallerMemberName] string propertyName = null)

--- a/src/core/Microsoft.PowerToys.Settings.UI/ViewModels/FancyZonesViewModel.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/ViewModels/FancyZonesViewModel.cs
@@ -49,9 +49,15 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             this._highlightOpacity = Settings.Properties.FancyzonesHighlightOpacity.Value;
             this._excludedApps = Settings.Properties.FancyzonesExcludedApps.Value;
             this._editorHotkey = Settings.Properties.FancyzonesEditorHotkey.Value;
-            this._zoneInActiveColor = Settings.Properties.FancyzonesInActiveColor.Value.ToColor();
-            this._zoneBorderColor = Settings.Properties.FancyzonesBorderColor.Value.ToColor();
-            this._zoneHighlightColor = Settings.Properties.FancyzonesZoneHighlightColor.Value.ToColor();
+
+            string inactiveColor = Settings.Properties.FancyzonesInActiveColor.Value;
+            this._zoneInActiveColor = inactiveColor != "" ? inactiveColor.ToColor() : "#F5FCFF".ToColor();
+
+            string borderColor = Settings.Properties.FancyzonesBorderColor.Value;
+            this._zoneBorderColor = borderColor != "" ?  borderColor.ToColor() : "#FFFFFF".ToColor();
+
+            string highlightColor = Settings.Properties.FancyzonesBorderColor.Value;
+            this._zoneHighlightColor = highlightColor != "" ? highlightColor.ToColor() : "#0078D7".ToColor();
 
             GeneralSettings generalSettings;
             try
@@ -77,7 +83,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
         private bool _appLastZoneMoveWindows;
         private bool _useCursorPosEditorStartupScreen;
         private bool _showOnAllMonitors;
-        
+
         private int _highlightOpacity;
         private string _excludedApps;
         private HotkeySettings _editorHotkey;

--- a/src/core/Microsoft.PowerToys.Settings.UI/ViewModels/FancyZonesViewModel.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/ViewModels/FancyZonesViewModel.cs
@@ -51,13 +51,13 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             this._editorHotkey = Settings.Properties.FancyzonesEditorHotkey.Value;
 
             string inactiveColor = Settings.Properties.FancyzonesInActiveColor.Value;
-            this._zoneInActiveColor = inactiveColor != "" ? inactiveColor.ToColor() : "#F5FCFF".ToColor();
+            this._zoneInActiveColor = inactiveColor != string.Empty ? inactiveColor.ToColor() : "#F5FCFF".ToColor();
 
             string borderColor = Settings.Properties.FancyzonesBorderColor.Value;
-            this._zoneBorderColor = borderColor != "" ?  borderColor.ToColor() : "#FFFFFF".ToColor();
+            this._zoneBorderColor = borderColor != string.Empty ?  borderColor.ToColor() : "#FFFFFF".ToColor();
 
-            string highlightColor = Settings.Properties.FancyzonesBorderColor.Value;
-            this._zoneHighlightColor = highlightColor != "" ? highlightColor.ToColor() : "#0078D7".ToColor();
+            string highlightColor = Settings.Properties.FancyzonesZoneHighlightColor.Value;
+            this._zoneHighlightColor = highlightColor != string.Empty ? highlightColor.ToColor() : "#0078D7".ToColor();
 
             GeneralSettings generalSettings;
             try

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -142,44 +142,28 @@
                               IsColorSliderVisible="True"
                               IsColorChannelTextInputVisible="True"
                               IsHexInputVisible="True"
-                              IsAlphaEnabled="True"
-                              IsAlphaSliderVisible="True"
-                              IsAlphaTextInputVisible="True"
-                              Color="{Binding Path=ZoneHighlightColor, Mode=TwoWay, Source={StaticResource eventViewModel}}"
-                              IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"
-                              DataContext="{Binding ZoneHighlightColor, Source={StaticResource eventViewModel}}"/>
+                              IsAlphaEnabled="False"
+                              IsAlphaSliderVisible="False"
+                              IsAlphaTextInputVisible="False"
+                              Color="{Binding Path=ZoneHighlightColor, Mode=TwoWay}"
+                              IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"/>
 
-            <Button x:Uid="FancyZones_SaveZoneHighlightColor"
-                    Margin="{StaticResource SmallTopMargin}"
-                    Style="{StaticResource AccentButtonStyle}"
-                    Command = "{Binding SaveZoneHighlightColorEventHandler, Source={StaticResource eventViewModel}}"
-                    CommandParameter="{Binding Color, ElementName=FancyZones_ZoneHighlightColor}"
-                    IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"/>            
-            
             <TextBlock x:Uid="FancyZones_InActiveColor" 
                        Style="{StaticResource BodyTextBlockStyle}"
                        Margin="{StaticResource SmallTopMargin}" />
-            
-            <muxc:ColorPicker x:Name="FancyZones_InActiveColor"
+
+            <muxc:ColorPicker x:Name="FancyZones_InActiveColorPicker"
                               Margin="0,6,0,0"
                               HorizontalAlignment="Left"
                               IsMoreButtonVisible="True"
                               IsColorSliderVisible="True"
                               IsColorChannelTextInputVisible="True"
                               IsHexInputVisible="True"
-                              IsAlphaEnabled="True"
-                              IsAlphaSliderVisible="True"
-                              IsAlphaTextInputVisible="True"
-                              Color="{Binding Path=ZoneInActiveColor, Mode=TwoWay, Source={StaticResource eventViewModel}}"
-                              IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}" 
-                              DataContext="{Binding ZoneInActiveColor, Source={StaticResource eventViewModel}}"/>
-
-            <Button x:Uid="FancyZones_SaveZoneInActiveColor"
-                    Margin="{StaticResource SmallTopMargin}"
-                    Style="{StaticResource AccentButtonStyle}"
-                    Command = "{Binding SaveInActiveColorEventHandler, Source={StaticResource eventViewModel}}"
-                    CommandParameter="{Binding Color, ElementName=FancyZones_InActiveColor}"
-                    IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"/>
+                              IsAlphaEnabled="False"
+                              IsAlphaSliderVisible="False"
+                              IsAlphaTextInputVisible="False"
+                              Color="{Binding Path=ZoneInActiveColor, Mode=TwoWay}"
+                              IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"/>
 
             <TextBlock x:Uid="FancyZones_BorderColor" 
                        Style="{StaticResource BodyTextBlockStyle}"
@@ -192,19 +176,12 @@
                               IsColorSliderVisible="True"
                               IsColorChannelTextInputVisible="True"
                               IsHexInputVisible="True"
-                              IsAlphaEnabled="True"
-                              IsAlphaSliderVisible="True"
-                              IsAlphaTextInputVisible="True"
-                              Color="{Binding Path=ZoneBorderColor, Mode=TwoWay, Source={StaticResource eventViewModel}}"
-                              IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"
-                              DataContext="{Binding ZoneBorderColor, Source={StaticResource eventViewModel}}"/>
+                              IsAlphaEnabled="False"
+                              IsAlphaSliderVisible="False"
+                              IsAlphaTextInputVisible="False"
+                              Color="{Binding Path=ZoneBorderColor, Mode=TwoWay}"
+                              IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"/>
 
-            <Button x:Uid="FancyZones_SaveBorderColor"
-                    Margin="{StaticResource SmallTopMargin}"
-                    Style="{StaticResource AccentButtonStyle}"
-                    Command = "{Binding SaveBorderColorEventHandler, Source={StaticResource eventViewModel}}"
-                    CommandParameter="{Binding Color, ElementName=FancyZones_BorderColor}"
-                    IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"/>
             
             <TextBlock x:Uid="FancyZones_ExcludeApps"
                        Style="{StaticResource SettingsGroupTitleStyle}"/>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Settings v2 changed fancy zones color picker json format to ARGB which caused crush on displaying fancy zones.

Also: Changing any color resets fancyzones_highlight_opacity.
Changing fancyzones_highlight_opacity resets colors (fancyzones_zoneHighlightColor, fancyzones_zoneBorderColor, fancyzones_zoneColor)

After the change:
- Color are saved in RGB
- Transparency options for each color are removed since we have global transparency option
- All fancyzones are now saved when changing colorpicker or other setting
- Buttons responsible for saving colors are removed to match instant save which applies to other settings

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2763
