### PR TITLE
Disabling IsRightTapEnabled on all UI Elements that steal focus

### DIFF
--- a/src/modules/launcher/PowerLauncher.UI/App.xaml
+++ b/src/modules/launcher/PowerLauncher.UI/App.xaml
@@ -34,6 +34,115 @@
                 </Setter>
             </Style>
 
+            <Style x:Key="ListViewItemNoRightTap" TargetType="ListViewItem">
+                <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
+                <Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}" />
+                <Setter Property="Background" Value="{ThemeResource ListViewItemBackground}" />
+                <Setter Property="Foreground" Value="{ThemeResource ListViewItemForeground}" />
+                <Setter Property="TabNavigation" Value="Local" />
+                <Setter Property="IsHoldingEnabled" Value="True" />
+                <Setter Property="IsRightTapEnabled" Value="False" />
+                <Setter Property="Padding" Value="12,0,12,0" />
+                <Setter Property="HorizontalContentAlignment" Value="Left" />
+                <Setter Property="VerticalContentAlignment" Value="Center" />
+                <Setter Property="MinWidth" Value="{ThemeResource ListViewItemMinWidth}" />
+                <Setter Property="MinHeight" Value="{ThemeResource ListViewItemMinHeight}" />
+                <Setter Property="AllowDrop" Value="False" />
+                <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
+                <Setter Property="FocusVisualMargin" Value="0" />
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="ListViewItem">
+                            <ListViewItemPresenter IsRightTapEnabled="False" ContentTransitions="{TemplateBinding ContentTransitions}"
+                        x:Name="Root"
+                        Control.IsTemplateFocusTarget="True"
+                        FocusVisualMargin="{TemplateBinding FocusVisualMargin}"
+                        SelectionCheckMarkVisualEnabled="{ThemeResource ListViewItemSelectionCheckMarkVisualEnabled}"
+                        CheckBrush="{ThemeResource ListViewItemCheckBrush}"
+                        CheckBoxBrush="{ThemeResource ListViewItemCheckBoxBrush}"
+                        DragBackground="{ThemeResource ListViewItemDragBackground}"
+                        DragForeground="{ThemeResource ListViewItemDragForeground}"
+                        FocusBorderBrush="{ThemeResource ListViewItemFocusBorderBrush}"
+                        FocusSecondaryBorderBrush="{ThemeResource ListViewItemFocusSecondaryBorderBrush}"
+                        PlaceholderBackground="{ThemeResource ListViewItemPlaceholderBackground}"
+                        PointerOverBackground="{ThemeResource ListViewItemBackgroundPointerOver}"
+                        PointerOverForeground="{ThemeResource ListViewItemForegroundPointerOver}"
+                        SelectedBackground="{ThemeResource ListViewItemBackgroundSelected}"
+                        SelectedForeground="{ThemeResource ListViewItemForegroundSelected}"
+                        SelectedPointerOverBackground="{ThemeResource ListViewItemBackgroundSelectedPointerOver}"
+                        PressedBackground="{ThemeResource ListViewItemBackgroundPressed}"
+                        SelectedPressedBackground="{ThemeResource ListViewItemBackgroundSelectedPressed}"
+                        DisabledOpacity="{ThemeResource ListViewItemDisabledThemeOpacity}"
+                        DragOpacity="{ThemeResource ListViewItemDragThemeOpacity}"
+                        ReorderHintOffset="{ThemeResource ListViewItemReorderHintThemeOffset}"
+                        HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                        VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                        ContentMargin="{TemplateBinding Padding}"
+                        CheckMode="{ThemeResource ListViewItemCheckMode}"
+                        RevealBackground="{ThemeResource ListViewItemRevealBackground}"
+                        RevealBorderThickness="{ThemeResource ListViewItemRevealBorderThemeThickness}"
+                        RevealBorderBrush="{ThemeResource ListViewItemRevealBorderBrush}">
+
+                                <VisualStateManager.VisualStateGroups>
+                                    <VisualStateGroup x:Name="CommonStates">
+                                        <VisualState x:Name="Normal" />
+                                        <VisualState x:Name="Selected" />
+
+                                        <VisualState x:Name="PointerOver">
+                                            <VisualState.Setters>
+                                                <Setter Target="Root.(RevealBrush.State)" Value="PointerOver" />
+                                                <Setter Target="Root.RevealBorderBrush" Value="{ThemeResource ListViewItemRevealBorderBrushPointerOver}" />
+                                            </VisualState.Setters>
+                                        </VisualState>
+
+                                        <VisualState x:Name="PointerOverSelected">
+                                            <VisualState.Setters>
+                                                <Setter Target="Root.(RevealBrush.State)" Value="PointerOver" />
+                                                <Setter Target="Root.RevealBorderBrush" Value="{ThemeResource ListViewItemRevealBorderBrushPointerOver}" />
+                                            </VisualState.Setters>
+                                        </VisualState>
+                                        <VisualState x:Name="PointerOverPressed">
+                                            <VisualState.Setters>
+                                                <Setter Target="Root.(RevealBrush.State)" Value="Pressed" />
+                                                <Setter Target="Root.RevealBorderBrush" Value="{ThemeResource ListViewItemRevealBorderBrushPressed}" />
+                                            </VisualState.Setters>
+                                        </VisualState>
+
+                                        <VisualState x:Name="Pressed">
+                                            <VisualState.Setters>
+                                                <Setter Target="Root.(RevealBrush.State)" Value="Pressed" />
+                                                <Setter Target="Root.RevealBorderBrush" Value="{ThemeResource ListViewItemRevealBorderBrushPressed}" />
+                                            </VisualState.Setters>
+                                        </VisualState>
+
+                                        <VisualState x:Name="PressedSelected">
+                                            <VisualState.Setters>
+                                                <Setter Target="Root.(RevealBrush.State)" Value="Pressed" />
+                                                <Setter Target="Root.RevealBorderBrush" Value="{ThemeResource ListViewItemRevealBorderBrushPressed}" />
+                                            </VisualState.Setters>
+                                        </VisualState>
+
+                                    </VisualStateGroup>
+
+                                    <VisualStateGroup x:Name="DisabledStates">
+                                        <VisualState x:Name="Enabled" />
+
+                                        <VisualState x:Name="Disabled">
+                                            <VisualState.Setters>
+                                                <Setter Target="Root.RevealBorderThickness" Value="0" />
+                                            </VisualState.Setters>
+                                        </VisualState>
+
+                                    </VisualStateGroup>
+
+                                </VisualStateManager.VisualStateGroups>
+                            </ListViewItemPresenter>
+
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+
             <Style x:Key="IconOnlyButton" TargetType="Button">
                 <Setter Property="Background" Value="{ThemeResource ButtonRevealBackground}" />
                 <!--<Setter Property="Foreground" Value="{ThemeResource PrimaryTextColor}" />-->
