### PR TITLE
added error handling for FZ Hotkeys

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -278,7 +278,7 @@
   <data name="FancyZones_HighlightOpacity.Header" xml:space="preserve">
     <value>Zone highlight opacity</value>
   </data>
-  <data name="FancyZones_HokeyEditorControl_Header.Header" xml:space="preserve">
+  <data name="FancyZones_HokeyEditorControl.Text" xml:space="preserve">
     <value>Edit hot key / shortcut</value>
   </data>
   <data name="FancyZones_LaunchEditorButtonControl.Text" xml:space="preserve">

--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -278,8 +278,8 @@
   <data name="FancyZones_HighlightOpacity.Header" xml:space="preserve">
     <value>Zone highlight opacity</value>
   </data>
-  <data name="FancyZones_HokeyEditorControl.Text" xml:space="preserve">
-    <value>Edit hot key / shortcut</value>
+  <data name="FancyZones_HotkeyEditorControl.Text" xml:space="preserve">
+    <value>Edit hotkey / shortcut</value>
   </data>
   <data name="FancyZones_LaunchEditorButtonControl.Text" xml:space="preserve">
     <value>Launch zones editor</value>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -584,4 +584,13 @@
   <data name="General_RunAsAdminRequired.Text" xml:space="preserve">
     <value>You need to run as administrator to use this setting</value>
   </data>
+  <data name="FancyZones_HotkeyEditorControl.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Only shortcuts with the following hotkeys are valid: Win, Ctrl, Alt, Shift.</value>
+  </data>
+  <data name="FancyZones_HotkeyEditorControl_Icon.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Only shortcuts with the following hotkeys are valid: Win, Ctrl, Alt, Shift.</value>
+  </data>
+  <data name="FancyZones_HotkeyEditorControl_TextBox.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Only shortcuts with the following hotkeys are valid: Win, Ctrl, Alt, Shift.</value>
+  </data>
 </root>

--- a/src/core/Microsoft.PowerToys.Settings.UI/ViewModels/FancyZonesViewModel.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/ViewModels/FancyZonesViewModel.cs
@@ -49,13 +49,13 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             this._makeDraggedWindowTransparent = Settings.Properties.FancyzonesMakeDraggedWindowTransparent.Value;
             this._highlightOpacity = Settings.Properties.FancyzonesHighlightOpacity.Value;
             this._excludedApps = Settings.Properties.FancyzonesExcludedApps.Value;
-            this._editorHotkey = Settings.Properties.FancyzonesEditorHotkey.Value;
+            this.EditorHotkey = Settings.Properties.FancyzonesEditorHotkey.Value;
 
             string inactiveColor = Settings.Properties.FancyzonesInActiveColor.Value;
             this._zoneInActiveColor = inactiveColor != string.Empty ? inactiveColor.ToColor() : "#F5FCFF".ToColor();
 
             string borderColor = Settings.Properties.FancyzonesBorderColor.Value;
-            this._zoneBorderColor = borderColor != string.Empty ?  borderColor.ToColor() : "#FFFFFF".ToColor();
+            this._zoneBorderColor = borderColor != string.Empty ? borderColor.ToColor() : "#FFFFFF".ToColor();
 
             string highlightColor = Settings.Properties.FancyzonesZoneHighlightColor.Value;
             this._zoneHighlightColor = highlightColor != string.Empty ? highlightColor.ToColor() : "#0078D7".ToColor();
@@ -378,8 +378,16 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             {
                 if (value != _editorHotkey)
                 {
-                    _editorHotkey = value;
-                    Settings.Properties.FancyzonesEditorHotkey.Value = value;
+                    if (value.IsEmpty())
+                    {
+                        _editorHotkey = new HotkeySettings(true, false, false, false, "'", 192);
+                    }
+                    else
+                    {
+                        _editorHotkey = value;
+                    }
+
+                    Settings.Properties.FancyzonesEditorHotkey.Value = _editorHotkey;
                     RaisePropertyChanged();
                 }
             }

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -80,8 +80,9 @@
                            ToolTipService.ToolTip="Only the shortcuts with the following hotkeys are valid: Win, Ctrl, Alt, Shift."
                            Style="{StaticResource BodyTextStyle}"
                            Margin="{StaticResource SmallTopMargin}"
+                           Text="Editor Hotkeys"
                            Padding="{StaticResource SmallTopMargin}"/>
-                <Viewbox Height="12" Width="12" Margin="5, 27, 0, 0" >
+                <Viewbox Height="{StaticResource MediumFontSize}" Width="{StaticResource MediumFontSize}" Margin="5, 27, 0, 0" >
                     <PathIcon
                         VerticalAlignment="Center"
                         ToolTipService.ToolTip="Only the shortcuts with the following hotkeys are valid: Win, Ctrl, Alt, Shift."

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -77,24 +77,23 @@
 
             <StackPanel Orientation="Horizontal" Margin="{StaticResource SmallTopMargin}">
                 <TextBlock x:Uid="FancyZones_HotkeyEditorControl"
