### PR TITLE
[FancyZones] Don't restore minimized windows after layout is updated

### DIFF
--- a/src/modules/fancyzones/lib/util.cpp
+++ b/src/modules/fancyzones/lib/util.cpp
@@ -124,21 +124,22 @@ void SizeWindowToRect(HWND window, RECT rect) noexcept
     WINDOWPLACEMENT placement{};
     ::GetWindowPlacement(window, &placement);
 
-    //wait if SW_SHOWMINIMIZED would be removed from window (Issue #1685)
-    for (int i = 0; i < 5 && (placement.showCmd & SW_SHOWMINIMIZED) != 0; i++)
+    // Wait if SW_SHOWMINIMIZED would be removed from window (Issue #1685)
+    for (int i = 0; i < 5 && (placement.showCmd == SW_SHOWMINIMIZED); ++i)
     {
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
         ::GetWindowPlacement(window, &placement);
     }
 
     // Do not restore minimized windows. We change their placement though so they restore to the correct zone.
-    if ((placement.showCmd & SW_SHOWMINIMIZED) == 0)
+    if ((placement.showCmd != SW_SHOWMINIMIZED) &&
+        (placement.showCmd != SW_MINIMIZE))
     {
-        placement.showCmd = SW_RESTORE | SW_SHOWNA;
+        placement.showCmd = SW_RESTORE;
     }
 
     // Remove maximized show command to make sure window is moved to the correct zone.
-    if (placement.showCmd & SW_SHOWMAXIMIZED)
+    if (placement.showCmd == SW_SHOWMAXIMIZED)
     {
         placement.showCmd = SW_RESTORE;
         placement.flags &= ~WPF_RESTORETOMAXIMIZED;


### PR DESCRIPTION
## Summary of the Pull Request

Don't restore minimized windows after zone layout is updated. Update their placement information with modified position, but keep them minimized.

## PR Checklist
* [X] Applies to #4656
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

## Info on Pull Request

Show command from `WINDOWPLACEMENT` structure can only have one of the following values:
```
#define SW_HIDE             0
#define SW_SHOWNORMAL       1
#define SW_NORMAL           1
#define SW_SHOWMINIMIZED    2
#define SW_SHOWMAXIMIZED    3
#define SW_MAXIMIZE         3
#define SW_SHOWNOACTIVATE   4
#define SW_SHOW             5
#define SW_MINIMIZE         6
#define SW_SHOWMINNOACTIVE  7
#define SW_SHOWNA           8
#define SW_RESTORE          9
#define SW_SHOWDEFAULT      10
#define SW_FORCEMINIMIZE    11
#define SW_MAX              11
```
Checking show command should not be performed bit-wise since it could lead to undesired behavior.
## Validation Steps Performed
1. Assign window to zone.
2. Minimize that window.
3. Open editor and modify zone layout.

Expected result: Minimized window stayed in its state, but when manually opened, window coordinates are updated according to layout change which occured in the meantime.
