### PR TITLE
[Settings] Various UX tweaks

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -393,13 +393,13 @@
     <value>These settings allow you to manage your Windows File Explorer custom preview handlers.</value>
   </data>
   <data name="PowerRename_AutoCompleteHeader.Text" xml:space="preserve">
-    <value>Autocompletion</value>
+    <value>Autocomplete</value>
   </data>
   <data name="OpenSource_Notice.Text" xml:space="preserve">
     <value>Open-source notice</value>
   </data>
   <data name="PowerRename_Toggle_AutoComplete.Header" xml:space="preserve">
-    <value>Enable autocompletion for the search and replace fields</value>
+    <value>Enable autocomplete for the search and replace fields</value>
   </data>
   <data name="FancyZones_BorderColor.Text" xml:space="preserve">
     <value>Zone border color (Default: #FFFFFF)</value>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -227,7 +227,7 @@
     <value>Executable name</value>
   </data>
   <data name="PowerLauncher_MaximumNumberOfResults.Header" xml:space="preserve">
-    <value>Maximum numbers of results</value>
+    <value>Maximum number of results</value>
   </data>
   <data name="PowerLauncher_Shortcuts.Text" xml:space="preserve">
     <value>Shortcuts</value>
@@ -378,7 +378,7 @@
     <value>Appear only in extended context menu (Shift + Right-click)</value>
   </data>
   <data name="PowerRename_Toggle_MaxDispListNum.Header" xml:space="preserve">
-    <value>Maximum numbers of items to show in recently used list for autocomplete dropdown</value>
+    <value>Maximum number of items</value>
   </data>
   <data name="PowerRename_Toggle_RestoreFlagsOnLaunch.Header" xml:space="preserve">
     <value>Show values from last use</value>
@@ -392,14 +392,14 @@
   <data name="FileExplorerPreview_Description.Text" xml:space="preserve">
     <value>These settings allow you to manage your Windows File Explorer custom preview handlers.</value>
   </data>
-  <data name="Miscellaneous.Text" xml:space="preserve">
-    <value>Miscellaneous</value>
+  <data name="PowerRename_AutoCompleteHeader.Text" xml:space="preserve">
+    <value>Autocompletion</value>
   </data>
   <data name="OpenSource_Notice.Text" xml:space="preserve">
     <value>Open-source notice</value>
   </data>
   <data name="PowerRename_Toggle_AutoComplete.Header" xml:space="preserve">
-    <value>Enable auto-complete and auto-suggest of recently used list for autocomplete dropdown</value>
+    <value>Enable autocompletion for the search and replace fields</value>
   </data>
   <data name="FancyZones_BorderColor.Text" xml:space="preserve">
     <value>Zone border color (Default: #FFFFFF)</value>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -276,7 +276,7 @@
     <value>To exclude an application from snapping to zones add its name here (one per line). These apps will react only to Windows Snap.</value>
   </data>
   <data name="FancyZones_HighlightOpacity.Header" xml:space="preserve">
-    <value>Zone highlight opacity (%)</value>
+    <value>Zone highlight opacity</value>
   </data>
   <data name="FancyZones_HokeyEditorControl_Header.Header" xml:space="preserve">
     <value>Edit hot key / shortcut</value>
@@ -426,7 +426,7 @@
     <value>Enable Shortcut Guide</value>
   </data>
   <data name="ShortcutGuide_OverlayOpacity.Header" xml:space="preserve">
-    <value>Opacity of background (%)</value>
+    <value>Opacity of background</value>
   </data>
   <data name="ShortcutGuide_Theme.Header" xml:space="preserve">
     <value>Choose Shortcut Guide overlay color</value>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -8,11 +8,13 @@
     xmlns:viewModel="using:Microsoft.PowerToys.Settings.UI.ViewModels"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     xmlns:CustomControls="using:Microsoft.PowerToys.Settings.UI.Controls"
+    xmlns:converters="using:Microsoft.Toolkit.Uwp.UI.Converters"
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
     <Page.Resources>
         <viewModel:FancyZonesViewModel x:Key="eventViewModel"/>
+        <converters:StringFormatConverter x:Key="StringFormatConverter"/>
     </Page.Resources>
 
     <Grid ColumnSpacing="{StaticResource DefaultColumnSpacing}" RowSpacing="{StaticResource DefaultRowSpacing}">
@@ -134,16 +136,21 @@
             <TextBlock x:Uid="Appearance_GroupSettings"
                        Style="{StaticResource SettingsGroupTitleStyle}"/>
 
-            <muxc:NumberBox x:Uid="FancyZones_HighlightOpacity"
-                            Value="{ Binding Mode=TwoWay, Path=HighlightOpacity}"
-                            Minimum="0"
-                            Maximum="100"
-                            Width="240"
-                            SpinButtonPlacementMode="Compact"
-                            HorizontalAlignment="Left"
-                            Margin="{StaticResource SmallTopMargin}" 
-                            IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}" />
-             
+            <StackPanel Orientation="Horizontal" Margin="{StaticResource SmallTopMargin}" Spacing="12">
+            <Slider x:Uid="FancyZones_HighlightOpacity"
+                    Minimum="0"
+                    Maximum="100"
+                    Width="240"
+                    IsThumbToolTipEnabled="False"
+                    Value="{ Binding Mode=TwoWay, Path=HighlightOpacity}"
+                    HorizontalAlignment="Left"
+                    IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"/>
+                <TextBlock Text="{ Binding Mode=OneWay, Path=HighlightOpacity, Converter={StaticResource StringFormatConverter}, ConverterParameter=' {0}%' }" 
+                           VerticalAlignment="Center"
+                           FontSize="16"
+                           Margin="0,21,0,0"/>
+            </StackPanel>
+            
             <TextBlock x:Uid="FancyZones_ZoneHighlightColor" 
                        Style="{StaticResource BodyTextBlockStyle}"
                        Margin="{StaticResource SmallTopMargin}" />

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -75,7 +75,7 @@
 
             <CustomControls:HotkeySettingsControl 
                                           x:Uid="FancyZones_HokeyEditorControl_Header"
-                                          Width="320"
+                                          Width="240"
                                           HorizontalAlignment="Left"
                                           Margin="{StaticResource SmallTopMargin}"
                                           HotkeySettings="{x:Bind Path=ViewModel.EditorHotkey, Mode=TwoWay}"
@@ -134,11 +134,11 @@
             <TextBlock x:Uid="Appearance_GroupSettings"
                        Style="{StaticResource SettingsGroupTitleStyle}"/>
 
-            <!-- TO DO: Do we still need this numberbox? The colorpicker has an Alpha/Opacity option as well so we could use that -->
             <muxc:NumberBox x:Uid="FancyZones_HighlightOpacity"
                             Value="{ Binding Mode=TwoWay, Path=HighlightOpacity}"
                             Minimum="0"
                             Maximum="100"
+                            Width="240"
                             SpinButtonPlacementMode="Compact"
                             HorizontalAlignment="Left"
                             Margin="{StaticResource SmallTopMargin}" 
@@ -235,6 +235,9 @@
                      Margin="{StaticResource SmallTopMargin}"
                      Text="{ Binding Mode=TwoWay, Path=ExcludedApps}"
                      IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"
+                     Width="380"
+                     Height="160"
+                     HorizontalAlignment="Left"
                      TextWrapping="Wrap"
                      AcceptsReturn="True"/>
 

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
@@ -138,7 +138,7 @@
                                             Margin="{StaticResource SmallTopMargin}"/>
 
                             <ComboBox SelectedIndex="{Binding Path=Unit, Mode=TwoWay}"
-                                      Width="90"
+                                      Width="120"
                                       Height="34"
                                       VerticalAlignment="Center"
                                       Margin="{StaticResource SmallTopMargin}">
@@ -180,7 +180,7 @@
 
             <ComboBox Header="Fallback encoder"
                           SelectedIndex="{Binding Path=Encoder, Mode=TwoWay, Source={StaticResource ViewModel}}"
-                          MinWidth="240"
+                          Width="240"
                           Margin="{StaticResource SmallTopMargin}"
                           IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled, Source={StaticResource ViewModel}}">
                 <ComboBoxItem x:Uid="ImageResizer_FallbackEncoder_PNG" />
