### PR TITLE
[WinAppDriver tests] Affection on user setting files fix

### DIFF
--- a/src/modules/fancyzones/lib/JsonHelpers.h
+++ b/src/modules/fancyzones/lib/JsonHelpers.h
@@ -224,6 +224,7 @@ namespace JSONHelpers
         {
             std::wstring result = PTSettingsHelper::get_module_save_folder_location(moduleName);
             jsonFilePath = result + L"\\" + std::wstring(L"zones-settings.json");
+            appZoneHistoryFilePath = result + L"\\" + std::wstring(L"app-zone-history.json");
         }
 #endif
 

--- a/src/tests/win-app-driver/FancyZonesTests/EditorCanvasZoneResizeTests.cs
+++ b/src/tests/win-app-driver/FancyZonesTests/EditorCanvasZoneResizeTests.cs
@@ -261,6 +261,9 @@ namespace PowerToysTests
         public static void ClassInitialize(TestContext context)
         {
             Setup(context, false);
+            if (session == null)
+                return;
+
             ResetSettings();
 
             if (!isPowerToysLaunched)
@@ -281,6 +284,9 @@ namespace PowerToysTests
         [TestInitialize]
         public void TestInitialize()
         {
+            if (session == null)
+                return;
+
             //create canvas zone
             OpenCreatorWindow("Create new custom", "Custom layout creator");
             session.FindElementByAccessibilityId("newZoneButton").Click();
@@ -289,6 +295,9 @@ namespace PowerToysTests
         [TestCleanup]
         public void TestCleanup()
         {
+            if (session == null)
+                return;
+
             new Actions(session).MoveToElement(session.FindElementByXPath("//Button[@Name=\"Cancel\"]")).Click().Perform();
         }
     }

--- a/src/tests/win-app-driver/FancyZonesTests/EditorCustomLayoutsTests.cs
+++ b/src/tests/win-app-driver/FancyZonesTests/EditorCustomLayoutsTests.cs
@@ -292,6 +292,9 @@ namespace PowerToysTests
         public static void ClassInitialize(TestContext context)
         {
             Setup(context, false);
+            if (session == null)
+                return;
+
             ResetSettings();
         }
 
@@ -304,6 +307,9 @@ namespace PowerToysTests
         [TestInitialize]
         public void TestInitialize()
         {
+            if (session == null)
+                return;
+
             if (!isPowerToysLaunched)
             {
                 LaunchPowerToys();

--- a/src/tests/win-app-driver/FancyZonesTests/EditorGridZoneResizeTests.cs
+++ b/src/tests/win-app-driver/FancyZonesTests/EditorGridZoneResizeTests.cs
@@ -397,6 +397,9 @@ namespace PowerToysTests
         public static void ClassInitialize(TestContext context)
         {
             Setup(context, false);
+            if (session == null)
+                return;
+
             ResetSettings();
 
             if (!isPowerToysLaunched)

--- a/src/tests/win-app-driver/FancyZonesTests/EditorOpeningTests.cs
+++ b/src/tests/win-app-driver/FancyZonesTests/EditorOpeningTests.cs
@@ -233,6 +233,9 @@ namespace PowerToysTests
         public static void ClassInitialize(TestContext context)
         {
             Setup(context, false);
+            if (session == null)
+                return;
+
             ResetDefaultFancyZonesSettings(true);
         }
 

--- a/src/tests/win-app-driver/FancyZonesTests/EditorSettingsTests.cs
+++ b/src/tests/win-app-driver/FancyZonesTests/EditorSettingsTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -179,6 +179,9 @@ namespace PowerToysTests
         public static void ClassInitialize(TestContext context)
         {
             Setup(context, false);
+            if (session == null)
+                return;
+
             ResetSettings();
         }
 

--- a/src/tests/win-app-driver/FancyZonesTests/EditorTemplatesApplyTests.cs
+++ b/src/tests/win-app-driver/FancyZonesTests/EditorTemplatesApplyTests.cs
@@ -68,6 +68,9 @@ namespace PowerToysTests
         public static void ClassInitialize(TestContext context)
         {
             Setup(context, false);
+            if (session == null)
+                return;
+
             ResetDefaultFancyZonesSettings(true);
         }
 
@@ -81,6 +84,9 @@ namespace PowerToysTests
         [TestInitialize]
         public void TestInitialize()
         {
+            if (session == null)
+                return;
+
             OpenEditor();
             OpenTemplates();
         }

--- a/src/tests/win-app-driver/FancyZonesTests/EditorTemplatesEditTests.cs
+++ b/src/tests/win-app-driver/FancyZonesTests/EditorTemplatesEditTests.cs
@@ -157,6 +157,9 @@ namespace PowerToysTests
         public static void ClassInitialize(TestContext context)
         {
             Setup(context, false);
+            if (session == null)
+                return;
+
             ResetDefaultFancyZonesSettings(false);
             ResetDefaultZoneSettings(true);
         }
@@ -171,6 +174,9 @@ namespace PowerToysTests
         [TestInitialize]
         public void TestInitialize()
         {
+            if (session == null)
+                return;
+
             if (!isPowerToysLaunched)
             {
                 LaunchPowerToys();

--- a/src/tests/win-app-driver/FancyZonesTests/FancyZonesEditor.cs
+++ b/src/tests/win-app-driver/FancyZonesTests/FancyZonesEditor.cs
@@ -1,6 +1,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenQA.Selenium.Appium.Windows;
 using OpenQA.Selenium.Interactions;
+using System;
 
 namespace PowerToysTests
 {
@@ -16,13 +17,20 @@ namespace PowerToysTests
 
         protected static void OpenEditor()
         {
-            new Actions(session).KeyDown(OpenQA.Selenium.Keys.Command).SendKeys("`").KeyUp(OpenQA.Selenium.Keys.Command).Perform();
-            WaitSeconds(2);
-            //editorWindow = WaitElementByXPath("//Window[@Name=\"FancyZones Editor\"]");
-            editorWindow = WaitElementByName("FancyZones Editor");
-            //may not find editor by name in 0.16.1
-            //editorWindow = WaitElementByAccessibilityId("MainWindow1");
-            Assert.IsNotNull(editorWindow, "Couldn't find editor window");
+            try
+            {
+                new Actions(session).KeyDown(OpenQA.Selenium.Keys.Command).SendKeys("`").KeyUp(OpenQA.Selenium.Keys.Command).Perform();
+                WaitSeconds(2);
+                //editorWindow = WaitElementByXPath("//Window[@Name=\"FancyZones Editor\"]");
+                editorWindow = WaitElementByName("FancyZones Editor");
+                //may not find editor by name in 0.16.1
+                //editorWindow = WaitElementByAccessibilityId("MainWindow1");
+                Assert.IsNotNull(editorWindow, "Couldn't find editor window");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.Message);
+            }
         }
 
         protected static void CloseEditor()
@@ -42,28 +50,49 @@ namespace PowerToysTests
 
         protected static void OpenCustomLayouts()
         {
-            WindowsElement customsTab = session.FindElementByName("Custom");
-            customsTab.Click();
-            string isSelected = customsTab.GetAttribute("SelectionItem.IsSelected");
-            Assert.AreEqual("True", isSelected, "Custom tab cannot be opened");
+            try
+            {
+                WindowsElement customsTab = session.FindElementByName("Custom");
+                customsTab.Click();
+                string isSelected = customsTab.GetAttribute("SelectionItem.IsSelected");
+                Assert.AreEqual("True", isSelected, "Custom tab cannot be opened");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.Message);
+            }
         }
 
         protected static void OpenTemplates()
         {
-            WindowsElement templatesTab = session.FindElementByName("Templates");
-            templatesTab.Click();
-            string isSelected = templatesTab.GetAttribute("SelectionItem.IsSelected");
-            Assert.AreEqual("True", isSelected, "Templates tab cannot be opened");
+            try
+            {
+                WindowsElement templatesTab = session.FindElementByName("Templates");
+                templatesTab.Click();
+                string isSelected = templatesTab.GetAttribute("SelectionItem.IsSelected");
+                Assert.AreEqual("True", isSelected, "Templates tab cannot be opened");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.Message);
+            }
         }
 
         protected static void OpenCreatorWindow(string tabName, string creatorWindowName, string buttonId = "EditCustomButton")
         {
-            string elementXPath = "//Text[@Name=\"" + tabName + "\"]";
-            WaitElementByXPath(elementXPath).Click();
-            WaitElementByAccessibilityId(buttonId).Click();
+            try
+            {
+                string elementXPath = "//Text[@Name=\"" + tabName + "\"]";
+                WaitElementByXPath(elementXPath).Click();
+                WaitElementByAccessibilityId(buttonId).Click();
 
-            WindowsElement creatorWindow = WaitElementByName(creatorWindowName);
-            Assert.IsNotNull(creatorWindow, "Creator window didn't open");
+                WindowsElement creatorWindow = WaitElementByName(creatorWindowName);
+                Assert.IsNotNull(creatorWindow, "Creator window didn't open");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.Message);
+            }
         }
 
         protected void ZoneCountTest(int canvasZoneCount, int gridZoneCount)

--- a/src/tests/win-app-driver/FancyZonesTests/FancyZonesSettingsTests.cs
+++ b/src/tests/win-app-driver/FancyZonesTests/FancyZonesSettingsTests.cs
@@ -713,6 +713,9 @@ namespace PowerToysTests
         public static void ClassInitialize(TestContext context)
         {
             Setup(context);
+            if (session == null)
+                return;
+
             Init();
         }
 
@@ -740,6 +743,9 @@ namespace PowerToysTests
         [TestInitialize]
         public void TestInitialize()
         {
+            if (session == null)
+                return;
+
             try
             {
                 _initialSettingsJson = JObject.Parse(_initialSettings);

--- a/src/tests/win-app-driver/PowerToysSession.cs
+++ b/src/tests/win-app-driver/PowerToysSession.cs
@@ -22,9 +22,11 @@ namespace PowerToysTests
         protected static string _settingsFolderPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Microsoft\\PowerToys\\FancyZones");
         protected static string _settingsPath = _settingsFolderPath + "\\settings.json"; 
         protected static string _zoneSettingsPath = _settingsFolderPath + "\\zones-settings.json";
+        protected static string _appHistoryPath = _settingsFolderPath + "\\app-zone-history.json";
 
         protected static string _initialSettings = "";
         protected static string _initialZoneSettings = "";
+        protected static string _initialAppHistorySettings = "";
 
         protected const string _defaultSettings = "{\"version\":\"1.0\",\"name\":\"FancyZones\",\"properties\":{\"fancyzones_shiftDrag\":{\"value\":true},\"fancyzones_mouseSwitch\":{\"value\":false},\"fancyzones_overrideSnapHotkeys\":{\"value\":false},\"fancyzones_moveWindowAcrossMonitors\":{\"value\":false},\"fancyzones_zoneSetChange_flashZones\":{\"value\":false},\"fancyzones_displayChange_moveWindows\":{\"value\":false},\"fancyzones_zoneSetChange_moveWindows\":{\"value\":false},\"fancyzones_appLastZone_moveWindows\":{\"value\":false},\"use_cursorpos_editor_startupscreen\":{\"value\":true},\"fancyzones_zoneHighlightColor\":{\"value\":\"#0078D7\"},\"fancyzones_highlight_opacity\":{\"value\":90},\"fancyzones_editor_hotkey\":{\"value\":{\"win\":true,\"ctrl\":false,\"alt\":false,\"shift\":false,\"code\":192,\"key\":\"`\"}},\"fancyzones_excluded_apps\":{\"value\":\"\"}}}";
         protected const string _defaultZoneSettings = "{\"app-zone-history\":[],\"devices\":[],\"custom-zone-sets\":[]}";
@@ -271,9 +273,7 @@ namespace PowerToysTests
                 }
             }
             catch (Exception)
-            {
-                //failed to read settings
-            }
+            { }
 
             try
             {
@@ -283,9 +283,17 @@ namespace PowerToysTests
                 }
             }
             catch (Exception)
+            { }
+
+            try
             {
-                //failed to read settings
+                if (_initialAppHistorySettings.Length == 0)
+                {
+                    _initialAppHistorySettings = File.ReadAllText(_appHistoryPath);
+                }
             }
+            catch (Exception)
+            { }
         }
 
         private static void RestoreUserSettings()
@@ -306,6 +314,15 @@ namespace PowerToysTests
             else
             {
                 File.Delete(_zoneSettingsPath);
+            }
+
+            if (_initialAppHistorySettings.Length > 0)
+            {
+                File.WriteAllText(_appHistoryPath, _initialAppHistorySettings);
+            }
+            else
+            {
+                File.Delete(_appHistoryPath);
             }
         }
     }

--- a/src/tests/win-app-driver/PowerToysSession.cs
+++ b/src/tests/win-app-driver/PowerToysSession.cs
@@ -265,7 +265,10 @@ namespace PowerToysTests
         {
             try
             {
-                _initialSettings = File.ReadAllText(_settingsPath);
+                if (_initialSettings.Length == 0)
+                {
+                    _initialSettings = File.ReadAllText(_settingsPath);
+                }
             }
             catch (Exception)
             {
@@ -274,7 +277,10 @@ namespace PowerToysTests
 
             try
             {
-                _initialZoneSettings = File.ReadAllText(_zoneSettingsPath);
+                if (_initialZoneSettings.Length == 0)
+                {
+                    _initialZoneSettings = File.ReadAllText(_zoneSettingsPath);
+                }
             }
             catch (Exception)
             {

--- a/src/tests/win-app-driver/PowerToysSession.cs
+++ b/src/tests/win-app-driver/PowerToysSession.cs
@@ -200,12 +200,13 @@ namespace PowerToysTests
             trayButton.Click();
 
             WindowsElement pt = WaitElementByXPath("//Button[@Name=\"PowerToys\"]");
-            Assert.IsNotNull(pt, "Couldn't find \'PowerToys\' button");
-            new Actions(session).MoveToElement(pt).ContextClick().Perform();
-            
-            WaitElementByXPath("//MenuItem[@Name=\"Exit\"]").Click();
-            trayButton.Click(); //close tray
-            isPowerToysLaunched = false;
+            if (pt != null)
+            {
+                new Actions(session).MoveToElement(pt).ContextClick().Perform();
+                WaitElementByXPath("//MenuItem[@Name=\"Exit\"]").Click();
+                trayButton.Click(); //close tray
+                isPowerToysLaunched = false;
+            }
         }
 
         public static void ResetDefaultFancyZonesSettings(bool relaunch)

--- a/src/tests/win-app-driver/PowerToysSession.cs
+++ b/src/tests/win-app-driver/PowerToysSession.cs
@@ -32,23 +32,28 @@ namespace PowerToysTests
 
         public static void Setup(TestContext context, bool isLaunchRequired = true)
         {
-            ReadUserSettings(); //read settings before running tests to restore them after
-
             if (session == null)
             {
+                ReadUserSettings(); //read settings before running tests to restore them after
+
                 // Create a new Desktop session to use PowerToys.
                 AppiumOptions appiumOptions = new AppiumOptions();
                 appiumOptions.PlatformName = "Windows";
                 appiumOptions.AddAdditionalCapability("app", "Root");
-                session = new WindowsDriver<WindowsElement>(new Uri(WindowsApplicationDriverUrl), appiumOptions);
-                Assert.IsNotNull(session);
-
-                trayButton = session.FindElementByAccessibilityId("1502");
-
-                isPowerToysLaunched = CheckPowerToysLaunched();
-                if (!isPowerToysLaunched && isLaunchRequired)
+                try
                 {
-                    LaunchPowerToys();
+                    session = new WindowsDriver<WindowsElement>(new Uri(WindowsApplicationDriverUrl), appiumOptions);
+                    trayButton = session.FindElementByAccessibilityId("1502");
+
+                    isPowerToysLaunched = CheckPowerToysLaunched();
+                    if (!isPowerToysLaunched && isLaunchRequired)
+                    {
+                        LaunchPowerToys();
+                    }
+                } 
+                catch (Exception ex)
+                {
+                    Console.WriteLine(ex.Message);
                 }
             }
         }
@@ -125,19 +130,33 @@ namespace PowerToysTests
 
         public static void OpenSettings()
         {
-            trayButton.Click();
-            session.FindElementByXPath("//Button[@Name=\"PowerToys\"]").Click();
-            trayButton.Click();
+            try
+            {
+                trayButton.Click();
+                session.FindElementByXPath("//Button[@Name=\"PowerToys\"]").Click();
+                trayButton.Click();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.Message);
+            }
         }
 
         public static void OpenFancyZonesSettings()
         {
-            WindowsElement fzNavigationButton = WaitElementByXPath("//Button[@Name=\"FancyZones\"]");
-            Assert.IsNotNull(fzNavigationButton);
+            try
+            {
+                WindowsElement fzNavigationButton = WaitElementByXPath("//Button[@Name=\"FancyZones\"]");
+                Assert.IsNotNull(fzNavigationButton);
 
-            fzNavigationButton.Click();
-            fzNavigationButton.Click();
-        }
+                fzNavigationButton.Click();
+                fzNavigationButton.Click();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex.Message);
+            }
+}
 
         public static void CloseSettings()
         {
@@ -149,28 +168,27 @@ namespace PowerToysTests
                     settings.SendKeys(Keys.Alt + Keys.F4);
                 }
             }
