### PR TITLE
Rework the HotkeyManager and KeyboardHook interop classes

### DIFF
--- a/src/common/interop/HotkeyManager.h
+++ b/src/common/interop/HotkeyManager.h
@@ -26,7 +26,7 @@ public
 public
     delegate void HotkeyCallback();
 
-typedef unsigned short HOTKEY_HANDLE;
+    typedef unsigned short HOTKEY_HANDLE;
 
 public
     ref class HotkeyManager
@@ -46,12 +46,9 @@ public
         IsActiveCallback ^ isActiveCallback;
         FilterKeyboardEvent ^ filterKeyboardCallback;
 
-
         void KeyboardEventProc(KeyboardEvent ^ ev);
         bool IsActiveProc();
         bool FilterKeyboardProc(KeyboardEvent ^ ev);
         HOTKEY_HANDLE GetHotkeyHandle(Hotkey ^ hotkey);
-        void UpdatePressedKeys(KeyboardEvent ^ ev);
-        void UpdatePressedKey(DWORD code, bool replaceWith, unsigned char replaceWithKey);
     };
 }

--- a/src/common/interop/KeyboardHook.h
+++ b/src/common/interop/KeyboardHook.h
@@ -33,16 +33,12 @@ public
 
     private:
         delegate LRESULT HookProcDelegate(int nCode, WPARAM wParam, LPARAM lParam);
-        Thread ^ kbEventDispatch;
-        Queue<KeyboardEvent ^> ^ queue;
         KeyboardEventCallback ^ keyboardEventCallback;
         IsActiveCallback ^ isActiveCallback;
         FilterKeyboardEvent ^ filterKeyboardEvent;
-        bool quit;
         HHOOK hookHandle;
         HookProcDelegate ^ hookProc;
 
-        void DispatchProc();
         LRESULT CALLBACK HookProc(int nCode, WPARAM wParam, LPARAM lParam);
     };
 

--- a/src/core/Microsoft.PowerToys.Settings.UI.Runner/Program.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Runner/Program.cs
@@ -74,9 +74,6 @@ namespace Microsoft.PowerToys.Settings.UI.Runner
                         MessageBoxButton.OK);
                     app.Shutdown();
                 }
-
-                // Terminate all threads of the process
-                Environment.Exit(0);
             }
         }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR reworks the KeyboardHook and HotkeyManager interop classes to a much more simplistic form, which uses GetAsyncKeyState. The following behavior has been changed:
- Earlier the KeyboardHook class used to create a second thread, and the hook would add events to a queue and the thread would process these events. This could be a potential source of perf and concurrency issues when it comes to keyboard events. Now this has been avoided by directly processing the event in the low level hook itself rather than having an extra thread for it. (Similar to what is done for other hooks in PowerToys).
- Earlier the HotkeyManager would process every key event and and store its state in a variable. This had a major issue that it could cause hotkeys to be fired even with the incorrect order for example, <kbd>Space</kbd> followed by <kbd>Win</kbd> for <kbd>Win+Space</kbd> which shouldn't happen. This stored state based approach could have other issues as well, which is why it has been changed to use GetAsyncKeyState for all the modifiers and we only consider the last keydown event as the "action key" (Space in the above example). This is the same approach used by KBM and FZ.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Applies to #4578 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
- To reduce the amount of code refactoring and to make reviewing easier I have made only the sufficient changes to fix all the false positive and unexpected behavior. There is however room for further improvement in these classes. One would be to update the `KeyboardEvent` data structure to be more similar to what we use for `LowLevelKeyboardEvent`, so that more information can be considered rather than just the virtual key code and the `WPARAM`.
- Since we no longer have the additional thread, we can remove the Environment.Exit(0) statement in Settings added in #4496 . I manually validated that the process terminates correctly,.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Manually validated that I was able to change the hotkeys for FZ and PT Run and they would invoke correctly (to test changes on KeyboardHook class)
- Manually validated Alt+Space, Win+A and Win+Space for PT Run by hitting the hotkey a couple of times.