### PR TITLE
Fix for Unexpected priority of search results for 'term'

### DIFF
--- a/src/modules/launcher/Wox.Infrastructure/StringMatcher.cs
+++ b/src/modules/launcher/Wox.Infrastructure/StringMatcher.cs
@@ -83,9 +83,18 @@ namespace Wox.Infrastructure
             bool allSubstringsContainedInCompareString = true;
 
             var indexList = new List<int>();
+            List<int> spaceIndices = new List<int>();
 
             for (var compareStringIndex = 0; compareStringIndex < fullStringToCompareWithoutCase.Length; compareStringIndex++)
             {
+
+                // To maintain a list of indices which correspond to spaces in the string to compare
+                // To populate the list only for the first query substring
+                if (fullStringToCompareWithoutCase[compareStringIndex].Equals(' ') && currentQuerySubstringIndex == 0)
+                {
+                    spaceIndices.Add(compareStringIndex);
+                }
+
                 if (fullStringToCompareWithoutCase[compareStringIndex] != currentQuerySubstring[currentQuerySubstringCharacterIndex])
                 {
                     matchFoundInPreviousLoop = false;
@@ -147,12 +156,28 @@ namespace Wox.Infrastructure
             // proceed to calculate score if every char or substring without whitespaces matched
             if (allQuerySubstringsMatched)
             {
-                var score = CalculateSearchScore(query, stringToCompare, firstMatchIndex, lastMatchIndex - firstMatchIndex, allSubstringsContainedInCompareString);
+                var nearestSpaceIndex = CalculateClosestSpaceIndex(spaceIndices, firstMatchIndex);
+                var score = CalculateSearchScore(query, stringToCompare, firstMatchIndex - nearestSpaceIndex - 1, lastMatchIndex - firstMatchIndex, allSubstringsContainedInCompareString);
 
                 return new MatchResult(true, UserSettingSearchPrecision, indexList, score);
             }
 
             return new MatchResult (false, UserSettingSearchPrecision);
+        }
+
+        // To get the index of the closest space which preceeds the first matching index
+        private int CalculateClosestSpaceIndex(List<int> spaceIndices, int firstMatchIndex)
+        {
+            if(spaceIndices.Count == 0)
+            {
+                return -1;
+            }
+            else
+            {
+                int? ind = spaceIndices.OrderBy(item => (firstMatchIndex - item)).Where(item => firstMatchIndex > item).FirstOrDefault();
+                int closestSpaceIndex = ind ?? -1;
+                return closestSpaceIndex;
+            }
         }
 
         private static bool AllPreviousCharsMatched(int startIndexToVerify, int currentQuerySubstringCharacterIndex, 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Take space into consideration while calculating the first matched index. 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #3559 (master tracking item - #3371)
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
* The query `term` was showing up CharacterMap before Windows Terminal because the first match index in terminal was 8 whereas it was 6 for characterMap. 
* To mitigate this issue, setting the first start index relative to the preceeding space. This way windows terminal gets a higher weightage as the first match index is now 0.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
![image](https://user-images.githubusercontent.com/28739210/83292789-93d05f00-a19f-11ea-8df2-80d05111a383.png)
- Task Manager would have previously got a low score. However, now it is higher as we are giving preference to the fact that it is the start of a new word.

![image](https://user-images.githubusercontent.com/28739210/83292795-96cb4f80-a19f-11ea-8604-45af74f1c7ae.png)

