### PR TITLE
[Settings] Updated adaptive trigger behavior

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI.Runner/MainWindow.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Runner/MainWindow.xaml
@@ -7,7 +7,7 @@
         xmlns:Controls="clr-namespace:Microsoft.Toolkit.Wpf.UI.Controls;assembly=Microsoft.Toolkit.Wpf.UI.Controls"
         xmlns:xaml="clr-namespace:Microsoft.Toolkit.Wpf.UI.XamlHost;assembly=Microsoft.Toolkit.Wpf.UI.XamlHost"
         mc:Ignorable="d"
-        Title="PowerToys Settings" Height="800" Width="1100" Closing="MainWindow_Closing">
+        Title="PowerToys Settings" MinWidth="480" Height="800" Width="1100" Closing="MainWindow_Closing">
     <Grid>
         <xaml:WindowsXamlHost InitialTypeName="Microsoft.PowerToys.Settings.UI.Views.ShellPage" ChildChanged="WindowsXamlHost_ChildChanged" />
     </Grid>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -640,7 +640,7 @@
     <value>Remap shortcuts to other shortcuts or keys. Additionally, mappings can be targeted to specific applications as well.</value>
   </data>
   <data name="About_PowerToys.Text" xml:space="preserve">
-    <value>Microsoft PowerToys is a set of utilities for power users to tune and streamline their Windows experience for greater productivity</value>
+    <value>Microsoft PowerToys is a set of utilities for power users to tune and streamline their Windows experience for greater productivity.</value>
   </data>
   <data name="FancyZones_SpanZonesAcrossMonitorsCheckBoxControl.Content" xml:space="preserve">
     <value>Allow zones to span across monitors</value>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Styles/_Sizes.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Styles/_Sizes.xaml
@@ -6,10 +6,10 @@
     <x:Double x:Key="SidePanelWidth">240</x:Double>
 
     <!-- Breakpoint for wide layout (side panel next to content) -->
-    <x:Double x:Key="WideLayoutMinWidth">1008</x:Double>
+    <x:Double x:Key="WideLayoutMinWidth">720</x:Double>
     
-    <!-- Breakpoint for small layout (side panel under content) -->
-    <x:Double x:Key="SmallLayoutMinWidth">480</x:Double>
+    <!-- Breakpoint for small layout (side panel above content) -->
+    <x:Double x:Key="SmallLayoutMinWidth">600</x:Double>
 
     <!-- Column spacing between content and sidepanel -->
     <x:Double x:Key="DefaultColumnSpacing">24</x:Double>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
@@ -11,29 +11,23 @@
     d:DesignWidth="400" 
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-    <Grid ColumnSpacing="{StaticResource DefaultColumnSpacing}" RowSpacing="{StaticResource DefaultRowSpacing}">
+    <Grid RowSpacing="{StaticResource DefaultRowSpacing}">
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup x:Name="LayoutVisualStates">
                 <VisualState x:Name="WideLayout">
                     <VisualState.StateTriggers>
                         <AdaptiveTrigger MinWindowWidth="{StaticResource WideLayoutMinWidth}" />
                     </VisualState.StateTriggers>
-                    <VisualState.Setters>
-                        <Setter Target="SidePanel.(Grid.Column)" Value="1"/>
-                        <Setter Target="SidePanel.Width" Value="{StaticResource SidePanelWidth}"/>
-                        <Setter Target="ColorPickerSettingsView.(Grid.Row)" Value="0" />
-                        <Setter Target="LinksPanel.(RelativePanel.Below)" Value="AboutImage"/>
-                        <Setter Target="AboutTitle.Visibility" Value="Visible" />
-                    </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="SmallLayout">
                     <VisualState.StateTriggers>
                         <AdaptiveTrigger MinWindowWidth="{StaticResource SmallLayoutMinWidth}" />
+                        <AdaptiveTrigger MinWindowWidth="0" />
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
                         <Setter Target="SidePanel.(Grid.Column)" Value="0"/>