-            catch(Exception)
+            catch (Exception ex)
             {
-
+                Console.WriteLine(ex.Message);
             }
         }
 
         private static bool CheckPowerToysLaunched()        
         {
-            trayButton.Click();
             bool isLaunched = false;
-
             try
             {
+                trayButton.Click();
                 WindowsElement pt = WaitElementByXPath("//Button[@Name=\"PowerToys\"]");
                 isLaunched = (pt != null);
+                trayButton.Click(); //close
             }
             catch(OpenQA.Selenium.WebDriverException)
             {
                 //PowerToys not found
             }
-
-            trayButton.Click(); //close
+                        
             return isLaunched;
         }
 
@@ -197,15 +215,20 @@ namespace PowerToysTests
 
         public static void ExitPowerToys()
         {
-            trayButton.Click();
-
-            WindowsElement pt = WaitElementByXPath("//Button[@Name=\"PowerToys\"]");
-            if (pt != null)
+            try
             {
+                trayButton.Click();
+
+                WindowsElement pt = WaitElementByXPath("//Button[@Name=\"PowerToys\"]");
                 new Actions(session).MoveToElement(pt).ContextClick().Perform();
+
                 WaitElementByXPath("//MenuItem[@Name=\"Exit\"]").Click();
                 trayButton.Click(); //close tray
                 isPowerToysLaunched = false;
+            }
+            catch(Exception ex)
+            {
+                Console.WriteLine(ex.Message);
             }
         }
 

--- a/src/tests/win-app-driver/PowerToysTrayTests.cs
+++ b/src/tests/win-app-driver/PowerToysTrayTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenQA.Selenium.Appium;
 using OpenQA.Selenium.Appium.Windows;
 using OpenQA.Selenium.Interactions;
@@ -95,6 +95,9 @@ namespace PowerToysTests
         [TestInitialize]
         public void TestInitialize()
         {
+            if (session == null)
+                return;
+
             isSettingsOpened = false;
             isTrayOpened = false;
         }

--- a/src/tests/win-app-driver/TestShortcutHelper.cs
+++ b/src/tests/win-app-driver/TestShortcutHelper.cs
@@ -111,6 +111,9 @@ namespace PowerToysTests
         [TestInitialize]
         public void TestInitialize()
         {
+            if (session == null)
+                return;
+
             isWinKeyPressed = false;
 
             // If the start menu is open, close it.


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Removed assert from cleanup step that was able to stop program before settings files had been restored.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #3793 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx
