### PR TITLE
OS detection hotfix

### DIFF
--- a/src/common/common.cpp
+++ b/src/common/common.cpp
@@ -7,6 +7,7 @@
 #include "version.h"
 
 #include <wil/resource.h>
+#include <winrt/Windows.Foundation.Metadata.h>
 
 #pragma comment(lib, "advapi32.lib")
 #pragma comment(lib, "shlwapi.lib")
@@ -803,4 +804,23 @@ std::optional<std::string> exec_and_read_output(const std::wstring_view command,
 
     CloseHandle(piProcInfo.hProcess);
     return childOutput;
+}
+
+bool IsAPIContractVxAvailable(uint16_t APIVersion)
+{
+    static bool isAPIContractVxAvailableInitialized = false;
+    static bool isAPIContractVxAvailable = false;
+
+    if (!isAPIContractVxAvailableInitialized)
+    {
+        isAPIContractVxAvailableInitialized = true;
+        isAPIContractVxAvailable = winrt::Windows::Foundation::Metadata::ApiInformation::IsApiContractPresent(L"Windows.Foundation.UniversalApiContract", APIVersion);
+    }
+
+    return isAPIContractVxAvailable;
+}
+
+bool Is19H1OrHigher()
+{
+    return IsAPIContractVxAvailable(8);
 }

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -138,3 +138,5 @@ template<class... Ts>
 overloaded(Ts...)->overloaded<Ts...>;
 
 #define POWER_LAUNCHER_PID_SHARED_FILE L"Global\\3cbfbad4-199b-4e2c-9825-942d5d3d3c74"
+
+bool Is19H1OrHigher();

--- a/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
+++ b/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
@@ -132,6 +132,11 @@ public:
    // Enable the powertoy
   virtual void enable()
   {
+      if (Is19H1OrHigher() == false)
+      {
+          return;
+      }
+
       if (is_process_elevated(false) == false)
       {
           SHELLEXECUTEINFOW sei{ sizeof(sei) };

--- a/src/runner/runner.vcxproj
+++ b/src/runner/runner.vcxproj
@@ -64,7 +64,7 @@
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>..\common\inc;..\common\os-detection;..\common\Telemetry;..;..\modules;..\..\deps\cpprestsdk\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\common\inc;..\common\Telemetry;..;..\modules;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalOptions>/await %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
@@ -88,7 +88,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>..\common\inc;..\common\os-detection;..\common\Telemetry;..;..\modules;..\..\deps\cpprestsdk\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\common\inc;..\common\Telemetry;..;..\modules;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalOptions>/await %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
@@ -236,9 +236,6 @@
   <ItemGroup>
     <ProjectReference Include="..\common\common.vcxproj">
       <Project>{74485049-c722-400f-abe5-86ac52d929b3}</Project>
-    </ProjectReference>
-    <ProjectReference Include="..\common\os-detection\os-detection.vcxproj">
-      <Project>{e6410bfc-b341-498c-8c67-312c20cdd8d5}</Project>
     </ProjectReference>
     <ProjectReference Include="..\common\updating\updating.vcxproj">
       <Project>{17da04df-e393-4397-9cf0-84dabe11032e}</Project>

--- a/src/runner/settings_window.cpp
+++ b/src/runner/settings_window.cpp
@@ -14,7 +14,6 @@
 
 #include <common/json.h>
 #include <common\settings_helpers.cpp>
-#include <os-detect.h>
 
 #define BUFSIZE 1024
 
@@ -228,7 +227,7 @@ void run_settings_window()
     // Arg 1: executable path.
     std::wstring executable_path = get_module_folderpath();
 
-    if (UseNewSettings())
+    if (Is19H1OrHigher())
     {
         executable_path.append(L"\\SettingsUIRunner\\Microsoft.PowerToys.Settings.UI.Runner.exe");
     }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This is a hot fix ~for the OS detection problem some users reported~ to prevent PT Run from trying to start on 1809 and older.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to https://github.com/microsoft/PowerToys/issues/3354

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
~We haven't been able to reproduce the problem, so we asked the users effected by the bug to run a custom tool to validate different methods to determine the OS version.
The tool showed that all the methods used, including the method used in PowerToys, worked.
The difference between the test tool and PowerToys is that PowerToys implements the OS detection code in an interop dll, while the test tool has the code in the same executable.~
This fix ~is a wild guess, since it~ duplicates the code that is currently implemented in the interop DLL and defines the function in the common lib used by the runner.
It also adds code to prevent PT Run from trying to start on unsupported versions.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Verified that is doesn't cause regressions on 1809 and 1909.