### PR TITLE
Trying to dispose mouse hook earlier to potentialy fix the lagging mo…

### DIFF
--- a/src/modules/colorPicker/ColorPickerUI/Mouse/MouseHook.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Mouse/MouseHook.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using ColorPicker.Helpers;
 using System;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -71,7 +72,7 @@ namespace ColorPicker.Mouse
                 if (!result)
                 {
                     int errorCode = Marshal.GetLastWin32Error();
-                    throw new Win32Exception(errorCode);
+                    Logger.LogError("Failed to unsubscribe mouse hook with the error code" + errorCode);
                 }
             }
         }
@@ -90,7 +91,7 @@ namespace ColorPicker.Mouse
                 if (_mouseHookHandle == IntPtr.Zero)
                 {
                     int errorCode = Marshal.GetLastWin32Error();
-                    throw new Win32Exception(errorCode);
+                    Logger.LogError("Failed to subscribe mouse hook with the error code" + errorCode);
                 }
             }
         }

--- a/src/modules/colorPicker/ColorPickerUI/Mouse/MouseInfoProvider.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Mouse/MouseInfoProvider.cs
@@ -94,15 +94,7 @@ namespace ColorPicker.Mouse
 
         private void AppStateMonitor_AppClosed(object sender, EventArgs e)
         {
-            _timer.Stop();
-            _previousMousePosition = new System.Windows.Point(-1, 1);
-            _mouseHook.OnMouseDown -= MouseHook_OnMouseDown;
-            _mouseHook.OnMouseWheel -= MouseHook_OnMouseWheel;
-
-            if (_userSettings.ChangeCursor.Value)
-            {
-                CursorManager.RestoreOriginalCursors();
-            }
+            DisposeHook();
         }
 
         private void AppStateMonitor_AppShown(object sender, EventArgs e)
@@ -135,7 +127,25 @@ namespace ColorPicker.Mouse
 
         private void MouseHook_OnMouseDown(object sender, Point p)
         {
+            DisposeHook();
             OnMouseDown?.Invoke(this, p);
+        }
+
+        private void DisposeHook()
+        {
+            if (_timer.IsEnabled)
+            {
+                _timer.Stop();
+            }
+
+            _previousMousePosition = new System.Windows.Point(-1, 1);
+            _mouseHook.OnMouseDown -= MouseHook_OnMouseDown;
+            _mouseHook.OnMouseWheel -= MouseHook_OnMouseWheel;
+
+            if (_userSettings.ChangeCursor.Value)
+            {
+                CursorManager.RestoreOriginalCursors();
+            }
         }
     }
 }


### PR DESCRIPTION
…use bug after selecting the color

## Summary of the Pull Request

I suspect that mouse lag issue #5427 is happening due running all color copying stuff on the same thread as the mouse hook - if it takes longer for some reason (maybe telemetry?) it might cause reported scenario. Now I am removing hook immediately after the mouse is clicked.

Trying to fix #5427

## PR Checklist
* [x] Applies to #5427 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

Added some extra logging, removing mouse hook earlier

## Validation Steps Performed
Manual testing, works OK (I didn't have the reported issue before)