### PR TITLE
Fix settings issue where settings.json would get reset on runner startup

### DIFF
--- a/src/runner/general_settings.cpp
+++ b/src/runner/general_settings.cpp
@@ -114,7 +114,7 @@ GeneralSettings get_general_settings()
     return settings;
 }
 
-void apply_general_settings(const json::JsonObject& general_configs)
+void apply_general_settings(const json::JsonObject& general_configs, bool save)
 {
     run_as_elevated = general_configs.GetNamedBoolean(L"run_elevated", false);
 
@@ -195,9 +195,12 @@ void apply_general_settings(const json::JsonObject& general_configs)
         settings_theme = general_configs.GetNamedString(L"theme");
     }
 
-    GeneralSettings save_settings = get_general_settings();
-    PTSettingsHelper::save_general_settings(save_settings.to_json());
-    Trace::SettingsChanged(save_settings);
+    if (save)
+    {
+        GeneralSettings save_settings = get_general_settings();
+        PTSettingsHelper::save_general_settings(save_settings.to_json());
+        Trace::SettingsChanged(save_settings);
+    }
 }
 
 void start_initial_powertoys()

--- a/src/runner/general_settings.h
+++ b/src/runner/general_settings.h
@@ -21,5 +21,5 @@ struct GeneralSettings
 
 json::JsonObject load_general_settings();
 GeneralSettings get_general_settings();
-void apply_general_settings(const json::JsonObject& general_configs);
+void apply_general_settings(const json::JsonObject& general_configs, bool save = true);
 void start_initial_powertoys();

--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -376,6 +376,8 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         modules();
 
         auto general_settings = load_general_settings();
+
+        // Apply the general settings but don't save it as the modules() variable has not been loaded yet
         apply_general_settings(general_settings, false);
         int rvalue = 0;
         const bool elevated = is_process_elevated();

--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -376,7 +376,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         modules();
 
         auto general_settings = load_general_settings();
-        apply_general_settings(general_settings);
+        apply_general_settings(general_settings, false);
         int rvalue = 0;
         const bool elevated = is_process_elevated();
         if ((elevated ||


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR fixes the issue where settings.json `enabled` section gets reset when PowerToys is launched. This is happening because of the change in #4302 . When `apply_general_settings` is called, the modules() variable is empty (since that is loaded only after `runner()` is called), because of which the save to json step stores the enabled module set as empty. This results in all modules getting enabled. To avoid this an extra arg was added to that method, which is by default true. If it is set to false, we do not save to json. Since the default arg is true, the change only affects this particular function call.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Applies to #4523 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Launched PowerToys from clean settings, and from existing settings and verified that correct modules are enabled.
- Validated if the issue fixed by #4302 is still fixed.