### PR TITLE
[FancyZones] Remove Editor tmp files paths cmd args and make Editor 'debugable' easier 

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
@@ -154,7 +154,7 @@ namespace FancyZonesEditor.Models
             try
             {
                 string jsonString = JsonSerializer.Serialize(deletedLayouts, options);
-                File.WriteAllText(Settings.CustomZoneSetsTmpFile, jsonString);
+                File.WriteAllText(Settings.DeletedCustomZoneSetsTmpFile, jsonString);
             }
             catch (Exception ex)
             {
@@ -169,7 +169,7 @@ namespace FancyZonesEditor.Models
 
             try
             {
-                FileStream inputStream = File.Open(Settings.CustomZoneSetsTmpFile, FileMode.Open);
+                FileStream inputStream = File.Open(Settings.FancyZonesSettingsFile, FileMode.Open);
                 JsonDocument jsonObject = JsonDocument.Parse(inputStream, options: default);
                 JsonElement.ArrayEnumerator customZoneSetsEnumerator = jsonObject.RootElement.GetProperty("custom-zone-sets").EnumerateArray();
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/Settings.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/Settings.cs
@@ -53,11 +53,31 @@ namespace FancyZonesEditor
         public const ushort _blankCustomModelId = 0xFFFA;
         public const ushort _lastDefinedId = _blankCustomModelId;
 
+        // Localizable strings
+        private const string ErrorParsingDeviceInfo = "Error parsing device info data.";
+        private const string ErrorInvalidArgs = "FancyZones Editor arguments are invalid.";
+        private const string ErrorNonStandaloneApp = "FancyZones Editor should not be run as standalone application.";
+
+        // Non-localizable strings
+        private const string ErrorMessageBoxTitle = "FancyZones Editor Error";
+
         private const string ZonesSettingsFile = "\\Microsoft\\PowerToys\\FancyZones\\zones-settings.json";
 
         private const string ActiveZoneSetsTmpFileName = "FancyZonesActiveZoneSets.json";
         private const string AppliedZoneSetsTmpFileName = "FancyZonesAppliedZoneSets.json";
         private const string DeletedCustomZoneSetsTmpFileName = "FancyZonesDeletedCustomZoneSets.json";
+
+        private const string LayoutTypeBlankStr = "blank";
+        private const string NullUuidStr = "null";
+
+        // DeviceInfo JSON tags
+        private const string DeviceIdJsonTag = "device-id";
+        private const string ActiveZoneSetJsonTag = "active-zoneset";
+        private const string UuidJsonTag = "uuid";
+        private const string TypeJsonTag = "type";
+        private const string EditorShowSpacingJsonTag = "editor-show-spacing";
+        private const string EditorSpacingJsonTag = "editor-spacing";
+        private const string EditorZoneCountJsonTag = "editor-zone-count";
 
         // hard coded data for all the "Priority Grid" configurations that are unique to "Grid"
         private static readonly byte[][] _priorityData = new byte[][]
@@ -371,8 +391,8 @@ namespace FancyZonesEditor
         {
             try
             {
-                string layoutType = "blank";
-                ActiveZoneSetUUid = "null";
+                string layoutType = LayoutTypeBlankStr;
+                ActiveZoneSetUUid = NullUuidStr;
                 JsonElement jsonObject = default(JsonElement);
 
                 if (File.Exists(Settings.ActiveZoneSetTmpFile))
@@ -380,12 +400,12 @@ namespace FancyZonesEditor
                     FileStream inputStream = File.Open(Settings.ActiveZoneSetTmpFile, FileMode.Open);
                     jsonObject = JsonDocument.Parse(inputStream, options: default).RootElement;
                     inputStream.Close();
-                    UniqueKey = jsonObject.GetProperty("device-id").GetString();
-                    ActiveZoneSetUUid = jsonObject.GetProperty("active-zoneset").GetProperty("uuid").GetString();
-                    layoutType = jsonObject.GetProperty("active-zoneset").GetProperty("type").GetString();
+                    UniqueKey = jsonObject.GetProperty(DeviceIdJsonTag).GetString();
+                    ActiveZoneSetUUid = jsonObject.GetProperty(ActiveZoneSetJsonTag).GetProperty(UuidJsonTag).GetString();
+                    layoutType = jsonObject.GetProperty(ActiveZoneSetJsonTag).GetProperty(TypeJsonTag).GetString();
                 }
 
-                if (mode == ParseDeviceMode.Debug || ActiveZoneSetUUid == "null" || layoutType == "blank")
+                if (mode == ParseDeviceMode.Debug || ActiveZoneSetUUid == NullUuidStr || layoutType == LayoutTypeBlankStr)
                 {
                     // Default or there is no active layout on current device
                     ActiveZoneSetLayoutType = LayoutType.Focus;
@@ -417,14 +437,14 @@ namespace FancyZonesEditor
                             break;
                     }
 
-                    _showSpacing = jsonObject.GetProperty("editor-show-spacing").GetBoolean();
-                    _spacing = jsonObject.GetProperty("editor-spacing").GetInt32();
-                    _zoneCount = jsonObject.GetProperty("editor-zone-count").GetInt32();
+                    _showSpacing = jsonObject.GetProperty(EditorShowSpacingJsonTag).GetBoolean();
+                    _spacing = jsonObject.GetProperty(EditorSpacingJsonTag).GetInt32();
+                    _zoneCount = jsonObject.GetProperty(EditorZoneCountJsonTag).GetInt32();
                 }
             }
             catch (Exception ex)
             {
-                LayoutModel.ShowExceptionMessageBox("Error parsing device info data", ex);
+                LayoutModel.ShowExceptionMessageBox(ErrorParsingDeviceInfo, ex);
             }
         }
 
