### PR TITLE
[FancyZones] Move window into last known position on active work area (if possible)

### DIFF
--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -449,7 +449,7 @@ void FancyZones::OpenWindowOnActiveMonitor(HWND window, HMONITOR primary, HMONIT
                     }
                     else
                     {
-                        left = right - activeW;
+                        left = right - windowW;
                     }
                 }
                 if (bottom > activeMi.rcWork.bottom)
@@ -461,7 +461,7 @@ void FancyZones::OpenWindowOnActiveMonitor(HWND window, HMONITOR primary, HMONIT
                     }
                     else
                     {
-                        top = bottom - activeH;
+                        top = bottom - windowH;
                     }
                 }
 

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -215,7 +215,7 @@ private:
     std::pair<winrt::com_ptr<IZoneWindow>, std::vector<int>> GetZoneIndexSetFromWorkAreaHistory(HWND window, winrt::com_ptr<IZoneWindow> workArea);
     std::pair<winrt::com_ptr<IZoneWindow>, std::vector<int>> GetZoneIndexSetFromWorkAreaHistory(HWND window, HMONITOR monitor, std::unordered_map<HMONITOR, winrt::com_ptr<IZoneWindow>>& workAreaMap) noexcept;
     std::pair<winrt::com_ptr<IZoneWindow>, std::vector<int>> GetZoneIndexSetFromHistory(HWND window) noexcept;
-    void MoveWindowIntoLastKnownZone(HWND window, winrt::com_ptr<IZoneWindow> zoneWindow, const std::vector<int>& zoneIndexSet) noexcept;
+    void MoveWindowIntoZone(HWND window, winrt::com_ptr<IZoneWindow> zoneWindow, const std::vector<int>& zoneIndexSet) noexcept;
 
     void OnEditorExitEvent() noexcept;
     bool ShouldProcessSnapHotkey() noexcept;
@@ -407,7 +407,7 @@ std::pair<winrt::com_ptr<IZoneWindow>, std::vector<int>> FancyZones::GetZoneInde
     return out;
 }
 
-void FancyZones::MoveWindowIntoLastKnownZone(HWND window, winrt::com_ptr<IZoneWindow> zoneWindow, const std::vector<int>& zoneIndexSet) noexcept
+void FancyZones::MoveWindowIntoZone(HWND window, winrt::com_ptr<IZoneWindow> zoneWindow, const std::vector<int>& zoneIndexSet) noexcept
 {
     auto& fancyZonesData = JSONHelpers::FancyZonesDataInstance();
     if (!fancyZonesData.IsAnotherWindowOfApplicationInstanceZoned(window, zoneWindow->UniqueId()))
@@ -427,7 +427,7 @@ FancyZones::WindowCreated(HWND window) noexcept
         auto data = GetZoneIndexSetFromHistory(window);
         if (!data.second.empty())
         {
-            MoveWindowIntoLastKnownZone(window, data.first, data.second);
+            MoveWindowIntoZone(window, data.first, data.second);
         }
     }
 }

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -387,7 +387,6 @@ std::pair<winrt::com_ptr<IZoneWindow>, std::vector<int>> FancyZones::GetAppZoneH
     {
         HMONITOR monitor = MonitorFromWindow(nullptr, MONITOR_DEFAULTTOPRIMARY);
         appZoneHistoryInfo = GetAppZoneHistoryInfo(window, monitor, workAreaMap);
-
     }
     // 3. Search application history on remaining monitors.
     if (appZoneHistoryInfo.second.empty())

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -211,13 +211,13 @@ private:
     void RegisterVirtualDesktopUpdates(std::vector<GUID>& ids) noexcept;
 
     bool IsSplashScreen(HWND window);
-    bool ProcessNewWindow(HWND window) noexcept;
+    bool ShouldProcessNewWindow(HWND window) noexcept;
     winrt::com_ptr<IZoneWindow> WorkAreaFromCursorPosition() noexcept;
     std::vector<int> GetZoneIndexSetFromWorkAreaHistory(HWND window, winrt::com_ptr<IZoneWindow> zoneWindow) noexcept;
     void MoveWindowIntoLastKnownZone(HWND window, winrt::com_ptr<IZoneWindow> zoneWindow, const std::vector<int>& zoneIndexSet) noexcept;
 
     void OnEditorExitEvent() noexcept;
-    bool ProcessSnapHotkey() noexcept;
+    bool ShouldProcessSnapHotkey() noexcept;
 
     std::vector<std::pair<HMONITOR, RECT>> GetRawMonitorData() noexcept;
     std::vector<HMONITOR> GetMonitorsSorted() noexcept;
@@ -327,7 +327,7 @@ FancyZones::VirtualDesktopInitialize() noexcept
     PostMessage(m_window, WM_PRIV_VD_INIT, 0, 0);
 }
 
