### PR TITLE
Case invariant hash code calculation for removing duplicates

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32.cs
@@ -468,9 +468,9 @@ namespace Microsoft.Plugin.Program.Programs
                 int fullPathPrime = 31;
 
                 int result = 1;
-                result = result * namePrime + obj.Name.GetHashCode();
-                result = result * executablePrime + obj.ExecutableName.GetHashCode();
-                result = result * fullPathPrime + obj.FullPath.GetHashCode();
+                result = result * namePrime + obj.Name.ToLowerInvariant().GetHashCode();
+                result = result * executablePrime + obj.ExecutableName.ToLowerInvariant().GetHashCode();
+                result = result * fullPathPrime + obj.FullPath.ToLowerInvariant().GetHashCode();
 
                 return result;
             }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
While calculating the hash code, the case was being taken into consideration leading some duplicates to appear. Changed that to be case invariant now. 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #3180
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Before - the exe's were steam.exe and Steam.exe
![image](https://user-images.githubusercontent.com/28739210/84098998-7b411f80-a9bd-11ea-9833-b7ba883fcc62.png)

After - 
![image](https://user-images.githubusercontent.com/28739210/84099003-7e3c1000-a9bd-11ea-9f4d-4785e57ea658.png)