@@ -442,8 +462,7 @@ namespace FancyZonesEditor
                 }
                 else
                 {
-                    string title = "FancyZones Editor Error";
-                    MessageBox.Show("FancyZones Editor arguments are invalid.", title);
+                    MessageBox.Show(ErrorInvalidArgs, ErrorMessageBoxTitle);
                     ((App)Application.Current).Shutdown();
                 }
             }
@@ -452,8 +471,7 @@ namespace FancyZonesEditor
                 var parsedLocation = args[(int)CmdArgs.WorkAreaSize].Split('_');
                 if (parsedLocation.Length != 4)
                 {
-                    string title = "FancyZones Editor Error";
-                    MessageBox.Show("FancyZones Editor arguments are invalid.", title);
+                    MessageBox.Show(ErrorInvalidArgs, ErrorMessageBoxTitle);
                     ((App)Application.Current).Shutdown();
                 }
 
@@ -469,8 +487,7 @@ namespace FancyZonesEditor
             }
             else
             {
-                string title = "FancyZones Editor Error";
-                MessageBox.Show("FancyZones Editor should not be run as standalone application.", title);
+                MessageBox.Show(ErrorNonStandaloneApp, ErrorMessageBoxTitle);
                 ((App)Application.Current).Shutdown();
             }
         }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/Settings.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/Settings.cs
@@ -32,6 +32,12 @@ namespace FancyZonesEditor
             Height,
         }
 
+        private enum ParseDeviceMode
+        {
+            Prod,
+            Debug,
+        }
+
         private static CanvasLayoutModel _blankCustomModel;
         private readonly CanvasLayoutModel _focusModel;
         private readonly GridLayoutModel _rowsModel;
@@ -361,7 +367,7 @@ namespace FancyZonesEditor
             }
         }
 
