### PR TITLE
Fixed the broken link for example_settings.png

### DIFF
--- a/doc/devdocs/readme.md
+++ b/doc/devdocs/readme.md
@@ -156,4 +156,4 @@ This module has a setting to serve as an example for each of the currently imple
 - ColorPicker property
 - CustomAction property
 
-![Image of the Options](/doc/images/example_powertoy/settings.png)
+![Image of the Options](/doc/images/settings/example_settings.png)


### PR DESCRIPTION
Due to changes in the directory structure of the `doc/images` folder, the link for `examples_settings.png` was broken and image was not showing up. I have fixed the link and image is showing up in the README.md file.

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
The image link was broken and it was not showing up. 
![Broken-linkI](https://user-images.githubusercontent.com/36355951/86868456-5641e880-c0f2-11ea-899f-8f1f44c1dfa0.jpg)

### Fixed the broken link.






<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Checked if the link is properly displaying the image or not.
