### PR TITLE
Possible fix for dispose timer bug

### DIFF
--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -1,20 +1,16 @@
-﻿using System;
-using System.ComponentModel;
-using System.Windows;
-using System.Windows.Input;
-using System.Windows.Media.Animation;
-using PowerLauncher.Helper;
-using Wox.Infrastructure.UserSettings;
-using PowerLauncher.ViewModel;
-
-using Screen = System.Windows.Forms.Screen;
-using KeyEventArgs = System.Windows.Input.KeyEventArgs;
-using System.Windows.Controls;
-using System.Threading.Tasks;
-using System.Diagnostics;
-using System.Timers;
-using Microsoft.PowerLauncher.Telemetry;
+﻿using Microsoft.PowerLauncher.Telemetry;
 using Microsoft.PowerToys.Telemetry;
+using PowerLauncher.Helper;
+using PowerLauncher.ViewModel;
+using System;
+using System.ComponentModel;
+using System.Timers;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using Wox.Infrastructure.UserSettings;
+using KeyEventArgs = System.Windows.Input.KeyEventArgs;
+using Screen = System.Windows.Forms.Screen;
 
 
 namespace PowerLauncher
@@ -47,10 +43,13 @@ namespace PowerLauncher
 
         private void CheckForFirstDelete(object sender, ElapsedEventArgs e)
         {
-            _firstDeleteTimer.Stop();
-            if (_deletePressed)
+            if (_firstDeleteTimer != null)
             {
-                PowerToysTelemetry.Log.WriteEvent(new LauncherFirstDeleteEvent());
+                _firstDeleteTimer.Stop();
+                if (_deletePressed)
+                {
+                    PowerToysTelemetry.Log.WriteEvent(new LauncherFirstDeleteEvent());
+                }
             }
 
         }
@@ -350,7 +349,10 @@ namespace PowerLauncher
             if (Visibility == Visibility.Visible)
             {
                 _deletePressed = false;
-                _firstDeleteTimer.Start();
+                if (_firstDeleteTimer != null)
+                {
+                    _firstDeleteTimer.Start();
+                }
                 // (this.FindResource("IntroStoryboard") as Storyboard).Begin();
 
                 SearchBox.QueryTextBox.Focus();
@@ -376,7 +378,10 @@ namespace PowerLauncher
             }
             else
             {
-                _firstDeleteTimer.Stop();
+                if (_firstDeleteTimer != null)
+                {
+                    _firstDeleteTimer.Stop();
+                }
             }
         }
 
@@ -402,11 +407,15 @@ namespace PowerLauncher
             {
                 if (disposing)
                 {
-                    _firstDeleteTimer.Dispose();
+                    if (_firstDeleteTimer != null)
+                    {
+                        _firstDeleteTimer.Dispose();
+                    }
                 }
 
                 // TODO: free unmanaged resources (unmanaged objects) and override finalizer
                 // TODO: set large fields to null
+                _firstDeleteTimer = null;
                 disposedValue = true;
             }
         }


### PR DESCRIPTION
## Summary of the Pull Request

#5400's stacktrace shows a timer being accessed after being disposed.  My fix basically in dispose sets it to null and checks across the board.

**Issues for testing**

I don't know how to actually get the dispose method to fire here to validate fix.

**Larger questions**

If the page is being disposed, how is that event even being fired as it is fired when the dialog is visible.

**Secondary question for telem item**
@ryanbodrug-microsoft looking at the checkin statement, i don't think this is capturing what the heart of what the telem item is supposed to be.  Add telemetry event for when the user presses delete within the first two seconds. This just is 'did someone press delete'

## PR Checklist
* [x] Applies to #5400
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

## Validation Steps Performed

_How does someone test & validate?_
