### PR TITLE
[FancyZones Editor] Prevent new zones from being unreachable

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditorWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditorWindow.xaml
@@ -12,7 +12,7 @@
         SizeToContent="Height"            
         Background="White"
         ResizeMode="NoResize"
-        WindowStartupLocation="Manual"
+        WindowStartupLocation="CenterScreen"
         Closed="OnClosed">
 
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditorWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditorWindow.xaml
@@ -12,7 +12,7 @@
         SizeToContent="Height"            
         Background="White"
         ResizeMode="NoResize"
-        WindowStartupLocation="CenterScreen"
+        WindowStartupLocation="Manual"
         Closed="OnClosed">
 
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditorWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditorWindow.xaml.cs
@@ -21,20 +21,18 @@ namespace FancyZonesEditor
 
         private void OnAddZone(object sender, RoutedEventArgs e)
         {
-            if (_x_offset + ((int)(Settings.WorkArea.Width * 0.4) / 2) < (int)Settings.WorkArea.Width
-                && _y_offset + ((int)(Settings.WorkArea.Height * 0.4) / 2) < (int)Settings.WorkArea.Height)
+            if (_offset + (int)(Settings.WorkArea.Width * 0.4) < (int)Settings.WorkArea.Width
+                && _offset + (int)(Settings.WorkArea.Height * 0.4) < (int)Settings.WorkArea.Height)
             {
-                _model.AddZone(new Int32Rect(_x_offset, _y_offset, (int)(Settings.WorkArea.Width * 0.4), (int)(Settings.WorkArea.Height * 0.4)));
+                _model.AddZone(new Int32Rect(_offset, _offset, (int)(Settings.WorkArea.Width * 0.4), (int)(Settings.WorkArea.Height * 0.4)));
             }
             else
             {
-                _x_offset = 100;
-                _y_offset = 100;
-                _model.AddZone(new Int32Rect(_x_offset, _y_offset, (int)(Settings.WorkArea.Width * 0.4), (int)(Settings.WorkArea.Height * 0.4)));
+                _offset = 100;
+                _model.AddZone(new Int32Rect(_offset, _offset, (int)(Settings.WorkArea.Width * 0.4), (int)(Settings.WorkArea.Height * 0.4)));
             }
 
-            _x_offset += 50;
-            _y_offset += 50;
+            _offset += 50;
         }
 
         protected new void OnCancel(object sender, RoutedEventArgs e)
@@ -43,8 +41,7 @@ namespace FancyZonesEditor
             _stashedModel.RestoreTo(_model);
         }
 
-        private int _x_offset = 100;
-        private int _y_offset = 100;
+        private int _offset = 100;
         private CanvasLayoutModel _model;
         private CanvasLayoutModel _stashedModel;
     }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditorWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditorWindow.xaml.cs
@@ -21,7 +21,20 @@ namespace FancyZonesEditor
 
         private void OnAddZone(object sender, RoutedEventArgs e)
         {
-            _model.AddZone(new Int32Rect(_x_offset, _y_offset, (int)(Settings.WorkArea.Width * 0.4), (int)(Settings.WorkArea.Height * 0.4)));
+            if (_x_offset + ((int)(Settings.WorkArea.Width * 0.4) / 2) < (int)Settings.WorkArea.Width
+                && _y_offset + ((int)(Settings.WorkArea.Height * 0.4) / 2) < (int)Settings.WorkArea.Height)
+            {
+                _model.AddZone(new Int32Rect(_x_offset, _y_offset, (int)(Settings.WorkArea.Width * 0.4), (int)(Settings.WorkArea.Height * 0.4)));
+            }
+            else
+            {
+                _x_offset = 100;
+                _y_offset = 100;
+                _model.AddZone(new Int32Rect(_x_offset, _y_offset, (int)(Settings.WorkArea.Width * 0.4), (int)(Settings.WorkArea.Height * 0.4)));
+            }
+
+            _x_offset += 50;
+            _y_offset += 50;
         }
 
         protected new void OnCancel(object sender, RoutedEventArgs e)
@@ -30,8 +43,8 @@ namespace FancyZonesEditor
             _stashedModel.RestoreTo(_model);
         }
 
