### PR TITLE
FancyZones: fix possible crash in GetWorkAreasByDesktopId

### DIFF
--- a/src/modules/fancyzones/lib/MonitorWorkAreaHandler.cpp
+++ b/src/modules/fancyzones/lib/MonitorWorkAreaHandler.cpp
@@ -34,7 +34,8 @@ const std::unordered_map<HMONITOR, winrt::com_ptr<IZoneWindow>>& MonitorWorkArea
     {
         return workAreaMap[desktopId];
     }
-    return {};
+    static const std::unordered_map<HMONITOR, winrt::com_ptr<IZoneWindow>> empty;
+    return empty;
 }
 
 std::vector<winrt::com_ptr<IZoneWindow>> MonitorWorkAreaHandler::GetAllWorkAreas()


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
- do not return an address to a freed memory

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #1495

