### PR TITLE
[Settings V2] Updated default color values for fz

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/ConfigDefaults.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/ConfigDefaults.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.PowerToys.Settings.UI.Lib
+{
+    public static class ConfigDefaults
+    {
+        // Fancy Zones Default Colors
+        public static readonly string DefaultFancyZonesZoneHighlightColor = "#0078D7";
+        public static readonly string DefaultFancyZonesInActiveColor = "#F5FCFF";
+        public static readonly string DefaultFancyzonesBorderColor = "#FFFFFF";
+
+        // Fancy Zones Default Flags.
+        public static readonly bool DefaultFancyzonesShiftDrag = true;
+        public static readonly bool DefaultUseCursorposEditorStartupscreen = true;
+    }
+}

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/FZConfigProperties.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/FZConfigProperties.cs
@@ -20,7 +20,7 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
             this.FancyzonesAppLastZoneMoveWindows = new BoolProperty();
             this.UseCursorposEditorStartupscreen = new BoolProperty(true);
             this.FancyzonesShowOnAllMonitors = new BoolProperty();
-            this.FancyzonesZoneHighlightColor = new StringProperty("#F5FCFF");
+            this.FancyzonesZoneHighlightColor = new StringProperty("#0078D7");
             this.FancyzonesHighlightOpacity = new IntProperty(50);
             this.FancyzonesEditorHotkey = new KeyBoardKeysProperty(
                 new HotkeySettings()
@@ -35,7 +35,7 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
             this.FancyzonesMakeDraggedWindowTransparent = new BoolProperty();
             this.FancyzonesExcludedApps = new StringProperty();
             this.FancyzonesInActiveColor = new StringProperty("#F5FCFF");
-            this.FancyzonesBorderColor = new StringProperty("#F5FCFF");
+            this.FancyzonesBorderColor = new StringProperty("#FFFFFF");
         }
 
         [JsonPropertyName("fancyzones_shiftDrag")]

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/FZConfigProperties.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/FZConfigProperties.cs
@@ -10,7 +10,7 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
     {
         public FZConfigProperties()
         {
-            this.FancyzonesShiftDrag = new BoolProperty(true);
+            this.FancyzonesShiftDrag = new BoolProperty(ConfigDefaults.DefaultFancyzonesShiftDrag);
             this.FancyzonesOverrideSnapHotkeys = new BoolProperty();
             this.FancyzonesMouseSwitch = new BoolProperty();
             this.FancyzonesMoveWindowsAcrossMonitors = new BoolProperty();
@@ -18,9 +18,9 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
             this.FancyzonesZoneSetChangeMoveWindows = new BoolProperty();
             this.FancyzonesVirtualDesktopChangeMoveWindows = new BoolProperty();
             this.FancyzonesAppLastZoneMoveWindows = new BoolProperty();
-            this.UseCursorposEditorStartupscreen = new BoolProperty(true);
+            this.UseCursorposEditorStartupscreen = new BoolProperty(ConfigDefaults.DefaultUseCursorposEditorStartupscreen);
             this.FancyzonesShowOnAllMonitors = new BoolProperty();
-            this.FancyzonesZoneHighlightColor = new StringProperty("#0078D7");
+            this.FancyzonesZoneHighlightColor = new StringProperty(ConfigDefaults.DefaultFancyZonesZoneHighlightColor);
             this.FancyzonesHighlightOpacity = new IntProperty(50);
             this.FancyzonesEditorHotkey = new KeyBoardKeysProperty(
                 new HotkeySettings()
@@ -34,8 +34,8 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
                 });
             this.FancyzonesMakeDraggedWindowTransparent = new BoolProperty();
             this.FancyzonesExcludedApps = new StringProperty();
-            this.FancyzonesInActiveColor = new StringProperty("#F5FCFF");
-            this.FancyzonesBorderColor = new StringProperty("#FFFFFF");
+            this.FancyzonesInActiveColor = new StringProperty(ConfigDefaults.DefaultFancyZonesInActiveColor);
+            this.FancyzonesBorderColor = new StringProperty(ConfigDefaults.DefaultFancyzonesBorderColor);
         }
 
         [JsonPropertyName("fancyzones_shiftDrag")]

--- a/src/core/Microsoft.PowerToys.Settings.UnitTest/ViewModelTests/FancyZones.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UnitTest/ViewModelTests/FancyZones.cs
@@ -253,7 +253,7 @@ namespace ViewModelTests
         {
             // arrange
             FancyZonesViewModel viewModel = new FancyZonesViewModel();
-            Assert.AreEqual("#F5FCFF", ToRGBHex(viewModel.ZoneHighlightColor)); 
+            Assert.AreEqual("#0078D7", ToRGBHex(viewModel.ZoneHighlightColor)); 
 
             // Assert
             ShellPage.DefaultSndMSGCallback = msg =>
@@ -271,7 +271,7 @@ namespace ViewModelTests
         {
             // arrange
             FancyZonesViewModel viewModel = new FancyZonesViewModel();
-            Assert.AreEqual("#F5FCFF", ToRGBHex(viewModel.ZoneBorderColor)); 
+            Assert.AreEqual("#FFFFFF", ToRGBHex(viewModel.ZoneBorderColor)); 
 
             // Assert
             ShellPage.DefaultSndMSGCallback = msg =>

--- a/src/core/Microsoft.PowerToys.Settings.UnitTest/ViewModelTests/FancyZones.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UnitTest/ViewModelTests/FancyZones.cs
@@ -253,7 +253,7 @@ namespace ViewModelTests
         {
             // arrange
             FancyZonesViewModel viewModel = new FancyZonesViewModel();
-            Assert.AreEqual("#0078D7", ToRGBHex(viewModel.ZoneHighlightColor)); 
+            Assert.AreEqual(ConfigDefaults.DefaultFancyZonesZoneHighlightColor, ToRGBHex(viewModel.ZoneHighlightColor)); 
 
             // Assert
             ShellPage.DefaultSndMSGCallback = msg =>
@@ -271,7 +271,7 @@ namespace ViewModelTests
         {
             // arrange
             FancyZonesViewModel viewModel = new FancyZonesViewModel();
-            Assert.AreEqual("#FFFFFF", ToRGBHex(viewModel.ZoneBorderColor)); 
+            Assert.AreEqual(ConfigDefaults.DefaultFancyzonesBorderColor, ToRGBHex(viewModel.ZoneBorderColor)); 
 
             // Assert
             ShellPage.DefaultSndMSGCallback = msg =>
@@ -289,7 +289,7 @@ namespace ViewModelTests
         {
             // arrange
             FancyZonesViewModel viewModel = new FancyZonesViewModel();
-            Assert.AreEqual("#F5FCFF", ToRGBHex(viewModel.ZoneInActiveColor)); 
+            Assert.AreEqual(ConfigDefaults.DefaultFancyZonesInActiveColor, ToRGBHex(viewModel.ZoneInActiveColor)); 
 
             // Assert
             ShellPage.DefaultSndMSGCallback = msg =>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
- Updated default values for Fancy Zones colors.
<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
https://github.com/microsoft/PowerToys/issues/2964

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2964
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [] Requires documentation to be updated
* [] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #2964

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Deleted settings files and ran the settings ui to check if default values were set.
- ran tests.