### PR TITLE
Fix exceptions thrown by uninitialized Win32 description

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Plugin.Program.Programs
         public string LnkResolvedPath { get; set; }
         public string ParentDirectory { get; set; }
         public string ExecutableName { get; set; }
-        public string Description { get; set; }
+        public string Description { get; set; } = String.Empty;
         public bool Valid { get; set; }
         public bool Enabled { get; set; }
         public bool hasArguments { get; set; } = false;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
* The Description.Length is compared in apps which may not have it initialised leading to an exception.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
This fixes that exception as the description is now initialized to an empty string object.
