### PR TITLE
[FancyZones] ZoneWindow: thread safety

### DIFF
--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -525,7 +525,8 @@ ZoneWindow::ShowZoneWindow() noexcept
 
     SetWindowPos(window, windowInsertAfter, 0, 0, 0, 0, flags);
 
-    std::thread{ [=]() {
+    std::thread{ [this, strong_this{ get_strong() }]() {
+        auto window = m_window.get();
         AnimateWindow(window, m_showAnimationDuration, AW_BLEND);
         InvalidateRect(window, nullptr, true);
         if (!m_host->InMoveSize())


### PR DESCRIPTION
## Summary of the Pull Request

Capture strong reference in `ZoneWindow::ShowZoneWindow` to prevent this from being destructed during thread work.

## PR Checklist
* [x] Applies to #6064
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed

## Validation Steps Performed

Run `ZoneWindowUnitTests`, ensure that all tests passed without errors and exceptions.
