### PR TITLE
Index Desktop Applications

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32.cs
@@ -294,7 +294,7 @@ namespace Microsoft.Plugin.Program.Programs
             string scheme = string.Empty;
             bool validApp = false;
 
-            Regex urlSchemes = new Regex(@"^steam:\/\/rungameid\/|^com\.epicgames\.launcher:\/\/apps\/");
+            Regex InternetShortcutURLPrefixes = new Regex(@"^steam:\/\/(rungameid|run)\/|^com\.epicgames\.launcher:\/\/apps\/");
 
             const string urlPrefix = "URL=";
             const string iconFilePrefix = "IconFile=";
@@ -307,7 +307,7 @@ namespace Microsoft.Plugin.Program.Programs
                     Uri uri = new Uri(urlPath);
 
                     // To filter out only those steam shortcuts which have 'run' or 'rungameid' as the hostname
-                    if(urlSchemes.Match(urlPath).Success)
+                    if(InternetShortcutURLPrefixes.Match(urlPath).Success)
                     {
                         validApp = true;
                     }

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32.cs
@@ -240,10 +240,7 @@ namespace Microsoft.Plugin.Program.Programs
                     AcceleratorModifiers = (ModifierKeys.Control | ModifierKeys.Shift),
                     Action = _ =>
                     {
-
-
                         Main.StartProcess(Process.Start, new ProcessStartInfo("explorer", ParentDirectory));
-
                         return true;
                     }
                 }
@@ -292,6 +289,7 @@ namespace Microsoft.Plugin.Program.Programs
             string[] lines = System.IO.File.ReadAllLines(path);
             string appName = string.Empty;
             string iconPath = string.Empty;
+            string urlPath = string.Empty;
             string scheme = string.Empty;
             bool validApp = false;
 
@@ -305,7 +303,7 @@ namespace Microsoft.Plugin.Program.Programs
             {
                 if(line.StartsWith(urlPrefix))
                 {
-                    var urlPath = line.Substring(urlPrefix.Length);
+                    urlPath = line.Substring(urlPrefix.Length);
                     Uri uri = new Uri(urlPath);
 
                     // To filter out only those steam shortcuts which have 'run' or 'rungameid' as the hostname
@@ -335,7 +333,7 @@ namespace Microsoft.Plugin.Program.Programs
                     Name = Path.GetFileNameWithoutExtension(path),
                     ExecutableName = Path.GetFileName(path),
                     IcoPath = iconPath,
-                    FullPath = path.ToLower(),
+                    FullPath = urlPath,
                     UniqueIdentifier = path,
                     ParentDirectory = Directory.GetParent(path).FullName,
                     Valid = true,

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32.cs
@@ -13,6 +13,7 @@ using Microsoft.Plugin.Program.Logger;
 using Wox.Plugin;
 using System.Windows.Input;
 using System.Reflection;
+using System.Text.RegularExpressions;
 
 namespace Microsoft.Plugin.Program.Programs
 {
@@ -293,11 +294,10 @@ namespace Microsoft.Plugin.Program.Programs
             string scheme = string.Empty;
             bool validApp = false;
 
-            const string steamScheme = "steam";
+            Regex urlSchemes = new Regex(@"^steam:\/\/rungameid\/|^com\.epicgames\.launcher:\/\/apps\/");
+
             const string urlPrefix = "URL=";
             const string iconFilePrefix = "IconFile=";
-            const string hostnameRun = "run";
-            const string hostnameRunGameId = "rungameid";
 
             foreach(string line in lines)
             {
@@ -307,9 +307,7 @@ namespace Microsoft.Plugin.Program.Programs
                     Uri uri = new Uri(urlPath);
 
                     // To filter out only those steam shortcuts which have 'run' or 'rungameid' as the hostname
-                    if(uri.Scheme.Equals(steamScheme, StringComparison.OrdinalIgnoreCase)
-                        && (uri.Host.Equals(hostnameRun, StringComparison.OrdinalIgnoreCase)
-                        || uri.Host.Equals(hostnameRunGameId, StringComparison.OrdinalIgnoreCase)))
+                    if(urlSchemes.Match(urlPath).Success)
                     {
                         validApp = true;
                     }

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Settings.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Settings.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Plugin.Program
 
         public bool EnableStartMenuSource { get; set; } = true;
 
+        public bool EnableDesktopSource { get; set; } = true;
+
         public bool EnableRegistrySource { get; set; } = true;
 
         internal const char SuffixSeparator = ';';

--- a/src/modules/launcher/Wox.Test/Plugins/ProgramPluginTest.cs
+++ b/src/modules/launcher/Wox.Test/Plugins/ProgramPluginTest.cs
@@ -126,6 +126,24 @@ namespace Wox.Test.Plugins
             LnkResolvedPath = "c:\\programdata\\microsoft\\windows\\start menu\\programs\\test proxy.lnk"
         };
 
+        Win32 dummy_internetShortcut_app = new Win32
+        {
+            Name = "Shop Titans",
+            ExecutableName = "Shop Titans.url",           
+            FullPath = "steam://rungameid/1258080",
+            ParentDirectory = "C:\\Users\\temp\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\Steam",
+            LnkResolvedPath = null
+        };
+
+        Win32 dummy_internetShortcut_app_duplicate = new Win32
+        {
+            Name = "Shop Titans",
+            ExecutableName = "Shop Titans.url",
+            FullPath = "steam://rungameid/1258080",
+            ParentDirectory = "C:\\Users\\temp\\Desktop",
+            LnkResolvedPath = null
+        };
+
         [Test]
         public void DedupFunction_whenCalled_mustRemoveDuplicateNotepads()
         {
@@ -133,6 +151,21 @@ namespace Wox.Test.Plugins
             List<Win32> prgms = new List<Win32>();
             prgms.Add(notepad_appdata);
             prgms.Add(notepad_users);
+
+            // Act
+            Win32[] apps = Win32.DeduplicatePrograms(prgms.AsParallel());
+
+            // Assert
+            Assert.AreEqual(apps.Length, 1);
+        }
+
+        [Test]
+        public void DedupFunction_whenCalled_MustRemoveInternetShortcuts()
+        {
+            // Arrange
+            List<Win32> prgms = new List<Win32>();
+            prgms.Add(dummy_internetShortcut_app);
+            prgms.Add(dummy_internetShortcut_app_duplicate);
 
             // Act
             Win32[] apps = Win32.DeduplicatePrograms(prgms.AsParallel());


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR adds the functionality to index desktop programs and find games installed with Epic games gaming platform. 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #4056
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
1. Added functionality to index desktop programs. 
2. Added functionality to dedup .URL files. A dedup was caused when shortcut was present both in start menu and desktop.
3. Added support to find games installed through the Epic game platform. 

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
1. Manually validated that programs present on desktop are indexed. 

![samuraishadow](https://user-images.githubusercontent.com/10995909/85314745-c9026100-b46e-11ea-8366-e8b1e36f1909.PNG)
