### PR TITLE
[PT Run] Updated themes (dark/light/highcontrast)

### DIFF
--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml
@@ -54,10 +54,10 @@
             x:Name="SearchBoxBorder" 
             Grid.Row="0" 
             Margin="24,24,24,8"  
-            BorderThickness="0" 
+            BorderThickness="1" 
             CornerRadius="4"
             Background="{DynamicResource SystemChromeLow}"
-            BorderBrush="{DynamicResource SystemChromeLow}">
+            BorderBrush="{DynamicResource BorderBrush}">
             <Border.Effect>
                 <DropShadowEffect BlurRadius="12" Opacity="0.3" ShadowDepth="0" />
             </Border.Effect>
@@ -75,11 +75,11 @@
             x:Name="ListBoxBorder"
             Grid.Row="1" 
             Margin="24,8,24,24" 
-            BorderThickness="0"
+            BorderThickness="1"
             CornerRadius="4" 
             Visibility="{Binding Results.Visibility}"
             Background="{DynamicResource SystemChromeLow}"
-            BorderBrush="{DynamicResource SystemChromeLow}">
+            BorderBrush="{DynamicResource BorderBrush}">
             <!--<Border.RenderTransform>
                 <TranslateTransform />
             </Border.RenderTransform>-->

--- a/src/modules/launcher/PowerLauncher/ResultList.xaml
+++ b/src/modules/launcher/PowerLauncher/ResultList.xaml
@@ -76,7 +76,7 @@
                             <ControlTemplate.Triggers>
                                 <!-- Setting the opacity of the highlight border to improve the contrast of the AccentColorbrush when selected. In UWP we could call a different brush, in WPF we need to play with the opacity of the WindowGlassBrush-->
                                 <Trigger Property="IsMouseOver" Value="True">
-                                    <Setter Property="Opacity" TargetName="HighlightBorder" Value="0.1" />
+                                    <Setter Property="Opacity" TargetName="HighlightBorder" Value="1" />
                                     <Setter Property="Background" TargetName="HighlightBorder" Value="{DynamicResource ListViewItemBackgroundPointerOver}"/>
                                 </Trigger>
                                 <Trigger Property="IsSelected" Value="True">
@@ -158,7 +158,7 @@
                         </Grid.RowDefinitions>
                         <Image x:Name="AppIcon" Height="36" MaxWidth="56" Grid.RowSpan="2" Margin="-8,0,0,0" HorizontalAlignment="Center" Source="{Binding Image}" />
                         <TextBlock x:Name="Title" Grid.Column="1" Text="{Binding Result.Title}" FontWeight="SemiBold" FontSize="20" Margin="0,0,0,-2" VerticalAlignment="Bottom"/>
-                        <TextBlock x:Name="Path" Grid.Column="1" Text= "{Binding Result.SubTitle}" Grid.Row="1" Opacity="0.6" Margin="0,2,0,0" VerticalAlignment="Top"/>
+                        <TextBlock x:Name="Path" Grid.Column="1" Text= "{Binding Result.SubTitle}" Grid.Row="1" Foreground="{DynamicResource SecondaryTextBrush}" Margin="0,2,0,0" VerticalAlignment="Top"/>
                         <ListView                                  
                             HorizontalAlignment="Right" 
                             VerticalAlignment="Center"                                  

--- a/src/modules/launcher/PowerLauncher/Themes/Dark.xaml
+++ b/src/modules/launcher/PowerLauncher/Themes/Dark.xaml
@@ -24,8 +24,9 @@
     <SolidColorBrush x:Key="ButtonBorderPointerOver" Color="#61FFFFFF" />
     <SolidColorBrush x:Key="ButtonBackgroundPressed" Color="#30FFFFFF" />
     <SolidColorBrush x:Key="ButtonBorderPressed" Color="#61FFFFFF" />
-    <SolidColorBrush x:Key="ListViewItemBackgroundPointerOver" Color="#FFFFFFFF" />
+    <SolidColorBrush x:Key="ListViewItemBackgroundPointerOver" Color="#22FFFFFF" />
     <SolidColorBrush x:Key="ControlTextBrushKey" Color="White" />
+    <SolidColorBrush x:Key="SecondaryTextBrush" Color="#66FFFFFF" />
     <SolidColorBrush x:Key="InactiveSelectionHighlightBrushKey" Color="White" />
-
+    <SolidColorBrush x:Key="BorderBrush" Color="Transparent" />
 </ResourceDictionary>

--- a/src/modules/launcher/PowerLauncher/Themes/HighContrast1.xaml
+++ b/src/modules/launcher/PowerLauncher/Themes/HighContrast1.xaml
@@ -14,17 +14,19 @@
     <system:String x:Key="Theme.ColorScheme">Accent2</system:String>
     <Color x:Key="Theme.PrimaryAccentColor">White</Color>
 
-    <Color x:Key="SystemBaseMediumLowColor">#FF000000</Color>
-    <SolidColorBrush x:Key="SystemChromeLow" Color="White" options:Freeze="True" />
-    <SolidColorBrush x:Key="TextControlPlaceholderForeground" Color="#FF000000" />
+    <Color x:Key="SystemBaseMediumLowColor">#ffff00</Color>
+    <SolidColorBrush x:Key="SystemChromeLow" Color="Black" options:Freeze="True" />
+    <SolidColorBrush x:Key="TextControlPlaceholderForeground" Color="#FF008000" />
     <SolidColorBrush x:Key="TextBox.Static.Border" Color="Transparent"/>
     <SolidColorBrush x:Key="TextBox.MouseOver.Border" Color="Transparent"/>
     <SolidColorBrush x:Key="TextBox.Focus.Border" Color="Transparent"/>
-    <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="#FFFFFFFF" />
-    <SolidColorBrush x:Key="ButtonBorderPointerOver" Color="#FFFFFFFF" />
-    <SolidColorBrush x:Key="ButtonBackgroundPressed" Color="#FFFFFFFF" />
-    <SolidColorBrush x:Key="ButtonBorderPressed" Color="#FFFFFFFF" />
-    <SolidColorBrush x:Key="ListViewItemBackgroundPointerOver" Color="#FF000000" />
-    <SolidColorBrush x:Key="ControlTextBrushKey" Color="#FF000000" />
+    <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="Black" />
+    <SolidColorBrush x:Key="ButtonBorderPointerOver" Color="White" />
+    <SolidColorBrush x:Key="ButtonBackgroundPressed" Color="White" />
+    <SolidColorBrush x:Key="ButtonBorderPressed" Color="White" />
+    <SolidColorBrush x:Key="ListViewItemBackgroundPointerOver" Color="#66008000" />
+    <SolidColorBrush x:Key="ControlTextBrushKey" Color="#FFffff00" />
+    <SolidColorBrush x:Key="SecondaryTextBrush" Color="#FF008000" />
     <SolidColorBrush x:Key="InactiveSelectionHighlightBrushKey" Color="#FFFFFFFF" />
+    <SolidColorBrush x:Key="BorderBrush" Color="White" />
 </ResourceDictionary>

--- a/src/modules/launcher/PowerLauncher/Themes/HighContrast2.xaml
+++ b/src/modules/launcher/PowerLauncher/Themes/HighContrast2.xaml
@@ -14,17 +14,19 @@
     <system:String x:Key="Theme.ColorScheme">Accent3</system:String>
     <Color x:Key="Theme.PrimaryAccentColor">White</Color>
 
-    <Color x:Key="SystemBaseMediumLowColor">#FF000000</Color>
-    <SolidColorBrush x:Key="SystemChromeLow" Color="Orange" options:Freeze="True" />
-    <SolidColorBrush x:Key="TextControlPlaceholderForeground" Color="#FF000000" />
+    <Color x:Key="SystemBaseMediumLowColor">#ffff00</Color>
+    <SolidColorBrush x:Key="SystemChromeLow" Color="Black" options:Freeze="True" />
+    <SolidColorBrush x:Key="TextControlPlaceholderForeground" Color="#FFc0c0c0" />
     <SolidColorBrush x:Key="TextBox.Static.Border" Color="Transparent"/>
     <SolidColorBrush x:Key="TextBox.MouseOver.Border" Color="Transparent"/>
     <SolidColorBrush x:Key="TextBox.Focus.Border" Color="Transparent"/>
-    <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="#FFFFFFFF" />
-    <SolidColorBrush x:Key="ButtonBorderPointerOver" Color="#FFFFFFFF" />
-    <SolidColorBrush x:Key="ButtonBackgroundPressed" Color="#FFFFFFFF" />
+    <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="Black" />
+    <SolidColorBrush x:Key="ButtonBorderPointerOver" Color="Black" />
+    <SolidColorBrush x:Key="ButtonBackgroundPressed" Color="Black" />
     <SolidColorBrush x:Key="ButtonBorderPressed" Color="#FFFFFFFF" />
-    <SolidColorBrush x:Key="ListViewItemBackgroundPointerOver" Color="#FF000000" />
-    <SolidColorBrush x:Key="ControlTextBrushKey" Color="#FF000000" />
+    <SolidColorBrush x:Key="ListViewItemBackgroundPointerOver" Color="#FF0000ff" />
+    <SolidColorBrush x:Key="ControlTextBrushKey" Color="#FF00ff00" />
+    <SolidColorBrush x:Key="SecondaryTextBrush" Color="#6f6f6f" />
     <SolidColorBrush x:Key="InactiveSelectionHighlightBrushKey" Color="#FFFFFFFF" />
+    <SolidColorBrush x:Key="BorderBrush" Color="White" />
 </ResourceDictionary>

--- a/src/modules/launcher/PowerLauncher/Themes/HighContrastBlack.xaml
+++ b/src/modules/launcher/PowerLauncher/Themes/HighContrastBlack.xaml
@@ -14,17 +14,19 @@
     <system:String x:Key="Theme.ColorScheme">Accent4</system:String>
     <Color x:Key="Theme.PrimaryAccentColor">White</Color>
 
-    <Color x:Key="SystemBaseMediumLowColor">#FF000000</Color>
-    <SolidColorBrush x:Key="SystemChromeLow" Color="Green" options:Freeze="True" />
-    <SolidColorBrush x:Key="TextControlPlaceholderForeground" Color="#FF000000" />
+    <Color x:Key="SystemBaseMediumLowColor">#66FFFFFF</Color>
+    <SolidColorBrush x:Key="SystemChromeLow" Color="Black" options:Freeze="True" />
+    <SolidColorBrush x:Key="TextControlPlaceholderForeground" Color="#FF3ff23f" />
     <SolidColorBrush x:Key="TextBox.Static.Border" Color="Transparent"/>
     <SolidColorBrush x:Key="TextBox.MouseOver.Border" Color="Transparent"/>
     <SolidColorBrush x:Key="TextBox.Focus.Border" Color="Transparent"/>
-    <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="#FFFFFFFF" />
-    <SolidColorBrush x:Key="ButtonBorderPointerOver" Color="#FFFFFFFF" />
-    <SolidColorBrush x:Key="ButtonBackgroundPressed" Color="#FFFFFFFF" />
-    <SolidColorBrush x:Key="ButtonBorderPressed" Color="#FFFFFFFF" />
-    <SolidColorBrush x:Key="ListViewItemBackgroundPointerOver" Color="#FF000000" />
-    <SolidColorBrush x:Key="ControlTextBrushKey" Color="#FF000000" />
-    <SolidColorBrush x:Key="InactiveSelectionHighlightBrushKey" Color="#FFFFFFFF" />
+    <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="#30FFFFFF" />
+    <SolidColorBrush x:Key="ButtonBorderPointerOver" Color="#61FFFFFF" />
+    <SolidColorBrush x:Key="ButtonBackgroundPressed" Color="#30FFFFFF" />
+    <SolidColorBrush x:Key="ButtonBorderPressed" Color="#61FFFFFF" />
+    <SolidColorBrush x:Key="ListViewItemBackgroundPointerOver" Color="#771aebff" />
+    <SolidColorBrush x:Key="ControlTextBrushKey" Color="White" />
+    <SolidColorBrush x:Key="SecondaryTextBrush" Color="#FF3ff23f" />
+    <SolidColorBrush x:Key="InactiveSelectionHighlightBrushKey" Color="White" />
+    <SolidColorBrush x:Key="BorderBrush" Color="White" />
 </ResourceDictionary>

--- a/src/modules/launcher/PowerLauncher/Themes/HighContrastWhite.xaml
+++ b/src/modules/launcher/PowerLauncher/Themes/HighContrastWhite.xaml
@@ -14,17 +14,19 @@
     <system:String x:Key="Theme.ColorScheme">Accent5</system:String>
     <Color x:Key="Theme.PrimaryAccentColor">White</Color>
 
