### PR TITLE
[FancyZones] Shift + StickyKeys behavior fix 

### DIFF
--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -15,7 +15,6 @@
 #include "trace.h"
 #include "VirtualDesktopUtils.h"
 #include "MonitorWorkAreaHandler.h"
-#include "KeyState.h"
 
 #include <lib/SecondaryMouseButtonsHook.h>
 #include <lib/GenericKeyHook.h>
@@ -47,12 +46,11 @@ public:
     FancyZones(HINSTANCE hinstance, const winrt::com_ptr<IFancyZonesSettings>& settings) noexcept :
         m_hinstance(hinstance),
         m_settings(settings),
-        m_windowMoveHandler(settings, &m_keyState)
+        m_windowMoveHandler(settings, [this]() {
+            PostMessageW(m_window, WM_PRIV_LOCATIONCHANGE, NULL, NULL);
+        })
     {
         m_settings->SetCallback(this);
-        m_keyState.setCallback([this]() {
-            PostMessageW(m_window, WM_PRIV_LOCATIONCHANGE, NULL, NULL);
-        });
     }
 
     // IFancyZones
@@ -245,7 +243,6 @@ private:
     HWND m_window{};
     WindowMoveHandler m_windowMoveHandler;
     MonitorWorkAreaHandler m_workAreaHandler;
-    KeyState m_keyState;
 
     winrt::com_ptr<IFancyZonesSettings> m_settings{};
     GUID m_previousDesktopId{}; // UUID of previously active virtual desktop.

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -17,7 +17,6 @@
 #include "MonitorWorkAreaHandler.h"
 
 #include <lib/SecondaryMouseButtonsHook.h>
