### PR TITLE
Close KBM windows if the user disable KBM from Settings

### DIFF
--- a/src/modules/keyboardmanager/common/KeyboardManagerConstants.h
+++ b/src/modules/keyboardmanager/common/KeyboardManagerConstants.h
@@ -56,7 +56,7 @@ namespace KeyboardManagerConstants
     inline const long RemapTableArrowColIndex = 1;
     inline const long RemapTableNewColIndex = 2;
     inline const long RemapTableRemoveColIndex = 3;
-    inline const long RemapTableDropDownWidth = 110;
+    inline const DWORD RemapTableDropDownWidth = 110;
 
     // Shortcut table constants
     inline const long ShortcutTableColCount = 4;
@@ -65,14 +65,14 @@ namespace KeyboardManagerConstants
     inline const long ShortcutTableArrowColIndex = 1;
     inline const long ShortcutTableNewColIndex = 2;
     inline const long ShortcutTableRemoveColIndex = 3;
-    inline const long ShortcutTableDropDownWidth = 110;
-    inline const long ShortcutTableDropDownSpacing = 10;
+    inline const DWORD ShortcutTableDropDownWidth = 110;
+    inline const DWORD ShortcutTableDropDownSpacing = 10;
 
     // Drop down height used for both Edit Keyboard and Edit Shortcuts
-    inline const long TableDropDownHeight = 200;
-    inline const long TableArrowColWidth = 20;
-    inline const long TableRemoveColWidth = 20;
-    inline const long TableWarningColWidth = 20;
+    inline const DWORD TableDropDownHeight = 200;
+    inline const DWORD TableArrowColWidth = 20;
+    inline const DWORD TableRemoveColWidth = 20;
+    inline const DWORD TableWarningColWidth = 20;
 
     // Shared style constants for both Remap Table and Shortcut Table
     inline const double HeaderButtonWidth = 100;

--- a/src/modules/keyboardmanager/dll/dllmain.cpp
+++ b/src/modules/keyboardmanager/dll/dllmain.cpp
@@ -279,6 +279,9 @@ public:
         m_enabled = false;
         // Log telemetry
         Trace::EnableKeyboardManager(false);
+        // Close active windows
+        CloseActiveEditKeyboardWindow();
+        CloseActiveEditShortcutsWindow();
         // Stop keyboard hook
         stop_lowlevel_keyboard_hook();
     }

--- a/src/modules/keyboardmanager/ui/EditKeyboardWindow.cpp
+++ b/src/modules/keyboardmanager/ui/EditKeyboardWindow.cpp
@@ -147,12 +147,12 @@ void createEditKeyboardWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMan
         windowClass.hInstance = hInst;
         windowClass.lpszClassName = szWindowClass;
         windowClass.hbrBackground = (HBRUSH)(COLOR_WINDOW);