-                        <Setter Target="SidePanel.Width" Value="500"/>
-                        <Setter Target="ColorPickerSettingsView.(Grid.Row)" Value="1" />
+                        <Setter Target="SidePanel.Width" Value="Auto"/>
+                        <Setter Target="ColorPickerView.(Grid.Row)" Value="1" />
                         <Setter Target="LinksPanel.(RelativePanel.RightOf)" Value="AboutImage"/>
                         <Setter Target="LinksPanel.(RelativePanel.AlignTopWith)" Value="AboutImage"/>
                         <Setter Target="AboutImage.Margin" Value="0,12,12,0"/>
@@ -51,7 +45,7 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <StackPanel Orientation="Vertical" x:Name="ColorPickerSettingsView">
+        <StackPanel Orientation="Vertical" x:Name="ColorPickerView">
             <ToggleSwitch x:Uid="ColorPicker_EnableColorPicker" 
                           IsOn="{Binding IsEnabled, Mode=TwoWay}"/>
 
@@ -111,6 +105,7 @@
                 <Image Source="ms-appx:///Assets/Modules/ColorPicker.png" />
             </Border>
             <StackPanel x:Name="LinksPanel"
+                        Margin="0,1,0,0"
                         RelativePanel.Below="AboutImage"
                         Orientation="Vertical" >
                 <HyperlinkButton NavigateUri="https://aka.ms/PowerToysOverview_ColorPicker">

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -19,31 +19,23 @@
         <converters:StringFormatConverter x:Key="StringFormatConverter"/>
     </Page.Resources>
 
-    <Grid ColumnSpacing="{StaticResource DefaultColumnSpacing}"
-          RowSpacing="{StaticResource DefaultRowSpacing}"
-          x:Name="MainView">
+    <Grid x:Name="MainView" RowSpacing="{StaticResource DefaultRowSpacing}">
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup x:Name="LayoutVisualStates">
                 <VisualState x:Name="WideLayout">
                     <VisualState.StateTriggers>
                         <AdaptiveTrigger MinWindowWidth="{StaticResource WideLayoutMinWidth}" />
                     </VisualState.StateTriggers>
-                    <VisualState.Setters>
-                        <Setter Target="SidePanel.(Grid.Column)" Value="1"/>
-                        <Setter Target="SidePanel.Width" Value="{StaticResource SidePanelWidth}"/>
-                        <Setter Target="FZSettingsView.(Grid.Row)" Value="0" />
-                        <Setter Target="LinksPanel.(RelativePanel.Below)" Value="AboutImage"/>
-                        <Setter Target="AboutTitle.Visibility" Value="Visible" />
-                    </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="SmallLayout">
                     <VisualState.StateTriggers>
                         <AdaptiveTrigger MinWindowWidth="{StaticResource SmallLayoutMinWidth}" />
+                        <AdaptiveTrigger MinWindowWidth="0" />
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
                         <Setter Target="SidePanel.(Grid.Column)" Value="0"/>
-                        <Setter Target="SidePanel.Width" Value="500"/>
-                        <Setter Target="FZSettingsView.(Grid.Row)" Value="1" />
+                        <Setter Target="SidePanel.Width" Value="Auto"/>
+                        <Setter Target="FZView.(Grid.Row)" Value="1" />
                         <Setter Target="LinksPanel.(RelativePanel.RightOf)" Value="AboutImage"/>
                         <Setter Target="LinksPanel.(RelativePanel.AlignTopWith)" Value="AboutImage"/>
                         <Setter Target="AboutImage.Margin" Value="0,12,12,0"/>
@@ -61,7 +53,7 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <StackPanel x:Name="FZSettingsView" Orientation="Vertical">
+        <StackPanel x:Name="FZView" Orientation="Vertical">
             <ToggleSwitch x:Name="FancyZones_EnableToggleControl_HeaderText"
                             x:Uid="FancyZones_EnableToggleControl_HeaderText"
                             IsOn="{x:Bind Mode=TwoWay, Path=ViewModel.IsEnabled}"/>
@@ -315,6 +307,7 @@
             </Border>
 
             <StackPanel x:Name="LinksPanel"
+                        Margin="0,1,0,0"
                         RelativePanel.Below="AboutImage"
                         Orientation="Vertical" >
                 <HyperlinkButton NavigateUri="https://aka.ms/PowerToysOverview_FancyZones">

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml
@@ -17,30 +17,23 @@
         <viewModel:GeneralViewModel x:Key="eventViewModel"/>
     </Page.Resources>
 
-
-    <Grid ColumnSpacing="{StaticResource DefaultColumnSpacing}" RowSpacing="{StaticResource DefaultRowSpacing}">
+    <Grid RowSpacing="{StaticResource DefaultRowSpacing}">
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup x:Name="LayoutVisualStates">
                 <VisualState x:Name="WideLayout">
                     <VisualState.StateTriggers>
                         <AdaptiveTrigger MinWindowWidth="{StaticResource WideLayoutMinWidth}" />
                     </VisualState.StateTriggers>
-                    <VisualState.Setters>
-                        <Setter Target="SidePanel.(Grid.Column)" Value="1"/>
-                        <Setter Target="SidePanel.Width" Value="{StaticResource SidePanelWidth}"/>
-                        <Setter Target="GeneralSettingsView.(Grid.Row)" Value="0" />
-                        <Setter Target="LinksPanel.(RelativePanel.Below)" Value="AboutImage"/>
-                        <Setter Target="AboutTitle.Visibility" Value="Visible" />
-                    </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="SmallLayout">
                     <VisualState.StateTriggers>
                         <AdaptiveTrigger MinWindowWidth="{StaticResource SmallLayoutMinWidth}" />
+                        <AdaptiveTrigger MinWindowWidth="0" />
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
                         <Setter Target="SidePanel.(Grid.Column)" Value="0"/>
-                        <Setter Target="SidePanel.Width" Value="500"/>
-                        <Setter Target="GeneralSettingsView.(Grid.Row)" Value="1" />
+                        <Setter Target="SidePanel.Width" Value="Auto"/>
+                        <Setter Target="GeneralView.(Grid.Row)" Value="1" />
                         <Setter Target="LinksPanel.(RelativePanel.RightOf)" Value="AboutImage"/>
                         <Setter Target="LinksPanel.(RelativePanel.AlignTopWith)" Value="AboutImage"/>
                         <Setter Target="AboutImage.Margin" Value="0,12,12,0"/>
@@ -59,7 +52,7 @@
         </Grid.RowDefinitions>
 
         <StackPanel Orientation="Vertical" 
-                    x:Name="GeneralSettingsView">
+                    x:Name="GeneralView">
             <TextBlock x:Uid="Admin_Mode" FontWeight="SemiBold"
                        Style="{StaticResource SubtitleTextBlockStyle}"/>
 
@@ -158,6 +151,7 @@
                 <Image Source="ms-appx:///Assets/Modules/PT.png" />
             </Border>
             <StackPanel x:Name="LinksPanel"
+                        Margin="0,1,0,0"
                         RelativePanel.Below="AboutImage"
                         Orientation="Vertical" >
 

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml.cs
@@ -26,7 +26,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             InitializeComponent();
 
             ViewModel = new GeneralViewModel();
-            GeneralSettingsView.DataContext = ViewModel;
+            GeneralView.DataContext = ViewModel;
         }
     }
 }

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
@@ -15,28 +15,22 @@
         <viewModel:ImageResizerViewModel x:Key="ViewModel"/>
     </Page.Resources>
 
-    <Grid ColumnSpacing="{StaticResource DefaultColumnSpacing}" RowSpacing="{StaticResource DefaultRowSpacing}">
+    <Grid RowSpacing="{StaticResource DefaultRowSpacing}">
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup x:Name="LayoutVisualStates">
                 <VisualState x:Name="WideLayout">
                     <VisualState.StateTriggers>
                         <AdaptiveTrigger MinWindowWidth="{StaticResource WideLayoutMinWidth}" />
                     </VisualState.StateTriggers>
-                    <VisualState.Setters>
-                        <Setter Target="SidePanel.(Grid.Column)" Value="1"/>
-                        <Setter Target="SidePanel.Width" Value="{StaticResource SidePanelWidth}"/>
-                        <Setter Target="ImageResizerView.(Grid.Row)" Value="0" />
-                        <Setter Target="LinksPanel.(RelativePanel.Below)" Value="AboutImage"/>
-                        <Setter Target="AboutTitle.Visibility" Value="Visible" />
-                    </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="SmallLayout">
                     <VisualState.StateTriggers>
                         <AdaptiveTrigger MinWindowWidth="{StaticResource SmallLayoutMinWidth}" />
