### PR TITLE
[runner] start PT Run with user privileges

### DIFF
--- a/installer/Version.props
+++ b/installer/Version.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <Version>0.18.1</Version>
+    <Version>0.18.2</Version>
     <DefineConstants>Version=$(Version);</DefineConstants>
   </PropertyGroup>
 </Project>

--- a/src/action_runner/action_runner.cpp
+++ b/src/action_runner/action_runner.cpp
@@ -186,26 +186,23 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int)
     }
     std::wstring_view action{ args[1] };
 
-
     if (action == L"-start_PowerLauncher")
     {
-        if (is_process_elevated(false) == true)
-        {
-            drop_elevated_privileges();
-        }
-
         HANDLE hMapFile = OpenFileMappingW(FILE_MAP_WRITE, FALSE, POWER_LAUNCHER_PID_SHARED_FILE);
-        PDWORD pidBuffer = reinterpret_cast<PDWORD>(MapViewOfFile(hMapFile, FILE_MAP_ALL_ACCESS, 0, 0, sizeof(DWORD)));
-        if (pidBuffer)
+        if (hMapFile)
         {
-            *pidBuffer = 0;
-            run_non_elevated(L"modules\\launcher\\PowerLauncher.exe", L"", pidBuffer);
-            FlushViewOfFile(pidBuffer, sizeof(DWORD));
-            UnmapViewOfFile(pidBuffer);
-        }
+            PDWORD pidBuffer = reinterpret_cast<PDWORD>(MapViewOfFile(hMapFile, FILE_MAP_ALL_ACCESS, 0, 0, sizeof(DWORD)));
+            if (pidBuffer)
+            {
+                *pidBuffer = 0;
+                run_same_elevation(L"modules\\launcher\\PowerLauncher.exe", L"", pidBuffer);
+                FlushViewOfFile(pidBuffer, sizeof(DWORD));
+                UnmapViewOfFile(pidBuffer);
+            }
 
-        FlushFileBuffers(hMapFile);
-        CloseHandle(hMapFile);
+            FlushFileBuffers(hMapFile);
+            CloseHandle(hMapFile);
+        }
     }
     else if (action == L"-install_dotnet")
     {

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -72,8 +72,8 @@ bool run_elevated(const std::wstring& file, const std::wstring& params);
 // Run command as non-elevated user, returns true if succeeded, puts the process id into returnPid if returnPid != NULL
 bool run_non_elevated(const std::wstring& file, const std::wstring& params, DWORD* returnPid);
 
-// Run command with the same elevation, returns true if succedded
-bool run_same_elevation(const std::wstring& file, const std::wstring& params);
+// Run command with the same elevation, returns true if succeeded
+bool run_same_elevation(const std::wstring& file, const std::wstring& params, DWORD* returnPid);
 
 // Returns true if the current process is running from administrator account
 bool check_user_is_admin();
@@ -137,4 +137,4 @@ struct overloaded : Ts...
 template<class... Ts>
 overloaded(Ts...)->overloaded<Ts...>;
 
-#define POWER_LAUNCHER_PID_SHARED_FILE L"Global\\3cbfbad4-199b-4e2c-9825-942d5d3d3c74"
+#define POWER_LAUNCHER_PID_SHARED_FILE L"Local\\3cbfbad4-199b-4e2c-9825-942d5d3d3c74"

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/Telemetry/Events/SettingsBootEvent.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/Telemetry/Events/SettingsBootEvent.cs
@@ -14,7 +14,7 @@ namespace Microsoft.PowerLauncher.Telemetry
         /// <summary>
         /// Gets The version string. TODO: This should be replaced by a P/Invoke call to get_product_version
         /// </summary>
-        public string Version => "v0.18.1";
+        public string Version => "v0.18.2";
 
         public double BootTimeMs { get; set; }
 

--- a/src/core/Microsoft.PowerToys.Settings.UI.Runner/Microsoft.PowerToys.Settings.UI.Runner.csproj
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Runner/Microsoft.PowerToys.Settings.UI.Runner.csproj
@@ -14,7 +14,7 @@
     <RepositoryUrl>https://github.com/microsoft/PowerToys</RepositoryUrl>
     <RepositoryType>Github</RepositoryType>
     <PackageTags>PowerToys</PackageTags>
-    <Version>0.15.2.0</Version>
+    <Version>0.18.2.0</Version>
     <Platforms>x64</Platforms>
     <ApplicationIcon>icon.ico</ApplicationIcon>
     <Win32Resource />

--- a/src/core/Microsoft.PowerToys.Settings.UI/Package.appxmanifest
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Package.appxmanifest
@@ -9,7 +9,7 @@
   <Identity
     Name="f4f787a5-f0ae-47a9-be89-5408b1dd2b47"
     Publisher="CN=lamotile"
-    Version="0.15.2.0" />
+    Version="0.18.2.0" />
 
   <mp:PhoneIdentity PhoneProductId="f4f787a5-f0ae-47a9-be89-5408b1dd2b47" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 

--- a/src/modules/launcher/PowerLauncher.Telemetry/Events/LauncherBootEvent.cs
+++ b/src/modules/launcher/PowerLauncher.Telemetry/Events/LauncherBootEvent.cs
@@ -10,7 +10,7 @@ namespace Microsoft.PowerLauncher.Telemetry
         /// <summary>
         /// TODO: This should be replaced by a P/Invoke call to get_product_version
         /// </summary>
-        public string Version => "v0.18.1";
+        public string Version => "v0.18.2";
 
         public double BootTimeMs { get; set; }
 

--- a/src/modules/previewpane/MarkDownPreviewHandler/Telemetry/Events/MarkdownFileHandlerLoaded.cs
+++ b/src/modules/previewpane/MarkDownPreviewHandler/Telemetry/Events/MarkdownFileHandlerLoaded.cs
@@ -17,7 +17,7 @@ namespace MarkdownPreviewHandler.Telemetry.Events
         /// <summary>
         /// Gets The version string. TODO: This should be replaced by a P/Invoke call to get_product_version.
         /// </summary>
-        public string Version => "v0.18.1";
+        public string Version => "v0.18.2";
 
         /// <inheritdoc/>
         public PartA_PrivTags PartA_PrivTags => PartA_PrivTags.ProductAndServiceUsage;

--- a/src/modules/previewpane/SvgPreviewHandler/Telemetry/Events/SvgFileHandlerLoaded.cs
+++ b/src/modules/previewpane/SvgPreviewHandler/Telemetry/Events/SvgFileHandlerLoaded.cs
@@ -17,7 +17,7 @@ namespace SvgPreviewHandler.Telemetry.Events
         /// <summary>
         /// Gets The version string. TODO: This should be replaced by a P/Invoke call to get_product_version.
         /// </summary>
-        public string Version => "v0.18.1";
+        public string Version => "v0.18.2";
 
         /// <inheritdoc/>
         public PartA_PrivTags PartA_PrivTags => PartA_PrivTags.ProductAndServiceUsage;

--- a/src/runner/restart_elevated.cpp
+++ b/src/runner/restart_elevated.cpp
@@ -47,5 +47,5 @@ bool restart_same_elevation()
     constexpr DWORD exe_path_size = 0xFFFF;
     auto exe_path = std::make_unique<wchar_t[]>(exe_path_size);
     GetModuleFileNameW(nullptr, exe_path.get(), exe_path_size);
-    return run_same_elevation(exe_path.get(), L"--dont-elevate");
+    return run_same_elevation(exe_path.get(), L"--dont-elevate", nullptr);
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Hot fix for PowerToy Run to be executed with user privileges when PowerToys is running elevated.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to https://github.com/microsoft/PowerToys/issues/3215 https://github.com/microsoft/PowerToys/issues/3646

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
The previous method to run PT Run with user privileges was dropping the privileges "too much" causing the process to not have access to the user's file.
The current method uses a well know technique to ask Explorer to start a process with the same privileges of Explorer. This methods works fine with C++ and .Net Framework apps, but causes .NET Core app to crash. The workaround is to first start an intermediate C++ app that in turn starts the .NET Core app.
If the user has the UAC turned off, Explorer runs elevated and so it will the intermediate C++ app and in turn also PT Run, but in this scenario it's OK to have PT Run run elevated since it's the user choice to run everything elevated.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Tested manually and verified that the user files are shown in the PT Run search results and that processes started from PT Run are not elevated.