### PR TITLE
Fix PT Settings tests

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UnitTest/ViewModelTests/ColorPicker.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UnitTest/ViewModelTests/ColorPicker.cs
@@ -19,7 +19,7 @@ namespace ViewModelTests
             var colorPickerSettings = new ColorPickerSettings();
 
             SettingsUtils.SaveSettings(generalSettings.ToJsonString());
-            SettingsUtils.SaveSettings(colorPickerSettings.ToJsonString(), colorPickerSettings.Name, ModuleName + ".json");
+            SettingsUtils.SaveSettings(colorPickerSettings.ToJsonString(), ModuleName);
         }
 
         [TestCleanup]
@@ -35,6 +35,8 @@ namespace ViewModelTests
             {
                 DeleteFolder(ModuleName);
             }
+
+            ShellPage.DefaultSndMSGCallback = null;
         }
 
         [TestMethod]

--- a/src/core/Microsoft.PowerToys.Settings.UnitTest/ViewModelTests/PowerLauncherViewModelTest.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UnitTest/ViewModelTests/PowerLauncherViewModelTest.cs
@@ -82,7 +82,7 @@ namespace ViewModelTests
             viewModel.OpenFileLocation = openFileLocation;
             viewModel.CopyPathLocation = copyFileLocation;
 
-            Assert.AreEqual(4, sendCallbackMock.TimesSent);
+            Assert.AreEqual(3, sendCallbackMock.TimesSent);
 
             AssertHotkeySettings(
                 mockSettings.Properties.open_powerlauncher,
@@ -99,14 +99,6 @@ namespace ViewModelTests
                 false,
                 false,
                 (int)Windows.System.VirtualKey.A
-                );
-            AssertHotkeySettings(
-                mockSettings.Properties.open_console,
-                false,
-                false,
-                true,
-                false,
-                (int)Windows.System.VirtualKey.D
                 );
             AssertHotkeySettings(
                 mockSettings.Properties.copy_path_location,


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR fixes the PowerLauncherViewModelTest and the FZViewModelTests that were failing.
- The Powerlauncher hotkey test was failing since it was checking for the `OpenConsole` method's JSON entry even though that logic had been removed.
- The first FZ test was failing because the `CleanUp` method in the ColorPicker test class was missing a statement to set a callback to `null`, and the FZ tests would execute right after the ColorPicker test.

![image](https://user-images.githubusercontent.com/32061677/88314038-381ae180-ccc9-11ea-8393-d918f9f88abe.png)

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Validated that all tests pass