### PR TITLE
Add 1903 requirement to README

### DIFF
--- a/src/modules/launcher/README.md
+++ b/src/modules/launcher/README.md
@@ -6,7 +6,11 @@ modular for additional plugins. Press Alt+Space and start typing!
 ![](../../../doc/images/Launcher/QuickStart.gif)
 
 # 1\. Get Started 
-## 1\.1 Features
+## 1\.1 Requirements
+
+- Windows 10 version 1903 or higher
+
+## 1\.2 Features
 Search for applications, folders, or files
 ![](../../../doc/images/Launcher/Features.gif)
 
@@ -27,13 +31,13 @@ Do a simple calculation using calculator
 
 ![](../../../doc/images/Launcher/FeaturesCalculator.gif)
 
-## 1\.2 Settings 
+## 1\.3 Settings 
   | **Settings**   |               **Action** |
   | --------------- | ------------------------------------------------------------------------------- |
   | Maximum number of results  |   Maximum number of results shown without scrolling on PowerToys Run |
   | Open PowerToys Run shortcut |  The keyboard shortcut to open/hide PowerToys Run |
 
-## 1\.3 Keyboard Shortcuts
+## 1\.4 Keyboard Shortcuts
   | **Shortcuts**   |   **Action** |
   | ------------------ | ---------------------------------------------------------------------------------|
   | Alt+Space |         Open or hide PowerToys Run |


### PR DESCRIPTION
Adds the requirement for Windows 10 1903 to the `README.md`

Have not seen this requirement mentioned anywhere until after PowerToys is already installed.
For those installing PowerToys specifically to try this, it would be useful to know the requirement in advance, especially given that https://github.com/microsoft/PowerToys/blob/master/README.md mentions only 1803.


## PR Checklist
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Requires documentation to be updated