### PR TITLE
save general settings to file upon launch

### DIFF
--- a/src/runner/settings_window.cpp
+++ b/src/runner/settings_window.cpp
@@ -291,6 +291,10 @@ void run_settings_window()
         settings_isUserAnAdmin = L"false";
     }
 
+    // create general settings file to initialze the settings file with installation configurations like :
+    // 1. Run on start up.
+    PTSettingsHelper::save_general_settings(save_settings.to_json());
+
     std::wstring executable_args = L"\"";
     executable_args.append(executable_path);
     executable_args.append(L"\" ");


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
for settings v1, initialisation of settings comes from the runner sending the settings to the settings v1 application. The settings were not saved to file, thus configurations set on installation like "Run On Start-Up" are not passed on to settings v2 since the settings V2 application checks for the settings file and creates a new one if one is not found thus overriding existing "Run On Start Up" configuration set on installation. To prevent that, I save/create the General settings file with updated configurations upon launch. 
  
<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x ] Applies to #3875
* [x ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Disabled run on startup, create the MSI, installed the MSI, and checked the Run On Start Up checkbox, verified that the settings was applied when settings v2 is launched.