### PR TITLE
[FancyZones] Don't create new custom layout when applying Focus layout

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -149,13 +149,14 @@ namespace FancyZonesEditor
 
             if (mainEditor.DataContext is LayoutModel model)
             {
-                if (model is GridLayoutModel)
+                // If custom canvas layout has been scaled, persisting is needed
+                if (model is CanvasLayoutModel && (model as CanvasLayoutModel).IsScaled)
                 {
-                    model.Apply();
+                    model.Persist();
                 }
                 else
                 {
-                    model.Persist();
+                    model.Apply();
                 }
 
                 Close();

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/CanvasLayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/CanvasLayoutModel.cs
@@ -19,6 +19,7 @@ namespace FancyZonesEditor.Models
         {
             lastWorkAreaWidth = workAreaWidth;
             lastWorkAreaHeight = workAreaHeight;
+            IsScaled = false;
 
             if (ShouldScaleLayout())
             {
@@ -33,6 +34,7 @@ namespace FancyZonesEditor.Models
         public CanvasLayoutModel(string name, LayoutType type)
         : base(name, type)
         {
+            IsScaled = false;
         }
 
         // Zones - the list of all zones in this layout, described as independent rectangles
@@ -41,6 +43,8 @@ namespace FancyZonesEditor.Models
         private int lastWorkAreaWidth = (int)Settings.WorkArea.Width;
 
         private int lastWorkAreaHeight = (int)Settings.WorkArea.Height;
+
+        public bool IsScaled { get; private set; }
 
         // RemoveZoneAt
         //  Removes the specified index from the Zones list, and fires a property changed notification for the Zones property
@@ -107,6 +111,7 @@ namespace FancyZonesEditor.Models
 
             lastWorkAreaHeight = (int)Settings.WorkArea.Height;
             lastWorkAreaWidth = (int)Settings.WorkArea.Width;
+            IsScaled = true;
         }
 
         private struct Zone

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/CanvasLayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/CanvasLayoutModel.cs
@@ -37,6 +37,11 @@ namespace FancyZonesEditor.Models
             IsScaled = false;
         }
 
+        public CanvasLayoutModel(string name)
+        : base(name)
+        {
+        }
+
         // Zones - the list of all zones in this layout, described as independent rectangles
         public IList<Int32Rect> Zones { get; private set; } = new List<Int32Rect>();
 
@@ -67,7 +72,7 @@ namespace FancyZonesEditor.Models
         //  Clones the data from this CanvasLayoutModel to a new CanvasLayoutModel
         public override LayoutModel Clone()
         {
-            CanvasLayoutModel layout = new CanvasLayoutModel(Name, Type);
+            CanvasLayoutModel layout = new CanvasLayoutModel(Name);
 
             foreach (Int32Rect zone in Zones)
             {

--- a/src/modules/fancyzones/lib/ZoneSet.cpp
+++ b/src/modules/fancyzones/lib/ZoneSet.cpp
@@ -420,8 +420,8 @@ bool ZoneSet::CalculateFocusLayout(Rect workArea, int zoneCount) noexcept
 
     long left{ long(workArea.width() * 0.1) };
     long top{ long(workArea.height() * 0.1) };
-    long right{ long(workArea.width() * 0.6) };
-    long bottom{ long(workArea.height() * 0.6) };
+    long right { left + long(workArea.width() * 0.6) };
+    long bottom { top + long(workArea.height() * 0.6) };
 
     RECT focusZoneRect{ left, top, right, bottom };
 

--- a/src/modules/fancyzones/lib/ZoneSet.cpp
+++ b/src/modules/fancyzones/lib/ZoneSet.cpp
@@ -420,8 +420,8 @@ bool ZoneSet::CalculateFocusLayout(Rect workArea, int zoneCount) noexcept
 
     long left{ long(workArea.width() * 0.1) };
     long top{ long(workArea.height() * 0.1) };
-    long right { left + long(workArea.width() * 0.6) };
-    long bottom { top + long(workArea.height() * 0.6) };
+    long right{ left + long(workArea.width() * 0.6) };
+    long bottom{ top + long(workArea.height() * 0.6) };
 
     RECT focusZoneRect{ left, top, right, bottom };
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
When applying Focus layout, new (duplicate) custom layout is created. This should not happen. The issue was introduced with scaling logic for custom canvas layout where data was persisted (reported as a new custom layout) on applying all existing canvas layouts, but should be just for scaled ones.


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #4803 #4348
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Apply Focus layout and confirm that new custom layout is not created.
Run unit tests.