### PR TITLE
PowerRename settings bugfix

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/PowerRenameLocalProperties.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/PowerRenameLocalProperties.cs
@@ -38,6 +38,10 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
                 {
                     _maxSize = 0;
                 }
+                else
+                {
+                    _maxSize = value;
+                }
             }
         }
 

--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -383,7 +383,7 @@
   <data name="PowerRename_Toggle_EnableOnExtendedContextMenu.Header" xml:space="preserve">
     <value>Appear only in extended context menu (Shift + Right-click)</value>
   </data>
-  <data name="PowerRename_Toggle_MaxDispListNum.Text" xml:space="preserve">
+  <data name="PowerRename_Toggle_MaxDispListNum.Header" xml:space="preserve">
     <value>Maximum numbers of items to show in recently used list for autocomplete dropdown</value>
   </data>
   <data name="PowerRename_Toggle_RestoreFlagsOnLaunch.Header" xml:space="preserve">

--- a/src/core/Microsoft.PowerToys.Settings.UI/ViewModels/PowerRenameViewModel.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/ViewModels/PowerRenameViewModel.cs
@@ -76,6 +76,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
 
                         _powerRenameEnabled = value;
                         OnPropertyChanged("IsEnabled");
+                        RaisePropertyChanged("GlobalAndMruEnabled");
                     }
                 }
             }
@@ -95,9 +96,19 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                     _autoComplete = value;
                     Settings.properties.MRUEnabled.Value = value;
                     RaisePropertyChanged();
+                    RaisePropertyChanged("GlobalAndMruEnabled");
                 }
             }
         }
+
+        public bool GlobalAndMruEnabled
+        {
+            get
+            {
+                return _autoComplete && _powerRenameEnabled;
+            }
+        }
+
 
         public bool EnabledOnContextMenu
         {

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerRenamePage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerRenamePage.xaml
@@ -53,12 +53,6 @@
             <TextBlock  x:Uid="PowerRename_ShellIntergration"
                         Style="{StaticResource SettingsGroupTitleStyle}"/>
 
-            <ToggleSwitch x:Uid="PowerRename_Toggle_AutoComplete"
-                          Margin="{StaticResource SmallTopMargin}" 
-                          IsOn="{Binding Mode=TwoWay, Path=MRUEnabled}"
-                          IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"
-                           />
-
             <ToggleSwitch x:Uid="PowerRename_Toggle_EnableOnContextMenu"
                           Margin="{StaticResource SmallTopMargin}" 
                           IsOn="{Binding Mode=TwoWay, Path=EnabledOnContextMenu}"
@@ -80,20 +74,23 @@
                           IsOn="{Binding Mode=TwoWay, Path=MRUEnabled}"
                           IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"
                            />
-            
+
+            <muxc:NumberBox x:Uid="PowerRename_Toggle_MaxDispListNum"
+                            SpinButtonPlacementMode="Inline"
+                            HorizontalAlignment="Left"
+                            Margin="{StaticResource SmallTopMargin}" 
+                            Value="{Binding Mode=TwoWay, Path=MaxDispListNum}"
+                            Minimum="0"
+                            Maximum="1000"
+                            IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"
+                            Visibility="{ Binding Mode=TwoWay, Path=MRUEnabled}"
+                            />
+
             <ToggleSwitch x:Uid="PowerRename_Toggle_RestoreFlagsOnLaunch"
                           Margin="{StaticResource SmallTopMargin}" 
                           IsOn="{Binding Mode=TwoWay, Path=RestoreFlagsOnLaunch}"
                           IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"
                            />
-
-            <muxc:NumberBox x:Name="PowerRename_Toggle_MaxDispListNum"
-                            SpinButtonPlacementMode="Inline"
-                            HorizontalAlignment="Left"
-                            Margin="{StaticResource SmallTopMargin}" 
-                            Value="{Binding Mode=TwoWay, Path=MaxDispListNum}"
-                            IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"
-                            />
         </StackPanel>
 
 

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerRenamePage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerRenamePage.xaml
@@ -81,7 +81,7 @@
                             Margin="{StaticResource SmallTopMargin}" 
                             Value="{Binding Mode=TwoWay, Path=MaxDispListNum}"
                             Minimum="0"
-                            Maximum="1000"
+                            Maximum="20"
                             IsEnabled="{ Binding Mode=TwoWay, Path=GlobalAndMruEnabled}"
                             />
 

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerRenamePage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerRenamePage.xaml
@@ -82,8 +82,7 @@
                             Value="{Binding Mode=TwoWay, Path=MaxDispListNum}"
                             Minimum="0"
                             Maximum="1000"
-                            IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"
-                            Visibility="{ Binding Mode=TwoWay, Path=MRUEnabled}"
+                            IsEnabled="{ Binding Mode=TwoWay, Path=GlobalAndMruEnabled}"
                             />
 
             <ToggleSwitch x:Uid="PowerRename_Toggle_RestoreFlagsOnLaunch"

--- a/src/core/Microsoft.PowerToys.Settings.UnitTest/ViewModelTests/PowerRename.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UnitTest/ViewModelTests/PowerRename.cs
@@ -81,6 +81,55 @@ namespace ViewModelTests
         }
 
         [TestMethod]
