### PR TITLE
[Launcher] Resize suggestion list when MaxResultsToShow changes

### DIFF
--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -315,6 +315,18 @@ namespace PowerLauncher
             _resultList.SuggestionsList.SelectionChanged += SuggestionsList_SelectionChanged;
             _resultList.SuggestionsList.ContainerContentChanging += SuggestionList_UpdateListSize;
             _resultList.PropertyChanged += UserControl_PropertyChanged;
+
+            // Trigger window resizing when MaxResultsToShow changes.            
+            _settings.PropertyChanged += (s, e) =>
+            {
+                if (e.PropertyName == nameof(_settings.MaxResultsToShow))
+                {
+                    Application.Current.Dispatcher.Invoke(() =>
+                    {
+                        UpdateListSize();
+                    });
+                }
+            };
         }
 
         private void SuggestionsList_Loaded(object sender, Windows.UI.Xaml.RoutedEventArgs e)
@@ -389,15 +401,19 @@ namespace PowerLauncher
             }
         }
 
+        private void UpdateListSize()
+        {
+            int count = _viewModel?.Results?.Results.Count ?? 0;
+            int displayCount = Math.Min(count, _settings.MaxResultsToShow);
+            _resultList.Height = displayCount * ROW_HEIGHT;
+        }
         /* Note: This function has been added because a white-background was observed when the list resized,
          * when the number of elements were lesser than the maximum capacity of the list (ie. 4).
          * Binding Height/MaxHeight Properties did not solve this issue.
          */
         private void SuggestionList_UpdateListSize(object sender, Windows.UI.Xaml.Controls.ContainerContentChangingEventArgs e)
         {
-            int count = _viewModel?.Results?.Results.Count ?? 0;
-            int displayCount = Math.Min(count, _settings.MaxResultsToShow);
-            _resultList.Height = displayCount * ROW_HEIGHT;
+            UpdateListSize();
         }
 
         private void SuggestionsList_SelectionChanged(object sender, Windows.UI.Xaml.Controls.SelectionChangedEventArgs e)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
* Fixes black/white result items appearing in the bottom of the suggestion list when changing MaxResultsToShow value from Settings.


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2456
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
1. Start PowerToys.
2. Open PowerToys Run. Type settings.
3. Change Settings\Run\Max results to show to a larger value.
4. Re-open PowerToys Run. Suggestion box window should be resized accordingly.