### PR TITLE
Fix Accessibility issues of the shortcut guide settings page

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -597,6 +597,9 @@
   <data name="About_ShortcutGuide.Text" xml:space="preserve">
     <value>About Shortcut Guide</value>
   </data>
+  <data name="Shortcut_Guide_Image.AutomationProperties.Name" xml:space="preserve">
+    <value>Shortcut Guide</value>
+  </data>
   <data name="General_Repository.Text" xml:space="preserve">
     <value>GitHub repository</value>
   </data>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ShortcutGuidePage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ShortcutGuidePage.xaml
@@ -56,7 +56,8 @@
                        Style="{StaticResource SettingsGroupTitleStyle}"
                        Foreground="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToForegroundConverter}}"/>
 
-            <TextBlock x:Uid="ShortcutGuide_PressTime"
+            <TextBlock Name="ShortcutGuide_PressTime"
+                x:Uid="ShortcutGuide_PressTime"
                 Margin="{StaticResource SmallTopMargin}"
                 Foreground="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToForegroundConverter}}"/>
 
@@ -68,7 +69,8 @@
                             Value="{x:Bind Mode=TwoWay, Path=ViewModel.PressTime}"
                             IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}" 
                             SmallChange="50" 
-                            LargeChange="100"/>
+                            LargeChange="100"
+                            AutomationProperties.LabeledBy="{Binding ElementName=ShortcutGuide_PressTime}"/>
 
             <StackPanel Orientation="Horizontal" Margin="{StaticResource MediumTopMargin}" Spacing="12">
                 <Slider x:Uid="ShortcutGuide_OverlayOpacity"

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ShortcutGuidePage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ShortcutGuidePage.xaml
@@ -130,7 +130,7 @@
                     HorizontalAlignment="Left"
                     Margin="{StaticResource SmallTopBottomMargin}"
                     RelativePanel.Below="DescriptionPanel">
-                <Image Source="ms-appx:///Assets/Modules/ShortcutGuide.png" />
+                <Image x:Uid="Shortcut_Guide_Image" Source="ms-appx:///Assets/Modules/ShortcutGuide.png" />
             </Border>
 
             <StackPanel x:Name="LinksPanel"

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ShortcutGuidePage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ShortcutGuidePage.xaml
@@ -91,14 +91,18 @@
                     Foreground="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToForegroundConverter}}"/>
             </StackPanel>
 
-            <TextBlock x:Uid="ShortcutGuide_Theme"
+            <!-- We cannot navigate to all the radio buttons using the arrow keys because of an XYNavigation issue in the RadioButtons control.
+            The screen reader does not read the heading when we tab into a radio button, even though the LabeledBy automation property is set.
+            Link to the issue in the winui repository - https://github.com/microsoft/microsoft-ui-xaml/issues/3156 -->
+            <TextBlock Name="ShortcutGuide_Theme"
+                x:Uid="ShortcutGuide_Theme"
                 Margin="{StaticResource SmallTopMargin}"
                 Foreground="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToForegroundConverter}}"/>
-
             <muxc:RadioButtons IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"
                                SelectedIndex="{x:Bind Mode=TwoWay, Path=ViewModel.ThemeIndex}"
-                               Margin="{StaticResource HeaderTextTopMargin}">
-                <RadioButton x:Uid="GeneralPage_Radio_Theme_Dark"/>
+                               Margin="{StaticResource HeaderTextTopMargin}"
+                               AutomationProperties.LabeledBy="{Binding ElementName=ShortcutGuide_Theme}">
+                <RadioButton x:Uid="GeneralPage_Radio_Theme_Dark" />
                 <RadioButton x:Uid="GeneralPage_Radio_Theme_Light" />
                 <RadioButton x:Uid="GeneralPage_Radio_Theme_Default"/>
             </muxc:RadioButtons>


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

This PR fixes the accessibility issues of the shortcut guide pane in the settings page.

## PR Checklist
* [x] Applies to #5741
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

The following changes have been made in this PR to fix accesibility issues - 
1. Set the Automation property to the number box so that it is now being labeled by the text block.
2. Added a comment regarding the accessibility issue in the radio button and a link to the issue in the microsoft-ui-xaml repository.
3. Added more context to the image so that it now says 'Shortcut Guide graphic' instead of just graphic.

The rest of the issues have an external dependency on the controls being fixed by the microsoft-ui-xaml team - #6083.

## Validation Steps Performed

_How does someone test & validate?_

* Install NVDA and listen to the screen reader on focusing on an item.