### PR TITLE
Power Launcher | #5062 Moved Start Typing... to resource file

### DIFF
--- a/src/modules/launcher/PowerLauncher/Languages/da.xaml
+++ b/src/modules/launcher/PowerLauncher/Languages/da.xaml
@@ -2,6 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--MainWindow-->
+    <system:String x:Key="startTyping">Start typing...</system:String>
     <system:String x:Key="registerHotkeyFailed">Kunne ikke registrere genvejstast: {0}</system:String>
     <system:String x:Key="couldnotStartCmd">Kunne ikke starte {0}</system:String>
     <system:String x:Key="invalidWoxPluginFileFormat">Ugyldigt Wox plugin filformat</system:String>

--- a/src/modules/launcher/PowerLauncher/Languages/de.xaml
+++ b/src/modules/launcher/PowerLauncher/Languages/de.xaml
@@ -2,6 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--MainWindow-->
+    <system:String x:Key="startTyping">Start typing...</system:String>
     <system:String x:Key="registerHotkeyFailed">Tastenkombinationregistrierung: {0} fehlgeschlagen</system:String>
     <system:String x:Key="couldnotStartCmd">Kann {0} nicht starten</system:String>
     <system:String x:Key="invalidWoxPluginFileFormat">Fehlerhaftes Wox-Plugin Dateiformat</system:String>

--- a/src/modules/launcher/PowerLauncher/Languages/en.xaml
+++ b/src/modules/launcher/PowerLauncher/Languages/en.xaml
@@ -2,6 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--MainWindow-->
+    <system:String x:Key="startTyping">Start typing...</system:String>
     <system:String x:Key="registerHotkeyFailed">Failed to register hotkey: {0}</system:String>
     <system:String x:Key="couldnotStartCmd">Could not start {0}</system:String>
     <system:String x:Key="invalidWoxPluginFileFormat">Invalid Wox plugin file format</system:String>

--- a/src/modules/launcher/PowerLauncher/Languages/fr.xaml
+++ b/src/modules/launcher/PowerLauncher/Languages/fr.xaml
@@ -2,6 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--MainWindow-->
+    <system:String x:Key="startTyping">Start typing...</system:String>
     <system:String x:Key="registerHotkeyFailed">Échec lors de l'enregistrement du raccourci : {0}</system:String>
     <system:String x:Key="couldnotStartCmd">Impossible de lancer {0}</system:String>
     <system:String x:Key="invalidWoxPluginFileFormat">Le format de fichier n'est pas un plugin Wox valide</system:String>

--- a/src/modules/launcher/PowerLauncher/Languages/it.xaml
+++ b/src/modules/launcher/PowerLauncher/Languages/it.xaml
@@ -2,6 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--MainWindow-->
+    <system:String x:Key="startTyping">Start typing...</system:String>
     <system:String x:Key="registerHotkeyFailed">Impossibile salvare il tasto di scelta rapida: {0}</system:String>
     <system:String x:Key="couldnotStartCmd">Avvio fallito {0}</system:String>
     <system:String x:Key="invalidWoxPluginFileFormat">Formato file plugin non valido</system:String>

--- a/src/modules/launcher/PowerLauncher/Languages/ja.xaml
+++ b/src/modules/launcher/PowerLauncher/Languages/ja.xaml
@@ -2,6 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--MainWindow-->
+    <system:String x:Key="startTyping">Start typing...</system:String>
     <system:String x:Key="registerHotkeyFailed">ホットキー「{0}」の登録に失敗しました</system:String>
     <system:String x:Key="couldnotStartCmd">{0}の起動に失敗しました</system:String>
     <system:String x:Key="invalidWoxPluginFileFormat">Woxプラグインの形式が正しくありません</system:String>

