### PR TITLE
[Settings V2] Remove multiple pop-ups on double tap

### DIFF
--- a/src/runner/settings_window.cpp
+++ b/src/runner/settings_window.cpp
@@ -16,11 +16,10 @@
 #include <common\settings_helpers.cpp>
 #include <os-detect.h>
 
-
 #define BUFSIZE 1024
 
 TwoWayPipeMessageIPC* current_settings_ipc = NULL;
-bool g_isLaunchInProgress = false;
+std::atomic_bool g_isLaunchInProgress = false;
 
 json::JsonObject get_power_toys_settings()
 {
@@ -211,7 +210,6 @@ BOOL run_settings_non_elevated(LPCWSTR executable_path, LPWSTR executable_args, 
 
 
 DWORD g_settings_process_id = 0;
-
 
 void run_settings_window()
 {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
- In the event the runner takes time to launch the Settings UI, and if the user clicks the launch icon again while the runner is in the process of launching the first window, the runner will create another process to launch another settings window. To prevent this, I added a flag to tell if the runner is still launching the first window and to discard any clicks from the launch icon until the first settings window is launched. 

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
https://github.com/microsoft/PowerToys/issues/2900

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2900
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [] Tests added/passed
* [] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #2900

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Added a loop (on line 218) to delay the launching of the first settings UI so the runner can start two processes to launch the settings UI.

```
for (int c = 1; c <= 32767; c++)
{
        for (int d = 1; d <= 32767; d++)
        {
        }
}
```

- Without the flag, on double click, the runner should launch two windows. With the flag, the runner should only launch one window.
