### PR TITLE
Fixed an issue of not being able to change settings for ColorPicker

### DIFF
--- a/src/modules/colorPicker/ColorPicker/ColorPicker.rc
+++ b/src/modules/colorPicker/ColorPicker/ColorPicker.rc
@@ -4,8 +4,8 @@
 
 STRINGTABLE
 BEGIN
-    IDS_LAUNCHER_NAME            L"Color Picker" 
-    IDS_LAUNCHER_SETTINGS_DESC   L"This feature requires Windows 10 version 1903 or higher"
+    IDS_COLORPICKER_NAME            L"ColorPicker" 
+    IDS_COLORPICKER_SETTINGS_DESC   L"This feature requires Windows 10 version 1903 or higher"
 END
 
 1 VERSIONINFO

--- a/src/modules/colorPicker/ColorPicker/dllmain.cpp
+++ b/src/modules/colorPicker/ColorPicker/dllmain.cpp
@@ -45,7 +45,7 @@ private:
 public:
     ColorPicker()
     {
-        app_name = GET_RESOURCE_STRING(IDS_LAUNCHER_NAME);
+        app_name = GET_RESOURCE_STRING(IDS_COLORPICKER_NAME);
     }
 
     ~ColorPicker()
@@ -74,7 +74,7 @@ public:
 
         // Create a Settings object.
         PowerToysSettings::Settings settings(hinstance, get_name());
-        settings.set_description(GET_RESOURCE_STRING(IDS_LAUNCHER_SETTINGS_DESC));
+        settings.set_description(GET_RESOURCE_STRING(IDS_COLORPICKER_SETTINGS_DESC));
 
         settings.set_overview_link(L"https://aka.ms/PowerToysOverview_ColorPicker");
 

--- a/src/modules/colorPicker/ColorPicker/resource.h
+++ b/src/modules/colorPicker/ColorPicker/resource.h
@@ -12,5 +12,5 @@
 // Non-localizable
 //////////////////////////////
 
-#define IDS_LAUNCHER_NAME             601
-#define IDS_LAUNCHER_SETTINGS_DESC    602
+#define IDS_COLORPICKER_NAME             601
+#define IDS_COLORPICKER_SETTINGS_DESC    602


### PR DESCRIPTION
## Summary of the Pull Request
ColorPicker module name had a space in it, in C++ part, so it was not reacting to settings.json changes requested by Settings UI
fixes #5347
## PR Checklist
* [x] Applies to #5347
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request


## Validation Steps Performed
Manual testing 