--- a/src/modules/launcher/PowerLauncher/Languages/ko.xaml
+++ b/src/modules/launcher/PowerLauncher/Languages/ko.xaml
@@ -2,6 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--MainWindow-->
+    <system:String x:Key="startTyping">Start typing...</system:String>
     <system:String x:Key="registerHotkeyFailed">핫키 등록 실패: {0}</system:String>
     <system:String x:Key="couldnotStartCmd">{0}을 실행할 수 없습니다.</system:String>
     <system:String x:Key="invalidWoxPluginFileFormat">Wox 플러그인 파일 형식이 유효하지 않습니다.</system:String>

--- a/src/modules/launcher/PowerLauncher/Languages/nb-NO.xaml
+++ b/src/modules/launcher/PowerLauncher/Languages/nb-NO.xaml
@@ -2,6 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--MainWindow-->
+    <system:String x:Key="startTyping">Start typing...</system:String>
     <system:String x:Key="registerHotkeyFailed">Kunne ikke registrere hurtigtast: {0}</system:String>
     <system:String x:Key="couldnotStartCmd">Kunne ikke starte {0}</system:String>
     <system:String x:Key="invalidWoxPluginFileFormat">Ugyldig filformat for Wox-utvidelse</system:String>

--- a/src/modules/launcher/PowerLauncher/Languages/nl.xaml
+++ b/src/modules/launcher/PowerLauncher/Languages/nl.xaml
@@ -2,6 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--MainWindow-->
+    <system:String x:Key="startTyping">Start typing...</system:String>
     <system:String x:Key="registerHotkeyFailed">Sneltoets registratie: {0} mislukt</system:String>
     <system:String x:Key="couldnotStartCmd">Kan {0} niet starten</system:String>
     <system:String x:Key="invalidWoxPluginFileFormat">Ongeldige Wox plugin bestandsextensie</system:String>

--- a/src/modules/launcher/PowerLauncher/Languages/pl.xaml
+++ b/src/modules/launcher/PowerLauncher/Languages/pl.xaml
@@ -2,6 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--MainWindow-->
+    <system:String x:Key="startTyping">Start typing...</system:String>
     <system:String x:Key="registerHotkeyFailed">Nie udało się ustawić skrótu klawiszowego: {0}</system:String>
     <system:String x:Key="couldnotStartCmd">Nie udało się uruchomić: {0}</system:String>
     <system:String x:Key="invalidWoxPluginFileFormat">Niepoprawny format pliku wtyczki</system:String>

--- a/src/modules/launcher/PowerLauncher/Languages/pt-br.xaml
+++ b/src/modules/launcher/PowerLauncher/Languages/pt-br.xaml
@@ -2,6 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--MainWindow-->
+    <system:String x:Key="startTyping">Start typing...</system:String>
     <system:String x:Key="registerHotkeyFailed">Falha ao registrar atalho: {0}</system:String>
     <system:String x:Key="couldnotStartCmd">Não foi possível iniciar {0}</system:String>
     <system:String x:Key="invalidWoxPluginFileFormat">Formato de plugin Wox inválido</system:String>

--- a/src/modules/launcher/PowerLauncher/Languages/ru.xaml
+++ b/src/modules/launcher/PowerLauncher/Languages/ru.xaml
@@ -2,6 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--MainWindow-->
+    <system:String x:Key="startTyping">Start typing...</system:String>
     <system:String x:Key="registerHotkeyFailed">Регистрация хоткея {0} не удалась</system:String>
     <system:String x:Key="couldnotStartCmd">Не удалось запустить {0}</system:String>
     <system:String x:Key="invalidWoxPluginFileFormat">Неверный формат файла wox плагина</system:String>

--- a/src/modules/launcher/PowerLauncher/Languages/sk.xaml
+++ b/src/modules/launcher/PowerLauncher/Languages/sk.xaml
@@ -2,6 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--MainWindow-->
+    <system:String x:Key="startTyping">Start typing...</system:String>
     <system:String x:Key="registerHotkeyFailed">Nepodarilo sa registrovať klávesovú skratku {0}</system:String>
     <system:String x:Key="couldnotStartCmd">Nepodarilo sa spustiť {0}</system:String>
     <system:String x:Key="invalidWoxPluginFileFormat">Neplatný formát súboru pre plugin Wox</system:String>

