### PR TITLE
Fix Accessibility issues of the File Explorer Preview Settings page

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -579,6 +579,9 @@
   <data name="About_FileExplorerPreview.Text" xml:space="preserve">
     <value>About File Explorer Preview</value>
   </data>
+  <data name="FileExplorerPreview_Image.AutomationProperties.Name" xml:space="preserve">
+    <value>File Explorer Preview</value>
+  </data>
   <data name="About_ImageResizer.Text" xml:space="preserve">
     <value>About Image Resizer</value>
   </data>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerPreviewPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerPreviewPage.xaml
@@ -76,7 +76,7 @@
                     HorizontalAlignment="Left"
                     Margin="{StaticResource SmallTopBottomMargin}"
                     RelativePanel.Below="DescriptionPanel">
-                <Image Source="https://aka.ms/powerToysPowerPreviewSettingImage" />
+                <Image x:Uid="FileExplorerPreview_Image" Source="https://aka.ms/powerToysPowerPreviewSettingImage" />
             </Border>
 
             <StackPanel x:Name="LinksPanel"


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

The image was previously being read as 'graphic' by the screen reader. Now we add more context by setting an automation property so that it says `File Explorer Preview graphic`.

## PR Checklist
* [x] Applies to #5735
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #5671 

## Validation Steps Performed

_How does someone test & validate?_

Install NVDA screen reader and read the contents of the app by pressing Insert+B.
