### PR TITLE
Run UI contrast accessibility

### DIFF
--- a/src/modules/launcher/PowerLauncher/Themes/Dark.xaml
+++ b/src/modules/launcher/PowerLauncher/Themes/Dark.xaml
@@ -26,7 +26,7 @@
     <SolidColorBrush x:Key="ButtonBorderPressed" Color="#61FFFFFF" />
     <SolidColorBrush x:Key="ListViewItemBackgroundPointerOver" Color="#FF363636" />
     <SolidColorBrush x:Key="ControlTextBrushKey" Color="White" />
-    <SolidColorBrush x:Key="SecondaryTextForeground" Color="#FF818181" />
+    <SolidColorBrush x:Key="SecondaryTextForeground" Color="#FFa1a1a1" />
     <SolidColorBrush x:Key="InactiveSelectionHighlightBrushKey" Color="White" />
     <SolidColorBrush x:Key="BorderBrush" Color="Transparent" />
     

--- a/src/modules/launcher/PowerLauncher/Themes/Light.xaml
+++ b/src/modules/launcher/PowerLauncher/Themes/Light.xaml
@@ -26,7 +26,7 @@
     <SolidColorBrush x:Key="ButtonBorderPressed" Color="#61000000" />
     <SolidColorBrush x:Key="ListViewItemBackgroundPointerOver" Color="#FFd2d2d2" />
     <SolidColorBrush x:Key="ControlTextBrushKey" Color="Black" />
-    <SolidColorBrush x:Key="SecondaryTextForeground" Color="#FF5b5b5b" />
+    <SolidColorBrush x:Key="SecondaryTextForeground" Color="#FF434343" />
     <SolidColorBrush x:Key="InactiveSelectionHighlightBrushKey" Color="Black" />
     <SolidColorBrush x:Key="BorderBrush" Color="Transparent" />
     <SolidColorBrush x:Key="ScrollBarThumbBackground" Color="#FF7a7a7a" />

--- a/src/modules/launcher/PowerLauncher/Themes/Light.xaml
+++ b/src/modules/launcher/PowerLauncher/Themes/Light.xaml
@@ -22,7 +22,7 @@
     <SolidColorBrush x:Key="TextBox.Focus.Border" Color="Transparent"/>
     <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="#2E000000" />
     <SolidColorBrush x:Key="ButtonBorderPointerOver" Color="#61000000" />
-    <SolidColorBrush x:Key="ButtonBackgroundPressed" Color="#33000000" />
+    <SolidColorBrush x:Key="ButtonBackgroundPressed" Color="#30000000" />
     <SolidColorBrush x:Key="ButtonBorderPressed" Color="#61000000" />
     <SolidColorBrush x:Key="ListViewItemBackgroundPointerOver" Color="#FFd2d2d2" />
     <SolidColorBrush x:Key="ControlTextBrushKey" Color="Black" />


### PR DESCRIPTION
## Summary of the Pull Request
This PR fixes the contrast issues indicated by the accessibility insights tool. 

## PR Checklist
* [x] Applies to #5367 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed

## Info on Pull Request
1. Fixed subtitle contrast issue with background in light mode. 

![ac-2-0](https://user-images.githubusercontent.com/10995909/90546900-92c82180-e13f-11ea-9e3f-694b67811653.PNG)
![ac-2-1](https://user-images.githubusercontent.com/10995909/90546901-9360b800-e13f-11ea-9a09-708437d0b61c.PNG)

2. Fixed subtitle contrast issue with background in dark mode. 

![ac-1-0](https://user-images.githubusercontent.com/10995909/90546940-a1163d80-e13f-11ea-86c1-6d0628d40568.PNG)
![ac-1-1](https://user-images.githubusercontent.com/10995909/90546941-a1aed400-e13f-11ea-9944-00233f46928e.PNG)

3. Fixed context menu glyph contrast issue with background in light mode. 

![ac-3-0](https://user-images.githubusercontent.com/10995909/90547004-bd19df00-e13f-11ea-8f42-f7785263187e.png)
![ac-3-1](https://user-images.githubusercontent.com/10995909/90549414-54ccfc80-e143-11ea-89ae-a3c63d78aa15.PNG)

## Validation Steps Performed
Manually validated using exact values (if possible) that contrast ratio is above the threshold.