### PR TITLE
[intern] FancyZone Hotkey for each custom layout

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditorWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditorWindow.xaml
@@ -152,6 +152,12 @@
             <Setter Property="FontSize" Value="12"/>
             <Setter Property="Margin" Value="16,12,0,0"/>
         </Style>
+        <Style x:Key="hotkeyLabel" TargetType="TextBlock">
+            <Setter Property="FontFamily" Value="SegoeUI"/>
+            <Setter Property="FontWeight" Value="Bold"/>
+            <Setter Property="FontSize" Value="16"/>
+            <Setter Property="Margin" Value="16,12,0,0"/>
+        </Style>
         <Style x:Key="textBox" TargetType="TextBox">
             <Setter Property="BorderBrush" Value="#cccccc"/>
             <Setter Property="BorderThickness" Value="1"/>
@@ -174,6 +180,11 @@
         </Button>
         <TextBlock Text="{x:Static props:Resources.Name}" Style="{StaticResource textLabel}" />
         <TextBox Text="{Binding Name}" Width="496" Style="{StaticResource textBox}" />
+        <TextBlock Text="Hotkey" Style="{StaticResource textLabel}" />
+        <StackPanel Orientation="Horizontal" Margin="0,8,0,0" HorizontalAlignment="Left">
+        <TextBlock Text="Win + ` + " Style="{StaticResource hotkeyLabel}" />
+        <TextBox Text="{Binding Keyid}" Width="60" Style="{StaticResource textBox}"/>
+        </StackPanel>
         <!--
         <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
             <CheckBox x:Name="showGridSetting" VerticalAlignment="Center" HorizontalAlignment="Center" IsChecked="True" Margin="16,4,0,0"/>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditorWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditorWindow.xaml
@@ -182,7 +182,7 @@
         <TextBox Text="{Binding Name}" Width="496" Style="{StaticResource textBox}" />
         <TextBlock Text="Hotkey" Style="{StaticResource textLabel}" />
         <StackPanel Orientation="Horizontal" Margin="0,8,0,0" HorizontalAlignment="Left">
-        <TextBlock Text="Win + ` + " Style="{StaticResource hotkeyLabel}" />
+        <TextBlock Text="Alt + " Style="{StaticResource hotkeyLabel}" />
         <TextBox Text="{Binding Keyid}" Width="60" Style="{StaticResource textBox}"/>
         </StackPanel>
         <!--

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditorWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditorWindow.xaml
@@ -175,7 +175,7 @@
         <TextBlock Text="{x:Static props:Resources.Name}" Style="{StaticResource textLabel}" />
         <TextBox Text="{Binding Name}" Style="{StaticResource textBox}" />
         <StackPanel Orientation="Horizontal" Margin="0,8,0,0" HorizontalAlignment="Left">
-            <TextBlock Text="Win + ` + " Style="{StaticResource hotkeyLabel}" />
+            <TextBlock Text="Alt + " Style="{StaticResource hotkeyLabel}" />
             <TextBox Text="{Binding Keyid}" Width="60" Style="{StaticResource textBox}"/>
         </StackPanel>
         <!--        

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditorWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditorWindow.xaml
@@ -150,6 +150,12 @@
             <Setter Property="FontSize" Value="12"/>
             <Setter Property="Margin" Value="0,12,0,0"/>
         </Style>
+        <Style x:Key="hotkeyLabel" TargetType="TextBlock">
+            <Setter Property="FontFamily" Value="SegoeUI"/>
+            <Setter Property="FontWeight" Value="Bold"/>
+            <Setter Property="FontSize" Value="16"/>
+            <Setter Property="Margin" Value="8,12,0,0"/>
+        </Style>
         <Style x:Key="textBox" TargetType="TextBox">
             <Setter Property="BorderBrush" Value="#cccccc"/>
             <Setter Property="BorderThickness" Value="1"/>
@@ -168,7 +174,11 @@
         <TextBlock Text="{x:Static props:Resources.Note_Custom_Table}" Style="{StaticResource textLabel}" TextWrapping="Wrap" />
         <TextBlock Text="{x:Static props:Resources.Name}" Style="{StaticResource textLabel}" />
         <TextBox Text="{Binding Name}" Style="{StaticResource textBox}" />
