### PR TITLE
[Shortcut Guide] fix Virtual-Key Code range

### DIFF
--- a/src/modules/shortcut_guide/keyboard_state.cpp
+++ b/src/modules/shortcut_guide/keyboard_state.cpp
@@ -8,18 +8,87 @@ bool winkey_held()
     return (left & 0x8000) || (right & 0x8000);
 }
 
+// Returns true if the VK code is in the range of valid keys.
+// Some VK codes should not be checked because they would return
+// false positives when checking if only the "Win" key is pressed.
+constexpr bool should_check(int vk)
+{
+    switch (vk)
+    {
+    case VK_CANCEL:
+    case VK_BACK:
+    case VK_TAB:
+    case VK_CLEAR:
+    case VK_ESCAPE:
+    case VK_APPS:
+    case VK_SLEEP:
+    case VK_NUMLOCK:
+    case VK_SCROLL:
+    case VK_OEM_102:
+        return true;
+    }
+
+    if (vk >= VK_SHIFT && vk <= VK_CAPITAL)
+    {
+        return true;
+    }
+
+    if (vk >= VK_SPACE && vk <= VK_HELP)
+    {
+        return true;
+    }
+
+    // Digits
+    if (vk >= 0x30 && vk <= 0x39)
+    {
+        return true;
+    }
+
+    // Letters
+    if (vk >= 0x41 && vk <= 0x5A)
+    {
+        return true;
+    }
+
+    if (vk >= VK_NUMPAD0 && vk <= VK_F24)
+    {
+        return true;
+    }
+
+    if (vk >= VK_LSHIFT && vk <= VK_LAUNCH_APP2)
+    {
+        return true;
+    }
+
+    if (vk >= VK_OEM_1 && vk <= VK_OEM_3)
+    {
+        return true;
+    }
+
+    if (vk >= VK_OEM_4 && vk <= VK_OEM_8)
+    {
+        return true;
+    }
+
+    if (vk >= VK_ATTN && vk <= VK_OEM_CLEAR)
+    {
+        return true;
+    }
+
+    return false;
+}
+
 bool only_winkey_key_held()
 {
-    /* There are situations, when some of the keys are not registered correctly by
-     GetKeyboardState. The M key can get stuck as "pressed" after Win+M, and
-     Shift etc. keys are not always reported as expected.
-  */
-    for (int vk = 0; vk <= VK_OEM_CLEAR; ++vk)
+    for (int vk = VK_CANCEL; vk <= VK_OEM_CLEAR; vk++)
     {
-        if (vk == VK_LWIN || vk == VK_RWIN)
-            continue;
-        if (GetAsyncKeyState(vk) & 0x8000)
-            return false;
+        if (should_check(vk))
+        {
+            if (GetAsyncKeyState(vk) & 0x8000)
+            {
+                return false;
+            }
+        }
     }
     return true;
 }


### PR DESCRIPTION
## Summary of the Pull Request

Fix the range of virtual key codes when checking if any other key is pressed along with the `Win` key.
The new range only includes key codes that are well defined (see https://docs.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes)

## PR Checklist
* [x] Applies to https://github.com/microsoft/PowerToys/issues/6004 https://github.com/microsoft/PowerToys/issues/4460 https://github.com/microsoft/PowerToys/issues/3090

## Validation Steps Performed
See the fixed issues for repro steps and validation
