### PR TITLE
[FZEditor] Grid layout resizers fixes

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/FancyZonesEditor.csproj
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/FancyZonesEditor.csproj
@@ -110,6 +110,7 @@
       <SubType>Designer</SubType>
     </ApplicationDefinition>
     <Compile Include="DashCaseNamingPolicy.cs" />
+    <Compile Include="GridData.cs" />
     <Compile Include="StringUtils.cs" />
     <Compile Include="Converters\BooleanToBrushConverter.xaml.cs" />
     <Compile Include="Converters\BooleanToIntConverter.xaml.cs" />

--- a/src/modules/fancyzones/editor/FancyZonesEditor/FancyZonesEditor.csproj
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/FancyZonesEditor.csproj
@@ -111,6 +111,7 @@
     </ApplicationDefinition>
     <Compile Include="DashCaseNamingPolicy.cs" />
     <Compile Include="GridData.cs" />
+    <Compile Include="GridDragHandles.cs" />
     <Compile Include="StringUtils.cs" />
     <Compile Include="Converters\BooleanToBrushConverter.xaml.cs" />
     <Compile Include="Converters\BooleanToIntConverter.xaml.cs" />

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridData.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridData.cs
@@ -391,7 +391,7 @@ namespace FancyZonesEditor
                 if (delta > 0)
                 {
                     int sourcRow = 0;
-                    for (int row = 0; row < rows; row++) 
+                    for (int row = 0; row < rows; row++)
                     {
                         for (int col = 0; col < cols; col++)
                         {

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridData.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridData.cs
@@ -298,7 +298,7 @@ namespace FancyZonesEditor
             }
         }
 
-        public void ManageZones(UIElementCollection zones, int spacing)
+        public void ArrangeZones(UIElementCollection zones, int spacing)
         {
             int rows = _model.Rows;
             int cols = _model.Columns;
@@ -367,7 +367,7 @@ namespace FancyZonesEditor
             }
         }
 
-        public void ManageResizers(UIElementCollection adornerChildren, int spacing)
+        public void ArrangeResizers(UIElementCollection adornerChildren, int spacing)
         {
             int rows = _model.Rows;
             int cols = _model.Columns;

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridData.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridData.cs
@@ -497,6 +497,7 @@ namespace FancyZonesEditor
                 return;
             }
 
+            int zoneNumber = 1;
             double left, top;
             for (int row = 0; row < rows; row++)
             {
@@ -512,7 +513,7 @@ namespace FancyZonesEditor
                         top = _rowInfo[row].Start;
                         Canvas.SetLeft(zone, left);
                         Canvas.SetTop(zone, top);
-                        zone.LabelID.Content = i + 1;
+                        zone.LabelID.Content = zoneNumber++;
 
                         int maxRow = row;
                         while (((maxRow + 1) < rows) && (_model.CellChildMap[maxRow + 1, col] == i))

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridData.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridData.cs
@@ -376,7 +376,7 @@ namespace FancyZonesEditor
             {
                 if (resizer.Orientation == Orientation.Horizontal)
                 {
-                    if (resizer.EndCol <= cols)
+                    if (resizer.EndCol <= cols && resizer.StartRow < rows)
                     {
                         // hard coding this as (resizer.ActualHeight / 2) will still evaluate to 0 here ... a layout hasn't yet happened
                         Canvas.SetTop(resizer, _rowInfo[resizer.StartRow].End + (spacing / 2) - 24);
@@ -385,7 +385,7 @@ namespace FancyZonesEditor
                 }
                 else
                 {
-                    if (resizer.EndRow <= rows)
+                    if (resizer.EndRow <= rows && resizer.StartCol < cols)
                     {
                         // hard coding this as (resizer.ActualWidth / 2) will still evaluate to 0 here ... a layout hasn't yet happened
                         Canvas.SetLeft(resizer, _colInfo[resizer.StartCol].End + (spacing / 2) - 24);

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridData.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridData.cs
@@ -286,7 +286,6 @@ namespace FancyZonesEditor
                 int[,] cellChildMap = _model.CellChildMap;
                 int[,] newCellChildMap = new int[rows, cols];
 
-                double newTotalExtent = actualWidth - (space * (cols + 1));
                 int draggedResizerStartCol = resizer.StartCol;
 
                 if (delta > 0)
@@ -319,14 +318,6 @@ namespace FancyZonesEditor
 
                     _model.ColumnPercents[draggedResizerStartCol + 1] = split[0].Percent;
                     _model.ColumnPercents.Insert(draggedResizerStartCol + 2, split[1].Percent);
-
-                    for (int col = 0; col < cols; col++)
-                    {
-                        if (col != draggedResizerStartCol + 1 && col != draggedResizerStartCol + 2)
-                        {
-                            _colInfo[col].RecalculatePercent(newTotalExtent);
-                        }
-                    }
                 }
                 else
                 {
@@ -364,14 +355,6 @@ namespace FancyZonesEditor
 
                     _model.ColumnPercents[draggedResizerStartCol] = split[0].Percent;
                     _model.ColumnPercents.Insert(draggedResizerStartCol, split[1].Percent);
-
-                    for (int col = 0; col < cols; col++)
-                    {
-                        if (col != draggedResizerStartCol)
-                        {
-                            _colInfo[col].RecalculatePercent(newTotalExtent);
-                        }
-                    }
                 }
 
                 FixAccuracyError(_colInfo, _model.ColumnPercents);
@@ -385,7 +368,6 @@ namespace FancyZonesEditor
                 int[,] cellChildMap = _model.CellChildMap;
                 int[,] newCellChildMap = new int[rows, cols];
 
-                double newTotalExtent = actualWidth - (space * (rows + 1));
                 int draggedResizerStartRow = resizer.StartRow;
 
                 if (delta > 0)
@@ -422,7 +404,7 @@ namespace FancyZonesEditor
                 else
                 {
                     int sourceRow = 0;
-                    for (int row = 0; row < rows; row++) 
+                    for (int row = 0; row < rows; row++)
                     {
                         for (int col = 0; col < cols; col++)
                         {

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridData.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridData.cs
@@ -482,7 +482,7 @@ namespace FancyZonesEditor
             percents[index + 1] = info[index + 1].Percent = nextPercent - data.NewPercent;
         }
 
-        public bool SwapNegativePercents(Orientation orientation, int rowIndex, int colIndex)
+        public bool SwapNegativePercents(Orientation orientation, int startRow, int endRow, int startCol, int endCol)
         {
             List<int> percents;
             int index;
@@ -491,28 +491,36 @@ namespace FancyZonesEditor
             if (orientation == Orientation.Vertical)
             {
                 percents = _model.ColumnPercents;
-                index = colIndex;
+                index = startCol;
 
                 swapIndicesPrevLine = () =>
                 {
-                    _model.CellChildMap[rowIndex, colIndex] = _model.CellChildMap[rowIndex, colIndex + 1];
+                    for (int row = startRow; row < endRow; row++)
+                    {
+                        _model.CellChildMap[row, startCol] = _model.CellChildMap[row, startCol + 1];
+                    }
+
                     for (int row = 0; row < _model.Rows; row++)
                     {
-                        if (row != rowIndex)
+                        if (row < startRow || row >= endRow)
                         {
-                            _model.CellChildMap[row, colIndex] = _model.CellChildMap[row, colIndex - 1];
+                            _model.CellChildMap[row, startCol] = _model.CellChildMap[row, startCol - 1];
                         }
                     }
                 };
 
                 swapIndicesNextLine = () =>
                 {
-                    _model.CellChildMap[rowIndex, colIndex + 1] = _model.CellChildMap[rowIndex, colIndex];
+                    for (int row = startRow; row < endRow; row++)
+                    {
+                        _model.CellChildMap[row, startCol + 1] = _model.CellChildMap[row, startCol];
+                    }
+
                     for (int row = 0; row < _model.Rows; row++)
                     {
-                        if (row != rowIndex)
+                        if (row < startRow || row >= endRow)
                         {
-                            _model.CellChildMap[row, colIndex + 1] = _model.CellChildMap[row, colIndex + 2];
+                            _model.CellChildMap[row, startCol + 1] = _model.CellChildMap[row, startCol + 2];
                         }
                     }
                 };
@@ -520,28 +528,36 @@ namespace FancyZonesEditor
             else
             {
                 percents = _model.RowPercents;
-                index = rowIndex;
+                index = startRow;
 
                 swapIndicesPrevLine = () =>
                 {
-                    _model.CellChildMap[rowIndex, colIndex] = _model.CellChildMap[rowIndex + 1, colIndex];
+                    for (int col = startCol; col < endCol; col++)
+                    {
+                        _model.CellChildMap[startRow, col] = _model.CellChildMap[startRow + 1, col];
+                    }
+
                     for (int col = 0; col < _model.Columns; col++)
                     {
-                        if (col != colIndex)
+                        if (col < startCol || col >= endCol)
                         {
-                            _model.CellChildMap[rowIndex, col] = _model.CellChildMap[rowIndex - 1, col];
+                            _model.CellChildMap[startRow, col] = _model.CellChildMap[startRow - 1, col];
                         }
                     }
                 };
 
                 swapIndicesNextLine = () =>
                 {
-                    _model.CellChildMap[rowIndex + 1, colIndex] = _model.CellChildMap[rowIndex, colIndex];
+                    for (int col = startCol; col < endCol; col++)
+                    {
+                        _model.CellChildMap[startRow + 1, col] = _model.CellChildMap[startRow, col];
+                    }
+
                     for (int col = 0; col < _model.Columns; col++)
                     {
-                        if (col != colIndex)
+                        if (col < startCol || col >= endCol)
                         {
-                            _model.CellChildMap[rowIndex + 1, col] = _model.CellChildMap[rowIndex + 2, col];
+                            _model.CellChildMap[startRow + 1, col] = _model.CellChildMap[startRow + 2, col];
                         }
                     }
                 };

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridData.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridData.cs
@@ -1,3 +1,7 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Windows;
 using System.Windows.Controls;
@@ -5,8 +9,61 @@ using FancyZonesEditor.Models;
 
 namespace FancyZonesEditor
 {
-    class GridData
+    public class GridData
     {
+        public class ResizeInfo
+        {
+            public ResizeInfo()
+            {
+            }
+
+            public int NewPercent { get; private set; }
+
+            public int AdjacentPercent { get; private set; }
+
+            public int TotalPercent { get; private set; }
+
+            public int CurrentPercent { get; set; }
+
+            public double CurrentExtent { get; set; }
+
+            public bool IsResizeAllowed
+            {
+                get
+                {
+                    return (NewPercent > 0) && (NewPercent < TotalPercent);
+                }
+            }
+
+            public void CalcNewPercent(double delta)
+            {
+                double newExtent = CurrentExtent + _adjacentExtent + delta;
+                NewPercent = (int)((CurrentPercent + AdjacentPercent) * newExtent / (CurrentExtent + _adjacentExtent));
+            }
+
+            public void CalcAdjacentZones(int index, int size, RowColInfo[] info, Func<int, bool> indexCmpr)
+            {
+                int ind = index;
+                while (ind > 0 && indexCmpr(ind))
+                {
+                    ind--;
+                    _adjacentExtent += info[ind].Extent;
+                    AdjacentPercent += info[ind].Percent;
+                }
+
+                TotalPercent = CurrentPercent + AdjacentPercent + info[index + 1].Percent;
+
+                ind = index + 2;
+                while (ind < size && indexCmpr(ind))
+                {
+                    TotalPercent += info[ind].Percent;
+                    ind++;
+                }
+            }
+
+            private double _adjacentExtent;
+        }
+
         public GridData(GridLayoutModel model)
         {
             _model = model;
@@ -39,6 +96,7 @@ namespace FancyZonesEditor
                         maxIndex = Math.Max(maxIndex, _model.CellChildMap[row, col]);
                     }
                 }
+
                 return maxIndex;
             }
         }
@@ -370,13 +428,39 @@ namespace FancyZonesEditor
             }
         }
 
-        public bool DragResizer(GridResizer resizer, double delta)
+        public ResizeInfo CalculateResizeInfo(GridResizer resizer, double delta)
         {
-            RowColInfo[] info;
-            int[] percents;
+            ResizeInfo res = new ResizeInfo();
 
             int rowIndex = resizer.RowIndex;
             int colIndex = resizer.ColIndex;
+            int[,] indices = _model.CellChildMap;
+
+            if (resizer.Orientation == Orientation.Vertical)
+            {
+                res.CurrentExtent = _colInfo[colIndex].Extent;
+                res.CurrentPercent = _colInfo[colIndex].Percent;
+
+                Func<int, bool> indexCmpr = i => indices[rowIndex, i] == indices[rowIndex, i - 1];
+                res.CalcAdjacentZones(colIndex, _model.Columns, _colInfo, indexCmpr);
+            }
+            else
+            {
+                res.CurrentExtent = _rowInfo[rowIndex].Extent;
+                res.CurrentPercent = _rowInfo[rowIndex].Percent;
+
+                Func<int, bool> indexCmpr = i => indices[i, colIndex] == indices[i - 1, colIndex];
+                res.CalcAdjacentZones(rowIndex, _model.Rows, _rowInfo, indexCmpr);
+            }
+
+            res.CalcNewPercent(delta);
+            return res;
+        }
+
+        public void DragResizer(GridResizer resizer, ResizeInfo data)
+        {
+            RowColInfo[] info;
+            int[] percents;
             int index;
 
             if (resizer.Orientation == Orientation.Vertical)
@@ -392,17 +476,53 @@ namespace FancyZonesEditor
                 index = resizer.RowIndex;
             }
 
-            ResizeInfo data = ResizedPercent(resizer, delta);
+            int nextPercent = data.CurrentPercent + data.AdjacentPercent + info[index + 1].Percent;
 
-            if ((data.NewPercent > 0) && (data.NewPercent < data.TotalPercent))
+            percents[index] = info[index].Percent = data.NewPercent - data.AdjacentPercent;
+            percents[index + 1] = info[index + 1].Percent = nextPercent - data.NewPercent;
+        }
+
+        public bool SwapNegativePercents(Orientation orientation, int rowIndex, int colIndex)
+        {
+            int[] percents;
+            int index;
+            Action swapIndicesPrevLine, swapIndicesNextLine;
+
+            if (orientation == Orientation.Vertical)
             {
-                int nextPercent = data.CurrentPercent + data.AdjacentPercent + info[index + 1].Percent;
+                percents = _model.ColumnPercents;
+                index = colIndex;
 
-                percents[index] = info[index].Percent = data.NewPercent - data.AdjacentPercent;
-                percents[index + 1] = info[index + 1].Percent = nextPercent - data.NewPercent;
+                swapIndicesPrevLine = () =>
+                {
+                    _model.CellChildMap[rowIndex, colIndex] = _model.CellChildMap[rowIndex, colIndex + 1];
+                    for (int row = 0; row < _model.Rows; row++)
+                    {
+                        if (row != rowIndex)
+                        {
+                            _model.CellChildMap[row, colIndex] = _model.CellChildMap[row, colIndex - 1];
+                        }
+                    }
+                };
 
-                // TODO cols
-                if (percents[index] < 0)
+                swapIndicesNextLine = () =>
+                {
+                    _model.CellChildMap[rowIndex, colIndex + 1] = _model.CellChildMap[rowIndex, colIndex];
+                    for (int row = 0; row < _model.Rows; row++)
+                    {
+                        if (row != rowIndex)
+                        {
+                            _model.CellChildMap[row, colIndex + 1] = _model.CellChildMap[row, colIndex + 2];
+                        }
+                    }
+                };
+            }
+            else
+            {
+                percents = _model.RowPercents;
+                index = rowIndex;
+
+                swapIndicesPrevLine = () =>
                 {
                     _model.CellChildMap[rowIndex, colIndex] = _model.CellChildMap[rowIndex + 1, colIndex];
                     for (int col = 0; col < _model.Columns; col++)
@@ -412,28 +532,58 @@ namespace FancyZonesEditor
                             _model.CellChildMap[rowIndex, col] = _model.CellChildMap[rowIndex - 1, col];
                         }
                     }
+                };
 
-                    percents[rowIndex] = _rowInfo[rowIndex].Percent = -percents[rowIndex];
-                    percents[rowIndex - 1] = _rowInfo[rowIndex - 1].Percent = percents[rowIndex - 1] - percents[rowIndex];
-
-                    resizer.RowIndex--;
-                }
-
-                if (percents[index + 1] < 0)
+                swapIndicesNextLine = () =>
                 {
                     _model.CellChildMap[rowIndex + 1, colIndex] = _model.CellChildMap[rowIndex, colIndex];
                     for (int col = 0; col < _model.Columns; col++)
                     {
                         if (col != colIndex)
                         {
-                            _model.CellChildMap[rowIndex, col] = _model.CellChildMap[rowIndex + 2, col];
+                            _model.CellChildMap[rowIndex + 1, col] = _model.CellChildMap[rowIndex + 2, col];
                         }
                     }
+                };
+            }
 
-                    percents[index + 1] = _rowInfo[index + 1].Percent = -percents[index + 1];
-                    percents[index] = _rowInfo[index].Percent = percents[index] - percents[index + 1];
+            if (percents[index] < 0)
+            {
+                swapIndicesPrevLine();
 
-                    resizer.RowIndex++;
+                percents[index] = -percents[index];
+                percents[index - 1] = percents[index - 1] - percents[index];
+
+                if (orientation == Orientation.Vertical)
+                {
+                    _colInfo[index].Percent = percents[index];
+                    _colInfo[index - 1].Percent = percents[index - 1];
+                }
+                else
+                {
+                    _rowInfo[index].Percent = percents[index];
+                    _rowInfo[index - 1].Percent = percents[index - 1];
+                }
+
+                return true;
+            }
+
+            if (percents[index + 1] < 0)
+            {
+                swapIndicesNextLine();
+
+                percents[index + 1] = -percents[index + 1];
+                percents[index] = percents[index] - percents[index + 1];
+
+                if (orientation == Orientation.Vertical)
+                {
+                    _colInfo[index].Percent = percents[index];
+                    _colInfo[index + 1].Percent = percents[index + 1];
+                }
+                else
+                {
+                    _rowInfo[index].Percent = percents[index];
+                    _rowInfo[index + 1].Percent = percents[index + 1];
                 }
 
                 return true;
@@ -480,78 +630,6 @@ namespace FancyZonesEditor
             }
 
             return -1;
-        }
-
-        private ResizeInfo ResizedPercent(GridResizer resizer, double delta)
-        {
-            ResizeInfo res = new ResizeInfo();
-
-            int rowIndex = resizer.RowIndex;
-            int colIndex = resizer.ColIndex;
-            int[,] indices = _model.CellChildMap;
-
-            if (resizer.Orientation == Orientation.Vertical)
-            {
-                res.CurrentExtent = _colInfo[colIndex].Extent;
-                res.CurrentPercent = _colInfo[colIndex].Percent;
-
-                Func<int, bool> indexCmpr = i => indices[rowIndex, i] == indices[rowIndex, i - 1];
-                res.CalcAdjacentZones(colIndex, _model.Columns, _colInfo, indexCmpr);
-            }
-            else
-            {
-                res.CurrentExtent = _rowInfo[rowIndex].Extent;
-                res.CurrentPercent = _rowInfo[rowIndex].Percent;
-
-                Func<int, bool> indexCmpr = i => indices[i, colIndex] == indices[i - 1, colIndex];
-                res.CalcAdjacentZones(rowIndex, _model.Rows, _rowInfo, indexCmpr);
-            }
-
-            res.CalcNewPercent(delta);
-            return res;
-        }
-
-        private class ResizeInfo
-        {
-            public ResizeInfo() { }
-
-            public int NewPercent { get; private set; }
-
-            public int AdjacentPercent { get; private set; }
-
-            public int TotalPercent { get; private set; }
-
-            public int CurrentPercent { get; set; }
-
-            public double CurrentExtent { get; set; }
-
-            public void CalcNewPercent(double delta)
-            {
-                double newExtent = CurrentExtent + _adjacentExtent + delta;
-                NewPercent = (int)((CurrentPercent + AdjacentPercent) * newExtent / (CurrentExtent + _adjacentExtent));
-            }
-
-            public void CalcAdjacentZones(int index, int size, RowColInfo[] info, Func<int, bool> indexCmpr)
-            {
-                int ind = index;
-                while (ind > 0 && indexCmpr(ind))
-                {
-                    ind--;
-                    _adjacentExtent += info[ind].Extent;
-                    AdjacentPercent += info[ind].Percent;
-                }
-
-                TotalPercent = CurrentPercent + AdjacentPercent + info[index + 1].Percent;
-
-                ind = index + 2;
-                while (ind < size && indexCmpr(ind))
-                {
-                    TotalPercent += info[ind].Percent;
-                    ind++;
-                }
-            }
-
-            private double _adjacentExtent;
         }
 
         private GridLayoutModel _model;

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridData.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridData.cs
@@ -220,6 +220,7 @@ namespace FancyZonesEditor
                 }
             }
 
