### PR TITLE
[Color Picker] Don't wait for ColorPicker.exe to close

### DIFF
--- a/src/modules/colorPicker/ColorPicker/dllmain.cpp
+++ b/src/modules/colorPicker/ColorPicker/dllmain.cpp
@@ -132,7 +132,7 @@ public:
     {
         if (m_enabled)
         {
-            terminateProcess();
+            TerminateProcess(m_hProcess, 1);
         }
 
         m_enabled = false;
@@ -141,28 +141,6 @@ public:
     virtual bool is_enabled() override
     {
         return m_enabled;
-    }
-
-    static BOOL CALLBACK requestMainWindowClose(HWND nextWindow, LPARAM closePid)
-    {
-        DWORD windowPid;
-        GetWindowThreadProcessId(nextWindow, &windowPid);
-
-        if (windowPid == (DWORD)closePid)
-            ::PostMessage(nextWindow, WM_CLOSE, 0, 0);
-
-        return true;
-    }
-
-    void terminateProcess()
-    {
-        DWORD processID = GetProcessId(m_hProcess);
-        EnumWindows(&requestMainWindowClose, processID);
-        const DWORD result = WaitForSingleObject(m_hProcess, MAX_WAIT_MILLISEC);
-        if (result == WAIT_TIMEOUT)
-        {
-            TerminateProcess(m_hProcess, 1);
-        }
     }
 };
 


### PR DESCRIPTION
## Summary of the Pull Request

Unlike PowerLauncher, we can safely immediately terminate ColorPicker.exe when the module is disabled/PT quits.

## PR Checklist
* [x] Applies to #5860
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Validation Steps Performed

Ran PT, enabled/disabled Color Picker, terminated PT and checked that CP quits, also all of this when running as admin.
