### PR TITLE
Fix sequence empty exception on calling max in program plugin

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Main.cs
@@ -87,8 +87,11 @@ namespace Microsoft.Plugin.Program
                 .Select(p => p.Result(query.Search, _context.API));
 
             var result = results1.Concat(results2).Where(r => r != null && r.Score > 0);
-            var maxScore = result.Max(x => x.Score);
-            result = result.Where(x => x.Score > Settings.MinScoreThreshold * maxScore);
+            if (result.Any())
+            {
+                var maxScore = result.Max(x => x.Score);
+                result = result.Where(x => x.Score > Settings.MinScoreThreshold * maxScore);
+            }
 
             return result.ToList();
         }


### PR DESCRIPTION
## Summary of the Pull Request
Fix `Sequence contains no elements` on calling max in program plugin.

## PR Checklist
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed

## Info on Pull Request
`Sequence contains no elements` error was thrown when the program plugin returned empty results. This PR fixes this by explicitly checking for an empty list before calling this function. 

## Validation Steps Performed
Manually validated that error is not thrown if the program plugin returns empty result.