### PR TITLE
[FancyZones] Unit-tests fix: keeping user settings unchanged  

### DIFF
--- a/src/modules/fancyzones/lib/JsonHelpers.cpp
+++ b/src/modules/fancyzones/lib/JsonHelpers.cpp
@@ -217,9 +217,9 @@ namespace JSONHelpers
         return instance;
     }
 
-    FancyZonesData::FancyZonesData()
+    FancyZonesData::FancyZonesData(std::wstring_view moduleName)
     {
-        std::wstring result = PTSettingsHelper::get_module_save_folder_location(L"FancyZones");
+        std::wstring result = PTSettingsHelper::get_module_save_folder_location(moduleName);
         jsonFilePath = result + L"\\" + std::wstring(FANCY_ZONES_DATA_FILE);
     }
 

--- a/src/modules/fancyzones/lib/JsonHelpers.cpp
+++ b/src/modules/fancyzones/lib/JsonHelpers.cpp
@@ -217,9 +217,9 @@ namespace JSONHelpers
         return instance;
     }
 
-    FancyZonesData::FancyZonesData(std::wstring_view moduleName)
+    FancyZonesData::FancyZonesData()
     {
-        std::wstring result = PTSettingsHelper::get_module_save_folder_location(moduleName);
+        std::wstring result = PTSettingsHelper::get_module_save_folder_location(L"FancyZones");
         jsonFilePath = result + L"\\" + std::wstring(FANCY_ZONES_DATA_FILE);
     }
 

--- a/src/modules/fancyzones/lib/JsonHelpers.h
+++ b/src/modules/fancyzones/lib/JsonHelpers.h
@@ -168,7 +168,7 @@ namespace JSONHelpers
         mutable std::recursive_mutex dataLock;
 
     public:
-        FancyZonesData(std::wstring_view moduleName = L"FancyZones");
+        FancyZonesData();
 
         inline const std::wstring& GetPersistFancyZonesJSONPath() const
         {
@@ -216,6 +216,12 @@ namespace JSONHelpers
         inline void SetDeviceInfo(const std::wstring& deviceId, DeviceInfoData data)
         {
             deviceInfoMap[deviceId] = data;
+        }
+
+        inline void SetSettingsModulePath(std::wstring_view moduleName)
+        {
+            std::wstring result = PTSettingsHelper::get_module_save_folder_location(moduleName);
+            jsonFilePath = result + L"\\" + std::wstring(L"zones-settings.json");
         }
 #endif
 

--- a/src/modules/fancyzones/lib/JsonHelpers.h
+++ b/src/modules/fancyzones/lib/JsonHelpers.h
@@ -168,7 +168,7 @@ namespace JSONHelpers
         mutable std::recursive_mutex dataLock;
 
     public:
-        FancyZonesData();
+        FancyZonesData(std::wstring_view moduleName = L"FancyZones");
 
         inline const std::wstring& GetPersistFancyZonesJSONPath() const
         {

--- a/src/modules/fancyzones/tests/UnitTests/FancyZones.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/FancyZones.Spec.cpp
@@ -16,13 +16,19 @@ namespace FancyZonesUnitTests
     {
         HINSTANCE m_hInst;
         winrt::com_ptr<IFancyZonesSettings> m_settings;
+        const std::wstring_view m_moduleName = L"FancyZonesUnitTests";
 
         TEST_METHOD_INITIALIZE(Init)
             {
                 m_hInst = (HINSTANCE)GetModuleHandleW(nullptr);
-                m_settings = MakeFancyZonesSettings(m_hInst, L"FancyZonesUnitTests");
+                m_settings = MakeFancyZonesSettings(m_hInst, m_moduleName.data());
                 Assert::IsTrue(m_settings != nullptr);
             }
+
+        TEST_METHOD_CLEANUP(CleanUp)
+        {
+            std::filesystem::remove_all(PTSettingsHelper::get_module_save_folder_location(m_moduleName));
+        }
 
             TEST_METHOD (Create)
             {

--- a/src/modules/fancyzones/tests/UnitTests/FancyZonesSettings.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/FancyZonesSettings.Spec.cpp
@@ -55,7 +55,7 @@ namespace FancyZonesUnitTests
     TEST_CLASS (FancyZonesSettingsCreationUnitTest)
     {
         HINSTANCE m_hInst;
-        PCWSTR m_moduleName = L"FancyZonesTest";
+        PCWSTR m_moduleName = L"FancyZonesUnitTests";
         std::wstring m_tmpName;
 
         const PowerToysSettings::HotkeyObject m_defaultHotkeyObject = PowerToysSettings::HotkeyObject::from_settings(true, false, false, false, VK_OEM_3);
@@ -68,8 +68,7 @@ namespace FancyZonesUnitTests
             }
             TEST_METHOD_CLEANUP(Cleanup)
                 {
-                    std::filesystem::remove(m_tmpName);
-                    std::filesystem::remove(PTSettingsHelper::get_module_save_folder_location(m_moduleName));
+                    std::filesystem::remove_all(PTSettingsHelper::get_module_save_folder_location(m_moduleName));
                 }
 
                 TEST_METHOD (CreateWithHinstanceDefault)
@@ -375,7 +374,7 @@ namespace FancyZonesUnitTests
     TEST_CLASS (FancyZonesSettingsCallbackUnitTests)
     {
         winrt::com_ptr<IFancyZonesSettings> m_settings = nullptr;
-        PCWSTR m_moduleName = L"FancyZonesTest";
+        PCWSTR m_moduleName = L"FancyZonesUnitTests";
 
         struct FZCallback : public winrt::implements<FZCallback, IFancyZonesCallback>
         {
@@ -476,8 +475,7 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD_CLEANUP(Cleanup)
                 {
-                    const auto settingsFile = PTSettingsHelper::get_module_save_folder_location(m_moduleName) + L"\\settings.json";
-                    std::filesystem::remove(settingsFile);
+                    std::filesystem::remove_all(PTSettingsHelper::get_module_save_folder_location(m_moduleName));
                 }
 
                 TEST_METHOD (CallbackSetConfig)
@@ -551,7 +549,7 @@ namespace FancyZonesUnitTests
     {
         winrt::com_ptr<IFancyZonesSettings> m_settings = nullptr;
         PowerToysSettings::Settings* m_ptSettings = nullptr;
-        PCWSTR m_moduleName = L"FancyZonesTest";
+        PCWSTR m_moduleName = L"FancyZonesUnitTests";
 
         std::wstring serializedPowerToySettings(const Settings& settings)
         {
@@ -653,8 +651,7 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD_CLEANUP(Cleanup)
                 {
-                    const auto settingsFile = PTSettingsHelper::get_module_save_folder_location(m_moduleName) + L"\\settings.json";
-                    std::filesystem::remove(settingsFile);
+                    std::filesystem::remove_all(PTSettingsHelper::get_module_save_folder_location(m_moduleName));
                 }
 
                 TEST_METHOD (GetConfig)

--- a/src/modules/fancyzones/tests/UnitTests/JsonHelpers.Tests.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/JsonHelpers.Tests.cpp
@@ -883,6 +883,7 @@ namespace FancyZonesUnitTests
     TEST_CLASS (FancyZonesDataUnitTests)
     {
     private:
+        const std::wstring_view m_moduleName = L"FancyZonesUnitTests";
         const std::wstring m_defaultDeviceId = L"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1539}";
         const std::wstring m_defaultCustomDeviceStr = L"{\"device-id\": \"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1539}\", \"active-zoneset\": {\"type\": \"custom\", \"uuid\": \"{33A2B101-06E0-437B-A61E-CDBECF502906}\"}, \"editor-show-spacing\": true, \"editor-spacing\": 16, \"editor-zone-count\": 3}";
         const json::JsonValue m_defaultCustomDeviceValue = json::JsonValue::Parse(m_defaultCustomDeviceStr);
@@ -909,13 +910,13 @@ namespace FancyZonesUnitTests
         public:
             TEST_METHOD (FancyZonesDataPath)
             {
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
                 Assert::IsFalse(data.GetPersistFancyZonesJSONPath().empty());
             }
 
             TEST_METHOD (FancyZonesDataJsonEmpty)
             {
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
                 const auto jsonPath = data.GetPersistFancyZonesJSONPath();
                 auto savedJson = json::from_file(jsonPath);
 
@@ -937,7 +938,7 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (FancyZonesDataJson)
             {
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
                 const auto jsonPath = data.GetPersistFancyZonesJSONPath();
                 auto savedJson = json::from_file(jsonPath);
 
@@ -964,14 +965,14 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (FancyZonesDataDeviceInfoMap)
             {
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
                 const auto actual = data.GetDeviceInfoMap();
                 Assert::IsTrue(actual.empty());
             }
 
             TEST_METHOD (FancyZonesDataDeviceInfoMapParseEmpty)
             {
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
 
                 json::JsonObject json;
                 data.ParseDeviceInfos(json);
@@ -982,7 +983,7 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (FancyZonesDataDeviceInfoMapParseValidEmpty)
             {
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
 
                 json::JsonObject expected;
                 json::JsonArray zoneSets;
@@ -1003,7 +1004,7 @@ namespace FancyZonesUnitTests
                 json::JsonObject expected;
                 expected.SetNamedValue(L"devices", devices);
 
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
                 auto actual = data.ParseDeviceInfos(expected);
 
                 Assert::IsFalse(actual);
@@ -1016,7 +1017,7 @@ namespace FancyZonesUnitTests
                 json::JsonObject expected;
                 expected.SetNamedValue(L"devices", devices);
 
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
                 data.ParseDeviceInfos(expected);
 
                 const auto actualMap = data.GetDeviceInfoMap();
@@ -1038,7 +1039,7 @@ namespace FancyZonesUnitTests
                 Logger::WriteMessage(expected.Stringify().c_str());
                 Logger::WriteMessage("\n");
 
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
                 data.ParseDeviceInfos(expected);
 
                 const auto actualMap = data.GetDeviceInfoMap();
@@ -1052,7 +1053,7 @@ namespace FancyZonesUnitTests
                 json::JsonObject expected;
                 expected.SetNamedValue(L"devices", expectedDevices);
 
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
                 data.ParseDeviceInfos(expected);
 
                 auto actual = data.SerializeDeviceInfos();
@@ -1061,7 +1062,7 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (DeviceInfoSaveTemp)
             {
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
                 DeviceInfoJSON deviceInfo{ L"default_device_id", DeviceInfoData{ ZoneSetData{ L"uuid", ZoneSetLayoutType::Custom }, true, 16, 3 } };
 
                 const std::wstring path = data.GetPersistFancyZonesJSONPath() + L".test_tmp";
@@ -1079,8 +1080,8 @@ namespace FancyZonesUnitTests
             }
 
             TEST_METHOD (DeviceInfoReadTemp)
-            {
-                FancyZonesData data;
+            {;
+                FancyZonesData data(m_moduleName);
                 const std::wstring deviceId = m_defaultDeviceId;
                 DeviceInfoJSON expected{ deviceId, DeviceInfoData{ ZoneSetData{ L"{33A2B101-06E0-437B-A61E-CDBECF502906}", ZoneSetLayoutType::Custom }, true, 16, 3 } };
                 const std::wstring path = data.GetPersistFancyZonesJSONPath() + L".test_tmp";
@@ -1108,7 +1109,7 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (DeviceInfoReadTempUnexsisted)
             {
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
                 const std::wstring path = data.GetPersistFancyZonesJSONPath() + L".test_tmp";
                 data.ParseDeviceInfoFromTmpFile(path);
 
@@ -1129,7 +1130,7 @@ namespace FancyZonesUnitTests
                 zoneHistoryArray.Append(AppZoneHistoryJSON::ToJson(expected));
                 json.SetNamedValue(L"app-zone-history", json::JsonValue::Parse(zoneHistoryArray.Stringify()));
 
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
                 data.ParseAppZoneHistory(json);
 
                 const auto actualProcessHistoryMap = data.GetAppZoneHistoryMap();
@@ -1155,7 +1156,7 @@ namespace FancyZonesUnitTests
 
                 json.SetNamedValue(L"app-zone-history", json::JsonValue::Parse(zoneHistoryArray.Stringify()));
 
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
                 data.ParseAppZoneHistory(json);
 
                 auto actualMap = data.GetAppZoneHistoryMap();
@@ -1191,7 +1192,7 @@ namespace FancyZonesUnitTests
                 zoneHistoryArray.Append(AppZoneHistoryJSON::ToJson(AppZoneHistoryJSON{ appPath, expected }));
                 json.SetNamedValue(L"app-zone-history", json::JsonValue::Parse(zoneHistoryArray.Stringify()));
 
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
                 data.ParseAppZoneHistory(json);
 
                 const auto actualProcessHistoryMap = data.GetAppZoneHistoryMap();
@@ -1205,7 +1206,7 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (AppZoneHistoryParseEmpty)
             {
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
                 data.ParseAppZoneHistory(json::JsonObject());
 
                 auto actual = data.GetAppZoneHistoryMap();
@@ -1219,7 +1220,7 @@ namespace FancyZonesUnitTests
                 AppZoneHistoryJSON expected{ appPath, AppZoneHistoryData{ .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502906}", .deviceId = L"device-id", .zoneIndex = 54321 } };
                 json.SetNamedValue(L"app-zone-history", json::JsonValue::Parse(AppZoneHistoryJSON::ToJson(expected).Stringify()));
 
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
                 bool actual = data.ParseAppZoneHistory(json);
 
                 Assert::IsFalse(actual);
@@ -1232,7 +1233,7 @@ namespace FancyZonesUnitTests
                 AppZoneHistoryJSON expected{ appPath, AppZoneHistoryData{ .zoneSetUuid = L"zoneset-uuid", .deviceId = L"device-id", .zoneIndex = 54321 } };
                 json.SetNamedValue(L"app-zone-history", json::JsonValue::Parse(AppZoneHistoryJSON::ToJson(expected).Stringify()));
 
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
                 bool actual = data.ParseAppZoneHistory(json);
 
                 Assert::IsFalse(actual);
@@ -1246,7 +1247,7 @@ namespace FancyZonesUnitTests
                 json::JsonObject json;
                 json.SetNamedValue(L"app-zone-history", json::JsonValue::Parse(expected.Stringify()));
 
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
                 data.ParseAppZoneHistory(json);
 
                 auto actual = data.SerializeAppZoneHistory();
@@ -1263,7 +1264,7 @@ namespace FancyZonesUnitTests
                 expected.Append(AppZoneHistoryJSON::ToJson(AppZoneHistoryJSON{ L"app-path-4", AppZoneHistoryData{ .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502906}", .deviceId = m_defaultDeviceId, .zoneIndex = 54321 } }));
                 json.SetNamedValue(L"app-zone-history", json::JsonValue::Parse(expected.Stringify()));
 
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
                 data.ParseAppZoneHistory(json);
 
                 auto actual = data.SerializeAppZoneHistory();
@@ -1276,7 +1277,7 @@ namespace FancyZonesUnitTests
                 json::JsonObject json;
                 json.SetNamedValue(L"app-zone-history", json::JsonValue::Parse(expected.Stringify()));
 
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
                 data.ParseAppZoneHistory(json);
 
                 auto actual = data.SerializeAppZoneHistory();
@@ -1299,7 +1300,7 @@ namespace FancyZonesUnitTests
                 array.Append(CustomZoneSetJSON::ToJson(expected));
                 json.SetNamedValue(L"custom-zone-sets", json::JsonValue::Parse(array.Stringify()));
 
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
                 data.ParseCustomZoneSets(json);
 
                 auto actualMap = data.GetCustomZoneSetsMap();
@@ -1331,7 +1332,7 @@ namespace FancyZonesUnitTests
                 array.Append(CustomZoneSetJSON::ToJson(CustomZoneSetJSON{ L"{33A2B101-06E0-437B-A61E-CDBECF502903}", CustomZoneSetData{ L"name", CustomLayoutType::Canvas, CanvasLayoutInfo{ 1, 2 } } }));
                 json.SetNamedValue(L"custom-zone-sets", json::JsonValue::Parse(array.Stringify()));
 
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
                 data.ParseCustomZoneSets(json);
 
                 auto actualMap = data.GetCustomZoneSetsMap();
@@ -1366,7 +1367,7 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (CustomZoneSetsParseEmpty)
             {
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
                 data.ParseCustomZoneSets(json::JsonObject());
 
                 auto actual = data.GetCustomZoneSetsMap();
@@ -1379,7 +1380,7 @@ namespace FancyZonesUnitTests
                 CustomZoneSetJSON expected{ L"uuid", CustomZoneSetData{ L"name", CustomLayoutType::Grid, GridLayoutInfo(GridLayoutInfo::Minimal{ 1, 2 }) } };
                 json.SetNamedValue(L"custom-zone-sets", json::JsonValue::Parse(CustomZoneSetJSON::ToJson(expected).Stringify()));
 
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
                 auto actual = data.ParseCustomZoneSets(json);
 
                 Assert::IsFalse(actual);
@@ -1398,7 +1399,7 @@ namespace FancyZonesUnitTests
                 json::JsonObject json;
                 json.SetNamedValue(L"custom-zone-sets", json::JsonValue::Parse(expected.Stringify()));
 
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
                 data.ParseCustomZoneSets(json);
 
                 auto actual = data.SerializeCustomZoneSets();
@@ -1422,7 +1423,7 @@ namespace FancyZonesUnitTests
                 expected.Append(CustomZoneSetJSON::ToJson(CustomZoneSetJSON{ L"{33A2B101-06E0-437B-A61E-CDBECF502903}", CustomZoneSetData{ L"name", CustomLayoutType::Canvas, CanvasLayoutInfo{ 1, 2 } } }));
                 json.SetNamedValue(L"custom-zone-sets", json::JsonValue::Parse(expected.Stringify()));
 
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
                 data.ParseCustomZoneSets(json);
 
                 auto actual = data.SerializeCustomZoneSets();
@@ -1435,7 +1436,7 @@ namespace FancyZonesUnitTests
                 json::JsonObject json;
                 json.SetNamedValue(L"custom-zone-sets", json::JsonValue::Parse(expected.Stringify()));
 
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
                 data.ParseCustomZoneSets(json);
 
                 auto actual = data.SerializeCustomZoneSets();
@@ -1465,7 +1466,7 @@ namespace FancyZonesUnitTests
                     .cellChildMap = { { 0, 1, 2 } } }));
                 CustomZoneSetJSON expected{ uuid, CustomZoneSetData{ L"name", CustomLayoutType::Grid, grid } };
 
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
                 const std::wstring path = data.GetPersistFancyZonesJSONPath() + L".test_tmp";
                 json::to_file(path, CustomZoneSetJSON::ToJson(expected));
                 m_fzData.ParseCustomZoneSetFromTmpFile(path);
@@ -1501,7 +1502,7 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (SetActiveZoneSet)
             {
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
                 const std::wstring uniqueId = m_defaultDeviceId;
 
                 json::JsonArray devices;
@@ -1524,7 +1525,7 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (SetActiveZoneSetUuidEmpty)
             {
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
                 const std::wstring expected = L"{39B25DD2-130D-4B5D-8851-4791D66B1539}";
                 const std::wstring uniqueId = m_defaultDeviceId;
 
@@ -1548,7 +1549,7 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (SetActiveZoneSetUniqueIdInvalid)
             {
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
                 const std::wstring expected = L"{33A2B101-06E0-437B-A61E-CDBECF502906}";
                 const std::wstring uniqueId = L"id-not-contained-by-device-info-map_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1539}";
 
@@ -1574,7 +1575,7 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (LoadFancyZonesDataFromJson)
             {
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
                 const auto jsonPath = data.GetPersistFancyZonesJSONPath();
                 auto savedJson = json::from_file(jsonPath);
 
@@ -1620,7 +1621,7 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (LoadFancyZonesDataFromCroppedJson)
             {
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
                 const auto jsonPath = data.GetPersistFancyZonesJSONPath();
                 auto savedJson = json::from_file(jsonPath);
 
@@ -1649,7 +1650,7 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (LoadFancyZonesDataFromJsonWithCyrillicSymbols)
             {
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
                 const auto jsonPath = data.GetPersistFancyZonesJSONPath();
                 auto savedJson = json::from_file(jsonPath);
 
@@ -1677,7 +1678,7 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (LoadFancyZonesDataFromJsonWithInvalidTypes)
             {
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
                 const auto jsonPath = data.GetPersistFancyZonesJSONPath();
                 auto savedJson = json::from_file(jsonPath);
 
@@ -1705,7 +1706,7 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (LoadFancyZonesDataFromRegistry)
             {
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
                 const auto jsonPath = data.GetPersistFancyZonesJSONPath();
                 auto savedJson = json::from_file(jsonPath);
 
@@ -1730,7 +1731,7 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (SaveFancyZonesData)
             {
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
                 const auto jsonPath = data.GetPersistFancyZonesJSONPath();
                 auto savedJson = json::from_file(jsonPath);
 
@@ -1759,7 +1760,7 @@ namespace FancyZonesUnitTests
                 const std::wstring deviceId = L"device-id";
                 const std::wstring zoneSetId = L"zoneset-uuid";
                 const auto window = Mocks::WindowCreate(m_hInst);
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
 
                 Assert::AreEqual(-1, data.GetAppLastZoneIndex(window, deviceId, zoneSetId));
 
@@ -1773,7 +1774,7 @@ namespace FancyZonesUnitTests
                 const std::wstring zoneSetId = L"zoneset-uuid";
                 const std::wstring deviceId = L"device-id";
                 const auto window = Mocks::WindowCreate(m_hInst);
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
 
                 const int expectedZoneIndex = 0;
                 Assert::IsTrue(data.SetAppLastZone(window, deviceId, zoneSetId, expectedZoneIndex));
@@ -1785,7 +1786,7 @@ namespace FancyZonesUnitTests
                 const std::wstring zoneSetId = L"zoneset-uuid";
                 const std::wstring deviceId = L"device-id";
                 const auto window = Mocks::WindowCreate(m_hInst);
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
 
                 const int expectedZoneIndex = -1;
                 Assert::IsTrue(data.SetAppLastZone(window, deviceId, zoneSetId, expectedZoneIndex));
@@ -1797,7 +1798,7 @@ namespace FancyZonesUnitTests
                 const std::wstring zoneSetId = L"zoneset-uuid";
                 const std::wstring deviceId = L"device-id";
                 const auto window = Mocks::WindowCreate(m_hInst);
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
 
                 const long expectedZoneIndex = LONG_MAX;
                 Assert::IsTrue(data.SetAppLastZone(window, deviceId, zoneSetId, expectedZoneIndex));
@@ -1809,7 +1810,7 @@ namespace FancyZonesUnitTests
                 const std::wstring zoneSetId = L"zoneset-uuid";
                 const std::wstring deviceId = L"device-id";
                 const auto window = Mocks::WindowCreate(m_hInst);
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
 
                 const int expectedZoneIndex = 3;
                 Assert::IsTrue(data.SetAppLastZone(window, deviceId, zoneSetId, 1));
@@ -1823,7 +1824,7 @@ namespace FancyZonesUnitTests
                 const std::wstring zoneSetId = L"zoneset-uuid";
                 const std::wstring deviceId = L"device-id";
                 const auto window = Mocks::Window();
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
 
                 Assert::AreEqual(-1, data.GetAppLastZoneIndex(window, deviceId, zoneSetId));
 
@@ -1835,7 +1836,7 @@ namespace FancyZonesUnitTests
             {
                 const std::wstring zoneSetId = L"zoneset-uuid";
                 const auto window = nullptr;
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
 
                 const int expectedZoneIndex = 1;
                 Assert::IsFalse(data.SetAppLastZone(window, L"device-id", zoneSetId, expectedZoneIndex));
@@ -1847,7 +1848,7 @@ namespace FancyZonesUnitTests
                 const std::wstring deviceId1 = L"device-id-1";
                 const std::wstring deviceId2 = L"device-id-2";
                 const auto window = Mocks::WindowCreate(m_hInst);
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
 
                 const int expectedZoneIndex = 10;
                 Assert::IsTrue(data.SetAppLastZone(window, deviceId1, zoneSetId, expectedZoneIndex));
@@ -1861,7 +1862,7 @@ namespace FancyZonesUnitTests
                 const std::wstring zoneSetId2 = L"zoneset-uuid-2";
                 const std::wstring deviceId = L"device-id";
                 const auto window = Mocks::WindowCreate(m_hInst);
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
 
                 const int expectedZoneIndex = 10;
                 Assert::IsTrue(data.SetAppLastZone(window, deviceId, zoneSetId1, expectedZoneIndex));
@@ -1874,7 +1875,7 @@ namespace FancyZonesUnitTests
                 const std::wstring zoneSetId = L"zoneset-uuid";
                 const std::wstring deviceId = L"device-id";
                 const auto window = Mocks::WindowCreate(m_hInst);
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
 
                 Assert::IsTrue(data.SetAppLastZone(window, deviceId, zoneSetId, 1));
                 Assert::IsTrue(data.RemoveAppLastZone(window, deviceId, zoneSetId));
@@ -1886,7 +1887,7 @@ namespace FancyZonesUnitTests
                 const std::wstring zoneSetId = L"zoneset-uuid";
                 const std::wstring deviceId = L"device-id";
                 const auto window = Mocks::WindowCreate(m_hInst);
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
 
                 Assert::IsFalse(data.RemoveAppLastZone(window, deviceId, zoneSetId));
                 Assert::AreEqual(-1, data.GetAppLastZoneIndex(window, deviceId, zoneSetId));
@@ -1898,7 +1899,7 @@ namespace FancyZonesUnitTests
                 const std::wstring zoneSetIdToRemove = L"zoneset-uuid-to-remove";
                 const std::wstring deviceId = L"device-id";
                 const auto window = Mocks::WindowCreate(m_hInst);
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
 
                 Assert::IsTrue(data.SetAppLastZone(window, deviceId, zoneSetIdToInsert, 1));
                 Assert::IsFalse(data.RemoveAppLastZone(window, deviceId, zoneSetIdToRemove));
@@ -1911,7 +1912,7 @@ namespace FancyZonesUnitTests
                 const std::wstring deviceIdToInsert = L"device-id-insert";
                 const std::wstring deviceIdToRemove = L"device-id-remove";
                 const auto window = Mocks::WindowCreate(m_hInst);
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
 
                 Assert::IsTrue(data.SetAppLastZone(window, deviceIdToInsert, zoneSetId, 1));
                 Assert::IsFalse(data.RemoveAppLastZone(window, deviceIdToRemove, zoneSetId));
@@ -1923,7 +1924,7 @@ namespace FancyZonesUnitTests
                 const std::wstring zoneSetId = L"zoneset-uuid";
                 const std::wstring deviceId = L"device-id";
                 const auto window = Mocks::WindowCreate(m_hInst);
-                FancyZonesData data;
+                FancyZonesData data(m_moduleName);
 
                 Assert::IsFalse(data.RemoveAppLastZone(nullptr, deviceId, zoneSetId));
             }

--- a/src/modules/fancyzones/tests/UnitTests/JsonHelpers.Tests.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/JsonHelpers.Tests.cpp
@@ -907,6 +907,11 @@ namespace FancyZonesUnitTests
                 m_fzData.clear_data();
             }
 
+        TEST_METHOD_CLEANUP(CleanUp)
+        {    
+            std::filesystem::remove_all(PTSettingsHelper::get_module_save_folder_location(m_moduleName));
+        }
+
         public:
             TEST_METHOD (FancyZonesDataPath)
             {

--- a/src/modules/fancyzones/tests/UnitTests/JsonHelpers.Tests.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/JsonHelpers.Tests.cpp
@@ -915,13 +915,15 @@ namespace FancyZonesUnitTests
         public:
             TEST_METHOD (FancyZonesDataPath)
             {
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
                 Assert::IsFalse(data.GetPersistFancyZonesJSONPath().empty());
             }
 
             TEST_METHOD (FancyZonesDataJsonEmpty)
             {
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
                 const auto jsonPath = data.GetPersistFancyZonesJSONPath();
                 auto savedJson = json::from_file(jsonPath);
 
@@ -943,7 +945,8 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (FancyZonesDataJson)
             {
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
                 const auto jsonPath = data.GetPersistFancyZonesJSONPath();
                 auto savedJson = json::from_file(jsonPath);
 
@@ -970,14 +973,16 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (FancyZonesDataDeviceInfoMap)
             {
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
                 const auto actual = data.GetDeviceInfoMap();
                 Assert::IsTrue(actual.empty());
             }
 
             TEST_METHOD (FancyZonesDataDeviceInfoMapParseEmpty)
             {
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
 
                 json::JsonObject json;
                 data.ParseDeviceInfos(json);
@@ -988,7 +993,8 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (FancyZonesDataDeviceInfoMapParseValidEmpty)
             {
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
 
                 json::JsonObject expected;
                 json::JsonArray zoneSets;
@@ -1009,7 +1015,8 @@ namespace FancyZonesUnitTests
                 json::JsonObject expected;
                 expected.SetNamedValue(L"devices", devices);
 
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
                 auto actual = data.ParseDeviceInfos(expected);
 
                 Assert::IsFalse(actual);
@@ -1022,7 +1029,8 @@ namespace FancyZonesUnitTests
                 json::JsonObject expected;
                 expected.SetNamedValue(L"devices", devices);
 
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
                 data.ParseDeviceInfos(expected);
 
                 const auto actualMap = data.GetDeviceInfoMap();
@@ -1044,7 +1052,8 @@ namespace FancyZonesUnitTests
                 Logger::WriteMessage(expected.Stringify().c_str());
                 Logger::WriteMessage("\n");
 
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
                 data.ParseDeviceInfos(expected);
 
                 const auto actualMap = data.GetDeviceInfoMap();
@@ -1058,7 +1067,8 @@ namespace FancyZonesUnitTests
                 json::JsonObject expected;
                 expected.SetNamedValue(L"devices", expectedDevices);
 
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
                 data.ParseDeviceInfos(expected);
 
                 auto actual = data.SerializeDeviceInfos();
@@ -1067,7 +1077,8 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (DeviceInfoSaveTemp)
             {
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
                 DeviceInfoJSON deviceInfo{ L"default_device_id", DeviceInfoData{ ZoneSetData{ L"uuid", ZoneSetLayoutType::Custom }, true, 16, 3 } };
 
                 const std::wstring path = data.GetPersistFancyZonesJSONPath() + L".test_tmp";
@@ -1085,8 +1096,9 @@ namespace FancyZonesUnitTests
             }
 
             TEST_METHOD (DeviceInfoReadTemp)
-            {;
-                FancyZonesData data(m_moduleName);
+            {
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
                 const std::wstring deviceId = m_defaultDeviceId;
                 DeviceInfoJSON expected{ deviceId, DeviceInfoData{ ZoneSetData{ L"{33A2B101-06E0-437B-A61E-CDBECF502906}", ZoneSetLayoutType::Custom }, true, 16, 3 } };
                 const std::wstring path = data.GetPersistFancyZonesJSONPath() + L".test_tmp";
@@ -1114,7 +1126,8 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (DeviceInfoReadTempUnexsisted)
             {
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
                 const std::wstring path = data.GetPersistFancyZonesJSONPath() + L".test_tmp";
                 data.ParseDeviceInfoFromTmpFile(path);
 
@@ -1135,7 +1148,8 @@ namespace FancyZonesUnitTests
                 zoneHistoryArray.Append(AppZoneHistoryJSON::ToJson(expected));
                 json.SetNamedValue(L"app-zone-history", json::JsonValue::Parse(zoneHistoryArray.Stringify()));
 
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
                 data.ParseAppZoneHistory(json);
 
                 const auto actualProcessHistoryMap = data.GetAppZoneHistoryMap();
@@ -1161,7 +1175,8 @@ namespace FancyZonesUnitTests
 
                 json.SetNamedValue(L"app-zone-history", json::JsonValue::Parse(zoneHistoryArray.Stringify()));
 
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
                 data.ParseAppZoneHistory(json);
 
                 auto actualMap = data.GetAppZoneHistoryMap();
@@ -1197,7 +1212,8 @@ namespace FancyZonesUnitTests
                 zoneHistoryArray.Append(AppZoneHistoryJSON::ToJson(AppZoneHistoryJSON{ appPath, expected }));
                 json.SetNamedValue(L"app-zone-history", json::JsonValue::Parse(zoneHistoryArray.Stringify()));
 
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
                 data.ParseAppZoneHistory(json);
 
                 const auto actualProcessHistoryMap = data.GetAppZoneHistoryMap();
@@ -1211,7 +1227,8 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (AppZoneHistoryParseEmpty)
             {
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
                 data.ParseAppZoneHistory(json::JsonObject());
 
                 auto actual = data.GetAppZoneHistoryMap();
@@ -1225,7 +1242,8 @@ namespace FancyZonesUnitTests
                 AppZoneHistoryJSON expected{ appPath, AppZoneHistoryData{ .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502906}", .deviceId = L"device-id", .zoneIndex = 54321 } };
                 json.SetNamedValue(L"app-zone-history", json::JsonValue::Parse(AppZoneHistoryJSON::ToJson(expected).Stringify()));
 
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
                 bool actual = data.ParseAppZoneHistory(json);
 
                 Assert::IsFalse(actual);
@@ -1238,7 +1256,8 @@ namespace FancyZonesUnitTests
                 AppZoneHistoryJSON expected{ appPath, AppZoneHistoryData{ .zoneSetUuid = L"zoneset-uuid", .deviceId = L"device-id", .zoneIndex = 54321 } };
                 json.SetNamedValue(L"app-zone-history", json::JsonValue::Parse(AppZoneHistoryJSON::ToJson(expected).Stringify()));
 
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
                 bool actual = data.ParseAppZoneHistory(json);
 
                 Assert::IsFalse(actual);
@@ -1252,7 +1271,8 @@ namespace FancyZonesUnitTests
                 json::JsonObject json;
                 json.SetNamedValue(L"app-zone-history", json::JsonValue::Parse(expected.Stringify()));
 
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
                 data.ParseAppZoneHistory(json);
 
                 auto actual = data.SerializeAppZoneHistory();
@@ -1269,7 +1289,8 @@ namespace FancyZonesUnitTests
                 expected.Append(AppZoneHistoryJSON::ToJson(AppZoneHistoryJSON{ L"app-path-4", AppZoneHistoryData{ .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502906}", .deviceId = m_defaultDeviceId, .zoneIndex = 54321 } }));
                 json.SetNamedValue(L"app-zone-history", json::JsonValue::Parse(expected.Stringify()));
 
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
                 data.ParseAppZoneHistory(json);
 
                 auto actual = data.SerializeAppZoneHistory();
@@ -1282,7 +1303,8 @@ namespace FancyZonesUnitTests
                 json::JsonObject json;
                 json.SetNamedValue(L"app-zone-history", json::JsonValue::Parse(expected.Stringify()));
 
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
                 data.ParseAppZoneHistory(json);
 
                 auto actual = data.SerializeAppZoneHistory();
@@ -1305,7 +1327,8 @@ namespace FancyZonesUnitTests
                 array.Append(CustomZoneSetJSON::ToJson(expected));
                 json.SetNamedValue(L"custom-zone-sets", json::JsonValue::Parse(array.Stringify()));
 
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
                 data.ParseCustomZoneSets(json);
 
                 auto actualMap = data.GetCustomZoneSetsMap();
@@ -1337,7 +1360,8 @@ namespace FancyZonesUnitTests
                 array.Append(CustomZoneSetJSON::ToJson(CustomZoneSetJSON{ L"{33A2B101-06E0-437B-A61E-CDBECF502903}", CustomZoneSetData{ L"name", CustomLayoutType::Canvas, CanvasLayoutInfo{ 1, 2 } } }));
                 json.SetNamedValue(L"custom-zone-sets", json::JsonValue::Parse(array.Stringify()));
 
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
                 data.ParseCustomZoneSets(json);
 
                 auto actualMap = data.GetCustomZoneSetsMap();
@@ -1372,7 +1396,8 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (CustomZoneSetsParseEmpty)
             {
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
                 data.ParseCustomZoneSets(json::JsonObject());
 
                 auto actual = data.GetCustomZoneSetsMap();
@@ -1385,7 +1410,8 @@ namespace FancyZonesUnitTests
                 CustomZoneSetJSON expected{ L"uuid", CustomZoneSetData{ L"name", CustomLayoutType::Grid, GridLayoutInfo(GridLayoutInfo::Minimal{ 1, 2 }) } };
                 json.SetNamedValue(L"custom-zone-sets", json::JsonValue::Parse(CustomZoneSetJSON::ToJson(expected).Stringify()));
 
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
                 auto actual = data.ParseCustomZoneSets(json);
 
                 Assert::IsFalse(actual);
@@ -1404,7 +1430,8 @@ namespace FancyZonesUnitTests
                 json::JsonObject json;
                 json.SetNamedValue(L"custom-zone-sets", json::JsonValue::Parse(expected.Stringify()));
 
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
                 data.ParseCustomZoneSets(json);
 
                 auto actual = data.SerializeCustomZoneSets();
@@ -1428,7 +1455,8 @@ namespace FancyZonesUnitTests
                 expected.Append(CustomZoneSetJSON::ToJson(CustomZoneSetJSON{ L"{33A2B101-06E0-437B-A61E-CDBECF502903}", CustomZoneSetData{ L"name", CustomLayoutType::Canvas, CanvasLayoutInfo{ 1, 2 } } }));
                 json.SetNamedValue(L"custom-zone-sets", json::JsonValue::Parse(expected.Stringify()));
 
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
                 data.ParseCustomZoneSets(json);
 
                 auto actual = data.SerializeCustomZoneSets();
@@ -1441,7 +1469,8 @@ namespace FancyZonesUnitTests
                 json::JsonObject json;
                 json.SetNamedValue(L"custom-zone-sets", json::JsonValue::Parse(expected.Stringify()));
 
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
                 data.ParseCustomZoneSets(json);
 
                 auto actual = data.SerializeCustomZoneSets();
@@ -1471,7 +1500,8 @@ namespace FancyZonesUnitTests
                     .cellChildMap = { { 0, 1, 2 } } }));
                 CustomZoneSetJSON expected{ uuid, CustomZoneSetData{ L"name", CustomLayoutType::Grid, grid } };
 
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
                 const std::wstring path = data.GetPersistFancyZonesJSONPath() + L".test_tmp";
                 json::to_file(path, CustomZoneSetJSON::ToJson(expected));
                 m_fzData.ParseCustomZoneSetFromTmpFile(path);
@@ -1507,7 +1537,8 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (SetActiveZoneSet)
             {
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
                 const std::wstring uniqueId = m_defaultDeviceId;
 
                 json::JsonArray devices;
@@ -1530,7 +1561,8 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (SetActiveZoneSetUuidEmpty)
             {
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
                 const std::wstring expected = L"{39B25DD2-130D-4B5D-8851-4791D66B1539}";
                 const std::wstring uniqueId = m_defaultDeviceId;
 
@@ -1554,7 +1586,9 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (SetActiveZoneSetUniqueIdInvalid)
             {
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
+
                 const std::wstring expected = L"{33A2B101-06E0-437B-A61E-CDBECF502906}";
                 const std::wstring uniqueId = L"id-not-contained-by-device-info-map_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1539}";
 
@@ -1580,7 +1614,8 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (LoadFancyZonesDataFromJson)
             {
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
                 const auto jsonPath = data.GetPersistFancyZonesJSONPath();
                 auto savedJson = json::from_file(jsonPath);
 
@@ -1626,7 +1661,9 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (LoadFancyZonesDataFromCroppedJson)
             {
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
+
                 const auto jsonPath = data.GetPersistFancyZonesJSONPath();
                 auto savedJson = json::from_file(jsonPath);
 
@@ -1655,7 +1692,8 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (LoadFancyZonesDataFromJsonWithCyrillicSymbols)
             {
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
                 const auto jsonPath = data.GetPersistFancyZonesJSONPath();
                 auto savedJson = json::from_file(jsonPath);
 
@@ -1683,7 +1721,8 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (LoadFancyZonesDataFromJsonWithInvalidTypes)
             {
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
                 const auto jsonPath = data.GetPersistFancyZonesJSONPath();
                 auto savedJson = json::from_file(jsonPath);
 
@@ -1711,7 +1750,8 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (LoadFancyZonesDataFromRegistry)
             {
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
                 const auto jsonPath = data.GetPersistFancyZonesJSONPath();
                 auto savedJson = json::from_file(jsonPath);
 
@@ -1736,7 +1776,8 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (SaveFancyZonesData)
             {
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
                 const auto jsonPath = data.GetPersistFancyZonesJSONPath();
                 auto savedJson = json::from_file(jsonPath);
 
@@ -1765,7 +1806,8 @@ namespace FancyZonesUnitTests
                 const std::wstring deviceId = L"device-id";
                 const std::wstring zoneSetId = L"zoneset-uuid";
                 const auto window = Mocks::WindowCreate(m_hInst);
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
 
                 Assert::AreEqual(-1, data.GetAppLastZoneIndex(window, deviceId, zoneSetId));
 
@@ -1779,7 +1821,8 @@ namespace FancyZonesUnitTests
                 const std::wstring zoneSetId = L"zoneset-uuid";
                 const std::wstring deviceId = L"device-id";
                 const auto window = Mocks::WindowCreate(m_hInst);
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
 
                 const int expectedZoneIndex = 0;
                 Assert::IsTrue(data.SetAppLastZone(window, deviceId, zoneSetId, expectedZoneIndex));
@@ -1791,7 +1834,8 @@ namespace FancyZonesUnitTests
                 const std::wstring zoneSetId = L"zoneset-uuid";
                 const std::wstring deviceId = L"device-id";
                 const auto window = Mocks::WindowCreate(m_hInst);
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
 
                 const int expectedZoneIndex = -1;
                 Assert::IsTrue(data.SetAppLastZone(window, deviceId, zoneSetId, expectedZoneIndex));
@@ -1803,7 +1847,8 @@ namespace FancyZonesUnitTests
                 const std::wstring zoneSetId = L"zoneset-uuid";
                 const std::wstring deviceId = L"device-id";
                 const auto window = Mocks::WindowCreate(m_hInst);
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
 
                 const long expectedZoneIndex = LONG_MAX;
                 Assert::IsTrue(data.SetAppLastZone(window, deviceId, zoneSetId, expectedZoneIndex));
@@ -1815,7 +1860,8 @@ namespace FancyZonesUnitTests
                 const std::wstring zoneSetId = L"zoneset-uuid";
                 const std::wstring deviceId = L"device-id";
                 const auto window = Mocks::WindowCreate(m_hInst);
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
 
                 const int expectedZoneIndex = 3;
                 Assert::IsTrue(data.SetAppLastZone(window, deviceId, zoneSetId, 1));
@@ -1829,7 +1875,8 @@ namespace FancyZonesUnitTests
                 const std::wstring zoneSetId = L"zoneset-uuid";
                 const std::wstring deviceId = L"device-id";
                 const auto window = Mocks::Window();
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
 
                 Assert::AreEqual(-1, data.GetAppLastZoneIndex(window, deviceId, zoneSetId));
 
@@ -1841,7 +1888,8 @@ namespace FancyZonesUnitTests
             {
                 const std::wstring zoneSetId = L"zoneset-uuid";
                 const auto window = nullptr;
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
 
                 const int expectedZoneIndex = 1;
                 Assert::IsFalse(data.SetAppLastZone(window, L"device-id", zoneSetId, expectedZoneIndex));
@@ -1853,7 +1901,8 @@ namespace FancyZonesUnitTests
                 const std::wstring deviceId1 = L"device-id-1";
                 const std::wstring deviceId2 = L"device-id-2";
                 const auto window = Mocks::WindowCreate(m_hInst);
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
 
                 const int expectedZoneIndex = 10;
                 Assert::IsTrue(data.SetAppLastZone(window, deviceId1, zoneSetId, expectedZoneIndex));
@@ -1867,7 +1916,8 @@ namespace FancyZonesUnitTests
                 const std::wstring zoneSetId2 = L"zoneset-uuid-2";
                 const std::wstring deviceId = L"device-id";
                 const auto window = Mocks::WindowCreate(m_hInst);
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
 
                 const int expectedZoneIndex = 10;
                 Assert::IsTrue(data.SetAppLastZone(window, deviceId, zoneSetId1, expectedZoneIndex));
@@ -1880,7 +1930,8 @@ namespace FancyZonesUnitTests
                 const std::wstring zoneSetId = L"zoneset-uuid";
                 const std::wstring deviceId = L"device-id";
                 const auto window = Mocks::WindowCreate(m_hInst);
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
 
                 Assert::IsTrue(data.SetAppLastZone(window, deviceId, zoneSetId, 1));
                 Assert::IsTrue(data.RemoveAppLastZone(window, deviceId, zoneSetId));
@@ -1892,7 +1943,8 @@ namespace FancyZonesUnitTests
                 const std::wstring zoneSetId = L"zoneset-uuid";
                 const std::wstring deviceId = L"device-id";
                 const auto window = Mocks::WindowCreate(m_hInst);
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
 
                 Assert::IsFalse(data.RemoveAppLastZone(window, deviceId, zoneSetId));
                 Assert::AreEqual(-1, data.GetAppLastZoneIndex(window, deviceId, zoneSetId));
@@ -1904,7 +1956,8 @@ namespace FancyZonesUnitTests
                 const std::wstring zoneSetIdToRemove = L"zoneset-uuid-to-remove";
                 const std::wstring deviceId = L"device-id";
                 const auto window = Mocks::WindowCreate(m_hInst);
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
 
                 Assert::IsTrue(data.SetAppLastZone(window, deviceId, zoneSetIdToInsert, 1));
                 Assert::IsFalse(data.RemoveAppLastZone(window, deviceId, zoneSetIdToRemove));
@@ -1917,7 +1970,8 @@ namespace FancyZonesUnitTests
                 const std::wstring deviceIdToInsert = L"device-id-insert";
                 const std::wstring deviceIdToRemove = L"device-id-remove";
                 const auto window = Mocks::WindowCreate(m_hInst);
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
 
                 Assert::IsTrue(data.SetAppLastZone(window, deviceIdToInsert, zoneSetId, 1));
                 Assert::IsFalse(data.RemoveAppLastZone(window, deviceIdToRemove, zoneSetId));
@@ -1929,7 +1983,8 @@ namespace FancyZonesUnitTests
                 const std::wstring zoneSetId = L"zoneset-uuid";
                 const std::wstring deviceId = L"device-id";
                 const auto window = Mocks::WindowCreate(m_hInst);
-                FancyZonesData data(m_moduleName);
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
 
                 Assert::IsFalse(data.RemoveAppLastZone(nullptr, deviceId, zoneSetId));
             }

--- a/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
@@ -66,7 +66,7 @@ namespace FancyZonesUnitTests
 
         winrt::com_ptr<IZoneWindow> m_zoneWindow;
 
-        JSONHelpers::FancyZonesData& m_fancyZonesData = JSONHelpers::FancyZonesDataInstance();
+        JSONHelpers::FancyZonesData m_fancyZonesData = JSONHelpers::FancyZonesData(L"FancyZonesUnitTests");
 
         TEST_METHOD_INITIALIZE(Init)
         {

--- a/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
@@ -66,7 +66,7 @@ namespace FancyZonesUnitTests
 
         winrt::com_ptr<IZoneWindow> m_zoneWindow;
 
-        JSONHelpers::FancyZonesData m_fancyZonesData = JSONHelpers::FancyZonesData(L"FancyZonesUnitTests");
+        JSONHelpers::FancyZonesData& m_fancyZonesData = JSONHelpers::FancyZonesDataInstance();
 
         TEST_METHOD_INITIALIZE(Init)
         {
@@ -87,6 +87,7 @@ namespace FancyZonesUnitTests
             Assert::IsFalse(std::filesystem::exists(ZoneWindowUtils::GetAppliedZoneSetTmpPath()));
             Assert::IsFalse(std::filesystem::exists(ZoneWindowUtils::GetCustomZoneSetsTmpPath()));
 
+            m_fancyZonesData.SetSettingsModulePath(L"FancyZonesUnitTests");
             m_fancyZonesData.clear_data();
         }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Unit tests no more affectes user settings files. 

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #3408
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Added explicitly set module name to `FancyZonesData` for testing to prevent changing users files.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Run unit tests, check if `zone-settings.json` remains the same.  