### PR TITLE
fixing MSB3052 project warnings

### DIFF
--- a/installer/Version.props
+++ b/installer/Version.props
@@ -2,6 +2,5 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Version>0.20.1</Version>
-    <DefineConstants>Version=$(Version);</DefineConstants>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Fixing compiler warning: MSB3052	The parameter to the compiler is invalid, '/define:Version=0.20.1' will be ignored.

This will remove 5 warnings