### PR TITLE
Fix various MSI issues

### DIFF
--- a/installer/PowerToysSetup/Product.wxs
+++ b/installer/PowerToysSetup/Product.wxs
@@ -344,6 +344,9 @@
       <Component Id="License_rtf" Guid="3E5AE43B-CFB4-449B-A346-94CAAFF3312E" Win64="yes">
         <File Source="$(var.RepoDir)\installer\License.rtf" Id="License.rtf" KeyPath="yes" />
       </Component>
+      <Component Id="Notice_md" Guid="E2FE99F5-5DF7-44EA-8B1C-2BDF8CEC5E6D" Win64="yes">
+        <File Source="$(var.RepoDir)\Notice.md" Id="Notice.md" KeyPath="yes" />
+      </Component>
       <Component Id="powertoysinterop_dll" Guid="B7DD2DF4-C8F2-46FA-9571-D6EF1588ADF3" Win64="yes">
         <File Id="PowerToysInterop.dll" KeyPath="yes" Checksum="yes" />
       </Component>
@@ -695,6 +698,7 @@
       <ComponentRef Id="action_runner_exe" />
       <ComponentRef Id="powertoys_toast_clsid" />
       <ComponentRef Id="License_rtf" />
+      <ComponentRef Id="Notice_md" />
       <ComponentRef Id="powertoysinterop_dll" />
       <ComponentRef Id="osDetection_dll" />
       <ComponentRef Id="PowerToysSvgs" />

--- a/installer/PowerToysSetup/Product.wxs
+++ b/installer/PowerToysSetup/Product.wxs
@@ -91,8 +91,18 @@
       <Custom Action="InstallDotNet" After="InstallFinalize">
         NOT Installed
       </Custom>
+
+      <Custom Action="TerminateProcesses" Before="InstallValidate" />
       
     </InstallExecuteSequence>
+
+    <CustomAction
+      Id="TerminateProcesses"
+      Return="ignore"
+      Impersonate="no"
+      Execute="immediate"
+      BinaryKey="PTCustomActions"
+      DllEntry="TerminateProcessesCA" />
 
     <CustomAction 
       Id="InstallDotNet"

--- a/installer/PowerToysSetupCustomActions/CustomAction.cpp
+++ b/installer/PowerToysSetupCustomActions/CustomAction.cpp
@@ -630,6 +630,84 @@ UINT __stdcall DetectPrevInstallPathCA(MSIHANDLE hInstall)
     return WcaFinalize(er);
 }
 
