### PR TITLE
[ShortcutGuide&Installer] Move Shortcut Guide to separate build and install folder

### DIFF
--- a/.pipelines/pipeline.user.windows.yml
+++ b/.pipelines/pipeline.user.windows.yml
@@ -103,7 +103,7 @@ build:
             - 'modules\launcher\Wox.Plugin.dll'
             - 'modules\Microsoft.Launcher.dll'
             - 'modules\PowerRenameExt.dll'
-            - 'modules\shortcut_guide.dll'
+            - 'modules\ShortcutGuide\ShortcutGuide.dll'
             - 'Notifications.dll'
             - 'os-detection.dll'
             - 'PowerToys.exe'

--- a/installer/PowerToysSetup/Product.wxs
+++ b/installer/PowerToysSetup/Product.wxs
@@ -3,6 +3,8 @@
      xmlns:util="http://schemas.microsoft.com/wix/UtilExtension"
      xmlns:netfx="http://schemas.microsoft.com/wix/NetFxExtension" >
 
+  <?define ShortcutGuideProjectName="shortcut_guide"?>
+
   <?define RepoDir="$(var.ProjectDir)..\..\" ?>
   <?define BinX64Dir="$(var.RepoDir)x64\$(var.Configuration)\" ?>
   <Product Id="*"
@@ -215,6 +217,7 @@
         <Directory Id="INSTALLFOLDER" Name="PowerToys">
           <Directory Id="SvgsInstallFolder" Name="svgs"/>
           <Directory Id="ModulesInstallFolder" Name="modules">
+            <Directory Id="ShortcutGuideInstallFolder" Name="$(var.ShortcutGuideProjectName)"/>
             <!-- Resource file directories -->
             <?foreach Language in ar;bg;ca;cs;de;es;eu-ES;fr;he;hu;it;nb-NO;nl;pl;pt-BR;ru;sk;tr;zh-Hans?>
               <!--NB: Ids can't contain hyphens-->
@@ -402,10 +405,6 @@
     </DirectoryRef>
 
     <DirectoryRef Id="ModulesInstallFolder" FileSource="$(var.BinX64Dir)modules\">
-      <Component Id="Module_ShortcutGuide" Guid="CBD0AC09-91D3-428E-B2B3-05745ADF3473" Win64="yes">
-        <File Source="$(var.BinX64Dir)modules\shortcut_guide.dll" KeyPath="yes" />
-      </Component>
-
       <Component Id="Module_PowerRename" Guid="E4401D08-27FE-4F96-BA17-0C61FD79E684" Win64="yes">
         <File Source="$(var.BinX64Dir)modules\PowerRenameExt.dll" KeyPath="yes" />
         <RegistryKey Root="HKCR" Key="CLSID\{0440049F-D1DC-4E46-B27B-98393D79486B}">
@@ -571,7 +570,13 @@
         </RegistryKey>
       </Component>
     </DirectoryRef>
-    
+
+    <DirectoryRef Id="ShortcutGuideInstallFolder" FileSource="$(var.BinX64Dir)modules\$(var.ShortcutGuideProjectName)\">
+      <Component Id="Module_ShortcutGuide" Guid="CBD0AC09-91D3-428E-B2B3-05745ADF3473" Win64="yes">
+        <File Source="$(var.BinX64Dir)modules\$(var.ShortcutGuideProjectName)\shortcut_guide.dll" KeyPath="yes" />
+      </Component>
+    </DirectoryRef>
+
     <DirectoryRef Id="FileExplorerPreviewInstallFolder" FileSource="$(var.RepoDir)\modules\FileExplorerPreview\">
       <Component Id="Module_PowerPreview" Guid="FF1700D5-1B07-4E07-9A62-4D206645EEA9" Win64="yes">
         <!-- Component to include PowerPreview Module Source dll's -->

--- a/installer/PowerToysSetup/Product.wxs
+++ b/installer/PowerToysSetup/Product.wxs
@@ -3,7 +3,7 @@
      xmlns:util="http://schemas.microsoft.com/wix/UtilExtension"
      xmlns:netfx="http://schemas.microsoft.com/wix/NetFxExtension" >
 
-  <?define ShortcutGuideProjectName="shortcut_guide"?>
+  <?define ShortcutGuideProjectName="ShortcutGuide"?>
 
   <?define RepoDir="$(var.ProjectDir)..\..\" ?>
   <?define BinX64Dir="$(var.RepoDir)x64\$(var.Configuration)\" ?>
@@ -573,7 +573,7 @@
 
     <DirectoryRef Id="ShortcutGuideInstallFolder" FileSource="$(var.BinX64Dir)modules\$(var.ShortcutGuideProjectName)\">
       <Component Id="Module_ShortcutGuide" Guid="CBD0AC09-91D3-428E-B2B3-05745ADF3473" Win64="yes">
-        <File Source="$(var.BinX64Dir)modules\$(var.ShortcutGuideProjectName)\shortcut_guide.dll" KeyPath="yes" />
+        <File Source="$(var.BinX64Dir)modules\$(var.ShortcutGuideProjectName)\$(var.ShortcutGuideProjectName).dll" KeyPath="yes" />
       </Component>
     </DirectoryRef>
 

--- a/src/modules/shortcut_guide/shortcut_guide.vcxproj
+++ b/src/modules/shortcut_guide/shortcut_guide.vcxproj
@@ -17,6 +17,7 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>overlaywindow</RootNamespace>
     <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+    <ProjectName>ShortcutGuide</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/src/modules/shortcut_guide/shortcut_guide.vcxproj
+++ b/src/modules/shortcut_guide/shortcut_guide.vcxproj
@@ -48,12 +48,12 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
-    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\modules\</OutDir>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\modules\$(ProjectName)\</OutDir>
     <IntDir>$(SolutionDir)$(Platform)\$(Configuration)\obj\$(ProjectName)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
-    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\modules\</OutDir>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\modules\$(ProjectName)\</OutDir>
     <IntDir>$(SolutionDir)$(Platform)\$(Configuration)\obj\$(ProjectName)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">

--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -126,7 +126,7 @@ int runner(bool isProcessElevated)
         std::wstring baseModuleFolder = L"modules/";
 
         std::unordered_set<std::wstring> known_dlls = {
-            L"shortcut_guide.dll",
+            L"ShortcutGuide.dll",
             L"fancyzones.dll",
             L"PowerRenameExt.dll",
             L"Microsoft.Launcher.dll",
@@ -140,7 +140,7 @@ int runner(bool isProcessElevated)
             L"",
             L"FileExplorerPreview/",
             L"FancyZones/",
-            L"shortcut_guide/"
+            L"ShortcutGuide/"
         };
 
         for (std::wstring subfolderName : module_folders)

--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -135,10 +135,12 @@ int runner(bool isProcessElevated)
             L"KeyboardManager.dll"
         };
 
+        // TODO(stefan): When all modules get their OutputDir delete this and simplify "search for .dll logic"
         std::unordered_set<std::wstring> module_folders = {
             L"",
             L"FileExplorerPreview/",
-            L"FancyZones/"
+            L"FancyZones/",
+            L"shortcut_guide/"
         };
 
         for (std::wstring subfolderName : module_folders)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
In order to organize build and installation directories, move Shortcut Guide to it's own folder both for build and install.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #3809 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
1. Installed 0.18.1
2. Installed 0.18.2
3. Confirmed that Shortcut Guide is in own installaction folder under PowerToys/modules. Confirmed that it is working as expected. Confirmed that old shortcut_guide.dll is deleted by 0.18.2 installer.