### PR TITLE
bootstrapper: add support for silent arg

### DIFF
--- a/installer/PowerToysBootstrapper/bootstrapper/pch.h
+++ b/installer/PowerToysBootstrapper/bootstrapper/pch.h
@@ -9,3 +9,5 @@
 #include <fstream>
 #include <wil/resource.h>
 #include <Msi.h>
+
+#include <unordered_set>

--- a/src/action_runner/action_runner.cpp
+++ b/src/action_runner/action_runner.cpp
@@ -98,7 +98,7 @@ bool install_new_version_stage_1(const std::wstring_view installer_filename, con
     }
 }
 
-bool install_new_version_stage_2(std::wstring installer_path, std::wstring_view install_path, const bool launch_powertoys)
+bool install_new_version_stage_2(std::wstring installer_path, std::wstring_view install_path, bool launch_powertoys)
 {
     std::transform(begin(installer_path), end(installer_path), begin(installer_path), ::towlower);
 
@@ -115,7 +115,17 @@ bool install_new_version_stage_2(std::wstring installer_path, std::wstring_view 
         sei.fMask = { SEE_MASK_FLAG_NO_UI | SEE_MASK_NOASYNC | SEE_MASK_NOCLOSEPROCESS | SEE_MASK_NO_CONSOLE};
         sei.lpFile = installer_path.c_str();
         sei.nShow = SW_SHOWNORMAL;
-        sei.lpParameters = L"-silent";
+        std::wstring parameters = L"--no_full_ui";
+        if(launch_powertoys)
+        {
+          // .exe installer launches the main app by default
+          launch_powertoys = false;
+        }
+        else
+        {
+          parameters += L"--no_start_pt";
+        }
+        sei.lpParameters = parameters.c_str();
 
         success = ShellExecuteExW(&sei) == TRUE;
         // Wait for the install completion

--- a/src/action_runner/action_runner.cpp
+++ b/src/action_runner/action_runner.cpp
@@ -112,18 +112,18 @@ bool install_new_version_stage_2(std::wstring installer_path, std::wstring_view 
     {
         // If it's not .msi, then it's our .exe installer
         SHELLEXECUTEINFOW sei{ sizeof(sei) };
-        sei.fMask = { SEE_MASK_FLAG_NO_UI | SEE_MASK_NOASYNC | SEE_MASK_NOCLOSEPROCESS | SEE_MASK_NO_CONSOLE};
+        sei.fMask = { SEE_MASK_FLAG_NO_UI | SEE_MASK_NOASYNC | SEE_MASK_NOCLOSEPROCESS | SEE_MASK_NO_CONSOLE };
         sei.lpFile = installer_path.c_str();
         sei.nShow = SW_SHOWNORMAL;
         std::wstring parameters = L"--no_full_ui";
-        if(launch_powertoys)
+        if (launch_powertoys)
         {
-          // .exe installer launches the main app by default
-          launch_powertoys = false;
+            // .exe installer launches the main app by default
+            launch_powertoys = false;
         }
         else
         {
-          parameters += L"--no_start_pt";
+            parameters += L"--no_start_pt";
         }
         sei.lpParameters = parameters.c_str();
 

--- a/src/common/common.cpp
+++ b/src/common/common.cpp
@@ -451,7 +451,7 @@ std::wstring get_process_path(DWORD pid) noexcept
     return name;
 }
 
-bool run_elevated(const std::wstring& file, const std::wstring& params)
+HANDLE run_elevated(const std::wstring& file, const std::wstring& params)
 {
     SHELLEXECUTEINFOW exec_info = { 0 };
     exec_info.cbSize = sizeof(SHELLEXECUTEINFOW);
@@ -464,14 +464,7 @@ bool run_elevated(const std::wstring& file, const std::wstring& params)
     exec_info.hInstApp = 0;
     exec_info.nShow = SW_SHOWDEFAULT;
 
-    if (ShellExecuteExW(&exec_info))
-    {
-        return exec_info.hProcess != nullptr;
-    }
-    else
-    {
-        return false;
-    }
+    return ShellExecuteExW(&exec_info) ? exec_info.hProcess : nullptr;
 }
 
 bool run_non_elevated(const std::wstring& file, const std::wstring& params, DWORD* returnPid)

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -67,7 +67,7 @@ bool is_process_elevated(const bool use_cached_value = true);
 bool drop_elevated_privileges();
 
 // Run command as elevated user, returns true if succeeded
-bool run_elevated(const std::wstring& file, const std::wstring& params);
+HANDLE run_elevated(const std::wstring& file, const std::wstring& params);
 
 // Run command as non-elevated user, returns true if succeeded, puts the process id into returnPid if returnPid != NULL
 bool run_non_elevated(const std::wstring& file, const std::wstring& params, DWORD* returnPid);


### PR DESCRIPTION
## Summary of the Pull Request
EXE installer now supports 3 cmd flags:
- `--no_full_ui` - uses reduced MSI UI, i.e. only the progress bar w/o dialogs and confirmations. toast progress bar is active
- `--silent` - no toast notifications, no MSI UI. UAC breaks MSI if the process isn't elevated, so we must relaunch installer elevated for it to work
- `--no_start_pt` - doesn't launch PowerToys after successful installation

## PR Checklist
* [x] Applies to #5381

## Validation Steps Performed
- install PT with various flags combinations
- restart PT elevated