@@ -50,7 +159,7 @@
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="Button">
-                            <Grid x:Name="RootGrid" Background="Transparent" CornerRadius="{TemplateBinding CornerRadius}">
+                            <Grid x:Name="RootGrid" IsRightTapEnabled="False" Background="Transparent" CornerRadius="{TemplateBinding CornerRadius}">
 
                                 <VisualStateManager.VisualStateGroups>
                                     <VisualStateGroup x:Name="CommonStates">
@@ -98,7 +207,7 @@
                                     </VisualStateGroup>
 
                                 </VisualStateManager.VisualStateGroups>
-                                <ContentPresenter x:Name="ContentPresenter" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="0" CornerRadius="{TemplateBinding CornerRadius}" Content="{TemplateBinding Content}" ContentTransitions="{TemplateBinding ContentTransitions}" ContentTemplate="{TemplateBinding ContentTemplate}" Padding="{TemplateBinding Padding}" HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" AutomationProperties.AccessibilityView="Raw" />
+                                <ContentPresenter x:Name="ContentPresenter" IsRightTapEnabled="False" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="0" CornerRadius="{TemplateBinding CornerRadius}" Content="{TemplateBinding Content}" ContentTransitions="{TemplateBinding ContentTransitions}" ContentTemplate="{TemplateBinding ContentTemplate}" Padding="{TemplateBinding Padding}" HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" AutomationProperties.AccessibilityView="Raw" />
 
                             </Grid>
 

--- a/src/modules/launcher/PowerLauncher.UI/ResultList.xaml
+++ b/src/modules/launcher/PowerLauncher.UI/ResultList.xaml
@@ -20,7 +20,7 @@
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="GridViewItem">
-                        <ListViewItemPresenter x:Name="Root" VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}">
+                        <ListViewItemPresenter x:Name="Root" IsRightTapEnabled="False" VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}">
                             <VisualStateManager.VisualStateGroups>
                                 <VisualStateGroup x:Name="CommonStates">
                                     <VisualState x:Name="Normal"/>
