### PR TITLE
[launcher] Default to four results

### DIFF
--- a/src/modules/launcher/Wox.Infrastructure/UserSettings/Settings.cs
+++ b/src/modules/launcher/Wox.Infrastructure/UserSettings/Settings.cs
@@ -83,7 +83,7 @@ namespace Wox.Infrastructure.UserSettings
         public double WindowLeft { get; set; }
         public double WindowTop { get; set; }
 
-        private int _maxResultsToShow = 6;
+        private int _maxResultsToShow = 4;
         public int MaxResultsToShow 
         {
             get


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
* By default we want four results to show and not six, before settings loads the json file.

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
* Delete the PowerToys Run Appdata folder and run Launcher to get four results at start-up.

**NOTE** - Delete the AppData PowerToys Run folder before validating.