### PR TITLE
Allows Hotkey Picker to not necessarily need a "Combo Key" 

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/HotkeySettings.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/HotkeySettings.cs
@@ -98,9 +98,41 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
             return output.ToString();
         }
 
-        public bool IsValid()
+        public bool IsValid(string necessaryKeys)
         {
-            return (Alt || Ctrl || Win || Shift) && Code != 0;
+            return HasAtLeastOneOfNecessaryKeys(necessaryKeys) && Code != 0;
+        }
+
+        // Checks if at least one of the necessary keys matches,
+        // if necessaryKeys is empty, then it will always return true.
+        private bool HasAtLeastOneOfNecessaryKeys(string necessaryKeys)
+        {
+            if (string.IsNullOrWhiteSpace(necessaryKeys))
+            {
+                return true;
+            }
+
+            if (necessaryKeys.Contains("Win") && Win)
+            {
+                return true;
+            }
+
+            if (necessaryKeys.Contains("Ctrl") && Ctrl)
+            {
+                return true;
+            }
+
+            if (necessaryKeys.Contains("Alt") && Alt)
+            {
+                return true;
+            }
+
+            if (necessaryKeys.Contains("Shift") && Shift)
+            {
+                return true;
+            }
+
+            return false;
         }
 
         public bool IsEmpty()

--- a/src/core/Microsoft.PowerToys.Settings.UI/Controls/HotkeySettingsControl.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Controls/HotkeySettingsControl.xaml
@@ -10,10 +10,10 @@
     d:DesignWidth="400">
     <StackPanel Orientation="Vertical">
         <ToolTipService.ToolTip>
-            <ToolTip>
+            <ToolTip Name="HotkeyTooltip">
                 <StackPanel Orientation="Vertical">
                     <TextBlock x:Uid="ShortcutWarningLabel"/>
-                    <TextBlock Text="{x:Bind Keys, Mode=OneTime}" FontWeight="SemiBold"/>
+                    <TextBlock Text="{x:Bind _keys, Mode=OneTime}" FontWeight="SemiBold"/>
                 </StackPanel>
             </ToolTip>
         </ToolTipService.ToolTip>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Controls/HotkeySettingsControl.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Controls/HotkeySettingsControl.xaml
@@ -13,7 +13,7 @@
             <ToolTip Name="HotkeyTooltip">
                 <StackPanel Orientation="Vertical">
                     <TextBlock x:Uid="ShortcutWarningLabel"/>
-                    <TextBlock Text="{x:Bind _keys, Mode=OneTime}" FontWeight="SemiBold"/>
+                    <TextBlock Text="{x:Bind Keys, Mode=OneTime}" FontWeight="SemiBold"/>
                 </StackPanel>
             </ToolTip>
         </ToolTipService.ToolTip>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Controls/HotkeySettingsControl.xaml.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Controls/HotkeySettingsControl.xaml.cs
@@ -192,7 +192,7 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
 
         private void HotkeyTextBox_LosingFocus(object sender, RoutedEventArgs e)
         {
-            if (lastValidSettings != null && (lastValidSettings.IsValid(_keys) || lastValidSettings.IsEmpty()))
+            if (lastValidSettings != null && (lastValidSettings.IsValid(Keys) || lastValidSettings.IsEmpty()))
             {
                 HotkeySettings = lastValidSettings.Clone();
             }

--- a/src/core/Microsoft.PowerToys.Settings.UI/Controls/HotkeySettingsControl.xaml.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Controls/HotkeySettingsControl.xaml.cs
@@ -14,7 +14,31 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
     {
         public string Header { get; set; }
 
-        public string Keys { get; set; }
+        private string _keys;
+
+        public string Keys
+        {
+            get
+            {
+                return _keys;
+            }
+
+            set
+            {
+                _keys = value;
+
+                if (string.IsNullOrWhiteSpace(_keys))
+                {
+                    TitleGlyph.Visibility = Visibility.Collapsed;
+                    HotkeyTooltip.IsEnabled = false;
+                }
+                else
+                {
+                    TitleGlyph.Visibility = Visibility.Visible;
+                    HotkeyTooltip.IsEnabled = true;
+                }
+            }
+        }
 
         public static readonly DependencyProperty IsActiveProperty =
             DependencyProperty.Register(
@@ -93,6 +117,7 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
             HotkeyTextBox.GettingFocus += HotkeyTextBox_GettingFocus;
             HotkeyTextBox.LosingFocus += HotkeyTextBox_LosingFocus;
             HotkeyTextBox.Unloaded += HotkeyTextBox_Unloaded;
+
             hook = new HotkeySettingsControlHook(Hotkey_KeyDown, Hotkey_KeyUp, Hotkey_IsActive);
         }
 
@@ -168,7 +193,7 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
 
         private void HotkeyTextBox_LosingFocus(object sender, RoutedEventArgs e)
         {
-            if (lastValidSettings != null && (lastValidSettings.IsValid() || lastValidSettings.IsEmpty()))
+            if (lastValidSettings != null && (lastValidSettings.IsValid(_keys) || lastValidSettings.IsEmpty()))
             {
                 HotkeySettings = lastValidSettings.Clone();
             }

--- a/src/core/Microsoft.PowerToys.Settings.UI/Controls/HotkeySettingsControl.xaml.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Controls/HotkeySettingsControl.xaml.cs
@@ -117,7 +117,6 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
             HotkeyTextBox.GettingFocus += HotkeyTextBox_GettingFocus;
             HotkeyTextBox.LosingFocus += HotkeyTextBox_LosingFocus;
             HotkeyTextBox.Unloaded += HotkeyTextBox_Unloaded;
-
             hook = new HotkeySettingsControlHook(Hotkey_KeyDown, Hotkey_KeyUp, Hotkey_IsActive);
         }
 

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
@@ -64,7 +64,7 @@
                                                   HorizontalAlignment="Left"
                                                   Margin="{StaticResource SmallTopMargin}"
                                                   HotkeySettings="{x:Bind Path=ViewModel.OpenPowerLauncher, Mode=TwoWay}"
-                                                  Keys="Win, Ctrl, Alt, Shift"
+                                                  Keys=""
                                                   Enabled="{x:Bind Mode=OneWay, Path=ViewModel.EnablePowerLauncher}"/>
             <!--<Custom:HotkeySettingsControl x:Uid="PowerLauncher_OpenFileLocation"
                                           Width="320"


### PR DESCRIPTION
## Summary of the Pull Request

This PR allows Hotkey Picker to not necessarily have a combo key and removes this requisite from the *PowerToys Run*. (Closes #4203)

The user must still choose one of the keys present on the *Keys* attribute, so, for example, the *Color Picker* PowerToy Hotkey Chooser will not be affected by these changes.

This PR also removes the tooltip informing the user of the required keys when they are not present.

## PR Checklist
* [x] Applies to #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

The option for people creating new toys that have the Hotkey Component to not force users to have at least one "Combo Key" present, and removes the "Combo Key" obligation from the *PowerToys Run*. So a user can now use, for example, just the `Caps Lock` key to activate the Launcher.

## Validation Steps Performed

1 - Verify that there were no changes on the Color Picker Hotkey component.
2 - Verify that the tooltip on the *PowerToys Run* does not exist and does not pop-up after mousing over.
3 - Verify that after choosing a key (for example `Caps Lock`) and focusing out, the key chosen persists.
4 - Verify that after pressing the chosen key, the Launcher opens.