### PR TITLE
[FancyZones]  Secondary mouse buttons click to toggle zones activation

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -291,7 +291,7 @@
     <value>Make dragged window transparent</value>
   </data>
   <data name="FancyZones_MouseDragCheckBoxControl_Header.Content" xml:space="preserve">
-    <value>Hold a non-primary mouse button to activate zones while dragging</value>
+    <value>Use a non-primary mouse button to toggle zone activation</value>
   </data>
   <data name="FancyZones_MoveWindowsAcrossAllMonitorsCheckBoxControl.Content" xml:space="preserve">
     <value>Move windows between zones across all monitors when snapping with (Win + Arrow)</value>

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -32,7 +32,7 @@ public:
     FancyZones(HINSTANCE hinstance, const winrt::com_ptr<IFancyZonesSettings>& settings) noexcept :
         m_hinstance(hinstance),
         m_settings(settings),
-        m_windowMoveHandler(settings)
+        m_windowMoveHandler(settings, &m_window)
     {
         m_settings->SetCallback(this);
     }

--- a/src/modules/fancyzones/lib/FancyZonesLib.vcxproj
+++ b/src/modules/fancyzones/lib/FancyZonesLib.vcxproj
@@ -104,6 +104,7 @@
     <ClInclude Include="MonitorWorkAreaHandler.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="resource.h" />
+    <ClInclude Include="SecondaryMouseButtonsHook.h" />
     <ClInclude Include="Settings.h" />
     <ClInclude Include="trace.h" />
     <ClInclude Include="util.h" />
@@ -121,6 +122,7 @@
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(CIBuild)'!='true'">Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="SecondaryMouseButtonsHook.cpp" />
     <ClCompile Include="Settings.cpp" />
     <ClCompile Include="trace.cpp" />
     <ClCompile Include="util.cpp" />

--- a/src/modules/fancyzones/lib/FancyZonesLib.vcxproj.filters
+++ b/src/modules/fancyzones/lib/FancyZonesLib.vcxproj.filters
@@ -54,6 +54,9 @@
     <ClInclude Include="FancyZonesWinHookEventIDs.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="SecondaryMouseButtonsHook.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="MonitorWorkAreaHandler.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -93,6 +96,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="FancyZonesWinHookEventIDs.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="SecondaryMouseButtonsHook.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="MonitorWorkAreaHandler.cpp">

--- a/src/modules/fancyzones/lib/SecondaryMouseButtonsHook.cpp
+++ b/src/modules/fancyzones/lib/SecondaryMouseButtonsHook.cpp
@@ -3,29 +3,29 @@
 
 #pragma region public
 
-HHOOK SecondaryMouseButtonsHook::m_hHook = {};
+HHOOK SecondaryMouseButtonsHook::hHook = {};
 std::function<void()> SecondaryMouseButtonsHook::callback = {};
 
 SecondaryMouseButtonsHook::SecondaryMouseButtonsHook(std::function<void()> extCallback)
 {
     callback = std::move(extCallback);
-    m_hHook = SetWindowsHookEx(WH_MOUSE_LL, SecondaryMouseButtonsProc, GetModuleHandle(NULL), 0);
+    hHook = SetWindowsHookEx(WH_MOUSE_LL, SecondaryMouseButtonsProc, GetModuleHandle(NULL), 0);
 }
 
 void SecondaryMouseButtonsHook::enable()
 {
-    if (!m_hHook)
+    if (!hHook)
     {
-        m_hHook = SetWindowsHookEx(WH_MOUSE_LL, SecondaryMouseButtonsProc, GetModuleHandle(NULL), 0);
+        hHook = SetWindowsHookEx(WH_MOUSE_LL, SecondaryMouseButtonsProc, GetModuleHandle(NULL), 0);
     }
 }
 
 void SecondaryMouseButtonsHook::disable()
 {
-    if (m_hHook)
+    if (hHook)
     {
-        UnhookWindowsHookEx(m_hHook);
-        m_hHook = NULL;
+        UnhookWindowsHookEx(hHook);
+        hHook = NULL;
     }
 }
 
@@ -42,7 +42,7 @@ LRESULT CALLBACK SecondaryMouseButtonsHook::SecondaryMouseButtonsProc(int nCode,
             callback();
         }
     }
-    return CallNextHookEx(m_hHook, nCode, wParam, lParam);
+    return CallNextHookEx(hHook, nCode, wParam, lParam);
 }
 
 #pragma endregion

--- a/src/modules/fancyzones/lib/SecondaryMouseButtonsHook.cpp
+++ b/src/modules/fancyzones/lib/SecondaryMouseButtonsHook.cpp
@@ -1,0 +1,48 @@
+#include "pch.h"
+#include "SecondaryMouseButtonsHook.h"
+
+#pragma region public
+
+HHOOK SecondaryMouseButtonsHook::m_hHook = {};
+std::function<void()> SecondaryMouseButtonsHook::callback = {};
+
+SecondaryMouseButtonsHook::SecondaryMouseButtonsHook(std::function<void()> extCallback)
+{
+    callback = std::move(extCallback);
+    m_hHook = SetWindowsHookEx(WH_MOUSE_LL, SecondaryMouseButtonsProc, GetModuleHandle(NULL), 0);
+}
+
+void SecondaryMouseButtonsHook::enable()
+{
+    if (!m_hHook)
+    {
+        m_hHook = SetWindowsHookEx(WH_MOUSE_LL, SecondaryMouseButtonsProc, GetModuleHandle(NULL), 0);
+    }
+}
+
+void SecondaryMouseButtonsHook::disable()
+{
+    if (m_hHook)
+    {
+        UnhookWindowsHookEx(m_hHook);
+        m_hHook = NULL;
+    }
+}
+
+#pragma endregion
+
+#pragma region private
+
+LRESULT CALLBACK SecondaryMouseButtonsHook::SecondaryMouseButtonsProc(int nCode, WPARAM wParam, LPARAM lParam)
+{
+    if (nCode == HC_ACTION)
+    {
+        if (wParam == (GetSystemMetrics(SM_SWAPBUTTON) ? WM_LBUTTONDOWN : WM_RBUTTONDOWN) || wParam == WM_MBUTTONDOWN || wParam == WM_XBUTTONDOWN)
+        {
+            callback();
+        }
+    }
+    return CallNextHookEx(m_hHook, nCode, wParam, lParam);
+}
+
+#pragma endregion

--- a/src/modules/fancyzones/lib/SecondaryMouseButtonsHook.h
+++ b/src/modules/fancyzones/lib/SecondaryMouseButtonsHook.h
@@ -10,7 +10,7 @@ public:
     void disable();
 
 private:
-    static HHOOK m_hHook;
+    static HHOOK hHook;
     static std::function<void()> callback;
     static LRESULT CALLBACK SecondaryMouseButtonsProc(int, WPARAM, LPARAM);
 };

--- a/src/modules/fancyzones/lib/SecondaryMouseButtonsHook.h
+++ b/src/modules/fancyzones/lib/SecondaryMouseButtonsHook.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <functional>
+
+class SecondaryMouseButtonsHook
+{
+public:
+    SecondaryMouseButtonsHook(std::function<void()>);
+    void enable();
+    void disable();
+
+private:
+    static HHOOK m_hHook;
+    static std::function<void()> callback;
+    static LRESULT CALLBACK SecondaryMouseButtonsProc(int, WPARAM, LPARAM);
+};

