### PR TITLE
[FancyZones] Update app zone history on window removal

### DIFF
--- a/src/modules/fancyzones/lib/JsonHelpers.cpp
+++ b/src/modules/fancyzones/lib/JsonHelpers.cpp
@@ -2,6 +2,7 @@
 #include "JsonHelpers.h"
 #include "ZoneSet.h"
 #include "trace.h"
+#include "Settings.h"
 
 #include <common/common.h>
 
@@ -464,10 +465,12 @@ namespace JSONHelpers
                             data->processIdToHandleMap.erase(processId);
                         }
 
-                        // if there is another instance placed don't erase history
+                        // if there is another instance of same application placed in the same zone don't erase history
+                        size_t windowZoneStamp = reinterpret_cast<size_t>(::GetProp(window, MULTI_ZONE_STAMP));
                         for (auto placedWindow : data->processIdToHandleMap)
                         {
-                            if (IsWindow(placedWindow.second))
+                            size_t placedWindowZoneStamp = reinterpret_cast<size_t>(::GetProp(placedWindow.second, MULTI_ZONE_STAMP));
+                            if (IsWindow(placedWindow.second) && (windowZoneStamp == placedWindowZoneStamp))
                             {
                                 return false;
                             }

--- a/src/modules/fancyzones/lib/JsonHelpers.cpp
+++ b/src/modules/fancyzones/lib/JsonHelpers.cpp
@@ -518,14 +518,7 @@ namespace JSONHelpers
             {
                 if (data.deviceId == deviceId)
                 {
-                    for (auto placedWindow : data.processIdToHandleMap)
-                    {
-                        if (IsWindow(placedWindow.second) && processId != placedWindow.first)
-                        {
-                            return false;
-                        }
-                    }
-                    // application already has history on this desktop, but zone (or zone layout) has changed
+                    // application already has history on this work area, update it with new window position
                     data.processIdToHandleMap[processId] = window;
                     data.zoneSetUuid = zoneSetId;
                     data.zoneIndexSet = zoneIndexSet;
@@ -535,7 +528,7 @@ namespace JSONHelpers
             }
         }
 
-        std::map<DWORD, HWND> processIdToHandleMap{};
+        std::unordered_map<DWORD, HWND> processIdToHandleMap{};
         processIdToHandleMap[processId] = window;
         AppZoneHistoryData data{ .processIdToHandleMap = processIdToHandleMap,
                                  .zoneSetUuid = zoneSetId,

--- a/src/modules/fancyzones/lib/JsonHelpers.h
+++ b/src/modules/fancyzones/lib/JsonHelpers.h
@@ -133,7 +133,7 @@ namespace JSONHelpers
 
     struct AppZoneHistoryData
     {
-        std::map<DWORD, HWND> processIdToHandleMap; // Maps process id(DWORD) of application to zoned window handle(HWND)
+        std::unordered_map<DWORD, HWND> processIdToHandleMap; // Maps process id(DWORD) of application to zoned window handle(HWND)
 
         std::wstring zoneSetUuid;
         std::wstring deviceId;

--- a/src/modules/fancyzones/lib/WindowMoveHandler.cpp
+++ b/src/modules/fancyzones/lib/WindowMoveHandler.cpp
@@ -293,8 +293,6 @@ void WindowMoveHandlerPrivate::MoveSizeEnd(HWND window, POINT const& ptScreen, c
     }
     else
     {
-        ::RemoveProp(window, MULTI_ZONE_STAMP);
-
         if (m_settings->GetSettings()->restoreSize)
         {
             if (WindowMoveHandlerUtils::IsCursorTypeIndicatingSizeEvent())
@@ -325,6 +323,7 @@ void WindowMoveHandlerPrivate::MoveSizeEnd(HWND window, POINT const& ptScreen, c
                 }
             }
         }
+        ::RemoveProp(window, MULTI_ZONE_STAMP);
     }
 
     // Also, hide all windows (regardless of settings)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
If there are several windows of same application zoned in same work area, app zone history is remembered for only one of them. If that window is removed from zone, we need to try to update app zone history with zone set from some other window (of same application). If there are several options, windows are sorted by creation time and oldest (earliest started process).

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #4356
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
1. Create zone layout on one of the monitors (it behaves same for both primary and secondary monitors). For example three zone column.
2. Assign window to zone 0.
3. Open on same monitor another window of same application (gets zoned on opening to zone 0).
4. Zone that new window to a zone 1. **History still shows zone 0 -> expected**
5. Move first window out of zone. **History updated, now history shows zone 1 (belonging to remaining instance) -> expected**
6. Now zone first window to zone 2. **History still shows zone 1 -> expected**
7. Move second window out of zone. **History updated, now history shows zone 2 (belonging to remaining instance) -> expected**

Essentially, when window is removed from zone, if that zone was saved in app zone history, we try to find another window of same application, within same work are to update history. If there are more than one, we use zone set from "oldest" window (earliest started process).

Try same procedure with more than two instances of same application to confirm behavior when oldest window zone is selected for new zone in history.