### PR TITLE
[Settings] Adding collapse button to settings navview

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI.Runner/MainWindow.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Runner/MainWindow.xaml
@@ -7,7 +7,7 @@
         xmlns:Controls="clr-namespace:Microsoft.Toolkit.Wpf.UI.Controls;assembly=Microsoft.Toolkit.Wpf.UI.Controls"
         xmlns:xaml="clr-namespace:Microsoft.Toolkit.Wpf.UI.XamlHost;assembly=Microsoft.Toolkit.Wpf.UI.XamlHost"
         mc:Ignorable="d"
-        Title="PowerToys Settings" Height="800" Width="1000" Closing="MainWindow_Closing">
+        Title="PowerToys Settings" Height="800" Width="1100" Closing="MainWindow_Closing">
     <Grid>
         <xaml:WindowsXamlHost InitialTypeName="Microsoft.PowerToys.Settings.UI.Views.ShellPage" ChildChanged="WindowsXamlHost_ChildChanged" />
     </Grid>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Styles/_Sizes.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Styles/_Sizes.xaml
@@ -6,7 +6,7 @@
     <x:Double x:Key="SidePanelWidth">240</x:Double>
 
     <!-- Breakpoint for wide layout (side panel next to content) -->
-    <x:Double x:Key="WideLayoutMinWidth">1100</x:Double>
+    <x:Double x:Key="WideLayoutMinWidth">1008</x:Double>
     
     <!-- Breakpoint for small layout (side panel under content) -->
     <x:Double x:Key="SmallLayoutMinWidth">480</x:Double>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ShellPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ShellPage.xaml
@@ -24,7 +24,8 @@
         IsBackButtonVisible="Collapsed"
         IsBackEnabled="{x:Bind ViewModel.IsBackEnabled, Mode=OneWay}"
         SelectedItem="{x:Bind ViewModel.Selected, Mode=OneWay}"
-        IsSettingsVisible="False" 
+        IsSettingsVisible="False"
+        OpenPaneLength="296"
         CompactModeThresholdWidth="0"
         Background="{ThemeResource SystemControlBackgroundAltHighBrush}">
             <winui:NavigationView.MenuItems>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ShellPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ShellPage.xaml
@@ -24,11 +24,9 @@
         IsBackButtonVisible="Collapsed"
         IsBackEnabled="{x:Bind ViewModel.IsBackEnabled, Mode=OneWay}"
         SelectedItem="{x:Bind ViewModel.Selected, Mode=OneWay}"
-        IsSettingsVisible="False"
-        IsPaneToggleButtonVisible="False" 
-        PaneDisplayMode="Left"
-        Background="{ThemeResource SystemControlBackgroundAltHighBrush}"
-            >
+        IsSettingsVisible="False" 
+        CompactModeThresholdWidth="0"
+        Background="{ThemeResource SystemControlBackgroundAltHighBrush}">
             <winui:NavigationView.MenuItems>
                 <winui:NavigationViewItem x:Uid="Shell_General" helpers:NavHelper.NavigateTo="views:GeneralPage">
                     <winui:NavigationViewItem.Icon>
@@ -96,7 +94,7 @@
                     <behaviors:NavigationViewHeaderBehavior.DefaultHeaderTemplate>
                         <DataTemplate>
                             <!-- TODO: Style clean up-->
-                            <Grid Margin="0, 12, 0, 6">
+                            <Grid Margin="0, -2, 0, 6">
                                 <TextBlock
                                 Text="{Binding}"
                                 FontWeight="Bold"


### PR DESCRIPTION
## Summary of the Pull Request

This PR adds back the NavigationView collapse button. With it, it comes with auto collapsing when resizing the window, which is great for smaller screen sizes. The default window width was increased to 1100 so the navview auto expands.

![Settings Navview](https://user-images.githubusercontent.com/9866362/88463936-e20b9100-ceb6-11ea-89f0-36c2e13489ee.gif)


## PR Checklist
* [X] Applies to #5122
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx
 