### PR TITLE
chore: add most used projects helper build script

### DIFF
--- a/tools/build/build-essentials.ps1
+++ b/tools/build/build-essentials.ps1
@@ -1,0 +1,16 @@
+cd $PSScriptRoot
+cd ..\..
+$cwd = Get-Location
+$SolutionDir = $cwd,"" -join "\"
+cd $SolutionDir
+$BuildArgs = "/p:Configuration=Release /p:Platform=x64 /p:BuildProjectReferences=false /p:SolutionDir=$SolutionDir"
+
+$ProjectsToBuild = 
+  ".\src\runner\runner.vcxproj",
+  ".\src\modules\shortcut_guide\shortcut_guide.vcxproj",
+  ".\src\modules\fancyzones\lib\FancyZonesLib.vcxproj",
+  ".\src\modules\fancyzones\dll\FancyZonesModule.vcxproj"
+
+$ProjectsToBuild | % {
+  Invoke-Expression "msbuild $_ $BuildArgs"
+}


### PR DESCRIPTION
## Summary of the Pull Request
- Implement helper PowerShell script which can be easily configured for your most used projects:
- VS tools should be available in %PATH%
- invocation dir isn't important