+                        <AdaptiveTrigger MinWindowWidth="0" />
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
                         <Setter Target="SidePanel.(Grid.Column)" Value="0"/>
-                        <Setter Target="SidePanel.Width" Value="500"/>
+                        <Setter Target="SidePanel.Width" Value="Auto"/>
                         <Setter Target="ImageResizerView.(Grid.Row)" Value="1" />
                         <Setter Target="LinksPanel.(RelativePanel.RightOf)" Value="AboutImage"/>
                         <Setter Target="LinksPanel.(RelativePanel.AlignTopWith)" Value="AboutImage"/>
@@ -320,6 +314,7 @@
             </Border>
             
             <StackPanel x:Name="LinksPanel"
+                        Margin="0,1,0,0"
                         RelativePanel.Below="AboutImage"
                         Orientation="Vertical" >
                 <HyperlinkButton NavigateUri="https://aka.ms/PowerToysOverview_ImageResizer">

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/KeyboardManagerPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/KeyboardManagerPage.xaml
@@ -173,28 +173,22 @@
         </DataTemplate>
     </Page.Resources>
 
-    <Grid ColumnSpacing="{StaticResource DefaultColumnSpacing}" RowSpacing="{StaticResource DefaultRowSpacing}">
+    <Grid RowSpacing="{StaticResource DefaultRowSpacing}">
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup x:Name="LayoutVisualStates">
                 <VisualState x:Name="WideLayout">
                     <VisualState.StateTriggers>
                         <AdaptiveTrigger MinWindowWidth="{StaticResource WideLayoutMinWidth}" />
                     </VisualState.StateTriggers>
-                    <VisualState.Setters>
-                        <Setter Target="SidePanel.(Grid.Column)" Value="1"/>
-                        <Setter Target="SidePanel.Width" Value="{StaticResource SidePanelWidth}"/>
-                        <Setter Target="KeyboardManagerView.(Grid.Row)" Value="0" />
-                        <Setter Target="LinksPanel.(RelativePanel.Below)" Value="AboutImage"/>
-                        <Setter Target="AboutTitle.Visibility" Value="Visible" />
-                    </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="SmallLayout">
                     <VisualState.StateTriggers>
                         <AdaptiveTrigger MinWindowWidth="{StaticResource SmallLayoutMinWidth}" />
+                        <AdaptiveTrigger MinWindowWidth="0" />
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
                         <Setter Target="SidePanel.(Grid.Column)" Value="0"/>
-                        <Setter Target="SidePanel.Width" Value="500"/>
+                        <Setter Target="SidePanel.Width" Value="Auto"/>
                         <Setter Target="KeyboardManagerView.(Grid.Row)" Value="1" />
                         <Setter Target="LinksPanel.(RelativePanel.RightOf)" Value="AboutImage"/>
                         <Setter Target="LinksPanel.(RelativePanel.AlignTopWith)" Value="AboutImage"/>
@@ -342,6 +336,7 @@
             </Border>
 
             <StackPanel x:Name="LinksPanel"
+                        Margin="0,1,0,0"
                         RelativePanel.Below="AboutImage"
                         Orientation="Vertical" >
                 <HyperlinkButton NavigateUri="https://aka.ms/PowerToysOverview_KeyboardManager">

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/KeyboardManagerPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/KeyboardManagerPage.xaml
@@ -270,6 +270,7 @@
 
             <TextBlock x:Uid="KeyboardManager_RemapShortcutsSubtitle"
                        Margin="{StaticResource SmallTopMargin}"