-                           ToolTipService.ToolTip="Only the shortcuts with the following hotkeys are valid: Win, Ctrl, Alt, Shift."
                            Text="Editor Hotkeys"/>
-                <Viewbox Height="{StaticResource MediumFontSize}" Width="{StaticResource MediumFontSize}" Margin="5,2,0,0" >
+                <Viewbox Height="14" Width="14" Margin="5,2,0,0" >
                     <PathIcon
+                        x:Uid="FancyZones_HotkeyEditorControl_Icon"
                         VerticalAlignment="Center"
-                        ToolTipService.ToolTip="Only the shortcuts with the following hotkeys are valid: Win, Ctrl, Alt, Shift."
                         Data="M960 1920q-133 0-255-34t-230-96-194-150-150-195-97-229T0 960q0-133 34-255t96-230 150-194 195-150 229-97T960 0q133 0 255 34t230 96 194 150 150 195 97 229 34 256q0 133-34 255t-96 230-150 194-195 150-229 97-256 34zm0-1792q-115 0-221 30t-198 84-169 130-130 168-84 199-30 221q0 114 30 220t84 199 130 169 168 130 199 84 221 30q114 0 220-30t199-84 169-130 130-168 84-199 30-221q0-114-30-220t-84-199-130-169-168-130-199-84-221-30zm-64 640h128v640H896V768zm0-256h128v128H896V512z"/>
                 </Viewbox>
             </StackPanel>
 
             <CustomControls:HotkeySettingsControl 
-                                          Width="240"
-                                          HorizontalAlignment="Left"
-                                          ToolTipService.ToolTip="Only shortcuts with the following hotkeys are valid: Win, Ctrl, Alt, Shift."
-                                          Margin="0,8,0,0"
-                                          HotkeySettings="{x:Bind Path=ViewModel.EditorHotkey, Mode=TwoWay}"
-                                          IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"    
-                                        />
+                x:Uid="FancyZones_HotkeyEditorControl_TextBox"
+                Width="240"
+                HorizontalAlignment="Left"
+                Margin="0,5,0,0"
+                HotkeySettings="{x:Bind Path=ViewModel.EditorHotkey, Mode=TwoWay}"
+                IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"
+                />
 
             <CheckBox x:Uid="FancyZones_ShiftDragCheckBoxControl_Header"
                       IsChecked="{ Binding Mode=TwoWay, Path=ShiftDrag}"

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -70,18 +70,29 @@
                     <TextBlock Margin="12,0,0,0" x:Uid="FancyZones_LaunchEditorButtonControl"/>
                 </StackPanel>
             </Button>
-            
-            <TextBlock x:Uid="FancyZones_ZoneBehavior_GroupSettings"
+
+            <StackPanel Orientation="Horizontal">
+                <TextBlock x:Uid="FancyZones_ZoneBehavior_GroupSettings"
                        Style="{StaticResource SettingsGroupTitleStyle}"
                        />
+
+                <Viewbox Height="12" Width="12" Margin="5, 30, 0, 0">
+                    <PathIcon
+                        VerticalAlignment="Center"
+                        ToolTipService.ToolTip="Only the follwing shortcuts are valid: Win, Ctrl, Alt, Shift."
+                        Data="M960 1920q-133 0-255-34t-230-96-194-150-150-195-97-229T0 960q0-133 34-255t96-230 150-194 195-150 229-97T960 0q133 0 255 34t230 96 194 150 150 195 97 229 34 256q0 133-34 255t-96 230-150 194-195 150-229 97-256 34zm0-1792q-115 0-221 30t-198 84-169 130-130 168-84 199-30 221q0 114 30 220t84 199 130 169 168 130 199 84 221 30q114 0 220-30t199-84 169-130 130-168 84-199 30-221q0-114-30-220t-84-199-130-169-168-130-199-84-221-30zm-64 640h128v640H896V768zm0-256h128v128H896V512z"/>
+                </Viewbox>
+            </StackPanel>
+
 
             <CustomControls:HotkeySettingsControl 
                                           x:Uid="FancyZones_HokeyEditorControl_Header"
                                           Width="240"
                                           HorizontalAlignment="Left"
+                                          ToolTipService.ToolTip="Only the follwing shortcuts are valid: Win, Ctrl, Alt, Shift."
                                           Margin="{StaticResource SmallTopMargin}"
                                           HotkeySettings="{x:Bind Path=ViewModel.EditorHotkey, Mode=TwoWay}"
-                                          IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"        
+                                          IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"    
                                         />
 
             <CheckBox x:Uid="FancyZones_ShiftDragCheckBoxControl_Header"

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -75,14 +75,11 @@
                        Style="{StaticResource SettingsGroupTitleStyle}"
                        />
 
-            <StackPanel Orientation="Horizontal">
-                <TextBlock x:Uid="FancyZones_HokeyEditorControl"
+            <StackPanel Orientation="Horizontal" Margin="{StaticResource SmallTopMargin}">
+                <TextBlock x:Uid="FancyZones_HotkeyEditorControl"
                            ToolTipService.ToolTip="Only the shortcuts with the following hotkeys are valid: Win, Ctrl, Alt, Shift."
