### PR TITLE
Fix inconsistent landing page remap list

### DIFF
--- a/src/common/interop/interop.h
+++ b/src/common/interop/interop.h
@@ -6,6 +6,7 @@
 #include "..\keyboard_layout.h"
 #include "..\two_way_pipe_message_ipc.h"
 #include "..\common.h"
+#include "..\shared_constants.h"
 
 using namespace System;
 using namespace System::Runtime::InteropServices;
@@ -113,5 +114,12 @@ public
         {
             return gcnew String(get_product_version().c_str());
         } 
+    };
+
+    public
+    ref class Constants
+    {
+    public:
+        literal int VK_WIN_BOTH = CommonSharedConstants::VK_WIN_BOTH;
     };
 }

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/Utilities/Helper.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/Utilities/Helper.cs
@@ -117,5 +117,7 @@ namespace Microsoft.PowerToys.Settings.UI.Lib.Utilities
                 throw new FormatException("Bad product version format");
             }
         }
+
+        public const uint VirtualKeyWindows = interop.Constants.VK_WIN_BOTH;
     }
 }

--- a/src/modules/keyboardmanager/ui/EditKeyboardWindow.cpp
+++ b/src/modules/keyboardmanager/ui/EditKeyboardWindow.cpp
@@ -106,6 +106,32 @@ static IAsyncAction OnClickAccept(KeyboardManagerState& keyboardManagerState, Xa
     }
     ApplyRemappings();
 }
