### PR TITLE
[PowerToys Run] Add "ignore hotkeys in fullscreen" setting (#3262)

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/PowerLauncherProperties.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/PowerLauncherProperties.cs
@@ -24,6 +24,8 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
 
         public bool override_win_s_key { get; set; }
 
+        public bool ignore_hotkeys_in_fullscreen { get; set; }
+
         public PowerLauncherProperties()
         {
             open_powerlauncher = new HotkeySettings();
@@ -32,6 +34,7 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
             open_console = new HotkeySettings();
             search_result_preference = "most_recently_used";
             search_type_preference = "application_name";
+            ignore_hotkeys_in_fullscreen = false;
         }
     }
 }

--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -250,6 +250,9 @@
   <data name="PowerLauncher_OverrideWinSKey.Content" xml:space="preserve">
     <value>Override Win+S key</value>
   </data>
+  <data name="PowerLauncher_IgnoreHotkeysInFullScreen.Content" xml:space="preserve">
+    <value>Ignore hotkeys in fullscreen mode</value>
+  </data>
   <data name="KeyboardManager_KeysMappingLayoutRightHeader.Text" xml:space="preserve">
     <value>To:</value>
     <comment>Keyboard Manager mapping keys view right header</comment>

--- a/src/core/Microsoft.PowerToys.Settings.UI/ViewModels/PowerLauncherViewModel.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/ViewModels/PowerLauncherViewModel.cs
@@ -235,5 +235,22 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 }
             }
         }
+
+        public bool IgnoreHotkeysInFullScreen
+        {
+            get
+            {
+                return settings.properties.ignore_hotkeys_in_fullscreen;
+            }
+
+            set
+            {
+                if (settings.properties.ignore_hotkeys_in_fullscreen != value)
+                {
+                    settings.properties.ignore_hotkeys_in_fullscreen = value;
+                    UpdateSettings();
+                }
+            }
+        }
     }
 }

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
@@ -129,6 +129,12 @@
                       IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.OverrideWinSKey}"
                       IsEnabled="False"
                       />-->
+
+            <CheckBox x:Uid="PowerLauncher_IgnoreHotkeysInFullScreen"
+                      Margin="{StaticResource SmallTopMargin}"
+                      IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.IgnoreHotkeysInFullScreen}"
+                      IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.EnablePowerLauncher}"
+                      />
         </StackPanel>
         <StackPanel
             x:Name="SidePanel"

--- a/src/modules/launcher/PowerLauncher/SettingsWatcher.cs
+++ b/src/modules/launcher/PowerLauncher/SettingsWatcher.cs
@@ -66,6 +66,11 @@ namespace PowerLauncher
                     {
                         _settings.MaxResultsToShow = overloadSettings.properties.maximum_number_of_results;
                     }
+
+                    if (_settings.IgnoreHotkeysOnFullscreen != overloadSettings.properties.ignore_hotkeys_in_fullscreen)
+                    {
+                        _settings.IgnoreHotkeysOnFullscreen = overloadSettings.properties.ignore_hotkeys_in_fullscreen;
+                    }
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
Connect Wox's existing "ignore hotkeys in fullscreen mode" setting to PowerLauncher and the PowerToys settings UI.

## Summary of the Pull Request
This allows PowerLauncher to ignore hotkeys if any application is currently in fullscreen mode, whether it's real exclusive fullscreen or borderless windowed mode. This applies to things like fullscreen games, video and presentations but not maximized windows.

## References
- Fixes #3262 

## PR Checklist
* [x] Applies to #3262
* [x] CLA signed
* [x] Tests added/passed
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.

## Validation Steps Performed
### Settings persistence check
1. Opened PowerToys settings for the first time since this change. Ensured the default value for "Ignore hotkeys in fullscreen mode" is "off" (unchecked).
2. Enabled the setting, closed settings UI, closed PowerToys and relaunched. Ensured the value is still "on" (checked).
3. Repeated (2) several more times for "on" and "off".

### Check behavior when an app is/isn't fullscreen
1. Enabled "Ignore hotkeys in fullscreen mode"
2. Launched the following applications and attempted to press the configured hotkey (Alt+Space) to open "Run":
  * Overwatch
    * ✅ In "Fullscreen" (exclusive fullscreen) mode -- hotkey ignored
    * ✅ In "Borderless Windowed" ("fake" fullscreen) mode -- hotkey ignored
    * ✅ In "Windowed" (not maximized) mode -- hotkey handled
    * ✅ In "Windowed" (maximized) mode -- hotkey handled
  * VLC (non-UWP)
    * ✅ In fullscreen (not exclusive) mode -- hotkey ignored
    * ✅ In windowed (not maximized) mode -- hotkey handled
    * ✅ In windowed (maximized) mode -- hotkey handled
  * VLC (UWP)
    * ✅ In fullscreen (not exclusive) mode -- hotkey ignored
    * ✅ In windowed (not maximized) mode -- hotkey handled
    * ✅ In windowed (maximized) mode -- hotkey handled
  * Microsoft Edge (Chromium-based) 81.0.416.77
    * ✅ In fullscreen (F11, not exclusive) mode -- hotkey ignored
    * ✅ In windowed (not maximized) mode -- hotkey handled
    * ✅ In windowed (maximized) mode -- hotkey handled
  * Windows Media Player
    * ❌ In fullscreen (not exclusive) mode -- hotkey **not ignored** (handled normally)
    * ✅ In windowed (not maximized) mode -- hotkey handled
    * ✅ In windowed (maximized) mode -- hotkey handled
  * Microsoft Powerpoint (Build 12730.20270 Click-to-Run)
    * ✅ In presentation mode -- hotkey ignored
    * ✅ In windowed (not maximized) mode -- hotkey handled
    * ✅ In windowed (maximized) mode -- hotkey handled
3. Disabled "Ignore hotkeys in fullscreen mode"
4. Repeated (2); hotkey handled normally in all scenarios

In Windows Media Player's case, PowerLauncher stealing focus also brings WMP out of fullscreen mode. Since this is a preexisting bug in Wox's behavior and code, I think it shouldn't be a blocker for this PR and should be tracked and fixed there separately.