### PR TITLE
Fix settings process not terminating on FZ and PT Run pages

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI.Runner/Program.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Runner/Program.cs
@@ -72,6 +72,9 @@ namespace Microsoft.PowerToys.Settings.UI.Runner
                         MessageBoxButton.OK);
                     app.Shutdown();
                 }
+
+                // Terminate all threads of the process
+                Environment.Exit(0);
             }
         }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR fixes the scenario of the settings process not terminating when the window is closed while FZ/PT Run pages are the current pages.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Applies to #4429, #4430
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
- The issue seemed to arise because even after the change in #4449, the Unloaded handler does not seem to get called when the window is closed and no destructor gets called either, even though the main thread was found to terminate.
- The ideal solution would be to find another event instead of Unloaded that would get fired in this scenario, but Window.Closed and Application.Suspending do not seem to get fired. This could be a xaml islands issue.
- The other alternative would be to modify the keyboardhook.cpp logic to add another thread which checks if the Settings window has been closed and if so it terminates the thread however that makes the code less re-usable and can affect perf. Plus extra threads is what caused the bug in the first place so I'm wary of adding logic like that.
- The easy way that I implemented was to call Environment.Exit after App.run has completed. This ensures that the entire process gets terminated along with all threads. We still need to keep the Unloaded logic in to avoid threads being added every time someone changes the settings page, so the Environment.Exit scenario mainly fixes the scenario mentioned in the summary specifically.
- I also found that this seems to the minimized settings not terminating issue (#4430 ) - dont know why this happens but it looks like the minimized case also results in some threads not being terminated. In addition to that this bug wasn't reproducible when the process was attached to the debugger so I can't 100% validate what threads were causing the issue.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Tried exiting settings on each page and then reopening. Also tried switching pages and changing hotkeys.