### PR TITLE
Fix for Binding error on startup

### DIFF
--- a/src/modules/launcher/PowerLauncher/ResultList.xaml
+++ b/src/modules/launcher/PowerLauncher/ResultList.xaml
@@ -123,7 +123,6 @@
             Background="Transparent"
             BorderThickness="0"
             MaxHeight="{Binding Results.MaxHeight}"
-            MinHeight="{Binding Results.MinHeight}"          
             Margin="0"
             ItemsSource="{Binding Results.Results, Mode=OneWay}"
             Padding="0, 0"


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Fix for following error on startup : 
`System.Windows.Data Error: 40 : BindingExpression path error: 'MinHeight' property not found on 'object' ''ResultsViewModel' (HashCode=31815862)'. BindingExpression:Path=Results.MinHeight; DataItem='MainViewModel' (HashCode=12698356); target element is 'ListView' (Name='SuggestionsList'); target property is 'MinHeight' (type 'Double')
`

This error is being thrown because the corresponding Binding property is not present in `ResultsViewModel` class. 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Applies to #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx
 !-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manually validated that error is not thrown on startup