--- a/src/modules/fancyzones/lib/WindowMoveHandler.cpp
+++ b/src/modules/fancyzones/lib/WindowMoveHandler.cpp
@@ -148,9 +148,13 @@ void WindowMoveHandlerPrivate::MoveSizeStart(HWND window, HMONITOR monitor, POIN
 
     m_windowMoveSize = window;
 
+    if (m_settings->GetSettings()->mouseSwitch)
+    {
+        m_secondaryHook->enable();
+    }
+
     // This updates m_dragEnabled depending on if the shift key is being held down.
     UpdateDragState(window);
-    m_secondaryHook->enable();
 
     if (m_dragEnabled)
     {
@@ -321,11 +325,11 @@ void WindowMoveHandlerPrivate::UpdateDragState(HWND window) noexcept
 
     if (m_settings->GetSettings()->shiftDrag)
     {
-        m_dragEnabled = (shift | m_secondaryMouseButtonState);
+        m_dragEnabled = (shift ^ m_secondaryMouseButtonState);
     }
     else
     {
-        m_dragEnabled = !(shift | m_secondaryMouseButtonState);
+        m_dragEnabled = !(shift ^ m_secondaryMouseButtonState);
     }
 
     static bool warning_shown = false;

--- a/src/modules/fancyzones/lib/WindowMoveHandler.cpp
+++ b/src/modules/fancyzones/lib/WindowMoveHandler.cpp
@@ -256,7 +256,7 @@ void WindowMoveHandlerPrivate::MoveSizeEnd(HWND window, POINT const& ptScreen, c
 
     m_inMoveSize = false;
     m_dragEnabled = false;
-    m_dragEnabled = false;
+    m_secondaryMouseButtonState = false;
     m_windowMoveSize = nullptr;
     if (m_zoneWindowMoveSize)
     {

--- a/src/modules/fancyzones/lib/WindowMoveHandler.cpp
+++ b/src/modules/fancyzones/lib/WindowMoveHandler.cpp
@@ -10,7 +10,6 @@
 #include "lib/util.h"
 #include "VirtualDesktopUtils.h"
 #include "lib/SecondaryMouseButtonsHook.h"
-#include <lib/FancyZonesWinHookEventIDs.h>
 
 extern "C" IMAGE_DOS_HEADER __ImageBase;
 

--- a/src/modules/fancyzones/lib/WindowMoveHandler.cpp
+++ b/src/modules/fancyzones/lib/WindowMoveHandler.cpp
@@ -165,7 +165,7 @@ void WindowMoveHandlerPrivate::MoveSizeStart(HWND window, HMONITOR monitor, POIN
     if (m_dragEnabled)
     {
         m_zoneWindowMoveSize = iter->second;
-        m_zoneWindowMoveSize->MoveSizeEnter(window, m_dragEnabled);
+        m_zoneWindowMoveSize->MoveSizeEnter(window);
         if (m_settings->GetSettings()->showZonesOnAllMonitors)
         {
             for (auto [keyMonitor, zoneWindow] : zoneWindowMap)
@@ -236,7 +236,7 @@ void WindowMoveHandlerPrivate::MoveSizeUpdate(HMONITOR monitor, POINT const& ptS
                         m_zoneWindowMoveSize->HideZoneWindow();
                     }
                     m_zoneWindowMoveSize = iter->second;
-                    m_zoneWindowMoveSize->MoveSizeEnter(m_windowMoveSize, m_zoneWindowMoveSize->IsDragEnabled());
+                    m_zoneWindowMoveSize->MoveSizeEnter(m_windowMoveSize);
                 }
 
                 for (auto [keyMonitor, zoneWindow] : zoneWindowMap)

--- a/src/modules/fancyzones/lib/WindowMoveHandler.h
+++ b/src/modules/fancyzones/lib/WindowMoveHandler.h
@@ -6,7 +6,7 @@ interface IZoneWindow;
 class WindowMoveHandler
 {
 public:
-    WindowMoveHandler(const winrt::com_ptr<IFancyZonesSettings>& settings);
+    WindowMoveHandler(const winrt::com_ptr<IFancyZonesSettings>& settings, HWND* fancyZonesWindow);
     ~WindowMoveHandler();
 
     bool InMoveSize() const noexcept;

--- a/src/modules/fancyzones/lib/WindowMoveHandler.h
+++ b/src/modules/fancyzones/lib/WindowMoveHandler.h
@@ -2,15 +2,18 @@
 
 interface IFancyZonesSettings;
 interface IZoneWindow;
+interface SecondaryMouseButtonsHook;
 
 class WindowMoveHandler
 {
 public:
-    WindowMoveHandler(const winrt::com_ptr<IFancyZonesSettings>& settings, HWND* fancyZonesWindow);
+    WindowMoveHandler(const winrt::com_ptr<IFancyZonesSettings>& settings, SecondaryMouseButtonsHook* mouseHook);
     ~WindowMoveHandler();
 
     bool InMoveSize() const noexcept;
     bool IsDragEnabled() const noexcept;
+
+    void OnMouseDown() noexcept;
 
     void MoveSizeStart(HWND window, HMONITOR monitor, POINT const& ptScreen, const std::unordered_map<HMONITOR, winrt::com_ptr<IZoneWindow>>& zoneWindowMap) noexcept;
     void MoveSizeUpdate(HMONITOR monitor, POINT const& ptScreen, const std::unordered_map<HMONITOR, winrt::com_ptr<IZoneWindow>>& zoneWindowMap) noexcept;

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -206,13 +206,11 @@ public:
 
     bool Init(IZoneWindowHost* host, HINSTANCE hinstance, HMONITOR monitor, const std::wstring& uniqueId, const std::wstring& parentUniqueId, bool flashZones);
 
-    IFACEMETHODIMP MoveSizeEnter(HWND window, bool dragEnabled) noexcept;
+    IFACEMETHODIMP MoveSizeEnter(HWND window) noexcept;
     IFACEMETHODIMP MoveSizeUpdate(POINT const& ptScreen, bool dragEnabled) noexcept;
     IFACEMETHODIMP MoveSizeEnd(HWND window, POINT const& ptScreen) noexcept;
     IFACEMETHODIMP_(void)
     RestoreOriginalTransparency() noexcept;
-    IFACEMETHODIMP_(bool)
-    IsDragEnabled() noexcept { return m_dragEnabled; }
     IFACEMETHODIMP_(void)
     MoveWindowIntoZoneByIndex(HWND window, int index) noexcept;
     IFACEMETHODIMP_(void)
@@ -258,7 +256,6 @@ private:
     HWND m_windowMoveSize{};
     bool m_drawHints{};
     bool m_flashMode{};
-    bool m_dragEnabled{};
     winrt::com_ptr<IZoneSet> m_activeZoneSet;
     std::vector<winrt::com_ptr<IZoneSet>> m_zoneSets;
     std::vector<int> m_highlightZone;
@@ -342,7 +339,7 @@ bool ZoneWindow::Init(IZoneWindowHost* host, HINSTANCE hinstance, HMONITOR monit
     return true;
 }
 
-IFACEMETHODIMP ZoneWindow::MoveSizeEnter(HWND window, bool dragEnabled) noexcept
+IFACEMETHODIMP ZoneWindow::MoveSizeEnter(HWND window) noexcept
 {
     if (m_windowMoveSize)
     {
@@ -363,7 +360,6 @@ IFACEMETHODIMP ZoneWindow::MoveSizeEnter(HWND window, bool dragEnabled) noexcept
         SetLayeredWindowAttributes(window, 0, (255 * 50) / 100, LWA_ALPHA);
     }
 
-    m_dragEnabled = dragEnabled;
     m_windowMoveSize = window;
     m_drawHints = true;
     m_highlightZone = {};
@@ -376,8 +372,6 @@ IFACEMETHODIMP ZoneWindow::MoveSizeUpdate(POINT const& ptScreen, bool dragEnable
     bool redraw = false;
     POINT ptClient = ptScreen;
     MapWindowPoints(nullptr, m_window.get(), &ptClient, 1);
-
-    m_dragEnabled = dragEnabled;
 
     if (dragEnabled)
     {

--- a/src/modules/fancyzones/lib/ZoneWindow.h
+++ b/src/modules/fancyzones/lib/ZoneWindow.h
@@ -24,7 +24,7 @@ interface __declspec(uuid("{7F017528-8110-4FB3-BE41-F472969C2560}")) IZoneWindow
      * @param   dragEnabled Boolean indicating is giving hints about active zone layout enabled.
      *                      Hints are given while dragging window while holding SHIFT key.
      */
-    IFACEMETHOD(MoveSizeEnter)(HWND window, bool dragEnabled) = 0;
+    IFACEMETHOD(MoveSizeEnter)(HWND window) = 0;
     /**
      * A window has changed location, shape, or size. Track down window position and give zone layout
      * hints if dragging functionality is enabled.
@@ -42,11 +42,6 @@ interface __declspec(uuid("{7F017528-8110-4FB3-BE41-F472969C2560}")) IZoneWindow
      * @param ptScreen Cursor coordinates where window is dropped.
      */
     IFACEMETHOD(MoveSizeEnd)(HWND window, POINT const& ptScreen) = 0;
-    /**
-     * @returns Boolean indicating is giving hints about active zone layout enabled. Hints are
-     *          given while dragging window while holding SHIFT key.
-     */
-    IFACEMETHOD_(bool, IsDragEnabled)() = 0;
     /**
      * Assign window to the zone based on zone index inside zone layout.
      *

--- a/src/modules/fancyzones/lib/fancyzones.rc
+++ b/src/modules/fancyzones/lib/fancyzones.rc
@@ -7,7 +7,7 @@ STRINGTABLE
 BEGIN
     IDS_SETTING_DESCRIPTION                                    "Create window layouts to help make multi-tasking easy"
     IDS_SETTING_DESCRIPTION_SHIFTDRAG                          "Hold Shift key to activate zones while dragging"
-    IDS_SETTING_DESCRIPTION_MOUSESWITCH                        "Hold a non-primary mouse button to activate zones while dragging"
+    IDS_SETTING_DESCRIPTION_MOUSESWITCH                        "Use a non-primary mouse button to toggle zone activation"
     IDS_SETTING_DESCRIPTION_OVERRIDE_SNAP_HOTKEYS              "Override Windows Snap hotkeys (Win + Arrow) to move windows between zones"
     IDS_SETTING_DESCRIPTION_MOVE_WINDOW_ACROSS_MONITORS        "Move windows between zones across all monitors when snapping with (Win + Arrow)"
     IDS_SETTING_DESCRIPTION_DISPLAYCHANGE_MOVEWINDOWS          "Keep windows in their zones when the screen resolution changes"

--- a/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
@@ -129,7 +129,6 @@ namespace FancyZonesUnitTests
             const std::wstring expectedWorkArea = std::to_wstring(m_monitorInfo.rcMonitor.right) + L"_" + std::to_wstring(m_monitorInfo.rcMonitor.bottom);
 
             Assert::IsNotNull(zoneWindow.get());
-            Assert::IsFalse(zoneWindow->IsDragEnabled());
             Assert::AreEqual(m_uniqueId.str().c_str(), zoneWindow->UniqueId().c_str());
             Assert::AreEqual(expectedWorkArea, zoneWindow->WorkAreaKey());
         }
@@ -184,7 +183,6 @@ namespace FancyZonesUnitTests
             const std::wstring expectedUniqueId = L"FallbackDevice_" + std::to_wstring(m_monitorInfo.rcMonitor.right) + L"_" + std::to_wstring(m_monitorInfo.rcMonitor.bottom) + L"_" + m_virtualDesktopId;
 
             Assert::IsNotNull(m_zoneWindow.get());
-            Assert::IsFalse(m_zoneWindow->IsDragEnabled());
             Assert::AreEqual(expectedUniqueId.c_str(), m_zoneWindow->UniqueId().c_str());
             Assert::AreEqual(expectedWorkArea, m_zoneWindow->WorkAreaKey());
             Assert::IsNull(m_zoneWindow->ActiveZoneSet());
@@ -198,7 +196,6 @@ namespace FancyZonesUnitTests
 
             const std::wstring expectedWorkArea = std::to_wstring(m_monitorInfo.rcMonitor.right) + L"_" + std::to_wstring(m_monitorInfo.rcMonitor.bottom);
             Assert::IsNotNull(m_zoneWindow.get());
-            Assert::IsFalse(m_zoneWindow->IsDragEnabled());
             Assert::IsTrue(m_zoneWindow->UniqueId().empty());
             Assert::IsNull(m_zoneWindow->ActiveZoneSet());
             Assert::IsNull(m_zoneWindow->ActiveZoneSet());
@@ -448,10 +445,9 @@ namespace FancyZonesUnitTests
             m_zoneWindow = MakeZoneWindow(m_hostPtr, m_hInst, m_monitor, m_uniqueId.str(), {}, false);
 
             const auto expected = S_OK;
-            const auto actual = m_zoneWindow->MoveSizeEnter(Mocks::Window(), true);
+            const auto actual = m_zoneWindow->MoveSizeEnter(Mocks::Window());
 
             Assert::AreEqual(expected, actual);
-            Assert::IsTrue(m_zoneWindow->IsDragEnabled());
         }
 
         TEST_METHOD(MoveSizeEnterTwice)
@@ -460,11 +456,10 @@ namespace FancyZonesUnitTests
 
             const auto expected = E_INVALIDARG;
 
-            m_zoneWindow->MoveSizeEnter(Mocks::Window(), true);
-            const auto actual = m_zoneWindow->MoveSizeEnter(Mocks::Window(), false);
+            m_zoneWindow->MoveSizeEnter(Mocks::Window());
+            const auto actual = m_zoneWindow->MoveSizeEnter(Mocks::Window());
 
             Assert::AreEqual(expected, actual);
-            Assert::IsTrue(m_zoneWindow->IsDragEnabled());
         }
 
         TEST_METHOD(MoveSizeUpdate)
@@ -475,7 +470,6 @@ namespace FancyZonesUnitTests
             const auto actual = m_zoneWindow->MoveSizeUpdate(POINT{ 0, 0 }, true);
 
             Assert::AreEqual(expected, actual);
-            Assert::IsTrue(m_zoneWindow->IsDragEnabled());
         }
 
         TEST_METHOD(MoveSizeUpdatePointNegativeCoordinates)
@@ -486,7 +480,6 @@ namespace FancyZonesUnitTests
             const auto actual = m_zoneWindow->MoveSizeUpdate(POINT{ -10, -10 }, true);
 
             Assert::AreEqual(expected, actual);
-            Assert::IsTrue(m_zoneWindow->IsDragEnabled());
         }
 
         TEST_METHOD(MoveSizeUpdatePointBigCoordinates)
@@ -497,7 +490,6 @@ namespace FancyZonesUnitTests
             const auto actual = m_zoneWindow->MoveSizeUpdate(POINT{ m_monitorInfo.rcMonitor.right + 1, m_monitorInfo.rcMonitor.bottom + 1 }, true);
 
             Assert::AreEqual(expected, actual);
-            Assert::IsTrue(m_zoneWindow->IsDragEnabled());
         }
 
         TEST_METHOD(MoveSizeEnd)
@@ -505,7 +497,7 @@ namespace FancyZonesUnitTests
             auto zoneWindow = InitZoneWindowWithActiveZoneSet();
 
             const auto window = Mocks::Window();
-            zoneWindow->MoveSizeEnter(window, true);
+            zoneWindow->MoveSizeEnter(window);
 
             const auto expected = S_OK;
             const auto actual = zoneWindow->MoveSizeEnd(window, POINT{ 0, 0 });
@@ -522,7 +514,7 @@ namespace FancyZonesUnitTests
             auto zoneWindow = InitZoneWindowWithActiveZoneSet();
 
             const auto window = Mocks::Window();
-            zoneWindow->MoveSizeEnter(window, true);
+            zoneWindow->MoveSizeEnter(window);
 
             const auto expected = S_OK;
             const auto actual = zoneWindow->MoveSizeEnd(window, POINT{ -100, -100 });
@@ -538,7 +530,7 @@ namespace FancyZonesUnitTests
             m_zoneWindow = MakeZoneWindow(m_hostPtr, m_hInst, m_monitor, m_uniqueId.str(), {}, false);
 
             const auto window = Mocks::Window();
-            m_zoneWindow->MoveSizeEnter(window, true);
+            m_zoneWindow->MoveSizeEnter(window);
 
             const auto expected = E_INVALIDARG;
             const auto actual = m_zoneWindow->MoveSizeEnd(Mocks::Window(), POINT{ 0, 0 });
@@ -561,7 +553,7 @@ namespace FancyZonesUnitTests
             auto zoneWindow = InitZoneWindowWithActiveZoneSet();
 
             const auto window = Mocks::Window();
-            zoneWindow->MoveSizeEnter(window, true);
+            zoneWindow->MoveSizeEnter(window);
 
             const auto expected = S_OK;
             const auto actual = zoneWindow->MoveSizeEnd(window, POINT{ -1, -1 });


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Changed behaviour for secondary mouse buttons from hold to switch.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2136 https://github.com/microsoft/PowerToys/issues/1529
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manually tested. Activated/deactivated zones by click when moving different windows.
