### PR TITLE
Fix Accessibility issues in the PowerRename settings page

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -594,6 +594,9 @@
   <data name="About_PowerRename.Text" xml:space="preserve">
     <value>About Power Rename</value>
   </data>
+  <data name="PowerRename_Image.AutomationProperties.Name" xml:space="preserve">
+    <value>Power Rename</value>
+  </data>
   <data name="About_ShortcutGuide.Text" xml:space="preserve">
     <value>About Shortcut Guide</value>
   </data>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerRenamePage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerRenamePage.xaml
@@ -75,7 +75,8 @@
                           IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"
                            />
 
-            <TextBlock x:Uid="PowerRename_Toggle_MaxDispListNum"
+            <TextBlock Name="PowerRename_Toggle_MaxDispListNum"
+                x:Uid="PowerRename_Toggle_MaxDispListNum"
                 Margin="{StaticResource SmallTopMargin}"
                 Foreground="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToForegroundConverter}}"/>
 
@@ -86,7 +87,8 @@
                             Minimum="0"
                             Width="240"
                             Maximum="20"
-                            IsEnabled="{ x:Bind Mode=OneWay, Path=ViewModel.GlobalAndMruEnabled}"/>
+                            IsEnabled="{ x:Bind Mode=OneWay, Path=ViewModel.GlobalAndMruEnabled}"
+                            AutomationProperties.LabeledBy="{Binding ElementName=PowerRename_Toggle_MaxDispListNum}"/>
 
             <CheckBox x:Uid="PowerRename_Toggle_RestoreFlagsOnLaunch"
                           Margin="0, 17, 0, 0" 

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerRenamePage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerRenamePage.xaml
@@ -117,7 +117,7 @@
                     HorizontalAlignment="Left"
                     Margin="{StaticResource SmallTopBottomMargin}"
                     RelativePanel.Below="DescriptionPanel">
-                <Image Source="ms-appx:///Assets/Modules/PowerRename.png" />
+                <Image x:Uid="PowerRename_Image" Source="ms-appx:///Assets/Modules/PowerRename.png" />
             </Border>
 
             <StackPanel x:Name="LinksPanel"


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

This PR fixes a couple of the PowerRename settings page.

## PR Checklist
* [x] Applies to #5737
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

The following changes have been made in this PR - 
1. The number box is now labeled by the text block so that the screen reader reads out `Maximum number of items` when the edit box is on focus. 
2. There is more information regarding the image. Previously, it was being read out as just 'graphic', but now it is going to be read as 'Power Rename graphic'.

## Validation Steps Performed

_How does someone test & validate?_

* Install NVDA screen reader and press Insert+B to read the entire app content.