### PR TITLE
[FancyZones] App zone history on multiple desktops

### DIFF
--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -849,21 +849,11 @@ void FancyZones::RegisterVirtualDesktopUpdates(std::vector<GUID>& ids) noexcept
 {
     std::unique_lock writeLock(m_lock);
 
-    std::vector<GUID> deleted{};
-    m_workAreaHandler.RegisterUpdates(ids, deleted);
-
-    bool modified{ false };
-    for (const auto& id : deleted)
+    m_workAreaHandler.RegisterUpdates(ids);
+    std::vector<std::wstring> active{};
+    if (VirtualDesktopUtils::GetVirtualDesktopIds(active))
     {
-        wil::unique_cotaskmem_string virtualDesktopId;
-        if (SUCCEEDED(StringFromCLSID(id, &virtualDesktopId)))
-        {
-            modified |= JSONHelpers::FancyZonesDataInstance().RemoveDevicesByVirtualDesktopId(virtualDesktopId.get());
-        }
-    }
-    if (modified)
-    {
-        JSONHelpers::FancyZonesDataInstance().SaveFancyZonesData();
+        JSONHelpers::FancyZonesDataInstance().RemoveDeletedDesktops(active);
     }
 }
 

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -333,10 +333,10 @@ FancyZones::WindowCreated(HWND window) noexcept
                     std::vector<int> zoneIndexSet = fancyZonesData.GetAppLastZoneIndexSet(window, zoneWindow->UniqueId(), guidString.get());
                     if (zoneIndexSet.size() &&
                         !IsSplashScreen(window) &&
-                        !fancyZonesData.IsAnotherWindowOfApplicationInstanceZoned(window))
+                        !fancyZonesData.IsAnotherWindowOfApplicationInstanceZoned(window, zoneWindow->UniqueId()))
                     {
                         m_windowMoveHandler.MoveWindowIntoZoneByIndexSet(window, zoneIndexSet, zoneWindow);
-                        fancyZonesData.UpdateProcessIdToHandleMap(window);
+                        fancyZonesData.UpdateProcessIdToHandleMap(window, zoneWindow->UniqueId());
                     }
                 }
             }

--- a/src/modules/fancyzones/lib/JsonHelpers.cpp
+++ b/src/modules/fancyzones/lib/JsonHelpers.cpp
@@ -39,7 +39,7 @@ namespace JSONHelpers
     bool isValidGuid(const std::wstring& str)
     {
         GUID id;
-        return SUCCEEDED_LOG(CLSIDFromString(str.c_str(), &id));
+        return SUCCEEDED(CLSIDFromString(str.c_str(), &id));
     }
 
     bool isValidDeviceId(const std::wstring& str)

--- a/src/modules/fancyzones/lib/JsonHelpers.cpp
+++ b/src/modules/fancyzones/lib/JsonHelpers.cpp
@@ -452,20 +452,20 @@ namespace JSONHelpers
             if (history != std::end(appZoneHistoryMap))
             {
                 auto& perDesktopData = history->second;
-                for (auto& data : perDesktopData)
+                for (auto data = std::begin(perDesktopData); data != std::end(perDesktopData);)
                 {
-                    if (data.deviceId == deviceId && data.zoneSetUuid == zoneSetId)
+                    if (data->deviceId == deviceId && data->zoneSetUuid == zoneSetId)
                     {
                         if (!IsAnotherWindowOfApplicationInstanceZoned(window, deviceId))
                         {
                             DWORD processId = 0;
                             GetWindowThreadProcessId(window, &processId);
 
-                            data.processIdToHandleMap.erase(processId);
+                            data->processIdToHandleMap.erase(processId);
                         }
 
                         // if there is another instance placed don't erase history
-                        for (auto placedWindow : data.processIdToHandleMap)
+                        for (auto placedWindow : data->processIdToHandleMap)
                         {
                             if (IsWindow(placedWindow.second))
                             {
@@ -473,9 +473,17 @@ namespace JSONHelpers
                             }
                         }
 
-                        appZoneHistoryMap.erase(processPath);
+                        data = perDesktopData.erase(data);
+                        if (perDesktopData.empty())
+                        {
+                            appZoneHistoryMap.erase(processPath);
+                        }
                         SaveFancyZonesData();
                         return true;
+                    }
+                    else
+                    {
+                        ++data;
                     }
                 }
             }

--- a/src/modules/fancyzones/lib/JsonHelpers.cpp
+++ b/src/modules/fancyzones/lib/JsonHelpers.cpp
@@ -412,6 +412,7 @@ namespace JSONHelpers
                         DWORD processId = 0;
                         GetWindowThreadProcessId(window, &processId);
                         data.processIdToHandleMap[processId] = window;
+                        break;
                     }
                 }
             }
@@ -535,7 +536,7 @@ namespace JSONHelpers
 
         if (appZoneHistoryMap.contains(processPath))
         {
-            // application already has history but on other desktop, update with new desktop info
+            // application already has history but on other desktop, add with new desktop info
             appZoneHistoryMap[processPath].push_back(data);
         }
         else

--- a/src/modules/fancyzones/lib/JsonHelpers.cpp
+++ b/src/modules/fancyzones/lib/JsonHelpers.cpp
@@ -1046,6 +1046,10 @@ namespace JSONHelpers
                     result.data.push_back(std::move(data.value()));
                 }
             }
+            if (result.data.empty())
+            {
+                return std::nullopt;
+            }
 
             return result;
         }

--- a/src/modules/fancyzones/lib/JsonHelpers.h
+++ b/src/modules/fancyzones/lib/JsonHelpers.h
@@ -143,7 +143,7 @@ namespace JSONHelpers
     struct AppZoneHistoryJSON
     {
         std::wstring appPath;
-        AppZoneHistoryData data;
+        std::vector<AppZoneHistoryData> data;
 
         static json::JsonObject ToJson(const AppZoneHistoryJSON& appZoneHistory);
         static std::optional<AppZoneHistoryJSON> FromJson(const json::JsonObject& zoneSet);
@@ -201,7 +201,7 @@ namespace JSONHelpers
             return customZoneSetsMap;
         }
 