+            FixAccuracyError(_colInfo, _model.ColumnPercents);
             _model.CellChildMap = newCellChildMap;
             _model.Columns++;
         }
@@ -269,6 +270,7 @@ namespace FancyZonesEditor
                 }
             }
 
+            FixAccuracyError(_rowInfo, _model.RowPercents);
             _model.CellChildMap = newCellChildMap;
             _model.Rows++;
         }
@@ -648,6 +650,8 @@ namespace FancyZonesEditor
             }
 
             CollapseIndices();
+            FixAccuracyError(_rowInfo, _model.RowPercents);
+            FixAccuracyError(_colInfo, _model.ColumnPercents);
         }
 
         public void CollapseIndices()
@@ -766,6 +770,31 @@ namespace FancyZonesEditor
 
             _model.Rows = rows;
             _model.Columns = cols;
+        }
+
+        public void FixAccuracyError(List<RowColInfo> info, List<int> percents)
+        {
+            int total = 0;
+            for (int i = 0; i < info.Count; i++)
+            {
+                total += info[i].Percent;
+            }
+
+            int totalDiff = total - 10000;
+            if (totalDiff != 0)
+            {
+                int perLineDiff = totalDiff / percents.Count;
+                int lastLineDiff = totalDiff - (perLineDiff * (percents.Count - 1));
+
+                for (int i = 0; i < percents.Count - 1 && perLineDiff != 0; i++)
+                {
+                    info[i].Percent -= perLineDiff;
+                    percents[i] -= perLineDiff;
+                }
+
+                info[percents.Count - 1].Percent -= lastLineDiff;
+                percents[percents.Count - 1] -= lastLineDiff;
+            }
         }
 
         private GridLayoutModel _model;

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridData.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridData.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Windows;
 using System.Windows.Controls;
+using ControlzEx.Standard;
 using FancyZonesEditor.Models;
 
 namespace FancyZonesEditor
@@ -366,64 +367,25 @@ namespace FancyZonesEditor
             int rows = _model.Rows;
             int cols = _model.Columns;
 
-            int childIndex = 0;
-            for (int row = 0; row < rows - 1; row++)
+            foreach (GridResizer resizer in adornerChildren)
             {
-                GridResizer resizer = (GridResizer)adornerChildren[childIndex++];
-                int startCol = -1;
-                int endCol = cols - 1;
-                for (int col = 0; col < cols; col++)
+                if (resizer.Orientation == Orientation.Horizontal)
                 {
-                    if ((startCol == -1) && (_model.CellChildMap[row, col] != _model.CellChildMap[row + 1, col]))
+                    if (resizer.EndCol <= cols)
                     {
-                        startCol = col;
+                        // hard coding this as (resizer.ActualHeight / 2) will still evaluate to 0 here ... a layout hasn't yet happened
+                        Canvas.SetTop(resizer, _rowInfo[resizer.StartRow].End + (spacing / 2) - 24);
+                        Canvas.SetLeft(resizer, (_colInfo[resizer.EndCol - 1].End + _colInfo[resizer.StartCol].Start) / 2);
                     }
-                    else if ((startCol != -1) && (_model.CellChildMap[row, col] == _model.CellChildMap[row + 1, col]))
-                    {
-                        endCol = col - 1;
-                        break;
-                    }
-                }
-
-                if (startCol != -1)
-                {
-                    // hard coding this as (resizer.ActualHeight / 2) will still evaluate to 0 here ... a layout hasn't yet happened
-                    Canvas.SetTop(resizer, _rowInfo[row].End + (spacing / 2) - 24);
-                    Canvas.SetLeft(resizer, (_colInfo[endCol].End + _colInfo[startCol].Start) / 2);
                 }
                 else
                 {
-                    resizer.Visibility = Visibility.Collapsed;
-                }
-            }
-
-            for (int col = 0; col < cols - 1; col++)
-            {
-                GridResizer resizer = (GridResizer)adornerChildren[childIndex++];
-                int startRow = -1;
-                int endRow = rows - 1;
-                for (int row = 0; row < rows; row++)
-                {
-                    if ((startRow == -1) && (_model.CellChildMap[row, col] != _model.CellChildMap[row, col + 1]))
+                    if (resizer.EndRow <= rows)
                     {
-                        startRow = row;
+                        // hard coding this as (resizer.ActualWidth / 2) will still evaluate to 0 here ... a layout hasn't yet happened
+                        Canvas.SetLeft(resizer, _colInfo[resizer.StartCol].End + (spacing / 2) - 24);
+                        Canvas.SetTop(resizer, (_rowInfo[resizer.EndRow - 1].End + _rowInfo[resizer.StartRow].Start) / 2);
                     }
-                    else if ((startRow != -1) && (_model.CellChildMap[row, col] == _model.CellChildMap[row, col + 1]))
-                    {
-                        endRow = row - 1;
-                        break;
-                    }
-                }
-
-                if (startRow != -1)
-                {
-                    Canvas.SetLeft(resizer, _colInfo[col].End + (spacing / 2) - 24); // hard coding this as (resizer.ActualWidth / 2) will still evaluate to 0 here ... a layout hasn't yet happened
-                    Canvas.SetTop(resizer, (_rowInfo[endRow].End + _rowInfo[startRow].Start) / 2);
-                    resizer.Visibility = Visibility.Visible;
-                }
-                else
-                {
-                    resizer.Visibility = Visibility.Collapsed;
                 }
             }
         }
@@ -432,8 +394,8 @@ namespace FancyZonesEditor
         {
             ResizeInfo res = new ResizeInfo();
 
-            int rowIndex = resizer.RowIndex;
-            int colIndex = resizer.ColIndex;
+            int rowIndex = resizer.StartRow;
+            int colIndex = resizer.StartCol;
             int[,] indices = _model.CellChildMap;
 
             if (resizer.Orientation == Orientation.Vertical)
@@ -467,13 +429,13 @@ namespace FancyZonesEditor
             {
                 info = _colInfo;
                 percents = _model.ColumnPercents;
-                index = resizer.ColIndex;
+                index = resizer.StartCol;
             }
             else
             {
                 info = _rowInfo;
                 percents = _model.RowPercents;
-                index = resizer.RowIndex;
+                index = resizer.StartRow;
             }
 
             int nextPercent = data.CurrentPercent + data.AdjacentPercent + info[index + 1].Percent;

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridData.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridData.cs
@@ -414,7 +414,17 @@ namespace FancyZonesEditor
                 percents = _model.ColumnPercents;
                 index = colIndex;
 
-                Func<int, bool> indexCmpr = i => indices[rowIndex, i] == indices[rowIndex, i - 1];
+                Func<int, bool> indexCmpr = (ind) =>
+                {
+                    bool sameIndices = true;
+                    for (int i = resizer.StartRow; i < resizer.EndRow && sameIndices; i++)
+                    {
+                        sameIndices &= indices[i, ind] == indices[i, ind - 1];
+                    }
+
+                    return sameIndices;
+                };
+
                 res.CalcAdjacentZones(colIndex, _model.Columns, _colInfo, indexCmpr);
             }
             else
@@ -426,7 +436,17 @@ namespace FancyZonesEditor
                 percents = _model.RowPercents;
                 index = rowIndex;
 
-                Func<int, bool> indexCmpr = i => indices[i, colIndex] == indices[i - 1, colIndex];
+                Func<int, bool> indexCmpr = (ind) =>
+                {
+                    bool sameIndices = true;
+                    for (int i = resizer.StartCol; i < resizer.EndCol && sameIndices; i++)
+                    {
+                        sameIndices &= indices[ind, i] == indices[ind - 1, i];
+                    }
+
+                    return sameIndices;
+                };
+
                 res.CalcAdjacentZones(rowIndex, _model.Rows, _rowInfo, indexCmpr);
             }
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridData.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridData.cs
@@ -418,14 +418,6 @@ namespace FancyZonesEditor
 
                     _model.RowPercents[draggedResizerStartRow + 1] = split[0].Percent;
                     _model.RowPercents.Insert(draggedResizerStartRow + 2, split[1].Percent);
-
-                    for (int row = 0; row < rows; row++)
-                    {
-                        if (row != draggedResizerStartRow + 1 && row != draggedResizerStartRow + 2)
-                        {
-                            _rowInfo[row].RecalculatePercent(newTotalExtent);
-                        }
-                    }
                 }
                 else
                 {
@@ -463,14 +455,6 @@ namespace FancyZonesEditor
 
                     _model.RowPercents[draggedResizerStartRow] = split[0].Percent;
                     _model.RowPercents.Insert(draggedResizerStartRow, split[1].Percent);
-
-                    for (int row = 0; row < rows; row++)
-                    {
-                        if (row != draggedResizerStartRow)
-                        {
-                            _rowInfo[row].RecalculatePercent(newTotalExtent);
-                        }
-                    }
                 }
 
                 FixAccuracyError(_rowInfo, _model.RowPercents);
@@ -1040,8 +1024,14 @@ namespace FancyZonesEditor
 
                 for (int i = 0; i < percents.Count - 1 && perLineDiff != 0; i++)
                 {
-                    info[i].Percent -= perLineDiff;
-                    percents[i] -= perLineDiff;
+                    int percent = percents[i] - perLineDiff;
+                    if (percent < 0)
+                    {
+                        percent = 0;
+                    }
+
+                    percents[i] = percent;
+                    info[i].Percent = percent;
                 }
 
                 info[percents.Count - 1].Percent -= lastLineDiff;

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridData.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridData.cs
@@ -277,7 +277,7 @@ namespace FancyZonesEditor
             _model.Rows++;
         }
 
-        public void SplitOnDrag(GridResizer resizer, double delta, double space, double actualWidth, double actualHeight)
+        public void SplitOnDrag(GridResizer resizer, double delta, double space)
         {
             if (resizer.Orientation == Orientation.Vertical)
             {
@@ -342,19 +342,14 @@ namespace FancyZonesEditor
                         }
                     }
 
-                    double end = 0;
-                    if (draggedResizerStartCol > 0)
-                    {
-                        end = _colInfo[draggedResizerStartCol - 1].End;
-                    }
+                    double offset = _colInfo[draggedResizerStartCol].End - _colInfo[draggedResizerStartCol].Start + delta;
+                    RowColInfo[] split = _colInfo[draggedResizerStartCol].Split(offset - space, space);
 
-                    RowColInfo[] split = _colInfo[draggedResizerStartCol].Split(end - delta, space);
+                    _colInfo[draggedResizerStartCol] = split[1];
+                    _colInfo.Insert(draggedResizerStartCol + 1, split[0]);
 
-                    _colInfo[draggedResizerStartCol] = split[0];
-                    _colInfo.Insert(draggedResizerStartCol, split[1]);
-
-                    _model.ColumnPercents[draggedResizerStartCol] = split[0].Percent;
-                    _model.ColumnPercents.Insert(draggedResizerStartCol, split[1].Percent);
+                    _model.ColumnPercents[draggedResizerStartCol] = split[1].Percent;
+                    _model.ColumnPercents.Insert(draggedResizerStartCol + 1, split[0].Percent);
                 }
 
                 FixAccuracyError(_colInfo, _model.ColumnPercents);
@@ -424,19 +419,14 @@ namespace FancyZonesEditor
                         }
                     }
 
-                    double end = 0;
-                    if (draggedResizerStartRow > 0)
-                    {
-                        end = _rowInfo[draggedResizerStartRow - 1].End;
-                    }
-
-                    RowColInfo[] split = _rowInfo[draggedResizerStartRow].Split(end - delta, space);
+                    double offset = _rowInfo[draggedResizerStartRow].End - _rowInfo[draggedResizerStartRow].Start + delta;
+                    RowColInfo[] split = _rowInfo[draggedResizerStartRow].Split(offset - space, space);
 
                     _rowInfo[draggedResizerStartRow] = split[0];
-                    _rowInfo.Insert(draggedResizerStartRow, split[1]);
+                    _rowInfo.Insert(draggedResizerStartRow + 1, split[1]);
 
                     _model.RowPercents[draggedResizerStartRow] = split[0].Percent;
-                    _model.RowPercents.Insert(draggedResizerStartRow, split[1].Percent);
+                    _model.RowPercents.Insert(draggedResizerStartRow + 1, split[1].Percent);
                 }
 
                 FixAccuracyError(_rowInfo, _model.RowPercents);

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridData.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridData.cs
@@ -1,0 +1,527 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Controls;
+using FancyZonesEditor.Models;
+
+namespace FancyZonesEditor
+{
+    class GridData
+    {
+        public GridData(GridLayoutModel model)
+        {
+            _model = model;
+
+            int rows = model.Rows;
+            int cols = model.Columns;
+
+            _rowInfo = new RowColInfo[rows];
+            for (int row = 0; row < rows; row++)
+            {
+                _rowInfo[row] = new RowColInfo(model.RowPercents[row]);
+            }
+
+            _colInfo = new RowColInfo[cols];
+            for (int col = 0; col < cols; col++)
+            {
+                _colInfo[col] = new RowColInfo(model.ColumnPercents[col]);
+            }
+        }
+
+        public int ZoneCount
+        {
+            get
+            {
+                int maxIndex = 0;
+                for (int row = 0; row < _model.Rows; row++)
+                {
+                    for (int col = 0; col < _model.Columns; col++)
+                    {
+                        maxIndex = Math.Max(maxIndex, _model.CellChildMap[row, col]);
+                    }
+                }
+                return maxIndex;
+            }
+        }
+
+        public Tuple<int, int> RowColByIndex(int index)
+        {
+            int foundRow = -1;
+            int foundCol = -1;
+
+            for (int row = 0; row < _model.Rows && foundRow == -1; row++)
+            {
+                for (int col = 0; col < _model.Columns && foundCol == -1; col++)
+                {
+                    if (_model.CellChildMap[row, col] == index)
+                    {
+                        foundRow = row;
+                        foundCol = col;
+                    }
+                }
+            }
+
+            return new Tuple<int, int>(foundRow, foundCol);
+        }
+
+        public int GetIndex(int row, int col)
+        {
+            return _model.CellChildMap[row, col];
+        }
+
+        public double ColumnTop(int column)
+        {
+            return _colInfo[column].Start;
+        }
+
+        public double ColumnBottom(int column)
+        {
+            return _colInfo[column].End;
+        }
+
+        public double RowStart(int row)
+        {
+            return _rowInfo[row].Start;
+        }
+
+        public double RowEnd(int row)
+        {
+            return _rowInfo[row].End;
+        }
+
+        public void SetIndex(int row, int col, int index)
+        {
+            _model.CellChildMap[row, col] = index;
+        }
+
+        public void SplitColumn(int foundCol, int spliteeIndex, int newChildIndex, double space, double offset, double actualWidth)
+        {
+            int rows = _model.Rows;
+            int cols = _model.Columns + 1;
+
+            int[,] newCellChildMap = new int[rows, cols];
+            int[] newColPercents = new int[cols];
+            RowColInfo[] newColInfo = new RowColInfo[cols];
+
+            int sourceCol = 0;
+            for (int col = 0; col < cols; col++)
+            {
+                for (int row = 0; row < rows; row++)
+                {
+                    if ((col > foundCol) && (_model.CellChildMap[row, sourceCol] == spliteeIndex))
+                    {
+                        newCellChildMap[row, col] = newChildIndex;
+                    }
+                    else
+                    {
+                        newCellChildMap[row, col] = _model.CellChildMap[row, sourceCol];
+                    }
+                }
+
+                if (col != foundCol)
+                {
+                    sourceCol++;
+                }
+            }
+
+            sourceCol = 0;
+            double newTotalExtent = actualWidth - (space * (cols + 1));
+            for (int col = 0; col < cols; col++)
+            {
+                if (col == foundCol)
+                {
+                    RowColInfo[] split = _colInfo[col].Split(offset, space);
+                    newColInfo[col] = split[0];
+                    newColPercents[col] = split[0].Percent;
+                    col++;
+
+                    newColInfo[col] = split[1];
+                    newColPercents[col] = split[1].Percent;
+                }
+                else
+                {
+                    newColInfo[col] = _colInfo[sourceCol];
+                    newColInfo[col].RecalculatePercent(newTotalExtent);
+
+                    newColPercents[col] = _model.ColumnPercents[sourceCol];
+                }
+
+                sourceCol++;
+            }
+
+            _model.CellChildMap = newCellChildMap;
+            _model.ColumnPercents = newColPercents;
+            _colInfo = newColInfo;
+
+            _model.Columns++;
+        }
+
+        public void SplitRow(int foundRow, int spliteeIndex, int newChildIndex, double space, double offset, double actualHeight)
+        {
+            int rows = _model.Rows + 1;
+            int cols = _model.Columns;
+
+            int[,] newCellChildMap = new int[rows, cols];
+            int[] newRowPercents = new int[rows];
+            RowColInfo[] newRowInfo = new RowColInfo[rows];
+
+            int sourceRow = 0;
+            for (int row = 0; row < rows; row++)
+            {
+                for (int col = 0; col < cols; col++)
+                {
+                    if ((row > foundRow) && (_model.CellChildMap[sourceRow, col] == spliteeIndex))
+                    {
+                        newCellChildMap[row, col] = newChildIndex;
+                    }
+                    else
+                    {
+                        newCellChildMap[row, col] = _model.CellChildMap[sourceRow, col];
+                    }
+                }
+
+                if (row != foundRow)
+                {
+                    sourceRow++;
+                }
+            }
+
+            sourceRow = 0;
+            double newTotalExtent = actualHeight - (space * (rows + 1));
+            for (int row = 0; row < rows; row++)
+            {
+                if (row == foundRow)
+                {
+                    RowColInfo[] split = _rowInfo[row].Split(offset, space);
+                    newRowInfo[row] = split[0];
+                    newRowPercents[row] = split[0].Percent;
+                    row++;
+
+                    newRowInfo[row] = split[1];
+                    newRowPercents[row] = split[1].Percent;
+                }
+                else
+                {
+                    newRowInfo[row] = _rowInfo[sourceRow];
+                    newRowInfo[row].RecalculatePercent(newTotalExtent);
+
+                    newRowPercents[row] = _model.RowPercents[sourceRow];
+                }
+
+                sourceRow++;
+            }
+
+            _rowInfo = newRowInfo;
+            _model.CellChildMap = newCellChildMap;
+            _model.RowPercents = newRowPercents;
+
+            _model.Rows++;
+        }
+
+        public void RecalculateZones(int spacing, Size arrangeSize)
+        {
+            int rows = _model.Rows;
+            int cols = _model.Columns;
+
+            double totalWidth = arrangeSize.Width - (spacing * (cols + 1));
+            double totalHeight = arrangeSize.Height - (spacing * (rows + 1));
+
+            double top = spacing;
+            for (int row = 0; row < rows; row++)
+            {
+                double cellHeight = _rowInfo[row].Recalculate(top, totalHeight);
+                top += cellHeight + spacing;
+            }
+
+            double left = spacing;
+            for (int col = 0; col < cols; col++)
+            {
+                double cellWidth = _colInfo[col].Recalculate(left, totalWidth);
+                left += cellWidth + spacing;
+            }
+        }
+
+        public void ManageZones(UIElementCollection zones, int spacing)
+        {
+            int rows = _model.Rows;
+            int cols = _model.Columns;
+
+            double left, top;
+            for (int row = 0; row < rows; row++)
+            {
+                for (int col = 0; col < cols; col++)
+                {
+                    int i = _model.CellChildMap[row, col];
+                    if (((row == 0) || (_model.CellChildMap[row - 1, col] != i)) &&
+                        ((col == 0) || (_model.CellChildMap[row, col - 1] != i)))
+                    {
+                        // this is not a continuation of a span
+                        GridZone zone = (GridZone)zones[i];
+                        left = _colInfo[col].Start;
+                        top = _rowInfo[row].Start;
+                        Canvas.SetLeft(zone, left);
+                        Canvas.SetTop(zone, top);
+                        zone.LabelID.Content = i + 1;
+
+                        int maxRow = row;
+                        while (((maxRow + 1) < rows) && (_model.CellChildMap[maxRow + 1, col] == i))
+                        {
+                            maxRow++;
+                        }
+
+                        zone.HorizontalSnapPoints = null;
+                        if (maxRow > row)
+                        {
+                            zone.HorizontalSnapPoints = new double[maxRow - row];
+                            int pointsIndex = 0;
+                            for (int walk = row; walk < maxRow; walk++)
+                            {
+                                zone.HorizontalSnapPoints[pointsIndex++] = _rowInfo[walk].End + (spacing / 2) - top;
+                            }
+                        }
+
+                        int maxCol = col;
+                        while (((maxCol + 1) < cols) && (_model.CellChildMap[row, maxCol + 1] == i))
+                        {
+                            maxCol++;
+                        }
+
+                        zone.VerticalSnapPoints = null;
+                        if (maxCol > col)
+                        {
+                            zone.VerticalSnapPoints = new double[maxCol - col];
+                            int pointsIndex = 0;
+                            for (int walk = col; walk < maxCol; walk++)
+                            {
+                                zone.VerticalSnapPoints[pointsIndex++] = _colInfo[walk].End + (spacing / 2) - left;
+                            }
+                        }
+
+                        zone.MinWidth = _colInfo[maxCol].End - left;
+                        zone.MinHeight = _rowInfo[maxRow].End - top;
+                    }
+                }
+            }
+        }
+
+        public void ManageResizers(UIElementCollection adornerChildren, int spacing)
+        {
+            int rows = _model.Rows;
+            int cols = _model.Columns;
+
+            int childIndex = 0;
+            for (int row = 0; row < rows - 1; row++)
+            {
+                GridResizer resizer = (GridResizer)adornerChildren[childIndex++];
+                int startCol = -1;
+                int endCol = cols - 1;
+                for (int col = 0; col < cols; col++)
+                {
+                    if ((startCol == -1) && (_model.CellChildMap[row, col] != _model.CellChildMap[row + 1, col]))
+                    {
+                        startCol = col;
+                    }
+                    else if ((startCol != -1) && (_model.CellChildMap[row, col] == _model.CellChildMap[row + 1, col]))
+                    {
+                        endCol = col - 1;
+                        break;
+                    }
+                }
+
+                if (startCol != -1)
+                {
+                    // hard coding this as (resizer.ActualHeight / 2) will still evaluate to 0 here ... a layout hasn't yet happened
+                    Canvas.SetTop(resizer, _rowInfo[row].End + (spacing / 2) - 24);
+                    Canvas.SetLeft(resizer, (_colInfo[endCol].End + _colInfo[startCol].Start) / 2);
+                }
+                else
+                {
+                    resizer.Visibility = Visibility.Collapsed;
+                }
+            }
+
+            for (int col = 0; col < cols - 1; col++)
+            {
+                GridResizer resizer = (GridResizer)adornerChildren[childIndex++];
+                int startRow = -1;
+                int endRow = rows - 1;
+                for (int row = 0; row < rows; row++)
+                {
+                    if ((startRow == -1) && (_model.CellChildMap[row, col] != _model.CellChildMap[row, col + 1]))
+                    {
+                        startRow = row;
+                    }
+                    else if ((startRow != -1) && (_model.CellChildMap[row, col] == _model.CellChildMap[row, col + 1]))
+                    {
+                        endRow = row - 1;
+                        break;
+                    }
+                }
+
+                if (startRow != -1)
+                {
+                    Canvas.SetLeft(resizer, _colInfo[col].End + (spacing / 2) - 24); // hard coding this as (resizer.ActualWidth / 2) will still evaluate to 0 here ... a layout hasn't yet happened
+                    Canvas.SetTop(resizer, (_rowInfo[endRow].End + _rowInfo[startRow].Start) / 2);
+                    resizer.Visibility = Visibility.Visible;
+                }
+                else
+                {
+                    resizer.Visibility = Visibility.Collapsed;
+                }
+            }
+        }
+
+        public bool DragResizer(GridResizer resizer, double delta)
+        {
+            RowColInfo[] info;
+            int rowIndex = resizer.RowIndex;
+            int colIndex = resizer.ColIndex;
+            int[,] indices = _model.CellChildMap;
+            int[] percents = (resizer.Orientation == Orientation.Vertical) ? _model.ColumnPercents : _model.RowPercents;
+
+            double currentExtent, adjacentExtent = 0;
+            int currentPercent, adjacentPercent = 0, totalPercent, nextPercent;
+            int index;
+
+            if (resizer.Orientation == Orientation.Vertical)
+            {
+                info = _colInfo;
+                index = colIndex;
+
+                currentExtent = _colInfo[colIndex].Extent;
+                currentPercent = _colInfo[colIndex].Percent;
+
+                int col = colIndex;
+                while (col > 0 && indices[rowIndex, col] == indices[rowIndex, col - 1])
+                {
+                    col--;
+                    adjacentExtent += _colInfo[col].Extent;
+                    adjacentPercent += _colInfo[col].Percent;
+                }
+
+                nextPercent = currentPercent + adjacentPercent + info[index + 1].Percent;
+                totalPercent = nextPercent;
+
+                col = colIndex;
+                while (col < _model.Columns - 1 && indices[rowIndex, col] == indices[rowIndex, col + 1])
+                {
+                    col++;
+                    totalPercent += _colInfo[col].Percent;
+                }
+            }
+            else
+            {
+                info = _rowInfo;
+                index = rowIndex;
+
+                currentExtent = _rowInfo[rowIndex].Extent;
+                currentPercent = _rowInfo[rowIndex].Percent;
+
+                int row = rowIndex;
+                while (row > 0 && indices[row, colIndex] == indices[row - 1, colIndex])
+                {
+                    row--;
+                    adjacentExtent += _rowInfo[row].Extent;
+                    adjacentPercent += _rowInfo[row].Percent;
+                }
+
+                nextPercent = currentPercent + adjacentPercent + info[index + 1].Percent;
+                totalPercent = nextPercent;
+
+                row = rowIndex + 1;
+                while (row < _model.Rows - 1 && indices[row, colIndex] == indices[row + 1, colIndex])
+                {
+                    row++;
+                    totalPercent += _rowInfo[row].Percent;
+                }
+            }
+
+            double newExtent = currentExtent + adjacentExtent + delta;
+            int newPercent = (int)((currentPercent + adjacentPercent) * newExtent / (currentExtent + adjacentExtent));
+
+            if ((newPercent > 0) && (newPercent < totalPercent))
+            {
+                percents[rowIndex] = info[index].Percent = newPercent - adjacentPercent;
+                percents[rowIndex + 1] = info[index + 1].Percent = nextPercent - newPercent;
+
+                // TODO cols
+                if (percents[rowIndex] < 0)
+                {
+                    _model.CellChildMap[rowIndex, colIndex] = _model.CellChildMap[rowIndex + 1, colIndex];
+                    for (int col = 0; col < _model.Columns; col++)
+                    {
+                        if (col != colIndex)
+                        {
+                            _model.CellChildMap[rowIndex, col] = _model.CellChildMap[rowIndex - 1, col];
+                        }
+                    }
+
+                    percents[rowIndex] = _rowInfo[rowIndex].Percent = -percents[rowIndex];
+                    percents[rowIndex - 1] = _rowInfo[rowIndex - 1].Percent = percents[rowIndex - 1] - percents[rowIndex];
+                }
+
+                if (percents[rowIndex + 1] < 0)
+                {
+                    _model.CellChildMap[rowIndex + 1, colIndex] = _model.CellChildMap[rowIndex, colIndex];
+                    for (int col = 0; col < _model.Columns; col++)
+                    {
+                        if (col != colIndex)
+                        {
+                            _model.CellChildMap[rowIndex, col] = _model.CellChildMap[rowIndex + 2, col];
+                        }
+                    }
+
+                    percents[rowIndex + 1] = _rowInfo[rowIndex + 1].Percent = -percents[rowIndex + 1];
+                    percents[rowIndex] = _rowInfo[rowIndex].Percent = percents[rowIndex] - percents[rowIndex + 1];
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+
+        public int SwappedIndexAfterResize(GridResizer resizer)
+        {
+            if (resizer.Orientation == Orientation.Horizontal)
+            {
+                for (int i = 0; i < _model.Rows; i++)
+                {
+                    if (_rowInfo[i].Percent < 0)
+                    {
+                        _rowInfo[i].Percent = -_rowInfo[i].Percent;
+                        _rowInfo[i - 1].Percent -= _rowInfo[i].Percent;
+                        _rowInfo[i + 1].Percent -= _rowInfo[i].Percent;
+
+                        _model.RowPercents[i - 1] = _rowInfo[i - 1].Percent;
+                        _model.RowPercents[i] = _rowInfo[i].Percent;
+                        _model.RowPercents[i + 1] = _rowInfo[i + 1].Percent;
+
+                        return i;
+                    }
+                }
+            }
+            else
+            {
+                for (int i = 1; i < _model.Columns; i++)
+                {
+                    if (_colInfo[i].Percent < 0)
+                    {
+                        _colInfo[i - 1].Percent += _colInfo[i].Percent;
+                        _colInfo[i].Percent = -_colInfo[i].Percent;
+
+                        _model.ColumnPercents[i - 1] = _colInfo[i - 1].Percent;
+                        _model.ColumnPercents[i] = _colInfo[i].Percent;
+
+                        return i;
+                    }
+                }
+            }
+
+            return -1;
+        }
+
+        private GridLayoutModel _model;
+        private RowColInfo[] _rowInfo;
+        private RowColInfo[] _colInfo;
+    }
+}

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridData.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridData.cs
@@ -42,7 +42,7 @@ namespace FancyZonesEditor
                 NewPercent = (int)((CurrentPercent + AdjacentPercent) * newExtent / (CurrentExtent + _adjacentExtent));
             }
 
-            public void CalcAdjacentZones(int index, int spacing, int size, List<RowColInfo> info, Func<int, bool> indexCmpr)
+            public void CalcAdjacentZones(int index, int size, List<RowColInfo> info, Func<int, bool> indexCmpr)
             {
                 int ind = index;
                 while (ind > 0 && indexCmpr(ind))
@@ -393,7 +393,7 @@ namespace FancyZonesEditor
             }
         }
 
-        public ResizeInfo CalculateResizeInfo(GridResizer resizer, double delta, int spacing)
+        public ResizeInfo CalculateResizeInfo(GridResizer resizer, double delta)
         {
             ResizeInfo res = new ResizeInfo();
 
@@ -415,7 +415,7 @@ namespace FancyZonesEditor
                 index = colIndex;
 
                 Func<int, bool> indexCmpr = i => indices[rowIndex, i] == indices[rowIndex, i - 1];
-                res.CalcAdjacentZones(colIndex, spacing, _model.Columns, _colInfo, indexCmpr);
+                res.CalcAdjacentZones(colIndex, _model.Columns, _colInfo, indexCmpr);
             }
             else
             {
@@ -427,7 +427,7 @@ namespace FancyZonesEditor
                 index = rowIndex;
 
                 Func<int, bool> indexCmpr = i => indices[i, colIndex] == indices[i - 1, colIndex];
-                res.CalcAdjacentZones(rowIndex, spacing, _model.Rows, _rowInfo, indexCmpr);
+                res.CalcAdjacentZones(rowIndex, _model.Rows, _rowInfo, indexCmpr);
             }
 
             res.FixAccuracyError(info, percents, delta > 0 ? index + 2 : index + 1);

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridData.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridData.cs
@@ -301,6 +301,12 @@ namespace FancyZonesEditor
             int rows = _model.Rows;
             int cols = _model.Columns;
 
+            if (_model.CellChildMap.Length < rows * cols)
+            {
+                // Merge was not finished yet, rows and cols values are invalid
+                return;
+            }
+
             double left, top;
             for (int row = 0; row < rows; row++)
             {

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridDragHandles.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridDragHandles.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using FancyZonesEditor.Models;
@@ -28,7 +27,14 @@ namespace FancyZonesEditor
                     {
                         if (indices[row, col] != indices[row + 1, col])
                         {
-                            AddDragHandle(Orientation.Horizontal, row, row + 1, col, col + 1, row);
+                            int endCol = col + 1;
+                            while (endCol < model.Columns && indices[row, endCol] != indices[row + 1, endCol])
+                            {
+                                endCol++;
+                            }
+
+                            AddDragHandle(Orientation.Horizontal, row, row + 1, col, endCol, row);
+                            col = endCol - 1;
                         }
                     }
                 }
@@ -40,7 +46,14 @@ namespace FancyZonesEditor
                     {
                         if (indices[row, col] != indices[row, col + 1])
                         {
-                            AddDragHandle(Orientation.Vertical, row, row + 1, col, col + 1, col + model.Rows - 1);
+                            int endRow = row + 1;
+                            while (endRow < model.Rows && indices[endRow, col] != indices[endRow, col + 1])
+                            {
+                                endRow++;
+                            }
+
+                            AddDragHandle(Orientation.Vertical, row, endRow, col, col + 1, col + model.Rows - 1);
+                            row = endRow - 1;
                         }
                     }
                 }
@@ -296,86 +309,6 @@ namespace FancyZonesEditor
                 incValues(resizer);
                 differentOrientationResizersUpdate();
                 sameOrientationResizersUpdate(delta < 0);
-            }
-        }
-
-        public void UpdateAfterMerge(int startRow, int endRow, int startCol, int endCol, int rows)
-        {
-            int shift = 0;
-            List<int> horizontalRemoved = new List<int>(), verticalRemoved = new List<int>();
-
-            for (int i = 0; i < _resizers.Count; i++)
-            {
-                GridResizer resizer = (GridResizer)_resizers[i];
-
-                bool isStartRowColRemovable = resizer.StartRow >= startRow && resizer.StartCol >= startCol;
-                bool horizontalResizerToBeRemoved = resizer.Orientation == Orientation.Horizontal
-                    && isStartRowColRemovable && resizer.EndRow <= endRow && resizer.EndCol - 1 <= endCol;
-                bool verticalResizerToBeRemoved = resizer.Orientation == Orientation.Vertical
-                    && isStartRowColRemovable && resizer.EndRow - 1 <= endRow && resizer.EndCol <= endCol;
-
-                if (horizontalResizerToBeRemoved || verticalResizerToBeRemoved)
-                {
-                    if (resizer.Orientation == Orientation.Horizontal)
-                    {
-                        horizontalRemoved.Add(i + shift);
-                        rows--;
-                    }
-                    else
-                    {
-                        verticalRemoved.Add(i - rows + 1);
-                    }
-
-                    _resizers.Remove(resizer);
-                    i--;
-                    shift++;
-                }
-            }
-
-            foreach (GridResizer resizer in _resizers)
-            {
-                if (resizer.Orientation == Orientation.Horizontal)
-                {
-                    int diff = 0;
-                    for (int i = 0; i < horizontalRemoved.Count && horizontalRemoved[i] < resizer.StartRow; i++)
-                    {
-                        diff++;
-                    }
-
-                    resizer.StartRow -= diff;
-                    resizer.EndRow -= diff;
-
-                    for (int i = 0; i < verticalRemoved.Count && verticalRemoved[i] < resizer.EndCol; i++)
-                    {
-                        if (resizer.StartCol > verticalRemoved[i])
-                        {
-                            resizer.StartCol--;
-                        }
-
-                        resizer.EndCol--;
-                    }
-                }
-                else
-                {
-                    int diff = 0;
-                    for (int i = 0; i < verticalRemoved.Count && verticalRemoved[i] < resizer.StartCol; i++)
-                    {
-                        diff++;
-                    }
-
-                    resizer.StartCol -= diff;
-                    resizer.EndCol -= diff;
-
-                    for (int i = 0; i < horizontalRemoved.Count && horizontalRemoved[i] < resizer.EndRow; i++)
-                    {
-                        if (resizer.StartRow > horizontalRemoved[i])
-                        {
-                            resizer.StartRow--;
-                        }
-
-                        resizer.EndRow--;
-                    }
-                }
             }
         }
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridDragHandles.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridDragHandles.cs
@@ -124,7 +124,7 @@ namespace FancyZonesEditor
                 return resizer.StartRow == foundRow + 1;
             };
 
-            if (!UpdateDragHanlderForExistingSplit(Orientation.Vertical, cmpr, endCmpr, startCmpr))
+            if (!UpdateDragHandlerForExistingSplit(Orientation.Vertical, cmpr, endCmpr, startCmpr))
             {
                 AddDragHandle(Orientation.Vertical, foundRow, splitCol, model);
             }
@@ -147,7 +147,7 @@ namespace FancyZonesEditor
                 return resizer.StartCol == foundCol + 1;
             };
 
-            if (!UpdateDragHanlderForExistingSplit(Orientation.Horizontal, cmpr, endCmpr, startCmpr))
+            if (!UpdateDragHandlerForExistingSplit(Orientation.Horizontal, cmpr, endCmpr, startCmpr))
             {
                 AddDragHandle(Orientation.Horizontal, splitRow, foundCol, model);
             }
@@ -530,7 +530,7 @@ namespace FancyZonesEditor
             }
         }
 
-        private bool UpdateDragHanlderForExistingSplit(Orientation orientation, Func<GridResizer, bool> cmpr, Func<GridResizer, bool> endCmpr, Func<GridResizer, bool> startCmpr)
+        private bool UpdateDragHandlerForExistingSplit(Orientation orientation, Func<GridResizer, bool> cmpr, Func<GridResizer, bool> endCmpr, Func<GridResizer, bool> startCmpr)
         {
             bool updCurrentResizers = false;
             GridResizer leftNeighbour = null;

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridDragHandles.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridDragHandles.cs
@@ -191,192 +191,154 @@ namespace FancyZonesEditor
             }
         }
 
-        public void UpdateAfterNegativeSwap(GridResizer resizer, double delta)
+        public void UpdateAfterSwap(GridResizer resizer, double delta)
         {
-            bool isHorizontal = resizer.Orientation == Orientation.Horizontal;
-            if (delta < 0)
+            Orientation orientation = resizer.Orientation;
+            bool isHorizontal = orientation == Orientation.Horizontal;
+            bool isDeltaNegative = delta < 0;
+            List<GridResizer> swappedResizers = new List<GridResizer>();
+
+            if (isDeltaNegative)
             {
-                DecreaseResizerValues(resizer, resizer.Orientation);
-                List<GridResizer> swappedResizers = new List<GridResizer>();
-
-                foreach (GridResizer r in _resizers)
-                {
-                    if (r.Orientation == resizer.Orientation)
-                    {
-                        if ((isHorizontal && r.StartRow == resizer.StartRow && r.StartCol != resizer.StartCol) ||
-                            (!isHorizontal && r.StartCol == resizer.StartCol && r.StartRow != resizer.StartRow))
-                        {
-                            IncreaseResizerValues(r, resizer.Orientation);
-                            swappedResizers.Add(r);
-                        }
-                    }
-                }
-
-                foreach (GridResizer r in _resizers)
-                {
-                    if (r.Orientation != resizer.Orientation)
-                    {
-                        if (isHorizontal)
-                        {
-                            // vertical resizers corresponfding to dragged resizer
-                            if (r.StartCol >= resizer.StartCol && r.EndCol < resizer.EndCol)
-                            {
-                                if (r.StartRow == resizer.StartRow + 2)
-                                {
-                                    r.StartRow--;
-                                }
-
-                                if (r.EndRow == resizer.EndRow + 1)
-                                {
-                                    r.EndRow--;
-                                }
-                            }
-                            else
-                            {
-                                // vertical resizers corresponfding to swapped resizers
-                                foreach (GridResizer sr in swappedResizers)
-                                {
-                                    if (r.StartCol >= sr.StartCol && r.EndCol <= sr.EndCol)
-                                    {
-                                        if (r.StartRow == resizer.StartRow + 1)
-                                        {
-                                            r.StartRow++;
-                                        }
-
-                                        if (r.EndRow == resizer.EndRow)
-                                        {
-                                            r.EndRow++;
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        else
-                        {
-                            // horizontal resizers corresponfding to dragged resizer
-                            if (r.StartRow >= resizer.StartRow && r.EndRow < resizer.EndRow)
-                            {
-                                if (r.StartCol == resizer.StartCol + 2)
-                                {
-                                    r.StartCol--;
-                                }
-
-                                if (r.EndCol == resizer.EndCol + 1)
-                                {
-                                    r.EndCol--;
-                                }
-                            }
-                            else
-                            {
-                                // horizontal resizers corresponfding to swapped resizers
-                                foreach (GridResizer sr in swappedResizers)
-                                {
-                                    if (r.StartRow >= sr.StartRow && r.EndRow <= sr.EndRow)
-                                    {
-                                        if (r.StartCol == resizer.StartCol + 1)
-                                        {
-                                            r.StartCol++;
-                                        }
-
-                                        if (r.EndCol == resizer.EndCol)
-                                        {
-                                            r.EndCol++;
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
+                DecreaseResizerValues(resizer, orientation);
             }
             else
             {
-                IncreaseResizerValues(resizer, resizer.Orientation);
-                List<GridResizer> swappedResizers = new List<GridResizer>();
+                IncreaseResizerValues(resizer, orientation);
+            }
 
-                foreach (GridResizer r in _resizers)
+            // same orientation resizers update
+            foreach (GridResizer r in _resizers)
+            {
+                if (r.Orientation == orientation)
                 {
-                    if (r.Orientation == resizer.Orientation)
+                    if ((isHorizontal && r.StartRow == resizer.StartRow && r.StartCol != resizer.StartCol) ||
+                        (!isHorizontal && r.StartCol == resizer.StartCol && r.StartRow != resizer.StartRow))
                     {
-                        if ((isHorizontal && r.StartRow == resizer.StartRow && r.StartCol != resizer.StartCol) ||
-                            (!isHorizontal && r.StartCol == resizer.StartCol && r.StartRow != resizer.StartRow))
+                        if (isDeltaNegative)
                         {
-                            DecreaseResizerValues(r, resizer.Orientation);
-                            swappedResizers.Add(r);
+                            IncreaseResizerValues(r, orientation);
                         }
+                        else
+                        {
+                            DecreaseResizerValues(r, orientation);
+                        }
+
+                        swappedResizers.Add(r);
                     }
                 }
+            }
 
-                foreach (GridResizer r in _resizers)
+            // different orientation resizers update
+            foreach (GridResizer r in _resizers)
+            {
+                if (r.Orientation != resizer.Orientation)
                 {
-                    if (r.Orientation != resizer.Orientation)
+                    if (isHorizontal)
                     {
-                        if (isHorizontal)
+                        // vertical resizers corresponding to dragged resizer
+                        if (r.StartCol >= resizer.StartCol && r.EndCol < resizer.EndCol)
                         {
-                            // vertical resizers corresponfding to dragged resizer
-                            if (r.StartCol >= resizer.StartCol && r.EndCol < resizer.EndCol)
+                            if (r.StartRow == resizer.StartRow + 2 && isDeltaNegative)
                             {
-                                if (r.StartRow == resizer.StartRow)
-                                {
-                                    r.StartRow++;
-                                }
-
-                                if (r.EndRow == resizer.EndRow - 1)
-                                {
-                                    r.EndRow++;
-                                }
+                                r.StartRow--;
                             }
-                            else
-                            {
-                                // vertical resizers corresponfding to swapped resizers
-                                foreach (GridResizer sr in swappedResizers)
-                                {
-                                    if (r.StartCol >= sr.StartCol && r.EndCol <= sr.EndCol)
-                                    {
-                                        if (r.StartRow == resizer.StartRow + 1)
-                                        {
-                                            r.StartRow--;
-                                        }
 
-                                        if (r.EndRow == resizer.EndRow)
-                                        {
-                                            r.EndRow--;
-                                        }
-                                    }
-                                }
+                            if (r.EndRow == resizer.EndRow + 1 && isDeltaNegative)
+                            {
+                                r.EndRow--;
+                            }
+
+                            if (r.StartRow == resizer.StartRow && !isDeltaNegative)
+                            {
+                                r.StartRow++;
+                            }
+
+                            if (r.EndRow == resizer.EndRow - 1 && !isDeltaNegative)
+                            {
+                                r.EndRow++;
                             }
                         }
                         else
                         {
-                            // horizontal resizers corresponfding to dragged resizer
-                            if (r.StartRow >= resizer.StartRow && r.EndRow < resizer.EndRow)
+                            // vertical resizers corresponding to swapped resizers
+                            foreach (GridResizer sr in swappedResizers)
                             {
-                                if (r.StartCol == resizer.StartCol)
+                                if (r.StartCol >= sr.StartCol && r.EndCol <= sr.EndCol)
                                 {
-                                    r.StartCol++;
-                                }
+                                    if (r.StartRow == resizer.StartRow + 1 && isDeltaNegative)
+                                    {
+                                        r.StartRow++;
+                                    }
 
-                                if (r.EndCol == resizer.EndCol - 1)
-                                {
-                                    r.EndCol++;
+                                    if (r.EndRow == resizer.EndRow && isDeltaNegative)
+                                    {
+                                        r.EndRow++;
+                                    }
+
+                                    if (r.StartRow == resizer.StartRow + 1 && !isDeltaNegative)
+                                    {
+                                        r.StartRow--;
+                                    }
+
+                                    if (r.EndRow == resizer.EndRow && !isDeltaNegative)
+                                    {
+                                        r.EndRow--;
+                                    }
                                 }
                             }
-                            else
+                        }
+                    }
+                    else
+                    {
+                        // horizontal resizers corresponding to dragged resizer
+                        if (r.StartRow >= resizer.StartRow && r.EndRow < resizer.EndRow)
+                        {
+                            if (r.StartCol == resizer.StartCol + 3 && isDeltaNegative)
                             {
-                                // horizontal resizers corresponfding to swapped resizers
-                                foreach (GridResizer sr in swappedResizers)
-                                {
-                                    if (r.StartRow >= sr.StartRow && r.EndRow <= sr.EndRow)
-                                    {
-                                        if (r.StartCol == resizer.StartCol + 1)
-                                        {
-                                            r.StartCol--;
-                                        }
+                                r.StartCol--;
+                            }
 
-                                        if (r.EndCol == resizer.EndCol)
-                                        {
-                                            r.EndCol--;
-                                        }
+                            if (r.EndCol == resizer.EndCol + 1 && isDeltaNegative)
+                            {
+                                r.EndCol--;
+                            }
+
+                            if (r.StartCol == resizer.StartCol && !isDeltaNegative)
+                            {
+                                r.StartCol++;
+                            }
+
+                            if (r.EndCol == resizer.EndCol - 1 && !isDeltaNegative)
+                            {
+                                r.EndCol++;
+                            }
+                        }
+                        else
+                        {
+                            // horizontal resizers corresponding to swapped resizers
+                            foreach (GridResizer sr in swappedResizers)
+                            {
+                                if (r.StartRow >= sr.StartRow && r.EndRow <= sr.EndRow)
+                                {
+                                    if (r.StartCol == resizer.StartCol + 1 && isDeltaNegative)
+                                    {
+                                        r.StartCol++;
+                                    }
+
+                                    if (r.EndCol == resizer.EndCol && isDeltaNegative)
+                                    {
+                                        r.EndCol++;
+                                    }
+
+                                    if (r.StartCol == resizer.StartCol + 1 && !isDeltaNegative)
+                                    {
+                                        r.StartCol--;
+                                    }
+
+                                    if (r.EndCol == resizer.EndCol && !isDeltaNegative)
+                                    {
+                                        r.EndCol--;
                                     }
                                 }
                             }
@@ -386,123 +348,112 @@ namespace FancyZonesEditor
             }
         }
 
-        public void UpdateAfterDragSplit(GridResizer resizer, double delta)
+        public void UpdateAfterDetach(GridResizer resizer, double delta)
         {
-            Action differentOrientationResizersUpdate = () =>
+            bool isDeltaNegative = delta < 0;
+            Orientation orientation = resizer.Orientation;
+
+            foreach (GridResizer r in _resizers)
             {
-                foreach (GridResizer r in _resizers)
+                bool notEqual = r.StartRow != resizer.StartRow || r.EndRow != resizer.EndRow || r.StartCol != resizer.StartCol || r.EndCol != resizer.EndCol;
+                if (r.Orientation == orientation && notEqual)
                 {
-                    if (r.Orientation != resizer.Orientation)
+                    if (orientation == Orientation.Horizontal)
                     {
-                        if (resizer.Orientation == Orientation.Vertical)
+                        if (r.StartRow > resizer.StartRow || (r.StartRow == resizer.StartRow && isDeltaNegative))
                         {
-                            if (delta > 0)
+                            r.StartRow++;
+                        }
+
+                        if (r.EndRow > resizer.EndRow || (r.EndRow == resizer.EndRow && isDeltaNegative))
+                        {
+                            r.EndRow++;
+                        }
+                    }
+                    else
+                    {
+                        if (r.StartCol > resizer.StartCol || (r.StartCol == resizer.StartCol && isDeltaNegative))
+                        {
+                            r.StartCol++;
+                        }
+
+                        if (r.EndCol > resizer.EndCol || (r.EndCol == resizer.EndCol && isDeltaNegative))
+                        {
+                            r.EndCol++;
+                        }
+                    }
+                }
+            }
+
+            if (!isDeltaNegative)
+            {
+                IncreaseResizerValues(resizer, orientation);
+            }
+
+            foreach (GridResizer r in _resizers)
+            {
+                if (r.Orientation != orientation)
+                {
+                    if (orientation == Orientation.Vertical)
+                    {
+                        if (isDeltaNegative)
+                        {
+                            bool isRowNonAdjacent = r.EndRow < resizer.StartRow || r.StartRow > resizer.EndRow;
+
+                            if (r.StartCol > resizer.StartCol + 1 || (r.StartCol == resizer.StartCol + 1 && isRowNonAdjacent))
                             {
-                                bool isInside = r.StartRow >= resizer.StartRow && r.EndRow < resizer.EndRow;
-
-                                if (r.StartCol > resizer.StartCol || (r.StartCol == resizer.StartCol && isInside))
-                                {
-                                    r.StartCol++;
-                                }
-
-                                if (r.EndCol > resizer.StartCol || (r.EndCol == resizer.StartCol && isInside))
-                                {
-                                    r.EndCol++;
-                                }
+                                r.StartCol++;
                             }
-                            else
+
+                            if (r.EndCol > resizer.EndCol || (r.EndCol == resizer.EndCol && isRowNonAdjacent))
                             {
-                                bool isOutside = r.StartRow >= resizer.EndRow || r.EndRow <= resizer.StartRow;
-
-                                if (r.StartCol > resizer.StartCol || (r.StartCol == resizer.StartCol && isOutside))
-                                {
-                                    r.StartCol++;
-                                }
-
-                                if (r.EndCol > resizer.EndCol || (r.EndCol == resizer.EndCol && isOutside))
-                                {
-                                    r.EndCol++;
-                                }
+                                r.EndCol++;
                             }
                         }
                         else
                         {
-                            if (delta > 0)
+                            if (r.StartCol > resizer.StartCol || (r.StartCol == resizer.StartCol && r.StartRow >= resizer.StartRow && r.EndRow <= resizer.EndRow))
                             {
-                                bool isInside = r.StartCol >= resizer.StartCol && r.EndCol < resizer.EndCol;
-
-                                if (r.StartRow > resizer.StartRow || (r.StartRow == resizer.StartRow && isInside))
-                                {
-                                    r.StartRow++;
-                                }
-
-                                if (r.EndRow > resizer.StartRow || (r.EndRow == resizer.StartRow && isInside))
-                                {
-                                    r.EndRow++;
-                                }
+                                r.StartCol++;
                             }
-                            else
+
+                            if (r.EndCol > resizer.EndCol - 1 || (r.EndCol == resizer.EndCol - 1 && r.StartRow >= resizer.StartRow && r.EndRow <= resizer.EndRow))
                             {
-                                bool isOutside = r.StartCol >= resizer.EndCol || r.EndCol <= resizer.StartCol;
-
-                                if (r.StartRow > resizer.StartRow || (r.StartRow == resizer.StartRow && isOutside))
-                                {
-                                    r.StartRow++;
-                                }
-
-                                if (r.EndRow > resizer.EndRow || (r.EndRow == resizer.EndRow && isOutside))
-                                {
-                                    r.EndRow++;
-                                }
+                                r.EndCol++;
                             }
                         }
                     }
-                }
-            };
-
-            Action sameOrientationResizersUpdate = () =>
-            {
-                foreach (GridResizer r in _resizers)
-                {
-                    bool notEqual = r.StartRow != resizer.StartRow || r.EndRow != resizer.EndRow || r.StartCol != resizer.StartCol || r.EndCol != resizer.EndCol;
-                    if (r.Orientation == resizer.Orientation)
+                    else
                     {
-                        if (resizer.Orientation == Orientation.Horizontal)
+                        if (isDeltaNegative)
                         {
-                            if (r.StartRow > resizer.StartRow)
+                            bool isColNonAdjacent = r.EndCol < resizer.StartCol || r.StartCol > resizer.EndCol;
+
+                            if (r.StartRow > resizer.StartRow + 1 || (r.StartRow == resizer.StartRow + 1 && isColNonAdjacent))
                             {
                                 r.StartRow++;
                             }
 
-                            if (r.EndRow > resizer.StartRow && notEqual)
+                            if (r.EndRow > resizer.EndRow || (r.EndRow == resizer.EndRow && isColNonAdjacent))
                             {
                                 r.EndRow++;
                             }
                         }
                         else
                         {
-                            if (r.StartCol > resizer.StartCol)
+                            if (r.StartRow > resizer.StartRow || (r.StartRow == resizer.StartRow && r.StartCol >= resizer.StartCol && r.EndCol <= resizer.EndCol))
                             {
-                                r.StartCol++;
+                                r.StartRow++;
                             }
 
-                            if (r.EndCol > resizer.StartCol && notEqual)
+                            if (r.EndRow > resizer.EndRow - 1 || (r.EndRow == resizer.EndRow - 1 && r.StartCol >= resizer.StartCol && r.EndCol <= resizer.EndCol))
                             {
-                                r.EndCol++;
+                                r.EndRow++;
                             }
                         }
                     }
                 }
-            };
-
-            sameOrientationResizersUpdate();
-
-            if (delta > 0)
-            {
-                IncreaseResizerValues(resizer, resizer.Orientation);
             }
-
-            differentOrientationResizersUpdate();
         }
 
         public void RemoveDragHandles()

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridDragHandles.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridDragHandles.cs
@@ -1,0 +1,458 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using FancyZonesEditor.Models;
+
+namespace FancyZonesEditor
+{
+    public class GridDragHandles
+    {
+        public GridDragHandles(UIElementCollection resizers, Action<object, DragDeltaEventArgs> dragDelta, Action<object, DragCompletedEventArgs> dragCompleted)
+        {
+            _resizers = resizers;
+            _dragDelta = dragDelta;
+            _dragCompleted = dragCompleted;
+        }
+
+        public void InitDragHandles(GridLayoutModel model)
+        {
+            if (_resizers.Count == 0)
+            {
+                int[,] indices = model.CellChildMap;
+
+                // horizontal resizers
+                for (int row = 0; row < model.Rows - 1; row++)
+                {
+                    for (int col = 0; col < model.Columns; col++)
+                    {
+                        if (indices[row, col] != indices[row + 1, col])
+                        {
+                            AddDragHandle(Orientation.Horizontal, row, row + 1, col, col + 1, row);
+                        }
+                    }
+                }
+
+                // vertical resizers
+                for (int col = 0; col < model.Columns - 1; col++)
+                {
+                    for (int row = 0; row < model.Rows; row++)
+                    {
+                        if (indices[row, col] != indices[row, col + 1])
+                        {
+                            AddDragHandle(Orientation.Vertical, row, row + 1, col, col + 1, col + model.Rows - 1);
+                        }
+                    }
+                }
+            }
+        }
+
+        public void AddDragHandle(Orientation orientation, int foundRow, int foundCol, GridLayoutModel model)
+        {
+            int[,] indices = model.CellChildMap;
+
+            int endRow = foundRow + 1;
+            while (endRow < model.Rows && indices[endRow, foundCol] == indices[endRow - 1, foundCol])
+            {
+                endRow++;
+            }
+
+            int endCol = foundCol + 1;
+            while (endCol < model.Columns && indices[foundRow, endCol] == indices[foundRow, endCol - 1])
+            {
+                endCol++;
+            }
+
+            int index = (orientation == Orientation.Horizontal) ? foundRow : foundCol + model.Rows - 1;
+            AddDragHandle(orientation, foundRow, endRow, foundCol, endCol, index);
+        }
+
+        public void AddDragHandle(Orientation orientation, int rowStart, int rowEnd, int colStart, int colEnd, int index)
+        {
+            GridResizer resizer = new GridResizer
+            {
+                Orientation = orientation,
+                StartRow = rowStart,
+                EndRow = rowEnd,
+                StartCol = colStart,
+                EndCol = colEnd,
+            };
+
+            resizer.DragDelta += (obj, eventArgs) => _dragDelta(obj, eventArgs);
+            resizer.DragCompleted += (obj, eventArgs) => _dragCompleted(obj, eventArgs);
+
+            if (index > _resizers.Count)
+            {
+                index = _resizers.Count;
+            }
+
+            _resizers.Insert(index, resizer);
+        }
+
+        public void UpdateForExistingVerticalSplit(GridLayoutModel model, int foundRow, int splitCol)
+        {
+            Func<GridResizer, bool> cmpr = (GridResizer resizer) =>
+            {
+                return resizer.Orientation == Orientation.Vertical && resizer.StartCol == splitCol;
+            };
+
+            Func<GridResizer, bool> endCmpr = (GridResizer resizer) =>
+            {
+                return resizer.EndRow == foundRow;
+            };
+
+            Func<GridResizer, bool> startCmpr = (GridResizer resizer) =>
+            {
+                return resizer.StartRow == foundRow + 1;
+            };
+
+            if (!UpdateDragHanlderForExistingSplit(Orientation.Vertical, cmpr, endCmpr, startCmpr))
+            {
+                AddDragHandle(Orientation.Vertical, foundRow, splitCol, model);
+            }
+        }
+
+        public void UpdateForExistingHorizontalSplit(GridLayoutModel model, int splitRow, int foundCol)
+        {
+            Func<GridResizer, bool> cmpr = (GridResizer resizer) =>
+            {
+                return resizer.Orientation == Orientation.Horizontal && resizer.StartRow == splitRow;
+            };
+
+            Func<GridResizer, bool> endCmpr = (GridResizer resizer) =>
+            {
+                return resizer.EndCol == foundCol;
+            };
+
+            Func<GridResizer, bool> startCmpr = (GridResizer resizer) =>
+            {
+                return resizer.StartCol == foundCol + 1;
+            };
+
+            if (!UpdateDragHanlderForExistingSplit(Orientation.Horizontal, cmpr, endCmpr, startCmpr))
+            {
+                AddDragHandle(Orientation.Horizontal, splitRow, foundCol, model);
+            }
+        }
+
+        /**
+         * Has to be called on split before adding new drag handle
+         */
+        public void UpdateAfterVerticalSplit(int foundCol)
+        {
+            foreach (GridResizer r in _resizers)
+            {
+                if (r.StartCol > foundCol || (r.StartCol == foundCol && r.Orientation == Orientation.Vertical))
+                {
+                    r.StartCol++;
+                }
+
+                if (r.EndCol > foundCol)
+                {
+                    r.EndCol++;
+                }
+            }
+        }
+
+        /**
+         * Has to be called on split before adding new drag handle
+         */
+        public void UpdateAfterHorizontalSplit(int foundRow)
+        {
+            foreach (GridResizer r in _resizers)
+            {
+                if (r.StartRow > foundRow || (r.StartRow == foundRow && r.Orientation == Orientation.Horizontal))
+                {
+                    r.StartRow++;
+                }
+
+                if (r.EndRow > foundRow)
+                {
+                    r.EndRow++;
+                }
+            }
+        }
+
+        public void UpdateAfterNegativeSwap(GridResizer resizer, double delta)
+        {
+            Action<GridResizer> incValues = r =>
+            {
+                if (resizer.Orientation == Orientation.Vertical)
+                {
+                    r.StartCol++;
+                    r.EndCol++;
+                }
+                else
+                {
+                    r.StartRow++;
+                    r.EndRow++;
+                }
+            };
+
+            Action<GridResizer> decValues = r =>
+            {
+                if (resizer.Orientation == Orientation.Vertical)
+                {
+                    r.StartCol--;
+                    r.EndCol--;
+                }
+                else
+                {
+                    r.StartRow--;
+                    r.EndRow--;
+                }
+            };
+
+            Action<GridResizer> horizontalResizersRowsUpd = r =>
+            {
+                if (r.StartCol == resizer.StartCol)
+                {
+                    r.StartCol++;
+                }
+                else if (r.StartCol == resizer.EndCol)
+                {
+                    r.StartCol--;
+                }
+
+                if (r.EndCol == resizer.StartCol)
+                {
+                    r.EndCol++;
+                }
+                else if (r.EndCol == resizer.EndCol)
+                {
+                    r.EndCol--;
+                }
+            };
+
+            Action<GridResizer> verticalResizersColumnsUpd = r =>
+            {
+                if (r.StartRow == resizer.StartRow)
+                {
+                    r.StartRow++;
+                }
+                else if (r.StartRow == resizer.EndRow)
+                {
+                    r.StartRow--;
+                }
+
+                if (r.EndRow == resizer.StartRow)
+                {
+                    r.EndRow++;
+                }
+                else if (r.EndRow == resizer.EndRow)
+                {
+                    r.EndRow--;
+                }
+            };
+
+            Action differentOrientationResizersUpdate = () =>
+            {
+                foreach (GridResizer r in _resizers)
+                {
+                    if (r.Orientation != resizer.Orientation)
+                    {
+                        if (resizer.Orientation == Orientation.Vertical)
+                        {
+                            horizontalResizersRowsUpd(r);
+                        }
+                        else
+                        {
+                            verticalResizersColumnsUpd(r);
+                        }
+                    }
+                }
+            };
+
+            Action<bool> sameOrientationResizersUpdate = isDeltaNegative =>
+            {
+                foreach (GridResizer r in _resizers)
+                {
+                    bool isSameCol = resizer.StartRow != r.StartRow && resizer.StartCol == r.StartCol && resizer.Orientation == Orientation.Vertical;
+                    bool isSameRow = resizer.StartRow == r.StartRow && resizer.StartCol != r.StartCol && resizer.Orientation == Orientation.Horizontal;
+                    if (r.Orientation == resizer.Orientation && (isSameCol || isSameRow))
+                    {
+                        if (isDeltaNegative)
+                        {
+                            incValues(r);
+                        }
+                        else
+                        {
+                            decValues(r);
+                        }
+
+                        break;
+                    }
+                }
+            };
+
+            if (delta < 0)
+            {
+                differentOrientationResizersUpdate();
+                decValues(resizer);
+                sameOrientationResizersUpdate(delta < 0);
+            }
+            else
+            {
+                incValues(resizer);
+                differentOrientationResizersUpdate();
+                sameOrientationResizersUpdate(delta < 0);
+            }
+        }
+
+        public void UpdateAfterMerge(int startRow, int endRow, int startCol, int endCol, int rows)
+        {
+            int shift = 0;
+            List<int> horizontalRemoved = new List<int>(), verticalRemoved = new List<int>();
+
+            for (int i = 0; i < _resizers.Count; i++)
+            {
+                GridResizer resizer = (GridResizer)_resizers[i];
+
+                bool isStartRowColRemovable = resizer.StartRow >= startRow && resizer.StartCol >= startCol;
+                bool horizontalResizerToBeRemoved = resizer.Orientation == Orientation.Horizontal
+                    && isStartRowColRemovable && resizer.EndRow <= endRow && resizer.EndCol - 1 <= endCol;
+                bool verticalResizerToBeRemoved = resizer.Orientation == Orientation.Vertical
+                    && isStartRowColRemovable && resizer.EndRow - 1 <= endRow && resizer.EndCol <= endCol;
+
+                if (horizontalResizerToBeRemoved || verticalResizerToBeRemoved)
+                {
+                    if (resizer.Orientation == Orientation.Horizontal)
+                    {
+                        horizontalRemoved.Add(i + shift);
+                        rows--;
+                    }
+                    else
+                    {
+                        verticalRemoved.Add(i - rows + 1);
+                    }
+
+                    _resizers.Remove(resizer);
+                    i--;
+                    shift++;
+                }
+            }
+
+            foreach (GridResizer resizer in _resizers)
+            {
+                if (resizer.Orientation == Orientation.Horizontal)
+                {
+                    int diff = 0;
+                    for (int i = 0; i < horizontalRemoved.Count && horizontalRemoved[i] < resizer.StartRow; i++)
+                    {
+                        diff++;
+                    }
+
+                    resizer.StartRow -= diff;
+                    resizer.EndRow -= diff;
+
+                    for (int i = 0; i < verticalRemoved.Count && verticalRemoved[i] < resizer.EndCol; i++)
+                    {
+                        if (resizer.StartCol > verticalRemoved[i])
+                        {
+                            resizer.StartCol--;
+                        }
+
+                        resizer.EndCol--;
+                    }
+                }
+                else
+                {
+                    int diff = 0;
+                    for (int i = 0; i < verticalRemoved.Count && verticalRemoved[i] < resizer.StartCol; i++)
+                    {
+                        diff++;
+                    }
+
+                    resizer.StartCol -= diff;
+                    resizer.EndCol -= diff;
+
+                    for (int i = 0; i < horizontalRemoved.Count && horizontalRemoved[i] < resizer.EndRow; i++)
+                    {
+                        if (resizer.StartRow > horizontalRemoved[i])
+                        {
+                            resizer.StartRow--;
+                        }
+
+                        resizer.EndRow--;
+                    }
+                }
+            }
+        }
+
+        public void RemoveDragHandles()
+        {
+            _resizers.Clear();
+        }
+
+        private bool UpdateDragHanlderForExistingSplit(Orientation orientation, Func<GridResizer, bool> cmpr, Func<GridResizer, bool> endCmpr, Func<GridResizer, bool> startCmpr)
+        {
+            bool updCurrentResizers = false;
+            GridResizer leftNeighbour = null;
+            GridResizer rightNeighbour = null;
+
+            for (int i = 0; i < _resizers.Count && (leftNeighbour == null || rightNeighbour == null); i++)
+            {
+                GridResizer resizer = (GridResizer)_resizers[i];
+                if (cmpr(resizer))
+                {
+                    if (leftNeighbour == null && endCmpr(resizer))
+                    {
+                        leftNeighbour = resizer;
+                        updCurrentResizers = true;
+                    }
+
+                    if (rightNeighbour == null && startCmpr(resizer))
+                    {
+                        rightNeighbour = resizer;
+                        updCurrentResizers = true;
+                    }
+                }
+            }
+
+            if (updCurrentResizers)
+            {
+                if (leftNeighbour != null && rightNeighbour != null)
+                {
+                    if (orientation == Orientation.Vertical)
+                    {
+                        leftNeighbour.EndRow = rightNeighbour.EndRow;
+                    }
+                    else
+                    {
+                        leftNeighbour.EndCol = rightNeighbour.EndCol;
+                    }
+
+                    _resizers.Remove(rightNeighbour);
+                }
+                else if (leftNeighbour != null)
+                {
+                    if (orientation == Orientation.Vertical)
+                    {
+                        leftNeighbour.EndRow++;
+                    }
+                    else
+                    {
+                        leftNeighbour.EndCol++;
+                    }
+                }
+                else if (rightNeighbour != null)
+                {
+                    if (orientation == Orientation.Vertical)
+                    {
+                        rightNeighbour.StartRow--;
+                    }
+                    else
+                    {
+                        rightNeighbour.StartCol--;
+                    }
+                }
+            }
+
+            return updCurrentResizers;
+        }
+
+        private readonly UIElementCollection _resizers;
+        private readonly Action<object, DragDeltaEventArgs> _dragDelta;
+        private readonly Action<object, DragCompletedEventArgs> _dragCompleted;
+    }
+}

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridDragHandles.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridDragHandles.cs
@@ -1,4 +1,9 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
+using System.Collections.Generic;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using FancyZonesEditor.Models;
@@ -188,99 +193,196 @@ namespace FancyZonesEditor
 
         public void UpdateAfterNegativeSwap(GridResizer resizer, double delta)
         {
-            Action<GridResizer> horizontalResizersRowsUpd = r =>
+            bool isHorizontal = resizer.Orientation == Orientation.Horizontal;
+            if (delta < 0)
             {
-                if (r.StartCol == resizer.StartCol)
+                DecreaseResizerValues(resizer, resizer.Orientation);
+                List<GridResizer> swappedResizers = new List<GridResizer>();
+
+                foreach (GridResizer r in _resizers)
                 {
-                    r.StartCol++;
-                }
-                else if (r.StartCol == resizer.EndCol)
-                {
-                    r.StartCol--;
+                    if (r.Orientation == resizer.Orientation)
+                    {
+                        if ((isHorizontal && r.StartRow == resizer.StartRow && r.StartCol != resizer.StartCol) ||
+                            (!isHorizontal && r.StartCol == resizer.StartCol && r.StartRow != resizer.StartRow))
+                        {
+                            IncreaseResizerValues(r, resizer.Orientation);
+                            swappedResizers.Add(r);
+                        }
+                    }
                 }
 
-                if (r.EndCol == resizer.StartCol)
-                {
-                    r.EndCol++;
-                }
-                else if (r.EndCol == resizer.EndCol)
-                {
-                    r.EndCol--;
-                }
-            };
-
-            Action<GridResizer> verticalResizersColumnsUpd = r =>
-            {
-                if (r.StartRow == resizer.StartRow)
-                {
-                    r.StartRow++;
-                }
-                else if (r.StartRow == resizer.EndRow)
-                {
-                    r.StartRow--;
-                }
-
-                if (r.EndRow == resizer.StartRow)
-                {
-                    r.EndRow++;
-                }
-                else if (r.EndRow == resizer.EndRow)
-                {
-                    r.EndRow--;
-                }
-            };
-
-            Action differentOrientationResizersUpdate = () =>
-            {
                 foreach (GridResizer r in _resizers)
                 {
                     if (r.Orientation != resizer.Orientation)
                     {
-                        if (resizer.Orientation == Orientation.Vertical)
+                        if (isHorizontal)
                         {
-                            horizontalResizersRowsUpd(r);
+                            // vertical resizers corresponfding to dragged resizer
+                            if (r.StartCol >= resizer.StartCol && r.EndCol < resizer.EndCol)
+                            {
+                                if (r.StartRow == resizer.StartRow + 2)
+                                {
+                                    r.StartRow--;
+                                }
+
+                                if (r.EndRow == resizer.EndRow + 1)
+                                {
+                                    r.EndRow--;
+                                }
+                            }
+                            else
+                            {
+                                // vertical resizers corresponfding to swapped resizers
+                                foreach (GridResizer sr in swappedResizers)
+                                {
+                                    if (r.StartCol >= sr.StartCol && r.EndCol <= sr.EndCol)
+                                    {
+                                        if (r.StartRow == resizer.StartRow + 1)
+                                        {
+                                            r.StartRow++;
+                                        }
+
+                                        if (r.EndRow == resizer.EndRow)
+                                        {
+                                            r.EndRow++;
+                                        }
+                                    }
+                                }
+                            }
                         }
                         else
                         {
-                            verticalResizersColumnsUpd(r);
+                            // horizontal resizers corresponfding to dragged resizer
+                            if (r.StartRow >= resizer.StartRow && r.EndRow < resizer.EndRow)
+                            {
+                                if (r.StartCol == resizer.StartCol + 2)
+                                {
+                                    r.StartCol--;
+                                }
+
+                                if (r.EndCol == resizer.EndCol + 1)
+                                {
+                                    r.EndCol--;
+                                }
+                            }
+                            else
+                            {
+                                // horizontal resizers corresponfding to swapped resizers
+                                foreach (GridResizer sr in swappedResizers)
+                                {
+                                    if (r.StartRow >= sr.StartRow && r.EndRow <= sr.EndRow)
+                                    {
+                                        if (r.StartCol == resizer.StartCol + 1)
+                                        {
+                                            r.StartCol++;
+                                        }
+
+                                        if (r.EndCol == resizer.EndCol)
+                                        {
+                                            r.EndCol++;
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                 }
-            };
-
-            Action<bool> sameOrientationResizersUpdate = isDeltaNegative =>
-            {
-                foreach (GridResizer r in _resizers)
-                {
-                    bool isSameCol = resizer.StartRow != r.StartRow && resizer.StartCol == r.StartCol && resizer.Orientation == Orientation.Vertical;
-                    bool isSameRow = resizer.StartRow == r.StartRow && resizer.StartCol != r.StartCol && resizer.Orientation == Orientation.Horizontal;
-                    if (r.Orientation == resizer.Orientation && (isSameCol || isSameRow))
-                    {
-                        if (isDeltaNegative)
-                        {
-                            IncreaseResizerValues(r, resizer.Orientation);
-                        }
-                        else
-                        {
-                            DecreaseResizerValues(r, resizer.Orientation);
-                        }
-
-                        break;
-                    }
-                }
-            };
-
-            if (delta < 0)
-            {
-                differentOrientationResizersUpdate();
-                DecreaseResizerValues(resizer, resizer.Orientation);
-                sameOrientationResizersUpdate(delta < 0);
             }
             else
             {
                 IncreaseResizerValues(resizer, resizer.Orientation);
-                differentOrientationResizersUpdate();
-                sameOrientationResizersUpdate(delta < 0);
+                List<GridResizer> swappedResizers = new List<GridResizer>();
+
+                foreach (GridResizer r in _resizers)
+                {
+                    if (r.Orientation == resizer.Orientation)
+                    {
+                        if ((isHorizontal && r.StartRow == resizer.StartRow && r.StartCol != resizer.StartCol) ||
+                            (!isHorizontal && r.StartCol == resizer.StartCol && r.StartRow != resizer.StartRow))
+                        {
+                            DecreaseResizerValues(r, resizer.Orientation);
+                            swappedResizers.Add(r);
+                        }
+                    }
+                }
+
+                foreach (GridResizer r in _resizers)
+                {
+                    if (r.Orientation != resizer.Orientation)
+                    {
+                        if (isHorizontal)
+                        {
+                            // vertical resizers corresponfding to dragged resizer
+                            if (r.StartCol >= resizer.StartCol && r.EndCol < resizer.EndCol)
+                            {
+                                if (r.StartRow == resizer.StartRow)
+                                {
+                                    r.StartRow++;
+                                }
+
+                                if (r.EndRow == resizer.EndRow - 1)
+                                {
+                                    r.EndRow++;
+                                }
+                            }
+                            else
+                            {
+                                // vertical resizers corresponfding to swapped resizers
+                                foreach (GridResizer sr in swappedResizers)
+                                {
+                                    if (r.StartCol >= sr.StartCol && r.EndCol <= sr.EndCol)
+                                    {
+                                        if (r.StartRow == resizer.StartRow + 1)
+                                        {
+                                            r.StartRow--;
+                                        }
+
+                                        if (r.EndRow == resizer.EndRow)
+                                        {
+                                            r.EndRow--;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        else
+                        {
+                            // horizontal resizers corresponfding to dragged resizer
+                            if (r.StartRow >= resizer.StartRow && r.EndRow < resizer.EndRow)
+                            {
+                                if (r.StartCol == resizer.StartCol)
+                                {
+                                    r.StartCol++;
+                                }
+
+                                if (r.EndCol == resizer.EndCol - 1)
+                                {
+                                    r.EndCol++;
+                                }
+                            }
+                            else
+                            {
+                                // horizontal resizers corresponfding to swapped resizers
+                                foreach (GridResizer sr in swappedResizers)
+                                {
+                                    if (r.StartRow >= sr.StartRow && r.EndRow <= sr.EndRow)
+                                    {
+                                        if (r.StartCol == resizer.StartCol + 1)
+                                        {
+                                            r.StartCol--;
+                                        }
+
+                                        if (r.EndCol == resizer.EndCol)
+                                        {
+                                            r.EndCol--;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
 
@@ -419,7 +521,7 @@ namespace FancyZonesEditor
              * ------------------------------
              * |      4      |      5       |
              * ------------------------------
-             * 
+             *
              * Resizers between zones 0,1 and 2,3 are snapped to each other and adjascent.
              * ------------------------------
              * |      0      |      1       |

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridDragHandles.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridDragHandles.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using FancyZonesEditor.Models;
@@ -188,34 +188,6 @@ namespace FancyZonesEditor
 
         public void UpdateAfterNegativeSwap(GridResizer resizer, double delta)
         {
-            Action<GridResizer> incValues = r =>
-            {
-                if (resizer.Orientation == Orientation.Vertical)
-                {
-                    r.StartCol++;
-                    r.EndCol++;
-                }
-                else
-                {
-                    r.StartRow++;
-                    r.EndRow++;
-                }
-            };
-
-            Action<GridResizer> decValues = r =>
-            {
-                if (resizer.Orientation == Orientation.Vertical)
-                {
-                    r.StartCol--;
-                    r.EndCol--;
-                }
-                else
-                {
-                    r.StartRow--;
-                    r.EndRow--;
-                }
-            };
-
             Action<GridResizer> horizontalResizersRowsUpd = r =>
             {
                 if (r.StartCol == resizer.StartCol)
@@ -286,11 +258,11 @@ namespace FancyZonesEditor
                     {
                         if (isDeltaNegative)
                         {
-                            incValues(r);
+                            IncreaseResizerValues(r, resizer.Orientation);
                         }
                         else
                         {
-                            decValues(r);
+                            DecreaseResizerValues(r, resizer.Orientation);
                         }
 
                         break;
@@ -301,12 +273,12 @@ namespace FancyZonesEditor
             if (delta < 0)
             {
                 differentOrientationResizersUpdate();
-                decValues(resizer);
+                DecreaseResizerValues(resizer, resizer.Orientation);
                 sameOrientationResizersUpdate(delta < 0);
             }
             else
             {
-                incValues(resizer);
+                IncreaseResizerValues(resizer, resizer.Orientation);
                 differentOrientationResizersUpdate();
                 sameOrientationResizersUpdate(delta < 0);
             }
@@ -315,6 +287,34 @@ namespace FancyZonesEditor
         public void RemoveDragHandles()
         {
             _resizers.Clear();
+        }
+
+        private static void IncreaseResizerValues(GridResizer resizer, Orientation orientation)
+        {
+            if (orientation == Orientation.Vertical)
+            {
+                resizer.StartCol++;
+                resizer.EndCol++;
+            }
+            else
+            {
+                resizer.StartRow++;
+                resizer.EndRow++;
+            }
+        }
+
+        private static void DecreaseResizerValues(GridResizer resizer, Orientation orientation)
+        {
+            if (orientation == Orientation.Vertical)
+            {
+                resizer.StartCol--;
+                resizer.EndCol--;
+            }
+            else
+            {
+                resizer.StartRow--;
+                resizer.EndRow--;
+            }
         }
 
         private bool UpdateDragHanlderForExistingSplit(Orientation orientation, Func<GridResizer, bool> cmpr, Func<GridResizer, bool> endCmpr, Func<GridResizer, bool> startCmpr)

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
@@ -218,27 +218,46 @@ namespace FancyZonesEditor
                     if (foundExistingSplit)
                     {
                         UIElementCollection resizers = AdornerLayer.Children;
-                        bool resizerUpdated = false;
-                        foreach (GridResizer resizer in resizers)
+                        bool updCurrentResizers = false;
+
+                        GridResizer leftNeighbour = null;
+                        GridResizer rightNeighbour = null;
+                        for (int i = 0; i < resizers.Count && (leftNeighbour == null || rightNeighbour == null); i++)
                         {
+                            GridResizer resizer = (GridResizer)resizers[i];
                             if (resizer.Orientation == Orientation.Vertical && resizer.StartCol == foundCol)
                             {
-                                if (resizer.StartRow == foundRow + 1)
+                                if (leftNeighbour == null && resizer.EndRow == foundRow)
                                 {
-                                    resizer.StartRow--;
-                                    resizerUpdated = true;
-                                    break;
+                                    leftNeighbour = resizer;
+                                    updCurrentResizers = true;
                                 }
-                                else if (resizer.EndRow == foundRow)
+
+                                if (rightNeighbour == null && resizer.StartRow == foundRow + 1)
                                 {
-                                    resizer.EndRow++;
-                                    resizerUpdated = true;
-                                    break;
+                                    rightNeighbour = resizer;
+                                    updCurrentResizers = true;
                                 }
                             }
                         }
 
-                        if (!resizerUpdated)
+                        if (updCurrentResizers)
+                        {
+                            if (leftNeighbour != null && rightNeighbour != null)
+                            {
+                                leftNeighbour.EndRow = rightNeighbour.EndRow;
+                                resizers.Remove(rightNeighbour);
+                            }
+                            else if (leftNeighbour != null)
+                            {
+                                leftNeighbour.EndRow++;
+                            }
+                            else if (rightNeighbour != null)
+                            {
+                                rightNeighbour.StartRow--;
+                            }
+                        }
+                        else
                         {
                             AddDragHandle(Orientation.Vertical, foundRow, foundCol);
                         }
@@ -303,27 +322,46 @@ namespace FancyZonesEditor
                     if (foundExistingSplit)
                     {
                         UIElementCollection resizers = AdornerLayer.Children;
-                        bool resizerUpdated = false;
-                        foreach (GridResizer resizer in resizers)
+                        bool updCurrentResizers = false;
+
+                        GridResizer leftNeighbour = null;
+                        GridResizer rightNeighbour = null;
+                        for (int i = 0; i < resizers.Count && (leftNeighbour == null || rightNeighbour == null); i++)
                         {
+                            GridResizer resizer = (GridResizer)resizers[i];
                             if (resizer.Orientation == Orientation.Horizontal && resizer.StartRow == foundRow)
                             {
-                                if (resizer.StartCol == foundCol + 1)
+                                if (leftNeighbour == null && resizer.EndCol == foundCol)
                                 {
-                                    resizer.StartCol--;
-                                    resizerUpdated = true;
-                                    break;
+                                    leftNeighbour = resizer;
+                                    updCurrentResizers = true;
                                 }
-                                else if (resizer.EndCol == foundCol)
+
+                                if (rightNeighbour == null && resizer.StartCol == foundCol + 1)
                                 {
-                                    resizer.EndCol++;
-                                    resizerUpdated = true;
-                                    break;
+                                    rightNeighbour = resizer;
+                                    updCurrentResizers = true;
                                 }
                             }
                         }
 
-                        if (!resizerUpdated)
+                        if (updCurrentResizers)
+                        {
+                            if (leftNeighbour != null && rightNeighbour != null)
+                            {
+                                leftNeighbour.EndCol = rightNeighbour.EndCol;
+                                resizers.Remove(rightNeighbour);
+                            }
+                            else if (leftNeighbour != null)
+                            {
+                                leftNeighbour.EndCol++;
+                            }
+                            else if (rightNeighbour != null)
+                            {
+                                rightNeighbour.StartCol--;
+                            }
+                        }
+                        else
                         {
                             AddDragHandle(Orientation.Horizontal, foundRow, foundCol);
                         }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
@@ -559,13 +559,13 @@ namespace FancyZonesEditor
         {
             MergePanel.Visibility = Visibility.Collapsed;
 
-            _dragHandles.UpdateAfterMerge(_startRow, _endRow, _startCol, _endCol, Model.Rows);
-
             Action<int> deleteAction = (childIndex) =>
             {
                 DeleteZone(childIndex);
             };
             _data.MergeZones(_startRow, _endRow, _startCol, _endCol, deleteAction);
+            _dragHandles.RemoveDragHandles();
+            _dragHandles.InitDragHandles(Model);
 
             OnGridDimensionsChanged();
             ClearSelection();

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
-using ControlzEx.Standard;
 using FancyZonesEditor.Models;
 
 namespace FancyZonesEditor
@@ -768,6 +767,24 @@ namespace FancyZonesEditor
                         model.CellChildMap[row, col] = mergedIndex;
                         DeleteZone(childIndex);
                     }
+                }
+            }
+
+            UIElementCollection resizers = AdornerLayer.Children;
+            for (int i = 0; i < resizers.Count; i++)
+            {
+                GridResizer resizer = (GridResizer)resizers[i];
+
+                bool isStartRowColRemovable = resizer.StartRow >= _startRow && resizer.StartCol >= _startCol;
+                bool horizontalResizerToBeRemoved = resizer.Orientation == Orientation.Horizontal
+                    && isStartRowColRemovable && resizer.EndRow <= _endRow && resizer.EndCol - 1 <= _endCol;
+                bool verticalResizerToBeRemoved = resizer.Orientation == Orientation.Vertical
+                    && isStartRowColRemovable && resizer.EndRow - 1 <= _endRow && resizer.EndCol <= _endCol;
+
+                if (horizontalResizerToBeRemoved || verticalResizerToBeRemoved)
+                {
+                    resizers.Remove(resizer);
+                    i--;
                 }
             }
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
@@ -395,14 +395,14 @@ namespace FancyZonesEditor
                     }
 
                     _data.SplitOnDrag(resizer, delta, spacing, ActualWidth, ActualHeight);
-                    _dragHandles.UpdateAfterDragSplit(resizer, delta);
+                    _dragHandles.UpdateAfterDetach(resizer, delta);
                 }
                 else
                 {
                     _data.DragResizer(resizer, resizeInfo);
                     if (_data.SwapNegativePercents(resizer.Orientation, resizer.StartRow, resizer.EndRow, resizer.StartCol, resizer.EndCol))
                     {
-                        _dragHandles.UpdateAfterNegativeSwap(resizer, delta);
+                        _dragHandles.UpdateAfterSwap(resizer, delta);
                     }
                 }
             }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
@@ -26,6 +26,7 @@ namespace FancyZonesEditor
         {
             InitializeComponent();
             Loaded += GridEditor_Loaded;
+            Unloaded += GridEditor_Unloaded;
             ((App)Application.Current).ZoneSettings.PropertyChanged += ZoneSettings_PropertyChanged;
             gridEditorUniqueId = ++gridEditorUniqueIdCounter;
         }
@@ -54,6 +55,11 @@ namespace FancyZonesEditor
 
             Model.PropertyChanged += OnGridDimensionsChanged;
             _dragHandles.InitDragHandles(model);
+        }
+
+        private void GridEditor_Unloaded(object sender, RoutedEventArgs e)
+        {
+            gridEditorUniqueId = -1;
         }
 
         private void ZoneSettings_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
@@ -195,6 +195,7 @@ namespace FancyZonesEditor
                     offset += Canvas.GetLeft(splitee);
                     int count = splitee.VerticalSnapPoints.Length;
                     bool foundExistingSplit = false;
+                    int splitCol = foundCol;
 
                     for (int i = 0; i <= count; i++)
                     {
@@ -210,7 +211,7 @@ namespace FancyZonesEditor
                         if (_data.ColumnBottom(foundCol + i) == offset)
                         {
                             foundExistingSplit = true;
-
+                            splitCol = foundCol + i;
                             // use existing division
                         }
                     }
@@ -225,7 +226,7 @@ namespace FancyZonesEditor
                         for (int i = 0; i < resizers.Count && (leftNeighbour == null || rightNeighbour == null); i++)
                         {
                             GridResizer resizer = (GridResizer)resizers[i];
-                            if (resizer.Orientation == Orientation.Vertical && resizer.StartCol == foundCol)
+                            if (resizer.Orientation == Orientation.Vertical && resizer.StartCol == splitCol)
                             {
                                 if (leftNeighbour == null && resizer.EndRow == foundRow)
                                 {
@@ -259,7 +260,7 @@ namespace FancyZonesEditor
                         }
                         else
                         {
-                            AddDragHandle(Orientation.Vertical, foundRow, foundCol);
+                            AddDragHandle(Orientation.Vertical, foundRow, splitCol);
                         }
 
                         OnGridDimensionsChanged();
@@ -299,6 +300,7 @@ namespace FancyZonesEditor
                     offset += Canvas.GetTop(splitee);
                     int count = splitee.HorizontalSnapPoints.Length;
                     bool foundExistingSplit = false;
+                    int splitRow = foundRow;
 
                     for (int i = 0; i <= count; i++)
                     {
@@ -314,7 +316,7 @@ namespace FancyZonesEditor
                         if (_data.RowEnd(foundRow + i) == offset)
                         {
                             foundExistingSplit = true;
-
+                            splitRow = foundRow + i;
                             // use existing division
                         }
                     }
@@ -329,7 +331,7 @@ namespace FancyZonesEditor
                         for (int i = 0; i < resizers.Count && (leftNeighbour == null || rightNeighbour == null); i++)
                         {
                             GridResizer resizer = (GridResizer)resizers[i];
-                            if (resizer.Orientation == Orientation.Horizontal && resizer.StartRow == foundRow)
+                            if (resizer.Orientation == Orientation.Horizontal && resizer.StartRow == splitRow)
                             {
                                 if (leftNeighbour == null && resizer.EndCol == foundCol)
                                 {
@@ -363,7 +365,7 @@ namespace FancyZonesEditor
                         }
                         else
                         {
-                            AddDragHandle(Orientation.Horizontal, foundRow, foundCol);
+                            AddDragHandle(Orientation.Horizontal, splitRow, foundCol);
                         }
 
                         OnGridDimensionsChanged();

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
@@ -221,6 +221,7 @@ namespace FancyZonesEditor
 
                     if (foundExistingSplit)
                     {
+                        _data.ReplaceIndicesToMaintainOrder(Preview.Children.Count);
                         _dragHandles.UpdateForExistingVerticalSplit(model, foundRow, splitCol);
                         OnGridDimensionsChanged();
                         return;
@@ -269,6 +270,7 @@ namespace FancyZonesEditor
 
                     if (foundExistingSplit)
                     {
+                        _data.ReplaceIndicesToMaintainOrder(Preview.Children.Count);
                         _dragHandles.UpdateForExistingHorizontalSplit(model, splitRow, foundCol);
                         OnGridDimensionsChanged();
                         return;

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
@@ -458,10 +458,12 @@ namespace FancyZonesEditor
         private void Resizer_DragDelta(object sender, System.Windows.Controls.Primitives.DragDeltaEventArgs e)
         {
             GridResizer resizer = (GridResizer)sender;
-            int index = AdornerLayer.Children.IndexOf(resizer);
-            double delta = (resizer.Orientation == Orientation.Vertical) ? e.HorizontalChange : e.VerticalChange;
+            Settings settings = ((App)Application.Current).ZoneSettings;
 
-            GridData.ResizeInfo resizeInfo = _data.CalculateResizeInfo(resizer, delta);
+            double delta = (resizer.Orientation == Orientation.Vertical) ? e.HorizontalChange : e.VerticalChange;
+            int spacing = settings.ShowSpacing ? settings.Spacing : 0;
+
+            GridData.ResizeInfo resizeInfo = _data.CalculateResizeInfo(resizer, delta, spacing);
 
             if (resizeInfo.IsResizeAllowed)
             {

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
@@ -289,21 +289,9 @@ namespace FancyZonesEditor
             ArrangeGridRects(actualSize);
         }
 
-        private void DeleteZone(int index)
+        private void DeleteZone(int startIndex, int endIndex)
         {
-            IList<int> freeZones = Model.FreeZones;
-
-            if (freeZones.Contains(index))
-            {
-                return;
-            }
-
-            freeZones.Add(index);
-
-            GridZone zone = (GridZone)Preview.Children[index];
-            zone.Visibility = Visibility.Hidden;
-            zone.MinHeight = 0;
-            zone.MinWidth = 0;
+            Preview.Children.RemoveRange(startIndex, endIndex - startIndex);
         }
 
         private int AddZone()
@@ -559,9 +547,9 @@ namespace FancyZonesEditor
         {
             MergePanel.Visibility = Visibility.Collapsed;
 
-            Action<int> deleteAction = (childIndex) =>
+            Action<int, int> deleteAction = (start, end) =>
             {
-                DeleteZone(childIndex);
+                DeleteZone(start, end);
             };
             _data.MergeZones(_startRow, _endRow, _startCol, _endCol, deleteAction);
             _dragHandles.RemoveDragHandles();

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
@@ -436,8 +436,100 @@ namespace FancyZonesEditor
             GridResizer resizer = (GridResizer)sender;
             double delta = (resizer.Orientation == Orientation.Vertical) ? e.HorizontalChange : e.VerticalChange;
 
-            if (_data.DragResizer(resizer, delta))
+            GridData.ResizeInfo resizeInfo = _data.CalculateResizeInfo(resizer, delta);
+            if (resizeInfo.IsResizeAllowed)
             {
+                _data.DragResizer(resizer, resizeInfo);
+                if (_data.SwapNegativePercents(resizer.Orientation, resizer.RowIndex, resizer.ColIndex))
+                {
+                    if (resizer.Orientation == Orientation.Vertical)
+                    {
+                        if (delta < 0)
+                        {
+                            resizer.ColIndex--;
+
+                            UIElementCollection resizers = AdornerLayer.Children;
+                            int ind = resizers.IndexOf(resizer);
+
+                            for (int i = 0; i < resizers.Count; i++)
+                            {
+                                GridResizer r = (GridResizer)resizers[i];
+                                if (r.Orientation == resizer.Orientation && resizer.RowIndex != r.RowIndex && resizer.ColIndex == r.ColIndex)
+                                {
+                                    r.ColIndex++;
+
+                                    resizers.RemoveAt(ind);
+                                    resizers.Insert(i, resizer);
+                                    break;
+                                }
+                            }
+                        }
+                        else if (delta > 0)
+                        {
+                            resizer.ColIndex++;
+
+                            UIElementCollection resizers = AdornerLayer.Children;
+                            int ind = resizers.IndexOf(resizer);
+
+                            for (int i = 0; i < resizers.Count; i++)
+                            {
+                                GridResizer r = (GridResizer)resizers[i];
+                                if (r.Orientation == resizer.Orientation && resizer.RowIndex != r.RowIndex && resizer.ColIndex == r.ColIndex)
+                                {
+                                    r.ColIndex--;
+
+                                    resizers.RemoveAt(i);
+                                    resizers.Insert(ind, resizer);
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    else
+                    {
+                        if (delta < 0)
+                        {
+                            resizer.RowIndex--;
+
+                            UIElementCollection resizers = AdornerLayer.Children;
+                            int ind = resizers.IndexOf(resizer);
+
+                            for (int i = 0; i < resizers.Count; i++)
+                            {
+                                GridResizer r = (GridResizer)resizers[i];
+                                if (r.Orientation == resizer.Orientation && resizer.RowIndex == r.RowIndex && resizer.ColIndex != r.ColIndex)
+                                {
+                                    r.RowIndex++;
+
+                                    resizers.RemoveAt(ind);
+                                    resizers.Insert(i, resizer);
+                                    break;
+                                }
+                            }
+                        }
+                        else if (delta > 0)
+                        {
+                            resizer.RowIndex++;
+
+                            UIElementCollection resizers = AdornerLayer.Children;
+                            int ind = resizers.IndexOf(resizer);
+
+                            for (int i = 0; i < resizers.Count; i++)
+                            {
+                                GridResizer r = (GridResizer)resizers[i];
+                                if (r.Orientation == resizer.Orientation && resizer.RowIndex == r.RowIndex && resizer.ColIndex != r.ColIndex)
+                                {
+                                    r.RowIndex--;
+
+                                    resizers.RemoveAt(i);
+                                    resizers.Insert(ind, r);
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+
                 Size actualSize = new Size(ActualWidth, ActualHeight);
                 ArrangeGridRects(actualSize);
             }
@@ -449,15 +541,6 @@ namespace FancyZonesEditor
             int index = _data.SwappedIndexAfterResize(resizer);
             if (index != -1)
             {
-                if (resizer.Orientation == Orientation.Horizontal)
-                {
-                    
-                }
-                else
-                {
-                    
-                }
-
                 Size actualSize = new Size(ActualWidth, ActualHeight);
                 ArrangeGridRects(actualSize);
             }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
@@ -402,7 +402,7 @@ namespace FancyZonesEditor
                         spacing = settings.Spacing;
                     }
 
-                    _data.SplitOnDrag(resizer, delta, spacing, ActualWidth, ActualHeight);
+                    _data.SplitOnDrag(resizer, delta, spacing);
                     _dragHandles.UpdateAfterDetach(resizer, delta);
                 }
                 else

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
@@ -515,13 +515,10 @@ namespace FancyZonesEditor
         private void Resizer_DragDelta(object sender, System.Windows.Controls.Primitives.DragDeltaEventArgs e)
         {
             GridResizer resizer = (GridResizer)sender;
-            Settings settings = ((App)Application.Current).ZoneSettings;
 
             double delta = (resizer.Orientation == Orientation.Vertical) ? e.HorizontalChange : e.VerticalChange;
-            int spacing = settings.ShowSpacing ? settings.Spacing : 0;
 
-            GridData.ResizeInfo resizeInfo = _data.CalculateResizeInfo(resizer, delta, spacing);
-
+            GridData.ResizeInfo resizeInfo = _data.CalculateResizeInfo(resizer, delta);
             if (resizeInfo.IsResizeAllowed)
             {
                 _data.DragResizer(resizer, resizeInfo);

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
@@ -558,6 +558,7 @@ namespace FancyZonesEditor
                                 if (r.Orientation == resizer.Orientation && resizer.StartRow != r.StartRow && resizer.StartCol == r.StartCol)
                                 {
                                     r.StartCol--;
+                                    r.EndCol--;
                                     break;
                                 }
                             }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
@@ -291,9 +291,9 @@ namespace FancyZonesEditor
             ArrangeGridRects(actualSize);
         }
 
-        private void DeleteZone(int startIndex, int endIndex)
+        private void DeleteZone(int index)
         {
-            Preview.Children.RemoveRange(startIndex, endIndex - startIndex);
+            Preview.Children.RemoveAt(index);
         }
 
         private int AddZone()
@@ -551,11 +551,11 @@ namespace FancyZonesEditor
         {
             MergePanel.Visibility = Visibility.Collapsed;
 
-            Action<int, int> deleteAction = (start, end) =>
+            Action<int> deleteAction = (index) =>
             {
-                DeleteZone(start, end);
+                DeleteZone(index);
             };
-            _data.MergeZones(_startRow, _endRow, _startCol, _endCol, deleteAction);
+            _data.MergeZones(_startRow, _endRow, _startCol, _endCol, deleteAction, Preview.Children.Count);
             _dragHandles.RemoveDragHandles();
             _dragHandles.InitDragHandles(Model);
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
@@ -385,16 +385,31 @@ namespace FancyZonesEditor
             GridData.ResizeInfo resizeInfo = _data.CalculateResizeInfo(resizer, delta);
             if (resizeInfo.IsResizeAllowed)
             {
-                _data.DragResizer(resizer, resizeInfo);
-                if (_data.SwapNegativePercents(resizer.Orientation, resizer.StartRow, resizer.EndRow, resizer.StartCol, resizer.EndCol))
+                if (_dragHandles.HasSnappedNonAdjascentResizers(resizer))
                 {
-                    _dragHandles.UpdateAfterNegativeSwap(resizer, delta);
-                }
+                    double spacing = 0;
+                    Settings settings = ((App)Application.Current).ZoneSettings;
+                    if (settings.ShowSpacing)
+                    {
+                        spacing = settings.Spacing;
+                    }
 
-                Size actualSize = new Size(ActualWidth, ActualHeight);
-                ArrangeGridRects(actualSize);
-                AdornerLayer.UpdateLayout();
+                    _data.SplitOnDrag(resizer, delta, spacing, ActualWidth, ActualHeight);
+                    _dragHandles.UpdateAfterDragSplit(resizer, delta);
+                }
+                else
+                {
+                    _data.DragResizer(resizer, resizeInfo);
+                    if (_data.SwapNegativePercents(resizer.Orientation, resizer.StartRow, resizer.EndRow, resizer.StartCol, resizer.EndCol))
+                    {
+                        _dragHandles.UpdateAfterNegativeSwap(resizer, delta);
+                    }
+                }
             }
+
+            Size actualSize = new Size(ActualWidth, ActualHeight);
+            ArrangeGridRects(actualSize);
+            AdornerLayer.UpdateLayout();
         }
 
         private void Resizer_DragCompleted(object sender, System.Windows.Controls.Primitives.DragCompletedEventArgs e)

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
@@ -171,6 +171,8 @@ namespace FancyZonesEditor
 
         private void OnSplit(object o, SplitEventArgs e)
         {
+            MergeCancelClick(null, null);
+
             UIElementCollection previewChildren = Preview.Children;
             GridZone splitee = (GridZone)o;
 
@@ -370,6 +372,8 @@ namespace FancyZonesEditor
 
         private void Resizer_DragDelta(object sender, System.Windows.Controls.Primitives.DragDeltaEventArgs e)
         {
+            MergeCancelClick(null, null);
+
             GridResizer resizer = (GridResizer)sender;
 
             double delta = (resizer.Orientation == Orientation.Vertical) ? e.HorizontalChange : e.VerticalChange;
@@ -559,7 +563,7 @@ namespace FancyZonesEditor
             ClearSelection();
         }
 
-        private void CancelClick(object sender, RoutedEventArgs e)
+        private void MergeCancelClick(object sender, RoutedEventArgs e)
         {
             MergePanel.Visibility = Visibility.Collapsed;
             ClearSelection();
@@ -567,7 +571,7 @@ namespace FancyZonesEditor
 
         private void MergePanelMouseUp(object sender, MouseButtonEventArgs e)
         {
-            CancelClick(null, null);
+            MergeCancelClick(null, null);
         }
 
         protected override Size ArrangeOverride(Size arrangeBounds)

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
@@ -218,6 +218,32 @@ namespace FancyZonesEditor
 
                     if (foundExistingSplit)
                     {
+                        UIElementCollection resizers = AdornerLayer.Children;
+                        bool resizerUpdated = false;
+                        foreach (GridResizer resizer in resizers)
+                        {
+                            if (resizer.Orientation == Orientation.Vertical && resizer.StartCol == foundCol)
+                            {
+                                if (resizer.StartRow == foundRow + 1)
+                                {
+                                    resizer.StartRow--;
+                                    resizerUpdated = true;
+                                    break;
+                                }
+                                else if (resizer.EndRow == foundRow)
+                                {
+                                    resizer.EndRow++;
+                                    resizerUpdated = true;
+                                    break;
+                                }
+                            }
+                        }
+
+                        if (!resizerUpdated)
+                        {
+                            AddDragHandle(Orientation.Vertical, foundRow, foundRow + 1, foundCol, foundCol + 1, foundCol + model.Rows - 1);
+                        }
+
                         OnGridDimensionsChanged();
                         return;
                     }
@@ -278,6 +304,32 @@ namespace FancyZonesEditor
 
                     if (foundExistingSplit)
                     {
+                        UIElementCollection resizers = AdornerLayer.Children;
+                        bool resizerUpdated = false;
+                        foreach (GridResizer resizer in resizers)
+                        {
+                            if (resizer.Orientation == Orientation.Horizontal && resizer.StartRow == foundRow)
+                            {
+                                if (resizer.StartCol == foundCol + 1)
+                                {
+                                    resizer.StartCol--;
+                                    resizerUpdated = true;
+                                    break;
+                                }
+                                else if (resizer.EndCol == foundCol)
+                                {
+                                    resizer.EndCol++;
+                                    resizerUpdated = true;
+                                    break;
+                                }
+                            }
+                        }
+
+                        if (!resizerUpdated)
+                        {
+                            AddDragHandle(Orientation.Horizontal, foundRow, foundRow + 1, foundCol, foundCol + 1, foundRow);
+                        }
+
                         OnGridDimensionsChanged();
                         return;
                     }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
@@ -36,6 +36,7 @@ namespace FancyZonesEditor
             if (model != null)
             {
                 _data = new GridData(model);
+                _dragHandles = new GridDragHandles(AdornerLayer.Children, Resizer_DragDelta, Resizer_DragCompleted);
 
                 int zoneCount = _data.ZoneCount;
                 for (int i = 0; i <= zoneCount; i++)
@@ -52,7 +53,7 @@ namespace FancyZonesEditor
             }
 
             Model.PropertyChanged += OnGridDimensionsChanged;
-            AddDragHandles();
+            _dragHandles.InitDragHandles(model);
         }
 
         private void ZoneSettings_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
@@ -96,7 +97,7 @@ namespace FancyZonesEditor
                 {
                     if (model.CellChildMap[row, col] == spliteeIndex)
                     {
-                        RemoveDragHandles();
+                        _dragHandles.RemoveDragHandles();
                         _startRow = _endRow = row;
                         _startCol = _endCol = col;
                         ExtendRangeToHaveEvenCellEdges();
@@ -218,51 +219,7 @@ namespace FancyZonesEditor
 
                     if (foundExistingSplit)
                     {
-                        UIElementCollection resizers = AdornerLayer.Children;
-                        bool updCurrentResizers = false;
-
-                        GridResizer leftNeighbour = null;
-                        GridResizer rightNeighbour = null;
-                        for (int i = 0; i < resizers.Count && (leftNeighbour == null || rightNeighbour == null); i++)
-                        {
-                            GridResizer resizer = (GridResizer)resizers[i];
-                            if (resizer.Orientation == Orientation.Vertical && resizer.StartCol == splitCol)
-                            {
-                                if (leftNeighbour == null && resizer.EndRow == foundRow)
-                                {
-                                    leftNeighbour = resizer;
-                                    updCurrentResizers = true;
-                                }
-
-                                if (rightNeighbour == null && resizer.StartRow == foundRow + 1)
-                                {
-                                    rightNeighbour = resizer;
-                                    updCurrentResizers = true;
-                                }
-                            }
-                        }
-
-                        if (updCurrentResizers)
-                        {
-                            if (leftNeighbour != null && rightNeighbour != null)
-                            {
-                                leftNeighbour.EndRow = rightNeighbour.EndRow;
-                                resizers.Remove(rightNeighbour);
-                            }
-                            else if (leftNeighbour != null)
-                            {
-                                leftNeighbour.EndRow++;
-                            }
-                            else if (rightNeighbour != null)
-                            {
-                                rightNeighbour.StartRow--;
-                            }
-                        }
-                        else
-                        {
-                            AddDragHandle(Orientation.Vertical, foundRow, splitCol);
-                        }
-
+                        _dragHandles.UpdateForExistingVerticalSplit(model, foundRow, splitCol);
                         OnGridDimensionsChanged();
                         return;
                     }
@@ -275,22 +232,9 @@ namespace FancyZonesEditor
                     offset -= _data.ColumnTop(foundCol);
                 }
 
-                // update resizers data
-                foreach (GridResizer r in AdornerLayer.Children)
-                {
-                    if (r.StartCol > foundCol || (r.StartCol == foundCol && r.Orientation == Orientation.Vertical))
-                    {
-                        r.StartCol++;
-                    }
-
-                    if (r.EndCol > foundCol)
-                    {
-                        r.EndCol++;
-                    }
-                }
-
+                _dragHandles.UpdateAfterVerticalSplit(foundCol);
                 _data.SplitColumn(foundCol, spliteeIndex, newChildIndex, space, offset, ActualWidth);
-                AddDragHandle(Orientation.Vertical, foundRow, foundCol);
+                _dragHandles.AddDragHandle(Orientation.Vertical, foundRow, foundCol, model);
             }
             else
             {
@@ -323,51 +267,7 @@ namespace FancyZonesEditor
 
                     if (foundExistingSplit)
                     {
-                        UIElementCollection resizers = AdornerLayer.Children;
-                        bool updCurrentResizers = false;
-
-                        GridResizer leftNeighbour = null;
-                        GridResizer rightNeighbour = null;
-                        for (int i = 0; i < resizers.Count && (leftNeighbour == null || rightNeighbour == null); i++)
-                        {
-                            GridResizer resizer = (GridResizer)resizers[i];
-                            if (resizer.Orientation == Orientation.Horizontal && resizer.StartRow == splitRow)
-                            {
-                                if (leftNeighbour == null && resizer.EndCol == foundCol)
-                                {
-                                    leftNeighbour = resizer;
-                                    updCurrentResizers = true;
-                                }
-
-                                if (rightNeighbour == null && resizer.StartCol == foundCol + 1)
-                                {
-                                    rightNeighbour = resizer;
-                                    updCurrentResizers = true;
-                                }
-                            }
-                        }
-
-                        if (updCurrentResizers)
-                        {
-                            if (leftNeighbour != null && rightNeighbour != null)
-                            {
-                                leftNeighbour.EndCol = rightNeighbour.EndCol;
-                                resizers.Remove(rightNeighbour);
-                            }
-                            else if (leftNeighbour != null)
-                            {
-                                leftNeighbour.EndCol++;
-                            }
-                            else if (rightNeighbour != null)
-                            {
-                                rightNeighbour.StartCol--;
-                            }
-                        }
-                        else
-                        {
-                            AddDragHandle(Orientation.Horizontal, splitRow, foundCol);
-                        }
-
+                        _dragHandles.UpdateForExistingHorizontalSplit(model, splitRow, foundCol);
                         OnGridDimensionsChanged();
                         return;
                     }
@@ -380,107 +280,13 @@ namespace FancyZonesEditor
                     offset -= _data.RowStart(foundRow);
                 }
 
-                // update resizers data
-                foreach (GridResizer r in AdornerLayer.Children)
-                {
-                    if (r.StartRow > foundRow || (r.StartRow == foundRow && r.Orientation == Orientation.Horizontal))
-                    {
-                        r.StartRow++;
-                    }
-
-                    if (r.EndRow > foundRow)
-                    {
-                        r.EndRow++;
-                    }
-                }
-
+                _dragHandles.UpdateAfterHorizontalSplit(foundRow);
                 _data.SplitRow(foundRow, spliteeIndex, newChildIndex, space, offset, ActualHeight);
-                AddDragHandle(Orientation.Horizontal, foundRow, foundCol);
+                _dragHandles.AddDragHandle(Orientation.Horizontal, foundRow, foundCol, model);
             }
 
             Size actualSize = new Size(ActualWidth, ActualHeight);
             ArrangeGridRects(actualSize);
-        }
-
-        private void RemoveDragHandles()
-        {
-            AdornerLayer.Children.Clear();
-        }
-
-        private void AddDragHandles()
-        {
-            if (AdornerLayer.Children.Count == 0)
-            {
-                GridLayoutModel model = Model;
-                int[,] indices = model.CellChildMap;
-
-                // horizontal resizers
-                for (int row = 0; row < model.Rows - 1; row++)
-                {
-                    for (int col = 0; col < model.Columns; col++)
-                    {
-                        if (indices[row, col] != indices[row + 1, col])
-                        {
-                            AddDragHandle(Orientation.Horizontal, row, row + 1, col, col + 1, row);
-                        }
-                    }
-                }
-
-                // vertical resizers
-                for (int col = 0; col < model.Columns - 1; col++)
-                {
-                    for (int row = 0; row < model.Rows; row++)
-                    {
-                        if (indices[row, col] != indices[row, col + 1])
-                        {
-                            AddDragHandle(Orientation.Vertical, row, row + 1, col, col + 1, col + model.Rows - 1);
-                        }
-                    }
-                }
-            }
-        }
-
-        private void AddDragHandle(Orientation orientation, int rowStart, int rowEnd, int colStart, int colEnd, int index)
-        {
-            GridResizer resizer = new GridResizer
-            {
-                Orientation = orientation,
-                StartRow = rowStart,
-                EndRow = rowEnd,
-                StartCol = colStart,
-                EndCol = colEnd,
-                Model = Model,
-            };
-            resizer.DragDelta += Resizer_DragDelta;
-            resizer.DragCompleted += Resizer_DragCompleted;
-
-            if (index > AdornerLayer.Children.Count)
-            {
-                index = AdornerLayer.Children.Count;
-            }
-
-            AdornerLayer.Children.Insert(index, resizer);
-        }
-
-        private void AddDragHandle(Orientation orientation, int foundRow, int foundCol)
-        {
-            GridLayoutModel model = Model;
-            int[,] indices = model.CellChildMap;
-
-            int endRow = foundRow + 1;
-            while (endRow < model.Rows && indices[endRow, foundCol] == indices[endRow - 1, foundCol])
-            {
-                endRow++;
-            }
-
-            int endCol = foundCol + 1;
-            while (endCol < model.Columns && indices[foundRow, endCol] == indices[foundRow, endCol - 1])
-            {
-                endCol++;
-            }
-
-            int index = (orientation == Orientation.Horizontal) ? foundRow : foundCol + model.Rows - 1;
-            AddDragHandle(orientation, foundRow, endRow, foundCol, endCol, index);
         }
 
         private void DeleteZone(int index)
@@ -569,9 +375,9 @@ namespace FancyZonesEditor
             int spacing = settings.ShowSpacing ? settings.Spacing : 0;
 
             _data.RecalculateZones(spacing, arrangeSize);
-            _data.ManageZones(Preview.Children, spacing);
-            AddDragHandles();
-            _data.ManageResizers(AdornerLayer.Children, spacing);
+            _data.ArrangeZones(Preview.Children, spacing);
+            _dragHandles.InitDragHandles(model);
+            _data.ArrangeResizers(AdornerLayer.Children, spacing);
         }
 
         private void Resizer_DragDelta(object sender, System.Windows.Controls.Primitives.DragDeltaEventArgs e)
@@ -590,130 +396,7 @@ namespace FancyZonesEditor
                 _data.DragResizer(resizer, resizeInfo);
                 if (_data.SwapNegativePercents(resizer.Orientation, resizer.StartRow, resizer.EndRow, resizer.StartCol, resizer.EndCol))
                 {
-                    UIElementCollection resizers = AdornerLayer.Children;
-
-                    Action<GridResizer> incValues = r =>
-                    {
-                        if (resizer.Orientation == Orientation.Vertical)
-                        {
-                            r.StartCol++;
-                            r.EndCol++;
-                        }
-                        else
-                        {
-                            r.StartRow++;
-                            r.EndRow++;
-                        }
-                    };
-
-                    Action<GridResizer> decValues = r =>
-                    {
-                        if (resizer.Orientation == Orientation.Vertical)
-                        {
-                            r.StartCol--;
-                            r.EndCol--;
-                        }
-                        else
-                        {
-                            r.StartRow--;
-                            r.EndRow--;
-                        }
-                    };
-
-                    Action<GridResizer> horizontalResizersRowsUpd = r =>
-                    {
-                        if (r.StartCol == resizer.StartCol)
-                        {
-                            r.StartCol++;
-                        }
-                        else if (r.StartCol == resizer.EndCol)
-                        {
-                            r.StartCol--;
-                        }
-
-                        if (r.EndCol == resizer.StartCol)
-                        {
-                            r.EndCol++;
-                        }
-                        else if (r.EndCol == resizer.EndCol)
-                        {
-                            r.EndCol--;
-                        }
-                    };
-
-                    Action<GridResizer> verticalResizersColumnsUpd = r =>
-                    {
-                        if (r.StartRow == resizer.StartRow)
-                        {
-                            r.StartRow++;
-                        }
-                        else if (r.StartRow == resizer.EndRow)
-                        {
-                            r.StartRow--;
-                        }
-
-                        if (r.EndRow == resizer.StartRow)
-                        {
-                            r.EndRow++;
-                        }
-                        else if (r.EndRow == resizer.EndRow)
-                        {
-                            r.EndRow--;
-                        }
-                    };
-
-                    Action differentOrientationResizersUpdate = () =>
-                    {
-                        foreach (GridResizer r in resizers)
-                        {
-                            if (r.Orientation != resizer.Orientation)
-                            {
-                                if (resizer.Orientation == Orientation.Vertical)
-                                {
-                                    horizontalResizersRowsUpd(r);
-                                }
-                                else
-                                {
-                                    verticalResizersColumnsUpd(r);
-                                }
-                            }
-                        }
-                    };
-
-                    Action<bool> sameOrientationResizersUpdate = isDeltaNegative =>
-                    {
-                        foreach (GridResizer r in resizers)
-                        {
-                            bool isSameCol = resizer.StartRow != r.StartRow && resizer.StartCol == r.StartCol && resizer.Orientation == Orientation.Vertical;
-                            bool isSameRow = resizer.StartRow == r.StartRow && resizer.StartCol != r.StartCol && resizer.Orientation == Orientation.Horizontal;
-                            if (r.Orientation == resizer.Orientation && (isSameCol || isSameRow))
-                            {
-                                if (isDeltaNegative)
-                                {
-                                    incValues(r);
-                                }
-                                else
-                                {
-                                    decValues(r);
-                                }
-
-                                break;
-                            }
-                        }
-                    };
-
-                    if (delta < 0)
-                    {
-                        differentOrientationResizersUpdate();
-                        decValues(resizer);
-                        sameOrientationResizersUpdate(delta < 0);
-                    }
-                    else
-                    {
-                        incValues(resizer);
-                        differentOrientationResizersUpdate();
-                        sameOrientationResizersUpdate(delta < 0);
-                    }
+                    _dragHandles.UpdateAfterNegativeSwap(resizer, delta);
                 }
 
                 Size actualSize = new Size(ActualWidth, ActualHeight);
@@ -876,85 +559,7 @@ namespace FancyZonesEditor
         {
             MergePanel.Visibility = Visibility.Collapsed;
 
-            int rows = Model.Rows;
-            int shift = 0;
-
-            UIElementCollection resizers = AdornerLayer.Children;
-            List<int> horizontalRemoved = new List<int>(), verticalRemoved = new List<int>();
-
-            for (int i = 0; i < resizers.Count; i++)
-            {
-                GridResizer resizer = (GridResizer)resizers[i];
-
-                bool isStartRowColRemovable = resizer.StartRow >= _startRow && resizer.StartCol >= _startCol;
-                bool horizontalResizerToBeRemoved = resizer.Orientation == Orientation.Horizontal
-                    && isStartRowColRemovable && resizer.EndRow <= _endRow && resizer.EndCol - 1 <= _endCol;
-                bool verticalResizerToBeRemoved = resizer.Orientation == Orientation.Vertical
-                    && isStartRowColRemovable && resizer.EndRow - 1 <= _endRow && resizer.EndCol <= _endCol;
-
-                if (horizontalResizerToBeRemoved || verticalResizerToBeRemoved)
-                {
-                    if (resizer.Orientation == Orientation.Horizontal)
-                    {
-                        horizontalRemoved.Add(i + shift);
-                        rows--;
-                    }
-                    else
-                    {
-                        verticalRemoved.Add(i - rows + 1);
-                    }
-
-                    resizers.Remove(resizer);
-                    i--;
-                    shift++;
-                }
-            }
-
-            foreach (GridResizer resizer in resizers)
-            {
-                if (resizer.Orientation == Orientation.Horizontal)
-                {
-                    int diff = 0;
-                    for (int i = 0; i < horizontalRemoved.Count && horizontalRemoved[i] < resizer.StartRow; i++)
-                    {
-                        diff++;
-                    }
-
-                    resizer.StartRow -= diff;
-                    resizer.EndRow -= diff;
-
-                    for (int i = 0; i < verticalRemoved.Count && verticalRemoved[i] < resizer.EndCol; i++)
-                    {
-                        if (resizer.StartCol > verticalRemoved[i])
-                        {
-                            resizer.StartCol--;
-                        }
-
-                        resizer.EndCol--;
-                    }
-                }
-                else
-                {
-                    int diff = 0;
-                    for (int i = 0; i < verticalRemoved.Count && verticalRemoved[i] < resizer.StartCol; i++)
-                    {
-                        diff++;
-                    }
-
-                    resizer.StartCol -= diff;
-                    resizer.EndCol -= diff;
-
-                    for (int i = 0; i < horizontalRemoved.Count && horizontalRemoved[i] < resizer.EndRow; i++)
-                    {
-                        if (resizer.StartRow > horizontalRemoved[i])
-                        {
-                            resizer.StartRow--;
-                        }
-
-                        resizer.EndRow--;
-                    }
-                }
-            }
+            _dragHandles.UpdateAfterMerge(_startRow, _endRow, _startCol, _endCol, Model.Rows);
 
             Action<int> deleteAction = (childIndex) =>
             {
@@ -986,6 +591,7 @@ namespace FancyZonesEditor
         }
 
         private GridData _data;
+        private GridDragHandles _dragHandles;
 
         private int _startRow = -1;
         private int _endRow = -1;

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
@@ -752,23 +752,13 @@ namespace FancyZonesEditor
 
         private void MergeClick(object sender, RoutedEventArgs e)
         {
-            GridLayoutModel model = Model;
-
             MergePanel.Visibility = Visibility.Collapsed;
-            int mergedIndex = model.CellChildMap[_startRow, _startCol];
 
-            for (int row = _startRow; row <= _endRow; row++)
+            Action<int> deleteAction = (childIndex) =>
             {
-                for (int col = _startCol; col <= _endCol; col++)
-                {
-                    int childIndex = model.CellChildMap[row, col];
-                    if (childIndex != mergedIndex)
-                    {
-                        model.CellChildMap[row, col] = mergedIndex;
-                        DeleteZone(childIndex);
-                    }
-                }
-            }
+                DeleteZone(childIndex);
+            };
+            _data.MergeZones(_startRow, _endRow, _startCol, _endCol, deleteAction);
 
             UIElementCollection resizers = AdornerLayer.Children;
             for (int i = 0; i < resizers.Count; i++)

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridResizer.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridResizer.xaml.cs
@@ -17,7 +17,9 @@ namespace FancyZonesEditor
     {
         private static readonly RotateTransform _rotateTransform = new RotateTransform(90, 24, 24);
 
-        public int Index { get; set; }
+        public int RowIndex { get; set; }
+
+        public int ColIndex { get; set; }
 
         public LayoutModel Model { get; set; }
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridResizer.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridResizer.xaml.cs
@@ -17,9 +17,13 @@ namespace FancyZonesEditor
     {
         private static readonly RotateTransform _rotateTransform = new RotateTransform(90, 24, 24);
 
-        public int RowIndex { get; set; }
+        public int StartRow { get; set; }
 
-        public int ColIndex { get; set; }
+        public int EndRow { get; set; }
+
+        public int StartCol { get; set; }
+
+        public int EndCol { get; set; }
 
         public LayoutModel Model { get; set; }
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/GridLayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/GridLayoutModel.cs
@@ -60,10 +60,10 @@ namespace FancyZonesEditor.Models
         public int[,] CellChildMap { get; set; }
 
         // RowPercents - represents the %age height of each row in the grid
-        public int[] RowPercents { get; set; }
+        public List<int> RowPercents { get; set; }
 
         // ColumnPercents - represents the %age width of each column in the grid
-        public int[] ColumnPercents { get; set; }
+        public List<int> ColumnPercents { get; set; }
 
         // FreeZones (not persisted) - used to keep track of child indices that are no longer in use in the CellChildMap,
         //  making them candidates for re-use when it's needed to add another child
@@ -85,7 +85,7 @@ namespace FancyZonesEditor.Models
         {
         }
 
-        public GridLayoutModel(string uuid, string name, LayoutType type, int rows, int cols, int[] rowPercents, int[] colsPercents, int[,] cellChildMap)
+        public GridLayoutModel(string uuid, string name, LayoutType type, int rows, int cols, List<int> rowPercents, List<int> colsPercents, int[,] cellChildMap)
             : base(uuid, name, type)
         {
             _rows = rows;
@@ -103,16 +103,16 @@ namespace FancyZonesEditor.Models
             Rows = data[i++];
             Columns = data[i++];
 
-            RowPercents = new int[Rows];
+            RowPercents = new List<int>(Rows);
             for (int row = 0; row < Rows; row++)
             {
-                RowPercents[row] = (data[i++] * 256) + data[i++];
+                RowPercents.Add((data[i++] * 256) + data[i++]);
             }
 
-            ColumnPercents = new int[Columns];
+            ColumnPercents = new List<int>(Columns);
             for (int col = 0; col < Columns; col++)
             {
-                ColumnPercents[col] = (data[i++] * 256) + data[i++];
+                ColumnPercents.Add((data[i++] * 256) + data[i++]);
             }
 
             CellChildMap = new int[Rows, Columns];
@@ -154,18 +154,18 @@ namespace FancyZonesEditor.Models
 
             layout.CellChildMap = cellChildMap;
 
-            int[] rowPercents = new int[rows];
+            List<int> rowPercents = new List<int>(rows);
             for (int row = 0; row < rows; row++)
             {
-                rowPercents[row] = RowPercents[row];
+                rowPercents.Add(RowPercents[row]);
             }
 
             layout.RowPercents = rowPercents;
 
-            int[] colPercents = new int[cols];
+            List<int> colPercents = new List<int>(cols);
             for (int col = 0; col < cols; col++)
             {
-                colPercents[col] = ColumnPercents[col];
+                colPercents.Add(ColumnPercents[col]);
             }
 
             layout.ColumnPercents = colPercents;
@@ -177,9 +177,9 @@ namespace FancyZonesEditor.Models
 
             public int Columns { get; set; }
 
-            public int[] RowsPercentage { get; set; }
+            public List<int> RowsPercentage { get; set; }
 
-            public int[] ColumnsPercentage { get; set; }
+            public List<int> ColumnsPercentage { get; set; }
 
             public int[][] CellChildMap { get; set; }
         }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
@@ -184,23 +184,22 @@ namespace FancyZonesEditor.Models
                     {
                         int rows = info.GetProperty("rows").GetInt32();
                         int columns = info.GetProperty("columns").GetInt32();
-                        int[] rowsPercentage = new int[rows];
+
+                        List<int> rowsPercentage = new List<int>(rows);
                         JsonElement.ArrayEnumerator rowsPercentageEnumerator = info.GetProperty("rows-percentage").EnumerateArray();
-                        int i = 0;
                         while (rowsPercentageEnumerator.MoveNext())
                         {
-                            rowsPercentage[i++] = rowsPercentageEnumerator.Current.GetInt32();
+                            rowsPercentage.Add(rowsPercentageEnumerator.Current.GetInt32());
                         }
 
-                        i = 0;
-                        int[] columnsPercentage = new int[columns];
+                        List<int> columnsPercentage = new List<int>(columns);
                         JsonElement.ArrayEnumerator columnsPercentageEnumerator = info.GetProperty("columns-percentage").EnumerateArray();
                         while (columnsPercentageEnumerator.MoveNext())
                         {
-                            columnsPercentage[i++] = columnsPercentageEnumerator.Current.GetInt32();
+                            columnsPercentage.Add(columnsPercentageEnumerator.Current.GetInt32());
                         }
 
-                        i = 0;
+                        int i = 0;
                         JsonElement.ArrayEnumerator cellChildMapRows = info.GetProperty("cell-child-map").EnumerateArray();
                         int[,] cellChildMap = new int[rows, columns];
                         while (cellChildMapRows.MoveNext())

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/Settings.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/Settings.cs
@@ -133,14 +133,14 @@ namespace FancyZonesEditor
             _columnsModel = new GridLayoutModel("Columns", LayoutType.Columns)
             {
                 Rows = 1,
-                RowPercents = new int[1] { _multiplier },
+                RowPercents = new List<int>(1) { _multiplier },
             };
             DefaultModels.Add(_columnsModel);
 
             _rowsModel = new GridLayoutModel("Rows", LayoutType.Rows)
             {
                 Columns = 1,
-                ColumnPercents = new int[1] { _multiplier },
+                ColumnPercents = new List<int>(1) { _multiplier },
             };
             DefaultModels.Add(_rowsModel);
 
@@ -308,7 +308,7 @@ namespace FancyZonesEditor
             _rowsModel.CellChildMap = new int[ZoneCount, 1];
             _columnsModel.CellChildMap = new int[1, ZoneCount];
             _rowsModel.Rows = _columnsModel.Columns = ZoneCount;
-            _rowsModel.RowPercents = _columnsModel.ColumnPercents = new int[ZoneCount];
+            _rowsModel.RowPercents = _columnsModel.ColumnPercents = new List<int>(ZoneCount);
 
             for (int i = 0; i < ZoneCount; i++)
             {
@@ -318,7 +318,7 @@ namespace FancyZonesEditor
                 // Note: This is NOT equal to _multiplier / ZoneCount and is done like this to make
                 // the sum of all RowPercents exactly (_multiplier).
                 // _columnsModel is sharing the same array
-                _rowsModel.RowPercents[i] = ((_multiplier * (i + 1)) / ZoneCount) - ((_multiplier * i) / ZoneCount);
+                _rowsModel.RowPercents.Add(((_multiplier * (i + 1)) / ZoneCount) - ((_multiplier * i) / ZoneCount));
             }
 
             // Update the "Grid" Default Layout
@@ -341,20 +341,20 @@ namespace FancyZonesEditor
 
             _gridModel.Rows = rows;
             _gridModel.Columns = cols;
-            _gridModel.RowPercents = new int[rows];
-            _gridModel.ColumnPercents = new int[cols];
+            _gridModel.RowPercents = new List<int>(rows);
+            _gridModel.ColumnPercents = new List<int>(cols);
             _gridModel.CellChildMap = new int[rows, cols];
 
             // Note: The following are NOT equal to _multiplier divided by rows or columns and is
             // done like this to make the sum of all RowPercents exactly (_multiplier).
             for (int row = 0; row < rows; row++)
             {
-                _gridModel.RowPercents[row] = ((_multiplier * (row + 1)) / rows) - ((_multiplier * row) / rows);
+                _gridModel.RowPercents.Add(((_multiplier * (row + 1)) / rows) - ((_multiplier * row) / rows));
             }
 
             for (int col = 0; col < cols; col++)
             {
-                _gridModel.ColumnPercents[col] = ((_multiplier * (col + 1)) / cols) - ((_multiplier * col) / cols);
+                _gridModel.ColumnPercents.Add(((_multiplier * (col + 1)) / cols) - ((_multiplier * col) / cols));
             }
 
             int index = ZoneCount - 1;

--- a/src/modules/fancyzones/editor/FancyZonesEditor/RowColInfo.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/RowColInfo.cs
@@ -21,6 +21,14 @@ namespace FancyZonesEditor
             Percent = percent;
         }
 
+        public RowColInfo(RowColInfo other)
+        {
+            Percent = other.Percent;
+            Extent = other.Extent;
+            Start = other.Start;
+            End = other.End;
+        }
+
         public RowColInfo(int index, int count)
         {
             Percent = (_multiplier / count) + ((index == 0) ? (_multiplier % count) : 0);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
* Fixed
  * missing grid resizers
  * moving grid resizers after merge
  * gap between zones and taskbar

* Added possibility to move grid resizers along whole available space of row/column. 
* Refactored code and changed some data structures (raw arrays to lists)

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2507, #2483, #2326, https://github.com/microsoft/PowerToys/issues/766, https://github.com/microsoft/PowerToys/issues/2440
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
* Missing grid resizers fix:
![2507_1 (Medium)](https://user-images.githubusercontent.com/8949536/83850972-55e0b700-a71a-11ea-8e80-f27608a0b096.png)

* Gap between zones was caused by calculation error after splitting zones. Zones are represented as a percentage of the whole screen, and after calculations total percentage could be less than original `10000`. 
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/8949536/83857006-09e64000-a723-11ea-8d90-5a9c0dcf2b5c.gif)

* After merge zones redundant data wasn't removed. This caused the problem that users can't move dividers over the other dividers that are still present in data structures, but invisible for users.
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/8949536/83858052-8decf780-a724-11ea-8ede-4faa09b2dd31.gif)

* Dividers now can be moved through whole available area
![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/8949536/83858546-56cb1600-a725-11ea-8b12-29927e7addc6.gif)
 