### PR TITLE
[FancyZones] draw active zones on top of inactive zones

### DIFF
--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -163,6 +163,7 @@ namespace ZoneWindowDrawUtils
             isHighlighted[x] = true;
         }
 
+        // First draw the inactive zones
         for (auto iter = zones.begin(); iter != zones.end(); iter++)
         {
             int zoneId = static_cast<int>(iter - zones.begin());
@@ -188,7 +189,19 @@ namespace ZoneWindowDrawUtils
                     DrawZone(hdc, colorViewer, zone, zones, flashMode);
                 }
             }
-            else
+        }
+
+        // Draw the active zones on top of the inactive zones
+        for (auto iter = zones.begin(); iter != zones.end(); iter++)
+        {
+            int zoneId = static_cast<int>(iter - zones.begin());
+            winrt::com_ptr<IZone> zone = iter->try_as<IZone>();
+            if (!zone)
+            {
+                continue;
+            }
+
+            if (isHighlighted[zoneId])
             {
                 colorHighlight.fill = highlightColor;
                 colorHighlight.border = zoneBorderColor;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
See the referenced issue for details.

Instead of using one loop to draw both the active and inactive zones in a predefined order, draw the inactive zones in the first loop and the active zones in the second loop.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to https://github.com/microsoft/PowerToys/issues/4726

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manually tested with focus template and custom layouts.