### PR TITLE
Improve loading/saving of settings by using bytes instead of string for read/writes

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/BasePTModuleSettings.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/BasePTModuleSettings.cs
@@ -2,7 +2,6 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.PowerToys.Settings.UI.Lib
@@ -16,12 +15,5 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
         // Gets or sets the powertoys version.
         [JsonPropertyName("version")]
         public string Version { get; set; }
-
-        // converts the current to a json string.
-        public virtual string ToJsonString()
-        {
-            // By default JsonSerializer will only serialize the properties in the base class. This can be avoided by passing the object type (more details at https://stackoverflow.com/a/62498888)
-            return JsonSerializer.Serialize(this, GetType());
-        }
     }
 }

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/ColorPickerSettings.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/ColorPickerSettings.cs
@@ -24,13 +24,7 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
 
         public virtual void Save(ISettingsUtils settingsUtils)
         {
-            // Save settings to file
-            var options = new JsonSerializerOptions
-            {
-                WriteIndented = true,
-            };
-
-            settingsUtils.SaveSettings(JsonSerializer.Serialize(this, options), ModuleName);
+            settingsUtils.SaveSettings(this, ModuleName);
         }
 
         public string GetModuleName()

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/GeneralSettings.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/GeneralSettings.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.PowerToys.Settings.UI.Lib.Interface;
 using Microsoft.PowerToys.Settings.UI.Lib.Utilities;
@@ -73,12 +72,6 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
 
             Enabled = new EnabledModules();
             CustomActionName = string.Empty;
-        }
-
-        // converts the current to a json string.
-        public string ToJsonString()
-        {
-            return JsonSerializer.Serialize(this);
         }
 
         private static string DefaultPowertoysVersion()

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/ISettingsUtils.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/ISettingsUtils.cs
@@ -9,9 +9,10 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
     public interface ISettingsUtils
     {
         T GetSettings<T>(string powertoy = "", string fileName = "settings.json")
-            where T : ISettingsConfig, new();
+            where T : class, ISettingsConfig, new();
 
-        void SaveSettings(string jsonSettings, string powertoy = "", string fileName = "settings.json");
+        void SaveSettings<T>(T settingsObject, string powertoy = "", string fileName = "settings.json")
+            where T : class, new();
 
         bool SettingsExists(string powertoy = "", string fileName = "settings.json");
 

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/ImageResizerSettings.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/ImageResizerSettings.cs
@@ -2,7 +2,6 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.PowerToys.Settings.UI.Lib.Interface;
 
@@ -20,15 +19,6 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
             Version = "1";
             Name = ModuleName;
             Properties = new ImageResizerProperties();
-        }
-
-        public override string ToJsonString()
-        {
-            var options = new JsonSerializerOptions
-            {
-                WriteIndented = true,
-            };
-            return JsonSerializer.Serialize(this, options);
         }
 
         public string GetModuleName()

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/Interface/ISettingsConfig.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/Interface/ISettingsConfig.cs
@@ -7,8 +7,6 @@ namespace Microsoft.PowerToys.Settings.UI.Lib.Interface
     // Common interface to be implemented by all the objects which get and store settings properties.
     public interface ISettingsConfig
     {
-        string ToJsonString();
-
         string GetModuleName();
 
         bool UpgradeSettingsConfiguration();

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/KeyboardManagerProfile.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/KeyboardManagerProfile.cs
@@ -2,7 +2,6 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.PowerToys.Settings.UI.Lib.Interface;
 
@@ -20,11 +19,6 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
         {
             RemapKeys = new RemapKeysDataModel();
             RemapShortcuts = new ShortcutsKeyDataModel();
-        }
-
-        public string ToJsonString()
-        {
-            return JsonSerializer.Serialize(this);
         }
 
         public string GetModuleName()

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/PowerLauncherSettings.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/PowerLauncherSettings.cs
@@ -24,13 +24,7 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
 
         public virtual void Save(ISettingsUtils settingsUtils)
         {
-            // Save settings to file
-            var options = new JsonSerializerOptions
-            {
-                WriteIndented = true,
-            };
-
-            settingsUtils.SaveSettings(JsonSerializer.Serialize(this, options), ModuleName);
+            settingsUtils.SaveSettings(this, ModuleName);
         }
 
         public string GetModuleName()

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/PowerRenameLocalProperties.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/PowerRenameLocalProperties.cs
@@ -2,7 +2,6 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Text.Json;
 using Microsoft.PowerToys.Settings.UI.Lib.Interface;
 
 namespace Microsoft.PowerToys.Settings.UI.Lib
@@ -47,11 +46,6 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
         public bool ShowIcon { get; set; }
 
         public bool ExtendedContextMenuOnly { get; set; }
-
-        public string ToJsonString()
-        {
-            return JsonSerializer.Serialize(this);
-        }
 
         // This function is required to implement the ISettingsConfig interface and obtain the settings configurations.
         public string GetModuleName()

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/Utilities/IIOProvider.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/Utilities/IIOProvider.cs
@@ -16,6 +16,10 @@ namespace Microsoft.PowerToys.Settings.UI.Lib.Utilities
 
         void WriteAllText(string path, string content);
 
+        void WriteAllBytes(string path, byte[] content);
+
         string ReadAllText(string path);
+
+        byte[] ReadAllBytes(string path);
     }
 }

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/Utilities/SystemIOProvider.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/Utilities/SystemIOProvider.cs
@@ -34,9 +34,19 @@ namespace Microsoft.PowerToys.Settings.UI.Lib.Utilities
             return File.ReadAllText(path);
         }
 
+        public byte[] ReadAllBytes(string path)
+        {
+            return File.ReadAllBytes(path);
+        }
+
         public void WriteAllText(string path, string content)
         {
             File.WriteAllText(path, content);
+        }
+
+        public void WriteAllBytes(string path, byte[] content)
+        {
+            File.WriteAllBytes(path, content);
         }
     }
 }

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/ViewModels/ImageResizerViewModel.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/ViewModels/ImageResizerViewModel.cs
@@ -37,7 +37,7 @@ namespace Microsoft.PowerToys.Settings.UI.Lib.ViewModels
             catch
             {
                 Settings = new ImageResizerSettings();
-                _settingsUtils.SaveSettings(Settings.ToJsonString(), ModuleName);
+                _settingsUtils.SaveSettings(Settings, ModuleName);
             }
 
             // set the callback functions value to hangle outgoing IPC message.
@@ -120,7 +120,7 @@ namespace Microsoft.PowerToys.Settings.UI.Lib.ViewModels
                 {
                     _jpegQualityLevel = value;
                     Settings.Properties.ImageresizerJpegQualityLevel.Value = value;
-                    _settingsUtils.SaveSettings(Settings.ToJsonString(), ModuleName);
+                    _settingsUtils.SaveSettings(Settings, ModuleName);
                     OnPropertyChanged(nameof(JPEGQualityLevel));
                 }
             }
@@ -139,7 +139,7 @@ namespace Microsoft.PowerToys.Settings.UI.Lib.ViewModels
                 {
                     _pngInterlaceOption = value;
                     Settings.Properties.ImageresizerPngInterlaceOption.Value = value;
-                    _settingsUtils.SaveSettings(Settings.ToJsonString(), ModuleName);
+                    _settingsUtils.SaveSettings(Settings, ModuleName);
                     OnPropertyChanged(nameof(PngInterlaceOption));
                 }
             }
@@ -158,7 +158,7 @@ namespace Microsoft.PowerToys.Settings.UI.Lib.ViewModels
                 {
                     _tiffCompressOption = value;
                     Settings.Properties.ImageresizerTiffCompressOption.Value = value;
-                    _settingsUtils.SaveSettings(Settings.ToJsonString(), ModuleName);
+                    _settingsUtils.SaveSettings(Settings, ModuleName);
                     OnPropertyChanged(nameof(TiffCompressOption));
                 }
             }
@@ -177,7 +177,7 @@ namespace Microsoft.PowerToys.Settings.UI.Lib.ViewModels
                 {
                     _fileName = value;
                     Settings.Properties.ImageresizerFileName.Value = value;
-                    _settingsUtils.SaveSettings(Settings.ToJsonString(), ModuleName);
+                    _settingsUtils.SaveSettings(Settings, ModuleName);
                     OnPropertyChanged(nameof(FileName));
                 }
             }
@@ -194,7 +194,7 @@ namespace Microsoft.PowerToys.Settings.UI.Lib.ViewModels
             {
                 _keepDateModified = value;
                 Settings.Properties.ImageresizerKeepDateModified.Value = value;
-                _settingsUtils.SaveSettings(Settings.ToJsonString(), ModuleName);
+                _settingsUtils.SaveSettings(Settings, ModuleName);
                 OnPropertyChanged(nameof(KeepDateModified));
             }
         }
@@ -211,9 +211,9 @@ namespace Microsoft.PowerToys.Settings.UI.Lib.ViewModels
                 if (_encoderGuidId != value)
                 {
                     _encoderGuidId = value;
-                    _settingsUtils.SaveSettings(Settings.Properties.ImageresizerSizes.ToJsonString(), ModuleName, "sizes.json");
+                    _settingsUtils.SaveSettings(Settings.Properties.ImageresizerSizes, ModuleName, "sizes.json");
                     Settings.Properties.ImageresizerFallbackEncoder.Value = GetEncoderGuid(value);
-                    _settingsUtils.SaveSettings(Settings.ToJsonString(), ModuleName);
+                    _settingsUtils.SaveSettings(Settings, ModuleName);
                     OnPropertyChanged(nameof(Encoder));
                 }
             }
@@ -250,9 +250,9 @@ namespace Microsoft.PowerToys.Settings.UI.Lib.ViewModels
 
         public void SavesImageSizes(ObservableCollection<ImageSize> imageSizes)
         {
-            _settingsUtils.SaveSettings(Settings.Properties.ImageresizerSizes.ToJsonString(), ModuleName, "sizes.json");
+            _settingsUtils.SaveSettings(Settings.Properties.ImageresizerSizes, ModuleName, "sizes.json");
             Settings.Properties.ImageresizerSizes = new ImageResizerSizes(imageSizes);
-            _settingsUtils.SaveSettings(Settings.ToJsonString(), ModuleName);
+            _settingsUtils.SaveSettings(Settings, ModuleName);
         }
 
         public static string GetEncoderGuid(int value)

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/ViewModels/KeyboardManagerViewModel.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/ViewModels/KeyboardManagerViewModel.cs
@@ -65,7 +65,7 @@ namespace Microsoft.PowerToys.Settings.UI.Lib.ViewModels
             else
             {
                 Settings = new KeyboardManagerSettings();
-                _settingsUtils.SaveSettings(Settings.ToJsonString(), PowerToyName);
+                _settingsUtils.SaveSettings(Settings, PowerToyName);
             }
         }
 

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/ViewModels/PowerRenameViewModel.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/ViewModels/PowerRenameViewModel.cs
@@ -40,7 +40,7 @@ namespace Microsoft.PowerToys.Settings.UI.Lib.ViewModels
             {
                 PowerRenameLocalProperties localSettings = new PowerRenameLocalProperties();
                 Settings = new PowerRenameSettings(localSettings);
-                _settingsUtils.SaveSettings(localSettings.ToJsonString(), GetSettingsSubPath(), "power-rename-settings.json");
+                _settingsUtils.SaveSettings(localSettings, GetSettingsSubPath(), "power-rename-settings.json");
             }
 
             // set the callback functions value to hangle outgoing IPC message.

--- a/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/BackwardsCompatibility/BackCompatTestProperties.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/BackwardsCompatibility/BackCompatTestProperties.cs
@@ -15,7 +15,7 @@ namespace Microsoft.PowerToys.Settings.UI.UnitTests.BackwardsCompatibility
     {
         public const string RootPathStubFiles = "..\\..\\..\\..\\src\\core\\Microsoft.PowerToys.Settings.UI.UnitTests\\BackwardsCompatibility\\TestFiles\\{0}\\Microsoft\\PowerToys\\{1}\\{2}";
 
-        internal class MockSettingsRepository<T> : ISettingsRepository<T> where T : ISettingsConfig, new()
+        internal class MockSettingsRepository<T> : ISettingsRepository<T> where T : class, ISettingsConfig, new()
         {
             T _settingsConfig;
             readonly ISettingsUtils _settingsUtils;

--- a/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/Mocks/ISettingsUtilsMocks.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/Mocks/ISettingsUtilsMocks.cs
@@ -9,7 +9,7 @@ namespace Microsoft.PowerToys.Settings.UI.UnitTests.Mocks
     {
         //Stubs out empty values for imageresizersettings and general settings as needed by the imageresizer viewmodel
         internal static Mock<ISettingsUtils> GetStubSettingsUtils<T>()
-            where T : ISettingsConfig, new()
+            where T : class, ISettingsConfig, new()
         {
             var settingsUtils = new Mock<ISettingsUtils>();
             settingsUtils.Setup(x => x.GetSettings<T>(It.IsAny<string>(), It.IsAny<string>()))

--- a/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/ModelsTests/BasePTModuleSettingsTest.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/ModelsTests/BasePTModuleSettingsTest.cs
@@ -1,8 +1,9 @@
-// Copyright (c) Microsoft Corporation
+﻿// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Text.Json;
 using Microsoft.PowerToys.Settings.UI.Lib;
 using Microsoft.PowerToys.Settings.UI.Lib.Utilities;
 using Microsoft.PowerToys.Settings.UI.UnitTests.Mocks;
@@ -48,12 +49,12 @@ namespace CommonLibTest
                 'additionalProperties': false
                 }";
 
-            string testSettingsConfigs = new BasePTSettingsTest().ToJsonString();
+            var testSettingsConfigs = new BasePTSettingsTest();
             settingsUtils.SaveSettings(testSettingsConfigs, file_name);
             JsonSchema expectedSchema = JsonSchema.Parse(expectedSchemaText);
 
             // Act
-            JObject actualSchema = JObject.Parse(settingsUtils.GetSettings<BasePTSettingsTest>(file_name).ToJsonString());
+            JObject actualSchema = JObject.Parse(JsonSerializer.Serialize(settingsUtils.GetSettings<BasePTSettingsTest>(file_name), typeof(BasePTSettingsTest)));
             bool valid = actualSchema.IsValid(expectedSchema);
 
             // Assert

--- a/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/ModelsTests/SettingsUtilsTests.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/ModelsTests/SettingsUtilsTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation
+﻿// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -37,7 +37,11 @@ namespace CommonLibTest
             BasePTSettingsTest actual_json = settingsUtils.GetSettings<BasePTSettingsTest>(file_name);
 
             // Assert
-            Assert.AreEqual(expected_json.ToJsonString(), actual_json.ToJsonString());
+            Assert.AreEqual(expected_json.Name, actual_json.Name);
+            Assert.AreEqual(expected_json.Version, actual_json.Version);
+            Assert.AreEqual(expected_json.Name, "powertoy module name");
+            Assert.AreEqual(expected_json.Version, "powertoy version");
+
         }
 
         [TestMethod]
@@ -55,7 +59,10 @@ namespace CommonLibTest
             BasePTSettingsTest actual_json = settingsUtils.GetSettings<BasePTSettingsTest>(file_name);
 
             // Assert
-            Assert.AreEqual(expected_json.ToJsonString(), actual_json.ToJsonString());
+            Assert.AreEqual(expected_json.Name, actual_json.Name);
+            Assert.AreEqual(expected_json.Version, actual_json.Version);
+            Assert.AreEqual(expected_json.Name, "powertoy module name");
+            Assert.AreEqual(expected_json.Version, "powertoy version");
         }
 
         [TestMethod]

--- a/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/ViewModelTests/ImageResizer.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/ViewModelTests/ImageResizer.cs
@@ -166,9 +166,9 @@ namespace ViewModelTests
             // arrange
             var settingUtils = ISettingsUtilsMocks.GetStubSettingsUtils<ImageResizerSettings>();
 
-            var expectedSettingsString = new ImageResizerSettings() { Properties = new ImageResizerProperties() { ImageresizerKeepDateModified = new BoolProperty() { Value = true } } }.ToJsonString();
+            var expectedSettingsString = new ImageResizerSettings() { Properties = new ImageResizerProperties() { ImageresizerKeepDateModified = new BoolProperty() { Value = true } } };
             settingUtils.Setup(x => x.SaveSettings(
-                                        It.Is<string>(content => content.Equals(expectedSettingsString, StringComparison.Ordinal)),
+                                        It.IsAny<ImageResizerSettings>(),
                                         It.Is<string>(module => module.Equals(ImageResizerSettings.ModuleName, StringComparison.Ordinal)),
                                         It.IsAny<string>()))
                                      .Verifiable();

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/CanvasLayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/CanvasLayoutModel.cs
@@ -200,8 +200,8 @@ namespace FancyZonesEditor.Models
 
             try
             {
-                string jsonString = JsonSerializer.Serialize(jsonObj, options);
-                File.WriteAllText(Settings.AppliedZoneSetTmpFile, jsonString);
+                byte[] jsonBytes = JsonSerializer.SerializeToUtf8Bytes(jsonObj, options);
+                File.WriteAllBytes(Settings.AppliedZoneSetTmpFile, jsonBytes);
             }
             catch (Exception ex)
             {

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/GridLayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/GridLayoutModel.cs
@@ -236,8 +236,8 @@ namespace FancyZonesEditor.Models
 
             try
             {
-                string jsonString = JsonSerializer.Serialize(jsonObj, options);
-                File.WriteAllText(Settings.AppliedZoneSetTmpFile, jsonString);
+                byte[] jsonBytes = JsonSerializer.SerializeToUtf8Bytes(jsonObj, options);
+                File.WriteAllBytes(Settings.AppliedZoneSetTmpFile, jsonBytes);
             }
             catch (Exception ex)
             {

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation
+﻿// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -193,8 +193,8 @@ namespace FancyZonesEditor.Models
 
             try
             {
-                string jsonString = JsonSerializer.Serialize(deletedLayouts, options);
-                File.WriteAllText(Settings.DeletedCustomZoneSetsTmpFile, jsonString);
+                byte[] jsonBytes = JsonSerializer.SerializeToUtf8Bytes(deletedLayouts, options);
+                File.WriteAllBytes(Settings.DeletedCustomZoneSetsTmpFile, jsonBytes);
             }
             catch (Exception ex)
             {
@@ -436,8 +436,8 @@ namespace FancyZonesEditor.Models
 
             try
             {
-                string jsonString = JsonSerializer.Serialize(zoneSet, options);
-                File.WriteAllText(Settings.ActiveZoneSetTmpFile, jsonString);
+                byte[] jsonBytes = JsonSerializer.SerializeToUtf8Bytes(zoneSet, options);
+                File.WriteAllBytes(Settings.ActiveZoneSetTmpFile, jsonBytes);
             }
             catch (Exception ex)
             {

--- a/src/modules/launcher/Wox.Infrastructure/Storage/StoragePowerToysVersionInfo.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Storage/StoragePowerToysVersionInfo.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.IO;
+using System.Text;
 
 namespace Wox.Infrastructure.Storage
 {
@@ -119,7 +120,7 @@ namespace Wox.Infrastructure.Storage
         public void Close()
         {
             // Update the Version file to the current version of powertoys
-            File.WriteAllText(FilePath, currentPowerToysVersion);
+            File.WriteAllBytes(FilePath, Encoding.UTF8.GetBytes(currentPowerToysVersion));
         }
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request

Improve loading/saving of settings by using bytes instead of string for read/writes.


## PR Checklist
* [ ] Applies to #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

I saw we are currently using Strings as buffer for reading/writing (json) settings, this can be optimized by using byte arrays, this PR implements the improvement.

Quick performance check against the settings.json of PowerToys.
https://gist.github.com/royvou/f83bffcb73365014a0fd39e4dc034044

|             Method |     Mean |   Error |  StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------- |---------:|--------:|--------:|-------:|------:|------:|----------:|
| ReadBytes_Indented | 402.7 us | 7.25 us | 6.78 us | 1.4648 |     - |     - |   5.66 KB |
|          ReadBytes | 399.0 us | 7.10 us | 6.64 us | 1.4648 |     - |     - |   5.66 KB |
|         ReadString | 413.9 us | 7.46 us | 6.98 us | 5.8594 |     - |     - |  19.06 KB |

## Validation Steps Performed

- Manually Opened the (new) settings app
- Validate Settings are correctly read
- Change some settings in PT Run Module (max results 4 to 5)
- Close the (new) settings app
- Open the Live settings App
- Validate PT Run settings

Added unit test which does a string write + read + byte write + read and compares all results. 
