### PR TITLE
Fixed Launcher not exiting when PT is terminated

### DIFF
--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -828,7 +828,7 @@ namespace PowerLauncher.ViewModel
                         _hotkeyManager.UnregisterHotkey(_hotkeyHandle);
                     }
                     _hotkeyManager.Dispose();
-                    _updateSource.Dispose();
+                    _updateSource?.Dispose();
                     _disposed = true;
                 }
             }

--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -827,7 +827,7 @@ namespace PowerLauncher.ViewModel
                     {
                         _hotkeyManager.UnregisterHotkey(_hotkeyHandle);
                     }
-                    _hotkeyManager.Dispose();
+                    _hotkeyManager?.Dispose();
                     _updateSource?.Dispose();
                     _disposed = true;
                 }


### PR DESCRIPTION
## Summary of the Pull Request

In 0.20, terminating PowerToys from the Task Manager results in an exception in PT Run, which prevents it from quitting properly. This fixes the exception.

## PR Checklist
* [x] Somewhat related to #5400
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

Added a null check. This should have been there anyway.

## Validation Steps Performed

Checked that PT Run exits when PowerToys.exe is terminated.
