### PR TITLE
[PT Run] Handled exceptions in indexer plugin and delayed execution logic

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/SearchHelper/OleDBSearch.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/SearchHelper/OleDBSearch.cs
@@ -28,25 +28,34 @@ namespace Microsoft.Plugin.Indexer.SearchHelper
                 // open the connection
                 conn.Open();
 
-                // now create an OleDB command object with the query we built above and the connection we just opened.
-                using (command = new OleDbCommand(sqlQuery, conn))
+                try
                 {
-                    using (wDSResults = command.ExecuteReader())
+                    // now create an OleDB command object with the query we built above and the connection we just opened.
+                    using (command = new OleDbCommand(sqlQuery, conn))
                     {
-                        if (!wDSResults.IsClosed && wDSResults.HasRows)
+                        using (wDSResults = command.ExecuteReader())
                         {
-                            while (!wDSResults.IsClosed && wDSResults.Read())
+                            if (!wDSResults.IsClosed && wDSResults.HasRows)
                             {
-                                List<object> fieldData = new List<object>();
-                                for (int i = 0; i < wDSResults.FieldCount; i++)
+                                while (!wDSResults.IsClosed && wDSResults.Read())
                                 {
-                                    fieldData.Add(wDSResults.GetValue(i));
-                                }
+                                    List<object> fieldData = new List<object>();
+                                    for (int i = 0; i < wDSResults.FieldCount; i++)
+                                    {
+                                        fieldData.Add(wDSResults.GetValue(i));
+                                    }
 
-                                result.Add(new OleDBResult(fieldData));
+                                    result.Add(new OleDBResult(fieldData));
+                                }
                             }
                         }
                     }
+                }
+
+                // AccessViolationException can occur if another query is made before the current query completes. Since the old query would be cancelled we can ignore the exception
+                catch (System.AccessViolationException)
+                {
+                    // do nothing
                 }
             }
 

--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -512,32 +512,39 @@ namespace PowerLauncher.ViewModel
                             currentCancellationToken.ThrowIfCancellationRequested();
                             Parallel.ForEach(plugins, (plugin) =>
                                 {
-                                    if (!plugin.Metadata.Disabled)
+                                    try
                                     {
-                                        var results = PluginManager.QueryForPlugin(plugin, query, true);
-                                        currentCancellationToken.ThrowIfCancellationRequested();
-                                        if ((results?.Count ?? 0) != 0)
+                                        if (!plugin.Metadata.Disabled)
                                         {
-                                            lock (_addResultsLock)
-                                            {
-                                                if (query.RawQuery == _currentQuery.RawQuery)
-                                                {
-                                                    currentCancellationToken.ThrowIfCancellationRequested();
-
-                                                    // Remove the original results from the plugin
-                                                    Results.Results.RemoveAll(r => r.Result.PluginID == plugin.Metadata.ID);
-                                                    currentCancellationToken.ThrowIfCancellationRequested();
-
-                                                    // Add the new results from the plugin
-                                                    UpdateResultView(results, query, currentCancellationToken);
-                                                    currentCancellationToken.ThrowIfCancellationRequested();
-                                                    Results.Sort();
-                                                }
-                                            }
-
+                                            var results = PluginManager.QueryForPlugin(plugin, query, true);
                                             currentCancellationToken.ThrowIfCancellationRequested();
-                                            UpdateResultsListViewAfterQuery(query, true);
+                                            if ((results?.Count ?? 0) != 0)
+                                            {
+                                                lock (_addResultsLock)
+                                                {
+                                                    if (query.RawQuery == _currentQuery.RawQuery)
+                                                    {
+                                                        currentCancellationToken.ThrowIfCancellationRequested();
+
+                                                        // Remove the original results from the plugin
+                                                        Results.Results.RemoveAll(r => r.Result.PluginID == plugin.Metadata.ID);
+                                                        currentCancellationToken.ThrowIfCancellationRequested();
+
+                                                        // Add the new results from the plugin
+                                                        UpdateResultView(results, query, currentCancellationToken);
+                                                        currentCancellationToken.ThrowIfCancellationRequested();
+                                                        Results.Sort();
+                                                    }
+                                                }
+
+                                                currentCancellationToken.ThrowIfCancellationRequested();
+                                                UpdateResultsListViewAfterQuery(query, true);
+                                            }
                                         }
+                                    }
+                                    catch (OperationCanceledException)
+                                    {
+                                        // nothing to do here
                                     }
                                 });
 


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

This PR handles the exceptions introduced in #5748 .
- On cancelling a query within the Parallel.ForEach loop the exception was not getting handled by the try catch block outside the loop, since it would appear as a System.AggregateException. This has been resolved by adding a try catch block for OperationCanceledException within the ForEach loop.
![MicrosoftTeams-image (10)](https://user-images.githubusercontent.com/32061677/90052883-9fa3cb80-dc8e-11ea-8ab8-dae53e38e317.png)

- When multiple indexer queries occur in parallel, the OleDbDataReader throws an exception. The exception is thrown on the older query, so we should ignore the exception. Earlier a check was added for whether `wDSResults` was closed and that solved the issue of the exception where we were calling HasRows or Read while the reader object was closed, however it didnt take account of the scenario where the reader gets closed while HasRows or Read are executing. To handle this a try catch for AccessViolationException was added.
![MicrosoftTeams-image (11)](https://user-images.githubusercontent.com/32061677/90052906-a6cad980-dc8e-11ea-98ef-0268f634c3c4.png)

## Validation Steps Performed

_How does someone test & validate?_

Type quickly with "." in the query or any other keyword that would require LIKE to force multiple indexer queries