### PR TITLE
Fixed folder naming for powertoys run

### DIFF
--- a/src/modules/launcher/Wox.Infrastructure/Wox.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Wox.cs
@@ -8,7 +8,7 @@ namespace Wox.Infrastructure
     public static class Constant
     {
         public const string ExeFileName = "PowerLauncher";
-        public const string ModuleLocation = "Microsoft\\PowerToys\\PowerToysRun";
+        public const string ModuleLocation = "Microsoft\\PowerToys\\PowerToys Run";
         public const string Plugins = "Plugins";
 
         private static readonly Assembly Assembly = Assembly.GetExecutingAssembly();


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR fixes issue causing two sets of module name for powertoys run as indicated in the image below

 ![MicrosoftTeams-image (1)](https://user-images.githubusercontent.com/10995909/81990650-69ee3880-95f4-11ea-9fb5-37d50a5cc3a4.png)

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #3027 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manually validated only one folder named "PowerToys Run" is produced for both settings and power toys run configuration using steps given below :  
1. Clean "Microsoft\\PowerToys\\PowerToysRun" folder in appdata folder, if present.
2. Build runner 
3. Verify that only one folder named "PowerToys Run" is produced for launcher. 
