### PR TITLE
OnInstall and OnUpdate functionality via toast activation (OOBE POC)

### DIFF
--- a/POC-OOBE/OOBE-Sandbox/PowerToys Settings Sandbox/App.xaml.cs
+++ b/POC-OOBE/OOBE-Sandbox/PowerToys Settings Sandbox/App.xaml.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Microsoft.QueryStringDotNET;
 using PowerToys_Settings_Sandbox.Services;
-
+using PowerToys_Settings_Sandbox.Views;
 using Windows.ApplicationModel.Activation;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -47,18 +47,17 @@ namespace PowerToys_Settings_Sandbox
 
                 switch (args["action"])
                 {
-                    case "openApp":
+                    case "OpenApp":
                         if (rootFrame == null)
                         {
                             rootFrame = new Frame();
                             Window.Current.Content = rootFrame;
                         }
 
-                        rootFrame.Navigate(typeof(Views.ShellPage));
-                        NavigationService.Navigate(typeof(Views.MainPage));
-                        Window.Current.Activate();
-                        break;
-
+                        rootFrame.Navigate(typeof(ShellPage));
+                        NavigationService.Navigate(typeof(MainPage), args["status"]);
+                        break;                        
+                    
                     default:
                         break;
                 }
@@ -71,12 +70,12 @@ namespace PowerToys_Settings_Sandbox
 
         private ActivationService CreateActivationService()
         {
-            return new ActivationService(this, typeof(Views.MainPage), new Lazy<UIElement>(CreateShell));
+            return new ActivationService(this, typeof(MainPage), new Lazy<UIElement>(CreateShell));
         }
 
         private UIElement CreateShell()
         {
-            return new Views.ShellPage();
+            return new ShellPage();
         }
     }
 }

--- a/POC-OOBE/OOBE-Sandbox/PowerToys Settings Sandbox/App.xaml.cs
+++ b/POC-OOBE/OOBE-Sandbox/PowerToys Settings Sandbox/App.xaml.cs
@@ -5,6 +5,7 @@ using PowerToys_Settings_Sandbox.Views;
 using Windows.ApplicationModel.Activation;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Microsoft.Toolkit.Uwp.Helpers;
 
 namespace PowerToys_Settings_Sandbox
 {
@@ -29,10 +30,12 @@ namespace PowerToys_Settings_Sandbox
         {
             if (!args.PrelaunchActivated)
             {
-                await ActivationService.ActivateAsync(args);
-                NotificationService.AppInstalledToast();
-                NotificationService.AppUpdatedToast();
+                await ActivationService.ActivateAsync(args); 
             }
+
+            NotificationService.AppInstalledToast();
+            NotificationService.AppUpdatedToast();
+
         }
 
         protected override async void OnActivated(IActivatedEventArgs e)
@@ -56,17 +59,14 @@ namespace PowerToys_Settings_Sandbox
 
                         rootFrame.Navigate(typeof(ShellPage));
                         NavigationService.Navigate(typeof(MainPage), args["status"]);
-                        break;                        
-                    
+                        Window.Current.Activate();
+                        break;
+
                     default:
                         break;
                 }
             }
-
-
         }
