### PR TITLE
Adding Telemetry Events for svg and markdown enable/disable

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/BoolPropertyJsonConverter.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/BoolPropertyJsonConverter.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.PowerToys.Settings.UI.Lib
+{
+    public class BoolPropertyJsonConverter : JsonConverter<bool>
+    {
+        public override bool Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var boolProperty = JsonSerializer.Deserialize<BoolProperty>(ref reader, options);
+            return boolProperty.Value;
+        }
+
+        public override void Write(Utf8JsonWriter writer, bool value, JsonSerializerOptions options)
+        {
+            var boolProperty = new BoolProperty(value);
+            JsonSerializer.Serialize(writer, boolProperty, options);
+        }
+    }
+}

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/EnabledModules.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/EnabledModules.cs
@@ -133,10 +133,10 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
 
         private void LogTelemetryEvent(bool value, [CallerMemberName] string moduleName = null )
         {
-            var dataEvent = new SettingsEnabledModuleEvent()
+            var dataEvent = new SettingsEnabledEvent()
             {
                 Value = value,
-                ModuleName = moduleName,
+                Name = moduleName,
             };
             PowerToysTelemetry.Log.WriteEvent(dataEvent);
         }

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/PowerPreviewProperties.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/PowerPreviewProperties.cs
@@ -2,6 +2,9 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.PowerToys.Settings.Telemetry;
+using Microsoft.PowerToys.Telemetry;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -9,21 +12,58 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
 {
     public class PowerPreviewProperties
     {
+
         [JsonPropertyName("svg-previewer-toggle-setting")]
-        public BoolProperty EnableSvg { get; set; }
+        private BoolProperty EnableSvgInner { get; set; }
+
+        public bool EnableSvg
+        {
+            get => this.EnableSvgInner.Value;
+            set
+            {
+                if (value != this.EnableSvgInner.Value)
+                {
+                    LogTelemetryEvent(value);
+                    this.EnableSvgInner.Value = value;
+                }
+            }
+        }
 
         [JsonPropertyName("md-previewer-toggle-setting")]
-        public BoolProperty EnableMd { get; set; }
+        private BoolProperty EnableMdInner { get; set; }
+
+        public bool EnableMd
+        {
+            get => this.EnableMdInner.Value;
+            set
+            {
+                if (value != this.EnableMdInner.Value)
+                {
+                    LogTelemetryEvent(value);
+                    this.EnableMdInner.Value = value;
+                }
+            }
+        }
 
         public PowerPreviewProperties()
         {
-            EnableSvg = new BoolProperty();
-            EnableMd = new BoolProperty();
+            EnableSvgInner = new BoolProperty(true);
+            EnableMdInner = new BoolProperty(true);
         }
 
         public override string ToString()
         {
             return JsonSerializer.Serialize(this);
+        }
+
+        private void LogTelemetryEvent(bool value, [CallerMemberName] string propertyName = null)
+        {
+            var dataEvent = new SettingsEnabledEvent()
+            {
+                Value = value,
+                Name = propertyName,
+            };
+            PowerToysTelemetry.Log.WriteEvent(dataEvent);
         }
     }
 }

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/PowerPreviewProperties.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/PowerPreviewProperties.cs
@@ -2,53 +2,53 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.PowerToys.Settings.Telemetry;
-using Microsoft.PowerToys.Telemetry;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Microsoft.PowerToys.Settings.Telemetry;
+using Microsoft.PowerToys.Telemetry;
 
 namespace Microsoft.PowerToys.Settings.UI.Lib
 {
     public class PowerPreviewProperties
     {
+        private bool enableSvg = true;
 
         [JsonPropertyName("svg-previewer-toggle-setting")]
-        private BoolProperty EnableSvgInner { get; set; }
-
+        [JsonConverter(typeof(BoolPropertyJsonConverter))]
         public bool EnableSvg
         {
-            get => this.EnableSvgInner.Value;
+            get => this.enableSvg;
             set
             {
-                if (value != this.EnableSvgInner.Value)
+                if (value != this.enableSvg)
                 {
                     LogTelemetryEvent(value);
-                    this.EnableSvgInner.Value = value;
+                    this.enableSvg = value;
                 }
             }
         }
 
-        [JsonPropertyName("md-previewer-toggle-setting")]
-        private BoolProperty EnableMdInner { get; set; }
+        private bool enableMd = true;
 
+        [JsonPropertyName("md-previewer-toggle-setting")]
+        [JsonConverter(typeof(BoolPropertyJsonConverter))]
         public bool EnableMd
         {
-            get => this.EnableMdInner.Value;
+            get => this.enableMd;
             set
             {
-                if (value != this.EnableMdInner.Value)
+                if (value != this.enableMd)
                 {
                     LogTelemetryEvent(value);
-                    this.EnableMdInner.Value = value;
+                    this.enableMd = value;
                 }
             }
         }
 
         public PowerPreviewProperties()
         {
-            EnableSvgInner = new BoolProperty(true);
-            EnableMdInner = new BoolProperty(true);
+
         }
 
         public override string ToString()

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/Telemetry/Events/SettingsEnabledEvent.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/Telemetry/Events/SettingsEnabledEvent.cs
@@ -3,9 +3,9 @@
 namespace Microsoft.PowerToys.Settings.Telemetry
 {
     [EventData]
-    public class SettingsEnabledModuleEvent
+    public class SettingsEnabledEvent
     {
-        public string ModuleName { get; set; }
+        public string Name { get; set; }
 
         public bool Value { get; set; }
     }

--- a/src/core/Microsoft.PowerToys.Settings.UI/ViewModels/PowerPreviewViewModel.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/ViewModels/PowerPreviewViewModel.cs
@@ -27,8 +27,8 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 SettingsUtils.SaveSettings(Settings.ToJsonString(), ModuleName);
             }
 
-            this._svgRenderIsEnabled = Settings.properties.EnableSvg.Value;
-            this._mdRenderIsEnabled = Settings.properties.EnableMd.Value;
+            this._svgRenderIsEnabled = Settings.properties.EnableSvg;
+            this._mdRenderIsEnabled = Settings.properties.EnableMd;
         }
 
         private bool _svgRenderIsEnabled = false;
@@ -46,7 +46,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 if (value != _svgRenderIsEnabled)
                 {
                     _svgRenderIsEnabled = value;
-                    Settings.properties.EnableSvg.Value = value;
+                    Settings.properties.EnableSvg = value;
                     RaisePropertyChanged();
                 }
             }
