### PR TITLE
Partial Fix for Memory issue - Limiting the number of ImageSources cached

### DIFF
--- a/src/modules/launcher/Wox.Infrastructure/Image/ImageCache.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Image/ImageCache.cs
@@ -31,20 +31,16 @@ namespace Wox.Infrastructure.Image
                 // This is done so that we don't constantly perform this resizing operation and also maintain the image cache size at the same time
                 if (_data.Count > permissibleFactor * MaxCached)
                 {
-                    Task.Run(() =>
+                    Cleanup();
+                    foreach (var key in _data.Keys)
                     {
-                        Cleanup();
-                        foreach (var key in _data.Keys)
+                        int dictValue;
+                        if (!Usage.TryGetValue(key, out dictValue))
                         {
-                            int dictValue;
-                            if (!Usage.TryGetValue(key, out dictValue))
-                            {
-                                ImageSource test;
-                                _data.TryRemove(key, out test);
-                            }
+                            ImageSource test;
+                            _data.TryRemove(key, out test);
                         }
                     }
-                    );
                 }
             }
         }

--- a/src/modules/launcher/Wox.Infrastructure/Image/ImageCache.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Image/ImageCache.cs
@@ -2,6 +2,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Windows.Media;
 using Windows.ApplicationModel.Chat;
 
@@ -25,22 +26,24 @@ namespace Wox.Infrastructure.Image
             }
             set 
             {
-                cnt++;
-                _data[path] = value; 
+                _data[path] = value;
 
-                if(cnt > 2*MaxCached)
+                if (_data.Count > 2 * MaxCached)
                 {
-                    cnt = MaxCached;
-                    Cleanup();
-                    foreach(var key in _data.Keys)
+                    Task.Run(() =>
                     {
-                        int dictValue;
-                        if(!Usage.TryGetValue(key, out dictValue))
+                        Cleanup();
+                        foreach (var key in _data.Keys)
                         {
-                            ImageSource test;
-                            _data.TryRemove(key, out test);
+                            int dictValue;
+                            if (!Usage.TryGetValue(key, out dictValue))
+                            {
+                                ImageSource test;
+                                _data.TryRemove(key, out test);
+                            }
                         }
                     }
+                    );
                 }
             }
         }

