### PR TITLE
Fix for result on empty query

### DIFF
--- a/src/modules/launcher/Wox/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/Wox/ViewModel/MainViewModel.cs
@@ -28,6 +28,7 @@ namespace Wox.ViewModel
 
         private bool _isQueryRunning;
         private Query _lastQuery;
+        private static Query _emptyQuery = new Query();
         private static bool _disposed;
         private string _queryTextBeforeLeaveResults;
 
@@ -55,7 +56,7 @@ namespace Wox.ViewModel
             _hotkeyManager = new HotkeyManager();
             _saved = false;
             _queryTextBeforeLeaveResults = "";
-            _lastQuery = new Query();
+            _lastQuery = _emptyQuery;
             _disposed = false;
 
             _settings = settings;
@@ -475,6 +476,7 @@ namespace Wox.ViewModel
             }
             else
             {
+                _lastQuery = _emptyQuery;
                 Results.SelectedItem = null;
                 Results.Clear();                
                 Results.Visibility = Visibility.Collapsed;

--- a/src/modules/launcher/Wox/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/Wox/ViewModel/MainViewModel.cs
@@ -476,6 +476,7 @@ namespace Wox.ViewModel
             }
             else
             {
+                _updateSource?.Cancel();
                 _lastQuery = _emptyQuery;
                 Results.SelectedItem = null;
                 Results.Clear();                


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Fix issue with results appearing on empty query. 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #3893 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
The issue happened because of incorrect sync between clearing and adding results. When results were delayed from a plugin they were added 
1. Query `Q1` is made which starts a new thread `T`. 
2. Query `Q2` is made which is an empty query causing clearing of results. 
3. Thread `T` writes back result of `Q1` since it has not been canceled in step 2.

#### Steps to repro this issue : 
1. Add `Thread.Sleep(1000)`  just before [this](https://github.com/microsoft/PowerToys/blob/master/src/modules/launcher/Wox/ViewModel/MainViewModel.cs#L431) line. 

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manually validated that all tests pass and results are not displayed on an empty query.

Note : No tests have been added for this because we cannot easily mock `PluginManager` which is a static class.  `PluginManager` cannot be made non-static class because `PublicInstanceAPI` depends on `PluginManager` and `PluginManager` depends on `PublicInstanceAPI` causing a circular dependency. 