### PR TITLE
upgraded the version number of .msi installer file in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ PowerToys will now enable two types of files to be previewed: Markdown (.md) & S
 
 ### Via GitHub with MSI [Recommended]
 
-Install from the [Microsoft PowerToys GitHub releases page][github-release-link]. Click on `Assets` to show the files available in the release and then click on `PowerToysSetup-0.19.0-x64.msi` to download the PowerToys installer.
+Install from the [Microsoft PowerToys GitHub releases page][github-release-link]. Click on `Assets` to show the files available in the release and then click on `PowerToysSetup-0.19.1-x64.msi` to download the PowerToys installer.
 
 **Note:** After installing, you will have to start PowerToys for the first time.  We will improve install experience this moving forward but due to a possible install dependency, we can't start after install currently.
 


### PR DESCRIPTION
# The previous version was 0.19.0 in line-77, upgraded that to 0.19.1.

 In README.md the name of the msi installer was `PowerToysSetup-0.19.0-x64.msi` which was the old version, it has now been updated to the new version which is `PowerToysSetup-0.19.1-x64.msi`
