### PR TITLE
[FancyZones] Removed the stampZone argument

### DIFF
--- a/src/modules/fancyzones/lib/ZoneSet.cpp
+++ b/src/modules/fancyzones/lib/ZoneSet.cpp
@@ -129,9 +129,9 @@ public:
     IFACEMETHODIMP_(std::vector<winrt::com_ptr<IZone>>)
     GetZones() noexcept { return m_zones; }
     IFACEMETHODIMP_(void)
-    MoveWindowIntoZoneByIndex(HWND window, HWND zoneWindow, int index, bool stampZone) noexcept;
+    MoveWindowIntoZoneByIndex(HWND window, HWND zoneWindow, int index) noexcept;
     IFACEMETHODIMP_(void)
-    MoveWindowIntoZoneByIndexSet(HWND window, HWND windowZone, const std::vector<int>& indexSet, bool stampZone) noexcept;
+    MoveWindowIntoZoneByIndexSet(HWND window, HWND windowZone, const std::vector<int>& indexSet) noexcept;
     IFACEMETHODIMP_(bool)
     MoveWindowIntoZoneByDirection(HWND window, HWND zoneWindow, DWORD vkCode, bool cycle) noexcept;
     IFACEMETHODIMP_(void)
@@ -254,13 +254,13 @@ std::vector<int> ZoneSet::GetZoneIndexSetFromWindow(HWND window) noexcept
 }
 
 IFACEMETHODIMP_(void)
-ZoneSet::MoveWindowIntoZoneByIndex(HWND window, HWND windowZone, int index, bool stampZone) noexcept
+ZoneSet::MoveWindowIntoZoneByIndex(HWND window, HWND windowZone, int index) noexcept
 {
-    MoveWindowIntoZoneByIndexSet(window, windowZone, { index }, stampZone);
+    MoveWindowIntoZoneByIndexSet(window, windowZone, { index });
 }
 
 IFACEMETHODIMP_(void)
