### PR TITLE
Fix saving to JSON in PT Settings

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/BasePTModuleSettings.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/BasePTModuleSettings.cs
@@ -20,7 +20,7 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
         // converts the current to a json string.
         public virtual string ToJsonString()
         {
-            return JsonSerializer.Serialize(this);
+            return JsonSerializer.Serialize(this, this.GetType());
         }
     }
 }

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/BasePTModuleSettings.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/BasePTModuleSettings.cs
@@ -20,6 +20,7 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
         // converts the current to a json string.
         public virtual string ToJsonString()
         {
+            // By default JsonSerializer will only serialize the properties in the base class. This can be avoided by passing the object type (more details at https://stackoverflow.com/a/62498888)
             return JsonSerializer.Serialize(this, this.GetType());
         }
     }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR fixes the issue where all the JSON properties do not get serialized to the settings file from PT Settings.


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Applies to #xxx
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [X] Tests passed

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
If JsonSerializer is called drectly n the base class, only the properties in that class get serialized. More details here https://stackoverflow.com/questions/62498668/jsonserializer-serialize-only-serializes-the-properties-of-the-base-class

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Validated after deleting the keyboard manager settings.json that it is created in the correct format.