### PR TITLE
Running color picker as non-elevated when PT is running as admin

### DIFF
--- a/src/common/common.h
+++ b/src/common/common.h
@@ -138,3 +138,4 @@ template<class... Ts>
 overloaded(Ts...) -> overloaded<Ts...>;
 
 #define POWER_LAUNCHER_PID_SHARED_FILE L"Local\\3cbfbad4-199b-4e2c-9825-942d5d3d3c74"
+#define COLORPICKER_PID_SHARED_FILE L"Local\\a1ccc22e-2d4a-cc55-f727-b03deacc52e9"

--- a/src/modules/colorPicker/ColorPicker/dllmain.cpp
+++ b/src/modules/colorPicker/ColorPicker/dllmain.cpp
@@ -112,21 +112,7 @@ public:
         {
             unsigned long powertoys_pid = GetCurrentProcessId();
 
-            if (!is_process_elevated(false))
-            {
-                std::wstring executable_args = L"";
-                executable_args.append(std::to_wstring(powertoys_pid));
-
-                SHELLEXECUTEINFOW sei{ sizeof(sei) };
-                sei.fMask = { SEE_MASK_NOCLOSEPROCESS | SEE_MASK_FLAG_NO_UI };
-                sei.lpFile = L"modules\\ColorPicker\\ColorPicker.exe";
-                sei.nShow = SW_SHOWNORMAL;
-                sei.lpParameters = executable_args.data();
-                ShellExecuteExW(&sei);
-
-                m_hProcess = sei.hProcess;
-            }
-            else
+            if (is_process_elevated(false))
             {
                 std::wstring action_runner_path = get_module_folderpath();
 
@@ -166,7 +152,20 @@ public:
                     CloseHandle(hMapFile);
                 }
             }
-          
+            else
+            {
+                std::wstring executable_args = L"";
+                executable_args.append(std::to_wstring(powertoys_pid));
+
+                SHELLEXECUTEINFOW sei{ sizeof(sei) };
+                sei.fMask = { SEE_MASK_NOCLOSEPROCESS | SEE_MASK_FLAG_NO_UI };
+                sei.lpFile = L"modules\\ColorPicker\\ColorPicker.exe";
+                sei.nShow = SW_SHOWNORMAL;
+                sei.lpParameters = executable_args.data();
+                ShellExecuteExW(&sei);
+
+                m_hProcess = sei.hProcess;
+            }
 
             m_enabled = true;
         }


### PR DESCRIPTION
## Summary of the Pull Request

Do not run ColorPicker elevated when PT is running elevated 

## PR Checklist
* [X] Applies to #5348
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

## Validation Steps Performed

_How does someone test & validate?_