-bool FancyZones::ProcessNewWindow(HWND window) noexcept
+bool FancyZones::ShouldProcessNewWindow(HWND window) noexcept
 {
     // Avoid processing splash screens, already stamped (zoned) windows, or those windows
     // that belong to excluded applications list.
@@ -382,7 +382,7 @@ IFACEMETHODIMP_(void)
 FancyZones::WindowCreated(HWND window) noexcept
 {
     std::shared_lock readLock(m_lock);
-    if (m_settings->GetSettings()->appLastZone_moveWindows && ProcessNewWindow(window))
+    if (m_settings->GetSettings()->appLastZone_moveWindows && ShouldProcessNewWindow(window))
     {
         std::vector<int> zoneIndexSet{};
         // Try to find application history in active monitor work area.
@@ -430,7 +430,7 @@ FancyZones::OnKeyDown(PKBDLLHOOKSTRUCT info) noexcept
         }
         else if ((info->vkCode == VK_RIGHT) || (info->vkCode == VK_LEFT))
         {
-            if (ProcessSnapHotkey())
+            if (ShouldProcessSnapHotkey())
             {
                 Trace::FancyZones::OnKeyDown(info->vkCode, win, ctrl, false /*inMoveSize*/);
                 // Win+Left, Win+Right will cycle through Zones in the active ZoneSet when WM_PRIV_LOWLEVELKB's handled
@@ -950,7 +950,7 @@ void FancyZones::OnEditorExitEvent() noexcept
     }
 }
 
-bool FancyZones::ProcessSnapHotkey() noexcept
+bool FancyZones::ShouldProcessSnapHotkey() noexcept
 {
     if (m_settings->GetSettings()->overrideSnapHotkeys)
     {

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -350,7 +350,7 @@ IFACEMETHODIMP_(void)
 FancyZones::WindowCreated(HWND window) noexcept
 {
     // Avoid processing splash screens and already stamped (zoned) windows.
-    if (IsSplashScreen(window) &&
+    if (IsSplashScreen(window) ||
         reinterpret_cast<size_t>(::GetProp(window, MULTI_ZONE_STAMP)) != 0)
     {
         return;

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -470,7 +470,7 @@ FancyZones::WindowCreated(HWND window) noexcept
         }
         else if (!primaryActive)
         {
-            // No application history on currently active monitor, open window u
+            // No application history on currently active monitor, open window un-zoned.
             OpenOnCurrentlyActiveMonitor(window, primary, active);
         }
     }

--- a/src/modules/fancyzones/lib/util.cpp
+++ b/src/modules/fancyzones/lib/util.cpp
@@ -4,6 +4,12 @@
 #include <common/common.h>
 #include <common/dpi_aware.h>
 
+namespace
+{
+    const wchar_t POWER_TOYS_APP_POWER_LAUCHER[] = L"POWERLAUNCHER.EXE";
+    const wchar_t POWER_TOYS_APP_FANCY_ZONES_EDITOR[] = L"FANCYZONESEDITOR.EXE";
+}
+
 typedef BOOL(WINAPI* GetDpiForMonitorInternalFunc)(HMONITOR, UINT, UINT*, UINT*);
 UINT GetDpiForMonitor(HMONITOR monitor) noexcept
 {
@@ -157,11 +163,11 @@ bool IsInterestingWindow(HWND window, const std::vector<std::wstring>& excludedA
     {
         return false;
     }
-    if (find_app_name_in_path(filtered.process_path, { L"POWERLAUNCHER.EXE" }))
+    if (find_app_name_in_path(filtered.process_path, { POWER_TOYS_APP_POWER_LAUCHER }))
     {
         return false;
     }
-    if (find_app_name_in_path(filtered.process_path, { L"FANCYZONESEDITOR.EXE" }))
+    if (find_app_name_in_path(filtered.process_path, { POWER_TOYS_APP_FANCY_ZONES_EDITOR }))
     {
         return false;
     }

--- a/src/modules/fancyzones/lib/util.cpp
+++ b/src/modules/fancyzones/lib/util.cpp
@@ -161,5 +161,9 @@ bool IsInterestingWindow(HWND window, const std::vector<std::wstring>& excludedA
     {
         return false;
     }
+    if (find_app_name_in_path(filtered.process_path, { L"FANCYZONESEDITOR.EXE" }))
+    {
+        return false;
+    }
     return true;
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Since we are supporting app zone history on multiple work areas (virtual desktops, monitors) we need to distinguish on which monitor window should be opened (within same virtual desktop) and try to zone it there based on app zone history, if possible:
1. Use monitor on which cursors is currently possitioned and virtual desktop on which is window that we want to zone. If in that work area we have zone history for this process, zone it.
2. If we failed to zone window in previous step for any reason, fallback to previosus solution, which is primary monitor (windows is always opened on primary monitor).

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #4182
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
1. Two (or more) monitor setup. Create two (or more) virtual desktops.
2. Open several instances of same application and zone it on different monitors / virtual desktops.
3. Check `C:\Users\<user-name>\AppData\Local\Microsoft\PowerToys\FancyZones\app-zone-history.josn` if zone history is valid.
4. Close those instances, and reopen them again on different monitors / virtual desktops.

Expected result: Window is placed into last known zone. Monitor itself is being determined based on cursor position (similar to opening FZ editor).
