### PR TITLE
Color picker tweaks

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/ColorPickerProperties.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/ColorPickerProperties.cs
@@ -17,8 +17,8 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
     {
         public ColorPickerProperties()
         {
-            ActivationShortcut = new HotkeySettings(false, true, false, false, "Break", 3);
-            ChangeCursor = true;
+            ActivationShortcut = new HotkeySettings(true, false, false, true, 0x43);
+            ChangeCursor = false;
         }
 
         public HotkeySettings ActivationShortcut { get; set; }

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/FZConfigProperties.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/FZConfigProperties.cs
@@ -2,9 +2,6 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -12,35 +9,28 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
 {
     public class FZConfigProperties
     {
+        public static readonly HotkeySettings DefaultHotkeyValue = new HotkeySettings(true, false, false, false, 0xc0);
+
         public FZConfigProperties()
         {
-            this.FancyzonesShiftDrag = new BoolProperty(ConfigDefaults.DefaultFancyzonesShiftDrag);
-            this.FancyzonesOverrideSnapHotkeys = new BoolProperty();
-            this.FancyzonesMouseSwitch = new BoolProperty();
-            this.FancyzonesMoveWindowsAcrossMonitors = new BoolProperty();
-            this.FancyzonesDisplayChangeMoveWindows = new BoolProperty();
-            this.FancyzonesZoneSetChangeMoveWindows = new BoolProperty();
-            this.FancyzonesAppLastZoneMoveWindows = new BoolProperty();
-            this.FancyzonesOpenWindowOnActiveMonitor = new BoolProperty();
-            this.FancyzonesRestoreSize = new BoolProperty();
-            this.UseCursorposEditorStartupscreen = new BoolProperty(ConfigDefaults.DefaultUseCursorposEditorStartupscreen);
-            this.FancyzonesShowOnAllMonitors = new BoolProperty();
-            this.FancyzonesZoneHighlightColor = new StringProperty(ConfigDefaults.DefaultFancyZonesZoneHighlightColor);
-            this.FancyzonesHighlightOpacity = new IntProperty(50);
-            this.FancyzonesEditorHotkey = new KeyboardKeysProperty(
-                new HotkeySettings()
-                {
-                    Win = true,
-                    Ctrl = false,
-                    Alt = false,
-                    Shift = false,
-                    Key = "`",
-                    Code = 192,
-                });
-            this.FancyzonesMakeDraggedWindowTransparent = new BoolProperty();
-            this.FancyzonesExcludedApps = new StringProperty();
-            this.FancyzonesInActiveColor = new StringProperty(ConfigDefaults.DefaultFancyZonesInActiveColor);
-            this.FancyzonesBorderColor = new StringProperty(ConfigDefaults.DefaultFancyzonesBorderColor);
+            FancyzonesShiftDrag = new BoolProperty(ConfigDefaults.DefaultFancyzonesShiftDrag);
+            FancyzonesOverrideSnapHotkeys = new BoolProperty();
+            FancyzonesMouseSwitch = new BoolProperty();
+            FancyzonesMoveWindowsAcrossMonitors = new BoolProperty();
+            FancyzonesDisplayChangeMoveWindows = new BoolProperty();
+            FancyzonesZoneSetChangeMoveWindows = new BoolProperty();
+            FancyzonesAppLastZoneMoveWindows = new BoolProperty();
+            FancyzonesOpenWindowOnActiveMonitor = new BoolProperty();
+            FancyzonesRestoreSize = new BoolProperty();
+            UseCursorposEditorStartupscreen = new BoolProperty(ConfigDefaults.DefaultUseCursorposEditorStartupscreen);
+            FancyzonesShowOnAllMonitors = new BoolProperty();
+            FancyzonesZoneHighlightColor = new StringProperty(ConfigDefaults.DefaultFancyZonesZoneHighlightColor);
+            FancyzonesHighlightOpacity = new IntProperty(50);
+            FancyzonesEditorHotkey = new KeyboardKeysProperty(DefaultHotkeyValue);
+            FancyzonesMakeDraggedWindowTransparent = new BoolProperty();
+            FancyzonesExcludedApps = new StringProperty();
+            FancyzonesInActiveColor = new StringProperty(ConfigDefaults.DefaultFancyZonesInActiveColor);
+            FancyzonesBorderColor = new StringProperty(ConfigDefaults.DefaultFancyzonesBorderColor);
         }
 
         [JsonPropertyName("fancyzones_shiftDrag")]

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/HotkeySettings.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/HotkeySettings.cs
@@ -26,7 +26,6 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
         /// <param name="ctrl">Should Ctrl key be used</param>
         /// <param name="alt">Should Alt key be used</param>
         /// <param name="shift">Should Shift key be used</param>
-        /// <param name="key">Hot key</param>
         /// <param name="code">Go to https://docs.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes to see list of v-keys</param>
         public HotkeySettings(bool win, bool ctrl, bool alt, bool shift, int code)
         {

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/HotkeySettings.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/HotkeySettings.cs
@@ -12,27 +12,34 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
     {
         public HotkeySettings()
         {
-            this.Win = false;
-            this.Ctrl = false;
-            this.Alt = false;
-            this.Shift = false;
-            this.Key = string.Empty;
-            this.Code = 0;
+            Win = false;
+            Ctrl = false;
+            Alt = false;
+            Shift = false;
+            Code = 0;
         }
 
-        public HotkeySettings(bool win, bool ctrl, bool alt, bool shift, string key, int code)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HotkeySettings"/> class.
+        /// </summary>
+        /// <param name="win">Should Windows key be used</param>
+        /// <param name="ctrl">Should Ctrl key be used</param>
+        /// <param name="alt">Should Alt key be used</param>
+        /// <param name="shift">Should Shift key be used</param>
+        /// <param name="key">Hot key</param>
+        /// <param name="code">Go to https://docs.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes to see list of v-keys</param>
+        public HotkeySettings(bool win, bool ctrl, bool alt, bool shift, int code)
         {
             Win = win;
             Ctrl = ctrl;
             Alt = alt;
             Shift = shift;
-            Key = key;
             Code = code;
         }
 
         public HotkeySettings Clone()
         {
-            return new HotkeySettings(Win, Ctrl, Alt, Shift, Key, Code);
+            return new HotkeySettings(Win, Ctrl, Alt, Shift, Code);
         }
 
         [JsonPropertyName("win")]
@@ -46,9 +53,6 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
 
         [JsonPropertyName("shift")]
         public bool Shift { get; set; }
-
-        [JsonPropertyName("key")]
-        public string Key { get; set; }
 
         [JsonPropertyName("code")]
         public int Code { get; set; }

--- a/src/core/Microsoft.PowerToys.Settings.UI/Controls/HotkeySettingsControl.xaml.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Controls/HotkeySettingsControl.xaml.cs
@@ -126,7 +126,6 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
                     return;
                 default:
                     internalSettings.Code = matchValueCode;
-                    internalSettings.Key = matchValueText;
                     break;
             }
         }

--- a/src/core/Microsoft.PowerToys.Settings.UI/ViewModels/FancyZonesViewModel.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/ViewModels/FancyZonesViewModel.cs
@@ -420,7 +420,8 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 {
                     if (value.IsEmpty())
                     {
-                        _editorHotkey = new HotkeySettings(true, false, false, false, "'", 192);
+
+                        _editorHotkey = FZConfigProperties.DefaultHotkeyValue;
                     }
                     else
                     {

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
@@ -70,7 +70,9 @@
             </ComboBox>
 
             <!--
-            Disabiling this until we have a safer way to reset cursor as we can hit a state hwere 
+            Disabling this until we have a safer way to reset cursor as 
+            we can hit a state where the cursor doesn't reset
+            
             <ToggleSwitch x:Uid="ColorPicker_ChangeCursor" 
                           IsOn="{Binding ChangeCursor, Mode=TwoWay}"
                           Margin="{StaticResource MediumTopMargin}"

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
@@ -69,10 +69,13 @@
                 <ComboBoxItem Content="RGB - RGB(100, 50, 75)"/>
             </ComboBox>
 
+            <!--
+            Disabiling this until we have a safer way to reset cursor as we can hit a state hwere 
             <ToggleSwitch x:Uid="ColorPicker_ChangeCursor" 
                           IsOn="{Binding ChangeCursor, Mode=TwoWay}"
                           Margin="{StaticResource MediumTopMargin}"
-                          IsEnabled="{Binding IsEnabled}"/>
+                          IsEnabled="{Binding IsEnabled}" />
+            -->
         </StackPanel>
         <StackPanel 
             x:Name="SidePanel"

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ShellPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ShellPage.xaml
@@ -46,6 +46,12 @@
                     </winui:NavigationViewItem.Icon>
                 </winui:NavigationViewItem>
 
+                <winui:NavigationViewItem x:Uid="Shell_ColorPicker" helpers:NavHelper.NavigateTo="views:ColorPickerPage">
+                    <winui:NavigationViewItem.Icon>
+                        <FontIcon Glyph="&#xEF3C;"/>
+                    </winui:NavigationViewItem.Icon>
+                </winui:NavigationViewItem>
+                
                 <!-- TO DO: Update icon -->
                 <winui:NavigationViewItem x:Uid="Shell_FancyZones" helpers:NavHelper.NavigateTo="views:FancyZonesPage">
                     <winui:NavigationViewItem.Icon>
@@ -93,13 +99,6 @@
                         <FontIcon Glyph="&#xEDA7;"/>
                     </winui:NavigationViewItem.Icon>
                 </winui:NavigationViewItem>
-
-                <winui:NavigationViewItem x:Uid="Shell_ColorPicker" helpers:NavHelper.NavigateTo="views:ColorPickerPage">
-                    <winui:NavigationViewItem.Icon>
-                        <FontIcon Glyph="&#xEF3C;"/>
-                    </winui:NavigationViewItem.Icon>
-                </winui:NavigationViewItem>
-
             </winui:NavigationView.MenuItems>
             <i:Interaction.Behaviors>
                 <behaviors:NavigationViewHeaderBehavior


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

- Adjusting key to be Win+Shift+C to match 
   - This does conflict with "charms" but can't seem to find an app that uses this.
- adjusted location for Color Picker
- Redid how HotKeySettings works since Key is actually orphaned
- created a readonly static property for FancyZones so single default values
- disabling cursor override for now

