### PR TITLE
[FancyZones Editor] Fix odd-number zones Grid layout difference between Editor and engine 

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
@@ -568,6 +568,7 @@ namespace FancyZonesEditor
                 left += cellWidth + spacing;
             }
 
+            int zoneNumber = 1;
             for (int row = 0; row < rows; row++)
             {
                 for (int col = 0; col < cols; col++)
@@ -582,7 +583,7 @@ namespace FancyZonesEditor
                         top = _rowInfo[row].Start;
                         Canvas.SetLeft(zone, left);
                         Canvas.SetTop(zone, top);
-                        zone.LabelID.Content = i + 1;
+                        zone.LabelID.Content = zoneNumber++;
 
                         int maxRow = row;
                         while (((maxRow + 1) < rows) && (model.CellChildMap[maxRow + 1, col] == i))

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/Settings.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/Settings.cs
@@ -329,9 +329,9 @@ namespace FancyZonesEditor
             }
 
             int index = ZoneCount - 1;
-            for (int row = rows - 1; row >= 0; row--)
+            for (int col = cols - 1; col >= 0; col--)
             {
-                for (int col = cols - 1; col >= 0; col--)
+                for (int row = rows - 1; row >= 0; row--)
                 {
                     _gridModel.CellChildMap[row, col] = index--;
                     if (index < 0)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Applying e.g. 5-zones grid layout is different then shown in editor. Fix populating cell child map in Editor but without affecting zone numbers increasing from left to right.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #4441 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
 - Apply 5-zones grid layout.
 - Check that applied layout is the same as shown in Editor.
 - Check that cycling window through zones via Win+number is following zones numbers
 
 - Unit tests are passing 