### PR TITLE
Including valid package information when path is invalid. 

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/PackageWrapper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/PackageWrapper.cs
@@ -41,7 +41,13 @@ namespace Microsoft.Plugin.Program.Programs
             catch (Exception e) when (e is ArgumentException || e is FileNotFoundException)
             {
                 ProgramLogger.LogException($"PackageWrapper", "GetWrapperFromPackage", "package.InstalledLocation.Path", $"Exception {package.Id.Name}", e);
-                return new PackageWrapper();
+                return new PackageWrapper(
+                    package.Id.Name,
+                    package.Id.FullName,
+                    package.Id.FamilyName,
+                    package.IsFramework,
+                    package.IsDevelopmentMode, 
+                    string.Empty);
             }
 
             return new PackageWrapper(


### PR DESCRIPTION


## Summary of the Pull Request

In certain situations such as uninstall, the path of a UWP/packaged application will be invalid.  In this situation we still want to include the available information so that it can be compared to currently stored applications in the results. 

## PR Checklist
* [x] Applies to #5372
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

## Validation Steps Performed

Performed the validation step included in #5372, and verified that we get the expected results. 
