### PR TITLE
Fixed exceptions in dispose not allowing PT Run to terminate

### DIFF
--- a/src/modules/launcher/PowerLauncher/App.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/App.xaml.cs
@@ -60,8 +60,15 @@ namespace PowerLauncher
         {
             RunnerHelper.WaitForPowerToysRunner(_powerToysPid, () =>
             {
-                Dispose();
-                Environment.Exit(0);
+                try
+                {
+                    Dispose();
+                }
+                finally
+                {
+
+                    Environment.Exit(0);
+                }
             });
 
             var bootTime = new System.Diagnostics.Stopwatch();


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

While #5560 and #5588 fixed the null reference exceptions, if for some reason an exception occurs while disposing the PowerLauncher.exe process will not terminate. This can be reproduced easily by adding a `throw new Exception()` line at the end of the Dispose method, and exiting PowerToys.exe from task manager, the PowerLauncher process does not get terminated. This occurs because Dispose is being called from Task.Run in the WaitForPowerToysRunner method, and Task.Run does not rethrow exceptions on the main thread, unless a Task.Wait statement is present after it. However we cant add Task.Wait here since we dont want this thread to be blocking. To resolve this we can use try/finally and ensure Environment.Exit(0) is always called when runner exits.

        protected virtual void Dispose(bool disposing)
        {
            if (!_disposed)
            {
                Stopwatch.Normal("|App.OnExit|Exit cost", () =>
                {
                    Log.Info("|App.OnExit| Start PowerToys Run Exit----------------------------------------------------  ");
                    if (disposing)
                    {
                        _themeManager.ThemeChanged -= OnThemeChanged;
                        API.SaveAppAllSettings();
                        PluginManager.Dispose();
                        _mainWindow.Dispose();
                        API.Dispose();
                        _mainVM.Dispose();
                        _themeManager.Dispose();
                        _disposed = true;
                    }

                    // TODO: free unmanaged resources (unmanaged objects) and override finalizer
                    // TODO: set large fields to null
                    _disposed = true;
                    Log.Info("|App.OnExit| End PowerToys Run Exit ----------------------------------------------------  ");
                    throw new Exception();
                });
            }
        }

## PR Checklist
* [X] Applies to #5400 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

## Info on Pull Request

_What does this include?_
Adds a try/finally block to ensure PowerLauncher.exe gets terminated when runner is closed.

## Validation Steps Performed

_How does someone test & validate?_
1. Test no exception scenario by running PowerToys.exe and ending the task from Task Manager. PowerLauncher.exe should get terminated.
2. Test exception scenario by adding the throw new Exception statement and repeat the above steps.

## Note
I tested the above for Restart as admin, however when there is an exception in Dispose, Restart as admin still behaves weirdly and PT Run appears on the screen but then the process crashes, so a user has to disable/re-enable PT Run for it to work.