### PR TITLE
[FancyZones] Remove m_workArea from ZoneWindow

### DIFF
--- a/src/modules/fancyzones/lib/ZoneSet.h
+++ b/src/modules/fancyzones/lib/ZoneSet.h
@@ -111,19 +111,16 @@ struct ZoneSetConfig
     ZoneSetConfig(
         GUID id,
         FancyZonesDataTypes::ZoneSetLayoutType layoutType,
-        HMONITOR monitor,
-        PCWSTR resolutionKey) noexcept :
+        HMONITOR monitor) noexcept :
             Id(id),
             LayoutType(layoutType),
-            Monitor(monitor),
-            ResolutionKey(resolutionKey)
+            Monitor(monitor)
     {
     }
 
     GUID Id{};
     FancyZonesDataTypes::ZoneSetLayoutType LayoutType{};
     HMONITOR Monitor{};
-    PCWSTR ResolutionKey{};
 };
 
 winrt::com_ptr<IZoneSet> MakeZoneSet(ZoneSetConfig const& config) noexcept;

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -262,7 +262,6 @@ bool ZoneWindow::Init(IZoneWindowHost* host, HINSTANCE hinstance, HMONITOR monit
 
     m_monitor = monitor;
     const UINT dpi = GetDpiForMonitor(m_monitor);
-    const Rect monitorRect(mi.rcMonitor);
     const Rect workAreaRect(mi.rcWork, dpi);
 
     m_uniqueId = uniqueId;

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -184,8 +184,6 @@ public:
     CycleActiveZoneSet(DWORD vkCode) noexcept;
     IFACEMETHODIMP_(std::wstring)
     UniqueId() noexcept { return { m_uniqueId }; }
-    IFACEMETHODIMP_(std::wstring)
-    WorkAreaKey() noexcept { return { m_workArea }; }
     IFACEMETHODIMP_(void)
     SaveWindowProcessToZoneIndex(HWND window) noexcept;
     IFACEMETHODIMP_(IZoneSet*)
@@ -216,7 +214,6 @@ private:
     winrt::com_ptr<IZoneWindowHost> m_host;
     HMONITOR m_monitor{};
     std::wstring m_uniqueId; // Parsed deviceId + resolution + virtualDesktopId
-    wchar_t m_workArea[256]{};
     wil::unique_hwnd m_window{}; // Hidden tool window used to represent current monitor desktop work area.
     HWND m_windowMoveSize{};
     bool m_drawHints{};
@@ -267,7 +264,6 @@ bool ZoneWindow::Init(IZoneWindowHost* host, HINSTANCE hinstance, HMONITOR monit
     const UINT dpi = GetDpiForMonitor(m_monitor);
     const Rect monitorRect(mi.rcMonitor);
     const Rect workAreaRect(mi.rcWork, dpi);
-    StringCchPrintf(m_workArea, ARRAYSIZE(m_workArea), L"%d_%d", monitorRect.width(), monitorRect.height());
 
     m_uniqueId = uniqueId;
     InitializeZoneSets(parentUniqueId);
@@ -570,8 +566,7 @@ void ZoneWindow::CalculateZoneSet() noexcept
         auto zoneSet = MakeZoneSet(ZoneSetConfig(
             zoneSetId,
             activeZoneSet.type,
-            m_monitor,
-            m_workArea));
+            m_monitor));
         MONITORINFO monitorInfo{};
         monitorInfo.cbSize = sizeof(monitorInfo);
         if (GetMonitorInfoW(m_monitor, &monitorInfo))

--- a/src/modules/fancyzones/lib/ZoneWindow.h
+++ b/src/modules/fancyzones/lib/ZoneWindow.h
@@ -86,10 +86,6 @@ interface __declspec(uuid("{7F017528-8110-4FB3-BE41-F472969C2560}")) IZoneWindow
      */
     IFACEMETHOD_(std::wstring, UniqueId)() = 0;
     /**
-     * @returns Work area resolution (not same as monitor resolution).
-     */
-    IFACEMETHOD_(std::wstring, WorkAreaKey)() = 0;
-    /**
      * @returns Active zone layout for this work area.
      */
     IFACEMETHOD_(IZoneSet*, ActiveZoneSet)() = 0;

--- a/src/modules/fancyzones/tests/UnitTests/ZoneSet.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/ZoneSet.Spec.cpp
@@ -18,7 +18,6 @@ namespace FancyZonesUnitTests
     {
         GUID m_id;
         const ZoneSetLayoutType m_layoutType = ZoneSetLayoutType::Custom;
-        const PCWSTR m_resolutionKey = L"WorkAreaIn";
 
         winrt::com_ptr<IZoneSet> m_set;
 
@@ -27,7 +26,7 @@ namespace FancyZonesUnitTests
                 auto hres = CoCreateGuid(&m_id);
                 Assert::AreEqual(S_OK, hres);
 
-                ZoneSetConfig m_config = ZoneSetConfig(m_id, m_layoutType, Mocks::Monitor(), m_resolutionKey);
+                ZoneSetConfig m_config = ZoneSetConfig(m_id, m_layoutType, Mocks::Monitor());
                 m_set = MakeZoneSet(m_config);
             }
 
