### PR TITLE
Fix accessibility issues related to the General Settings page

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -399,6 +399,9 @@
   <data name="RadioButtons_Name_Theme.Header" xml:space="preserve">
     <value>Settings theme</value>
   </data>
+  <data name="RadioButtons_Name_Theme.AutomationProperties.Name" xml:space="preserve">
+    <value>Settings theme</value>
+  </data>
   <data name="PowerRename_Toggle_EnableOnContextMenu.Header" xml:space="preserve">
     <value>Show icon on context menu</value>
   </data>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -396,10 +396,7 @@
   <data name="PowerRename_Toggle_Enable.Header" xml:space="preserve">
     <value>Enable PowerRename</value>
   </data>
-  <data name="RadioButtons_Name_Theme.Header" xml:space="preserve">
-    <value>Settings theme</value>
-  </data>
-  <data name="RadioButtons_Name_Theme.AutomationProperties.Name" xml:space="preserve">
+  <data name="RadioButtons_Name_Theme.Text" xml:space="preserve">
     <value>Settings theme</value>
   </data>
   <data name="PowerRename_Toggle_EnableOnContextMenu.Header" xml:space="preserve">

--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -360,6 +360,9 @@
   <data name="GeneralPage_AboutPowerToysHeader.Text" xml:space="preserve">
     <value>About PowerToys</value>
   </data>
+  <data name="PowerToys_Icon.AutomationProperties.Name" xml:space="preserve">
+    <value>PowerToys Icon</value>
+  </data>
   <data name="GeneralPage_CheckForUpdates.Content" xml:space="preserve">
     <value>Check for updates</value>
   </data>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml
@@ -82,8 +82,10 @@
             <TextBlock x:Uid="ShortcutGuide_Appearance_Behavior"
                        Style="{StaticResource SettingsGroupTitleStyle}"/>
 
-            <muxc:RadioButtons x:Uid="RadioButtons_Name_Theme"
-                               Margin="{StaticResource SmallTopMargin}">
+            <TextBlock Name="RadioButtons_Name_Theme" 
+                       x:Uid="RadioButtons_Name_Theme"
+                       Margin="{StaticResource SmallTopMargin}"/>
+            <StackPanel AutomationProperties.LabeledBy="{Binding ElementName=RadioButtons_Name_Theme}">
                 <RadioButton x:Uid="GeneralPage_Radio_Theme_Dark"
                              Content="Dark"
                              IsChecked="{ Binding Mode=TwoWay, Path=IsDarkThemeRadioButtonChecked}"/>
@@ -95,7 +97,7 @@
                 <RadioButton x:Uid="GeneralPage_Radio_Theme_Default"
                              Content="System default"
                              IsChecked="{ Binding Mode=TwoWay, Path=IsSystemThemeRadioButtonChecked}"/>
-            </muxc:RadioButtons>
+            </StackPanel>
 
             <ToggleSwitch x:Uid="GeneralPage_ToggleSwitch_RunAtStartUp"  
                           Margin="{StaticResource SmallTopMargin}" 

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml
@@ -82,6 +82,8 @@
             <TextBlock x:Uid="ShortcutGuide_Appearance_Behavior"
                        Style="{StaticResource SettingsGroupTitleStyle}"/>
 
+            <!-- Replaced the Radiobuttons parent control with a StackPanel to mitigate the Tab and Arrow key related keyboard navigation issues due to XAML Islands
+            Tracking issue in the winui repository - https://github.com/microsoft/microsoft-ui-xaml/issues/3156 -->
             <TextBlock Name="RadioButtons_Name_Theme" 
                        x:Uid="RadioButtons_Name_Theme"
                        Margin="{StaticResource SmallTopMargin}"/>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml
@@ -107,7 +107,9 @@
 
             <TextBlock x:Uid="General_Updates"
                        Style="{StaticResource SettingsGroupTitleStyle}"/>
-            <StackPanel Orientation="Horizontal" Margin="{StaticResource SmallTopMargin}">
+            <StackPanel Orientation="Horizontal" 
+                        Margin="{StaticResource SmallTopMargin}"
+                        AutomationProperties.LabeledBy="{Binding ElementName=General_Version}">
                 <TextBlock Text="Version: " x:Uid="General_Version"  />
                 <HyperlinkButton NavigateUri="https://github.com/microsoft/PowerToys/releases" Margin="4,-6,0,0">
                     <TextBlock Text="{x:Bind ViewModel.PowerToysVersion }" />

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml
@@ -150,7 +150,7 @@
                     HorizontalAlignment="Left"
                     Margin="{StaticResource SmallTopBottomMargin}"
                     RelativePanel.Below="DescriptionPanel">
-                <Image Source="ms-appx:///Assets/Modules/PT.png" />
+                <Image x:Uid="PowerToys_Icon" Source="ms-appx:///Assets/Modules/PT.png"/>
             </Border>
             <StackPanel x:Name="LinksPanel"
                         Margin="0,1,0,0"


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

This PR fixes accessibility issues related to the general settings page of PowerToys Settings.

## PR Checklist
* [x] Applies to #5726
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

The following changes have been made in this PR - 
1. There was a tab related issue regarding the radio buttons where they were all not accessible by the keyboard. This was due to xaml islands. Replacing the `RadioButtons` control with a `StackPanel` and `TextBlock` fixed this issue. Now we can tab through all the elements and also use the arrow keys to navigate through the radio buttons in a cyclic manner.
![image](https://user-images.githubusercontent.com/28739210/90569765-48f13280-e163-11ea-9b14-4dfa24b205ff.png)
2. When using a screen reader to read the entire content of the general settings page, only the word `Dark` was being read. Adding a label automation property so that whenever we tab into the radio buttons, the heading ie. `Settings Theme` is also read by the screen reader.
3. Made a similar change for the version of powerToys. Previously, it was just reading out `v0.20.1`. Now it reads out `Version v0.20.1` to give visually challenged people more context on the number.
4. Additional information has been added to the image on the right which previously only read the word 'graphic'. Now, it reads out 'PowerToys icon graphic' to give more context.
![image](https://user-images.githubusercontent.com/28739210/90570039-d0d73c80-e163-11ea-9b1b-4c8e7be635e2.png)

## Validation Steps Performed

_How does someone test & validate?_

For the screen reader related tests:
* Install a screen reader (NVDA)
* Press Insert+B to read the entire app.