### PR TITLE
Runner: autoupdate should prefer .exe installer instead of .msi

### DIFF
--- a/src/common/updating/updating.h
+++ b/src/common/updating/updating.h
@@ -21,8 +21,8 @@ namespace updating
     {
         winrt::Windows::Foundation::Uri release_page_uri;
         std::wstring version_string;
-        winrt::Windows::Foundation::Uri msi_download_url;
-        std::wstring msi_filename;
+        winrt::Windows::Foundation::Uri installer_download_url;
+        std::wstring installer_filename;
     };
 
     std::future<std::optional<new_version_download_info>> get_new_github_version_info_async();

--- a/src/runner/update_state.cpp
+++ b/src/runner/update_state.cpp
@@ -17,6 +17,7 @@ UpdateState deserialize(const json::JsonObject& json)
 
     result.github_update_last_checked_date = timeutil::from_string(json.GetNamedString(L"github_update_last_checked_date", L"invalid").c_str());
     result.pending_update = json.GetNamedBoolean(L"pending_update", false);
+    result.pending_installer_filename = json.GetNamedString(L"pending_installer_filename", L"");
 
     return result;
 }
@@ -29,6 +30,7 @@ json::JsonObject serialize(const UpdateState& state)
         json.SetNamedValue(L"github_update_last_checked_date", json::value(timeutil::to_string(*state.github_update_last_checked_date)));
     }
     json.SetNamedValue(L"pending_update", json::value(state.pending_update));
+    json.SetNamedValue(L"pending_installer_filename", json::value(state.pending_installer_filename));
 
     return json;
 }

--- a/src/runner/update_state.h
+++ b/src/runner/update_state.h
@@ -9,6 +9,7 @@ struct UpdateState
 {
     std::optional<std::time_t> github_update_last_checked_date;
     bool pending_update = false;
+    std::wstring pending_installer_filename;
 
     // To prevent concurrent modification of the file, we enforce this interface, which locks the file while
     // the state_modifier is active.

--- a/src/runner/update_utils.cpp
+++ b/src/runner/update_utils.cpp
@@ -75,8 +75,13 @@ bool launch_pending_update()
         {
             UpdateState::store([](UpdateState& state) {
                 state.pending_update = false;
+                state.pending_installer_filename = {};
             });
-            launch_action_runner(UPDATE_NOW_LAUNCH_STAGE1_START_PT_CMDARG);
+            std::wstring args{ UPDATE_NOW_LAUNCH_STAGE1_START_PT_CMDARG };
+            args += L' ';
+            args += update_state.pending_installer_filename;
+
+            launch_action_runner(args.c_str());
             return true;
         }
     }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
- Try searching for .exe first, then fallback to .msi, since we may need to release early 0.19.X patches w/o implementing 
- Launch an .exe if it's found instead of using MSI Installation API

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #4214

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Test the updated code using custom .exe utility