### PR TITLE
[Settings] Right-clicking on Settings in taskbar shows the correct title 

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI.Runner/Microsoft.PowerToys.Settings.UI.Runner.csproj
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Runner/Microsoft.PowerToys.Settings.UI.Runner.csproj
@@ -10,6 +10,7 @@
     <Authors>Microsoft Corporation</Authors>
     <Product>PowerToys</Product>
     <Description>PowerToys Settings UI Runner</Description>
+    <AssemblyName>PowerToys Settings</AssemblyName>
     <Copyright>Copyright (C) 2020 Microsoft Corporation</Copyright>
     <Company>Microsoft Corporation</Company>
     <PackageIcon>logo.png</PackageIcon>


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

## PR Checklist
* [x] Applies to #5234
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

This configures the generated "AssemblyTitleAttribute" which is used in TaskManager / Right Click Task Menu

[assembly: System.Reflection.AssemblyTitleAttribute("PowerToys Settings")]

## Validation Steps Performed

- Run Microsoft.PowerToys.Settings.UI.Runner
- Right click Taskbar icon and validated name
- Open Task Manager and validated name

Task Bar:
![tasktrayicon](https://user-images.githubusercontent.com/16852398/89124761-c5d0ab00-d4d9-11ea-8b16-7b241bcd7e1e.png)
Task Manager:
![taskmanager](https://user-images.githubusercontent.com/16852398/89124780-e993f100-d4d9-11ea-92e8-7b5e1ad87070.png)

