### PR TITLE
Fixing potentially infinite loop with logs in Color Picker

### DIFF
--- a/src/modules/colorPicker/ColorPickerUI/Helpers/Logger.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/Logger.cs
@@ -69,7 +69,7 @@ namespace ColorPicker.Helpers
 
             var methodName = stackTrace.GetFrame(3)?.GetMethod();
             var className = methodName?.DeclaringType.Name;
-            return "[Method]: " + methodName.Name + " [Class]: " + className;
+            return "[Method]: " + methodName?.Name + " [Class]: " + className;
         }
     }
 }

--- a/src/modules/colorPicker/ColorPickerUI/Settings/UserSettings.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Settings/UserSettings.cs
@@ -83,7 +83,13 @@ namespace ColorPicker.Settings
                         }
                         catch (Exception ex)
                         {
+                            if (retryCount > MaxNumberOfRetry)
+                            {
+                                retry = false;
+                            }
+
                             Logger.LogError("Failed to read changed settings", ex);
+                            Thread.Sleep(500);
                         }
                     }
                 }


### PR DESCRIPTION
## Summary of the Pull Request

When there is an issue in reading settings and exception is thrown (other than IOException) it will loop infinitely and append logs non-stop.
I suspect this is the issue #5555

## PR Checklist
* [x] Applies to #5555 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

## Validation Steps Performed

_How does someone test & validate?_
