### PR TITLE
[PowerRename] Add Filtering Feature

### DIFF
--- a/src/modules/powerrename/dll/PowerRenameExt.cpp
+++ b/src/modules/powerrename/dll/PowerRenameExt.cpp
@@ -166,7 +166,7 @@ DWORD WINAPI CPowerRenameMenu::s_PowerRenameUIThreadProc(_In_ void* pData)
             if (SUCCEEDED(hr))
             {
                 // Pass the factory to the manager
-                hr = spsrm->put_renameItemFactory(spsrif);
+                hr = spsrm->putRenameItemFactory(spsrif);
                 if (SUCCEEDED(hr))
                 {
                     // Create the rename UI instance and pass the rename manager

--- a/src/modules/powerrename/dll/PowerRenameExt.cpp
+++ b/src/modules/powerrename/dll/PowerRenameExt.cpp
@@ -166,7 +166,7 @@ DWORD WINAPI CPowerRenameMenu::s_PowerRenameUIThreadProc(_In_ void* pData)
             if (SUCCEEDED(hr))
             {
                 // Pass the factory to the manager
-                hr = spsrm->putRenameItemFactory(spsrif);
+                hr = spsrm->PutRenameItemFactory(spsrif);
                 if (SUCCEEDED(hr))
                 {
                     // Create the rename UI instance and pass the rename manager

--- a/src/modules/powerrename/lib/Helpers.cpp
+++ b/src/modules/powerrename/lib/Helpers.cpp
@@ -307,21 +307,21 @@ HRESULT _ParseEnumItems(_In_ IEnumShellItems* pesi, _In_ IPowerRenameManager* ps
         while ((S_OK == pesi->Next(1, &spsi, &celtFetched)) && (SUCCEEDED(hr)))
         {
             CComPtr<IPowerRenameItemFactory> spsrif;
-            hr = psrm->getRenameItemFactory(&spsrif);
+            hr = psrm->GetRenameItemFactory(&spsrif);
             if (SUCCEEDED(hr))
             {
                 CComPtr<IPowerRenameItem> spNewItem;
                 hr = spsrif->Create(spsi, &spNewItem);
                 if (SUCCEEDED(hr))
                 {
-                    spNewItem->putDepth(depth);
+                    spNewItem->PutDepth(depth);
                     hr = psrm->AddItem(spNewItem);
                 }
 
                 if (SUCCEEDED(hr))
                 {
                     bool isFolder = false;
-                    if (SUCCEEDED(spNewItem->getIsFolder(&isFolder)) && isFolder)
+                    if (SUCCEEDED(spNewItem->GetIsFolder(&isFolder)) && isFolder)
                     {
                         // Bind to the IShellItem for the IEnumShellItems interface
                         CComPtr<IEnumShellItems> spesiNext;

--- a/src/modules/powerrename/lib/Helpers.cpp
+++ b/src/modules/powerrename/lib/Helpers.cpp
@@ -307,21 +307,21 @@ HRESULT _ParseEnumItems(_In_ IEnumShellItems* pesi, _In_ IPowerRenameManager* ps
         while ((S_OK == pesi->Next(1, &spsi, &celtFetched)) && (SUCCEEDED(hr)))
         {
             CComPtr<IPowerRenameItemFactory> spsrif;
-            hr = psrm->get_renameItemFactory(&spsrif);
+            hr = psrm->getRenameItemFactory(&spsrif);
             if (SUCCEEDED(hr))
             {
                 CComPtr<IPowerRenameItem> spNewItem;
                 hr = spsrif->Create(spsi, &spNewItem);
                 if (SUCCEEDED(hr))
                 {
-                    spNewItem->put_depth(depth);
+                    spNewItem->putDepth(depth);
                     hr = psrm->AddItem(spNewItem);
                 }
 
                 if (SUCCEEDED(hr))
                 {
                     bool isFolder = false;
-                    if (SUCCEEDED(spNewItem->get_isFolder(&isFolder)) && isFolder)
+                    if (SUCCEEDED(spNewItem->getIsFolder(&isFolder)) && isFolder)
                     {
                         // Bind to the IShellItem for the IEnumShellItems interface
                         CComPtr<IEnumShellItems> spesiNext;

--- a/src/modules/powerrename/lib/PowerRenameInterfaces.h
+++ b/src/modules/powerrename/lib/PowerRenameInterfaces.h
@@ -107,10 +107,10 @@ public:
     IFACEMETHOD(GetVisibleItemCount)(_Out_ UINT* count) = 0;
     IFACEMETHOD(GetSelectedItemCount)(_Out_ UINT* count) = 0;
     IFACEMETHOD(GetRenameItemCount)(_Out_ UINT* count) = 0;
-    IFACEMETHOD(switchFilter)(_In_ int columnNumber) = 0;
     IFACEMETHOD(get_flags)(_Out_ DWORD* flags) = 0;
     IFACEMETHOD(put_flags)(_In_ DWORD flags) = 0;
     IFACEMETHOD(get_filter)(_Out_ DWORD * filter) = 0;
+    IFACEMETHOD(switchFilter)(_In_ int columnNumber) = 0;
     IFACEMETHOD(get_renameRegEx)(_COM_Outptr_ IPowerRenameRegEx** ppRegEx) = 0;
     IFACEMETHOD(put_renameRegEx)(_In_ IPowerRenameRegEx* pRegEx) = 0;
     IFACEMETHOD(get_renameItemFactory)(_COM_Outptr_ IPowerRenameItemFactory** ppItemFactory) = 0;

--- a/src/modules/powerrename/lib/PowerRenameInterfaces.h
+++ b/src/modules/powerrename/lib/PowerRenameInterfaces.h
@@ -110,6 +110,7 @@ public:
     IFACEMETHOD(switchFilter)(_In_ int columnNumber) = 0;
     IFACEMETHOD(get_flags)(_Out_ DWORD* flags) = 0;
     IFACEMETHOD(put_flags)(_In_ DWORD flags) = 0;
+    IFACEMETHOD(get_filter)(_Out_ DWORD * filter) = 0;
     IFACEMETHOD(get_renameRegEx)(_COM_Outptr_ IPowerRenameRegEx** ppRegEx) = 0;
     IFACEMETHOD(put_renameRegEx)(_In_ IPowerRenameRegEx* pRegEx) = 0;
     IFACEMETHOD(get_renameItemFactory)(_COM_Outptr_ IPowerRenameItemFactory** ppItemFactory) = 0;

--- a/src/modules/powerrename/lib/PowerRenameInterfaces.h
+++ b/src/modules/powerrename/lib/PowerRenameInterfaces.h
@@ -21,7 +21,8 @@ enum PowerRenameFilters
 {
     None = 1,
     Selected = 2,
-    ShoulRename = 3
+    FlagsApplicable = 3,
+    ShouldRename = 4,
 };
 
 interface __declspec(uuid("3ECBA62B-E0F0-4472-AA2E-DEE7A1AA46B9")) IPowerRenameRegExEvents : public IUnknown

--- a/src/modules/powerrename/lib/PowerRenameInterfaces.h
+++ b/src/modules/powerrename/lib/PowerRenameInterfaces.h
@@ -99,11 +99,11 @@ public:
     IFACEMETHOD(Rename)(_In_ HWND hwndParent) = 0;
     IFACEMETHOD(AddItem)(_In_ IPowerRenameItem* pItem) = 0;
     IFACEMETHOD(GetItemByIndex)(_In_ UINT index, _COM_Outptr_ IPowerRenameItem** ppItem) = 0;
-    IFACEMETHOD(GetVisibleItemByIndex)(_In_ UINT index, _COM_Outptr_ IPowerRenameItem * *ppItem) = 0;
+    IFACEMETHOD(GetVisibleItemByIndex)(_In_ UINT index, _COM_Outptr_ IPowerRenameItem ** ppItem) = 0;
     IFACEMETHOD(setVisible)() = 0;
     IFACEMETHOD(GetItemById)(_In_ int id, _COM_Outptr_ IPowerRenameItem** ppItem) = 0;
     IFACEMETHOD(GetItemCount)(_Out_ UINT* count) = 0;
-    IFACEMETHOD(GetVisibleItemCount)(_Out_ UINT * count) = 0;
+    IFACEMETHOD(GetVisibleItemCount)(_Out_ UINT* count) = 0;
     IFACEMETHOD(GetSelectedItemCount)(_Out_ UINT* count) = 0;
     IFACEMETHOD(GetRenameItemCount)(_Out_ UINT* count) = 0;
     IFACEMETHOD(switchFilter)(_In_ int columnNumber) = 0;

--- a/src/modules/powerrename/lib/PowerRenameInterfaces.h
+++ b/src/modules/powerrename/lib/PowerRenameInterfaces.h
@@ -38,32 +38,32 @@ interface __declspec(uuid("E3ED45B5-9CE0-47E2-A595-67EB950B9B72")) IPowerRenameR
 public:
     IFACEMETHOD(Advise)(_In_ IPowerRenameRegExEvents* regExEvents, _Out_ DWORD* cookie) = 0;
     IFACEMETHOD(UnAdvise)(_In_ DWORD cookie) = 0;
-    IFACEMETHOD(getSearchTerm)(_Outptr_ PWSTR* searchTerm) = 0;
-    IFACEMETHOD(putSearchTerm)(_In_ PCWSTR searchTerm) = 0;
-    IFACEMETHOD(getReplaceTerm)(_Outptr_ PWSTR* replaceTerm) = 0;
-    IFACEMETHOD(putReplaceTerm)(_In_ PCWSTR replaceTerm) = 0;
-    IFACEMETHOD(getFlags)(_Out_ DWORD* flags) = 0;
-    IFACEMETHOD(putFlags)(_In_ DWORD flags) = 0;
+    IFACEMETHOD(GetSearchTerm)(_Outptr_ PWSTR* searchTerm) = 0;
+    IFACEMETHOD(PutSearchTerm)(_In_ PCWSTR searchTerm) = 0;
+    IFACEMETHOD(GetReplaceTerm)(_Outptr_ PWSTR* replaceTerm) = 0;
+    IFACEMETHOD(PutReplaceTerm)(_In_ PCWSTR replaceTerm) = 0;
+    IFACEMETHOD(GetFlags)(_Out_ DWORD* flags) = 0;
+    IFACEMETHOD(PutFlags)(_In_ DWORD flags) = 0;
     IFACEMETHOD(Replace)(_In_ PCWSTR source, _Outptr_ PWSTR* result) = 0;
 };
 
 interface __declspec(uuid("C7F59201-4DE1-4855-A3A2-26FC3279C8A5")) IPowerRenameItem : public IUnknown
 {
 public:
-    IFACEMETHOD(getPath)(_Outptr_ PWSTR* path) = 0;
-    IFACEMETHOD(getDate)(_Outptr_ SYSTEMTIME* date) = 0;
-    IFACEMETHOD(getShellItem)(_Outptr_ IShellItem** ppsi) = 0;
-    IFACEMETHOD(getOriginalName)(_Outptr_ PWSTR* originalName) = 0;
-    IFACEMETHOD(getNewName)(_Outptr_ PWSTR* newName) = 0;
-    IFACEMETHOD(putNewName)(_In_opt_ PCWSTR newName) = 0;
-    IFACEMETHOD(getIsFolder)(_Out_ bool* isFolder) = 0;
-    IFACEMETHOD(getIsSubFolderContent)(_Out_ bool* isSubFolderContent) = 0;
-    IFACEMETHOD(getSelected)(_Out_ bool* selected) = 0;
-    IFACEMETHOD(putSelected)(_In_ bool selected) = 0;
-    IFACEMETHOD(getId)(_Out_ int *id) = 0;
-    IFACEMETHOD(getIconIndex)(_Out_ int* iconIndex) = 0;
-    IFACEMETHOD(getDepth)(_Out_ UINT* depth) = 0;
-    IFACEMETHOD(putDepth)(_In_ int depth) = 0;
+    IFACEMETHOD(GetPath)(_Outptr_ PWSTR* path) = 0;
+    IFACEMETHOD(GetDate)(_Outptr_ SYSTEMTIME* date) = 0;
+    IFACEMETHOD(GetShellItem)(_Outptr_ IShellItem** ppsi) = 0;
+    IFACEMETHOD(GetOriginalName)(_Outptr_ PWSTR* originalName) = 0;
+    IFACEMETHOD(GetNewName)(_Outptr_ PWSTR* newName) = 0;
+    IFACEMETHOD(PutNewName)(_In_opt_ PCWSTR newName) = 0;
+    IFACEMETHOD(GetIsFolder)(_Out_ bool* isFolder) = 0;
+    IFACEMETHOD(GetIsSubFolderContent)(_Out_ bool* isSubFolderContent) = 0;
+    IFACEMETHOD(GetSelected)(_Out_ bool* selected) = 0;
+    IFACEMETHOD(PutSelected)(_In_ bool selected) = 0;
+    IFACEMETHOD(GetId)(_Out_ int *id) = 0;
+    IFACEMETHOD(GetIconIndex)(_Out_ int* iconIndex) = 0;
+    IFACEMETHOD(GetDepth)(_Out_ UINT* depth) = 0;
+    IFACEMETHOD(PutDepth)(_In_ int depth) = 0;
     IFACEMETHOD(ShouldRenameItem)(_In_ DWORD flags, _Out_ bool* shouldRename) = 0;
     IFACEMETHOD(IsItemVisible)(_In_ DWORD filter, _In_ DWORD flags, _Out_ bool* isItemVisible) = 0;
     IFACEMETHOD(Reset)() = 0;
@@ -101,20 +101,20 @@ public:
     IFACEMETHOD(AddItem)(_In_ IPowerRenameItem* pItem) = 0;
     IFACEMETHOD(GetItemByIndex)(_In_ UINT index, _COM_Outptr_ IPowerRenameItem** ppItem) = 0;
     IFACEMETHOD(GetVisibleItemByIndex)(_In_ UINT index, _COM_Outptr_ IPowerRenameItem ** ppItem) = 0;
-    IFACEMETHOD(setVisible)() = 0;
+    IFACEMETHOD(SetVisible)() = 0;
     IFACEMETHOD(GetItemById)(_In_ int id, _COM_Outptr_ IPowerRenameItem** ppItem) = 0;
     IFACEMETHOD(GetItemCount)(_Out_ UINT* count) = 0;
     IFACEMETHOD(GetVisibleItemCount)(_Out_ UINT* count) = 0;
     IFACEMETHOD(GetSelectedItemCount)(_Out_ UINT* count) = 0;
     IFACEMETHOD(GetRenameItemCount)(_Out_ UINT* count) = 0;
-    IFACEMETHOD(getFlags)(_Out_ DWORD* flags) = 0;
-    IFACEMETHOD(putFlags)(_In_ DWORD flags) = 0;
-    IFACEMETHOD(getFilter)(_Out_ DWORD * filter) = 0;
-    IFACEMETHOD(switchFilter)(_In_ int columnNumber) = 0;
-    IFACEMETHOD(getRenameRegEx)(_COM_Outptr_ IPowerRenameRegEx** ppRegEx) = 0;
-    IFACEMETHOD(putRenameRegEx)(_In_ IPowerRenameRegEx* pRegEx) = 0;
-    IFACEMETHOD(getRenameItemFactory)(_COM_Outptr_ IPowerRenameItemFactory** ppItemFactory) = 0;
-    IFACEMETHOD(putRenameItemFactory)(_In_ IPowerRenameItemFactory* pItemFactory) = 0;
+    IFACEMETHOD(GetFlags)(_Out_ DWORD* flags) = 0;
+    IFACEMETHOD(PutFlags)(_In_ DWORD flags) = 0;
+    IFACEMETHOD(GetFilter)(_Out_ DWORD * filter) = 0;
+    IFACEMETHOD(SwitchFilter)(_In_ int columnNumber) = 0;
+    IFACEMETHOD(GetRenameRegEx)(_COM_Outptr_ IPowerRenameRegEx** ppRegEx) = 0;
+    IFACEMETHOD(PutRenameRegEx)(_In_ IPowerRenameRegEx* pRegEx) = 0;
+    IFACEMETHOD(GetRenameItemFactory)(_COM_Outptr_ IPowerRenameItemFactory** ppItemFactory) = 0;
+    IFACEMETHOD(PutRenameItemFactory)(_In_ IPowerRenameItemFactory* pItemFactory) = 0;
 };
 
 interface __declspec(uuid("E6679DEB-460D-42C1-A7A8-E25897061C99")) IPowerRenameUI : public IUnknown

--- a/src/modules/powerrename/lib/PowerRenameInterfaces.h
+++ b/src/modules/powerrename/lib/PowerRenameInterfaces.h
@@ -95,6 +95,7 @@ public:
     IFACEMETHOD(GetItemCount)(_Out_ UINT* count) = 0;
     IFACEMETHOD(GetSelectedItemCount)(_Out_ UINT* count) = 0;
     IFACEMETHOD(GetRenameItemCount)(_Out_ UINT* count) = 0;
+    IFACEMETHOD(SortItems)(_In_ bool isFilterOn) = 0;
     IFACEMETHOD(get_flags)(_Out_ DWORD* flags) = 0;
     IFACEMETHOD(put_flags)(_In_ DWORD flags) = 0;
     IFACEMETHOD(get_renameRegEx)(_COM_Outptr_ IPowerRenameRegEx** ppRegEx) = 0;

--- a/src/modules/powerrename/lib/PowerRenameInterfaces.h
+++ b/src/modules/powerrename/lib/PowerRenameInterfaces.h
@@ -57,6 +57,7 @@ public:
     IFACEMETHOD(get_depth)(_Out_ UINT* depth) = 0;
     IFACEMETHOD(put_depth)(_In_ int depth) = 0;
     IFACEMETHOD(ShouldRenameItem)(_In_ DWORD flags, _Out_ bool* shouldRename) = 0;
+    IFACEMETHOD(IsItemVisible)(_In_ bool filter, _In_ DWORD flags, _Out_ bool* isItemVisible) = 0;
     IFACEMETHOD(Reset)() = 0;
 };
 
@@ -91,11 +92,14 @@ public:
     IFACEMETHOD(Rename)(_In_ HWND hwndParent) = 0;
     IFACEMETHOD(AddItem)(_In_ IPowerRenameItem* pItem) = 0;
     IFACEMETHOD(GetItemByIndex)(_In_ UINT index, _COM_Outptr_ IPowerRenameItem** ppItem) = 0;
+    IFACEMETHOD(GetVisibleItemByIndex)(_In_ UINT index, _COM_Outptr_ IPowerRenameItem * *ppItem) = 0;
+    IFACEMETHOD(setVisible)() = 0;
     IFACEMETHOD(GetItemById)(_In_ int id, _COM_Outptr_ IPowerRenameItem** ppItem) = 0;
     IFACEMETHOD(GetItemCount)(_Out_ UINT* count) = 0;
+    IFACEMETHOD(GetVisibleItemCount)(_Out_ UINT * count) = 0;
     IFACEMETHOD(GetSelectedItemCount)(_Out_ UINT* count) = 0;
     IFACEMETHOD(GetRenameItemCount)(_Out_ UINT* count) = 0;
-    IFACEMETHOD(SortItems)(_In_ bool isFilterOn) = 0;
+    IFACEMETHOD(toggleFilter)() = 0;
     IFACEMETHOD(get_flags)(_Out_ DWORD* flags) = 0;
     IFACEMETHOD(put_flags)(_In_ DWORD flags) = 0;
     IFACEMETHOD(get_renameRegEx)(_COM_Outptr_ IPowerRenameRegEx** ppRegEx) = 0;

--- a/src/modules/powerrename/lib/PowerRenameInterfaces.h
+++ b/src/modules/powerrename/lib/PowerRenameInterfaces.h
@@ -17,6 +17,13 @@ enum PowerRenameFlags
     Titlecase = 0x800
 };
 
+enum PowerRenameFilters
+{
+    None = 1,
+    Selected = 2,
+    ShoulRename = 3
+};
+
 interface __declspec(uuid("3ECBA62B-E0F0-4472-AA2E-DEE7A1AA46B9")) IPowerRenameRegExEvents : public IUnknown
 {
 public:
@@ -57,7 +64,7 @@ public:
     IFACEMETHOD(get_depth)(_Out_ UINT* depth) = 0;
     IFACEMETHOD(put_depth)(_In_ int depth) = 0;
     IFACEMETHOD(ShouldRenameItem)(_In_ DWORD flags, _Out_ bool* shouldRename) = 0;
-    IFACEMETHOD(IsItemVisible)(_In_ bool filter, _In_ DWORD flags, _Out_ bool* isItemVisible) = 0;
+    IFACEMETHOD(IsItemVisible)(_In_ DWORD filter, _In_ DWORD flags, _Out_ bool* isItemVisible) = 0;
     IFACEMETHOD(Reset)() = 0;
 };
 
@@ -99,7 +106,7 @@ public:
     IFACEMETHOD(GetVisibleItemCount)(_Out_ UINT * count) = 0;
     IFACEMETHOD(GetSelectedItemCount)(_Out_ UINT* count) = 0;
     IFACEMETHOD(GetRenameItemCount)(_Out_ UINT* count) = 0;
-    IFACEMETHOD(toggleFilter)() = 0;
+    IFACEMETHOD(switchFilter)(_In_ int columnNumber) = 0;
     IFACEMETHOD(get_flags)(_Out_ DWORD* flags) = 0;
     IFACEMETHOD(put_flags)(_In_ DWORD flags) = 0;
     IFACEMETHOD(get_renameRegEx)(_COM_Outptr_ IPowerRenameRegEx** ppRegEx) = 0;

--- a/src/modules/powerrename/lib/PowerRenameInterfaces.h
+++ b/src/modules/powerrename/lib/PowerRenameInterfaces.h
@@ -38,32 +38,32 @@ interface __declspec(uuid("E3ED45B5-9CE0-47E2-A595-67EB950B9B72")) IPowerRenameR
 public:
     IFACEMETHOD(Advise)(_In_ IPowerRenameRegExEvents* regExEvents, _Out_ DWORD* cookie) = 0;
     IFACEMETHOD(UnAdvise)(_In_ DWORD cookie) = 0;
-    IFACEMETHOD(get_searchTerm)(_Outptr_ PWSTR* searchTerm) = 0;
-    IFACEMETHOD(put_searchTerm)(_In_ PCWSTR searchTerm) = 0;
-    IFACEMETHOD(get_replaceTerm)(_Outptr_ PWSTR* replaceTerm) = 0;
-    IFACEMETHOD(put_replaceTerm)(_In_ PCWSTR replaceTerm) = 0;
-    IFACEMETHOD(get_flags)(_Out_ DWORD* flags) = 0;
-    IFACEMETHOD(put_flags)(_In_ DWORD flags) = 0;
+    IFACEMETHOD(getSearchTerm)(_Outptr_ PWSTR* searchTerm) = 0;
+    IFACEMETHOD(putSearchTerm)(_In_ PCWSTR searchTerm) = 0;
+    IFACEMETHOD(getReplaceTerm)(_Outptr_ PWSTR* replaceTerm) = 0;
+    IFACEMETHOD(putReplaceTerm)(_In_ PCWSTR replaceTerm) = 0;
+    IFACEMETHOD(getFlags)(_Out_ DWORD* flags) = 0;
+    IFACEMETHOD(putFlags)(_In_ DWORD flags) = 0;
     IFACEMETHOD(Replace)(_In_ PCWSTR source, _Outptr_ PWSTR* result) = 0;
 };
 
 interface __declspec(uuid("C7F59201-4DE1-4855-A3A2-26FC3279C8A5")) IPowerRenameItem : public IUnknown
 {
 public:
-    IFACEMETHOD(get_path)(_Outptr_ PWSTR* path) = 0;
-    IFACEMETHOD(get_date)(_Outptr_ SYSTEMTIME* date) = 0;
-    IFACEMETHOD(get_shellItem)(_Outptr_ IShellItem** ppsi) = 0;
-    IFACEMETHOD(get_originalName)(_Outptr_ PWSTR* originalName) = 0;
-    IFACEMETHOD(get_newName)(_Outptr_ PWSTR* newName) = 0;
-    IFACEMETHOD(put_newName)(_In_opt_ PCWSTR newName) = 0;
-    IFACEMETHOD(get_isFolder)(_Out_ bool* isFolder) = 0;
-    IFACEMETHOD(get_isSubFolderContent)(_Out_ bool* isSubFolderContent) = 0;
-    IFACEMETHOD(get_selected)(_Out_ bool* selected) = 0;
-    IFACEMETHOD(put_selected)(_In_ bool selected) = 0;
-    IFACEMETHOD(get_id)(_Out_ int *id) = 0;
-    IFACEMETHOD(get_iconIndex)(_Out_ int* iconIndex) = 0;
-    IFACEMETHOD(get_depth)(_Out_ UINT* depth) = 0;
-    IFACEMETHOD(put_depth)(_In_ int depth) = 0;
+    IFACEMETHOD(getPath)(_Outptr_ PWSTR* path) = 0;
+    IFACEMETHOD(getDate)(_Outptr_ SYSTEMTIME* date) = 0;
+    IFACEMETHOD(getShellItem)(_Outptr_ IShellItem** ppsi) = 0;
+    IFACEMETHOD(getOriginalName)(_Outptr_ PWSTR* originalName) = 0;
+    IFACEMETHOD(getNewName)(_Outptr_ PWSTR* newName) = 0;
+    IFACEMETHOD(putNewName)(_In_opt_ PCWSTR newName) = 0;
+    IFACEMETHOD(getIsFolder)(_Out_ bool* isFolder) = 0;
+    IFACEMETHOD(getIsSubFolderContent)(_Out_ bool* isSubFolderContent) = 0;
+    IFACEMETHOD(getSelected)(_Out_ bool* selected) = 0;
+    IFACEMETHOD(putSelected)(_In_ bool selected) = 0;
+    IFACEMETHOD(getId)(_Out_ int *id) = 0;
+    IFACEMETHOD(getIconIndex)(_Out_ int* iconIndex) = 0;
+    IFACEMETHOD(getDepth)(_Out_ UINT* depth) = 0;
+    IFACEMETHOD(putDepth)(_In_ int depth) = 0;
     IFACEMETHOD(ShouldRenameItem)(_In_ DWORD flags, _Out_ bool* shouldRename) = 0;
     IFACEMETHOD(IsItemVisible)(_In_ DWORD filter, _In_ DWORD flags, _Out_ bool* isItemVisible) = 0;
     IFACEMETHOD(Reset)() = 0;
@@ -107,14 +107,14 @@ public:
     IFACEMETHOD(GetVisibleItemCount)(_Out_ UINT* count) = 0;
     IFACEMETHOD(GetSelectedItemCount)(_Out_ UINT* count) = 0;
     IFACEMETHOD(GetRenameItemCount)(_Out_ UINT* count) = 0;
-    IFACEMETHOD(get_flags)(_Out_ DWORD* flags) = 0;
-    IFACEMETHOD(put_flags)(_In_ DWORD flags) = 0;
-    IFACEMETHOD(get_filter)(_Out_ DWORD * filter) = 0;
+    IFACEMETHOD(getFlags)(_Out_ DWORD* flags) = 0;
+    IFACEMETHOD(putFlags)(_In_ DWORD flags) = 0;
+    IFACEMETHOD(getFilter)(_Out_ DWORD * filter) = 0;
     IFACEMETHOD(switchFilter)(_In_ int columnNumber) = 0;
-    IFACEMETHOD(get_renameRegEx)(_COM_Outptr_ IPowerRenameRegEx** ppRegEx) = 0;
-    IFACEMETHOD(put_renameRegEx)(_In_ IPowerRenameRegEx* pRegEx) = 0;
-    IFACEMETHOD(get_renameItemFactory)(_COM_Outptr_ IPowerRenameItemFactory** ppItemFactory) = 0;
-    IFACEMETHOD(put_renameItemFactory)(_In_ IPowerRenameItemFactory* pItemFactory) = 0;
+    IFACEMETHOD(getRenameRegEx)(_COM_Outptr_ IPowerRenameRegEx** ppRegEx) = 0;
+    IFACEMETHOD(putRenameRegEx)(_In_ IPowerRenameRegEx* pRegEx) = 0;
+    IFACEMETHOD(getRenameItemFactory)(_COM_Outptr_ IPowerRenameItemFactory** ppItemFactory) = 0;
+    IFACEMETHOD(putRenameItemFactory)(_In_ IPowerRenameItemFactory* pItemFactory) = 0;
 };
 
 interface __declspec(uuid("E6679DEB-460D-42C1-A7A8-E25897061C99")) IPowerRenameUI : public IUnknown

--- a/src/modules/powerrename/lib/PowerRenameItem.cpp
+++ b/src/modules/powerrename/lib/PowerRenameItem.cpp
@@ -183,6 +183,24 @@ IFACEMETHODIMP CPowerRenameItem::ShouldRenameItem(_In_ DWORD flags, _Out_ bool* 
     return S_OK;
 }
 
+IFACEMETHODIMP CPowerRenameItem::IsItemVisible(_In_ bool filter, _In_ DWORD flags, _Out_ bool* isItemVisible)
+{
+    if (!filter)
+    {
+        *isItemVisible = true;
+    }
+    else
+    {
+        bool shouldRenameItem = false;
+        if (SUCCEEDED(ShouldRenameItem(flags, &shouldRenameItem)) && shouldRenameItem)
+        {
+            *isItemVisible = true;
+        }
+    }
+
+    return S_OK;
+}
+
 IFACEMETHODIMP CPowerRenameItem::Reset()
 {
     CSRWSharedAutoLock lock(&m_lock);

--- a/src/modules/powerrename/lib/PowerRenameItem.cpp
+++ b/src/modules/powerrename/lib/PowerRenameItem.cpp
@@ -30,7 +30,7 @@ IFACEMETHODIMP CPowerRenameItem::QueryInterface(_In_ REFIID riid, _Outptr_ void*
     return QISearch(this, qit, riid, ppv);
 }
 
-IFACEMETHODIMP CPowerRenameItem::getPath(_Outptr_ PWSTR* path)
+IFACEMETHODIMP CPowerRenameItem::GetPath(_Outptr_ PWSTR* path)
 {
     *path = nullptr;
     CSRWSharedAutoLock lock(&m_lock);
@@ -42,7 +42,7 @@ IFACEMETHODIMP CPowerRenameItem::getPath(_Outptr_ PWSTR* path)
     return hr;
 }
 
-IFACEMETHODIMP CPowerRenameItem::getDate(_Outptr_ SYSTEMTIME* date)
+IFACEMETHODIMP CPowerRenameItem::GetDate(_Outptr_ SYSTEMTIME* date)
 {
     CSRWSharedAutoLock lock(&m_lock);
     HRESULT hr = m_isDateParsed ? S_OK : E_FAIL ;
@@ -72,12 +72,12 @@ IFACEMETHODIMP CPowerRenameItem::getDate(_Outptr_ SYSTEMTIME* date)
     return hr;
 }
 
-IFACEMETHODIMP CPowerRenameItem::getShellItem(_Outptr_ IShellItem** ppsi)
+IFACEMETHODIMP CPowerRenameItem::GetShellItem(_Outptr_ IShellItem** ppsi)
 {
     return SHCreateItemFromParsingName(m_path, nullptr, IID_PPV_ARGS(ppsi));
 }
 
-IFACEMETHODIMP CPowerRenameItem::getOriginalName(_Outptr_ PWSTR* originalName)
+IFACEMETHODIMP CPowerRenameItem::GetOriginalName(_Outptr_ PWSTR* originalName)
 {
     CSRWSharedAutoLock lock(&m_lock);
     HRESULT hr = m_originalName ? S_OK : E_FAIL;
@@ -88,7 +88,7 @@ IFACEMETHODIMP CPowerRenameItem::getOriginalName(_Outptr_ PWSTR* originalName)
     return hr;
 }
 
-IFACEMETHODIMP CPowerRenameItem::putNewName(_In_opt_ PCWSTR newName)
+IFACEMETHODIMP CPowerRenameItem::PutNewName(_In_opt_ PCWSTR newName)
 {
     CSRWSharedAutoLock lock(&m_lock);
     CoTaskMemFree(m_newName);
@@ -101,7 +101,7 @@ IFACEMETHODIMP CPowerRenameItem::putNewName(_In_opt_ PCWSTR newName)
     return hr;
 }
 
-IFACEMETHODIMP CPowerRenameItem::getNewName(_Outptr_ PWSTR* newName)
+IFACEMETHODIMP CPowerRenameItem::GetNewName(_Outptr_ PWSTR* newName)
 {
     CSRWSharedAutoLock lock(&m_lock);
     HRESULT hr = m_newName ? S_OK : E_FAIL;
@@ -112,42 +112,42 @@ IFACEMETHODIMP CPowerRenameItem::getNewName(_Outptr_ PWSTR* newName)
     return hr;
 }
 
-IFACEMETHODIMP CPowerRenameItem::getIsFolder(_Out_ bool* isFolder)
+IFACEMETHODIMP CPowerRenameItem::GetIsFolder(_Out_ bool* isFolder)
 {
     CSRWSharedAutoLock lock(&m_lock);
     *isFolder = m_isFolder;
     return S_OK;
 }
 
-IFACEMETHODIMP CPowerRenameItem::getIsSubFolderContent(_Out_ bool* isSubFolderContent)
+IFACEMETHODIMP CPowerRenameItem::GetIsSubFolderContent(_Out_ bool* isSubFolderContent)
 {
     CSRWSharedAutoLock lock(&m_lock);
     *isSubFolderContent = m_depth > 0;
     return S_OK;
 }
 
-IFACEMETHODIMP CPowerRenameItem::getSelected(_Out_ bool* selected)
+IFACEMETHODIMP CPowerRenameItem::GetSelected(_Out_ bool* selected)
 {
     CSRWSharedAutoLock lock(&m_lock);
     *selected = m_selected;
     return S_OK;
 }
 
-IFACEMETHODIMP CPowerRenameItem::putSelected(_In_ bool selected)
+IFACEMETHODIMP CPowerRenameItem::PutSelected(_In_ bool selected)
 {
     CSRWSharedAutoLock lock(&m_lock);
     m_selected = selected;
     return S_OK;
 }
 
-IFACEMETHODIMP CPowerRenameItem::getId(_Out_ int* id)
+IFACEMETHODIMP CPowerRenameItem::GetId(_Out_ int* id)
 {
     CSRWSharedAutoLock lock(&m_lock);
     *id = m_id;
     return S_OK;
 }
 
-IFACEMETHODIMP CPowerRenameItem::getIconIndex(_Out_ int* iconIndex)
+IFACEMETHODIMP CPowerRenameItem::GetIconIndex(_Out_ int* iconIndex)
 {
     if (m_iconIndex == -1)
     {
@@ -157,13 +157,13 @@ IFACEMETHODIMP CPowerRenameItem::getIconIndex(_Out_ int* iconIndex)
     return S_OK;
 }
 
-IFACEMETHODIMP CPowerRenameItem::getDepth(_Out_ UINT* depth)
+IFACEMETHODIMP CPowerRenameItem::GetDepth(_Out_ UINT* depth)
 {
     *depth = m_depth;
     return S_OK;
 }
 
-IFACEMETHODIMP CPowerRenameItem::putDepth(_In_ int depth)
+IFACEMETHODIMP CPowerRenameItem::PutDepth(_In_ int depth)
 {
     m_depth = depth;
     return S_OK;
@@ -191,7 +191,7 @@ IFACEMETHODIMP CPowerRenameItem::IsItemVisible(_In_ DWORD filter, _In_ DWORD fla
         *isItemVisible = true;
         break;
     case PowerRenameFilters::Selected:
-        getSelected(isItemVisible);
+        GetSelected(isItemVisible);
         break;
     case PowerRenameFilters::FlagsApplicable:
         *isItemVisible = !((m_isFolder && (flags & PowerRenameFlags::ExcludeFolders)) || 

--- a/src/modules/powerrename/lib/PowerRenameItem.cpp
+++ b/src/modules/powerrename/lib/PowerRenameItem.cpp
@@ -179,7 +179,6 @@ IFACEMETHODIMP CPowerRenameItem::ShouldRenameItem(_In_ DWORD flags, _Out_ bool* 
     bool excludeBecauseSubFolderContent = (m_depth > 0 && (flags & PowerRenameFlags::ExcludeSubfolders));
     *shouldRename = (m_selected && m_canRename && hasChanged && !excludeBecauseFile &&
                      !excludeBecauseFolder && !excludeBecauseSubFolderContent);
-
     return S_OK;
 }
 
@@ -194,7 +193,6 @@ IFACEMETHODIMP CPowerRenameItem::IsItemVisible(_In_ DWORD filter, _In_ DWORD fla
     case PowerRenameFilters::Selected:
         get_selected(isItemVisible);
         break;
-
     case PowerRenameFilters::FlagsApplicable:
         *isItemVisible = !((m_isFolder && (flags & PowerRenameFlags::ExcludeFolders)) || 
             (!m_isFolder && (flags & PowerRenameFlags::ExcludeFiles)) || 
@@ -204,7 +202,6 @@ IFACEMETHODIMP CPowerRenameItem::IsItemVisible(_In_ DWORD filter, _In_ DWORD fla
         ShouldRenameItem(flags, isItemVisible);
         break;
     }
-
     return S_OK;
 }
 

--- a/src/modules/powerrename/lib/PowerRenameItem.cpp
+++ b/src/modules/powerrename/lib/PowerRenameItem.cpp
@@ -183,19 +183,20 @@ IFACEMETHODIMP CPowerRenameItem::ShouldRenameItem(_In_ DWORD flags, _Out_ bool* 
     return S_OK;
 }
 
-IFACEMETHODIMP CPowerRenameItem::IsItemVisible(_In_ bool filter, _In_ DWORD flags, _Out_ bool* isItemVisible)
+IFACEMETHODIMP CPowerRenameItem::IsItemVisible(_In_ DWORD filter, _In_ DWORD flags, _Out_ bool* isItemVisible)
 {
-    if (!filter)
+    bool shouldRenameItem = false;
+    switch (filter)
     {
+    case PowerRenameFilters::None:
         *isItemVisible = true;
-    }
-    else
-    {
-        bool shouldRenameItem = false;
-        if (SUCCEEDED(ShouldRenameItem(flags, &shouldRenameItem)) && shouldRenameItem)
-        {
-            *isItemVisible = true;
-        }
+        break;
+    case PowerRenameFilters::Selected:
+        get_selected(isItemVisible);
+        break;
+    case PowerRenameFilters::ShoulRename:
+        ShouldRenameItem(flags, isItemVisible);
+        break;
     }
 
     return S_OK;

--- a/src/modules/powerrename/lib/PowerRenameItem.cpp
+++ b/src/modules/powerrename/lib/PowerRenameItem.cpp
@@ -30,7 +30,7 @@ IFACEMETHODIMP CPowerRenameItem::QueryInterface(_In_ REFIID riid, _Outptr_ void*
     return QISearch(this, qit, riid, ppv);
 }
 
-IFACEMETHODIMP CPowerRenameItem::get_path(_Outptr_ PWSTR* path)
+IFACEMETHODIMP CPowerRenameItem::getPath(_Outptr_ PWSTR* path)
 {
     *path = nullptr;
     CSRWSharedAutoLock lock(&m_lock);
@@ -42,7 +42,7 @@ IFACEMETHODIMP CPowerRenameItem::get_path(_Outptr_ PWSTR* path)
     return hr;
 }
 
-IFACEMETHODIMP CPowerRenameItem::get_date(_Outptr_ SYSTEMTIME* date)
+IFACEMETHODIMP CPowerRenameItem::getDate(_Outptr_ SYSTEMTIME* date)
 {
     CSRWSharedAutoLock lock(&m_lock);
     HRESULT hr = m_isDateParsed ? S_OK : E_FAIL ;
@@ -72,12 +72,12 @@ IFACEMETHODIMP CPowerRenameItem::get_date(_Outptr_ SYSTEMTIME* date)
     return hr;
 }
 
-IFACEMETHODIMP CPowerRenameItem::get_shellItem(_Outptr_ IShellItem** ppsi)
+IFACEMETHODIMP CPowerRenameItem::getShellItem(_Outptr_ IShellItem** ppsi)
 {
     return SHCreateItemFromParsingName(m_path, nullptr, IID_PPV_ARGS(ppsi));
 }
 
-IFACEMETHODIMP CPowerRenameItem::get_originalName(_Outptr_ PWSTR* originalName)
+IFACEMETHODIMP CPowerRenameItem::getOriginalName(_Outptr_ PWSTR* originalName)
 {
     CSRWSharedAutoLock lock(&m_lock);
     HRESULT hr = m_originalName ? S_OK : E_FAIL;
@@ -88,7 +88,7 @@ IFACEMETHODIMP CPowerRenameItem::get_originalName(_Outptr_ PWSTR* originalName)
     return hr;
 }
 
-IFACEMETHODIMP CPowerRenameItem::put_newName(_In_opt_ PCWSTR newName)
+IFACEMETHODIMP CPowerRenameItem::putNewName(_In_opt_ PCWSTR newName)
 {
     CSRWSharedAutoLock lock(&m_lock);
     CoTaskMemFree(m_newName);
@@ -101,7 +101,7 @@ IFACEMETHODIMP CPowerRenameItem::put_newName(_In_opt_ PCWSTR newName)
     return hr;
 }
 
-IFACEMETHODIMP CPowerRenameItem::get_newName(_Outptr_ PWSTR* newName)
+IFACEMETHODIMP CPowerRenameItem::getNewName(_Outptr_ PWSTR* newName)
 {
     CSRWSharedAutoLock lock(&m_lock);
     HRESULT hr = m_newName ? S_OK : E_FAIL;
@@ -112,42 +112,42 @@ IFACEMETHODIMP CPowerRenameItem::get_newName(_Outptr_ PWSTR* newName)
     return hr;
 }
 
-IFACEMETHODIMP CPowerRenameItem::get_isFolder(_Out_ bool* isFolder)
+IFACEMETHODIMP CPowerRenameItem::getIsFolder(_Out_ bool* isFolder)
 {
     CSRWSharedAutoLock lock(&m_lock);
     *isFolder = m_isFolder;
     return S_OK;
 }
 
-IFACEMETHODIMP CPowerRenameItem::get_isSubFolderContent(_Out_ bool* isSubFolderContent)
+IFACEMETHODIMP CPowerRenameItem::getIsSubFolderContent(_Out_ bool* isSubFolderContent)
 {
     CSRWSharedAutoLock lock(&m_lock);
     *isSubFolderContent = m_depth > 0;
     return S_OK;
 }
 
-IFACEMETHODIMP CPowerRenameItem::get_selected(_Out_ bool* selected)
+IFACEMETHODIMP CPowerRenameItem::getSelected(_Out_ bool* selected)
 {
     CSRWSharedAutoLock lock(&m_lock);
     *selected = m_selected;
     return S_OK;
 }
 
-IFACEMETHODIMP CPowerRenameItem::put_selected(_In_ bool selected)
+IFACEMETHODIMP CPowerRenameItem::putSelected(_In_ bool selected)
 {
     CSRWSharedAutoLock lock(&m_lock);
     m_selected = selected;
     return S_OK;
 }
 
-IFACEMETHODIMP CPowerRenameItem::get_id(_Out_ int* id)
+IFACEMETHODIMP CPowerRenameItem::getId(_Out_ int* id)
 {
     CSRWSharedAutoLock lock(&m_lock);
     *id = m_id;
     return S_OK;
 }
 
-IFACEMETHODIMP CPowerRenameItem::get_iconIndex(_Out_ int* iconIndex)
+IFACEMETHODIMP CPowerRenameItem::getIconIndex(_Out_ int* iconIndex)
 {
     if (m_iconIndex == -1)
     {
@@ -157,13 +157,13 @@ IFACEMETHODIMP CPowerRenameItem::get_iconIndex(_Out_ int* iconIndex)
     return S_OK;
 }
 
-IFACEMETHODIMP CPowerRenameItem::get_depth(_Out_ UINT* depth)
+IFACEMETHODIMP CPowerRenameItem::getDepth(_Out_ UINT* depth)
 {
     *depth = m_depth;
     return S_OK;
 }
 
-IFACEMETHODIMP CPowerRenameItem::put_depth(_In_ int depth)
+IFACEMETHODIMP CPowerRenameItem::putDepth(_In_ int depth)
 {
     m_depth = depth;
     return S_OK;
@@ -191,7 +191,7 @@ IFACEMETHODIMP CPowerRenameItem::IsItemVisible(_In_ DWORD filter, _In_ DWORD fla
         *isItemVisible = true;
         break;
     case PowerRenameFilters::Selected:
-        get_selected(isItemVisible);
+        getSelected(isItemVisible);
         break;
     case PowerRenameFilters::FlagsApplicable:
         *isItemVisible = !((m_isFolder && (flags & PowerRenameFlags::ExcludeFolders)) || 

--- a/src/modules/powerrename/lib/PowerRenameItem.cpp
+++ b/src/modules/powerrename/lib/PowerRenameItem.cpp
@@ -194,7 +194,13 @@ IFACEMETHODIMP CPowerRenameItem::IsItemVisible(_In_ DWORD filter, _In_ DWORD fla
     case PowerRenameFilters::Selected:
         get_selected(isItemVisible);
         break;
-    case PowerRenameFilters::ShoulRename:
+
+    case PowerRenameFilters::FlagsApplicable:
+        *isItemVisible = !((m_isFolder && (flags & PowerRenameFlags::ExcludeFolders)) || 
+            (!m_isFolder && (flags & PowerRenameFlags::ExcludeFiles)) || 
+            (m_depth > 0 && (flags & PowerRenameFlags::ExcludeSubfolders)));
+        break;
+    case PowerRenameFilters::ShouldRename:
         ShouldRenameItem(flags, isItemVisible);
         break;
     }

--- a/src/modules/powerrename/lib/PowerRenameItem.h
+++ b/src/modules/powerrename/lib/PowerRenameItem.h
@@ -14,20 +14,20 @@ public:
     IFACEMETHODIMP_(ULONG) Release();
 
     // IPowerRenameItem
-    IFACEMETHODIMP get_path(_Outptr_ PWSTR* path);
-    IFACEMETHODIMP get_date(_Outptr_ SYSTEMTIME* date);
-    IFACEMETHODIMP get_shellItem(_Outptr_ IShellItem** ppsi);
-    IFACEMETHODIMP get_originalName(_Outptr_ PWSTR* originalName);
-    IFACEMETHODIMP put_newName(_In_opt_ PCWSTR newName);
-    IFACEMETHODIMP get_newName(_Outptr_ PWSTR* newName);
-    IFACEMETHODIMP get_isFolder(_Out_ bool* isFolder);
-    IFACEMETHODIMP get_isSubFolderContent(_Out_ bool* isSubFolderContent);
-    IFACEMETHODIMP get_selected(_Out_ bool* selected);
-    IFACEMETHODIMP put_selected(_In_ bool selected);
-    IFACEMETHODIMP get_id(_Out_ int* id);
-    IFACEMETHODIMP get_iconIndex(_Out_ int* iconIndex);
-    IFACEMETHODIMP get_depth(_Out_ UINT* depth);
-    IFACEMETHODIMP put_depth(_In_ int depth);
+    IFACEMETHODIMP getPath(_Outptr_ PWSTR* path);
+    IFACEMETHODIMP getDate(_Outptr_ SYSTEMTIME* date);
+    IFACEMETHODIMP getShellItem(_Outptr_ IShellItem** ppsi);
+    IFACEMETHODIMP getOriginalName(_Outptr_ PWSTR* originalName);
+    IFACEMETHODIMP putNewName(_In_opt_ PCWSTR newName);
+    IFACEMETHODIMP getNewName(_Outptr_ PWSTR* newName);
+    IFACEMETHODIMP getIsFolder(_Out_ bool* isFolder);
+    IFACEMETHODIMP getIsSubFolderContent(_Out_ bool* isSubFolderContent);
+    IFACEMETHODIMP getSelected(_Out_ bool* selected);
+    IFACEMETHODIMP putSelected(_In_ bool selected);
+    IFACEMETHODIMP getId(_Out_ int* id);
+    IFACEMETHODIMP getIconIndex(_Out_ int* iconIndex);
+    IFACEMETHODIMP getDepth(_Out_ UINT* depth);
+    IFACEMETHODIMP putDepth(_In_ int depth);
     IFACEMETHODIMP Reset();
     IFACEMETHODIMP ShouldRenameItem(_In_ DWORD flags, _Out_ bool* shouldRename);
     IFACEMETHODIMP IsItemVisible(_In_ DWORD filter, _In_ DWORD flags, _Out_ bool* isItemVisible);

--- a/src/modules/powerrename/lib/PowerRenameItem.h
+++ b/src/modules/powerrename/lib/PowerRenameItem.h
@@ -30,7 +30,7 @@ public:
     IFACEMETHODIMP put_depth(_In_ int depth);
     IFACEMETHODIMP Reset();
     IFACEMETHODIMP ShouldRenameItem(_In_ DWORD flags, _Out_ bool* shouldRename);
-    IFACEMETHODIMP IsItemVisible(_In_ bool filter, _In_ DWORD flags, _Out_ bool* isItemVisible);
+    IFACEMETHODIMP IsItemVisible(_In_ DWORD filter, _In_ DWORD flags, _Out_ bool* isItemVisible);
 
     // IPowerRenameItemFactory
     IFACEMETHODIMP Create(_In_ IShellItem* psi, _Outptr_ IPowerRenameItem** ppItem)

--- a/src/modules/powerrename/lib/PowerRenameItem.h
+++ b/src/modules/powerrename/lib/PowerRenameItem.h
@@ -14,20 +14,20 @@ public:
     IFACEMETHODIMP_(ULONG) Release();
 
     // IPowerRenameItem
-    IFACEMETHODIMP getPath(_Outptr_ PWSTR* path);
-    IFACEMETHODIMP getDate(_Outptr_ SYSTEMTIME* date);
-    IFACEMETHODIMP getShellItem(_Outptr_ IShellItem** ppsi);
-    IFACEMETHODIMP getOriginalName(_Outptr_ PWSTR* originalName);
-    IFACEMETHODIMP putNewName(_In_opt_ PCWSTR newName);
-    IFACEMETHODIMP getNewName(_Outptr_ PWSTR* newName);
-    IFACEMETHODIMP getIsFolder(_Out_ bool* isFolder);
-    IFACEMETHODIMP getIsSubFolderContent(_Out_ bool* isSubFolderContent);
-    IFACEMETHODIMP getSelected(_Out_ bool* selected);
-    IFACEMETHODIMP putSelected(_In_ bool selected);
-    IFACEMETHODIMP getId(_Out_ int* id);
-    IFACEMETHODIMP getIconIndex(_Out_ int* iconIndex);
-    IFACEMETHODIMP getDepth(_Out_ UINT* depth);
-    IFACEMETHODIMP putDepth(_In_ int depth);
+    IFACEMETHODIMP GetPath(_Outptr_ PWSTR* path);
+    IFACEMETHODIMP GetDate(_Outptr_ SYSTEMTIME* date);
+    IFACEMETHODIMP GetShellItem(_Outptr_ IShellItem** ppsi);
+    IFACEMETHODIMP GetOriginalName(_Outptr_ PWSTR* originalName);
+    IFACEMETHODIMP PutNewName(_In_opt_ PCWSTR newName);
+    IFACEMETHODIMP GetNewName(_Outptr_ PWSTR* newName);
+    IFACEMETHODIMP GetIsFolder(_Out_ bool* isFolder);
+    IFACEMETHODIMP GetIsSubFolderContent(_Out_ bool* isSubFolderContent);
+    IFACEMETHODIMP GetSelected(_Out_ bool* selected);
+    IFACEMETHODIMP PutSelected(_In_ bool selected);
+    IFACEMETHODIMP GetId(_Out_ int* id);
+    IFACEMETHODIMP GetIconIndex(_Out_ int* iconIndex);
+    IFACEMETHODIMP GetDepth(_Out_ UINT* depth);
+    IFACEMETHODIMP PutDepth(_In_ int depth);
     IFACEMETHODIMP Reset();
     IFACEMETHODIMP ShouldRenameItem(_In_ DWORD flags, _Out_ bool* shouldRename);
     IFACEMETHODIMP IsItemVisible(_In_ DWORD filter, _In_ DWORD flags, _Out_ bool* isItemVisible);

--- a/src/modules/powerrename/lib/PowerRenameItem.h
+++ b/src/modules/powerrename/lib/PowerRenameItem.h
@@ -30,6 +30,7 @@ public:
     IFACEMETHODIMP put_depth(_In_ int depth);
     IFACEMETHODIMP Reset();
     IFACEMETHODIMP ShouldRenameItem(_In_ DWORD flags, _Out_ bool* shouldRename);
+    IFACEMETHODIMP IsItemVisible(_In_ bool filter, _In_ DWORD flags, _Out_ bool* isItemVisible);
 
     // IPowerRenameItemFactory
     IFACEMETHODIMP Create(_In_ IShellItem* psi, _Outptr_ IPowerRenameItem** ppItem)

--- a/src/modules/powerrename/lib/PowerRenameManager.cpp
+++ b/src/modules/powerrename/lib/PowerRenameManager.cpp
@@ -159,7 +159,12 @@ IFACEMETHODIMP CPowerRenameManager::GetVisibleItemByIndex(_In_ UINT index, _COM_
     CSRWSharedAutoLock lock(&m_lockItems);
     UINT count = 0;
     HRESULT hr = E_FAIL;
-    if (SUCCEEDED(GetVisibleItemCount(&count)) && index < count)
+
+    if (m_filter == PowerRenameFilters::None)
+    {
+        hr = GetItemByIndex(index, ppItem);
+    }
+    else if (SUCCEEDED(GetVisibleItemCount(&count)) && index < count)
     {
         int realIndex = 0;
         int visibleIndex = -1;
@@ -241,15 +246,23 @@ IFACEMETHODIMP CPowerRenameManager::GetVisibleItemCount(_Out_ UINT* count)
     *count = 0;
     CSRWSharedAutoLock lock(&m_lockItems);
 
-    setVisible();
-
-    for (size_t i=0 ; i<m_isVisible.size(); i++)
+    if (m_filter != PowerRenameFilters::None)
     {
-        if (m_isVisible[i])
+        setVisible();
+
+        for (size_t i = 0; i < m_isVisible.size(); i++)
         {
-            (*count)++;
+            if (m_isVisible[i])
+            {
+                (*count)++;
+            }
         }
     }
+    else
+    {
+        GetItemCount(count);
+    }
+    
 
     return S_OK;
 }

--- a/src/modules/powerrename/lib/PowerRenameManager.cpp
+++ b/src/modules/powerrename/lib/PowerRenameManager.cpp
@@ -329,6 +329,12 @@ IFACEMETHODIMP CPowerRenameManager::put_flags(_In_ DWORD flags)
     return S_OK;
 }
 
+IFACEMETHODIMP CPowerRenameManager::get_filter(_Out_ DWORD* filter)
+{
+    *filter = m_filter;
+    return S_OK;
+}
+
 IFACEMETHODIMP CPowerRenameManager::get_renameRegEx(_COM_Outptr_ IPowerRenameRegEx** ppRegEx)
 {
     *ppRegEx = nullptr;

--- a/src/modules/powerrename/lib/PowerRenameManager.cpp
+++ b/src/modules/powerrename/lib/PowerRenameManager.cpp
@@ -263,7 +263,6 @@ IFACEMETHODIMP CPowerRenameManager::GetVisibleItemCount(_Out_ UINT* count)
         GetItemCount(count);
     }
     
-
     return S_OK;
 }
 
@@ -299,27 +298,6 @@ IFACEMETHODIMP CPowerRenameManager::GetRenameItemCount(_Out_ UINT* count)
             (*count)++;
         }
     }
- 
-    return S_OK;
-}
-
-IFACEMETHODIMP CPowerRenameManager::switchFilter(_In_ int columnNumber) 
-{
-    switch (m_filter)
-    {
-    case PowerRenameFilters::None:
-        m_filter = (columnNumber == 0)?PowerRenameFilters::Selected:PowerRenameFilters::ShouldRename;
-        break;
-    case PowerRenameFilters::Selected:
-        m_filter = (columnNumber == 0) ? PowerRenameFilters::FlagsApplicable : PowerRenameFilters::ShouldRename;
-        break;
-    case PowerRenameFilters::FlagsApplicable:
-        m_filter = (columnNumber == 0) ? PowerRenameFilters::None : PowerRenameFilters::ShouldRename;
-        break;
-    case PowerRenameFilters::ShouldRename:
-        m_filter = (columnNumber == 0) ? PowerRenameFilters::Selected : PowerRenameFilters::None;
-        break;
-    }
 
     return S_OK;
 }
@@ -345,6 +323,27 @@ IFACEMETHODIMP CPowerRenameManager::put_flags(_In_ DWORD flags)
 IFACEMETHODIMP CPowerRenameManager::get_filter(_Out_ DWORD* filter)
 {
     *filter = m_filter;
+    return S_OK;
+}
+
+IFACEMETHODIMP CPowerRenameManager::switchFilter(_In_ int columnNumber)
+{
+    switch (m_filter)
+    {
+    case PowerRenameFilters::None:
+        m_filter = (columnNumber == 0)?PowerRenameFilters::Selected:PowerRenameFilters::ShouldRename;
+        break;
+    case PowerRenameFilters::Selected:
+        m_filter = (columnNumber == 0)?PowerRenameFilters::FlagsApplicable:PowerRenameFilters::ShouldRename;
+        break;
+    case PowerRenameFilters::FlagsApplicable:
+        m_filter = (columnNumber == 0)?PowerRenameFilters::None:PowerRenameFilters::ShouldRename;
+        break;
+    case PowerRenameFilters::ShouldRename:
+        m_filter = (columnNumber == 0)?PowerRenameFilters::Selected:PowerRenameFilters::None;
+        break;
+    }
+
     return S_OK;
 }
 

--- a/src/modules/powerrename/lib/PowerRenameManager.cpp
+++ b/src/modules/powerrename/lib/PowerRenameManager.cpp
@@ -223,7 +223,7 @@ IFACEMETHODIMP CPowerRenameManager::setVisible()
         {
             lastVisibleDepth = itemDepth;
         }
-        else if ( lastVisibleDepth == itemDepth+1 )
+        else if (lastVisibleDepth == itemDepth+1)
         {
             isVisible = true;
             lastVisibleDepth = itemDepth;
@@ -292,8 +292,8 @@ IFACEMETHODIMP CPowerRenameManager::GetRenameItemCount(_Out_ UINT* count)
 
 IFACEMETHODIMP CPowerRenameManager::switchFilter(_In_ int columnNumber) 
 {
-    DWORD clickedFilter = (columnNumber == 0) ? PowerRenameFilters::Selected : PowerRenameFilters::ShoulRename;
-    m_filter = (m_filter == clickedFilter) ? PowerRenameFilters::None : clickedFilter;
+    DWORD clickedFilter = (columnNumber == 0)?PowerRenameFilters::Selected:PowerRenameFilters::ShoulRename;
+    m_filter = (m_filter == clickedFilter)?PowerRenameFilters::None:clickedFilter;
 
     return S_OK;
 }

--- a/src/modules/powerrename/lib/PowerRenameManager.cpp
+++ b/src/modules/powerrename/lib/PowerRenameManager.cpp
@@ -895,13 +895,13 @@ DWORD WINAPI CPowerRenameManager::s_regexWorkerThread(_In_ void* pv)
                                 PWSTR replaceTerm = nullptr;
                                 SYSTEMTIME LocalTime;
 
-                                if (SUCCEEDED(spRenameRegEx->get_replaceTerm(&replaceTerm)) && isFileAttributesUsed(replaceTerm))
+                                if (SUCCEEDED(spRenameRegEx->GetReplaceTerm(&replaceTerm)) && isFileAttributesUsed(replaceTerm))
                                 {
-                                    if (SUCCEEDED(spItem->get_date(&LocalTime)))
+                                    if (SUCCEEDED(spItem->GetDate(&LocalTime)))
                                     {
                                         if (SUCCEEDED(GetDatedFileName(newReplaceTerm, ARRAYSIZE(newReplaceTerm), replaceTerm, LocalTime)))
                                         {
-                                            spRenameRegEx->put_replaceTerm(newReplaceTerm);
+                                            spRenameRegEx->PutReplaceTerm(newReplaceTerm);
                                         }
                                     }
                                 }
@@ -911,7 +911,7 @@ DWORD WINAPI CPowerRenameManager::s_regexWorkerThread(_In_ void* pv)
                                 // Call put_newName with null in that case to reset it
                                 spRenameRegEx->Replace(sourceName, &newName);
 
-                                spRenameRegEx->put_replaceTerm(replaceTerm);
+                                spRenameRegEx->PutReplaceTerm(replaceTerm);
 
                                 wchar_t resultName[MAX_PATH] = { 0 };
 

--- a/src/modules/powerrename/lib/PowerRenameManager.cpp
+++ b/src/modules/powerrename/lib/PowerRenameManager.cpp
@@ -175,7 +175,7 @@ IFACEMETHODIMP CPowerRenameManager::GetVisibleItemByIndex(_In_ UINT index, _COM_
                 break;
             }
         }
-        return GetItemByIndex(realIndex, ppItem);
+        hr = GetItemByIndex(realIndex, ppItem);
     }
 
     return hr;

--- a/src/modules/powerrename/lib/PowerRenameManager.cpp
+++ b/src/modules/powerrename/lib/PowerRenameManager.cpp
@@ -117,7 +117,7 @@ IFACEMETHODIMP CPowerRenameManager::AddItem(_In_ IPowerRenameItem* pItem)
     {
         CSRWExclusiveAutoLock lock(&m_lockItems);
         int id = 0;
-        pItem->get_id(&id);
+        pItem->getId(&id);
         // Verify the item isn't already added
         if (m_renameItems.find(id) == m_renameItems.end())
         {
@@ -222,7 +222,7 @@ IFACEMETHODIMP CPowerRenameManager::setVisible()
         rit->second->IsItemVisible(m_filter, m_flags, &isVisible);
 
         UINT itemDepth = 0;
-        rit->second->get_depth(&itemDepth);
+        rit->second->getDepth(&itemDepth);
 
         //Make an item visible if it has a least one visible subitem
         if (isVisible)
@@ -276,7 +276,7 @@ IFACEMETHODIMP CPowerRenameManager::GetSelectedItemCount(_Out_ UINT* count)
     {
         IPowerRenameItem* pItem = it.second;
         bool selected = false;
-        if (SUCCEEDED(pItem->get_selected(&selected)) && selected)
+        if (SUCCEEDED(pItem->getSelected(&selected)) && selected)
         {
             (*count)++;
         }
@@ -303,25 +303,25 @@ IFACEMETHODIMP CPowerRenameManager::GetRenameItemCount(_Out_ UINT* count)
     return S_OK;
 }
 
-IFACEMETHODIMP CPowerRenameManager::get_flags(_Out_ DWORD* flags)
+IFACEMETHODIMP CPowerRenameManager::getFlags(_Out_ DWORD* flags)
 {
     _EnsureRegEx();
     *flags = m_flags;
     return S_OK;
 }
 
-IFACEMETHODIMP CPowerRenameManager::put_flags(_In_ DWORD flags)
+IFACEMETHODIMP CPowerRenameManager::putFlags(_In_ DWORD flags)
 {
     if (flags != m_flags)
     {
         m_flags = flags;
         _EnsureRegEx();
-        m_spRegEx->put_flags(flags);
+        m_spRegEx->putFlags(flags);
     }
     return S_OK;
 }
 
-IFACEMETHODIMP CPowerRenameManager::get_filter(_Out_ DWORD* filter)
+IFACEMETHODIMP CPowerRenameManager::getFilter(_Out_ DWORD* filter)
 {
     *filter = m_filter;
     return S_OK;
@@ -332,23 +332,23 @@ IFACEMETHODIMP CPowerRenameManager::switchFilter(_In_ int columnNumber)
     switch (m_filter)
     {
     case PowerRenameFilters::None:
-        m_filter = (columnNumber == 0)?PowerRenameFilters::Selected:PowerRenameFilters::ShouldRename;
+        m_filter = (columnNumber == 0) ? PowerRenameFilters::Selected : PowerRenameFilters::ShouldRename;
         break;
     case PowerRenameFilters::Selected:
-        m_filter = (columnNumber == 0)?PowerRenameFilters::FlagsApplicable:PowerRenameFilters::ShouldRename;
+        m_filter = (columnNumber == 0) ? PowerRenameFilters::FlagsApplicable : PowerRenameFilters::ShouldRename;
         break;
     case PowerRenameFilters::FlagsApplicable:
-        m_filter = (columnNumber == 0)?PowerRenameFilters::None:PowerRenameFilters::ShouldRename;
+        m_filter = (columnNumber == 0) ? PowerRenameFilters::None : PowerRenameFilters::ShouldRename;
         break;
     case PowerRenameFilters::ShouldRename:
-        m_filter = (columnNumber == 0)?PowerRenameFilters::Selected:PowerRenameFilters::None;
+        m_filter = (columnNumber == 0) ? PowerRenameFilters::Selected : PowerRenameFilters::None;
         break;
     }
 
     return S_OK;
 }
 
-IFACEMETHODIMP CPowerRenameManager::get_renameRegEx(_COM_Outptr_ IPowerRenameRegEx** ppRegEx)
+IFACEMETHODIMP CPowerRenameManager::getRenameRegEx(_COM_Outptr_ IPowerRenameRegEx** ppRegEx)
 {
     *ppRegEx = nullptr;
     HRESULT hr = _EnsureRegEx();
@@ -360,14 +360,14 @@ IFACEMETHODIMP CPowerRenameManager::get_renameRegEx(_COM_Outptr_ IPowerRenameReg
     return hr;
 }
 
-IFACEMETHODIMP CPowerRenameManager::put_renameRegEx(_In_ IPowerRenameRegEx* pRegEx)
+IFACEMETHODIMP CPowerRenameManager::putRenameRegEx(_In_ IPowerRenameRegEx* pRegEx)
 {
     _ClearRegEx();
     m_spRegEx = pRegEx;
     return S_OK;
 }
 
-IFACEMETHODIMP CPowerRenameManager::get_renameItemFactory(_COM_Outptr_ IPowerRenameItemFactory** ppItemFactory)
+IFACEMETHODIMP CPowerRenameManager::getRenameItemFactory(_COM_Outptr_ IPowerRenameItemFactory** ppItemFactory)
 {
     *ppItemFactory = nullptr;
     HRESULT hr = E_FAIL;
@@ -380,7 +380,7 @@ IFACEMETHODIMP CPowerRenameManager::get_renameItemFactory(_COM_Outptr_ IPowerRen
     return hr;
 }
 
-IFACEMETHODIMP CPowerRenameManager::put_renameItemFactory(_In_ IPowerRenameItemFactory* pItemFactory)
+IFACEMETHODIMP CPowerRenameManager::putRenameItemFactory(_In_ IPowerRenameItemFactory* pItemFactory)
 {
     m_spItemFactory = pItemFactory;
     return S_OK;
@@ -538,7 +538,7 @@ void CPowerRenameManager::_LogOperationTelemetry()
     GetItemCount(&totalItemCount);
     GetSelectedItemCount(&selectedItemCount);
     GetRenameItemCount(&renameItemCount);
-    get_flags(&flags);
+    getFlags(&flags);
 
 
     // Enumerate extensions used into a map
@@ -549,7 +549,7 @@ void CPowerRenameManager::_LogOperationTelemetry()
         if (SUCCEEDED(GetItemByIndex(i, &spItem)))
         {
             PWSTR originalName;
-            if (SUCCEEDED(spItem->get_originalName(&originalName)))
+            if (SUCCEEDED(spItem->getOriginalName(&originalName)))
             {
                 std::wstring extension = fs::path(originalName).extension().wstring();
                 std::map<std::wstring, int>::iterator it = extensionsMap.find(extension);
@@ -665,14 +665,14 @@ DWORD WINAPI CPowerRenameManager::s_fileOpWorkerThread(_In_ void* pv)
             if (WaitForSingleObject(pwtd->startEvent, INFINITE) == WAIT_OBJECT_0)
             {
                 CComPtr<IPowerRenameRegEx> spRenameRegEx;
-                if (SUCCEEDED(pwtd->spsrm->get_renameRegEx(&spRenameRegEx)))
+                if (SUCCEEDED(pwtd->spsrm->getRenameRegEx(&spRenameRegEx)))
                 {
                     // Create IFileOperation interface
                     CComPtr<IFileOperation> spFileOp;
                     if (SUCCEEDED(CoCreateInstance(CLSID_FileOperation, nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&spFileOp))))
                     {
                         DWORD flags = 0;
-                        spRenameRegEx->get_flags(&flags);
+                        spRenameRegEx->getFlags(&flags);
 
                         UINT itemCount = 0;
                         pwtd->spsrm->GetItemCount(&itemCount);
@@ -689,7 +689,7 @@ DWORD WINAPI CPowerRenameManager::s_fileOpWorkerThread(_In_ void* pv)
                             if (SUCCEEDED(pwtd->spsrm->GetItemByIndex(u, &spItem)))
                             {
                                 UINT depth = 0;
-                                spItem->get_depth(&depth);
+                                spItem->getDepth(&depth);
                                 matrix[depth].push_back(u);
                             }
                         }
@@ -706,10 +706,10 @@ DWORD WINAPI CPowerRenameManager::s_fileOpWorkerThread(_In_ void* pv)
                                     if (SUCCEEDED(spItem->ShouldRenameItem(flags, &shouldRename)) && shouldRename)
                                     {
                                         PWSTR newName = nullptr;
-                                        if (SUCCEEDED(spItem->get_newName(&newName)))
+                                        if (SUCCEEDED(spItem->getNewName(&newName)))
                                         {
                                             CComPtr<IShellItem> spShellItem;
-                                            if (SUCCEEDED(spItem->get_shellItem(&spShellItem)))
+                                            if (SUCCEEDED(spItem->getShellItem(&spShellItem)))
                                             {
                                                 spFileOp->RenameItem(spShellItem, newName, nullptr);
                                             }
@@ -814,10 +814,10 @@ DWORD WINAPI CPowerRenameManager::s_regexWorkerThread(_In_ void* pv)
             if (WaitForSingleObject(pwtd->startEvent, INFINITE) == WAIT_OBJECT_0)
             {
                 CComPtr<IPowerRenameRegEx> spRenameRegEx;
-                if (SUCCEEDED(pwtd->spsrm->get_renameRegEx(&spRenameRegEx)))
+                if (SUCCEEDED(pwtd->spsrm->getRenameRegEx(&spRenameRegEx)))
                 {
                     DWORD flags = 0;
-                    spRenameRegEx->get_flags(&flags);
+                    spRenameRegEx->getFlags(&flags);
 
                     UINT itemCount = 0;
                     unsigned long itemEnumIndex = 1;
@@ -837,18 +837,18 @@ DWORD WINAPI CPowerRenameManager::s_regexWorkerThread(_In_ void* pv)
                         if (SUCCEEDED(pwtd->spsrm->GetItemByIndex(u, &spItem)))
                         {
                             int id = -1;
-                            spItem->get_id(&id);
+                            spItem->getId(&id);
 
                             bool isFolder = false;
                             bool isSubFolderContent = false;
-                            spItem->get_isFolder(&isFolder);
-                            spItem->get_isSubFolderContent(&isSubFolderContent);
+                            spItem->getIsFolder(&isFolder);
+                            spItem->getIsSubFolderContent(&isSubFolderContent);
                             if ((isFolder && (flags & PowerRenameFlags::ExcludeFolders)) ||
                                 (!isFolder && (flags & PowerRenameFlags::ExcludeFiles)) ||
                                 (isSubFolderContent && (flags & PowerRenameFlags::ExcludeSubfolders)))
                             {
                                 // Exclude this item from renaming.  Ensure new name is cleared.
-                                spItem->put_newName(nullptr);
+                                spItem->putNewName(nullptr);
 
                                 // Send the manager thread the item processed message
                                 PostMessage(pwtd->hwndManager, SRM_REGEX_ITEM_UPDATED, GetCurrentThreadId(), id);
@@ -857,10 +857,10 @@ DWORD WINAPI CPowerRenameManager::s_regexWorkerThread(_In_ void* pv)
                             }
 
                             PWSTR originalName = nullptr;
-                            if (SUCCEEDED(spItem->get_originalName(&originalName)))
+                            if (SUCCEEDED(spItem->getOriginalName(&originalName)))
                             {
                                 PWSTR currentNewName = nullptr;
-                                spItem->get_newName(&currentNewName);
+                                spItem->getNewName(&currentNewName);
 
                                 wchar_t sourceName[MAX_PATH] = { 0 };
                                 if (flags & NameOnly)
@@ -974,7 +974,7 @@ DWORD WINAPI CPowerRenameManager::s_regexWorkerThread(_In_ void* pv)
                                     itemEnumIndex++;
                                 }
 
-                                spItem->put_newName(newNameToUse);
+                                spItem->putNewName(newNameToUse);
 
                                 // Was there a change?
                                 if (lstrcmp(currentNewName, newNameToUse) != 0)
@@ -1048,7 +1048,7 @@ HRESULT CPowerRenameManager::_EnsureRegEx()
             // Get the flags
             if (SUCCEEDED(hr))
             {
-                m_spRegEx->get_flags(&m_flags);
+                m_spRegEx->getFlags(&m_flags);
             }
         }
     }

--- a/src/modules/powerrename/lib/PowerRenameManager.cpp
+++ b/src/modules/powerrename/lib/PowerRenameManager.cpp
@@ -218,21 +218,16 @@ IFACEMETHODIMP CPowerRenameManager::setVisible()
         UINT itemDepth = 0;
         rit->second->get_depth(&itemDepth);
 
-        /*Make an item visible if it has a least one visible subitem
-
+        //Make an item visible if it has a least one visible subitem
         if (isVisible)
         {
             lastVisibleDepth = itemDepth;
         }
-        else if ( lastVisibleDepth > itemDepth )
+        else if ( lastVisibleDepth == itemDepth+1 )
         {
             isVisible = true;
+            lastVisibleDepth = itemDepth;
         }
-        else if ( lastVisibleDepth < itemDepth )
-        {
-            lastVisibleDepth = 0;
-        }*/
-
         
         m_isVisible[i] = isVisible;
         hr = S_OK;

--- a/src/modules/powerrename/lib/PowerRenameManager.cpp
+++ b/src/modules/powerrename/lib/PowerRenameManager.cpp
@@ -208,17 +208,17 @@ IFACEMETHODIMP CPowerRenameManager::GetItemCount(_Out_ UINT* count)
 
 IFACEMETHODIMP CPowerRenameManager::setVisible()
 {
-    IPowerRenameItem* item = nullptr;
     HRESULT hr = E_FAIL;
-    UINT lastVisibleDepth = 0;
-    for (size_t i = m_isVisible.size(); i-- > 0;)
+    UINT lastVisibleDepth = 0, i = m_isVisible.size() - 1;
+    for (auto rit = m_renameItems.rbegin(); rit != m_renameItems.rend(); ++rit, --i)
     {
         bool isVisible = false;
-        GetItemByIndex(i, &item);
-        item->IsItemVisible(m_filter, m_flags, &isVisible);
+        rit->second->IsItemVisible(m_filter, m_flags, &isVisible);
 
         UINT itemDepth = 0;
-        item->get_depth(&itemDepth);
+        rit->second->get_depth(&itemDepth);
+
+        /*Make an item visible if it has a least one visible subitem
 
         if (isVisible)
         {
@@ -231,7 +231,7 @@ IFACEMETHODIMP CPowerRenameManager::setVisible()
         else if ( lastVisibleDepth < itemDepth )
         {
             lastVisibleDepth = 0;
-        }
+        }*/
 
         
         m_isVisible[i] = isVisible;
@@ -294,31 +294,6 @@ IFACEMETHODIMP CPowerRenameManager::GetRenameItemCount(_Out_ UINT* count)
  
     return S_OK;
 }
-
-struct cmp
-{
-    public:
-    cmp(std::vector<bool> shouldAppear) { 
-        this->shouldAppear = shouldAppear; 
-    }
-
-    bool operator()(const std::pair<int, IPowerRenameItem*>& a, const std::pair<int, IPowerRenameItem*>& b)
-    {
-        /*bool isSelected1, isSelected2;
-        a.second->ShouldRenameItem(flags, &isSelected1);
-        b.second->ShouldRenameItem(flags, &isSelected2);*/
-
-        if (shouldAppear[a.first-2] && !shouldAppear[b.first-2])
-            return true;
-        else if (!shouldAppear[a.first-2] && shouldAppear[b.first-2])
-            return false;
-        else
-            return a.first < b.first;
-    }
-
-    private:
-    std::vector<bool> shouldAppear;
-};
 
 IFACEMETHODIMP CPowerRenameManager::toggleFilter() 
 {

--- a/src/modules/powerrename/lib/PowerRenameManager.cpp
+++ b/src/modules/powerrename/lib/PowerRenameManager.cpp
@@ -292,8 +292,21 @@ IFACEMETHODIMP CPowerRenameManager::GetRenameItemCount(_Out_ UINT* count)
 
 IFACEMETHODIMP CPowerRenameManager::switchFilter(_In_ int columnNumber) 
 {
-    DWORD clickedFilter = (columnNumber == 0)?PowerRenameFilters::Selected:PowerRenameFilters::ShoulRename;
-    m_filter = (m_filter == clickedFilter)?PowerRenameFilters::None:clickedFilter;
+    switch (m_filter)
+    {
+    case PowerRenameFilters::None:
+        m_filter = (columnNumber == 0)?PowerRenameFilters::Selected:PowerRenameFilters::ShouldRename;
+        break;
+    case PowerRenameFilters::Selected:
+        m_filter = (columnNumber == 0) ? PowerRenameFilters::FlagsApplicable : PowerRenameFilters::ShouldRename;
+        break;
+    case PowerRenameFilters::FlagsApplicable:
+        m_filter = (columnNumber == 0) ? PowerRenameFilters::None : PowerRenameFilters::ShouldRename;
+        break;
+    case PowerRenameFilters::ShouldRename:
+        m_filter = (columnNumber == 0) ? PowerRenameFilters::Selected : PowerRenameFilters::None;
+        break;
+    }
 
     return S_OK;
 }

--- a/src/modules/powerrename/lib/PowerRenameManager.cpp
+++ b/src/modules/powerrename/lib/PowerRenameManager.cpp
@@ -213,6 +213,7 @@ IFACEMETHODIMP CPowerRenameManager::GetItemCount(_Out_ UINT* count)
 
 IFACEMETHODIMP CPowerRenameManager::setVisible()
 {
+    CSRWSharedAutoLock lock(&m_lockItems);
     HRESULT hr = E_FAIL;
     UINT lastVisibleDepth = 0, i = m_isVisible.size() - 1;
     for (auto rit = m_renameItems.rbegin(); rit != m_renameItems.rend(); ++rit, --i)

--- a/src/modules/powerrename/lib/PowerRenameManager.cpp
+++ b/src/modules/powerrename/lib/PowerRenameManager.cpp
@@ -290,9 +290,11 @@ IFACEMETHODIMP CPowerRenameManager::GetRenameItemCount(_Out_ UINT* count)
     return S_OK;
 }
 
-IFACEMETHODIMP CPowerRenameManager::toggleFilter() 
+IFACEMETHODIMP CPowerRenameManager::switchFilter(_In_ int columnNumber) 
 {
-    m_filter = !m_filter;
+    DWORD clickedFilter = (columnNumber == 0) ? PowerRenameFilters::Selected : PowerRenameFilters::ShoulRename;
+    m_filter = (m_filter == clickedFilter) ? PowerRenameFilters::None : clickedFilter;
+
     return S_OK;
 }
 

--- a/src/modules/powerrename/lib/PowerRenameManager.h
+++ b/src/modules/powerrename/lib/PowerRenameManager.h
@@ -29,18 +29,18 @@ public:
     IFACEMETHODIMP GetVisibleItemByIndex(_In_ UINT index, _COM_Outptr_ IPowerRenameItem** ppItem);
     IFACEMETHODIMP GetItemById(_In_ int id, _COM_Outptr_ IPowerRenameItem** ppItem);
     IFACEMETHODIMP GetItemCount(_Out_ UINT* count);
-    IFACEMETHODIMP setVisible();
+    IFACEMETHODIMP SetVisible();
     IFACEMETHODIMP GetVisibleItemCount(_Out_ UINT* count);
     IFACEMETHODIMP GetSelectedItemCount(_Out_ UINT* count);
     IFACEMETHODIMP GetRenameItemCount(_Out_ UINT* count);
-    IFACEMETHODIMP getFlags(_Out_ DWORD* flags);
-    IFACEMETHODIMP putFlags(_In_ DWORD flags);
-    IFACEMETHODIMP getFilter(_Out_ DWORD* filter);
-    IFACEMETHODIMP switchFilter(_In_ int columnNumber);
-    IFACEMETHODIMP getRenameRegEx(_COM_Outptr_ IPowerRenameRegEx** ppRegEx);
-    IFACEMETHODIMP putRenameRegEx(_In_ IPowerRenameRegEx* pRegEx);
-    IFACEMETHODIMP getRenameItemFactory(_COM_Outptr_ IPowerRenameItemFactory** ppItemFactory);
-    IFACEMETHODIMP putRenameItemFactory(_In_ IPowerRenameItemFactory* pItemFactory);
+    IFACEMETHODIMP GetFlags(_Out_ DWORD* flags);
+    IFACEMETHODIMP PutFlags(_In_ DWORD flags);
+    IFACEMETHODIMP GetFilter(_Out_ DWORD* filter);
+    IFACEMETHODIMP SwitchFilter(_In_ int columnNumber);
+    IFACEMETHODIMP GetRenameRegEx(_COM_Outptr_ IPowerRenameRegEx** ppRegEx);
+    IFACEMETHODIMP PutRenameRegEx(_In_ IPowerRenameRegEx* pRegEx);
+    IFACEMETHODIMP GetRenameItemFactory(_COM_Outptr_ IPowerRenameItemFactory** ppItemFactory);
+    IFACEMETHODIMP PutRenameItemFactory(_In_ IPowerRenameItemFactory* pItemFactory);
 
     // IPowerRenameRegExEvents
     IFACEMETHODIMP OnSearchTermChanged(_In_ PCWSTR searchTerm);

--- a/src/modules/powerrename/lib/PowerRenameManager.h
+++ b/src/modules/powerrename/lib/PowerRenameManager.h
@@ -26,11 +26,14 @@ public:
     IFACEMETHODIMP Rename(_In_ HWND hwndParent);
     IFACEMETHODIMP AddItem(_In_ IPowerRenameItem* pItem);
     IFACEMETHODIMP GetItemByIndex(_In_ UINT index, _COM_Outptr_ IPowerRenameItem** ppItem);
+    IFACEMETHODIMP GetVisibleItemByIndex(_In_ UINT index, _COM_Outptr_ IPowerRenameItem** ppItem);
     IFACEMETHODIMP GetItemById(_In_ int id, _COM_Outptr_ IPowerRenameItem** ppItem);
     IFACEMETHODIMP GetItemCount(_Out_ UINT* count);
+    IFACEMETHODIMP CPowerRenameManager::setVisible();
+    IFACEMETHODIMP GetVisibleItemCount(_Out_ UINT* count);
     IFACEMETHODIMP GetSelectedItemCount(_Out_ UINT* count);
     IFACEMETHODIMP GetRenameItemCount(_Out_ UINT* count);
-    IFACEMETHODIMP SortItems( _In_ bool isFilterOn );
+    IFACEMETHODIMP toggleFilter();
     IFACEMETHODIMP get_flags(_Out_ DWORD* flags);
     IFACEMETHODIMP put_flags(_In_ DWORD flags);
     IFACEMETHODIMP get_renameRegEx(_COM_Outptr_ IPowerRenameRegEx** ppRegEx);
@@ -97,12 +100,13 @@ protected:
 
     CSRWLock m_lockEvents;
     CSRWLock m_lockItems;
-    CSRWLock m_lockItemsNoFilter;
 
     DWORD m_flags = 0;
 
     DWORD m_cookie = 0;
     DWORD m_regExAdviseCookie = 0;
+
+    bool m_filter = false;
 
     struct RENAME_MGR_EVENT
     {
@@ -115,7 +119,7 @@ protected:
 
     _Guarded_by_(m_lockEvents) std::vector<RENAME_MGR_EVENT> m_powerRenameManagerEvents;
     _Guarded_by_(m_lockItems) std::map<int, IPowerRenameItem*> m_renameItems;
-    _Guarded_by_(m_lockItemsNoFilter) std::map<int, IPowerRenameItem*> m_renameItemsNoFilter;
+    _Guarded_by_(m_lockItems) std::vector<bool> m_isVisible;
 
     // Parent HWND used by IFileOperation
     HWND m_hwndParent = nullptr;

--- a/src/modules/powerrename/lib/PowerRenameManager.h
+++ b/src/modules/powerrename/lib/PowerRenameManager.h
@@ -33,7 +33,7 @@ public:
     IFACEMETHODIMP GetVisibleItemCount(_Out_ UINT* count);
     IFACEMETHODIMP GetSelectedItemCount(_Out_ UINT* count);
     IFACEMETHODIMP GetRenameItemCount(_Out_ UINT* count);
-    IFACEMETHODIMP toggleFilter();
+    IFACEMETHODIMP switchFilter(_In_ int columnNumber);
     IFACEMETHODIMP get_flags(_Out_ DWORD* flags);
     IFACEMETHODIMP put_flags(_In_ DWORD flags);
     IFACEMETHODIMP get_renameRegEx(_COM_Outptr_ IPowerRenameRegEx** ppRegEx);
@@ -106,7 +106,7 @@ protected:
     DWORD m_cookie = 0;
     DWORD m_regExAdviseCookie = 0;
 
-    bool m_filter = false;
+    DWORD m_filter = PowerRenameFilters::None;
 
     struct RENAME_MGR_EVENT
     {

--- a/src/modules/powerrename/lib/PowerRenameManager.h
+++ b/src/modules/powerrename/lib/PowerRenameManager.h
@@ -30,6 +30,7 @@ public:
     IFACEMETHODIMP GetItemCount(_Out_ UINT* count);
     IFACEMETHODIMP GetSelectedItemCount(_Out_ UINT* count);
     IFACEMETHODIMP GetRenameItemCount(_Out_ UINT* count);
+    IFACEMETHODIMP SortItems( _In_ bool isFilterOn );
     IFACEMETHODIMP get_flags(_Out_ DWORD* flags);
     IFACEMETHODIMP put_flags(_In_ DWORD flags);
     IFACEMETHODIMP get_renameRegEx(_COM_Outptr_ IPowerRenameRegEx** ppRegEx);
@@ -96,6 +97,7 @@ protected:
 
     CSRWLock m_lockEvents;
     CSRWLock m_lockItems;
+    CSRWLock m_lockItemsNoFilter;
 
     DWORD m_flags = 0;
 
@@ -113,6 +115,7 @@ protected:
 
     _Guarded_by_(m_lockEvents) std::vector<RENAME_MGR_EVENT> m_powerRenameManagerEvents;
     _Guarded_by_(m_lockItems) std::map<int, IPowerRenameItem*> m_renameItems;
+    _Guarded_by_(m_lockItemsNoFilter) std::map<int, IPowerRenameItem*> m_renameItemsNoFilter;
 
     // Parent HWND used by IFileOperation
     HWND m_hwndParent = nullptr;

--- a/src/modules/powerrename/lib/PowerRenameManager.h
+++ b/src/modules/powerrename/lib/PowerRenameManager.h
@@ -33,10 +33,10 @@ public:
     IFACEMETHODIMP GetVisibleItemCount(_Out_ UINT* count);
     IFACEMETHODIMP GetSelectedItemCount(_Out_ UINT* count);
     IFACEMETHODIMP GetRenameItemCount(_Out_ UINT* count);
-    IFACEMETHODIMP switchFilter(_In_ int columnNumber);
     IFACEMETHODIMP get_flags(_Out_ DWORD* flags);
     IFACEMETHODIMP put_flags(_In_ DWORD flags);
     IFACEMETHODIMP get_filter(_Out_ DWORD* filter);
+    IFACEMETHODIMP switchFilter(_In_ int columnNumber);
     IFACEMETHODIMP get_renameRegEx(_COM_Outptr_ IPowerRenameRegEx** ppRegEx);
     IFACEMETHODIMP put_renameRegEx(_In_ IPowerRenameRegEx* pRegEx);
     IFACEMETHODIMP get_renameItemFactory(_COM_Outptr_ IPowerRenameItemFactory** ppItemFactory);

--- a/src/modules/powerrename/lib/PowerRenameManager.h
+++ b/src/modules/powerrename/lib/PowerRenameManager.h
@@ -36,6 +36,7 @@ public:
     IFACEMETHODIMP switchFilter(_In_ int columnNumber);
     IFACEMETHODIMP get_flags(_Out_ DWORD* flags);
     IFACEMETHODIMP put_flags(_In_ DWORD flags);
+    IFACEMETHODIMP get_filter(_Out_ DWORD* filter);
     IFACEMETHODIMP get_renameRegEx(_COM_Outptr_ IPowerRenameRegEx** ppRegEx);
     IFACEMETHODIMP put_renameRegEx(_In_ IPowerRenameRegEx* pRegEx);
     IFACEMETHODIMP get_renameItemFactory(_COM_Outptr_ IPowerRenameItemFactory** ppItemFactory);

--- a/src/modules/powerrename/lib/PowerRenameManager.h
+++ b/src/modules/powerrename/lib/PowerRenameManager.h
@@ -33,14 +33,14 @@ public:
     IFACEMETHODIMP GetVisibleItemCount(_Out_ UINT* count);
     IFACEMETHODIMP GetSelectedItemCount(_Out_ UINT* count);
     IFACEMETHODIMP GetRenameItemCount(_Out_ UINT* count);
-    IFACEMETHODIMP get_flags(_Out_ DWORD* flags);
-    IFACEMETHODIMP put_flags(_In_ DWORD flags);
-    IFACEMETHODIMP get_filter(_Out_ DWORD* filter);
+    IFACEMETHODIMP getFlags(_Out_ DWORD* flags);
+    IFACEMETHODIMP putFlags(_In_ DWORD flags);
+    IFACEMETHODIMP getFilter(_Out_ DWORD* filter);
     IFACEMETHODIMP switchFilter(_In_ int columnNumber);
-    IFACEMETHODIMP get_renameRegEx(_COM_Outptr_ IPowerRenameRegEx** ppRegEx);
-    IFACEMETHODIMP put_renameRegEx(_In_ IPowerRenameRegEx* pRegEx);
-    IFACEMETHODIMP get_renameItemFactory(_COM_Outptr_ IPowerRenameItemFactory** ppItemFactory);
-    IFACEMETHODIMP put_renameItemFactory(_In_ IPowerRenameItemFactory* pItemFactory);
+    IFACEMETHODIMP getRenameRegEx(_COM_Outptr_ IPowerRenameRegEx** ppRegEx);
+    IFACEMETHODIMP putRenameRegEx(_In_ IPowerRenameRegEx* pRegEx);
+    IFACEMETHODIMP getRenameItemFactory(_COM_Outptr_ IPowerRenameItemFactory** ppItemFactory);
+    IFACEMETHODIMP putRenameItemFactory(_In_ IPowerRenameItemFactory* pItemFactory);
 
     // IPowerRenameRegExEvents
     IFACEMETHODIMP OnSearchTermChanged(_In_ PCWSTR searchTerm);

--- a/src/modules/powerrename/lib/PowerRenameManager.h
+++ b/src/modules/powerrename/lib/PowerRenameManager.h
@@ -29,7 +29,7 @@ public:
     IFACEMETHODIMP GetVisibleItemByIndex(_In_ UINT index, _COM_Outptr_ IPowerRenameItem** ppItem);
     IFACEMETHODIMP GetItemById(_In_ int id, _COM_Outptr_ IPowerRenameItem** ppItem);
     IFACEMETHODIMP GetItemCount(_Out_ UINT* count);
-    IFACEMETHODIMP CPowerRenameManager::setVisible();
+    IFACEMETHODIMP setVisible();
     IFACEMETHODIMP GetVisibleItemCount(_Out_ UINT* count);
     IFACEMETHODIMP GetSelectedItemCount(_Out_ UINT* count);
     IFACEMETHODIMP GetRenameItemCount(_Out_ UINT* count);

--- a/src/modules/powerrename/lib/PowerRenameRegEx.cpp
+++ b/src/modules/powerrename/lib/PowerRenameRegEx.cpp
@@ -71,7 +71,7 @@ IFACEMETHODIMP CPowerRenameRegEx::UnAdvise(_In_ DWORD cookie)
     return hr;
 }
 
-IFACEMETHODIMP CPowerRenameRegEx::getSearchTerm(_Outptr_ PWSTR* searchTerm)
+IFACEMETHODIMP CPowerRenameRegEx::GetSearchTerm(_Outptr_ PWSTR* searchTerm)
 {
     *searchTerm = nullptr;
     HRESULT hr = m_searchTerm ? S_OK : E_FAIL;
@@ -83,7 +83,7 @@ IFACEMETHODIMP CPowerRenameRegEx::getSearchTerm(_Outptr_ PWSTR* searchTerm)
     return hr;
 }
 
-IFACEMETHODIMP CPowerRenameRegEx::putSearchTerm(_In_ PCWSTR searchTerm)
+IFACEMETHODIMP CPowerRenameRegEx::PutSearchTerm(_In_ PCWSTR searchTerm)
 {
     bool changed = false;
     HRESULT hr = searchTerm ? S_OK : E_INVALIDARG;
@@ -106,7 +106,7 @@ IFACEMETHODIMP CPowerRenameRegEx::putSearchTerm(_In_ PCWSTR searchTerm)
     return hr;
 }
 
-IFACEMETHODIMP CPowerRenameRegEx::getReplaceTerm(_Outptr_ PWSTR* replaceTerm)
+IFACEMETHODIMP CPowerRenameRegEx::GetReplaceTerm(_Outptr_ PWSTR* replaceTerm)
 {
     *replaceTerm = nullptr;
     HRESULT hr = m_replaceTerm ? S_OK : E_FAIL;
@@ -118,7 +118,7 @@ IFACEMETHODIMP CPowerRenameRegEx::getReplaceTerm(_Outptr_ PWSTR* replaceTerm)
     return hr;
 }
 
-IFACEMETHODIMP CPowerRenameRegEx::putReplaceTerm(_In_ PCWSTR replaceTerm)
+IFACEMETHODIMP CPowerRenameRegEx::PutReplaceTerm(_In_ PCWSTR replaceTerm)
 {
     bool changed = false;
     HRESULT hr = replaceTerm ? S_OK : E_INVALIDARG;
@@ -141,13 +141,13 @@ IFACEMETHODIMP CPowerRenameRegEx::putReplaceTerm(_In_ PCWSTR replaceTerm)
     return hr;
 }
 
-IFACEMETHODIMP CPowerRenameRegEx::getFlags(_Out_ DWORD* flags)
+IFACEMETHODIMP CPowerRenameRegEx::GetFlags(_Out_ DWORD* flags)
 {
     *flags = m_flags;
     return S_OK;
 }
 
-IFACEMETHODIMP CPowerRenameRegEx::putFlags(_In_ DWORD flags)
+IFACEMETHODIMP CPowerRenameRegEx::PutFlags(_In_ DWORD flags)
 {
     if (m_flags != flags)
     {

--- a/src/modules/powerrename/lib/PowerRenameRegEx.cpp
+++ b/src/modules/powerrename/lib/PowerRenameRegEx.cpp
@@ -71,7 +71,7 @@ IFACEMETHODIMP CPowerRenameRegEx::UnAdvise(_In_ DWORD cookie)
     return hr;
 }
 
-IFACEMETHODIMP CPowerRenameRegEx::get_searchTerm(_Outptr_ PWSTR* searchTerm)
+IFACEMETHODIMP CPowerRenameRegEx::getSearchTerm(_Outptr_ PWSTR* searchTerm)
 {
     *searchTerm = nullptr;
     HRESULT hr = m_searchTerm ? S_OK : E_FAIL;
@@ -83,7 +83,7 @@ IFACEMETHODIMP CPowerRenameRegEx::get_searchTerm(_Outptr_ PWSTR* searchTerm)
     return hr;
 }
 
-IFACEMETHODIMP CPowerRenameRegEx::put_searchTerm(_In_ PCWSTR searchTerm)
+IFACEMETHODIMP CPowerRenameRegEx::putSearchTerm(_In_ PCWSTR searchTerm)
 {
     bool changed = false;
     HRESULT hr = searchTerm ? S_OK : E_INVALIDARG;
@@ -106,7 +106,7 @@ IFACEMETHODIMP CPowerRenameRegEx::put_searchTerm(_In_ PCWSTR searchTerm)
     return hr;
 }
 
-IFACEMETHODIMP CPowerRenameRegEx::get_replaceTerm(_Outptr_ PWSTR* replaceTerm)
+IFACEMETHODIMP CPowerRenameRegEx::getReplaceTerm(_Outptr_ PWSTR* replaceTerm)
 {
     *replaceTerm = nullptr;
     HRESULT hr = m_replaceTerm ? S_OK : E_FAIL;
@@ -118,7 +118,7 @@ IFACEMETHODIMP CPowerRenameRegEx::get_replaceTerm(_Outptr_ PWSTR* replaceTerm)
     return hr;
 }
 
-IFACEMETHODIMP CPowerRenameRegEx::put_replaceTerm(_In_ PCWSTR replaceTerm)
+IFACEMETHODIMP CPowerRenameRegEx::putReplaceTerm(_In_ PCWSTR replaceTerm)
 {
     bool changed = false;
     HRESULT hr = replaceTerm ? S_OK : E_INVALIDARG;
@@ -141,13 +141,13 @@ IFACEMETHODIMP CPowerRenameRegEx::put_replaceTerm(_In_ PCWSTR replaceTerm)
     return hr;
 }
 
-IFACEMETHODIMP CPowerRenameRegEx::get_flags(_Out_ DWORD* flags)
+IFACEMETHODIMP CPowerRenameRegEx::getFlags(_Out_ DWORD* flags)
 {
     *flags = m_flags;
     return S_OK;
 }
 
-IFACEMETHODIMP CPowerRenameRegEx::put_flags(_In_ DWORD flags)
+IFACEMETHODIMP CPowerRenameRegEx::putFlags(_In_ DWORD flags)
 {
     if (m_flags != flags)
     {

--- a/src/modules/powerrename/lib/PowerRenameRegEx.h
+++ b/src/modules/powerrename/lib/PowerRenameRegEx.h
@@ -19,12 +19,12 @@ public:
     // IPowerRenameRegEx
     IFACEMETHODIMP Advise(_In_ IPowerRenameRegExEvents* regExEvents, _Out_ DWORD* cookie);
     IFACEMETHODIMP UnAdvise(_In_ DWORD cookie);
-    IFACEMETHODIMP getSearchTerm(_Outptr_ PWSTR* searchTerm);
-    IFACEMETHODIMP putSearchTerm(_In_ PCWSTR searchTerm);
-    IFACEMETHODIMP getReplaceTerm(_Outptr_ PWSTR* replaceTerm);
-    IFACEMETHODIMP putReplaceTerm(_In_ PCWSTR replaceTerm);
-    IFACEMETHODIMP getFlags(_Out_ DWORD* flags);
-    IFACEMETHODIMP putFlags(_In_ DWORD flags);
+    IFACEMETHODIMP GetSearchTerm(_Outptr_ PWSTR* searchTerm);
+    IFACEMETHODIMP PutSearchTerm(_In_ PCWSTR searchTerm);
+    IFACEMETHODIMP GetReplaceTerm(_Outptr_ PWSTR* replaceTerm);
+    IFACEMETHODIMP PutReplaceTerm(_In_ PCWSTR replaceTerm);
+    IFACEMETHODIMP GetFlags(_Out_ DWORD* flags);
+    IFACEMETHODIMP PutFlags(_In_ DWORD flags);
     IFACEMETHODIMP Replace(_In_ PCWSTR source, _Outptr_ PWSTR* result);
 
     static HRESULT s_CreateInstance(_Outptr_ IPowerRenameRegEx **renameRegEx);

--- a/src/modules/powerrename/lib/PowerRenameRegEx.h
+++ b/src/modules/powerrename/lib/PowerRenameRegEx.h
@@ -19,12 +19,12 @@ public:
     // IPowerRenameRegEx
     IFACEMETHODIMP Advise(_In_ IPowerRenameRegExEvents* regExEvents, _Out_ DWORD* cookie);
     IFACEMETHODIMP UnAdvise(_In_ DWORD cookie);
-    IFACEMETHODIMP get_searchTerm(_Outptr_ PWSTR* searchTerm);
-    IFACEMETHODIMP put_searchTerm(_In_ PCWSTR searchTerm);
-    IFACEMETHODIMP get_replaceTerm(_Outptr_ PWSTR* replaceTerm);
-    IFACEMETHODIMP put_replaceTerm(_In_ PCWSTR replaceTerm);
-    IFACEMETHODIMP get_flags(_Out_ DWORD* flags);
-    IFACEMETHODIMP put_flags(_In_ DWORD flags);
+    IFACEMETHODIMP getSearchTerm(_Outptr_ PWSTR* searchTerm);
+    IFACEMETHODIMP putSearchTerm(_In_ PCWSTR searchTerm);
+    IFACEMETHODIMP getReplaceTerm(_Outptr_ PWSTR* replaceTerm);
+    IFACEMETHODIMP putReplaceTerm(_In_ PCWSTR replaceTerm);
+    IFACEMETHODIMP getFlags(_Out_ DWORD* flags);
+    IFACEMETHODIMP putFlags(_In_ DWORD flags);
     IFACEMETHODIMP Replace(_In_ PCWSTR source, _Outptr_ PWSTR* result);
 
     static HRESULT s_CreateInstance(_Outptr_ IPowerRenameRegEx **renameRegEx);

--- a/src/modules/powerrename/testapp/PowerRenameTest.cpp
+++ b/src/modules/powerrename/testapp/PowerRenameTest.cpp
@@ -43,7 +43,7 @@ int APIENTRY wWinMain(
             if (SUCCEEDED(CPowerRenameItem::s_CreateInstance(nullptr, IID_PPV_ARGS(&spsrif))))
             {
                 // Pass the factory to the manager
-                if (SUCCEEDED(spsrm->putRenameItemFactory(spsrif)))
+                if (SUCCEEDED(spsrm->PutRenameItemFactory(spsrif)))
                 {
                     // Create the rename UI instance and pass the manager
                     CComPtr<IPowerRenameUI> spsrui;

--- a/src/modules/powerrename/testapp/PowerRenameTest.cpp
+++ b/src/modules/powerrename/testapp/PowerRenameTest.cpp
@@ -43,7 +43,7 @@ int APIENTRY wWinMain(
             if (SUCCEEDED(CPowerRenameItem::s_CreateInstance(nullptr, IID_PPV_ARGS(&spsrif))))
             {
                 // Pass the factory to the manager
-                if (SUCCEEDED(spsrm->put_renameItemFactory(spsrif)))
+                if (SUCCEEDED(spsrm->putRenameItemFactory(spsrif)))
                 {
                     // Create the rename UI instance and pass the manager
                     CComPtr<IPowerRenameUI> spsrui;

--- a/src/modules/powerrename/ui/PowerRenameUI.cpp
+++ b/src/modules/powerrename/ui/PowerRenameUI.cpp
@@ -1060,16 +1060,17 @@ void CPowerRenameListView::ToggleAll(_In_ IPowerRenameManager* psrm, _In_ bool s
     if (m_hwndLV)
     {
         UINT itemCount = 0;
-        psrm->GetVisibleItemCount(&itemCount);
+        psrm->GetItemCount(&itemCount);
         for (UINT i = 0; i < itemCount; i++)
         {
             CComPtr<IPowerRenameItem> spItem;
-            if (SUCCEEDED(psrm->GetVisibleItemByIndex(i, &spItem)))
+            if (SUCCEEDED(psrm->GetItemByIndex(i, &spItem)))
             {
                 spItem->put_selected(selected);
             }
         }
 
+        psrm->GetVisibleItemCount(&itemCount);
         RedrawItems(0, itemCount);
         SetItemCount(itemCount);
     }

--- a/src/modules/powerrename/ui/PowerRenameUI.cpp
+++ b/src/modules/powerrename/ui/PowerRenameUI.cpp
@@ -704,12 +704,19 @@ BOOL CPowerRenameUI::_OnNotify(_In_ WPARAM wParam, _In_ LPARAM lParam)
     LPNMHDR pnmdr = (LPNMHDR)lParam;
     LPNMLISTVIEW pnmlv = (LPNMLISTVIEW)pnmdr;
     NMLVEMPTYMARKUP* pnmMarkup = NULL;
-
+    
     if (pnmdr)
     {
         BOOL checked = FALSE;
         switch (pnmdr->code)
         {
+        case LVN_COLUMNCLICK:
+            if (m_spsrm)
+            {
+                m_listview.OnColumnClick(m_spsrm, pnmdr);
+                _UpdateCounts();
+            }
+            break;
         case HDN_ITEMSTATEICONCLICK:
             if (m_spsrm)
             {
@@ -1312,3 +1319,35 @@ void CPowerRenameListView::_UpdateHeaderCheckState(_In_ bool check)
         Header_SetItem(hwndHeader, 0, &hdi);
     }
 }
+int CALLBACK comp(LPARAM lParam1, LPARAM lParam2, LPARAM lParam)
+{
+    NMLISTVIEW* pnmlv = (NMLISTVIEW*)lParam;
+
+    TCHAR str[MAX_PATH];
+    TCHAR str2[MAX_PATH];
+
+    ListView_GetItemText(pnmlv->hdr.hwndFrom, lParam1, pnmlv->iSubItem, str, MAX_PATH);
+    ListView_GetItemText(pnmlv->hdr.hwndFrom, lParam2, pnmlv->iSubItem, str2, MAX_PATH);
+
+
+    MessageBox(NULL, str2, str, MB_OK | MB_SYSTEMMODAL);
+    return (lstrcmp(str2, str));
+}
+void CPowerRenameListView::OnColumnClick(_In_ IPowerRenameManager* psrm, LPNMHDR pnmListView)
+{
+    isFilterOn = isFilterOn ? false : true ;
+
+    psrm->SortItems( isFilterOn );
+
+    UINT itemCount, renamingCount;
+    psrm->GetItemCount(&itemCount);
+    psrm->GetRenameItemCount(&renamingCount);
+
+    
+    RedrawItems(0, itemCount);
+
+    ListView_SetItemCount(m_hwndLV, isFilterOn ? renamingCount :itemCount);
+
+    //ListView_SortItems(m_hwndLV, comp, 1);
+}
+    

--- a/src/modules/powerrename/ui/PowerRenameUI.cpp
+++ b/src/modules/powerrename/ui/PowerRenameUI.cpp
@@ -1327,12 +1327,71 @@ void CPowerRenameListView::_UpdateHeaderCheckState(_In_ bool check)
     }
 }
 
+void CPowerRenameListView::_UpdateHeaderFilterState(_In_ DWORD filter)
+{
+    // Get a handle to the header of the columns
+    HWND hwndHeader = ListView_GetHeader(m_hwndLV);
+    if (hwndHeader)
+    {
+        wchar_t bufferOriginal[MAX_PATH] = { 0 };
+        bufferOriginal[0] = L'\0';
+
+        // Retrieve the existing header first so we
+        // don't trash the text already there
+        HDITEM hdiOriginal = { 0 };
+        hdiOriginal.mask = HDI_FORMAT | HDI_TEXT;
+        hdiOriginal.pszText = bufferOriginal;
+        hdiOriginal.cchTextMax = ARRAYSIZE(bufferOriginal);
+
+        Header_GetItem(hwndHeader, 0, &hdiOriginal);
+
+        if (filter == PowerRenameFilters::Selected || filter == PowerRenameFilters::FlagsApplicable)
+        {
+            hdiOriginal.fmt |= HDF_SORTDOWN;
+        }
+        else
+        {
+            hdiOriginal.fmt &= ~HDF_SORTDOWN;
+        }
+
+        Header_SetItem(hwndHeader, 0, &hdiOriginal);
+
+        wchar_t bufferRename[MAX_PATH] = { 0 };
+        bufferRename[0] = L'\0';
+
+        // Retrieve the existing header first so we
+        // don't trash the text already there
+        HDITEM hdiRename = { 0 };
+        hdiRename.mask = HDI_FORMAT | HDI_TEXT;
+        hdiRename.pszText = bufferRename;
+        hdiRename.cchTextMax = ARRAYSIZE(bufferRename);
+
+        Header_GetItem(hwndHeader, 1, &hdiRename);
+
+        if (filter == PowerRenameFilters::ShouldRename)
+        {
+            hdiRename.fmt |= HDF_SORTDOWN;
+        }
+        else
+        {
+            hdiRename.fmt &= ~HDF_SORTDOWN;
+        }
+
+        Header_SetItem(hwndHeader, 1, &hdiRename);
+
+    }
+}
+
 void CPowerRenameListView::OnColumnClick(_In_ IPowerRenameManager* psrm, _In_ int columnNumber)
 {
+    DWORD filter = PowerRenameFilters::None;
     psrm->switchFilter(columnNumber);
     UINT visibleItemCount = 0;
     psrm->GetVisibleItemCount(&visibleItemCount);
     RedrawItems(0, visibleItemCount);
     SetItemCount(visibleItemCount);
+
+    psrm->get_filter(&filter);
+    _UpdateHeaderFilterState(filter);
 }
     

--- a/src/modules/powerrename/ui/PowerRenameUI.cpp
+++ b/src/modules/powerrename/ui/PowerRenameUI.cpp
@@ -180,8 +180,8 @@ IFACEMETHODIMP CPowerRenameUI::OnUpdate(_In_ IPowerRenameItem*)
     {
         m_spsrm->GetVisibleItemCount(&visibleItemCount);
     }
-    m_listview.RedrawItems(0, visibleItemCount);
     m_listview.SetItemCount(visibleItemCount);
+    m_listview.RedrawItems(0, visibleItemCount);
     _UpdateCounts();
     return S_OK;
 }
@@ -1071,8 +1071,8 @@ void CPowerRenameListView::ToggleAll(_In_ IPowerRenameManager* psrm, _In_ bool s
         }
 
         psrm->GetVisibleItemCount(&visibleItemCount);
-        RedrawItems(0, visibleItemCount);
         SetItemCount(visibleItemCount);
+        RedrawItems(0, visibleItemCount);
     }
 }
 
@@ -1088,8 +1088,8 @@ void CPowerRenameListView::ToggleItem(_In_ IPowerRenameManager* psrm, _In_ int i
         
         UINT visibleItemCount = 0;
         psrm->GetVisibleItemCount(&visibleItemCount);
-        RedrawItems(0, visibleItemCount);
         SetItemCount(visibleItemCount);
+        RedrawItems(0, visibleItemCount);
     }
 }
 
@@ -1138,8 +1138,8 @@ void CPowerRenameListView::UpdateItemCheckState(_In_ IPowerRenameManager* psrm, 
             // Update the rename column if necessary
             UINT visibleItemCount = 0;
             psrm->GetVisibleItemCount(&visibleItemCount);
-            RedrawItems(0, visibleItemCount);
             SetItemCount(visibleItemCount);
+            RedrawItems(0, visibleItemCount);
         }
 
         // Get the total number of list items and compare it to what is selected
@@ -1243,7 +1243,11 @@ void CPowerRenameListView::RedrawItems(_In_ int first, _In_ int last)
 
 void CPowerRenameListView::SetItemCount(_In_ UINT itemCount)
 {
-    ListView_SetItemCount(m_hwndLV, itemCount);
+    if (m_itemCount != itemCount)
+    {
+        m_itemCount = itemCount;
+        ListView_SetItemCount(m_hwndLV, itemCount);
+    }
 }
 
 void CPowerRenameListView::_UpdateColumns()
@@ -1388,8 +1392,8 @@ void CPowerRenameListView::OnColumnClick(_In_ IPowerRenameManager* psrm, _In_ in
     psrm->switchFilter(columnNumber);
     UINT visibleItemCount = 0;
     psrm->GetVisibleItemCount(&visibleItemCount);
-    RedrawItems(0, visibleItemCount);
     SetItemCount(visibleItemCount);
+    RedrawItems(0, visibleItemCount);
 
     psrm->get_filter(&filter);
     _UpdateHeaderFilterState(filter);

--- a/src/modules/powerrename/ui/PowerRenameUI.cpp
+++ b/src/modules/powerrename/ui/PowerRenameUI.cpp
@@ -714,7 +714,7 @@ BOOL CPowerRenameUI::_OnNotify(_In_ WPARAM wParam, _In_ LPARAM lParam)
         case LVN_COLUMNCLICK:
             if (m_spsrm)
             {
-                m_listview.OnColumnClick(m_spsrm, pnmdr);
+                m_listview.OnColumnClick(m_spsrm, ((LPNMLISTVIEW)lParam)->iSubItem);
             }
             break;
         case HDN_ITEMSTATEICONCLICK:
@@ -1329,9 +1329,9 @@ void CPowerRenameListView::_UpdateHeaderCheckState(_In_ bool check)
     }
 }
 
-void CPowerRenameListView::OnColumnClick(_In_ IPowerRenameManager* psrm, LPNMHDR pnmListView)
+void CPowerRenameListView::OnColumnClick(_In_ IPowerRenameManager* psrm, _In_ int columnNumber)
 {
-    psrm->toggleFilter();
+    psrm->switchFilter(columnNumber);
     UINT itemCount = 0;
     psrm->GetVisibleItemCount(&itemCount);
     ListView_RedrawItems(m_hwndLV, 0, itemCount);

--- a/src/modules/powerrename/ui/PowerRenameUI.cpp
+++ b/src/modules/powerrename/ui/PowerRenameUI.cpp
@@ -175,13 +175,13 @@ IFACEMETHODIMP CPowerRenameUI::OnItemAdded(_In_ IPowerRenameItem*)
 
 IFACEMETHODIMP CPowerRenameUI::OnUpdate(_In_ IPowerRenameItem*)
 {
-    UINT itemCount = 0;
+    UINT visibleItemCount = 0;
     if (m_spsrm)
     {
-        m_spsrm->GetVisibleItemCount(&itemCount);
+        m_spsrm->GetVisibleItemCount(&visibleItemCount);
     }
-    m_listview.RedrawItems(0, itemCount);
-    m_listview.SetItemCount(itemCount);
+    m_listview.RedrawItems(0, visibleItemCount);
+    m_listview.SetItemCount(visibleItemCount);
     _UpdateCounts();
     return S_OK;
 }
@@ -1059,7 +1059,7 @@ void CPowerRenameListView::ToggleAll(_In_ IPowerRenameManager* psrm, _In_ bool s
 {
     if (m_hwndLV)
     {
-        UINT itemCount = 0;
+        UINT visibleItemCount = 0, itemCount = 0;
         psrm->GetItemCount(&itemCount);
         for (UINT i = 0; i < itemCount; i++)
         {
@@ -1070,9 +1070,9 @@ void CPowerRenameListView::ToggleAll(_In_ IPowerRenameManager* psrm, _In_ bool s
             }
         }
 
-        psrm->GetVisibleItemCount(&itemCount);
-        RedrawItems(0, itemCount);
-        SetItemCount(itemCount);
+        psrm->GetVisibleItemCount(&visibleItemCount);
+        RedrawItems(0, visibleItemCount);
+        SetItemCount(visibleItemCount);
     }
 }
 
@@ -1086,10 +1086,10 @@ void CPowerRenameListView::ToggleItem(_In_ IPowerRenameManager* psrm, _In_ int i
         spItem->put_selected(!selected);
 
         
-        UINT itemCount = 0;
-        psrm->GetVisibleItemCount(&itemCount);
-        ListView_RedrawItems(m_hwndLV, 0, itemCount);
-        ListView_SetItemCount(m_hwndLV, itemCount);
+        UINT visibleItemCount = 0;
+        psrm->GetVisibleItemCount(&visibleItemCount);
+        RedrawItems(0, visibleItemCount);
+        SetItemCount(visibleItemCount);
     }
 }
 
@@ -1136,12 +1136,10 @@ void CPowerRenameListView::UpdateItemCheckState(_In_ IPowerRenameManager* psrm, 
             ListView_SetItemState(m_hwndLV, iItem, uSelected, LVIS_SELECTED);
 
             // Update the rename column if necessary
-            int id = 0;
-            spItem->get_id(&id);
-            UINT itemCount = 0;
-            psrm->GetVisibleItemCount(&itemCount);
-            ListView_RedrawItems(m_hwndLV, 0, itemCount);
-            ListView_SetItemCount(m_hwndLV, itemCount);
+            UINT visibleItemCount = 0;
+            psrm->GetVisibleItemCount(&visibleItemCount);
+            RedrawItems(0, visibleItemCount);
+            SetItemCount(visibleItemCount);
         }
 
         // Get the total number of list items and compare it to what is selected
@@ -1332,9 +1330,9 @@ void CPowerRenameListView::_UpdateHeaderCheckState(_In_ bool check)
 void CPowerRenameListView::OnColumnClick(_In_ IPowerRenameManager* psrm, _In_ int columnNumber)
 {
     psrm->switchFilter(columnNumber);
-    UINT itemCount = 0;
-    psrm->GetVisibleItemCount(&itemCount);
-    ListView_RedrawItems(m_hwndLV, 0, itemCount);
-    ListView_SetItemCount(m_hwndLV, itemCount);
+    UINT visibleItemCount = 0;
+    psrm->GetVisibleItemCount(&visibleItemCount);
+    RedrawItems(0, visibleItemCount);
+    SetItemCount(visibleItemCount);
 }
     

--- a/src/modules/powerrename/ui/PowerRenameUI.cpp
+++ b/src/modules/powerrename/ui/PowerRenameUI.cpp
@@ -154,13 +154,13 @@ IFACEMETHODIMP CPowerRenameUI::Update()
     return S_OK;
 }
 
-IFACEMETHODIMP CPowerRenameUI::get_hwnd(_Out_ HWND* hwnd)
+IFACEMETHODIMP CPowerRenameUI::GetHwnd(_Out_ HWND* hwnd)
 {
     *hwnd = m_hwnd;
     return S_OK;
 }
 
-IFACEMETHODIMP CPowerRenameUI::get_showUI(_Out_ bool* showUI)
+IFACEMETHODIMP CPowerRenameUI::GetShowUI(_Out_ bool* showUI)
 {
     // Let callers know that it is OK to show UI (ex: progress dialog, error dialog and conflict dialog UI)
     *showUI = true;
@@ -401,14 +401,14 @@ HRESULT CPowerRenameUI::_ReadSettings()
     if (CSettingsInstance().GetPersistState())
     {
         flags = CSettingsInstance().GetFlags();
-        m_spsrm->putFlags(flags);
+        m_spsrm->PutFlags(flags);
 
         SetDlgItemText(m_hwnd, IDC_EDIT_SEARCHFOR, CSettingsInstance().GetSearchText().c_str());
         SetDlgItemText(m_hwnd, IDC_EDIT_REPLACEWITH, CSettingsInstance().GetReplaceText().c_str());
     }
     else
     {
-        m_spsrm->getFlags(&flags);
+        m_spsrm->GetFlags(&flags);
     }
 
     _SetCheckboxesFromFlags(flags);
@@ -422,7 +422,7 @@ HRESULT CPowerRenameUI::_WriteSettings()
     if (CSettingsInstance().GetPersistState())
     {
         DWORD flags = 0;
-        m_spsrm->getFlags(&flags);
+        m_spsrm->GetFlags(&flags);
         CSettingsInstance().SetFlags(flags);
 
         wchar_t buffer[CSettings::MAX_INPUT_STRING_LEN];
@@ -861,16 +861,16 @@ void CPowerRenameUI::_OnSearchReplaceChanged()
 {
     // Pass updated search and replace terms to the IPowerRenameRegEx handler
     CComPtr<IPowerRenameRegEx> spRegEx;
-    if (m_spsrm && SUCCEEDED(m_spsrm->getRenameRegEx(&spRegEx)))
+    if (m_spsrm && SUCCEEDED(m_spsrm->GetRenameRegEx(&spRegEx)))
     {
         wchar_t buffer[CSettings::MAX_INPUT_STRING_LEN];
         buffer[0] = L'\0';
         GetDlgItemText(m_hwnd, IDC_EDIT_SEARCHFOR, buffer, ARRAYSIZE(buffer));
-        spRegEx->putSearchTerm(buffer);
+        spRegEx->PutSearchTerm(buffer);
 
         buffer[0] = L'\0';
         GetDlgItemText(m_hwnd, IDC_EDIT_REPLACEWITH, buffer, ARRAYSIZE(buffer));
-        spRegEx->putReplaceTerm(buffer);
+        spRegEx->PutReplaceTerm(buffer);
     }
 }
 
@@ -888,7 +888,7 @@ DWORD CPowerRenameUI::_GetFlagsFromCheckboxes()
     // Ensure we update flags
     if (m_spsrm)
     {
-        m_spsrm->putFlags(flags);
+        m_spsrm->PutFlags(flags);
     }
 
     return flags;
@@ -1066,7 +1066,7 @@ void CPowerRenameListView::ToggleAll(_In_ IPowerRenameManager* psrm, _In_ bool s
             CComPtr<IPowerRenameItem> spItem;
             if (SUCCEEDED(psrm->GetItemByIndex(i, &spItem)))
             {
-                spItem->putSelected(selected);
+                spItem->PutSelected(selected);
             }
         }
 
@@ -1082,8 +1082,8 @@ void CPowerRenameListView::ToggleItem(_In_ IPowerRenameManager* psrm, _In_ int i
     if (SUCCEEDED(psrm->GetVisibleItemByIndex(item, &spItem)))
     {
         bool selected = false;
-        spItem->getSelected(&selected);
-        spItem->putSelected(!selected);
+        spItem->GetSelected(&selected);
+        spItem->PutSelected(!selected);
 
         
         UINT visibleItemCount = 0;
@@ -1130,7 +1130,7 @@ void CPowerRenameListView::UpdateItemCheckState(_In_ IPowerRenameManager* psrm, 
         if (SUCCEEDED(psrm->GetVisibleItemByIndex(iItem, &spItem)))
         {
             bool checked = ListView_GetCheckState(m_hwndLV, iItem);
-            spItem->putSelected(checked);
+            spItem->PutSelected(checked);
 
             UINT uSelected = (checked) ? LVIS_SELECTED : 0;
             ListView_SetItemState(m_hwndLV, iItem, uSelected, LVIS_SELECTED);
@@ -1168,7 +1168,7 @@ void CPowerRenameListView::GetDisplayInfo(_In_ IPowerRenameManager* psrm, _Inout
     {
         if (plvdi->item.mask & LVIF_IMAGE)
         {
-            renameItem->getIconIndex(&plvdi->item.iImage);
+            renameItem->GetIconIndex(&plvdi->item.iImage);
         }
 
         if (plvdi->item.mask & LVIF_STATE)
@@ -1176,7 +1176,7 @@ void CPowerRenameListView::GetDisplayInfo(_In_ IPowerRenameManager* psrm, _Inout
             plvdi->item.stateMask = LVIS_STATEIMAGEMASK;
 
             bool isSelected = false;
-            renameItem->getSelected(&isSelected);
+            renameItem->GetSelected(&isSelected);
             if (isSelected)
             {
                 // Turn check box on
@@ -1192,14 +1192,14 @@ void CPowerRenameListView::GetDisplayInfo(_In_ IPowerRenameManager* psrm, _Inout
         if (plvdi->item.mask & LVIF_PARAM)
         {
             int id = 0;
-            renameItem->getId(&id);
+            renameItem->GetId(&id);
             plvdi->item.lParam = static_cast<LPARAM>(id);
         }
 
         if (plvdi->item.mask & LVIF_INDENT)
         {
             UINT depth = 0;
-            renameItem->getDepth(&depth);
+            renameItem->GetDepth(&depth);
             plvdi->item.iIndent = static_cast<int>(depth);
         }
 
@@ -1208,16 +1208,16 @@ void CPowerRenameListView::GetDisplayInfo(_In_ IPowerRenameManager* psrm, _Inout
             PWSTR subItemText = nullptr;
             if (plvdi->item.iSubItem == COL_ORIGINAL_NAME)
             {
-                renameItem->getOriginalName(&subItemText);
+                renameItem->GetOriginalName(&subItemText);
             }
             else if (plvdi->item.iSubItem == COL_NEW_NAME)
             {
                 DWORD flags = 0;
-                psrm->getFlags(&flags);
+                psrm->GetFlags(&flags);
                 bool shouldRename = false;
                 if (SUCCEEDED(renameItem->ShouldRenameItem(flags, &shouldRename)) && shouldRename)
                 {
-                    renameItem->getNewName(&subItemText);
+                    renameItem->GetNewName(&subItemText);
                 }
             }
 
@@ -1389,13 +1389,13 @@ void CPowerRenameListView::_UpdateHeaderFilterState(_In_ DWORD filter)
 void CPowerRenameListView::OnColumnClick(_In_ IPowerRenameManager* psrm, _In_ int columnNumber)
 {
     DWORD filter = PowerRenameFilters::None;
-    psrm->switchFilter(columnNumber);
+    psrm->SwitchFilter(columnNumber);
     UINT visibleItemCount = 0;
     psrm->GetVisibleItemCount(&visibleItemCount);
     SetItemCount(visibleItemCount);
     RedrawItems(0, visibleItemCount);
 
-    psrm->getFilter(&filter);
+    psrm->GetFilter(&filter);
     _UpdateHeaderFilterState(filter);
 }
     

--- a/src/modules/powerrename/ui/PowerRenameUI.cpp
+++ b/src/modules/powerrename/ui/PowerRenameUI.cpp
@@ -401,14 +401,14 @@ HRESULT CPowerRenameUI::_ReadSettings()
     if (CSettingsInstance().GetPersistState())
     {
         flags = CSettingsInstance().GetFlags();
-        m_spsrm->put_flags(flags);
+        m_spsrm->putFlags(flags);
 
         SetDlgItemText(m_hwnd, IDC_EDIT_SEARCHFOR, CSettingsInstance().GetSearchText().c_str());
         SetDlgItemText(m_hwnd, IDC_EDIT_REPLACEWITH, CSettingsInstance().GetReplaceText().c_str());
     }
     else
     {
-        m_spsrm->get_flags(&flags);
+        m_spsrm->getFlags(&flags);
     }
 
     _SetCheckboxesFromFlags(flags);
@@ -422,7 +422,7 @@ HRESULT CPowerRenameUI::_WriteSettings()
     if (CSettingsInstance().GetPersistState())
     {
         DWORD flags = 0;
-        m_spsrm->get_flags(&flags);
+        m_spsrm->getFlags(&flags);
         CSettingsInstance().SetFlags(flags);
 
         wchar_t buffer[CSettings::MAX_INPUT_STRING_LEN];
@@ -861,16 +861,16 @@ void CPowerRenameUI::_OnSearchReplaceChanged()
 {
     // Pass updated search and replace terms to the IPowerRenameRegEx handler
     CComPtr<IPowerRenameRegEx> spRegEx;
-    if (m_spsrm && SUCCEEDED(m_spsrm->get_renameRegEx(&spRegEx)))
+    if (m_spsrm && SUCCEEDED(m_spsrm->getRenameRegEx(&spRegEx)))
     {
         wchar_t buffer[CSettings::MAX_INPUT_STRING_LEN];
         buffer[0] = L'\0';
         GetDlgItemText(m_hwnd, IDC_EDIT_SEARCHFOR, buffer, ARRAYSIZE(buffer));
-        spRegEx->put_searchTerm(buffer);
+        spRegEx->putSearchTerm(buffer);
 
         buffer[0] = L'\0';
         GetDlgItemText(m_hwnd, IDC_EDIT_REPLACEWITH, buffer, ARRAYSIZE(buffer));
-        spRegEx->put_replaceTerm(buffer);
+        spRegEx->putReplaceTerm(buffer);
     }
 }
 
@@ -888,7 +888,7 @@ DWORD CPowerRenameUI::_GetFlagsFromCheckboxes()
     // Ensure we update flags
     if (m_spsrm)
     {
-        m_spsrm->put_flags(flags);
+        m_spsrm->putFlags(flags);
     }
 
     return flags;
@@ -1066,7 +1066,7 @@ void CPowerRenameListView::ToggleAll(_In_ IPowerRenameManager* psrm, _In_ bool s
             CComPtr<IPowerRenameItem> spItem;
             if (SUCCEEDED(psrm->GetItemByIndex(i, &spItem)))
             {
-                spItem->put_selected(selected);
+                spItem->putSelected(selected);
             }
         }
 
@@ -1082,8 +1082,8 @@ void CPowerRenameListView::ToggleItem(_In_ IPowerRenameManager* psrm, _In_ int i
     if (SUCCEEDED(psrm->GetVisibleItemByIndex(item, &spItem)))
     {
         bool selected = false;
-        spItem->get_selected(&selected);
-        spItem->put_selected(!selected);
+        spItem->getSelected(&selected);
+        spItem->putSelected(!selected);
 
         
         UINT visibleItemCount = 0;
@@ -1130,7 +1130,7 @@ void CPowerRenameListView::UpdateItemCheckState(_In_ IPowerRenameManager* psrm, 
         if (SUCCEEDED(psrm->GetVisibleItemByIndex(iItem, &spItem)))
         {
             bool checked = ListView_GetCheckState(m_hwndLV, iItem);
-            spItem->put_selected(checked);
+            spItem->putSelected(checked);
 
             UINT uSelected = (checked) ? LVIS_SELECTED : 0;
             ListView_SetItemState(m_hwndLV, iItem, uSelected, LVIS_SELECTED);
@@ -1168,7 +1168,7 @@ void CPowerRenameListView::GetDisplayInfo(_In_ IPowerRenameManager* psrm, _Inout
     {
         if (plvdi->item.mask & LVIF_IMAGE)
         {
-            renameItem->get_iconIndex(&plvdi->item.iImage);
+            renameItem->getIconIndex(&plvdi->item.iImage);
         }
 
         if (plvdi->item.mask & LVIF_STATE)
@@ -1176,7 +1176,7 @@ void CPowerRenameListView::GetDisplayInfo(_In_ IPowerRenameManager* psrm, _Inout
             plvdi->item.stateMask = LVIS_STATEIMAGEMASK;
 
             bool isSelected = false;
-            renameItem->get_selected(&isSelected);
+            renameItem->getSelected(&isSelected);
             if (isSelected)
             {
                 // Turn check box on
@@ -1192,14 +1192,14 @@ void CPowerRenameListView::GetDisplayInfo(_In_ IPowerRenameManager* psrm, _Inout
         if (plvdi->item.mask & LVIF_PARAM)
         {
             int id = 0;
-            renameItem->get_id(&id);
+            renameItem->getId(&id);
             plvdi->item.lParam = static_cast<LPARAM>(id);
         }
 
         if (plvdi->item.mask & LVIF_INDENT)
         {
             UINT depth = 0;
-            renameItem->get_depth(&depth);
+            renameItem->getDepth(&depth);
             plvdi->item.iIndent = static_cast<int>(depth);
         }
 
@@ -1208,16 +1208,16 @@ void CPowerRenameListView::GetDisplayInfo(_In_ IPowerRenameManager* psrm, _Inout
             PWSTR subItemText = nullptr;
             if (plvdi->item.iSubItem == COL_ORIGINAL_NAME)
             {
-                renameItem->get_originalName(&subItemText);
+                renameItem->getOriginalName(&subItemText);
             }
             else if (plvdi->item.iSubItem == COL_NEW_NAME)
             {
                 DWORD flags = 0;
-                psrm->get_flags(&flags);
+                psrm->getFlags(&flags);
                 bool shouldRename = false;
                 if (SUCCEEDED(renameItem->ShouldRenameItem(flags, &shouldRename)) && shouldRename)
                 {
-                    renameItem->get_newName(&subItemText);
+                    renameItem->getNewName(&subItemText);
                 }
             }
 
@@ -1395,7 +1395,7 @@ void CPowerRenameListView::OnColumnClick(_In_ IPowerRenameManager* psrm, _In_ in
     SetItemCount(visibleItemCount);
     RedrawItems(0, visibleItemCount);
 
-    psrm->get_filter(&filter);
+    psrm->getFilter(&filter);
     _UpdateHeaderFilterState(filter);
 }
     

--- a/src/modules/powerrename/ui/PowerRenameUI.h
+++ b/src/modules/powerrename/ui/PowerRenameUI.h
@@ -31,6 +31,7 @@ private:
     void _UpdateHeaderCheckState(_In_ bool check);
     void _UpdateHeaderFilterState(_In_ DWORD filter);
 
+    UINT m_itemCount = 0;
     HWND m_hwndLV = nullptr;
 };
 

--- a/src/modules/powerrename/ui/PowerRenameUI.h
+++ b/src/modules/powerrename/ui/PowerRenameUI.h
@@ -20,6 +20,7 @@ public:
     void SetItemCount(_In_ UINT itemCount);
     void OnKeyDown(_In_ IPowerRenameManager* psrm, _In_ LV_KEYDOWN* lvKeyDown);
     void OnClickList(_In_ IPowerRenameManager* psrm, NM_LISTVIEW* pnmListView);
+    void OnColumnClick(_In_ IPowerRenameManager* psrm, LPNMHDR pnmListView);
     void GetDisplayInfo(_In_ IPowerRenameManager* psrm, _Inout_ LV_DISPINFO* plvdi);
     void OnSize();
     HWND GetHWND() { return m_hwndLV; }
@@ -29,6 +30,7 @@ private:
     void _UpdateColumnSizes();
     void _UpdateHeaderCheckState(_In_ bool check);
 
+    bool isFilterOn = false;
     HWND m_hwndLV = nullptr;
 };
 

--- a/src/modules/powerrename/ui/PowerRenameUI.h
+++ b/src/modules/powerrename/ui/PowerRenameUI.h
@@ -54,8 +54,8 @@ public:
     IFACEMETHODIMP Show(_In_opt_ HWND hwndParent);
     IFACEMETHODIMP Close();
     IFACEMETHODIMP Update();
-    IFACEMETHODIMP get_hwnd(_Out_ HWND* hwnd);
-    IFACEMETHODIMP get_showUI(_Out_ bool* showUI);
+    IFACEMETHODIMP GetHwnd(_Out_ HWND* hwnd);
+    IFACEMETHODIMP GetShowUI(_Out_ bool* showUI);
 
     // IPowerRenameManagerEvents
     IFACEMETHODIMP OnItemAdded(_In_ IPowerRenameItem* renameItem);

--- a/src/modules/powerrename/ui/PowerRenameUI.h
+++ b/src/modules/powerrename/ui/PowerRenameUI.h
@@ -20,7 +20,7 @@ public:
     void SetItemCount(_In_ UINT itemCount);
     void OnKeyDown(_In_ IPowerRenameManager* psrm, _In_ LV_KEYDOWN* lvKeyDown);
     void OnClickList(_In_ IPowerRenameManager* psrm, NM_LISTVIEW* pnmListView);
-    void OnColumnClick(_In_ IPowerRenameManager* psrm, LPNMHDR pnmListView);
+    void OnColumnClick(_In_ IPowerRenameManager* psrm, _In_ int pnmListView);
     void GetDisplayInfo(_In_ IPowerRenameManager* psrm, _Inout_ LV_DISPINFO* plvdi);
     void OnSize();
     HWND GetHWND() { return m_hwndLV; }

--- a/src/modules/powerrename/ui/PowerRenameUI.h
+++ b/src/modules/powerrename/ui/PowerRenameUI.h
@@ -29,6 +29,7 @@ private:
     void _UpdateColumns();
     void _UpdateColumnSizes();
     void _UpdateHeaderCheckState(_In_ bool check);
+    void _UpdateHeaderFilterState(_In_ DWORD filter);
 
     HWND m_hwndLV = nullptr;
 };

--- a/src/modules/powerrename/ui/PowerRenameUI.h
+++ b/src/modules/powerrename/ui/PowerRenameUI.h
@@ -30,7 +30,6 @@ private:
     void _UpdateColumnSizes();
     void _UpdateHeaderCheckState(_In_ bool check);
 
-    bool isFilterOn = false;
     HWND m_hwndLV = nullptr;
 };
 

--- a/src/modules/powerrename/unittests/PowerRenameManagerTests.cpp
+++ b/src/modules/powerrename/unittests/PowerRenameManagerTests.cpp
@@ -81,13 +81,13 @@ namespace PowerRenameManagerTests
             // TODO: Setup match and replace parameters
             wchar_t newReplaceTerm[MAX_PATH] = { 0 };
             CComPtr<IPowerRenameRegEx> renRegEx;
-            Assert::IsTrue(mgr->get_renameRegEx(&renRegEx) == S_OK);
+            Assert::IsTrue(mgr->GetRenameRegEx(&renRegEx) == S_OK);
             renRegEx->PutFlags(flags);
             renRegEx->PutSearchTerm(searchTerm.c_str());
             if (isFileAttributesUsed(replaceTerm.c_str()) && SUCCEEDED(GetDatedFileName(newReplaceTerm, ARRAYSIZE(newReplaceTerm), replaceTerm.c_str(), LocalTime)))
             {
                 renRegEx->PutReplaceTerm(newReplaceTerm);
-            }                
+            }
             else
             {
                 renRegEx->PutReplaceTerm(replaceTerm.c_str());
@@ -284,7 +284,7 @@ namespace PowerRenameManagerTests
         {
             rename_pairs renamePairs[] = {
                 { L"foo.FOO", L"foo.bar", false, true, 0 },
-                { L"foo.bar", L"foo.bar_rename", false, false, 0 }
+                { L"foo.bar", L"foo.bar_norename", false, false, 0 }
             };
 
             RenameHelper(renamePairs, ARRAYSIZE(renamePairs), L"foo", L"bar", SYSTEMTIME{ 2020, 7, 3, 22, 15, 6, 42, 453 }, DEFAULT_FLAGS | Lowercase | ExtensionOnly);

--- a/src/modules/powerrename/unittests/PowerRenameManagerTests.cpp
+++ b/src/modules/powerrename/unittests/PowerRenameManagerTests.cpp
@@ -68,13 +68,13 @@ namespace PowerRenameManagerTests
                                                      &item);
 
                 int itemId = 0;
-                Assert::IsTrue(item->get_id(&itemId) == S_OK);
+                Assert::IsTrue(item->getId(&itemId) == S_OK);
                 mgr->AddItem(item);
 
                 // Verify the item we added is the same from the event
                 Assert::IsTrue(mockMgrEvents->m_itemAdded != nullptr && mockMgrEvents->m_itemAdded == item);
                 int eventItemId = 0;
-                Assert::IsTrue(mockMgrEvents->m_itemAdded->get_id(&eventItemId) == S_OK);
+                Assert::IsTrue(mockMgrEvents->m_itemAdded->getId(&eventItemId) == S_OK);
                 Assert::IsTrue(itemId == eventItemId);
             }
 
@@ -82,17 +82,16 @@ namespace PowerRenameManagerTests
             wchar_t newReplaceTerm[MAX_PATH] = { 0 };
             CComPtr<IPowerRenameRegEx> renRegEx;
             Assert::IsTrue(mgr->get_renameRegEx(&renRegEx) == S_OK);
-            renRegEx->put_flags(flags);
-            renRegEx->put_searchTerm(searchTerm.c_str());
+            renRegEx->PutFlags(flags);
+            renRegEx->PutSearchTerm(searchTerm.c_str());
             if (isFileAttributesUsed(replaceTerm.c_str()) && SUCCEEDED(GetDatedFileName(newReplaceTerm, ARRAYSIZE(newReplaceTerm), replaceTerm.c_str(), LocalTime)))
             {
-                renRegEx->put_replaceTerm(newReplaceTerm);
+                renRegEx->PutReplaceTerm(newReplaceTerm);
             }                
             else
             {
-                renRegEx->put_replaceTerm(replaceTerm.c_str());
+                renRegEx->PutReplaceTerm(replaceTerm.c_str());
             }
-
             Sleep(1000);
 
             // Perform the rename
@@ -146,13 +145,13 @@ namespace PowerRenameManagerTests
             CComPtr<IPowerRenameItem> item;
             CMockPowerRenameItem::CreateInstance(L"foo", L"foo", 0, false, &item);
             int itemId = 0;
-            Assert::IsTrue(item->get_id(&itemId) == S_OK);
+            Assert::IsTrue(item->getId(&itemId) == S_OK);
             mgr->AddItem(item);
 
             // Verify the item we added is the same from the event
             Assert::IsTrue(mockMgrEvents->m_itemAdded != nullptr && mockMgrEvents->m_itemAdded == item);
             int eventItemId = 0;
-            Assert::IsTrue(mockMgrEvents->m_itemAdded->get_id(&eventItemId) == S_OK);
+            Assert::IsTrue(mockMgrEvents->m_itemAdded->getId(&eventItemId) == S_OK);
             Assert::IsTrue(itemId == eventItemId);
             Assert::IsTrue(mgr->Shutdown() == S_OK);
 

--- a/src/modules/powerrename/unittests/PowerRenameManagerTests.cpp
+++ b/src/modules/powerrename/unittests/PowerRenameManagerTests.cpp
@@ -68,13 +68,13 @@ namespace PowerRenameManagerTests
                                                      &item);
 
                 int itemId = 0;
-                Assert::IsTrue(item->getId(&itemId) == S_OK);
+                Assert::IsTrue(item->GetId(&itemId) == S_OK);
                 mgr->AddItem(item);
 
                 // Verify the item we added is the same from the event
                 Assert::IsTrue(mockMgrEvents->m_itemAdded != nullptr && mockMgrEvents->m_itemAdded == item);
                 int eventItemId = 0;
-                Assert::IsTrue(mockMgrEvents->m_itemAdded->getId(&eventItemId) == S_OK);
+                Assert::IsTrue(mockMgrEvents->m_itemAdded->GetId(&eventItemId) == S_OK);
                 Assert::IsTrue(itemId == eventItemId);
             }
 
@@ -145,13 +145,13 @@ namespace PowerRenameManagerTests
             CComPtr<IPowerRenameItem> item;
             CMockPowerRenameItem::CreateInstance(L"foo", L"foo", 0, false, &item);
             int itemId = 0;
-            Assert::IsTrue(item->getId(&itemId) == S_OK);
+            Assert::IsTrue(item->GetId(&itemId) == S_OK);
             mgr->AddItem(item);
 
             // Verify the item we added is the same from the event
             Assert::IsTrue(mockMgrEvents->m_itemAdded != nullptr && mockMgrEvents->m_itemAdded == item);
             int eventItemId = 0;
-            Assert::IsTrue(mockMgrEvents->m_itemAdded->getId(&eventItemId) == S_OK);
+            Assert::IsTrue(mockMgrEvents->m_itemAdded->GetId(&eventItemId) == S_OK);
             Assert::IsTrue(itemId == eventItemId);
             Assert::IsTrue(mgr->Shutdown() == S_OK);
 

--- a/src/modules/powerrename/unittests/PowerRenameRegExTests.cpp
+++ b/src/modules/powerrename/unittests/PowerRenameRegExTests.cpp
@@ -22,8 +22,8 @@ namespace PowerRenameRegExTests
                 CComPtr<IPowerRenameRegEx> renameRegEx;
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     PWSTR result = nullptr;
-    Assert::IsTrue(renameRegEx->put_searchTerm(L"foo") == S_OK);
-    Assert::IsTrue(renameRegEx->put_replaceTerm(L"big") == S_OK);
+    Assert::IsTrue(renameRegEx->putSearchTerm(L"foo") == S_OK);
+    Assert::IsTrue(renameRegEx->putReplaceTerm(L"big") == S_OK);
     Assert::IsTrue(renameRegEx->Replace(L"foobar", &result) == S_OK);
     Assert::IsTrue(wcscmp(result, L"bigbar") == 0);
     CoTaskMemFree(result);
@@ -34,8 +34,8 @@ TEST_METHOD(ReplaceNoMatch)
     CComPtr<IPowerRenameRegEx> renameRegEx;
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     PWSTR result = nullptr;
-    Assert::IsTrue(renameRegEx->put_searchTerm(L"notfound") == S_OK);
-    Assert::IsTrue(renameRegEx->put_replaceTerm(L"big") == S_OK);
+    Assert::IsTrue(renameRegEx->putSearchTerm(L"notfound") == S_OK);
+    Assert::IsTrue(renameRegEx->putReplaceTerm(L"big") == S_OK);
     Assert::IsTrue(renameRegEx->Replace(L"foobar", &result) == S_OK);
     Assert::IsTrue(wcscmp(result, L"foobar") == 0);
     CoTaskMemFree(result);
@@ -56,7 +56,7 @@ TEST_METHOD(ReplaceNoReplaceTerm)
     CComPtr<IPowerRenameRegEx> renameRegEx;
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     PWSTR result = nullptr;
-    Assert::IsTrue(renameRegEx->put_searchTerm(L"foo") == S_OK);
+    Assert::IsTrue(renameRegEx->putSearchTerm(L"foo") == S_OK);
     Assert::IsTrue(renameRegEx->Replace(L"foobar", &result) == S_OK);
     Assert::IsTrue(wcscmp(result, L"bar") == 0);
     CoTaskMemFree(result);
@@ -67,8 +67,8 @@ TEST_METHOD(ReplaceEmptyStringReplaceTerm)
     CComPtr<IPowerRenameRegEx> renameRegEx;
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     PWSTR result = nullptr;
-    Assert::IsTrue(renameRegEx->put_searchTerm(L"foo") == S_OK);
-    Assert::IsTrue(renameRegEx->put_replaceTerm(L"") == S_OK);
+    Assert::IsTrue(renameRegEx->putSearchTerm(L"foo") == S_OK);
+    Assert::IsTrue(renameRegEx->putReplaceTerm(L"") == S_OK);
     Assert::IsTrue(renameRegEx->Replace(L"foobar", &result) == S_OK);
     Assert::IsTrue(wcscmp(result, L"bar") == 0);
     CoTaskMemFree(result);
@@ -79,7 +79,7 @@ TEST_METHOD(VerifyDefaultFlags)
     CComPtr<IPowerRenameRegEx> renameRegEx;
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     DWORD flags = 0;
-    Assert::IsTrue(renameRegEx->get_flags(&flags) == S_OK);
+    Assert::IsTrue(renameRegEx->getFlags(&flags) == S_OK);
     Assert::IsTrue(flags == MatchAllOccurences);
 }
 
@@ -88,7 +88,7 @@ TEST_METHOD(VerifyCaseSensitiveSearch)
     CComPtr<IPowerRenameRegEx> renameRegEx;
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     DWORD flags = CaseSensitive;
-    Assert::IsTrue(renameRegEx->put_flags(flags) == S_OK);
+    Assert::IsTrue(renameRegEx->putFlags(flags) == S_OK);
 
     SearchReplaceExpected sreTable[] = {
         { L"Foo", L"Foo", L"FooBar", L"FooBar" },
@@ -100,8 +100,8 @@ TEST_METHOD(VerifyCaseSensitiveSearch)
     for (int i = 0; i < ARRAYSIZE(sreTable); i++)
     {
         PWSTR result = nullptr;
-        Assert::IsTrue(renameRegEx->put_searchTerm(sreTable[i].search) == S_OK);
-        Assert::IsTrue(renameRegEx->put_replaceTerm(sreTable[i].replace) == S_OK);
+        Assert::IsTrue(renameRegEx->putSearchTerm(sreTable[i].search) == S_OK);
+        Assert::IsTrue(renameRegEx->putReplaceTerm(sreTable[i].replace) == S_OK);
         Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
@@ -113,7 +113,7 @@ TEST_METHOD(VerifyReplaceFirstOnly)
     CComPtr<IPowerRenameRegEx> renameRegEx;
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     DWORD flags = 0;
-    Assert::IsTrue(renameRegEx->put_flags(flags) == S_OK);
+    Assert::IsTrue(renameRegEx->putFlags(flags) == S_OK);
 
     SearchReplaceExpected sreTable[] = {
         { L"B", L"BB", L"ABA", L"ABBA" },
@@ -124,8 +124,8 @@ TEST_METHOD(VerifyReplaceFirstOnly)
     for (int i = 0; i < ARRAYSIZE(sreTable); i++)
     {
         PWSTR result = nullptr;
-        Assert::IsTrue(renameRegEx->put_searchTerm(sreTable[i].search) == S_OK);
-        Assert::IsTrue(renameRegEx->put_replaceTerm(sreTable[i].replace) == S_OK);
+        Assert::IsTrue(renameRegEx->putSearchTerm(sreTable[i].search) == S_OK);
+        Assert::IsTrue(renameRegEx->putReplaceTerm(sreTable[i].replace) == S_OK);
         Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
@@ -137,7 +137,7 @@ TEST_METHOD(VerifyReplaceAll)
     CComPtr<IPowerRenameRegEx> renameRegEx;
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     DWORD flags = MatchAllOccurences;
-    Assert::IsTrue(renameRegEx->put_flags(flags) == S_OK);
+    Assert::IsTrue(renameRegEx->putFlags(flags) == S_OK);
 
     SearchReplaceExpected sreTable[] = {
         { L"B", L"BB", L"ABA", L"ABBA" },
@@ -148,8 +148,8 @@ TEST_METHOD(VerifyReplaceAll)
     for (int i = 0; i < ARRAYSIZE(sreTable); i++)
     {
         PWSTR result = nullptr;
-        Assert::IsTrue(renameRegEx->put_searchTerm(sreTable[i].search) == S_OK);
-        Assert::IsTrue(renameRegEx->put_replaceTerm(sreTable[i].replace) == S_OK);
+        Assert::IsTrue(renameRegEx->putSearchTerm(sreTable[i].search) == S_OK);
+        Assert::IsTrue(renameRegEx->putReplaceTerm(sreTable[i].replace) == S_OK);
         Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
@@ -161,7 +161,7 @@ TEST_METHOD(VerifyReplaceAllCaseInsensitive)
     CComPtr<IPowerRenameRegEx> renameRegEx;
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     DWORD flags = MatchAllOccurences | CaseSensitive;
-    Assert::IsTrue(renameRegEx->put_flags(flags) == S_OK);
+    Assert::IsTrue(renameRegEx->putFlags(flags) == S_OK);
 
     SearchReplaceExpected sreTable[] = {
         { L"B", L"BB", L"ABA", L"ABBA" },
@@ -173,8 +173,8 @@ TEST_METHOD(VerifyReplaceAllCaseInsensitive)
     for (int i = 0; i < ARRAYSIZE(sreTable); i++)
     {
         PWSTR result = nullptr;
-        Assert::IsTrue(renameRegEx->put_searchTerm(sreTable[i].search) == S_OK);
-        Assert::IsTrue(renameRegEx->put_replaceTerm(sreTable[i].replace) == S_OK);
+        Assert::IsTrue(renameRegEx->putSearchTerm(sreTable[i].search) == S_OK);
+        Assert::IsTrue(renameRegEx->putReplaceTerm(sreTable[i].replace) == S_OK);
         Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
@@ -186,7 +186,7 @@ TEST_METHOD(VerifyReplaceFirstOnlyUseRegEx)
     CComPtr<IPowerRenameRegEx> renameRegEx;
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     DWORD flags = UseRegularExpressions;
-    Assert::IsTrue(renameRegEx->put_flags(flags) == S_OK);
+    Assert::IsTrue(renameRegEx->putFlags(flags) == S_OK);
 
     SearchReplaceExpected sreTable[] = {
         { L"B", L"BB", L"ABA", L"ABBA" },
@@ -197,8 +197,8 @@ TEST_METHOD(VerifyReplaceFirstOnlyUseRegEx)
     for (int i = 0; i < ARRAYSIZE(sreTable); i++)
     {
         PWSTR result = nullptr;
-        Assert::IsTrue(renameRegEx->put_searchTerm(sreTable[i].search) == S_OK);
-        Assert::IsTrue(renameRegEx->put_replaceTerm(sreTable[i].replace) == S_OK);
+        Assert::IsTrue(renameRegEx->putSearchTerm(sreTable[i].search) == S_OK);
+        Assert::IsTrue(renameRegEx->putReplaceTerm(sreTable[i].replace) == S_OK);
         Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
@@ -210,7 +210,7 @@ TEST_METHOD(VerifyReplaceAllUseRegEx)
     CComPtr<IPowerRenameRegEx> renameRegEx;
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     DWORD flags = MatchAllOccurences | UseRegularExpressions;
-    Assert::IsTrue(renameRegEx->put_flags(flags) == S_OK);
+    Assert::IsTrue(renameRegEx->putFlags(flags) == S_OK);
 
     SearchReplaceExpected sreTable[] = {
         { L"B", L"BB", L"ABA", L"ABBA" },
@@ -221,8 +221,8 @@ TEST_METHOD(VerifyReplaceAllUseRegEx)
     for (int i = 0; i < ARRAYSIZE(sreTable); i++)
     {
         PWSTR result = nullptr;
-        Assert::IsTrue(renameRegEx->put_searchTerm(sreTable[i].search) == S_OK);
-        Assert::IsTrue(renameRegEx->put_replaceTerm(sreTable[i].replace) == S_OK);
+        Assert::IsTrue(renameRegEx->putSearchTerm(sreTable[i].search) == S_OK);
+        Assert::IsTrue(renameRegEx->putReplaceTerm(sreTable[i].replace) == S_OK);
         Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
@@ -234,7 +234,7 @@ TEST_METHOD(VerifyReplaceAllUseRegExCaseSensitive)
     CComPtr<IPowerRenameRegEx> renameRegEx;
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     DWORD flags = MatchAllOccurences | UseRegularExpressions | CaseSensitive;
-    Assert::IsTrue(renameRegEx->put_flags(flags) == S_OK);
+    Assert::IsTrue(renameRegEx->putFlags(flags) == S_OK);
 
     SearchReplaceExpected sreTable[] = {
         { L"B", L"BB", L"ABA", L"ABBA" },
@@ -245,8 +245,8 @@ TEST_METHOD(VerifyReplaceAllUseRegExCaseSensitive)
     for (int i = 0; i < ARRAYSIZE(sreTable); i++)
     {
         PWSTR result = nullptr;
-        Assert::IsTrue(renameRegEx->put_searchTerm(sreTable[i].search) == S_OK);
-        Assert::IsTrue(renameRegEx->put_replaceTerm(sreTable[i].replace) == S_OK);
+        Assert::IsTrue(renameRegEx->putSearchTerm(sreTable[i].search) == S_OK);
+        Assert::IsTrue(renameRegEx->putReplaceTerm(sreTable[i].replace) == S_OK);
         Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
@@ -258,7 +258,7 @@ TEST_METHOD(VerifyMatchAllWildcardUseRegEx)
     CComPtr<IPowerRenameRegEx> renameRegEx;
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     DWORD flags = MatchAllOccurences | UseRegularExpressions;
-    Assert::IsTrue(renameRegEx->put_flags(flags) == S_OK);
+    Assert::IsTrue(renameRegEx->putFlags(flags) == S_OK);
 
     SearchReplaceExpected sreTable[] = {
         { L".*", L"Foo", L"AAAAAA", L"Foo" },
@@ -267,8 +267,8 @@ TEST_METHOD(VerifyMatchAllWildcardUseRegEx)
     for (int i = 0; i < ARRAYSIZE(sreTable); i++)
     {
         PWSTR result = nullptr;
-        Assert::IsTrue(renameRegEx->put_searchTerm(sreTable[i].search) == S_OK);
-        Assert::IsTrue(renameRegEx->put_replaceTerm(sreTable[i].replace) == S_OK);
+        Assert::IsTrue(renameRegEx->putSearchTerm(sreTable[i].search) == S_OK);
+        Assert::IsTrue(renameRegEx->putReplaceTerm(sreTable[i].replace) == S_OK);
         Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
@@ -279,13 +279,13 @@ void VerifyReplaceFirstWildcard(SearchReplaceExpected sreTable[], int tableSize,
 {
     CComPtr<IPowerRenameRegEx> renameRegEx;
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
-    Assert::IsTrue(renameRegEx->put_flags(flags) == S_OK);
+    Assert::IsTrue(renameRegEx->putFlags(flags) == S_OK);
 
     for (int i = 0; i < tableSize; i++)
     {
         PWSTR result = nullptr;
-        Assert::IsTrue(renameRegEx->put_searchTerm(sreTable[i].search) == S_OK);
-        Assert::IsTrue(renameRegEx->put_replaceTerm(sreTable[i].replace) == S_OK);
+        Assert::IsTrue(renameRegEx->putSearchTerm(sreTable[i].search) == S_OK);
+        Assert::IsTrue(renameRegEx->putReplaceTerm(sreTable[i].replace) == S_OK);
         Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
         Assert::AreEqual(sreTable[i].expected, result);
         CoTaskMemFree(result);
@@ -336,7 +336,7 @@ TEST_METHOD(VerifyHandleCapturingGroups)
     CComPtr<IPowerRenameRegEx> renameRegEx;
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     DWORD flags = MatchAllOccurences | UseRegularExpressions | CaseSensitive;
-    Assert::IsTrue(renameRegEx->put_flags(flags) == S_OK);
+    Assert::IsTrue(renameRegEx->putFlags(flags) == S_OK);
 
     SearchReplaceExpected sreTable[] = {
         //search, replace, test, result
@@ -354,8 +354,8 @@ TEST_METHOD(VerifyHandleCapturingGroups)
     for (int i = 0; i < ARRAYSIZE(sreTable); i++)
     {
         PWSTR result = nullptr;
-        Assert::IsTrue(renameRegEx->put_searchTerm(sreTable[i].search) == S_OK);
-        Assert::IsTrue(renameRegEx->put_replaceTerm(sreTable[i].replace) == S_OK);
+        Assert::IsTrue(renameRegEx->putSearchTerm(sreTable[i].search) == S_OK);
+        Assert::IsTrue(renameRegEx->putReplaceTerm(sreTable[i].replace) == S_OK);
         Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
@@ -372,9 +372,9 @@ TEST_METHOD(VerifyEventsFire)
     DWORD cookie = 0;
     Assert::IsTrue(renameRegEx->Advise(regExEvents, &cookie) == S_OK);
     DWORD flags = MatchAllOccurences | UseRegularExpressions | CaseSensitive;
-    Assert::IsTrue(renameRegEx->put_flags(flags) == S_OK);
-    Assert::IsTrue(renameRegEx->put_searchTerm(L"FOO") == S_OK);
-    Assert::IsTrue(renameRegEx->put_replaceTerm(L"BAR") == S_OK);
+    Assert::IsTrue(renameRegEx->putFlags(flags) == S_OK);
+    Assert::IsTrue(renameRegEx->putSearchTerm(L"FOO") == S_OK);
+    Assert::IsTrue(renameRegEx->putReplaceTerm(L"BAR") == S_OK);
     Assert::IsTrue(lstrcmpi(L"FOO", mockEvents->m_searchTerm) == 0);
     Assert::IsTrue(lstrcmpi(L"BAR", mockEvents->m_replaceTerm) == 0);
     Assert::IsTrue(flags == mockEvents->m_flags);

--- a/src/modules/powerrename/unittests/PowerRenameRegExTests.cpp
+++ b/src/modules/powerrename/unittests/PowerRenameRegExTests.cpp
@@ -22,8 +22,8 @@ namespace PowerRenameRegExTests
                 CComPtr<IPowerRenameRegEx> renameRegEx;
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     PWSTR result = nullptr;
-    Assert::IsTrue(renameRegEx->putSearchTerm(L"foo") == S_OK);
-    Assert::IsTrue(renameRegEx->putReplaceTerm(L"big") == S_OK);
+    Assert::IsTrue(renameRegEx->PutSearchTerm(L"foo") == S_OK);
+    Assert::IsTrue(renameRegEx->PutReplaceTerm(L"big") == S_OK);
     Assert::IsTrue(renameRegEx->Replace(L"foobar", &result) == S_OK);
     Assert::IsTrue(wcscmp(result, L"bigbar") == 0);
     CoTaskMemFree(result);
@@ -34,8 +34,8 @@ TEST_METHOD(ReplaceNoMatch)
     CComPtr<IPowerRenameRegEx> renameRegEx;
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     PWSTR result = nullptr;
-    Assert::IsTrue(renameRegEx->putSearchTerm(L"notfound") == S_OK);
-    Assert::IsTrue(renameRegEx->putReplaceTerm(L"big") == S_OK);
+    Assert::IsTrue(renameRegEx->PutSearchTerm(L"notfound") == S_OK);
+    Assert::IsTrue(renameRegEx->PutReplaceTerm(L"big") == S_OK);
     Assert::IsTrue(renameRegEx->Replace(L"foobar", &result) == S_OK);
     Assert::IsTrue(wcscmp(result, L"foobar") == 0);
     CoTaskMemFree(result);
@@ -56,7 +56,7 @@ TEST_METHOD(ReplaceNoReplaceTerm)
     CComPtr<IPowerRenameRegEx> renameRegEx;
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     PWSTR result = nullptr;
-    Assert::IsTrue(renameRegEx->putSearchTerm(L"foo") == S_OK);
+    Assert::IsTrue(renameRegEx->PutSearchTerm(L"foo") == S_OK);
     Assert::IsTrue(renameRegEx->Replace(L"foobar", &result) == S_OK);
     Assert::IsTrue(wcscmp(result, L"bar") == 0);
     CoTaskMemFree(result);
@@ -67,8 +67,8 @@ TEST_METHOD(ReplaceEmptyStringReplaceTerm)
     CComPtr<IPowerRenameRegEx> renameRegEx;
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     PWSTR result = nullptr;
-    Assert::IsTrue(renameRegEx->putSearchTerm(L"foo") == S_OK);
-    Assert::IsTrue(renameRegEx->putReplaceTerm(L"") == S_OK);
+    Assert::IsTrue(renameRegEx->PutSearchTerm(L"foo") == S_OK);
+    Assert::IsTrue(renameRegEx->PutReplaceTerm(L"") == S_OK);
     Assert::IsTrue(renameRegEx->Replace(L"foobar", &result) == S_OK);
     Assert::IsTrue(wcscmp(result, L"bar") == 0);
     CoTaskMemFree(result);
@@ -79,7 +79,7 @@ TEST_METHOD(VerifyDefaultFlags)
     CComPtr<IPowerRenameRegEx> renameRegEx;
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     DWORD flags = 0;
-    Assert::IsTrue(renameRegEx->getFlags(&flags) == S_OK);
+    Assert::IsTrue(renameRegEx->GetFlags(&flags) == S_OK);
     Assert::IsTrue(flags == MatchAllOccurences);
 }
 
@@ -88,7 +88,7 @@ TEST_METHOD(VerifyCaseSensitiveSearch)
     CComPtr<IPowerRenameRegEx> renameRegEx;
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     DWORD flags = CaseSensitive;
-    Assert::IsTrue(renameRegEx->putFlags(flags) == S_OK);
+    Assert::IsTrue(renameRegEx->PutFlags(flags) == S_OK);
 
     SearchReplaceExpected sreTable[] = {
         { L"Foo", L"Foo", L"FooBar", L"FooBar" },
@@ -100,8 +100,8 @@ TEST_METHOD(VerifyCaseSensitiveSearch)
     for (int i = 0; i < ARRAYSIZE(sreTable); i++)
     {
         PWSTR result = nullptr;
-        Assert::IsTrue(renameRegEx->putSearchTerm(sreTable[i].search) == S_OK);
-        Assert::IsTrue(renameRegEx->putReplaceTerm(sreTable[i].replace) == S_OK);
+        Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
+        Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
         Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
@@ -113,7 +113,7 @@ TEST_METHOD(VerifyReplaceFirstOnly)
     CComPtr<IPowerRenameRegEx> renameRegEx;
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     DWORD flags = 0;
-    Assert::IsTrue(renameRegEx->putFlags(flags) == S_OK);
+    Assert::IsTrue(renameRegEx->PutFlags(flags) == S_OK);
 
     SearchReplaceExpected sreTable[] = {
         { L"B", L"BB", L"ABA", L"ABBA" },
@@ -124,8 +124,8 @@ TEST_METHOD(VerifyReplaceFirstOnly)
     for (int i = 0; i < ARRAYSIZE(sreTable); i++)
     {
         PWSTR result = nullptr;
-        Assert::IsTrue(renameRegEx->putSearchTerm(sreTable[i].search) == S_OK);
-        Assert::IsTrue(renameRegEx->putReplaceTerm(sreTable[i].replace) == S_OK);
+        Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
+        Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
         Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
@@ -137,7 +137,7 @@ TEST_METHOD(VerifyReplaceAll)
     CComPtr<IPowerRenameRegEx> renameRegEx;
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     DWORD flags = MatchAllOccurences;
-    Assert::IsTrue(renameRegEx->putFlags(flags) == S_OK);
+    Assert::IsTrue(renameRegEx->PutFlags(flags) == S_OK);
 
     SearchReplaceExpected sreTable[] = {
         { L"B", L"BB", L"ABA", L"ABBA" },
@@ -148,8 +148,8 @@ TEST_METHOD(VerifyReplaceAll)
     for (int i = 0; i < ARRAYSIZE(sreTable); i++)
     {
         PWSTR result = nullptr;
-        Assert::IsTrue(renameRegEx->putSearchTerm(sreTable[i].search) == S_OK);
-        Assert::IsTrue(renameRegEx->putReplaceTerm(sreTable[i].replace) == S_OK);
+        Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
+        Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
         Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
@@ -161,7 +161,7 @@ TEST_METHOD(VerifyReplaceAllCaseInsensitive)
     CComPtr<IPowerRenameRegEx> renameRegEx;
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     DWORD flags = MatchAllOccurences | CaseSensitive;
-    Assert::IsTrue(renameRegEx->putFlags(flags) == S_OK);
+    Assert::IsTrue(renameRegEx->PutFlags(flags) == S_OK);
 
     SearchReplaceExpected sreTable[] = {
         { L"B", L"BB", L"ABA", L"ABBA" },
@@ -173,8 +173,8 @@ TEST_METHOD(VerifyReplaceAllCaseInsensitive)
     for (int i = 0; i < ARRAYSIZE(sreTable); i++)
     {
         PWSTR result = nullptr;
-        Assert::IsTrue(renameRegEx->putSearchTerm(sreTable[i].search) == S_OK);
-        Assert::IsTrue(renameRegEx->putReplaceTerm(sreTable[i].replace) == S_OK);
+        Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
+        Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
         Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
@@ -186,7 +186,7 @@ TEST_METHOD(VerifyReplaceFirstOnlyUseRegEx)
     CComPtr<IPowerRenameRegEx> renameRegEx;
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     DWORD flags = UseRegularExpressions;
-    Assert::IsTrue(renameRegEx->putFlags(flags) == S_OK);
+    Assert::IsTrue(renameRegEx->PutFlags(flags) == S_OK);
 
     SearchReplaceExpected sreTable[] = {
         { L"B", L"BB", L"ABA", L"ABBA" },
@@ -197,8 +197,8 @@ TEST_METHOD(VerifyReplaceFirstOnlyUseRegEx)
     for (int i = 0; i < ARRAYSIZE(sreTable); i++)
     {
         PWSTR result = nullptr;
-        Assert::IsTrue(renameRegEx->putSearchTerm(sreTable[i].search) == S_OK);
-        Assert::IsTrue(renameRegEx->putReplaceTerm(sreTable[i].replace) == S_OK);
+        Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
+        Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
         Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
@@ -210,7 +210,7 @@ TEST_METHOD(VerifyReplaceAllUseRegEx)
     CComPtr<IPowerRenameRegEx> renameRegEx;
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     DWORD flags = MatchAllOccurences | UseRegularExpressions;
-    Assert::IsTrue(renameRegEx->putFlags(flags) == S_OK);
+    Assert::IsTrue(renameRegEx->PutFlags(flags) == S_OK);
 
     SearchReplaceExpected sreTable[] = {
         { L"B", L"BB", L"ABA", L"ABBA" },
@@ -221,8 +221,8 @@ TEST_METHOD(VerifyReplaceAllUseRegEx)
     for (int i = 0; i < ARRAYSIZE(sreTable); i++)
     {
         PWSTR result = nullptr;
-        Assert::IsTrue(renameRegEx->putSearchTerm(sreTable[i].search) == S_OK);
-        Assert::IsTrue(renameRegEx->putReplaceTerm(sreTable[i].replace) == S_OK);
+        Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
+        Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
         Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
@@ -234,7 +234,7 @@ TEST_METHOD(VerifyReplaceAllUseRegExCaseSensitive)
     CComPtr<IPowerRenameRegEx> renameRegEx;
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     DWORD flags = MatchAllOccurences | UseRegularExpressions | CaseSensitive;
-    Assert::IsTrue(renameRegEx->putFlags(flags) == S_OK);
+    Assert::IsTrue(renameRegEx->PutFlags(flags) == S_OK);
 
     SearchReplaceExpected sreTable[] = {
         { L"B", L"BB", L"ABA", L"ABBA" },
@@ -245,8 +245,8 @@ TEST_METHOD(VerifyReplaceAllUseRegExCaseSensitive)
     for (int i = 0; i < ARRAYSIZE(sreTable); i++)
     {
         PWSTR result = nullptr;
-        Assert::IsTrue(renameRegEx->putSearchTerm(sreTable[i].search) == S_OK);
-        Assert::IsTrue(renameRegEx->putReplaceTerm(sreTable[i].replace) == S_OK);
+        Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
+        Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
         Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
@@ -258,7 +258,7 @@ TEST_METHOD(VerifyMatchAllWildcardUseRegEx)
     CComPtr<IPowerRenameRegEx> renameRegEx;
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     DWORD flags = MatchAllOccurences | UseRegularExpressions;
-    Assert::IsTrue(renameRegEx->putFlags(flags) == S_OK);
+    Assert::IsTrue(renameRegEx->PutFlags(flags) == S_OK);
 
     SearchReplaceExpected sreTable[] = {
         { L".*", L"Foo", L"AAAAAA", L"Foo" },
@@ -267,8 +267,8 @@ TEST_METHOD(VerifyMatchAllWildcardUseRegEx)
     for (int i = 0; i < ARRAYSIZE(sreTable); i++)
     {
         PWSTR result = nullptr;
-        Assert::IsTrue(renameRegEx->putSearchTerm(sreTable[i].search) == S_OK);
-        Assert::IsTrue(renameRegEx->putReplaceTerm(sreTable[i].replace) == S_OK);
+        Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
+        Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
         Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
@@ -279,13 +279,13 @@ void VerifyReplaceFirstWildcard(SearchReplaceExpected sreTable[], int tableSize,
 {
     CComPtr<IPowerRenameRegEx> renameRegEx;
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
-    Assert::IsTrue(renameRegEx->putFlags(flags) == S_OK);
+    Assert::IsTrue(renameRegEx->PutFlags(flags) == S_OK);
 
     for (int i = 0; i < tableSize; i++)
     {
         PWSTR result = nullptr;
-        Assert::IsTrue(renameRegEx->putSearchTerm(sreTable[i].search) == S_OK);
-        Assert::IsTrue(renameRegEx->putReplaceTerm(sreTable[i].replace) == S_OK);
+        Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
+        Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
         Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
         Assert::AreEqual(sreTable[i].expected, result);
         CoTaskMemFree(result);
@@ -336,7 +336,7 @@ TEST_METHOD(VerifyHandleCapturingGroups)
     CComPtr<IPowerRenameRegEx> renameRegEx;
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     DWORD flags = MatchAllOccurences | UseRegularExpressions | CaseSensitive;
-    Assert::IsTrue(renameRegEx->putFlags(flags) == S_OK);
+    Assert::IsTrue(renameRegEx->PutFlags(flags) == S_OK);
 
     SearchReplaceExpected sreTable[] = {
         //search, replace, test, result
@@ -354,8 +354,8 @@ TEST_METHOD(VerifyHandleCapturingGroups)
     for (int i = 0; i < ARRAYSIZE(sreTable); i++)
     {
         PWSTR result = nullptr;
-        Assert::IsTrue(renameRegEx->putSearchTerm(sreTable[i].search) == S_OK);
-        Assert::IsTrue(renameRegEx->putReplaceTerm(sreTable[i].replace) == S_OK);
+        Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
+        Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
         Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
@@ -372,9 +372,9 @@ TEST_METHOD(VerifyEventsFire)
     DWORD cookie = 0;
     Assert::IsTrue(renameRegEx->Advise(regExEvents, &cookie) == S_OK);
     DWORD flags = MatchAllOccurences | UseRegularExpressions | CaseSensitive;
-    Assert::IsTrue(renameRegEx->putFlags(flags) == S_OK);
-    Assert::IsTrue(renameRegEx->putSearchTerm(L"FOO") == S_OK);
-    Assert::IsTrue(renameRegEx->putReplaceTerm(L"BAR") == S_OK);
+    Assert::IsTrue(renameRegEx->PutFlags(flags) == S_OK);
+    Assert::IsTrue(renameRegEx->PutSearchTerm(L"FOO") == S_OK);
+    Assert::IsTrue(renameRegEx->PutReplaceTerm(L"BAR") == S_OK);
     Assert::IsTrue(lstrcmpi(L"FOO", mockEvents->m_searchTerm) == 0);
     Assert::IsTrue(lstrcmpi(L"BAR", mockEvents->m_replaceTerm) == 0);
     Assert::IsTrue(flags == mockEvents->m_flags);


### PR DESCRIPTION
## Summary of the Pull Request

Adds filtering feature where you can click on the column headers to see certain type of files.



## PR Checklist
* [x] Applies to #5026 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [x] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

Current filters
* First column cycles between **Selected** and **Flags Applicable** filter
    - **Selected**: An item is visible if it is checked in the interface.
    - **Flags Applicable**: An Item is visible if current flags are applicable to the file.
* Second column toggles **Should Rename** filter on/off
    - **Should Rename**: An item is visible if rename operation will be performed on it.

I am not sure about having two filters on first column, removing less desirable would be good. I would appreciate feedback about it.

PowerRename runs bulkier when a filter is on, that is because changing the number of items in the list view performs heavy memory operations. (Performance shouldn't be effected when no filter is selected)

