### PR TITLE
Fix registration of PowerRename to work with OneDrive placeholders

### DIFF
--- a/installer/PowerToysSetup/Product.wxs
+++ b/installer/PowerToysSetup/Product.wxs
@@ -589,6 +589,7 @@
         <File Source="$(var.BinX64Dir)modules\$(var.PowerRenameProjectName)\PowerRenameExt.dll" KeyPath="yes" />
         <RegistryKey Root="HKCR" Key="CLSID\{0440049F-D1DC-4E46-B27B-98393D79486B}">
           <RegistryValue Type="string" Value="PowerRename Shell Extension" />
+          <RegistryValue Type="string" Name="ContextMenuOptIn" Value="" />
           <RegistryValue Type="string" Key="InprocServer32" Value="[PowerRenameInstallFolder]PowerRenameExt.dll" />
           <RegistryValue Type="string" Key="InprocServer32" Name="ThreadingModel" Value="Apartment" />
         </RegistryKey>


### PR DESCRIPTION
This change adds a ContextMenuOptIn registry name which is required for shell context menu extensions to appear on the context menu for OneDrive placeholders. 

See https://docs.microsoft.com/en-us/windows/win32/api/shobjidl_core/ne-shobjidl_core-default_folder_menu_restrictions.

Applies to https://github.com/microsoft/PowerToys/issues/708