### PR TITLE
[Settings][Fix][Image Resizer ]  Unused text box when selecting custom percent in new settings

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/ImageSize.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/ImageSize.cs
@@ -68,6 +68,36 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
             }
         }
 
+        public int ExtraBoxOpacity
+        {
+            get
+            {
+                if (Unit == 2)
+                {
+                    return 0;
+                }
+                else
+                {
+                    return 100;
+                }
+            }
+        }
+
+        public bool EnableEtraBoxes
+        {
+            get
+            {
+                if (Unit == 2)
+                {
+                    return false;
+                }
+                else
+                {
+                    return true;
+                }
+            }
+        }
+
         [JsonPropertyName("name")]
         public string Name
         {
@@ -154,6 +184,8 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
                 {
                     _unit = value;
                     OnPropertyChanged();
+                    OnPropertyChanged("ExtraBoxOpacity");
+                    OnPropertyChanged("EnableEtraBoxes");
                 }
             }
         }

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
@@ -128,6 +128,7 @@
                                        TextAlignment="Center"
                                        VerticalAlignment="Center"
                                        Margin="{StaticResource SmallTopMargin}" 
+                                       Opacity="{x:Bind Path=ExtraBoxOpacity, Mode=OneWay}"                                    
                                        Width="25"/>
 
                             <muxc:NumberBox Value="{x:Bind Path=Height, Mode=TwoWay}" 
@@ -135,6 +136,8 @@
                                             Height="34"
                                             VerticalAlignment="Center"
                                             SpinButtonPlacementMode="Compact"
+                                            Opacity="{x:Bind Path=ExtraBoxOpacity, Mode=OneWay}"
+                                            IsEnabled="{x:Bind Path=EnableEtraBoxes, Mode=OneWay}"
                                             Margin="{StaticResource SmallTopMargin}"/>
 
                             <ComboBox SelectedIndex="{Binding Path=Unit, Mode=TwoWay}"

--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -48,7 +48,6 @@ namespace
 {
     const wchar_t MSI_VERSION_MUTEX_NAME[] = L"Local\\PowerToyRunMutex";
     const wchar_t MSIX_VERSION_MUTEX_NAME[] = L"Local\\PowerToyMSIXRunMutex";
-
     const wchar_t PT_URI_PROTOCOL_SCHEME[] = L"powertoys://";
 }
 

--- a/src/runner/settings_window.cpp
+++ b/src/runner/settings_window.cpp
@@ -291,6 +291,10 @@ void run_settings_window()
         settings_isUserAnAdmin = L"false";
     }
 
+    // create general settings file to initialze the settings file with installation configurations like :
+    // 1. Run on start up.
+    PTSettingsHelper::save_general_settings(save_settings.to_json());
+
     std::wstring executable_args = L"\"";
     executable_args.append(executable_path);
     executable_args.append(L"\" ");


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

- Added flags to hide and disable the "x" icon and the Hieght checkbox when unit is set to percentage. 

Question:
- Should we order by unit to group the percentage sizes so that the table looks consistent?
![image](https://user-images.githubusercontent.com/58791731/84834043-62e88a80-afe5-11ea-8174-b3300baca851.png)

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #3015
* [ x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Toggle the unit dropdown of the Image Sizes control to see if changes are applied