### PR TITLE
Fix for Camera App not showing up

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/UWP.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/UWP.cs
@@ -449,6 +449,10 @@ namespace Microsoft.Plugin.Program.Programs
                     {
                         parsed = prefix + "//" + key;
                     }
+                    else if (key.Contains("resources", StringComparison.OrdinalIgnoreCase))
+                    {
+                        parsed = prefix + key;
+                    }
                     else
                     {
                         parsed = prefix + "///resources/" + key;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This was happening because of the way the `resource` was passed to the `SHLoadIndirectString` function.
For some apps like Camera, the resource is `LensSDK/Resources/AppTitle` whereas for most other applications it is just `AppTitle` or `AppDescription` and the code was written such that the `resources` keyword would be prefixed. However, this does not work when there is a namespace with Resources already defined like in the case of the Camera app.
Due to this the DisplayName and Description were not being retrived and hence the app was not displayed. Another app for which this was happening on my system is `XBox Console companion`.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
* https://docs.microsoft.com/en-us/windows/win32/api/shlwapi/nf-shlwapi-shloadindirectstring?redirectedfrom=MSDN

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #3532 (Parent tracking item - #3223)
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
* If the word `resource` is present in the `DisplayName` parameter of the Appmanifest.xml file, we do not add an extra resource string.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
* The camera app shows up now. 
![image](https://user-images.githubusercontent.com/28739210/83210241-3096ec00-a10f-11ea-8c02-b60d7422ff56.png)
* Set breakpoints where exceptions were thrown when the SHLoadIndirectString function returned an hresult other than S_OK and verified that all those cases are now solved, which was Camera and Xbox Companion console apps in my case.
