### PR TITLE
Expose InMoveSize from WindowMoveHandler.

### DIFF
--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -172,7 +172,7 @@ public:
     }
 
     IFACEMETHODIMP_(bool)
-    IsMakeDraggedWindowTransparentActive() noexcept
+    isMakeDraggedWindowTransparentActive() noexcept
     {
         return m_settings->GetSettings()->makeDraggedWindowTransparent;
     }

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -55,14 +55,6 @@ public:
     IFACEMETHODIMP_(void)
     Destroy() noexcept;
 
-    // IFancyZonesCallback
-    IFACEMETHODIMP_(bool)
-    InMoveSize() noexcept
-    {
-        std::shared_lock readLock(m_lock);
-        return m_windowMoveHandler.InMoveSize();
-    }
-
     void MoveSizeStart(HWND window, HMONITOR monitor, POINT const& ptScreen) noexcept
     {
         std::unique_lock writeLock(m_lock);
@@ -180,9 +172,16 @@ public:
     }
 
     IFACEMETHODIMP_(bool)
-    isMakeDraggedWindowTransparentActive() noexcept
+    IsMakeDraggedWindowTransparentActive() noexcept
     {
         return m_settings->GetSettings()->makeDraggedWindowTransparent;
+    }
+
+    IFACEMETHODIMP_(bool)
+    InMoveSize() noexcept
+    {
+        std::shared_lock readLock(m_lock);
+        return m_windowMoveHandler.InMoveSize();
     }
 
     LRESULT WndProc(HWND, UINT, WPARAM, LPARAM) noexcept;

--- a/src/modules/fancyzones/lib/FancyZones.h
+++ b/src/modules/fancyzones/lib/FancyZones.h
@@ -83,7 +83,7 @@ interface __declspec(uuid("{5C8D99D6-34B2-4F4A-A8E5-7483F6869775}")) IZoneWindow
     /**
      * @returns Boolean indicating if dragged window should be transparrent.
      */
-    IFACEMETHOD_(bool, IsMakeDraggedWindowTransparentActive) () = 0;
+    IFACEMETHOD_(bool, isMakeDraggedWindowTransparentActive) () = 0;
     /**
      * @returns Boolean indicating if move/size operation is currently active.
      */

--- a/src/modules/fancyzones/lib/FancyZones.h
+++ b/src/modules/fancyzones/lib/FancyZones.h
@@ -81,9 +81,13 @@ interface __declspec(uuid("{5C8D99D6-34B2-4F4A-A8E5-7483F6869775}")) IZoneWindow
      */
     IFACEMETHOD_(int, GetZoneHighlightOpacity)() = 0;
     /**
-     * @returns Bool indicating if dragged window should be transparrent 
+     * @returns Boolean indicating if dragged window should be transparrent.
      */
-    IFACEMETHOD_(bool, isMakeDraggedWindowTransparentActive) () = 0;
+    IFACEMETHOD_(bool, IsMakeDraggedWindowTransparentActive) () = 0;
+    /**
+     * @returns Boolean indicating if move/size operation is currently active.
+     */
+    IFACEMETHOD_(bool, InMoveSize) () = 0;
 };
 
 winrt::com_ptr<IFancyZones> MakeFancyZones(HINSTANCE hinstance, const winrt::com_ptr<IFancyZonesSettings>& settings) noexcept;

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -351,7 +351,7 @@ IFACEMETHODIMP ZoneWindow::MoveSizeEnter(HWND window, bool dragEnabled) noexcept
         return E_INVALIDARG;
     }
 
