### PR TITLE
Remove all plugin results on query change

### DIFF
--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -31,7 +31,7 @@ namespace PowerLauncher.ViewModel
     {
         #region Private Fields
 
-        private Query _lastQuery;
+        private Query _currentQuery;
         private static Query _emptyQuery = new Query();
         private static bool _disposed;
         private string _queryTextBeforeLeaveResults;
@@ -65,7 +65,7 @@ namespace PowerLauncher.ViewModel
             _hotkeyManager = new HotkeyManager();
             _saved = false;
             _queryTextBeforeLeaveResults = "";
-            _lastQuery = _emptyQuery;
+            _currentQuery = _emptyQuery;
             _disposed = false;
 
             _settings = settings ?? throw new ArgumentNullException(nameof(settings));
@@ -118,7 +118,7 @@ namespace PowerLauncher.ViewModel
                     Task.Run(() =>
                     {
                         PluginManager.UpdatePluginMetadata(e.Results, pair.Metadata, e.Query);
-                        UpdateResultView(e.Results, pair.Metadata, e.Query, _updateToken);
+                        UpdateResultView(e.Results, e.Query, _updateToken);
                     }, _updateToken);
                 };
             }
@@ -413,7 +413,6 @@ namespace PowerLauncher.ViewModel
 
         private void QueryHistory()
         {
-            const string id = "Query History ID";
 #pragma warning disable CA1308 // Normalize strings to uppercase
             var query = QueryText.ToLower(CultureInfo.InvariantCulture).Trim();
 #pragma warning restore CA1308 // Normalize strings to uppercase
@@ -447,11 +446,11 @@ namespace PowerLauncher.ViewModel
                     r => StringMatcher.FuzzySearch(query, r.Title).IsSearchPrecisionScoreMet() ||
                          StringMatcher.FuzzySearch(query, r.SubTitle).IsSearchPrecisionScoreMet()
                 ).ToList();
-                History.AddResults(filtered, id, _updateToken);
+                History.AddResults(filtered, _updateToken);
             }
             else
             {
-                History.AddResults(results, id, _updateToken);
+                History.AddResults(results, _updateToken);
             }
         }
 
