### PR TITLE
[FancyZonesEditor] Delete custom layout if it has malformed data

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
@@ -293,6 +293,7 @@ namespace FancyZonesEditor.Models
                         if (error)
                         {
                             ShowExceptionMessageBox(string.Format(ErrorLayoutMalformedData, name));
+                            _deletedCustomModels.Add(Guid.Parse(uuid).ToString().ToUpper());
                             continue;
                         }
 
@@ -332,6 +333,7 @@ namespace FancyZonesEditor.Models
                         if (error)
                         {
                             ShowExceptionMessageBox(string.Format(ErrorLayoutMalformedData, name));
+                            _deletedCustomModels.Add(Guid.Parse(uuid).ToString().ToUpper());
                             continue;
                         }
 


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
If malformed custom layout is detected it gets deleted (only MessageBox was shown prior to this PR every time Editor was spawned - as layout wasn't deleted). 

## PR Checklist
* [X] Applies to #5809 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Validation Steps Performed

_How does someone test & validate?_
 - Open Editor
 - Create Custom layout
 - Make it malformed by manually editing zones-settings file (e.g. set any zone width to negative value)
 - Open Editor again - Confirm that MessageBox is shown and that malformed custom layout is not shown in Editor
 - Close Editor and open it once again to confirm that layout was properly deleted