### PR TITLE
[FancyZones] fix warnings

### DIFF
--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -250,10 +250,10 @@ private:
 
     bool IsSplashScreen(HWND window);
     bool ShouldProcessNewWindow(HWND window) noexcept;
-    std::vector<int> GetZoneIndexSetFromWorkAreaHistory(HWND window, winrt::com_ptr<IZoneWindow> workArea) noexcept;
-    std::pair<winrt::com_ptr<IZoneWindow>, std::vector<int>> GetAppZoneHistoryInfo(HWND window, HMONITOR monitor, std::unordered_map<HMONITOR, winrt::com_ptr<IZoneWindow>>& workAreaMap) noexcept;
-    std::pair<winrt::com_ptr<IZoneWindow>, std::vector<int>> GetAppZoneHistoryInfo(HWND window, HMONITOR monitor, bool isPrimaryMonitor) noexcept;
-    void MoveWindowIntoZone(HWND window, winrt::com_ptr<IZoneWindow> zoneWindow, const std::vector<int>& zoneIndexSet) noexcept;
+    std::vector<size_t> GetZoneIndexSetFromWorkAreaHistory(HWND window, winrt::com_ptr<IZoneWindow> workArea) noexcept;
+    std::pair<winrt::com_ptr<IZoneWindow>, std::vector<size_t>> GetAppZoneHistoryInfo(HWND window, HMONITOR monitor, std::unordered_map<HMONITOR, winrt::com_ptr<IZoneWindow>>& workAreaMap) noexcept;
+    std::pair<winrt::com_ptr<IZoneWindow>, std::vector<size_t>> GetAppZoneHistoryInfo(HWND window, HMONITOR monitor, bool isPrimaryMonitor) noexcept;
+    void MoveWindowIntoZone(HWND window, winrt::com_ptr<IZoneWindow> zoneWindow, const std::vector<size_t>& zoneIndexSet) noexcept;
 
     void OnEditorExitEvent() noexcept;
     bool ShouldProcessSnapHotkey(DWORD vkCode) noexcept;
@@ -383,7 +383,7 @@ bool FancyZones::ShouldProcessNewWindow(HWND window) noexcept
     return true;
 }
 