--- a/src/modules/launcher/PowerLauncher/Languages/sr.xaml
+++ b/src/modules/launcher/PowerLauncher/Languages/sr.xaml
@@ -2,6 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--MainWindow-->
+    <system:String x:Key="startTyping">Start typing...</system:String>
     <system:String x:Key="registerHotkeyFailed">Neuspešno registrovana prečica: {0}</system:String>
     <system:String x:Key="couldnotStartCmd">Neuspešno pokretanje {0}</system:String>
     <system:String x:Key="invalidWoxPluginFileFormat">Nepravilni Wox plugin format datoteke</system:String>

--- a/src/modules/launcher/PowerLauncher/Languages/tr.xaml
+++ b/src/modules/launcher/PowerLauncher/Languages/tr.xaml
@@ -2,6 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--MainWindow-->
+    <system:String x:Key="startTyping">Start typing...</system:String>
     <system:String x:Key="registerHotkeyFailed">Kısayol tuşu ataması başarısız oldu: {0}</system:String>
     <system:String x:Key="couldnotStartCmd">{0} başlatılamıyor</system:String>
     <system:String x:Key="invalidWoxPluginFileFormat">Geçersiz Wox eklenti dosyası formatı</system:String>

--- a/src/modules/launcher/PowerLauncher/Languages/uk-UA.xaml
+++ b/src/modules/launcher/PowerLauncher/Languages/uk-UA.xaml
@@ -2,6 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--MainWindow-->
+    <system:String x:Key="startTyping">Start typing...</system:String>
     <system:String x:Key="registerHotkeyFailed">Реєстрація хоткея {0} не вдалася</system:String>
     <system:String x:Key="couldnotStartCmd">Не вдалося запустити {0}</system:String>
     <system:String x:Key="invalidWoxPluginFileFormat">Невірний формат файлу плагіна Wox</system:String>

--- a/src/modules/launcher/PowerLauncher/Languages/zh-cn.xaml
+++ b/src/modules/launcher/PowerLauncher/Languages/zh-cn.xaml
@@ -2,6 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--主窗体-->
+    <system:String x:Key="startTyping">Start typing...</system:String>
     <system:String x:Key="registerHotkeyFailed">注册热键：{0} 失败</system:String>
     <system:String x:Key="couldnotStartCmd">启动命令 {0} 失败</system:String>
     <system:String x:Key="invalidWoxPluginFileFormat">不是合法的Wox插件格式</system:String>

--- a/src/modules/launcher/PowerLauncher/Languages/zh-tw.xaml
+++ b/src/modules/launcher/PowerLauncher/Languages/zh-tw.xaml
@@ -2,6 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:system="clr-namespace:System;assembly=mscorlib">
     <!--主視窗-->
+    <system:String x:Key="startTyping">Start typing...</system:String>
     <system:String x:Key="registerHotkeyFailed">登錄快速鍵：{0} 失敗</system:String>
     <system:String x:Key="couldnotStartCmd">啟動命令 {0} 失敗</system:String>
     <system:String x:Key="invalidWoxPluginFileFormat">無效的 Wox 外掛格式</system:String>

--- a/src/modules/launcher/PowerLauncher/LauncherControl.xaml
+++ b/src/modules/launcher/PowerLauncher/LauncherControl.xaml
@@ -99,7 +99,7 @@
             VerticalAlignment="Center"
             FontSize="24"
             Style="{StaticResource QueryTextBoxStyle}"
-            Tag="Start typing..."
+            Tag="{DynamicResource startTyping}"
             />
 
         <TextBlock


### PR DESCRIPTION
## Summary of the Pull Request

Fixes #5062 
Moved "Start Typing..." on the Power Launcher to a resource file

## PR Checklist
* [X] Applies to #5062 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

- Update to the LauncherCoOntrol.xaml
- Resource files

## Validation Steps Performed

Set PowerLauncher as Startup Project
Run it
Alt + Space
Make sure the text specified in the resource file shows up
