### PR TITLE
Set default shortcut for activating launcher, creating settings.json …

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/PowerLauncherProperties.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/PowerLauncherProperties.cs
@@ -46,7 +46,7 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
 
         public PowerLauncherProperties()
         {
-            OpenPowerLauncher = new HotkeySettings(false, false, true, false, 68);
+            OpenPowerLauncher = new HotkeySettings(false, false, true, false, 32);
             OpenFileLocation = new HotkeySettings();
             CopyPathLocation = new HotkeySettings();
             OpenConsole = new HotkeySettings();
@@ -55,7 +55,7 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
             IgnoreHotkeysInFullscreen = false;
             DisableDriveDetectionWarning = false;
             ClearInputOnLaunch = false;
-            MaximumNumberOfResults = 9;
+            MaximumNumberOfResults = 4;
         }
     }
 }

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/PowerLauncherProperties.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/PowerLauncherProperties.cs
@@ -46,7 +46,7 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
 
         public PowerLauncherProperties()
         {
-            OpenPowerLauncher = new HotkeySettings();
+            OpenPowerLauncher = new HotkeySettings(false, false, true, false, 68);
             OpenFileLocation = new HotkeySettings();
             CopyPathLocation = new HotkeySettings();
             OpenConsole = new HotkeySettings();
@@ -55,6 +55,7 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
             IgnoreHotkeysInFullscreen = false;
             DisableDriveDetectionWarning = false;
             ClearInputOnLaunch = false;
+            MaximumNumberOfResults = 9;
         }
     }
 }


### PR DESCRIPTION
…on a start if it does not exists

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Launcher is not creating settings.json when it does not exists - fresh installation. Therefore it didn't register a default shortcut and you would have to go to settings to setup your shortcut which created settings.json
Now it does. 

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References
Fixes #5176 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #5176 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
