### PR TITLE
Scoring Tweak - Reduced the description weight by half

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/UWP.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/UWP.cs
@@ -265,7 +265,7 @@ namespace Microsoft.Plugin.Program.Programs
             {
                 var displayNameMatch = StringMatcher.FuzzySearch(query, DisplayName);
                 var descriptionMatch = StringMatcher.FuzzySearch(query, Description);
-                var score = new[] { displayNameMatch.Score, descriptionMatch.Score }.Max();
+                var score = new[] { displayNameMatch.Score, descriptionMatch.Score/2 }.Max();
                 return score;
             }
 

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Plugin.Program.Programs
             var nameMatch = StringMatcher.FuzzySearch(query, Name);
             var descriptionMatch = StringMatcher.FuzzySearch(query, Description);
             var executableNameMatch = StringMatcher.FuzzySearch(query, ExecutableName);
-            var score = new[] { nameMatch.Score, descriptionMatch.Score, executableNameMatch.Score }.Max();
+            var score = new[] { nameMatch.Score, descriptionMatch.Score/2, executableNameMatch.Score }.Max();
             return score;
         }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
* Some results were weighted higher than the others because of a match in the description name. So this PR temporarily fixes that issue by reducing the score of the description by half, while calculating the score of the result.

* Going forward, we need to decide a better weighting strategy. Some work regarding that is in this branch - https://github.com/alekhyareddy28/PowerToys/tree/prioritize_scoring, where the score is converted to a class object instead of an integer. It is a Work in progress.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #4229
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Visual no longer pulls up excel.
![image](https://user-images.githubusercontent.com/28739210/85879328-03317280-b78f-11ea-8c30-d438596c6c1e.png)
