### PR TITLE
[Keyboard Manager] Confirmation Dialog for orphaned keys and partial remappings.

### DIFF
--- a/src/modules/keyboardmanager/common/KeyboardManagerConstants.h
+++ b/src/modules/keyboardmanager/common/KeyboardManagerConstants.h
@@ -73,4 +73,7 @@ namespace KeyboardManagerConstants
     inline const long TableArrowColWidth = 20;
     inline const long TableRemoveColWidth = 20;
     inline const long TableWarningColWidth = 20;
+
+    // Shared style constants for both Remap Table and Shortcut Table
+    inline const double HeaderButtonWidth = 100;
 }

--- a/src/modules/keyboardmanager/ui/Dialog.cpp
+++ b/src/modules/keyboardmanager/ui/Dialog.cpp
@@ -1,0 +1,17 @@
+#include "pch.h"
+#include "Dialog.h"
+
+IAsyncOperation<bool> Dialog::PartialRemappingConfirmationDialog(XamlRoot root)
+{
+    ContentDialog confirmationDialog;
+    confirmationDialog.XamlRoot(root);
+    confirmationDialog.Title(box_value(L"Some of the keys could not be remapped. Do you want to continue anyway?"));
+    confirmationDialog.IsPrimaryButtonEnabled(true);
+    confirmationDialog.DefaultButton(ContentDialogButton::Primary);
+    confirmationDialog.PrimaryButtonText(winrt::hstring(L"Continue Anyway"));
+    confirmationDialog.IsSecondaryButtonEnabled(true);
+    confirmationDialog.SecondaryButtonText(winrt::hstring(L"Cancel"));
+
+    ContentDialogResult res = co_await confirmationDialog.ShowAsync();
+    co_return res == ContentDialogResult::Primary;
+}

--- a/src/modules/keyboardmanager/ui/Dialog.h
+++ b/src/modules/keyboardmanager/ui/Dialog.h
@@ -1,0 +1,43 @@
+#pragma once
+#include <vector>
+#include <functional>
+#include <keyboardmanager/common/Helpers.h>
+#include <set>
+#include <winrt/Windows.UI.Xaml.h>
+
+using namespace winrt::Windows::Foundation;
+
+namespace Dialog
+{
+    template<typename T>
+    KeyboardManagerHelper::ErrorType CheckIfRemappingsAreValid(
+        const std::vector<std::vector<T>>& remappings,
+        std::function<void(int)> onRemappingError,
+        std::function<bool(T)> isValid)
+    {
+        KeyboardManagerHelper::ErrorType isSuccess = KeyboardManagerHelper::ErrorType::NoError;
+        std::set<T> ogKeys;
+        for (int i = 0; i < remappings.size(); i++)
+        {
+            T ogKey = remappings[i][0];
+            T newKey = remappings[i][1];
+
+            if (isValid(ogKey) && isValid(newKey) && ogKeys.find(ogKey) == ogKeys.end())
+            {
+                ogKeys.insert(ogKey);
+            }
+            else if (isValid(ogKey) && isValid(newKey) && ogKeys.find(ogKey) != ogKeys.end())
+            {
+                isSuccess = KeyboardManagerHelper::ErrorType::RemapUnsuccessful;
+            }
+            else
+            {
+                isSuccess = KeyboardManagerHelper::ErrorType::RemapUnsuccessful;
+                onRemappingError(i);
+            }
+        }
+        return isSuccess;
+    }
+
+    IAsyncOperation<bool> PartialRemappingConfirmationDialog(winrt::Windows::UI::Xaml::XamlRoot root);
+};

--- a/src/modules/keyboardmanager/ui/Dialog.h
+++ b/src/modules/keyboardmanager/ui/Dialog.h
@@ -12,7 +12,6 @@ namespace Dialog
     template<typename T>
     KeyboardManagerHelper::ErrorType CheckIfRemappingsAreValid(
         const std::vector<std::vector<T>>& remappings,
-        std::function<void(int)> onRemappingError,
         std::function<bool(T)> isValid)
     {
         KeyboardManagerHelper::ErrorType isSuccess = KeyboardManagerHelper::ErrorType::NoError;
@@ -33,7 +32,6 @@ namespace Dialog
             else
             {
                 isSuccess = KeyboardManagerHelper::ErrorType::RemapUnsuccessful;
-                onRemappingError(i);
             }
         }
         return isSuccess;

