### PR TITLE
Fix for handling exceptions thrown by dispatcher which were crashing PT Run

### DIFF
--- a/src/modules/launcher/PowerLauncher/Languages/da.xaml
+++ b/src/modules/launcher/PowerLauncher/Languages/da.xaml
@@ -115,7 +115,7 @@
     <system:String x:Key="reportWindow_sending">Sender</system:String>
     <system:String x:Key="reportWindow_report_succeed">Rapport sendt korrekt</system:String>
     <system:String x:Key="reportWindow_report_failed">Kunne ikke sende rapport</system:String>
-    <system:String x:Key="reportWindow_wox_got_an_error">Wox fik en fejl</system:String>
+    <system:String x:Key="reportWindow_wox_got_an_error">PT Run fik en fejl</system:String>
 
     <!--update-->
     <system:String x:Key="update_wox_update_new_version_available">Ny Wox udgivelse {0} er nu tilgængelig</system:String>

--- a/src/modules/launcher/PowerLauncher/Languages/de.xaml
+++ b/src/modules/launcher/PowerLauncher/Languages/de.xaml
@@ -115,7 +115,7 @@
     <system:String x:Key="reportWindow_sending">Sende</system:String>
     <system:String x:Key="reportWindow_report_succeed">Report erfolgreich</system:String>
     <system:String x:Key="reportWindow_report_failed">Report fehlgeschlagen</system:String>
-    <system:String x:Key="reportWindow_wox_got_an_error">Wox hat einen Fehler</system:String>
+    <system:String x:Key="reportWindow_wox_got_an_error">PT Run hat einen Fehler</system:String>
 
     <!--update-->
     <system:String x:Key="update_wox_update_new_version_available">V{0} von Wox ist verfügbar</system:String>

--- a/src/modules/launcher/PowerLauncher/Languages/en.xaml
+++ b/src/modules/launcher/PowerLauncher/Languages/en.xaml
@@ -129,7 +129,7 @@
     <system:String x:Key="reportWindow_sending">Sending</system:String>
     <system:String x:Key="reportWindow_report_succeed">Report sent successfully</system:String>
     <system:String x:Key="reportWindow_report_failed">Failed to send report</system:String>
-    <system:String x:Key="reportWindow_wox_got_an_error">Wox got an error</system:String>
+    <system:String x:Key="reportWindow_wox_got_an_error">PT Run got an error</system:String>
 
     <!--update-->
     <system:String x:Key="update_wox_update_new_version_available">New Wox release {0} is now available</system:String>

--- a/src/modules/launcher/PowerLauncher/Languages/fr.xaml
+++ b/src/modules/launcher/PowerLauncher/Languages/fr.xaml
@@ -121,7 +121,7 @@
     <system:String x:Key="reportWindow_sending">Envoi en cours</system:String>
     <system:String x:Key="reportWindow_report_succeed">Signalement envoyé</system:String>
     <system:String x:Key="reportWindow_report_failed">Échec de l'envoi du signalement</system:String>
-    <system:String x:Key="reportWindow_wox_got_an_error">Wox a rencontré une erreur</system:String>
+    <system:String x:Key="reportWindow_wox_got_an_error">PT Run a rencontré une erreur</system:String>
 
     <!--update-->
     <system:String x:Key="update_wox_update_new_version_available">Version v{0} de Wox disponible</system:String>

--- a/src/modules/launcher/PowerLauncher/Languages/it.xaml
+++ b/src/modules/launcher/PowerLauncher/Languages/it.xaml
@@ -124,7 +124,7 @@
     <system:String x:Key="reportWindow_sending">Invio in corso</system:String>
     <system:String x:Key="reportWindow_report_succeed">Rapporto inviato correttamente</system:String>
     <system:String x:Key="reportWindow_report_failed">Invio rapporto fallito</system:String>
-    <system:String x:Key="reportWindow_wox_got_an_error">Wox ha riportato un errore</system:String>
+    <system:String x:Key="reportWindow_wox_got_an_error">PT Run ha riportato un errore</system:String>
 
     <!--update-->
     <system:String x:Key="update_wox_update_new_version_available">E' disponibile la nuova release {0} di Wox</system:String>

--- a/src/modules/launcher/PowerLauncher/Languages/ja.xaml
+++ b/src/modules/launcher/PowerLauncher/Languages/ja.xaml
@@ -127,7 +127,7 @@
     <system:String x:Key="reportWindow_sending">送信中</system:String>
     <system:String x:Key="reportWindow_report_succeed">クラッシュレポートの送信に成功しました</system:String>
     <system:String x:Key="reportWindow_report_failed">クラッシュレポートの送信に失敗しました</system:String>
-    <system:String x:Key="reportWindow_wox_got_an_error">Woxにエラーが発生しました</system:String>
+    <system:String x:Key="reportWindow_wox_got_an_error">PT Runにエラーが発生しました</system:String>
 
     <!--update-->
     <system:String x:Key="update_wox_update_new_version_available">Wox の最新バージョン V{0} が入手可能です</system:String>

--- a/src/modules/launcher/PowerLauncher/Languages/ko.xaml
+++ b/src/modules/launcher/PowerLauncher/Languages/ko.xaml
@@ -119,7 +119,7 @@
     <system:String x:Key="reportWindow_sending">보내는 중</system:String>
     <system:String x:Key="reportWindow_report_succeed">보고서를 정상적으로 보냈습니다.</system:String>
     <system:String x:Key="reportWindow_report_failed">보고서를 보내지 못했습니다.</system:String>
-    <system:String x:Key="reportWindow_wox_got_an_error">Wox에 문제가 발생했습니다.</system:String>
+    <system:String x:Key="reportWindow_wox_got_an_error">PT Run에 문제가 발생했습니다.</system:String>
 
     <!--update-->
     <system:String x:Key="update_wox_update_new_version_available">새 Wox 버전({0})을 사용할 수 있습니다.</system:String>

--- a/src/modules/launcher/PowerLauncher/Languages/nb-NO.xaml
+++ b/src/modules/launcher/PowerLauncher/Languages/nb-NO.xaml
@@ -124,7 +124,7 @@
     <system:String x:Key="reportWindow_sending">Sender</system:String>
     <system:String x:Key="reportWindow_report_succeed">Rapport sendt med suksess</system:String>
     <system:String x:Key="reportWindow_report_failed">Kunne ikke sende rapport</system:String>
-    <system:String x:Key="reportWindow_wox_got_an_error">Wox møtte på en feil</system:String>
+    <system:String x:Key="reportWindow_wox_got_an_error">PT Run møtte på en feil</system:String>
 
     <!--update-->
     <system:String x:Key="update_wox_update_new_version_available">Versjon {0} av Wox er nå tilgjengelig</system:String>

--- a/src/modules/launcher/PowerLauncher/Languages/nl.xaml
+++ b/src/modules/launcher/PowerLauncher/Languages/nl.xaml
@@ -115,7 +115,7 @@
     <system:String x:Key="reportWindow_sending">Versturen</system:String>
     <system:String x:Key="reportWindow_report_succeed">Rapport succesvol</system:String>
     <system:String x:Key="reportWindow_report_failed">Rapport mislukt</system:String>
-    <system:String x:Key="reportWindow_wox_got_an_error">Wox heeft een error</system:String>
+    <system:String x:Key="reportWindow_wox_got_an_error">PT Run heeft een error</system:String>
 
     <!--update-->
     <system:String x:Key="update_wox_update_new_version_available">Nieuwe Wox release {0} nu beschikbaar</system:String>

--- a/src/modules/launcher/PowerLauncher/Languages/pl.xaml
+++ b/src/modules/launcher/PowerLauncher/Languages/pl.xaml
@@ -115,7 +115,7 @@
     <system:String x:Key="reportWindow_sending">Wysyłam raport...</system:String>
     <system:String x:Key="reportWindow_report_succeed">Raport wysłany pomyślnie</system:String>
     <system:String x:Key="reportWindow_report_failed">Nie udało się wysłać raportu</system:String>
-    <system:String x:Key="reportWindow_wox_got_an_error">W programie Wox wystąpił błąd</system:String>
+    <system:String x:Key="reportWindow_wox_got_an_error">PT Run programie Wox wystąpił błąd</system:String>
 
     <!--update-->
     <system:String x:Key="update_wox_update_new_version_available">Nowa wersja Wox {0} jest dostępna</system:String>

--- a/src/modules/launcher/PowerLauncher/Languages/pt-br.xaml
+++ b/src/modules/launcher/PowerLauncher/Languages/pt-br.xaml
@@ -124,7 +124,7 @@
     <system:String x:Key="reportWindow_sending">Enviando</system:String>
     <system:String x:Key="reportWindow_report_succeed">Relatório enviado com sucesso</system:String>
     <system:String x:Key="reportWindow_report_failed">Falha ao enviar relatório</system:String>
-    <system:String x:Key="reportWindow_wox_got_an_error">Wox apresentou um erro</system:String>
+    <system:String x:Key="reportWindow_wox_got_an_error">PT Run apresentou um erro</system:String>
 
     <!--update-->
     <system:String x:Key="update_wox_update_new_version_available">A nova versão {0} do Wox agora está disponível</system:String>

--- a/src/modules/launcher/PowerLauncher/Languages/ru.xaml
+++ b/src/modules/launcher/PowerLauncher/Languages/ru.xaml
@@ -115,7 +115,7 @@
     <system:String x:Key="reportWindow_sending">Отправляем</system:String>
     <system:String x:Key="reportWindow_report_succeed">Отчёт успешно отправлен</system:String>
     <system:String x:Key="reportWindow_report_failed">Не удалось отправить отчёт</system:String>
-    <system:String x:Key="reportWindow_wox_got_an_error">Произошёл сбой в Wox</system:String>
+    <system:String x:Key="reportWindow_wox_got_an_error">Произошёл сбой в PT Run</system:String>
 
     <!--update-->
     <system:String x:Key="update_wox_update_new_version_available">Доступна новая версия Wox V{0}</system:String>

--- a/src/modules/launcher/PowerLauncher/Languages/sk.xaml
+++ b/src/modules/launcher/PowerLauncher/Languages/sk.xaml
@@ -125,7 +125,7 @@
     <system:String x:Key="reportWindow_sending">Odosiela sa</system:String>
     <system:String x:Key="reportWindow_report_succeed">Hlásenie bolo úspešne odoslané</system:String>
     <system:String x:Key="reportWindow_report_failed">Odoslanie hlásenia zlyhalo</system:String>
-    <system:String x:Key="reportWindow_wox_got_an_error">Wox zaznamenal chybu</system:String>
+    <system:String x:Key="reportWindow_wox_got_an_error">PT Run zaznamenal chybu</system:String>
 
     <!--update-->
     <system:String x:Key="update_wox_update_new_version_available">Je dostupné nové vydanie Wox {0}</system:String>

--- a/src/modules/launcher/PowerLauncher/Languages/sr.xaml
+++ b/src/modules/launcher/PowerLauncher/Languages/sr.xaml
@@ -124,7 +124,7 @@
     <system:String x:Key="reportWindow_sending">Slanje</system:String>
     <system:String x:Key="reportWindow_report_succeed">Izveštaj uspešno poslat</system:String>
     <system:String x:Key="reportWindow_report_failed">Izveštaj neuspešno poslat</system:String>
-    <system:String x:Key="reportWindow_wox_got_an_error">Wox je dobio grešku</system:String>
+    <system:String x:Key="reportWindow_wox_got_an_error">PT Run je dobio grešku</system:String>
 
     <!--update-->
     <system:String x:Key="update_wox_update_new_version_available">Nova verzija Wox-a {0} je dostupna</system:String>

--- a/src/modules/launcher/PowerLauncher/Languages/tr.xaml
+++ b/src/modules/launcher/PowerLauncher/Languages/tr.xaml
@@ -128,7 +128,7 @@
     <system:String x:Key="reportWindow_sending">Gönderiliyor</system:String>
     <system:String x:Key="reportWindow_report_succeed">Hata raporu başarıyla gönderildi</system:String>
     <system:String x:Key="reportWindow_report_failed">Hata raporu gönderimi başarısız oldu</system:String>
-    <system:String x:Key="reportWindow_wox_got_an_error">Wox'ta bir hata oluştu</system:String>
+    <system:String x:Key="reportWindow_wox_got_an_error">PT Run'ta bir hata oluştu</system:String>
 
     <!--update-->
     <system:String x:Key="update_wox_update_new_version_available">Wox'un yeni bir sürümü ({0}) mevcut</system:String>

--- a/src/modules/launcher/PowerLauncher/Languages/uk-UA.xaml
+++ b/src/modules/launcher/PowerLauncher/Languages/uk-UA.xaml
@@ -115,7 +115,7 @@
     <system:String x:Key="reportWindow_sending">Відправити</system:String>
     <system:String x:Key="reportWindow_report_succeed">Звіт успішно відправлено</system:String>
     <system:String x:Key="reportWindow_report_failed">Не вдалося відправити звіт</system:String>
-    <system:String x:Key="reportWindow_wox_got_an_error">Стався збій в додатоку Wox</system:String>
+    <system:String x:Key="reportWindow_wox_got_an_error">Стався збій в додатоку PT Run</system:String>
 
     <!--update-->
     <system:String x:Key="update_wox_update_new_version_available">Доступна нова версія Wox V{0}</system:String>

--- a/src/modules/launcher/PowerLauncher/Languages/zh-cn.xaml
+++ b/src/modules/launcher/PowerLauncher/Languages/zh-cn.xaml
@@ -122,7 +122,7 @@
     <system:String x:Key="reportWindow_sending">发送中</system:String>
     <system:String x:Key="reportWindow_report_succeed">发送成功</system:String>
     <system:String x:Key="reportWindow_report_failed">发送失败</system:String>
-    <system:String x:Key="reportWindow_wox_got_an_error">Wox出错啦</system:String>
+    <system:String x:Key="reportWindow_wox_got_an_error">PT Run出错啦</system:String>
 
     <!--更新-->
     <system:String x:Key="update_wox_update_new_version_available">发现Wox新版本 V{0}</system:String>

--- a/src/modules/launcher/PowerLauncher/Languages/zh-tw.xaml
+++ b/src/modules/launcher/PowerLauncher/Languages/zh-tw.xaml
@@ -115,7 +115,7 @@
     <system:String x:Key="reportWindow_sending">傳送中</system:String>
     <system:String x:Key="reportWindow_report_succeed">傳送成功</system:String>
     <system:String x:Key="reportWindow_report_failed">傳送失敗</system:String>
-    <system:String x:Key="reportWindow_wox_got_an_error">Wox 出錯啦</system:String>
+    <system:String x:Key="reportWindow_wox_got_an_error">PT Run出錯啦</system:String>
 
     <!--更新-->
     <system:String x:Key="update_wox_update_new_version_available">發現 Wox 新版本 V{0}</system:String>

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -323,7 +323,6 @@ namespace PowerLauncher
                 await System.Windows.Application.Current.Dispatcher.BeginInvoke(new Action(() =>
                 {
                     _viewModel.Query();
-                    throw new Exception();
                 }));
             }
         }

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -323,6 +323,7 @@ namespace PowerLauncher
                 await System.Windows.Application.Current.Dispatcher.BeginInvoke(new Action(() =>
                 {
                     _viewModel.Query();
+                    throw new Exception();
                 }));
             }
         }

--- a/src/modules/launcher/PowerLauncher/ReportWindow.xaml
+++ b/src/modules/launcher/PowerLauncher/ReportWindow.xaml
@@ -5,7 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              mc:Ignorable="d" 
              WindowStartupLocation="CenterScreen"
-             Icon="Images/app_error.png"
+             Icon="Images/app_error.dark.png"
              Topmost="True"
              ResizeMode="NoResize"
              Width="600"

--- a/src/modules/launcher/PowerLauncher/ReportWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/ReportWindow.xaml.cs
@@ -10,6 +10,9 @@ using PowerLauncher.Helper;
 using Wox.Infrastructure;
 using Wox.Infrastructure.Logger;
 using System.Windows.Navigation;
+using Wox.Infrastructure.Image;
+using System.Drawing;
+using System.Windows.Media.Imaging;
 
 namespace PowerLauncher
 {
@@ -18,6 +21,11 @@ namespace PowerLauncher
         public ReportWindow(Exception exception)
         {
             InitializeComponent();
+            BitmapImage image = GetImageFromPath(ImageLoader.ErrorIconPath);
+            if(image != null)
+            {
+                this.Icon = image;
+            }
             ErrorTextbox.Document.Blocks.FirstBlock.Margin = new Thickness(0);
             SetException(exception);
         }
@@ -41,6 +49,28 @@ namespace PowerLauncher
             paragraph = new Paragraph();
             paragraph.Inlines.Add(content.ToString());
             ErrorTextbox.Document.Blocks.Add(paragraph);
+        }
+
+        private static BitmapImage GetImageFromPath(string path)
+        {
+            if (File.Exists(path))
+            {
+                MemoryStream memoryStream = new MemoryStream();
+
+                byte[] fileBytes = File.ReadAllBytes(path);
+                memoryStream.Write(fileBytes, 0, fileBytes.Length);
+                memoryStream.Position = 0;
+
+                var image = new BitmapImage();
+                image.BeginInit();
+                image.StreamSource = memoryStream;
+                image.EndInit();
+                return image;
+            }
+            else
+            {
+                return null;
+            }
         }
 
         private static void LinkOnRequestNavigate(object sender, RequestNavigateEventArgs e)

--- a/src/modules/launcher/PowerLauncher/ReportWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/ReportWindow.xaml.cs
@@ -9,6 +9,7 @@ using System.Windows.Documents;
 using PowerLauncher.Helper;
 using Wox.Infrastructure;
 using Wox.Infrastructure.Logger;
+using System.Windows.Navigation;
 
 namespace PowerLauncher
 {
@@ -42,6 +43,16 @@ namespace PowerLauncher
             ErrorTextbox.Document.Blocks.Add(paragraph);
         }
 
+        private static void LinkOnRequestNavigate(object sender, RequestNavigateEventArgs e)
+        {
+            var ps = new ProcessStartInfo(e.Uri.ToString())
+            {
+                UseShellExecute = true,
+                Verb = "open"
+            };
+            Process.Start(ps);
+        }
+
         private static Paragraph Hyperlink(string textBeforeUrl, string url)
         {
             var paragraph = new Paragraph();
@@ -50,8 +61,7 @@ namespace PowerLauncher
             var link = new Hyperlink { IsEnabled = true };
             link.Inlines.Add(url);
             link.NavigateUri = new Uri(url);
-            link.RequestNavigate += (s, e) => Process.Start(e.Uri.ToString());
-            link.Click += (s, e) => Process.Start(url);
+            link.RequestNavigate += LinkOnRequestNavigate;
 
             paragraph.Inlines.Add(textBeforeUrl);
             paragraph.Inlines.Add(link);

--- a/src/modules/launcher/PowerLauncher/ReportWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/ReportWindow.xaml.cs
@@ -51,6 +51,7 @@ namespace PowerLauncher
             ErrorTextbox.Document.Blocks.Add(paragraph);
         }
 
+        // Function to get the Bitmap Image from the path
         private static BitmapImage GetImageFromPath(string path)
         {
             if (File.Exists(path))

--- a/src/modules/launcher/Wox.Infrastructure/Image/ImageLoader.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Image/ImageLoader.cs
@@ -71,8 +71,8 @@ namespace Wox.Infrastructure.Image
         {
             if (theme == Theme.Light || theme == Theme.HighContrastWhite)
             {
-                ErrorIconPath = Constant.ErrorIcon;
-                DefaultIconPath = Constant.DefaultIcon;
+                ErrorIconPath = Constant.LightThemedErrorIcon;
+                DefaultIconPath = Constant.LightThemedDefaultIcon;
             }
             else
             {

--- a/src/modules/launcher/Wox.Infrastructure/Wox.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Wox.cs
@@ -34,7 +34,7 @@ namespace Wox.Infrastructure
         public static readonly string DataDirectory = DetermineDataDirectory();
         public static readonly string PluginsDirectory = Path.Combine(DataDirectory, Plugins);
         public static readonly string PreinstalledDirectory = Path.Combine(ProgramDirectory, Plugins);
-        public const string Issue = "https://github.com/microsoft/PowerToys/issues/new";
+        public const string Issue = "https://github.com/microsoft/PowerToys/issues";
         public static readonly string Version = FileVersionInfo.GetVersionInfo(Assembly.Location.NonNull()).ProductVersion;
 
         public static readonly int ThumbnailSize = 64;

--- a/src/modules/launcher/Wox.Infrastructure/Wox.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Wox.cs
@@ -40,5 +40,7 @@ namespace Wox.Infrastructure
         public static readonly int ThumbnailSize = 64;
         public static readonly string DefaultIcon = Path.Combine(ProgramDirectory, "Images", "app.dark.png");
         public static readonly string ErrorIcon = Path.Combine(ProgramDirectory, "Images", "app_error.dark.png");
+        public static readonly string LightThemedDefaultIcon = Path.Combine(ProgramDirectory, "Images", "app.light.png");
+        public static readonly string LightThemedErrorIcon = Path.Combine(ProgramDirectory, "Images", "app_error.light.png");
     }
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
- Many of the Event Viewer logs where users observed crashing of PowerToys have an exception as follows - 
`System.IO.IOException: Cannot locate resource 'images/app_error.png'.`
![image](https://user-images.githubusercontent.com/28739210/88348671-ee4eed00-cd02-11ea-9b25-402d339dccfb.png)

This is because we made the app icons theme aware and the image app_error.png no longer exists. Due to this whenever there is an exception in the Dispatcher thread, an error reporting window is supposed to pop up, but PT Run crashes instead of showing that window because the img file no longer exists.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #5055
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
The changes made in this PR are as follows -
- Modified the error icon so that the window pops up as expected.
- Changed the User facing name of app to PT Run in the error reporting window.
- `Process.Start(uri)` throws a file not found exception in .NET Core apps, hence it had to be changed to use ProcessStartInfo instead.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- To replicate the Dispatcher exception, I added a `throw new Exception();` statement after the _viewModel.Query() is invoked in the dispatcher (MainViewModel.xaml.cs file). On typing in the search box, an exception is raised, which shows the error reporting window but does not crash the PT Run process, like it used to before.

```
 private async Task DelayedCheck(DateTime latestTimeOfTyping)
        {
            await Task.Delay(millisecondsToWait).ConfigureAwait(false);
            if (latestTimeOfTyping.Equals(s_lastTimeOfTyping))
            {
                await System.Windows.Application.Current.Dispatcher.BeginInvoke(new Action(() =>
                {
                    _viewModel.Query();
                }));
            }
        }
```
- Previously any exception in the dispatcher was leading to PT Run crashing. However, now it is handled and shows a window with information about the exception raised in the dispatcher. 
- 
![image](https://user-images.githubusercontent.com/28739210/88348998-bc8a5600-cd03-11ea-8d6c-3e658ccb4d31.png)
![image](https://user-images.githubusercontent.com/28739210/88349000-c01ddd00-cd03-11ea-8059-1b8f07b902b8.png)
