### PR TITLE
[intern] Color picker clipboard support

### DIFF
--- a/POC/ColorPicker/ColorPicker/MainWindow.xaml
+++ b/POC/ColorPicker/ColorPicker/MainWindow.xaml
@@ -72,7 +72,8 @@
         <Label Grid.Column="2" Grid.Row="0" Content="RGB" Margin="0,0,11,5" Padding="0" />
         <TextBox Name="RgbTextBox" Grid.Column="2" Grid.Row="1" IsReadOnly="True"
                  HorizontalAlignment="Stretch" VerticalContentAlignment="Center" Margin="0,0,11,0" Text="255, 255, 255" Padding="10,5"
-                 BorderBrush="{StaticResource BorderColor}" Foreground="{StaticResource TextboxTextColor}">
+                 BorderBrush="{StaticResource BorderColor}" Foreground="{StaticResource TextboxTextColor}"
+                 PreviewMouseLeftButtonDown="OnTextBoxPreviewMouseLeftButtonDown" GotFocus="OnTextBoxFocus">
             <TextBox.Resources>
                 <Style TargetType="{x:Type Border}">
                     <Setter Property="CornerRadius" Value="2"/>
@@ -83,7 +84,8 @@
         <Label Grid.Column="3" Grid.Row="0" Content="HEX" Margin="0,0,11,6" Padding="0"/>
         <TextBox Name="HexTextBox" Grid.Column="3" Grid.Row="1" IsReadOnly="True"
                  HorizontalAlignment="Stretch" VerticalContentAlignment="Center" Text="#FFFFFF" Padding="10,5"
-                 BorderBrush="{StaticResource BorderColor}" Foreground="{StaticResource TextboxTextColor}">
+                 BorderBrush="{StaticResource BorderColor}" Foreground="{StaticResource TextboxTextColor}"
+                 PreviewMouseLeftButtonDown="OnTextBoxPreviewMouseLeftButtonDown" GotFocus="OnTextBoxFocus">
             <TextBox.Resources>
                 <Style TargetType="{x:Type Border}">
                     <Setter Property="CornerRadius" Value="2"/>

--- a/POC/ColorPicker/ColorPicker/MainWindow.xaml
+++ b/POC/ColorPicker/ColorPicker/MainWindow.xaml
@@ -17,6 +17,8 @@
         <SolidColorBrush x:Key="DefaultPreviewColor" Color="#FFA70087"/>
         <SolidColorBrush x:Key="BorderColor" Color="#FF666666"/>
         <SolidColorBrush x:Key="TextboxTextColor" Color="#FF666666"/>
+        <SolidColorBrush x:Key="PopupBackgroundColor" Color="#FFF2F2F2"/>
+        <SolidColorBrush x:Key="PopupBorderColor" Color="#FFD0D0D0"/>
     </Window.Resources>
     <Grid Margin="11,8,11,16">
         <Grid.ColumnDefinitions>
@@ -80,6 +82,12 @@
                 </Style>
             </TextBox.Resources>
         </TextBox>
+        <Popup Name="RgbCopiedPopup" PlacementTarget="{Binding ElementName=RgbTextBox}" Placement="Bottom" VerticalOffset="4"
+               HorizontalOffset="7" Width="125" Height="28" Margin="0,10,0,0" AllowsTransparency="True" PopupAnimation="Fade">
+            <Border Background="{StaticResource PopupBackgroundColor}" BorderThickness="1" BorderBrush="{StaticResource PopupBorderColor}" CornerRadius="3">
+                <TextBlock TextAlignment="Center" FontSize="12" Padding="7,5,7,4">Copied to Clipboard</TextBlock>
+            </Border>
+        </Popup>
 
         <Label Grid.Column="3" Grid.Row="0" Content="HEX" Margin="0,0,11,6" Padding="0"/>
         <TextBox Name="HexTextBox" Grid.Column="3" Grid.Row="1" IsReadOnly="True"
@@ -92,5 +100,11 @@
                 </Style>
             </TextBox.Resources>
         </TextBox>
