### PR TITLE
Prevent copying of files from folder to shell plugin

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Shell/Microsoft.Plugin.Shell.csproj
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Shell/Microsoft.Plugin.Shell.csproj
@@ -63,7 +63,9 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Wox.Infrastructure\Wox.Infrastructure.csproj" />
     <ProjectReference Include="..\..\Wox.Plugin\Wox.Plugin.csproj" />
-    <ProjectReference Include="..\Microsoft.Plugin.Folder\Microsoft.Plugin.Folder.csproj" />
+    <ProjectReference Include="..\Microsoft.Plugin.Folder\Microsoft.Plugin.Folder.csproj">
+      <Private>false</Private>
+    </ProjectReference>
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
## Summary of the Pull Request
Fix for shell plugin.json being overwritten by folder plugin. 

## References 
1. https://docs.microsoft.com/en-us/dotnet/framework/deployment/how-the-runtime-locates-assemblies
2. https://docs.microsoft.com/en-us/dotnet/api/vslangproj.reference.copylocal?view=visualstudiosdk-2017

## PR Checklist
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed

## Info on Pull Request
The issue is caused because shell plugin was referencing folder plugin. The shell plugin project is built in the same output directory as the folder plugin project. This was causing commonly named files/folder to be overwritten during the build. 

Setting `CopyLocal` to `true` for folder plugin prevents this from happening. The reference is resolved at runtime because it has been loaded by Plugin Manager. 

## Validation Steps Performed
Manually validated in the MSI and build that folder plugin assets are not present in shell plugin output directory.