+        public void WhenIsEnabledIsOffAndMRUEnabledIsOffGlobalAndMruShouldBeOff()
+        {
+            PowerRenameViewModel viewModel = new PowerRenameViewModel();
+            ShellPage.DefaultSndMSGCallback = msg => { };
+
+            viewModel.IsEnabled = false;
+            viewModel.MRUEnabled = false;
+
+            Assert.IsFalse(viewModel.GlobalAndMruEnabled);
+        }
+
+        [TestMethod]
+        public void WhenIsEnabledIsOffAndMRUEnabledIsOnGlobalAndMruShouldBeOff()
+        {
+            PowerRenameViewModel viewModel = new PowerRenameViewModel();
+            ShellPage.DefaultSndMSGCallback = msg => { };
+
+            viewModel.IsEnabled = false;
+            viewModel.MRUEnabled = true;
+
+
+            Assert.IsFalse(viewModel.GlobalAndMruEnabled);
+        }
+
+        [TestMethod]
+        public void WhenIsEnabledIsOnAndMRUEnabledIsOffGlobalAndMruShouldBeOff()
+        {
+            PowerRenameViewModel viewModel = new PowerRenameViewModel();
+            ShellPage.DefaultSndMSGCallback = msg => { };
+
+            viewModel.IsEnabled = true;
+            viewModel.MRUEnabled = false;
+
+            Assert.IsFalse(viewModel.GlobalAndMruEnabled);
+        }
+
+        [TestMethod]
+        public void WhenIsEnabledIsOnAndMRUEnabledIsOnGlobalAndMruShouldBeOn()
+        {
+            PowerRenameViewModel viewModel = new PowerRenameViewModel();
+            ShellPage.DefaultSndMSGCallback = msg => { };
+
+            viewModel.IsEnabled = true;
+            viewModel.MRUEnabled = true;
+
+            Assert.IsTrue(viewModel.GlobalAndMruEnabled);
+        }
+
+        [TestMethod]
         public void EnabledOnContextMenu_ShouldSetValue2True_WhenSuccessful()
         {
             // arrange
@@ -141,7 +190,7 @@ namespace ViewModelTests
             ShellPage.DefaultSndMSGCallback = msg =>
             {
                 PowerRenameSettingsIPCMessage snd = JsonSerializer.Deserialize<PowerRenameSettingsIPCMessage>(msg);
-                Assert.AreEqual(20,snd.Powertoys.PowerRename.properties.MaxMRUSize.Value);
+                Assert.AreEqual(20, snd.Powertoys.PowerRename.properties.MaxMRUSize.Value);
             };
 
             // act


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
"Maximum numbers of items to show in recently used list for autocomplete dropdown."  had:
- No default value in settings
- "Enable autocomplete and autosuggest of recently used list for autocomplete dropdown." was duplicated in settings
- Had no caption
- Had no limits for min and max value
- Could be edited while "Enable autocomplete and autosuggest of recently used list for autocomplete dropdown." was off

This PR fixes this problems.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to ##2792
