### PR TITLE
[FancyZones] Fixed shift behavior

### DIFF
--- a/src/modules/fancyzones/lib/WindowMoveHandler.cpp
+++ b/src/modules/fancyzones/lib/WindowMoveHandler.cpp
@@ -174,10 +174,7 @@ void WindowMoveHandlerPrivate::MoveSizeStart(HWND window, HMONITOR monitor, POIN
         m_mouseHook->enable();
     }
 
-    if (m_settings->GetSettings()->shiftDrag || !m_settings->GetSettings()->mouseSwitch)
-    {
-        m_shiftHook->enable();
-    }
+    m_shiftHook->enable();
 
     // This updates m_dragEnabled depending on if the shift key is being held down.
     UpdateDragState(window);

--- a/src/modules/fancyzones/lib/WindowMoveHandler.cpp
+++ b/src/modules/fancyzones/lib/WindowMoveHandler.cpp
@@ -174,7 +174,7 @@ void WindowMoveHandlerPrivate::MoveSizeStart(HWND window, HMONITOR monitor, POIN
         m_mouseHook->enable();
     }
 
-    if (m_settings->GetSettings()->shiftDrag)
+    if (m_settings->GetSettings()->shiftDrag || !m_settings->GetSettings()->mouseSwitch)
     {
         m_shiftHook->enable();
     }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Fixed shift behavior to disable zones when both mouse and shift checkboxes toggled off

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Applies to #4646 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
1. Toggled off checkboxes "Hold Shift key..." and "Use a non-primary mouse..."
2. Checked that shift disables zones