--- a/src/modules/keyboardmanager/ui/EditKeyboardWindow.cpp
+++ b/src/modules/keyboardmanager/ui/EditKeyboardWindow.cpp
@@ -6,6 +6,7 @@
 #include <keyboardmanager/common/trace.h>
 #include <set>
 #include <common/windows_colors.h>
+#include "Styles.h"
 
 using namespace winrt::Windows::Foundation;
 
@@ -325,8 +326,9 @@ void createEditKeyboardWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMan
     // Main Header Apply button
     Button applyButton;
     applyButton.Content(winrt::box_value(L"OK"));
-    applyButton.Background(winrt::Windows::UI::Xaml::Media::SolidColorBrush{ WindowsColors::get_accent_color() });
-    applyButton.Foreground(winrt::Windows::UI::Xaml::Media::SolidColorBrush{ winrt::Windows::UI::Colors::White() });
+    applyButton.Style(AccentButtonStyle());
+    applyButton.MinWidth(HeaderButtonWidth);
+    cancelButton.MinWidth(HeaderButtonWidth);
     header.SetAlignRightWithPanel(cancelButton, true);
     header.SetLeftOf(applyButton, cancelButton);
     applyButton.Flyout(applyFlyout);

--- a/src/modules/keyboardmanager/ui/EditKeyboardWindow.cpp
+++ b/src/modules/keyboardmanager/ui/EditKeyboardWindow.cpp
@@ -54,7 +54,7 @@ IAsyncAction ConfirmationDialog(
     confirmationDialog.Title(box_value(L"The following keys are unassigned and you won't be able to use them:"));
     confirmationDialog.IsPrimaryButtonEnabled(true);
     confirmationDialog.DefaultButton(ContentDialogButton::Primary);
-    confirmationDialog.PrimaryButtonText(winrt::hstring(L"Continue anyway"));
+    confirmationDialog.PrimaryButtonText(winrt::hstring(L"Continue Anyway"));
     confirmationDialog.IsSecondaryButtonEnabled(true);
     confirmationDialog.SecondaryButtonText(winrt::hstring(L"Cancel"));
 
@@ -293,6 +293,7 @@ void createEditKeyboardWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMan
     Button applyButton;
     applyButton.Content(winrt::box_value(L"OK"));
     applyButton.Background(winrt::Windows::UI::Xaml::Media::SolidColorBrush{ WindowsColors::get_accent_color() });
+    applyButton.Foreground(winrt::Windows::UI::Xaml::Media::SolidColorBrush{ winrt::Windows::UI::Colors::White() });
     header.SetAlignRightWithPanel(cancelButton, true);
     header.SetLeftOf(applyButton, cancelButton);
     applyButton.Flyout(applyFlyout);

--- a/src/modules/keyboardmanager/ui/EditKeyboardWindow.cpp
+++ b/src/modules/keyboardmanager/ui/EditKeyboardWindow.cpp
@@ -72,6 +72,7 @@ static IAsyncOperation<bool> OrphanKeysConfirmationDialog(
     }
     orphanKeyString = orphanKeyString.substr(0, max(0, orphanKeyString.length() - 2));
     orphanKeysBlock.Text(winrt::hstring(orphanKeyString));
+    orphanKeysBlock.TextWrapping(TextWrapping::Wrap);
     confirmationDialog.Content(orphanKeysBlock);
 
     ContentDialogResult res = co_await confirmationDialog.ShowAsync();

--- a/src/modules/keyboardmanager/ui/EditShortcutsWindow.cpp
+++ b/src/modules/keyboardmanager/ui/EditShortcutsWindow.cpp
@@ -105,7 +105,7 @@ void createEditShortcutsWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMa
     cancelButton.Content(winrt::box_value(L"Cancel"));
     cancelButton.Margin({ 10, 0, 0, 0 });
     cancelButton.Click([&](winrt::Windows::Foundation::IInspectable const& sender, RoutedEventArgs const&) {
-        // Close the window since settings0 do not need to be saved
+        // Close the window since settings do not need to be saved
         PostMessage(_hWndEditShortcutsWindow, WM_CLOSE, 0, 0);
     });
 

--- a/src/modules/keyboardmanager/ui/EditShortcutsWindow.cpp
+++ b/src/modules/keyboardmanager/ui/EditShortcutsWindow.cpp
@@ -4,6 +4,7 @@
 #include "KeyDropDownControl.h"
 #include "XamlBridge.h"
 #include <keyboardmanager/common/trace.h>
+#include <common/windows_colors.h>
 
 LRESULT CALLBACK EditShortcutsWindowProc(HWND, UINT, WPARAM, LPARAM);
 
@@ -101,9 +102,9 @@ void createEditShortcutsWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMa
     // Cancel button
     Button cancelButton;
     cancelButton.Content(winrt::box_value(L"Cancel"));
-    cancelButton.Margin({ 0, 0, 10, 0 });
+    cancelButton.Margin({ 10, 0, 0, 0 });
     cancelButton.Click([&](winrt::Windows::Foundation::IInspectable const& sender, RoutedEventArgs const&) {
-        // Close the window since settings do not need to be saved
+        // Close the window since settings0 do not need to be saved
         PostMessage(_hWndEditShortcutsWindow, WM_CLOSE, 0, 0);
     });
 
@@ -189,9 +190,11 @@ void createEditShortcutsWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMa
 
     // Apply button
     Button applyButton;
-    applyButton.Content(winrt::box_value(L"Apply"));
-    header.SetAlignRightWithPanel(applyButton, true);
-    header.SetLeftOf(cancelButton, applyButton);
+    applyButton.Content(winrt::box_value(L"OK"));
+    applyButton.Background(winrt::Windows::UI::Xaml::Media::SolidColorBrush{ WindowsColors::get_accent_color() });
+    applyButton.Foreground(winrt::Windows::UI::Xaml::Media::SolidColorBrush{ winrt::Windows::UI::Colors::White() });
+    header.SetAlignRightWithPanel(cancelButton, true);
+    header.SetLeftOf(applyButton, cancelButton);
     applyButton.Flyout(applyFlyout);
     applyButton.Click([&](winrt::Windows::Foundation::IInspectable const& sender, RoutedEventArgs const&) {
         KeyboardManagerHelper::ErrorType isSuccess = KeyboardManagerHelper::ErrorType::NoError;
@@ -231,6 +234,10 @@ void createEditShortcutsWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMa
         }
         Trace::OSLevelShortcutRemapCount(successfulRemapCount);
         settingsMessage.Text(KeyboardManagerHelper::GetErrorMessage(isSuccess));
+        if (isSuccess == KeyboardManagerHelper::ErrorType::NoError)
+        {
+            PostMessage(_hWndEditShortcutsWindow, WM_CLOSE, 0, 0);
+        }
     });
 
     header.Children().Append(headerText);

