### PR TITLE
[PowerRename] Clear capturing groups with more than 1 digit

### DIFF
--- a/src/modules/powerrename/lib/PowerRenameRegEx.cpp
+++ b/src/modules/powerrename/lib/PowerRenameRegEx.cpp
@@ -202,7 +202,7 @@ HRESULT CPowerRenameRegEx::Replace(_In_ PCWSTR source, _Outptr_ PWSTR* result)
             std::wstring replaceTerm(m_replaceTerm ? wstring(m_replaceTerm) : wstring(L""));
 
             replaceTerm = regex_replace(replaceTerm, std::wregex(L"\\$[0]+"), L"$");
-            replaceTerm = regex_replace(replaceTerm, std::wregex(L"\\$[0]*[1-9]{2,}"), L"");
+            replaceTerm = regex_replace(replaceTerm, std::wregex(L"\\$[0]*[1-9][0-9]+"), L"");
 
             if (m_flags & UseRegularExpressions)
             {

--- a/src/modules/powerrename/lib/PowerRenameRegEx.cpp
+++ b/src/modules/powerrename/lib/PowerRenameRegEx.cpp
@@ -201,6 +201,9 @@ HRESULT CPowerRenameRegEx::Replace(_In_ PCWSTR source, _Outptr_ PWSTR* result)
             std::wstring searchTerm(m_searchTerm);
             std::wstring replaceTerm(m_replaceTerm ? wstring(m_replaceTerm) : wstring(L""));
 
+            replaceTerm = regex_replace(replaceTerm, std::wregex(L"\\$[0]+"), L"$");
+            replaceTerm = regex_replace(replaceTerm, std::wregex(L"\\$[0]*[1-9]{2,}"), L"");
+
             if (m_flags & UseRegularExpressions)
             {
                 std::wregex pattern(m_searchTerm, (!(m_flags & CaseSensitive)) ? regex_constants::icase | regex_constants::ECMAScript : regex_constants::ECMAScript);

--- a/src/modules/powerrename/lib/PowerRenameRegEx.cpp
+++ b/src/modules/powerrename/lib/PowerRenameRegEx.cpp
@@ -201,8 +201,8 @@ HRESULT CPowerRenameRegEx::Replace(_In_ PCWSTR source, _Outptr_ PWSTR* result)
             std::wstring searchTerm(m_searchTerm);
             std::wstring replaceTerm(m_replaceTerm ? wstring(m_replaceTerm) : wstring(L""));
 
-            replaceTerm = regex_replace(replaceTerm, std::wregex(L"([^\\$])\\$[0]"), L"$1$$$0");
-            replaceTerm = regex_replace(replaceTerm, std::wregex(L"([^\\$])\\$([1-9])"), L"$1$0$2");
+            replaceTerm = regex_replace(replaceTerm, std::wregex(L"(([^\\$]|^)(\\$\\$)*)\\$[0]"), L"$1$$$0");
+            replaceTerm = regex_replace(replaceTerm, std::wregex(L"(([^\\$]|^)(\\$\\$)*)\\$([1-9])"), L"$1$0$4");
 
             if (m_flags & UseRegularExpressions)
             {

--- a/src/modules/powerrename/lib/PowerRenameRegEx.cpp
+++ b/src/modules/powerrename/lib/PowerRenameRegEx.cpp
@@ -201,8 +201,8 @@ HRESULT CPowerRenameRegEx::Replace(_In_ PCWSTR source, _Outptr_ PWSTR* result)
             std::wstring searchTerm(m_searchTerm);
             std::wstring replaceTerm(m_replaceTerm ? wstring(m_replaceTerm) : wstring(L""));
 
-            replaceTerm = regex_replace(replaceTerm, std::wregex(L"\\$[0]+"), L"$");
-            replaceTerm = regex_replace(replaceTerm, std::wregex(L"\\$[0]*[1-9][0-9]+"), L"");
+            replaceTerm = regex_replace(replaceTerm, std::wregex(L"([^\\$])\\$[0]"), L"$1$$$0");
+            replaceTerm = regex_replace(replaceTerm, std::wregex(L"([^\\$])\\$([1-9])"), L"$1$0$2");
 
             if (m_flags & UseRegularExpressions)
             {

--- a/src/modules/powerrename/unittests/PowerRenameRegExTests.cpp
+++ b/src/modules/powerrename/unittests/PowerRenameRegExTests.cpp
@@ -342,6 +342,13 @@ TEST_METHOD(VerifyHandleCapturingGroups)
         //search, replace, test, result
         { L"(foo)(bar)", L"$1_$002_$223_$001021_$00001", L"foobar", L"foo_$002_bar23_$001021_$00001" },
         { L"(foo)(bar)", L"_$1$2_$123$040", L"foobar", L"_foobar_foo23$040" },
+        { L"(foo)(bar)", L"$$$1", L"foobar", L"$foo" },
+        { L"(foo)(bar)", L"$$1", L"foobar", L"$1" },
+        { L"(foo)(bar)", L"$12", L"foobar", L"foo2" },
+        { L"(foo)(bar)", L"$10", L"foobar", L"foo0" },
+        { L"(foo)(bar)", L"$01", L"foobar", L"$01" },
+        { L"(foo)(bar)", L"$$$11", L"foobar", L"$foo1" },
+        { L"(foo)(bar)", L"$$$$113a", L"foobar", L"$$113a" },
     };
 
     for (int i = 0; i < ARRAYSIZE(sreTable); i++)

--- a/src/modules/powerrename/unittests/PowerRenameRegExTests.cpp
+++ b/src/modules/powerrename/unittests/PowerRenameRegExTests.cpp
@@ -340,8 +340,8 @@ TEST_METHOD(VerifyHandleCapturingGroups)
 
     SearchReplaceExpected sreTable[] = {
         //search, replace, test, result
-        { L"(foo)(bar)", L"$1_$002_$223_$001021_$00001", L"foobar", L"foo_bar___foo" },
-        { L"(foo)(bar)", L"_$1$2_$123$040", L"foobar", L"_foobar_" },
+        { L"(foo)(bar)", L"$1_$002_$223_$001021_$00001", L"foobar", L"foo_$002_bar23_$001021_$00001" },
+        { L"(foo)(bar)", L"_$1$2_$123$040", L"foobar", L"_foobar_foo23$040" },
     };
 
     for (int i = 0; i < ARRAYSIZE(sreTable); i++)

--- a/src/modules/powerrename/unittests/PowerRenameRegExTests.cpp
+++ b/src/modules/powerrename/unittests/PowerRenameRegExTests.cpp
@@ -331,6 +331,30 @@ TEST_METHOD(VerifyReplaceFirstWildNoFlags)
     VerifyReplaceFirstWildcard(sreTable, ARRAYSIZE(sreTable), 0);
 }
 
+TEST_METHOD(VerifyHandleCapturingGroups)
+{
+    CComPtr<IPowerRenameRegEx> renameRegEx;
+    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
+    DWORD flags = MatchAllOccurences | UseRegularExpressions | CaseSensitive;
+    Assert::IsTrue(renameRegEx->put_flags(flags) == S_OK);
+
+    SearchReplaceExpected sreTable[] = {
+        //search, replace, test, result
+        { L"(foo)(bar)", L"$1_$002_$223_$001021_$00001", L"foobar", L"foo_bar___foo" },
+        { L"(foo)(bar)", L"_$1$2_$123$040", L"foobar", L"_foobar_" },
+    };
+
+    for (int i = 0; i < ARRAYSIZE(sreTable); i++)
+    {
+        PWSTR result = nullptr;
+        Assert::IsTrue(renameRegEx->put_searchTerm(sreTable[i].search) == S_OK);
+        Assert::IsTrue(renameRegEx->put_replaceTerm(sreTable[i].replace) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
+        CoTaskMemFree(result);
+    }
+}
+
 TEST_METHOD(VerifyEventsFire)
 {
     CComPtr<IPowerRenameRegEx> renameRegEx;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

As discussed in #4125, number of capturing groups available in PowerRename will be limited to 1 digit numbers. Other capturing groups will be cleared.

~~Assume pattern:`(foo)_(bar)` matches. Then,~~
* ~~`$1` will become `foo`~~
* ~~`$0001` will become `foo`~~
* ~~`$002` will become `bar`~~
* ~~`$3`, `$4`, `$5`, `$12`, `$004` etc. will become empty string.~~
- Only `$1` to `$9` will be treated specially. Other patterns are treated as just regular text.
- `$01` or `$001` will be treated as regular text.
- `$12` will be treated as `($1)2`. (Replace with capturing group if existent then insert rest.)

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #4125 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [x] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
