### PR TITLE
Fix for File Not Found exception while indexing invalid Package App

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program.UnitTests/Programs/UWPTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program.UnitTests/Programs/UWPTests.cs
@@ -3,8 +3,6 @@ using Microsoft.Plugin.Program.Programs;
 using Moq;
 using NUnit.Framework;
 using System.Collections.Generic;
-using System.IO.Packaging;
-using Windows.Storage;
 
 namespace Microsoft.Plugin.Program.UnitTests.Programs
 {

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program.UnitTests/Programs/UWPTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program.UnitTests/Programs/UWPTests.cs
@@ -3,6 +3,8 @@ using Microsoft.Plugin.Program.Programs;
 using Moq;
 using NUnit.Framework;
 using System.Collections.Generic;
+using System.IO.Packaging;
+using Windows.Storage;
 
 namespace Microsoft.Plugin.Program.UnitTests.Programs
 {
@@ -71,6 +73,24 @@ namespace Microsoft.Plugin.Program.UnitTests.Programs
             // Assert
             Assert.AreEqual(applications.Length, 1);
             Assert.IsTrue(applications.FindAll(x => x.Name == "PackagedApp").Length > 0);
+        }
+
+        [Test]
+        public void PowerToysRun_ShouldNotAddInvalidApp_WhenIndexingUWPApplications()
+        {
+            // Arrange
+            PackageWrapper invalidPackagedApp = new PackageWrapper();
+            Main._settings = new Settings();
+            List<IPackage> packages = new List<IPackage>() {invalidPackagedApp };
+            var mock = new Mock<IPackageManager>();
+            mock.Setup(x => x.FindPackagesForCurrentUser()).Returns(packages);
+            UWP.PackageManagerWrapper = mock.Object;
+
+            // Act
+            var applications = UWP.All();
+
+            // Assert
+            Assert.AreEqual(applications.Length, 0);
         }
     }
 }

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/PackageWrapper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/PackageWrapper.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Plugin.Program.Programs
                         package.Id.Name,
                         package.Id.FullName,
                         package.Id.FamilyName,
-                        package.IsFramework,
+                        package.IsFramework, 
                         package.IsDevelopmentMode,
                         package.InstalledLocation.Path
                         );

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/PackageWrapper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/PackageWrapper.cs
@@ -1,20 +1,24 @@
-﻿using Package = Windows.ApplicationModel.Package;
+﻿using Microsoft.Plugin.Program.Logger;
+using System.IO;
+using Package = Windows.ApplicationModel.Package;
 
 namespace Microsoft.Plugin.Program.Programs
 {
     public class PackageWrapper : IPackage
     {
-        public string Name { get; }
+        public string Name { get; } = string.Empty;
 
-        public string FullName { get; }
+        public string FullName { get; } = string.Empty;
 
-        public string FamilyName { get; }
+        public string FamilyName { get; } = string.Empty;
 
-        public bool IsFramework { get; }
+        public bool IsFramework { get; } = false;
 
-        public bool IsDevelopmentMode { get; }
+        public bool IsDevelopmentMode { get; } = false;
 
-        public string InstalledLocation { get; }
+        public string InstalledLocation { get; } = string.Empty;
+
+        public PackageWrapper() { }
 
         public PackageWrapper(string Name, string FullName, string FamilyName, bool IsFramework, bool IsDevelopmentMode, string InstalledLocation)
         {
@@ -28,14 +32,22 @@ namespace Microsoft.Plugin.Program.Programs
 
         public static PackageWrapper GetWrapperFromPackage(Package package)
         {
-            return new PackageWrapper(
+            try
+            {
+                return new PackageWrapper(
                         package.Id.Name,
                         package.Id.FullName,
                         package.Id.FamilyName,
-                        package.IsFramework, 
+                        package.IsFramework,
                         package.IsDevelopmentMode,
                         package.InstalledLocation.Path
                         );
+            }
+            catch(FileNotFoundException ex)
+            {
+                ProgramLogger.LogException($"PackageWrapper", "GetWrapperFromPackage","package.InstalledLocation.Path",$"File Not Found for package {package.Id.Name}", ex);
+                return new PackageWrapper();
+            }
         }
     }
 }

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Storage/PackageRepository.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Storage/PackageRepository.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Plugin.Program.Storage
                     if(!string.IsNullOrEmpty(packageWrapper.InstalledLocation))
                     {
                         var uwp = new UWP(packageWrapper);
-                        uwp.InitializeAppInfo(args.Package.InstalledLocation.Path);
+                        uwp.InitializeAppInfo(packageWrapper.InstalledLocation);
                         foreach (var app in uwp.Apps)
                         {
                             Add(app);

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Storage/PackageRepository.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Storage/PackageRepository.cs
@@ -35,11 +35,14 @@ namespace Microsoft.Plugin.Program.Storage
                 try
                 {
                     var packageWrapper = PackageWrapper.GetWrapperFromPackage(args.Package);
-                    var uwp = new UWP(packageWrapper);
-                    uwp.InitializeAppInfo(args.Package.InstalledLocation.Path);
-                    foreach (var app in uwp.Apps)
+                    if(!string.IsNullOrEmpty(packageWrapper.InstalledLocation))
                     {
-                        Add(app);
+                        var uwp = new UWP(packageWrapper);
+                        uwp.InitializeAppInfo(args.Package.InstalledLocation.Path);
+                        foreach (var app in uwp.Apps)
+                        {
+                            Add(app);
+                        }
                     }
                 }
                 //InitializeAppInfo will throw if there is no AppxManifest.xml for the package. 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
- While trying to retrieve the installed location of a packaged app using `package.InstalledLocation.Path`, a FileNotFound Exception is thrown if the path does not exist. Added a catch block to capture that exception and to prevent PT from crashing.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #4970
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx
