### PR TITLE
Moved publishing to publish.cmd script to unblock signing

### DIFF
--- a/.pipelines/build.cmd
+++ b/.pipelines/build.cmd
@@ -4,3 +4,5 @@ call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Too
 call msbuild ../PowerToys.sln /p:Configuration=Release /p:Platform=x64 || exit /b 1
 call msbuild ../src/common/notifications/notifications_dll.vcxproj /p:Configuration=Release /p:Platform=x64 || exit /b 1
 call msbuild ../src/common/notifications_winrt/notifications.vcxproj /p:Configuration=Release /p:Platform=x64 || exit /b 1
+SET PTRoot=..
+call "..\installer\PowerToysSetup\publish.cmd"

--- a/installer/PowerToysSetup/PowerToysSetup.wixproj
+++ b/installer/PowerToysSetup/PowerToysSetup.wixproj
@@ -69,76 +69,8 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\WiX.3.11.2\build\wix.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\WiX.3.11.2\build\wix.props'))" />
   </Target>
-
   <PropertyGroup>
-    <PreBuildEvent>setlocal enableDelayedExpansion
-
-rem Publish Settings
-SET settingsProfileFolderName=..\..\..\..\src\core\Microsoft.PowerToys.Settings.UI.Runner\Properties\PublishProfiles\
-rem Create the publish profile folder if it doesn%27t exist
-IF NOT EXIST !settingsProfileFolderName! (mkdir !settingsProfileFolderName!)
-SET settingsProfileFileName=SettingsProfile.pubxml
-SET settingsPublishProfile=!settingsProfileFolderName!!settingsProfileFileName!
-
-rem Create the publish profile pubxml
-echo ^&lt;%3fxml version="1.0" encoding="utf-8"%3f^&gt; &gt; !settingsPublishProfile!
-echo ^&lt;^^!-- &gt;&gt; !settingsPublishProfile!
-echo https://go.microsoft.com/fwlink/%3fLinkID=208121.  &gt;&gt; !settingsPublishProfile!
-echo --^&gt; &gt;&gt; !settingsPublishProfile!
-echo ^&lt;Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003"^&gt; &gt;&gt; !settingsPublishProfile!
-echo   ^&lt;PropertyGroup^&gt; &gt;&gt; !settingsPublishProfile!
-echo     ^&lt;PublishProtocol^&gt;FileSystem^&lt;/PublishProtocol^&gt; &gt;&gt; !settingsPublishProfile!
-echo     ^&lt;Configuration^&gt;$(ConfigurationName)^&lt;/Configuration^&gt; &gt;&gt; !settingsPublishProfile!
-echo     ^&lt;Platform^&gt;$(PlatformName)^&lt;/Platform^&gt; &gt;&gt; !settingsPublishProfile!
-echo     ^&lt;TargetFramework^&gt;netcoreapp3.1^&lt;/TargetFramework^&gt; &gt;&gt; !settingsPublishProfile!
-echo     ^&lt;PublishDir^&gt;..\..\..\$(PlatformName)\$(ConfigurationName)\SettingsUIRunner^&lt;/PublishDir^&gt; &gt;&gt; !settingsPublishProfile!
-echo     ^&lt;RuntimeIdentifier^&gt;win-x64^&lt;/RuntimeIdentifier^&gt; &gt;&gt; !settingsPublishProfile!
-echo     ^&lt;SelfContained^&gt;false^&lt;/SelfContained^&gt; &gt;&gt; !settingsPublishProfile!
-echo     ^&lt;PublishSingleFile^&gt;False^&lt;/PublishSingleFile^&gt; &gt;&gt; !settingsPublishProfile!
-echo     ^&lt;PublishReadyToRun^&gt;False^&lt;/PublishReadyToRun^&gt; &gt;&gt; !settingsPublishProfile!
-echo   ^&lt;/PropertyGroup^&gt; &gt;&gt; !settingsPublishProfile!
-echo ^&lt;/Project^&gt; &gt;&gt; !settingsPublishProfile!
-
-rem In case of Release we should not use Debug CRT in VCRT forwarders
-IF $(ConfigurationName)==Release (
-"$(MSBuildBinPath)\msbuild.exe" ..\..\..\..\src\core\Microsoft.PowerToys.Settings.UI.Runner\Microsoft.PowerToys.Settings.UI.Runner.csproj -t:Publish -p:Configuration="$(ConfigurationName)" -p:Platform="$(PlatformName)" -p:AppxBundle=Never -p:VCRTForwarders-IncludeDebugCRT=false -p:PublishProfile=!settingsProfileFileName!
-) ELSE (
-"$(MSBuildBinPath)\msbuild.exe" ..\..\..\..\src\core\Microsoft.PowerToys.Settings.UI.Runner\Microsoft.PowerToys.Settings.UI.Runner.csproj -t:Publish -p:Configuration="$(ConfigurationName)" -p:Platform="$(PlatformName)" -p:AppxBundle=Never -p:PublishProfile=!settingsProfileFileName!
-)
-
-rem Publish Launcher
-SET launcherProfileFolderName=..\..\..\..\src\modules\launcher\PowerLauncher\Properties\PublishProfiles\
-
-rem Create the publish profile folder if it doesn%27t exist
-IF NOT EXIST !launcherProfileFolderName! (mkdir !launcherProfileFolderName!)
-SET launcherProfileFileName=LauncherProfile.pubxml
-SET launcherPublishProfile=!launcherProfileFolderName!!launcherProfileFileName!
-
-rem Create the publish profile pubxml
-echo ^&lt;%3fxml version="1.0" encoding="utf-8"%3f^&gt; &gt; !launcherPublishProfile!
-echo ^&lt;^^!-- &gt;&gt; !launcherPublishProfile!
-echo https://go.microsoft.com/fwlink/%3fLinkID=208121.  &gt;&gt; !launcherPublishProfile!
-echo --^&gt; &gt;&gt; !launcherPublishProfile!
-echo ^&lt;Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003"^&gt; &gt;&gt; !launcherPublishProfile!
-echo   ^&lt;PropertyGroup^&gt; &gt;&gt; !launcherPublishProfile!
-echo     ^&lt;PublishProtocol^&gt;FileSystem^&lt;/PublishProtocol^&gt; &gt;&gt; !launcherPublishProfile!
-echo     ^&lt;Configuration^&gt;$(ConfigurationName)^&lt;/Configuration^&gt; &gt;&gt; !launcherPublishProfile!
-echo     ^&lt;Platform^&gt;$(PlatformName)^&lt;/Platform^&gt; &gt;&gt; !launcherPublishProfile!
-echo     ^&lt;TargetFramework^&gt;netcoreapp3.1^&lt;/TargetFramework^&gt; &gt;&gt; !launcherPublishProfile!
-echo     ^&lt;PublishDir^&gt;..\..\..\..\$(PlatformName)\$(ConfigurationName)\modules\launcher^&lt;/PublishDir^&gt; &gt;&gt; !launcherPublishProfile!
-echo     ^&lt;RuntimeIdentifier^&gt;win-x64^&lt;/RuntimeIdentifier^&gt; &gt;&gt; !launcherPublishProfile!
-echo     ^&lt;SelfContained^&gt;false^&lt;/SelfContained^&gt; &gt;&gt; !launcherPublishProfile!
-echo     ^&lt;PublishSingleFile^&gt;False^&lt;/PublishSingleFile^&gt; &gt;&gt; !launcherPublishProfile!
-echo     ^&lt;PublishReadyToRun^&gt;False^&lt;/PublishReadyToRun^&gt; &gt;&gt; !launcherPublishProfile!
-echo   ^&lt;/PropertyGroup^&gt; &gt;&gt; !launcherPublishProfile!
-echo ^&lt;/Project^&gt; &gt;&gt; !launcherPublishProfile!
-
-rem In case of Release we should not use Debug CRT in VCRT forwarders
-IF $(ConfigurationName)==Release (
-"$(MSBuildBinPath)\msbuild.exe" ..\..\..\..\src\modules\launcher\PowerLauncher\PowerLauncher.csproj -t:Publish -p:Configuration="$(ConfigurationName)" -p:Platform="$(PlatformName)" -p:AppxBundle=Never -p:VCRTForwarders-IncludeDebugCRT=false -p:PublishProfile=!launcherProfileFileName!
-) ELSE (
-"$(MSBuildBinPath)\msbuild.exe" ..\..\..\..\src\modules\launcher\PowerLauncher\PowerLauncher.csproj -t:Publish -p:Configuration="$(ConfigurationName)" -p:Platform="$(PlatformName)" -p:AppxBundle=Never -p:PublishProfile=!launcherProfileFileName!
-)</PreBuildEvent>
+    <PreBuildEvent />
   </PropertyGroup>
   <!--
 	To modify your build process, add your task inside one of the targets below and uncomment it.

--- a/installer/PowerToysSetup/publish.cmd
+++ b/installer/PowerToysSetup/publish.cmd
@@ -1,0 +1,63 @@
+setlocal enableDelayedExpansion
+
+IF NOT DEFINED PTRoot (SET PTRoot=..\..)
+
+rem Publish Settings
+SET settingsProfileFolderName=!PTRoot!\src\core\Microsoft.PowerToys.Settings.UI.Runner\Properties\PublishProfiles\
+rem Create the publish profile folder if it doesn't exist
+IF NOT EXIST !settingsProfileFolderName! (mkdir !settingsProfileFolderName!)
+SET settingsProfileFileName=SettingsProfile.pubxml
+SET settingsPublishProfile=!settingsProfileFolderName!!settingsProfileFileName!
+
+rem Create the publish profile pubxml
+echo ^<?xml version="1.0" encoding="utf-8"?^> > !settingsPublishProfile!
+echo ^<^^!-- >> !settingsPublishProfile!
+echo https://go.microsoft.com/fwlink/?LinkID=208121.  >> !settingsPublishProfile!
+echo --^> >> !settingsPublishProfile!
+echo ^<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003"^> >> !settingsPublishProfile!
+echo   ^<PropertyGroup^> >> !settingsPublishProfile!
+echo     ^<PublishProtocol^>FileSystem^</PublishProtocol^> >> !settingsPublishProfile!
+echo     ^<Configuration^>Release^</Configuration^> >> !settingsPublishProfile!
+echo     ^<Platform^>x64^</Platform^> >> !settingsPublishProfile!
+echo     ^<TargetFramework^>netcoreapp3.1^</TargetFramework^> >> !settingsPublishProfile!
+echo     ^<PublishDir^>..\..\..\x64\Release\SettingsUIRunner^</PublishDir^> >> !settingsPublishProfile!
+echo     ^<RuntimeIdentifier^>win-x64^</RuntimeIdentifier^> >> !settingsPublishProfile!
+echo     ^<SelfContained^>false^</SelfContained^> >> !settingsPublishProfile!
+echo     ^<PublishSingleFile^>False^</PublishSingleFile^> >> !settingsPublishProfile!
+echo     ^<PublishReadyToRun^>False^</PublishReadyToRun^> >> !settingsPublishProfile!
+echo   ^</PropertyGroup^> >> !settingsPublishProfile!
+echo ^</Project^> >> !settingsPublishProfile!
+
+rem In case of Release we should not use Debug CRT in VCRT forwarders
+msbuild !PTRoot!\src\core\Microsoft.PowerToys.Settings.UI.Runner\Microsoft.PowerToys.Settings.UI.Runner.csproj -t:Publish -p:Configuration="Release" -p:Platform="x64" -p:AppxBundle=Never -p:VCRTForwarders-IncludeDebugCRT=false -p:PublishProfile=!settingsProfileFileName!
+
+
+rem Publish Launcher
+SET launcherProfileFolderName=!PTRoot!\src\modules\launcher\PowerLauncher\Properties\PublishProfiles\
+
+rem Create the publish profile folder if it doesn't exist
+IF NOT EXIST !launcherProfileFolderName! (mkdir !launcherProfileFolderName!)
+SET launcherProfileFileName=LauncherProfile.pubxml
+SET launcherPublishProfile=!launcherProfileFolderName!!launcherProfileFileName!
+
+rem Create the publish profile pubxml
+echo ^<?xml version="1.0" encoding="utf-8"?^> > !launcherPublishProfile!
+echo ^<^^!-- >> !launcherPublishProfile!
+echo https://go.microsoft.com/fwlink/?LinkID=208121.  >> !launcherPublishProfile!
+echo --^> >> !launcherPublishProfile!
+echo ^<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003"^> >> !launcherPublishProfile!
+echo   ^<PropertyGroup^> >> !launcherPublishProfile!
+echo     ^<PublishProtocol^>FileSystem^</PublishProtocol^> >> !launcherPublishProfile!
+echo     ^<Configuration^>Release^</Configuration^> >> !launcherPublishProfile!
+echo     ^<Platform^>x64^</Platform^> >> !launcherPublishProfile!
+echo     ^<TargetFramework^>netcoreapp3.1^</TargetFramework^> >> !launcherPublishProfile!
+echo     ^<PublishDir^>..\..\..\..\x64\Release\modules\launcher^</PublishDir^> >> !launcherPublishProfile!
+echo     ^<RuntimeIdentifier^>win-x64^</RuntimeIdentifier^> >> !launcherPublishProfile!
+echo     ^<SelfContained^>false^</SelfContained^> >> !launcherPublishProfile!
+echo     ^<PublishSingleFile^>False^</PublishSingleFile^> >> !launcherPublishProfile!
+echo     ^<PublishReadyToRun^>False^</PublishReadyToRun^> >> !launcherPublishProfile!
+echo   ^</PropertyGroup^> >> !launcherPublishProfile!
+echo ^</Project^> >> !launcherPublishProfile!
+
+rem In case of Release we should not use Debug CRT in VCRT forwarders
+msbuild !PTRoot!\src\modules\launcher\PowerLauncher\PowerLauncher.csproj -t:Publish -p:Configuration="Release" -p:Platform="x64" -p:AppxBundle=Never -p:VCRTForwarders-IncludeDebugCRT=false -p:PublishProfile=!launcherProfileFileName!


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR moves the publishing steps done as pre-build events to a separate publish.cmd which is called from the build.cmd script.

Since the paths in the script would depend on which folder it was being called from, a variable was set which would store the path of the powertoys root folder. This can be overrided before calling the publish script.

Note: With this change for making MSIs locally you need to separately run the publish.cmd first on cmd prompt after running the following command (required for msbuild to be accepted as a command)
`call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=amd64 -host_arch=amd64 -winsdk=10.0.18362.0`
I will make a separate PR for making this publish.cmd run automatically while building locally but not on the pipeline, but that need not be pushed as a hotfix into stable since it only affects local MSIs.

I also had to hard code in "Release" and "x64" since I could not use the $(Configuration) and $(Platform) anymore since those variables wouldn't be set when running it from cmd as compared to a build-event.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Applies to #3028
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Tested local MSI by running the publish.cmd script manually, and also verified on the build pipeline.
