### PR TITLE
Color picker respects right monitor side boundaries and does not go o…

### DIFF
--- a/src/modules/colorPicker/ColorPickerUI/Behaviors/ChangeWindowPositionBehavior.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Behaviors/ChangeWindowPositionBehavior.cs
@@ -13,7 +13,7 @@ namespace ColorPicker.Behaviors
     {
         // color window should not get into these zones, only mouse to avoid window getting outsize of monitor
         private const int MonitorRightSideDeadZone = 200;
-        private const int MonitorBottomSideDeadZone = 100;
+        private const int MonitorBottomSideDeadZone = 80;
 
         private const int YOffset = 10;
         private const int XOffset = 5;
@@ -58,14 +58,14 @@ namespace ColorPicker.Behaviors
             var windowLeft = mousePositionScaled.X + XOffset;
             var windowTop = mousePositionScaled.Y + YOffset;
 
-            if ((windowLeft + MonitorRightSideDeadZone) > monitorBounds.Right)
+            if ((windowLeft + MonitorRightSideDeadZone) > monitorBounds.Right / dpi.DpiScaleX)
             {
-                windowLeft -= MonitorRightSideDeadZone - ((int)monitorBounds.Right - windowLeft);
+                windowLeft -= MonitorRightSideDeadZone - (((int)monitorBounds.Right / dpi.DpiScaleX) - windowLeft);
             }
 
-            if ((windowTop + (MonitorBottomSideDeadZone / dpi.DpiScaleX)) > monitorBounds.Bottom / dpi.DpiScaleX)
+            if ((windowTop + MonitorBottomSideDeadZone) > monitorBounds.Bottom / dpi.DpiScaleX)
             {
-                windowTop -= (MonitorBottomSideDeadZone / dpi.DpiScaleX) - (((int)monitorBounds.Bottom / dpi.DpiScaleX) - windowTop);
+                windowTop -= MonitorBottomSideDeadZone - (((int)monitorBounds.Bottom / dpi.DpiScaleX) - windowTop);
             }
 
             AssociatedObject.Left = windowLeft;


### PR DESCRIPTION
## Summary of the Pull Request
Color picker was going out of the screen on the right side, fixed dead zones
fixes #5479 

## PR Checklist
* [x] Applies to #5479
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

## Validation Steps Performed
![Boundaries](https://user-images.githubusercontent.com/11967522/89119951-5b584480-d4b2-11ea-98cc-714a6e40c504.gif)

_How does someone test & validate?_