@@ -46,6 +46,7 @@
     <Grid 
         x:Name="PowerBar"  
         Background="{ThemeResource BackdropAcrylicBrush}"
+        IsRightTapEnabled="False"
         VerticalAlignment="Top">
 
         <ListView
@@ -55,15 +56,18 @@
             MinHeight="{Binding Results.MaxHeight}"
             AllowFocusOnInteraction="False"
             IsItemClickEnabled="True"
+            IsRightTapEnabled="False"
+            RightTapped="SuggestionsList_RightTapped"
             Margin="0"
             Padding="{ThemeResource AutoSuggestListPadding}"
             ItemsSource="{Binding Results.Results, Mode=OneWay}"
             SelectionMode="Single"
             SelectedIndex="{Binding Results.SelectedIndex, Mode=TwoWay}"
-            Style="{StaticResource ListViewNoAnimations}">
+            Style="{StaticResource ListViewNoAnimations}"
+            ItemContainerStyle="{StaticResource ListViewItemNoRightTap}">
             <ListView.ItemTemplate>
                 <DataTemplate >
-                    <Grid Height="72" Width="642" Background="Transparent" RowSpacing="0">
+                    <Grid IsRightTapEnabled ="False" Height="72" Width="642" Background="Transparent" RowSpacing="0">
                         <Interactivity:Interaction.Behaviors>
                             <Core:EventTriggerBehavior EventName="PointerEntered">
                                 <Core:InvokeCommandAction Command="{Binding ActivateContextButtonsHoverCommand}"/>
@@ -81,9 +85,9 @@
                             <RowDefinition Height="*"/>
                             <RowDefinition Height="*"/>
                         </Grid.RowDefinitions>
-                        <Image x:Name="AppIcon" Height="36" MaxWidth="56" Grid.RowSpan="2" Margin="-8,0,0,0" HorizontalAlignment="Center" Source="{Binding Image}" />
-                        <TextBlock x:Name="Title" Grid.Column="1" Text="{Binding Result.Title}" FontWeight="SemiBold" FontSize="20" Margin="0,0,0,-2" VerticalAlignment="Bottom"/>
-                        <TextBlock x:Name="Path" Grid.Column="1" Text= "{Binding Result.SubTitle}" Grid.Row="1" Opacity="0.6" Margin="0,2,0,0" VerticalAlignment="Top"/>
+                        <Image x:Name="AppIcon" IsRightTapEnabled ="False" Height="36" MaxWidth="56" Grid.RowSpan="2" Margin="-8,0,0,0" HorizontalAlignment="Center" Source="{Binding Image}" />
+                        <TextBlock x:Name="Title" IsRightTapEnabled ="False" Grid.Column="1" Text="{Binding Result.Title}" FontWeight="SemiBold" FontSize="20" Margin="0,0,0,-2" VerticalAlignment="Bottom"/>
+                        <TextBlock x:Name="Path" IsRightTapEnabled ="False" Grid.Column="1" Text= "{Binding Result.SubTitle}" Grid.Row="1" Opacity="0.6" Margin="0,2,0,0" VerticalAlignment="Top"/>
                         <GridView 
                                    ItemContainerStyle="{StaticResource CommandButtonGridViewItemContainerStyle}"
                                    HorizontalAlignment="Right" 
@@ -97,15 +101,17 @@
                                    ScrollViewer.HorizontalScrollBarVisibility="Disabled"                       
                                    ItemsSource="{Binding ContextMenuItems}" 
                                    SelectionMode="Single"
-                                   SelectedIndex="{Binding ContextMenuSelectedIndex}">
+                                   SelectedIndex="{Binding ContextMenuSelectedIndex}"
+                                   ContainerContentChanging="GridView_ContainerContentChanging"
+                                   IsRightTapEnabled ="False">
                             <GridView.ItemTemplate>
                                 <DataTemplate>
-                                    <Button   Command="{Binding Command}" VerticalAlignment="Center" CornerRadius="4" Height="42" Width="42" BorderThickness="1" Style="{ThemeResource IconOnlyButton}" Click="ContextButton_OnClick">
+                                    <Button  IsRightTapEnabled ="False"  Command="{Binding Command}" VerticalAlignment="Center" CornerRadius="4" Height="42" Width="42" BorderThickness="1" Style="{ThemeResource IconOnlyButton}" Click="ContextButton_OnClick">
                                         <ToolTipService.ToolTip>
