### PR TITLE
runner: don't try to restart explorer

### DIFF
--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -40,7 +40,7 @@ namespace localized_strings
     const wchar_t MSI_VERSION_IS_ALREADY_RUNNING[] = L"An older version of PowerToys is already running.";
     const wchar_t DOWNLOAD_UPDATE_ERROR[] = L"Couldn't download PowerToys update! Please report the issue on Github.";
     const wchar_t OLDER_MSIX_UNINSTALLED[] = L"An older MSIX version of PowerToys was uninstalled.";
-    const wchar_t PT_UPDATE_MESSAGE_BOX_TEXT[] = L"PowerToys was updated successfully! Some components may require explorer to be restarted.";
+    const wchar_t PT_UPDATE_MESSAGE_BOX_TEXT[] = L"PowerToys was updated successfully!";
 }
 
 namespace

--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -35,15 +35,12 @@
 
 extern "C" IMAGE_DOS_HEADER __ImageBase;
 
-// Window Explorer process name should not be localized.
-const wchar_t EXPLORER_PROCESS_NAME[] = L"explorer.exe";
-
 namespace localized_strings
 {
     const wchar_t MSI_VERSION_IS_ALREADY_RUNNING[] = L"An older version of PowerToys is already running.";
     const wchar_t DOWNLOAD_UPDATE_ERROR[] = L"Couldn't download PowerToys update! Please report the issue on Github.";
     const wchar_t OLDER_MSIX_UNINSTALLED[] = L"An older MSIX version of PowerToys was uninstalled.";
-    const wchar_t PT_UPDATE_MESSAGE_BOX_TEXT[] = L"PowerToys was updated and some components require Windows Explorer to restart. Do you want to restart Windows Explorer now?";
+    const wchar_t PT_UPDATE_MESSAGE_BOX_TEXT[] = L"PowerToys was updated successfully! Some components may require explorer to be restarted.";
 }
 
 namespace
@@ -260,43 +257,6 @@ toast_notification_handler_result toast_notification_handler(const std::wstring_
     }
 }
 
-void RequestExplorerRestart()
-{
-    if (MessageBoxW(nullptr,
-                    localized_strings::PT_UPDATE_MESSAGE_BOX_TEXT,
-                    L"PowerToys",
-                    MB_ICONINFORMATION | MB_YESNO | MB_DEFBUTTON1) != IDYES)
-    {
-        return;
-    }
-    std::thread{ [] {
-        RestartProcess(EXPLORER_PROCESS_NAME);
-
-        constexpr size_t max_checks = 10;
-        for (size_t i = 0; i < max_checks; ++i)
-        {
-            Sleep(1000);
-            const bool explorerStarted = !getProcessHandlesByName(L"explorer.exe", {}).empty();
-            if (explorerStarted)
-            {
-                return;
-            }
-        }
-
-        // Timeout - restart explorer manually
-        SHELLEXECUTEINFOW sei{ sizeof(sei) };
-        sei.fMask = { SEE_MASK_NOASYNC | SEE_MASK_FLAG_NO_UI | SEE_MASK_NO_CONSOLE | SEE_MASK_NOCLOSEPROCESS };
-        sei.lpFile = L"cmd";
-        sei.lpParameters = L"/c explorer.exe";
-        sei.nShow = SW_HIDE;
-        ShellExecuteExW(&sei);
-        // Let cmd launch explorer, then terminate it
-        Sleep(1000);
-        TerminateProcess(sei.hProcess, 0);
-        CloseHandle(sei.hProcess);
-    } }.detach();
-}
-
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow)
 {
     winrt::init_apartment();
@@ -332,7 +292,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
             return 0;
         }
     case SpecialMode::ReportSuccessfulUpdate:
-        RequestExplorerRestart();
+        notifications::show_toast(localized_strings::PT_UPDATE_MESSAGE_BOX_TEXT, L"PowerToys");
         break;
 
     case SpecialMode::None:


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
We now only notify the user that explorer may need restarting, instead of offering to restart it ourselves.

## PR Checklist
* [x] Applies to #5365

## Validation Steps Performed

- compile powertoys