### PR TITLE
[Settings] Localized image resizer filename formats

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -417,7 +417,7 @@
   <data name="FileExplorerPreview_ToggleSwitch_Preview_SVG.Header" xml:space="preserve">
     <value>Enable SVG (.svg) preview</value>
   </data>
-    <data name="FileExplorerPreview_ToggleSwitch_SVG_Thumbnail.Header" xml:space="preserve">
+  <data name="FileExplorerPreview_ToggleSwitch_SVG_Thumbnail.Header" xml:space="preserve">
     <value>Enable SVG (.svg) thumbnails</value>
   </data>
   <data name="FileExplorerPreview_Description.Text" xml:space="preserve">
@@ -641,5 +641,23 @@
   </data>
   <data name="About_PowerToys.Text" xml:space="preserve">
     <value>Microsoft PowerToys is a set of utilities for power users to tune and streamline their Windows experience for greater productivity</value>
+  </data>
+  <data name="ImageResizer_Formatting_ActualHeight.Text" xml:space="preserve">
+    <value>Actual height</value>
+  </data>
+  <data name="ImageResizer_Formatting_ActualWidth.Text" xml:space="preserve">
+    <value>Actual width</value>
+  </data>
+  <data name="ImageResizer_Formatting_Filename.Text" xml:space="preserve">
+    <value>Original filename</value>
+  </data>
+  <data name="ImageResizer_Formatting_SelectedHeight.Text" xml:space="preserve">
+    <value>Selected height</value>
+  </data>
+  <data name="ImageResizer_Formatting_SelectedWidth.Text" xml:space="preserve">
+    <value>Selected width</value>
+  </data>
+  <data name="ImageResizer_Formatting_Sizename.Text" xml:space="preserve">
+    <value>Size name</value>
   </data>
 </root>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
@@ -259,32 +259,38 @@
                         <TextBlock x:Uid="ImageResizer_FileFormatDescription"/>
                         <TextBlock Margin="{StaticResource SmallTopMargin}">
                             <Run Text="%1" FontWeight="Bold" />
-                            <Run Text=" - Original filename" />
+                            <Run Text=" - "/>
+                            <Run x:Uid="ImageResizer_Formatting_Filename" />
                         </TextBlock>
 
                         <TextBlock>
                             <Run Text="%2" FontWeight="Bold" />
-                            <Run Text=" - Size name"/>
+                            <Run Text=" - "/>
+                            <Run x:Uid="ImageResizer_Formatting_Sizename"/>
                         </TextBlock>
 
                         <TextBlock>
                             <Run Text="%3" FontWeight="Bold" />
-                            <Run Text=" - Selected width"/>
+                            <Run Text=" - "/>
+                            <Run x:Uid="ImageResizer_Formatting_SelectedWidth"/>
                         </TextBlock>
 
                         <TextBlock>
                             <Run Text="%4" FontWeight="Bold" />
-                            <Run Text=" - Selected height"/>
+                            <Run Text=" - "/>
+                            <Run x:Uid="ImageResizer_Formatting_SelectedHeight"/>
                         </TextBlock>
 
                         <TextBlock>
                             <Run Text="%5" FontWeight="Bold" />
-                            <Run Text=" - Actual height"/>
+                            <Run Text=" - "/>
+                            <Run x:Uid="ImageResizer_Formatting_ActualWidth"/>
                         </TextBlock>
 
                         <TextBlock>
                             <Run Text="%6" FontWeight="Bold" />
-                            <Run Text=" - Actual width"/>
+                            <Run Text=" - "/>
+                            <Run x:Uid="ImageResizer_Formatting_ActualHeight"/>
                         </TextBlock>
                     </StackPanel>
                 </ToolTipService.ToolTip>


### PR DESCRIPTION
## Summary of the Pull Request
- Moved the strings describing the various filename formatting options to the Resources file.
- Fixes incorrect label: #5518, #2795

![image](https://user-images.githubusercontent.com/9866362/89162040-c3bb2a80-d573-11ea-832b-15248362ae32.png)

## PR Checklist
* [X] Applies to #5518, #2795
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx
