### PR TITLE
Fancy Zones | #4624 Added scrollbar to the input field for excluded apps

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -279,6 +279,9 @@
                      Width="380"
                      Height="160"
                      HorizontalAlignment="Left"
+                     ScrollViewer.VerticalScrollBarVisibility ="Visible"
+                     ScrollViewer.VerticalScrollMode="Enabled"
+                     ScrollViewer.IsVerticalRailEnabled="True"
                      TextWrapping="Wrap"
                      AcceptsReturn="True"/>
         </StackPanel>


### PR DESCRIPTION
## Summary of the Pull Request

Fixes #4624
Added scrollbar to the input field for excluded apps in the Fancy Zones settings page

## PR Checklist
* [X] Applies to #4624
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

In the Fancy Zones settings section, new vertical scrollbar for the excluded apps section

## Validation Steps Performed

Launch Settings
Go to Fancy Zones
Scroll down to the excluded apps
Type several lines until vertical scrollbar shows up

![image](https://user-images.githubusercontent.com/586656/89093710-bb53cb80-d38a-11ea-84ac-5ff684d1d156.png)
