### PR TITLE
fix settings path

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI.Runner/Microsoft.PowerToys.Settings.UI.Runner.csproj
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Runner/Microsoft.PowerToys.Settings.UI.Runner.csproj
@@ -10,7 +10,6 @@
     <Authors>Microsoft Corporation</Authors>
     <Product>PowerToys</Product>
     <Description>PowerToys Settings UI Runner</Description>
-    <AssemblyName>PowerToys Settings</AssemblyName>
     <Copyright>Copyright (C) 2020 Microsoft Corporation</Copyright>
     <Company>Microsoft Corporation</Company>
     <PackageIcon>logo.png</PackageIcon>

--- a/src/runner/settings_window.cpp
+++ b/src/runner/settings_window.cpp
@@ -248,7 +248,7 @@ void run_settings_window()
 
     if (UseNewSettings())
     {
-        executable_path.append(L"\\SettingsUIRunner\\Microsoft.PowerToys.Settings.UI.Runner.exe");
+        executable_path.append(L"\\SettingsUIRunner\\PowerToys Settings.exe");
     }
     else
     {

--- a/src/runner/settings_window.cpp
+++ b/src/runner/settings_window.cpp
@@ -248,7 +248,7 @@ void run_settings_window()
 
     if (UseNewSettings())
     {
-        executable_path.append(L"\\SettingsUIRunner\\PowerToys Settings.exe");
+        executable_path.append(L"\\SettingsUIRunner\\Microsoft.PowerToys.Settings.UI.Runner.exe");
     }
     else
     {


### PR DESCRIPTION
## Summary of the Pull Request

- Path to settings executable is broken. This PR fixes it.

## PR Checklist
* [x] Applies to #5691
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

## Validation Steps Performed

- Launched the settings from icon tray.
