### PR TITLE
Fixed initial focus on WPF issue

### DIFF
--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml
@@ -21,6 +21,7 @@
         Background="Transparent"
         LocationChanged="OnLocationChanged"
         Deactivated="OnDeactivated"
+        IsVisibleChanged="Window_IsVisibleChanged"
         Visibility="{Binding MainWindowVisibility, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
         d:DataContext="{d:DesignInstance vm:MainViewModel}">
     <Window.Resources>

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml
@@ -21,7 +21,7 @@
         Background="Transparent"
         LocationChanged="OnLocationChanged"
         Deactivated="OnDeactivated"
-        IsVisibleChanged="Window_IsVisibleChanged"
+        IsVisibleChanged="OnVisibilityChanged"
         Visibility="{Binding MainWindowVisibility, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
         d:DataContext="{d:DesignInstance vm:MainViewModel}">
     <Window.Resources>

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -317,7 +317,7 @@ namespace PowerLauncher
             }
         }
 
-        private void Window_IsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
+        private void OnVisibilityChanged(object sender, DependencyPropertyChangedEventArgs e)
         {
             if (Visibility == Visibility.Visible)
             {

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -102,6 +102,8 @@ namespace PowerLauncher
         {
             if (Visibility == System.Windows.Visibility.Visible)
             {
+                // Not called on first launch
+                // Additionally called when deactivated by clicking on screen  
                 UpdatePosition();
                 Activate();
 

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -78,6 +78,8 @@ namespace PowerLauncher
             ListBox.SuggestionsList.SelectionChanged += SuggestionsList_SelectionChanged;
             ListBox.SuggestionsList.PreviewMouseLeftButtonUp += SuggestionsList_PreviewMouseLeftButtonUp;
             _viewModel.PropertyChanged += ViewModel_PropertyChanged;
+
+            Activate();
         }
 
         private void SuggestionsList_PreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs e)
@@ -98,32 +100,14 @@ namespace PowerLauncher
 
         private void ViewModel_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            if (e.PropertyName == nameof(MainViewModel.MainWindowVisibility))
+            if (Visibility == System.Windows.Visibility.Visible)
             {
-                if (Visibility == System.Windows.Visibility.Visible)
+                UpdatePosition();
+                Activate();
+
+                if (!_viewModel.LastQuerySelected)
                 {
-                    _deletePressed = false;
-                    _firstDeleteTimer.Start();
-                    Activate();
-                    //(this.FindResource("IntroStoryboard") as Storyboard).Begin();
-
-                    UpdatePosition();
-                    SearchBox.QueryTextBox.Focus();
-                    _settings.ActivateTimes++;
-
-                    if (!_viewModel.LastQuerySelected)
-                    {
-                        _viewModel.LastQuerySelected = true;
-                    }
-
-                    if (!String.IsNullOrEmpty(SearchBox.QueryTextBox.Text))
-                    {
-                        SearchBox.QueryTextBox.SelectAll();
-                    }
-                }
-                else
-                {
-                    _firstDeleteTimer.Stop();
+                    _viewModel.LastQuerySelected = true;
                 }
             }
             else if (e.PropertyName == nameof(MainViewModel.SystemQueryText))
@@ -333,7 +317,26 @@ namespace PowerLauncher
 
         private void Window_IsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
         {
-            System.Diagnostics.Debug.WriteLine("Changed");
+            if (Visibility == Visibility.Visible)
+            {
+                _deletePressed = false;
+                _firstDeleteTimer.Start();
+                // (this.FindResource("IntroStoryboard") as Storyboard).Begin();
+
+                SearchBox.QueryTextBox.Focus();
+                Keyboard.Focus(SearchBox.QueryTextBox);
+
+                _settings.ActivateTimes++;
+
+                if (!String.IsNullOrEmpty(SearchBox.QueryTextBox.Text))
+                {
+                    SearchBox.QueryTextBox.SelectAll();
+                }
+            }
+            else
+            {
+                _firstDeleteTimer.Stop();
+            }
         }
 
         private void OutroStoryboard_Completed(object sender, EventArgs e)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR solves issue with focus not being set on first launch. 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #3971, #2973 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
`onLoaded` callback is being fired on the first launch and we are registering ViewModel_PropertyChanged in `onLoaded` callback. And this causes property change event for visibility to be missed on first launch. We can solve this by moving this to `VisibilityChanged` callback of main window. 

Note: Using Activate() and UpdatePosition() in `Window_IsVisibleChanged` is interfering with WPF lifecycle and resulting in launcher never being visible.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manually validated from MSI that focus issue is not being hit on first launch and subsequent launch. 