@@ -196,7 +196,7 @@
                             Minimum="0"
                             Maximum="100"
                             Value="{ Binding Mode=TwoWay, Path=JPEGQualityLevel, Source={StaticResource ViewModel}}"
-                            MinWidth="240"
+                            Width="240"
                             SpinButtonPlacementMode="Compact"
                             HorizontalAlignment="Left"
                             Margin="{StaticResource SmallTopMargin}" 
@@ -204,7 +204,7 @@
 
             <ComboBox Header="PNG interlacing"
                           SelectedIndex="{ Binding Mode=TwoWay, Path=PngInterlaceOption, Source={StaticResource ViewModel}}"
-                          MinWidth="240"
+                          Width="240"
                           Margin="{StaticResource SmallTopMargin}"
                           IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled, Source={StaticResource ViewModel}}">
                 <ComboBoxItem x:Uid="Default"/>
@@ -214,7 +214,7 @@
 
             <ComboBox Header="TIFF Compression"
                           SelectedIndex="{ Binding Mode=TwoWay, Path=TiffCompressOption, Source={StaticResource ViewModel}}"
-                          MinWidth="240"
+                          Width="240"
                           Margin="{StaticResource SmallTopMargin}"
                           IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled, Source={StaticResource ViewModel}}">
                 <ComboBoxItem x:Uid="ImageResizer_ENCODER_TIFF_Default"/>
@@ -226,11 +226,9 @@
                 <ComboBoxItem x:Uid="ImageResizer_ENCODER_TIFF_Zip"/>
             </ComboBox>
 
-            <TextBlock Text="File" 
-                       Style="{StaticResource SettingsGroupTitleStyle}"/>
+            <TextBlock Text="File" Style="{StaticResource SettingsGroupTitleStyle}"/>
 
-            <TextBlock Text="The following parameters can be used:"
-                           Margin="{StaticResource SmallTopBottomMargin}"/>
+            <TextBlock Text="The following parameters can be used:" Margin="{StaticResource SmallTopBottomMargin}"/>
 
             <TextBlock FontSize="12">
                 <Run FontWeight="Bold">%1</Run>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
@@ -77,7 +77,7 @@
 
             <muxc:NumberBox x:Uid="PowerLauncher_MaximumNumberOfResults" 
                             Value="{x:Bind Mode=TwoWay, Path=ViewModel.MaximumNumberOfResults}"
-                            Width="320"
+                            Width="240"
                             SpinButtonPlacementMode="Compact"
                             HorizontalAlignment="Left"
                             Margin="{StaticResource SmallTopMargin}"
@@ -85,12 +85,11 @@
                             IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.EnablePowerLauncher}"/>
 
             <TextBlock x:Uid="PowerLauncher_Shortcuts"
-                       Width="320"
                        HorizontalAlignment="Left"
                        Style="{StaticResource SettingsGroupTitleStyle}"/>
 
             <Custom:HotkeySettingsControl x:Uid="PowerLauncher_OpenPowerLauncher"
-                                          Width="320"
+                                          Width="240"
                                           HorizontalAlignment="Left"
                                           Margin="{StaticResource SmallTopMargin}"
                                           HotkeySettings="{x:Bind Path=ViewModel.OpenPowerLauncher, Mode=TwoWay}"

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerRenamePage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerRenamePage.xaml
@@ -83,6 +83,7 @@
                             Margin="{StaticResource SmallTopMargin}" 
                             Value="{Binding Mode=TwoWay, Path=MaxDispListNum}"
                             Minimum="0"
+                            Width="320"
                             Maximum="20"
                             IsEnabled="{ Binding Mode=TwoWay, Path=GlobalAndMruEnabled}"
                             />

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerRenamePage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerRenamePage.xaml
@@ -67,7 +67,7 @@
                           IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"
                            />
 
-            <TextBlock x:Uid="Miscellaneous" 
+            <TextBlock x:Uid="PowerRename_AutoCompleteHeader" 
                        Style="{StaticResource SettingsGroupTitleStyle}"/>
 
 
@@ -83,7 +83,7 @@
                             Margin="{StaticResource SmallTopMargin}" 
                             Value="{Binding Mode=TwoWay, Path=MaxDispListNum}"
                             Minimum="0"
-                            Width="320"
+                            Width="240"
                             Maximum="20"
                             IsEnabled="{ Binding Mode=TwoWay, Path=GlobalAndMruEnabled}"
                             />

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerRenamePage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerRenamePage.xaml
@@ -89,7 +89,7 @@
                             />
 
             <ToggleSwitch x:Uid="PowerRename_Toggle_RestoreFlagsOnLaunch"
-                          Margin="{StaticResource SmallTopMargin}" 
+                          Margin="0, 17, 0, 0" 
                           IsOn="{Binding Mode=TwoWay, Path=RestoreFlagsOnLaunch}"
                           IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"
                            />

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ShellPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ShellPage.xaml
@@ -101,7 +101,7 @@
                     <behaviors:NavigationViewHeaderBehavior.DefaultHeaderTemplate>
                         <DataTemplate>
                             <!-- TODO: Style clean up-->
-                            <Grid Margin="0, 24, 0, 6">
+                            <Grid Margin="0, 12, 0, 6">
                                 <TextBlock
                                 Text="{Binding}"
                                 FontWeight="Bold"

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ShortcutGuidePage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ShortcutGuidePage.xaml
@@ -5,10 +5,14 @@
     xmlns:local="using:Microsoft.PowerToys.Settings.UI.Views"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls" xmlns:converters="using:Microsoft.Toolkit.Uwp.UI.Converters"
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
+    <Page.Resources>
+        <converters:StringFormatConverter x:Key="StringFormatConverter"/>
+    </Page.Resources>
+    
     <Grid ColumnSpacing="{StaticResource DefaultColumnSpacing}" RowSpacing="{StaticResource DefaultRowSpacing}">
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup x:Name="LayoutVisualStates">
@@ -58,19 +62,25 @@
                             SpinButtonPlacementMode="Compact"
                             HorizontalAlignment="Left"
                             Margin="{StaticResource SmallTopMargin}"
-                            MinWidth="240"
+                            Width="240"
                             Value="{ Binding Mode=TwoWay, Path=PressTime}"
                             IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}" SmallChange="50" LargeChange="100"/>
 
-            <Slider x:Uid="ShortcutGuide_OverlayOpacity"
+            <StackPanel Orientation="Horizontal" Margin="{StaticResource MediumTopMargin}" Spacing="12">
+                <Slider x:Uid="ShortcutGuide_OverlayOpacity"
                     Minimum="0"
                     Maximum="100"
                     Width="240"
                     Value="{ Binding Mode=TwoWay, Path=OverlayOpacity}"
+                    IsThumbToolTipEnabled="False"
                     HorizontalAlignment="Left"
-                    Margin="{StaticResource MediumTopMargin}"
                     IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"/>
-
+                <TextBlock Text="{ Binding Mode=OneWay, Path=OverlayOpacity, Converter={StaticResource StringFormatConverter}, ConverterParameter=' {0}%' }" 
+                           VerticalAlignment="Center"
+                           FontSize="16"
+                           Margin="0,21,0,0"/>
+            </StackPanel>
+            
             <muxc:RadioButtons x:Uid="ShortcutGuide_Theme"
                                Margin="{StaticResource SmallTopMargin}"
                                IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ShortcutGuidePage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ShortcutGuidePage.xaml
@@ -58,12 +58,14 @@
                             SpinButtonPlacementMode="Compact"
                             HorizontalAlignment="Left"
                             Margin="{StaticResource SmallTopMargin}"
+                            MinWidth="240"
                             Value="{ Binding Mode=TwoWay, Path=PressTime}"
                             IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}" SmallChange="50" LargeChange="100"/>
 
             <Slider x:Uid="ShortcutGuide_OverlayOpacity"
                     Minimum="0"
                     Maximum="100"
+                    Width="240"
                     Value="{ Binding Mode=TwoWay, Path=OverlayOpacity}"
                     HorizontalAlignment="Left"
                     Margin="{StaticResource MediumTopMargin}"


### PR DESCRIPTION
## Summary of the Pull Request
- Page header position corrected: now center aligned with the first navigation item, similar to W10 settings app. (#3837)
- Changed FZ opacity NumberBox to Slider (#3686)
- Set fixed widths for input elements, so they are consistent on every page and look better (#3692 and #3733 )
- Opacity value is now shown next to the opacity sliders for Shortcut Guide and FZ (#3234)
- Updated labels for PowerRename (#3906)

Centered header page + consistent widths for input controls
![image](https://user-images.githubusercontent.com/9866362/83263966-b5d9d980-a1bf-11ea-9dce-06ae69dc453a.png)

Slider for FZ + value is now shown
![Slider](https://user-images.githubusercontent.com/9866362/83264067-da35b600-a1bf-11ea-973d-5b40d5e35a85.gif)



* [X] Applies to #3837 #3686 #3692 #3733 #3234 #3906
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA