### PR TITLE
[Settings] UX improvements to the FancyZones config page

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -390,10 +390,10 @@
     <value>Show values from last use</value>
   </data>
   <data name="FileEplorerPreview_ToggleSwitch_Preview_MD.Header" xml:space="preserve">
-    <value>Markdown Preview Handler</value>
+    <value>Enable Markdown (.md) preview</value>
   </data>
   <data name="FileEplorerPreview_ToggleSwitch_Preview_SVG.Header" xml:space="preserve">
-    <value>Svg Preview Handler</value>
+    <value>Enable SVG (.svg) preview</value>
   </data>
   <data name="FileExplorerPreview_Description.Text" xml:space="preserve">
     <value>These settings allow you to manage your Windows File Explorer custom preview handlers.</value>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -284,8 +284,8 @@
   <data name="FancyZones_KeepWindowsPinned.Content" xml:space="preserve">
     <value>Keep windows pinned to multiple desktops in the same zone when the active desktop changes</value>
   </data>
-  <data name="FancyZones_LaunchEditorButtonControl_Header.Content" xml:space="preserve">
-    <value>Launch Zones Editor</value>
+  <data name="FancyZones_LaunchEditorButtonControl.Text" xml:space="preserve">
+    <value>Launch Zones editor</value>
   </data>
   <data name="FancyZones_MakeDraggedWindowTransparentCheckBoxControl.Content" xml:space="preserve">
     <value>Make dragged window transparent</value>
@@ -318,7 +318,7 @@
     <value>Zone behavior</value>
   </data>
   <data name="FancyZones_ZoneHighlightColor.Text" xml:space="preserve">
-    <value>Zone highlight color (default: #0078D7)</value>
+    <value>Zone highlight color (Default: #0078D7)</value>
   </data>
   <data name="FancyZones_ZoneSetChangeMoveWindows.Content" xml:space="preserve">
     <value>During zone layout changes, windows assigned to a zone will match new size/positions</value>
@@ -408,10 +408,10 @@
     <value>Enable auto-complete and auto-suggest of recently used list for autocomplete dropdown</value>
   </data>
   <data name="FancyZones_BorderColor.Text" xml:space="preserve">
-    <value>Zone border color (Default #FFFFFF)</value>
+    <value>Zone border color (Default: #FFFFFF)</value>
   </data>
   <data name="FancyZones_InActiveColor.Text" xml:space="preserve">
-    <value>Zone inactive color (Default #F5FCFF)</value>
+    <value>Zone inactive color (Default: #F5FCFF)</value>
   </data>
   <data name="FancyZones_SaveBorderColor.Content" xml:space="preserve">
     <value>Save Zone Border Color Choice</value>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -285,7 +285,7 @@
     <value>Keep windows pinned to multiple desktops in the same zone when the active desktop changes</value>
   </data>
   <data name="FancyZones_LaunchEditorButtonControl.Text" xml:space="preserve">
-    <value>Launch Zones editor</value>
+    <value>Launch zones editor</value>
   </data>
   <data name="FancyZones_MakeDraggedWindowTransparentCheckBoxControl.Content" xml:space="preserve">
     <value>Make dragged window transparent</value>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -55,22 +55,27 @@
                           IsOn="{ Binding Mode=TwoWay, Path=IsEnabled}"
                           Margin="{StaticResource MediumTopMargin}" />
 
+            <Button Margin="{StaticResource MediumTopMargin}"
+                    Style="{StaticResource AccentButtonStyle}"
+                    Command = "{Binding LaunchEditorEventHandler, Source={StaticResource eventViewModel}}"
+                    IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}">
+                <StackPanel Orientation="Horizontal">
+                    <Viewbox Height="12" Width="12">
+                    <PathIcon Data="M896 0v896H0V0h896zM768 768V128H128v640h640zM0 1920v-896h1920v896H0zm128-768v640h1664v-640H128zM1024 0h896v896h-896V0zm768 768V128h-640v640h640z"/>
+                    </Viewbox>
+                    <TextBlock Margin="12,0,0,0" x:Uid="FancyZones_LaunchEditorButtonControl"/>
+                </StackPanel>
+            </Button>
+            
             <TextBlock x:Uid="FancyZones_ZoneBehavior_GroupSettings"
                        Style="{StaticResource SettingsGroupTitleStyle}"
                        />
-
-            <Button x:Uid="FancyZones_LaunchEditorButtonControl_Header"
-                    Margin="{StaticResource SmallTopMargin}"
-                    Style="{StaticResource AccentButtonStyle}"
-                    Command = "{Binding LaunchEditorEventHandler, Source={StaticResource eventViewModel}}"
-                    IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"
-                    />
 
             <CustomControls:HotkeySettingsControl 
                                           x:Uid="FancyZones_HokeyEditorControl_Header"
                                           Width="320"
                                           HorizontalAlignment="Left"
-                                          Margin="{StaticResource MediumTopMargin}"
+                                          Margin="{StaticResource SmallTopMargin}"
                                           HotkeySettings="{x:Bind Path=ViewModel.EditorHotkey, Mode=TwoWay}"
                                           IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"        
                                         />
@@ -151,7 +156,15 @@
                        Style="{StaticResource BodyTextBlockStyle}"
                        Margin="{StaticResource SmallTopMargin}" />
 
-            <muxc:ColorPicker x:Name="FancyZones_ZoneHighlightColor"
+            <muxc:DropDownButton Margin="0,4,0,0" IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}" Padding="4,4,8,4">
+                <Border Width="48" CornerRadius="2" Height="24">
+                    <Border.Background>
+                        <SolidColorBrush Color="{Binding Path=ZoneHighlightColor, Mode=TwoWay}"/>
+                    </Border.Background>
+                </Border>
+                <muxc:DropDownButton.Flyout>
+                    <Flyout>
+                    <muxc:ColorPicker x:Name="FancyZones_ZoneHighlightColor"
                               Margin="0,6,0,0"
                               HorizontalAlignment="Left"
                               IsMoreButtonVisible="True"
@@ -162,13 +175,26 @@
                               IsAlphaSliderVisible="False"
                               IsAlphaTextInputVisible="False"
                               Color="{Binding Path=ZoneHighlightColor, Mode=TwoWay}"
-                              IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"/>
+                              />
+                    </Flyout>
+                </muxc:DropDownButton.Flyout>
+            
+            </muxc:DropDownButton>
+            
 
             <TextBlock x:Uid="FancyZones_InActiveColor" 
                        Style="{StaticResource BodyTextBlockStyle}"
                        Margin="{StaticResource SmallTopMargin}" />
 
-            <muxc:ColorPicker x:Name="FancyZones_InActiveColorPicker"
+            <muxc:DropDownButton Margin="0,4,0,0" IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}" Padding="4,4,8,4">
+                <Border Width="48" CornerRadius="2" Height="24">
+                    <Border.Background>
+                        <SolidColorBrush Color="{Binding Path=ZoneInActiveColor, Mode=TwoWay}"/>
+                    </Border.Background>
+                </Border>
+                <muxc:DropDownButton.Flyout>
+                    <Flyout>
+                        <muxc:ColorPicker x:Name="FancyZones_InActiveColorPicker"
                               Margin="0,6,0,0"
                               HorizontalAlignment="Left"
                               IsMoreButtonVisible="True"
@@ -178,14 +204,26 @@
                               IsAlphaEnabled="False"
                               IsAlphaSliderVisible="False"
                               IsAlphaTextInputVisible="False"
-                              Color="{Binding Path=ZoneInActiveColor, Mode=TwoWay}"
-                              IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"/>
-
+                              Color="{Binding Path=ZoneInActiveColor, Mode=TwoWay}"/>
+                    </Flyout>
+                </muxc:DropDownButton.Flyout>
+            </muxc:DropDownButton>
+            
+            
             <TextBlock x:Uid="FancyZones_BorderColor" 
                        Style="{StaticResource BodyTextBlockStyle}"
                        Margin="{StaticResource SmallTopMargin}" />
-            
-            <muxc:ColorPicker x:Name="FancyZones_BorderColor"
+
+
+            <muxc:DropDownButton Margin="0,4,0,0" IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}" Padding="4,4,8,4">
+                <Border Width="48" CornerRadius="2" Height="24">
+                    <Border.Background>
+                        <SolidColorBrush Color="{Binding Path=ZoneBorderColor, Mode=TwoWay}"/>
+                    </Border.Background>
+                </Border>
+                <muxc:DropDownButton.Flyout>
+                    <Flyout>
+                        <muxc:ColorPicker x:Name="FancyZones_BorderColor"
                               Margin="0,6,0,0"
                               HorizontalAlignment="Left"
                               IsMoreButtonVisible="True"
@@ -197,8 +235,10 @@
                               IsAlphaTextInputVisible="False"
                               Color="{Binding Path=ZoneBorderColor, Mode=TwoWay}"
                               IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"/>
+                    </Flyout>
+                </muxc:DropDownButton.Flyout>
+            </muxc:DropDownButton>
 
-            
             <TextBlock x:Uid="FancyZones_ExcludeApps"
                        Style="{StaticResource SettingsGroupTitleStyle}"/>
 


### PR DESCRIPTION
##  Summary of the Pull Request
This PR improves readability on the FancyZones page by:

- Separating the launch FZ editor button out of the Zone behavior section and directly below the module toggleswitch.
- Added the colorpickers to a DropDownButton so the selected colors are easier to identify, and a lot of space is saved.
- Minor changes to some resource strings.

![FZColors](https://user-images.githubusercontent.com/9866362/82731988-a6174c80-9d0a-11ea-824a-247a30b96f0d.gif)

## References
#3601 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X ] Applies to #3601
* [X ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [X] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #3601