### PR TITLE
[Hotfix] Change build order in build.cmd

### DIFF
--- a/.pipelines/build.cmd
+++ b/.pipelines/build.cmd
@@ -1,6 +1,6 @@
 cd /D "%~dp0"
 
 call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=amd64 -host_arch=amd64 -winsdk=10.0.18362.0
+call msbuild ../PowerToys.sln /p:Configuration=Release /p:Platform=x64 || exit /b 1
 call msbuild ../src/common/notifications/notifications_dll.vcxproj /p:Configuration=Release /p:Platform=x64 || exit /b 1
 call msbuild ../src/common/notifications_winrt/notifications.vcxproj /p:Configuration=Release /p:Platform=x64 || exit /b 1
-call msbuild ../PowerToys.sln /p:Configuration=Release /p:Platform=x64 || exit /b 1


### PR DESCRIPTION
This seems to fix the missing Generated Files\version_gen.h error

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
* Built using `.pipeline\build.cmd` from a clean repo seems to work 
* Got a functioning run from the pipeline.