### PR TITLE
[FancyZones] Remove workarounds related to 0000 dekstop GUID

### DIFF
--- a/src/modules/fancyzones/lib/JsonHelpers.cpp
+++ b/src/modules/fancyzones/lib/JsonHelpers.cpp
@@ -281,10 +281,6 @@ namespace JSONHelpers
     bool FancyZonesData::RemoveDevicesByVirtualDesktopId(const std::wstring& virtualDesktopId)
     {
         std::scoped_lock lock{ dataLock };
-        if (virtualDesktopId == DEFAULT_GUID)
-        {
-            return false;
-        }
         bool modified{ false };
         for (auto it = deviceInfoMap.begin(); it != deviceInfoMap.end();)
         {

--- a/src/modules/fancyzones/lib/VirtualDesktopUtils.cpp
+++ b/src/modules/fancyzones/lib/VirtualDesktopUtils.cpp
@@ -5,7 +5,6 @@
 namespace VirtualDesktopUtils
 {
     const CLSID CLSID_ImmersiveShell = { 0xC2F03A33, 0x21F5, 0x47FA, 0xB4, 0xBB, 0x15, 0x63, 0x62, 0xA2, 0xF2, 0x39 };
-    const wchar_t GUID_EmptyGUID[] = L"{00000000-0000-0000-0000-000000000000}";
 
     const wchar_t RegCurrentVirtualDesktop[] = L"CurrentVirtualDesktop";
     const wchar_t RegVirtualDesktopIds[] = L"VirtualDesktopIDs";
@@ -44,10 +43,6 @@ namespace VirtualDesktopUtils
         // Format: <device-id>_<resolution>_<virtual-desktop-id>
         std::wstring uniqueId = zoneWindow->UniqueId();
         std::wstring virtualDesktopId = uniqueId.substr(uniqueId.rfind('_') + 1);
-        if (virtualDesktopId == GUID_EmptyGUID)
-        {
-            return false;
-        }
         return SUCCEEDED(CLSIDFromString(virtualDesktopId.c_str(), desktopId));
     }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
After implementing solution for handling 0000 GUID on primary desktop in https://github.com/microsoft/PowerToys/pull/2339 (first start, no virtual desktop switch occurred), workarounds for it are no longer needed.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2633
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

