### PR TITLE
Potential fix for a crash in OnThreadExecutor

### DIFF
--- a/src/common/on_thread_executor.h
+++ b/src/common/on_thread_executor.h
@@ -22,10 +22,9 @@ public:
 private:
     void worker_thread();
 
-    std::thread _worker_thread;
-
     std::mutex _task_mutex;
     std::condition_variable _task_cv;
     std::atomic_bool _shutdown_request;
     std::queue<std::packaged_task<void()>> _task_queue;
+    std::thread _worker_thread;
 };


### PR DESCRIPTION
## Summary of the Pull Request

If the `worker_thread` runs before the `_shutdown_request` is set to `false`, it could quit immediately, causing problems.
This PR makes sure that `_shutdown_request` is set to false before the thread starts.

Although we didn't verify it yet, this could change the behavior seen in #5626

## PR Checklist
* [x] Applies to #5626
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

Changed the initialization order. For more info, see [this reference](https://en.cppreference.com/w/cpp/language/constructor).

## Validation Steps Performed

Built and ran PT, tested some basic functionality of FancyZones, turned it off/on, etc.
