### PR TITLE
fixing images so they deep link to module overview versus the img in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ PowerToys will now enable two types of files to be previewed: Markdown (.md) & S
 
 ### PowerToys Run
 
-<img align="left" src="./doc/images/overview/PowerLauncher_small.png" /> [PowerToys Run](src/modules/launcher/) is a new toy in PowerToys that can help you search and launch your app instantly! It is open source and modular for additional plugins.  Window Walker is now inside!
+[<img align="left" src="./doc/images/overview/PowerLauncher_small.png" />](src/modules/launcher/) [PowerToys Run](src/modules/launcher/) is a new toy in PowerToys that can help you search and launch your app instantly! It is open source and modular for additional plugins.  Window Walker is now inside!
 <br>
 <br>
 <br>

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Microsoft PowerToys is a set of utilities for power users to tune and streamline
 
 ### FancyZones
 
-<img align="left" src="./doc/images/overview/FancyZones_small.png" />[FancyZones](/src/modules/fancyzones/) is a window manager that makes it easy to create complex window layouts and quickly position windows into those layouts.
+[<img align="left" src="./doc/images/overview/FancyZones_small.png" />](/src/modules/fancyzones/) [FancyZones](/src/modules/fancyzones/) is a window manager that makes it easy to create complex window layouts and quickly position windows into those layouts.
 <br>
 <br>
 <br>
@@ -23,7 +23,7 @@ Microsoft PowerToys is a set of utilities for power users to tune and streamline
 
 ### Shortcut Guide
 
-<img align="left" src="./doc/images/overview/Shortcut guide_small.png" />[Windows key shortcut guide](/src/modules/shortcut_guide) appears when a user holds the Windows key down for more than one second and shows the available shortcuts for the current state of the desktop.
+[<img align="left" src="./doc/images/overview/Shortcut guide_small.png" />](/src/modules/shortcut_guide)  [Windows key shortcut guide](/src/modules/shortcut_guide) appears when a user holds the Windows key down for more than one second and shows the available shortcuts for the current state of the desktop.
 <br>
 <br>
 <br>
@@ -32,13 +32,13 @@ Microsoft PowerToys is a set of utilities for power users to tune and streamline
 
 ### PowerRename
 
