### PR TITLE
Fix for UWP icons not showing up

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/UWP.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/UWP.cs
@@ -542,6 +542,9 @@ namespace Microsoft.Plugin.Program.Programs
                     var prefix = path.Substring(0, end);
                     var paths = new List<string> { path };
 
+                    //To be set along with the WPF theme, to either light or dark mode, ie: contract-white or contrast-black.
+                    var theme = "contrast-black";
+
                     var scaleFactors = new Dictionary<PackageVersion, List<int>>
                     {
                         // scale factors on win10: https://docs.microsoft.com/en-us/windows/uwp/controls-and-patterns/tiles-and-notifications-app-assets#asset-size-tables,
@@ -555,6 +558,8 @@ namespace Microsoft.Plugin.Program.Programs
                         foreach (var factor in scaleFactors[Package.Version])
                         {
                             paths.Add($"{prefix}.scale-{factor}{extension}");
+                            paths.Add($"{prefix}.scale-{factor}_{theme}{extension}");
+                            paths.Add($"{prefix}.{theme}_scale-{factor}{extension}");
                         }
                     }
 
@@ -565,9 +570,26 @@ namespace Microsoft.Plugin.Program.Programs
                     }
                     else
                     {
-                        ProgramLogger.LogException($"|UWP|LogoPathFromUri|{Package.Location}" +
-                                                    $"|{UserModelId} can't find logo uri for {uri} in package location: {Package.Location}", new FileNotFoundException());
-                        return string.Empty;
+                        var targetSizes = new List<int>{ 16, 24, 30, 36, 40, 44, 60, 72, 96, 256 };
+
+                        foreach (var factor in targetSizes)
+                        {
+                            paths.Add($"{prefix}.targetsize-{factor}{extension}");
+                            paths.Add($"{prefix}.targetsize-{factor}_{theme}{extension}");
+                            paths.Add($"{prefix}.{theme}_targetsize-{factor}{extension}");
+                        }
+
+                        var selectedIconPath = paths.FirstOrDefault(File.Exists);
+                        if (!string.IsNullOrEmpty(selectedIconPath))
+                        {
+                            return selectedIconPath;
+                        }
+                        else
+                        {
+                            ProgramLogger.LogException($"|UWP|LogoPathFromUri|{Package.Location}" +
+                                $"|{UserModelId} can't find logo uri for {uri} in package location: {Package.Location}", new FileNotFoundException());
+                            return string.Empty;
+                        }
                     }
                 }
                 else

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/UWP.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/UWP.cs
@@ -21,6 +21,7 @@ using System.Windows.Input;
 using System.Runtime.InteropServices.ComTypes;
 using Wox.Plugin.SharedCommands;
 using System.Reflection;
+using NLog.Targets;
 
 namespace Microsoft.Plugin.Program.Programs
 {
@@ -571,16 +572,26 @@ namespace Microsoft.Plugin.Program.Programs
                     }
                     else
                     {
-                        var targetSizes = new List<int>{256 , 180, 128, 96, 72, 60, 44, 40, 36, 30, 24, 16};
+                        int appIconSize = 36;
+                        var targetSizes = new List<int>{16, 24, 30, 36, 44, 60, 72, 96, 128, 180, 256}.AsParallel();
+                        Dictionary<string, int> pathFactorPairs = new Dictionary<string, int>();
 
                         foreach (var factor in targetSizes)
                         {
-                            paths.Add($"{prefix}.targetsize-{factor}{extension}");
-                            paths.Add($"{prefix}.targetsize-{factor}_{theme}{extension}");
-                            paths.Add($"{prefix}.{theme}_targetsize-{factor}{extension}");
+                            string simplePath = $"{prefix}.targetsize-{factor}{extension}";
+                            string suffixThemePath = $"{prefix}.targetsize-{factor}_{theme}{extension}";
+                            string prefixThemePath = $"{prefix}.{theme}_targetsize-{factor}{extension}";
+
+                            paths.Add(simplePath);
+                            paths.Add(suffixThemePath);
+                            paths.Add(prefixThemePath);
+
+                            pathFactorPairs.Add(simplePath, factor);
+                            pathFactorPairs.Add(suffixThemePath, factor);
+                            pathFactorPairs.Add(prefixThemePath, factor);
                         }
 
-                        var selectedIconPath = paths.FirstOrDefault(File.Exists);
+                        var selectedIconPath = paths.OrderBy(x => Math.Abs(pathFactorPairs.GetValueOrDefault(x) - appIconSize)).FirstOrDefault(File.Exists);
                         if (!string.IsNullOrEmpty(selectedIconPath))
                         {
                             return selectedIconPath;
@@ -601,7 +612,6 @@ namespace Microsoft.Plugin.Program.Programs
                     return string.Empty;
                 }
             }
-
 
             public ImageSource Logo()
             {

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/UWP.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/UWP.cs
@@ -21,7 +21,6 @@ using System.Windows.Input;
 using System.Runtime.InteropServices.ComTypes;
 using Wox.Plugin.SharedCommands;
 using System.Reflection;
-using NLog.Targets;
 
 namespace Microsoft.Plugin.Program.Programs
 {

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/UWP.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/UWP.cs
@@ -542,7 +542,8 @@ namespace Microsoft.Plugin.Program.Programs
                     var prefix = path.Substring(0, end);
                     var paths = new List<string> { path };
 
-                    //To be set along with the WPF theme, to either light or dark mode, ie: contract-white or contrast-black.
+                    // TODO: This value must be set in accordance to the WPF theme (work in progress).
+                    // Must be set to `contrast-white` for light theme and to `contrast-black` for dark theme to get an icon of the contrasting color.
                     var theme = "contrast-black";
 
                     var scaleFactors = new Dictionary<PackageVersion, List<int>>
@@ -570,7 +571,7 @@ namespace Microsoft.Plugin.Program.Programs
                     }
                     else
                     {
-                        var targetSizes = new List<int>{ 16, 24, 30, 36, 40, 44, 60, 72, 96, 256 };
+                        var targetSizes = new List<int>{256 , 180, 128, 96, 72, 60, 44, 40, 36, 30, 24, 16};
 
                         foreach (var factor in targetSizes)
                         {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Some of the applications did not have an icon such as calculator, snip & sketch and windows security.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
theme and Target size Ref - https://docs.microsoft.com/en-us/windows/uwp/app-resources/images-tailored-for-scale-theme-contrast#asset-size-tables

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #3541
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
* We were previously checking only the paths with scale factor. Some of the UWP applications such as calculator did not have it in that format, rather the path either had `theme` or `targetsize` included.
* Therefore, included paths with contrast and targetsize as well. 

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Windows Security - 
![image](https://user-images.githubusercontent.com/28739210/83582950-d1aee980-a4f7-11ea-9bf7-6666cfc89e76.png)

Calculator - 
![image](https://user-images.githubusercontent.com/28739210/83582960-d96e8e00-a4f7-11ea-82aa-cc3716e86060.png)

Snip & Sketch - 
![image](https://user-images.githubusercontent.com/28739210/83582962-db385180-a4f7-11ea-9a4d-f0fe06f868b0.png)
