### PR TITLE
upgrade xaml based nuget packages

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI.Runner/Microsoft.PowerToys.Settings.UI.Runner.csproj
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Runner/Microsoft.PowerToys.Settings.UI.Runner.csproj
@@ -58,9 +58,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Toolkit.UI.XamlHost" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Toolkit.Wpf.UI.Controls" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Toolkit.Wpf.UI.XamlHost" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Toolkit.UI.XamlHost" Version="6.1.0" />
+    <PackageReference Include="Microsoft.Toolkit.Wpf.UI.Controls" Version="6.1.0" />
+    <PackageReference Include="Microsoft.Toolkit.Wpf.UI.XamlHost" Version="6.1.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Microsoft.PowerToys.Settings.UI.csproj
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Microsoft.PowerToys.Settings.UI.csproj
@@ -167,13 +167,13 @@
       <Version>6.2.10</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI">
-      <Version>6.0.0</Version>
+      <Version>6.1.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Win32.UI.XamlApplication">
-      <Version>6.0.1</Version>
+      <Version>6.1.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.UI.Xaml">
-      <Version>2.4.0-prerelease.191217001</Version>
+      <Version>2.5.0-prerelease.200609001</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Xaml.Behaviors.Uwp.Managed">
       <Version>2.0.1</Version>

--- a/src/modules/launcher/Wox.Infrastructure/Wox.Infrastructure.csproj
+++ b/src/modules/launcher/Wox.Infrastructure/Wox.Infrastructure.csproj
@@ -48,7 +48,6 @@
 
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2020.1.0" />
-    <PackageReference Include="Microsoft.Toolkit.Wpf.UI.XamlHost" Version="6.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.6.2" />
     <PackageReference Include="NLog.Schema" Version="4.7.0" />

--- a/src/modules/launcher/Wox.Plugin/ContextMenuResult.cs
+++ b/src/modules/launcher/Wox.Plugin/ContextMenuResult.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Windows.Input;
-using Windows.UI.Xaml.Media;
 
 namespace Wox.Plugin
 {

--- a/src/modules/launcher/Wox.Plugin/Wox.Plugin.csproj
+++ b/src/modules/launcher/Wox.Plugin/Wox.Plugin.csproj
@@ -57,7 +57,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="JetBrains.Annotations" Version="2020.1.0" />
-    <PackageReference Include="Microsoft.Toolkit.Wpf.UI.XamlHost" Version="6.0.1" />
     <PackageReference Include="Mono.Cecil" Version="0.11.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="PropertyChanged.Fody" Version="3.2.8" />


### PR DESCRIPTION
1.) upgrade settings to latest WinUI package on 2.x branch
2.) upgrade xaml islands to 6.1.0
3.) Removed Xaml Host items inside launcher

tested both settings and PT run, both execute appropriately.