### PR TITLE
[FancyZones] Dragging a window across monitors transparency fix

### DIFF
--- a/src/modules/fancyzones/lib/WindowMoveHandler.cpp
+++ b/src/modules/fancyzones/lib/WindowMoveHandler.cpp
@@ -79,7 +79,7 @@ public:
     bool MoveWindowIntoZoneByDirection(HWND window, DWORD vkCode, bool cycle, winrt::com_ptr<IZoneWindow> zoneWindow);
 
 private:
-    void ElevatedDragCheck(HWND window) noexcept;
+    void WarnIfElevationIsRequired(HWND window) noexcept;
     void UpdateDragState() noexcept;
 
     void SetWindowTransparency(HWND window) noexcept;
@@ -207,8 +207,11 @@ void WindowMoveHandlerPrivate::MoveSizeStart(HWND window, HMONITOR monitor, POIN
     m_shiftHook->enable();
     m_ctrlHook->enable();
 
-    UpdateDragState(); // This updates m_dragEnabled depending on if the shift key is being held down    
-    ElevatedDragCheck(window); // Notifies user if unable to drag elevated window
+    // This updates m_dragEnabled depending on if the shift key is being held down
+    UpdateDragState();
+
+    // Notifies user if unable to drag elevated window
+    WarnIfElevationIsRequired(window);
 
     if (m_dragEnabled)
     {
@@ -385,7 +388,7 @@ bool WindowMoveHandlerPrivate::MoveWindowIntoZoneByDirection(HWND window, DWORD 
     return zoneWindow && zoneWindow->MoveWindowIntoZoneByDirection(window, vkCode, cycle);
 }
 
-void WindowMoveHandlerPrivate::ElevatedDragCheck(HWND window) noexcept
+void WindowMoveHandlerPrivate::WarnIfElevationIsRequired(HWND window) noexcept
 {
     static bool warning_shown = false;
     if (!is_process_elevated() && IsProcessOfWindowElevated(window))

--- a/src/modules/fancyzones/lib/WindowMoveHandler.cpp
+++ b/src/modules/fancyzones/lib/WindowMoveHandler.cpp
@@ -263,12 +263,12 @@ void WindowMoveHandlerPrivate::MoveSizeUpdate(HMONITOR monitor, POINT const& ptS
         {
             // Drag got disabled, tell it to cancel and hide all windows
             m_zoneWindowMoveSize = nullptr;
+            ResetWindowTransparency();
 
             for (auto [keyMonitor, zoneWindow] : zoneWindowMap)
             {
                 if (zoneWindow)
                 {
-                    ResetWindowTransparency();
                     zoneWindow->HideZoneWindow();
                 }
             }

--- a/src/modules/fancyzones/lib/WindowMoveHandler.cpp
+++ b/src/modules/fancyzones/lib/WindowMoveHandler.cpp
@@ -284,7 +284,6 @@ void WindowMoveHandlerPrivate::MoveSizeUpdate(HMONITOR monitor, POINT const& ptS
                     m_zoneWindowMoveSize->ClearSelectedZones();
                     if (!m_settings->GetSettings()->showZonesOnAllMonitors)
                     {
-                        ResetWindowTransparency(); 
                         m_zoneWindowMoveSize->HideZoneWindow();
                     }
 

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -309,11 +309,6 @@ bool ZoneWindow::Init(IZoneWindowHost* host, HINSTANCE hinstance, HMONITOR monit
 
 IFACEMETHODIMP ZoneWindow::MoveSizeEnter(HWND window) noexcept
 {
-    if (m_windowMoveSize)
-    {
-        return E_INVALIDARG;
-    }
-
     if (m_host->isMakeDraggedWindowTransparentActive())
     {
         draggedWindowExstyle = GetWindowLong(window, GWL_EXSTYLE);

--- a/src/modules/fancyzones/lib/ZoneWindow.h
+++ b/src/modules/fancyzones/lib/ZoneWindow.h
@@ -17,10 +17,9 @@ interface __declspec(uuid("{7F017528-8110-4FB3-BE41-F472969C2560}")) IZoneWindow
      * hints if dragging functionality is enabled.
      *
      * @param   window      Handle of window being moved or resized.
-     * @param   dragEnabled Boolean indicating is giving hints about active zone layout enabled.
-     *                      Hints are given while dragging window while holding SHIFT key.
      */
     IFACEMETHOD(MoveSizeEnter)(HWND window) = 0;
+
     /**
      * A window has changed location, shape, or size. Track down window position and give zone layout
      * hints if dragging functionality is enabled.
@@ -74,10 +73,7 @@ interface __declspec(uuid("{7F017528-8110-4FB3-BE41-F472969C2560}")) IZoneWindow
      * @param   vkCode Pressed key representing layout index.
      */
     IFACEMETHOD_(void, CycleActiveZoneSet)(DWORD vkCode) = 0;
-    /**
-     * Restore original transaprency of dragged window.
-     */
-    IFACEMETHOD_(void, RestoreOriginalTransparency) () = 0;
+
     /**
      * Save information about zone in which window was assigned, when closing the window.
      * Used once we open same window again to assign it to its previous zone.

--- a/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
@@ -457,7 +457,7 @@ namespace FancyZonesUnitTests
         {
             m_zoneWindow = MakeZoneWindow(m_hostPtr, m_hInst, m_monitor, m_uniqueId.str(), {}, false);
 
-            const auto expected = E_INVALIDARG;
+            const auto expected = S_OK;
 
             m_zoneWindow->MoveSizeEnter(Mocks::Window());
             const auto actual = m_zoneWindow->MoveSizeEnter(Mocks::Window());


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Removed unnecessary check that broke functionality during moving the window across monitors.
Moved part with checking if elevated window could be snapped to a zone outside the `UpdateDragState`. It's enough to call it once when dragging was started.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #4828 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
`ZoneWindow::MoveSizeEnter` has been called only from `WindowMoveHandler::MoveSizeStart` and required `m_windowMoveSize` not to be assigned. After some changes `ZoneWindow::MoveSizeEnter` call was added to `WindowMoveHandler::MoveSizeUpdate` that made this requirement invalid. 

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

- Have all FZ options on
- Create a zone layout on two adjacent monitors
- Drag a window from one monitor to another, then back to the first monitor

The dragged window should stay transparent until dropped.