### PR TITLE
Added check for Type key/shortcut open but not in focus

### DIFF
--- a/src/modules/keyboardmanager/common/KeyboardManagerState.cpp
+++ b/src/modules/keyboardmanager/common/KeyboardManagerState.cpp
@@ -38,6 +38,16 @@ bool KeyboardManagerState::CheckUIState(KeyboardManagerUIState state)
             return true;
         }
     }
+    // If we are checking for EditKeyboardWindowActivated then it's possible the state could be DetectSingleKeyRemapWindowActivated but not in focus
+    else if (state == KeyboardManagerUIState::EditKeyboardWindowActivated && uiState == KeyboardManagerUIState::DetectSingleKeyRemapWindowActivated)
+    {
+        return true;
+    }
+    // If we are checking for EditShortcutsWindowActivated then it's possible the state could be DetectShortcutWindowActivated but not in focus
+    else if (state == KeyboardManagerUIState::EditShortcutsWindowActivated && uiState == KeyboardManagerUIState::DetectShortcutWindowActivated)
+    {
+        return true;
+    }
 
     return false;
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Fixes a scenario where a user could open Type key and switch to some other window but remappings would not be disabled.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Applies to #3227 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Verified that keys appear as expected in each of the window states.