### PR TITLE
Change Auto-download settings' title

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -537,7 +537,7 @@
     <value>Learn more about administrator mode</value>
   </data>
   <data name="GeneralPage_ToggleSwitch_AutoDownloadUpdates.Header" xml:space="preserve">
-    <value>Download updates automatically (Except on metered connections, where charges may apply)</value>
+    <value>Download updates automatically (Except on metered connections)</value>
   </data>
   <data name="GeneralPage_ToggleSwitch_RunningAsAdminNote.Text" xml:space="preserve">
     <value>Currently running as administrator</value>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -537,7 +537,7 @@
     <value>Learn more about administrator mode</value>
   </data>
   <data name="GeneralPage_ToggleSwitch_AutoDownloadUpdates.Header" xml:space="preserve">
-    <value>Download updates automatically</value>
+    <value>Download updates automatically (Except on metered connections, where charges may apply)</value>
   </data>
   <data name="GeneralPage_ToggleSwitch_RunningAsAdminNote.Text" xml:space="preserve">
     <value>Currently running as administrator</value>

--- a/src/settings-web/src/components/GeneralSettings.tsx
+++ b/src/settings-web/src/components/GeneralSettings.tsx
@@ -127,7 +127,7 @@ export class GeneralSettings extends React.Component <any, any> {
 
         {this.state.settings.general.is_admin &&
         (<Stack>
-          <Label>Download updates automatically</Label>
+          <Label>Download updates automatically (Except on metered connections, where charges may apply)</Label>
           <BoolToggleSettingsControl
             setting={{value: this.state.settings.general.download_updates_automatically}}
             disabled={!this.state.settings.general.is_admin}

--- a/src/settings-web/src/components/GeneralSettings.tsx
+++ b/src/settings-web/src/components/GeneralSettings.tsx
@@ -127,7 +127,7 @@ export class GeneralSettings extends React.Component <any, any> {
 
         {this.state.settings.general.is_admin &&
         (<Stack>
-          <Label>Download updates automatically (Except on metered connections, where charges may apply)</Label>
+          <Label>Download updates automatically (Except on metered connections)</Label>
           <BoolToggleSettingsControl
             setting={{value: this.state.settings.general.download_updates_automatically}}
             disabled={!this.state.settings.general.is_admin}


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR changes the title of the auto-download setting in the old and new settings ui.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2967 (original proposal in #2885)
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #2967

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
The updates don't get automatically downloaded when the user is connected over a metered connection. This is something the user should known about. Because of not have to be afraid on having extra costs and to not being confused if it not works on metered connections.

Old title: `Download updates automatically`

New Title: `Download updates automatically (Except on metered connections, where charges may apply)`


<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Not validation steps done.