@@ -51,7 +50,7 @@ namespace FancyZonesUnitTests
             TEST_METHOD (TestCreateZoneSetGuidEmpty)
             {
                 GUID zoneSetId{};
-                ZoneSetConfig config(zoneSetId, m_layoutType, Mocks::Monitor(), m_resolutionKey);
+                ZoneSetConfig config(zoneSetId, m_layoutType, Mocks::Monitor());
                 winrt::com_ptr<IZoneSet> set = MakeZoneSet(config);
 
                 Assert::IsNotNull(&set);
@@ -61,7 +60,7 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (TestCreateZoneSetMonitorEmpty)
             {
-                ZoneSetConfig config(m_id, m_layoutType, nullptr, m_resolutionKey);
+                ZoneSetConfig config(m_id, m_layoutType, nullptr);
                 winrt::com_ptr<IZoneSet> set = MakeZoneSet(config);
                 Assert::IsNotNull(&set);
                 CustomAssert::AreEqual(set->Id(), m_id);
@@ -70,7 +69,7 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (TestCreateZoneSetKeyEmpty)
             {
-                ZoneSetConfig config(m_id, m_layoutType, Mocks::Monitor(), nullptr);
+                ZoneSetConfig config(m_id, m_layoutType, Mocks::Monitor());
                 winrt::com_ptr<IZoneSet> set = MakeZoneSet(config);
                 Assert::IsNotNull(&set);
                 CustomAssert::AreEqual(set->Id(), m_id);
@@ -492,7 +491,7 @@ namespace FancyZonesUnitTests
 
         TEST_METHOD_INITIALIZE(Initialize)
         {
-            ZoneSetConfig config({}, ZoneSetLayoutType::Custom, Mocks::Monitor(), L"WorkAreaIn");
+            ZoneSetConfig config({}, ZoneSetLayoutType::Custom, Mocks::Monitor());
             m_set = MakeZoneSet(config);
 
             // Add a couple of zones.
@@ -506,7 +505,7 @@ namespace FancyZonesUnitTests
 
         TEST_METHOD (EmptyZonesLeft)
         {
-            ZoneSetConfig config({}, ZoneSetLayoutType::Custom, Mocks::Monitor(), L"WorkAreaIn");
+            ZoneSetConfig config({}, ZoneSetLayoutType::Custom, Mocks::Monitor());
             auto set = MakeZoneSet(config);
 
             set->MoveWindowIntoZoneByDirection(Mocks::Window(), Mocks::Window(), VK_LEFT, true);
@@ -514,7 +513,7 @@ namespace FancyZonesUnitTests
 
         TEST_METHOD (EmptyZonesRight)
         {
-            ZoneSetConfig config({}, ZoneSetLayoutType::Custom, Mocks::Monitor(), L"WorkAreaIn");
+            ZoneSetConfig config({}, ZoneSetLayoutType::Custom, Mocks::Monitor());
             auto set = MakeZoneSet(config);
 
             set->MoveWindowIntoZoneByDirection(Mocks::Window(), Mocks::Window(), VK_RIGHT, true);
@@ -746,7 +745,7 @@ namespace FancyZonesUnitTests
 
                 m_monitor = MonitorFromPoint(POINT{ 0, 0 }, MONITOR_DEFAULTTOPRIMARY);
 
-                ZoneSetConfig m_config = ZoneSetConfig(m_id, m_layoutType, m_monitor, m_resolutionKey);
+                ZoneSetConfig m_config = ZoneSetConfig(m_id, m_layoutType, m_monitor);
                 m_set = MakeZoneSet(m_config);
             }
 
@@ -787,7 +786,7 @@ namespace FancyZonesUnitTests
 
                     for (int type = static_cast<int>(ZoneSetLayoutType::Focus); type < static_cast<int>(ZoneSetLayoutType::Custom); type++)
                     {
-                        ZoneSetConfig m_config = ZoneSetConfig(m_id, static_cast<ZoneSetLayoutType>(type), m_monitor, m_resolutionKey);
+                        ZoneSetConfig m_config = ZoneSetConfig(m_id, static_cast<ZoneSetLayoutType>(type), m_monitor);
 
                         for (const auto& monitorInfo : m_popularMonitors)
                         {
@@ -805,7 +804,7 @@ namespace FancyZonesUnitTests
 
                     for (int type = static_cast<int>(ZoneSetLayoutType::Focus); type < static_cast<int>(ZoneSetLayoutType::Custom); type++)
                     {
-                        ZoneSetConfig m_config = ZoneSetConfig(m_id, static_cast<ZoneSetLayoutType>(type), m_monitor, m_resolutionKey);
+                        ZoneSetConfig m_config = ZoneSetConfig(m_id, static_cast<ZoneSetLayoutType>(type), m_monitor);
                         auto set = MakeZoneSet(m_config);
 
                         MONITORINFO info{};
@@ -821,7 +820,7 @@ namespace FancyZonesUnitTests
 
                     for (int type = static_cast<int>(ZoneSetLayoutType::Focus); type < static_cast<int>(ZoneSetLayoutType::Custom); type++)
                     {
-                        ZoneSetConfig m_config = ZoneSetConfig(m_id, static_cast<ZoneSetLayoutType>(type), m_monitor, m_resolutionKey);
+                        ZoneSetConfig m_config = ZoneSetConfig(m_id, static_cast<ZoneSetLayoutType>(type), m_monitor);
 
                         for (const auto& monitorInfo : m_popularMonitors)
                         {
@@ -840,7 +839,7 @@ namespace FancyZonesUnitTests
 
                     for (int type = static_cast<int>(ZoneSetLayoutType::Focus); type < static_cast<int>(ZoneSetLayoutType::Custom); type++)
                     {
-                        ZoneSetConfig m_config = ZoneSetConfig(m_id, static_cast<ZoneSetLayoutType>(type), m_monitor, m_resolutionKey);
+                        ZoneSetConfig m_config = ZoneSetConfig(m_id, static_cast<ZoneSetLayoutType>(type), m_monitor);
                         auto set = MakeZoneSet(m_config);
 
                         for (const auto& monitorInfo : m_popularMonitors)
@@ -865,7 +864,7 @@ namespace FancyZonesUnitTests
 
                     for (int type = static_cast<int>(ZoneSetLayoutType::Focus); type < static_cast<int>(ZoneSetLayoutType::Custom); type++)
                     {
-                        ZoneSetConfig m_config = ZoneSetConfig(m_id, static_cast<ZoneSetLayoutType>(type), m_monitor, m_resolutionKey);
+                        ZoneSetConfig m_config = ZoneSetConfig(m_id, static_cast<ZoneSetLayoutType>(type), m_monitor);
                         auto set = MakeZoneSet(m_config);
 
                         for (const auto& monitorInfo : m_popularMonitors)
@@ -891,7 +890,7 @@ namespace FancyZonesUnitTests
 
                     for (int type = static_cast<int>(ZoneSetLayoutType::Focus); type < static_cast<int>(ZoneSetLayoutType::Custom); type++)
                     {
-                        ZoneSetConfig m_config = ZoneSetConfig(m_id, static_cast<ZoneSetLayoutType>(type), m_monitor, m_resolutionKey);
+                        ZoneSetConfig m_config = ZoneSetConfig(m_id, static_cast<ZoneSetLayoutType>(type), m_monitor);
                         auto set = MakeZoneSet(m_config);
 
                         for (const auto& monitorInfo : m_popularMonitors)
@@ -918,7 +917,7 @@ namespace FancyZonesUnitTests
 
                     for (int type = static_cast<int>(ZoneSetLayoutType::Focus); type < static_cast<int>(ZoneSetLayoutType::Custom); type++)
                     {
-                        ZoneSetConfig m_config = ZoneSetConfig(m_id, static_cast<ZoneSetLayoutType>(type), m_monitor, m_resolutionKey);
+                        ZoneSetConfig m_config = ZoneSetConfig(m_id, static_cast<ZoneSetLayoutType>(type), m_monitor);
                         auto set = MakeZoneSet(m_config);
 
                         for (const auto& monitorInfo : m_popularMonitors)
@@ -938,7 +937,7 @@ namespace FancyZonesUnitTests
                         const int spacing = 10;
                         const int zoneCount = 40; //editor limit
 
-                        ZoneSetConfig m_config = ZoneSetConfig(m_id, static_cast<ZoneSetLayoutType>(type), m_monitor, m_resolutionKey);
+                        ZoneSetConfig m_config = ZoneSetConfig(m_id, static_cast<ZoneSetLayoutType>(type), m_monitor);
 
                         for (const auto& monitorInfo : m_popularMonitors)
                         {
@@ -961,7 +960,7 @@ namespace FancyZonesUnitTests
                         std::filesystem::remove(m_path);
                     }
 
-                    ZoneSetConfig m_config = ZoneSetConfig(m_id, ZoneSetLayoutType::Custom, m_monitor, m_resolutionKey);
+                    ZoneSetConfig m_config = ZoneSetConfig(m_id, ZoneSetLayoutType::Custom, m_monitor);
                     auto set = MakeZoneSet(m_config);
 
                     for (const auto& monitorInfo : m_popularMonitors)
@@ -979,7 +978,7 @@ namespace FancyZonesUnitTests
                     Assert::IsTrue(std::filesystem::create_directories(m_path));
                     Assert::IsTrue(std::filesystem::exists(m_path));
 
-                    ZoneSetConfig m_config = ZoneSetConfig(m_id, ZoneSetLayoutType::Custom, m_monitor, m_resolutionKey);
+                    ZoneSetConfig m_config = ZoneSetConfig(m_id, ZoneSetLayoutType::Custom, m_monitor);
                     auto set = MakeZoneSet(m_config);
 
                     for (const auto& monitorInfo : m_popularMonitors)
@@ -1000,7 +999,7 @@ namespace FancyZonesUnitTests
                     const int spacing = 10;
                     const int zoneCount = static_cast<int>(info.zones.size());
 
-                    ZoneSetConfig m_config = ZoneSetConfig(m_id, ZoneSetLayoutType::Custom, m_monitor, m_resolutionKey);
+                    ZoneSetConfig m_config = ZoneSetConfig(m_id, ZoneSetLayoutType::Custom, m_monitor);
                     auto set = MakeZoneSet(m_config);
 
                     for (const auto& monitorInfo : m_popularMonitors)
@@ -1026,7 +1025,7 @@ namespace FancyZonesUnitTests
                     const int spacing = 0;
                     const int zoneCount = grid.rows() * grid.columns();
 
-                    ZoneSetConfig m_config = ZoneSetConfig(m_id, ZoneSetLayoutType::Custom, m_monitor, m_resolutionKey);
+                    ZoneSetConfig m_config = ZoneSetConfig(m_id, ZoneSetLayoutType::Custom, m_monitor);
                     auto set = MakeZoneSet(m_config);
 
                     for (const auto& monitorInfo : m_popularMonitors)
@@ -1061,7 +1060,7 @@ namespace FancyZonesUnitTests
                     //test
                     const int spacing = 10;
                     const int zoneCount = static_cast<int>(info.zones.size());
-                    ZoneSetConfig m_config = ZoneSetConfig(m_id, ZoneSetLayoutType::Custom, m_monitor, m_resolutionKey);
+                    ZoneSetConfig m_config = ZoneSetConfig(m_id, ZoneSetLayoutType::Custom, m_monitor);
                     for (const auto& monitorInfo : m_popularMonitors)
                     {
                         auto set = MakeZoneSet(m_config);
@@ -1101,7 +1100,7 @@ namespace FancyZonesUnitTests
                     const int spacing = 10;
                     const int zoneCount = grid.rows() * grid.columns();
 
-                    ZoneSetConfig m_config = ZoneSetConfig(m_id, ZoneSetLayoutType::Custom, m_monitor, m_resolutionKey);
+                    ZoneSetConfig m_config = ZoneSetConfig(m_id, ZoneSetLayoutType::Custom, m_monitor);
 
                     for (const auto& monitorInfo : m_popularMonitors)
                     {
@@ -1125,7 +1124,7 @@ namespace FancyZonesUnitTests
                     const int spacing = 0;
                     const int zoneCount = grid.rows() * grid.columns();
 
-                    ZoneSetConfig m_config = ZoneSetConfig(m_id, ZoneSetLayoutType::Custom, m_monitor, m_resolutionKey);
+                    ZoneSetConfig m_config = ZoneSetConfig(m_id, ZoneSetLayoutType::Custom, m_monitor);
                     auto set = MakeZoneSet(m_config);
 
                     for (const auto& monitorInfo : m_popularMonitors)

--- a/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
@@ -133,7 +133,6 @@ namespace FancyZonesUnitTests
 
             Assert::IsNotNull(zoneWindow.get());
             Assert::AreEqual(m_uniqueId.str().c_str(), zoneWindow->UniqueId().c_str());
-            Assert::AreEqual(expectedWorkArea, zoneWindow->WorkAreaKey());
         }
 
     public:
@@ -187,7 +186,6 @@ namespace FancyZonesUnitTests
 
             Assert::IsNotNull(m_zoneWindow.get());
             Assert::AreEqual(expectedUniqueId.c_str(), m_zoneWindow->UniqueId().c_str());
-            Assert::AreEqual(expectedWorkArea, m_zoneWindow->WorkAreaKey());
             Assert::IsNull(m_zoneWindow->ActiveZoneSet());
         }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This PR removes an unused member of the ZoneWindow class.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

Relevant issue: #5184

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #5184
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Compiled PT and checked that FZ works.