### PR TITLE
Fix Accessibility issues of the FancyZones Settings page

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI/Controls/HotkeySettingsControl.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Controls/HotkeySettingsControl.xaml
@@ -23,8 +23,9 @@
                        Text="{x:Bind Header, Mode=OneTime}"
                        Foreground="{Binding Path=IsEnabled, ElementName=HotkeyTextBox, Converter={StaticResource ModuleEnabledToForegroundConverter}}"
                        />
-            
-            <TextBlock x:Name="TitleGlyph" Text="&#xE946;"
+
+            <TextBlock x:Uid="FancyZones_SettingsPage_ZonesEditor_Glyph"
+                       x:Name="TitleGlyph" Text="&#xE946;"
                        FontFamily="Segoe MDL2 Assets"
                        Margin="4,4,0,0"
                        Foreground="{Binding Path=IsEnabled, ElementName=HotkeyTextBox, Converter={StaticResource ModuleEnabledToForegroundConverter}}"

--- a/src/core/Microsoft.PowerToys.Settings.UI/Controls/HotkeySettingsControl.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Controls/HotkeySettingsControl.xaml
@@ -32,7 +32,8 @@
                        />
         
         </StackPanel>
-        <TextBox x:Name="HotkeyTextBox"
+        <TextBox x:Uid="FancyZones_SettingsPage_ZonesEditorWindow"
+                 x:Name="HotkeyTextBox"
                  Margin="0,5,0,0"
                  IsReadOnly="True"
                  />

