### PR TITLE
Activate OOBE experience based on app state

### DIFF
--- a/POC-OOBE/OOBE-Sandbox/PowerToys Settings Sandbox/App.xaml.cs
+++ b/POC-OOBE/OOBE-Sandbox/PowerToys Settings Sandbox/App.xaml.cs
@@ -5,7 +5,7 @@ using PowerToys_Settings_Sandbox.Views;
 using Windows.ApplicationModel.Activation;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
-using Microsoft.Toolkit.Uwp.Helpers;
+using Windows.Storage;
 
 namespace PowerToys_Settings_Sandbox
 {
@@ -28,17 +28,48 @@ namespace PowerToys_Settings_Sandbox
 
         protected override async void OnLaunched(LaunchActivatedEventArgs args)
         {
+            /// <summary>
+            /// Sandbox settings is a way to emulate background notifications on install and update
+            /// Not to be inclued when added to final product
+            /// </summary>
+            SandboxNotifications();
+            
             if (!args.PrelaunchActivated)
             {
                 await ActivationService.ActivateAsync(args); 
             }
-
-            NotificationService.AppInstalledToast();
-            NotificationService.AppUpdatedToast();
-
+           
         }
 
-        protected override async void OnActivated(IActivatedEventArgs e)
+        /// <summary>
+        /// These notifications should be activated in conjunction with new app installs or updates
+        /// </summary>
+        private void SandboxNotifications()
+        {
+            var lSettings = ApplicationData.Current.LocalSettings;
+            lSettings.Values["IsFirstRun"] = true;
+            lSettings.Values["NewVersion"] = "1.0.0.1"; // Reference to the newest version just installed
+            Object firstRun = lSettings.Values["IsFirstRun"];
+            Object currentVersion = lSettings.Values["currentVersion"];
+            Object newVersion = lSettings.Values["NewVersion"];
+
+            /// <summary>
+            /// Paste code wherever first run would occur
+            /// </summary>
+            if (!(firstRun is null) && (bool)firstRun == true)
+            {
+                NotificationService.AppInstalledToast();
+            }
+            /// <summary>
+            /// Paste code wherever updated app would occur
+            /// </summary>
+            if (!(currentVersion is null) && (string)currentVersion != (string)newVersion)
+            {
+                NotificationService.AppUpdatedToast();
+            }
+        }
+
+protected override async void OnActivated(IActivatedEventArgs e)
         {
             Frame rootFrame = Window.Current.Content as Frame;           
 

--- a/POC-OOBE/OOBE-Sandbox/PowerToys Settings Sandbox/App.xaml.cs
+++ b/POC-OOBE/OOBE-Sandbox/PowerToys Settings Sandbox/App.xaml.cs
@@ -6,6 +6,7 @@ using Windows.ApplicationModel.Activation;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.Storage;
+using Windows.UI.Notifications;
 
 namespace PowerToys_Settings_Sandbox
 {
@@ -28,9 +29,10 @@ namespace PowerToys_Settings_Sandbox
 
         protected override async void OnLaunched(LaunchActivatedEventArgs args)
         {
-            /// <summary>
+            ToastNotificationManager.History.Clear();
+            /// <summary> 
             /// Sandbox settings is a way to emulate background notifications on install and update
-            /// Not to be inclued when added to final product
+            /// Not to be included when added to final product
             /// </summary>
             SandboxNotifications();
             
@@ -57,7 +59,7 @@ namespace PowerToys_Settings_Sandbox
             NotificationService.AppUpdatedToast();
         }
 
-protected override async void OnActivated(IActivatedEventArgs e)
+        protected override async void OnActivated(IActivatedEventArgs e)
         {
             Frame rootFrame = Window.Current.Content as Frame;           
 

--- a/POC-OOBE/OOBE-Sandbox/PowerToys Settings Sandbox/App.xaml.cs
+++ b/POC-OOBE/OOBE-Sandbox/PowerToys Settings Sandbox/App.xaml.cs
@@ -49,6 +49,7 @@ namespace PowerToys_Settings_Sandbox
             var lSettings = ApplicationData.Current.LocalSettings;
             lSettings.Values["IsFirstRun"] = true;
             lSettings.Values["NewVersion"] = "1.0.0.1"; // Reference to the newest version just installed
+            lSettings.Values["currentVersion"] = "1.0.0.0"; // Reference to the previous installed version
             Object firstRun = lSettings.Values["IsFirstRun"];
             Object currentVersion = lSettings.Values["currentVersion"];
             Object newVersion = lSettings.Values["NewVersion"];

--- a/POC-OOBE/OOBE-Sandbox/PowerToys Settings Sandbox/App.xaml.cs
+++ b/POC-OOBE/OOBE-Sandbox/PowerToys Settings Sandbox/App.xaml.cs
@@ -46,28 +46,15 @@ namespace PowerToys_Settings_Sandbox
         /// </summary>
         private void SandboxNotifications()
         {
-            var lSettings = ApplicationData.Current.LocalSettings;
-            lSettings.Values["IsFirstRun"] = true;
-            lSettings.Values["NewVersion"] = "1.0.0.1"; // Reference to the newest version just installed
-            lSettings.Values["currentVersion"] = "1.0.0.0"; // Reference to the previous installed version
-            Object firstRun = lSettings.Values["IsFirstRun"];
-            Object currentVersion = lSettings.Values["currentVersion"];
-            Object newVersion = lSettings.Values["NewVersion"];
+            /// <summary>
+            /// Paste code wherever background activity may detect app installation
+            /// </summary>
+            NotificationService.AppInstalledToast();
 
             /// <summary>
-            /// Paste code wherever first run would occur
+            /// Paste code wherever background activity would update an app
             /// </summary>
-            if (!(firstRun is null) && (bool)firstRun == true)
-            {
-                NotificationService.AppInstalledToast();
-            }
-            /// <summary>
-            /// Paste code wherever updated app would occur
-            /// </summary>
-            if (!(currentVersion is null) && (string)currentVersion != (string)newVersion)
-            {
-                NotificationService.AppUpdatedToast();
-            }
+            NotificationService.AppUpdatedToast();
         }
 
 protected override async void OnActivated(IActivatedEventArgs e)

--- a/POC-OOBE/OOBE-Sandbox/PowerToys Settings Sandbox/Views/MainPage.xaml.cs
+++ b/POC-OOBE/OOBE-Sandbox/PowerToys Settings Sandbox/Views/MainPage.xaml.cs
@@ -5,6 +5,7 @@ using PowerToys_Settings_Sandbox.ViewModels;
 using Windows.UI.Xaml.Navigation;
 using Microsoft.Toolkit.Uwp.Helpers;
 using Windows.UI.Notifications;
+using Windows.Storage;
 
 namespace PowerToys_Settings_Sandbox.Views
 {
@@ -17,20 +18,48 @@ namespace PowerToys_Settings_Sandbox.Views
             InitializeComponent();
         }
 
+
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
             if (e.Parameter is string x)
             {
+                var lSettings = ApplicationData.Current.LocalSettings;
+                Object firstRun = lSettings.Values["IsFirstRun"];
+                Object currentVersion = lSettings.Values["currentVersion"];
+                Object newVersion = lSettings.Values["newVersion"];
+
+                /// <summary>
+                /// Will run appropriate startups when toast is clicked
+                /// </summary>
                 if (x == "FirstOpen")
                 {
                     PowerOnLaunchDialog();
-                    ToastNotificationManager.History.Clear();
+                    lSettings.Values["IsFirstRun"] = false;
                 }
                 else if (x == "NewUpdateOpen")
                 {
                     DisplayUpdateDialog();
-                    ToastNotificationManager.History.Clear();
+                    lSettings.Values["currentVersion"] = newVersion;
                 }
+                /// <summary>
+                /// Check for current status of app (new update or new install) on launch
+                /// Comment out this section if using sandbox notifications in App.xaml.cs
+                /// </summary>
+                /*
+                else
+                {
+                    if (!(firstRun is null) && (bool)firstRun == true)
+                    {
+                        PowerOnLaunchDialog();
+                        lSettings.Values["IsFirstRun"] = false;
+                    }
+                    else if (!(currentVersion is null) && (string)currentVersion != (string)newVersion)
+                    {
+                        DisplayUpdateDialog();
+                        lSettings.Values["currentVersion"] = newVersion;
+                    }
+                }
+                */
             }
         }
 
@@ -41,7 +70,6 @@ namespace PowerToys_Settings_Sandbox.Views
             await dialog.ShowAsync();
         }
 
-        //TODO: Customize to be called only once after update is installed
         private async void DisplayUpdateDialog()
         {
             ContentDialog updateDialog = new UpdateContentDialog();

--- a/POC-OOBE/OOBE-Sandbox/PowerToys Settings Sandbox/Views/MainPage.xaml.cs
+++ b/POC-OOBE/OOBE-Sandbox/PowerToys Settings Sandbox/Views/MainPage.xaml.cs
@@ -21,16 +21,16 @@ namespace PowerToys_Settings_Sandbox.Views
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
-            if (e.Parameter is string x)
+            if (e.Parameter is string status)
             {
                 /// <summary>
                 /// Will run appropriate startups when toast is clicked
                 /// </summary>
-                if (x == "FirstOpen")
+                if (status == "FirstOpen")
                 {
                     PowerOnLaunchDialog();
                 }
-                else if (x == "NewUpdateOpen")
+                else if (status == "NewUpdateOpen")
                 {
                     DisplayUpdateDialog();
                 }
@@ -73,10 +73,6 @@ namespace PowerToys_Settings_Sandbox.Views
 
         // This method opens the first teaching tip on the General Settings page
         // Should open automatically only on initial install after user starts tutorial
-        public void BeginSettingsTips()
-        {
-            OpenFirstGeneralSettingsTip();
-        }
 
         private void OpenFirstGeneralSettingsTip()
         {

--- a/POC-OOBE/OOBE-Sandbox/PowerToys Settings Sandbox/Views/MainPage.xaml.cs
+++ b/POC-OOBE/OOBE-Sandbox/PowerToys Settings Sandbox/Views/MainPage.xaml.cs
@@ -23,39 +23,31 @@ namespace PowerToys_Settings_Sandbox.Views
         {
             if (e.Parameter is string x)
             {
-                var lSettings = ApplicationData.Current.LocalSettings;
-                Object firstRun = lSettings.Values["IsFirstRun"];
-                Object currentVersion = lSettings.Values["currentVersion"];
-                Object newVersion = lSettings.Values["newVersion"];
-
                 /// <summary>
                 /// Will run appropriate startups when toast is clicked
                 /// </summary>
                 if (x == "FirstOpen")
                 {
                     PowerOnLaunchDialog();
-                    lSettings.Values["IsFirstRun"] = false;
                 }
                 else if (x == "NewUpdateOpen")
                 {
                     DisplayUpdateDialog();
-                    lSettings.Values["currentVersion"] = newVersion;
                 }
                 /// <summary>
                 /// Check for current status of app (new update or new install) on launch
                 /// Comment out this section if using sandbox notifications in App.xaml.cs
+                /// Replace the SystemInformation with flags present in current powertoys app if required
                 /// </summary>
                 else
                 {
-                    if (!(firstRun is null) && (bool)firstRun == true)
+                    if (SystemInformation.IsFirstRun)
                     {
                         PowerOnLaunchDialog();
-                        lSettings.Values["IsFirstRun"] = false;
                     }
-                    else if (!(currentVersion is null) && (string)currentVersion != (string)newVersion)
+                    else if (SystemInformation.IsAppUpdated)
                     {
                         DisplayUpdateDialog();
-                        lSettings.Values["currentVersion"] = newVersion;
                     }
                 }
             }

--- a/POC-OOBE/OOBE-Sandbox/PowerToys Settings Sandbox/Views/MainPage.xaml.cs
+++ b/POC-OOBE/OOBE-Sandbox/PowerToys Settings Sandbox/Views/MainPage.xaml.cs
@@ -45,7 +45,6 @@ namespace PowerToys_Settings_Sandbox.Views
                 /// Check for current status of app (new update or new install) on launch
                 /// Comment out this section if using sandbox notifications in App.xaml.cs
                 /// </summary>
-                /*
                 else
                 {
                     if (!(firstRun is null) && (bool)firstRun == true)
@@ -59,7 +58,6 @@ namespace PowerToys_Settings_Sandbox.Views
                         lSettings.Values["currentVersion"] = newVersion;
                     }
                 }
-                */
             }
         }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
- Add ApplicationSettings listeners so that *Update* popup and *First Install* popup only appear after an update or install
- Create a sandbox function in App.xaml.cs so that toast notifications will be triggered on launch
 - Toasts can also trigger the appropriate popups
 - Sandbox notification function is present to replicate the background activation that should trigger toasts

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
- Comment out final else statement in the MainPage.xaml.cs onNavigation (as described in comments) to prevent the *First Install* popup to appear on launch (as the current system properties will view your launch as a "firstlaunch"
- Two content dialogs cannot be open at the same time.

