### PR TITLE
Skip ErrorIcon and DefaultIcon while resizing the dictionary

### DIFF
--- a/src/modules/launcher/Wox.Infrastructure/Image/ImageCache.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Image/ImageCache.cs
@@ -1,5 +1,4 @@
-﻿using interop;
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/modules/launcher/Wox.Infrastructure/Image/ImageCache.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Image/ImageCache.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using interop;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -38,7 +39,7 @@ namespace Wox.Infrastructure.Image
                     foreach (var key in _data.Keys)
                     {
                         int dictValue;
-                        if (!Usage.TryGetValue(key, out dictValue))
+                        if (!Usage.TryGetValue(key, out dictValue) && !(key.Equals(Constant.ErrorIcon) || key.Equals(Constant.DefaultIcon)))
                         {
                             ImageSource imgSource;
                             _data.TryRemove(key, out imgSource);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Resolves this exception which occurs after the dictionary is resized and app_error or app.png was removed.
![MicrosoftTeams-image (5)](https://user-images.githubusercontent.com/32061677/85887380-89a08100-b79c-11ea-9931-b91ac77884b4.png)

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
- While resizing we skip the key if it matches either ErrorIcon or DefaultIcon.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manually validated that the exception isnt hit in a repro scenario.

