### PR TITLE
Fix FZ not forwarding events to next hook

### DIFF
--- a/src/modules/fancyzones/dll/dllmain.cpp
+++ b/src/modules/fancyzones/dll/dllmain.cpp
@@ -208,7 +208,10 @@ private:
             event.wParam = wParam;
             if (s_instance)
             {
-                return s_instance->HandleKeyboardHookEvent(&event);
+                if (s_instance->HandleKeyboardHookEvent(&event) == 1)
+                {
+                    return 1;
+                }
             }
         }
         return CallNextHookEx(NULL, nCode, wParam, lParam);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR fixes a bug where FZ would not `CallNextHook` if it doesn't have to suppress the key event.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Applies to #3043
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Instead of return the value of the HandleKeyboardHookEvent function, return 1 only if it is equal to 1.