### PR TITLE
[PowerLauncher] Improved font rendering

### DIFF
--- a/src/modules/launcher/PowerLauncher/LauncherControl.xaml
+++ b/src/modules/launcher/PowerLauncher/LauncherControl.xaml
@@ -10,7 +10,7 @@
     d:DesignWidth="720">
     <UserControl.Resources>
         <Style x:Key="QueryTextBoxStyle" TargetType="{x:Type TextBox}">
-            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="Background" Value="{DynamicResource SystemChromeLow}" />
             <Setter Property="BorderThickness" Value="0" />
             <Setter Property="Foreground" Value="{DynamicResource ControlTextBrushKey}"/>
             <Setter Property="CaretBrush" Value="{DynamicResource ControlTextBrushKey}"/>
@@ -25,7 +25,18 @@
                 <Setter.Value>
                     <ControlTemplate TargetType="{x:Type TextBox}">
                         <Grid>
-                            <TextBlock Margin="15, 1, 0, 0" Text="{TemplateBinding Tag}">
+                            <Border x:Name="border" Background="{TemplateBinding Background}" BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}" SnapsToDevicePixels="True">
+                                <ScrollViewer x:Name="PART_ContentHost" Background="{TemplateBinding Background}" Focusable="false" HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Hidden">
+                                    <ScrollViewer.ContentTemplate>
+                                        <DataTemplate>
+                                            <Grid Background="{Binding Background, ElementName=PART_ContentHost}" RenderOptions.ClearTypeHint="Enabled" TextOptions.TextFormattingMode="Display">
+                                                <ContentPresenter Content="{Binding Path=Content, ElementName=PART_ContentHost}"/>
+                                            </Grid>
+                                        </DataTemplate>
+                                    </ScrollViewer.ContentTemplate>
+                                </ScrollViewer>
+                            </Border>
+                            <TextBlock Margin="14, 0, 0, 0" Text="{TemplateBinding Tag}">
                                 <TextBlock.Style>
                                     <Style TargetType="{x:Type TextBlock}">
                                         <Setter Property="Foreground" Value="Transparent"/>
@@ -37,9 +48,6 @@
                                     </Style>
                                 </TextBlock.Style>
                             </TextBlock>
-                            <Border x:Name="border" Background="{TemplateBinding Background}" BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}" SnapsToDevicePixels="True">
-                                <ScrollViewer x:Name="PART_ContentHost" Focusable="false" HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Hidden"/>
-                            </Border>
                         </Grid>
                         <ControlTemplate.Triggers>
                             <Trigger Property="IsEnabled" Value="false">

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml
@@ -10,6 +10,9 @@
         Topmost="True"
         SizeToContent="Height"
         ResizeMode="NoResize"
+        TextOptions.TextRenderingMode="ClearType"
+        TextOptions.TextFormattingMode="Display"
+        RenderOptions.ClearTypeHint="Enabled"
         WindowStyle="None"
         WindowStartupLocation="Manual"
         AllowDrop="True"
@@ -52,49 +55,45 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
-        <Border 
+        <Grid 
             x:Name="SearchBoxBorder" 
             Grid.Row="0" 
-            Margin="24,24,24,24"  
-            BorderThickness="1" 
-            CornerRadius="4"
-            Background="{DynamicResource SystemChromeLow}"
-            BorderBrush="{DynamicResource BorderBrush}">
-            <Border.Effect>
-                <DropShadowEffect BlurRadius="32" Opacity="0.28" ShadowDepth="1" />
-            </Border.Effect>
+            Margin="24,24,24,24">
+            <Rectangle Fill="{DynamicResource SystemChromeLow}" RadiusX="4" RadiusY="4" Stroke="{DynamicResource BorderBrush}" StrokeThickness="1">
+                <Rectangle.Effect>
+                    <DropShadowEffect BlurRadius="32" Opacity="0.28" ShadowDepth="1" />
+                </Rectangle.Effect>
+            </Rectangle>
             <local:LauncherControl 
                 x:Name="SearchBox">
                 <!--<local:LauncherControl.RenderTransform>
                     <TranslateTransform />
                 </local:LauncherControl.RenderTransform>-->
             </local:LauncherControl>
