### PR TITLE
[PowerToys Run] Implemented Setting to Clear Search Query when PowerToys Run is Launched

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/PowerLauncherProperties.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/PowerLauncherProperties.cs
@@ -26,6 +26,8 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
 
         public bool ignore_hotkeys_in_fullscreen { get; set; }
 
+        public bool clear_input_on_launch { get; set; }
+
         public PowerLauncherProperties()
         {
             open_powerlauncher = new HotkeySettings();
@@ -35,6 +37,7 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
             search_result_preference = "most_recently_used";
             search_type_preference = "application_name";
             ignore_hotkeys_in_fullscreen = false;
+            clear_input_on_launch = false;
         }
     }
 }

--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -253,6 +253,9 @@
   <data name="PowerLauncher_IgnoreHotkeysInFullScreen.Content" xml:space="preserve">
     <value>Ignore hotkeys in fullscreen mode</value>
   </data>
+  <data name="PowerLauncher_ClearInputOnLaunch.Content" xml:space="preserve">
+    <value>Clear the previous query on launch</value>
+  </data>
   <data name="KeyboardManager_KeysMappingLayoutRightHeader.Text" xml:space="preserve">
     <value>To:</value>
     <comment>Keyboard Manager mapping keys view right header</comment>

--- a/src/core/Microsoft.PowerToys.Settings.UI/ViewModels/PowerLauncherViewModel.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/ViewModels/PowerLauncherViewModel.cs
@@ -252,5 +252,22 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 }
             }
         }
+
+        public bool ClearInputOnLaunch
+        {
+	        get
+	        {
+		        return settings.properties.clear_input_on_launch;
+	        }
+
+	        set
+	        {
+		        if (settings.properties.clear_input_on_launch != value)
+		        {
+			        settings.properties.clear_input_on_launch = value;
+			        UpdateSettings();
+		        }
+	        }
+        }
     }
 }

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
@@ -134,6 +134,12 @@
                       IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.IgnoreHotkeysInFullScreen}"
                       IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.EnablePowerLauncher}"
                       />
+
+            <CheckBox x:Uid="PowerLauncher_ClearInputOnLaunch"
+                      Margin="{StaticResource SmallTopMargin}"
+                      IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.ClearInputOnLaunch}"
+                      IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.EnablePowerLauncher}"
+            />
         </StackPanel>
         <StackPanel
             x:Name="SidePanel"

--- a/src/core/Microsoft.PowerToys.Settings.UnitTest/ViewModelTests/PowerLauncherViewModelTest.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UnitTest/ViewModelTests/PowerLauncherViewModelTest.cs
@@ -131,5 +131,7 @@ namespace ViewModelTests
             Assert.IsTrue(mockSettings.properties.override_win_r_key);
             Assert.IsFalse(mockSettings.properties.override_win_s_key);
         }
+
+
     }
 }

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml
@@ -20,6 +20,7 @@
         Closing="OnClosing"
         Background="Transparent"
         LocationChanged="OnLocationChanged"
+        Activated="OnActivated"
         Deactivated="OnDeactivated"
         IsVisibleChanged="OnVisibilityChanged"
         Visibility="{Binding MainWindowVisibility, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -155,7 +155,7 @@ namespace PowerLauncher
         {
 	        if (_settings.ClearInputOnLaunch)
 	        {
-		        SearchBox.QueryTextBox.Text = string.Empty;
+		        _viewModel.ClearQueryCommand.Execute(null);
 	        }
 
             if (_settings.HideWhenDeactivated)

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -151,14 +151,17 @@ namespace PowerLauncher
             _settings.WindowLeft = Left;
         }
 
-        private void OnDeactivated(object sender, EventArgs e)
+        private void OnActivated(object sender, EventArgs e)
         {
 	        if (_settings.ClearInputOnLaunch)
 	        {
 		        _viewModel.ClearQueryCommand.Execute(null);
 	        }
+        }
 