-                                            <TextBlock Text="{Binding Title}"/>
+                                            <TextBlock x:Name="ToolTip" Loaded="ToolTip_Loaded" IsRightTapEnabled="False" Text="{Binding Title}"/>
                                         </ToolTipService.ToolTip>
                                         <Button.Content>
-                                            <FontIcon FontFamily="{Binding FontFamily}" FontSize="16" Glyph="{Binding Glyph}"/>
+                                            <FontIcon x:Name="FontIcon" Loaded="FontIcon_Loaded"  IsRightTapEnabled="False" FontFamily="{Binding FontFamily}" FontSize="16" Glyph="{Binding Glyph}"/>
                                         </Button.Content>
                                         <Button.KeyboardAccelerators>
                                             <KeyboardAccelerator

--- a/src/modules/launcher/PowerLauncher.UI/ResultList.xaml.cs
+++ b/src/modules/launcher/PowerLauncher.UI/ResultList.xaml.cs
@@ -2,8 +2,10 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices.WindowsRuntime;
 using Windows.Foundation;
@@ -89,5 +91,74 @@ namespace PowerLauncher.UI
         public event PropertyChangedEventHandler PropertyChanged;
 
         private void OnPropertyChanged(string propertyName) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+
+        private void SuggestionsList_RightTapped(object sender, Windows.UI.Xaml.Input.RightTappedRoutedEventArgs e)
+        {
+            Debug.WriteLine($"Right Tap was triggered on {e.OriginalSource}");
+        }
+
+        private void FontIcon_Loaded(object sender, RoutedEventArgs e)
+        {
+            DisableRightClick(sender);
+        }
+
+        private void ToolTip_Loaded(object sender, RoutedEventArgs e)
+        {
+            DisableRightClick(sender);
+        }
+
+
+        private void GridView_ContainerContentChanging(ListViewBase sender, ContainerContentChangingEventArgs args)
+        {
+            DisableRightClick(sender);
+        }
+
+        private void DisableRightClick(object o)
+        {
+            var element = o as UIElement;
+            if (element != null)
+            {
+                DisableRightClick(element, isRecursive: true);
+            }
+        }
+
+        public void DisableRightClick(UIElement element, bool isRecursive)
+        {
+            element.IsRightTapEnabled = false;
+
+
+            if (isRecursive)
+            {
+                var children = FindChildren<UIElement>(element);
+                foreach (var child in children)
+                {
+                    child.IsRightTapEnabled = false;
+                }
+            }
+        }
+
+        private static List<T> FindChildren<T>(DependencyObject startNode, List<T> results = null)
+  where T : DependencyObject
+        {
+            if (results == null)
+            {
+                results = new List<T>();
+            }
+
+            int count = VisualTreeHelper.GetChildrenCount(startNode);
+            for (int i = 0; i < count; i++)
+            {
+                DependencyObject current = VisualTreeHelper.GetChild(startNode, i);
+                if ((current.GetType()).Equals(typeof(T)) || (current.GetType().GetTypeInfo().IsSubclassOf(typeof(T))))
+                {
+                    T asType = (T)current;
+                    results.Add(asType);
+                }
+                FindChildren<T>(current, results);
+            }
+
+            return results;
+        }
+
     }
 }


### PR DESCRIPTION

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
- This PR disables the IsRightTapEnabled on all UIElements. 
<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2259 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [] Tests added/passed
* [] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
1. Where provided in xaml specify IsRightTapEnabled=False
2. Override the listviewitem control template so that IsRightTapEnabled can be set to false on the ListViewItemPresenter 
3. On items with no control template such as tool tip and font icon, recurse the visual tree, and set IsRightTapEnabled to false. 
4. WHen the context button items are changing then recurse the visual tree and set IsRightTapEnabled.  Note this is less efficient than overwritting the template but this is only done on selected or hovered items and there are a small number of elements in the visual tree.   Alternatively we could overwrite the GridView and GridView item control templates, but this is quite verbose and error prone, for small perf impact. 
![image](https://user-images.githubusercontent.com/56318517/82479936-e74bfa00-9a87-11ea-84c1-4c4a4ed1ab3b.png)


<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Click on various places around the results window.  And observe either of the following are true:
1. There is nothing in the output window. eg. Right Tap was triggered on Right Tap was triggered on Windows.UI.Xaml.Shapes.Rectangle

or

2.  Focus remains on the textbox and pressing space doesn't highlight the result.  _Note:  The scrollbar on the right will still trigger the right click event, but doesn't steal focus._  