### PR TITLE
Prevent clicking through when selecting a color using color picker

### DIFF
--- a/src/modules/colorPicker/ColorPickerUI/Mouse/MouseHook.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Mouse/MouseHook.cs
@@ -92,6 +92,7 @@ namespace ColorPicker.Mouse
                     {
                         MouseDown.Invoke(null, new System.Drawing.Point(mouseHookStruct.pt.x, mouseHookStruct.pt.y));
                     }
+                    return new IntPtr(-1);
                 }
                 if (wParam.ToInt32() == WM_MOUSEWHEEL)
                 {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Left mouse click is not propagated to other controls when picking a color

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
fixes #5195

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #5195 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manual testing