### PR TITLE
[FancyZones] Fix a regression with Chrome tabs jamming FZ

### DIFF
--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -522,6 +522,10 @@ ZoneWindow::ShowZoneWindow() noexcept
     std::thread{ [=]() {
         AnimateWindow(window, m_showAnimationDuration, AW_BLEND);
         InvalidateRect(window, nullptr, true);
+        if (m_windowMoveSize == nullptr)
+        {
+            HideZoneWindow();
+        }
     } }.detach();
 }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

A hotfix which _should_ fix the issue #534 with Chrome. A more robust fix should be considered for v0.19

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

See #534.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #534
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Tested manually on Chrome.