### PR TITLE
Runner: move Launcher to its own folder and simplify dll loading

### DIFF
--- a/installer/PowerToysSetup/Product.wxs
+++ b/installer/PowerToysSetup/Product.wxs
@@ -406,10 +406,6 @@
 
     <DirectoryRef Id="ModulesInstallFolder" FileSource="$(var.BinX64Dir)modules\">
       
-      <Component Id="Module_Launcher" Guid="9A343236-B49D-451D-A27D-4C336F460A45" Win64="yes">
-        <File Source="$(var.BinX64Dir)modules\Microsoft.Launcher.dll" />
-      </Component>
-
       <Component Id="Module_PowerPreview_PerUserRegistry" Guid="CD90ADC0-7CD5-4A62-B0AF-23545C1E6DD3" Win64="yes">
         <!-- Added a separate component for Per-User registry changes -->
         <!-- Registry Key for Class Registration of Svg Preview Handler -->
@@ -742,7 +738,6 @@
       <ComponentRef Id="Module_ImageResizer_Registry" />
       <ComponentRef Id="Module_PowerPreview" />
       <ComponentRef Id="Module_PowerPreview_PerUserRegistry" />
-      <ComponentRef Id="Module_Launcher" />
       <ComponentRef Id="Module_KeyboardManager" />
       <ComponentRef Id="SettingsV2" />
       <ComponentRef Id="SettingsV2Assets" />
@@ -783,6 +778,7 @@
   <Fragment>
     <ComponentGroup Id="LauncherComponents">
       <Component Id="launcherInstallComponent" Directory="LauncherInstallFolder" Guid="5E688DB4-C522-4268-BA54-ED1CDFFE9DB6">
+        <File Source="$(var.BinX64Dir)modules\Launcher\Microsoft.Launcher.dll" />
         <?foreach File in concrt140_app.dll;ICSharpCode.SharpZipLib.dll;JetBrains.Annotations.dll;Mages.Core.dll;Microsoft.Search.Interop.dll;EntityFramework.SqlServer.dll;EntityFramework.dll;Mono.Cecil.dll;Mono.Cecil.Mdb.dll;Mono.Cecil.Pdb.dll;Mono.Cecil.Rocks.dll;msvcp140_1_app.dll;msvcp140_2_app.dll;msvcp140_app.dll;Newtonsoft.Json.dll;NLog.dll;NLog.Extensions.Logging.dll;Pinyin4Net.dll;PowerLauncher.deps.json;PowerLauncher.dll;PowerLauncher.exe;Microsoft.Toolkit.Win32.UI.XamlHost.Managed.dll;Microsoft.Toolkit.Wpf.UI.XamlHost.dll;Microsoft.Xaml.Behaviors.dll;System.Text.Json.dll;sni.dll;System.Data.SQLite.EF6.dll;PowerLauncher.runtimeconfig.json;SQLite.Interop.dll;System.Data.OleDb.dll;System.Data.SqlClient.dll;System.Data.SQLite.dll;vcamp140_app.dll;vccorlib140_app.dll;vcomp140_app.dll;vcruntime140_1_app.dll;vcruntime140_app.dll;WindowsInput.dll;Wox.Core.dll;Wox.dll;Wox.Infrastructure.dll;Wox.Plugin.dll;PowerToysInterop.dll;Telemetry.dll;PowerLauncher.Telemetry.dll;PropertyChanged.dll;Microsoft.Extensions.Configuration.Abstractions.dll;Microsoft.Extensions.Configuration.Binder.dll;Microsoft.Extensions.Configuration.dll;Microsoft.Extensions.DependencyInjection.Abstractions.dll;Microsoft.Extensions.DependencyInjection.dll;Microsoft.Extensions.Logging.Abstractions.dll;Microsoft.Extensions.Logging.dll;Microsoft.Extensions.Options.dll;Microsoft.Extensions.Primitives.dll;ControlzEx.dll;MahApps.Metro.dll?>
           <File Id="File_$(var.File)" Source="$(var.BinX64Dir)modules\launcher\$(var.File)" />
         <?endforeach?>

