### PR TITLE
Warning: additional dependencies in common project

### DIFF
--- a/src/common/common.vcxproj
+++ b/src/common/common.vcxproj
@@ -114,7 +114,8 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <Lib>
-      <AdditionalDependencies>shlwapi.lib;shcore.lib</AdditionalDependencies>
+      <AdditionalDependencies>
+      </AdditionalDependencies>
     </Lib>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/src/common/common.vcxproj
+++ b/src/common/common.vcxproj
@@ -82,7 +82,8 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <Lib>
-      <AdditionalDependencies>shlwapi.lib;shcore.lib</AdditionalDependencies>
+      <AdditionalDependencies>
+      </AdditionalDependencies>
     </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(CIBuild)'!='true'">

--- a/src/common/dpi_aware.h
+++ b/src/common/dpi_aware.h
@@ -1,6 +1,8 @@
 #pragma once
 #include "windef.h"
 
+#pragma comment(lib, "shcore.lib")
+
 namespace DPIAware
 {
     constexpr inline int DEFAULT_DPI = 96;


### PR DESCRIPTION
## Summary of the Pull Request

Removed `schwapi.lib`, `shcore.lib` from project dependencies, added link into the `dpi_aware.h`

## PR Checklist
* [x] Applies to #5907
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx
