### PR TITLE
[FancyZones] Cleanup unused command line arguments pased to FancyZonesEditor

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/App.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/App.xaml.cs
@@ -2,7 +2,6 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Windows;
 using FancyZonesEditor.Models;
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/Settings.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/Settings.cs
@@ -21,9 +21,7 @@ namespace FancyZonesEditor
     {
         private enum CmdArgs
         {
-            MonitorHandle = 1,
-            X_Y_Width_Height,
-            ResolutionKey,
+            X_Y_Width_Height = 1,
             ActiveZoneSetTmpFile,
             AppliedZoneSetTmpFile,
             CustomZoneSetsTmpFile,
@@ -217,8 +215,6 @@ namespace FancyZonesEditor
 
         public static Rect WorkArea { get; private set; }
 
-        public static uint Monitor { get; private set; }
-
         public static string UniqueKey { get; private set; }
 
         public static string ActiveZoneSetUUid { get; private set; }
@@ -245,8 +241,6 @@ namespace FancyZonesEditor
         }
 
         private static string _customZoneSetsTmpFile;
-
-        public static string WorkAreaKey { get; private set; }
 
         // UpdateLayoutModels
         // Update the five default layouts based on the new ZoneCount
@@ -414,16 +408,10 @@ namespace FancyZonesEditor
         private void ParseCommandLineArgs()
         {
             WorkArea = SystemParameters.WorkArea;
-            Monitor = 0;
 
             string[] args = Environment.GetCommandLineArgs();
-            if (args.Length == 7)
+            if (args.Length == 5)
             {
-                if (uint.TryParse(args[(int)CmdArgs.MonitorHandle], out uint monitor))
-                {
-                    Monitor = monitor;
-                }
-
                 var parsedLocation = args[(int)CmdArgs.X_Y_Width_Height].Split('_');
                 var x = int.Parse(parsedLocation[0]);
                 var y = int.Parse(parsedLocation[1]);
@@ -431,8 +419,6 @@ namespace FancyZonesEditor
                 var height = int.Parse(parsedLocation[3]);
 
                 WorkArea = new Rect(x, y, width, height);
-
-                WorkAreaKey = args[(int)CmdArgs.ResolutionKey];
 
                 _activeZoneSetTmpFile = args[(int)CmdArgs.ActiveZoneSetTmpFile];
                 _appliedZoneSetTmpFile = args[(int)CmdArgs.AppliedZoneSetTmpFile];

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -445,9 +445,6 @@ void FancyZones::ToggleEditor() noexcept
                       } })
         .wait();
 
-    const auto& fancyZonesData = JSONHelpers::FancyZonesDataInstance();
-    fancyZonesData.CustomZoneSetsToJsonFile(ZoneWindowUtils::GetCustomZoneSetsTmpPath());
-
     const auto taskbar_x_offset = mi.rcWork.left - mi.rcMonitor.left;
     const auto taskbar_y_offset = mi.rcWork.top - mi.rcMonitor.top;
     const auto x = mi.rcMonitor.left + taskbar_x_offset;
@@ -460,6 +457,9 @@ void FancyZones::ToggleEditor() noexcept
         std::to_wstring(width) + L"_" +
         std::to_wstring(height);
 
+    const auto& fancyZonesData = JSONHelpers::FancyZonesDataInstance();
+    fancyZonesData.CustomZoneSetsToJsonFile(ZoneWindowUtils::GetCustomZoneSetsTmpPath());
+
     const auto deviceInfo = fancyZonesData.FindDeviceInfo(zoneWindow->UniqueId());
     if (!deviceInfo.has_value())
     {
@@ -470,12 +470,10 @@ void FancyZones::ToggleEditor() noexcept
     fancyZonesData.SerializeDeviceInfoToTmpFile(deviceInfoJson, ZoneWindowUtils::GetActiveZoneSetTmpPath());
 
     const std::wstring params =
-        /*1*/ std::to_wstring(reinterpret_cast<UINT_PTR>(monitor)) + L" " +
-        /*2*/ editorLocation + L" " +
-        /*3*/ zoneWindow->WorkAreaKey() + L" " +
-        /*4*/ L"\"" + ZoneWindowUtils::GetActiveZoneSetTmpPath() + L"\" " +
-        /*5*/ L"\"" + ZoneWindowUtils::GetAppliedZoneSetTmpPath() + L"\" " +
-        /*6*/ L"\"" + ZoneWindowUtils::GetCustomZoneSetsTmpPath() + L"\"";
+        /*1*/ editorLocation + L" " +
+        /*2*/ L"\"" + ZoneWindowUtils::GetActiveZoneSetTmpPath() + L"\" " +
+        /*3*/ L"\"" + ZoneWindowUtils::GetAppliedZoneSetTmpPath() + L"\" " +
+        /*4*/ L"\"" + ZoneWindowUtils::GetCustomZoneSetsTmpPath() + L"\"";
 
     SHELLEXECUTEINFO sei{ sizeof(sei) };
     sei.fMask = { SEE_MASK_NOCLOSEPROCESS | SEE_MASK_FLAG_NO_UI };


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Changes made in FancyZonesEditor in last few releases reduced number of needed command line argument and left 2 of them unused. This PR removes them.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to https://github.com/microsoft/PowerToys/issues/1278
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Tested whether Editor starts and works correctly.