### PR TITLE
autoupdate: handle exceptions in download_update

### DIFF
--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -40,6 +40,7 @@ const wchar_t EXPLORER_PROCESS_NAME[] = L"explorer.exe";
 namespace localized_strings
 {
     const wchar_t MSI_VERSION_IS_ALREADY_RUNNING[] = L"An older version of PowerToys is already running.";
+    const wchar_t DOWNLOAD_UPDATE_ERROR[] = L"Couldn't download PowerToys update! Please report the issue on Github.";
     const wchar_t OLDER_MSIX_UNINSTALLED[] = L"An older MSIX version of PowerToys was uninstalled.";
     const wchar_t PT_UPDATE_MESSAGE_BOX_TEXT[] = L"PowerToys was updated and some components require Windows Explorer to restart. Do you want to restart Windows Explorer now?";
 }
@@ -233,14 +234,26 @@ toast_notification_handler_result toast_notification_handler(const std::wstring_
     }
     else if (param.starts_with(download_and_install_update))
     {
-        std::wstring installer_filename = updating::download_update().get();
+        try
+        {
+            std::wstring installer_filename = updating::download_update().get();
 
-        std::wstring args{ UPDATE_NOW_LAUNCH_STAGE1_CMDARG };
-        args += L' ';
-        args += installer_filename;
-        launch_action_runner(args.c_str());
+            std::wstring args{ UPDATE_NOW_LAUNCH_STAGE1_CMDARG };
+            args += L' ';
+            args += installer_filename;
+            launch_action_runner(args.c_str());
 
-        return toast_notification_handler_result::exit_success;
+            return toast_notification_handler_result::exit_success;
+        }
+        catch (...)
+        {
+            MessageBoxW(nullptr,
+                        localized_strings::DOWNLOAD_UPDATE_ERROR,
+                        L"PowerToys",
+                        MB_ICONWARNING | MB_OK);
+
+            return toast_notification_handler_result::exit_error;
+        }
     }
     else
     {


### PR DESCRIPTION
## Summary of the Pull Request
We've tried investigating [the issue mentioned here](https://github.com/microsoft/PowerToys/pull/5204#issuecomment-664419659) with @ivan100sic and it looks like atm we could only handle exceptions and report the error for visibility.

## PR Checklist
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Validation Steps Performed

- update PT