+                       TextWrapping="WrapWholeWords"
                        Foreground="{x:Bind Mode=OneWay, Path=ViewModel.Enabled, Converter={StaticResource ModuleEnabledToForegroundConverter}}"/>
 
             <Button x:Uid="KeyboardManager_RemapShortcutsButton"

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
@@ -11,29 +11,23 @@
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-    <Grid ColumnSpacing="{StaticResource DefaultColumnSpacing}" RowSpacing="{StaticResource DefaultRowSpacing}">
+    <Grid RowSpacing="{StaticResource DefaultRowSpacing}">
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup x:Name="LayoutVisualStates">
                 <VisualState x:Name="WideLayout">
                     <VisualState.StateTriggers>
                         <AdaptiveTrigger MinWindowWidth="{StaticResource WideLayoutMinWidth}" />
                     </VisualState.StateTriggers>
-                    <VisualState.Setters>
-                        <Setter Target="SidePanel.(Grid.Column)" Value="1"/>
-                        <Setter Target="SidePanel.Width" Value="{StaticResource SidePanelWidth}"/>
-                        <Setter Target="PowerToysRunView.(Grid.Row)" Value="0" />
-                        <Setter Target="LinksPanel.(RelativePanel.Below)" Value="AboutImage"/>
-                        <Setter Target="AboutTitle.Visibility" Value="Visible" />
-                    </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="SmallLayout">
                     <VisualState.StateTriggers>
                         <AdaptiveTrigger MinWindowWidth="{StaticResource SmallLayoutMinWidth}" />
+                        <AdaptiveTrigger MinWindowWidth="0" />
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
                         <Setter Target="SidePanel.(Grid.Column)" Value="0"/>
-                        <Setter Target="SidePanel.Width" Value="500"/>
-                        <Setter Target="PowerToysRunView.(Grid.Row)" Value="1" />
+                        <Setter Target="SidePanel.Width" Value="Auto"/>
+                        <Setter Target="LauncherView.(Grid.Row)" Value="1" />
                         <Setter Target="LinksPanel.(RelativePanel.RightOf)" Value="AboutImage"/>
                         <Setter Target="LinksPanel.(RelativePanel.AlignTopWith)" Value="AboutImage"/>
                         <Setter Target="AboutImage.Margin" Value="0,12,12,0"/>
@@ -51,7 +45,7 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <StackPanel Orientation="Vertical" x:Name="PowerToysRunView">
+        <StackPanel Orientation="Vertical" x:Name="LauncherView">
             <ToggleSwitch x:Uid="PowerLauncher_EnablePowerLauncher" 
                           IsOn="{x:Bind Mode=TwoWay, Path=ViewModel.EnablePowerLauncher}"/>
 
@@ -182,6 +176,7 @@
             </Border>
             
             <StackPanel x:Name="LinksPanel"
+                        Margin="0,1,0,0"
                         RelativePanel.Below="AboutImage"
                         Orientation="Vertical" >
                 <HyperlinkButton NavigateUri="https://aka.ms/PowerToysOverview_PowerToysRun">

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerPreviewPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerPreviewPage.xaml
@@ -7,29 +7,23 @@
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-    <Grid ColumnSpacing="{StaticResource DefaultColumnSpacing}" RowSpacing="{StaticResource DefaultRowSpacing}">
+    <Grid RowSpacing="{StaticResource DefaultRowSpacing}">
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup x:Name="LayoutVisualStates">
                 <VisualState x:Name="WideLayout">
                     <VisualState.StateTriggers>
                         <AdaptiveTrigger MinWindowWidth="{StaticResource WideLayoutMinWidth}" />
                     </VisualState.StateTriggers>
-                    <VisualState.Setters>
-                        <Setter Target="SidePanel.(Grid.Column)" Value="1"/>
-                        <Setter Target="SidePanel.Width" Value="{StaticResource SidePanelWidth}"/>
-                        <Setter Target="PowerPreviewSettingsView.(Grid.Row)" Value="0" />
-                        <Setter Target="LinksPanel.(RelativePanel.Below)" Value="AboutImage"/>
-                        <Setter Target="AboutTitle.Visibility" Value="Visible" />
-                    </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="SmallLayout">
                     <VisualState.StateTriggers>
                         <AdaptiveTrigger MinWindowWidth="{StaticResource SmallLayoutMinWidth}" />
+                        <AdaptiveTrigger MinWindowWidth="0" />
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
                         <Setter Target="SidePanel.(Grid.Column)" Value="0"/>
-                        <Setter Target="SidePanel.Width" Value="500"/>
-                        <Setter Target="PowerPreviewSettingsView.(Grid.Row)" Value="1" />
+                        <Setter Target="SidePanel.Width" Value="Auto"/>
+                        <Setter Target="PowerPreviewView.(Grid.Row)" Value="1" />
                         <Setter Target="LinksPanel.(RelativePanel.RightOf)" Value="AboutImage"/>
                         <Setter Target="LinksPanel.(RelativePanel.AlignTopWith)" Value="AboutImage"/>
                         <Setter Target="AboutImage.Margin" Value="0,12,12,0"/>
@@ -48,7 +42,7 @@
         </Grid.RowDefinitions>
 
         <StackPanel Orientation="Vertical" 
-                    x:Name="PowerPreviewSettingsView">
+                    x:Name="PowerPreviewView">
 
             <ToggleSwitch x:Uid="FileExplorerPreview_ToggleSwitch_Preview_SVG"
                           IsOn="{Binding Mode=TwoWay, Path=SVGRenderIsEnabled}" />
@@ -86,6 +80,7 @@
             </Border>
 
             <StackPanel x:Name="LinksPanel"
+                        Margin="0,1,0,0"
                         RelativePanel.Below="AboutImage"
                         Orientation="Vertical" >
                 <HyperlinkButton NavigateUri="https://aka.ms/PowerToysOverview_FileExplorerAddOns">

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerPreviewPage.xaml.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerPreviewPage.xaml.cs
@@ -18,7 +18,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
         {
             InitializeComponent();
             ViewModel = new PowerPreviewViewModel();
-            PowerPreviewSettingsView.DataContext = ViewModel;
+            PowerPreviewView.DataContext = ViewModel;
         }
     }
 }

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerRenamePage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerRenamePage.xaml
@@ -8,30 +8,24 @@
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
-    
-    <Grid ColumnSpacing="{StaticResource DefaultColumnSpacing}" RowSpacing="{StaticResource DefaultRowSpacing}">
+
+    <Grid RowSpacing="{StaticResource DefaultRowSpacing}">
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup x:Name="LayoutVisualStates">
                 <VisualState x:Name="WideLayout">
                     <VisualState.StateTriggers>
                         <AdaptiveTrigger MinWindowWidth="{StaticResource WideLayoutMinWidth}" />
                     </VisualState.StateTriggers>
-                    <VisualState.Setters>
-                        <Setter Target="SidePanel.(Grid.Column)" Value="1"/>
-                        <Setter Target="SidePanel.Width" Value="{StaticResource SidePanelWidth}"/>
-                        <Setter Target="PowerRenameSettingsView.(Grid.Row)" Value="0" />
-                        <Setter Target="LinksPanel.(RelativePanel.Below)" Value="AboutImage"/>
-                        <Setter Target="AboutTitle.Visibility" Value="Visible" />
-                    </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="SmallLayout">
                     <VisualState.StateTriggers>
                         <AdaptiveTrigger MinWindowWidth="{StaticResource SmallLayoutMinWidth}" />
+                        <AdaptiveTrigger MinWindowWidth="0" />
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
                         <Setter Target="SidePanel.(Grid.Column)" Value="0"/>
-                        <Setter Target="SidePanel.Width" Value="500"/>
-                        <Setter Target="PowerRenameSettingsView.(Grid.Row)" Value="1" />
+                        <Setter Target="SidePanel.Width" Value="Auto"/>
+                        <Setter Target="PowerRenameView.(Grid.Row)" Value="1" />
                         <Setter Target="LinksPanel.(RelativePanel.RightOf)" Value="AboutImage"/>
                         <Setter Target="LinksPanel.(RelativePanel.AlignTopWith)" Value="AboutImage"/>
                         <Setter Target="AboutImage.Margin" Value="0,12,12,0"/>
@@ -49,7 +43,7 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
         <StackPanel Orientation="Vertical"
-                    x:Name="PowerRenameSettingsView">
+                    x:Name="PowerRenameView">
 
             <ToggleSwitch x:Uid="PowerRename_Toggle_Enable"
                           IsOn="{x:Bind Mode=TwoWay, Path=ViewModel.IsEnabled}"                          
