### PR TITLE
[Power Run] Added Accented Border

### DIFF
--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml
@@ -54,10 +54,9 @@
             x:Name="SearchBoxBorder" 
             Grid.Row="0" 
             Margin="24,24,24,8"  
-            BorderThickness="0" 
+            BorderThickness="2" 
             CornerRadius="4"
-            Background="{DynamicResource SystemChromeLow}"
-            BorderBrush="{DynamicResource SystemChromeLow}">
+            Background="{DynamicResource SystemChromeLow}">
             <Border.Effect>
                 <DropShadowEffect BlurRadius="12" Opacity="0.3" ShadowDepth="0" />
             </Border.Effect>
@@ -75,7 +74,7 @@
             x:Name="ListBoxBorder"
             Grid.Row="1" 
             Margin="24,8,24,24" 
-            BorderThickness="0"
+            BorderThickness="2"
             CornerRadius="4" 
             Visibility="{Binding Results.Visibility}"
             Background="{DynamicResource SystemChromeLow}"


### PR DESCRIPTION
## Summary of the Pull Request
Added a 2px accent colored border around the search box. If the user has selected not to show color in borders, the border is a translucent black.
## References
#2428 
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2428
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [] Tests added/passed
* [] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
The accent color can be easily obtained via the UISettings class as mentioned [here](https://devblogs.microsoft.com/oldnewthing/20170405-00/?p=95905) but checking whether the user has enabled "show accent color in title bar" setting is a bit more [involved](https://www.askvg.com/tweak-colorization-settings-for-titlebar-taskbar-and-start-menu-in-windows-10/). I also removed the border of the resultlist to match with the concept design.

Its my first time here so this PR might require significant changes before merge as I am not entirely familiar with the codebase. 

## Validation steps performed
Tested manually

## Screenshots
![Screenshot (337)](https://user-images.githubusercontent.com/36439704/81935751-c4948e00-960e-11ea-9ae5-9f2b9b1ee75c.png)
![Screenshot (338)](https://user-images.githubusercontent.com/36439704/81935761-c8281500-960e-11ea-8ce8-78c7a3b3f0f5.png)
![Screenshot (339)](https://user-images.githubusercontent.com/36439704/81935768-c9f1d880-960e-11ea-96b7-d2c27eb31dd0.png)


cc @niels9001 