### PR TITLE
Fix Accessibility issues in the color picker settings page

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -588,6 +588,9 @@
   <data name="About_ColorPicker.Text" xml:space="preserve">
     <value>About Color Picker</value>
   </data>
+  <data name="ColorPicker_Image.AutomationProperties.Name" xml:space="preserve">
+    <value>Color Picker</value>
+  </data>
   <data name="About_PowerLauncher.Text" xml:space="preserve">
     <value>About PowerToys Run</value>
   </data>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
@@ -102,7 +102,7 @@
                     HorizontalAlignment="Left"
                     Margin="{StaticResource SmallTopBottomMargin}"
                     RelativePanel.Below="DescriptionPanel">
-                <Image Source="ms-appx:///Assets/Modules/ColorPicker.png" />
+                <Image x:Uid="ColorPicker_Image" Source="ms-appx:///Assets/Modules/ColorPicker.png" />
             </Border>
             <StackPanel x:Name="LinksPanel"
                         Margin="0,1,0,0"


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

This PR fixes some of the accessibility issues of the color picker tab of the PT settings page.

## PR Checklist
* [x] Applies to #5734.
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

The only change is this PR is that additional information has been set for the color picker image. It previously used to read out just `graphic`, now it is made more accessible by setting an automation property.

## Validation Steps Performed

_How does someone test & validate?_

* Install NVDA screen reader.
* Press Insert+B to read all the entire app content.