-
-
 
         private ActivationService CreateActivationService()
         {

--- a/POC-OOBE/OOBE-Sandbox/PowerToys Settings Sandbox/Services/NotificationService.cs
+++ b/POC-OOBE/OOBE-Sandbox/PowerToys Settings Sandbox/Services/NotificationService.cs
@@ -35,7 +35,7 @@ namespace PowerToys_Settings_Sandbox.Services
 
         public static void AppUpdatedToast()
         {
-            string title = "Power Toys Updated";
+            string title = "New PowerToys Update";
             string logo = "../Assets/MiniLogo.png";
 
             ToastVisual visual = createToastVisual(title, logo);
@@ -70,7 +70,7 @@ namespace PowerToys_Settings_Sandbox.Services
                     // Action for updating app
                 }.ToString();
 
-            ToastActionsCustom actions = createToastAction("Update", onActionClick);
+            ToastActionsCustom actions = createToastAction("Update Now", onActionClick);
 
             string onLaunch = new QueryString()
                 {

--- a/POC-OOBE/OOBE-Sandbox/PowerToys Settings Sandbox/Services/NotificationService.cs
+++ b/POC-OOBE/OOBE-Sandbox/PowerToys Settings Sandbox/Services/NotificationService.cs
@@ -17,18 +17,13 @@ namespace PowerToys_Settings_Sandbox.Services
 
             string onActionClick = new QueryString()
                 {
-                    { "action", "openApp"},
-                    { "status", "openFirst"},
+                    { "action", "OpenApp"},
+                    { "status", "FirstOpen"},
                 }.ToString();
 
             ToastActionsCustom actions = createToastAction("Get Started", onActionClick);
 
-            string onLaunch = new QueryString()
-                {
-                    {"action", "openApp"},
-                }.ToString();
-
-            ToastContent toastContent = createToastContent(visual, actions, onLaunch);
+            ToastContent toastContent = createToastContent(visual, actions, onActionClick);
 
             ToastNotification toast = new ToastNotification(toastContent.GetXml());
 
@@ -47,18 +42,13 @@ namespace PowerToys_Settings_Sandbox.Services
 
             string onActionClick = new QueryString()
                 {
-                    { "action", "openApp"},
-                    { "status", "openUpdate"},
+                    { "action", "OpenApp"},
+                    { "status", "NewUpdateOpen"},
                 }.ToString();
 
             ToastActionsCustom actions = createToastAction("See Updates", onActionClick);
 
-            string onLaunch = new QueryString()
-                {
-                    {"action", "openApp"},
-                }.ToString();
-
-            ToastContent toastContent = createToastContent(visual, actions, onLaunch);
+            ToastContent toastContent = createToastContent(visual, actions, onActionClick);
 
             ToastNotification toast = new ToastNotification(toastContent.GetXml());
 
@@ -84,7 +74,7 @@ namespace PowerToys_Settings_Sandbox.Services
 
             string onLaunch = new QueryString()
                 {
-                    {"action", "openApp"},
+                    {"action", "OpenApp"},
                 }.ToString();
 
             ToastContent toastContent = createToastContent(visual, actions, onLaunch);
@@ -128,11 +118,7 @@ namespace PowerToys_Settings_Sandbox.Services
                 Buttons =
                     {
                         new ToastButtonDismiss("Not now"),
-                        new ToastButton("Get Started", new QueryString()
-                        {
-                            {"action", "openApp"},
-                            {"status", "openFirst"},
-                        }.ToString()),
+                        new ToastButton(title, query),
                     }
             };
             return actions;

--- a/POC-OOBE/OOBE-Sandbox/PowerToys Settings Sandbox/Views/MainPage.xaml.cs
+++ b/POC-OOBE/OOBE-Sandbox/PowerToys Settings Sandbox/Views/MainPage.xaml.cs
@@ -3,6 +3,7 @@ using System;
 using Windows.UI.Xaml.Controls;
 using PowerToys_Settings_Sandbox.ViewModels;
 using Windows.UI.Xaml.Navigation;
+using Microsoft.Toolkit.Uwp.Helpers;
 
 namespace PowerToys_Settings_Sandbox.Views
 {

--- a/POC-OOBE/OOBE-Sandbox/PowerToys Settings Sandbox/Views/MainPage.xaml.cs
+++ b/POC-OOBE/OOBE-Sandbox/PowerToys Settings Sandbox/Views/MainPage.xaml.cs
@@ -4,6 +4,7 @@ using Windows.UI.Xaml.Controls;
 using PowerToys_Settings_Sandbox.ViewModels;
 using Windows.UI.Xaml.Navigation;
 using Microsoft.Toolkit.Uwp.Helpers;
+using Windows.UI.Notifications;
 
 namespace PowerToys_Settings_Sandbox.Views
 {
@@ -23,10 +24,12 @@ namespace PowerToys_Settings_Sandbox.Views
                 if (x == "FirstOpen")
                 {
                     PowerOnLaunchDialog();
+                    ToastNotificationManager.History.Clear();
                 }
                 else if (x == "NewUpdateOpen")
                 {
                     DisplayUpdateDialog();
+                    ToastNotificationManager.History.Clear();
                 }
             }
         }

--- a/POC-OOBE/OOBE-Sandbox/PowerToys Settings Sandbox/Views/MainPage.xaml.cs
+++ b/POC-OOBE/OOBE-Sandbox/PowerToys Settings Sandbox/Views/MainPage.xaml.cs
@@ -2,7 +2,7 @@
 using System;
 using Windows.UI.Xaml.Controls;
 using PowerToys_Settings_Sandbox.ViewModels;
-
+using Windows.UI.Xaml.Navigation;
 
 namespace PowerToys_Settings_Sandbox.Views
 {
@@ -13,13 +13,29 @@ namespace PowerToys_Settings_Sandbox.Views
         public MainPage()
         {
             InitializeComponent();
-            powerOnLaunchDialog();
         }
-        private async void powerOnLaunchDialog()
+
+        protected override void OnNavigatedTo(NavigationEventArgs e)
+        {
+            if (e.Parameter is string x)
+            {
+                if (x == "FirstOpen")
+                {
+                    powerOnLaunchDialog();
+                }
+                else if (x == "NewUpdateOpen")
+                {
+
+                }
+            }
+        }
+
+        public async void powerOnLaunchDialog()
         {
             onLaunchContentDialog dialog = new onLaunchContentDialog();
             dialog.PrimaryButtonClick += Dialog_PrimaryButtonClick;
             await dialog.ShowAsync();
+<<<<<<< HEAD
         }
 
         //TODO: Customize to be called only once after update is installed
@@ -28,6 +44,8 @@ namespace PowerToys_Settings_Sandbox.Views
             ContentDialog updateDialog = new UpdateContentDialog();
 
             await updateDialog.ShowAsync();
+=======
+>>>>>>> 26743a58... Recognize first launch
         }
         
         private void Dialog_PrimaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)