-        private void ParseDeviceInfoData(bool debug = false)
+        private void ParseDeviceInfoData(ParseDeviceMode mode = ParseDeviceMode.Prod)
         {
             try
             {
@@ -379,7 +385,7 @@ namespace FancyZonesEditor
                     layoutType = jsonObject.GetProperty("active-zoneset").GetProperty("type").GetString();
                 }
 
-                if (debug || ActiveZoneSetUUid == "null" || layoutType == "blank")
+                if (mode == ParseDeviceMode.Debug || ActiveZoneSetUUid == "null" || layoutType == "blank")
                 {
                     // Default or there is no active layout on current device
                     ActiveZoneSetLayoutType = LayoutType.Focus;
@@ -432,7 +438,7 @@ namespace FancyZonesEditor
             {
                 if (args[1].Equals("Debug"))
                 {
-                    ParseDeviceInfoData(true /* debug mode */);
+                    ParseDeviceInfoData(ParseDeviceMode.Debug);
                 }
                 else
                 {

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/Settings.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/Settings.cs
@@ -357,51 +357,55 @@ namespace FancyZonesEditor
         {
             try
             {
+                string layoutType = "blank";
+                ActiveZoneSetUUid = "null";
+                JsonElement jsonObject = default(JsonElement);
+
                 if (File.Exists(Settings.ActiveZoneSetTmpFile))
                 {
                     FileStream inputStream = File.Open(Settings.ActiveZoneSetTmpFile, FileMode.Open);
-                    JsonElement jsonObject = JsonDocument.Parse(inputStream, options: default).RootElement;
+                    jsonObject = JsonDocument.Parse(inputStream, options: default).RootElement;
                     inputStream.Close();
                     UniqueKey = jsonObject.GetProperty("device-id").GetString();
                     ActiveZoneSetUUid = jsonObject.GetProperty("active-zoneset").GetProperty("uuid").GetString();
-                    string layoutType = jsonObject.GetProperty("active-zoneset").GetProperty("type").GetString();
+                    layoutType = jsonObject.GetProperty("active-zoneset").GetProperty("type").GetString();
+                }
 
-                    if (debug || ActiveZoneSetUUid == "null" || layoutType == "blank")
+                if (debug || ActiveZoneSetUUid == "null" || layoutType == "blank")
+                {
+                    // Default or there is no active layout on current device
+                    ActiveZoneSetLayoutType = LayoutType.Focus;
+                    _showSpacing = true;
+                    _spacing = 16;
+                    _zoneCount = 3;
+                }
+                else
+                {
+                    switch (layoutType)
                     {
-                        // Default or there is no active layout on current device
-                        ActiveZoneSetLayoutType = LayoutType.Focus;
-                        _showSpacing = true;
-                        _spacing = 16;
-                        _zoneCount = 3;
+                        case "focus":
+                            ActiveZoneSetLayoutType = LayoutType.Focus;
+                            break;
+                        case "columns":
+                            ActiveZoneSetLayoutType = LayoutType.Columns;
+                            break;
+                        case "rows":
+                            ActiveZoneSetLayoutType = LayoutType.Rows;
+                            break;
+                        case "grid":
+                            ActiveZoneSetLayoutType = LayoutType.Grid;
+                            break;
+                        case "priority-grid":
+                            ActiveZoneSetLayoutType = LayoutType.PriorityGrid;
+                            break;
+                        case "custom":
+                            ActiveZoneSetLayoutType = LayoutType.Custom;
+                            break;
                     }
-                    else
-                    {
-                        switch (layoutType)
-                        {
-                            case "focus":
-                                ActiveZoneSetLayoutType = LayoutType.Focus;
-                                break;
-                            case "columns":
-                                ActiveZoneSetLayoutType = LayoutType.Columns;
-                                break;
-                            case "rows":
-                                ActiveZoneSetLayoutType = LayoutType.Rows;
-                                break;
-                            case "grid":
-                                ActiveZoneSetLayoutType = LayoutType.Grid;
-                                break;
-                            case "priority-grid":
-                                ActiveZoneSetLayoutType = LayoutType.PriorityGrid;
-                                break;
-                            case "custom":
-                                ActiveZoneSetLayoutType = LayoutType.Custom;
-                                break;
-                        }
 
-                        _showSpacing = jsonObject.GetProperty("editor-show-spacing").GetBoolean();
-                        _spacing = jsonObject.GetProperty("editor-spacing").GetInt32();
-                        _zoneCount = jsonObject.GetProperty("editor-zone-count").GetInt32();
-                    }
+                    _showSpacing = jsonObject.GetProperty("editor-show-spacing").GetBoolean();
+                    _spacing = jsonObject.GetProperty("editor-spacing").GetInt32();
+                    _zoneCount = jsonObject.GetProperty("editor-zone-count").GetInt32();
                 }
             }
             catch (Exception ex)

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/Settings.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/Settings.cs
@@ -54,13 +54,12 @@ namespace FancyZonesEditor
         public const ushort _lastDefinedId = _blankCustomModelId;
 
         // Localizable strings
+        private const string ErrorMessageBoxTitle = "FancyZones Editor Error";
         private const string ErrorParsingDeviceInfo = "Error parsing device info data.";
         private const string ErrorInvalidArgs = "FancyZones Editor arguments are invalid.";
         private const string ErrorNonStandaloneApp = "FancyZones Editor should not be run as standalone application.";
 
         // Non-localizable strings
-        private const string ErrorMessageBoxTitle = "FancyZones Editor Error";
-
         private const string ZonesSettingsFile = "\\Microsoft\\PowerToys\\FancyZones\\zones-settings.json";
 
         private const string ActiveZoneSetsTmpFileName = "FancyZonesActiveZoneSets.json";

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/Settings.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/Settings.cs
@@ -353,61 +353,55 @@ namespace FancyZonesEditor
             }
         }
 
-        private void ParseDeviceInfoData(string deviceInfo = null)
+        private void ParseDeviceInfoData(bool debug = false)
         {
             try
             {
-                JsonElement jsonObject;
-                if (deviceInfo == null)
+                if (File.Exists(Settings.ActiveZoneSetTmpFile))
                 {
                     FileStream inputStream = File.Open(Settings.ActiveZoneSetTmpFile, FileMode.Open);
-                    jsonObject = JsonDocument.Parse(inputStream, options: default).RootElement;
+                    JsonElement jsonObject = JsonDocument.Parse(inputStream, options: default).RootElement;
                     inputStream.Close();
-                }
-                else
-                {
-                    jsonObject = JsonDocument.Parse(deviceInfo, options: default).RootElement;
-                }
+                    UniqueKey = jsonObject.GetProperty("device-id").GetString();
+                    ActiveZoneSetUUid = jsonObject.GetProperty("active-zoneset").GetProperty("uuid").GetString();
+                    string layoutType = jsonObject.GetProperty("active-zoneset").GetProperty("type").GetString();
 
-                UniqueKey = jsonObject.GetProperty("device-id").GetString();
-                ActiveZoneSetUUid = jsonObject.GetProperty("active-zoneset").GetProperty("uuid").GetString();
-                string layoutType = jsonObject.GetProperty("active-zoneset").GetProperty("type").GetString();
-
-                if (ActiveZoneSetUUid == "null" || layoutType == "blank")
-                {
-                    // Default selection is Focus
-                    ActiveZoneSetLayoutType = LayoutType.Focus;
-                    _showSpacing = true;
-                    _spacing = 16;
-                    _zoneCount = 3;
-                }
-                else
-                {
-                    switch (layoutType)
+                    if (debug || ActiveZoneSetUUid == "null" || layoutType == "blank")
                     {
-                        case "focus":
-                            ActiveZoneSetLayoutType = LayoutType.Focus;
-                            break;
-                        case "columns":
-                            ActiveZoneSetLayoutType = LayoutType.Columns;
-                            break;
-                        case "rows":
-                            ActiveZoneSetLayoutType = LayoutType.Rows;
-                            break;
-                        case "grid":
-                            ActiveZoneSetLayoutType = LayoutType.Grid;
-                            break;
-                        case "priority-grid":
-                            ActiveZoneSetLayoutType = LayoutType.PriorityGrid;
-                            break;
-                        case "custom":
-                            ActiveZoneSetLayoutType = LayoutType.Custom;
-                            break;
+                        // Default or there is no active layout on current device
+                        ActiveZoneSetLayoutType = LayoutType.Focus;
+                        _showSpacing = true;
+                        _spacing = 16;
+                        _zoneCount = 3;
                     }
+                    else
+                    {
+                        switch (layoutType)
+                        {
+                            case "focus":
+                                ActiveZoneSetLayoutType = LayoutType.Focus;
+                                break;
+                            case "columns":
+                                ActiveZoneSetLayoutType = LayoutType.Columns;
+                                break;
+                            case "rows":
+                                ActiveZoneSetLayoutType = LayoutType.Rows;
+                                break;
+                            case "grid":
+                                ActiveZoneSetLayoutType = LayoutType.Grid;
+                                break;
+                            case "priority-grid":
+                                ActiveZoneSetLayoutType = LayoutType.PriorityGrid;
+                                break;
+                            case "custom":
+                                ActiveZoneSetLayoutType = LayoutType.Custom;
+                                break;
+                        }
 
-                    _showSpacing = jsonObject.GetProperty("editor-show-spacing").GetBoolean();
-                    _spacing = jsonObject.GetProperty("editor-spacing").GetInt32();
-                    _zoneCount = jsonObject.GetProperty("editor-zone-count").GetInt32();
+                        _showSpacing = jsonObject.GetProperty("editor-show-spacing").GetBoolean();
+                        _spacing = jsonObject.GetProperty("editor-spacing").GetInt32();
+                        _zoneCount = jsonObject.GetProperty("editor-zone-count").GetInt32();
+                    }
                 }
             }
             catch (Exception ex)
@@ -426,19 +420,7 @@ namespace FancyZonesEditor
             {
                 if (args[1].Equals("Debug"))
                 {
-                    const string debugDeviceInfoJson =
-                        @"{
-                        ""device-id"": ""BOE06C6#4&a213ba1&0&UID265988_1920_1080_{03891D5D-CC32-4FD9-9B94-846FE43F4690}"",
-                        ""active-zoneset"": {
-                            ""uuid"": ""{C82EBE61-9234-49BA-8392-09963C2C4CED}"",
-                            ""type"": ""columns""
-                        },
-                        ""editor-show-spacing"": true,
-                        ""editor-spacing"": 16,
-                        ""editor-zone-count"": 4
-                    }";
-
-                    ParseDeviceInfoData(debugDeviceInfoJson);
+                    ParseDeviceInfoData(true /* debug mode */);
                 }
                 else
                 {

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/Settings.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/Settings.cs
@@ -20,8 +20,16 @@ namespace FancyZonesEditor
     {
         private enum CmdArgs
         {
-            X_Y_Width_Height = 1,
+            WorkAreaSize = 1,
             PowerToysPID,
+        }
+
+        private enum WorkAreaCmdArgElements
+        {
+            X = 0,
+            Y,
+            Width,
+            Height,
         }
 
         private static CanvasLayoutModel _blankCustomModel;
@@ -435,7 +443,7 @@ namespace FancyZonesEditor
             }
             else if (args.Length == 3)
             {
-                var parsedLocation = args[(int)CmdArgs.X_Y_Width_Height].Split('_');
+                var parsedLocation = args[(int)CmdArgs.WorkAreaSize].Split('_');
                 if (parsedLocation.Length != 4)
                 {
                     string title = "FancyZones Editor Error";
@@ -443,10 +451,10 @@ namespace FancyZonesEditor
                     ((App)Application.Current).Shutdown();
                 }
 
-                var x = int.Parse(parsedLocation[0]);
-                var y = int.Parse(parsedLocation[1]);
-                var width = int.Parse(parsedLocation[2]);
-                var height = int.Parse(parsedLocation[3]);
+                var x = int.Parse(parsedLocation[(int)WorkAreaCmdArgElements.X]);
+                var y = int.Parse(parsedLocation[(int)WorkAreaCmdArgElements.Y]);
+                var width = int.Parse(parsedLocation[(int)WorkAreaCmdArgElements.Width]);
+                var height = int.Parse(parsedLocation[(int)WorkAreaCmdArgElements.Height]);
 
                 WorkArea = new Rect(x, y, width, height);
 

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -470,7 +470,6 @@ void FancyZones::ToggleEditor() noexcept
         std::to_wstring(height);
 
     const auto& fancyZonesData = JSONHelpers::FancyZonesDataInstance();
-    fancyZonesData.CustomZoneSetsToJsonFile(ZoneWindowUtils::GetCustomZoneSetsTmpPath());
 
     const auto deviceInfo = fancyZonesData.FindDeviceInfo(zoneWindow->UniqueId());
     if (!deviceInfo.has_value())
@@ -483,10 +482,7 @@ void FancyZones::ToggleEditor() noexcept
 
     const std::wstring params =
         /*1*/ editorLocation + L" " +
-        /*2*/ L"\"" + ZoneWindowUtils::GetActiveZoneSetTmpPath() + L"\" " +
-        /*3*/ L"\"" + ZoneWindowUtils::GetAppliedZoneSetTmpPath() + L"\" " +
-        /*4*/ L"\"" + ZoneWindowUtils::GetCustomZoneSetsTmpPath() + L"\" " +
-        /*5*/ L"\"" + std::to_wstring(GetCurrentProcessId()) + L"\"";
+        /*2*/ L"\"" + std::to_wstring(GetCurrentProcessId()) + L"\"";
 
     SHELLEXECUTEINFO sei{ sizeof(sei) };
     sei.fMask = { SEE_MASK_NOCLOSEPROCESS | SEE_MASK_FLAG_NO_UI };
@@ -886,7 +882,7 @@ void FancyZones::OnEditorExitEvent() noexcept
 {
     // Collect information about changes in zone layout after editor exited.
     JSONHelpers::FancyZonesDataInstance().ParseDeviceInfoFromTmpFile(ZoneWindowUtils::GetActiveZoneSetTmpPath());
-    JSONHelpers::FancyZonesDataInstance().ParseDeletedCustomZoneSetsFromTmpFile(ZoneWindowUtils::GetCustomZoneSetsTmpPath());
+    JSONHelpers::FancyZonesDataInstance().ParseDeletedCustomZoneSetsFromTmpFile(ZoneWindowUtils::GetDeletedCustomZoneSetsTmpPath());
     JSONHelpers::FancyZonesDataInstance().ParseCustomZoneSetFromTmpFile(ZoneWindowUtils::GetAppliedZoneSetTmpPath());
     JSONHelpers::FancyZonesDataInstance().SaveFancyZonesData();
 

--- a/src/modules/fancyzones/lib/JsonHelpers.cpp
+++ b/src/modules/fancyzones/lib/JsonHelpers.cpp
@@ -763,15 +763,6 @@ namespace JSONHelpers
         return customZoneSetsJSON;
     }
 
-    void FancyZonesData::CustomZoneSetsToJsonFile(std::wstring_view filePath) const
-    {
-        std::scoped_lock lock{ dataLock };
-        const auto& customZoneSetsJson = SerializeCustomZoneSets();
-        json::JsonObject root{};
-        root.SetNamedValue(L"custom-zone-sets", customZoneSetsJson);
-        json::to_file(filePath, root);
-    }
-
     void FancyZonesData::LoadFancyZonesData()
     {
         std::scoped_lock lock{ dataLock };

--- a/src/modules/fancyzones/lib/JsonHelpers.h
+++ b/src/modules/fancyzones/lib/JsonHelpers.h
@@ -257,7 +257,6 @@ namespace JSONHelpers
         json::JsonArray SerializeDeviceInfos() const;
         bool ParseCustomZoneSets(const json::JsonObject& fancyZonesDataJSON);
         json::JsonArray SerializeCustomZoneSets() const;
-        void CustomZoneSetsToJsonFile(std::wstring_view filePath) const;
 
         void LoadFancyZonesData();
         void SaveFancyZonesData() const;

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -8,60 +8,52 @@
 
 #include <ShellScalingApi.h>
 #include <mutex>
+#include <fileapi.h>
 
 #include <gdiplus.h>
 
 namespace ZoneWindowUtils
 {
-    const std::wstring& GetActiveZoneSetTmpPath()
+    const wchar_t ActiveZoneSetsTmpFileName[] = L"FancyZonesActiveZoneSets.json";
+    const wchar_t AppliedZoneSetsTmpFileName[] = L"FancyZonesAppliedZoneSets.json";
+    const wchar_t DeletedCustomZoneSetsTmpFileName[] = L"FancyZonesDeletedCustomZoneSets.json";
+
+    const std::wstring& GetTempDirPath()
     {
-        static std::wstring activeZoneSetTmpFileName;
+        static std::wstring tmpDirPath;
         static std::once_flag flag;
 
         std::call_once(flag, []() {
-            wchar_t fileName[L_tmpnam_s];
+            wchar_t buffer[MAX_PATH];
 
-            if (_wtmpnam_s(fileName, L_tmpnam_s) != 0)
-                abort();
+            auto charsWritten = GetTempPath(MAX_PATH, buffer);
+            if (charsWritten > MAX_PATH || (charsWritten == 0))
+            {
+                abort();            
+            }
 
-            activeZoneSetTmpFileName = std::wstring{ fileName };
+            tmpDirPath = std::wstring{ buffer };
         });
 
+        return tmpDirPath;
+    }
+
+    const std::wstring& GetActiveZoneSetTmpPath()
+    {
+        static std::wstring activeZoneSetTmpFileName = GetTempDirPath() + ActiveZoneSetsTmpFileName;
         return activeZoneSetTmpFileName;
     }
 
     const std::wstring& GetAppliedZoneSetTmpPath()
     {
-        static std::wstring appliedZoneSetTmpFileName;
-        static std::once_flag flag;
-
-        std::call_once(flag, []() {
-            wchar_t fileName[L_tmpnam_s];
-
-            if (_wtmpnam_s(fileName, L_tmpnam_s) != 0)
-                abort();
-
-            appliedZoneSetTmpFileName = std::wstring{ fileName };
-        });
-
+        static std::wstring appliedZoneSetTmpFileName = GetTempDirPath() + AppliedZoneSetsTmpFileName;
         return appliedZoneSetTmpFileName;
     }
 
-    const std::wstring& GetCustomZoneSetsTmpPath()
+    const std::wstring& GetDeletedCustomZoneSetsTmpPath()
     {
-        static std::wstring customZoneSetsTmpFileName;
-        static std::once_flag flag;
-
-        std::call_once(flag, []() {
-            wchar_t fileName[L_tmpnam_s];
-
-            if (_wtmpnam_s(fileName, L_tmpnam_s) != 0)
-                abort();
-
-            customZoneSetsTmpFileName = std::wstring{ fileName };
-        });
-
-        return customZoneSetsTmpFileName;
+        static std::wstring deletedCustomZoneSetsTmpFileName = GetTempDirPath() + DeletedCustomZoneSetsTmpFileName;
+        return deletedCustomZoneSetsTmpFileName;
     }
 
     std::wstring GenerateUniqueId(HMONITOR monitor, PCWSTR deviceId, PCWSTR virtualDesktopId)

--- a/src/modules/fancyzones/lib/ZoneWindow.h
+++ b/src/modules/fancyzones/lib/ZoneWindow.h
@@ -6,7 +6,7 @@ namespace ZoneWindowUtils
 {
     const std::wstring& GetActiveZoneSetTmpPath();
     const std::wstring& GetAppliedZoneSetTmpPath();
-    const std::wstring& GetCustomZoneSetsTmpPath();
+    const std::wstring& GetDeletedCustomZoneSetsTmpPath();
 
     std::wstring GenerateUniqueId(HMONITOR monitor, PCWSTR deviceId, PCWSTR virtualDesktopId);
 }

--- a/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
@@ -86,11 +86,11 @@ namespace FancyZonesUnitTests
 
             Assert::IsFalse(ZoneWindowUtils::GetActiveZoneSetTmpPath().empty());
             Assert::IsFalse(ZoneWindowUtils::GetAppliedZoneSetTmpPath().empty());
-            Assert::IsFalse(ZoneWindowUtils::GetCustomZoneSetsTmpPath().empty());
+            Assert::IsFalse(ZoneWindowUtils::GetDeletedCustomZoneSetsTmpPath().empty());
 
             Assert::IsFalse(std::filesystem::exists(ZoneWindowUtils::GetActiveZoneSetTmpPath()));
             Assert::IsFalse(std::filesystem::exists(ZoneWindowUtils::GetAppliedZoneSetTmpPath()));
-            Assert::IsFalse(std::filesystem::exists(ZoneWindowUtils::GetCustomZoneSetsTmpPath()));
+            Assert::IsFalse(std::filesystem::exists(ZoneWindowUtils::GetDeletedCustomZoneSetsTmpPath()));
 
             m_fancyZonesData.SetSettingsModulePath(L"FancyZonesUnitTests");
             m_fancyZonesData.clear_data();
@@ -101,7 +101,7 @@ namespace FancyZonesUnitTests
             //cleanup temp files if were created
             std::filesystem::remove(ZoneWindowUtils::GetActiveZoneSetTmpPath());
             std::filesystem::remove(ZoneWindowUtils::GetAppliedZoneSetTmpPath());
-            std::filesystem::remove(ZoneWindowUtils::GetCustomZoneSetsTmpPath());
+            std::filesystem::remove(ZoneWindowUtils::GetDeletedCustomZoneSetsTmpPath());
 
             m_zoneWindow = nullptr;
         }
@@ -295,7 +295,7 @@ namespace FancyZonesUnitTests
             //save required data
             const auto activeZoneSetTempPath = ZoneWindowUtils::GetActiveZoneSetTmpPath();
             const auto appliedZoneSetTempPath = ZoneWindowUtils::GetAppliedZoneSetTmpPath();
-            const auto deletedZonesTempPath = ZoneWindowUtils::GetCustomZoneSetsTmpPath();
+            const auto deletedZonesTempPath = ZoneWindowUtils::GetDeletedCustomZoneSetsTmpPath();
 
             const ZoneSetLayoutType type = ZoneSetLayoutType::Custom;
             const auto customSetGuid = Helpers::CreateGuidString();
@@ -341,7 +341,7 @@ namespace FancyZonesUnitTests
             //save required data
             const auto activeZoneSetTempPath = ZoneWindowUtils::GetActiveZoneSetTmpPath();
             const auto appliedZoneSetTempPath = ZoneWindowUtils::GetAppliedZoneSetTmpPath();
-            const auto deletedZonesTempPath = ZoneWindowUtils::GetCustomZoneSetsTmpPath();
+            const auto deletedZonesTempPath = ZoneWindowUtils::GetDeletedCustomZoneSetsTmpPath();
 
             const ZoneSetLayoutType type = ZoneSetLayoutType::Custom;
             const auto customSetGuid = Helpers::CreateGuidString();


### PR DESCRIPTION
- Removed 3 tmp paths from Editor cmd args.
- Editor now reads Custom Layouts from zone-settings.json itself (this enables debugging custom layouts as well)
- Introduce "Debug arguments" so Editor can be easily run as a standalone app for debugging purposes. (passing "Debug" as only cmd arg to Editor)
- Introduce checks for invalid arguments passed to Editor

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #4280, #1278 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Run Editor with all of the valid&invalid arguments passed. Tested whether FancyZones still works as expected.