### PR TITLE
[PT Run] Added dummy key event to prevent Start Menu from popping up

### DIFF
--- a/src/common/interop/HotkeyManager.cpp
+++ b/src/common/interop/HotkeyManager.cpp
@@ -31,6 +31,13 @@ void HotkeyManager::KeyboardEventProc(KeyboardEvent ^ ev)
     if (hotkeys->ContainsKey(pressedKeysHandle))
     {
         hotkeys[pressedKeysHandle]->Invoke();
+
+        // After invoking the hotkey send a dummy key to prevent Start Menu from activating
+        INPUT dummyEvent[1] = {};
+        dummyEvent[0].type = INPUT_KEYBOARD;
+        dummyEvent[0].ki.wVk = 0xFF;
+        dummyEvent[0].ki.dwFlags = KEYEVENTF_KEYUP;
+        SendInput(1, dummyEvent, sizeof(INPUT));
     }
 }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR tweaks the HotkeyManager code such that a dummy key event is sent after invoking the shortcut. This is required to prevent Start Menu from popping up in the scenario where user releases Win key before Space (if Win+Space is the shortcut). The same procedure is done in Keyboard Manager when remapping shortcuts, because in case of Windows shortcuts Start menu appears, and if its an Alt based shortcut, the application's menu bar may get triggered.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Applies to #4578 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Validated manually that Start menu doesn't open while releasing Win key before Space.