-        inline const std::unordered_map<std::wstring, AppZoneHistoryData>& GetAppZoneHistoryMap() const
+        inline const std::unordered_map<std::wstring, std::vector<AppZoneHistoryData>>& GetAppZoneHistoryMap() const
         {
             std::scoped_lock lock{ dataLock };
             return appZoneHistoryMap;
@@ -237,8 +237,8 @@ namespace JSONHelpers
         void UpdatePrimaryDesktopData(const std::wstring& desktopId);
         void RemoveDeletedDesktops(const std::vector<std::wstring>& activeDesktops);
 
-        bool IsAnotherWindowOfApplicationInstanceZoned(HWND window) const;
-        void UpdateProcessIdToHandleMap(HWND window);
+        bool IsAnotherWindowOfApplicationInstanceZoned(HWND window, const std::wstring_view& deviceId) const;
+        void UpdateProcessIdToHandleMap(HWND window, const std::wstring_view& deviceId);
         std::vector<int> GetAppLastZoneIndexSet(HWND window, const std::wstring_view& deviceId, const std::wstring_view& zoneSetId) const;
         bool RemoveAppLastZone(HWND window, const std::wstring_view& deviceId, const std::wstring_view& zoneSetId);
         bool SetAppLastZones(HWND window, const std::wstring& deviceId, const std::wstring& zoneSetId, const std::vector<int>& zoneIndexSet);
@@ -266,7 +266,7 @@ namespace JSONHelpers
         void MigrateCustomZoneSetsFromRegistry();
         void RemoveDesktopAppZoneHistory(const std::wstring& desktopId);
 
-        std::unordered_map<std::wstring, AppZoneHistoryData> appZoneHistoryMap{};
+        std::unordered_map<std::wstring, std::vector<AppZoneHistoryData>> appZoneHistoryMap{};
         std::unordered_map<std::wstring, DeviceInfoData> deviceInfoMap{};
         std::unordered_map<std::wstring, CustomZoneSetData> customZoneSetsMap{};
 

--- a/src/modules/fancyzones/lib/JsonHelpers.h
+++ b/src/modules/fancyzones/lib/JsonHelpers.h
@@ -233,7 +233,6 @@ namespace JSONHelpers
         }
 
         void AddDevice(const std::wstring& deviceId);
-        bool RemoveDevicesByVirtualDesktopId(const std::wstring& virtualDesktopId);
         void CloneDeviceInfo(const std::wstring& source, const std::wstring& destination);
         void UpdatePrimaryDesktopData(const std::wstring& desktopId);
         void RemoveDeletedDesktops(const std::vector<std::wstring>& activeDesktops);
@@ -265,6 +264,7 @@ namespace JSONHelpers
 
     private:
         void MigrateCustomZoneSetsFromRegistry();
+        void RemoveDesktopAppZoneHistory(const std::wstring& desktopId);
 
         std::unordered_map<std::wstring, AppZoneHistoryData> appZoneHistoryMap{};
         std::unordered_map<std::wstring, DeviceInfoData> deviceInfoMap{};

--- a/src/modules/fancyzones/lib/MonitorWorkAreaHandler.cpp
+++ b/src/modules/fancyzones/lib/MonitorWorkAreaHandler.cpp
@@ -73,7 +73,7 @@ bool MonitorWorkAreaHandler::IsNewWorkArea(const GUID& desktopId, HMONITOR monit
     return true;
 }
 
