### PR TITLE
[launcher] - Increase the score for Exact matches in the Name of the Application

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32.cs
@@ -41,6 +41,12 @@ namespace Microsoft.Plugin.Program.Programs
             var descriptionMatch = StringMatcher.FuzzySearch(query, Description);
             var executableNameMatch = StringMatcher.FuzzySearch(query, ExecutableName);
             var score = new[] { nameMatch.Score, descriptionMatch.Score, executableNameMatch.Score }.Max();
+
+            // To increase the score of an exact match
+            if(String.Equals(query, Name, StringComparison.CurrentCultureIgnoreCase))
+            {
+                score += 10;
+            }
             return score;
         }
 

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32.cs
@@ -41,12 +41,6 @@ namespace Microsoft.Plugin.Program.Programs
             var descriptionMatch = StringMatcher.FuzzySearch(query, Description);
             var executableNameMatch = StringMatcher.FuzzySearch(query, ExecutableName);
             var score = new[] { nameMatch.Score, descriptionMatch.Score, executableNameMatch.Score }.Max();
-
-            // To increase the score of an exact match
-            if(String.Equals(query, Name, StringComparison.CurrentCultureIgnoreCase))
-            {
-                score += 10;
-            }
             return score;
         }
 

--- a/src/modules/launcher/Wox.Infrastructure/StringMatcher.cs
+++ b/src/modules/launcher/Wox.Infrastructure/StringMatcher.cs
@@ -223,7 +223,6 @@ namespace Wox.Infrastructure
                 }
             }
 
-            // To increase the score of an exact match
             if (String.Equals(query, stringToCompare, StringComparison.CurrentCultureIgnoreCase))
             {
                 var bonusForExactMatch = 10;

--- a/src/modules/launcher/Wox.Infrastructure/StringMatcher.cs
+++ b/src/modules/launcher/Wox.Infrastructure/StringMatcher.cs
@@ -223,6 +223,12 @@ namespace Wox.Infrastructure
                 }
             }
 
+            // To increase the score of an exact match
+            if (String.Equals(query, stringToCompare, StringComparison.CurrentCultureIgnoreCase))
+            {
+                score += 10;
+            }
+
             return score;
         }
 

--- a/src/modules/launcher/Wox.Infrastructure/StringMatcher.cs
+++ b/src/modules/launcher/Wox.Infrastructure/StringMatcher.cs
@@ -226,7 +226,8 @@ namespace Wox.Infrastructure
             // To increase the score of an exact match
             if (String.Equals(query, stringToCompare, StringComparison.CurrentCultureIgnoreCase))
             {
-                score += 10;
+                var bonusForExactMatch = 10;
+                score += bonusForExactMatch;
             }
 
             return score;

--- a/src/modules/launcher/Wox.Test/FuzzyMatcherTest.cs
+++ b/src/modules/launcher/Wox.Test/FuzzyMatcherTest.cs
@@ -122,21 +122,37 @@ namespace Wox.Test
             }
         }
 
-        [TestCase(Chrome, Chrome, 137)]
-        [TestCase(Chrome, LastIsChrome, 83)]
-        [TestCase(Chrome, HelpCureHopeRaiseOnMindEntityChrome, 21)]
-        [TestCase(Chrome, UninstallOrChangeProgramsOnYourComputer, 15)]
-        [TestCase(Chrome, CandyCrushSagaFromKing, 0)]
-        [TestCase("sql", MicrosoftSqlServerManagementStudio, 56)]
-        [TestCase("sql  manag", MicrosoftSqlServerManagementStudio, 79)]//double spacing intended
-        public void WhenGivenQueryStringThenShouldReturnCurrentScoring(string queryString, string compareString, int expectedScore)
+        [Test]
+        public void WhenMultipleResults_ExactMatchingResult_ShouldHaveGreatestScore()
         {
-            // When, Given
-            var matcher = new StringMatcher();
-            var rawScore = matcher.FuzzyMatch(queryString, compareString).RawScore;
+            // Arrange
+            string queryString = "vim";
 
-            // Should
-            Assert.AreEqual(expectedScore, rawScore, $"Expected score for compare string '{compareString}': {expectedScore}, Actual: {rawScore}");
+            // Vim
+            string firstName = "Vim";
+            string firstDescription = "Vi Improved - A Text Editor";
+            string firstExecutableName = "vim.exe";
+
+            // Vim Diff
+            string secondName = "Vim Diff";
+            string secondDescription = "Vi Improved - A Text Editor";
+            string secondExecutableName = "vim.exe";
+
+            // Act
+            var matcher = new StringMatcher();
+            var firstNameMatch = matcher.FuzzyMatch(queryString, firstName).RawScore;
+            var firstDescriptionMatch = matcher.FuzzyMatch(queryString, firstDescription).RawScore;
+            var firstExecutableNameMatch = matcher.FuzzyMatch(queryString, firstExecutableName).RawScore;
+
+            var secondNameMatch = matcher.FuzzyMatch(queryString, secondName).RawScore;
+            var secondDescriptionMatch = matcher.FuzzyMatch(queryString, secondDescription).RawScore;
+            var secondExecutableNameMatch = matcher.FuzzyMatch(queryString, secondExecutableName).RawScore;
+
+            var firstScore = new[] { firstNameMatch, firstDescriptionMatch, firstExecutableNameMatch }.Max();
+            var secondScore = new[] { secondNameMatch, secondDescriptionMatch, secondExecutableNameMatch }.Max();
+
+            // Assert
+            Assert.IsTrue(firstScore > secondScore);
         }
 
         [TestCase("goo", "Google Chrome", StringMatcher.SearchPrecisionScore.Regular, true)]

--- a/src/modules/launcher/Wox.Test/FuzzyMatcherTest.cs
+++ b/src/modules/launcher/Wox.Test/FuzzyMatcherTest.cs
@@ -122,22 +122,9 @@ namespace Wox.Test
             }
         }
 
-        [Test]
-        public void WhenMultipleResults_ExactMatchingResult_ShouldHaveGreatestScore()
+        [TestCase("vim", "Vim", "ignoreDescription", "ignore.exe", "Vim Diff", "ignoreDescription", "ignore.exe")]
+        public void WhenMultipleResults_ExactMatchingResult_ShouldHaveGreatestScore(string queryString, string firstName, string firstDescription, string firstExecutableName, string secondName, string secondDescription, string secondExecutableName)
         {
-            // Arrange
-            string queryString = "vim";
-
-            // Vim
-            string firstName = "Vim";
-            string firstDescription = "Vi Improved - A Text Editor";
-            string firstExecutableName = "vim.exe";
-
-            // Vim Diff
-            string secondName = "Vim Diff";
-            string secondDescription = "Vi Improved - A Text Editor";
-            string secondExecutableName = "vim.exe";
-
             // Act
             var matcher = new StringMatcher();
             var firstNameMatch = matcher.FuzzyMatch(queryString, firstName).RawScore;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
* On typing `vim`, `Vim Diff` was showing up as the first result and instead of `Vim`. 
* This was happening because we assign a score to the results which is the max matching score of it's name, description and the executable name.
* However, since all of them had the same executable name `vim.exe` all the results were getting the same score.
 
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #3128 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added for exact matching results to get a greater score.

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
* The score is increased by 10 when there is an exact match in the name of the search result.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
* Tests added.
* Manually validated.
![image](https://user-images.githubusercontent.com/28739210/82374558-1012b780-99d4-11ea-8ae7-348d1606cb44.png)
![image](https://user-images.githubusercontent.com/28739210/82374589-1b65e300-99d4-11ea-83b6-200cb09b04e3.png)
