### PR TITLE
[Run] Fix for visual glitch

### DIFF
--- a/src/modules/launcher/Wox/ViewModel/ResultViewModel.cs
+++ b/src/modules/launcher/Wox/ViewModel/ResultViewModel.cs
@@ -69,7 +69,16 @@ namespace Wox.ViewModel
                 LoadContextMenu();
             }
 
-            AreContextButtonsActive = true;
+            // Result does not contain any context menu items - we don't need to show the context menu ListView at all.
+            if (ContextMenuItems.Count > 0)
+            {
+                AreContextButtonsActive = true;
+            }
+            else
+            {
+                AreContextButtonsActive = false;
+            }
+         
 
             if (activationType == ActivationType.Selection)
             {
@@ -105,7 +114,15 @@ namespace Wox.ViewModel
                 IsHovered = false;
             }
 
-            AreContextButtonsActive = IsSelected || IsHovered;
+            // Result does not contain any context menu items - we don't need to show the context menu ListView at all.
+            if (ContextMenuItems.Count > 0)
+            {
+                AreContextButtonsActive = IsSelected || IsHovered;
+            }
+            else
+            {
+                AreContextButtonsActive = false;
+            }  
         }
 
 


### PR DESCRIPTION
## Summary of the Pull Request
Old behavior:
![Visual glitch](https://user-images.githubusercontent.com/9866362/85921373-44ec1700-b87c-11ea-8ea8-72fdcdbe57e7.gif)


This PR checks if there are actually any context items. If that number is 0, the AreContextButtonsActive = false. This will hide the ListView when hovering or in focus.

New behavior:
![Visual glitch solution](https://user-images.githubusercontent.com/9866362/85922046-d2ca0100-b880-11ea-8b28-51bb14efb076.gif)


## PR Checklist
* [X] Applies to #4535