### PR TITLE
Fix Accessibility Issues of PT Run settings page

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -591,6 +591,9 @@
   <data name="About_PowerLauncher.Text" xml:space="preserve">
     <value>About PowerToys Run</value>
   </data>
+  <data name="PowerToys_Run_Image.AutomationProperties.Name" xml:space="preserve">
+    <value>PowerToys Run</value>
+  </data>
   <data name="About_PowerRename.Text" xml:space="preserve">
     <value>About Power Rename</value>
   </data>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
@@ -174,7 +174,7 @@
                     HorizontalAlignment="Left"
                     Margin="{StaticResource SmallTopBottomMargin}"
                     RelativePanel.Below="DescriptionPanel">
-                <Image Source="ms-appx:///Assets/Modules/PowerLauncher.png" />
+                <Image x:Uid="PowerToys_Run_Image" Source="ms-appx:///Assets/Modules/PowerLauncher.png" />
             </Border>
 
             <StackPanel x:Name="LinksPanel"


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

This PR fixes the PT Run settings page accessibility issues.

## PR Checklist
* [x] Applies to #5739
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

The following changes are made in this PR:
1. The number box has been labeled by the textblock above it so that the screen reader reads out the heading `Maximum number of results` when the focus is set on the edit number box.
2. Additional information has been set to the image on the right so that it reads out `PowerToys Run graphic` now instead of just the word `graphic`.

##Note:
1. The issues related to the custom controls have been fixed in the fancy zones settings page accessibility fixes PR. #6045
2.  The number box related issues are being tracked in the tracker as they have a dependency on the WinUI team.  #6083
3. The null bounding rectangle property issue would be fixed once we move to winui 3. #6083

## Validation Steps Performed

_How does someone test & validate?_

* Install NVDA (screen reader).
* Tab to the elements or read the entire app using Insert+B.