### PR TITLE
[PowerToys Run] run non-elevated when runner is elevated

### DIFF
--- a/src/action_runner/action_runner.cpp
+++ b/src/action_runner/action_runner.cpp
@@ -186,7 +186,17 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int)
     }
     std::wstring_view action{ args[1] };
 
-    if (action == L"-install_dotnet")
+
+    if (action == L"-start_PowerLauncher")
+    {
+        if (is_process_elevated(false) == true)
+        {
+            drop_elevated_privileges();
+        }
+
+        run_non_elevated(L"modules\\launcher\\PowerLauncher.exe", L"");
+    }
+    else if (action == L"-install_dotnet")
     {
         if (dotnet_is_installed())
         {

--- a/src/action_runner/action_runner.cpp
+++ b/src/action_runner/action_runner.cpp
@@ -194,7 +194,18 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int)
             drop_elevated_privileges();
         }
 
-        run_non_elevated(L"modules\\launcher\\PowerLauncher.exe", L"");
+        HANDLE hMapFile = OpenFileMappingW(FILE_MAP_WRITE, FALSE, POWER_LAUNCHER_PID_SHARED_FILE);
+        PDWORD pidBuffer = reinterpret_cast<PDWORD>(MapViewOfFile(hMapFile, FILE_MAP_ALL_ACCESS, 0, 0, sizeof(DWORD)));
+        if (pidBuffer)
+        {
+            *pidBuffer = 0;
+            run_non_elevated(L"modules\\launcher\\PowerLauncher.exe", L"", pidBuffer);
+            FlushViewOfFile(pidBuffer, sizeof(DWORD));
+            UnmapViewOfFile(pidBuffer);
+        }
+
+        FlushFileBuffers(hMapFile);
+        CloseHandle(hMapFile);
     }
     else if (action == L"-install_dotnet")
     {

--- a/src/common/common.cpp
+++ b/src/common/common.cpp
@@ -461,7 +461,7 @@ bool run_elevated(const std::wstring& file, const std::wstring& params)
     }
 }
 
-bool run_non_elevated(const std::wstring& file, const std::wstring& params)
+bool run_non_elevated(const std::wstring& file, const std::wstring& params, DWORD* returnPid)
 {
     auto executable_args = L"\"" + file + L"\"";
     if (!params.empty())
@@ -521,8 +521,14 @@ bool run_non_elevated(const std::wstring& file, const std::wstring& params)
                                     nullptr,
                                     &siex.StartupInfo,
                                     &process_info);
+
     if (process_info.hProcess)
     {
+        if (returnPid)
+        {
+            *returnPid = GetProcessId(process_info.hProcess);
+        }
+
         CloseHandle(process_info.hProcess);
     }
     if (process_info.hThread)

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -69,8 +69,8 @@ bool drop_elevated_privileges();
 // Run command as elevated user, returns true if succeeded
 bool run_elevated(const std::wstring& file, const std::wstring& params);
 
-// Run command as non-elevated user, returns true if succeeded
-bool run_non_elevated(const std::wstring& file, const std::wstring& params);
+// Run command as non-elevated user, returns true if succeeded, puts the process id into returnPid if returnPid != NULL
+bool run_non_elevated(const std::wstring& file, const std::wstring& params, DWORD* returnPid);
 
 // Run command with the same elevation, returns true if succedded
 bool run_same_elevation(const std::wstring& file, const std::wstring& params);
@@ -136,3 +136,5 @@ struct overloaded : Ts...
 };
 template<class... Ts>
 overloaded(Ts...)->overloaded<Ts...>;
+
+#define POWER_LAUNCHER_PID_SHARED_FILE L"Global\\3cbfbad4-199b-4e2c-9825-942d5d3d3c74"

--- a/src/runner/restart_elevated.cpp
+++ b/src/runner/restart_elevated.cpp
@@ -36,7 +36,7 @@ bool restart_if_scheduled()
     case RestartAsElevated:
         return run_elevated(exe_path.get(), {});
     case RestartAsNonElevated:
-        return run_non_elevated(exe_path.get(), L"--dont-elevate");
+        return run_non_elevated(exe_path.get(), L"--dont-elevate", NULL);
     default:
         return false;
     }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
When PowerToys run elevated, run **PowerToys Run** non-elevated.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to https://github.com/microsoft/PowerToys/issues/3215

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
This is a quick fix, far from "production quality", it will be improved and it will be possible to use it for any module, right now it only supports **PowerToys Run**.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manual tests.