### PR TITLE
Hide xaml island loading icon for Settings and Launcher

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI/App.xaml.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/App.xaml.cs
@@ -4,7 +4,6 @@
 
 using System.Runtime.InteropServices;
 using Microsoft.Toolkit.Win32.UI.XamlHost;
-using WUC = Windows.UI.Core;
 
 namespace Microsoft.PowerToys.Settings.UI
 {
@@ -20,7 +19,7 @@ namespace Microsoft.PowerToys.Settings.UI
 
     internal static class Interop
     {
-        public static ICoreWindowInterop GetInterop(this WUC.CoreWindow @this)
+        public static ICoreWindowInterop GetInterop(this Windows.UI.Core.CoreWindow @this)
         {
             var unkIntPtr = Marshal.GetIUnknownForObject(@this);
             try
@@ -49,7 +48,7 @@ namespace Microsoft.PowerToys.Settings.UI
             Initialize();
 
             // Hide the Xaml Island window
-            var coreWindow = WUC.CoreWindow.GetForCurrentThread();
+            var coreWindow = Windows.UI.Core.CoreWindow.GetForCurrentThread();
             var coreWindowInterop = Interop.GetInterop(coreWindow);
             Interop.ShowWindow(coreWindowInterop.WindowHandle, Interop.SW_HIDE);
         }

--- a/src/core/Microsoft.PowerToys.Settings.UI/App.xaml.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/App.xaml.cs
@@ -2,15 +2,56 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.InteropServices;
 using Microsoft.Toolkit.Win32.UI.XamlHost;
+using WUC = Windows.UI.Core;
 
 namespace Microsoft.PowerToys.Settings.UI
 {
+    [ComImport]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    [Guid("45D64A29-A63E-4CB6-B498-5781D298CB4F")]
+    internal interface ICoreWindowInterop
+    {
+        System.IntPtr WindowHandle { get; }
+
+        void MessageHandled(bool value);
+    }
+
+    internal static class Interop
+    {
+        public static ICoreWindowInterop GetInterop(this WUC.CoreWindow @this)
+        {
+            var unkIntPtr = Marshal.GetIUnknownForObject(@this);
+            try
+            {
+                var interopObj = Marshal.GetTypedObjectForIUnknown(unkIntPtr, typeof(ICoreWindowInterop)) as ICoreWindowInterop;
+                return interopObj;
+            }
+            finally
+            {
+                Marshal.Release(unkIntPtr);
+                unkIntPtr = System.IntPtr.Zero;
+            }
+        }
+
+
+        [DllImport("user32.dll")]
+        public static extern bool ShowWindow(System.IntPtr hWnd, int nCmdShow);
+
+        public const int SW_HIDE = 0;
+    }
+
     public sealed partial class App : XamlApplication
     {
         public App()
         {
             Initialize();
+
+            // Hide the Xaml Island window
+            var coreWindow = WUC.CoreWindow.GetForCurrentThread();
+            var coreWindowInterop = Interop.GetInterop(coreWindow);
+            Interop.ShowWindow(coreWindowInterop.WindowHandle, Interop.SW_HIDE);
         }
     }
 }

--- a/src/modules/launcher/PowerLauncher.UI/App.xaml.cs
+++ b/src/modules/launcher/PowerLauncher.UI/App.xaml.cs
@@ -1,5 +1,4 @@
 ﻿using System.Runtime.InteropServices;
-using WUC = Windows.UI.Core;
 
 namespace PowerLauncher.UI
 {
@@ -15,7 +14,7 @@ namespace PowerLauncher.UI
 
     internal static class Interop
     {
-        public static ICoreWindowInterop GetInterop(this WUC.CoreWindow @this)
+        public static ICoreWindowInterop GetInterop(this Windows.UI.Core.CoreWindow @this)
         {
             var unkIntPtr = Marshal.GetIUnknownForObject(@this);
             try
@@ -44,7 +43,7 @@ namespace PowerLauncher.UI
             this.Initialize();
 
             // Hide the Xaml Island window
-            var coreWindow = WUC.CoreWindow.GetForCurrentThread();
+            var coreWindow = Windows.UI.Core.CoreWindow.GetForCurrentThread();
             var coreWindowInterop = Interop.GetInterop(coreWindow);
             Interop.ShowWindow(coreWindowInterop.WindowHandle, Interop.SW_HIDE);
         }

--- a/src/modules/launcher/PowerLauncher.UI/App.xaml.cs
+++ b/src/modules/launcher/PowerLauncher.UI/App.xaml.cs
@@ -1,10 +1,52 @@
-﻿namespace PowerLauncher.UI
+﻿using System.Runtime.InteropServices;
+using WUC = Windows.UI.Core;
+
+namespace PowerLauncher.UI
 {
+    [ComImport]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    [Guid("45D64A29-A63E-4CB6-B498-5781D298CB4F")]
+    internal interface ICoreWindowInterop
+    {
+        System.IntPtr WindowHandle { get; }
+
+        void MessageHandled(bool value);
+    }
+
+    internal static class Interop
+    {
+        public static ICoreWindowInterop GetInterop(this WUC.CoreWindow @this)
+        {
+            var unkIntPtr = Marshal.GetIUnknownForObject(@this);
+            try
+            {
+                var interopObj = Marshal.GetTypedObjectForIUnknown(unkIntPtr, typeof(ICoreWindowInterop)) as ICoreWindowInterop;
+                return interopObj;
+            }
+            finally
+            {
+                Marshal.Release(unkIntPtr);
+                unkIntPtr = System.IntPtr.Zero;
+            }
+        }
+
+
+        [DllImport("user32.dll")]
+        public static extern bool ShowWindow(System.IntPtr hWnd, int nCmdShow);
+
+        public const int SW_HIDE = 0;
+    }
+
     public sealed partial class App : Microsoft.Toolkit.Win32.UI.XamlHost.XamlApplication
     {
         public App()
         {
             this.Initialize();
+
+            // Hide the Xaml Island window
+            var coreWindow = WUC.CoreWindow.GetForCurrentThread();
+            var coreWindowInterop = Interop.GetInterop(coreWindow);
+            Interop.ShowWindow(coreWindowInterop.WindowHandle, Interop.SW_HIDE);
         }
     }
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR hides the loading icon which appears for the Settings and Launcher xaml island projects. After these changes an icon symbol still quickly appears and then disappears but it's for a couple of milliseconds.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Applies to #xxx
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
- Once the XamlApplication has been initialized we get the CoreWindow and set it's window state to SW_HIDE as suggested by @ocalvo 

