### PR TITLE
[Runner] Apply general settings on runner startup

### DIFF
--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -375,6 +375,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         modules();
 
         auto general_settings = load_general_settings();
+        apply_general_settings(general_settings);
         int rvalue = 0;
         const bool elevated = is_process_elevated();
         if ((elevated ||


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
When starting PT, general settings need to be applied to reflect actual settings from json file.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #4002 #3875 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
1)
Installed PT 0.17
Installed PT 0.18
Check that PT runs on restart without UAC prompt

2)
Delete all settings
Fresh install PT with "start at logon" checked
Check that `Run on startup` general setting is on
Check that PT actually runs at logon