### PR TITLE
Unlinked the MaxSearchCount value from Indexer Settings and set to fixed value of 30

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/IndexerSettings.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/IndexerSettings.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Plugin.Indexer
     {
         public List<ContextMenu> ContextMenus { get; } = new List<ContextMenu>();
 
-        public int MaxSearchCount { get; set; } = 100;
+        public int MaxSearchCount { get; set; } = 30;
 
         public bool UseLocationAsWorkingDir { get; set; } = false;
     }

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Main.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Plugin.Indexer
                 var searchQuery = query.Search;
                 if (_settings.MaxSearchCount <= 0)
                 {
-                    _settings.MaxSearchCount = 50;
+                    _settings.MaxSearchCount = 30;
                 }
 
                 var regexMatch = Regex.Match(searchQuery, reservedStringPattern);
@@ -211,7 +211,6 @@ namespace Microsoft.Plugin.Indexer
 
         public void UpdateSettings(PowerLauncherSettings settings)
         {
-            _settings.MaxSearchCount = settings.Properties.MaximumNumberOfResults;
             _driveDetection.IsDriveDetectionWarningCheckBoxSelected = settings.Properties.DisableDriveDetectionWarning;
         }
 


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

This PR fixes the MaxSearchCount being linked to the MaximumNumberOfResults in PT Settings. This was causing a 4 result cap on Indexer by default. This has been tweaked such that it is fixed to 30, and it can be changed in the future to be linked to some other appropriate setting.

## PR Checklist
* [X] Applies to #5740
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [X] Tests passed

## Info on Pull Request

_What does this include?_
- Remove the statement for updating the MaxSearchCount based on PT Run settings
- Set all default values to 30/

## Validation Steps Performed

_How does someone test & validate?_

Validated by searching for files and checking the SQL query in the indexer plugin. In order to verify that it's working you will have to delete the Microsoft.Plugin.Indexer folder from AppData/Local/Microsoft/PowerToys/PowerToys Run/Settings/Plugins since it will try to load the value in that cache unless there is a version number increase, and the value in the cache would most likely be 4.