### PR TITLE
notifications: provide default app id to fix FZ toast crashes

### DIFF
--- a/src/bootstrapper/bootstrapper.cpp
+++ b/src/bootstrapper/bootstrapper.cpp
@@ -90,7 +90,7 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int)
     {
         return 1;
     }
-    notifications::set_application_id(APPLICATION_ID);
+    notifications::override_application_id(APPLICATION_ID);
 
     fs::path iconPath{ L"C:\\" };
     if (auto extractedIcon = extractIcon())

--- a/src/common/notifications.cpp
+++ b/src/common/notifications.cpp
@@ -37,7 +37,7 @@ namespace
     constexpr std::wstring_view PACKAGED_APPLICATION_ID = L"PowerToys";
     constexpr std::wstring_view APPIDS_REGISTRY = LR"(Software\Classes\AppUserModelId\)";
 
-    std::wstring APPLICATION_ID;
+    std::wstring APPLICATION_ID = L"Microsoft.PowerToysWin32";
 }
 
 namespace localized_strings
@@ -184,7 +184,7 @@ void notifications::unregister_application_id()
     RegDeleteKeyW(registryRoot.get(), APPLICATION_ID.data());
 }
 
-void notifications::set_application_id(const std::wstring_view appID)
+void notifications::override_application_id(const std::wstring_view appID)
 {
     APPLICATION_ID = appID;
     SetCurrentProcessExplicitAppUserModelID(APPLICATION_ID.c_str());

--- a/src/common/notifications.cpp
+++ b/src/common/notifications.cpp
@@ -30,6 +30,7 @@ using winrt::Windows::UI::Notifications::ToastNotificationManager;
 
 namespace fs = std::filesystem;
 
+// This namespace contains strings that SHOULD NOT be localized
 namespace
 {
     constexpr std::wstring_view TASK_NAME = L"PowerToysBackgroundNotificationsHandler";

--- a/src/common/notifications.h
+++ b/src/common/notifications.h
@@ -10,7 +10,7 @@ namespace notifications
 {
     constexpr inline const wchar_t TOAST_ACTIVATED_LAUNCH_ARG[] = L"-ToastActivated";
 
-    void set_application_id(const std::wstring_view appID);
+    void override_application_id(const std::wstring_view appID);
     void register_background_toast_handler();
     void run_desktop_app_activator_loop();
 

--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -48,7 +48,6 @@ namespace localized_strings
 namespace
 {
     const wchar_t PT_URI_PROTOCOL_SCHEME[] = L"powertoys://";
-    const wchar_t APPLICATION_ID[] = L"Microsoft.PowerToysWin32";
 }
 
 void chdir_current_executable()
@@ -305,8 +304,6 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     {
         return 0;
     }
-    notifications::set_application_id(APPLICATION_ID);
-
     int n_cmd_args = 0;
     LPWSTR* cmd_arg_list = CommandLineToArgvW(GetCommandLineW(), &n_cmd_args);
     switch (should_run_in_special_mode(n_cmd_args, cmd_arg_list))


### PR DESCRIPTION
## Summary of the Pull Request
Provide a default app id to fix FZ toast crash.

## PR Checklist
* [x] Applies to #5540

## Validation Steps Performed
- installed PT
- bootstrapper toasts work
- "dragging elevated window" warning toast works