### PR TITLE
Launcher does not open files in system that are not in english

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/SearchHelper/WindowsSearchAPI.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/SearchHelper/WindowsSearchAPI.cs
@@ -36,11 +36,12 @@ namespace Microsoft.Plugin.Indexer.SearchHelper
                         {
                             while (WDSResults.Read())
                             {
-                                if(WDSResults.GetValue(0) != DBNull.Value && WDSResults.GetValue(1) != DBNull.Value)
+                                if (WDSResults.GetValue(0) != DBNull.Value && WDSResults.GetValue(1) != DBNull.Value)
                                 {
+                                    var uri_path = new Uri(WDSResults.GetString(0));
                                     var result = new SearchResult
                                     {
-                                        Path = WDSResults.GetString(0),
+                                        Path = uri_path.LocalPath,
                                         Title = WDSResults.GetString(1)
                                     };
                                     _Result.Add(result);
@@ -90,7 +91,7 @@ namespace Microsoft.Plugin.Indexer.SearchHelper
             queryHelper.QueryMaxResults = maxCount;
 
             // Set list of columns we want to display, getting the path presently
-            queryHelper.QuerySelectColumns = "System.ItemPathDisplay, System.FileName";
+            queryHelper.QuerySelectColumns = "System.ItemUrl, System.FileName";
 
             // Set additional query restriction
             queryHelper.QueryWhereRestrictions = "AND scope='file:'";


### PR DESCRIPTION
Because of the way windows works in systems that are not in english, launcher was trying to open localized paths instead of the real path.s File explorer can translate them to the "real path" but Proccess.Start doesn't do that.

## PR Checklist
* [ x ] Applies to #3209 
* [ x ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

When Microsoft.Plugin.Indexer is querying it is selecting the System.ItemPathDisplay that returns the localized path of the file/folder. For some reason Proccess.Start does not like localized paths i supposed that is the same reason why powershell does not let me launch localized paths.

Detailed Description of the Pull Request:

I changed System.ItemPathDisplay to System.ItemUrl and remove the scheme from the url during the ExecuteQuery.

## Validation Steps Performed
Launch Powertoys Run and search for a file or folder.
Files appear as they should with icons and all actions work.
