### PR TITLE
[KBM] Updated menu key name, and added missing IME key codes

### DIFF
--- a/src/common/keyboard_layout.cpp
+++ b/src/common/keyboard_layout.cpp
@@ -130,7 +130,7 @@ void LayoutMap::LayoutMapImpl::UpdateLayout()
     keyboardLayoutMap[VK_HELP] = L"Help";
     keyboardLayoutMap[VK_LWIN] = L"Win (Left)";
     keyboardLayoutMap[VK_RWIN] = L"Win (Right)";
-    keyboardLayoutMap[VK_APPS] = L"Menu";
+    keyboardLayoutMap[VK_APPS] = L"Apps/Menu";
     keyboardLayoutMap[VK_SLEEP] = L"Sleep";
     keyboardLayoutMap[VK_NUMPAD0] = L"NumPad 0";
     keyboardLayoutMap[VK_NUMPAD1] = L"NumPad 1";
@@ -204,7 +204,17 @@ void LayoutMap::LayoutMapImpl::UpdateLayout()
     keyboardLayoutMap[VK_OEM_CLEAR] = L"Clear";
     keyboardLayoutMap[0xFF] = L"Undefined";
     keyboardLayoutMap[CommonSharedConstants::VK_WIN_BOTH] = L"Win";
-    // To do: Add IME key names
+    keyboardLayoutMap[VK_KANA] = L"IME Kana";
+    keyboardLayoutMap[VK_HANGEUL] = L"IME Hangeul";
+    keyboardLayoutMap[VK_HANGUL] = L"IME Hangul";
+    keyboardLayoutMap[VK_JUNJA] = L"IME Junja";
+    keyboardLayoutMap[VK_FINAL] = L"IME Final";
+    keyboardLayoutMap[VK_HANJA] = L"IME Hanja";
+    keyboardLayoutMap[VK_KANJI] = L"IME Kanji";
+    keyboardLayoutMap[VK_CONVERT] = L"IME Convert";
+    keyboardLayoutMap[VK_NONCONVERT] = L"IME Non-Convert";
+    keyboardLayoutMap[VK_ACCEPT] = L"IME Kana";
+    keyboardLayoutMap[VK_MODECHANGE] = L"IME Mode Change";
 }
 
 // Function to return the list of key codes in the order for the drop down. It creates it if it doesn't exist


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
- Updated the name for `VK 93` to `Apps/Menu` instead of `Menu`, since it is documents as `Applications key` in [documentation page](https://docs.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes), however it is also known as the Menu key.
- Added key names for all the IME keys which are documented in the msdn page. VK_IME_ON and VK_IME_OFF were not added since they do not exist in Windows SDK even though they are documented in the msdn page.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Applies to #3153, #3392
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Checked if the correct key names appear in the KBM drop downs.
![image](https://user-images.githubusercontent.com/32061677/87979802-77f28680-ca87-11ea-95e4-0f53233633fc.png)