-std::vector<int> FancyZones::GetZoneIndexSetFromWorkAreaHistory(
+std::vector<size_t> FancyZones::GetZoneIndexSetFromWorkAreaHistory(
     HWND window,
     winrt::com_ptr<IZoneWindow> workArea) noexcept
 {
@@ -399,7 +399,7 @@ std::vector<int> FancyZones::GetZoneIndexSetFromWorkAreaHistory(
     return {};
 }
 
-std::pair<winrt::com_ptr<IZoneWindow>, std::vector<int>> FancyZones::GetAppZoneHistoryInfo(
+std::pair<winrt::com_ptr<IZoneWindow>, std::vector<size_t>> FancyZones::GetAppZoneHistoryInfo(
     HWND window,
     HMONITOR monitor,
     std::unordered_map<HMONITOR, winrt::com_ptr<IZoneWindow>>& workAreaMap) noexcept
@@ -413,9 +413,9 @@ std::pair<winrt::com_ptr<IZoneWindow>, std::vector<int>> FancyZones::GetAppZoneH
     return { nullptr, {} };
 }
 
-std::pair<winrt::com_ptr<IZoneWindow>, std::vector<int>> FancyZones::GetAppZoneHistoryInfo(HWND window, HMONITOR monitor, bool isPrimaryMonitor) noexcept
+std::pair<winrt::com_ptr<IZoneWindow>, std::vector<size_t>> FancyZones::GetAppZoneHistoryInfo(HWND window, HMONITOR monitor, bool isPrimaryMonitor) noexcept
 {
-    std::pair<winrt::com_ptr<IZoneWindow>, std::vector<int>> appZoneHistoryInfo{ nullptr, {} };
+    std::pair<winrt::com_ptr<IZoneWindow>, std::vector<size_t>> appZoneHistoryInfo{ nullptr, {} };
     auto workAreaMap = m_workAreaHandler.GetWorkAreasByDesktopId(m_currentDesktopId);
 
     // Search application history on currently active monitor.
@@ -437,7 +437,7 @@ std::pair<winrt::com_ptr<IZoneWindow>, std::vector<int>> FancyZones::GetAppZoneH
     return appZoneHistoryInfo;
 }
 
-void FancyZones::MoveWindowIntoZone(HWND window, winrt::com_ptr<IZoneWindow> zoneWindow, const std::vector<int>& zoneIndexSet) noexcept
+void FancyZones::MoveWindowIntoZone(HWND window, winrt::com_ptr<IZoneWindow> zoneWindow, const std::vector<size_t>& zoneIndexSet) noexcept
 {
     auto& fancyZonesData = FancyZonesDataInstance();
     if (!fancyZonesData.IsAnotherWindowOfApplicationInstanceZoned(window, zoneWindow->UniqueId()))
@@ -543,7 +543,7 @@ FancyZones::WindowCreated(HWND window) noexcept
         if (moveToAppLastZone)
         {
             const bool primaryActive = (primary == active);
-            std::pair<winrt::com_ptr<IZoneWindow>, std::vector<int>> appZoneHistoryInfo = GetAppZoneHistoryInfo(window, active, primaryActive);
+            std::pair<winrt::com_ptr<IZoneWindow>, std::vector<size_t>> appZoneHistoryInfo = GetAppZoneHistoryInfo(window, active, primaryActive);
             if (!appZoneHistoryInfo.second.empty())
             {
                 MoveWindowIntoZone(window, appZoneHistoryInfo.first, appZoneHistoryInfo.second);
@@ -1032,7 +1032,7 @@ void FancyZones::UpdateWindowsPositions() noexcept
 
         if (bitmask != 0)
         {
-            std::vector<int> indexSet;
+            std::vector<size_t> indexSet;
             for (int i = 0; i < std::numeric_limits<size_t>::digits; i++)
             {
                 if ((1ull << i) & bitmask)
@@ -1136,6 +1136,8 @@ bool FancyZones::OnSnapHotkeyBasedOnZoneNumber(HWND window, DWORD vkCode) noexce
             return m_windowMoveHandler.MoveWindowIntoZoneByDirectionAndIndex(window, vkCode, true /* cycle through zones */, m_workAreaHandler.GetWorkArea(m_currentDesktopId, current));
         }
     }
+
+    return false;
 }
 
 bool FancyZones::OnSnapHotkeyBasedOnPosition(HWND window, DWORD vkCode) noexcept
@@ -1211,7 +1213,7 @@ bool FancyZones::OnSnapHotkeyBasedOnPosition(HWND window, DWORD vkCode) noexcept
         {
             // Moving to another monitor succeeded
             const auto& [trueZoneIdx, zoneWindow] = zoneRectsInfo[chosenIdx];
-            m_windowMoveHandler.MoveWindowIntoZoneByIndexSet(window, { static_cast<int>(trueZoneIdx) }, zoneWindow);
+            m_windowMoveHandler.MoveWindowIntoZoneByIndexSet(window, { trueZoneIdx }, zoneWindow);
             return true;
         }
 
@@ -1253,7 +1255,7 @@ bool FancyZones::OnSnapHotkeyBasedOnPosition(HWND window, DWORD vkCode) noexcept
         {
             // Moving to another monitor succeeded
             const auto& [trueZoneIdx, zoneWindow] = zoneRectsInfo[chosenIdx];
-            m_windowMoveHandler.MoveWindowIntoZoneByIndexSet(window, { static_cast<int>(trueZoneIdx) }, zoneWindow);
+            m_windowMoveHandler.MoveWindowIntoZoneByIndexSet(window, { trueZoneIdx }, zoneWindow);
             return true;
         }
         else

--- a/src/modules/fancyzones/lib/FancyZonesData.cpp
+++ b/src/modules/fancyzones/lib/FancyZonesData.cpp
@@ -244,7 +244,7 @@ void FancyZonesData::UpdateProcessIdToHandleMap(HWND window, const std::wstring_
     }
 }
 
-std::vector<int> FancyZonesData::GetAppLastZoneIndexSet(HWND window, const std::wstring_view& deviceId, const std::wstring_view& zoneSetId) const
+std::vector<size_t> FancyZonesData::GetAppLastZoneIndexSet(HWND window, const std::wstring_view& deviceId, const std::wstring_view& zoneSetId) const
 {
     std::scoped_lock lock{ dataLock };
     auto processPath = get_process_path(window);
@@ -319,7 +319,7 @@ bool FancyZonesData::RemoveAppLastZone(HWND window, const std::wstring_view& dev
     return false;
 }
 
-bool FancyZonesData::SetAppLastZones(HWND window, const std::wstring& deviceId, const std::wstring& zoneSetId, const std::vector<int>& zoneIndexSet)
+bool FancyZonesData::SetAppLastZones(HWND window, const std::wstring& deviceId, const std::wstring& zoneSetId, const std::vector<size_t>& zoneIndexSet)
 {
     std::scoped_lock lock{ dataLock };
 

--- a/src/modules/fancyzones/lib/FancyZonesData.h
+++ b/src/modules/fancyzones/lib/FancyZonesData.h
@@ -65,9 +65,9 @@ public:
 
     bool IsAnotherWindowOfApplicationInstanceZoned(HWND window, const std::wstring_view& deviceId) const;
     void UpdateProcessIdToHandleMap(HWND window, const std::wstring_view& deviceId);
-    std::vector<int> GetAppLastZoneIndexSet(HWND window, const std::wstring_view& deviceId, const std::wstring_view& zoneSetId) const;
+    std::vector<size_t> GetAppLastZoneIndexSet(HWND window, const std::wstring_view& deviceId, const std::wstring_view& zoneSetId) const;
     bool RemoveAppLastZone(HWND window, const std::wstring_view& deviceId, const std::wstring_view& zoneSetId);
-    bool SetAppLastZones(HWND window, const std::wstring& deviceId, const std::wstring& zoneSetId, const std::vector<int>& zoneIndexSet);
+    bool SetAppLastZones(HWND window, const std::wstring& deviceId, const std::wstring& zoneSetId, const std::vector<size_t>& zoneIndexSet);
 
     void SetActiveZoneSet(const std::wstring& deviceId, const FancyZonesDataTypes::ZoneSetData& zoneSet);
 

--- a/src/modules/fancyzones/lib/FancyZonesDataTypes.h
+++ b/src/modules/fancyzones/lib/FancyZonesDataTypes.h
@@ -105,7 +105,7 @@ namespace FancyZonesDataTypes
 
         std::wstring zoneSetUuid;
         std::wstring deviceId;
-        std::vector<int> zoneIndexSet;
+        std::vector<size_t> zoneIndexSet;
     };
 
     struct DeviceInfoData

--- a/src/modules/fancyzones/lib/JsonHelpers.cpp
+++ b/src/modules/fancyzones/lib/JsonHelpers.cpp
@@ -79,12 +79,12 @@ namespace
             data.zoneIndexSet = {};
             for (auto& value : json.GetNamedArray(NonLocalizable::ZoneIndexSetStr))
             {
-                data.zoneIndexSet.push_back(static_cast<int>(value.GetNumber()));
+                data.zoneIndexSet.push_back(static_cast<size_t>(value.GetNumber()));
             }
         }
         else if (json.HasKey(NonLocalizable::ZoneIndexStr))
         {
-            data.zoneIndexSet = { static_cast<int>(json.GetNamedNumber(NonLocalizable::ZoneIndexStr)) };
+            data.zoneIndexSet = { static_cast<size_t>(json.GetNamedNumber(NonLocalizable::ZoneIndexStr)) };
         }
 
         data.deviceId = json.GetNamedString(NonLocalizable::DeviceIdStr);
@@ -338,9 +338,9 @@ namespace JSONHelpers
         {
             json::JsonObject desktopData;
             json::JsonArray jsonIndexSet;
-            for (int index : data.zoneIndexSet)
+            for (size_t index : data.zoneIndexSet)
             {
-                jsonIndexSet.Append(json::value(index));
+                jsonIndexSet.Append(json::value(static_cast<int>(index)));
             }
 
             desktopData.SetNamedValue(NonLocalizable::ZoneIndexSetStr, jsonIndexSet);

--- a/src/modules/fancyzones/lib/WindowMoveHandler.cpp
+++ b/src/modules/fancyzones/lib/WindowMoveHandler.cpp
@@ -82,7 +82,7 @@ public:
     void MoveSizeUpdate(HMONITOR monitor, POINT const& ptScreen, const std::unordered_map<HMONITOR, winrt::com_ptr<IZoneWindow>>& zoneWindowMap) noexcept;
     void MoveSizeEnd(HWND window, POINT const& ptScreen, const std::unordered_map<HMONITOR, winrt::com_ptr<IZoneWindow>>& zoneWindowMap) noexcept;
 
-    void MoveWindowIntoZoneByIndexSet(HWND window, const std::vector<int>& indexSet, winrt::com_ptr<IZoneWindow> zoneWindow) noexcept;
+    void MoveWindowIntoZoneByIndexSet(HWND window, const std::vector<size_t>& indexSet, winrt::com_ptr<IZoneWindow> zoneWindow) noexcept;
     bool MoveWindowIntoZoneByDirectionAndIndex(HWND window, DWORD vkCode, bool cycle, winrt::com_ptr<IZoneWindow> zoneWindow);
     bool MoveWindowIntoZoneByDirectionAndPosition(HWND window, DWORD vkCode, bool cycle, winrt::com_ptr<IZoneWindow> zoneWindow);
 
@@ -165,7 +165,7 @@ void WindowMoveHandler::MoveSizeEnd(HWND window, POINT const& ptScreen, const st
     pimpl->MoveSizeEnd(window, ptScreen, zoneWindowMap);
 }
 
-void WindowMoveHandler::MoveWindowIntoZoneByIndexSet(HWND window, const std::vector<int>& indexSet, winrt::com_ptr<IZoneWindow> zoneWindow) noexcept
+void WindowMoveHandler::MoveWindowIntoZoneByIndexSet(HWND window, const std::vector<size_t>& indexSet, winrt::com_ptr<IZoneWindow> zoneWindow) noexcept
 {
     pimpl->MoveWindowIntoZoneByIndexSet(window, indexSet, zoneWindow);
 }
@@ -387,7 +387,7 @@ void WindowMoveHandlerPrivate::MoveSizeEnd(HWND window, POINT const& ptScreen, c
     }
 }
 
-void WindowMoveHandlerPrivate::MoveWindowIntoZoneByIndexSet(HWND window, const std::vector<int>& indexSet, winrt::com_ptr<IZoneWindow> zoneWindow) noexcept
+void WindowMoveHandlerPrivate::MoveWindowIntoZoneByIndexSet(HWND window, const std::vector<size_t>& indexSet, winrt::com_ptr<IZoneWindow> zoneWindow) noexcept
 {
     if (window != m_windowMoveSize)
     {

--- a/src/modules/fancyzones/lib/WindowMoveHandler.h
+++ b/src/modules/fancyzones/lib/WindowMoveHandler.h
@@ -23,7 +23,7 @@ public:
     void MoveSizeUpdate(HMONITOR monitor, POINT const& ptScreen, const std::unordered_map<HMONITOR, winrt::com_ptr<IZoneWindow>>& zoneWindowMap) noexcept;
     void MoveSizeEnd(HWND window, POINT const& ptScreen, const std::unordered_map<HMONITOR, winrt::com_ptr<IZoneWindow>>& zoneWindowMap) noexcept;
 
-    void MoveWindowIntoZoneByIndexSet(HWND window, const std::vector<int>& indexSet, winrt::com_ptr<IZoneWindow> zoneWindow) noexcept;
+    void MoveWindowIntoZoneByIndexSet(HWND window, const std::vector<size_t>& indexSet, winrt::com_ptr<IZoneWindow> zoneWindow) noexcept;
     bool MoveWindowIntoZoneByDirectionAndIndex(HWND window, DWORD vkCode, bool cycle, winrt::com_ptr<IZoneWindow> zoneWindow);
     bool MoveWindowIntoZoneByDirectionAndPosition(HWND window, DWORD vkCode, bool cycle, winrt::com_ptr<IZoneWindow> zoneWindow);
 

--- a/src/modules/fancyzones/lib/ZoneSet.cpp
+++ b/src/modules/fancyzones/lib/ZoneSet.cpp
@@ -127,16 +127,16 @@ public:
     IFACEMETHODIMP_(FancyZonesDataTypes::ZoneSetLayoutType)
     LayoutType() noexcept { return m_config.LayoutType; }
     IFACEMETHODIMP AddZone(winrt::com_ptr<IZone> zone) noexcept;
-    IFACEMETHODIMP_(std::vector<int>)
+    IFACEMETHODIMP_(std::vector<size_t>)
     ZonesFromPoint(POINT pt) noexcept;
-    IFACEMETHODIMP_(std::vector<int>)
+    IFACEMETHODIMP_(std::vector<size_t>)
     GetZoneIndexSetFromWindow(HWND window) noexcept;
     IFACEMETHODIMP_(std::vector<winrt::com_ptr<IZone>>)
     GetZones() noexcept { return m_zones; }
     IFACEMETHODIMP_(void)
-    MoveWindowIntoZoneByIndex(HWND window, HWND zoneWindow, int index) noexcept;
+    MoveWindowIntoZoneByIndex(HWND window, HWND zoneWindow, size_t index) noexcept;
     IFACEMETHODIMP_(void)
-    MoveWindowIntoZoneByIndexSet(HWND window, HWND windowZone, const std::vector<int>& indexSet) noexcept;
+    MoveWindowIntoZoneByIndexSet(HWND window, HWND windowZone, const std::vector<size_t>& indexSet) noexcept;
     IFACEMETHODIMP_(bool)
     MoveWindowIntoZoneByDirectionAndIndex(HWND window, HWND zoneWindow, DWORD vkCode, bool cycle) noexcept;
     IFACEMETHODIMP_(bool)
@@ -158,7 +158,7 @@ private:
     void StampWindow(HWND window, size_t bitmask) noexcept;
 
     std::vector<winrt::com_ptr<IZone>> m_zones;
-    std::map<HWND, std::vector<int>> m_windowIndexSet;
+    std::map<HWND, std::vector<size_t>> m_windowIndexSet;
     ZoneSetConfig m_config;
 };
 
@@ -172,12 +172,12 @@ IFACEMETHODIMP ZoneSet::AddZone(winrt::com_ptr<IZone> zone) noexcept
     return S_OK;
 }
 
-IFACEMETHODIMP_(std::vector<int>)
+IFACEMETHODIMP_(std::vector<size_t>)
 ZoneSet::ZonesFromPoint(POINT pt) noexcept
 {
     const int SENSITIVITY_RADIUS = 20;
-    std::vector<int> capturedZones;
-    std::vector<int> strictlyCapturedZones;
+    std::vector<size_t> capturedZones;
+    std::vector<size_t> strictlyCapturedZones;
     for (size_t i = 0; i < m_zones.size(); i++)
     {
         auto zone = m_zones[i];
@@ -187,13 +187,13 @@ ZoneSet::ZonesFromPoint(POINT pt) noexcept
             if (newZoneRect.left - SENSITIVITY_RADIUS <= pt.x && pt.x <= newZoneRect.right + SENSITIVITY_RADIUS &&
                 newZoneRect.top - SENSITIVITY_RADIUS <= pt.y && pt.y <= newZoneRect.bottom + SENSITIVITY_RADIUS)
             {
-                capturedZones.emplace_back(static_cast<int>(i));
+                capturedZones.emplace_back(i);
             }
             
             if (newZoneRect.left <= pt.x && pt.x < newZoneRect.right &&
                 newZoneRect.top <= pt.y && pt.y < newZoneRect.bottom)
             {
-                strictlyCapturedZones.emplace_back(static_cast<int>(i));
+                strictlyCapturedZones.emplace_back(i);
             }
         }
     }
@@ -247,7 +247,7 @@ ZoneSet::ZonesFromPoint(POINT pt) noexcept
     return capturedZones;
 }
 
-std::vector<int> ZoneSet::GetZoneIndexSetFromWindow(HWND window) noexcept
+std::vector<size_t> ZoneSet::GetZoneIndexSetFromWindow(HWND window) noexcept
 {
     auto it = m_windowIndexSet.find(window);
     if (it == m_windowIndexSet.end())
@@ -261,13 +261,13 @@ std::vector<int> ZoneSet::GetZoneIndexSetFromWindow(HWND window) noexcept
 }
 
 IFACEMETHODIMP_(void)
-ZoneSet::MoveWindowIntoZoneByIndex(HWND window, HWND windowZone, int index) noexcept
+ZoneSet::MoveWindowIntoZoneByIndex(HWND window, HWND windowZone, size_t index) noexcept
 {
     MoveWindowIntoZoneByIndexSet(window, windowZone, { index });
 }
 
 IFACEMETHODIMP_(void)
-ZoneSet::MoveWindowIntoZoneByIndexSet(HWND window, HWND windowZone, const std::vector<int>& indexSet) noexcept
+ZoneSet::MoveWindowIntoZoneByIndexSet(HWND window, HWND windowZone, const std::vector<size_t>& indexSet) noexcept
 {
     if (m_zones.empty())
     {
@@ -281,9 +281,9 @@ ZoneSet::MoveWindowIntoZoneByIndexSet(HWND window, HWND windowZone, const std::v
     auto& storedIndexSet = m_windowIndexSet[window];
     storedIndexSet = {};
 
-    for (int index : indexSet)
+    for (size_t index : indexSet)
     {
-        if (index < static_cast<int>(m_zones.size()))
+        if (index < m_zones.size())
         {
             RECT newSize = m_zones.at(index)->ComputeActualZoneRect(window, windowZone);
             if (!sizeEmpty)
@@ -325,7 +325,7 @@ ZoneSet::MoveWindowIntoZoneByDirectionAndIndex(HWND window, HWND windowZone, DWO
     }
 
     auto indexSet = GetZoneIndexSetFromWindow(window);
-    int numZones = static_cast<int>(m_zones.size());
+    size_t numZones = m_zones.size();
 
     // The window was not assigned to any zone here
     if (indexSet.size() == 0)
@@ -334,7 +334,7 @@ ZoneSet::MoveWindowIntoZoneByDirectionAndIndex(HWND window, HWND windowZone, DWO
         return true;
     }
 
-    int oldIndex = indexSet[0];
+    size_t oldIndex = indexSet[0];
 
     // We reached the edge
     if ((vkCode == VK_LEFT && oldIndex == 0) || (vkCode == VK_RIGHT && oldIndex == numZones - 1))

--- a/src/modules/fancyzones/lib/ZoneSet.h
+++ b/src/modules/fancyzones/lib/ZoneSet.h
@@ -33,14 +33,14 @@ interface __declspec(uuid("{E4839EB7-669D-49CF-84A9-71A2DFD851A3}")) IZoneSet : 
      * @param   pt Cursor coordinates.
      * @returns Vector of indices, corresponding to the current set of zones - the zones considered active.
      */
-    IFACEMETHOD_(std::vector<int>, ZonesFromPoint)(POINT pt) = 0;
+    IFACEMETHOD_(std::vector<size_t>, ZonesFromPoint)(POINT pt) = 0;
     /**
      * Get index set of the zones to which the window was assigned.
      *
      * @param   window Handle of the window.
-     * @returns A vector of integers, 0-based, the index set.
+     * @returns A vector of size_t, 0-based, the index set.
      */
-    IFACEMETHOD_(std::vector<int>, GetZoneIndexSetFromWindow)(HWND window) = 0;
+    IFACEMETHOD_(std::vector<size_t>, GetZoneIndexSetFromWindow)(HWND window) = 0;
     /**
      * @returns Array of zone objects (defining coordinates of the zone) inside this zone layout.
      */
@@ -53,7 +53,7 @@ interface __declspec(uuid("{E4839EB7-669D-49CF-84A9-71A2DFD851A3}")) IZoneSet : 
      *                     current monitor desktop work area.
      * @param   index      Zone index within zone layout.
      */
-    IFACEMETHOD_(void, MoveWindowIntoZoneByIndex)(HWND window, HWND zoneWindow, int index) = 0;
+    IFACEMETHOD_(void, MoveWindowIntoZoneByIndex)(HWND window, HWND zoneWindow, size_t index) = 0;
     /**
      * Assign window to the zones based on the set of zone indices inside zone layout.
      *
@@ -62,7 +62,7 @@ interface __declspec(uuid("{E4839EB7-669D-49CF-84A9-71A2DFD851A3}")) IZoneSet : 
      *                     current monitor desktop work area.
      * @param   indexSet   The set of zone indices within zone layout.
      */
-    IFACEMETHOD_(void, MoveWindowIntoZoneByIndexSet)(HWND window, HWND zoneWindow, const std::vector<int>& indexSet) = 0;
+    IFACEMETHOD_(void, MoveWindowIntoZoneByIndexSet)(HWND window, HWND zoneWindow, const std::vector<size_t>& indexSet) = 0;
     /**
      * Assign window to the zone based on direction (using WIN + LEFT/RIGHT arrow), based on zone index numbers,
      * not their on-screen position.

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -123,7 +123,7 @@ namespace ZoneWindowDrawUtils
                            COLORREF highlightColor,
                            int zoneOpacity,
                            const std::vector<winrt::com_ptr<IZone>>& zones,
-                           const std::vector<int>& highlightZones,
+                           const std::vector<size_t>& highlightZones,
                            bool flashMode,
                            bool drawHints) noexcept
     {
@@ -134,7 +134,7 @@ namespace ZoneWindowDrawUtils
         ColorSetting const colorFlash{ OpacitySettingToAlpha(zoneOpacity), RGB(81, 92, 107), 200, RGB(104, 118, 138), -2 };
 
         std::vector<bool> isHighlighted(zones.size(), false);
-        for (int x : highlightZones)
+        for (size_t x : highlightZones)
         {
             isHighlighted[x] = true;
         }
@@ -142,7 +142,7 @@ namespace ZoneWindowDrawUtils
         // First draw the inactive zones
         for (auto iter = zones.begin(); iter != zones.end(); iter++)
         {
-            int zoneId = static_cast<int>(iter - zones.begin());
+            size_t zoneId = iter - zones.begin();
             winrt::com_ptr<IZone> zone = iter->try_as<IZone>();
             if (!zone)
             {
@@ -170,7 +170,7 @@ namespace ZoneWindowDrawUtils
         // Draw the active zones on top of the inactive zones
         for (auto iter = zones.begin(); iter != zones.end(); iter++)
         {
-            int zoneId = static_cast<int>(iter - zones.begin());
+            size_t zoneId = iter - zones.begin();
             winrt::com_ptr<IZone> zone = iter->try_as<IZone>();
             if (!zone)
             {
@@ -199,9 +199,9 @@ public:
     IFACEMETHODIMP MoveSizeUpdate(POINT const& ptScreen, bool dragEnabled, bool selectManyZones) noexcept;
     IFACEMETHODIMP MoveSizeEnd(HWND window, POINT const& ptScreen) noexcept;
     IFACEMETHODIMP_(void)
-    MoveWindowIntoZoneByIndex(HWND window, int index) noexcept;
+    MoveWindowIntoZoneByIndex(HWND window, size_t index) noexcept;
     IFACEMETHODIMP_(void)
-    MoveWindowIntoZoneByIndexSet(HWND window, const std::vector<int>& indexSet) noexcept;
+    MoveWindowIntoZoneByIndexSet(HWND window, const std::vector<size_t>& indexSet) noexcept;
     IFACEMETHODIMP_(bool)
     MoveWindowIntoZoneByDirectionAndIndex(HWND window, DWORD vkCode, bool cycle) noexcept;
     IFACEMETHODIMP_(bool)
@@ -233,7 +233,7 @@ private:
     LRESULT WndProc(UINT message, WPARAM wparam, LPARAM lparam) noexcept;
     void OnPaint(wil::unique_hdc& hdc) noexcept;
     void OnKeyUp(WPARAM wparam) noexcept;
-    std::vector<int> ZonesFromPoint(POINT pt) noexcept;
+    std::vector<size_t> ZonesFromPoint(POINT pt) noexcept;
     void CycleActiveZoneSetInternal(DWORD wparam, Trace::ZoneWindow::InputMode mode) noexcept;
     void FlashZones() noexcept;
 
@@ -246,8 +246,8 @@ private:
     bool m_flashMode{};
     winrt::com_ptr<IZoneSet> m_activeZoneSet;
     std::vector<winrt::com_ptr<IZoneSet>> m_zoneSets;
-    std::vector<int> m_initialHighlightZone;
-    std::vector<int> m_highlightZone;
+    std::vector<size_t> m_initialHighlightZone;
+    std::vector<size_t> m_highlightZone;
     WPARAM m_keyLast{};
     size_t m_keyCycle{};
     static const UINT m_showAnimationDuration = 200; // ms
@@ -360,14 +360,14 @@ IFACEMETHODIMP ZoneWindow::MoveSizeUpdate(POINT const& ptScreen, bool dragEnable
             }
             else
             {
-                std::vector<int> newHighlightZone;
+                std::vector<size_t> newHighlightZone;
                 std::set_union(begin(highlightZone), end(highlightZone), begin(m_initialHighlightZone), end(m_initialHighlightZone), std::back_inserter(newHighlightZone));
 
                 RECT boundingRect;
                 bool boundingRectEmpty = true;
                 auto zones = m_activeZoneSet->GetZones();
 
-                for (int zoneId : newHighlightZone)
+                for (size_t zoneId : newHighlightZone)
                 {
                     RECT rect = zones[zoneId]->GetZoneRect();
                     if (boundingRectEmpty)
@@ -394,7 +394,7 @@ IFACEMETHODIMP ZoneWindow::MoveSizeUpdate(POINT const& ptScreen, bool dragEnable
                         if (boundingRect.left <= rect.left && rect.right <= boundingRect.right &&
                             boundingRect.top <= rect.top && rect.bottom <= boundingRect.bottom)
                         {
-                            highlightZone.push_back(static_cast<int>(zoneId));
+                            highlightZone.push_back(zoneId);
                         }
                     }
                 }
@@ -444,13 +444,13 @@ IFACEMETHODIMP ZoneWindow::MoveSizeEnd(HWND window, POINT const& ptScreen) noexc
 }
 
 IFACEMETHODIMP_(void)
-ZoneWindow::MoveWindowIntoZoneByIndex(HWND window, int index) noexcept
+ZoneWindow::MoveWindowIntoZoneByIndex(HWND window, size_t index) noexcept
 {
     MoveWindowIntoZoneByIndexSet(window, { index });
 }
 
 IFACEMETHODIMP_(void)
-ZoneWindow::MoveWindowIntoZoneByIndexSet(HWND window, const std::vector<int>& indexSet) noexcept
+ZoneWindow::MoveWindowIntoZoneByIndexSet(HWND window, const std::vector<size_t>& indexSet) noexcept
 {
     if (m_activeZoneSet)
     {
@@ -747,7 +747,7 @@ void ZoneWindow::OnKeyUp(WPARAM wparam) noexcept
     }
 }
 
-std::vector<int> ZoneWindow::ZonesFromPoint(POINT pt) noexcept
+std::vector<size_t> ZoneWindow::ZonesFromPoint(POINT pt) noexcept
 {
     if (m_activeZoneSet)
     {

--- a/src/modules/fancyzones/lib/ZoneWindow.h
+++ b/src/modules/fancyzones/lib/ZoneWindow.h
@@ -49,14 +49,14 @@ interface __declspec(uuid("{7F017528-8110-4FB3-BE41-F472969C2560}")) IZoneWindow
      * @param   window Handle of window which should be assigned to zone.
      * @param   index  Zone index within zone layout.
      */
-    IFACEMETHOD_(void, MoveWindowIntoZoneByIndex)(HWND window, int index) = 0;
+    IFACEMETHOD_(void, MoveWindowIntoZoneByIndex)(HWND window, size_t index) = 0;
     /**
      * Assign window to the zones based on the set of zone indices inside zone layout.
      *
      * @param   window   Handle of window which should be assigned to zone.
      * @param   indexSet The set of zone indices within zone layout.
      */
-    IFACEMETHOD_(void, MoveWindowIntoZoneByIndexSet)(HWND window, const std::vector<int>& indexSet) = 0;
+    IFACEMETHOD_(void, MoveWindowIntoZoneByIndexSet)(HWND window, const std::vector<size_t>& indexSet) = 0;
     /**
      * Assign window to the zone based on direction (using WIN + LEFT/RIGHT arrow), based on zone index numbers,
      * not their on-screen position.

--- a/src/modules/fancyzones/tests/UnitTests/JsonHelpers.Tests.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/JsonHelpers.Tests.cpp
@@ -723,7 +723,7 @@ namespace FancyZonesUnitTests
 
             Assert::AreEqual(expected.appPath.c_str(), actual->appPath.c_str());
             Assert::AreEqual(expected.data.size(), actual->data.size());
-            Assert::AreEqual(expected.data[0].zoneIndexSet, actual->data[0].zoneIndexSet);
+            Assert::IsTrue(expected.data[0].zoneIndexSet == actual->data[0].zoneIndexSet);
             Assert::AreEqual(expected.data[0].deviceId.c_str(), actual->data[0].deviceId.c_str());
             Assert::AreEqual(expected.data[0].zoneSetUuid.c_str(), actual->data[0].zoneSetUuid.c_str());
         }
@@ -808,7 +808,7 @@ namespace FancyZonesUnitTests
 
             for (size_t i = 0; i < expected.data.size(); ++i)
             {
-                Assert::AreEqual(expected.data[i].zoneIndexSet, actual->data[i].zoneIndexSet);
+                Assert::IsTrue(expected.data[i].zoneIndexSet == actual->data[i].zoneIndexSet);
                 Assert::AreEqual(expected.data[i].deviceId.c_str(), actual->data[i].deviceId.c_str());
                 Assert::AreEqual(expected.data[i].zoneSetUuid.c_str(), actual->data[i].zoneSetUuid.c_str());
             }
@@ -1141,7 +1141,7 @@ namespace FancyZonesUnitTests
                 const std::wstring expectedAppPath = L"appPath";
                 const std::wstring expectedDeviceId = m_defaultDeviceId;
                 const std::wstring expectedZoneSetId = L"{33A2B101-06E0-437B-A61E-CDBECF502906}";
-                const int expectedIndex = 54321;
+                const size_t expectedIndex = 54321;
 
                 AppZoneHistoryData data{
                     .zoneSetUuid = expectedZoneSetId, .deviceId = expectedDeviceId, .zoneIndexSet = { expectedIndex }
@@ -1163,7 +1163,7 @@ namespace FancyZonesUnitTests
                 Assert::AreEqual(expected.data.size(), entryData.size());
                 Assert::AreEqual(expectedZoneSetId.c_str(), entryData[0].zoneSetUuid.c_str());
                 Assert::AreEqual(expectedDeviceId.c_str(), entryData[0].deviceId.c_str());
-                Assert::AreEqual({ expectedIndex }, entryData[0].zoneIndexSet);
+                Assert::IsTrue(std::vector<size_t>{ expectedIndex } == entryData[0].zoneIndexSet);
             }
 
             TEST_METHOD (AppZoneHistoryParseManyApps)
@@ -1202,7 +1202,7 @@ namespace FancyZonesUnitTests
                     Assert::AreEqual(expected->data.size(), actual.size());
                     Assert::AreEqual(expected->data[0].deviceId.c_str(), actual[0].deviceId.c_str());
                     Assert::AreEqual(expected->data[0].zoneSetUuid.c_str(), actual[0].zoneSetUuid.c_str());
-                    Assert::AreEqual(expected->data[0].zoneIndexSet, actual[0].zoneIndexSet);
+                    Assert::IsTrue(expected->data[0].zoneIndexSet == actual[0].zoneIndexSet);
 
                     iter.MoveNext();
                 }
@@ -1240,7 +1240,7 @@ namespace FancyZonesUnitTests
                 Assert::AreEqual((size_t)1, actual.size());
                 Assert::AreEqual(expected.deviceId.c_str(), actual[0].deviceId.c_str());
                 Assert::AreEqual(expected.zoneSetUuid.c_str(), actual[0].zoneSetUuid.c_str());
-                Assert::AreEqual(expected.zoneIndexSet, actual[0].zoneIndexSet);
+                Assert::IsTrue(expected.zoneIndexSet == actual[0].zoneIndexSet);
             }
 
             TEST_METHOD (AppZoneHistoryParseEmpty)
@@ -1761,11 +1761,11 @@ namespace FancyZonesUnitTests
                 FancyZonesData data;
                 data.SetSettingsModulePath(m_moduleName);
 
-                Assert::AreEqual({}, data.GetAppLastZoneIndexSet(window, deviceId, zoneSetId));
+                Assert::IsTrue(std::vector<size_t>{} == data.GetAppLastZoneIndexSet(window, deviceId, zoneSetId));
 
                 const int expectedZoneIndex = 10;
                 Assert::IsTrue(data.SetAppLastZones(window, deviceId, zoneSetId, { expectedZoneIndex } ));
-                Assert::AreEqual({ expectedZoneIndex }, data.GetAppLastZoneIndexSet(window, deviceId, zoneSetId));
+                Assert::IsTrue(std::vector<size_t>{ expectedZoneIndex } == data.GetAppLastZoneIndexSet(window, deviceId, zoneSetId));
             }
 
             TEST_METHOD (AppLastZoneIndexZero)
@@ -1778,7 +1778,7 @@ namespace FancyZonesUnitTests
 
                 const int expectedZoneIndex = 0;
                 Assert::IsTrue(data.SetAppLastZones(window, deviceId, zoneSetId, { expectedZoneIndex }));
-                Assert::AreEqual({ expectedZoneIndex }, data.GetAppLastZoneIndexSet(window, deviceId, zoneSetId));
+                Assert::IsTrue(std::vector<size_t>{ expectedZoneIndex } == data.GetAppLastZoneIndexSet(window, deviceId, zoneSetId));
             }
 
             TEST_METHOD (AppLastZoneIndexNegative)
@@ -1789,9 +1789,9 @@ namespace FancyZonesUnitTests
                 FancyZonesData data;
                 data.SetSettingsModulePath(m_moduleName);
 
-                const int expectedZoneIndex = -1;
+                const size_t expectedZoneIndex = -1;
                 Assert::IsTrue(data.SetAppLastZones(window, deviceId, zoneSetId, { expectedZoneIndex }));
-                Assert::AreEqual({ expectedZoneIndex }, data.GetAppLastZoneIndexSet(window, deviceId, zoneSetId));
+                Assert::IsTrue(std::vector<size_t>{ expectedZoneIndex } == data.GetAppLastZoneIndexSet(window, deviceId, zoneSetId));
             }
 
             TEST_METHOD (AppLastZoneIndexOverflow)
@@ -1802,9 +1802,9 @@ namespace FancyZonesUnitTests
                 FancyZonesData data;
                 data.SetSettingsModulePath(m_moduleName);
 
-                const long expectedZoneIndex = LONG_MAX;
+                const size_t expectedZoneIndex = ULLONG_MAX;
                 Assert::IsTrue(data.SetAppLastZones(window, deviceId, zoneSetId, { expectedZoneIndex }));
-                Assert::AreEqual({ static_cast<int>(expectedZoneIndex) }, data.GetAppLastZoneIndexSet(window, deviceId, zoneSetId));
+                Assert::IsTrue(std::vector<size_t>{ expectedZoneIndex } == data.GetAppLastZoneIndexSet(window, deviceId, zoneSetId));
             }
 
             TEST_METHOD (AppLastZoneIndexOverride)
@@ -1819,7 +1819,7 @@ namespace FancyZonesUnitTests
                 Assert::IsTrue(data.SetAppLastZones(window, deviceId, zoneSetId, { 1 }));
                 Assert::IsTrue(data.SetAppLastZones(window, deviceId, zoneSetId, { 2 }));
                 Assert::IsTrue(data.SetAppLastZones(window, deviceId, zoneSetId, { expectedZoneIndex }));
-                Assert::AreEqual({ expectedZoneIndex }, data.GetAppLastZoneIndexSet(window, deviceId, zoneSetId));
+                Assert::IsTrue(std::vector<size_t>{ expectedZoneIndex } == data.GetAppLastZoneIndexSet(window, deviceId, zoneSetId));
             }
 
             TEST_METHOD (AppLastZoneInvalidWindow)
@@ -1830,7 +1830,7 @@ namespace FancyZonesUnitTests
                 FancyZonesData data;
                 data.SetSettingsModulePath(m_moduleName);
 
-                Assert::AreEqual({}, data.GetAppLastZoneIndexSet(window, deviceId, zoneSetId));
+                Assert::IsTrue(std::vector<size_t>{} == data.GetAppLastZoneIndexSet(window, deviceId, zoneSetId));
 
                 const int expectedZoneIndex = 1;
                 Assert::IsFalse(data.SetAppLastZones(window, deviceId, zoneSetId, { expectedZoneIndex }));
@@ -1858,8 +1858,8 @@ namespace FancyZonesUnitTests
 
                 const int expectedZoneIndex = 10;
                 Assert::IsTrue(data.SetAppLastZones(window, deviceId1, zoneSetId, { expectedZoneIndex }));
-                Assert::AreEqual({ expectedZoneIndex }, data.GetAppLastZoneIndexSet(window, deviceId1, zoneSetId));
-                Assert::AreEqual({}, data.GetAppLastZoneIndexSet(window, deviceId2, zoneSetId));
+                Assert::IsTrue(std::vector<size_t>{ expectedZoneIndex } == data.GetAppLastZoneIndexSet(window, deviceId1, zoneSetId));
+                Assert::IsTrue(std::vector<size_t>{} == data.GetAppLastZoneIndexSet(window, deviceId2, zoneSetId));
             }
 
             TEST_METHOD (AppLastZoneSetIdTest)
@@ -1873,8 +1873,8 @@ namespace FancyZonesUnitTests
 
                 const int expectedZoneIndex = 10;
                 Assert::IsTrue(data.SetAppLastZones(window, deviceId, zoneSetId1, { expectedZoneIndex }));
-                Assert::AreEqual({ expectedZoneIndex }, data.GetAppLastZoneIndexSet(window, deviceId, zoneSetId1));
-                Assert::AreEqual({}, data.GetAppLastZoneIndexSet(window, deviceId, zoneSetId2));
+                Assert::IsTrue(std::vector<size_t>{ expectedZoneIndex } == data.GetAppLastZoneIndexSet(window, deviceId, zoneSetId1));
+                Assert::IsTrue(std::vector<size_t>{} == data.GetAppLastZoneIndexSet(window, deviceId, zoneSetId2));
             }
 
             TEST_METHOD (AppLastZoneRemoveWindow)
@@ -1887,7 +1887,7 @@ namespace FancyZonesUnitTests
 
                 Assert::IsTrue(data.SetAppLastZones(window, deviceId, zoneSetId, { 1 }));
                 Assert::IsTrue(data.RemoveAppLastZone(window, deviceId, zoneSetId));
-                Assert::AreEqual({}, data.GetAppLastZoneIndexSet(window, deviceId, zoneSetId));
+                Assert::IsTrue(std::vector<size_t>{} == data.GetAppLastZoneIndexSet(window, deviceId, zoneSetId));
             }
 
             TEST_METHOD (AppLastZoneRemoveUnknownWindow)
@@ -1899,7 +1899,7 @@ namespace FancyZonesUnitTests
                 data.SetSettingsModulePath(m_moduleName);
 
                 Assert::IsFalse(data.RemoveAppLastZone(window, deviceId, zoneSetId));
-                Assert::AreEqual({}, data.GetAppLastZoneIndexSet(window, deviceId, zoneSetId));
+                Assert::IsTrue(std::vector<size_t>{} == data.GetAppLastZoneIndexSet(window, deviceId, zoneSetId));
             }
 
             TEST_METHOD (AppLastZoneRemoveUnknownZoneSetId)
@@ -1913,7 +1913,7 @@ namespace FancyZonesUnitTests
 
                 Assert::IsTrue(data.SetAppLastZones(window, deviceId, zoneSetIdToInsert, { 1 }));
                 Assert::IsFalse(data.RemoveAppLastZone(window, deviceId, zoneSetIdToRemove));
-                Assert::AreEqual({ 1 }, data.GetAppLastZoneIndexSet(window, deviceId, zoneSetIdToInsert));
+                Assert::IsTrue(std::vector<size_t>{ 1 } == data.GetAppLastZoneIndexSet(window, deviceId, zoneSetIdToInsert));
             }
 
             TEST_METHOD (AppLastZoneRemoveUnknownWindowId)
@@ -1927,7 +1927,7 @@ namespace FancyZonesUnitTests
 
                 Assert::IsTrue(data.SetAppLastZones(window, deviceIdToInsert, zoneSetId, { 1 }));
                 Assert::IsFalse(data.RemoveAppLastZone(window, deviceIdToRemove, zoneSetId));
-                Assert::AreEqual({ 1 }, data.GetAppLastZoneIndexSet(window, deviceIdToInsert, zoneSetId));
+                Assert::IsTrue(std::vector<size_t>{ 1 } == data.GetAppLastZoneIndexSet(window, deviceIdToInsert, zoneSetId));
             }
 
             TEST_METHOD (AppLastZoneRemoveNullWindow)

--- a/src/modules/fancyzones/tests/UnitTests/ZoneSet.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/ZoneSet.Spec.cpp
@@ -297,7 +297,7 @@ namespace FancyZonesUnitTests
                 m_set->MoveWindowIntoZoneByIndexSet(window, zoneWindow, { 0 });
 
                 auto actual = m_set->GetZoneIndexSetFromWindow(Mocks::Window());
-                Assert::AreEqual({}, actual);
+                Assert::IsTrue(std::vector<size_t>{} == actual);
             }
 
             TEST_METHOD (ZoneIndexFromWindowNull)
@@ -309,7 +309,7 @@ namespace FancyZonesUnitTests
                 m_set->MoveWindowIntoZoneByIndexSet(window, zoneWindow, { 0 });
 
                 auto actual = m_set->GetZoneIndexSetFromWindow(nullptr);
-                Assert::AreEqual({}, actual);
+                Assert::IsTrue(std::vector<size_t>{} == actual);
             }
 
             TEST_METHOD (MoveWindowIntoZoneByIndex)
@@ -323,7 +323,7 @@ namespace FancyZonesUnitTests
 
                 HWND window = Mocks::Window();
                 m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 1);
-                Assert::AreEqual({ 1 }, m_set->GetZoneIndexSetFromWindow(window));
+                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window));
             }
 
             TEST_METHOD (MoveWindowIntoZoneByIndexWithNoZones)
@@ -343,7 +343,7 @@ namespace FancyZonesUnitTests
 
                 HWND window = Mocks::Window();
                 m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 100);
-                Assert::AreEqual({} , m_set->GetZoneIndexSetFromWindow(window));
+                Assert::IsTrue(std::vector<size_t>{} == m_set->GetZoneIndexSetFromWindow(window));
             }
 
             TEST_METHOD (MoveWindowIntoZoneByIndexSeveralTimesSameWindow)
@@ -358,13 +358,13 @@ namespace FancyZonesUnitTests
 
                 HWND window = Mocks::Window();
                 m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0);
-                Assert::AreEqual({0}, m_set->GetZoneIndexSetFromWindow(window));
+                Assert::IsTrue(std::vector<size_t>{ 0 } == m_set->GetZoneIndexSetFromWindow(window));
 
                 m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 1);
-                Assert::AreEqual({1}, m_set->GetZoneIndexSetFromWindow(window));
+                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window));
 
                 m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 2);
-                Assert::AreEqual({2}, m_set->GetZoneIndexSetFromWindow(window));
+                Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window));
             }
 
             TEST_METHOD (MoveWindowIntoZoneByIndexSeveralTimesSameIndex)
@@ -381,7 +381,7 @@ namespace FancyZonesUnitTests
                 m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0);
                 m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0);
                 m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0);
-                Assert::AreEqual({ 0 }, m_set->GetZoneIndexSetFromWindow(window));
+                Assert::IsTrue(std::vector<size_t>{ 0 } == m_set->GetZoneIndexSetFromWindow(window));
             }
 
             TEST_METHOD (MoveWindowIntoZoneByPointEmpty)
@@ -397,7 +397,7 @@ namespace FancyZonesUnitTests
                 auto window = Mocks::Window();
                 m_set->MoveWindowIntoZoneByPoint(window, Mocks::Window(), POINT{ 200, 200 });
 
-                Assert::AreEqual({}, m_set->GetZoneIndexSetFromWindow(window));
+                Assert::IsTrue(std::vector<size_t>{} == m_set->GetZoneIndexSetFromWindow(window));
             }
 
             TEST_METHOD (MoveWindowIntoZoneByPointInnerPoint)
@@ -408,7 +408,7 @@ namespace FancyZonesUnitTests
                 auto window = Mocks::Window();
                 m_set->MoveWindowIntoZoneByPoint(window, Mocks::Window(), POINT{ 50, 50 });
 
-                Assert::AreEqual({ 0 }, m_set->GetZoneIndexSetFromWindow(window));
+                Assert::IsTrue(std::vector<size_t>{ 0 } == m_set->GetZoneIndexSetFromWindow(window));
             }
 
             TEST_METHOD (MoveWindowIntoZoneByPointInnerPointOverlappingZones)
@@ -421,7 +421,7 @@ namespace FancyZonesUnitTests
                 auto window = Mocks::Window();
                 m_set->MoveWindowIntoZoneByPoint(window, Mocks::Window(), POINT{ 50, 50 });
 
-                Assert::AreEqual({ 1 }, m_set->GetZoneIndexSetFromWindow(window));
+                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window));
             }
 
             TEST_METHOD (MoveWindowIntoZoneByPointDropAddWindow)
@@ -439,7 +439,7 @@ namespace FancyZonesUnitTests
 
                 m_set->MoveWindowIntoZoneByPoint(window, Mocks::Window(), POINT{ 50, 50 });
 
-                Assert::AreEqual({ 1 }, m_set->GetZoneIndexSetFromWindow(window));
+                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window));
             }
 
             TEST_METHOD (MoveWindowIntoZoneByPointDropAddWindowToSameZone)
@@ -457,7 +457,7 @@ namespace FancyZonesUnitTests
 
                 m_set->MoveWindowIntoZoneByPoint(window, Mocks::Window(), POINT{ 50, 50 });
 
-                Assert::AreEqual({ 1 }, m_set->GetZoneIndexSetFromWindow(window));
+                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window));
             }
 
             TEST_METHOD (MoveWindowIntoZoneByPointSeveralZonesWithSameWindow)
@@ -477,7 +477,7 @@ namespace FancyZonesUnitTests
 
                 m_set->MoveWindowIntoZoneByPoint(window, Mocks::Window(), POINT{ 50, 50 });
 
-                Assert::AreEqual({ 2 }, m_set->GetZoneIndexSetFromWindow(window));
+                Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window));
             }
     };
 
@@ -523,14 +523,14 @@ namespace FancyZonesUnitTests
         {
             HWND window = Mocks::Window();
             m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_RIGHT, true);
-            Assert::AreEqual({ 0 }, m_set->GetZoneIndexSetFromWindow(window));
+            Assert::IsTrue(std::vector<size_t>{ 0 } == m_set->GetZoneIndexSetFromWindow(window));
         }
 
         TEST_METHOD (MoveLeftNoZones)
         {
             HWND window = Mocks::Window();
             m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_LEFT, true);
-            Assert::AreEqual({ 2 }, m_set->GetZoneIndexSetFromWindow(window));
+            Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window));
         }
 
         TEST_METHOD (MoveRightTwice)
@@ -538,7 +538,7 @@ namespace FancyZonesUnitTests
             HWND window = Mocks::Window();
             m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_RIGHT, true);
             m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_RIGHT, true);
-            Assert::AreEqual({ 1 }, m_set->GetZoneIndexSetFromWindow(window));
+            Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window));
         }
 
         TEST_METHOD (MoveLeftTwice)
@@ -546,7 +546,7 @@ namespace FancyZonesUnitTests
             HWND window = Mocks::Window();
             m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_LEFT, true);
             m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_LEFT, true);
-            Assert::AreEqual({ 1 }, m_set->GetZoneIndexSetFromWindow(window));
+            Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window));
         }
 
         TEST_METHOD (MoveRightMoreThanZonesCount)
@@ -557,7 +557,7 @@ namespace FancyZonesUnitTests
                 m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_RIGHT, true);
             }
 
-            Assert::AreEqual({ 0 }, m_set->GetZoneIndexSetFromWindow(window));
+            Assert::IsTrue(std::vector<size_t>{ 0 } == m_set->GetZoneIndexSetFromWindow(window));
         }
 
         TEST_METHOD (MoveLeftMoreThanZonesCount)
@@ -568,7 +568,7 @@ namespace FancyZonesUnitTests
                 m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_LEFT, true);
             }
             
-            Assert::AreEqual({ 2 }, m_set->GetZoneIndexSetFromWindow(window));
+            Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window));
         }
 
         TEST_METHOD (MoveWindowIntoZoneByDirectionRight)
@@ -576,10 +576,10 @@ namespace FancyZonesUnitTests
             HWND window = Mocks::Window();
             m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0);
             m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_RIGHT, true);
-            Assert::AreEqual({ 1 }, m_set->GetZoneIndexSetFromWindow(window));
+            Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window));
 
             m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_RIGHT, true);
-            Assert::AreEqual({ 2 }, m_set->GetZoneIndexSetFromWindow(window));
+            Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window));
         }
 
         TEST_METHOD (MoveRightWithSameWindowAdded)
@@ -587,13 +587,13 @@ namespace FancyZonesUnitTests
             HWND window = Mocks::Window();
             m_set->MoveWindowIntoZoneByIndexSet(window, Mocks::Window(), { 0, 1 });
 
-            Assert::AreEqual({ 0, 1 }, m_set->GetZoneIndexSetFromWindow(window));
+            Assert::IsTrue(std::vector<size_t>{ 0, 1 } == m_set->GetZoneIndexSetFromWindow(window));
 
             m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_RIGHT, true);
-            Assert::AreEqual({ 1 }, m_set->GetZoneIndexSetFromWindow(window));
+            Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window));
 
             m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_RIGHT, true);
-            Assert::AreEqual({ 2 }, m_set->GetZoneIndexSetFromWindow(window));
+            Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window));
         }
 
         TEST_METHOD (MoveRightWithDifferentWindowsAdded)
@@ -603,18 +603,18 @@ namespace FancyZonesUnitTests
             m_set->MoveWindowIntoZoneByIndex(window1, Mocks::Window(), { 0 });
             m_set->MoveWindowIntoZoneByIndex(window2, Mocks::Window(), { 1 });
 
-            Assert::AreEqual({ 0 }, m_set->GetZoneIndexSetFromWindow(window1));
-            Assert::AreEqual({ 1 }, m_set->GetZoneIndexSetFromWindow(window2));
+            Assert::IsTrue(std::vector<size_t>{ 0 } == m_set->GetZoneIndexSetFromWindow(window1));
+            Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window2));
 
             m_set->MoveWindowIntoZoneByDirectionAndIndex(window1, Mocks::Window(), VK_RIGHT, true);
             
-            Assert::AreEqual({ 1 }, m_set->GetZoneIndexSetFromWindow(window1));
-            Assert::AreEqual({ 1 }, m_set->GetZoneIndexSetFromWindow(window2));
+            Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window1));
+            Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window2));
 
             m_set->MoveWindowIntoZoneByDirectionAndIndex(window1, Mocks::Window(), VK_RIGHT, true);
             
-            Assert::AreEqual({ 2 }, m_set->GetZoneIndexSetFromWindow(window1));
-            Assert::AreEqual({ 1 }, m_set->GetZoneIndexSetFromWindow(window2));
+            Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window1));
+            Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window2));
         }
 
         TEST_METHOD (MoveWindowIntoZoneByDirectionLeft)
@@ -622,10 +622,10 @@ namespace FancyZonesUnitTests
             HWND window = Mocks::Window();
             m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 2);
             m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_LEFT, true);
-            Assert::AreEqual({ 1 }, m_set->GetZoneIndexSetFromWindow(window));
+            Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window));
 
             m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_LEFT, true);
-            Assert::AreEqual({ 0 }, m_set->GetZoneIndexSetFromWindow(window));
+            Assert::IsTrue(std::vector<size_t>{ 0 } == m_set->GetZoneIndexSetFromWindow(window));
         }
 
         TEST_METHOD (MoveLeftWithSameWindowAdded)
@@ -633,13 +633,13 @@ namespace FancyZonesUnitTests
             HWND window = Mocks::Window();
             m_set->MoveWindowIntoZoneByIndexSet(window, Mocks::Window(), {1, 2});
 
-            Assert::AreEqual({ 1, 2 }, m_set->GetZoneIndexSetFromWindow(window));
+            Assert::IsTrue(std::vector<size_t>{ 1, 2 } == m_set->GetZoneIndexSetFromWindow(window));
 
             m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_LEFT, true);
-            Assert::AreEqual({ 0 }, m_set->GetZoneIndexSetFromWindow(window));
+            Assert::IsTrue(std::vector<size_t>{ 0 } == m_set->GetZoneIndexSetFromWindow(window));
 
             m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_LEFT, true);
-            Assert::AreEqual({ 2 }, m_set->GetZoneIndexSetFromWindow(window));
+            Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window));
         }
 
         TEST_METHOD (MoveLeftWithDifferentWindowsAdded)
@@ -649,16 +649,16 @@ namespace FancyZonesUnitTests
             m_set->MoveWindowIntoZoneByIndex(window1, Mocks::Window(), 1);
             m_set->MoveWindowIntoZoneByIndex(window2, Mocks::Window(), 2);
 
-            Assert::AreEqual({ 1 }, m_set->GetZoneIndexSetFromWindow(window1));
-            Assert::AreEqual({ 2 }, m_set->GetZoneIndexSetFromWindow(window2));
+            Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window1));
+            Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window2));
 
             m_set->MoveWindowIntoZoneByDirectionAndIndex(window2, Mocks::Window(), VK_LEFT, true);
-            Assert::AreEqual({ 1 }, m_set->GetZoneIndexSetFromWindow(window1));
-            Assert::AreEqual({ 1 }, m_set->GetZoneIndexSetFromWindow(window2));
+            Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window1));
+            Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window2));
 
             m_set->MoveWindowIntoZoneByDirectionAndIndex(window2, Mocks::Window(), VK_LEFT, true);
-            Assert::AreEqual({ 1 }, m_set->GetZoneIndexSetFromWindow(window1));
-            Assert::AreEqual({ 0 }, m_set->GetZoneIndexSetFromWindow(window2));
+            Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window1));
+            Assert::IsTrue(std::vector<size_t>{ 0 } == m_set->GetZoneIndexSetFromWindow(window2));
         }
 
         TEST_METHOD (MoveWindowIntoZoneByDirectionWrapAroundRight)
@@ -666,7 +666,7 @@ namespace FancyZonesUnitTests
             HWND window = Mocks::Window();
             m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 2);
             m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_RIGHT, true);
-            Assert::AreEqual({ 0 }, m_set->GetZoneIndexSetFromWindow(window));
+            Assert::IsTrue(std::vector<size_t>{ 0 } == m_set->GetZoneIndexSetFromWindow(window));
         }
 
         TEST_METHOD (MoveWindowIntoZoneByDirectionWrapAroundLeft)
@@ -674,7 +674,7 @@ namespace FancyZonesUnitTests
             HWND window = Mocks::Window();
             m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0);
             m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_LEFT, true);
-            Assert::AreEqual({ 2 }, m_set->GetZoneIndexSetFromWindow(window));
+            Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window));
         }
 
         TEST_METHOD (MoveSecondWindowIntoSameZone)
@@ -685,8 +685,8 @@ namespace FancyZonesUnitTests
             HWND window2 = Mocks::Window();
             m_set->MoveWindowIntoZoneByDirectionAndIndex(window2, Mocks::Window(), VK_RIGHT, true);
 
-            Assert::AreEqual({ 0 }, m_set->GetZoneIndexSetFromWindow(window1));
-            Assert::AreEqual({ 0 }, m_set->GetZoneIndexSetFromWindow(window2));
+            Assert::IsTrue(std::vector<size_t>{ 0 } == m_set->GetZoneIndexSetFromWindow(window1));
+            Assert::IsTrue(std::vector<size_t>{ 0 } == m_set->GetZoneIndexSetFromWindow(window2));
         }
 
         TEST_METHOD (MoveRightMoreThanZoneCountReturnsFalse)

--- a/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
@@ -538,7 +538,7 @@ namespace FancyZonesUnitTests
             const auto zoneSet = zoneWindow->ActiveZoneSet();
             zoneSet->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0);
             const auto actualZoneIndexSet = zoneSet->GetZoneIndexSetFromWindow(window);
-            Assert::AreNotEqual({}, actualZoneIndexSet);
+            Assert::IsFalse(std::vector<size_t>{} == actualZoneIndexSet);
         }
 
         TEST_METHOD(MoveSizeEndWindowNotAdded)
@@ -555,7 +555,7 @@ namespace FancyZonesUnitTests
 
             const auto zoneSet = zoneWindow->ActiveZoneSet();
             const auto actualZoneIndexSet = zoneSet->GetZoneIndexSetFromWindow(window);
-            Assert::AreEqual({}, actualZoneIndexSet);
+            Assert::IsTrue(std::vector<size_t>{} == actualZoneIndexSet);
         }
 
         TEST_METHOD(MoveSizeEndDifferentWindows)
@@ -596,7 +596,7 @@ namespace FancyZonesUnitTests
             const auto zoneSet = zoneWindow->ActiveZoneSet();
             zoneSet->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0);
             const auto actualZoneIndex = zoneSet->GetZoneIndexSetFromWindow(window);
-            Assert::AreNotEqual({}, actualZoneIndex); //with invalid point zone remains the same
+            Assert::IsFalse(std::vector<size_t>{} == actualZoneIndex); // with invalid point zone remains the same
         }
 
         TEST_METHOD(MoveWindowIntoZoneByIndexNoActiveZoneSet)
@@ -639,7 +639,7 @@ namespace FancyZonesUnitTests
             Assert::AreEqual((size_t)1, actualAppZoneHistory.size());
             const auto& appHistoryArray = actualAppZoneHistory.begin()->second;
             Assert::AreEqual((size_t)1, appHistoryArray.size());
-            Assert::AreEqual({ 0 }, appHistoryArray[0].zoneIndexSet);
+            Assert::IsTrue(std::vector<size_t>{ 0 } == appHistoryArray[0].zoneIndexSet);
         }
 
         TEST_METHOD(MoveWindowIntoZoneByDirectionManyTimes)
@@ -657,7 +657,7 @@ namespace FancyZonesUnitTests
             Assert::AreEqual((size_t)1, actualAppZoneHistory.size());
             const auto& appHistoryArray = actualAppZoneHistory.begin()->second;
             Assert::AreEqual((size_t)1, appHistoryArray.size());
-            Assert::AreEqual({ 2 }, appHistoryArray[0].zoneIndexSet);
+            Assert::IsTrue(std::vector<size_t>{ 2 } == appHistoryArray[0].zoneIndexSet);
         }
 
         TEST_METHOD(SaveWindowProcessToZoneIndexNoActiveZoneSet)
@@ -715,7 +715,7 @@ namespace FancyZonesUnitTests
             Assert::AreEqual((size_t)1, m_fancyZonesData.GetAppZoneHistoryMap().size());
             const auto& appHistoryArray1 = m_fancyZonesData.GetAppZoneHistoryMap().at(processPath);
             Assert::AreEqual((size_t)1, appHistoryArray1.size());
-            Assert::AreEqual({ 0 }, appHistoryArray1[0].zoneIndexSet);
+            Assert::IsTrue(std::vector<size_t>{ 0 } == appHistoryArray1[0].zoneIndexSet);
 
             // add zone without window
             const auto zone = MakeZone(RECT{ 0, 0, 100, 100 });
@@ -725,7 +725,7 @@ namespace FancyZonesUnitTests
             Assert::AreEqual((size_t)1, m_fancyZonesData.GetAppZoneHistoryMap().size());
             const auto& appHistoryArray2 = m_fancyZonesData.GetAppZoneHistoryMap().at(processPath);
             Assert::AreEqual((size_t)1, appHistoryArray2.size());
-            Assert::AreEqual({ 0 }, appHistoryArray2[0].zoneIndexSet);
+            Assert::IsTrue(std::vector<size_t>{ 0 } == appHistoryArray2[0].zoneIndexSet);
         }
 
         TEST_METHOD(SaveWindowProcessToZoneIndexWindowAdded)
@@ -748,7 +748,7 @@ namespace FancyZonesUnitTests
             Assert::AreEqual((size_t)1, m_fancyZonesData.GetAppZoneHistoryMap().size());
             const auto& appHistoryArray = m_fancyZonesData.GetAppZoneHistoryMap().at(processPath);
             Assert::AreEqual((size_t)1, appHistoryArray.size());
-            Assert::AreEqual({ 2 }, appHistoryArray[0].zoneIndexSet);
+            Assert::IsTrue(std::vector<size_t>{ 2 } == appHistoryArray[0].zoneIndexSet);
 
             zoneWindow->SaveWindowProcessToZoneIndex(window);
 
@@ -756,7 +756,7 @@ namespace FancyZonesUnitTests
             Assert::AreEqual((size_t)1, actualAppZoneHistory.size());
             const auto& expected = zoneWindow->ActiveZoneSet()->GetZoneIndexSetFromWindow(window);
             const auto& actual = appHistoryArray[0].zoneIndexSet;
-            Assert::AreEqual(expected, actual);
+            Assert::IsTrue(expected == actual);
         }
 
         TEST_METHOD(WhenWindowIsNotResizablePlacingItIntoTheZoneShouldNotResizeIt)

--- a/src/runner/PowerToys.exe.manifest
+++ b/src/runner/PowerToys.exe.manifest
@@ -2,7 +2,6 @@
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
-      <maxversiontested Id="10.0.18362.0"/>
     </application>
   </compatibility>
 </assembly>


### PR DESCRIPTION
## Summary of the Pull Request

Unified data type in all methods that process the zone index set.
Remove `maxversiontested` from the app manifest (it's not a required field as per https://docs.microsoft.com/en-us/windows/win32/sbscs/application-manifests)

## PR Checklist
* [x] Applies to https://github.com/microsoft/PowerToys/issues/6093
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

Replace `int` with `size_t` to avoid explicit casting.

## Validation Steps Performed

All unit tests passed.