-        windowClass.hIcon = (HICON) LoadImageW(
-            windowClass.hInstance, 
-            MAKEINTRESOURCE(IDS_KEYBOARDMANAGER_ICON), 
-            IMAGE_ICON, 
-            48, 
-            48, 
+        windowClass.hIcon = (HICON)LoadImageW(
+            windowClass.hInstance,
+            MAKEINTRESOURCE(IDS_KEYBOARDMANAGER_ICON),
+            IMAGE_ICON,
+            48,
+            48,
             LR_DEFAULTCOLOR);
         if (RegisterClassEx(&windowClass) == NULL)
         {
@@ -175,7 +175,7 @@ void createEditKeyboardWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMan
     HWND _hWndEditKeyboardWindow = CreateWindow(
         szWindowClass,
         L"Remap Keyboard",
-        WS_OVERLAPPEDWINDOW | WS_VISIBLE,
+        WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_THICKFRAME | WS_MAXIMIZEBOX,
         (desktopRect.right / 2) - (windowWidth / 2),
         (desktopRect.bottom / 2) - (windowHeight / 2),
         windowWidth,
@@ -492,4 +492,14 @@ bool CheckEditKeyboardWindowActive()
     }
 
     return result;
+}
+
+// Function to close any active Edit Keyboard window
+void CloseActiveEditKeyboardWindow()
+{
+    std::unique_lock<std::mutex> hwndLock(editKeyboardWindowMutex);
+    if (hwndEditKeyboardNativeWindow != nullptr)
+    {
+        PostMessage(hwndEditKeyboardNativeWindow, WM_CLOSE, 0, 0);
+    }
 }

--- a/src/modules/keyboardmanager/ui/EditKeyboardWindow.h
+++ b/src/modules/keyboardmanager/ui/EditKeyboardWindow.h
@@ -6,3 +6,6 @@ void createEditKeyboardWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMan
 
 // Function to check if there is already a window active if yes bring to foreground
 bool CheckEditKeyboardWindowActive();
+
+// Function to close any active Edit Keyboard window
+void CloseActiveEditKeyboardWindow();

--- a/src/modules/keyboardmanager/ui/EditShortcutsWindow.cpp
+++ b/src/modules/keyboardmanager/ui/EditShortcutsWindow.cpp
@@ -61,10 +61,10 @@ void createEditShortcutsWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMa
         windowClass.hbrBackground = (HBRUSH)(COLOR_WINDOW);
         windowClass.hIcon = (HICON)LoadImageW(
             windowClass.hInstance,
-            MAKEINTRESOURCE(IDS_KEYBOARDMANAGER_ICON), 
-            IMAGE_ICON, 
-            48, 
-            48, 
+            MAKEINTRESOURCE(IDS_KEYBOARDMANAGER_ICON),
+            IMAGE_ICON,
+            48,
+            48,
             LR_DEFAULTCOLOR);
         if (RegisterClassEx(&windowClass) == NULL)
         {
@@ -87,7 +87,7 @@ void createEditShortcutsWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMa
     HWND _hWndEditShortcutsWindow = CreateWindow(
         szWindowClass,
         L"Remap Shortcuts",
-        WS_OVERLAPPEDWINDOW | WS_VISIBLE,
+        WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_THICKFRAME | WS_MAXIMIZEBOX,
         (desktopRect.right / 2) - (windowWidth / 2),
         (desktopRect.bottom / 2) - (windowHeight / 2),
         windowWidth,
@@ -376,4 +376,14 @@ bool CheckEditShortcutsWindowActive()
     }
 
     return result;
+}
+
+// Function to close any active Edit Shortcuts window
+void CloseActiveEditShortcutsWindow()
+{
+    std::unique_lock<std::mutex> hwndLock(editShortcutsWindowMutex);
+    if (hwndEditShortcutsNativeWindow != nullptr)
+    {
+        PostMessage(hwndEditShortcutsNativeWindow, WM_CLOSE, 0, 0);
+    }
 }

--- a/src/modules/keyboardmanager/ui/EditShortcutsWindow.h
+++ b/src/modules/keyboardmanager/ui/EditShortcutsWindow.h
@@ -8,3 +8,6 @@ void createEditShortcutsWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMa
 
 // Function to check if there is already a window active if yes bring to foreground
 bool CheckEditShortcutsWindowActive();
+
+// Function to close any active Edit Shortcuts window
+void CloseActiveEditShortcutsWindow();


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR changes the disable behavior such that it closes all active KBM windows. This ensures that users do not see unexpected behavior on disabling KBM but continuing to use the UI since the hook would be disabled.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Applies to #2914 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
- Added functions to close active windows, which are called from dllmain
- Changed some constants data types to fix warnings
- Removed the minimize option from both windows to convey the idea of a dialog box. More details [here](https://docs.microsoft.com/en-us/windows/win32/winmsg/window-styles)

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Verified that behavior is as expected if disabling when windows are open or closed. The one scenario I'm a bit concerned with is if the user clicks OK and then quickly goes and disables the saving to file could get interrupted, but I wasn't able to repro this.