-                <!--<Border.RenderTransform>
+            <!--<Border.RenderTransform>
                     <TranslateTransform />
                 </Border.RenderTransform>-->
-        </Border>
-        <Border 
+        </Grid>
+        <Grid
             x:Name="ListBoxBorder"
-            Grid.Row="1" 
+            Grid.Row="1"
             Margin="24,-8,24,24" 
-            BorderThickness="1"
-            CornerRadius="4" 
-            Visibility="{Binding Results.Visibility}"
-            Background="{DynamicResource SystemChromeLow}"
-            BorderBrush="{DynamicResource BorderBrush}">
+            Visibility="{Binding Results.Visibility}">
             <!--<Border.RenderTransform>
                 <TranslateTransform />
             </Border.RenderTransform>-->
-            <Border.Effect>
-                <DropShadowEffect BlurRadius="32" Opacity="0.28" ShadowDepth="1" />
-            </Border.Effect>
+            <Rectangle Fill="{DynamicResource SystemChromeLow}" RadiusX="4" RadiusY="4" Stroke="{DynamicResource BorderBrush}" StrokeThickness="1">
+                <Rectangle.Effect>
+                    <DropShadowEffect BlurRadius="32" Opacity="0.28" ShadowDepth="1" />
+                </Rectangle.Effect>
+            </Rectangle>
             <local:ResultList x:Name="ListBox" 
                 PreviewMouseDown="ListBox_PreviewMouseDown" >
                 <!--<local:ResultList.RenderTransform>
                     <TranslateTransform />
                 </local:ResultList.RenderTransform>-->
             </local:ResultList>
-        </Border>
+        </Grid>
     </Grid> 
     <Window.InputBindings>
         <KeyBinding Key="Escape" Command="{Binding EscCommand}" />

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml
@@ -11,7 +11,6 @@
         SizeToContent="Height"
         ResizeMode="NoResize"
         TextOptions.TextRenderingMode="ClearType"
-        TextOptions.TextFormattingMode="Display"
         RenderOptions.ClearTypeHint="Enabled"
         WindowStyle="None"
         WindowStartupLocation="Manual"

--- a/src/modules/launcher/PowerLauncher/ResultList.xaml
+++ b/src/modules/launcher/PowerLauncher/ResultList.xaml
@@ -239,11 +239,11 @@
                                     <Button Style="{StaticResource IconButtonStyle}" Command="{Binding Command}" VerticalAlignment="Center" Height="42" Width="42" BorderThickness="1" >
                                         <ToolTipService.ToolTip>
                                             <ToolTip >
-                                                <TextBlock Text="{Binding Title}" Foreground="{DynamicResource ToolTipForegroundBrushKey}" Margin="8,5" FontSize="12"/>
+                                                <TextBlock Text="{Binding Title}" Foreground="{DynamicResource ToolTipForegroundBrushKey}" Margin="8,5" FontSize="12" RenderOptions.ClearTypeHint="Enabled"/>
                                             </ToolTip>
                                         </ToolTipService.ToolTip>
                                         <Button.Content>
-                                            <TextBlock FontFamily="{Binding FontFamily}" FontSize="16" Text="{Binding Glyph}"/>
+                                            <TextBlock FontFamily="{Binding FontFamily}" FontSize="16" Text="{Binding Glyph}" TextOptions.TextFormattingMode="Display"/>
                                         </Button.Content>
                                     </Button>
                                 </DataTemplate>

--- a/src/modules/launcher/PowerLauncher/ResultList.xaml
+++ b/src/modules/launcher/PowerLauncher/ResultList.xaml
@@ -33,7 +33,6 @@
                 <Setter Property="Focusable" Value="False"/>
                 <Setter Property="HorizontalContentAlignment" Value="Center"/>
                 <Setter Property="VerticalContentAlignment" Value="Center"/>
-                <Setter Property="Padding" Value="1"/>
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="{x:Type Button}">
@@ -71,7 +70,7 @@
                     <Setter.Value>
                         <ControlTemplate TargetType="{x:Type ListViewItem}">
                             <Grid Background="Transparent">
-                                <Border x:Name="HighlightBorder" BorderThickness="0" Background="Transparent" BorderBrush="Transparent" SnapsToDevicePixels="true"/>
+                                <Border x:Name="HighlightBorder" BorderThickness="0" Background="{DynamicResource SystemChromeLow}" BorderBrush="Transparent" SnapsToDevicePixels="true"/>
                                 <ContentPresenter x:Name="contentPresenter" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" Margin="{TemplateBinding Padding}" RecognizesAccessKey="True" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
                             </Grid>
                             <ControlTemplate.Triggers>
@@ -94,7 +93,7 @@
 
             <Style x:Key="CommandButtonListViewItemContainerStyle"  TargetType="ListViewItem">
                 <Setter Property="Background" Value="Transparent" />
-                <Setter Property="Padding" Value="0" />
+                <Setter Property="Margin" Value="1" />
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="{x:Type ListViewItem}">
@@ -208,8 +207,8 @@
                             </ToolTip>
                         </Grid.ToolTip>
                         <Image x:Name="AppIcon" Height="36" MaxWidth="56" Grid.RowSpan="2" Margin="-6,-2,0,0" HorizontalAlignment="Center" Source="{Binding Image}" />
-                        <TextBlock x:Name="Title" Grid.Column="1" Text="{Binding Result.Title}" FontWeight="SemiBold" FontSize="20" Margin="0,0,0,-2" VerticalAlignment="Bottom"/>
-                        <TextBlock x:Name="Path" Grid.Column="1" Text= "{Binding Result.SubTitle}" Grid.Row="1" Foreground="{DynamicResource SecondaryTextForeground}" Margin="0,2,0,0" VerticalAlignment="Top"/>
+                        <TextBlock x:Name="Title" Grid.Column="1" Text="{Binding Result.Title}" FontWeight="SemiBold" FontSize="20" Margin="0,0,0,-2" RenderOptions.ClearTypeHint="Enabled" VerticalAlignment="Bottom"/>
+                        <TextBlock x:Name="Path" Grid.Column="1" Text= "{Binding Result.SubTitle}" Grid.Row="1" Foreground="{DynamicResource SecondaryTextForeground}" Margin="0,2,0,0" RenderOptions.ClearTypeHint="Enabled" VerticalAlignment="Top"/>
                         <ListView                                  
                             HorizontalAlignment="Right" 
                             VerticalAlignment="Center"                                  

--- a/src/modules/launcher/PowerLauncher/ResultList.xaml
+++ b/src/modules/launcher/PowerLauncher/ResultList.xaml
@@ -81,7 +81,7 @@
                                     <Setter Property="Background" TargetName="HighlightBorder" Value="{DynamicResource ListViewItemBackgroundPointerOver}"/>
                                 </Trigger>
                                 <Trigger Property="IsSelected" Value="True">
-                                    <Setter Property="Opacity" TargetName="HighlightBorder" Value="1" />
+                                    <Setter Property="Opacity" TargetName="HighlightBorder" Value="0.4" />
                                     <Setter Property="Background" TargetName="HighlightBorder" Value="{Binding Source={x:Static SystemParameters.WindowGlassBrush}}"/>
                                     <!-- Accent color brush -->
                                 </Trigger>

--- a/src/modules/launcher/PowerLauncher/ResultList.xaml
+++ b/src/modules/launcher/PowerLauncher/ResultList.xaml
@@ -33,6 +33,7 @@
                 <Setter Property="Focusable" Value="False"/>
                 <Setter Property="HorizontalContentAlignment" Value="Center"/>
                 <Setter Property="VerticalContentAlignment" Value="Center"/>
