### PR TITLE
Fix for PWAs and command prompt not showing up as the first result

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/ShellLinkHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/ShellLinkHelper.cs
@@ -102,6 +102,8 @@ namespace Microsoft.Plugin.Program.Programs
         // To initialize the app description
         public String description = String.Empty;
 
+        // Sets to true if the program takes in arguments
+        public bool hasArguments = false;
 
         // Retrieve the target path using Shell Link
         public string retrieveTargetPath(string path)
@@ -125,6 +127,15 @@ namespace Microsoft.Plugin.Program.Programs
                 buffer = new StringBuilder(MAX_PATH);
                 ((IShellLinkW)link).GetDescription(buffer, MAX_PATH);
                 description = buffer.ToString();
+
+                StringBuilder argumentBuffer = new StringBuilder(MAX_PATH);
+                ((IShellLinkW)link).GetArguments(argumentBuffer, argumentBuffer.Capacity);
+
+                // Set variable to true if the program takes in any arguments
+                if (argumentBuffer.Length != 0)
+                {
+                    hasArguments = true;
+                }
             }
             return target;
         }

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32.cs
@@ -57,7 +57,8 @@ namespace Microsoft.Plugin.Program.Programs
 
             if(!hasArguments)
             {
-                score += 5;
+                var noArgumentScoreModifier = 5;
+                score += noArgumentScoreModifier;
             }
 
             var result = new Result

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Plugin.Program.Programs
         public string Description { get; set; }
         public bool Valid { get; set; }
         public bool Enabled { get; set; }
+        public bool hasArguments { get; set; } = false;
         public string Location => ParentDirectory;
 
         private const string ShortcutExtension = "lnk";
@@ -52,6 +53,11 @@ namespace Microsoft.Plugin.Program.Programs
             if (score <= 0)
             { // no need to create result if this is zero
                 return null;
+            }
+
+            if(!hasArguments)
+            {
+                score += 5;
             }
 
             var result = new Result
@@ -191,6 +197,7 @@ namespace Microsoft.Plugin.Program.Programs
                         program.LnkResolvedPath = program.FullPath;
                         program.FullPath = Path.GetFullPath(target).ToLower();
                         program.ExecutableName = Path.GetFileName(target);
+                        program.hasArguments = _helper.hasArguments;
 
                         var description = _helper.description;
                         if (!string.IsNullOrEmpty(description))


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
* Applications which take in no arguments should show up before others.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #3461, #3459 
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
* Applications which take in no arguments are scored higher than the others.
* The IShellLink interface is used to extract the arguments that the object takes and if an application does not take any arguments, it's score is increased by 5.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
* Solves the ranking of PWAs issue -
![image](https://user-images.githubusercontent.com/28739210/83659864-f4351700-a578-11ea-9d14-27b1e31c13bc.png)

* Solves the command prompt issue - 
![image](https://user-images.githubusercontent.com/28739210/83659881-f8613480-a578-11ea-8fc0-c4f82418f054.png)