--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -444,6 +444,9 @@
   <data name="FancyZones_BorderColor.Text" xml:space="preserve">
     <value>Zone border color (Default: #FFFFFF)</value>
   </data>
+  <data name="FancyZones_BorderColor_Textblock.Text" xml:space="preserve">
+    <value>Zone border color</value>
+  </data>
   <data name="FancyZones_InActiveColor.Text" xml:space="preserve">
     <value>Zone inactive color (Default: #F5FCFF)</value>
   </data>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -309,6 +309,9 @@
   <data name="FancyZones_HotkeyEditorControl.Header" xml:space="preserve">
     <value>Open zones editor</value>
   </data>
+  <data name="FancyZones_SettingsPage_ZonesEditor_Glyph.AutomationProperties.Name" xml:space="preserve">
+    <value>Open zones editor Information</value>
+  </data>
   <data name="FancyZones_LaunchEditorButtonControl.Text" xml:space="preserve">
     <value>Launch zones editor</value>
   </data>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -348,6 +348,9 @@
   <data name="FancyZones_ZoneBehavior_GroupSettings.Text" xml:space="preserve">
     <value>Zone behavior</value>
   </data>
+  <data name="FancyZones_ZoneHighlightColor_Textblock.Text" xml:space="preserve">
+    <value>Zone highlight color</value>
+  </data>
   <data name="FancyZones_ZoneHighlightColor.Text" xml:space="preserve">
     <value>Zone highlight color (Default: #0078D7)</value>
   </data>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -288,6 +288,9 @@
   <data name="Appearance_GroupSettings.Text" xml:space="preserve">
     <value>Appearance</value>
   </data>
+  <data name="Fancyzones_Image.AutomationProperties.Name" xml:space="preserve">
+    <value>Fancyzones windows</value>
+  </data>
   <data name="FancyZones_Description.Text" xml:space="preserve">
     <value>Create window layouts to help make multi-tasking easy.</value>
   </data>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -289,7 +289,7 @@
     <value>Appearance</value>
   </data>
   <data name="Fancyzones_Image.AutomationProperties.Name" xml:space="preserve">
-    <value>Fancyzones windows</value>
+    <value>FancyZones windows</value>
   </data>
   <data name="FancyZones_Description.Text" xml:space="preserve">
     <value>Create window layouts to help make multi-tasking easy.</value>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -348,9 +348,6 @@
   <data name="FancyZones_ZoneBehavior_GroupSettings.Text" xml:space="preserve">
     <value>Zone behavior</value>
   </data>
-  <data name="FancyZones_ZoneHighlightColor_Textblock.Text" xml:space="preserve">
-    <value>Zone highlight color</value>
-  </data>
   <data name="FancyZones_ZoneHighlightColor.Text" xml:space="preserve">
     <value>Zone highlight color (Default: #0078D7)</value>
   </data>
@@ -443,9 +440,6 @@
   </data>
   <data name="FancyZones_BorderColor.Text" xml:space="preserve">
     <value>Zone border color (Default: #FFFFFF)</value>
-  </data>
-  <data name="FancyZones_BorderColor_Textblock.Text" xml:space="preserve">
-    <value>Zone border color</value>
   </data>
   <data name="FancyZones_InActiveColor.Text" xml:space="preserve">
     <value>Zone inactive color (Default: #F5FCFF)</value>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -309,6 +309,9 @@
   <data name="FancyZones_HotkeyEditorControl.Header" xml:space="preserve">
     <value>Open zones editor</value>
   </data>
+  <data name="FancyZones_SettingsPage_ZonesEditorWindow.AutomationProperties.Name" xml:space="preserve">
+    <value>Enter shortcut to open zones here</value>
+  </data>
   <data name="FancyZones_SettingsPage_ZonesEditor_Glyph.AutomationProperties.Name" xml:space="preserve">
     <value>Open zones editor Information</value>
   </data>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -242,13 +242,15 @@
                 </muxc:DropDownButton.Flyout>
             </muxc:DropDownButton>
 
-            <TextBlock x:Uid="FancyZones_BorderColor"
+            <TextBlock Name="FancyZones_BorderColor_Textblock"
+                x:Uid="FancyZones_BorderColor_Textblock"
                 Margin="{StaticResource SmallTopMargin}"
                 Foreground="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToForegroundConverter}}"/>
 
             <muxc:DropDownButton Margin="0,4,0,0"
                                  IsEnabled="{x:Bind Mode=TwoWay, Path=ViewModel.IsEnabled}"
-                                 Padding="4,4,8,4">
+                                 Padding="4,4,8,4"
+                                 AutomationProperties.LabeledBy="{Binding ElementName=FancyZones_BorderColor_Textblock}">
                 <Border Width="48" CornerRadius="2" Height="24">
                     <Border.Background>
                         <SolidColorBrush Color="{x:Bind Path=ViewModel.ZoneBorderColor, Mode=TwoWay}"/>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -212,13 +212,15 @@
 
             </muxc:DropDownButton>
 
-            <TextBlock x:Uid="FancyZones_InActiveColor"
+            <TextBlock Name="FancyZones_InActiveColor"
+                x:Uid="FancyZones_InActiveColor"
                 Margin="{StaticResource SmallTopMargin}"
                 Foreground="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToForegroundConverter}}"/>
 
             <muxc:DropDownButton Margin="0,4,0,0"
                                  IsEnabled="{x:Bind Mode=TwoWay, Path=ViewModel.IsEnabled}"
-                                 Padding="4,4,8,4">
+                                 Padding="4,4,8,4"
+                                 AutomationProperties.LabeledBy="{Binding ElementName=FancyZones_InActiveColor}">
                 <Border Width="48" CornerRadius="2" Height="24">
                     <Border.Background>
                         <SolidColorBrush Color="{x:Bind Path=ViewModel.ZoneInActiveColor, Mode=TwoWay}"/>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -178,15 +178,15 @@
                 
             </StackPanel>
 
-            <TextBlock Name="FancyZones_ZoneHighlightColor_Textblock"
-                x:Uid="FancyZones_ZoneHighlightColor_Textblock"
+            <TextBlock Name="FancyZones_ZoneHighlightColor"
+                x:Uid="FancyZones_ZoneHighlightColor"
                 Margin="{StaticResource SmallTopMargin}"
                 Foreground="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToForegroundConverter}}"/>
 
             <muxc:DropDownButton Margin="0,4,0,0"
                                  IsEnabled="{x:Bind Mode=TwoWay, Path=ViewModel.IsEnabled}"
                                  Padding="4,4,8,4"
-                                 AutomationProperties.LabeledBy="{Binding ElementName=FancyZones_ZoneHighlightColor_Textblock}">
+                                 AutomationProperties.LabeledBy="{Binding ElementName=FancyZones_ZoneHighlightColor}">
                 <Border Width="48"
                         CornerRadius="2"
                         Height="24">
@@ -196,7 +196,7 @@
                 </Border>
                 <muxc:DropDownButton.Flyout>
                     <Flyout>
-                        <muxc:ColorPicker x:Name="FancyZones_ZoneHighlightColor"
+                        <muxc:ColorPicker x:Name="FancyZones_ZoneHighlightColorPicker"
                               Margin="0,6,0,0"
                               HorizontalAlignment="Left"
                               IsColorSliderVisible="True"
@@ -242,15 +242,15 @@
                 </muxc:DropDownButton.Flyout>
             </muxc:DropDownButton>
 
-            <TextBlock Name="FancyZones_BorderColor_Textblock"
-                x:Uid="FancyZones_BorderColor_Textblock"
+            <TextBlock Name="FancyZones_BorderColor"
+                x:Uid="FancyZones_BorderColor"
                 Margin="{StaticResource SmallTopMargin}"
                 Foreground="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToForegroundConverter}}"/>
 
             <muxc:DropDownButton Margin="0,4,0,0"
                                  IsEnabled="{x:Bind Mode=TwoWay, Path=ViewModel.IsEnabled}"
                                  Padding="4,4,8,4"
-                                 AutomationProperties.LabeledBy="{Binding ElementName=FancyZones_BorderColor_Textblock}">
+                                 AutomationProperties.LabeledBy="{Binding ElementName=FancyZones_BorderColor}">
                 <Border Width="48" CornerRadius="2" Height="24">
                     <Border.Background>
                         <SolidColorBrush Color="{x:Bind Path=ViewModel.ZoneBorderColor, Mode=TwoWay}"/>
@@ -258,7 +258,7 @@
                 </Border>
                 <muxc:DropDownButton.Flyout>
                     <Flyout>
-                        <muxc:ColorPicker x:Name="FancyZones_BorderColor"
+                        <muxc:ColorPicker x:Name="FancyZones_BorderColorPicker"
                               Margin="0,6,0,0"
                               HorizontalAlignment="Left"
                               IsColorSliderVisible="True"                             

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -60,12 +60,14 @@
             <Button Margin="{StaticResource MediumTopMargin}"
                     Style="{StaticResource AccentButtonStyle}"
                     Command = "{x:Bind ViewModel.LaunchEditorEventHandler}"
-                    IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}">
+                    IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"
+                    AutomationProperties.LabeledBy="{Binding ElementName=FancyZones_LaunchEditorButtonControl}">
                 <StackPanel Orientation="Horizontal">
                     <Viewbox Height="12" Width="12">
                         <PathIcon Data="M896 0v896H0V0h896zM768 768V128H128v640h640zM0 1920v-896h1920v896H0zm128-768v640h1664v-640H128zM1024 0h896v896h-896V0zm768 768V128h-640v640h640z"/>
                     </Viewbox>
                     <TextBlock Margin="12,0,0,0"
+                               Name="FancyZones_LaunchEditorButtonControl"
                                x:Uid="FancyZones_LaunchEditorButtonControl"/>
                 </StackPanel>
             </Button>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -178,13 +178,15 @@
                 
             </StackPanel>
 
-            <TextBlock x:Uid="FancyZones_ZoneHighlightColor"
+            <TextBlock Name="FancyZones_ZoneHighlightColor_Textblock"
+                x:Uid="FancyZones_ZoneHighlightColor_Textblock"
                 Margin="{StaticResource SmallTopMargin}"
                 Foreground="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToForegroundConverter}}"/>
 
             <muxc:DropDownButton Margin="0,4,0,0"
                                  IsEnabled="{x:Bind Mode=TwoWay, Path=ViewModel.IsEnabled}"
-                                 Padding="4,4,8,4">
+                                 Padding="4,4,8,4"
+                                 AutomationProperties.LabeledBy="{Binding ElementName=FancyZones_ZoneHighlightColor_Textblock}">
                 <Border Width="48"
                         CornerRadius="2"
                         Height="24">

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -311,7 +311,7 @@
                     HorizontalAlignment="Left"
                     Margin="{StaticResource SmallTopBottomMargin}"
                     RelativePanel.Below="DescriptionPanel">
-                <Image Source="ms-appx:///Assets/Modules/FancyZones.png" />
+                <Image x:Uid="Fancyzones_Image" Source="ms-appx:///Assets/Modules/FancyZones.png" />
             </Border>
 
             <StackPanel x:Name="LinksPanel"


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

This PR fixes the accessibility issues related to the Fancy Zones settings page.

## PR Checklist
* [x] Applies to #5733
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

The following changes have been made in this PR to fix the accessibility issues related to the FZ settings page -
1. The Launch zones editor window did not have a name and it was being read out as button by the screen reader. This has been fixed by setting the automation property and it is now read as the 'Launch zones editor button', instead of only 'button'.
2. The open zones editor window and the info glyph were throwing errors because their names were not set. If the name is not set the text is taken as the name, however special characters are not allowed so an accessible name had to be added for the glyph and the custom control.
3. The drop down buttons and the text boxes related to them had the same Uid and name which has been fixed. This was preventing us from adding as accessible label to the drop down button.
4. The image on the right showing the fancy zones windows was previously being read as 'graphic', now it has been made more accessible by adding more context to the image. It now reads 'FancyZones windows graphic'.

The following issues have been fixed:
![image](https://user-images.githubusercontent.com/28739210/90665598-1c8bf380-e201-11ea-9112-ff5c8ddf7e33.png)
![image](https://user-images.githubusercontent.com/28739210/90665603-1e55b700-e201-11ea-84cf-df2915ae0057.png)
![image](https://user-images.githubusercontent.com/28739210/90665605-1eee4d80-e201-11ea-8292-1f3e2ab400ae.png)
![image](https://user-images.githubusercontent.com/28739210/90665607-201f7a80-e201-11ea-8d07-380066f5b5ab.png)


## Known Issues:
* If we run accessibility insights on FancyZones there are two issues that still appear which are related to XAML Islands, namely that an onscreen element must not have a null bounding rectangle property.
![image](https://user-images.githubusercontent.com/28739210/90665577-1269f500-e201-11ea-9edf-756bf0c800b1.png)


## Validation Steps Performed

_How does someone test & validate?_
* Install and run Accessibility insights. There were previously 20 issues, however now there are only 2 (XAML island issues).
* Install a screen reader. Every single element on the screen is read.
