### PR TITLE
[FancyZones] Changed callback call position when disabling shift hook

### DIFF
--- a/src/modules/fancyzones/lib/ShiftKeyHook.cpp
+++ b/src/modules/fancyzones/lib/ShiftKeyHook.cpp
@@ -38,9 +38,9 @@ void ShiftKeyHook::disable()
 {
     if (hHook)
     {
-        callback(false);
         UnhookWindowsHookEx(hHook);
         hHook = NULL;
+        callback(false);
     }
 }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Changed callback(false) call position when disabling shift hook

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Applies to #4514 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Changed callback call position when disabling shift hook to avoid bugs with activating shift between `callback(false)` and `UnhookWindowsHookEx(hHook)`

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manually tested