-<!--        
+        <StackPanel Orientation="Horizontal" Margin="0,8,0,0" HorizontalAlignment="Left">
+            <TextBlock Text="Win + ` + " Style="{StaticResource hotkeyLabel}" />
+            <TextBox Text="{Binding Keyid}" Width="60" Style="{StaticResource textBox}"/>
+        </StackPanel>
+        <!--        
         <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
             <CheckBox x:Name="showGridSetting" VerticalAlignment="Center" HorizontalAlignment="Center" IsChecked="True" Margin="21,4,0,0"/>
             <TextBlock Text="Show snap grid" Style="{StaticResource settingText}" />

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/CanvasLayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/CanvasLayoutModel.cs
@@ -193,7 +193,7 @@ namespace FancyZonesEditor.Models
             CanvasLayoutJson jsonObj = new CanvasLayoutJson
             {
                 Uuid = "{" + Guid.ToString().ToUpper() + "}",
-                Eventid = rnd.Next(),
+                Eventid = rnd.Next(), // TODO: Give Eventid a unique int
                 Keyid = Keyid,
                 Name = Name,
                 Type = "canvas",
@@ -209,7 +209,6 @@ namespace FancyZonesEditor.Models
             {
                 string jsonString = JsonSerializer.Serialize(jsonObj, options);
                 File.WriteAllText(Settings.AppliedZoneSetTmpFile, jsonString);
-                MessageBox.Show(Settings.AppliedZoneSetTmpFile);
             }
             catch (Exception ex)
             {

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/CanvasLayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/CanvasLayoutModel.cs
@@ -22,6 +22,14 @@ namespace FancyZonesEditor.Models
             Zones = zones;
         }
 
+        public CanvasLayoutModel(string uuid, int hotkey_keyid, int hotkey_eventid, string name, LayoutType type, int referenceWidth, int referenceHeight, IList<Int32Rect> zones)
+            : base(uuid, hotkey_keyid, hotkey_eventid, name, type)
+        {
+            _referenceWidth = referenceWidth;
+            _referenceHeight = referenceHeight;
+            Zones = zones;
+        }
+
         public CanvasLayoutModel(string name, LayoutType type, int referenceWidth, int referenceHeight)
         : base(name, type)
         {
@@ -146,12 +154,18 @@ namespace FancyZonesEditor.Models
         {
             public string Uuid { get; set; }
 
+            public int Eventid { get; set; }
+
+            public int Keyid { get; set; }
+
             public string Name { get; set; }
 
             public string Type { get; set; }
 
             public CanvasLayoutInfo Info { get; set; }
         }
+
+        private readonly Random rnd = new Random();
 
         // PersistData
         // Implements the LayoutModel.PersistData abstract method
@@ -179,6 +193,8 @@ namespace FancyZonesEditor.Models
             CanvasLayoutJson jsonObj = new CanvasLayoutJson
             {
                 Uuid = "{" + Guid.ToString().ToUpper() + "}",
+                Eventid = rnd.Next(),
+                Keyid = Keyid,
                 Name = Name,
                 Type = "canvas",
                 Info = layoutInfo,
@@ -193,6 +209,7 @@ namespace FancyZonesEditor.Models
             {
                 string jsonString = JsonSerializer.Serialize(jsonObj, options);
                 File.WriteAllText(Settings.AppliedZoneSetTmpFile, jsonString);
+                MessageBox.Show(Settings.AppliedZoneSetTmpFile);
             }
             catch (Exception ex)
             {

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/GridLayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/GridLayoutModel.cs
@@ -235,10 +235,7 @@ namespace FancyZonesEditor.Models
             GridLayoutJson jsonObj = new GridLayoutJson
             {
                 Uuid = "{" + Guid.ToString().ToUpper() + "}",
-
-                // This is not ideal, only temporary fix
-
-                Eventid = rnd.Next(),
+                Eventid = rnd.Next(), // TODO: Give Eventid a unique int
                 Keyid = Keyid,
                 Name = Name,
                 Type = "grid",
@@ -253,7 +250,6 @@ namespace FancyZonesEditor.Models
             {
                 string jsonString = JsonSerializer.Serialize(jsonObj, options);
                 File.WriteAllText(Settings.AppliedZoneSetTmpFile, jsonString);
-                MessageBox.Show(Settings.AppliedZoneSetTmpFile);
             }
             catch (Exception ex)
             {

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/GridLayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/GridLayoutModel.cs
@@ -95,6 +95,16 @@ namespace FancyZonesEditor.Models
             CellChildMap = cellChildMap;
         }
 
+        public GridLayoutModel(string uuid, int hotkey_keyid, int hotkey_eventid, string name, LayoutType type, int rows, int cols, int[] rowPercents, int[] colsPercents, int[,] cellChildMap)
+            : base(uuid, hotkey_keyid, hotkey_eventid, name, type)
+        {
+            _rows = rows;
+            _cols = cols;
+            RowPercents = rowPercents;
+            ColumnPercents = colsPercents;
+            CellChildMap = cellChildMap;
+        }
+
         public void Reload(byte[] data)
         {
             // Skip version (2 bytes), id (2 bytes), and type (1 bytes)
@@ -188,12 +198,18 @@ namespace FancyZonesEditor.Models
         {
             public string Uuid { get; set; }
 
+            public int Eventid { get; set; }
+
+            public int Keyid { get; set; }
+
             public string Name { get; set; }
 
             public string Type { get; set; }
 
             public GridLayoutInfo Info { get; set; }
         }
+
+        private readonly Random rnd = new Random();
 
         // PersistData
         // Implements the LayoutModel.PersistData abstract method
@@ -219,6 +235,11 @@ namespace FancyZonesEditor.Models
             GridLayoutJson jsonObj = new GridLayoutJson
             {
                 Uuid = "{" + Guid.ToString().ToUpper() + "}",
+
+                // This is not ideal, only temporary fix
+
+                Eventid = rnd.Next(),
+                Keyid = Keyid,
                 Name = Name,
                 Type = "grid",
                 Info = layoutInfo,
@@ -232,6 +253,7 @@ namespace FancyZonesEditor.Models
             {
                 string jsonString = JsonSerializer.Serialize(jsonObj, options);
                 File.WriteAllText(Settings.AppliedZoneSetTmpFile, jsonString);
+                MessageBox.Show(Settings.AppliedZoneSetTmpFile);
             }
             catch (Exception ex)
             {

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
@@ -228,10 +228,8 @@ namespace FancyZonesEditor.Models
                     string name = current.GetProperty("name").GetString();
                     string type = current.GetProperty("type").GetString();
                     string uuid = current.GetProperty("uuid").GetString();
-
                     int hotkey_eventID = current.GetProperty("eventid").GetInt32();
                     int hotkey_keyID = current.GetProperty("keyid").GetInt32();
-
                     var info = current.GetProperty("info");
                     if (type.Equals("grid"))
                     {

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
@@ -55,6 +55,16 @@ namespace FancyZonesEditor.Models
             Type = type;
         }
 
+        protected LayoutModel(string uuid, int hotkey_keyid, int hotkey_eventid, string name, LayoutType type)
+            : this()
+        {
+            _guid = Guid.Parse(uuid);
+            Eventid = hotkey_eventid;
+            Keyid = hotkey_keyid;
+            Name = name;
+            Type = type;
+        }
+
         protected LayoutModel(string name, LayoutType type)
             : this(name)
         {
@@ -81,6 +91,43 @@ namespace FancyZonesEditor.Models
         }
 
         private string _name;
+
+        public int Eventid
+        {
+            get
+            {
+                return _hotkey_eventID;
+            }
+
+            set
+            {
+                if (_hotkey_eventID != value)
+                {
+                    _hotkey_eventID = value;
+                }
+            }
+        }
+
+        private int _hotkey_eventID;
+
+        public int Keyid
+        {
+            get
+            {
+                return _hotkey_keyID;
+            }
+
+            set
+            {
+                if (_hotkey_keyID != (int)value)
+                {
+                    _hotkey_keyID = (int)value;
+                    FirePropertyChanged("Keyid");
+                }
+            }
+        }
+
+        private int _hotkey_keyID;
 
         public LayoutType Type { get; set; }
 
@@ -180,6 +227,10 @@ namespace FancyZonesEditor.Models
                     string name = current.GetProperty("name").GetString();
                     string type = current.GetProperty("type").GetString();
                     string uuid = current.GetProperty("uuid").GetString();
+
+                    int hotkey_eventID = current.GetProperty("eventid").GetInt32();
+                    int hotkey_keyID = current.GetProperty("keyid").GetInt32();
+
                     var info = current.GetProperty("info");
                     if (type.Equals("grid"))
                     {
@@ -216,7 +267,7 @@ namespace FancyZonesEditor.Models
                             i++;
                         }
 
-                        _customModels.Add(new GridLayoutModel(uuid, name, LayoutType.Custom, rows, columns, rowsPercentage, columnsPercentage, cellChildMap));
+                        _customModels.Add(new GridLayoutModel(uuid, hotkey_keyID, hotkey_eventID, name, LayoutType.Custom, rows, columns, rowsPercentage, columnsPercentage, cellChildMap));
                     }
                     else if (type.Equals("canvas"))
                     {
@@ -233,7 +284,7 @@ namespace FancyZonesEditor.Models
                             zones.Add(new Int32Rect(x, y, width, height));
                         }
 
-                        _customModels.Add(new CanvasLayoutModel(uuid, name, LayoutType.Custom, referenceWidth, referenceHeight, zones));
+                        _customModels.Add(new CanvasLayoutModel(uuid, hotkey_keyID, hotkey_eventID, name, LayoutType.Custom, referenceWidth, referenceHeight, zones));
                     }
                 }
 

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -582,15 +582,12 @@ LRESULT FancyZones::WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lpa
         }
         if (wparam == 2)
         {
-            // MessageBox(NULL, L"Zone Warning", L"Zone warning", MB_SETFOREGROUND); 
-            // notifications::show_toast(L"This won't work how you expect!!", {});
-            // notifications::show_toast(L"An older MSIX version of PowerToys was uninstalled.");
             std::vector<notifications::action_t> actions = {
                 notifications::link_button{ GET_RESOURCE_STRING(IDS_CANT_DRAG_ELEVATED_LEARN_MORE), L"https://aka.ms/powertoysDetectedElevatedHelp" },
                 notifications::link_button{ GET_RESOURCE_STRING(IDS_CANT_DRAG_ELEVATED_DIALOG_DONT_SHOW_AGAIN), L"powertoys://cant_drag_elevated_disable/" }
             };
-            notifications::show_toast_with_activations(GET_RESOURCE_STRING(IDS_CANT_DRAG_ELEVATED), {}, std::move(actions));
-           /** auto& fancyZonesData = JSONHelpers::FancyZonesDataInstance();
+            notifications::show_toast_with_activations(L"WARNING: the fancy zone you have chosen may not be applied as you intended. Resolutions do not match!", {}, std::move(actions));
+            auto& fancyZonesData = JSONHelpers::FancyZonesDataInstance();
             JSONHelpers::ZoneSetData dataa{ L"{E2E051C1-E9A4-466E-861C-E76DE510F00E}", JSONHelpers::ZoneSetLayoutType::Focus };
             auto deviceInfo = fancyZonesData.FindDeviceInfo(L"LGD0554#4&1aaa636&0&UID265988_3240_2160_{5760E426-600C-40F5-9E89-E90E5F568782}");
             deviceInfo->activeZoneSet = dataa;
@@ -599,7 +596,7 @@ LRESULT FancyZones::WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lpa
             fancyZonesData.SetActiveZoneSet(L"LGD0554#4&1aaa636&0&UID265988_3240_2160_{5760E426-600C-40F5-9E89-E90E5F568782}", dataa);
             fancyZonesData.SaveFancyZonesData();
             OnEditorExitEvent();
-            **/
+          
         }
     }
     break;

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -583,10 +583,11 @@ LRESULT FancyZones::WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lpa
         if (wparam == 2)
         {
             std::vector<notifications::action_t> actions = {
-                notifications::link_button{ GET_RESOURCE_STRING(IDS_CANT_DRAG_ELEVATED_LEARN_MORE), L"https://aka.ms/powertoysDetectedElevatedHelp" },
-                notifications::link_button{ GET_RESOURCE_STRING(IDS_CANT_DRAG_ELEVATED_DIALOG_DONT_SHOW_AGAIN), L"powertoys://cant_drag_elevated_disable/" }
+                notifications::link_button{ L"Learn more", L"https://aka.ms/powertoysDetectedElevatedHelp" },
+                notifications::link_button{ L"Don't Show Again", L"powertoys://cant_drag_elevated_disable/" }
             };
             notifications::show_toast_with_activations(L"WARNING: the fancy zone you have chosen may not be applied as you intended. Resolutions do not match!", {}, std::move(actions));
+            /*
             auto& fancyZonesData = JSONHelpers::FancyZonesDataInstance();
             JSONHelpers::ZoneSetData dataa{ L"{E2E051C1-E9A4-466E-861C-E76DE510F00E}", JSONHelpers::ZoneSetLayoutType::Focus };
             auto deviceInfo = fancyZonesData.FindDeviceInfo(L"LGD0554#4&1aaa636&0&UID265988_3240_2160_{5760E426-600C-40F5-9E89-E90E5F568782}");
@@ -596,6 +597,7 @@ LRESULT FancyZones::WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lpa
             fancyZonesData.SetActiveZoneSet(L"LGD0554#4&1aaa636&0&UID265988_3240_2160_{5760E426-600C-40F5-9E89-E90E5F568782}", dataa);
             fancyZonesData.SaveFancyZonesData();
             OnEditorExitEvent();
+            */
           
         }
     }

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -4,6 +4,9 @@
 #include <common/on_thread_executor.h>
 #include <common/window_helpers.h>
 
+#include <common/notifications.h>
+#include <common/notifications/fancyzones_notifications.h>
+
 #include "FancyZones.h"
 #include "lib/Settings.h"
 #include "lib/ZoneWindow.h"
@@ -16,6 +19,10 @@
 #include "VirtualDesktopUtils.h"
 
 #include <interface/win_hook_event_data.h>
+#include <common\notifications.h>
+
+extern "C" IMAGE_DOS_HEADER __ImageBase;
+
 
 enum class DisplayChangeType
 {
@@ -575,7 +582,15 @@ LRESULT FancyZones::WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lpa
         }
         if (wparam == 2)
         {
-            auto& fancyZonesData = JSONHelpers::FancyZonesDataInstance();
+            // MessageBox(NULL, L"Zone Warning", L"Zone warning", MB_SETFOREGROUND); 
+            // notifications::show_toast(L"This won't work how you expect!!", {});
+            // notifications::show_toast(L"An older MSIX version of PowerToys was uninstalled.");
+            std::vector<notifications::action_t> actions = {
+                notifications::link_button{ GET_RESOURCE_STRING(IDS_CANT_DRAG_ELEVATED_LEARN_MORE), L"https://aka.ms/powertoysDetectedElevatedHelp" },
+                notifications::link_button{ GET_RESOURCE_STRING(IDS_CANT_DRAG_ELEVATED_DIALOG_DONT_SHOW_AGAIN), L"powertoys://cant_drag_elevated_disable/" }
+            };
+            notifications::show_toast_with_activations(GET_RESOURCE_STRING(IDS_CANT_DRAG_ELEVATED), {}, std::move(actions));
+           /** auto& fancyZonesData = JSONHelpers::FancyZonesDataInstance();
             JSONHelpers::ZoneSetData dataa{ L"{E2E051C1-E9A4-466E-861C-E76DE510F00E}", JSONHelpers::ZoneSetLayoutType::Focus };
             auto deviceInfo = fancyZonesData.FindDeviceInfo(L"LGD0554#4&1aaa636&0&UID265988_3240_2160_{5760E426-600C-40F5-9E89-E90E5F568782}");
             deviceInfo->activeZoneSet = dataa;
@@ -584,6 +599,7 @@ LRESULT FancyZones::WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lpa
             fancyZonesData.SetActiveZoneSet(L"LGD0554#4&1aaa636&0&UID265988_3240_2160_{5760E426-600C-40F5-9E89-E90E5F568782}", dataa);
             fancyZonesData.SaveFancyZonesData();
             OnEditorExitEvent();
+            **/
         }
     }
     break;

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -288,6 +288,7 @@ FancyZones::Run() noexcept
         return;
 
     RegisterHotKey(m_window, 1, m_settings->GetSettings()->editorHotkey.get_modifiers(), m_settings->GetSettings()->editorHotkey.get_code());
+    RegisterHotKey(m_window, 2, MOD_ALT | MOD_NOREPEAT, 0x42);
 
     VirtualDesktopInitialize();
 
@@ -571,6 +572,18 @@ LRESULT FancyZones::WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lpa
         if (wparam == 1)
         {
             ToggleEditor();
+        }
+        if (wparam == 2)
+        {
+            auto& fancyZonesData = JSONHelpers::FancyZonesDataInstance();
+            JSONHelpers::ZoneSetData dataa{ L"{E2E051C1-E9A4-466E-861C-E76DE510F00E}", JSONHelpers::ZoneSetLayoutType::Focus };
+            auto deviceInfo = fancyZonesData.FindDeviceInfo(L"LGD0554#4&1aaa636&0&UID265988_3240_2160_{5760E426-600C-40F5-9E89-E90E5F568782}");
+            deviceInfo->activeZoneSet = dataa;
+            JSONHelpers::DeviceInfoJSON deviceInfoJson{ L"LGD0554#4&1aaa636&0&UID265988_3240_2160_{5760E426-600C-40F5-9E89-E90E5F568782}", *deviceInfo };
+            fancyZonesData.SerializeDeviceInfoToTmpFile(deviceInfoJson, ZoneWindowUtils::GetActiveZoneSetTmpPath());
+            fancyZonesData.SetActiveZoneSet(L"LGD0554#4&1aaa636&0&UID265988_3240_2160_{5760E426-600C-40F5-9E89-E90E5F568782}", dataa);
+            fancyZonesData.SaveFancyZonesData();
+            OnEditorExitEvent();
         }
     }
     break;

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -6,6 +6,7 @@
 
 #include <common/notifications.h>
 #include <common/notifications/fancyzones_notifications.h>
