### PR TITLE
[FancyZonesEditor] Don't load malformed custom layout and show appropriate message

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.IO;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Windows;
@@ -225,13 +226,13 @@ namespace FancyZonesEditor.Models
                         int rows = info.GetProperty(RowsJsonTag).GetInt32();
                         int columns = info.GetProperty(ColumnsJsonTag).GetInt32();
 
-                        if (rows <= 0 || columns <= 0)
+                        List<int> rowsPercentage = new List<int>(rows);
+                        JsonElement.ArrayEnumerator rowsPercentageEnumerator = info.GetProperty(RowsPercentageJsonTag).EnumerateArray();
+                        if (rows <= 0 || columns <= 0 || rowsPercentageEnumerator.Count() != rows)
                         {
                             error = true;
                         }
 
-                        List<int> rowsPercentage = new List<int>(rows);
-                        JsonElement.ArrayEnumerator rowsPercentageEnumerator = info.GetProperty(RowsPercentageJsonTag).EnumerateArray();
                         while (rowsPercentageEnumerator.MoveNext())
                         {
                             int percentage = rowsPercentageEnumerator.Current.GetInt32();
@@ -246,6 +247,11 @@ namespace FancyZonesEditor.Models
 
                         List<int> columnsPercentage = new List<int>(columns);
                         JsonElement.ArrayEnumerator columnsPercentageEnumerator = info.GetProperty(ColumnsPercentageJsonTag).EnumerateArray();
+                        if (columnsPercentageEnumerator.Count() != columns)
+                        {
+                            error = true;
+                        }
+
                         while (columnsPercentageEnumerator.MoveNext())
                         {
                             int percentage = columnsPercentageEnumerator.Current.GetInt32();
@@ -261,10 +267,22 @@ namespace FancyZonesEditor.Models
                         int i = 0;
                         JsonElement.ArrayEnumerator cellChildMapRows = info.GetProperty(CellChildMapJsonTag).EnumerateArray();
                         int[,] cellChildMap = new int[rows, columns];
+
+                        if (cellChildMapRows.Count() != rows)
+                        {
+                            error = true;
+                        }
+
                         while (cellChildMapRows.MoveNext())
                         {
                             int j = 0;
                             JsonElement.ArrayEnumerator cellChildMapRowElems = cellChildMapRows.Current.EnumerateArray();
+                            if (cellChildMapRowElems.Count() != columns)
+                            {
+                                error = true;
+                                break;
+                            }
+
                             while (cellChildMapRowElems.MoveNext())
                             {
                                 cellChildMap[i, j++] = cellChildMapRowElems.Current.GetInt32();
@@ -290,6 +308,12 @@ namespace FancyZonesEditor.Models
                         IList<Int32Rect> zones = new List<Int32Rect>();
 
                         bool error = false;
+
+                        if (lastWorkAreaWidth <= 0 || lastWorkAreaHeight <= 0)
+                        {
+                            error = true;
+                        }
+
                         while (zonesEnumerator.MoveNext())
                         {
                             int x = zonesEnumerator.Current.GetProperty(XJsonTag).GetInt32();

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
@@ -228,7 +228,11 @@ namespace FancyZonesEditor.Models
 
                         List<int> rowsPercentage = new List<int>(rows);
                         JsonElement.ArrayEnumerator rowsPercentageEnumerator = info.GetProperty(RowsPercentageJsonTag).EnumerateArray();
-                        if (rows <= 0 || columns <= 0 || rowsPercentageEnumerator.Count() != rows)
+
+                        List<int> columnsPercentage = new List<int>(columns);
+                        JsonElement.ArrayEnumerator columnsPercentageEnumerator = info.GetProperty(ColumnsPercentageJsonTag).EnumerateArray();
+
+                        if (rows <= 0 || columns <= 0 || rowsPercentageEnumerator.Count() != rows || columnsPercentageEnumerator.Count() != columns)
                         {
                             error = true;
                         }
@@ -236,7 +240,7 @@ namespace FancyZonesEditor.Models
                         while (rowsPercentageEnumerator.MoveNext())
                         {
                             int percentage = rowsPercentageEnumerator.Current.GetInt32();
-                            if (percentage <= 0)
+                            if (error || percentage <= 0)
                             {
                                 error = true;
                                 break;
@@ -245,17 +249,10 @@ namespace FancyZonesEditor.Models
                             rowsPercentage.Add(percentage);
                         }
 
-                        List<int> columnsPercentage = new List<int>(columns);
-                        JsonElement.ArrayEnumerator columnsPercentageEnumerator = info.GetProperty(ColumnsPercentageJsonTag).EnumerateArray();
-                        if (columnsPercentageEnumerator.Count() != columns)
-                        {
-                            error = true;
-                        }
-
                         while (columnsPercentageEnumerator.MoveNext())
                         {
                             int percentage = columnsPercentageEnumerator.Current.GetInt32();
-                            if (percentage <= 0)
+                            if (error || percentage <= 0)
                             {
                                 error = true;
                                 break;
@@ -277,7 +274,7 @@ namespace FancyZonesEditor.Models
                         {
                             int j = 0;
                             JsonElement.ArrayEnumerator cellChildMapRowElems = cellChildMapRows.Current.EnumerateArray();
-                            if (cellChildMapRowElems.Count() != columns)
+                            if (error || cellChildMapRowElems.Count() != columns)
                             {
                                 error = true;
                                 break;
@@ -321,7 +318,7 @@ namespace FancyZonesEditor.Models
                             int width = zonesEnumerator.Current.GetProperty(WidthJsonTag).GetInt32();
                             int height = zonesEnumerator.Current.GetProperty(HeightJsonTag).GetInt32();
 
-                            if (width <= 0 || height <= 0)
+                            if (error || width <= 0 || height <= 0)
                             {
                                 error = true;
                                 break;

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
@@ -216,6 +216,7 @@ namespace FancyZonesEditor.Models
                     string type = current.GetProperty(TypeJsonTag).GetString();
                     string uuid = current.GetProperty(UuidJsonTag).GetString();
                     var info = current.GetProperty(InfoJsonTag);
+
                     if (type.Equals(GridJsonTag))
                     {
                         int rows = info.GetProperty(RowsJsonTag).GetInt32();

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
@@ -237,10 +237,10 @@ namespace FancyZonesEditor.Models
                             error = true;
                         }
 
-                        while (rowsPercentageEnumerator.MoveNext())
+                        while (!error && rowsPercentageEnumerator.MoveNext())
                         {
                             int percentage = rowsPercentageEnumerator.Current.GetInt32();
-                            if (error || percentage <= 0)
+                            if (percentage <= 0)
                             {
                                 error = true;
                                 break;
@@ -249,10 +249,10 @@ namespace FancyZonesEditor.Models
                             rowsPercentage.Add(percentage);
                         }
 
-                        while (columnsPercentageEnumerator.MoveNext())
+                        while (!error && columnsPercentageEnumerator.MoveNext())
                         {
                             int percentage = columnsPercentageEnumerator.Current.GetInt32();
-                            if (error || percentage <= 0)
+                            if (percentage <= 0)
                             {
                                 error = true;
                                 break;
@@ -270,11 +270,11 @@ namespace FancyZonesEditor.Models
                             error = true;
                         }
 
-                        while (cellChildMapRows.MoveNext())
+                        while (!error && cellChildMapRows.MoveNext())
                         {
                             int j = 0;
                             JsonElement.ArrayEnumerator cellChildMapRowElems = cellChildMapRows.Current.EnumerateArray();
-                            if (error || cellChildMapRowElems.Count() != columns)
+                            if (cellChildMapRowElems.Count() != columns)
                             {
                                 error = true;
                                 break;
@@ -311,14 +311,14 @@ namespace FancyZonesEditor.Models
                             error = true;
                         }
 
-                        while (zonesEnumerator.MoveNext())
+                        while (!error && zonesEnumerator.MoveNext())
                         {
                             int x = zonesEnumerator.Current.GetProperty(XJsonTag).GetInt32();
                             int y = zonesEnumerator.Current.GetProperty(YJsonTag).GetInt32();
                             int width = zonesEnumerator.Current.GetProperty(WidthJsonTag).GetInt32();
                             int height = zonesEnumerator.Current.GetProperty(HeightJsonTag).GetInt32();
 
-                            if (error || width <= 0 || height <= 0)
+                            if (width <= 0 || height <= 0)
                             {
                                 error = true;
                                 break;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
If custom layout data is malformed for some reason (user entered data manually in zones-settings.json, some error in FZ malformed the data, etc..) error message is shown to user with appropriate message and malformed custom layout is not loaded into Editor.
Copy of https://github.com/stefansjfw/PowerToys/pull/23

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] Applies to #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manually updated zones-settings file to contain malformed custom layouts and confirm that error message is shown & layout is not shown in Editor.
Unit tests.