-void MonitorWorkAreaHandler::RegisterUpdates(const std::vector<GUID>& active, std::vector<GUID>& deleted)
+void MonitorWorkAreaHandler::RegisterUpdates(const std::vector<GUID>& active)
 {
     std::unordered_set<GUID> activeVirtualDesktops(std::begin(active), std::end(active));
     for (auto desktopIt = std::begin(workAreaMap); desktopIt != std::end(workAreaMap);)
@@ -81,8 +81,7 @@ void MonitorWorkAreaHandler::RegisterUpdates(const std::vector<GUID>& active, st
         auto activeIt = activeVirtualDesktops.find(desktopIt->first);
         if (activeIt == std::end(activeVirtualDesktops))
         {
-            // register deleted virtual desktop
-            deleted.push_back(desktopIt->first);
+            // virtual desktop deleted, remove entry from the map
             desktopIt = workAreaMap.erase(desktopIt);
         }
         else

--- a/src/modules/fancyzones/lib/MonitorWorkAreaHandler.h
+++ b/src/modules/fancyzones/lib/MonitorWorkAreaHandler.h
@@ -77,10 +77,8 @@ public:
      * Register changes in current virtual desktop layout.
      *
      * @param[in]  active  Array of currently active virtual desktop identifiers.
-     * @param[out] deleted Array of virtual desktop identifiers belonging to previously registered but now deleted
-     *                      work areas.
      */
-    void RegisterUpdates(const std::vector<GUID>& active, std::vector<GUID>& deleted);
+    void RegisterUpdates(const std::vector<GUID>& active);
 
     /**
      * Clear all persisted work area related data.

--- a/src/modules/fancyzones/tests/UnitTests/JsonHelpers.Tests.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/JsonHelpers.Tests.cpp
@@ -719,7 +719,7 @@ namespace FancyZonesUnitTests
                 .zoneSetUuid = L"zoneset-uuid", .deviceId = L"device-id", .zoneIndexSet = { 54321 }
             };
             AppZoneHistoryJSON appZoneHistory{ L"appPath", std::vector<AppZoneHistoryData>{ data } };
-            json::JsonObject expected = json::JsonObject::Parse(L"{\"app-path\": \"appPath\", \"history\": [{\"device-id\": \"device-id\", \"zoneset-uuid\": \"zoneset-uuid\", \"zone-index-set\": [54321]}]}");
+            json::JsonObject expected = json::JsonObject::Parse(L"{\"app-path\": \"appPath\", \"history\":[{\"zone-index-set\": [54321], \"device-id\": \"device-id\", \"zoneset-uuid\": \"zoneset-uuid\"}]}");
 
             auto actual = AppZoneHistoryJSON::ToJson(appZoneHistory);
             compareJsonObjects(expected, actual);
@@ -795,9 +795,10 @@ namespace FancyZonesUnitTests
             AppZoneHistoryJSON appZoneHistory{
                 L"appPath", std::vector<AppZoneHistoryData>{ data1, data2 }
             };
-            json::JsonObject expected = json::JsonObject::Parse(L"{\"app-path\": \"appPath\", \"history\": [{\"device-id\": \"device-id1\", \"zoneset-uuid\": \"zoneset-uuid1\", \"zone-index-set\": [54321]}, {\"device-id\": \"device-id2\", \"zoneset-uuid\": \"zoneset-uuid2\", \"zone-index-set\": [12345]}]}");
+            json::JsonObject expected = json::JsonObject::Parse(L"{\"app-path\": \"appPath\", \"history\": [{\"zone-index-set\": [54321], \"device-id\": \"device-id1\", \"zoneset-uuid\": \"zoneset-uuid1\"}, {\"zone-index-set\": [12345], \"device-id\": \"device-id2\", \"zoneset-uuid\": \"zoneset-uuid2\"}]}");
 
             auto actual = AppZoneHistoryJSON::ToJson(appZoneHistory);
+            std::wstring s = actual.Stringify().c_str();
             compareJsonObjects(expected, actual);
         }
 

--- a/src/modules/fancyzones/tests/UnitTests/JsonHelpers.Tests.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/JsonHelpers.Tests.cpp
@@ -795,7 +795,7 @@ namespace FancyZonesUnitTests
             AppZoneHistoryJSON appZoneHistory{
                 L"appPath", std::vector<AppZoneHistoryData>{ data1, data2 }
             };
-            json::JsonObject expected = json::JsonObject::Parse(L"{\"app-path\": \"appPath\", \"history\": [{\"device-id\": \"device-id1\", \"zoneset-uuid1\": \"zoneset-uuid\", \"zone-index-set\": [54321]}, {\"device-id\": \"device-id2\", \"zoneset-uuid2\": \"zoneset-uuid\", \"zone-index-set\": [12345]}]}");
+            json::JsonObject expected = json::JsonObject::Parse(L"{\"app-path\": \"appPath\", \"history\": [{\"device-id\": \"device-id1\", \"zoneset-uuid\": \"zoneset-uuid1\", \"zone-index-set\": [54321]}, {\"device-id\": \"device-id2\", \"zoneset-uuid\": \"zoneset-uuid2\", \"zone-index-set\": [12345]}]}");
 
             auto actual = AppZoneHistoryJSON::ToJson(appZoneHistory);
             compareJsonObjects(expected, actual);
@@ -804,15 +804,15 @@ namespace FancyZonesUnitTests
         TEST_METHOD (FromJsonMultipleDesktopAppHistory)
         {
             AppZoneHistoryData data1{
-                .zoneSetUuid = L"zoneset-uuid1", .deviceId = L"device-id1", .zoneIndexSet = { 54321 }
+                .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502906}", .deviceId = L"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1539}", .zoneIndexSet = { 54321 }
             };
             AppZoneHistoryData data2{
-                .zoneSetUuid = L"zoneset-uuid2", .deviceId = L"device-id2", .zoneIndexSet = { 12345 }
+                .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502906}", .deviceId = L"AOC2460#4&fe3a015&0&UID65793_1920_1200_{8a0b9205-6128-45a2-934a-b97f5b271235}", .zoneIndexSet = { 12345 }
             };
             AppZoneHistoryJSON expected{
                 L"appPath", std::vector<AppZoneHistoryData>{ data1, data2 }
             };
-            json::JsonObject json = json::JsonObject::Parse(L"{\"app-path\": \"appPath\", \"history\": [{\"device-id\": \"device-id1\", \"zoneset-uuid1\": \"zoneset-uuid\", \"zone-index-set\": [54321]}, {\"device-id\": \"device-id2\", \"zoneset-uuid2\": \"zoneset-uuid\", \"zone-index-set\": [12345]}]}");
+            json::JsonObject json = json::JsonObject::Parse(L"{\"app-path\": \"appPath\", \"history\": [{\"device-id\": \"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1539}\", \"zoneset-uuid\": \"{33A2B101-06E0-437B-A61E-CDBECF502906}\", \"zone-index-set\": [54321]}, {\"device-id\": \"AOC2460#4&fe3a015&0&UID65793_1920_1200_{8a0b9205-6128-45a2-934a-b97f5b271235}\", \"zoneset-uuid\": \"{33A2B101-06E0-437B-A61E-CDBECF502906}\", \"zone-index-set\": [12345]}]}");
 
             auto actual = AppZoneHistoryJSON::FromJson(json);
             Assert::IsTrue(actual.has_value());

--- a/src/modules/fancyzones/tests/UnitTests/JsonHelpers.Tests.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/JsonHelpers.Tests.cpp
@@ -715,8 +715,11 @@ namespace FancyZonesUnitTests
     {
         TEST_METHOD (ToJson)
         {
-            AppZoneHistoryJSON appZoneHistory{ L"appPath", AppZoneHistoryData{ .zoneSetUuid = L"zoneset-uuid", .deviceId = L"device-id", .zoneIndexSet = { 54321 } } };
-            json::JsonObject expected = json::JsonObject::Parse(L"{\"app-path\": \"appPath\", \"device-id\": \"device-id\", \"zoneset-uuid\": \"zoneset-uuid\", \"zone-index-set\": [54321]}");
+            AppZoneHistoryData data{
+                .zoneSetUuid = L"zoneset-uuid", .deviceId = L"device-id", .zoneIndexSet = { 54321 }
+            };
+            AppZoneHistoryJSON appZoneHistory{ L"appPath", std::vector<AppZoneHistoryData>{ data } };
+            json::JsonObject expected = json::JsonObject::Parse(L"{\"app-path\": \"appPath\", \"history\": [{\"device-id\": \"device-id\", \"zoneset-uuid\": \"zoneset-uuid\", \"zone-index-set\": [54321]}]}");
 
             auto actual = AppZoneHistoryJSON::ToJson(appZoneHistory);
             compareJsonObjects(expected, actual);
@@ -724,35 +727,42 @@ namespace FancyZonesUnitTests
 
         TEST_METHOD (FromJson)
         {
-            AppZoneHistoryJSON expected{ L"appPath", AppZoneHistoryData{ .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502906}", .deviceId = L"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1539}", .zoneIndexSet = { 54321 } } };
-            json::JsonObject json = json::JsonObject::Parse(L"{\"app-path\": \"appPath\", \"device-id\": \"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1539}\", \"zoneset-uuid\": \"{33A2B101-06E0-437B-A61E-CDBECF502906}\", \"zone-index\": 54321}");
+            AppZoneHistoryData data{
+                .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502906}", .deviceId = L"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1539}", .zoneIndexSet = { 54321 }
+            };
+            AppZoneHistoryJSON expected{ L"appPath", std::vector<AppZoneHistoryData>{ data } };
+            json::JsonObject json = json::JsonObject::Parse(L"{\"app-path\": \"appPath\", \"history\": [{\"device-id\": \"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1539}\", \"zoneset-uuid\": \"{33A2B101-06E0-437B-A61E-CDBECF502906}\", \"zone-index\": 54321}]}");
 
             auto actual = AppZoneHistoryJSON::FromJson(json);
             Assert::IsTrue(actual.has_value());
 
             Assert::AreEqual(expected.appPath.c_str(), actual->appPath.c_str());
-            Assert::AreEqual(expected.data.zoneIndexSet, actual->data.zoneIndexSet);
-            Assert::AreEqual(expected.data.deviceId.c_str(), actual->data.deviceId.c_str());
-            Assert::AreEqual(expected.data.zoneSetUuid.c_str(), actual->data.zoneSetUuid.c_str());
+            Assert::AreEqual(expected.data.size(), actual->data.size());
+            Assert::AreEqual(expected.data[0].zoneIndexSet, actual->data[0].zoneIndexSet);
+            Assert::AreEqual(expected.data[0].deviceId.c_str(), actual->data[0].deviceId.c_str());
+            Assert::AreEqual(expected.data[0].zoneSetUuid.c_str(), actual->data[0].zoneSetUuid.c_str());
         }
 
         TEST_METHOD (FromJsonInvalidUuid)
         {
-            json::JsonObject json = json::JsonObject::Parse(L"{\"app-path\": \"appPath\", \"device-id\": \"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1539}\", \"zoneset-uuid\": \"zoneset-uuid\", \"zone-index\": 54321}");
+            json::JsonObject json = json::JsonObject::Parse(L"{\"app-path\": \"appPath\", \"history\": [{\"device-id\": \"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1539}\", \"zoneset-uuid\": \"zoneset-uuid\", \"zone-index\": 54321}]}");
             auto actual = AppZoneHistoryJSON::FromJson(json);
             Assert::IsFalse(actual.has_value());
         }
 
         TEST_METHOD (FromJsonInvalidDeviceId)
         {
-            json::JsonObject json = json::JsonObject::Parse(L"{\"app-path\": \"appPath\", \"device-id\": \"device-id\", \"zoneset-uuid\": \"{33A2B101-06E0-437B-A61E-CDBECF502906}\", \"zone-index\": 54321}");
+            json::JsonObject json = json::JsonObject::Parse(L"{\"app-path\": \"appPath\", \"history\": [{\"device-id\": \"device-id\", \"zoneset-uuid\": \"{33A2B101-06E0-437B-A61E-CDBECF502906}\", \"zone-index\": 54321}]}");
             auto actual = AppZoneHistoryJSON::FromJson(json);
             Assert::IsFalse(actual.has_value());
         }
 
         TEST_METHOD (FromJsonMissingKeys)
         {
-            AppZoneHistoryJSON appZoneHistory{ L"appPath", AppZoneHistoryData{ .zoneSetUuid = L"zoneset-uuid", .deviceId = L"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1539}", .zoneIndexSet = { 54321 } } };
+            AppZoneHistoryData data{
+                .zoneSetUuid = L"zoneset-uuid", .deviceId = L"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1539}", .zoneIndexSet = { 54321 }
+            };
+            AppZoneHistoryJSON appZoneHistory{ L"appPath", std::vector<AppZoneHistoryData>{ data } };
             const auto json = AppZoneHistoryJSON::ToJson(appZoneHistory);
 
             auto iter = json.First();
@@ -770,8 +780,52 @@ namespace FancyZonesUnitTests
 
         TEST_METHOD (FromJsonInvalidTypes)
         {
-            json::JsonObject json = json::JsonObject::Parse(L"{\"app-path\": false, \"device-id\": [], \"zoneset-uuid\": {}, \"zone-index\": \"54321\"}");
+            json::JsonObject json = json::JsonObject::Parse(L"{\"app-path\": false, \"history\": [{\"device-id\": [], \"zoneset-uuid\": {}, \"zone-index\": \"54321\"}]}");
             Assert::IsFalse(AppZoneHistoryJSON::FromJson(json).has_value());
+        }
+
+        TEST_METHOD (ToJsonMultipleDesktopAppHistory)
+        {
+            AppZoneHistoryData data1{
+                .zoneSetUuid = L"zoneset-uuid1", .deviceId = L"device-id1", .zoneIndexSet = { 54321 }
+            };
+            AppZoneHistoryData data2{
+                .zoneSetUuid = L"zoneset-uuid2", .deviceId = L"device-id2", .zoneIndexSet = { 12345 }
+            };
+            AppZoneHistoryJSON appZoneHistory{
+                L"appPath", std::vector<AppZoneHistoryData>{ data1, data2 }
+            };
+            json::JsonObject expected = json::JsonObject::Parse(L"{\"app-path\": \"appPath\", \"history\": [{\"device-id\": \"device-id1\", \"zoneset-uuid1\": \"zoneset-uuid\", \"zone-index-set\": [54321]}, {\"device-id\": \"device-id2\", \"zoneset-uuid2\": \"zoneset-uuid\", \"zone-index-set\": [12345]}]}");
+
+            auto actual = AppZoneHistoryJSON::ToJson(appZoneHistory);
+            compareJsonObjects(expected, actual);
+        }
+
+        TEST_METHOD (FromJsonMultipleDesktopAppHistory)
+        {
+            AppZoneHistoryData data1{
+                .zoneSetUuid = L"zoneset-uuid1", .deviceId = L"device-id1", .zoneIndexSet = { 54321 }
+            };
+            AppZoneHistoryData data2{
+                .zoneSetUuid = L"zoneset-uuid2", .deviceId = L"device-id2", .zoneIndexSet = { 12345 }
+            };
+            AppZoneHistoryJSON expected{
+                L"appPath", std::vector<AppZoneHistoryData>{ data1, data2 }
+            };
+            json::JsonObject json = json::JsonObject::Parse(L"{\"app-path\": \"appPath\", \"history\": [{\"device-id\": \"device-id1\", \"zoneset-uuid1\": \"zoneset-uuid\", \"zone-index-set\": [54321]}, {\"device-id\": \"device-id2\", \"zoneset-uuid2\": \"zoneset-uuid\", \"zone-index-set\": [12345]}]}");
+
+            auto actual = AppZoneHistoryJSON::FromJson(json);
+            Assert::IsTrue(actual.has_value());
+
+            Assert::AreEqual(expected.appPath.c_str(), actual->appPath.c_str());
+            Assert::AreEqual(expected.data.size(), actual->data.size());
+
+            for (size_t i = 0; i < expected.data.size(); ++i)
+            {
+                Assert::AreEqual(expected.data[i].zoneIndexSet, actual->data[i].zoneIndexSet);
+                Assert::AreEqual(expected.data[i].deviceId.c_str(), actual->data[i].deviceId.c_str());
+                Assert::AreEqual(expected.data[i].zoneSetUuid.c_str(), actual->data[i].zoneSetUuid.c_str());
+            }
         }
     };
 
@@ -1153,47 +1207,60 @@ namespace FancyZonesUnitTests
                 const std::wstring expectedZoneSetId = L"{33A2B101-06E0-437B-A61E-CDBECF502906}";
                 const int expectedIndex = 54321;
 
-                json::JsonObject json;
-                AppZoneHistoryJSON expected{ expectedAppPath, AppZoneHistoryData{ .zoneSetUuid = expectedZoneSetId, .deviceId = expectedDeviceId, .zoneIndexSet = { expectedIndex } } };
+                AppZoneHistoryData data{
+                    .zoneSetUuid = expectedZoneSetId, .deviceId = expectedDeviceId, .zoneIndexSet = { expectedIndex }
+                };
+                AppZoneHistoryJSON expected{ expectedAppPath, std::vector<AppZoneHistoryData>{ data } };
                 json::JsonArray zoneHistoryArray;
                 zoneHistoryArray.Append(AppZoneHistoryJSON::ToJson(expected));
+                json::JsonObject json;
                 json.SetNamedValue(L"app-zone-history", json::JsonValue::Parse(zoneHistoryArray.Stringify()));
 
-                FancyZonesData data;
-                data.SetSettingsModulePath(m_moduleName);
-                data.ParseAppZoneHistory(json);
+                FancyZonesData fancyZonesData;
+                fancyZonesData.SetSettingsModulePath(m_moduleName);
+                fancyZonesData.ParseAppZoneHistory(json);
 
-                const auto actualProcessHistoryMap = data.GetAppZoneHistoryMap();
+                const auto actualProcessHistoryMap = fancyZonesData.GetAppZoneHistoryMap();
                 Assert::AreEqual((size_t)zoneHistoryArray.Size(), actualProcessHistoryMap.size());
 
                 const auto actualProcessHistory = actualProcessHistoryMap.begin();
                 Assert::AreEqual(expectedAppPath.c_str(), actualProcessHistory->first.c_str());
 
                 const auto actualAppZoneHistory = actualProcessHistory->second;
-                Assert::AreEqual(expectedZoneSetId.c_str(), actualAppZoneHistory.zoneSetUuid.c_str());
-                Assert::AreEqual(expectedDeviceId.c_str(), actualAppZoneHistory.deviceId.c_str());
-                Assert::AreEqual({ expectedIndex }, actualAppZoneHistory.zoneIndexSet);
+                Assert::AreEqual(expected.data.size(), actualAppZoneHistory.size());
+                Assert::AreEqual(expectedZoneSetId.c_str(), actualAppZoneHistory[0].zoneSetUuid.c_str());
+                Assert::AreEqual(expectedDeviceId.c_str(), actualAppZoneHistory[0].deviceId.c_str());
+                Assert::AreEqual({ expectedIndex }, actualAppZoneHistory[0].zoneIndexSet);
             }
 
             TEST_METHOD (AppZoneHistoryParseManyApps)
             {
                 json::JsonObject json;
                 json::JsonArray zoneHistoryArray;
-                zoneHistoryArray.Append(AppZoneHistoryJSON::ToJson(AppZoneHistoryJSON{ L"app-path-1", AppZoneHistoryData{ .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502900}", .deviceId = L"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1530}", .zoneIndexSet = { 1 } } }));
-                zoneHistoryArray.Append(AppZoneHistoryJSON::ToJson(AppZoneHistoryJSON{ L"app-path-2", AppZoneHistoryData{ .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502901}", .deviceId = L"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1531}", .zoneIndexSet = { 2 } } }));
-                zoneHistoryArray.Append(AppZoneHistoryJSON::ToJson(AppZoneHistoryJSON{ L"app-path-3", AppZoneHistoryData{ .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502902}", .deviceId = L"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1532}", .zoneIndexSet = { 3 } } }));
-                zoneHistoryArray.Append(AppZoneHistoryJSON::ToJson(AppZoneHistoryJSON{ L"app-path-4", AppZoneHistoryData{ .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502903}", .deviceId = L"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1533}", .zoneIndexSet = { 4 } } }));
+                AppZoneHistoryData data1{
+                    .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502900}", .deviceId = L"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1530}", .zoneIndexSet = { 1 }
+                };
+                AppZoneHistoryData data2{
+                    .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502901}", .deviceId = L"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1531}", .zoneIndexSet = { 2 }
+                };
+                AppZoneHistoryData data3{
+                    .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502902}", .deviceId = L"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1532}", .zoneIndexSet = { 3 }
+                };
+                AppZoneHistoryData data4{
+                    .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502903}", .deviceId = L"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1533}", .zoneIndexSet = { 4 }
+                };
+                zoneHistoryArray.Append(AppZoneHistoryJSON::ToJson(AppZoneHistoryJSON{ L"app-path-1", std::vector<AppZoneHistoryData>{ data1 } }));
+                zoneHistoryArray.Append(AppZoneHistoryJSON::ToJson(AppZoneHistoryJSON{ L"app-path-2", std::vector<AppZoneHistoryData>{ data2 } }));
+                zoneHistoryArray.Append(AppZoneHistoryJSON::ToJson(AppZoneHistoryJSON{ L"app-path-3", std::vector<AppZoneHistoryData>{ data3 } }));
+                zoneHistoryArray.Append(AppZoneHistoryJSON::ToJson(AppZoneHistoryJSON{ L"app-path-4", std::vector<AppZoneHistoryData>{ data4 } }));
 
                 json.SetNamedValue(L"app-zone-history", json::JsonValue::Parse(zoneHistoryArray.Stringify()));
 
-                FancyZonesData data;
-                data.SetSettingsModulePath(m_moduleName);
-                data.ParseAppZoneHistory(json);
+                FancyZonesData fancyZonesData;
+                fancyZonesData.SetSettingsModulePath(m_moduleName);
+                fancyZonesData.ParseAppZoneHistory(json);
 
-                auto actualMap = data.GetAppZoneHistoryMap();
-                Assert::AreEqual((size_t)zoneHistoryArray.Size(), actualMap.size());
-
-                const auto actualProcessHistoryMap = data.GetAppZoneHistoryMap();
+                const auto actualProcessHistoryMap = fancyZonesData.GetAppZoneHistoryMap();
                 Assert::AreEqual((size_t)zoneHistoryArray.Size(), actualProcessHistoryMap.size());
 
                 auto iter = zoneHistoryArray.First();
@@ -1201,10 +1268,11 @@ namespace FancyZonesUnitTests
                 {
                     auto expected = AppZoneHistoryJSON::FromJson(json::JsonObject::Parse(iter.Current().Stringify()));
 
-                    const auto actual = actualProcessHistoryMap.at(expected->appPath);
-                    Assert::AreEqual(expected->data.deviceId.c_str(), actual.deviceId.c_str());
-                    Assert::AreEqual(expected->data.zoneSetUuid.c_str(), actual.zoneSetUuid.c_str());
-                    Assert::AreEqual(expected->data.zoneIndexSet, actual.zoneIndexSet);
+                    const auto& actual = actualProcessHistoryMap.at(expected->appPath);
+                    Assert::AreEqual(expected->data.size(), actual.size());
+                    Assert::AreEqual(expected->data[0].deviceId.c_str(), actual[0].deviceId.c_str());
+                    Assert::AreEqual(expected->data[0].zoneSetUuid.c_str(), actual[0].zoneSetUuid.c_str());
+                    Assert::AreEqual(expected->data[0].zoneIndexSet, actual[0].zoneIndexSet);
 
                     iter.MoveNext();
                 }
@@ -1216,24 +1284,36 @@ namespace FancyZonesUnitTests
                 json::JsonArray zoneHistoryArray;
 
                 const auto appPath = L"app-path";
-                zoneHistoryArray.Append(AppZoneHistoryJSON::ToJson(AppZoneHistoryJSON{ appPath, AppZoneHistoryData{ .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502900}", .deviceId = L"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1530}", .zoneIndexSet = { 1 } } }));
-                zoneHistoryArray.Append(AppZoneHistoryJSON::ToJson(AppZoneHistoryJSON{ appPath, AppZoneHistoryData{ .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502901}", .deviceId = L"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1531}", .zoneIndexSet = { 2 } } }));
-                zoneHistoryArray.Append(AppZoneHistoryJSON::ToJson(AppZoneHistoryJSON{ appPath, AppZoneHistoryData{ .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502902}", .deviceId = L"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1532}", .zoneIndexSet = { 3 } } }));
-                const auto expected = AppZoneHistoryData{ .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502903}", .deviceId = L"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1533}", .zoneIndexSet = { 4 } };
-                zoneHistoryArray.Append(AppZoneHistoryJSON::ToJson(AppZoneHistoryJSON{ appPath, expected }));
+                AppZoneHistoryData data1{
+                    .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502900}", .deviceId = L"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1530}", .zoneIndexSet = { 1 }
+                };
+                zoneHistoryArray.Append(AppZoneHistoryJSON::ToJson(AppZoneHistoryJSON{ appPath, std::vector<AppZoneHistoryData>{ data1 } }));
+                AppZoneHistoryData data2{
+                    .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502901}", .deviceId = L"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1531}", .zoneIndexSet = { 2 }
+                };
+                zoneHistoryArray.Append(AppZoneHistoryJSON::ToJson(AppZoneHistoryJSON{ appPath, std::vector<AppZoneHistoryData>{ data2 } }));
+                AppZoneHistoryData data3{
+                    .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502902}", .deviceId = L"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1532}", .zoneIndexSet = { 3 }
+                };
+                zoneHistoryArray.Append(AppZoneHistoryJSON::ToJson(AppZoneHistoryJSON{ appPath, std::vector<AppZoneHistoryData>{ data3 } }));
+                AppZoneHistoryData expected{
+                    .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502903}", .deviceId = L"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1533}", .zoneIndexSet = { 4 }
+                };
+                zoneHistoryArray.Append(AppZoneHistoryJSON::ToJson(AppZoneHistoryJSON{ appPath, std::vector<AppZoneHistoryData>{ expected } }));
                 json.SetNamedValue(L"app-zone-history", json::JsonValue::Parse(zoneHistoryArray.Stringify()));
 
-                FancyZonesData data;
-                data.SetSettingsModulePath(m_moduleName);
-                data.ParseAppZoneHistory(json);
+                FancyZonesData fancyZonesData;
+                fancyZonesData.SetSettingsModulePath(m_moduleName);
+                fancyZonesData.ParseAppZoneHistory(json);
 
-                const auto actualProcessHistoryMap = data.GetAppZoneHistoryMap();
+                const auto& actualProcessHistoryMap = fancyZonesData.GetAppZoneHistoryMap();
                 Assert::AreEqual((size_t)1, actualProcessHistoryMap.size());
 
-                const auto actual = actualProcessHistoryMap.at(appPath);
-                Assert::AreEqual(expected.deviceId.c_str(), actual.deviceId.c_str());
-                Assert::AreEqual(expected.zoneSetUuid.c_str(), actual.zoneSetUuid.c_str());
-                Assert::AreEqual(expected.zoneIndexSet, actual.zoneIndexSet);
+                const auto& actual = actualProcessHistoryMap.at(appPath);
+                Assert::AreEqual((size_t)1, actual.size());
+                Assert::AreEqual(expected.deviceId.c_str(), actual[0].deviceId.c_str());
+                Assert::AreEqual(expected.zoneSetUuid.c_str(), actual[0].zoneSetUuid.c_str());
+                Assert::AreEqual(expected.zoneIndexSet, actual[0].zoneIndexSet);
             }
 
             TEST_METHOD (AppZoneHistoryParseEmpty)
@@ -1250,12 +1330,15 @@ namespace FancyZonesUnitTests
             {
                 const std::wstring appPath = L"appPath";
                 json::JsonObject json;
-                AppZoneHistoryJSON expected{ appPath, AppZoneHistoryData{ .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502906}", .deviceId = L"device-id", .zoneIndexSet = { 54321 } } };
+                AppZoneHistoryData data{
+                    .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502906}", .deviceId = L"device-id", .zoneIndexSet = { 54321 }
+                };
+                AppZoneHistoryJSON expected{ appPath, std::vector<AppZoneHistoryData>{ data } };
                 json.SetNamedValue(L"app-zone-history", json::JsonValue::Parse(AppZoneHistoryJSON::ToJson(expected).Stringify()));
 
-                FancyZonesData data;
-                data.SetSettingsModulePath(m_moduleName);
-                bool actual = data.ParseAppZoneHistory(json);
+                FancyZonesData fancyZonesData;
+                fancyZonesData.SetSettingsModulePath(m_moduleName);
+                bool actual = fancyZonesData.ParseAppZoneHistory(json);
 
                 Assert::IsFalse(actual);
             }
@@ -1264,12 +1347,15 @@ namespace FancyZonesUnitTests
             {
                 const std::wstring appPath = L"appPath";
                 json::JsonObject json;
-                AppZoneHistoryJSON expected{ appPath, AppZoneHistoryData{ .zoneSetUuid = L"zoneset-uuid", .deviceId = L"device-id", .zoneIndexSet = { 54321 } } };
+                AppZoneHistoryData data{
+                    .zoneSetUuid = L"zoneset-uuid", .deviceId = L"device-id", .zoneIndexSet = { 54321 }
+                };
+                AppZoneHistoryJSON expected{ appPath, std::vector<AppZoneHistoryData>{ data } };
                 json.SetNamedValue(L"app-zone-history", json::JsonValue::Parse(AppZoneHistoryJSON::ToJson(expected).Stringify()));
 
-                FancyZonesData data;
-                data.SetSettingsModulePath(m_moduleName);
-                bool actual = data.ParseAppZoneHistory(json);
+                FancyZonesData fancyZonesData;
+                fancyZonesData.SetSettingsModulePath(m_moduleName);
+                bool actual = fancyZonesData.ParseAppZoneHistory(json);
 
                 Assert::IsFalse(actual);
             }
@@ -1278,15 +1364,21 @@ namespace FancyZonesUnitTests
             {
                 const std::wstring appPath = L"appPath";
                 json::JsonArray expected;
-                expected.Append(AppZoneHistoryJSON::ToJson(AppZoneHistoryJSON{ appPath, AppZoneHistoryData{ .zoneSetUuid = L"{39B25DD2-130D-4B5D-8851-4791D66B1539}", .deviceId = m_defaultDeviceId, .zoneIndexSet = { 54321 } } }));
+                AppZoneHistoryData data{
+                    .zoneSetUuid = L"{39B25DD2-130D-4B5D-8851-4791D66B1539}", .deviceId = m_defaultDeviceId, .zoneIndexSet = { 54321 }
+                };
+                AppZoneHistoryJSON appZoneHistory{
+                    appPath, std::vector<AppZoneHistoryData>{ data }
+                };
+                expected.Append(AppZoneHistoryJSON::ToJson(appZoneHistory));
                 json::JsonObject json;
                 json.SetNamedValue(L"app-zone-history", json::JsonValue::Parse(expected.Stringify()));
 
-                FancyZonesData data;
-                data.SetSettingsModulePath(m_moduleName);
-                data.ParseAppZoneHistory(json);
+                FancyZonesData fancyZonesData;
+                fancyZonesData.SetSettingsModulePath(m_moduleName);
+                fancyZonesData.ParseAppZoneHistory(json);
 
-                auto actual = data.SerializeAppZoneHistory();
+                auto actual = fancyZonesData.SerializeAppZoneHistory();
                 compareJsonArrays(expected, actual);
             }
 
@@ -1294,17 +1386,41 @@ namespace FancyZonesUnitTests
             {
                 json::JsonObject json;
                 json::JsonArray expected;
-                expected.Append(AppZoneHistoryJSON::ToJson(AppZoneHistoryJSON{ L"app-path-1", AppZoneHistoryData{ .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502906}", .deviceId = m_defaultDeviceId, .zoneIndexSet = { 54321 } } }));
-                expected.Append(AppZoneHistoryJSON::ToJson(AppZoneHistoryJSON{ L"app-path-2", AppZoneHistoryData{ .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502906}", .deviceId = m_defaultDeviceId, .zoneIndexSet = { 54321 } } }));
-                expected.Append(AppZoneHistoryJSON::ToJson(AppZoneHistoryJSON{ L"app-path-3", AppZoneHistoryData{ .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502906}", .deviceId = m_defaultDeviceId, .zoneIndexSet = { 54321 } } }));
-                expected.Append(AppZoneHistoryJSON::ToJson(AppZoneHistoryJSON{ L"app-path-4", AppZoneHistoryData{ .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502906}", .deviceId = m_defaultDeviceId, .zoneIndexSet = { 54321 } } }));
+                AppZoneHistoryData data1{
+                    .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502906}", .deviceId = m_defaultDeviceId, .zoneIndexSet = { 54321 }
+                };
+                AppZoneHistoryJSON appZoneHistory1{
+                    L"app-path-1", std::vector<AppZoneHistoryData>{ data1 }
+                };
+                AppZoneHistoryData data2{
+                    .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502906}", .deviceId = m_defaultDeviceId, .zoneIndexSet = { 54321 }
+                };
+                AppZoneHistoryJSON appZoneHistory2{
+                    L"app-path-2", std::vector<AppZoneHistoryData>{ data2 }
+                };
+                AppZoneHistoryData data3{
+                    .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502906}", .deviceId = m_defaultDeviceId, .zoneIndexSet = { 54321 }
+                };
+                AppZoneHistoryJSON appZoneHistory3{
+                    L"app-path-3", std::vector<AppZoneHistoryData>{ data3 }
+                };
+                AppZoneHistoryData data4{
+                    .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502906}", .deviceId = m_defaultDeviceId, .zoneIndexSet = { 54321 }
+                };
+                AppZoneHistoryJSON appZoneHistory4{
+                    L"app-path-4", std::vector<AppZoneHistoryData>{ data4 }
+                };
+                expected.Append(AppZoneHistoryJSON::ToJson(appZoneHistory1));
+                expected.Append(AppZoneHistoryJSON::ToJson(appZoneHistory2));
+                expected.Append(AppZoneHistoryJSON::ToJson(appZoneHistory3));
+                expected.Append(AppZoneHistoryJSON::ToJson(appZoneHistory4));
                 json.SetNamedValue(L"app-zone-history", json::JsonValue::Parse(expected.Stringify()));
 
-                FancyZonesData data;
-                data.SetSettingsModulePath(m_moduleName);
-                data.ParseAppZoneHistory(json);
+                FancyZonesData fancyZonesData;
+                fancyZonesData.SetSettingsModulePath(m_moduleName);
+                fancyZonesData.ParseAppZoneHistory(json);
 
-                auto actual = data.SerializeAppZoneHistory();
+                auto actual = fancyZonesData.SerializeAppZoneHistory();
                 compareJsonArrays(expected, actual);
             }
 
@@ -1625,9 +1741,9 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (LoadFancyZonesDataFromJson)
             {
-                FancyZonesData data;
-                data.SetSettingsModulePath(m_moduleName);
-                const auto jsonPath = data.GetPersistFancyZonesJSONPath();
+                FancyZonesData fancyZonesData;
+                fancyZonesData.SetSettingsModulePath(m_moduleName);
+                const auto jsonPath = fancyZonesData.GetPersistFancyZonesJSONPath();
                 auto savedJson = json::from_file(jsonPath);
 
                 if (std::filesystem::exists(jsonPath))
@@ -1642,7 +1758,10 @@ namespace FancyZonesUnitTests
                     .columnsPercents = { 2500, 5000, 2500 },
                     .cellChildMap = { { 0, 1, 2 } } }));
                 CustomZoneSetJSON zoneSets{ L"{33A2B101-06E0-437B-A61E-CDBECF502906}", CustomZoneSetData{ L"name", CustomLayoutType::Grid, grid } };
-                AppZoneHistoryJSON appZoneHistory{ L"app-path", AppZoneHistoryData{ .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502906}", .deviceId = L"device-id", .zoneIndexSet = { 54321 } } };
+                AppZoneHistoryData data{
+                    .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502906}", .deviceId = L"device-id", .zoneIndexSet = { 54321 }
+                };
+                AppZoneHistoryJSON appZoneHistory{ L"app-path", std::vector<AppZoneHistoryData>{ data } };
                 DeviceInfoJSON deviceInfo{ L"{33A2B101-06E0-437B-A61E-CDBECF502906}", DeviceInfoData{ ZoneSetData{ L"uuid", ZoneSetLayoutType::Custom }, true, 16, 3 } };
                 json::JsonArray zoneSetsArray, appZonesArray, deviceInfoArray;
                 zoneSetsArray.Append(CustomZoneSetJSON::ToJson(zoneSets));
@@ -1655,7 +1774,7 @@ namespace FancyZonesUnitTests
 
                 json::to_file(jsonPath, fancyZones);
 
-                data.LoadFancyZonesData();
+                fancyZonesData.LoadFancyZonesData();
                 if (savedJson)
                 {
                     json::to_file(jsonPath, *savedJson);
@@ -1665,9 +1784,9 @@ namespace FancyZonesUnitTests
                     std::filesystem::remove(jsonPath);
                 }
 
-                Assert::IsFalse(data.GetCustomZoneSetsMap().empty());
-                Assert::IsFalse(data.GetCustomZoneSetsMap().empty());
-                Assert::IsFalse(data.GetCustomZoneSetsMap().empty());
+                Assert::IsFalse(fancyZonesData.GetCustomZoneSetsMap().empty());
+                Assert::IsFalse(fancyZonesData.GetCustomZoneSetsMap().empty());
+                Assert::IsFalse(fancyZonesData.GetCustomZoneSetsMap().empty());
             }
 
             TEST_METHOD (LoadFancyZonesDataFromCroppedJson)

--- a/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
@@ -607,10 +607,11 @@ namespace FancyZonesUnitTests
             const auto window = Mocks::WindowCreate(m_hInst);
             m_zoneWindow->MoveWindowIntoZoneByDirection(window, VK_RIGHT, true);
 
-            const auto actualAppZoneHistory = m_fancyZonesData.GetAppZoneHistoryMap();
+            const auto& actualAppZoneHistory = m_fancyZonesData.GetAppZoneHistoryMap();
             Assert::AreEqual((size_t)1, actualAppZoneHistory.size());
-            const auto actual = actualAppZoneHistory.begin()->second;
-            Assert::AreEqual({ 0 }, actual.zoneIndexSet);
+            const auto& appHistoryArray = actualAppZoneHistory.begin()->second;
+            Assert::AreEqual((size_t)1, appHistoryArray.size());
+            Assert::AreEqual({ 0 }, appHistoryArray[0].zoneIndexSet);
         }
 
         TEST_METHOD(MoveWindowIntoZoneByDirectionManyTimes)
@@ -623,10 +624,11 @@ namespace FancyZonesUnitTests
             m_zoneWindow->MoveWindowIntoZoneByDirection(window, VK_RIGHT, true);
             m_zoneWindow->MoveWindowIntoZoneByDirection(window, VK_RIGHT, true);
 
-            const auto actualAppZoneHistory = m_fancyZonesData.GetAppZoneHistoryMap();
+            const auto& actualAppZoneHistory = m_fancyZonesData.GetAppZoneHistoryMap();
             Assert::AreEqual((size_t)1, actualAppZoneHistory.size());
-            const auto actual = actualAppZoneHistory.begin()->second;
-            Assert::AreEqual({ 2 }, actual.zoneIndexSet);
+            const auto& appHistoryArray = actualAppZoneHistory.begin()->second;
+            Assert::AreEqual((size_t)1, appHistoryArray.size());
+            Assert::AreEqual({ 2 }, appHistoryArray[0].zoneIndexSet);
         }
 
         TEST_METHOD(SaveWindowProcessToZoneIndexNoActiveZoneSet)
@@ -676,18 +678,22 @@ namespace FancyZonesUnitTests
             const auto deviceId = m_zoneWindow->UniqueId();
             const auto zoneSetId = m_zoneWindow->ActiveZoneSet()->Id();
 
-            //fill app zone history map
+            // fill app zone history map
             Assert::IsTrue(m_fancyZonesData.SetAppLastZones(window, deviceId, Helpers::GuidToString(zoneSetId), { 0 }));
             Assert::AreEqual((size_t)1, m_fancyZonesData.GetAppZoneHistoryMap().size());
-            Assert::AreEqual({ 0 }, m_fancyZonesData.GetAppZoneHistoryMap().at(processPath).zoneIndexSet);
+            const auto& appHistoryArray1 = m_fancyZonesData.GetAppZoneHistoryMap().at(processPath);
+            Assert::AreEqual((size_t)1, appHistoryArray1.size());
+            Assert::AreEqual({ 0 }, appHistoryArray1[0].zoneIndexSet);
 
-            //add zone without window
+            // add zone without window
             const auto zone = MakeZone(RECT{ 0, 0, 100, 100 });
             m_zoneWindow->ActiveZoneSet()->AddZone(zone);
 
             m_zoneWindow->SaveWindowProcessToZoneIndex(window);
             Assert::AreEqual((size_t)1, m_fancyZonesData.GetAppZoneHistoryMap().size());
-            Assert::AreEqual({ 0 }, m_fancyZonesData.GetAppZoneHistoryMap().at(processPath).zoneIndexSet);
+            const auto& appHistoryArray2 = m_fancyZonesData.GetAppZoneHistoryMap().at(processPath);
+            Assert::AreEqual((size_t)1, appHistoryArray2.size());
+            Assert::AreEqual({ 0 }, appHistoryArray2[0].zoneIndexSet);
         }
 
         TEST_METHOD(SaveWindowProcessToZoneIndexWindowAdded)
@@ -707,18 +713,20 @@ namespace FancyZonesUnitTests
             //fill app zone history map
             Assert::IsTrue(m_fancyZonesData.SetAppLastZones(window, deviceId, Helpers::GuidToString(zoneSetId), { 2 }));
             Assert::AreEqual((size_t)1, m_fancyZonesData.GetAppZoneHistoryMap().size());
-            Assert::AreEqual({ 2 }, m_fancyZonesData.GetAppZoneHistoryMap().at(processPath).zoneIndexSet);
+            const auto& appHistoryArray = m_fancyZonesData.GetAppZoneHistoryMap().at(processPath);
+            Assert::AreEqual((size_t)1, appHistoryArray.size());
+            Assert::AreEqual({ 2 }, appHistoryArray[0].zoneIndexSet);
 
             m_zoneWindow->SaveWindowProcessToZoneIndex(window);
 
-            const auto actualAppZoneHistory = m_fancyZonesData.GetAppZoneHistoryMap();
+            const auto& actualAppZoneHistory = m_fancyZonesData.GetAppZoneHistoryMap();
             Assert::AreEqual((size_t)1, actualAppZoneHistory.size());
-            const auto expected = m_zoneWindow->ActiveZoneSet()->GetZoneIndexSetFromWindow(window);
-            const auto actual = m_fancyZonesData.GetAppZoneHistoryMap().at(processPath).zoneIndexSet;
+            const auto& expected = m_zoneWindow->ActiveZoneSet()->GetZoneIndexSetFromWindow(window);
+            const auto& actual = appHistoryArray[0].zoneIndexSet;
             Assert::AreEqual(expected, actual);
         }
 
-        TEST_METHOD (WhenWindowIsNotResizablePlacingItIntoTheZoneShouldNotResizeIt)
+        TEST_METHOD(WhenWindowIsNotResizablePlacingItIntoTheZoneShouldNotResizeIt)
         {
             m_zoneWindow = InitZoneWindowWithActiveZoneSet();
             Assert::IsNotNull(m_zoneWindow->ActiveZoneSet());


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
1. Add support to save zone history over multiple desktops for single app.
2. After virtual desktop is deleted, remove app zone history as well.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2684 and #2678
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Multiple desktops app zone history:
1. Create more than one desktop and assign some layout to them.
2. Assign two instances of the same application to different desktops.
3. Close those instances.
4. Re-open them again.
5. Check `C:\Users\<user>\AppData\Local\Microsoft\PowerToys\FancyZones` files `app-zone-history.json`.

Expected result: Information about zone history of single application contains information for different desktops, after application is opened, it goes to the different zone based on which desktop it is.

App zone history data of deleted desktop:
1. Create more than one desktop and assign some layout to them.
2. Assign some applications into zones on all desktops.
3. Delete one of them.
4. Check `C:\Users\<user>\AppData\Local\Microsoft\PowerToys\FancyZones` files `app-zone-history.json` and `zones-settings.json`.

Expected result: No data belonging to deleted desktops is found.
