### PR TITLE
Add support for win32 packaged apps to run as admin

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/UWP.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/UWP.cs
@@ -261,7 +261,6 @@ namespace Microsoft.Plugin.Program.Programs
             public string EntryPoint { get; set; }
             public string Name => DisplayName;
             public string Location => Package.Location;
-            public string ExecutableName { get; set; }
             public bool Enabled { get; set; }
             public bool CanRunElevated {get;set;}
 
@@ -393,7 +392,6 @@ namespace Microsoft.Plugin.Program.Programs
                 BackgroundColor = manifestApp.GetStringValue("BackgroundColor");
                 Package = package;
                 EntryPoint = manifestApp.GetStringValue("EntryPoint");
-                ExecutableName = manifestApp.GetStringValue("Executable");
                                
                 DisplayName = ResourceFromPri(package.FullName, DisplayName);
                 Description = ResourceFromPri(package.FullName, Description);

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/UWP.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/UWP.cs
@@ -257,6 +257,7 @@ namespace Microsoft.Plugin.Program.Programs
             public string UserModelId { get; set; }
             public string BackgroundColor { get; set; }
 
+            public string EntryPoint { get; set; }
             public string Name => DisplayName;
             public string Location => Package.Location;
 
@@ -361,6 +362,9 @@ namespace Microsoft.Plugin.Program.Programs
                 Description = manifestApp.GetStringValue("Description");
                 BackgroundColor = manifestApp.GetStringValue("BackgroundColor");
                 Package = package;
+                EntryPoint = manifestApp.GetStringValue("EntryPoint");
+
+                Debug.WriteLine("Name: " + DisplayName +  " :" + UserModelId +  " :" + manifestApp.GetStringValue("EntryPoint"));
 
                 DisplayName = ResourceFromPri(package.FullName, DisplayName);
                 Description = ResourceFromPri(package.FullName, Description);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Added run as admin option for win32 packaged apps.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2497 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
In Win32 packaged app, the main Application entry will be something like this:
`<Application Id="MSIXHero" Executable="MSIXHero.exe" EntryPoint="Windows.FullTrustApplication">`. The property `EntryPoint="Windows.FullTrustApplication"` ensures that it is a win32 packaged app which can be run as admin. 

Another scenario in which a packaged app could be run as admin is if it contains `TrustLevel=mediumIL"` property in the Application Manifest 
 

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manually validated that Run as admin works for Win32 packaged  apps like Spotify, Window terminal but not for traditional sandboxed apps like Mail, Calender etc.