### PR TITLE
Check the shell attributes of items to ensure we can rename

### DIFF
--- a/src/modules/powerrename/dll/PowerRenameExt.cpp
+++ b/src/modules/powerrename/dll/PowerRenameExt.cpp
@@ -67,6 +67,10 @@ HRESULT CPowerRenameMenu::QueryContextMenu(HMENU hMenu, UINT index, UINT uIDFirs
     if (CSettingsInstance().GetExtendedContextMenuOnly() && (!(uFlags & CMF_EXTENDEDVERBS)))
         return E_FAIL;
 
+    // Check if at least one of the selected items is actually renamable.
+    if (!DataObjectContainsRenamableItem(m_spdo))
+        return E_FAIL;
+
     HRESULT hr = E_UNEXPECTED;
     if (m_spdo && !(uFlags & (CMF_DEFAULTONLY | CMF_VERBSONLY | CMF_OPTIMIZEFORINVOKE)))
     {

--- a/src/modules/powerrename/lib/Helpers.h
+++ b/src/modules/powerrename/lib/Helpers.h
@@ -6,6 +6,7 @@
 HRESULT GetTrimmedFileName(_Out_ PWSTR result, UINT cchMax, _In_ PCWSTR source);
 HRESULT GetTransformedFileName(_Out_ PWSTR result, UINT cchMax, _In_ PCWSTR source, DWORD flags);
 HRESULT GetDatedFileName(_Out_ PWSTR result, UINT cchMax, _In_ PCWSTR source, SYSTEMTIME LocalTime);
+bool DataObjectContainsRenamableItem(_In_ IUnknown* dataSource);
 HRESULT EnumerateDataObject(_In_ IUnknown* pdo, _In_ IPowerRenameManager* psrm);
 BOOL GetEnumeratedFileName(
     __out_ecount(cchMax) PWSTR pszUniqueName,

--- a/src/modules/powerrename/lib/PowerRenameItem.cpp
+++ b/src/modules/powerrename/lib/PowerRenameItem.cpp
@@ -177,7 +177,7 @@ IFACEMETHODIMP CPowerRenameItem::ShouldRenameItem(_In_ DWORD flags, _Out_ bool* 
     bool excludeBecauseFolder = (m_isFolder && (flags & PowerRenameFlags::ExcludeFolders));
     bool excludeBecauseFile = (!m_isFolder && (flags & PowerRenameFlags::ExcludeFiles));
     bool excludeBecauseSubFolderContent = (m_depth > 0 && (flags & PowerRenameFlags::ExcludeSubfolders));
-    *shouldRename = (m_selected && hasChanged && !excludeBecauseFile &&
+    *shouldRename = (m_selected && m_canRename && hasChanged && !excludeBecauseFile &&
                      !excludeBecauseFolder && !excludeBecauseSubFolderContent);
 
     return S_OK;
@@ -237,12 +237,16 @@ HRESULT CPowerRenameItem::_Init(_In_ IShellItem* psi)
         if (SUCCEEDED(hr))
         {
             // Check if we are a folder now so we can check this attribute quickly later
+            // Also check if the shell allows us to rename the item.
             SFGAOF att = 0;
-            hr = psi->GetAttributes(SFGAO_STREAM | SFGAO_FOLDER, &att);
+            hr = psi->GetAttributes(SFGAO_STREAM | SFGAO_FOLDER | SFGAO_CANRENAME, &att);
             if (SUCCEEDED(hr))
             {
                 // Some items can be both folders and streams (ex: zip folders).
                 m_isFolder = (att & SFGAO_FOLDER) && !(att & SFGAO_STREAM);
+                // The shell lets us know if an item should not be renamed
+                // (ex: user profile director, windows dir, etc).
+                m_canRename = (att & SFGAO_CANRENAME);
             }
         }
     }

--- a/src/modules/powerrename/lib/PowerRenameItem.h
+++ b/src/modules/powerrename/lib/PowerRenameItem.h
@@ -50,6 +50,7 @@ protected:
     bool        m_selected = true;
     bool        m_isFolder = false;
     bool        m_isDateParsed = false;
+    bool        m_canRename = true;
     int         m_id = -1;
     int         m_iconIndex = -1;
     UINT        m_depth = 0;

--- a/src/modules/previewpane/UnitTests-SvgThumbnailProvider/SvgThumbnailProviderTests.cs
+++ b/src/modules/previewpane/UnitTests-SvgThumbnailProvider/SvgThumbnailProviderTests.cs
@@ -33,7 +33,7 @@ namespace SvgThumbnailProviderUnitTests
         }
 
         [TestMethod]
-        public void CheckBlockedElements_ShouldReturnNullBitmap_IfBlockedElementsIsPresentInNestedLevel()
+        public void CheckBlockedElements_ShouldReturnNonNullBitmap_IfBlockedElementsIsPresentInNestedLevel()
         {
             var svgBuilder = new StringBuilder();
             svgBuilder.AppendLine("<svg viewBox=\"0 0 100 100\" xmlns=\"http://www.w3.org/2000/svg\">");
@@ -43,7 +43,7 @@ namespace SvgThumbnailProviderUnitTests
             svgBuilder.AppendLine("</svg>");
 
             Bitmap thumbnail = SvgThumbnailProvider.SvgThumbnailProvider.GetThumbnail(svgBuilder.ToString(), 256);
-            Assert.IsTrue(thumbnail == null);
+            Assert.IsTrue(thumbnail != null);
         }
 
         [TestMethod]


### PR DESCRIPTION
This change queries the windows shell to ensure that items we selected are capable of being renamed before showing PowerRename on the context menu or performing an actual rename.  Users noticed that while PowerRename was available on certain OS folders (user profile folder, windows folder, etc) the standard Rename menu item was not available.  To protect our users we should not show PowerRename in this case.

Also included in this change is a simple fix to a SVG Thumbnail Provider unit test.