-                           Style="{StaticResource BodyTextStyle}"
-                           Margin="{StaticResource SmallTopMargin}"
-                           Text="Editor Hotkeys"
-                           Padding="{StaticResource SmallTopMargin}"/>
-                <Viewbox Height="{StaticResource MediumFontSize}" Width="{StaticResource MediumFontSize}" Margin="5, 27, 0, 0" >
+                           Text="Editor Hotkeys"/>
+                <Viewbox Height="{StaticResource MediumFontSize}" Width="{StaticResource MediumFontSize}" Margin="5,2,0,0" >
                     <PathIcon
                         VerticalAlignment="Center"
                         ToolTipService.ToolTip="Only the shortcuts with the following hotkeys are valid: Win, Ctrl, Alt, Shift."
@@ -94,7 +91,7 @@
                                           Width="240"
                                           HorizontalAlignment="Left"
                                           ToolTipService.ToolTip="Only shortcuts with the following hot keys are valid: Win, Ctrl, Alt, Shift."
-                                          Margin="{StaticResource SmallTopMargin}"
+                                          Margin="0,8,0,0"
                                           HotkeySettings="{x:Bind Path=ViewModel.EditorHotkey, Mode=TwoWay}"
                                           IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"    
                                         />

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -90,7 +90,7 @@
             <CustomControls:HotkeySettingsControl 
                                           Width="240"
                                           HorizontalAlignment="Left"
-                                          ToolTipService.ToolTip="Only shortcuts with the following hot keys are valid: Win, Ctrl, Alt, Shift."
+                                          ToolTipService.ToolTip="Only shortcuts with the following hotkeys are valid: Win, Ctrl, Alt, Shift."
                                           Margin="0,8,0,0"
                                           HotkeySettings="{x:Bind Path=ViewModel.EditorHotkey, Mode=TwoWay}"
                                           IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"    

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -71,25 +71,28 @@
                 </StackPanel>
             </Button>
 
-            <StackPanel Orientation="Horizontal">
-                <TextBlock x:Uid="FancyZones_ZoneBehavior_GroupSettings"
+            <TextBlock x:Uid="FancyZones_ZoneBehavior_GroupSettings"
                        Style="{StaticResource SettingsGroupTitleStyle}"
                        />
 
-                <Viewbox Height="12" Width="12" Margin="5, 30, 0, 0">
+            <StackPanel Orientation="Horizontal">
+                <TextBlock x:Uid="FancyZones_HokeyEditorControl"
+                           ToolTipService.ToolTip="Only the shortcuts with the following hotkeys are valid: Win, Ctrl, Alt, Shift."
+                           Style="{StaticResource BodyTextStyle}"
+                           Margin="{StaticResource SmallTopMargin}"
+                           Padding="{StaticResource SmallTopMargin}"/>
+                <Viewbox Height="12" Width="12" Margin="5, 27, 0, 0" >
                     <PathIcon
                         VerticalAlignment="Center"
-                        ToolTipService.ToolTip="Only the follwing shortcuts are valid: Win, Ctrl, Alt, Shift."
+                        ToolTipService.ToolTip="Only the shortcuts with the following hotkeys are valid: Win, Ctrl, Alt, Shift."
                         Data="M960 1920q-133 0-255-34t-230-96-194-150-150-195-97-229T0 960q0-133 34-255t96-230 150-194 195-150 229-97T960 0q133 0 255 34t230 96 194 150 150 195 97 229 34 256q0 133-34 255t-96 230-150 194-195 150-229 97-256 34zm0-1792q-115 0-221 30t-198 84-169 130-130 168-84 199-30 221q0 114 30 220t84 199 130 169 168 130 199 84 221 30q114 0 220-30t199-84 169-130 130-168 84-199 30-221q0-114-30-220t-84-199-130-169-168-130-199-84-221-30zm-64 640h128v640H896V768zm0-256h128v128H896V512z"/>
                 </Viewbox>
             </StackPanel>
 
-
             <CustomControls:HotkeySettingsControl 
-                                          x:Uid="FancyZones_HokeyEditorControl_Header"
                                           Width="240"
                                           HorizontalAlignment="Left"
-                                          ToolTipService.ToolTip="Only the follwing shortcuts are valid: Win, Ctrl, Alt, Shift."
+                                          ToolTipService.ToolTip="Only shortcuts with the following hot keys are valid: Win, Ctrl, Alt, Shift."
                                           Margin="{StaticResource SmallTopMargin}"
                                           HotkeySettings="{x:Bind Path=ViewModel.EditorHotkey, Mode=TwoWay}"
                                           IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"    


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

- Added help text / tooltip for valid hotkeys.
![image](https://user-images.githubusercontent.com/58791731/83792211-91fb1580-a64f-11ea-930f-78e664794f37.png)

- Updated logic to set the hotkey to : "w+`" in the case none is set.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #3992
* [x ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Manually updated the json file as in below:
![image](https://user-images.githubusercontent.com/58791731/83792875-8cea9600-a650-11ea-851d-b27c846ade76.png)

and verified that the hotkey value is not set to null for FZ.