### PR TITLE
[FancyZones] Snap out of maximized window into zones with win + left/right arrow

### DIFF
--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -227,6 +227,7 @@ private:
     bool IsNewWorkArea(GUID virtualDesktopId, HMONITOR monitor) noexcept;
 
     void OnEditorExitEvent() noexcept;
+    bool ProcessSnapHotkey() noexcept;
 
     std::vector<std::pair<HMONITOR, RECT>> GetRawMonitorData() noexcept;
     std::vector<HMONITOR> GetMonitorsSorted() noexcept;
@@ -398,7 +399,7 @@ FancyZones::OnKeyDown(PKBDLLHOOKSTRUCT info) noexcept
         }
         else if ((info->vkCode == VK_RIGHT) || (info->vkCode == VK_LEFT))
         {
-            if (m_settings->GetSettings()->overrideSnapHotkeys)
+            if (ProcessSnapHotkey())
             {
                 Trace::FancyZones::OnKeyDown(info->vkCode, win, ctrl, false /*inMoveSize*/);
                 // Win+Left, Win+Right will cycle through Zones in the active ZoneSet when WM_PRIV_LOWLEVELKB's handled
@@ -947,6 +948,24 @@ void FancyZones::OnEditorExitEvent() noexcept
     {
         UpdateWindowsPositions();
     }
+}
+
+bool FancyZones::ProcessSnapHotkey() noexcept
+{
+    if (m_settings->GetSettings()->overrideSnapHotkeys)
+    {
+        const HMONITOR monitor = MonitorFromWindow(GetForegroundWindow(), MONITOR_DEFAULTTONULL);
+        if (monitor)
+        {
+            auto zoneWindow = m_zoneWindowMap.find(monitor);
+            if (zoneWindow != m_zoneWindowMap.end() &&
+                zoneWindow->second->ActiveZoneSet())
+            {
+                return true;
+            }
+        }
+    }
+    return false;
 }
 
 std::vector<HMONITOR> FancyZones::GetMonitorsSorted() noexcept

--- a/src/modules/fancyzones/lib/util.cpp
+++ b/src/modules/fancyzones/lib/util.cpp
@@ -128,6 +128,13 @@ void SizeWindowToRect(HWND window, RECT rect) noexcept
         placement.showCmd = SW_RESTORE | SW_SHOWNA;
     }
 
+    // Remove maximized show command to make sure window is moved to the correct zone.
+    if (placement.showCmd & SW_SHOWMAXIMIZED)
+    {
+        placement.showCmd = SW_RESTORE;
+        placement.flags &= ~WPF_RESTORETOMAXIMIZED;
+    }
+
     placement.rcNormalPosition = rect;
     placement.flags |= WPF_ASYNCWINDOWPLACEMENT;
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
While moving windows through zones with win + left/right arrow handle maximized windows as well.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to https://github.com/microsoft/PowerToys/issues/2068
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
1. Apply any zone layout to work area.
2. Take any window and maximize it.
3. Make sure `Override Windows Snap hotkeys (win+arrow) to move windows between zones` is ON.
4. Press win + left or right arrow.

Expected result: Window should be snapped out of maximized state and moved into correct zone.
