### PR TITLE
[PowerRename] capturing groups fix

### DIFF
--- a/src/modules/powerrename/lib/PowerRenameRegEx.cpp
+++ b/src/modules/powerrename/lib/PowerRenameRegEx.cpp
@@ -211,9 +211,31 @@ HRESULT CPowerRenameRegEx::Replace(_In_ PCWSTR source, _Outptr_ PWSTR* result)
                 else
                 {
                     std::wsmatch m;
+                    std::wstring resultName(sourceToUse);
                     if (std::regex_search(sourceToUse, m, pattern))
                     {
-                        res = sourceToUse.replace(m.prefix().length(), m.length(), replaceTerm);
+                        res = resultName.replace(m.prefix().length(), m.length(), replaceTerm);
+
+                        for ( int i=1 ; i<m.size(); i++ )
+                        {
+                            searchTerm = wstring(L"$" + std::to_wstring(i));
+                            replaceTerm = wstring(m[i]);
+                            size_t pos = 0;
+                            do
+                            {
+                                pos = _Find(resultName, searchTerm, (!(m_flags & CaseSensitive)), pos);
+                                if (pos != std::string::npos)
+                                {
+                                    res = resultName.replace(pos, searchTerm.length(), replaceTerm);
+                                    pos += replaceTerm.length();
+                                }
+                            } while (pos != std::string::npos);
+
+                        }
+
+                        std::wregex variablesPattern(L"\\$\\d+");
+                        res = regex_replace(wstring(res), variablesPattern, L"");
+                        
                     }
                 }
             }

--- a/src/modules/powerrename/lib/PowerRenameRegEx.cpp
+++ b/src/modules/powerrename/lib/PowerRenameRegEx.cpp
@@ -216,23 +216,11 @@ HRESULT CPowerRenameRegEx::Replace(_In_ PCWSTR source, _Outptr_ PWSTR* result)
                     {
                         res = resultName.replace(m.prefix().length(), m.length(), replaceTerm);
 
-                        for ( int i=1 ; i<m.size(); i++ )
+                        for (int i = 1; i < m.size(); i++)
                         {
-                            searchTerm = wstring(L"$" + std::to_wstring(i));
-                            replaceTerm = wstring(m[i]);
-                            size_t pos = 0;
-                            do
-                            {
-                                pos = _Find(resultName, searchTerm, (!(m_flags & CaseSensitive)), pos);
-                                if (pos != std::string::npos)
-                                {
-                                    res = resultName.replace(pos, searchTerm.length(), replaceTerm);
-                                    pos += replaceTerm.length();
-                                }
-                            } while (pos != std::string::npos);
-
+                            std::wregex captureGroup(L"\\$" + std::to_wstring(i) + L"(^|\\D)");
+                            res = regex_replace(wstring(res), captureGroup, wstring(m[i])+L"$1");
                         }
-
                         std::wregex variablesPattern(L"\\$\\d+");
                         res = regex_replace(wstring(res), variablesPattern, L"");
                         

--- a/src/modules/powerrename/lib/PowerRenameRegEx.cpp
+++ b/src/modules/powerrename/lib/PowerRenameRegEx.cpp
@@ -210,21 +210,7 @@ HRESULT CPowerRenameRegEx::Replace(_In_ PCWSTR source, _Outptr_ PWSTR* result)
                 }
                 else
                 {
-                    std::wsmatch m;
-                    std::wstring resultName(sourceToUse);
-                    if (std::regex_search(sourceToUse, m, pattern))
-                    {
-                        res = resultName.replace(m.prefix().length(), m.length(), replaceTerm);
-
-                        for (int i = 1; i < m.size(); i++)
-                        {
-                            std::wregex captureGroup(L"\\$0*" + std::to_wstring(i) + L"(^|\\D)");
-                            res = regex_replace(wstring(res), captureGroup, wstring(m[i])+L"$1");
-                        }
-                        std::wregex variablesPattern(L"\\$\\d+");
-                        res = regex_replace(wstring(res), variablesPattern, L"");
-                        
-                    }
+                    res = regex_replace(wstring(source), pattern, replaceTerm, regex_constants::format_first_only);
                 }
             }
             else

--- a/src/modules/powerrename/lib/PowerRenameRegEx.cpp
+++ b/src/modules/powerrename/lib/PowerRenameRegEx.cpp
@@ -218,7 +218,7 @@ HRESULT CPowerRenameRegEx::Replace(_In_ PCWSTR source, _Outptr_ PWSTR* result)
 
                         for (int i = 1; i < m.size(); i++)
                         {
-                            std::wregex captureGroup(L"\\$" + std::to_wstring(i) + L"(^|\\D)");
+                            std::wregex captureGroup(L"\\$0*" + std::to_wstring(i) + L"(^|\\D)");
                             res = regex_replace(wstring(res), captureGroup, wstring(m[i])+L"$1");
                         }
                         std::wregex variablesPattern(L"\\$\\d+");


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
When "Match All Occurrences" option is not selected, PowerRename was searching for the first occurrences manually and replacing it with the new string as raw text. Now it uses regex_replace() function with 'format_first_only' flag which makes the function replace only first occurrence.


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

* [x]  Applies to #1002 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

