### PR TITLE
[Settings] Remove 'AnyCPU' build configuration

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/Microsoft.PowerToys.Settings.UI.Lib.csproj
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/Microsoft.PowerToys.Settings.UI.Lib.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Platforms>AnyCPU;x64</Platforms>
+    <Platforms>x64</Platforms>
     <Version>$(Version).0</Version>
     <Authors>Microsoft Corporation</Authors>
     <Product>PowerToys</Product>

--- a/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/Microsoft.PowerToys.Settings.UI.UnitTests.csproj
+++ b/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/Microsoft.PowerToys.Settings.UI.UnitTests.csproj
@@ -5,7 +5,7 @@
 
     <IsPackable>false</IsPackable>
 
-    <Platforms>AnyCPU;x64</Platforms>
+    <Platforms>x64</Platforms>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">


### PR DESCRIPTION
## Summary of the Pull Request

The `AnyCPU` configuration is not needed.