-            if (_settings.HideWhenDeactivated)
+        private void OnDeactivated(object sender, EventArgs e)
+        {
+	        if (_settings.HideWhenDeactivated)
             {
                 //(this.FindResource("OutroStoryboard") as Storyboard).Begin();
                 Hide();

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -153,6 +153,11 @@ namespace PowerLauncher
 
         private void OnDeactivated(object sender, EventArgs e)
         {
+	        if (_settings.ClearInputOnLaunch)
+	        {
+		        SearchBox.QueryTextBox.Text = string.Empty;
+	        }
+
             if (_settings.HideWhenDeactivated)
             {
                 //(this.FindResource("OutroStoryboard") as Storyboard).Begin();

--- a/src/modules/launcher/PowerLauncher/SettingsWatcher.cs
+++ b/src/modules/launcher/PowerLauncher/SettingsWatcher.cs
@@ -65,6 +65,11 @@ namespace PowerLauncher
                     {
                         _settings.IgnoreHotkeysOnFullscreen = overloadSettings.properties.ignore_hotkeys_in_fullscreen;
                     }
+
+                    if (_settings.ClearInputOnLaunch != overloadSettings.properties.clear_input_on_launch)
+                    {
+	                    _settings.ClearInputOnLaunch = overloadSettings.properties.clear_input_on_launch;
+                    }
                 }
                 // the settings application can hold a lock on the settings.json file which will result in a IOException.  
                 // This should be changed to properly synch with the settings app instead of retrying.

--- a/src/modules/launcher/Wox.Infrastructure/UserSettings/Settings.cs
+++ b/src/modules/launcher/Wox.Infrastructure/UserSettings/Settings.cs
@@ -129,6 +129,8 @@ namespace Wox.Infrastructure.UserSettings
         }
         public bool LeaveCmdOpen { get; set; }
         public bool HideWhenDeactivated { get; set; } = true;
+        public bool ClearInputOnLaunch { get; set; } = false;
+
         public bool RememberLastLaunchLocation { get; set; }
         public bool IgnoreHotkeysOnFullscreen { get; set; }
 

--- a/src/modules/launcher/Wox/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/Wox/ViewModel/MainViewModel.cs
@@ -234,6 +234,12 @@ namespace Wox.ViewModel
                     SelectedResults = Results;
                 }
             });
+
+            ClearQueryCommand = new RelayCommand(_ =>
+            {
+	            ChangeQueryText(string.Empty,true);
+	            OnPropertyChanged(nameof(SystemQueryText));
+            });
         }
 
         #endregion
@@ -342,6 +348,8 @@ namespace Wox.ViewModel
         public ICommand LoadContextMenuCommand { get; set; }
         public ICommand LoadHistoryCommand { get; set; }
         public ICommand OpenResultCommand { get; set; }
+        public ICommand ClearQueryCommand { get; set; }
+
 
         #endregion
 

--- a/src/modules/launcher/Wox/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/Wox/ViewModel/MainViewModel.cs
@@ -237,8 +237,12 @@ namespace Wox.ViewModel
 
             ClearQueryCommand = new RelayCommand(_ =>
             {
-	            ChangeQueryText(string.Empty,true);
-	            OnPropertyChanged(nameof(SystemQueryText));
+                if(!string.IsNullOrEmpty(QueryText))
+                {
+	                ChangeQueryText(string.Empty,true);
+	                //Push Event to UI SystemQuery has changed
+	                OnPropertyChanged(nameof(SystemQueryText));
+				}
             });
         }
 


### PR DESCRIPTION
## Summary of the Pull Request

This pull requests adds an option in the setting which clears the previous Search Query when PowerToys Run is launched again.

## References

## PR Checklist
* [x] Applies to #3237 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed (Checked for "Passed", no new automatic tests added)
* [?] Requires documentation to be updated 
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Detailed Description of the Pull Request / Additional comments

When a new setting is enabled via the settings, it will clear the searchquery which was previously entered when a new PowerToys Run session is started.

Image showing the new setting i added.
![ClearThePreviousQueryOnLaunch](https://user-images.githubusercontent.com/16852398/87457782-3e45f980-c609-11ea-9462-bbbfedf68ad6.png)

GIF showing the new behavior (when enabled and running in Release mode)
![HideOnLaunch3](https://user-images.githubusercontent.com/16852398/87470546-34c68c80-c61d-11ea-9c2d-aa39b79f2068.gif)

## Validation Steps Performed

- i enabled the new settings on the PowerToys Run tab in the settings tray
- i pressed ALT-TAB to activate it, searched for "Feedback Hub"
- i pressed ALT-TAB again to dismiss PowerToys Run
- i pressed ALT-TAB again 
- i expect there to be no search query input / search results.

Same steps are executed when the setting has been disabled and the search query has not been affected.