@@ -64,7 +64,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 if (value != _mdRenderIsEnabled)
                 {
                     _mdRenderIsEnabled = value;
-                    Settings.properties.EnableMd.Value = value;
+                    Settings.properties.EnableMd = value;
                     RaisePropertyChanged();
                 }
             }

--- a/src/core/Microsoft.PowerToys.Settings.UnitTest/ViewModelTests/PowerPreview.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UnitTest/ViewModelTests/PowerPreview.cs
@@ -59,7 +59,7 @@ namespace ViewModelTests
             ShellPage.DefaultSndMSGCallback = msg =>
             {
                 SndModuleSettings<SndPowerPreviewSettings> snd = JsonSerializer.Deserialize<SndModuleSettings<SndPowerPreviewSettings>>(msg);
-                Assert.IsTrue(snd.powertoys.FileExplorerPreviewSettings.properties.EnableSvg.Value);
+                Assert.IsTrue(snd.powertoys.FileExplorerPreviewSettings.properties.EnableSvg);
             };
 
             // act
@@ -76,7 +76,7 @@ namespace ViewModelTests
             ShellPage.DefaultSndMSGCallback = msg =>
             {
                 SndModuleSettings<SndPowerPreviewSettings> snd = JsonSerializer.Deserialize<SndModuleSettings<SndPowerPreviewSettings>>(msg);
-                Assert.IsTrue(snd.powertoys.FileExplorerPreviewSettings.properties.EnableMd.Value);
+                Assert.IsTrue(snd.powertoys.FileExplorerPreviewSettings.properties.EnableMd);
             };
 
             // act


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR does the following. 
1) Enables svg and markdown preview by default. 
2) Raises telemetry events when enabling or disabling the markdown. 

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2060, #2745 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
The following considerations were made in this PR
1) To be backwards compatible with .17 we need to serialize and deserialize as a BoolProperty.   I've added a BoolPropertyJsonConverter to serialize and deserialize bool Properties as the `BoolProperty` type.
2) Because we want to detect when the EnableSvg and EnableMarkdown properties are set we don't want to expose this type to calling methods.  Eg. `Settings.properties.EnableSvg.Value = value;` becomes `Settings.properties.EnableMd = value;` and we don't interact with the BoolProperty directly. 

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Installed .17: 
- Verified that the settings are loaded into settings v2. 

Toggling EnableSvg and EnableMarkdown settings and verified. 
1) Telemetry Events are fired for both. 
2) Settings are serialized in the same format: 

Comparison of .17 settings and settngs v2: 
*.17*
![image](https://user-images.githubusercontent.com/56318517/81447266-306b8800-9131-11ea-8926-2a54fe812d5a.png)
*.18*
![image](https://user-images.githubusercontent.com/56318517/81447332-4f6a1a00-9131-11ea-9c58-1218ba90ac78.png)

*Note* name appears in a different order, but this is still equivalent from a json perspective

WPA Events: 
![image](https://user-images.githubusercontent.com/56318517/81447557-b4be0b00-9131-11ea-9b38-2d31d53618ef.png)
