### PR TITLE
Fixed hint text casing

### DIFF
--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -279,7 +279,8 @@ namespace PowerLauncher
                 {
                     if (selectedItem.IndexOf(input, StringComparison.InvariantCultureIgnoreCase) == 0)
                     {
-                        return selectedItem;
+                        // Use the same case as the input query for the matched portion of the string
+                        return input + selectedItem.Substring(input.Length);
                     }
                 }
             }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This fixes the casing issue for the hint text. The fix involves using the same casing as the query for the part of the hint string that is matched.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Applies to #4477 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manually validated that it appears correctly