--- a/POC-OOBE/OOBE-Sandbox/PowerToys Settings Sandbox/Views/MainPage.xaml.cs
+++ b/POC-OOBE/OOBE-Sandbox/PowerToys Settings Sandbox/Views/MainPage.xaml.cs
@@ -36,7 +36,6 @@ namespace PowerToys_Settings_Sandbox.Views
             onLaunchContentDialog dialog = new onLaunchContentDialog();
             dialog.PrimaryButtonClick += Dialog_PrimaryButtonClick;
             await dialog.ShowAsync();
-<<<<<<< HEAD
         }
 
         //TODO: Customize to be called only once after update is installed
@@ -45,8 +44,6 @@ namespace PowerToys_Settings_Sandbox.Views
             ContentDialog updateDialog = new UpdateContentDialog();
 
             await updateDialog.ShowAsync();
-=======
->>>>>>> 26743a58... Recognize first launch
         }
         
         private void Dialog_PrimaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)

--- a/POC-OOBE/OOBE-Sandbox/PowerToys Settings Sandbox/Views/MainPage.xaml.cs
+++ b/POC-OOBE/OOBE-Sandbox/PowerToys Settings Sandbox/Views/MainPage.xaml.cs
@@ -22,16 +22,16 @@ namespace PowerToys_Settings_Sandbox.Views
             {
                 if (x == "FirstOpen")
                 {
-                    powerOnLaunchDialog();
+                    PowerOnLaunchDialog();
                 }
                 else if (x == "NewUpdateOpen")
                 {
-
+                    DisplayUpdateDialog();
                 }
             }
         }
 
-        public async void powerOnLaunchDialog()
+        public async void PowerOnLaunchDialog()
         {
             onLaunchContentDialog dialog = new onLaunchContentDialog();
             dialog.PrimaryButtonClick += Dialog_PrimaryButtonClick;
@@ -42,7 +42,6 @@ namespace PowerToys_Settings_Sandbox.Views
         private async void DisplayUpdateDialog()
         {
             ContentDialog updateDialog = new UpdateContentDialog();
-
             await updateDialog.ShowAsync();
         }
         
@@ -50,9 +49,9 @@ namespace PowerToys_Settings_Sandbox.Views
         {
             OpenFirstGeneralSettingsTip();
         }
+
         // This method opens the first teaching tip on the General Settings page
         // Should open automatically only on initial install after user starts tutorial
-
         public void BeginSettingsTips()
         {
             OpenFirstGeneralSettingsTip();

--- a/POC-OOBE/OOBE-Sandbox/PowerToys Settings Sandbox/Views/MainPage.xaml.cs
+++ b/POC-OOBE/OOBE-Sandbox/PowerToys Settings Sandbox/Views/MainPage.xaml.cs
@@ -36,6 +36,12 @@ namespace PowerToys_Settings_Sandbox.Views
         }
         // This method opens the first teaching tip on the General Settings page
         // Should open automatically only on initial install after user starts tutorial
+
+        public void BeginSettingsTips()
+        {
+            OpenFirstGeneralSettingsTip();
+        }
+
         private void OpenFirstGeneralSettingsTip()
         {
             GeneralSettingsTip.IsOpen = true;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
### Summary of the Pull Request
- Create toasts that activate the OnInstall and OnUpdate functionality

### Detailed Description of the Pull Request / Additional comments
- On launch, two toasts icons pop up
- Pushing Get Started with PowerToys opens up OnInstall pop-up
- Pushing New PowerToys update opens Update popup
- Pressing either icon will remove all toasts immediately

