### PR TITLE
KBM - Change behavior to hold enter to accept rather than hold and release

### DIFF
--- a/src/modules/keyboardmanager/ui/EditKeyboardWindow.cpp
+++ b/src/modules/keyboardmanager/ui/EditKeyboardWindow.cpp
@@ -389,8 +389,8 @@ void createEditKeyboardWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMan
     });
 
     header.Children().Append(headerText);
-    header.Children().Append(cancelButton);
     header.Children().Append(applyButton);
+    header.Children().Append(cancelButton);
 
     // Add remap key button
     Windows::UI::Xaml::Controls::Button addRemapKey;

--- a/src/modules/keyboardmanager/ui/EditShortcutsWindow.cpp
+++ b/src/modules/keyboardmanager/ui/EditShortcutsWindow.cpp
@@ -272,8 +272,8 @@ void createEditShortcutsWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMa
     });
 
     header.Children().Append(headerText);
-    header.Children().Append(cancelButton);
     header.Children().Append(applyButton);
+    header.Children().Append(cancelButton);
 
     // Add shortcut button
     Windows::UI::Xaml::Controls::Button addShortcut;

--- a/src/modules/keyboardmanager/ui/ShortcutControl.cpp
+++ b/src/modules/keyboardmanager/ui/ShortcutControl.cpp
@@ -277,7 +277,7 @@ void ShortcutControl::createDetectShortcutWindow(winrt::Windows::Foundation::IIn
     stackPanel.Children().Append(holdEscInfo);
 
     TextBlock holdEnterInfo;
-    holdEnterInfo.Text(L"Hold Enter to apply");
+    holdEnterInfo.Text(L"Hold Enter to continue");
     holdEnterInfo.FontSize(12);
     holdEnterInfo.Margin({ 0, 0, 0, 0 });
     stackPanel.Children().Append(holdEnterInfo);

--- a/src/modules/keyboardmanager/ui/SingleKeyRemapControl.cpp
+++ b/src/modules/keyboardmanager/ui/SingleKeyRemapControl.cpp
@@ -131,11 +131,11 @@ void SingleKeyRemapControl::createDetectKeyWindow(winrt::Windows::Foundation::II
         t2.detach();
     };
 
-    auto onAccept = [linkedRemapDropDown,
-                     detectRemapKeyBox,
-                     &keyboardManagerState,
-                     &singleKeyRemapBuffer,
-                     unregisterKeys] {
+    auto onPressEnter = [linkedRemapDropDown,
+                         detectRemapKeyBox,
+                         &keyboardManagerState,
+                         &singleKeyRemapBuffer,
+                         unregisterKeys] {
         // Save the detected key in the linked text block
         DWORD detectedKey = keyboardManagerState.GetDetectedSingleRemapKey();
 
@@ -150,13 +150,23 @@ void SingleKeyRemapControl::createDetectKeyWindow(winrt::Windows::Foundation::II
                 linkedRemapDropDown.SelectedIndex((int32_t)std::distance(keyCodeList.begin(), it));
             }
         }
+        // Hide the type key UI
+        detectRemapKeyBox.Hide();
+    };
 
+    auto onReleaseEnter = [&keyboardManagerState,
+                           unregisterKeys] {
         // Reset the keyboard manager UI state
         keyboardManagerState.ResetUIState();
         // Revert UI state back to Edit Keyboard window
         keyboardManagerState.SetUIState(KeyboardManagerUIState::EditKeyboardWindowActivated, EditKeyboardWindowHandle);
         unregisterKeys();
-        detectRemapKeyBox.Hide();
+    };
+
+    auto onAccept = [onPressEnter,
+                     onReleaseEnter] {
+        onPressEnter();
+        onReleaseEnter();
     };
 
     TextBlock primaryButtonText;
@@ -173,16 +183,18 @@ void SingleKeyRemapControl::createDetectKeyWindow(winrt::Windows::Foundation::II
     keyboardManagerState.RegisterKeyDelay(
         VK_RETURN,
         std::bind(&KeyboardManagerState::SelectDetectedRemapKey, &keyboardManagerState, std::placeholders::_1),
-        [primaryButton, onAccept, detectRemapKeyBox](DWORD) {
+        [primaryButton, onPressEnter, detectRemapKeyBox](DWORD) {
             detectRemapKeyBox.Dispatcher().RunAsync(
                 Windows::UI::Core::CoreDispatcherPriority::Normal,
-                [primaryButton, onAccept] {
+                [primaryButton, onPressEnter] {
                     // Use the base medium low brush to be consistent with the theme
                     primaryButton.Background(Windows::UI::Xaml::Application::Current().Resources().Lookup(box_value(L"SystemControlBackgroundBaseMediumLowBrush")).as<Windows::UI::Xaml::Media::SolidColorBrush>());
-                    onAccept();
+                    onPressEnter();
                 });
         },
-        nullptr);
+        [onReleaseEnter](DWORD) {
+            onReleaseEnter();
+        });
 
     TextBlock cancelButtonText;
     cancelButtonText.Text(L"Cancel");

--- a/src/modules/keyboardmanager/ui/SingleKeyRemapControl.cpp
+++ b/src/modules/keyboardmanager/ui/SingleKeyRemapControl.cpp
@@ -173,21 +173,16 @@ void SingleKeyRemapControl::createDetectKeyWindow(winrt::Windows::Foundation::II
     keyboardManagerState.RegisterKeyDelay(
         VK_RETURN,
         std::bind(&KeyboardManagerState::SelectDetectedRemapKey, &keyboardManagerState, std::placeholders::_1),
-        [primaryButton, detectRemapKeyBox](DWORD) {
+        [primaryButton, onAccept, detectRemapKeyBox](DWORD) {
             detectRemapKeyBox.Dispatcher().RunAsync(
                 Windows::UI::Core::CoreDispatcherPriority::Normal,
-                [primaryButton] {
+                [primaryButton, onAccept] {
                     // Use the base medium low brush to be consistent with the theme
                     primaryButton.Background(Windows::UI::Xaml::Application::Current().Resources().Lookup(box_value(L"SystemControlBackgroundBaseMediumLowBrush")).as<Windows::UI::Xaml::Media::SolidColorBrush>());
-                });
-        },
-        [onAccept, detectRemapKeyBox](DWORD) {
-            detectRemapKeyBox.Dispatcher().RunAsync(
-                Windows::UI::Core::CoreDispatcherPriority::Normal,
-                [onAccept] {
                     onAccept();
                 });
-        });
+        },
+        nullptr);
 
     TextBlock cancelButtonText;
     cancelButtonText.Text(L"Cancel");

--- a/src/modules/keyboardmanager/ui/SingleKeyRemapControl.cpp
+++ b/src/modules/keyboardmanager/ui/SingleKeyRemapControl.cpp
@@ -252,7 +252,7 @@ void SingleKeyRemapControl::createDetectKeyWindow(winrt::Windows::Foundation::II
     stackPanel.Children().Append(holdEscInfo);
 
     TextBlock holdEnterInfo;
-    holdEnterInfo.Text(L"Hold Enter to apply");
+    holdEnterInfo.Text(L"Hold Enter to continue");
     holdEnterInfo.FontSize(12);
     holdEnterInfo.Margin({ 0, 0, 0, 0 });
     stackPanel.Children().Append(holdEnterInfo);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR changes the type key and type shortcut behavior to hold enter to accept instead of hold and release, so that it is consistent with the Esc behavior. It was also observed that in tab ordering for Remap Keyboard and Remap Shortcuts windows the Cancel key would get highlighted before OK which is not in the Left to Right order, so that has been swapped.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Applies to #2661 (Closes #2661)
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
- The onAccept lambda was split into two parts, onPress and onRelease 
- In onPress we perform all the accept logic followed by `detectKeyBox.hide()` but we do not perform the `ResetUIState` and `unregisterkeys()`
- The resetting of UI state along with disabling the key delay handler is done in onRelease. Because of this, we stop swallowing input only when Enter key is released, and this allows us to avoid the issue where pressing Enter triggers the Type key button again.
- onPress is performed in case of the long press delay handler (along with the primary button color change even though that would appear for just a few milliseconds but the user can notice it)
- onRelease is performed in case of the key release delay handler so that when user lets go of Enter key everything in the KBM state is cleared up
- We define onAccept as onPress followed by onRelease so that primary button click behavior remains unchanged

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Used OK and Cancel options from the type key/shortcut screen by clicking with mouse and also using hold enter and hold esc.
