### PR TITLE
Mitigated the race condition in os detection

### DIFF
--- a/src/common/os-detection/os-detect.cpp
+++ b/src/common/os-detection/os-detect.cpp
@@ -9,13 +9,7 @@
 template<uint16_t APIVersion>
 bool IsAPIContractVxAvailable()
 {
-    static bool isAPIContractVxAvailableInitialized = false;
-    static bool isAPIContractVxAvailable = false;
-    if (!isAPIContractVxAvailableInitialized)
-    {
-        isAPIContractVxAvailableInitialized = true;
-        isAPIContractVxAvailable = winrt::Windows::Foundation::Metadata::ApiInformation::IsApiContractPresent(L"Windows.Foundation.UniversalApiContract", APIVersion);
-    }
+    static bool isAPIContractVxAvailable = winrt::Windows::Foundation::Metadata::ApiInformation::IsApiContractPresent(L"Windows.Foundation.UniversalApiContract", APIVersion);
 
     return isAPIContractVxAvailable;
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
As suggested in [this](https://github.com/microsoft/PowerToys/issues/4432#issuecomment-651280300) comment, there was a race condition in the os detection code making it thread unsafe. 

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
- https://github.com/microsoft/PowerToys/issues/4432#issuecomment-651280300

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #4432, and other OS detection issues
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
- I was able to reproduce the race condition using mutexes. When one thread calls `UseNewSettings` with value as 0 and the other calls with value as 1, one of the threads returns `true` and the other returns `false`.
- The below code forces one thread to set the `isAPIContractVxAvailableInitialized` value to `true` and yields to the other thread before setting the value for `isAPIContractVxAvailable`, leaving it to be `false`. Now the second thread has `isAPIContractVxAvailableInitialized` set to true, because of the other thread and thinks that it already has the correct value for `isAPIContractVxAvailable`(which is false) and returns with that value, but that is incorrect as the other thread had not calculated the value of `isAPIContractVxAvailable` yet.

```
foo.lock();
    while (value && !done)
    {
        foo.unlock();
        std::this_thread::yield();
        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
        foo.lock();
    }
    foo.unlock();

    static bool isAPIContractVxAvailableInitialized = false;
    static bool isAPIContractVxAvailable = false;

    foo.lock();
    done = true;
    foo.unlock();

    foo.lock();
    while (!value && !set)
    {
        foo.unlock();
        std::this_thread::yield();
        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
        foo.lock();
    }
    foo.unlock();

    if (!isAPIContractVxAvailableInitialized)
    {
        isAPIContractVxAvailableInitialized = true;

        foo.lock();
        set = true;
        foo.unlock();

        std::this_thread::yield();
        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
        isAPIContractVxAvailable = winrt::Windows::Foundation::Metadata::ApiInformation::IsApiContractPresent(L"Windows.Foundation.UniversalApiContract", APIVersion);
    }

    return isAPIContractVxAvailable;

```

**Some Points to note** -
- The os-detection dll is being used by ImageResizer and other than that only one settings thread is supposed to call the UseNewSettings function. However, this race condition **could not** have been caused by ImageResizer because static variables are not shared across dlls, but only across threads. So the imageResizer is accessing another set of static variables which are not the same as the settings thread. 
- This implies that there is probably some path in the settings code which is calling the `std::thread(run_settings_window).detach();` function again before ` g_settings_process_id = process_info.dwProcessId;` is set leading to multiple settings windows to open. 
- I'm not sure what that path is but i was able to reproduce the multiple settings window condition by artificially calling this line of code `std::thread(run_settings_window).detach();` before the `g_settings_process_id` is called. Since many of the users have both the settings windows showing up in their issues, I feel there is still a corner case probably where multiple settings open up and if they happen in the interlocked fashion as forced above using mutexes, then we can end up with old and new settings versions.
- With the help of the mutexes and artificially calling the `std::thread(run_settings_window).detach();` function once, I was able to get both the settings windows. However, without this artificial function call, I was unable to reproduce it by clicking on the sys tray icon multiple times. 
![image](https://user-images.githubusercontent.com/28739210/86485944-e6f18080-bd0e-11ea-82a8-cfd5728579c9.png)



<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
* This would remove that race condition as C++ static variable initialization is thread safe (https://stackoverflow.com/questions/8102125/is-local-static-variable-initialization-thread-safe-in-c11).