-<img align="left" src="./doc/images/overview/PowerRename_small.PNG" />[PowerRename](/src/modules/powerrename) is a Windows Shell Extension for advanced bulk renaming using search and replace or regular expressions. PowerRename allows simple search and replace or more advanced regular expression matching. While you type in the search and replace input fields, the preview area will show what the items will be renamed to. PowerRename then calls into the Windows Explorer file operations engine to perform the rename. This has the benefit of allowing the rename operation to be undone after PowerRename exits. This code is based on [Chris Davis's SmartRename](https://github.com/chrdavis/SmartRename).
+[<img align="left" src="./doc/images/overview/PowerRename_small.PNG" />](/src/modules/powerrename) [PowerRename](/src/modules/powerrename) is a Windows Shell Extension for advanced bulk renaming using search and replace or regular expressions. PowerRename allows simple search and replace or more advanced regular expression matching. While you type in the search and replace input fields, the preview area will show what the items will be renamed to. PowerRename then calls into the Windows Explorer file operations engine to perform the rename. This has the benefit of allowing the rename operation to be undone after PowerRename exits. This code is based on [Chris Davis's SmartRename](https://github.com/chrdavis/SmartRename).
 <br>
 <br>
 
 ### File Explorer (Preview Panes)
 
-<img align="left" src="./doc/images/overview/PowerPreview_small.PNG" />[File Explorer](/src/modules/previewpane) add-ons right now are just limited to Preview Pane additions for File Explorer. Preview Pane is an existing feature in the File Explorer.  To enable it, you just click the View tab in the ribbon and then click "Preview Pane".
+[<img align="left" src="./doc/images/overview/PowerPreview_small.PNG" />](/src/modules/previewpane) [File Explorer](/src/modules/previewpane) add-ons right now are just limited to Preview Pane additions for File Explorer. Preview Pane is an existing feature in the File Explorer.  To enable it, you just click the View tab in the ribbon and then click "Preview Pane".
 
 PowerToys will now enable two types of files to be previewed: Markdown (.md) & SVG (.svg)
 <br>
@@ -47,14 +47,14 @@ PowerToys will now enable two types of files to be previewed: Markdown (.md) & S
 
 ### Image Resizer
 
-<img align="left" src="./doc/images/overview/ImageResizer_small.png" />[Image Resizer](/src/modules/imageresizer) is a Windows Shell Extension for quickly resizing images.  With a simple right click from File Explorer, resize one or many images instantly. This code is based on [Brice Lambson's Image Resizer](https://github.com/bricelam/ImageResizer).
+[<img align="left" src="./doc/images/overview/ImageResizer_small.png" />](/src/modules/imageresizer) [Image Resizer](/src/modules/imageresizer) is a Windows Shell Extension for quickly resizing images.  With a simple right click from File Explorer, resize one or many images instantly. This code is based on [Brice Lambson's Image Resizer](https://github.com/bricelam/ImageResizer).
 <br>
 <br>
 <br>
 
 ### Keyboard Manager
 
-<img align="left" src="./doc/images/overview/KBM_small.png" /> [Keyboard Manager](src/modules/keyboardmanager/) allows you to customize the keyboard to be more productive by remapping keys and creating your own keyboard shortcuts.
+[<img align="left" src="./doc/images/overview/KBM_small.png" />]](src/modules/keyboardmanager/ [Keyboard Manager](src/modules/keyboardmanager/) allows you to customize the keyboard to be more productive by remapping keys and creating your own keyboard shortcuts.
 <br>
 <br>
 <br>

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Microsoft PowerToys is a set of utilities for power users to tune and streamline
 <br>
 <br>
 <br>
-<br>
 
 ### PowerRename
 
@@ -43,11 +42,11 @@ Microsoft PowerToys is a set of utilities for power users to tune and streamline
 PowerToys will now enable two types of files to be previewed: Markdown (.md) & SVG (.svg)
 <br>
 <br>
-<br>
 
 ### Image Resizer
 
 [<img align="left" src="./doc/images/overview/ImageResizer_small.png" />](/src/modules/imageresizer) [Image Resizer](/src/modules/imageresizer) is a Windows Shell Extension for quickly resizing images.  With a simple right click from File Explorer, resize one or many images instantly. This code is based on [Brice Lambson's Image Resizer](https://github.com/bricelam/ImageResizer).
+<br>
 <br>
 <br>
 <br>
@@ -64,7 +63,6 @@ PowerToys will now enable two types of files to be previewed: Markdown (.md) & S
 ### PowerToys Run
 
 [<img align="left" src="./doc/images/overview/PowerLauncher_small.png" />](src/modules/launcher/) [PowerToys Run](src/modules/launcher/) is a new toy in PowerToys that can help you search and launch your app instantly! It is open source and modular for additional plugins.  Window Walker is now inside!
-<br>
 <br>
 <br>
 <br>

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ PowerToys will now enable two types of files to be previewed: Markdown (.md) & S
 
 ### Keyboard Manager
 
-[<img align="left" src="./doc/images/overview/KBM_small.png" />]](src/modules/keyboardmanager/ [Keyboard Manager](src/modules/keyboardmanager/) allows you to customize the keyboard to be more productive by remapping keys and creating your own keyboard shortcuts.
+[<img align="left" src="./doc/images/overview/KBM_small.png" />](src/modules/keyboardmanager/ [Keyboard Manager](src/modules/keyboardmanager/) allows you to customize the keyboard to be more productive by remapping keys and creating your own keyboard shortcuts.
 <br>
 <br>
 <br>

--- a/README.md
+++ b/README.md
@@ -63,8 +63,7 @@ PowerToys will now enable two types of files to be previewed: Markdown (.md) & S
 
 ### PowerToys Run
 
-[<img align="left" src="./doc/images/overview/PowerLauncher_small.png" />](src/modules/launcher/) [PowerToys Run](src/modules/launcher/) is a new toy in PowerToys that can help you search and launch your app instantly! It is open source and modular for additional plugins.  Window Walker is now inside!
-<br>
+[<img align="left" src="./doc/images/overview/PowerLauncher_small.png" />](src/modules/launcher/) [PowerToys Run](src/modules/launcher/) is a new toy in PowerToys that can help you search and launch your app instantly with a simple alt-space and start typing! It is open source and modular for additional plugins.  Window Walker is now inside!
 <br>
 <br>
 <br>

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Microsoft PowerToys is a set of utilities for power users to tune and streamline
 <br>
 <br>
 <br>
+<br>
 
 ### PowerRename
 
@@ -53,7 +54,7 @@ PowerToys will now enable two types of files to be previewed: Markdown (.md) & S
 
 ### Keyboard Manager
 
-[<img align="left" src="./doc/images/overview/KBM_small.png" />](src/modules/keyboardmanager/ [Keyboard Manager](src/modules/keyboardmanager/) allows you to customize the keyboard to be more productive by remapping keys and creating your own keyboard shortcuts.
+[<img align="left" src="./doc/images/overview/KBM_small.png" />](src/modules/keyboardmanager/) [Keyboard Manager](src/modules/keyboardmanager/) allows you to customize the keyboard to be more productive by remapping keys and creating your own keyboard shortcuts.
 <br>
 <br>
 <br>


### PR DESCRIPTION
fixing images so they deep link to module overview versus the img