### PR TITLE
Enable code analysis on Keyboard Manager projects

### DIFF
--- a/src/modules/keyboardmanager/common/KeyDelay.cpp
+++ b/src/modules/keyboardmanager/common/KeyDelay.cpp
@@ -24,7 +24,7 @@ KeyTimedEvent KeyDelay::NextEvent()
     return ev;
 }
 
-bool KeyDelay::CheckIfMillisHaveElapsed(DWORD first, DWORD last, DWORD duration)
+bool KeyDelay::CheckIfMillisHaveElapsed(DWORD64 first, DWORD64 last, DWORD64 duration)
 {
     if (first < last && first <= first + duration)
     {
@@ -32,8 +32,8 @@ bool KeyDelay::CheckIfMillisHaveElapsed(DWORD first, DWORD last, DWORD duration)
     }
     else
     {
-        first += ULONG_MAX / 2;
-        last += ULONG_MAX / 2;
+        first += ULLONG_MAX / 2;
+        last += ULLONG_MAX / 2;
         return first + duration < last;
     }
 }
@@ -99,7 +99,7 @@ bool KeyDelay::HandleOnHold(std::unique_lock<std::mutex>& cvLock)
         }
     }
 
-    if (CheckIfMillisHaveElapsed(_initialHoldKeyDown, GetTickCount(), LONG_PRESS_DELAY_MILLIS))
+    if (CheckIfMillisHaveElapsed(_initialHoldKeyDown, GetTickCount64(), LONG_PRESS_DELAY_MILLIS))
     {
         if (_onLongPressDetected != nullptr)
         {

--- a/src/modules/keyboardmanager/common/KeyDelay.h
+++ b/src/modules/keyboardmanager/common/KeyDelay.h
@@ -16,7 +16,7 @@ enum class KeyDelayState
 // Virtual key + timestamp (in millis since Windows startup)
 struct KeyTimedEvent
 {
-    DWORD time;
+    DWORD64 time;
     WPARAM message;
 };
 
@@ -61,7 +61,7 @@ private:
 
     // Check if <duration> milliseconds passed since <first> millisecond.
     // Also checks for overflow conditions.
-    bool CheckIfMillisHaveElapsed(DWORD first, DWORD last, DWORD duration);
+    bool CheckIfMillisHaveElapsed(DWORD64 first, DWORD64 last, DWORD64 duration);
 
     std::thread _delayThread;
     bool _quit;
@@ -81,11 +81,11 @@ private:
     std::condition_variable _cv;
 
     // Keeps track of the time at which the initial KEY_DOWN event happened.
-    DWORD _initialHoldKeyDown;
+    DWORD64 _initialHoldKeyDown;
 
     // Virtual Key provided in the constructor. Passed to callback functions.
     DWORD _key;
 
-    static const DWORD LONG_PRESS_DELAY_MILLIS = 900;
-    static const DWORD ON_HOLD_WAIT_TIMEOUT_MILLIS = 50;
+    static const DWORD64 LONG_PRESS_DELAY_MILLIS = 900;
+    static const DWORD64 ON_HOLD_WAIT_TIMEOUT_MILLIS = 50;
 };

--- a/src/modules/keyboardmanager/common/KeyboardManagerCommon.vcxproj
+++ b/src/modules/keyboardmanager/common/KeyboardManagerCommon.vcxproj
@@ -49,11 +49,13 @@
     <LinkIncremental>true</LinkIncremental>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\modules\KeyboardManager\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\obj\$(ProjectName)\</IntDir>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\modules\KeyboardManager\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\obj\$(ProjectName)\</IntDir>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>

--- a/src/modules/keyboardmanager/common/KeyboardManagerConstants.h
+++ b/src/modules/keyboardmanager/common/KeyboardManagerConstants.h
@@ -57,7 +57,7 @@ namespace KeyboardManagerConstants
     inline const long RemapTableArrowColIndex = 1;
     inline const long RemapTableNewColIndex = 2;
     inline const long RemapTableRemoveColIndex = 3;
-    inline const DWORD RemapTableDropDownWidth = 110;
+    inline const DWORD64 RemapTableDropDownWidth = 110;
 
     // Shortcut table constants
     inline const long ShortcutTableColCount = 4;
@@ -66,17 +66,17 @@ namespace KeyboardManagerConstants
     inline const long ShortcutTableArrowColIndex = 1;
     inline const long ShortcutTableNewColIndex = 2;
     inline const long ShortcutTableRemoveColIndex = 3;
-    inline const DWORD ShortcutTableDropDownWidth = 110;
-    inline const DWORD ShortcutTableDropDownSpacing = 10;
+    inline const DWORD64 ShortcutTableDropDownWidth = 110;
+    inline const DWORD64 ShortcutTableDropDownSpacing = 10;
 
     // Drop down height used for both Edit Keyboard and Edit Shortcuts
-    inline const DWORD TableDropDownHeight = 200;
-    inline const DWORD TableArrowColWidth = 20;
-    inline const DWORD TableRemoveColWidth = 20;
-    inline const DWORD TableWarningColWidth = 20;
+    inline const DWORD64 TableDropDownHeight = 200;
+    inline const DWORD64 TableArrowColWidth = 20;
+    inline const DWORD64 TableRemoveColWidth = 20;
+    inline const DWORD64 TableWarningColWidth = 20;
 
     // Shared style constants for both Remap Table and Shortcut Table
-    inline const double HeaderButtonWidth = 100;
+    inline const DWORD64 HeaderButtonWidth = 100;
 
     // Flags used for distinguishing key events sent by Keyboard Manager
     inline const ULONG_PTR KEYBOARDMANAGER_SINGLEKEY_FLAG = 0x11; // Single key remaps

--- a/src/modules/keyboardmanager/dll/KeyboardManager.vcxproj
+++ b/src/modules/keyboardmanager/dll/KeyboardManager.vcxproj
@@ -51,11 +51,13 @@
     <LinkIncremental>true</LinkIncremental>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\modules\$(ProjectName)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\obj\$(ProjectName)\</IntDir>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\modules\$(ProjectName)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\obj\$(ProjectName)\</IntDir>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>

--- a/src/modules/keyboardmanager/test/KeyboardManagerTest.vcxproj
+++ b/src/modules/keyboardmanager/test/KeyboardManagerTest.vcxproj
@@ -51,11 +51,13 @@
     <LinkIncremental>true</LinkIncremental>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\modules\KeyboardManager\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\obj\$(ProjectName)\</IntDir>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\modules\KeyboardManager\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\obj\$(ProjectName)\</IntDir>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>

--- a/src/modules/keyboardmanager/ui/KeyboardManagerUI.vcxproj
+++ b/src/modules/keyboardmanager/ui/KeyboardManagerUI.vcxproj
@@ -52,11 +52,13 @@
     <LinkIncremental>true</LinkIncremental>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\modules\KeyboardManager\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\obj\$(ProjectName)\</IntDir>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\modules\KeyboardManager\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\obj\$(ProjectName)\</IntDir>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR enables code analysis on the Keyboard Manager projects and fixes the following warnings:
- GetTickCount overflow: To fix this, GetTickCount was changed to [GetTickCount64](https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-gettickcount64) and all time variables were changed to DWORD64 instead of DWORD.
![image](https://user-images.githubusercontent.com/32061677/85478117-7f9a3a80-b570-11ea-94d1-c7550a8d4ece.png)

- Arithmetic casting overflow: To fix this, the constants used for UI dimensions were changed to DWORD64 instead of DWORD i.e. 8 byte values.
![image](https://user-images.githubusercontent.com/32061677/85478371-f20b1a80-b570-11ea-821d-9977c831322c.png)

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Applies to #4453 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manually validating by building and running on Debug/Release and checking if UI dimensions are correct in Edit Shortcuts (for 2nd warning fix), and if the hold Enter/Esc functionality is working as expected (for first warning fix).