@@ -470,7 +469,7 @@ namespace PowerLauncher.ViewModel
                 var query = QueryBuilder.Build(QueryText.Trim(), PluginManager.NonGlobalPlugins);
                 if (query != null)
                 {
-                    _lastQuery = query;
+                    _currentQuery = query;
                     Task.Run(() =>
                     {
                         Thread.Sleep(20);
@@ -493,21 +492,24 @@ namespace PowerLauncher.ViewModel
 
                             lock (_addResultsLock)
                             {
-                                RemoveOldQueryResults(query);
-                                foreach (var p in resultPluginPair)
+                                if (query.RawQuery == _currentQuery.RawQuery)
                                 {
-                                    UpdateResultView(p.Item1, p.Item2, query, currentCancellationToken);
-                                    currentCancellationToken.ThrowIfCancellationRequested();
-                                }
+                                    Results.Clear();
+                                    foreach (var p in resultPluginPair)
+                                    {
+                                        UpdateResultView(p.Item1, query, currentCancellationToken);
+                                        currentCancellationToken.ThrowIfCancellationRequested();
+                                    }
 
-                                currentCancellationToken.ThrowIfCancellationRequested();
-                                Results.Results.Sort();
+                                    currentCancellationToken.ThrowIfCancellationRequested();
+                                    Results.Results.Sort();
+                                }
                             }
 
                             currentCancellationToken.ThrowIfCancellationRequested();
                             Application.Current.Dispatcher.BeginInvoke(new Action(() =>
                             {
-                                if (query.RawQuery == _lastQuery.RawQuery)
+                                if (query.RawQuery == _currentQuery.RawQuery)
                                 {
                                     Results.Results.NotifyChanges();
                                 }
@@ -542,34 +544,10 @@ namespace PowerLauncher.ViewModel
             else
             {
                 _updateSource?.Cancel();
-                _lastQuery = _emptyQuery;
+                _currentQuery = _emptyQuery;
                 Results.SelectedItem = null;
                 Results.Visibility = Visibility.Hidden;
                 Results.Clear();
-            }
-        }
-
-        private void RemoveOldQueryResults(Query query)
-        {
-            string lastKeyword = _lastQuery.ActionKeyword;
-            string keyword = query.ActionKeyword;
-            if (string.IsNullOrEmpty(lastKeyword))
-            {
-                if (!string.IsNullOrEmpty(keyword))
-                {
-                    Results.RemoveResultsExcept(PluginManager.NonGlobalPlugins[keyword].Metadata);
-                }
-            }
-            else
-            {
-                if (string.IsNullOrEmpty(keyword))
-                {
-                    Results.RemoveResultsFor(PluginManager.NonGlobalPlugins[lastKeyword].Metadata);
-                }
-                else if (lastKeyword != keyword)
-                {
-                    Results.RemoveResultsExcept(PluginManager.NonGlobalPlugins[keyword].Metadata);
-                }
             }
         }
 
@@ -714,16 +692,11 @@ namespace PowerLauncher.ViewModel
         /// <summary>
         /// To avoid deadlock, this method should not called from main thread
         /// </summary>
-        public void UpdateResultView(List<Result> list, PluginMetadata metadata, Query originQuery, CancellationToken ct)
+        public void UpdateResultView(List<Result> list, Query originQuery, CancellationToken ct)
         {
             if (list == null)
             {
                 throw new ArgumentNullException(nameof(list));
-            }
-
-            if (metadata == null)
-            {
-                throw new ArgumentNullException(nameof(metadata));
             }
 
             if (originQuery == null)
@@ -743,10 +716,10 @@ namespace PowerLauncher.ViewModel
                 }
             }
 
-            if (originQuery.RawQuery == _lastQuery.RawQuery)
+            if (originQuery.RawQuery == _currentQuery.RawQuery)
             {
                 ct.ThrowIfCancellationRequested();
-                Results.AddResults(list, metadata.ID, ct);
+                Results.AddResults(list, ct);
             }
         }
 
@@ -759,7 +732,7 @@ namespace PowerLauncher.ViewModel
                 Title = "hello"
             };
             list.Add(r);
-            Results.AddResults(list, "0", _updateToken);
+            Results.AddResults(list, _updateToken);
             Results.Clear();
             MainWindowVisibility = System.Windows.Visibility.Collapsed;
 

--- a/src/modules/launcher/PowerLauncher/ViewModel/ResultsViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/ResultsViewModel.cs
@@ -222,7 +222,7 @@ namespace PowerLauncher.ViewModel
         /// <summary>
         /// Add new results to ResultCollection
         /// </summary>
-        public void AddResults(List<Result> newRawResults, string resultId, CancellationToken ct)
+        public void AddResults(List<Result> newRawResults, CancellationToken ct)
         {
             if (newRawResults == null)
             {
@@ -236,7 +236,6 @@ namespace PowerLauncher.ViewModel
                 ct.ThrowIfCancellationRequested();
             }
 
-            Results.RemoveAll(r => r.Result.PluginID == resultId);
             Results.AddRange(newResults);
         }
         #endregion


### PR DESCRIPTION
## Summary of the Pull Request
Fix for clearing shell plugin results on updating query text

## PR Checklist
* [x] Applies to #5793 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed

## Info on Pull Request
1. Current code only clears results for plugins which are returned by `PluginManager` for a given query. This causes an issue where if shell plugin was not valid for a query, results for it persisted in the list view. 
2. Changed naming of `_lastQuery` to  `_currentQuery` to make its use case clear.

## Validation Steps Performed
Manually validated that shell plugin results are cleared. 