### PR TITLE
Tweaked OS Detection project structure and added os check for PT Run

### DIFF
--- a/src/common/common.vcxproj
+++ b/src/common/common.vcxproj
@@ -125,6 +125,7 @@
     <ClInclude Include="keyboard_layout.h" />
     <ClInclude Include="keyboard_layout_impl.h" />
     <ClInclude Include="notifications.h" />
+    <ClInclude Include="os-detection\os-detect.h" />
     <ClInclude Include="shared_constants.h" />
     <ClInclude Include="timeutil.h" />
     <ClInclude Include="two_way_pipe_message_ipc.h" />
@@ -158,6 +159,7 @@
     <ClCompile Include="monitors.cpp" />
     <ClCompile Include="notifications.cpp" />
     <ClCompile Include="on_thread_executor.cpp" />
+    <ClCompile Include="os-detection\os-detect.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(CIBuild)'!='true'">Create</PrecompiledHeader>
     </ClCompile>

--- a/src/common/common.vcxproj.filters
+++ b/src/common/common.vcxproj.filters
@@ -111,6 +111,9 @@
     <ClInclude Include="two_way_pipe_message_ipc.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="os-detection\os-detect.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="d2d_svg.cpp">
@@ -178,6 +181,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="two_way_pipe_message_ipc.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="os-detection\os-detect.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
+++ b/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
@@ -10,266 +10,245 @@
 
 extern "C" IMAGE_DOS_HEADER __ImageBase;
 
-BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
-{
-    switch (ul_reason_for_call)
-    {
-    case DLL_PROCESS_ATTACH:
-        Trace::RegisterProvider();
-        break;
-    case DLL_THREAD_ATTACH:
-    case DLL_THREAD_DETACH:
-        break;
-    case DLL_PROCESS_DETACH:
-        Trace::UnregisterProvider();
-        break;
-    }
-    return TRUE;
+BOOL APIENTRY DllMain(HMODULE hModule, DWORD  ul_reason_for_call, LPVOID lpReserved) {
+  switch (ul_reason_for_call) {
+  case DLL_PROCESS_ATTACH:
+    Trace::RegisterProvider();
+    break;
+  case DLL_THREAD_ATTACH:
+  case DLL_THREAD_DETACH:
+    break;
+  case DLL_PROCESS_DETACH:
+    Trace::UnregisterProvider();
+    break;
+  }
+  return TRUE;
 }
 
+
 // These are the properties shown in the Settings page.
-struct ModuleSettings
-{
+struct ModuleSettings {
 } g_settings;
 
 // Implement the PowerToy Module Interface and all the required methods.
-class Microsoft_Launcher : public PowertoyModuleIface
-{
+class Microsoft_Launcher : public PowertoyModuleIface {
 private:
-    // The PowerToy state.
-    bool m_enabled = false;
+  // The PowerToy state.
+  bool m_enabled = false;
 
-    // Load initial settings from the persisted values.
-    void init_settings();
+  // Load initial settings from the persisted values.
+  void init_settings();
 
-    // Handle to launch and terminate the launcher
-    HANDLE m_hProcess;
+  // Handle to launch and terminate the launcher
+  HANDLE m_hProcess;
 
-    //contains the name of the powerToys
-    std::wstring app_name;
+  //contains the name of the powerToys
+  std::wstring app_name;
 
 public:
-    // Constructor
-    Microsoft_Launcher()
-    {
-        app_name = GET_RESOURCE_STRING(IDS_LAUNCHER_NAME);
-        init_settings();
-    };
+  // Constructor
+  Microsoft_Launcher() {
+    app_name = GET_RESOURCE_STRING(IDS_LAUNCHER_NAME);
+    init_settings();
+  };
 
-    ~Microsoft_Launcher()
-    {
-        if (m_enabled)
-        {
-            TerminateProcess(m_hProcess, 1);
-        }
-        m_enabled = false;
+  ~Microsoft_Launcher() {
+      if (m_enabled)
+      {
+          TerminateProcess(m_hProcess, 1);
+      }
+      m_enabled = false;
+  }
+
+  // Destroy the powertoy and free memory
+  virtual void destroy() override {
+    delete this;
+  }
+
+  // Return the display name of the powertoy, this will be cached by the runner
+  virtual const wchar_t* get_name() override {
+      return app_name.c_str();
+  }
+
+  // Return array of the names of all events that this powertoy listens for, with
+  // nullptr as the last element of the array. Nullptr can also be returned for empty
+  // list.
+  virtual const wchar_t** get_events() override {
+    static const wchar_t* events[] = { nullptr };
+    // Available events:
+    // - ll_keyboard
+    // - win_hook_event
+    //
+    // static const wchar_t* events[] = { ll_keyboard,
+    //                                   win_hook_event,
+    //                                   nullptr };
+
+    return events;
+  }
+
+  // Return JSON with the configuration options.
+  virtual bool get_config(wchar_t* buffer, int* buffer_size) override {
+    HINSTANCE hinstance = reinterpret_cast<HINSTANCE>(&__ImageBase);
+
+    // Create a Settings object.
+    PowerToysSettings::Settings settings(hinstance, get_name());
+    settings.set_description(GET_RESOURCE_STRING(IDS_LAUNCHER_SETTINGS_DESC));
+    settings.set_overview_link(L"https://github.com/microsoft/PowerToys/blob/master/src/modules/launcher/README.md");
+
+    return settings.serialize_to_buffer(buffer, buffer_size);
+  }
+
+  // Signal from the Settings editor to call a custom action.
+  // This can be used to spawn more complex editors.
+  virtual void call_custom_action(const wchar_t* action) override {
+    static UINT custom_action_num_calls = 0;
+    try {
+      // Parse the action values, including name.
+      PowerToysSettings::CustomActionObject action_object =
+        PowerToysSettings::CustomActionObject::from_json_string(action);
     }
-
-    // Destroy the powertoy and free memory
-    virtual void destroy() override
-    {
-        delete this;
+    catch (std::exception ex) {
+      // Improper JSON.
     }
+  }
 
-    // Return the display name of the powertoy, this will be cached by the runner
-    virtual const wchar_t* get_name() override
-    {
-        return app_name.c_str();
+  // Called by the runner to pass the updated settings values as a serialized JSON.
+  virtual void set_config(const wchar_t* config) override {
+    try {
+      // Parse the input JSON string.
+      PowerToysSettings::PowerToyValues values =
+        PowerToysSettings::PowerToyValues::from_json_string(config);
+
+      // If you don't need to do any custom processing of the settings, proceed
+      // to persists the values calling:
+      values.save_to_settings_file();
+      // Otherwise call a custom function to process the settings before saving them to disk:
+      // save_settings();
     }
-
-    // Return array of the names of all events that this powertoy listens for, with
-    // nullptr as the last element of the array. Nullptr can also be returned for empty
-    // list.
-    virtual const wchar_t** get_events() override
-    {
-        static const wchar_t* events[] = { nullptr };
-        // Available events:
-        // - ll_keyboard
-        // - win_hook_event
-        //
-        // static const wchar_t* events[] = { ll_keyboard,
-        //                                   win_hook_event,
-        //                                   nullptr };
-
-        return events;
+    catch (std::exception ex) {
+      // Improper JSON.
     }
+  }
 
-    // Return JSON with the configuration options.
-    virtual bool get_config(wchar_t* buffer, int* buffer_size) override
-    {
-        HINSTANCE hinstance = reinterpret_cast<HINSTANCE>(&__ImageBase);
+   // Enable the powertoy
+  virtual void enable()
+  {
+      // Start PowerLauncher.exe only if the OS is 19H1 or higher
+      if (UseNewSettings())
+      {
+          unsigned long powertoys_pid = GetCurrentProcessId();
 
-        // Create a Settings object.
-        PowerToysSettings::Settings settings(hinstance, get_name());
-        settings.set_description(GET_RESOURCE_STRING(IDS_LAUNCHER_SETTINGS_DESC));
-        settings.set_overview_link(L"https://github.com/microsoft/PowerToys/blob/master/src/modules/launcher/README.md");
+          if (!is_process_elevated(false))
+          {
+              std::wstring executable_args = L"";
+              executable_args.append(std::to_wstring(powertoys_pid));
 
-        return settings.serialize_to_buffer(buffer, buffer_size);
+              SHELLEXECUTEINFOW sei{ sizeof(sei) };
+              sei.fMask = { SEE_MASK_NOCLOSEPROCESS | SEE_MASK_FLAG_NO_UI };
+              sei.lpFile = L"modules\\launcher\\PowerLauncher.exe";
+              sei.nShow = SW_SHOWNORMAL;
+              sei.lpParameters = executable_args.data();
+              ShellExecuteExW(&sei);
+
+              m_hProcess = sei.hProcess;
+          }
+          else
+          {
+              std::wstring action_runner_path = get_module_folderpath();
+
+              std::wstring params;
+              params += L"-run-non-elevated ";
+              params += L"-target modules\\launcher\\PowerLauncher.exe ";
+              params += L"-pidFile ";
+              params += POWER_LAUNCHER_PID_SHARED_FILE;
+              params += L" " + std::to_wstring(powertoys_pid) + L" ";
+
+              action_runner_path += L"\\action_runner.exe";
+              // Set up the shared file from which to retrieve the PID of PowerLauncher
+              HANDLE hMapFile = CreateFileMappingW(INVALID_HANDLE_VALUE, NULL, PAGE_READWRITE, 0, sizeof(DWORD), POWER_LAUNCHER_PID_SHARED_FILE);
+              if (hMapFile)
+              {
+                  PDWORD pidBuffer = reinterpret_cast<PDWORD>(MapViewOfFile(hMapFile, FILE_MAP_ALL_ACCESS, 0, 0, sizeof(DWORD)));
+                  if (pidBuffer)
+                  {
+                      *pidBuffer = 0;
+                      m_hProcess = NULL;
+
+                      if (run_non_elevated(action_runner_path, params, pidBuffer))
+                      {
+                          const int maxRetries = 80;
+                          for (int retry = 0; retry < maxRetries; ++retry)
+                          {
+                              Sleep(50);
+                              DWORD pid = *pidBuffer;
+                              if (pid)
+                              {
+                                  m_hProcess = OpenProcess(PROCESS_TERMINATE, FALSE, pid);
+                                  break;
+                              }
+                          }
+                      }
+                  }
+                  CloseHandle(hMapFile);
+              }
+          }
+      }
+
+      m_enabled = true;
+  }
+
+  // Disable the powertoy
+  virtual void disable()
+  {
+      if (m_enabled)
+      {
+          TerminateProcess(m_hProcess, 1);
+      }
+
+      m_enabled = false;
+  }
+
+  // Returns if the powertoys is enabled
+  virtual bool is_enabled() override {
+    return m_enabled;
+  }
+
+  // Handle incoming event, data is event-specific
+  virtual intptr_t signal_event(const wchar_t* name, intptr_t data)  override {
+    if (wcscmp(name, ll_keyboard) == 0) {
+      auto& event = *(reinterpret_cast<LowlevelKeyboardEvent*>(data));
+      // Return 1 if the keypress is to be suppressed (not forwarded to Windows),
+      // otherwise return 0.
+      return 0;
     }
-
-    // Signal from the Settings editor to call a custom action.
-    // This can be used to spawn more complex editors.
-    virtual void call_custom_action(const wchar_t* action) override
-    {
-        static UINT custom_action_num_calls = 0;
-        try
-        {
-            // Parse the action values, including name.
-            PowerToysSettings::CustomActionObject action_object =
-                PowerToysSettings::CustomActionObject::from_json_string(action);
-        }
-        catch (std::exception ex)
-        {
-            // Improper JSON.
-        }
+    else if (wcscmp(name, win_hook_event) == 0) {
+      auto& event = *(reinterpret_cast<WinHookEvent*>(data));
+      // Return value is ignored
+      return 0;
     }
+    return 0;
+  }
 
-    // Called by the runner to pass the updated settings values as a serialized JSON.
-    virtual void set_config(const wchar_t* config) override
-    {
-        try
-        {
-            // Parse the input JSON string.
-            PowerToysSettings::PowerToyValues values =
-                PowerToysSettings::PowerToyValues::from_json_string(config);
-
-            // If you don't need to do any custom processing of the settings, proceed
-            // to persists the values calling:
-            values.save_to_settings_file();
-            // Otherwise call a custom function to process the settings before saving them to disk:
-            // save_settings();
-        }
-        catch (std::exception ex)
-        {
-            // Improper JSON.
-        }
-    }
-
-    // Enable the powertoy
-    virtual void enable()
-    {
-        // Start PowerLauncher.exe only if the OS is 19H1 or higher
-        if (UseNewSettings())
-        {
-            unsigned long powertoys_pid = GetCurrentProcessId();
-
-            if (!is_process_elevated(false))
-            {
-                std::wstring executable_args = L"";
-                executable_args.append(std::to_wstring(powertoys_pid));
-
-                SHELLEXECUTEINFOW sei{ sizeof(sei) };
-                sei.fMask = { SEE_MASK_NOCLOSEPROCESS | SEE_MASK_FLAG_NO_UI };
-                sei.lpFile = L"modules\\launcher\\PowerLauncher.exe";
-                sei.nShow = SW_SHOWNORMAL;
-                sei.lpParameters = executable_args.data();
-                ShellExecuteExW(&sei);
-
-                m_hProcess = sei.hProcess;
-            }
-            else
-            {
-                std::wstring action_runner_path = get_module_folderpath();
-
-                std::wstring params;
-                params += L"-run-non-elevated ";
-                params += L"-target modules\\launcher\\PowerLauncher.exe ";
-                params += L"-pidFile ";
-                params += POWER_LAUNCHER_PID_SHARED_FILE;
-                params += L" " + std::to_wstring(powertoys_pid) + L" ";
-
-                action_runner_path += L"\\action_runner.exe";
-                // Set up the shared file from which to retrieve the PID of PowerLauncher
-                HANDLE hMapFile = CreateFileMappingW(INVALID_HANDLE_VALUE, NULL, PAGE_READWRITE, 0, sizeof(DWORD), POWER_LAUNCHER_PID_SHARED_FILE);
-                if (hMapFile)
-                {
-                    PDWORD pidBuffer = reinterpret_cast<PDWORD>(MapViewOfFile(hMapFile, FILE_MAP_ALL_ACCESS, 0, 0, sizeof(DWORD)));
-                    if (pidBuffer)
-                    {
-                        *pidBuffer = 0;
-                        m_hProcess = NULL;
-
-                        if (run_non_elevated(action_runner_path, params, pidBuffer))
-                        {
-                            const int maxRetries = 80;
-                            for (int retry = 0; retry < maxRetries; ++retry)
-                            {
-                                Sleep(50);
-                                DWORD pid = *pidBuffer;
-                                if (pid)
-                                {
-                                    m_hProcess = OpenProcess(PROCESS_TERMINATE, FALSE, pid);
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                    CloseHandle(hMapFile);
-                }
-            }
-        }
-
-        m_enabled = true;
-    }
-
-    // Disable the powertoy
-    virtual void disable()
-    {
-        if (m_enabled)
-        {
-            TerminateProcess(m_hProcess, 1);
-        }
-
-        m_enabled = false;
-    }
-
-    // Returns if the powertoys is enabled
-    virtual bool is_enabled() override
-    {
-        return m_enabled;
-    }
-
-    // Handle incoming event, data is event-specific
-    virtual intptr_t signal_event(const wchar_t* name, intptr_t data) override
-    {
-        if (wcscmp(name, ll_keyboard) == 0)
-        {
-            auto& event = *(reinterpret_cast<LowlevelKeyboardEvent*>(data));
-            // Return 1 if the keypress is to be suppressed (not forwarded to Windows),
-            // otherwise return 0.
-            return 0;
-        }
-        else if (wcscmp(name, win_hook_event) == 0)
-        {
-            auto& event = *(reinterpret_cast<WinHookEvent*>(data));
-            // Return value is ignored
-            return 0;
-        }
-        return 0;
-    }
-
-    /* Register helper class to handle system menu items related actions. */
-    virtual void register_system_menu_helper(PowertoySystemMenuIface* helper) {}
-    /* Handle action on system menu item. */
-    virtual void signal_system_menu_action(const wchar_t* name) {}
+  /* Register helper class to handle system menu items related actions. */
+  virtual void register_system_menu_helper(PowertoySystemMenuIface* helper) {}
+  /* Handle action on system menu item. */
+  virtual void signal_system_menu_action(const wchar_t* name) {}
 };
 
 // Load the settings file.
-void Microsoft_Launcher::init_settings()
-{
-    try
-    {
-        // Load and parse the settings file for this PowerToy.
-        PowerToysSettings::PowerToyValues settings =
-            PowerToysSettings::PowerToyValues::load_from_settings_file(get_name());
-    }
-    catch (std::exception ex)
-    {
-        // Error while loading from the settings file. Let default values stay as they are.
-    }
+void Microsoft_Launcher::init_settings() {
+  try {
+    // Load and parse the settings file for this PowerToy.
+    PowerToysSettings::PowerToyValues settings =
+      PowerToysSettings::PowerToyValues::load_from_settings_file(get_name());
+
+  }
+  catch (std::exception ex) {
+    // Error while loading from the settings file. Let default values stay as they are.
+  }
 }
 
-extern "C" __declspec(dllexport) PowertoyModuleIface* __cdecl powertoy_create()
-{
-    return new Microsoft_Launcher();
+
+extern "C" __declspec(dllexport) PowertoyModuleIface* __cdecl powertoy_create() {
+  return new Microsoft_Launcher();
 }

--- a/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
+++ b/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
@@ -6,244 +6,270 @@
 #include <common/common.h>
 #include "trace.h"
 #include "resource.h"
+#include <common/os-detection/os-detect.h>
 
 extern "C" IMAGE_DOS_HEADER __ImageBase;
 
-BOOL APIENTRY DllMain(HMODULE hModule, DWORD  ul_reason_for_call, LPVOID lpReserved) {
-  switch (ul_reason_for_call) {
-  case DLL_PROCESS_ATTACH:
-    Trace::RegisterProvider();
-    break;
-  case DLL_THREAD_ATTACH:
-  case DLL_THREAD_DETACH:
-    break;
-  case DLL_PROCESS_DETACH:
-    Trace::UnregisterProvider();
-    break;
-  }
-  return TRUE;
+BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
+{
+    switch (ul_reason_for_call)
+    {
+    case DLL_PROCESS_ATTACH:
+        Trace::RegisterProvider();
+        break;
+    case DLL_THREAD_ATTACH:
+    case DLL_THREAD_DETACH:
+        break;
+    case DLL_PROCESS_DETACH:
+        Trace::UnregisterProvider();
+        break;
+    }
+    return TRUE;
 }
 
-
 // These are the properties shown in the Settings page.
-struct ModuleSettings {
+struct ModuleSettings
+{
 } g_settings;
 
 // Implement the PowerToy Module Interface and all the required methods.
-class Microsoft_Launcher : public PowertoyModuleIface {
+class Microsoft_Launcher : public PowertoyModuleIface
+{
 private:
-  // The PowerToy state.
-  bool m_enabled = false;
+    // The PowerToy state.
+    bool m_enabled = false;
 
-  // Load initial settings from the persisted values.
-  void init_settings();
+    // Load initial settings from the persisted values.
+    void init_settings();
 
-  // Handle to launch and terminate the launcher
-  HANDLE m_hProcess;
+    // Handle to launch and terminate the launcher
+    HANDLE m_hProcess;
 
-  //contains the name of the powerToys
-  std::wstring app_name;
+    //contains the name of the powerToys
+    std::wstring app_name;
 
 public:
-  // Constructor
-  Microsoft_Launcher() {
-    app_name = GET_RESOURCE_STRING(IDS_LAUNCHER_NAME);
-    init_settings();
-  };
+    // Constructor
+    Microsoft_Launcher()
+    {
+        app_name = GET_RESOURCE_STRING(IDS_LAUNCHER_NAME);
+        init_settings();
+    };
 
-  ~Microsoft_Launcher() {
-      if (m_enabled)
-      {
-          TerminateProcess(m_hProcess, 1);
-      }
-      m_enabled = false;
-  }
-
-  // Destroy the powertoy and free memory
-  virtual void destroy() override {
-    delete this;
-  }
-
-  // Return the display name of the powertoy, this will be cached by the runner
-  virtual const wchar_t* get_name() override {
-      return app_name.c_str();
-  }
-
-  // Return array of the names of all events that this powertoy listens for, with
-  // nullptr as the last element of the array. Nullptr can also be returned for empty
-  // list.
-  virtual const wchar_t** get_events() override {
-    static const wchar_t* events[] = { nullptr };
-    // Available events:
-    // - ll_keyboard
-    // - win_hook_event
-    //
-    // static const wchar_t* events[] = { ll_keyboard,
-    //                                   win_hook_event,
-    //                                   nullptr };
-
-    return events;
-  }
-
-  // Return JSON with the configuration options.
-  virtual bool get_config(wchar_t* buffer, int* buffer_size) override {
-    HINSTANCE hinstance = reinterpret_cast<HINSTANCE>(&__ImageBase);
-
-    // Create a Settings object.
-    PowerToysSettings::Settings settings(hinstance, get_name());
-    settings.set_description(GET_RESOURCE_STRING(IDS_LAUNCHER_SETTINGS_DESC));
-    settings.set_overview_link(L"https://github.com/microsoft/PowerToys/blob/master/src/modules/launcher/README.md");
-
-    return settings.serialize_to_buffer(buffer, buffer_size);
-  }
-
-  // Signal from the Settings editor to call a custom action.
-  // This can be used to spawn more complex editors.
-  virtual void call_custom_action(const wchar_t* action) override {
-    static UINT custom_action_num_calls = 0;
-    try {
-      // Parse the action values, including name.
-      PowerToysSettings::CustomActionObject action_object =
-        PowerToysSettings::CustomActionObject::from_json_string(action);
+    ~Microsoft_Launcher()
+    {
+        if (m_enabled)
+        {
+            TerminateProcess(m_hProcess, 1);
+        }
+        m_enabled = false;
     }
-    catch (std::exception ex) {
-      // Improper JSON.
+
+    // Destroy the powertoy and free memory
+    virtual void destroy() override
+    {
+        delete this;
     }
-  }
 
-  // Called by the runner to pass the updated settings values as a serialized JSON.
-  virtual void set_config(const wchar_t* config) override {
-    try {
-      // Parse the input JSON string.
-      PowerToysSettings::PowerToyValues values =
-        PowerToysSettings::PowerToyValues::from_json_string(config);
-
-      // If you don't need to do any custom processing of the settings, proceed
-      // to persists the values calling:
-      values.save_to_settings_file();
-      // Otherwise call a custom function to process the settings before saving them to disk:
-      // save_settings();
+    // Return the display name of the powertoy, this will be cached by the runner
+    virtual const wchar_t* get_name() override
+    {
+        return app_name.c_str();
     }
-    catch (std::exception ex) {
-      // Improper JSON.
+
+    // Return array of the names of all events that this powertoy listens for, with
+    // nullptr as the last element of the array. Nullptr can also be returned for empty
+    // list.
+    virtual const wchar_t** get_events() override
+    {
+        static const wchar_t* events[] = { nullptr };
+        // Available events:
+        // - ll_keyboard
+        // - win_hook_event
+        //
+        // static const wchar_t* events[] = { ll_keyboard,
+        //                                   win_hook_event,
+        //                                   nullptr };
+
+        return events;
     }
-  }
 
-   // Enable the powertoy
-  virtual void enable()
-  {
-      unsigned long powertoys_pid = GetCurrentProcessId();
+    // Return JSON with the configuration options.
+    virtual bool get_config(wchar_t* buffer, int* buffer_size) override
+    {
+        HINSTANCE hinstance = reinterpret_cast<HINSTANCE>(&__ImageBase);
 
-      if (!is_process_elevated(false))
-      {
-          std::wstring executable_args = L"";
-          executable_args.append(std::to_wstring(powertoys_pid));
+        // Create a Settings object.
+        PowerToysSettings::Settings settings(hinstance, get_name());
+        settings.set_description(GET_RESOURCE_STRING(IDS_LAUNCHER_SETTINGS_DESC));
+        settings.set_overview_link(L"https://github.com/microsoft/PowerToys/blob/master/src/modules/launcher/README.md");
 
-          SHELLEXECUTEINFOW sei{ sizeof(sei) };
-          sei.fMask = { SEE_MASK_NOCLOSEPROCESS | SEE_MASK_FLAG_NO_UI };
-          sei.lpFile = L"modules\\launcher\\PowerLauncher.exe";
-          sei.nShow = SW_SHOWNORMAL;
-          sei.lpParameters = executable_args.data(); 
-          ShellExecuteExW(&sei);
-
-          m_hProcess = sei.hProcess;
-      }
-      else
-      {
-          std::wstring action_runner_path = get_module_folderpath();
-
-          std::wstring params;
-          params += L"-run-non-elevated ";
-          params += L"-target modules\\launcher\\PowerLauncher.exe ";
-          params += L"-pidFile ";
-          params += POWER_LAUNCHER_PID_SHARED_FILE;
-          params += L" " + std::to_wstring(powertoys_pid) + L" ";
-
-          action_runner_path += L"\\action_runner.exe";
-          // Set up the shared file from which to retrieve the PID of PowerLauncher
-          HANDLE hMapFile = CreateFileMappingW(INVALID_HANDLE_VALUE, NULL, PAGE_READWRITE, 0, sizeof(DWORD), POWER_LAUNCHER_PID_SHARED_FILE);
-          if (hMapFile)
-          {
-              PDWORD pidBuffer = reinterpret_cast<PDWORD>(MapViewOfFile(hMapFile, FILE_MAP_ALL_ACCESS, 0, 0, sizeof(DWORD)));
-              if (pidBuffer)
-              {
-                  *pidBuffer = 0;
-                  m_hProcess = NULL;
-
-                  if (run_non_elevated(action_runner_path, params, pidBuffer))
-                  {
-                      const int maxRetries = 80;
-                      for (int retry = 0; retry < maxRetries; ++retry)
-                      {
-                          Sleep(50);
-                          DWORD pid = *pidBuffer;
-                          if (pid)
-                          {
-                              m_hProcess = OpenProcess(PROCESS_TERMINATE, FALSE, pid);
-                              break;
-                          }
-                      }
-                  }
-              }
-              CloseHandle(hMapFile);
-          }
-      }
-
-      m_enabled = true;
-  }
-
-  // Disable the powertoy
-  virtual void disable()
-  {
-      if (m_enabled)
-      {
-          TerminateProcess(m_hProcess, 1);
-      }
-
-      m_enabled = false;
-  }
-
-  // Returns if the powertoys is enabled
-  virtual bool is_enabled() override {
-    return m_enabled;
-  }
-
-  // Handle incoming event, data is event-specific
-  virtual intptr_t signal_event(const wchar_t* name, intptr_t data)  override {
-    if (wcscmp(name, ll_keyboard) == 0) {
-      auto& event = *(reinterpret_cast<LowlevelKeyboardEvent*>(data));
-      // Return 1 if the keypress is to be suppressed (not forwarded to Windows),
-      // otherwise return 0.
-      return 0;
+        return settings.serialize_to_buffer(buffer, buffer_size);
     }
-    else if (wcscmp(name, win_hook_event) == 0) {
-      auto& event = *(reinterpret_cast<WinHookEvent*>(data));
-      // Return value is ignored
-      return 0;
-    }
-    return 0;
-  }
 
-  /* Register helper class to handle system menu items related actions. */
-  virtual void register_system_menu_helper(PowertoySystemMenuIface* helper) {}
-  /* Handle action on system menu item. */
-  virtual void signal_system_menu_action(const wchar_t* name) {}
+    // Signal from the Settings editor to call a custom action.
+    // This can be used to spawn more complex editors.
+    virtual void call_custom_action(const wchar_t* action) override
+    {
+        static UINT custom_action_num_calls = 0;
+        try
+        {
+            // Parse the action values, including name.
+            PowerToysSettings::CustomActionObject action_object =
+                PowerToysSettings::CustomActionObject::from_json_string(action);
+        }
+        catch (std::exception ex)
+        {
+            // Improper JSON.
+        }
+    }
+
+    // Called by the runner to pass the updated settings values as a serialized JSON.
+    virtual void set_config(const wchar_t* config) override
+    {
+        try
+        {
+            // Parse the input JSON string.
+            PowerToysSettings::PowerToyValues values =
+                PowerToysSettings::PowerToyValues::from_json_string(config);
+
+            // If you don't need to do any custom processing of the settings, proceed
+            // to persists the values calling:
+            values.save_to_settings_file();
+            // Otherwise call a custom function to process the settings before saving them to disk:
+            // save_settings();
+        }
+        catch (std::exception ex)
+        {
+            // Improper JSON.
+        }
+    }
+
+    // Enable the powertoy
+    virtual void enable()
+    {
+        // Start PowerLauncher.exe only if the OS is 19H1 or higher
+        if (UseNewSettings())
+        {
+            unsigned long powertoys_pid = GetCurrentProcessId();
+
+            if (!is_process_elevated(false))
+            {
+                std::wstring executable_args = L"";
+                executable_args.append(std::to_wstring(powertoys_pid));
+
+                SHELLEXECUTEINFOW sei{ sizeof(sei) };
+                sei.fMask = { SEE_MASK_NOCLOSEPROCESS | SEE_MASK_FLAG_NO_UI };
+                sei.lpFile = L"modules\\launcher\\PowerLauncher.exe";
+                sei.nShow = SW_SHOWNORMAL;
+                sei.lpParameters = executable_args.data();
+                ShellExecuteExW(&sei);
+
+                m_hProcess = sei.hProcess;
+            }
+            else
+            {
+                std::wstring action_runner_path = get_module_folderpath();
+
+                std::wstring params;
+                params += L"-run-non-elevated ";
+                params += L"-target modules\\launcher\\PowerLauncher.exe ";
+                params += L"-pidFile ";
+                params += POWER_LAUNCHER_PID_SHARED_FILE;
+                params += L" " + std::to_wstring(powertoys_pid) + L" ";
+
+                action_runner_path += L"\\action_runner.exe";
+                // Set up the shared file from which to retrieve the PID of PowerLauncher
+                HANDLE hMapFile = CreateFileMappingW(INVALID_HANDLE_VALUE, NULL, PAGE_READWRITE, 0, sizeof(DWORD), POWER_LAUNCHER_PID_SHARED_FILE);
+                if (hMapFile)
+                {
+                    PDWORD pidBuffer = reinterpret_cast<PDWORD>(MapViewOfFile(hMapFile, FILE_MAP_ALL_ACCESS, 0, 0, sizeof(DWORD)));
+                    if (pidBuffer)
+                    {
+                        *pidBuffer = 0;
+                        m_hProcess = NULL;
+
+                        if (run_non_elevated(action_runner_path, params, pidBuffer))
+                        {
+                            const int maxRetries = 80;
+                            for (int retry = 0; retry < maxRetries; ++retry)
+                            {
+                                Sleep(50);
+                                DWORD pid = *pidBuffer;
+                                if (pid)
+                                {
+                                    m_hProcess = OpenProcess(PROCESS_TERMINATE, FALSE, pid);
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    CloseHandle(hMapFile);
+                }
+            }
+        }
+
+        m_enabled = true;
+    }
+
+    // Disable the powertoy
+    virtual void disable()
+    {
+        if (m_enabled)
+        {
+            TerminateProcess(m_hProcess, 1);
+        }
+
+        m_enabled = false;
+    }
+
+    // Returns if the powertoys is enabled
+    virtual bool is_enabled() override
+    {
+        return m_enabled;
+    }
+
+    // Handle incoming event, data is event-specific
+    virtual intptr_t signal_event(const wchar_t* name, intptr_t data) override
+    {
+        if (wcscmp(name, ll_keyboard) == 0)
+        {
+            auto& event = *(reinterpret_cast<LowlevelKeyboardEvent*>(data));
+            // Return 1 if the keypress is to be suppressed (not forwarded to Windows),
+            // otherwise return 0.
+            return 0;
+        }
+        else if (wcscmp(name, win_hook_event) == 0)
+        {
+            auto& event = *(reinterpret_cast<WinHookEvent*>(data));
+            // Return value is ignored
+            return 0;
+        }
+        return 0;
+    }
+
+    /* Register helper class to handle system menu items related actions. */
+    virtual void register_system_menu_helper(PowertoySystemMenuIface* helper) {}
+    /* Handle action on system menu item. */
+    virtual void signal_system_menu_action(const wchar_t* name) {}
 };
 
 // Load the settings file.
-void Microsoft_Launcher::init_settings() {
-  try {
-    // Load and parse the settings file for this PowerToy.
-    PowerToysSettings::PowerToyValues settings =
-      PowerToysSettings::PowerToyValues::load_from_settings_file(get_name());
-
-  }
-  catch (std::exception ex) {
-    // Error while loading from the settings file. Let default values stay as they are.
-  }
+void Microsoft_Launcher::init_settings()
+{
+    try
+    {
+        // Load and parse the settings file for this PowerToy.
+        PowerToysSettings::PowerToyValues settings =
+            PowerToysSettings::PowerToyValues::load_from_settings_file(get_name());
+    }
+    catch (std::exception ex)
+    {
+        // Error while loading from the settings file. Let default values stay as they are.
+    }
 }
 
-
-extern "C" __declspec(dllexport) PowertoyModuleIface* __cdecl powertoy_create() {
-  return new Microsoft_Launcher();
+extern "C" __declspec(dllexport) PowertoyModuleIface* __cdecl powertoy_create()
+{
+    return new Microsoft_Launcher();
 }

--- a/src/runner/runner.vcxproj
+++ b/src/runner/runner.vcxproj
@@ -238,9 +238,6 @@
     <ProjectReference Include="..\common\common.vcxproj">
       <Project>{74485049-c722-400f-abe5-86ac52d929b3}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\common\os-detection\os-detection.vcxproj">
-      <Project>{e6410bfc-b341-498c-8c67-312c20cdd8d5}</Project>
-    </ProjectReference>
     <ProjectReference Include="..\common\updating\updating.vcxproj">
       <Project>{17da04df-e393-4397-9cf0-84dabe11032e}</Project>
     </ProjectReference>

--- a/src/runner/settings_window.cpp
+++ b/src/runner/settings_window.cpp
@@ -14,7 +14,7 @@
 
 #include <common/json.h>
 #include <common\settings_helpers.cpp>
-#include <os-detect.h>
+#include <common/os-detection/os-detect.h>
 
 #define BUFSIZE 1024
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR fixes the issue of PowerLauncher.exe getting launched on OS version less than 19H1 and also makes a few changes to the os-detection project structure.
- os-detect.cpp and os-detect.h references have been added to `common` project. That way we can use the functions in C++ executables/dlls directly by referencing and without requiring os-detection.dll in that folder.
- The reference to os-detection.dll in runner has been removed, and instead the method is accessed from common
- os-detection.dll is still required for Image Resizer so no change has been made to affect that. In the future we could merge os-detection.dll into the PowerToysInterop library to reduce the number of additional projects/dlls.
- In the Microsoft.Launcher project (which is the PowerToyModule project for PT Run), under the enable method where PowerLauncher.exe is launched a check has been added to launch the executable only if it matches the OS requirement.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Applies to #3730 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Verified that behavior is as expected for Launcher/ImageResizer/Settings on 1909, 1809 VM and an internal build number VM. Only for the 1809 VM the old settings would be loaded, image resizer would use its old settings UI, and PowerLauncher.exe would not be launched.