### PR TITLE
Hotfix for blank settings dialog

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI.Runner/MainWindow.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Runner/MainWindow.xaml
@@ -7,7 +7,7 @@
         xmlns:Controls="clr-namespace:Microsoft.Toolkit.Wpf.UI.Controls;assembly=Microsoft.Toolkit.Wpf.UI.Controls"
         xmlns:xaml="clr-namespace:Microsoft.Toolkit.Wpf.UI.XamlHost;assembly=Microsoft.Toolkit.Wpf.UI.XamlHost"
         mc:Ignorable="d"
-        Title="PowerToys Settings" Height="800" Width="1000">
+        Title="PowerToys Settings" Height="800" Width="1000" Closing="MainWindow_Closing">
     <Grid>
         <xaml:WindowsXamlHost InitialTypeName="Microsoft.PowerToys.Settings.UI.Views.ShellPage" ChildChanged="WindowsXamlHost_ChildChanged" />
     </Grid>

--- a/src/core/Microsoft.PowerToys.Settings.UI.Runner/MainWindow.xaml.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Runner/MainWindow.xaml.cs
@@ -15,6 +15,8 @@ namespace Microsoft.PowerToys.Settings.UI.Runner
     // Interaction logic for MainWindow.xaml.
     public partial class MainWindow : Window
     {
+        private bool isOpen = true;
+
         public MainWindow()
         {
             var bootTime = new System.Diagnostics.Stopwatch();
@@ -52,6 +54,17 @@ namespace Microsoft.PowerToys.Settings.UI.Runner
                 shellPage.SetIsUserAnAdmin(Program.IsUserAnAdmin);
                 shellPage.Refresh();
             }
+
+            // If the window is open, explicity force it to be shown to solve the blank dialog issue https://github.com/microsoft/PowerToys/issues/3384
+            if (isOpen)
+            {
+                Show();
+            }
+        }
+
+        private void MainWindow_Closing(object sender, System.ComponentModel.CancelEventArgs e)
+        {
+            isOpen = false;
         }
     }
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR adds a workaround for the blank settings dialog issue. The issue was happening on machines with nView Desktop Manager, where it would intercept some window messages and cause WinUI to think the xaml island window was hidden. To work around this, in the WindowXamlHost when the ChildChanged event is called, if the window is not closed we call Show().

Since WPF does not have a property to check if the window is closing, we use the Closing event handler to set a bool variable to track if the window has started closing. This is required because Show throws an exception if the Closing or Closed handler have begun execution (more details [here](https://docs.microsoft.com/en-us/dotnet/api/system.windows.window.closing?view=netcore-3.1))

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Applies to #3384 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA


<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Tested on a machine not reproducing the error and on a machine with nView enabled.