### PR TITLE
Warning: uninitialized variable fix

### DIFF
--- a/src/settings/StreamUriResolverFromFile.h
+++ b/src/settings/StreamUriResolverFromFile.h
@@ -3,7 +3,7 @@
 
 struct StreamUriResolverFromFile : winrt::implements<StreamUriResolverFromFile, winrt::Windows::Web::IUriToStreamResolver>
 {
-    WCHAR base_path[MAX_PATH];
+    WCHAR base_path[MAX_PATH] = L"";
 
     winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Storage::Streams::IInputStream> UriToStreamAsync(const winrt::Windows::Foundation::Uri& uri) const;
 };


### PR DESCRIPTION
## Summary of the Pull Request

Added default init value for `base_path` in `StreamUriResolverFromFile`.

## PR Checklist
* [x] Applies to #5907 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx
