### PR TITLE
[intern] Fix bug where the overlay window was not closing on exit

### DIFF
--- a/proofOfConcept/ColorPickerAlpha/ColorPickerAlpha/MainWindow.xaml.cs
+++ b/proofOfConcept/ColorPickerAlpha/ColorPickerAlpha/MainWindow.xaml.cs
@@ -70,6 +70,7 @@ namespace ColorPickerAlpha
             {
                 Mouse.OverrideCursor = null;
                 isClosing = true;
+                overlayWnd.Close();
             };
 
             new Thread(() =>

--- a/proofOfConcept/ColorPickerAlpha/README.md
+++ b/proofOfConcept/ColorPickerAlpha/README.md
@@ -21,7 +21,6 @@ Have you ever struggled to sample the color of a picture or app on Windows? Then
 
 <h2>Current Issues / Future Goals</h2>
 
-* app continues to run in background after closing 
 * polishing UI
 * adding hot keys for improved accessibility and speed
 * adding magnification and a color picker wheel


### PR DESCRIPTION
## Summary of the Pull Request
Fix: The overlay window is the owner of the main window to make the main window always on top of the overlay. This was causing the overlay window to not be closed when the main window was closed.