### PR TITLE
Add Scoop (Unofficial) installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,23 @@ To upgrade PowerToys, run the following command from the command line / PowerShe
 ```powershell
 choco upgrade powertoys
 ```
+
+#### Via Scoop (Unofficial)
+
+Download and update PowerToys from [Scoop](https://scoop.sh). 
+
+To install PowerToys, run the following command from the command line / PowerShell:
+
+```powershell
+scoop install powertoys
+```
+
+To update PowerToys, run the following command from the command line / PowerShell:
+
+```powershell
+scoop update powertoys
+```
+
 ### Known issues
 
 - Color Picker at times won't work when PT is running elevated - [#5348](https://github.com/microsoft/PowerToys/issues/5348).  We are currently working on a fix now for this.


### PR DESCRIPTION
## Summary of the Pull Request

This adds an (unofficial) installation method for Scoop package manager users. Many developers using Windows (me included) use and love Scoop, so this would be a nifty addition to the Readme. 
I'm aware of the issues some users face because of installation from the 'extras' bucket, the reason being PowerToys does not have a portable installer yet. If that's a hurdle, I can make changes in this PR to install via the 'non-portable' bucket of Scoop instead. 

## PR Checklist
* [x] Requires documentation to be updated

## Info on Pull Request

_What does this include?_
Changes to README.md file.