### PR TITLE
[PT Run] Add additional checks in version info methods to avoid exceptions

### DIFF
--- a/src/modules/launcher/Wox.Infrastructure/Storage/StoragePowerToysVersionInfo.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Storage/StoragePowerToysVersionInfo.cs
@@ -40,13 +40,29 @@ namespace Wox.Infrastructure.Storage
             string[] split1 = version1.Split(new string[] { version, period }, StringSplitOptions.RemoveEmptyEntries);
             string[] split2 = version2.Split(new string[] { version, period }, StringSplitOptions.RemoveEmptyEntries);
 
+            // If an incomplete file write resulted in the version number not being saved completely, then the cache must be deleted
+            if (split1.Length != split2.Length || split1.Length != versionLength)
+            {
+                return true;
+            }
+
             for (int i = 0; i < versionLength; i++)
             {
-                if (int.Parse(split1[i]) < int.Parse(split2[i]))
+                if (int.TryParse(split1[i], out int version1AsInt) && int.TryParse(split2[i], out int version2AsInt))
+                {
+                    if (version1AsInt < version2AsInt)
+                    {
+                        return true;
+                    }
+                }
+
+                // If either of the values could not be parsed, the version number was not saved correctly and the cache must be deleted
+                else
                 {
                     return true;
                 }
             }
+
             return false;
         }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR adds additional checks in the `StoragePowerToysVersionInfo` `LessThan` method, to avoid exceptions if the version format is not correct in the version file. This was added because of the exceptions some users reported in their logs:

    System.FormatException: Input string was not in a correct format.
       Source: System.Private.CoreLib
       TargetAssembly: System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e
       TargetModule: System.Private.CoreLib.dll
       TargetSite: Void ThrowOverflowOrFormatException(ParsingStatus, System.TypeCode)
       at System.Number.ThrowOverflowOrFormatException(ParsingStatus status, TypeCode type)
       at Wox.Infrastructure.Storage.StoragePowerToysVersionInfo.Lessthan(String version1, String version2)
       at Wox.Infrastructure.Storage.StoragePowerToysVersionInfo..ctor(String AssociatedFilePath, Int32 type)
       at Wox.Infrastructure.Storage.BinaryStorage`1.TryLoad(T defaultData)
       at Wox.Infrastructure.Image.ImageLoader.Initialize(Theme theme)
       at PowerLauncher.App.<>c__DisplayClass16_0.<OnStartup>b__1()
       at Wox.Infrastructure.Stopwatch.Normal(String message, Action action)
       at PowerLauncher.App.OnStartup(Object sender, StartupEventArgs e)
       at System.Windows.Application.OnStartup(StartupEventArgs e)
       at System.Windows.Application.<.ctor>b__1_0(Object unused)
       at System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, Object args, Int32 numArgs)
       at System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, Delegate callback, Object args, Int32 numArgs, Delegate catchHandler)

While this scenario of invalid format shouldn't generally happen, the only possible way this can happen is if the File Write step fails midway, resulting in file creation but incomplete text. This is to be validated after receiving more info from community members in #5055 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Applies to #5055 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [X] Tests passed

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
TODO: Validate all the scenarios, i.e. upgrade path, new user path and general usage. Also test by manually modifying the version file to be missing some values.