### PR TITLE
[Launcher] Fix Copying of calculator value

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Calculator/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Calculator/Main.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Windows;
 using Mages.Core;
 using Wox.Plugin;
@@ -56,16 +57,23 @@ namespace Microsoft.Plugin.Caculator
                             SubTitle = Context.API.GetTranslation("wox_plugin_calculator_copy_number_to_clipboard"),
                             Action = c =>
                             {
-                                try
+                                var ret = false;
+                                var thread = new Thread(() =>
                                 {
-                                    Clipboard.SetText(result.ToString());
-                                    return true;
-                                }
-                                catch (ExternalException)
-                                {
-                                    MessageBox.Show("Copy failed, please try later");
-                                    return false;
-                                }
+                                    try
+                                    {
+                                        Clipboard.SetText(result.ToString());
+                                        ret = true;
+                                    }
+                                    catch (ExternalException)
+                                    {
+                                        MessageBox.Show("Copy failed, please try later");
+                                    }
+                                });
+                                thread.SetApartmentState(ApartmentState.STA);
+                                thread.Start();
+                                thread.Join();
+                                return ret;
                             }
                         } 
                     };


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
* Fixed the issue by starting a new Thread and setting it to STA.
* Clipboard needs to be accessed from an STA thread https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.clipboard?view=netcore-3.1 (for some reason, this warning appears in the System.Windows.Forms.Clipboard msdn page but not in System.Windows.Clipboard, but it seems both are affected)
* Clipboard opeartions launched from the context menu are not affected because they use the Main application thread and not the Task pool, which is set to STA.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2657
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
1. Launch Launcher and type 1 + 1
2. Click on the result
3. Paste somewhere. It should paste the number 2