-ZoneSet::MoveWindowIntoZoneByIndexSet(HWND window, HWND windowZone, const std::vector<int>& indexSet, bool stampZone) noexcept
+ZoneSet::MoveWindowIntoZoneByIndexSet(HWND window, HWND windowZone, const std::vector<int>& indexSet) noexcept
 {
     if (m_zones.empty())
     {
@@ -304,10 +304,7 @@ ZoneSet::MoveWindowIntoZoneByIndexSet(HWND window, HWND windowZone, const std::v
     if (!sizeEmpty)
     {
         SizeWindowToRect(window, size);
-        if (stampZone)
-        {
-            StampWindow(window, bitmask);
-        }
+        StampWindow(window, bitmask);
     }
 }
 
@@ -325,7 +322,7 @@ ZoneSet::MoveWindowIntoZoneByDirection(HWND window, HWND windowZone, DWORD vkCod
     // The window was not assigned to any zone here
     if (indexSet.size() == 0)
     {
-        MoveWindowIntoZoneByIndexSet(window, windowZone, { vkCode == VK_LEFT ? numZones - 1 : 0 }, true);
+        MoveWindowIntoZoneByIndexSet(window, windowZone, { vkCode == VK_LEFT ? numZones - 1 : 0 });
         return true;
     }
 
@@ -336,12 +333,12 @@ ZoneSet::MoveWindowIntoZoneByDirection(HWND window, HWND windowZone, DWORD vkCod
     {
         if (!cycle)
         {
-            MoveWindowIntoZoneByIndexSet(window, windowZone, {}, true);
+            MoveWindowIntoZoneByIndexSet(window, windowZone, {});
             return false;
         }
         else
         {
-            MoveWindowIntoZoneByIndexSet(window, windowZone, { vkCode == VK_LEFT ? numZones - 1 : 0 }, true);
+            MoveWindowIntoZoneByIndexSet(window, windowZone, { vkCode == VK_LEFT ? numZones - 1 : 0 });
             return true;
         }
     }
@@ -349,11 +346,11 @@ ZoneSet::MoveWindowIntoZoneByDirection(HWND window, HWND windowZone, DWORD vkCod
     // We didn't reach the edge
     if (vkCode == VK_LEFT)
     {
-        MoveWindowIntoZoneByIndexSet(window, windowZone, { oldIndex - 1 }, true);
+        MoveWindowIntoZoneByIndexSet(window, windowZone, { oldIndex - 1 });
     }
     else
     {
-        MoveWindowIntoZoneByIndexSet(window, windowZone, { oldIndex + 1 }, true);
+        MoveWindowIntoZoneByIndexSet(window, windowZone, { oldIndex + 1 });
     }
     return true;
 }
@@ -362,7 +359,7 @@ IFACEMETHODIMP_(void)
 ZoneSet::MoveWindowIntoZoneByPoint(HWND window, HWND zoneWindow, POINT ptClient) noexcept
 {
     auto zones = ZonesFromPoint(ptClient);
-    MoveWindowIntoZoneByIndexSet(window, zoneWindow, zones, true);
+    MoveWindowIntoZoneByIndexSet(window, zoneWindow, zones);
 }
 
 IFACEMETHODIMP_(bool)

--- a/src/modules/fancyzones/lib/ZoneSet.h
+++ b/src/modules/fancyzones/lib/ZoneSet.h
@@ -48,9 +48,8 @@ interface __declspec(uuid("{E4839EB7-669D-49CF-84A9-71A2DFD851A3}")) IZoneSet : 
      * @param   zoneWindow The m_window of a ZoneWindow, it's a hidden window representing the
      *                     current monitor desktop work area.
      * @param   index      Zone index within zone layout.
-     * @param   stampZone  Whether the window being added to the zone should be stamped.
      */
-    IFACEMETHOD_(void, MoveWindowIntoZoneByIndex)(HWND window, HWND zoneWindow, int index, bool stampZone) = 0;
+    IFACEMETHOD_(void, MoveWindowIntoZoneByIndex)(HWND window, HWND zoneWindow, int index) = 0;
     /**
      * Assign window to the zones based on the set of zone indices inside zone layout.
      *
@@ -58,10 +57,8 @@ interface __declspec(uuid("{E4839EB7-669D-49CF-84A9-71A2DFD851A3}")) IZoneSet : 
      * @param   zoneWindow The m_window of a ZoneWindow, it's a hidden window representing the
      *                     current monitor desktop work area.
      * @param   indexSet   The set of zone indices within zone layout.
-     * @param   stampZone  Whether the window being added to the zone should be stamped,
-                           in case a single window is to be added.
      */
-    IFACEMETHOD_(void, MoveWindowIntoZoneByIndexSet)(HWND window, HWND zoneWindow, const std::vector<int>& indexSet, bool stampZone) = 0;
+    IFACEMETHOD_(void, MoveWindowIntoZoneByIndexSet)(HWND window, HWND zoneWindow, const std::vector<int>& indexSet) = 0;
     /**
      * Assign window to the zone based on direction (using WIN + LEFT/RIGHT arrow).
      *

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -446,7 +446,7 @@ ZoneWindow::MoveWindowIntoZoneByIndexSet(HWND window, const std::vector<int>& in
 {
     if (m_activeZoneSet)
     {
-        m_activeZoneSet->MoveWindowIntoZoneByIndexSet(window, m_window.get(), indexSet, false);
+        m_activeZoneSet->MoveWindowIntoZoneByIndexSet(window, m_window.get(), indexSet);
     }
 }
 

--- a/src/modules/fancyzones/tests/UnitTests/ZoneSet.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/ZoneSet.Spec.cpp
@@ -293,7 +293,7 @@ namespace FancyZonesUnitTests
                 HWND window = Mocks::Window();
                 HWND zoneWindow = Mocks::Window();
                 m_set->AddZone(zone);
-                m_set->MoveWindowIntoZoneByIndexSet(window, zoneWindow, { 0 }, true);
+                m_set->MoveWindowIntoZoneByIndexSet(window, zoneWindow, { 0 });
 
                 auto actual = m_set->GetZoneIndexSetFromWindow(Mocks::Window());
                 Assert::AreEqual({}, actual);
@@ -305,7 +305,7 @@ namespace FancyZonesUnitTests
                 HWND window = Mocks::Window();
                 HWND zoneWindow = Mocks::Window();
                 m_set->AddZone(zone);
-                m_set->MoveWindowIntoZoneByIndexSet(window, zoneWindow, { 0 }, true);
+                m_set->MoveWindowIntoZoneByIndexSet(window, zoneWindow, { 0 });
 
                 auto actual = m_set->GetZoneIndexSetFromWindow(nullptr);
                 Assert::AreEqual({}, actual);
@@ -321,14 +321,14 @@ namespace FancyZonesUnitTests
                 m_set->AddZone(zone3);
 
                 HWND window = Mocks::Window();
-                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 1, false);
+                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 1);
                 Assert::AreEqual({ 1 }, m_set->GetZoneIndexSetFromWindow(window));
             }
 
             TEST_METHOD (MoveWindowIntoZoneByIndexWithNoZones)
             {
                 HWND window = Mocks::Window();
-                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0, false);
+                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0);
             }
 
             TEST_METHOD (MoveWindowIntoZoneByIndexWithInvalidIndex)
@@ -341,7 +341,7 @@ namespace FancyZonesUnitTests
                 m_set->AddZone(zone3);
 
                 HWND window = Mocks::Window();
-                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 100, false);
+                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 100);
                 Assert::AreEqual({} , m_set->GetZoneIndexSetFromWindow(window));
             }
 
@@ -356,13 +356,13 @@ namespace FancyZonesUnitTests
                 m_set->AddZone(zone3);
 
                 HWND window = Mocks::Window();
-                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0, false);
+                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0);
                 Assert::AreEqual({0}, m_set->GetZoneIndexSetFromWindow(window));
 
-                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 1, false);
+                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 1);
                 Assert::AreEqual({1}, m_set->GetZoneIndexSetFromWindow(window));
 
-                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 2, false);
+                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 2);
                 Assert::AreEqual({2}, m_set->GetZoneIndexSetFromWindow(window));
             }
 
@@ -377,9 +377,9 @@ namespace FancyZonesUnitTests
                 m_set->AddZone(zone3);
 
                 HWND window = Mocks::Window();
-                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0, false);
-                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0, false);
-                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0, false);
+                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0);
+                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0);
+                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0);
                 Assert::AreEqual({ 0 }, m_set->GetZoneIndexSetFromWindow(window));
             }
 
@@ -434,7 +434,7 @@ namespace FancyZonesUnitTests
                 m_set->AddZone(zone1);
                 m_set->AddZone(zone2);
                 
-                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0, true);
+                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0);
 
                 m_set->MoveWindowIntoZoneByPoint(window, Mocks::Window(), POINT{ 50, 50 });
 
@@ -449,7 +449,7 @@ namespace FancyZonesUnitTests
                 winrt::com_ptr<IZone> zone1 = MakeZone({ 0, 0, 100, 100 });
                 winrt::com_ptr<IZone> zone2 = MakeZone({ 10, 10, 90, 90 });
 
-                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 1, true);
+                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 1);
 
                 m_set->AddZone(zone1);
                 m_set->AddZone(zone2);
@@ -472,7 +472,7 @@ namespace FancyZonesUnitTests
                 m_set->AddZone(zone2);
                 m_set->AddZone(zone3);
 
-                m_set->MoveWindowIntoZoneByIndexSet(window, Mocks::Window(), { 0, 1, 2 }, true);
+                m_set->MoveWindowIntoZoneByIndexSet(window, Mocks::Window(), { 0, 1, 2 });
 
                 m_set->MoveWindowIntoZoneByPoint(window, Mocks::Window(), POINT{ 50, 50 });
 
@@ -573,7 +573,7 @@ namespace FancyZonesUnitTests
         TEST_METHOD (MoveWindowIntoZoneByDirectionRight)
         {
             HWND window = Mocks::Window();
-            m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0, false /* stampZone */);
+            m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0);
             m_set->MoveWindowIntoZoneByDirection(window, Mocks::Window(), VK_RIGHT, true);
             Assert::AreEqual({ 1 }, m_set->GetZoneIndexSetFromWindow(window));
 
@@ -584,7 +584,7 @@ namespace FancyZonesUnitTests
         TEST_METHOD (MoveRightWithSameWindowAdded)
         {
             HWND window = Mocks::Window();
-            m_set->MoveWindowIntoZoneByIndexSet(window, Mocks::Window(), { 0, 1 }, false);
+            m_set->MoveWindowIntoZoneByIndexSet(window, Mocks::Window(), { 0, 1 });
 
             Assert::AreEqual({ 0, 1 }, m_set->GetZoneIndexSetFromWindow(window));
 
@@ -599,8 +599,8 @@ namespace FancyZonesUnitTests
         {
             HWND window1 = Mocks::Window();
             HWND window2 = Mocks::Window();
-            m_set->MoveWindowIntoZoneByIndex(window1, Mocks::Window(), { 0 }, false /*stampZone*/);
-            m_set->MoveWindowIntoZoneByIndex(window2, Mocks::Window(), { 1 }, false /*stampZone*/);
+            m_set->MoveWindowIntoZoneByIndex(window1, Mocks::Window(), { 0 });
+            m_set->MoveWindowIntoZoneByIndex(window2, Mocks::Window(), { 1 });
 
             Assert::AreEqual({ 0 }, m_set->GetZoneIndexSetFromWindow(window1));
             Assert::AreEqual({ 1 }, m_set->GetZoneIndexSetFromWindow(window2));
@@ -619,7 +619,7 @@ namespace FancyZonesUnitTests
         TEST_METHOD (MoveWindowIntoZoneByDirectionLeft)
         {
             HWND window = Mocks::Window();
-            m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 2, false /*stampZone*/);
+            m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 2);
             m_set->MoveWindowIntoZoneByDirection(window, Mocks::Window(), VK_LEFT, true);
             Assert::AreEqual({ 1 }, m_set->GetZoneIndexSetFromWindow(window));
 
@@ -630,7 +630,7 @@ namespace FancyZonesUnitTests
         TEST_METHOD (MoveLeftWithSameWindowAdded)
         {
             HWND window = Mocks::Window();
-            m_set->MoveWindowIntoZoneByIndexSet(window, Mocks::Window(), {1, 2}, false /*stampZone*/);
+            m_set->MoveWindowIntoZoneByIndexSet(window, Mocks::Window(), {1, 2});
 
             Assert::AreEqual({ 1, 2 }, m_set->GetZoneIndexSetFromWindow(window));
 
@@ -645,8 +645,8 @@ namespace FancyZonesUnitTests
         {
             HWND window1 = Mocks::Window();
             HWND window2 = Mocks::Window();
-            m_set->MoveWindowIntoZoneByIndex(window1, Mocks::Window(), 1, false /*stampZone*/);
-            m_set->MoveWindowIntoZoneByIndex(window2, Mocks::Window(), 2, false /*stampZone*/);
+            m_set->MoveWindowIntoZoneByIndex(window1, Mocks::Window(), 1);
+            m_set->MoveWindowIntoZoneByIndex(window2, Mocks::Window(), 2);
 
             Assert::AreEqual({ 1 }, m_set->GetZoneIndexSetFromWindow(window1));
             Assert::AreEqual({ 2 }, m_set->GetZoneIndexSetFromWindow(window2));
@@ -663,7 +663,7 @@ namespace FancyZonesUnitTests
         TEST_METHOD (MoveWindowIntoZoneByDirectionWrapAroundRight)
         {
             HWND window = Mocks::Window();
-            m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 2, false /*stampZone*/);
+            m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 2);
             m_set->MoveWindowIntoZoneByDirection(window, Mocks::Window(), VK_RIGHT, true);
             Assert::AreEqual({ 0 }, m_set->GetZoneIndexSetFromWindow(window));
         }
@@ -671,7 +671,7 @@ namespace FancyZonesUnitTests
         TEST_METHOD (MoveWindowIntoZoneByDirectionWrapAroundLeft)
         {
             HWND window = Mocks::Window();
-            m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0, false /*stampZone*/);
+            m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0);
             m_set->MoveWindowIntoZoneByDirection(window, Mocks::Window(), VK_LEFT, true);
             Assert::AreEqual({ 2 }, m_set->GetZoneIndexSetFromWindow(window));
         }
@@ -679,7 +679,7 @@ namespace FancyZonesUnitTests
         TEST_METHOD (MoveSecondWindowIntoSameZone)
         {
             HWND window1 = Mocks::Window();
-            m_set->MoveWindowIntoZoneByIndex(window1, Mocks::Window(), 0, false /*stampZone*/);
+            m_set->MoveWindowIntoZoneByIndex(window1, Mocks::Window(), 0);
 
             HWND window2 = Mocks::Window();
             m_set->MoveWindowIntoZoneByDirection(window2, Mocks::Window(), VK_RIGHT, true);
@@ -691,7 +691,7 @@ namespace FancyZonesUnitTests
         TEST_METHOD (MoveRightMoreThanZoneCountReturnsFalse)
         {
             HWND window = Mocks::Window();
-            m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0, false /*stampZone*/);
+            m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0);
             for (size_t i = 0; i < m_set->GetZones().size() - 1; ++i)
             {
                 m_set->MoveWindowIntoZoneByDirection(window, Mocks::Window(), VK_RIGHT, false);
@@ -703,7 +703,7 @@ namespace FancyZonesUnitTests
         TEST_METHOD (MoveLeftMoreThanZoneCountReturnsFalse)
         {
             HWND window = Mocks::Window();
-            m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 2, false /*stampZone*/);
+            m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 2);
             for (size_t i = 0; i < m_set->GetZones().size() - 1; ++i)
             {
                 m_set->MoveWindowIntoZoneByDirection(window, Mocks::Window(), VK_LEFT, false);

--- a/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
@@ -512,7 +512,7 @@ namespace FancyZonesUnitTests
             Assert::AreEqual(expected, actual);
 
             const auto zoneSet = zoneWindow->ActiveZoneSet();
-            zoneSet->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0, false);
+            zoneSet->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0);
             const auto actualZoneIndexSet = zoneSet->GetZoneIndexSetFromWindow(window);
             Assert::AreNotEqual({}, actualZoneIndexSet);
         }
@@ -568,7 +568,7 @@ namespace FancyZonesUnitTests
             Assert::AreEqual(expected, actual);
 
             const auto zoneSet = zoneWindow->ActiveZoneSet();
-            zoneSet->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0, false);
+            zoneSet->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0);
             const auto actualZoneIndex = zoneSet->GetZoneIndexSetFromWindow(window);
             Assert::AreNotEqual({}, actualZoneIndex); //with invalid point zone remains the same
         }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

A recent PR #3132 was supposed to fix issue #3111 but it didn't. This PR fixes that by removing an argument from various functions. The argument was used inconsistently and is not needed anymore.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #3111
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

All unit tests pass and the scenario described in #3111 does not result in unexpected behavior.