+        <Popup Name="HexCopiedPopup" PlacementTarget="{Binding ElementName=HexTextBox}" Placement="Bottom" VerticalOffset="4"
+               HorizontalOffset="7" Width="125" Height="28" Margin="0,10,0,0" AllowsTransparency="True" PopupAnimation="Fade">
+            <Border Background="{StaticResource PopupBackgroundColor}" BorderThickness="1" BorderBrush="{StaticResource PopupBorderColor}" CornerRadius="3">
+                <TextBlock TextAlignment="Center" FontSize="12" Padding="7,5,7,4">Copied to Clipboard</TextBlock>
+            </Border>
+        </Popup>
     </Grid>
 </Window>

--- a/POC/ColorPicker/ColorPicker/MainWindow.xaml.cs
+++ b/POC/ColorPicker/ColorPicker/MainWindow.xaml.cs
@@ -110,7 +110,8 @@ namespace ColorPicker
 
         private void OnTextBoxFocus(object sender, RoutedEventArgs e)
         {
-            if (textBox = e.OriginalSource as TextBox)
+            TextBox textBox = e.OriginalSource as TextBox;
+            if (textBox != null)
             {
                 textBox.SelectAll();
                 CopyToClipboard(textBox);

--- a/POC/ColorPicker/ColorPicker/MainWindow.xaml.cs
+++ b/POC/ColorPicker/ColorPicker/MainWindow.xaml.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Threading;
@@ -31,6 +32,15 @@ namespace ColorPicker
             ActivateColorSelectionMode();
         }
 
+        protected override void OnLocationChanged(EventArgs e)
+        {
+            RgbCopiedPopup.HorizontalOffset += 1;
+            RgbCopiedPopup.HorizontalOffset -= 1;
+            HexCopiedPopup.HorizontalOffset += 1;
+            HexCopiedPopup.HorizontalOffset -= 1;
+            base.OnLocationChanged(e);
+        }
+
         protected override void OnClosing(CancelEventArgs e)
         {
             _transparentWindow.Close();
@@ -46,7 +56,7 @@ namespace ColorPicker
         private void ConfigureUpdateTimer()
         {
             _updateTimer.Tick += UpdateCurrentColor;
-            _updateTimer.Interval = new TimeSpan(1000);
+            _updateTimer.Interval = TimeSpan.FromMilliseconds(100);
         }
 
         private void OnTransparentScreenClick(object sender, EventArgs e)
@@ -102,6 +112,7 @@ namespace ColorPicker
             if (textBox != null)
             {
                 textBox.SelectAll();
+                CopyToClipboard(textBox);
             }
         }
 
@@ -133,6 +144,23 @@ namespace ColorPicker
             NewColorButton.IsChecked = false;
             _transparentWindow.Hide();
             _updateTimer.Stop();
+        }
+
+        private void CopyToClipboard(TextBox textBox)
+        {
+            textBox.Copy();
+
+            Popup popup = textBox == RgbTextBox ? RgbCopiedPopup : HexCopiedPopup;
+            popup.IsOpen = true;
+
+            DispatcherTimer popupTimer = new DispatcherTimer();
+            popupTimer.Interval = TimeSpan.FromSeconds(3);
+            popupTimer.Tick += (object sender, EventArgs e) =>
+            {
+                popup.IsOpen = false;
+                popupTimer.Stop();
+            };
+            popupTimer.Start();
         }
     }
 }

--- a/POC/ColorPicker/ColorPicker/MainWindow.xaml.cs
+++ b/POC/ColorPicker/ColorPicker/MainWindow.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Threading;
@@ -68,7 +69,7 @@ namespace ColorPicker
             }
         }
 
-        private void OnNewColorButtonClick(object sender, EventArgs e)
+        private void OnNewColorButtonClick(object sender, RoutedEventArgs e)
         {
             if (NewColorButton.IsChecked ?? false)
             {
@@ -77,6 +78,30 @@ namespace ColorPicker
             else
             {
                 DeactivateColorSelectionMode();
+            }
+        }
+
+        private void OnTextBoxPreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            // Source: https://www.intertech.com/Blog/how-to-select-all-text-in-a-wpf-textbox-on-focus/
+            // and https://stackoverflow.com/questions/660554/how-to-automatically-select-all-text-on-focus-in-wpf-textbox
+            TextBox textBox = sender as TextBox;
+            if (textBox != null && !textBox.IsKeyboardFocusWithin)
+            {
+                if (e.OriginalSource.GetType().Name == "TextBoxView")
+                {
+                    e.Handled = true;
+                    textBox.Focus();
+                }
+            }
+        }
+
+        private void OnTextBoxFocus(object sender, RoutedEventArgs e)
+        {
+            TextBox textBox = e.OriginalSource as TextBox;
+            if (textBox != null)
+            {
+                textBox.SelectAll();
             }
         }
 