-    <Color x:Key="SystemBaseMediumLowColor">#FF000000</Color>
-    <SolidColorBrush x:Key="SystemChromeLow" Color="Red" options:Freeze="True" />
-    <SolidColorBrush x:Key="TextControlPlaceholderForeground" Color="#FF000000" />
+    <Color x:Key="SystemBaseMediumLowColor">#66000000</Color>
+    <SolidColorBrush x:Key="SystemChromeLow" Color="White" options:Freeze="True" />
+    <SolidColorBrush x:Key="TextControlPlaceholderForeground" Color="#FF37006e" />
     <SolidColorBrush x:Key="TextBox.Static.Border" Color="Transparent"/>
     <SolidColorBrush x:Key="TextBox.MouseOver.Border" Color="Transparent"/>
     <SolidColorBrush x:Key="TextBox.Focus.Border" Color="Transparent"/>
-    <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="#FFFFFFFF" />
-    <SolidColorBrush x:Key="ButtonBorderPointerOver" Color="#FFFFFFFF" />
-    <SolidColorBrush x:Key="ButtonBackgroundPressed" Color="#FFFFFFFF" />
-    <SolidColorBrush x:Key="ButtonBorderPressed" Color="#FFFFFFFF" />
-    <SolidColorBrush x:Key="ListViewItemBackgroundPointerOver" Color="#FF000000" />
-    <SolidColorBrush x:Key="ControlTextBrushKey" Color="#FF000000" />
-    <SolidColorBrush x:Key="InactiveSelectionHighlightBrushKey" Color="#FFFFFFFF" />
+    <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="#2E000000" />
+    <SolidColorBrush x:Key="ButtonBorderPointerOver" Color="#61000000" />
+    <SolidColorBrush x:Key="ButtonBackgroundPressed" Color="#FF37006e" />
+    <SolidColorBrush x:Key="ButtonBorderPressed" Color="#FF37006e" />
+    <SolidColorBrush x:Key="ListViewItemBackgroundPointerOver" Color="#6637006e" />
+    <SolidColorBrush x:Key="ControlTextBrushKey" Color="Black" />
+    <SolidColorBrush x:Key="SecondaryTextBrush" Color="#FF37006e" />
+    <SolidColorBrush x:Key="InactiveSelectionHighlightBrushKey" Color="Black" />
+    <SolidColorBrush x:Key="BorderBrush" Color="Black" />
 </ResourceDictionary>

--- a/src/modules/launcher/PowerLauncher/Themes/Light.xaml
+++ b/src/modules/launcher/PowerLauncher/Themes/Light.xaml
@@ -16,7 +16,7 @@
 
     <Color x:Key="SystemBaseMediumLowColor">#66000000</Color>
     <SolidColorBrush x:Key="SystemChromeLow" Color="#FFF2F2F2" options:Freeze="True" />
-    <SolidColorBrush x:Key="TextControlPlaceholderForeground" Color="#66000000" />
+    <SolidColorBrush x:Key="TextControlPlaceholderForeground" Color="#d5000000" />
     <SolidColorBrush x:Key="TextBox.Static.Border" Color="Transparent"/>
     <SolidColorBrush x:Key="TextBox.MouseOver.Border" Color="Transparent"/>
     <SolidColorBrush x:Key="TextBox.Focus.Border" Color="Transparent"/>
@@ -24,8 +24,9 @@
     <SolidColorBrush x:Key="ButtonBorderPointerOver" Color="#61000000" />
     <SolidColorBrush x:Key="ButtonBackgroundPressed" Color="#33000000" />
     <SolidColorBrush x:Key="ButtonBorderPressed" Color="#61000000" />
-    <SolidColorBrush x:Key="ListViewItemBackgroundPointerOver" Color="#FF000000" />
+    <SolidColorBrush x:Key="ListViewItemBackgroundPointerOver" Color="#22000000" />
     <SolidColorBrush x:Key="ControlTextBrushKey" Color="Black" />
+    <SolidColorBrush x:Key="SecondaryTextBrush" Color="#d5000000" />
     <SolidColorBrush x:Key="InactiveSelectionHighlightBrushKey" Color="Black" />
-
+    <SolidColorBrush x:Key="BorderBrush" Color="Transparent" />
 </ResourceDictionary>


### PR DESCRIPTION
##  Summary of the Pull Request
- Added a brush for 'secondary text' (instead of primary text font with a lower opacity)
- Minor updates to the Light and Dark themes to reflect the updated secondary text brush
- Added a BorderThickness of 1 to visualize the border when a high contrast theme is selected. Transparant for Light and Dark
- Updated the high contrast themes, to reflect the default high contrast settings.

![Highcontrast](https://user-images.githubusercontent.com/9866362/83920870-742bce80-a77d-11ea-9101-7ba22b38105d.gif)


## PR Checklist
* [X] Applies to #4007 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA