### PR TITLE
Fix for Crash due to System.AccessViolationException when calling OleDBSearch from multiple threads.

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Main.cs
@@ -253,7 +253,6 @@ namespace Microsoft.Plugin.Indexer
             {
                 if (disposing)
                 {
-                    _search.Dispose();
                 }
 
                 disposedValue = true;

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/SearchHelper/OleDBSearch.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/SearchHelper/OleDBSearch.cs
@@ -8,13 +8,8 @@ using System.Data.OleDb;
 
 namespace Microsoft.Plugin.Indexer.SearchHelper
 {
-    public class OleDBSearch : ISearch, IDisposable
+    public class OleDBSearch : ISearch
     {
-        private OleDbCommand command;
-        private OleDbConnection conn;
-        private OleDbDataReader wDSResults;
-        private bool disposedValue;
-
         [System.Diagnostics.CodeAnalysis.SuppressMessage(
             "Security",
             "CA2100:Review SQL queries for security vulnerabilities",
@@ -22,101 +17,34 @@ namespace Microsoft.Plugin.Indexer.SearchHelper
         public List<OleDBResult> Query(string connectionString, string sqlQuery)
         {
             List<OleDBResult> result = new List<OleDBResult>();
-
-            using (conn = new OleDbConnection(connectionString))
+            using (var conn = new OleDbConnection(connectionString))
             {
                 // open the connection
                 conn.Open();
 
-                try
+                // now create an OleDB command object with the query we built above and the connection we just opened.
+                using (var command = new OleDbCommand(sqlQuery, conn))
                 {
-                    // now create an OleDB command object with the query we built above and the connection we just opened.
-                    using (command = new OleDbCommand(sqlQuery, conn))
+                    using (var wDSResults = command.ExecuteReader())
                     {
-                        using (wDSResults = command.ExecuteReader())
+                        if (!wDSResults.IsClosed && wDSResults.HasRows)
                         {
-                            if (!wDSResults.IsClosed && wDSResults.HasRows)
+                            while (wDSResults.IsClosed && wDSResults.Read())
                             {
-                                while (!wDSResults.IsClosed && wDSResults.Read())
+                                List<object> fieldData = new List<object>(wDSResults.FieldCount);
+                                for (int i = 0; i < wDSResults.FieldCount; i++)
                                 {
-                                    List<object> fieldData = new List<object>(wDSResults.FieldCount);
-                                    for (int i = 0; i < wDSResults.FieldCount; i++)
-                                    {
-                                        fieldData.Add(wDSResults.GetValue(i));
-                                    }
-
-                                    result.Add(new OleDBResult(fieldData));
+                                    fieldData.Add(wDSResults.GetValue(i));
                                 }
+
+                                result.Add(new OleDBResult(fieldData));
                             }
                         }
                     }
                 }
-
-                // AccessViolationException can occur if another query is made before the current query completes. Since the old query would be cancelled we can ignore the exception
-                catch (System.AccessViolationException)
-                {
-                    // do nothing
-                }
             }
 
             return result;
-        }
-
-        // Checks if all the variables related to database connection have been properly disposed
-        public bool HaveAllDisposableItemsBeenDisposed()
-        {
-            bool commandDisposed = false;
-            bool connDisposed = false;
-            bool resultDisposed = false;
-
-            try
-            {
-                command.ExecuteReader();
-            }
-            catch (InvalidOperationException)
-            {
-                commandDisposed = true;
-            }
-
-            try
-            {
-                wDSResults.Read();
-            }
-            catch (InvalidOperationException)
-            {
-                resultDisposed = true;
-            }
-
-            if (conn.State == System.Data.ConnectionState.Closed)
-            {
-                connDisposed = true;
-            }
-
-            return commandDisposed && resultDisposed && connDisposed;
-        }
-
-        protected virtual void Dispose(bool disposing)
-        {
-            if (!disposedValue)
-            {
-                if (disposing)
-                {
-                    command?.Dispose();
-                    conn?.Dispose();
-                    wDSResults?.Dispose();
-                }
-
-                // TODO: free unmanaged resources (unmanaged objects) and override finalizer
-                // TODO: set large fields to null
-                disposedValue = true;
-            }
-        }
-
-        public void Dispose()
-        {
-            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
-            Dispose(disposing: true);
-            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/modules/launcher/Wox.Test/Plugins/WindowsIndexerTest.cs
+++ b/src/modules/launcher/Wox.Test/Plugins/WindowsIndexerTest.cs
@@ -165,22 +165,6 @@ namespace Wox.Test.Plugins
         }
 
         [Test]
-        [Ignore("This method is throwing the follwoing exception in CI. Ignoring temporarily until I understand why. Can't repro locally. System.Data.OleDb.OleDbException : IErrorInfo.GetDescription failed with E_FAIL(0x80004005).")]
-        public void ExecuteQuery_ShouldDisposeAllConnections_AfterFunctionCall()
-        {
-            // Arrange
-            OleDBSearch oleDbSearch = new OleDBSearch();
-            WindowsSearchAPI api = new WindowsSearchAPI(oleDbSearch);
-            var mockSearchManager = GetMockSearchManager();
-
-            // Act
-            api.Search("FilePath", mockSearchManager);
-
-            // Assert
-            Assert.IsTrue(oleDbSearch.HaveAllDisposableItemsBeenDisposed());
-        }
-
-        [Test]
         public void WindowsSearchAPI_ShouldReturnResults_WhenSearchWasExecuted()
         {
             // Arrange


### PR DESCRIPTION
## Summary of the Pull Request

Removes member variables from OleDbSearch that was making it not thread safe.

## PR Checklist
* [x] Applies to #6050
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

1.  Removes OleDB* member variables that are not thread safe, and may be uses accross threads. 
2.  Removes the `catch (System.AccessViolationException)` as this doesn't handle exceptions from corrupted memory outside of CLR -- see [here](https://docs.microsoft.com/en-us/dotnet/api/system.accessviolationexception?view=netcore-3.1#accessviolationexception-and-trycatch-blocks)
3.  Removes ExecuteQuery_ShouldDisposeAllConnections_AfterFunctionCall' unit test as this requires the use of the member variable, and to be pedantic is really testing an implementation detail of the method (not a publicly observable state or side effect). 

## Validation Steps Performed

1. In Powertoys Run Repeat over and over and over again: 
 1.1 Type "C:/Repos/"
 1.2 Quickly Delete the above text
2. Run Wox.Test unit tests.

**Note**:   As concurrency issues tend to behave different on different machines.  It would be great if second person could verify that they a) can reproduce the issue, and b) can verify that this change 