### PR TITLE
Add keyboard shortcut in tooltip for context menu items

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/ContextMenuLoader.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/ContextMenuLoader.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Plugin.Folder
                             return false;
                         }
                     }
-                }); ;
+                });
             }
 
             return contextMenus;

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/ContextMenuLoader.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/ContextMenuLoader.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Plugin.Folder
                 contextMenus.Add(new ContextMenuResult
                 {
                     PluginName = Assembly.GetExecutingAssembly().GetName().Name,
-                    Title = "Copy path",
+                    Title = _context.API.GetTranslation("Microsoft_plugin_folder_copy_path"),
                     Glyph = "\xE8C8",
                     FontFamily = "Segoe MDL2 Assets",
                     SubTitle = $"Copy the current {fileOrFolder} path to clipboard",
@@ -58,7 +58,7 @@ namespace Microsoft.Plugin.Folder
                             return false;
                         }
                     }
-                });
+                }); ;
             }
 
             return contextMenus;

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Languages/de.xaml
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Languages/de.xaml
@@ -11,5 +11,6 @@
 
     <system:String x:Key="wox_plugin_folder_plugin_name">Ordner</system:String>
     <system:String x:Key="wox_plugin_folder_plugin_description">Öffne deine Lieblingsordner direkt von Wox aus</system:String>
+    <system:String x:Key="Microsoft_plugin_folder_copy_path">Copy path (Ctrl+C)</system:String>
 
 </ResourceDictionary>

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Languages/en.xaml
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Languages/en.xaml
@@ -11,5 +11,6 @@
 
     <system:String x:Key="wox_plugin_folder_plugin_name">Folder</system:String>
     <system:String x:Key="wox_plugin_folder_plugin_description">Open favorite folder from Wox directly</system:String>
+    <system:String x:Key="Microsoft_plugin_folder_copy_path">Copy path (Ctrl+C)</system:String>
 
 </ResourceDictionary>

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Languages/pl.xaml
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Languages/pl.xaml
@@ -11,5 +11,6 @@
 
     <system:String x:Key="wox_plugin_folder_plugin_name">Foldery</system:String>
     <system:String x:Key="wox_plugin_folder_plugin_description">Otwórz ulubione foldery bezpośrednio z poziomu Woxa</system:String>
-
+    <system:String x:Key="Microsoft_plugin_folder_copy_path">Copy path (Ctrl+C)</system:String>
+    
 </ResourceDictionary>

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Languages/tr.xaml
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Languages/tr.xaml
@@ -11,5 +11,6 @@
 
     <system:String x:Key="wox_plugin_folder_plugin_name">Klasör</system:String>
     <system:String x:Key="wox_plugin_folder_plugin_description">Favori klasörünüzü doğrudan Wox'tan açın</system:String>
+    <system:String x:Key="Microsoft_plugin_folder_copy_path">Copy path (Ctrl+C)</system:String>
 
 </ResourceDictionary>

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Languages/zh-cn.xaml
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Languages/zh-cn.xaml
@@ -11,5 +11,6 @@
 
     <system:String x:Key="wox_plugin_folder_plugin_name">文件夹</system:String>
     <system:String x:Key="wox_plugin_folder_plugin_description">在Wox中直接打开收藏的文件夹</system:String>
+    <system:String x:Key="Microsoft_plugin_folder_copy_path">Copy path (Ctrl+C)</system:String>
 
 </ResourceDictionary>

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Languages/zh-tw.xaml
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Languages/zh-tw.xaml
@@ -11,5 +11,6 @@
 
     <system:String x:Key="wox_plugin_folder_plugin_name">資料夾</system:String>
     <system:String x:Key="wox_plugin_folder_plugin_description">在 Wox 中直接開啟收藏的資料夾</system:String>
