### PR TITLE
Fix launcher height

### DIFF
--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml
@@ -42,7 +42,7 @@
             <Border.Effect>
                 <DropShadowEffect BlurRadius="16" Opacity="0.8" ShadowDepth="0" />
             </Border.Effect>
-            <local:LauncherControl x:Name="SearchBox" />
+            <local:LauncherControl x:Name="SearchBox" Height="60"/>
         </Border>
         <Border 
             x:Name="ListBoxBorder"

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml
@@ -42,7 +42,9 @@
             <Border.Effect>
                 <DropShadowEffect BlurRadius="16" Opacity="0.8" ShadowDepth="0" />
             </Border.Effect>
-            <local:LauncherControl x:Name="SearchBox" Height="60"/>
+            <local:LauncherControl
+                x:Name="SearchBox" 
+                Height="60"/>
         </Border>
         <Border 
             x:Name="ListBoxBorder"

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -265,8 +265,7 @@ namespace PowerLauncher
             var screen = Screen.FromPoint(System.Windows.Forms.Cursor.Position);
             var dpi1 = WindowsInteropHelper.TransformPixelsToDIP(this, 0, screen.WorkingArea.Y);
             var dpi2 = WindowsInteropHelper.TransformPixelsToDIP(this, 0, screen.WorkingArea.Height);
-            var totalHeight = this.SearchBoxBorder.Margin.Top + this.SearchBoxBorder.Margin.Bottom + this.SearchBox.Height + this.ListBoxBorder.Margin.Top + this.ListBoxBorder.Margin.Bottom + MAX_LIST_HEIGHT;
-            var top = (dpi2.Y - totalHeight) / 4 + dpi1.Y;
+            var top = (dpi2.Y - this.SearchBox.Height) / 4 + dpi1.Y;
             return top;
         }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR fixes issues with multi-monitor not centering correctly on vertical layout. The top was not being set after we migrated to WPF searchbox.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2994 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manually validated that powertoys run works in both vertical and horizontal layout. 

Note:  I am still noticing following issues : 
1. Shuddering after the first launch on monitor change. 
2. The launcher goes out of focus and the selected text is not highlighted as well on first launch after monitor change. The issue is fixed on subsequent launches. 