--- a/src/modules/launcher/Wox.Infrastructure/Image/ImageCache.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Image/ImageCache.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Media;
-using Windows.ApplicationModel.Chat;
 
 namespace Wox.Infrastructure.Image
 {
@@ -14,7 +13,7 @@ namespace Wox.Infrastructure.Image
         private const int MaxCached = 50;
         public ConcurrentDictionary<string, int> Usage = new ConcurrentDictionary<string, int>();
         private readonly ConcurrentDictionary<string, ImageSource> _data = new ConcurrentDictionary<string, ImageSource>();
-        private int cnt = 0;
+        private const int permissibleFactor = 2;
 
         public ImageSource this[string path]
         {
@@ -28,7 +27,9 @@ namespace Wox.Infrastructure.Image
             {
                 _data[path] = value;
 
-                if (_data.Count > 2 * MaxCached)
+                // To prevent the dictionary from drastically increasing in size by caching images, the dictionary size is not allowed to grow more than the permissibleFactor * maxCached size
+                // This is done so that we don't constantly perform this resizing operation and also maintain the image cache size at the same time
+                if (_data.Count > permissibleFactor * MaxCached)
                 {
                     Task.Run(() =>
                     {

--- a/src/modules/launcher/Wox.Infrastructure/Image/ImageCache.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Image/ImageCache.cs
@@ -31,14 +31,17 @@ namespace Wox.Infrastructure.Image
                 // This is done so that we don't constantly perform this resizing operation and also maintain the image cache size at the same time
                 if (_data.Count > permissibleFactor * MaxCached)
                 {
+                    // This function resizes the Usage dictionary, taking the top 'maxCached' number of items and filtering the image icons that are not accessed frequently.
                     Cleanup();
+
+                    // To delete the images from the data dictionary based on the resizing of the Usage Dictionary.
                     foreach (var key in _data.Keys)
                     {
                         int dictValue;
                         if (!Usage.TryGetValue(key, out dictValue))
                         {
-                            ImageSource test;
-                            _data.TryRemove(key, out test);
+                            ImageSource imgSource;
+                            _data.TryRemove(key, out imgSource);
                         }
                     }
                 }

--- a/src/modules/launcher/Wox.Infrastructure/Image/ImageLoader.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Image/ImageLoader.cs
@@ -185,10 +185,12 @@ namespace Wox.Infrastructure.Image
                 if (hash != null)
                 {
                     int ImageCacheValue;
-                    if (GuidToKey.TryGetValue(hash, out string key)
-                        && ImageCache.Usage.TryGetValue(path, out ImageCacheValue))
+                    if (GuidToKey.TryGetValue(hash, out string key))
                     { // image already exists
-                        img = ImageCache[key];
+                        if(ImageCache.Usage.TryGetValue(path, out ImageCacheValue))
+                        {
+                            img = ImageCache[key];
+                        }
                     }
                     else
                     { // new guid

--- a/src/modules/launcher/Wox.Infrastructure/Image/ImageLoader.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Image/ImageLoader.cs
@@ -184,8 +184,12 @@ namespace Wox.Infrastructure.Image
                 string hash = EnableImageHash ? _hashGenerator.GetHashFromImage(img) : null;
                 if (hash != null)
                 {
-                    if (GuidToKey.TryGetValue(hash, out string key))
+                    int test;
+                    if (GuidToKey.TryGetValue(hash, out string key)
+                        && ImageCache.Usage.TryGetValue(path, out test))
                     { // image already exists
+                        var cnt = ImageCache.CacheSize();
+                        var uniquecnt = ImageCache.UniqueImagesInCache();
                         img = ImageCache[key];
                     }
                     else

--- a/src/modules/launcher/Wox.Infrastructure/Image/ImageLoader.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Image/ImageLoader.cs
@@ -184,12 +184,10 @@ namespace Wox.Infrastructure.Image
                 string hash = EnableImageHash ? _hashGenerator.GetHashFromImage(img) : null;
                 if (hash != null)
                 {
-                    int test;
+                    int ImageCacheValue;
                     if (GuidToKey.TryGetValue(hash, out string key)
-                        && ImageCache.Usage.TryGetValue(path, out test))
+                        && ImageCache.Usage.TryGetValue(path, out ImageCacheValue))
                     { // image already exists
-                        var cnt = ImageCache.CacheSize();
-                        var uniquecnt = ImageCache.UniqueImagesInCache();
                         img = ImageCache[key];
                     }
                     else


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
* The memory used by PT Run was increasing on consecutive launches. One of the reasons for this to happen was that all the image icons were cached. 
* Even though the code had an upperlimit on the `maxCached` values which was set to 5000, this part of the code was never called unless powerToys was closed. 
* Therefore, since all the icons were being cached, the size of the dictionary continued to increase.

**Work around**-
* Instead of caching all images and increasing the size of the dictionary, the following changes have been made -
1. Reduce the number of cached images to 50.
2. If the number of images increase over the permissible factor (set to 2) of the cached images (ie. 2 * 50), then the ones which are infrequently used would be removed from the dictionary and there be 50 images that are cached.
This ensures that the dictionary size is always less than 100.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #2047.
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx


<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->

## Validation Steps Performed

The changes in this PR can be validated by following these steps -
1. Take snapshots of the memory usage by using the Diagnostic tools of Visual studio (Debug -> Windows -> Diagnostic tools).
2. Take the first snapshot after all the dlls are loaded and the memory utilization is stabilized.
3. Take the next memory snapshot after many queries (don't have to execute an application). The aim is to just load many icons.
4. Compare the second snapshot by setting the first one as the baseline.
5. Search for memory size diff in bytes for Concurrent Dictionary with value ImageSource.
6. Compare this value to that obtained without the changes in this PR, to get the results as shown in the following images.

* Before this change (after about twenty searches)-
![image](https://user-images.githubusercontent.com/28739210/85344943-e3a3fc80-b4a5-11ea-919e-6226a3132b16.png)

* After this change (after about twenty searches) -
![image](https://user-images.githubusercontent.com/28739210/85344930-df77df00-b4a5-11ea-98bf-cc5fc58c9c72.png)


## Outstanding tasks
* Even though this fixes the issue partially, the memory consumed by PT Run is still high. It starts off with 160/170 MB and after first launch goes up to 230/250 MB, following which it increases a little on each run.
* Another area where the memory utilization can be improved is the `Dictionary<int64, WeakReference>`. The following snapshots are after searching for a few apps using PT Run -
![image](https://user-images.githubusercontent.com/28739210/85345097-63ca6200-b4a6-11ea-80b3-fc80a78c9841.png)
![image](https://user-images.githubusercontent.com/28739210/85345103-69c04300-b4a6-11ea-899b-99bbaaa11e07.png)

It seems like this is related to the `ResourceDictionary` of the UI components. The number of elements in this dictionary and the components that they are referring to seem to increase on each run. This needs further investigation.

## Additional Information
* I tried to set a hard limit on the heap size using `runtime.config.json` and `System.GC.HeapHardLimit`. I did not notice any drastic differences in the Garbage collection when the limit was set to values ranging from 20 MB to 200 MB. Also, this might differ from system to system so I did not go down this route.

References - https://docs.microsoft.com/en-us/dotnet/core/run-time-config/garbage-collector