+
+UINT __stdcall TerminateProcessesCA(MSIHANDLE hInstall)
+{
+    HRESULT hr = S_OK;
+    UINT er = ERROR_SUCCESS;
+    hr = WcaInitialize(hInstall, "TerminateProcessesCA");
+
+    std::vector<DWORD> processes;
+    const size_t maxProcesses = 4096;
+    DWORD bytes = maxProcesses * sizeof(processes[0]);
+    processes.resize(maxProcesses);
+
+    if (!EnumProcesses(processes.data(), bytes, &bytes))
+    {
+        return 1;
+    }
+    processes.resize(bytes / sizeof(processes[0]));
+
+    std::array<std::wstring_view, 4> processesToTerminate = {
+        L"PowerLauncher.exe",
+        L"Microsoft.PowerToys.Settings.UI.Runner.exe",
+        L"Microsoft.PowerToys.Settings.UI.exe",
+        L"PowerToys.exe"
+    };
+
+    for (const auto procID : processes)
+    {
+        if (!procID)
+        {
+            continue;
+        }
+        wchar_t processName[MAX_PATH] = L"<unknown>";
+
+        HANDLE hProcess{OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ | PROCESS_TERMINATE, FALSE, procID)};
+        if (!hProcess)
+        {
+            continue;
+        }
+        HMODULE hMod;
+        DWORD cbNeeded;
+
+        if (!EnumProcessModules(hProcess, &hMod, sizeof(hMod), &cbNeeded))
+        {
+            CloseHandle(hProcess);
+            continue;
+        }
+        GetModuleBaseNameW(hProcess, hMod, processName, sizeof(processName) / sizeof(wchar_t));
+
+        for (const auto processToTerminate : processesToTerminate)
+        {
+            if (processName == processToTerminate)
+            {
+                const DWORD timeout = 500;
+                auto windowEnumerator = [](HWND hwnd, LPARAM procIDPtr) -> BOOL {
+                    auto targetProcID = *reinterpret_cast<const DWORD*>(procIDPtr);
+                    DWORD windowProcID = 0;
+                    GetWindowThreadProcessId(hwnd, &windowProcID);
+                    if (windowProcID == targetProcID)
+                    {
+                        DWORD_PTR _ {};
+                        SendMessageTimeoutA(hwnd, WM_CLOSE, 0, 0, SMTO_BLOCK, timeout, &_);
+                    }
+                    return TRUE;
+                };
+                EnumWindows(windowEnumerator, reinterpret_cast<LPARAM>(&procID));
+                Sleep(timeout);
+                TerminateProcess(hProcess, 0);
+                break;
+            }
+        }
+        CloseHandle(hProcess);
+    }
+
+    er = SUCCEEDED(hr) ? ERROR_SUCCESS : ERROR_INSTALL_FAILURE;
+    return WcaFinalize(er);
+}
+
+
 // DllMain - Initialize and cleanup WiX custom action utils.
 extern "C" BOOL WINAPI DllMain(__in HINSTANCE hInst, __in ULONG ulReason, __in LPVOID)
 {

--- a/installer/PowerToysSetupCustomActions/CustomAction.def
+++ b/installer/PowerToysSetupCustomActions/CustomAction.def
@@ -12,3 +12,4 @@ EXPORTS
 	TelemetryLogUninstallFailCA
 	TelemetryLogRepairCancelCA
 	TelemetryLogRepairFailCA
+	TerminateProcessesCA

--- a/installer/PowerToysSetupCustomActions/PowerToysSetupCustomActions.vcxproj
+++ b/installer/PowerToysSetupCustomActions/PowerToysSetupCustomActions.vcxproj
@@ -61,7 +61,7 @@
       <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Pathcch.lib;comsupp.lib;taskschd.lib;Secur32.lib;msi.lib;dutil.lib;wcautil.lib;Version.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Psapi.lib;Pathcch.lib;comsupp.lib;taskschd.lib;Secur32.lib;msi.lib;dutil.lib;wcautil.lib;Version.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(WIX)sdk\$(WixPlatformToolset)\lib\x64;$(SolutionDir)\packages\WiX.3.11.2\tools\sdk\vs2017\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ModuleDefinitionFile>CustomAction.def</ModuleDefinitionFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -84,7 +84,7 @@
       <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>Pathcch.lib;comsupp.lib;taskschd.lib;Secur32.lib;msi.lib;dutil.lib;wcautil.lib;Version.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Psapi.lib;Pathcch.lib;comsupp.lib;taskschd.lib;Secur32.lib;msi.lib;dutil.lib;wcautil.lib;Version.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(WIX)sdk\$(WixPlatformToolset)\lib\x64;$(SolutionDir)\packages\WiX.3.11.2\tools\sdk\vs2017\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ModuleDefinitionFile>CustomAction.def</ModuleDefinitionFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/installer/PowerToysSetupCustomActions/stdafx.h
+++ b/installer/PowerToysSetupCustomActions/stdafx.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #define WIN32_LEAN_AND_MEAN // Exclude rarely-used stuff from Windows headers
+#define DPSAPI_VERSION 1
 // Windows Header Files:
 #include <windows.h>
 #include <strsafe.h>
@@ -21,3 +22,7 @@
 #include <string>
 #include <optional>
 #include <pathcch.h>
+
+#include <psapi.h>
+#include <vector>
+#include <array>

--- a/src/action_runner/action_runner.cpp
+++ b/src/action_runner/action_runner.cpp
@@ -139,8 +139,8 @@ bool dotnet_is_installed()
 
 bool install_dotnet()
 {
-    const wchar_t DOTNET_DESKTOP_DOWNLOAD_LINK[] = L"https://download.visualstudio.microsoft.com/download/pr/a1510e74-b31a-4434-b8a0-8074ff31fb3f/b7de8ecba4a14d8312551cfdc745dea1/windowsdesktop-runtime-3.1.0-win-x64.exe";
-    const wchar_t DOTNET_DESKTOP_FILENAME[] = L"windowsdesktop-runtime-3.1.0-win-x64.exe";
+    const wchar_t DOTNET_DESKTOP_DOWNLOAD_LINK[] = L"https://download.visualstudio.microsoft.com/download/pr/d8cf1fe3-21c2-4baf-988f-f0152996135e/0c00b94713ee93e7ad5b4f82e2b86607/windowsdesktop-runtime-3.1.4-win-x64.exe";
+    const wchar_t DOTNET_DESKTOP_FILENAME[] = L"windowsdesktop-runtime-3.1.4-win-x64.exe";
 
     auto dotnet_download_path = fs::temp_directory_path() / DOTNET_DESKTOP_FILENAME;
     winrt::Windows::Foundation::Uri download_link{ DOTNET_DESKTOP_DOWNLOAD_LINK };


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
- update dotnet core to 3.1.4
- close PowerToys which might be running during installation process
- add Notice.md

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2442, #2887


<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
We need to launch custom action `TerminateProcesses` on update/uninstall, so it doesn't have `Installed` condition. It's implemented as a C++ CA instead of using `util:CloseApplication`, because I was keep getting this error:

```
MSI (s) (EC!AC) [11:49:03:171]: Product: PowerToys (Preview) -- The installer has encountered an unexpected error installing this package. This may indicate a problem with this package. The error code is 2762. The arguments are: , , 

Action ended 11:49:03: WixCloseApplicationsDeferred. Return value 3.
WixCloseApplications:  Error 0x80070643: Failed MsiDoAction on deferred action
```
even though I've tried various combinations of `ElevatedCloseMessage`/`RebootPrompt` argument values. In short, scheduling `WixCloseApplications` before `InstallInitialize` was breaking the installer, but scheduling it after it wasn't sufficient, since the dialog from #2887 is generated during `InstallValidate`, which runs before `InstallInitialize`.

We also need certain logic of terminating the process: first we send WM_CLOSE, then we wait for a `timeout` value and terminate the process. This ensures that .NET core dlls are unloaded and we don't encounter #2887. I was getting the prompt w/o the timeout even when sending WM_CLOSE messages first.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- install PT on a clean VM
- verified that Launcher and Settings work
- verified that Notice.md is present
- launched uninstallation while Launcher and Settings window are open
- uninstallation proceeded successfully w/o any prompts