### PR TITLE
added null value handle for image resizer size input

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/ImageSize.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/ImageSize.cs
@@ -144,9 +144,12 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
 
             set
             {
+                int newWidth = -1;
+                int.TryParse(value + string.Empty, out newWidth);
+
                 if (_width != value)
                 {
-                    _width = value;
+                    _width = newWidth;
                     OnPropertyChanged();
                 }
             }
@@ -162,9 +165,12 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
 
             set
             {
+                int newHeight = -1;
+                int.TryParse(value + string.Empty, out newHeight);
+
                 if (_height != value)
                 {
-                    _height = value;
+                    _height = newHeight;
                     OnPropertyChanged();
                 }
             }

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/ImageSize.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/ImageSize.cs
@@ -147,7 +147,12 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
                 int newWidth = -1;
                 int.TryParse(value + string.Empty, out newWidth);
 
-                if (_width != value)
+                if (newWidth < 0)
+                {
+                    newWidth = 0;
+                }
+
+                if (_width != value && newWidth >= 0)
                 {
                     _width = newWidth;
                     OnPropertyChanged();
@@ -168,7 +173,12 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
                 int newHeight = -1;
                 int.TryParse(value + string.Empty, out newHeight);
 
-                if (_height != value)
+                if (newHeight < 0)
+                {
+                    newHeight = 0;
+                }
+
+                if (_height != value && newHeight >= 0)
                 {
                     _height = newHeight;
                     OnPropertyChanged();

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/ImageSize.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/ImageSize.cs
@@ -152,7 +152,7 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
                     newWidth = 0;
                 }
 
-                if (_width != value && newWidth >= 0)
+                if (_width != value)
                 {
                     _width = newWidth;
                     OnPropertyChanged();
@@ -178,7 +178,7 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
                     newHeight = 0;
                 }
 
-                if (_height != value && newHeight >= 0)
+                if (_height != value)
                 {
                     _height = newHeight;
                     OnPropertyChanged();

--- a/src/core/Microsoft.PowerToys.Settings.UnitTest/ViewModelTests/ImageResizer.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UnitTest/ViewModelTests/ImageResizer.cs
@@ -188,11 +188,34 @@ namespace ViewModelTests
         public void UpdateWidthAndHeight_ShouldUpateSize_WhenCorrectValuesAreProvided()
         {
             // arrange
-            ImageSize imageSize = new ImageSize();
+            ImageSize imageSize = new ImageSize()
+            {
+                Id = 0,
+                Name = "Test",
+                Fit = (int)ResizeFit.Fit,
+                Width = 30,
+                Height = 30,
+                Unit = (int)ResizeUnit.Pixel,
+            };
 
-            double negativeWidth = -1.0;
-            double negativeHeight = -1.0;
+            double negativeWidth = -2.0;
+            double negativeHeight = -2.0;
 
+            // Act 
+            imageSize.Width = negativeWidth;
+            imageSize.Height = negativeHeight;
+
+            // Assert
+            Assert.AreEqual(0, imageSize.Width);
+            Assert.AreEqual(0, imageSize.Height);
+
+            // Act 
+            imageSize.Width = 50;
+            imageSize.Height = 50;
+
+            // Assert
+            Assert.AreEqual(50, imageSize.Width);
+            Assert.AreEqual(50, imageSize.Height);
         }
     }
 }

--- a/src/core/Microsoft.PowerToys.Settings.UnitTest/ViewModelTests/ImageResizer.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UnitTest/ViewModelTests/ImageResizer.cs
@@ -183,5 +183,16 @@ namespace ViewModelTests
             Assert.AreEqual(viewModel.Sizes.Count, sizeOfOriginalArray - 1);
             Assert.IsFalse(viewModel.Sizes.Contains(deleteCandidate));
         }
+
+        [TestMethod]
+        public void UpdateWidthAndHeight_ShouldUpateSize_WhenCorrectValuesAreProvided()
+        {
+            // arrange
+            ImageSize imageSize = new ImageSize();
+
+            double negativeWidth = -1.0;
+            double negativeHeight = -1.0;
+
+        }
     }
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Added validation for Image resizer number Width and Height fields.
Checks includes checking negative numbers and non-number values.

#4701

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #4701
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- deleted the width and height value to see if the settings crash.