+                <Setter Property="Padding" Value="1"/>
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="{x:Type Button}">
@@ -80,7 +81,7 @@
                                     <Setter Property="Background" TargetName="HighlightBorder" Value="{DynamicResource ListViewItemBackgroundPointerOver}"/>
                                 </Trigger>
                                 <Trigger Property="IsSelected" Value="True">
-                                    <Setter Property="Opacity" TargetName="HighlightBorder" Value="0.4" />
+                                    <Setter Property="Opacity" TargetName="HighlightBorder" Value="1" />
                                     <Setter Property="Background" TargetName="HighlightBorder" Value="{Binding Source={x:Static SystemParameters.WindowGlassBrush}}"/>
                                     <!-- Accent color brush -->
                                 </Trigger>
@@ -93,7 +94,8 @@
 
             <Style x:Key="CommandButtonListViewItemContainerStyle"  TargetType="ListViewItem">
                 <Setter Property="Background" Value="Transparent" />
-                <Setter Property="Margin" Value="1" />
+                <Setter Property="Padding" Value="0"/>
+                <Setter Property="Margin" Value="1"/>
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="{x:Type ListViewItem}">
@@ -133,11 +135,10 @@
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="{x:Type ToolTip}" >
-                            <StackPanel Margin="8,2" >
-                                <Border CornerRadius="4" Background="{DynamicResource ToolTipBackgroundBrushKey}" BorderBrush="{DynamicResource ToolTipBorderBrushKey}" BorderThickness="1">
-                                    <ContentPresenter Margin="4" HorizontalAlignment="Center" VerticalAlignment="Top" />
-                                </Border>
-                            </StackPanel>
+                            <Grid Margin="8,2" >
+                                <Rectangle Fill="{DynamicResource ToolTipBackgroundBrushKey}" RadiusX="4" RadiusY="4" Stroke="{DynamicResource ToolTipBorderBrushKey}" StrokeThickness="1"/>
+                                <ContentPresenter Margin="4" HorizontalAlignment="Center" VerticalAlignment="Top" />
+                            </Grid>
                         </ControlTemplate>
                     </Setter.Value>
                 </Setter>
@@ -195,13 +196,15 @@
                                 <StackPanel Margin="8,6">
                                     <TextBlock 
                                         Style="{DynamicResource CollapsableTextblock}"
-                                        Foreground="{DynamicResource ToolTipForegroundBrushKey}" FontWeight="Bold" FontSize="12"
+                                        Foreground="{DynamicResource ToolTipForegroundBrushKey}" FontWeight="Bold" FontSize="13"
                                         Text="{Binding Result.ToolTipData.Title}"
+                                        RenderOptions.ClearTypeHint="Enabled"
                                         TextWrapping="Wrap" />
                                     <TextBlock 
                                         Style="{DynamicResource CollapsableTextblock}"
                                         Foreground="{DynamicResource ToolTipForegroundBrushKey}" FontSize="12"
-                                        Text="{Binding Result.ToolTipData.Text}"                               
+                                        Text="{Binding Result.ToolTipData.Text}"
+                                        RenderOptions.ClearTypeHint="Enabled"
                                         TextWrapping="Wrap" />
                                 </StackPanel>
                             </ToolTip>
@@ -214,7 +217,7 @@
                             VerticalAlignment="Center"                                  
                             Background="Transparent"
                             BorderThickness="0"
-                            Grid.RowSpan="2" 
+                            Grid.RowSpan="2"
                             Grid.Column="2"
                             ScrollViewer.VerticalScrollBarVisibility="Disabled"
                             ScrollViewer.HorizontalScrollBarVisibility="Disabled"

