### PR TITLE
Color picker - fixed jerky zoom animation

### DIFF
--- a/src/modules/colorPicker/ColorPickerUI/Behaviors/MoveWindowBehavior.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Behaviors/MoveWindowBehavior.cs
@@ -19,7 +19,7 @@ namespace ColorPicker.Behaviors
             var sender = ((MoveWindowBehavior)d).AssociatedObject;
             var move = new DoubleAnimation(sender.Left, (double)e.NewValue, new Duration(TimeSpan.FromMilliseconds(150)), FillBehavior.Stop);
             move.EasingFunction = new QuadraticEase() { EasingMode = EasingMode.EaseOut };
-            sender.BeginAnimation(Window.LeftProperty, move, HandoffBehavior.SnapshotAndReplace);
+            sender.BeginAnimation(Window.LeftProperty, move, HandoffBehavior.Compose);
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1401:Fields should be private", Justification = "https://docs.microsoft.com/en-us/dotnet/framework/wpf/advanced/dependency-property-security#:~:text=Dependency%20properties%20should%20generally%20be%20considered%20to%20be,make%20security%20guarantees%20about%20a%20dependency%20property%20value.")]
@@ -30,7 +30,7 @@ namespace ColorPicker.Behaviors
             var sender = ((MoveWindowBehavior)d).AssociatedObject;
             var move = new DoubleAnimation(sender.Top, (double)e.NewValue, new Duration(TimeSpan.FromMilliseconds(150)), FillBehavior.Stop);
             move.EasingFunction = new QuadraticEase() { EasingMode = EasingMode.EaseOut };
-            sender.BeginAnimation(Window.TopProperty, move, HandoffBehavior.SnapshotAndReplace);
+            sender.BeginAnimation(Window.TopProperty, move, HandoffBehavior.Compose);
         }
 
         public double Left

--- a/src/modules/colorPicker/ColorPickerUI/Behaviors/ResizeBehavior.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Behaviors/ResizeBehavior.cs
@@ -25,7 +25,7 @@ namespace ColorPicker.Behaviors
             };
 
             move.EasingFunction = new QuadraticEase() { EasingMode = EasingMode.EaseOut };
-            sender.BeginAnimation(FrameworkElement.WidthProperty, move, HandoffBehavior.SnapshotAndReplace);
+            sender.BeginAnimation(FrameworkElement.WidthProperty, move, HandoffBehavior.Compose);
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1401:Fields should be private", Justification = "https://docs.microsoft.com/en-us/dotnet/framework/wpf/advanced/dependency-property-security#:~:text=Dependency%20properties%20should%20generally%20be%20considered%20to%20be,make%20security%20guarantees%20about%20a%20dependency%20property%20value.")]
@@ -42,7 +42,7 @@ namespace ColorPicker.Behaviors
             };
 
             move.EasingFunction = new QuadraticEase() { EasingMode = EasingMode.EaseOut };
-            sender.BeginAnimation(FrameworkElement.HeightProperty, move, HandoffBehavior.SnapshotAndReplace);
+            sender.BeginAnimation(FrameworkElement.HeightProperty, move, HandoffBehavior.Compose);
         }
 
         public double Width

--- a/src/modules/colorPicker/ColorPickerUI/ColorPickerUI.csproj
+++ b/src/modules/colorPicker/ColorPickerUI/ColorPickerUI.csproj
@@ -100,6 +100,8 @@
     <Reference Include="PresentationFramework" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Helpers\IThrottledActionInvoker.cs" />
+    <Compile Include="Helpers\ThrottledActionInvoker.cs" />
     <Compile Include="Settings\IUserSettings.cs" />
     <Compile Include="Settings\SettingItem.cs" />
     <Compile Include="Settings\UserSettings.cs" />

--- a/src/modules/colorPicker/ColorPickerUI/Helpers/IThrottledActionInvoker.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/IThrottledActionInvoker.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace ColorPicker.Helpers
+{
+    public interface IThrottledActionInvoker
+    {
+        void ScheduleAction(Action action, int miliseconds);
+    }
+}

--- a/src/modules/colorPicker/ColorPickerUI/Helpers/ThrottledActionInvoker.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/ThrottledActionInvoker.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Windows.Threading;
+
+namespace ColorPicker.Helpers
+{
+    [Export(typeof(IThrottledActionInvoker))]
+    public sealed class ThrottledActionInvoker : IThrottledActionInvoker
+    {
+        private Action _actionToRun;
+
+        private DispatcherTimer _timer;
+
+        public ThrottledActionInvoker()
+        {
+            _timer = new DispatcherTimer();
+            _timer.Tick += Timer_Tick;
+        }
+
+        public void ScheduleAction(Action action, int miliseconds)
+        {
+            if (_timer.IsEnabled)
+            {
+                _timer.Stop();
+            }
+
+            _actionToRun = action;
+            _timer.Interval = new TimeSpan(0, 0, 0, 0, miliseconds);
+
+            _timer.Start();
+        }
+
+        private void Timer_Tick(object sender, EventArgs e)
+        {
+            _actionToRun.Invoke();
+        }
+    }
+}


### PR DESCRIPTION
## Summary of the Pull Request

Quick zoom was causing ZoomWindow to jump and cut the animation
Fixes #5462
## PR Checklist
* [x] Applies to #5462 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

## Validation Steps Performed
Before 
![OldZoom](https://user-images.githubusercontent.com/11967522/89121037-acb90180-d4bb-11ea-8bb0-878debf6137a.gif)

Fixed
![NewZoom](https://user-images.githubusercontent.com/11967522/89121042-b2164c00-d4bb-11ea-8327-3c1395f59400.gif)