+
+// Function to pre process the remap table before loading it into the UI
+void CombineRemappings(std::unordered_map<DWORD, DWORD>& table, DWORD leftKey, DWORD rightKey, DWORD combinedKey)
+{
+    if (table.find(leftKey) != table.end() && table.find(rightKey) != table.end())
+    {
+        // If they are mapped to the same key, delete those entries and set the common version
+        if (table[leftKey] == table[rightKey])
+        {
+            table[combinedKey] = table[leftKey];
+            table.erase(leftKey);
+            table.erase(rightKey);
+        }
+    }
+}
+
+// Function to pre process the remap table before loading it into the UI
+void PreProcessRemapTable(std::unordered_map<DWORD, DWORD>& table)
+{
+    // Pre process the table to combine L and R versions of Ctrl/Alt/Shift/Win that are mapped to the same key
+    CombineRemappings(table, VK_LCONTROL, VK_RCONTROL, VK_CONTROL);
+    CombineRemappings(table, VK_LMENU, VK_RMENU, VK_MENU);
+    CombineRemappings(table, VK_LSHIFT, VK_RSHIFT, VK_SHIFT);
+    CombineRemappings(table, VK_LWIN, VK_RWIN, CommonSharedConstants::VK_WIN_BOTH);
+}
+
 // Function to create the Edit Keyboard Window
 void createEditKeyboardWindow(HINSTANCE hInst, KeyboardManagerState& keyboardManagerState)
 {
@@ -265,48 +291,7 @@ void createEditKeyboardWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMan
     std::unique_lock<std::mutex> lock(keyboardManagerState.singleKeyReMap_mutex);
     std::unordered_map<DWORD, DWORD> singleKeyRemapCopy = keyboardManagerState.singleKeyReMap;
     lock.unlock();
-
-    // Pre process the table to combine L and R versions of Ctrl/Alt/Shift/Win that are mapped to the same key
-    if (singleKeyRemapCopy.find(VK_LCONTROL) != singleKeyRemapCopy.end() && singleKeyRemapCopy.find(VK_RCONTROL) != singleKeyRemapCopy.end())
-    {
-        // If they are mapped to the same key, delete those entries and set the common version
-        if (singleKeyRemapCopy[VK_LCONTROL] == singleKeyRemapCopy[VK_RCONTROL])
-        {
-            singleKeyRemapCopy[VK_CONTROL] = singleKeyRemapCopy[VK_LCONTROL];
-            singleKeyRemapCopy.erase(VK_LCONTROL);
-            singleKeyRemapCopy.erase(VK_RCONTROL);
-        }
-    }
-    if (singleKeyRemapCopy.find(VK_LMENU) != singleKeyRemapCopy.end() && singleKeyRemapCopy.find(VK_RMENU) != singleKeyRemapCopy.end())
-    {
-        // If they are mapped to the same key, delete those entries and set the common version
-        if (singleKeyRemapCopy[VK_LMENU] == singleKeyRemapCopy[VK_RMENU])
-        {
-            singleKeyRemapCopy[VK_MENU] = singleKeyRemapCopy[VK_LMENU];
-            singleKeyRemapCopy.erase(VK_LMENU);
-            singleKeyRemapCopy.erase(VK_RMENU);
-        }
-    }
-    if (singleKeyRemapCopy.find(VK_LSHIFT) != singleKeyRemapCopy.end() && singleKeyRemapCopy.find(VK_RSHIFT) != singleKeyRemapCopy.end())
-    {
-        // If they are mapped to the same key, delete those entries and set the common version
-        if (singleKeyRemapCopy[VK_LSHIFT] == singleKeyRemapCopy[VK_RSHIFT])
-        {
-            singleKeyRemapCopy[VK_SHIFT] = singleKeyRemapCopy[VK_LSHIFT];
-            singleKeyRemapCopy.erase(VK_LSHIFT);
-            singleKeyRemapCopy.erase(VK_RSHIFT);
-        }
-    }
-    if (singleKeyRemapCopy.find(VK_LWIN) != singleKeyRemapCopy.end() && singleKeyRemapCopy.find(VK_RWIN) != singleKeyRemapCopy.end())
-    {
-        // If they are mapped to the same key, delete those entries and set the common version
-        if (singleKeyRemapCopy[VK_LWIN] == singleKeyRemapCopy[VK_RWIN])
-        {
-            singleKeyRemapCopy[CommonSharedConstants::VK_WIN_BOTH] = singleKeyRemapCopy[VK_LWIN];
-            singleKeyRemapCopy.erase(VK_LWIN);
-            singleKeyRemapCopy.erase(VK_RWIN);
-        }
-    }
+    PreProcessRemapTable(singleKeyRemapCopy);
 
     for (const auto& it : singleKeyRemapCopy)
     {

--- a/src/modules/keyboardmanager/ui/EditKeyboardWindow.cpp
+++ b/src/modules/keyboardmanager/ui/EditKeyboardWindow.cpp
@@ -107,7 +107,7 @@ static IAsyncAction OnClickAccept(KeyboardManagerState& keyboardManagerState, Xa
     ApplyRemappings();
 }
 
-// Function to pre process the remap table before loading it into the UI
+// Function to combine remappings if the L and R version of the modifier is mapped to the same key
 void CombineRemappings(std::unordered_map<DWORD, DWORD>& table, DWORD leftKey, DWORD rightKey, DWORD combinedKey)
 {
     if (table.find(leftKey) != table.end() && table.find(rightKey) != table.end())


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR adds the same preprocessing for the remapped keys list on the landing page as done on the C++ side. In the C++ side of the code, to make key handling easier since "VK_CONTROL" is never actually sent as a key message, it was decided that if a user remaps Ctrl_Left and Ctrl_Right to the same key then we combine it as Ctrl has been remapped, and similarly for all modifiers. However this was not reflected on the landing page.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Applies to #2783 (Closes #2783)
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLAx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
- Restructured the C++ side of the logic to be clean and readable with code re-use.
- Added a Constants class to the interop namespace in order to access constants from common.
- Added this constant from interop to the Helper class in Lib.Utilities
- Duplicated the C++ preprocessing logic in the LoadProfile function on the C# side. I did not use it through interop since I wasn't comfortable with moving it there since on the C++ side we manipulate an unordered_map but on the C# side we have to manipulate a list.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Tried adding L and R versions of modifiers and verified that the appear as expected when remapped to different keys and when remapped to the same key.
