### PR TITLE
Adding null check for HotKey Manager before using unregister hotkey function

### DIFF
--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -825,7 +825,7 @@ namespace PowerLauncher.ViewModel
                 {
                     if (_hotkeyHandle != 0)
                     {
-                        _hotkeyManager.UnregisterHotkey(_hotkeyHandle);
+                        _hotkeyManager?.UnregisterHotkey(_hotkeyHandle);
                     }
                     _hotkeyManager?.Dispose();
                     _updateSource?.Dispose();


### PR DESCRIPTION
## Summary of the Pull Request


Adding null check before using the hotkeyManager.
Related to PR #5588 which added a check for the Dispose function of HotKeyManager but not the UnregisterHotKey function.

## PR Checklist
* [ ] Applies to #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx
