### PR TITLE
[FancyZones] Make zone positions in priority grid layout consistent

### DIFF
--- a/src/modules/fancyzones/lib/ZoneSet.cpp
+++ b/src/modules/fancyzones/lib/ZoneSet.cpp
@@ -171,7 +171,7 @@ IFACEMETHODIMP ZoneSet::AddZone(winrt::com_ptr<IZone> zone, int id = -1) noexcep
 {
     if (id > m_zones.size())
     {
-		m_zones.emplace_back(zone);
+        m_zones.emplace_back(zone);
     }
     else
     {
@@ -180,7 +180,7 @@ IFACEMETHODIMP ZoneSet::AddZone(winrt::com_ptr<IZone> zone, int id = -1) noexcep
     }
     // Important not to set Id 0 since we store it in the HWND using SetProp.
     // SetProp(0) doesn't really work.
-	zone->SetId(id == -1 ? m_zones.size() : id + 1);
+    zone->SetId(id == -1 ? m_zones.size() : id + 1);
     return S_OK;
 }
 

--- a/src/modules/fancyzones/lib/ZoneSet.cpp
+++ b/src/modules/fancyzones/lib/ZoneSet.cpp
@@ -42,63 +42,77 @@ namespace
             .columns = 3,
             .rowsPercents = { 10000 },
             .columnsPercents = { 2500, 5000, 2500 },
-            .cellChildMap = { { 0, 1, 2 } } }),
+            .cellChildMap = { { 2, 0, 1 } } }),
         /* 4 */
         JSONHelpers::GridLayoutInfo(JSONHelpers::GridLayoutInfo::Full{
             .rows = 2,
             .columns = 3,
             .rowsPercents = { 5000, 5000 },
             .columnsPercents = { 2500, 5000, 2500 },
-            .cellChildMap = { { 0, 1, 2 }, { 0, 1, 3 } } }),
+            .cellChildMap = { { 2, 0, 1 }, 
+                              { 2, 0, 3 } } }),
         /* 5 */
         JSONHelpers::GridLayoutInfo(JSONHelpers::GridLayoutInfo::Full{
             .rows = 2,
             .columns = 3,
             .rowsPercents = { 5000, 5000 },
             .columnsPercents = { 2500, 5000, 2500 },
-            .cellChildMap = { { 0, 1, 2 }, { 3, 1, 4 } } }),
+            .cellChildMap = { { 2, 0, 1 }, 
+                              { 4, 0, 3 } } }),
         /* 6 */
         JSONHelpers::GridLayoutInfo(JSONHelpers::GridLayoutInfo::Full{
             .rows = 3,
             .columns = 3,
             .rowsPercents = { 3333, 3334, 3333 },
             .columnsPercents = { 2500, 5000, 2500 },
-            .cellChildMap = { { 0, 1, 2 }, { 0, 1, 3 }, { 4, 1, 5 } } }),
+            .cellChildMap = { { 2, 0, 1 }, 
+                              { 2, 0, 3 }, 
+                              { 4, 0, 5 } } }),
         /* 7 */
         JSONHelpers::GridLayoutInfo(JSONHelpers::GridLayoutInfo::Full{
             .rows = 3,
             .columns = 3,
             .rowsPercents = { 3333, 3334, 3333 },
             .columnsPercents = { 2500, 5000, 2500 },
-            .cellChildMap = { { 0, 1, 2 }, { 3, 1, 4 }, { 5, 1, 6 } } }),
+            .cellChildMap = { { 2, 0, 1 }, 
+                              { 4, 0, 3 }, 
+                              { 6, 0, 5 } } }),
         /* 8 */
         JSONHelpers::GridLayoutInfo(JSONHelpers::GridLayoutInfo::Full{
             .rows = 3,
             .columns = 4,
             .rowsPercents = { 3333, 3334, 3333 },
             .columnsPercents = { 2500, 2500, 2500, 2500 },
-            .cellChildMap = { { 0, 1, 2, 3 }, { 4, 1, 2, 5 }, { 6, 1, 2, 7 } } }),
+            .cellChildMap = { { 2, 0, 7, 1 }, 
+                              { 4, 0, 7, 3 }, 
+                              { 6, 0, 7, 5 } } }),
         /* 9 */
         JSONHelpers::GridLayoutInfo(JSONHelpers::GridLayoutInfo::Full{
             .rows = 3,
             .columns = 4,
             .rowsPercents = { 3333, 3334, 3333 },
             .columnsPercents = { 2500, 2500, 2500, 2500 },
-            .cellChildMap = { { 0, 1, 2, 3 }, { 4, 1, 2, 5 }, { 6, 1, 7, 8 } } }),
+            .cellChildMap = { { 2, 0, 7, 1 }, 
+                              { 4, 0, 7, 3 }, 
+                              { 6, 0, 8, 5 } } }),
         /* 10 */
         JSONHelpers::GridLayoutInfo(JSONHelpers::GridLayoutInfo::Full{
             .rows = 3,
             .columns = 4,
             .rowsPercents = { 3333, 3334, 3333 },
             .columnsPercents = { 2500, 2500, 2500, 2500 },
-            .cellChildMap = { { 0, 1, 2, 3 }, { 4, 1, 5, 6 }, { 7, 1, 8, 9 } } }),
+            .cellChildMap = { { 2, 0, 7, 1 }, 
+                              { 4, 0, 8, 3 }, 
+                              { 6, 0, 9, 5 } } }),
         /* 11 */
         JSONHelpers::GridLayoutInfo(JSONHelpers::GridLayoutInfo::Full{
             .rows = 3,
             .columns = 4,
             .rowsPercents = { 3333, 3334, 3333 },
             .columnsPercents = { 2500, 2500, 2500, 2500 },
-            .cellChildMap = { { 0, 1, 2, 3 }, { 4, 1, 5, 6 }, { 7, 8, 9, 10 } } }),
+            .cellChildMap = { { 2, 0,  7, 1 }, 
+                              { 4, 0,  8, 3 }, 
+                              { 6, 10, 9, 5 } } }),
     };
 }
 
@@ -120,7 +134,7 @@ public:
     Id() noexcept { return m_config.Id; }
     IFACEMETHODIMP_(JSONHelpers::ZoneSetLayoutType)
     LayoutType() noexcept { return m_config.LayoutType; }
-    IFACEMETHODIMP AddZone(winrt::com_ptr<IZone> zone) noexcept;
+    IFACEMETHODIMP AddZone(winrt::com_ptr<IZone> zone, int id) noexcept;
     IFACEMETHODIMP_(std::vector<int>)
     ZonesFromPoint(POINT pt) noexcept;
     IFACEMETHODIMP_(int)
@@ -153,13 +167,20 @@ private:
     ZoneSetConfig m_config;
 };
 
-IFACEMETHODIMP ZoneSet::AddZone(winrt::com_ptr<IZone> zone) noexcept
+IFACEMETHODIMP ZoneSet::AddZone(winrt::com_ptr<IZone> zone, int id = -1) noexcept
 {
-    m_zones.emplace_back(zone);
-
+    if (id > m_zones.size())
+    {
+		m_zones.emplace_back(zone);
+    }
+    else
+    {
+        auto pos = m_zones.begin() + id;
+        m_zones.insert(pos, zone);
+    }
     // Important not to set Id 0 since we store it in the HWND using SetProp.
     // SetProp(0) doesn't really work.
-    zone->SetId(m_zones.size());
+	zone->SetId(id == -1 ? m_zones.size() : id + 1);
     return S_OK;
 }
 
@@ -705,7 +726,7 @@ bool ZoneSet::CalculateGridZones(Rect workArea, JSONHelpers::GridLayoutInfo grid
                     success = false;
                 }
 
-                AddZone(MakeZone(RECT{ left, top, right, bottom }));
+                AddZone(MakeZone(RECT{ left, top, right, bottom }), i);
             }
         }
     }

--- a/src/modules/fancyzones/lib/ZoneSet.h
+++ b/src/modules/fancyzones/lib/ZoneSet.h
@@ -22,7 +22,7 @@ interface __declspec(uuid("{E4839EB7-669D-49CF-84A9-71A2DFD851A3}")) IZoneSet : 
      *
      * @param   zone Zone object (defining coordinates of the zone).
      */
-    IFACEMETHOD(AddZone)(winrt::com_ptr<IZone> zone) = 0;
+    IFACEMETHOD(AddZone)(winrt::com_ptr<IZone> zone, int id = -1) = 0;
     /**
      * Get zones from cursor coordinates.
      *


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Updated cellChildMaps for priority grid layout such that zones stay in the same location as the number of zones is increased or decreased.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #1890 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [] Tests added/passed
* [] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
The definition for the _IZoneSet_ interface was updated but in a way that should not impact any existing code. An overload param with default value was added to the existing AddZone method for use with the grid and priority grid layouts.

I didn't want to change the actual arrangement of zones in any way as this would require changes in the fancy zones editor to be made as well.

I feel as though above 7 zones the defined layouts may be inideal for most users. I only really imagine users with ultrawide monitors ever using this and some of the decisions such as there being 4 even rows don't seem desireable. Perhaps the userbase should be surveyed on this feature. 

That being said, it seems like some future work in the pipeline may invalidate this layout completely, what's the point in a priority zone that's two rows wide when you can stretch a window across multiple zones?

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Went from 0 zones to max with the _keep windows in zones when the layout changes_ option enabled to ensure that windows stay in the correct region of the screen.
