### PR TITLE
Dispose keyboard hook object in Settings

### DIFF
--- a/src/common/interop/KeyboardHook.cpp
+++ b/src/common/interop/KeyboardHook.cpp
@@ -25,6 +25,12 @@ KeyboardHook::KeyboardHook(
 KeyboardHook::~KeyboardHook()
 {
     quit = true;
+
+    // Notify the DispatchProc thread so that it isn't stuck at the Wait step
+    Monitor::Enter(queue);
+    Monitor::Pulse(queue);
+    Monitor::Exit(queue);
+
     kbEventDispatch->Join();
 
     // Unregister low level hook procedure

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/HotkeySettingsControlHook.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/HotkeySettingsControlHook.cs
@@ -6,7 +6,7 @@ using interop;
 namespace Microsoft.PowerToys.Settings.UI.Lib
 {
     public delegate void KeyEvent(int key);
-    
+
     public delegate bool IsActive();
 
     public class HotkeySettingsControlHook
@@ -48,6 +48,12 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
                     keyUp(ev.key);
                     break;
             }
+        }
+
+        public void Dispose()
+        {
+            // Dispose the KeyboardHook object to terminate the hook threads
+            hook.Dispose();
         }
     }
 }

--- a/src/core/Microsoft.PowerToys.Settings.UI/Controls/HotkeySettingsControl.xaml.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Controls/HotkeySettingsControl.xaml.cs
@@ -8,6 +8,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Input;
 using System;
+using System.Data;
 
 // The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
 namespace Microsoft.PowerToys.Settings.UI.Controls
@@ -54,7 +55,14 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
 
             HotkeyTextBox.GettingFocus += HotkeyTextBox_GettingFocus;
             HotkeyTextBox.LosingFocus += HotkeyTextBox_LosingFocus;
+            HotkeyTextBox.Unloaded += HotkeyTextBox_Unloaded;
             hook = new HotkeySettingsControlHook(Hotkey_KeyDown, Hotkey_KeyUp, Hotkey_IsActive);
+        }
+
+        private void HotkeyTextBox_Unloaded(object sender, RoutedEventArgs e)
+        {
+            // Dispose the HotkeySettingsControlHook object to terminate the hook threads when the textbox is unloaded
+            hook.Dispose();
         }
 
         private void KeyEventHandler(int key, bool matchValue, int matchValueCode, string matchValueText)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR fixes the issue of the Settings process not terminating when the FZ or PT Run page or opened. Because of the process not terminating, clicking the PowerToys icon from the systray wouldn't work. This was happening because there were threads created by the KeyboardHook object that weren't getting terminated. This was also resulting in new threads being created every time the FZ or PT Run page were opened, which could have perf/memory impact. With the changes in the PR, only one additional thread can be created at any point of time, and the thread is present only while the FZ or PT Run page are open.

- To fix this, in the Unloaded handler of the Hotkey user control we add a step to dispose the `KeyboardHook` object. This result in the KeyboardHook object's destructor getting called, however this was hanging on the step `kbmDispatch->Join()`. This was happening because DispatchProc was stuck on the [Monitor::Wait statement](https://github.com/microsoft/PowerToys/blob/147c08bd71ab5b260f077ce96957b0a79c33fbad/src/common/interop/KeyboardHook.cpp#L42) so even though `quit` was set to `false`, it would never reach that statement to exit the while loop. 

- This is fixed by calling [`Monitor::Pulse`](https://docs.microsoft.com/en-us/dotnet/api/system.threading.monitor.pulse?view=netcore-3.1) in the destructor to notify the `DispatchProc` thread to continue and end the [`Wait`](https://docs.microsoft.com/en-us/dotnet/api/system.threading.monitor.wait?view=netcore-3.1) statement. In order to call Pulse, the calling thread must have ownership of the Monitor, which is why `Monitor::Enter` and `Monitor::Exit` are also done in the destructor.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Applies to #4429 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manually validated that threads terminate by attaching debugger and that the hotkeys are modified correctly.