### PR TITLE
[Settings] Updated titles for the file explorer preview toggleswitches

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -390,10 +390,10 @@
     <value>Show values from last use</value>
   </data>
   <data name="FileEplorerPreview_ToggleSwitch_Preview_MD.Header" xml:space="preserve">
-    <value>Markdown Preview Handler</value>
+    <value>Enable Markdown (.md) preview</value>
   </data>
   <data name="FileEplorerPreview_ToggleSwitch_Preview_SVG.Header" xml:space="preserve">
-    <value>Svg Preview Handler</value>
+    <value>Enable SVG (.svg) preview</value>
   </data>
   <data name="FileExplorerPreview_Description.Text" xml:space="preserve">
     <value>These settings allow you to manage your Windows File Explorer custom preview handlers.</value>


### PR DESCRIPTION
##Summary of the Pull Request

Fix for #3202 

New titles are now inline with other PowerToys modules ("Enable ..."):
![image](https://user-images.githubusercontent.com/9866362/82595585-1bb5d800-9ba6-11ea-825c-ac1b0772ee13.png)

## References
#3202 


## PR Checklist
* [X] Applies to #3202 
* [X ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx