### PR TITLE
[FancyZones] Do not restore maximized windows

### DIFF
--- a/src/modules/fancyzones/lib/WindowMoveHandler.cpp
+++ b/src/modules/fancyzones/lib/WindowMoveHandler.cpp
@@ -337,7 +337,7 @@ void WindowMoveHandlerPrivate::MoveSizeEnd(HWND window, POINT const& ptScreen, c
             {
                 ::RemoveProp(window, RESTORE_SIZE_STAMP);
             }
-            else
+            else if (!IsWindowMaximized(window))
             {
                 RestoreWindowSize(window);
             }

--- a/src/modules/fancyzones/lib/util.cpp
+++ b/src/modules/fancyzones/lib/util.cpp
@@ -211,7 +211,7 @@ void RestoreWindowSize(HWND window) noexcept
 {
     WINDOWPLACEMENT placement{};
     if (GetWindowPlacement(window, &placement) &&
-        placement.showCmd & SW_SHOWMAXIMIZED)
+        placement.showCmd == SW_SHOWMAXIMIZED)
     {
         // Do not restore maximized windows.
         return;

--- a/src/modules/fancyzones/lib/util.cpp
+++ b/src/modules/fancyzones/lib/util.cpp
@@ -209,6 +209,14 @@ void SaveWindowSizeAndOrigin(HWND window) noexcept
 
 void RestoreWindowSize(HWND window) noexcept
 {
+    WINDOWPLACEMENT placement{};
+    if (GetWindowPlacement(window, &placement) &&
+        placement.showCmd & SW_SHOWMAXIMIZED)
+    {
+        // Do not restore maximized windows.
+        return;
+    }
+
     auto windowSizeData = GetPropW(window, RESTORE_SIZE_STAMP);
     if (windowSizeData)
     {

--- a/src/modules/fancyzones/lib/util.cpp
+++ b/src/modules/fancyzones/lib/util.cpp
@@ -177,6 +177,17 @@ bool IsInterestingWindow(HWND window, const std::vector<std::wstring>& excludedA
     return true;
 }
 
+bool IsWindowMaximized(HWND window) noexcept
+{
+    WINDOWPLACEMENT placement{};
+    if (GetWindowPlacement(window, &placement) &&
+        placement.showCmd == SW_SHOWMAXIMIZED)
+    {
+        return true;
+    }
+    return false;
+}
+
 void SaveWindowSizeAndOrigin(HWND window) noexcept
 {
     HANDLE handle = GetPropW(window, RESTORE_SIZE_STAMP);
@@ -209,14 +220,6 @@ void SaveWindowSizeAndOrigin(HWND window) noexcept
 
 void RestoreWindowSize(HWND window) noexcept
 {
-    WINDOWPLACEMENT placement{};
-    if (GetWindowPlacement(window, &placement) &&
-        placement.showCmd == SW_SHOWMAXIMIZED)
-    {
-        // Do not restore maximized windows.
-        return;
-    }
-
     auto windowSizeData = GetPropW(window, RESTORE_SIZE_STAMP);
     if (windowSizeData)
     {

--- a/src/modules/fancyzones/lib/util.h
+++ b/src/modules/fancyzones/lib/util.h
@@ -121,6 +121,7 @@ void OrderMonitors(std::vector<std::pair<HMONITOR, RECT>>& monitorInfo);
 void SizeWindowToRect(HWND window, RECT rect) noexcept;
 
 bool IsInterestingWindow(HWND window, const std::vector<std::wstring>& excludedApps) noexcept;
+bool IsWindowMaximized(HWND window) noexcept;
 void SaveWindowSizeAndOrigin(HWND window) noexcept;
 void RestoreWindowSize(HWND window) noexcept;
 void RestoreWindowOrigin(HWND window) noexcept;


### PR DESCRIPTION
## Summary of the Pull Request

After window is moved away from zone into maximized state, we should not restore it back to original position, but rather keep it maximized.

## PR Checklist
* [X] Applies to #5512
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

## Info on Pull Request

Check show command from window placement, and skip resizing window if show command indicates maximized state.

## Validation Steps Performed

1. Assign window to the zone.
2. Move window away from zone by dragging it to the top of the screen (essentially forcing it to go to maximized state).

Expected result: Window stays in maximized state.
