### PR TITLE
Added KeyboardManager directory to runner

### DIFF
--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -142,7 +142,8 @@ int runner(bool isProcessElevated)
             L"FancyZones/",
             L"ImageResizer/",
             L"PowerRename/",
-            L"ShortcutGuide/"
+            L"ShortcutGuide/",
+            L"KeyboardManager/"
         };
 
         for (std::wstring subfolderName : module_folders)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Added missing KeyboardManager folder declaration to runner. Otherwise the dll does not get loaded.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Build in debug locally, open PT Settings and clicked Remap keys/Remap shortcuts.