### PR TITLE
[FancyZones] Focus layout zones mismatch in Editor and applied layout

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/Settings.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/Settings.cs
@@ -293,6 +293,8 @@ namespace FancyZonesEditor
                 ZoneCount = 3;
             }
 
+            // If changing focus layout zones size and/or increment,
+            // same change should be applied in ZoneSet.cpp (ZoneSet::CalculateFocusLayout)
             Int32Rect focusZoneRect = new Int32Rect(100, 100, (int)(WorkArea.Width * 0.4), (int)(WorkArea.Height * 0.4));
             int focusRectXIncrement = (ZoneCount <= 1) ? 0 : 50;
             int focusRectYIncrement = (ZoneCount <= 1) ? 0 : 50;

--- a/src/modules/fancyzones/lib/ZoneSet.cpp
+++ b/src/modules/fancyzones/lib/ZoneSet.cpp
@@ -423,15 +423,15 @@ bool ZoneSet::CalculateFocusLayout(Rect workArea, int zoneCount) noexcept
 {
     bool success = true;
 
-    long left{ long(workArea.width() * 0.1) };
-    long top{ long(workArea.height() * 0.1) };
-    long right{ left + long(workArea.width() * 0.6) };
-    long bottom{ top + long(workArea.height() * 0.6) };
+    long left{ 100 };
+    long top{ 100 };
+    long right{ left + long(workArea.width() * 0.4) };
+    long bottom{ top + long(workArea.height() * 0.4) };
 
     RECT focusZoneRect{ left, top, right, bottom };
 
-    long focusRectXIncrement = (zoneCount <= 1) ? 0 : (int)(workArea.width() * 0.2) / (zoneCount - 1);
-    long focusRectYIncrement = (zoneCount <= 1) ? 0 : (int)(workArea.height() * 0.2) / (zoneCount - 1);
+    long focusRectXIncrement = (zoneCount <= 1) ? 0 : 50;
+    long focusRectYIncrement = (zoneCount <= 1) ? 0 : 50;
 
     if (left >= right || top >= bottom || left < 0 || right < 0 || top < 0 || bottom < 0)
     {


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
When applying focus layout, what was shown in Editor and what was actually applied was different. This PR fixes this behavior.

## PR Checklist
* [x] Applies to #5407
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

_How does someone test & validate?_
Apply focus layout
Open editor and confirm that layout preview matches with applied layout (hold shift and drag to show applied layout)