### PR TITLE
Fix remapped shortcuts not getting activated in succession

### DIFF
--- a/src/modules/keyboardmanager/dll/KeyboardEventHandlers.cpp
+++ b/src/modules/keyboardmanager/dll/KeyboardEventHandlers.cpp
@@ -459,15 +459,15 @@ namespace KeyboardEventHandlers
                                 i++;
                             }
 
-                            // key down for original shortcut action key
+                            // key down for original shortcut action key with shortcut flag so that we don't invoke the same shortcut remap again
                             if (isActionKeyPressed)
                             {
                                 KeyboardManagerHelper::SetKeyEvent(keyEventList, i, INPUT_KEYBOARD, (WORD)it.first.GetActionKey(), 0, KeyboardManagerConstants::KEYBOARDMANAGER_SHORTCUT_FLAG);
                                 i++;
                             }
 
-                            // Send current key pressed
-                            KeyboardManagerHelper::SetKeyEvent(keyEventList, i, INPUT_KEYBOARD, (WORD)data->lParam->vkCode, 0, KeyboardManagerConstants::KEYBOARDMANAGER_SHORTCUT_FLAG);
+                            // Send current key pressed without shortcut flag so that it can be reprocessed in case the physical keys pressed are a different remapped shortcut
+                            KeyboardManagerHelper::SetKeyEvent(keyEventList, i, INPUT_KEYBOARD, (WORD)data->lParam->vkCode, 0, 0);
                             i++;
 
                             // Send dummy key since the current key pressed could be a modifier
@@ -541,15 +541,15 @@ namespace KeyboardEventHandlers
                                 i++;
                             }
 
-                            // key down for original shortcut action key
+                            // key down for original shortcut action key with shortcut flag so that we don't invoke the same shortcut remap again
                             if (isActionKeyPressed)
                             {
                                 KeyboardManagerHelper::SetKeyEvent(keyEventList, i, INPUT_KEYBOARD, (WORD)it.first.GetActionKey(), 0, KeyboardManagerConstants::KEYBOARDMANAGER_SHORTCUT_FLAG);
                                 i++;
                             }
 
-                            // Send current key pressed
-                            KeyboardManagerHelper::SetKeyEvent(keyEventList, i, INPUT_KEYBOARD, (WORD)data->lParam->vkCode, 0, KeyboardManagerConstants::KEYBOARDMANAGER_SHORTCUT_FLAG);
+                            // Send current key pressed without shortcut flag so that it can be reprocessed in case the physical keys pressed are a different remapped shortcut
+                            KeyboardManagerHelper::SetKeyEvent(keyEventList, i, INPUT_KEYBOARD, (WORD)data->lParam->vkCode, 0, 0);
                             i++;
 
                             // Send dummy key

--- a/src/modules/keyboardmanager/test/OSLevelShortcutRemappingTests.cpp
+++ b/src/modules/keyboardmanager/test/OSLevelShortcutRemappingTests.cpp
@@ -1009,5 +1009,100 @@ namespace RemappingLogicTests
             Assert::AreEqual(mockedInputHandler.GetVirtualKeyState(VK_MENU), true);
             Assert::AreEqual(mockedInputHandler.GetVirtualKeyState(VK_TAB), false);
         }
+
+        // Test if invoking two remapped shortcuts (with different modifiers between original and new shortcut) that share modifiers in succession sets the correct keyboard states
+        TEST_METHOD (TwoRemappedShortcutsWithDifferentModifiersThatShareModifiers_ShouldSetRemappedKeyStates_OnPressingSecondShortcutActionKeyAfterInvokingFirstShortcutRemap)
+        {
+            // Remap Alt+A to Ctrl+C
+            Shortcut src;
+            src.SetKey(VK_MENU);
+            src.SetKey(0x41);
+            Shortcut dest;
+            dest.SetKey(VK_CONTROL);
+            dest.SetKey(0x43);
+            testState.AddOSLevelShortcut(src, dest);
+
+            // Remap Alt+V to Ctrl+X
+            Shortcut src1;
+            src1.SetKey(VK_MENU);
+            src1.SetKey(0x56);
+            Shortcut dest1;
+            dest1.SetKey(VK_CONTROL);
+            dest1.SetKey(0x58);
+            testState.AddOSLevelShortcut(src1, dest1);
+
+            const int nInputs = 4;
+            INPUT input[nInputs] = {};
+            input[0].type = INPUT_KEYBOARD;
+            input[0].ki.wVk = VK_MENU;
+            input[0].ki.dwFlags = 0;
+            input[1].type = INPUT_KEYBOARD;
+            input[1].ki.wVk = 0x41;
+            input[1].ki.dwFlags = 0;
+            input[2].type = INPUT_KEYBOARD;
+            input[2].ki.wVk = 0x41;
+            input[2].ki.dwFlags = KEYEVENTF_KEYUP;
+            input[3].type = INPUT_KEYBOARD;
+            input[3].ki.wVk = 0x56;
+            input[3].ki.dwFlags = 0;
+
+            // Send Alt+A, release A, press V
+            mockedInputHandler.SendVirtualInput(nInputs, input, sizeof(INPUT));
+
+            // Alt, A, C, V key states should be unchanged, Ctrl, X should be true
+            Assert::AreEqual(mockedInputHandler.GetVirtualKeyState(VK_MENU), false);
+            Assert::AreEqual(mockedInputHandler.GetVirtualKeyState(0x41), false);
+            Assert::AreEqual(mockedInputHandler.GetVirtualKeyState(0x43), false);
+            Assert::AreEqual(mockedInputHandler.GetVirtualKeyState(0x56), false);
+            Assert::AreEqual(mockedInputHandler.GetVirtualKeyState(VK_CONTROL), true);
+            Assert::AreEqual(mockedInputHandler.GetVirtualKeyState(0x58), true);
+        }
+
+        // Test if invoking two remapped shortcuts (with same modifiers between original and new shortcut) that share modifiers in succession sets the correct keyboard states
+        TEST_METHOD (TwoRemappedShortcutsWithSameModifiersThatShareModifiers_ShouldSetRemappedKeyStates_OnPressingSecondShortcutActionKeyAfterInvokingFirstShortcutRemap)
+        {
+            // Remap Ctrl+A to Ctrl+C
+            Shortcut src;
+            src.SetKey(VK_CONTROL);
+            src.SetKey(0x41);
+            Shortcut dest;
+            dest.SetKey(VK_CONTROL);
+            dest.SetKey(0x43);
+            testState.AddOSLevelShortcut(src, dest);
+
+            // Remap Ctrl+V to Ctrl+X
+            Shortcut src1;
+            src1.SetKey(VK_CONTROL);
+            src1.SetKey(0x56);
+            Shortcut dest1;
+            dest1.SetKey(VK_CONTROL);
+            dest1.SetKey(0x58);
+            testState.AddOSLevelShortcut(src1, dest1);
+
+            const int nInputs = 4;
+            INPUT input[nInputs] = {};
+            input[0].type = INPUT_KEYBOARD;
+            input[0].ki.wVk = VK_CONTROL;
+            input[0].ki.dwFlags = 0;
+            input[1].type = INPUT_KEYBOARD;
+            input[1].ki.wVk = 0x41;
+            input[1].ki.dwFlags = 0;
+            input[2].type = INPUT_KEYBOARD;
+            input[2].ki.wVk = 0x41;
+            input[2].ki.dwFlags = KEYEVENTF_KEYUP;
+            input[3].type = INPUT_KEYBOARD;
+            input[3].ki.wVk = 0x56;
+            input[3].ki.dwFlags = 0;
+
+            // Send Ctrl+A, release A, press V
+            mockedInputHandler.SendVirtualInput(nInputs, input, sizeof(INPUT));
+
+            // A, C, V key states should be unchanged, Ctrl, X should be true
+            Assert::AreEqual(mockedInputHandler.GetVirtualKeyState(0x41), false);
+            Assert::AreEqual(mockedInputHandler.GetVirtualKeyState(0x43), false);
+            Assert::AreEqual(mockedInputHandler.GetVirtualKeyState(0x56), false);
+            Assert::AreEqual(mockedInputHandler.GetVirtualKeyState(VK_CONTROL), true);
+            Assert::AreEqual(mockedInputHandler.GetVirtualKeyState(0x58), true);
+        }
     };
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR fixes a scenario where a user could remap Alt+A->Ctrl+A, Alt+V->Ctrl+V and if you press Alt+A, release A and press V, Ctrl+V was not getting invoked. This was happening because when we fixed Alt+Tab style shortcuts in #3965, we changed the behavior such that we release the remapped modifier only after a key apart from the invoked shortcut's keys are pressed. When this would happen, we would reset the keyboard state to whichever keys should be physically pressed at that time, however we were sending all the keys including the latest pressed key (V in the example), with the `KEYBOARDMANAGER_SHORTCUT_FLAG`, because of which when the system received Alt+V it would not remap it to Ctrl+V. The fix involves removing the flag for that particular key event. We still keep the shortcut flag for all the key events before that so that we don't reinvoke the initial shortcut and cause an infinite recursion.
Comments have been updated to clarify the flag usage and two test cases have been added to capture the scenario.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Applies to #4647 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [X] Tests added/passed


<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Added test cases and manually validated with the repro steps in the issue