--- a/src/modules/launcher/PowerLauncher/Themes/Dark.xaml
+++ b/src/modules/launcher/PowerLauncher/Themes/Dark.xaml
@@ -26,7 +26,7 @@
     <SolidColorBrush x:Key="ButtonBorderPressed" Color="#61FFFFFF" />
     <SolidColorBrush x:Key="ListViewItemBackgroundPointerOver" Color="#FF363636" />
     <SolidColorBrush x:Key="ControlTextBrushKey" Color="White" />
-    <SolidColorBrush x:Key="SecondaryTextForeground" Color="#FF818181" />
+    <SolidColorBrush x:Key="SecondaryTextForeground" Color="#40ffffff" />
     <SolidColorBrush x:Key="InactiveSelectionHighlightBrushKey" Color="White" />
     <SolidColorBrush x:Key="BorderBrush" Color="Transparent" />
     

--- a/src/modules/launcher/PowerLauncher/Themes/Light.xaml
+++ b/src/modules/launcher/PowerLauncher/Themes/Light.xaml
@@ -26,7 +26,7 @@
     <SolidColorBrush x:Key="ButtonBorderPressed" Color="#61000000" />
     <SolidColorBrush x:Key="ListViewItemBackgroundPointerOver" Color="#FFd2d2d2" />
     <SolidColorBrush x:Key="ControlTextBrushKey" Color="Black" />
-    <SolidColorBrush x:Key="SecondaryTextForeground" Color="#FF5b5b5b" />
+    <SolidColorBrush x:Key="SecondaryTextForeground" Color="#BB000000" />
     <SolidColorBrush x:Key="InactiveSelectionHighlightBrushKey" Color="Black" />
     <SolidColorBrush x:Key="BorderBrush" Color="Transparent" />
     <SolidColorBrush x:Key="ScrollBarThumbBackground" Color="#FF7a7a7a" />


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This PR enables cleartype and improves appearance of fonts.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
https://docs.microsoft.com/en-us/dotnet/api/system.windows.media.renderoptions.cleartypehint
https://blog.magnusmontin.net/2016/07/07/enabling-cleartype-on-a-textbox-in-a-transparent-wpf-window/
https://stackoverflow.com/questions/190344/wpf-blurry-fonts-issue-solutions
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #4172, #4825, #5078
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #4172

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

As mentioned [here](https://stackoverflow.com/a/1631635), text must not be drawn inside  ```Border``` and instead a ```Rectangle``` should be used inside a Grid. This fix significantly improves rendering but the antialiasing is still grayscale. To enable cleartype antialiasing, the textbox must have an opaque background and some flags set. This was achieved by following [this blog post](https://blog.magnusmontin.net/2016/07/07/enabling-cleartype-on-a-textbox-in-a-transparent-wpf-window/) and replacing transparent background with ```SystemChromeLow``` in required places. Finally the color of the subtitle text needed to be translucent as the contrast wasn't good enough when the item was selected and accent color was drawn behind text.

This PR enables cleartype antialiasing for
1. Searchbox Text
2. Search icon
3. Resultlist Text
4. Tooltip Text


It does NOT enable cleartype antialiasing BUT improves rendering for:
1. Subtitles that are too long (that get truncated by command buttons)
2. The icons of listview(open file location, run as admin etc)
3. ResultList selected listitem text (since background is translucent)

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manually Verified that text is sharp

## Screenshots:

## Before:
![Screenshot (376)](https://user-images.githubusercontent.com/36439704/88098928-25fd4e00-cbb8-11ea-9df8-8e6884791959.png)
![Screenshot (377)](https://user-images.githubusercontent.com/36439704/88098936-28f83e80-cbb8-11ea-8d12-da694a49690c.png)


## After:
![Screenshot (373)](https://user-images.githubusercontent.com/36439704/88098963-301f4c80-cbb8-11ea-95c4-bff02acda6f8.png)
![Screenshot (374)](https://user-images.githubusercontent.com/36439704/88098974-3281a680-cbb8-11ea-9d6b-f4c97fc658b9.png)
