### PR TITLE
autoupdate: wait for the .exe updater to exit before restarting PowerToys

### DIFF
--- a/src/action_runner/action_runner.cpp
+++ b/src/action_runner/action_runner.cpp
@@ -111,11 +111,17 @@ bool install_new_version_stage_2(std::wstring installer_path, std::wstring_view 
     {
         // If it's not .msi, then it's our .exe installer
         SHELLEXECUTEINFOW sei{ sizeof(sei) };
-        sei.fMask = { SEE_MASK_FLAG_NO_UI | SEE_MASK_NOASYNC };
+        sei.fMask = { SEE_MASK_FLAG_NO_UI | SEE_MASK_NOASYNC | SEE_MASK_NOCLOSEPROCESS | SEE_MASK_NO_CONSOLE};
         sei.lpFile = installer_path.c_str();
         sei.nShow = SW_SHOWNORMAL;
 
         success = ShellExecuteExW(&sei) == TRUE;
+        // Wait for the install completion
+        if (success)
+        {
+            WaitForSingleObject(sei.hProcess, INFINITE);
+            CloseHandle(sei.hProcess);
+        }
     }
 
     std::error_code _;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
See original issue for why we need this fix.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #5003

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
tested multiple executables with that `ShellExecuteExW` invocation:
- which returns 0 
- which sleeps for 30s before exiting
- which crashes instantly