### PR TITLE
Correcting floating point error on calculator

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Calculator/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Calculator/Main.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -71,11 +72,13 @@ namespace Microsoft.Plugin.Calculator
 
                 if (!string.IsNullOrEmpty(result?.ToString()))
                 {
+                    var roundedResult = Math.Round(Convert.ToDecimal(result, CultureInfo.CurrentCulture), 10, MidpointRounding.AwayFromZero);
+
                     return new List<Result>
                     {
                         new Result
                         {
-                            Title = result.ToString(),
+                            Title = roundedResult.ToString(CultureInfo.CurrentCulture),
                             IcoPath = IconPath,
                             Score = 300,
                             SubTitle = Context.API.GetTranslation("wox_plugin_calculator_copy_number_to_clipboard"),


### PR DESCRIPTION
## Summary of the Pull Request

Correcting floating point error.  Same tweak that Wox has.  Wonder why we didn't have it in.
https://github.com/Wox-launcher/Wox/blob/master/Plugins/Wox.Plugin.Calculator/Main.cs

## PR Checklist
* [x] Applies to #3697
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

## Validation Steps Performed

_How does someone test & validate?_