-        private int _x_offset = (int)(Settings.WorkArea.Width * 0.5) - (int)(Settings.WorkArea.Width * 0.2);
-        private int _y_offset = (int)(Settings.WorkArea.Height * 0.5) - (int)(Settings.WorkArea.Height * 0.2);
+        private int _x_offset = 100;
+        private int _y_offset = 100;
         private CanvasLayoutModel _model;
         private CanvasLayoutModel _stashedModel;
     }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditorWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditorWindow.xaml.cs
@@ -21,8 +21,7 @@ namespace FancyZonesEditor
 
         private void OnAddZone(object sender, RoutedEventArgs e)
         {
-            _model.AddZone(new Int32Rect(_offset, _offset, (int)(Settings.WorkArea.Width * 0.6), (int)(Settings.WorkArea.Height * 0.6)));
-            _offset += 100;
+            _model.AddZone(new Int32Rect(_x_offset, _y_offset, (int)(Settings.WorkArea.Width * 0.4), (int)(Settings.WorkArea.Height * 0.4)));
         }
 
         protected new void OnCancel(object sender, RoutedEventArgs e)
@@ -31,7 +30,8 @@ namespace FancyZonesEditor
             _stashedModel.RestoreTo(_model);
         }
 
-        private int _offset = 100;
+        private int _x_offset = (int)(Settings.WorkArea.Width * 0.5) - (int)(Settings.WorkArea.Width * 0.2);
+        private int _y_offset = (int)(Settings.WorkArea.Height * 0.5) - (int)(Settings.WorkArea.Height * 0.2);
         private CanvasLayoutModel _model;
         private CanvasLayoutModel _stashedModel;
     }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/Settings.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/Settings.cs
@@ -263,13 +263,13 @@ namespace FancyZonesEditor
                 ZoneCount = 3;
             }
 
-            Int32Rect focusZoneRect = new Int32Rect((int)(WorkArea.Width * 0.1), (int)(WorkArea.Height * 0.1), (int)(WorkArea.Width * 0.6), (int)(WorkArea.Height * 0.6));
-            int focusRectXIncrement = (ZoneCount <= 1) ? 0 : (int)(WorkArea.Width * 0.2) / (ZoneCount - 1);
-            int focusRectYIncrement = (ZoneCount <= 1) ? 0 : (int)(WorkArea.Height * 0.2) / (ZoneCount - 1);
+            Int32Rect focusZoneRect = new Int32Rect(100, 100, (int)(WorkArea.Width * 0.4), (int)(WorkArea.Height * 0.4));
+            int focusRectXIncrement = (ZoneCount <= 1) ? 0 : 50;
+            int focusRectYIncrement = (ZoneCount <= 1) ? 0 : 50;
 
             for (int i = 0; i < ZoneCount; i++)
             {
-                _focusModel.Zones.Add(focusZoneRect);
+                _focusModel.AddZone(focusZoneRect);
                 focusZoneRect.X += focusRectXIncrement;
                 focusZoneRect.Y += focusRectYIncrement;
             }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/Settings.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/Settings.cs
@@ -269,7 +269,7 @@ namespace FancyZonesEditor
 
             for (int i = 0; i < ZoneCount; i++)
             {
-                _focusModel.AddZone(focusZoneRect);
+                _focusModel.Zones.Add(focusZoneRect);
                 focusZoneRect.X += focusRectXIncrement;
                 focusZoneRect.Y += focusRectYIncrement;
             }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Addresses issue #1653, resets the position of new zones that would appear more than halfway off the screen. Also made default zone size smaller

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #1653 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
If a new zone was detected to be more than halfway across the screen (vertically or horizontally), then reset its position to (100,100) which is the starting coordinate of the first added zone. 
The default size of added zones was changed from WorkArea.Width/WorkArea.Height * 0.6 to WorkArea.Width/WorkArea.Height * 0.4. Also, the delta/offset decreased from 100 to 50. 
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manually Validated

**OLD:** 
![Original](https://user-images.githubusercontent.com/44409675/85492736-41664080-b59b-11ea-8e53-2f2433d1da09.gif)


**NEW:**
![Fix](https://user-images.githubusercontent.com/44409675/85492783-580c9780-b59b-11ea-9221-46b9d6dce39b.gif)
