### PR TITLE
Fix Launcher Network Path

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Main.cs
@@ -257,6 +257,11 @@ namespace Microsoft.Plugin.Folder
 
             var folderName = search.TrimEnd('\\').Split(new[] { Path.DirectorySeparatorChar }, StringSplitOptions.None).Last();
             var sanitizedPath = Regex.Replace(search, @"[\/\\]+", "\\");
+            // A network path must start with \\
+            if (sanitizedPath.StartsWith("\\"))
+            {
+                sanitizedPath = sanitizedPath.Insert(0, "\\");
+            }
 
             return new Result
             {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Launcher is broken with network path and is opening documents folder instead of the searched path

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #4096
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
The folder plugin is doing sanitization of the searched path removing duplicated slashes and backslashes but network path must start with `\\`

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
1. Open Launcher
2. Write a network path `\\localhost\c$\windows`
3. Press enter