### PR TITLE
Search packaged apps in development mode

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/UWP.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/UWP.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Plugin.Program.Programs
 
             IStream stream;
             const uint noAttribute = 0x80;
-            const Stgm exclusiveRead = Stgm.Read | Stgm.ShareExclusive;
+            const Stgm exclusiveRead = Stgm.Read | Stgm.DenyWrite;
             var hResult = SHCreateStreamOnFileEx(path, exclusiveRead, noAttribute, false, null, out stream);
 
             if (hResult == Hresult.Ok)
@@ -198,9 +198,8 @@ namespace Microsoft.Plugin.Program.Programs
                     try
                     {
                         var f = p.IsFramework;
-                        var d = p.IsDevelopmentMode;
                         var path = p.InstalledLocation.Path;
-                        valid = !f && !d && !string.IsNullOrEmpty(path);
+                        valid = !f && !string.IsNullOrEmpty(path);
                     }
                     catch (Exception e)
                     {
@@ -653,7 +652,7 @@ namespace Microsoft.Plugin.Program.Programs
         private enum Stgm : uint
         {
             Read = 0x0,
-            ShareExclusive = 0x10,
+            DenyWrite = 0x20,
         }
 
         private enum Hresult : uint


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Added support to search packaged apps which are in development mode

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
1. https://docs.microsoft.com/en-us/uwp/api/windows.applicationmodel.package.isdevelopmentmode?view=winrt-18362#Windows_ApplicationModel_Package_IsDevelopmentMode
2. https://docs.microsoft.com/en-us/windows/win32/stg/stgm-constants

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #3330 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Packaged apps that are in development mode were previously ignored during indexing of programs. This PR removes this restriction. The `grfMode` for `SHCreateStreamOnFileEx` is also changed because `Stgm.ShareExclusive` was preventing a second read of the AppxManifest.xaml in the `IfApplicationcanRunElevated` function. 

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manually validated that apps in development mode are shown in PowerToys Run. Following steps were followed for validation : 
1. Create a Blank UWP project. 
2. Start a debugging session on Local Machine. This would install the app locally and the app should be visible in the start menu. 
3. Start PowerToys Run and search for this app. 

