### PR TITLE
Improve query cancellation and ResultCollection performance

### DIFF
--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -111,7 +111,7 @@ namespace PowerLauncher.ViewModel
                     Task.Run(() =>
                     {
                         PluginManager.UpdatePluginMetadata(e.Results, pair.Metadata, e.Query);
-                        UpdateResultView(e.Results, pair.Metadata, e.Query);
+                        UpdateResultView(e.Results, pair.Metadata, e.Query, _updateToken);
                     }, _updateToken);
                 };
             }
@@ -421,11 +421,11 @@ namespace PowerLauncher.ViewModel
                     r => StringMatcher.FuzzySearch(query, r.Title).IsSearchPrecisionScoreMet() ||
                          StringMatcher.FuzzySearch(query, r.SubTitle).IsSearchPrecisionScoreMet()
                 ).ToList();
-                History.AddResults(filtered, id);
+                History.AddResults(filtered, id, _updateToken);
             }
             else
             {
-                History.AddResults(results, id);
+                History.AddResults(results, id, _updateToken);
             }
         }
 
@@ -448,23 +448,34 @@ namespace PowerLauncher.ViewModel
                     Task.Run(() =>
                     {
                         Thread.Sleep(20);
-                        RemoveOldQueryResults(query);
                         var plugins = PluginManager.ValidPluginsForQuery(query);
 
                         try
                         {
                             currentCancellationToken.ThrowIfCancellationRequested();
-                            foreach(PluginPair plugin in plugins)
+
+                            var resultPluginPair = new List<(List<Result>, PluginMetadata)>();
+                            foreach (PluginPair plugin in plugins)
                             {
-                                if (!plugin.Metadata.Disabled && !currentCancellationToken.IsCancellationRequested)
+                                if (!plugin.Metadata.Disabled)
                                 {
                                     var results = PluginManager.QueryForPlugin(plugin, query);
+                                    resultPluginPair.Add((results, plugin.Metadata));
                                     currentCancellationToken.ThrowIfCancellationRequested();
-                                    lock (_addResultsLock)
-                                    {
-                                        UpdateResultView(results, plugin.Metadata, query);
-                                    }
                                 }
+                            }
+
+                            lock (_addResultsLock)
+                            {
+                                RemoveOldQueryResults(query);
+                                foreach (var p in resultPluginPair)
+                                {
+                                    UpdateResultView(p.Item1, p.Item2, query, currentCancellationToken);
+                                    currentCancellationToken.ThrowIfCancellationRequested();
+                                }
+
+                                currentCancellationToken.ThrowIfCancellationRequested();
+                                Results.Results.Sort();
                             }
 
                             currentCancellationToken.ThrowIfCancellationRequested();
@@ -680,7 +691,7 @@ namespace PowerLauncher.ViewModel
         /// <summary>
         /// To avoid deadlock, this method should not called from main thread
         /// </summary>
-        public void UpdateResultView(List<Result> list, PluginMetadata metadata, Query originQuery)
+        public void UpdateResultView(List<Result> list, PluginMetadata metadata, Query originQuery, CancellationToken ct)
         {
             if (list == null)
             {
@@ -711,7 +722,8 @@ namespace PowerLauncher.ViewModel
 
             if (originQuery.RawQuery == _lastQuery.RawQuery)
             {
-                Results.AddResults(list, metadata.ID);
+                ct.ThrowIfCancellationRequested();
+                Results.AddResults(list, metadata.ID, ct);
             }
         }
 
@@ -724,7 +736,7 @@ namespace PowerLauncher.ViewModel
                 Title = "hello"
             };
             list.Add(r);
-            Results.AddResults(list, "0");
+            Results.AddResults(list, "0", _updateToken);
             Results.Clear();
             MainWindowVisibility = System.Windows.Visibility.Collapsed;
 

--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -447,7 +447,6 @@ namespace PowerLauncher.ViewModel
                     _lastQuery = query;
                     Task.Run(() =>
                     {
-                        Thread.Sleep(20);
                         var plugins = PluginManager.ValidPluginsForQuery(query);
 
                         try

--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#define DEBUG
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -447,6 +448,7 @@ namespace PowerLauncher.ViewModel
                     _lastQuery = query;
                     Task.Run(() =>
                     {
+                        Thread.Sleep(20);
                         var plugins = PluginManager.ValidPluginsForQuery(query);
 
                         try

--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -1,5 +1,4 @@
-﻿#define DEBUG
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;


### PR DESCRIPTION
## Summary of the Pull Request
This PR improves query cancellation and performance of `ResultCollection`

## References
1. https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.removeall?view=netcore-3.1#System_Collections_Generic_List_1_RemoveAll_System_Predicate__0__
2. https://docs.microsoft.com/en-us/dotnet/api/system.collections.objectmodel.collection-1.remove?view=netcore-3.1#System_Collections_ObjectModel_Collection_1_Remove__0_

## PR Checklist
* [x] Applies to #5261 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed

## Info on Pull Request
1. Changed `ResultCollection` base class from `ObservableCollection` to `List`. This was done to improve the bulk deletion of plugin results. `ObservableCollection` does not provide any bulk deletion function and each atomic remove operation is `O(n)`, resulting in `O(n^2)` overall complexity. `List` provides `RemoveAll` function which deletes all the elements matching a predicate in `O(n)`. 
2. Added cancellation checks in `AddResults` and `UpdateResultView` function.

## Validation Steps Performed
1. Modified calculator plugin to return 80,000 results and tested the time taken to update complete the query. The average time is given below : 
a. Old code: 125 sec
b. With this PR's change: 0.640 sec