@@ -125,6 +119,7 @@
             </Border>
 
             <StackPanel x:Name="LinksPanel"
+                        Margin="0,1,0,0"
                         RelativePanel.Below="AboutImage"
                         Orientation="Vertical" >
                 <HyperlinkButton NavigateUri="https://aka.ms/PowerToysOverview_PowerRename">

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ShortcutGuidePage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ShortcutGuidePage.xaml
@@ -14,30 +14,24 @@
     <Page.Resources>
         <converters:StringFormatConverter x:Key="StringFormatConverter"/>
     </Page.Resources>
-    
-    <Grid ColumnSpacing="{StaticResource DefaultColumnSpacing}" RowSpacing="{StaticResource DefaultRowSpacing}">
+
+    <Grid RowSpacing="{StaticResource DefaultRowSpacing}">
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup x:Name="LayoutVisualStates">
                 <VisualState x:Name="WideLayout">
                     <VisualState.StateTriggers>
                         <AdaptiveTrigger MinWindowWidth="{StaticResource WideLayoutMinWidth}" />
                     </VisualState.StateTriggers>
-                    <VisualState.Setters>
-                        <Setter Target="SidePanel.(Grid.Column)" Value="1"/>
-                        <Setter Target="SidePanel.Width" Value="{StaticResource SidePanelWidth}"/>
-                        <Setter Target="ShortCutGuideView.(Grid.Row)" Value="0" />
-                        <Setter Target="LinksPanel.(RelativePanel.Below)" Value="AboutImage"/>
-                        <Setter Target="AboutTitle.Visibility" Value="Visible" />
-                    </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="SmallLayout">
                     <VisualState.StateTriggers>
                         <AdaptiveTrigger MinWindowWidth="{StaticResource SmallLayoutMinWidth}" />
+                        <AdaptiveTrigger MinWindowWidth="0" />
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
                         <Setter Target="SidePanel.(Grid.Column)" Value="0"/>
-                        <Setter Target="SidePanel.Width" Value="500"/>
-                        <Setter Target="ShortCutGuideView.(Grid.Row)" Value="1" />
+                        <Setter Target="SidePanel.Width" Value="Auto"/>
+                        <Setter Target="ShortcutGuideView.(Grid.Row)" Value="1" />
                         <Setter Target="LinksPanel.(RelativePanel.RightOf)" Value="AboutImage"/>
                         <Setter Target="LinksPanel.(RelativePanel.AlignTopWith)" Value="AboutImage"/>
                         <Setter Target="AboutImage.Margin" Value="0,12,12,0"/>
@@ -54,7 +48,7 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-        <StackPanel Orientation="Vertical" x:Name="ShortCutGuideView">
+        <StackPanel Orientation="Vertical" x:Name="ShortcutGuideView">
             <ToggleSwitch x:Uid="ShortcutGuide_Enable"
                           IsOn="{x:Bind Mode=TwoWay, Path=ViewModel.IsEnabled}"/>
 
@@ -134,6 +128,7 @@
             </Border>
 
             <StackPanel x:Name="LinksPanel"
+                        Margin="0,1,0,0"
                         RelativePanel.Below="AboutImage"
                         Orientation="Vertical" >
                 <HyperlinkButton NavigateUri="https://aka.ms/PowerToysOverview_ShortcutGuide">


### PR DESCRIPTION
## Summary of the Pull Request

Especially on lower resolutions, the Settings page has some weird layout behavior when resizing the window. This PR fixes the following things:

- Improved layout behavior when resizing.
- Simplified the VisualStates
- Set a min window size for the WPF window, similar to min sizes for UWP apps (around 480px).

**Old behavior**
![OldBehaviour](https://user-images.githubusercontent.com/9866362/89102476-db769f80-d409-11ea-9ed7-b70e219ee202.gif)

**New behavior**
![NewBehaviour](https://user-images.githubusercontent.com/9866362/89102407-2217ca00-d409-11ea-8093-0993d4fa2781.gif)


## PR Checklist
* [X] Applies to #5417, #3878, #5465
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

