### PR TITLE
[FancyZones] Handle desktop switch and open on active monitor functionality

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -315,7 +315,7 @@
     <value>Move newly created windows to their last known zone</value>
   </data>
   <data name="FancyZones_OpenWindowOnActiveMonitor.Content" xml:space="preserve">
-    <value>Move newly created windows to the current active monitor</value>
+    <value>Move newly created windows to the current active monitor [EXPERIMENTAL]</value>
   </data>
   <data name="FancyZones_UseCursorPosEditorStartupScreen.Content" xml:space="preserve">
     <value>Follow mouse cursor instead of focus when launching editor in a multi screen environment</value>

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -499,6 +499,13 @@ IFACEMETHODIMP_(void)
 FancyZones::WindowCreated(HWND window) noexcept
 {
     std::shared_lock readLock(m_lock);
+    GUID desktopId{};
+    if (VirtualDesktopUtils::GetWindowDesktopId(window, &desktopId) && desktopId != m_currentDesktopId)
+    {
+        // Switch between virtual desktops results with posting same windows messages that also indicate
+        // creation of new window. We need to check if window being processed is on currently active desktop.
+        return;
+    }
     const bool moveToAppLastZone   = m_settings->GetSettings()->appLastZone_moveWindows;
     const bool openOnActiveMonitor = m_settings->GetSettings()->openWindowOnActiveMonitor;
     if ((moveToAppLastZone || openOnActiveMonitor) && ShouldProcessNewWindow(window))

--- a/src/modules/fancyzones/lib/fancyzones.rc
+++ b/src/modules/fancyzones/lib/fancyzones.rc
@@ -19,7 +19,7 @@ BEGIN
     IDS_SETTING_DESCRIPTION_ZONEHIGHLIGHTCOLOR                 "Zone highlight color (Default #008CFF)"
     IDS_SETTING_DESCRIPTION_USE_CURSORPOS_EDITOR_STARTUPSCREEN "Follow mouse cursor instead of focus when launching editor in a multi screen environment"
     IDS_SETTING_DESCRIPTION_APPLASTZONE_MOVEWINDOWS            "Move newly created windows to their last known zone"
-    IDS_SETTING_DESCRIPTION_OPEN_WINDOW_ON_ACTIVE_MONITOR      "Move newly created windows to the current active monitor"
+    IDS_SETTING_DESCRIPTION_OPEN_WINDOW_ON_ACTIVE_MONITOR      "Move newly created windows to the current active monitor [EXPERIMENTAL]"
     IDS_SETTING_DESCRIPTION_RESTORESIZE                        "Restore the original size of windows when unsnapping"
     IDS_SETTING_LAUNCH_EDITOR_LABEL                            "Zone configuration"
     IDS_SETTING_LAUNCH_EDITOR_BUTTON                           "Edit zones"


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Switching between virtual desktops causes same windows messages to be posted as window creation. That is why, in `WindowCreated` callback we need to check if window being processed is on current active desktop.

Add **[EXPERIMENTAL]** label with this option so users know it is a new one and still under development and polishing.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Applies to #5064
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
1. Turn on option Move newly created windows to current active monitor.
2. Have several windows opened on first virtual desktop.
3. Create new virtual desktop.
4. Switch back to primary desktop.

Expected result: All windows maintain their position while switching back and forth through virtual desktops.
