### PR TITLE
[FancyZones] Invalidate cached work areas when display resolution or taskbar position changes

### DIFF
--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -638,6 +638,9 @@ LRESULT FancyZones::WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lpa
     {
         if (wparam == SPI_SETWORKAREA)
         {
+            // Changes in taskbar position resulted with different size of work area.
+            // Ivalidate cached work areas so they can be recreated with latest information.
+            m_workAreaHandler.Clear();
             OnDisplayChange(DisplayChangeType::WorkArea);
         }
     }
@@ -645,6 +648,8 @@ LRESULT FancyZones::WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lpa
 
     case WM_DISPLAYCHANGE:
     {
+        // Display resolution changed. Invalidate cached work areas so they can be recreated with latest information.
+        m_workAreaHandler.Clear();
         OnDisplayChange(DisplayChangeType::DisplayChange);
     }
     break;

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -638,8 +638,8 @@ LRESULT FancyZones::WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lpa
     {
         if (wparam == SPI_SETWORKAREA)
         {
-            // Changes in taskbar position resulted with different size of work area.
-            // Ivalidate cached work areas so they can be recreated with latest information.
+            // Changes in taskbar position resulted in different size of work area.
+            // Invalidate cached work-areas so they can be recreated with latest information.
             m_workAreaHandler.Clear();
             OnDisplayChange(DisplayChangeType::WorkArea);
         }
@@ -648,7 +648,7 @@ LRESULT FancyZones::WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lpa
 
     case WM_DISPLAYCHANGE:
     {
-        // Display resolution changed. Invalidate cached work areas so they can be recreated with latest information.
+        // Display resolution changed. Invalidate cached work-areas so they can be recreated with latest information.
         m_workAreaHandler.Clear();
         OnDisplayChange(DisplayChangeType::DisplayChange);
     }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
We need to handle `WM_SETTINGCHANGE` (wparam indicating `SPI_SETWORKAREA`) and `WM_DISPLAYCHANGE` in such manner that cached work areas are deleted, and recreated again with up to date information.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #4694
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
1. Set one of the template zone layouts.
2. Assign window to one of the zones.
3. Change position of taskbar (left, top, right, bottom).
4. Change DPI and resolution of the screen.

Expected result: Work areas are updated on every change, so are the windows zoned into the layout (of course, for updates in window positions make sure You have _Keep windows in their zones when the screen resolution changes_ ON).