-#include <lib/GenericKeyHook.h>
 
 enum class DisplayChangeType
 {

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -47,10 +47,7 @@ public:
     FancyZones(HINSTANCE hinstance, const winrt::com_ptr<IFancyZonesSettings>& settings) noexcept :
         m_hinstance(hinstance),
         m_settings(settings),
-        m_mouseHook(std::bind(&FancyZones::OnMouseDown, this)),
-        m_shiftHook(std::bind(&FancyZones::OnShiftChangeState, this, std::placeholders::_1)),
-        m_ctrlHook(std::bind(&FancyZones::OnCtrlChangeState, this, std::placeholders::_1)),
-        m_windowMoveHandler(settings, &m_keyState, &m_mouseHook, &m_shiftHook, &m_ctrlHook)
+        m_windowMoveHandler(settings, &m_keyState)
     {
         m_settings->SetCallback(this);
         m_keyState.setCallback([this]() {
@@ -63,21 +60,6 @@ public:
     Run() noexcept;
     IFACEMETHODIMP_(void)
     Destroy() noexcept;
-
-    void OnMouseDown() noexcept
-    {
-        m_keyState.setMouseState(!m_keyState.mouseState());
-    }
-
-    void OnShiftChangeState(bool state) noexcept
-    {
-        m_keyState.setShiftState(state);
-    }
-
-    void OnCtrlChangeState(bool state) noexcept
-    {
-        m_keyState.setCtrlState(state);
-    }
 
     void MoveSizeStart(HWND window, HMONITOR monitor, POINT const& ptScreen) noexcept
     {
@@ -263,9 +245,6 @@ private:
     HWND m_window{};
     WindowMoveHandler m_windowMoveHandler;
     MonitorWorkAreaHandler m_workAreaHandler;
-    SecondaryMouseButtonsHook m_mouseHook;
-    ShiftKeyHook m_shiftHook;
-    CtrlKeyHook m_ctrlHook;
     KeyState m_keyState;
 
     winrt::com_ptr<IFancyZonesSettings> m_settings{};

--- a/src/modules/fancyzones/lib/FancyZonesLib.vcxproj
+++ b/src/modules/fancyzones/lib/FancyZonesLib.vcxproj
@@ -106,6 +106,7 @@
     <ClInclude Include="GenericKeyHook.h" />
     <ClInclude Include="FancyZonesData.h" />
     <ClInclude Include="JsonHelpers.h" />
+    <ClInclude Include="KeyState.h" />
     <ClInclude Include="MonitorWorkAreaHandler.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="resource.h" />

--- a/src/modules/fancyzones/lib/FancyZonesLib.vcxproj
+++ b/src/modules/fancyzones/lib/FancyZonesLib.vcxproj
@@ -124,7 +124,6 @@
     <ClCompile Include="FancyZones.cpp" />
     <ClCompile Include="FancyZonesDataTypes.cpp" />
     <ClCompile Include="FancyZonesWinHookEventIDs.cpp" />
-    <ClCompile Include="GenericKeyHook.cpp" />
     <ClCompile Include="FancyZonesData.cpp" />
     <ClCompile Include="JsonHelpers.cpp" />
     <ClCompile Include="MonitorWorkAreaHandler.cpp" />

--- a/src/modules/fancyzones/lib/FancyZonesLib.vcxproj.filters
+++ b/src/modules/fancyzones/lib/FancyZonesLib.vcxproj.filters
@@ -69,6 +69,9 @@
     <ClInclude Include="FancyZonesDataTypes.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="KeyState.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp">

--- a/src/modules/fancyzones/lib/FancyZonesLib.vcxproj.filters
+++ b/src/modules/fancyzones/lib/FancyZonesLib.vcxproj.filters
@@ -113,9 +113,6 @@
     <ClCompile Include="MonitorWorkAreaHandler.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="GenericKeyHook.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="FancyZonesData.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/src/modules/fancyzones/lib/GenericKeyHook.cpp
+++ b/src/modules/fancyzones/lib/GenericKeyHook.cpp
@@ -1,8 +1,0 @@
-#include "pch.h"
-#include "GenericKeyHook.h"
-
-HHOOK ShiftKeyHook::hHook{};
-std::function<void(bool)> ShiftKeyHook::callback{};
-
-HHOOK CtrlKeyHook::hHook{};
-std::function<void(bool)> CtrlKeyHook::callback{};

--- a/src/modules/fancyzones/lib/GenericKeyHook.h
+++ b/src/modules/fancyzones/lib/GenericKeyHook.h
@@ -57,6 +57,3 @@ private:
         return CallNextHookEx(hHook, nCode, wParam, lParam);
     }
 };
-
-typedef GenericKeyHook<VK_LSHIFT, VK_RSHIFT> ShiftKeyHook;
-typedef GenericKeyHook<VK_LCONTROL, VK_RCONTROL> CtrlKeyHook;

--- a/src/modules/fancyzones/lib/GenericKeyHook.h
+++ b/src/modules/fancyzones/lib/GenericKeyHook.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <functional>
 #include "pch.h"
+#include <functional>
 
 template<int... keys>
 class GenericKeyHook
@@ -38,8 +38,8 @@ public:
     }
 
 private:
-    static HHOOK hHook;
-    static std::function<void(bool)> callback;
+    inline static HHOOK hHook;
+    inline static std::function<void(bool)> callback;
 
     static LRESULT CALLBACK GenericKeyHookProc(int nCode, WPARAM wParam, LPARAM lParam)
     {

--- a/src/modules/fancyzones/lib/KeyState.h
+++ b/src/modules/fancyzones/lib/KeyState.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <functional>
+
+class KeyState
+{
+public:
+    KeyState() :
+        m_mouseState(false),
+        m_shiftState(false),
+        m_ctrlState(false)
+    {};
+
+    inline bool mouseState() const noexcept { return m_mouseState; }
+    inline bool shiftState() const noexcept { return m_shiftState; }
+    inline bool ctrlState() const noexcept { return m_ctrlState; }
+
+    inline void setCallback(const std::function<void()>& updateCallback) noexcept
+    {
+        m_updateCallback = updateCallback;
+    }
+    
+    inline void setMouseState(bool state) noexcept
+    {
+        if (m_mouseState != state)
+        {
+            m_mouseState = state;
+            if (m_updateCallback)
+            {
+                m_updateCallback();
+            }
+        }
+    }
+
+    inline void setShiftState(bool state) noexcept
+    {
+        if (m_shiftState != state)
+        {
+            m_shiftState = state;
+            if (m_updateCallback)
+            {
+                m_updateCallback();
+            }
+        }
+    }
+    
+    inline void setCtrlState(bool state) noexcept
+    {
+        if (m_ctrlState != state)
+        {
+            m_ctrlState = state;
+            if (m_updateCallback)
+            {
+                m_updateCallback();
+            }
+        }
+    }
+
+private:
+    std::atomic<bool> m_mouseState;
+    std::atomic<bool> m_shiftState;
+    std::atomic<bool> m_ctrlState;
+
+    std::function<void()> m_updateCallback;
+};

--- a/src/modules/fancyzones/lib/WindowMoveHandler.cpp
+++ b/src/modules/fancyzones/lib/WindowMoveHandler.cpp
@@ -193,7 +193,10 @@ void WindowMoveHandlerPrivate::MoveSizeStart(HWND window, HMONITOR monitor, POIN
     }
 
     m_shiftHook.enable();
+    m_keyState->setShiftState(GetKeyState(VK_SHIFT) & 0x800);
+
     m_ctrlHook.enable();
+    m_keyState->setCtrlState(GetKeyState(VK_CONTROL) & 0x800);
 
     // This updates m_dragEnabled depending on if the shift key is being held down
     UpdateDragState();

--- a/src/modules/fancyzones/lib/WindowMoveHandler.h
+++ b/src/modules/fancyzones/lib/WindowMoveHandler.h
@@ -10,7 +10,7 @@ class KeyState;
 class WindowMoveHandler
 {
 public:
-    WindowMoveHandler(const winrt::com_ptr<IFancyZonesSettings>& settings, KeyState* keyState, SecondaryMouseButtonsHook* mouseHook, ShiftKeyHook* shiftHook, CtrlKeyHook* ctrlHook);
+    WindowMoveHandler(const winrt::com_ptr<IFancyZonesSettings>& settings, KeyState* keyState);
     ~WindowMoveHandler();
 
     bool InMoveSize() const noexcept;

--- a/src/modules/fancyzones/lib/WindowMoveHandler.h
+++ b/src/modules/fancyzones/lib/WindowMoveHandler.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "SecondaryMouseButtonsHook.h"
-#include "GenericKeyHook.h"
 
 interface IFancyZonesSettings;
 interface IZoneWindow;

--- a/src/modules/fancyzones/lib/WindowMoveHandler.h
+++ b/src/modules/fancyzones/lib/WindowMoveHandler.h
@@ -5,19 +5,16 @@
 
 interface IFancyZonesSettings;
 interface IZoneWindow;
+class KeyState;
 
 class WindowMoveHandler
 {
 public:
-    WindowMoveHandler(const winrt::com_ptr<IFancyZonesSettings>& settings, SecondaryMouseButtonsHook* mouseHook, ShiftKeyHook* shiftHook, CtrlKeyHook* ctrlHook);
+    WindowMoveHandler(const winrt::com_ptr<IFancyZonesSettings>& settings, KeyState* keyState, SecondaryMouseButtonsHook* mouseHook, ShiftKeyHook* shiftHook, CtrlKeyHook* ctrlHook);
     ~WindowMoveHandler();
 
     bool InMoveSize() const noexcept;
     bool IsDragEnabled() const noexcept;
-
-    void OnMouseDown() noexcept;
-    void OnShiftChangeState(bool state) noexcept;  //True for shift down event false for shift up
-    void OnCtrlChangeState(bool state) noexcept;   //True for ctrl down event false for ctrl up
 
     void MoveSizeStart(HWND window, HMONITOR monitor, POINT const& ptScreen, const std::unordered_map<HMONITOR, winrt::com_ptr<IZoneWindow>>& zoneWindowMap) noexcept;
     void MoveSizeUpdate(HMONITOR monitor, POINT const& ptScreen, const std::unordered_map<HMONITOR, winrt::com_ptr<IZoneWindow>>& zoneWindowMap) noexcept;

--- a/src/modules/fancyzones/lib/WindowMoveHandler.h
+++ b/src/modules/fancyzones/lib/WindowMoveHandler.h
@@ -5,12 +5,11 @@
 
 interface IFancyZonesSettings;
 interface IZoneWindow;
-class KeyState;
 
 class WindowMoveHandler
 {
 public:
-    WindowMoveHandler(const winrt::com_ptr<IFancyZonesSettings>& settings, KeyState* keyState);
+    WindowMoveHandler(const winrt::com_ptr<IFancyZonesSettings>& settings, const std::function<void()>& keyUpdateCallback);
     ~WindowMoveHandler();
 
     bool InMoveSize() const noexcept;


### PR DESCRIPTION
## Summary of the Pull Request

Handle key state with Sticky Keys enabled.

## PR Checklist
* [x] Applies to #5784
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed

## Info on Pull Request

* Update key state on window drag start in case if it was pressed before dragging was started.
* Moved hooks from `FancyZones` to `WindowMoveHandler`. 

## Validation Steps Performed

_Prepare_
* Set FancyZones settings options
![image](https://user-images.githubusercontent.com/8949536/90629506-2bd26780-e228-11ea-8ffb-2299915b7982.png)

* _Optional_ Enable `Make dragged window transparent`
* Apply any FancyZones layout 

_Test with Sticky Keys enabled_
* Enable Sticky Keys (Settings -> Ease of Access -> Keyboard)
* Press and release 'Shift', drag any window. _Window should become transparent, possible to apply to a zone._
* Press and hold 'Shift', drag any window. _Window should become transparent, possible to apply to a zone._

_Test with Sticky Keys disabled_
* Press and release 'Shift', drag any window. _Window shouldn't become transparent, possible to apply to a zone._
* Press and hold 'Shift', drag any window. _Window should become transparent, possible to apply to a zone._