+#include <common/window_helpers.h>
 
 #include "FancyZones.h"
 #include "lib/Settings.h"
@@ -23,6 +24,8 @@
 
 extern "C" IMAGE_DOS_HEADER __ImageBase;
 
+
+extern "C" IMAGE_DOS_HEADER __ImageBase;
 
 enum class DisplayChangeType
 {
@@ -129,6 +132,8 @@ public:
     ToggleEditor() noexcept;
     IFACEMETHODIMP_(void)
     SettingsChanged() noexcept;
+    IFACEMETHODIMP_(void)
+    UpdateHotKeys() noexcept;
     
     void WindowCreated(HWND window) noexcept;
 
@@ -297,6 +302,11 @@ FancyZones::Run() noexcept
     RegisterHotKey(m_window, 1, m_settings->GetSettings()->editorHotkey.get_modifiers(), m_settings->GetSettings()->editorHotkey.get_code());
     RegisterHotKey(m_window, 2, MOD_ALT | MOD_NOREPEAT, 0x42);
 
+    for (int i = 3; i <= 7; i++)
+    {
+        RegisterHotKey(m_window, i, MOD_ALT | MOD_NOREPEAT, 72 + (i-3));
+    }
+
     VirtualDesktopInitialize();
 
     m_dpiUnawareThread.submit(OnThreadExecutor::task_t{ [] {
@@ -431,7 +441,26 @@ FancyZones::OnKeyDown(PKBDLLHOOKSTRUCT info) noexcept
     return false;
 }
 
-// IFancyZonesCallback
+void FancyZones::UpdateHotKeys() noexcept
+{
+    // Grab the list of customZones
+    auto& fancyZonesData = JSONHelpers::FancyZonesDataInstance();
+    auto fancyZoneDataJson = fancyZonesData.GetPersistFancyZonesJSON();
+    json::JsonArray customZonesJson = fancyZoneDataJson.GetNamedArray(L"custom-zone-sets");
+
+    uint32_t size = customZonesJson.Size();
+    for (uint32_t i = 0; i < size; ++i)
+    {
+        json::JsonObject customZoneJson = customZonesJson.GetObjectAt(i);
+        const int hotkey_eventID = static_cast<int>(customZoneJson.GetNamedNumber(L"hotkey_eventID"));
+        const int hotkey_letterID = static_cast<int>(customZoneJson.GetNamedNumber(L"hotkey_letterID"));
+        // Unregister hotkey
+        UnregisterHotKey(m_window, hotkey_eventID);
+        RegisterHotKey(m_window, hotkey_eventID, MOD_ALT | MOD_NOREPEAT, hotkey_letterID);
+    }
+
+}
+    // IFancyZonesCallback
 void FancyZones::ToggleEditor() noexcept
 {
     {
@@ -582,21 +611,57 @@ LRESULT FancyZones::WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lpa
         }
         if (wparam == 2)
         {
-            std::vector<notifications::action_t> actions = {
-                notifications::link_button{ GET_RESOURCE_STRING(IDS_CANT_DRAG_ELEVATED_LEARN_MORE), L"https://aka.ms/powertoysDetectedElevatedHelp" },
-                notifications::link_button{ GET_RESOURCE_STRING(IDS_CANT_DRAG_ELEVATED_DIALOG_DONT_SHOW_AGAIN), L"powertoys://cant_drag_elevated_disable/" }
-            };
-            notifications::show_toast_with_activations(L"WARNING: the fancy zone you have chosen may not be applied as you intended. Resolutions do not match!", {}, std::move(actions));
-            auto& fancyZonesData = JSONHelpers::FancyZonesDataInstance();
-            JSONHelpers::ZoneSetData dataa{ L"{E2E051C1-E9A4-466E-861C-E76DE510F00E}", JSONHelpers::ZoneSetLayoutType::Focus };
-            auto deviceInfo = fancyZonesData.FindDeviceInfo(L"LGD0554#4&1aaa636&0&UID265988_3240_2160_{5760E426-600C-40F5-9E89-E90E5F568782}");
-            deviceInfo->activeZoneSet = dataa;
-            JSONHelpers::DeviceInfoJSON deviceInfoJson{ L"LGD0554#4&1aaa636&0&UID265988_3240_2160_{5760E426-600C-40F5-9E89-E90E5F568782}", *deviceInfo };
-            fancyZonesData.SerializeDeviceInfoToTmpFile(deviceInfoJson, ZoneWindowUtils::GetActiveZoneSetTmpPath());
-            fancyZonesData.SetActiveZoneSet(L"LGD0554#4&1aaa636&0&UID265988_3240_2160_{5760E426-600C-40F5-9E89-E90E5F568782}", dataa);
-            fancyZonesData.SaveFancyZonesData();
-            OnEditorExitEvent();
-          
+                std::vector<notifications::action_t> actions = {
+                    notifications::link_button{ GET_RESOURCE_STRING(IDS_CANT_DRAG_ELEVATED_LEARN_MORE), L"https://aka.ms/powertoysDetectedElevatedHelp" },
+                    notifications::link_button{ GET_RESOURCE_STRING(IDS_CANT_DRAG_ELEVATED_DIALOG_DONT_SHOW_AGAIN), L"powertoys://cant_drag_elevated_disable/" }
+                };
+                notifications::show_toast_with_activations(L"WARNING: the fancy zone you have chosen may not be applied as you intended. Resolutions do not match!", {}, std::move(actions));
+
+                auto& fancyZonesData = JSONHelpers::FancyZonesDataInstance();
+                JSONHelpers::ZoneSetData dataa{ L"{E2E051C1-E9A4-466E-861C-E76DE510F00E}", JSONHelpers::ZoneSetLayoutType::Focus };
+                auto deviceInfo = fancyZonesData.FindDeviceInfo(L"ACR048F#4&1aaa636&0&UID200195_2560_1440_{5760E426-600C-40F5-9E89-E90E5F568782}");
+                deviceInfo->activeZoneSet = dataa;
+                JSONHelpers::DeviceInfoJSON deviceInfoJson{ L"ACR048F#4&1aaa636&0&UID200195_2560_1440_{5760E426-600C-40F5-9E89-E90E5F568782}", *deviceInfo };
+                fancyZonesData.SerializeDeviceInfoToTmpFile(deviceInfoJson, ZoneWindowUtils::GetActiveZoneSetTmpPath());
+                fancyZonesData.SetActiveZoneSet(L"ACR048F#4&1aaa636&0&UID200195_2560_1440_{5760E426-600C-40F5-9E89-E90E5F568782}", dataa);
+                fancyZonesData.SaveFancyZonesData();
+                OnEditorExitEvent();
+        }
+        for (int i = 3; i <= 7 ; i++)
+        {
+            if (wparam == i) {
+                auto& fancyZonesData = JSONHelpers::FancyZonesDataInstance();
+                auto fancyZoneDataJson = fancyZonesData.GetPersistFancyZonesJSON();
+                json::JsonArray customZonesJson = fancyZoneDataJson.GetNamedArray(L"custom-zone-sets");
+
+                uint32_t size = customZonesJson.Size();
+                if (i-3 < size)
+                {
+                 json::JsonObject customZoneJson = customZonesJson.GetObjectAt(i-3);
+                    const std::wstring newLayout = static_cast<std::wstring>(customZoneJson.GetNamedString(L"uuid"));
+
+                     // Grab the monitor
+                     POINT currentCursorPos{};
+                     HMONITOR monitor{};
+                     GetCursorPos(&currentCursorPos);
+                     monitor = MonitorFromPoint(currentCursorPos, MONITOR_DEFAULTTOPRIMARY);
+
+                     auto iter = m_zoneWindowMap.find(monitor);
+                     auto zoneWindow = iter->second;
+                     auto deviceInfo = fancyZonesData.FindDeviceInfo(zoneWindow->UniqueId());
+
+                     // auto deviceInfo = fancyZonesData.FindDeviceInfo(L"LGD0554#4&1aaa636&0&UID265988_3240_2160_{5760E426-600C-40F5-9E89-E90E5F568782}");
+                     JSONHelpers::ZoneSetData newZoneData{ newLayout, JSONHelpers::ZoneSetLayoutType::Custom };
+
+                     deviceInfo->activeZoneSet = newZoneData;
+
+                     JSONHelpers::DeviceInfoJSON deviceInfoJson{ zoneWindow->UniqueId(), *deviceInfo };
+                     fancyZonesData.SerializeDeviceInfoToTmpFile(deviceInfoJson, ZoneWindowUtils::GetActiveZoneSetTmpPath());
+                     fancyZonesData.SetActiveZoneSet(zoneWindow->UniqueId(), newZoneData);
+                     fancyZonesData.SaveFancyZonesData();
+                     OnEditorExitEvent();   
+                }
+            }
         }
     }
     break;
@@ -646,6 +711,7 @@ LRESULT FancyZones::WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lpa
             if (lparam == static_cast<LPARAM>(EditorExitKind::Exit))
             {
                 OnEditorExitEvent();
+                //UpdateHotKeys();
             }
 
             {

--- a/src/modules/fancyzones/lib/JsonHelpers.cpp
+++ b/src/modules/fancyzones/lib/JsonHelpers.cpp
@@ -789,8 +789,6 @@ namespace JSONHelpers
 
         result.SetNamedValue(L"uuid", json::value(zoneSet.uuid));
         result.SetNamedValue(L"type", json::value(TypeToString(zoneSet.type)));
-        // result.SetNamedValue(L"eventid", json::value(zoneSet.eventid));
-        // result.SetNamedValue(L"keyid", json::value(zoneSet.keyid));
 
         return result;
     }
@@ -802,8 +800,6 @@ namespace JSONHelpers
             ZoneSetData zoneSetData;
             zoneSetData.uuid = zoneSet.GetNamedString(L"uuid");
             zoneSetData.type = TypeFromString(std::wstring{ zoneSet.GetNamedString(L"type") });
-            // zoneSetData.eventid = zoneSet.GetNamedNumber(L"eventid");
-            // zoneSetData.keyid = zoneSet.GetNamedNumber(L"keyid");
 
             if (!isValidGuid(zoneSetData.uuid))
             {

--- a/src/modules/fancyzones/lib/JsonHelpers.cpp
+++ b/src/modules/fancyzones/lib/JsonHelpers.cpp
@@ -701,6 +701,8 @@ namespace JSONHelpers
                 CustomZoneSetData zoneSetData;
                 zoneSetData.name = std::wstring{ value };
                 zoneSetData.type = static_cast<CustomLayoutType>(data[2]);
+                zoneSetData.eventid = 1;
+                zoneSetData.keyid = 2;
                 // int version =  data[0] * 256 + data[1]; - Not used anymore
 
                 GUID guid;
@@ -787,6 +789,8 @@ namespace JSONHelpers
 
         result.SetNamedValue(L"uuid", json::value(zoneSet.uuid));
         result.SetNamedValue(L"type", json::value(TypeToString(zoneSet.type)));
+        // result.SetNamedValue(L"eventid", json::value(zoneSet.eventid));
+        // result.SetNamedValue(L"keyid", json::value(zoneSet.keyid));
 
         return result;
     }
@@ -798,6 +802,8 @@ namespace JSONHelpers
             ZoneSetData zoneSetData;
             zoneSetData.uuid = zoneSet.GetNamedString(L"uuid");
             zoneSetData.type = TypeFromString(std::wstring{ zoneSet.GetNamedString(L"type") });
+            // zoneSetData.eventid = zoneSet.GetNamedNumber(L"eventid");
+            // zoneSetData.keyid = zoneSet.GetNamedNumber(L"keyid");
 
             if (!isValidGuid(zoneSetData.uuid))
             {
@@ -1034,6 +1040,8 @@ namespace JSONHelpers
 
         result.SetNamedValue(L"uuid", json::value(customZoneSet.uuid));
         result.SetNamedValue(L"name", json::value(customZoneSet.data.name));
+        result.SetNamedValue(L"eventid", json::value(customZoneSet.data.eventid));
+        result.SetNamedValue(L"keyid", json::value(customZoneSet.data.keyid));
         switch (customZoneSet.data.type)
         {
         case CustomLayoutType::Canvas: {
@@ -1070,6 +1078,8 @@ namespace JSONHelpers
             }
             
             result.data.name = customZoneSet.GetNamedString(L"name");
+            result.data.eventid = customZoneSet.GetNamedNumber(L"eventid");
+            result.data.keyid = customZoneSet.GetNamedNumber(L"keyid");
 
             json::JsonObject infoJson = customZoneSet.GetNamedObject(L"info");
             std::wstring zoneSetType = std::wstring{ customZoneSet.GetNamedString(L"type") };

--- a/src/modules/fancyzones/lib/JsonHelpers.cpp
+++ b/src/modules/fancyzones/lib/JsonHelpers.cpp
@@ -701,8 +701,6 @@ namespace JSONHelpers
                 CustomZoneSetData zoneSetData;
                 zoneSetData.name = std::wstring{ value };
                 zoneSetData.type = static_cast<CustomLayoutType>(data[2]);
-                zoneSetData.eventid = 1;
-                zoneSetData.keyid = 2;
                 // int version =  data[0] * 256 + data[1]; - Not used anymore
 
                 GUID guid;

--- a/src/modules/fancyzones/lib/JsonHelpers.h
+++ b/src/modules/fancyzones/lib/JsonHelpers.h
@@ -108,6 +108,8 @@ namespace JSONHelpers
     {
         std::wstring name;
         CustomLayoutType type;
+        int eventid;
+        int keyid;
         std::variant<CanvasLayoutInfo, GridLayoutInfo> info;
     };
 
@@ -125,6 +127,8 @@ namespace JSONHelpers
     {
         std::wstring uuid;
         ZoneSetLayoutType type;
+        int eventid;
+        int keyid;
 
         static json::JsonObject ToJson(const ZoneSetData& zoneSet);
         static std::optional<ZoneSetData> FromJson(const json::JsonObject& zoneSet);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
POC of hotkey feature for to change custom layouts on focused monitor

There are a couple of TODOs before this feature is production ready:

- Allow the user to specify the hotkey combination (right now it is mapped to alt + 0-9
- Update hotkey configuration registration on proper update event (right now the mapping is updated when the editor is toggled event)
- Update notification messages
- Generate unique event ids for hotkey events (right now we have it on random int)
- Defensive measures against bad user input

 (I have added TODO comments where these changes might need to be placed)