+    <system:String x:Key="Microsoft_plugin_folder_copy_path">Copy path (Ctrl+C)</system:String>
 
 </ResourceDictionary>

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/ContextMenuLoader.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/ContextMenuLoader.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Plugin.Indexer
                 contextMenus.Add(new ContextMenuResult
                 {
                     PluginName = Assembly.GetExecutingAssembly().GetName().Name,
-                    Title = "Copy path",
+                    Title = _context.API.GetTranslation("Microsoft_plugin_indexer_copy_path"),
                     Glyph = "\xE8C8",
                     FontFamily = "Segoe MDL2 Assets",
                     SubTitle = $"Copy the current {fileOrFolder} path to clipboard",
@@ -75,7 +75,7 @@ namespace Microsoft.Plugin.Indexer
             return new ContextMenuResult
             {
                 PluginName = Assembly.GetExecutingAssembly().GetName().Name,
-                Title = "Open containing folder",
+                Title = _context.API.GetTranslation("Microsoft_plugin_indexer_open_containing_folder"),
                 Glyph = "\xE838",
                 FontFamily = "Segoe MDL2 Assets",
                 AcceleratorKey = Key.E,

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Languages/de.xaml
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Languages/de.xaml
@@ -1,0 +1,8 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:system="clr-namespace:System;assembly=mscorlib">
+    
+    <system:String x:Key="Microsoft_plugin_indexer_copy_path">Copy path (Ctrl+C)</system:String>
+    <system:String x:Key="Microsoft_plugin_indexer_open_containing_folder">Open containing folder (Ctrl+Shift+E)</system:String>
+
+</ResourceDictionary>

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Languages/en.xaml
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Languages/en.xaml
@@ -1,0 +1,8 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:system="clr-namespace:System;assembly=mscorlib">
+    
+    <system:String x:Key="Microsoft_plugin_indexer_copy_path">Copy path (Ctrl+C)</system:String>
+    <system:String x:Key="Microsoft_plugin_indexer_open_containing_folder">Open containing folder (Ctrl+Shift+E)</system:String>
+
+</ResourceDictionary>

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Languages/ja.xaml
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Languages/ja.xaml
@@ -1,0 +1,8 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:system="clr-namespace:System;assembly=mscorlib">
+    
+    <system:String x:Key="Microsoft_plugin_indexer_copy_path">Copy path (Ctrl+C)</system:String>
+    <system:String x:Key="Microsoft_plugin_indexer_open_containing_folder">Open containing folder (Ctrl+Shift+E)</system:String>
+
+</ResourceDictionary>

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Languages/pl.xaml
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Languages/pl.xaml
@@ -1,0 +1,8 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:system="clr-namespace:System;assembly=mscorlib">
+    
+    <system:String x:Key="Microsoft_plugin_indexer_copy_path">Copy path (Ctrl+C)</system:String>
+    <system:String x:Key="Microsoft_plugin_indexer_open_containing_folder">Open containing folder (Ctrl+Shift+E)</system:String>
+
+</ResourceDictionary>

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Languages/tr.xaml
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Languages/tr.xaml
@@ -1,0 +1,8 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:system="clr-namespace:System;assembly=mscorlib">
+    
+    <system:String x:Key="Microsoft_plugin_indexer_copy_path">Copy path (Ctrl+C)</system:String>
+    <system:String x:Key="Microsoft_plugin_indexer_open_containing_folder">Open containing folder (Ctrl+Shift+E)</system:String>
+
+</ResourceDictionary>

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Languages/zh-cn.xaml
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Languages/zh-cn.xaml
@@ -1,0 +1,8 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:system="clr-namespace:System;assembly=mscorlib">
+    
+    <system:String x:Key="Microsoft_plugin_indexer_copy_path">Copy path (Ctrl+C)</system:String>
+    <system:String x:Key="Microsoft_plugin_indexer_open_containing_folder">Open containing folder (Ctrl+Shift+E)</system:String>
+
+</ResourceDictionary>

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Languages/zh-tw.xaml
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Languages/zh-tw.xaml
@@ -1,0 +1,8 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:system="clr-namespace:System;assembly=mscorlib">
+    
+    <system:String x:Key="Microsoft_plugin_indexer_copy_path">Copy path (Ctrl+C)</system:String>
+    <system:String x:Key="Microsoft_plugin_indexer_open_containing_folder">Open containing folder (Ctrl+Shift+E)</system:String>
+
+</ResourceDictionary>

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Microsoft.Plugin.Indexer.csproj
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Microsoft.Plugin.Indexer.csproj
@@ -59,11 +59,42 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Content Include="Languages\de.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Languages\en.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Languages\ja.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Languages\pl.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Languages\tr.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Languages\zh-cn.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Languages\zh-tw.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
+
 
 </Project>

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Microsoft.Plugin.Indexer.csproj
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Microsoft.Plugin.Indexer.csproj
@@ -47,7 +47,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\core\Microsoft.PowerToys.Settings.UI.Lib\Microsoft.PowerToys.Settings.UI.Lib.csproj" />
     <ProjectReference Include="..\..\Wox.Infrastructure\Wox.Infrastructure.csproj" />
-    <ProjectReference Include="..\..\Wox.Plugin\Wox.Plugin.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Microsoft.Plugin.Indexer.csproj
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Microsoft.Plugin.Indexer.csproj
@@ -47,6 +47,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\core\Microsoft.PowerToys.Settings.UI.Lib\Microsoft.PowerToys.Settings.UI.Lib.csproj" />
     <ProjectReference Include="..\..\Wox.Infrastructure\Wox.Infrastructure.csproj" />
+    <ProjectReference Include="..\..\Wox.Plugin\Wox.Plugin.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -56,6 +57,14 @@
     <None Update="plugin.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="Languages\en.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
 </Project>

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Languages/de.xaml
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Languages/de.xaml
@@ -28,8 +28,8 @@
     <system:String x:Key="wox_plugin_program_update_file_suffixes">Dateiendungen wurden erfolgreich aktualisiert</system:String>
     <system:String x:Key="wox_plugin_program_suffixes_cannot_empty">Dateiendungen dürfen nicht leer sein</system:String>
 
-    <system:String x:Key="wox_plugin_program_run_as_administrator">Als Administrator ausführen</system:String>
-    <system:String x:Key="wox_plugin_program_open_containing_folder">Enthaltenden Ordner öffnen</system:String>
+    <system:String x:Key="wox_plugin_program_run_as_administrator">Als Administrator ausführen (Ctrl+Shift+Enter)</system:String>
+    <system:String x:Key="wox_plugin_program_open_containing_folder">Enthaltenden Ordner öffnen (Ctrl+Shift+E)</system:String>
 
     <system:String x:Key="wox_plugin_program_plugin_name">Programm</system:String>
     <system:String x:Key="wox_plugin_program_plugin_description">Suche Programme mit Wox</system:String>

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Languages/en.xaml
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Languages/en.xaml
@@ -32,8 +32,8 @@
     <system:String x:Key="wox_plugin_program_suffixes_cannot_empty">File suffixes can't be empty</system:String>
 
     <system:String x:Key="wox_plugin_program_run_as_different_user">Run As Different User</system:String>
-    <system:String x:Key="wox_plugin_program_run_as_administrator">Run As Administrator</system:String>
-    <system:String x:Key="wox_plugin_program_open_containing_folder">Open containing folder</system:String>
+    <system:String x:Key="wox_plugin_program_run_as_administrator">Run As Administrator (Ctrl+Shift+Enter)</system:String>
+    <system:String x:Key="wox_plugin_program_open_containing_folder">Open containing folder (Ctrl+Shift+E)</system:String>
     <system:String x:Key="wox_plugin_program_disable_program">Disable this program from displaying</system:String>
 
     <system:String x:Key="wox_plugin_program_plugin_name">Program</system:String>

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Languages/ja.xaml
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Languages/ja.xaml
@@ -29,8 +29,8 @@
     <system:String x:Key="wox_plugin_program_update_file_suffixes">Sucessfully update file suffixes</system:String>
     <system:String x:Key="wox_plugin_program_suffixes_cannot_empty">File suffixes can't be empty</system:String>
 
-    <system:String x:Key="wox_plugin_program_run_as_administrator">Run As Administrator</system:String>
-    <system:String x:Key="wox_plugin_program_open_containing_folder">Open containing folder</system:String>
+    <system:String x:Key="wox_plugin_program_run_as_administrator">Run As Administrator (Ctrl+Shift+Enter)</system:String>
+    <system:String x:Key="wox_plugin_program_open_containing_folder">Open containing folder (Ctrl+Shift+E)</system:String>
 
     <system:String x:Key="wox_plugin_program_plugin_name">Program</system:String>
     <system:String x:Key="wox_plugin_program_plugin_description">Search programs in Wox</system:String>

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Languages/pl.xaml
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Languages/pl.xaml
@@ -28,8 +28,8 @@
     <system:String x:Key="wox_plugin_program_update_file_suffixes">Pomyślnie zaktualizowano rozszerzenia plików</system:String>
     <system:String x:Key="wox_plugin_program_suffixes_cannot_empty">Musisz podać rozszerzenia plików</system:String>
 
-    <system:String x:Key="wox_plugin_program_run_as_administrator">Uruchom jako administrator</system:String>
-    <system:String x:Key="wox_plugin_program_open_containing_folder">Otwórz folder zawierający</system:String>
+    <system:String x:Key="wox_plugin_program_run_as_administrator">Uruchom jako administrator (Ctrl+Shift+Enter)</system:String>
+    <system:String x:Key="wox_plugin_program_open_containing_folder">Otwórz folder zawierający (Ctrl+Shift+E)</system:String>
 
     <system:String x:Key="wox_plugin_program_plugin_name">Programy</system:String>
     <system:String x:Key="wox_plugin_program_plugin_description">Szukaj i uruchamiaj programy z poziomu Woxa</system:String>

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Languages/tr.xaml
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Languages/tr.xaml
@@ -28,8 +28,8 @@
     <system:String x:Key="wox_plugin_program_update_file_suffixes">Dosya uzantıları başarıyla güncellendi</system:String>
     <system:String x:Key="wox_plugin_program_suffixes_cannot_empty">Dosya uzantıları boş olamaz</system:String>
 
-    <system:String x:Key="wox_plugin_program_run_as_administrator">Yönetici Olarak Çalıştır</system:String>
-    <system:String x:Key="wox_plugin_program_open_containing_folder">İçeren Klasörü Aç</system:String>
+    <system:String x:Key="wox_plugin_program_run_as_administrator">Yönetici Olarak Çalıştır (Ctrl+Shift+Enter)</system:String>
+    <system:String x:Key="wox_plugin_program_open_containing_folder">İçeren Klasörü Aç (Ctrl+Shift+E)</system:String>
 
     <system:String x:Key="wox_plugin_program_plugin_name">Program</system:String>
     <system:String x:Key="wox_plugin_program_plugin_description">Programları Wox'tan arayın</system:String>

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Languages/zh-cn.xaml
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Languages/zh-cn.xaml
@@ -28,8 +28,8 @@
     <system:String x:Key="wox_plugin_program_update_file_suffixes">成功更新索引文件后缀</system:String>
     <system:String x:Key="wox_plugin_program_suffixes_cannot_empty">文件后缀不能为空</system:String>
 
-    <system:String x:Key="wox_plugin_program_run_as_administrator">以管理员身份运行</system:String>
-    <system:String x:Key="wox_plugin_program_open_containing_folder">打开所属文件夹</system:String>
+    <system:String x:Key="wox_plugin_program_run_as_administrator">以管理员身份运行 (Ctrl+Shift+Enter)</system:String>
+    <system:String x:Key="wox_plugin_program_open_containing_folder">打开所属文件夹 (Ctrl+Shift+E)</system:String>
 
     <system:String x:Key="wox_plugin_program_plugin_name">程序</system:String>
     <system:String x:Key="wox_plugin_program_plugin_description">在Wox中搜索程序</system:String>

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Languages/zh-tw.xaml
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Languages/zh-tw.xaml
@@ -28,8 +28,8 @@
     <system:String x:Key="wox_plugin_program_update_file_suffixes">成功更新索引副檔名清單</system:String>
     <system:String x:Key="wox_plugin_program_suffixes_cannot_empty">副檔名不能為空</system:String>
     
-    <system:String x:Key="wox_plugin_program_run_as_administrator">以系統管理員身分執行</system:String>
-    <system:String x:Key="wox_plugin_program_open_containing_folder">開啟檔案位置</system:String>
+    <system:String x:Key="wox_plugin_program_run_as_administrator">以系統管理員身分執行 (Ctrl+Shift+Enter)</system:String>
+    <system:String x:Key="wox_plugin_program_open_containing_folder">開啟檔案位置 (Ctrl+Shift+E)</system:String>
 
     <system:String x:Key="wox_plugin_program_plugin_name">程式</system:String>
     <system:String x:Key="wox_plugin_program_plugin_description">在 Wox 中搜尋程式</system:String>

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Shell/Languages/de.xaml
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Shell/Languages/de.xaml
@@ -8,5 +8,5 @@
     <system:String x:Key="wox_plugin_cmd_plugin_description">Bereitstellung der Kommandozeile in Wox. Befehle müssem mit > starten</system:String>
     <system:String x:Key="wox_plugin_cmd_cmd_has_been_executed_times">Dieser Befehl wurde {0} mal ausgeführt</system:String>
     <system:String x:Key="wox_plugin_cmd_execute_through_shell">Führe Befehle mittels Kommandozeile aus</system:String>
-    <system:String x:Key="wox_plugin_cmd_run_as_administrator">Als Administrator ausführen</system:String>
+    <system:String x:Key="wox_plugin_cmd_run_as_administrator">Als Administrator ausführen (Ctrl+Shift+Enter)</system:String>
 </ResourceDictionary>

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Shell/Languages/en.xaml
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Shell/Languages/en.xaml
@@ -10,5 +10,5 @@
     <system:String x:Key="wox_plugin_cmd_plugin_description">Allows to execute system commands from Wox. Commands should start with ></system:String>
     <system:String x:Key="wox_plugin_cmd_cmd_has_been_executed_times">this command has been executed {0} times</system:String>
     <system:String x:Key="wox_plugin_cmd_execute_through_shell">execute command through command shell</system:String>
-    <system:String x:Key="wox_plugin_cmd_run_as_administrator">Run As Administrator</system:String>
+    <system:String x:Key="wox_plugin_cmd_run_as_administrator">Run As Administrator (Ctrl+Shift+Enter)</system:String>
 </ResourceDictionary>

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Shell/Languages/pl.xaml
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Shell/Languages/pl.xaml
@@ -8,5 +8,5 @@
     <system:String x:Key="wox_plugin_cmd_plugin_description">Pozwala wykonywać komend wiersza polecania z Woxa. Polecania zaczynają się od ></system:String>
     <system:String x:Key="wox_plugin_cmd_cmd_has_been_executed_times">to polecenie zostało wykonane {0} razy</system:String>
     <system:String x:Key="wox_plugin_cmd_execute_through_shell">wykonaj to polecenie w wierszu poleceń</system:String>
-    <system:String x:Key="wox_plugin_cmd_run_as_administrator">Uruchom jako administrator</system:String>
+    <system:String x:Key="wox_plugin_cmd_run_as_administrator">Uruchom jako administrator (Ctrl+Shift+Enter)</system:String>
 </ResourceDictionary>

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Shell/Languages/tr.xaml
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Shell/Languages/tr.xaml
@@ -8,5 +8,5 @@
     <system:String x:Key="wox_plugin_cmd_plugin_description">Wox üzerinden komut istemini kullanmanızı sağlar. Komutlar > işareti ile başlamalıdır.</system:String>
     <system:String x:Key="wox_plugin_cmd_cmd_has_been_executed_times">Bu komut {0} kez çalıştırıldı</system:String>
     <system:String x:Key="wox_plugin_cmd_execute_through_shell">Komut isteminde çalıştır</system:String>
-    <system:String x:Key="wox_plugin_cmd_run_as_administrator">Yönetici Olarak Çalıştır</system:String>
+    <system:String x:Key="wox_plugin_cmd_run_as_administrator">Yönetici Olarak Çalıştır (Ctrl+Shift+Enter)</system:String>
 </ResourceDictionary>

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Shell/Languages/zh-cn.xaml
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Shell/Languages/zh-cn.xaml
@@ -8,5 +8,5 @@
     <system:String x:Key="wox_plugin_cmd_plugin_description">提供从Wox中执行命令行的能力，命令应该以>开头</system:String>
     <system:String x:Key="wox_plugin_cmd_cmd_has_been_executed_times">此命令已经被执行了 {0} 次</system:String>
     <system:String x:Key="wox_plugin_cmd_execute_through_shell">执行此命令</system:String>
-    <system:String x:Key="wox_plugin_cmd_run_as_administrator">以管理员身份运行</system:String>
+    <system:String x:Key="wox_plugin_cmd_run_as_administrator">以管理员身份运行 (Ctrl+Shift+Enter)</system:String>
 </ResourceDictionary>

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Shell/Languages/zh-tw.xaml
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Shell/Languages/zh-tw.xaml
@@ -8,5 +8,5 @@
     <system:String x:Key="wox_plugin_cmd_plugin_description">提供從 Wox 中執行命令提示字元的功能，指令應該以>開頭</system:String>
     <system:String x:Key="wox_plugin_cmd_cmd_has_been_executed_times">此指令已執行了 {0} 次</system:String>
     <system:String x:Key="wox_plugin_cmd_execute_through_shell">執行指令</system:String>
-    <system:String x:Key="wox_plugin_cmd_run_as_administrator">以系統管理員身分執行</system:String>
+    <system:String x:Key="wox_plugin_cmd_run_as_administrator">以系統管理員身分執行 (Ctrl+Shift+Enter)</system:String>
 </ResourceDictionary>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
 - This PR adds the keyboard shortcut for all the context menu buttons.
- It adds a languages folder to the indexer plugin to localize the strings.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #3419
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Folder Plugin
![image](https://user-images.githubusercontent.com/28739210/86385924-e50fba80-bc45-11ea-86c7-b0a5852ea911.png)

- Indexer Plugin
![image](https://user-images.githubusercontent.com/28739210/86385939-e93bd800-bc45-11ea-8f3f-799c1e29eaae.png)
![image](https://user-images.githubusercontent.com/28739210/86385948-ec36c880-bc45-11ea-896a-b610996386f7.png)

- Program Plugin
![image](https://user-images.githubusercontent.com/28739210/86385954-ef31b900-bc45-11ea-90ac-dbf66ee17859.png)
![image](https://user-images.githubusercontent.com/28739210/86385957-f062e600-bc45-11ea-9bb6-45d236f55003.png)

- Shell Plugin
![image](https://user-images.githubusercontent.com/28739210/86385962-f22ca980-bc45-11ea-862e-94a97a20da1a.png)
