### PR TITLE
[FancyZones] Enable manual zoning of child windows

### DIFF
--- a/src/common/common.cpp
+++ b/src/common/common.cpp
@@ -102,7 +102,7 @@ static bool no_visible_owner(HWND window) noexcept
     return rect.top == rect.bottom || rect.left == rect.right;
 }
 
-FancyZonesFilter get_fancyzones_filtered_window(HWND window)
+FancyZonesFilter get_fancyzones_filtered_window(HWND window, bool IsNewlyCreatedWindow)
 {
     FancyZonesFilter result;
     if (GetAncestor(window, GA_ROOT) != window || !IsWindowVisible(window))
@@ -143,7 +143,7 @@ FancyZonesFilter get_fancyzones_filtered_window(HWND window)
     result.process_path = std::move(process_path);
     result.standard_window = true;
     result.no_visible_owner = no_visible_owner(window);
-    result.zonable = result.standard_window && result.no_visible_owner;
+    result.zonable = result.standard_window && (result.no_visible_owner || !IsNewlyCreatedWindow);
     return result;
 }
 

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -22,7 +22,7 @@ struct FancyZonesFilter
     bool no_visible_owner = false; // True if the window is a top-level window that does not have a visible owner
     std::wstring process_path; // Path to the executable owning the window
 };
-FancyZonesFilter get_fancyzones_filtered_window(HWND window);
+FancyZonesFilter get_fancyzones_filtered_window(HWND window, bool IsNewlyCreatedWindow);
 
 // Gets active foreground window, filtering out all "non standard" windows like the taskbar, etc.
 struct ShortcutGuideFilter

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -357,7 +357,7 @@ bool FancyZones::ShouldProcessNewWindow(HWND window) noexcept
     // that belong to excluded applications list.
     if (IsSplashScreen(window) ||
         (reinterpret_cast<size_t>(::GetProp(window, MULTI_ZONE_STAMP)) != 0) ||
-        !IsInterestingWindow(window, m_settings->GetSettings()->excludedAppsArray))
+        !IsInterestingWindow(window, m_settings->GetSettings()->excludedAppsArray, true))
     {
         return false;
     }

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -397,7 +397,11 @@ IFACEMETHODIMP ZoneWindow::MoveSizeEnd(HWND window, POINT const& ptScreen) noexc
         MapWindowPoints(nullptr, m_window.get(), &ptClient, 1);
         m_activeZoneSet->MoveWindowIntoZoneByIndexSet(window, m_window.get(), m_highlightZone);
 
-        SaveWindowProcessToZoneIndex(window);
+        auto filtered = get_fancyzones_filtered_window(window, false);
+        if (filtered.no_visible_owner)
+        {
+            SaveWindowProcessToZoneIndex(window);
+        }
     }
     Trace::ZoneWindow::MoveSizeEnd(m_activeZoneSet);
 
@@ -428,7 +432,11 @@ ZoneWindow::MoveWindowIntoZoneByDirection(HWND window, DWORD vkCode, bool cycle)
     {
         if (m_activeZoneSet->MoveWindowIntoZoneByDirection(window, m_window.get(), vkCode, cycle))
         {
-            SaveWindowProcessToZoneIndex(window);
+            auto filtered = get_fancyzones_filtered_window(window, false);
+            if (filtered.no_visible_owner)
+            {
+                SaveWindowProcessToZoneIndex(window);
+            }
             return true;
         }
     }

--- a/src/modules/fancyzones/lib/util.cpp
+++ b/src/modules/fancyzones/lib/util.cpp
@@ -153,9 +153,9 @@ void SizeWindowToRect(HWND window, RECT rect) noexcept
     ::SetWindowPlacement(window, &placement);
 }
 
-bool IsInterestingWindow(HWND window, const std::vector<std::wstring>& excludedApps) noexcept
+bool IsInterestingWindow(HWND window, const std::vector<std::wstring>& excludedApps, bool IsNewlyCreatedWindow) noexcept
 {
-    auto filtered = get_fancyzones_filtered_window(window);
+    auto filtered = get_fancyzones_filtered_window(window, IsNewlyCreatedWindow);
     if (!filtered.zonable)
     {
         return false;

--- a/src/modules/fancyzones/lib/util.h
+++ b/src/modules/fancyzones/lib/util.h
@@ -120,7 +120,7 @@ UINT GetDpiForMonitor(HMONITOR monitor) noexcept;
 void OrderMonitors(std::vector<std::pair<HMONITOR, RECT>>& monitorInfo);
 void SizeWindowToRect(HWND window, RECT rect) noexcept;
 
-bool IsInterestingWindow(HWND window, const std::vector<std::wstring>& excludedApps) noexcept;
+bool IsInterestingWindow(HWND window, const std::vector<std::wstring>& excludedApps, bool IsNewlyCreatedWindow = false) noexcept;
 void SaveWindowSizeAndOrigin(HWND window) noexcept;
 void RestoreWindowSize(HWND window) noexcept;
 void RestoreWindowOrigin(HWND window) noexcept;


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
Enable manual (using hotkey and shift+drag) zoning of child windows and do not keep them in zone app history.

## PR Checklist
* [X] Applies to #1445 #2834
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [X] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx
