### PR TITLE
Fix bootstrapper getting stuck on "installing dotnet"

### DIFF
--- a/src/common/common.cpp
+++ b/src/common/common.cpp
@@ -782,7 +782,11 @@ std::optional<std::string> exec_and_read_output(const std::wstring_view command,
     constexpr size_t bufferSize = 4096;
     // We must use a named pipe for async I/O
     char pipename[MAX_PATH + 1];
-    GetTempFileNameA(R"(\\.\pipe\)", "tmp", 1, pipename);
+    if (!GetTempFileNameA(R"(\\.\pipe\)", "tmp", 1, pipename))
+    {
+        return std::nullopt;
+    }
+
     wil::unique_handle readPipe{ CreateNamedPipeA(pipename, PIPE_ACCESS_INBOUND | FILE_FLAG_OVERLAPPED, PIPE_TYPE_BYTE | PIPE_READMODE_BYTE, PIPE_UNLIMITED_INSTANCES, bufferSize, bufferSize, 0, &saAttr) };
 
     saAttr.bInheritHandle = true;

--- a/src/common/common.cpp
+++ b/src/common/common.cpp
@@ -774,19 +774,21 @@ bool find_app_name_in_path(const std::wstring& where, const std::vector<std::wst
     return false;
 }
 
-std::optional<std::string> exec_and_read_output(const std::wstring_view command, const DWORD timeout)
+std::optional<std::string> exec_and_read_output(const std::wstring_view command, DWORD timeout_ms)
 {
     SECURITY_ATTRIBUTES saAttr{ sizeof(saAttr) };
+    saAttr.bInheritHandle = false;
+
+    constexpr size_t bufferSize = 4096;
+    // We must use a named pipe for async I/O
+    char pipename[MAX_PATH + 1];
+    GetTempFileNameA(R"(\\.\pipe\)", "tmp", 1, pipename);
+    wil::unique_handle readPipe{ CreateNamedPipeA(pipename, PIPE_ACCESS_INBOUND | FILE_FLAG_OVERLAPPED, PIPE_TYPE_BYTE | PIPE_READMODE_BYTE, PIPE_UNLIMITED_INSTANCES, bufferSize, bufferSize, 0, &saAttr) };
+
     saAttr.bInheritHandle = true;
+    wil::unique_handle writePipe{ CreateFileA(pipename, GENERIC_WRITE, 0, &saAttr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr) };
 
-    wil::unique_handle childStdoutRead;
-    wil::unique_handle childStdoutWrite;
-    if (!CreatePipe(&childStdoutRead, &childStdoutWrite, &saAttr, 0))
-    {
-        return std::nullopt;
-    }
-
-    if (!SetHandleInformation(childStdoutRead.get(), HANDLE_FLAG_INHERIT, 0))
+    if (!readPipe || !writePipe)
     {
         return std::nullopt;
     }
@@ -794,8 +796,8 @@ std::optional<std::string> exec_and_read_output(const std::wstring_view command,
     PROCESS_INFORMATION piProcInfo{};
     STARTUPINFOW siStartInfo{ sizeof(siStartInfo) };
 
-    siStartInfo.hStdError = childStdoutWrite.get();
-    siStartInfo.hStdOutput = childStdoutWrite.get();
+    siStartInfo.hStdError = writePipe.get();
+    siStartInfo.hStdOutput = writePipe.get();
     siStartInfo.dwFlags |= STARTF_USESTDHANDLES | STARTF_USESHOWWINDOW;
     siStartInfo.wShowWindow = SW_HIDE;
 
@@ -813,24 +815,49 @@ std::optional<std::string> exec_and_read_output(const std::wstring_view command,
     {
         return std::nullopt;
     }
+    // Child process inherited the write end of the pipe, we can close it now
+    writePipe.reset();
 
-    WaitForSingleObject(piProcInfo.hProcess, timeout);
-
-    childStdoutWrite.reset();
-    CloseHandle(piProcInfo.hThread);
+    auto closeProcessHandles = wil::scope_exit([&] {
+        CloseHandle(piProcInfo.hThread);
+        CloseHandle(piProcInfo.hProcess);
+    });
 
     std::string childOutput;
+    bool processExited = false;
     for (;;)
     {
-        char buffer[4096];
+        char buffer[bufferSize];
         DWORD gotBytes = 0;
-        if (!ReadFile(childStdoutRead.get(), buffer, sizeof(buffer), &gotBytes, nullptr) || !gotBytes)
-        {
-            break;
-        }
-        childOutput += std::string_view{ buffer, gotBytes };
-    }
+        wil::unique_handle IOEvent{ CreateEventW(nullptr, true, false, nullptr) };
+        OVERLAPPED overlapped{ .hEvent = IOEvent.get() };
+        ReadFile(readPipe.get(), buffer, sizeof(buffer), nullptr, &overlapped);
 
-    CloseHandle(piProcInfo.hProcess);
+        const std::array<HANDLE, 2> handlesToWait = { overlapped.hEvent, piProcInfo.hProcess };
+        switch (WaitForMultipleObjects(1 + !processExited, handlesToWait.data(), false, timeout_ms))
+        {
+        case WAIT_OBJECT_0 + 1:
+            if (!processExited)
+            {
+                // When the process exits, we can reduce timeout and read the rest of the output w/o possibly big timeout
+                timeout_ms = 1000;
+                processExited = true;
+                closeProcessHandles.reset();
+            }
+            [[fallthrough]];
+        case WAIT_OBJECT_0:
+            if (GetOverlappedResultEx(readPipe.get(), &overlapped, &gotBytes, timeout_ms, true))
+            {
+                childOutput += std::string_view{ buffer, gotBytes };
+                break;
+            }
+            // Timeout
+            [[fallthrough]];
+        default:
+            goto exit;
+        }
+    }
+exit:
+    CancelIo(readPipe.get());
     return childOutput;
 }

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -99,7 +99,7 @@ std::wstring get_resource_string(UINT resource_id, HINSTANCE instance, const wch
 // is added to the .cpp file.
 #define GET_RESOURCE_STRING(resource_id) get_resource_string(resource_id, reinterpret_cast<HINSTANCE>(&__ImageBase), L#resource_id)
 
-std::optional<std::string> exec_and_read_output(const std::wstring_view command, const DWORD timeout = INFINITE);
+std::optional<std::string> exec_and_read_output(const std::wstring_view command, DWORD timeout_ms = 30000);
 
 // Helper class for various COM-related APIs, e.g working with security descriptors
 template<typename T>


### PR DESCRIPTION
## Summary of the Pull Request
We detect installed dotnet versions using `exec_and_read_output` function. It created a child process, waited for its termination, then read its stdout from an anonymous pipe. That didn't work for some users, causing `dotnet` process to hang indefinitely, specifically for those who had so many dotnet versions installed, that `dotnet --list-runtimes` output exceeded the default anonymous pipe buffer size - 4KB. 

That caused dotnet process to block on some printf/Writeline call until the pipe buffer has space again. However, we were waiting indefinitely for the process to terminate instead of reading from the pipe buffer, as a result, we've had a deadlock.

This PR fixes the issue by reworking `exec_and_read_output` to have a default `30s` timeout value and employs overlapped I/O, since `ReadFile` will block indefinitely if no data is available. It also detects child process termination to figure when it's no longer useful to wait the full timeout. That required us to use a named pipe instead, since anonymous pipes created via `CreatePipe` do not support overlapped IO. 

## PR Checklist
* [x] Applies to #5484

## Validation Steps Performed
Tested `exec_and_read_output` with various scenarios: 
- small buffer < 4KB
- big buffer > 4KB
- a hang child process via Sleep
- Sleep at various intervals in a child process