--- a/src/modules/keyboardmanager/ui/EditShortcutsWindow.cpp
+++ b/src/modules/keyboardmanager/ui/EditShortcutsWindow.cpp
@@ -26,12 +26,10 @@ static XamlBridge* xamlBridgePtr = nullptr;
 static IAsyncAction OnClickAccept(
     KeyboardManagerState& keyboardManagerState,
     XamlRoot root,
-    std::function<void()> ApplyRemappings,
-    std::function<void(int)> onRemappingError)
+    std::function<void()> ApplyRemappings)
 {
     KeyboardManagerHelper::ErrorType isSuccess = Dialog::CheckIfRemappingsAreValid<Shortcut>(
         ShortcutControl::shortcutRemapBuffer,
-        onRemappingError,
         [](Shortcut shortcut) {
             return shortcut.IsValidShortcut();
         });
@@ -260,19 +258,8 @@ void createEditShortcutsWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMa
         PostMessage(_hWndEditShortcutsWindow, WM_CLOSE, 0, 0);
     };
 
-    auto ShowWarningFlyout = [shortcutTable](int index) {
-        // Show tooltip warning on the problematic row
-        uint32_t warningIndex;
-        // 2 at start, 4 in each row, and last element of each row
-        warningIndex = KeyboardManagerConstants::ShortcutTableHeaderCount + ((index + 1) * KeyboardManagerConstants::ShortcutTableColCount) - 1;
-        FontIcon warning = shortcutTable.Children().GetAt(warningIndex).as<FontIcon>();
-        ToolTip t = ToolTipService::GetToolTip(warning).as<ToolTip>();
-        t.Content(box_value(KeyboardManagerHelper::GetErrorMessage(KeyboardManagerHelper::ErrorType::MissingKey)));
-        warning.Visibility(Visibility::Visible);
-    };
-
-    applyButton.Click([&keyboardManagerState, applyButton, ApplyRemappings, ShowWarningFlyout](winrt::Windows::Foundation::IInspectable const& sender, RoutedEventArgs const&) {
-        OnClickAccept(keyboardManagerState, applyButton.XamlRoot(), ApplyRemappings, ShowWarningFlyout);
+    applyButton.Click([&keyboardManagerState, applyButton, ApplyRemappings](winrt::Windows::Foundation::IInspectable const& sender, RoutedEventArgs const&) {
+        OnClickAccept(keyboardManagerState, applyButton.XamlRoot(), ApplyRemappings);
     });
 
     header.Children().Append(headerText);

--- a/src/modules/keyboardmanager/ui/EditShortcutsWindow.cpp
+++ b/src/modules/keyboardmanager/ui/EditShortcutsWindow.cpp
@@ -5,6 +5,7 @@
 #include "XamlBridge.h"
 #include <keyboardmanager/common/trace.h>
 #include <common/windows_colors.h>
+#include "Styles.h"
 
 LRESULT CALLBACK EditShortcutsWindowProc(HWND, UINT, WPARAM, LPARAM);
 
@@ -191,8 +192,9 @@ void createEditShortcutsWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMa
     // Apply button
     Button applyButton;
     applyButton.Content(winrt::box_value(L"OK"));
-    applyButton.Background(winrt::Windows::UI::Xaml::Media::SolidColorBrush{ WindowsColors::get_accent_color() });
-    applyButton.Foreground(winrt::Windows::UI::Xaml::Media::SolidColorBrush{ winrt::Windows::UI::Colors::White() });
+    applyButton.Style(AccentButtonStyle());
+    applyButton.MinWidth(HeaderButtonWidth);
+    cancelButton.MinWidth(HeaderButtonWidth);
     header.SetAlignRightWithPanel(cancelButton, true);
     header.SetLeftOf(applyButton, cancelButton);
     applyButton.Flyout(applyFlyout);

--- a/src/modules/keyboardmanager/ui/EditShortcutsWindow.cpp
+++ b/src/modules/keyboardmanager/ui/EditShortcutsWindow.cpp
@@ -4,8 +4,12 @@
 #include "KeyDropDownControl.h"
 #include "XamlBridge.h"
 #include <keyboardmanager/common/trace.h>
+#include <keyboardmanager/common/KeyboardManagerConstants.h>
 #include <common/windows_colors.h>
 #include "Styles.h"
+#include "Dialog.h"
+
+using namespace winrt::Windows::Foundation;
 
 LRESULT CALLBACK EditShortcutsWindowProc(HWND, UINT, WPARAM, LPARAM);
 
@@ -18,6 +22,28 @@ HWND hwndEditShortcutsNativeWindow = nullptr;
 std::mutex editShortcutsWindowMutex;
 // Stores a pointer to the Xaml Bridge object so that it can be accessed from the window procedure
 static XamlBridge* xamlBridgePtr = nullptr;
+
+static IAsyncAction OnClickAccept(
+    KeyboardManagerState& keyboardManagerState,
+    XamlRoot root,
+    std::function<void()> ApplyRemappings,
+    std::function<void(int)> onRemappingError)
+{
+    KeyboardManagerHelper::ErrorType isSuccess = Dialog::CheckIfRemappingsAreValid<Shortcut>(
+        ShortcutControl::shortcutRemapBuffer,
+        onRemappingError,
+        [](Shortcut shortcut) {
+            return shortcut.IsValidShortcut();
+        });
+    if (isSuccess != KeyboardManagerHelper::ErrorType::NoError)
+    {
+        if (!co_await Dialog::PartialRemappingConfirmationDialog(root))
+        {
+            co_return;
+        }
+    }
+    ApplyRemappings();
+}
 
 // Function to create the Edit Shortcuts Window
 void createEditShortcutsWindow(HINSTANCE hInst, KeyboardManagerState& keyboardManagerState)
@@ -163,11 +189,6 @@ void createEditShortcutsWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMa
     shortcutTable.Children().Append(originalShortcutHeader);
     shortcutTable.Children().Append(newShortcutHeader);
 
-    // Message to display success/failure of saving settings.
-    Flyout applyFlyout;
-    TextBlock settingsMessage;
-    applyFlyout.Content(settingsMessage);
-
     // Store handle of edit shortcuts window
     ShortcutControl::EditShortcutsWindowHandle = _hWndEditShortcutsWindow;
     // Store keyboard manager state
@@ -193,12 +214,12 @@ void createEditShortcutsWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMa
     Button applyButton;
     applyButton.Content(winrt::box_value(L"OK"));
     applyButton.Style(AccentButtonStyle());
-    applyButton.MinWidth(HeaderButtonWidth);
-    cancelButton.MinWidth(HeaderButtonWidth);
+    applyButton.MinWidth(KeyboardManagerConstants::HeaderButtonWidth);
+    cancelButton.MinWidth(KeyboardManagerConstants::HeaderButtonWidth);
     header.SetAlignRightWithPanel(cancelButton, true);
     header.SetLeftOf(applyButton, cancelButton);
-    applyButton.Flyout(applyFlyout);
-    applyButton.Click([&](winrt::Windows::Foundation::IInspectable const& sender, RoutedEventArgs const&) {
+
+    auto ApplyRemappings = [&keyboardManagerState, _hWndEditShortcutsWindow]() {
         KeyboardManagerHelper::ErrorType isSuccess = KeyboardManagerHelper::ErrorType::NoError;
         // Clear existing shortcuts
         keyboardManagerState.ClearOSLevelShortcuts();
@@ -228,18 +249,30 @@ void createEditShortcutsWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMa
             }
         }
 
+        Trace::OSLevelShortcutRemapCount(successfulRemapCount);
         // Save the updated key remaps to file.
         bool saveResult = keyboardManagerState.SaveConfigToFile();
         if (!saveResult)
         {
             isSuccess = KeyboardManagerHelper::ErrorType::SaveFailed;
         }
-        Trace::OSLevelShortcutRemapCount(successfulRemapCount);
-        settingsMessage.Text(KeyboardManagerHelper::GetErrorMessage(isSuccess));
-        if (isSuccess == KeyboardManagerHelper::ErrorType::NoError)
-        {
-            PostMessage(_hWndEditShortcutsWindow, WM_CLOSE, 0, 0);
-        }
+
+        PostMessage(_hWndEditShortcutsWindow, WM_CLOSE, 0, 0);
+    };
+
+    auto ShowWarningFlyout = [shortcutTable](int index) {
+        // Show tooltip warning on the problematic row
+        uint32_t warningIndex;
+        // 2 at start, 4 in each row, and last element of each row
+        warningIndex = KeyboardManagerConstants::ShortcutTableHeaderCount + ((index + 1) * KeyboardManagerConstants::ShortcutTableColCount) - 1;
+        FontIcon warning = shortcutTable.Children().GetAt(warningIndex).as<FontIcon>();
+        ToolTip t = ToolTipService::GetToolTip(warning).as<ToolTip>();
+        t.Content(box_value(KeyboardManagerHelper::GetErrorMessage(KeyboardManagerHelper::ErrorType::MissingKey)));
+        warning.Visibility(Visibility::Visible);
+    };
+
+    applyButton.Click([&keyboardManagerState, applyButton, ApplyRemappings, ShowWarningFlyout](winrt::Windows::Foundation::IInspectable const& sender, RoutedEventArgs const&) {
+        OnClickAccept(keyboardManagerState, applyButton.XamlRoot(), ApplyRemappings, ShowWarningFlyout);
     });
 
     header.Children().Append(headerText);

--- a/src/modules/keyboardmanager/ui/KeyboardManagerUI.vcxproj
+++ b/src/modules/keyboardmanager/ui/KeyboardManagerUI.vcxproj
@@ -98,6 +98,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="Dialog.cpp" />
     <ClCompile Include="EditKeyboardWindow.cpp" />
     <ClCompile Include="EditShortcutsWindow.cpp" />
     <ClCompile Include="KeyDropDownControl.cpp" />
@@ -111,6 +112,7 @@
     <ClCompile Include="XamlBridge.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Dialog.h" />
     <ClInclude Include="EditKeyboardWindow.h" />
     <ClInclude Include="EditShortcutsWindow.h" />
     <ClInclude Include="Styles.h" />

--- a/src/modules/keyboardmanager/ui/KeyboardManagerUI.vcxproj
+++ b/src/modules/keyboardmanager/ui/KeyboardManagerUI.vcxproj
@@ -107,11 +107,13 @@
     </ClCompile>
     <ClCompile Include="ShortcutControl.cpp" />
     <ClCompile Include="SingleKeyRemapControl.cpp" />
+    <ClCompile Include="Styles.cpp" />
     <ClCompile Include="XamlBridge.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="EditKeyboardWindow.h" />
     <ClInclude Include="EditShortcutsWindow.h" />
+    <ClInclude Include="Styles.h" />
     <ClInclude Include="KeyDropDownControl.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="ShortcutControl.h" />

--- a/src/modules/keyboardmanager/ui/KeyboardManagerUI.vcxproj.filters
+++ b/src/modules/keyboardmanager/ui/KeyboardManagerUI.vcxproj.filters
@@ -8,6 +8,7 @@
     <ClCompile Include="SingleKeyRemapControl.cpp" />
     <ClCompile Include="KeyDropDownControl.cpp" />
     <ClCompile Include="XamlBridge.cpp" />
+    <ClCompile Include="Styles.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="EditKeyboardWindow.h" />
@@ -17,6 +18,7 @@
     <ClInclude Include="SingleKeyRemapControl.h" />
     <ClInclude Include="KeyDropDownControl.h" />
     <ClInclude Include="XamlBridge.h" />
+    <ClInclude Include="Styles.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/modules/keyboardmanager/ui/KeyboardManagerUI.vcxproj.filters
+++ b/src/modules/keyboardmanager/ui/KeyboardManagerUI.vcxproj.filters
@@ -9,6 +9,7 @@
     <ClCompile Include="KeyDropDownControl.cpp" />
     <ClCompile Include="XamlBridge.cpp" />
     <ClCompile Include="Styles.cpp" />
+    <ClCompile Include="Dialog.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="EditKeyboardWindow.h" />
@@ -19,6 +20,7 @@
     <ClInclude Include="KeyDropDownControl.h" />
     <ClInclude Include="XamlBridge.h" />
     <ClInclude Include="Styles.h" />
+    <ClInclude Include="Dialog.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/modules/keyboardmanager/ui/Styles.cpp
+++ b/src/modules/keyboardmanager/ui/Styles.cpp
@@ -1,0 +1,17 @@
+#include "pch.h"
+#include "Styles.h"
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.UI.Xaml.Interop.h>
+#include <common/windows_colors.h>
+
+Style AccentButtonStyle()
+{
+    Style style{ winrt::xaml_typename<Controls::Button>() };
+    style.Setters().Append(Setter{
+        Controls::Control::BackgroundProperty(),
+        winrt::Windows::UI::Xaml::Media::SolidColorBrush{ WindowsColors::get_accent_color() } });
+    style.Setters().Append(Setter{
+        Controls::Control::ForegroundProperty(),
+        winrt::Windows::UI::Xaml::Media::SolidColorBrush{ winrt::Windows::UI::Colors::White() } });
+    return style;
+}

--- a/src/modules/keyboardmanager/ui/Styles.h
+++ b/src/modules/keyboardmanager/ui/Styles.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <winrt/Windows.UI.Xaml.h>
+
+using namespace winrt::Windows::UI::Xaml;
+
+// TODO: Move to KeyboardManagerConstants.h
+inline const double HeaderButtonWidth = 100;
+Style AccentButtonStyle();

--- a/src/modules/keyboardmanager/ui/Styles.h
+++ b/src/modules/keyboardmanager/ui/Styles.h
@@ -3,6 +3,4 @@
 
 using namespace winrt::Windows::UI::Xaml;
 
-// TODO: Move to KeyboardManagerConstants.h
-inline const double HeaderButtonWidth = 100;
 Style AccentButtonStyle();


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
* A confirmation dialog appears for single key remappings if there are orphaned keys.
* Apply button is changed to OK, and closes the window after applying the changes.
* A confirmation dialog appears for both single key and shortcut remappings if not all remappings are valid. 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2461, #2779, #2815 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
![image](https://user-images.githubusercontent.com/9252240/81446508-e6ce6d80-912f-11ea-8442-7df35256e142.png)

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
* When remapping single keys, a confirmation dialog shows up if there is at least one orphaned key.
* When remapping either shortcuts or single keys, a confirmation dialog shows up if there is at least one invalid remapping.