### PR TITLE
Setting WS_CHILD on preview handler

### DIFF
--- a/src/modules/previewpane/common/controls/FormHandlerControl.cs
+++ b/src/modules/previewpane/common/controls/FormHandlerControl.cs
@@ -15,6 +15,12 @@ namespace Common
     public abstract class FormHandlerControl : Form, IPreviewHandlerControl
     {
         /// <summary>
+        /// Needed to make the form a child window.
+        /// </summary>
+        private static int gwlStyle = -16;
+        private static int wsChild = 0x40000000;
+
+        /// <summary>
         /// Holds the parent window handle.
         /// </summary>
         private IntPtr parentHwnd;
@@ -150,6 +156,12 @@ namespace Common
         [DllImport("user32.dll", CharSet = CharSet.Auto)]
         private static extern IntPtr GetFocus();
 
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern int GetWindowLong(IntPtr hWnd, int nIndex);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern int SetWindowLong(IntPtr hWnd, int nIndex, int dwNewLong);
+
         /// <summary>
         /// Update the Form Control window with the passed rectangle.
         /// </summary>
@@ -158,6 +170,13 @@ namespace Common
         {
             this.InvokeOnControlThread(() =>
             {
+                // We must set the WS_CHILD style to change the form to a control within the Explorer preview pane
+                int windowStyle = GetWindowLong(this.Handle, gwlStyle);
+                if ((windowStyle & wsChild) == 0)
+                {
+                    SetWindowLong(this.Handle, gwlStyle, windowStyle | wsChild);
+                }
+
                 SetParent(this.Handle, this.parentHwnd);
                 this.Bounds = windowBounds;
             });


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This is my suggestion of a bugfix for the issue I reported here:
https://github.com/microsoft/PowerToys/issues/2938

Explorer loses the focus (title bar changes color) when using the SVG preview handler, and we cannot switch to the next file with the cursor keys any more.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
No
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2938
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [] Tests added/passed
* [] Requires documentation to be updated
* [] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Before each call to SetParent, I check whether the form has the WS_CHILD style. If not, I set the style so it can become a child control within the Explorer preview pane.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
I have compiled the project, then replaced the installed PreviewHandlerCommon.dll with my copy and checked whether the issue still occurs or not.