--- a/POC/ColorPicker/ColorPicker/MainWindow.xaml.cs
+++ b/POC/ColorPicker/ColorPicker/MainWindow.xaml.cs
@@ -148,7 +148,7 @@ namespace ColorPicker
             _updateTimer.Stop();
         }
 
-        private void CopyToClipboard(TextBox textBox)
+        private void CopyToClipboardAndOpenPopup(TextBox textBox)
         {
             textBox.Copy();
 

--- a/POC/ColorPicker/ColorPicker/MainWindow.xaml.cs
+++ b/POC/ColorPicker/ColorPicker/MainWindow.xaml.cs
@@ -110,8 +110,7 @@ namespace ColorPicker
 
         private void OnTextBoxFocus(object sender, RoutedEventArgs e)
         {
-            TextBox textBox = e.OriginalSource as TextBox;
-            if (textBox != null)
+            if (e.OriginalSource is TextBox textBox)
             {
                 textBox.SelectAll();
                 CopyToClipboardAndOpenPopup(textBox);

--- a/POC/ColorPicker/ColorPicker/MainWindow.xaml.cs
+++ b/POC/ColorPicker/ColorPicker/MainWindow.xaml.cs
@@ -108,8 +108,7 @@ namespace ColorPicker
 
         private void OnTextBoxFocus(object sender, RoutedEventArgs e)
         {
-            TextBox textBox = e.OriginalSource as TextBox;
-            if (textBox != null)
+            if (var textBox = e.OriginalSource as TextBox)
             {
                 textBox.SelectAll();
                 CopyToClipboard(textBox);

--- a/POC/ColorPicker/ColorPicker/MainWindow.xaml.cs
+++ b/POC/ColorPicker/ColorPicker/MainWindow.xaml.cs
@@ -114,7 +114,7 @@ namespace ColorPicker
             if (textBox != null)
             {
                 textBox.SelectAll();
-                CopyToClipboard(textBox);
+                CopyToClipboardAndOpenPopup(textBox);
             }
         }
 

--- a/POC/ColorPicker/ColorPicker/MainWindow.xaml.cs
+++ b/POC/ColorPicker/ColorPicker/MainWindow.xaml.cs
@@ -34,6 +34,8 @@ namespace ColorPicker
 
         protected override void OnLocationChanged(EventArgs e)
         {
+            // Fix to let the pop-ups follow the window if it is dragged around
+            // Source: https://stackoverflow.com/questions/5736359/popup-control-moves-with-parent
             RgbCopiedPopup.HorizontalOffset += 1;
             RgbCopiedPopup.HorizontalOffset -= 1;
             HexCopiedPopup.HorizontalOffset += 1;
@@ -108,7 +110,7 @@ namespace ColorPicker
 
         private void OnTextBoxFocus(object sender, RoutedEventArgs e)
         {
-            if (var textBox = e.OriginalSource as TextBox)
+            if (textBox = e.OriginalSource as TextBox)
             {
                 textBox.SelectAll();
                 CopyToClipboard(textBox);


### PR DESCRIPTION
This adds support for copying the RGB or HEX values from the textboxes when clicking on them. This makes the overall user experience much more enjoyable by adding the chosen color to your clipboard as quickly as possible.

Screenshot:
![image](https://user-images.githubusercontent.com/30484238/82062124-a2931e00-9697-11ea-8636-bf3a90339341.png)


Flow:

- Select a color using the color selection mode (enabled on open, and then by clicking the "New Color" button after a first color is selected)
- Click on the textbox containing the desired color format (RGB or HEX)
- The text in the textbox is automatically selected, to give the user feedback, and copied to the clipboard
- A small pop-up appears below the clicked textbox to confirm that the color has been copied to the clipboard