-    if (m_host->IsMakeDraggedWindowTransparentActive())
+    if (m_host->isMakeDraggedWindowTransparentActive())
     {
         draggedWindowExstyle = GetWindowLong(window, GWL_EXSTYLE);
 
@@ -427,7 +427,7 @@ IFACEMETHODIMP ZoneWindow::MoveSizeEnd(HWND window, POINT const& ptScreen) noexc
 IFACEMETHODIMP_(void)
 ZoneWindow::RestoreOrginalTransparency() noexcept
 {
-    if (m_host->IsMakeDraggedWindowTransparentActive() && draggedWindow != nullptr)
+    if (m_host->isMakeDraggedWindowTransparentActive() && draggedWindow != nullptr)
     {
         SetLayeredWindowAttributes(draggedWindow, draggedWindowCrKey, draggedWindowInitialAlpha, draggedWindowDwFlags);
         SetWindowLong(draggedWindow, GWL_EXSTYLE, draggedWindowExstyle);

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -351,7 +351,7 @@ IFACEMETHODIMP ZoneWindow::MoveSizeEnter(HWND window, bool dragEnabled) noexcept
         return E_INVALIDARG;
     }
 
-    if (m_host->isMakeDraggedWindowTransparentActive())
+    if (m_host->IsMakeDraggedWindowTransparentActive())
     {
         draggedWindowExstyle = GetWindowLong(window, GWL_EXSTYLE);
 
@@ -427,7 +427,7 @@ IFACEMETHODIMP ZoneWindow::MoveSizeEnd(HWND window, POINT const& ptScreen) noexc
 IFACEMETHODIMP_(void)
 ZoneWindow::RestoreOrginalTransparency() noexcept
 {
-    if (m_host->isMakeDraggedWindowTransparentActive() && draggedWindow != nullptr)
+    if (m_host->IsMakeDraggedWindowTransparentActive() && draggedWindow != nullptr)
     {
         SetLayeredWindowAttributes(draggedWindow, draggedWindowCrKey, draggedWindowInitialAlpha, draggedWindowDwFlags);
         SetWindowLong(draggedWindow, GWL_EXSTYLE, draggedWindowExstyle);
@@ -522,7 +522,7 @@ ZoneWindow::ShowZoneWindow() noexcept
     std::thread{ [=]() {
         AnimateWindow(window, m_showAnimationDuration, AW_BLEND);
         InvalidateRect(window, nullptr, true);
-        if (m_windowMoveSize == nullptr)
+        if (!m_host->InMoveSize())
         {
             HideZoneWindow();
         }

--- a/src/modules/fancyzones/tests/UnitTests/FancyZones.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/FancyZones.Spec.cpp
@@ -254,7 +254,7 @@ namespace FancyZonesUnitTests
                     auto config = serializedPowerToySettings(settings);
                     m_settings->SetConfig(config.c_str());
 
-                    Assert::AreEqual(expected, m_zoneWindowHost->isMakeDraggedWindowTransparentActive());
+                    Assert::AreEqual(expected, m_zoneWindowHost->IsMakeDraggedWindowTransparentActive());
                 }
 
                 TEST_METHOD (GetCurrentMonitorZoneSetEmpty)

--- a/src/modules/fancyzones/tests/UnitTests/FancyZones.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/FancyZones.Spec.cpp
@@ -254,7 +254,7 @@ namespace FancyZonesUnitTests
                     auto config = serializedPowerToySettings(settings);
                     m_settings->SetConfig(config.c_str());
 
-                    Assert::AreEqual(expected, m_zoneWindowHost->IsMakeDraggedWindowTransparentActive());
+                    Assert::AreEqual(expected, m_zoneWindowHost->isMakeDraggedWindowTransparentActive());
                 }
 
                 TEST_METHOD (GetCurrentMonitorZoneSetEmpty)

--- a/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
@@ -43,7 +43,7 @@ namespace FancyZonesUnitTests
             return 100;
         }
         IFACEMETHODIMP_(bool)
-        IsMakeDraggedWindowTransparentActive() noexcept
+        isMakeDraggedWindowTransparentActive() noexcept
         {
             return true;
         }

--- a/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
@@ -43,7 +43,12 @@ namespace FancyZonesUnitTests
             return 100;
         }
         IFACEMETHODIMP_(bool)
-        isMakeDraggedWindowTransparentActive() noexcept
+        IsMakeDraggedWindowTransparentActive() noexcept
+        {
+            return true;
+        }
+        IFACEMETHODIMP_(bool)
+        InMoveSize() noexcept
         {
             return true;
         }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Expose `InMoveSize` method in `IZoneWindowHost` so all currently active `ZoneWindow` objects can use it while animating zone layout.

Relates to: #534 (original fix commit: https://github.com/microsoft/PowerToys/commit/e249bc585670f3d9d0f925ef8b7f38d9ab9259cb)
