### PR TITLE
Fix for Steam games not showing up

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32.cs
@@ -13,8 +13,6 @@ using Microsoft.Plugin.Program.Logger;
 using Wox.Plugin;
 using System.Windows.Input;
 using System.Reflection;
-using System.Drawing;
-using System.Security.Policy;
 
 namespace Microsoft.Plugin.Program.Programs
 {
@@ -33,7 +31,6 @@ namespace Microsoft.Plugin.Program.Programs
         public bool Valid { get; set; }
         public bool Enabled { get; set; }
         public string Location => ParentDirectory;
-
         public string AppType { get; set; }
 
         private const string ShortcutExtension = "lnk";
@@ -115,10 +112,7 @@ namespace Microsoft.Plugin.Program.Programs
                         AcceleratorModifiers = (ModifierKeys.Control | ModifierKeys.Shift),
                         Action = _ =>
                         {
-
-
                             Main.StartProcess(Process.Start, new ProcessStartInfo("explorer", ParentDirectory));
-
                             return true;
                         }
                     }

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Settings.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Settings.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Plugin.Program
         public DateTime LastIndexTime { get; set; }
         public List<ProgramSource> ProgramSources { get; set; } = new List<ProgramSource>();
         public List<DisabledProgramSource> DisabledProgramSources { get; set; } = new List<DisabledProgramSource>();
-        public string[] ProgramSuffixes { get; set; } = {"bat", "appref-ms", "exe", "lnk"};
+        public string[] ProgramSuffixes { get; set; } = {"bat", "appref-ms", "exe", "lnk", "url"};
 
         public bool EnableStartMenuSource { get; set; } = true;
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Steam games were not showing up while searching using PowerToys Run. This was happening as they were internet shortcut files with a url file extension.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
* List of URI Schemes - https://en.wikipedia.org/wiki/List_of_URI_schemes. There are many URI schemes and of all the one's that are officially recognized, steam seems to be the only one which launches apps using urls.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #3425
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Changes made in this PR -
* Filter out steam internet shortcut files and obtain their icon.
* Update description to `Internet Shortcut File` instead of Win32 application. This is the first step towards having separate subtitles so that we can update it for PWAs as well.
* Since Internet shortcut files don't have run as admin functionality, removed that context menu icon if it is an internet shortcut file.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
* Steam games show up - 
![image](https://user-images.githubusercontent.com/28739210/83924764-335e9600-a73a-11ea-80d3-755aeb839e09.png)
