### PR TITLE
[Settings] Updated text shown on the settings page of Shortcut Guide

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -434,6 +434,9 @@
   <data name="ShortcutGuide_OverlayOpacity.Header" xml:space="preserve">
     <value>Opacity of background (%)</value>
   </data>
+  <data name="ShortcutGuide_Theme.Header" xml:space="preserve">
+    <value>Choose Shortcut Guide overlay color</value>
+  </data>
   <data name="ImageResizer_CustomSizes.Text" xml:space="preserve">
     <value>Image Sizes</value>
   </data>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ShortcutGuidePage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ShortcutGuidePage.xaml
@@ -68,7 +68,7 @@
                     IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"/>
 
 
-            <muxc:RadioButtons x:Uid="RadioButtons_Name_Theme" 
+            <muxc:RadioButtons x:Uid="ShortcutGuide_Theme"
                                Margin="{StaticResource SmallTopMargin}"
                                IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"
                                SelectedIndex="{ Binding Mode=TwoWay, Path=ThemeIndex}">


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This PR changes the text shown on the settings page of Shortcut guide from 'Choose Settings color' to 'Choose Shortcut Guide overlay color', as it used to be in 0.17.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

#2839

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2839
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Built the solution and verified that both the text on the General page and Shortcut Guide page are correct, as they used the same resource string before.