### PR TITLE
[PT Run] Updated the PT Run icon to E771

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ShellPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ShellPage.xaml
@@ -83,7 +83,7 @@
                 <!-- TO DO: Update icon -->
                 <winui:NavigationViewItem x:Uid="Shell_PowerLauncher" helpers:NavHelper.NavigateTo="views:PowerLauncherPage">
                     <winui:NavigationViewItem.Icon>
-                        <FontIcon Glyph="&#xE8A7;"/>
+                        <FontIcon Glyph="&#xE773;"/>
                     </winui:NavigationViewItem.Icon>
                 </winui:NavigationViewItem>
 


### PR DESCRIPTION
## Summary of the Pull Request
Updated the PT Run icon in Settings to E771 (discussed in #4041)

Result:
![image](https://user-images.githubusercontent.com/9866362/83911578-cfa19080-a76c-11ea-9290-98dae0e3f38e.png)

## PR Checklist
* [X] Applies to #xxx
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA