### PR TITLE
Add telemetry event for measuring time taken to display PT Run

### DIFF
--- a/src/modules/launcher/PowerLauncher.Telemetry/Events/LauncherColdStateHotkeyEvent.cs
+++ b/src/modules/launcher/PowerLauncher.Telemetry/Events/LauncherColdStateHotkeyEvent.cs
@@ -9,9 +9,9 @@ using System.Diagnostics.Tracing;
 namespace Microsoft.PowerLauncher.Telemetry
 {
     [EventData]
-    public class LauncherHotkeyEvent : EventBase, IEvent
+    public class LauncherColdStateHotkeyEvent : EventBase, IEvent
     {
-        public double HotkeyToShowTimeMs { get; set; }
+        public double HotkeyToVisibleTimeMs { get; set; }
 
         public PartA_PrivTags PartA_PrivTags => PartA_PrivTags.ProductAndServiceUsage;
     }

--- a/src/modules/launcher/PowerLauncher.Telemetry/Events/LauncherHotkeyEvent.cs
+++ b/src/modules/launcher/PowerLauncher.Telemetry/Events/LauncherHotkeyEvent.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.PowerToys.Telemetry;
+using Microsoft.PowerToys.Telemetry.Events;
+using System.Diagnostics.Tracing;
+
+namespace Microsoft.PowerLauncher.Telemetry
+{
+    [EventData]
+    public class LauncherHotkeyEvent : EventBase, IEvent
+    {
+        public double HotkeyToShowTimeMs { get; set; }
+
+        public PartA_PrivTags PartA_PrivTags => PartA_PrivTags.ProductAndServiceUsage;
+    }
+}

--- a/src/modules/launcher/PowerLauncher.Telemetry/Events/LauncherWarmStateHotkeyEvent.cs
+++ b/src/modules/launcher/PowerLauncher.Telemetry/Events/LauncherWarmStateHotkeyEvent.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.PowerToys.Telemetry;
+using Microsoft.PowerToys.Telemetry.Events;
+using System.Diagnostics.Tracing;
+
+namespace Microsoft.PowerLauncher.Telemetry
+{
+    [EventData]
+    public class LauncherWarmStateHotkeyEvent : EventBase, IEvent
+    {
+        public double HotkeyToVisibleTimeMs { get; set; }
+
+        public PartA_PrivTags PartA_PrivTags => PartA_PrivTags.ProductAndServiceUsage;
+    }
+}

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -371,6 +371,9 @@ namespace PowerLauncher
                 {
                     SearchBox.QueryTextBox.SelectAll();
                 }
+
+                // Log the time taken from pressing the hotkey till launcher is visible
+                PowerToysTelemetry.Log.WriteEvent(new LauncherHotkeyEvent() { HotkeyToShowTimeMs = _viewModel.GetHotkeyEventTimeMs() });
             }
             else
             {

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -28,6 +28,7 @@ namespace PowerLauncher
         private bool _isTextSetProgrammatically;
         bool _deletePressed = false;
         Timer _firstDeleteTimer = new Timer();
+        bool _coldStateHotkeyPressed = false;
 
         #endregion
 
@@ -372,8 +373,16 @@ namespace PowerLauncher
                     SearchBox.QueryTextBox.SelectAll();
                 }
 
-                // Log the time taken from pressing the hotkey till launcher is visible
-                PowerToysTelemetry.Log.WriteEvent(new LauncherHotkeyEvent() { HotkeyToShowTimeMs = _viewModel.GetHotkeyEventTimeMs() });
+                // Log the time taken from pressing the hotkey till launcher is visible as separate events depending on if it's the first hotkey invoke or second
+                if (!_coldStateHotkeyPressed)
+                {
+                    PowerToysTelemetry.Log.WriteEvent(new LauncherColdStateHotkeyEvent() { HotkeyToVisibleTimeMs = _viewModel.GetHotkeyEventTimeMs() });
+                    _coldStateHotkeyPressed = true;
+                }
+                else
+                {
+                    PowerToysTelemetry.Log.WriteEvent(new LauncherWarmStateHotkeyEvent() { HotkeyToVisibleTimeMs = _viewModel.GetHotkeyEventTimeMs() });
+                }
             }
             else
             {

--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -46,6 +46,7 @@ namespace PowerLauncher.ViewModel
         private HotkeyManager _hotkeyManager { get; set; }
         private ushort _hotkeyHandle;
         private readonly Internationalization _translator = InternationalizationManager.Instance;
+        private System.Diagnostics.Stopwatch hotkeyTimer = new System.Diagnostics.Stopwatch();
 
         #endregion
 
@@ -618,7 +619,12 @@ namespace PowerLauncher.ViewModel
             {
                 if (!ShouldIgnoreHotkeys())
                 {
+                    // If launcher window was hidden and the hotkey was pressed, start telemetry event
+                    if (MainWindowVisibility != Visibility.Visible)
+                    {
 
+                        StartHotkeyTimer();
+                    }
                     if (_settings.LastQueryMode == LastQueryMode.Empty)
                     {
                         ChangeQueryText(string.Empty);
@@ -809,6 +815,21 @@ namespace PowerLauncher.ViewModel
         {
             Dispose(disposing: true);
             GC.SuppressFinalize(this);
+        }
+
+        public void StartHotkeyTimer()
+        {
+            hotkeyTimer.Start();
+        }
+
+        public long GetHotkeyEventTimeMs()
+        {
+            hotkeyTimer.Stop();
+            long recordedTime = hotkeyTimer.ElapsedMilliseconds;
+
+            // Reset the stopwatch and return the time elapsed
+            hotkeyTimer.Reset();
+            return recordedTime;
         }
 
         #endregion


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR adds two telemetry events:
- Logging the cold state hotkey event time, i.e. after opening PowerToys the first time Alt+Space is pressed, till the PT Run window is visible.
- Logging the warm state hotkey event time, i.e. after the first hotkey event has been done, all successive Alt+Space hits till PT Run is visible. In both these events, the time is only recorded for making PT Run visible, not for hiding it.

Since the Stopwatch for measuring the time had to be started in the view model's `OnHotkey` method and stopped in the MainWindow.xaml.cs OnVisibilityChanged handler, the Stopwatch variable was added as a member to the view model, and it is accessed by public TimerStart/Stop methods.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Applies to #5198 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [X] Tests passed

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Validated that the events are emitted using the steps provided in the telemetry Readme using WPA https://github.com/microsoft/PowerToys/blob/master/src/common/Telemetry/readme.md
For ColdStateHotkeyEvent I observed 125ms averaged over two events and 1ms for WarmStateHotkeyEvent averaged over 8 events on my machine.