--- a/src/modules/launcher/Microsoft.Launcher/Microsoft.Launcher.vcxproj
+++ b/src/modules/launcher/Microsoft.Launcher/Microsoft.Launcher.vcxproj
@@ -49,11 +49,11 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
-    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\modules\</OutDir>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\modules\launcher</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
-    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\modules\</OutDir>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\modules\launcher</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>

--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -128,48 +128,27 @@ int runner(bool isProcessElevated)
         notifications::register_background_toast_handler();
 
         chdir_current_executable();
-        // Load Powertoys DLLS
-        // For now only load known DLLs
+        // Load Powertoys DLLs
 
-        std::wstring baseModuleFolder = L"modules/";
-
-        std::unordered_set<std::wstring> known_dlls = {
-            L"ShortcutGuide.dll",
-            L"fancyzones.dll",
-            L"PowerRenameExt.dll",
-            L"Microsoft.Launcher.dll",
-            L"ImageResizerExt.dll",
-            L"powerpreview.dll",
-            L"KeyboardManager.dll"
+        const std::array<std::wstring_view, 7> knownModules = {
+            L"modules/FancyZones/fancyzones.dll",
+            L"modules/FileExplorerPreview/powerpreview.dll",
+            L"modules/ImageResizer/ImageResizerExt.dll",
+            L"modules/KeyboardManager/KeyboardManager.dll",
+            L"modules/Launcher/Microsoft.Launcher.dll",
+            L"modules/PowerRename/PowerRenameExt.dll",
+            L"modules/ShortcutGuide/ShortcutGuide.dll",
         };
 
-        // TODO(stefan): When all modules get their OutputDir delete this and simplify "search for .dll logic"
-        std::unordered_set<std::wstring> module_folders = {
-            L"",
-            L"FileExplorerPreview/",
-            L"FancyZones/",
-            L"ImageResizer/",
-            L"PowerRename/",
-            L"ShortcutGuide/",
-            L"KeyboardManager/"
-        };
-
-        for (std::wstring subfolderName : module_folders)
+        for (const auto & moduleSubdir : knownModules)
         {
-            for (auto& file : std::filesystem::directory_iterator(baseModuleFolder + subfolderName))
+            try
             {
-                if (file.path().extension() != L".dll")
-                    continue;
-                if (known_dlls.find(file.path().filename()) == known_dlls.end())
-                    continue;
-                try
-                {
-                    auto module = load_powertoy(file.path().wstring());
-                    modules().emplace(module->get_name(), std::move(module));
-                }
-                catch (...)
-                {
-                }
+                auto module = load_powertoy(moduleSubdir);
+                modules().emplace(module->get_name(), std::move(module));
+            }
+            catch (...)
+            {
             }
         }
         // Start initial powertoys

--- a/src/runner/powertoy_module.cpp
+++ b/src/runner/powertoy_module.cpp
@@ -7,9 +7,9 @@ std::map<std::wstring, PowertoyModule>& modules()
     return modules;
 }
 
-PowertoyModule load_powertoy(const std::wstring& filename)
+PowertoyModule load_powertoy(const std::wstring_view filename)
 {
-    auto handle = winrt::check_pointer(LoadLibraryW(filename.c_str()));
+    auto handle = winrt::check_pointer(LoadLibraryW(filename.data()));
     auto create = reinterpret_cast<powertoy_create_func>(GetProcAddress(handle, "powertoy_create"));
     if (!create)
     {

--- a/src/runner/powertoy_module.h
+++ b/src/runner/powertoy_module.h
@@ -49,5 +49,5 @@ private:
     std::unique_ptr<PowertoyModuleIface, PowertoyModuleDeleter> module;
 };
 
-PowertoyModule load_powertoy(const std::wstring& filename);
+PowertoyModule load_powertoy(const std::wstring_view filename);
 std::map<std::wstring, PowertoyModule>& modules();


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
- move `Microsoft.Launcher.dll` to launcher module's folder
- simplify runner modules' dlls loading logic, now we only load known modules (since Settings V2 use a non-generated .xaml setting page for each module, we prefer to keep all toys developed in-tree etc.)

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2761

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- build solution and installer, test that modules work