### PR TITLE
Add theme aware default icons to usage dictionary

### DIFF
--- a/src/modules/launcher/Wox.Infrastructure/Image/ImageCache.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Image/ImageCache.cs
@@ -38,7 +38,7 @@ namespace Wox.Infrastructure.Image
                     foreach (var key in _data.Keys)
                     {
                         int dictValue;
-                        if (!Usage.TryGetValue(key, out dictValue) && !(key.Equals(Constant.ErrorIcon) || key.Equals(Constant.DefaultIcon)))
+                        if (!Usage.TryGetValue(key, out dictValue) && !(key.Equals(Constant.ErrorIcon) || key.Equals(Constant.DefaultIcon) || key.Equals(Constant.LightThemedErrorIcon) || key.Equals(Constant.LightThemedDefaultIcon)))
                         {
                             ImageSource imgSource;
                             _data.TryRemove(key, out imgSource);

--- a/src/modules/launcher/Wox.Infrastructure/Image/ImageLoader.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Image/ImageLoader.cs
@@ -39,8 +39,7 @@ namespace Wox.Infrastructure.Image
             _hashGenerator = new ImageHashGenerator();
             ImageCache.SetUsageAsDictionary(_storage.TryLoad(new Dictionary<string, int>()));
 
-            // Todo : Add error and default icon specific to each theme
-            foreach (var icon in new[] { Constant.DefaultIcon, Constant.ErrorIcon })
+            foreach (var icon in new[] { Constant.DefaultIcon, Constant.ErrorIcon, Constant.LightThemedDefaultIcon, Constant.LightThemedErrorIcon })
             {
                 ImageSource img = new BitmapImage(new Uri(icon));
                 img.Freeze();


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
As a part of this PR - #5199, theme aware default icons were added. However, these default icons must be added to the usage dictionary without which an exception would be thrown.

<!-- Other than the issue solved, is this relevant to any other issues/existing PRs? --> 
## References

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] Applies to #xxx
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Manually validated that it does not throw that exception anymore.