### PR TITLE
[FancyZones Editor] Issue 2440

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
@@ -99,6 +99,8 @@ namespace FancyZonesEditor
 
         private void OnFullSplit(object o, SplitEventArgs e)
         {
+            CancelClick(null, null);
+
             UIElementCollection previewChildren = Preview.Children;
             UIElement splitee = (UIElement)o;
 
@@ -190,6 +192,8 @@ namespace FancyZonesEditor
 
         private void OnSplit(object o, SplitEventArgs e)
         {
+            CancelClick(null, null);
+
             UIElementCollection previewChildren = Preview.Children;
             GridZone splitee = (GridZone)o;
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
@@ -99,8 +99,6 @@ namespace FancyZonesEditor
 
         private void OnFullSplit(object o, SplitEventArgs e)
         {
-            CancelClick(null, null);
-
             UIElementCollection previewChildren = Preview.Children;
             UIElement splitee = (UIElement)o;
 

--- a/src/tests/win-app-driver/FancyZonesTests/EditorGridZoneResizeTests.cs
+++ b/src/tests/win-app-driver/FancyZonesTests/EditorGridZoneResizeTests.cs
@@ -409,15 +409,13 @@ namespace PowerToysTests
             WindowsElement mergeButton = session.FindElementByName("Merge zones");
             Assert.IsNotNull(mergeButton, "Cannot merge: no merge button");
 
-            int splitPos = zones[0].Rect.Y + zones[0].Rect.Height / 2;
-
             new Actions(session).MoveToElement(zones[0]).Click().Perform();
 
             zones = session.FindElementsByClassName("GridZone");
             Assert.AreEqual(4, zones.Count);
 
             mergeButton = session.FindElementByName("Merge zones");
-            Assert.IsNull(mergeButton, "Cannot merge: no merge button");
+            Assert.IsNull(mergeButton, "Can still merge: merge button exists");
         }
 
         [ClassInitialize]

--- a/src/tests/win-app-driver/FancyZonesTests/EditorGridZoneResizeTests.cs
+++ b/src/tests/win-app-driver/FancyZonesTests/EditorGridZoneResizeTests.cs
@@ -393,6 +393,7 @@ namespace PowerToysTests
             Assert.IsTrue(thumb.Rect.Right > 0);
         }
 
+        [TestMethod]
         public void MergeSelectSplit()
         {
             OpenCreatorWindow("Columns", "Custom table layout creator", "EditTemplateButton");

--- a/src/tests/win-app-driver/FancyZonesTests/EditorGridZoneResizeTests.cs
+++ b/src/tests/win-app-driver/FancyZonesTests/EditorGridZoneResizeTests.cs
@@ -393,6 +393,33 @@ namespace PowerToysTests
             Assert.IsTrue(thumb.Rect.Right > 0);
         }
 
+        public void MergeSelectSplit()
+        {
+            OpenCreatorWindow("Columns", "Custom table layout creator", "EditTemplateButton");
+            WindowsElement gridEditor = session.FindElementByClassName("GridEditor");
+            Assert.IsNotNull(gridEditor);
+
+            ReadOnlyCollection<WindowsElement> zones = session.FindElementsByClassName("GridZone");
+            ReadOnlyCollection<AppiumWebElement> thumbs = gridEditor.FindElementsByClassName("Thumb");
+            Assert.AreEqual(3, zones.Count);
+            Assert.AreEqual(2, thumbs.Count);
+
+            Move(zones[0], thumbs[0].Rect.X + thumbs[0].Rect.Width + 10, true, true, -(zones[0].Rect.Height / 2) + 10);
+
+            WindowsElement mergeButton = session.FindElementByName("Merge zones");
+            Assert.IsNotNull(mergeButton, "Cannot merge: no merge button");
+
+            int splitPos = zones[0].Rect.Y + zones[0].Rect.Height / 2;
+
+            new Actions(session).MoveToElement(zones[0]).Click().Perform();
+
+            zones = session.FindElementsByClassName("GridZone");
+            Assert.AreEqual(4, zones.Count);
+
+            mergeButton = session.FindElementByName("Merge zones");
+            Assert.IsNull(mergeButton, "Cannot merge: no merge button");
+        }
+
         [ClassInitialize]
         public static void ClassInitialize(TestContext context)
         {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? --> Fixes Zones Selection error
## Summary of the Pull Request

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2440
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->Clears isSelected property for UIElements that could have been selected for merging and clears MergePanel button when splitting
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Unit Tests Passed, added win app driver unit test to check for correct behavior
![issue 2440 fix gif](https://user-images.githubusercontent.com/53451580/85493126-53001600-b5a4-11ea-9bbb-783826f84762.gif)
