### PR TITLE
Remove the code for saving/loadingprogram plugin cache

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Main.cs
@@ -20,10 +20,7 @@ namespace Microsoft.Plugin.Program
     {
         internal static ProgramPluginSettings Settings { get; set; }
 
-        private static bool IsStartupIndexProgramsRequired => Settings.LastIndexTime.AddDays(3) < DateTime.Today;
-
         private static PluginInitContext _context;
-
         private readonly PluginJsonStorage<ProgramPluginSettings> _settingsStorage;
         private bool _disposed;
         private PackageRepository _packageRepository = new PackageRepository(new PackageCatalogWrapper(), new BinaryStorage<IList<UWPApplication>>("UWP"));
@@ -41,27 +38,14 @@ namespace Microsoft.Plugin.Program
             // Initialize the Win32ProgramRepository with the settings object
             _win32ProgramRepository = new Win32ProgramRepository(_win32ProgramRepositoryHelper.FileSystemWatchers.Cast<IFileSystemWatcherWrapper>().ToList(), new BinaryStorage<IList<Programs.Win32Program>>("Win32"), Settings, _win32ProgramRepositoryHelper.PathsToWatch);
 
-            Stopwatch.Normal("|Microsoft.Plugin.Program.Main|Preload programs cost", () =>
-            {
-                _win32ProgramRepository.Load();
-                _packageRepository.Load();
-            });
-            Log.Info($"|Microsoft.Plugin.Program.Main|Number of preload win32 programs <{_win32ProgramRepository.Count()}>");
-
             var a = Task.Run(() =>
             {
-                if (IsStartupIndexProgramsRequired || !_win32ProgramRepository.Any())
-                {
-                    Stopwatch.Normal("|Microsoft.Plugin.Program.Main|Win32Program index cost", _win32ProgramRepository.IndexPrograms);
-                }
+                Stopwatch.Normal("|Microsoft.Plugin.Program.Main|Win32Program index cost", _win32ProgramRepository.IndexPrograms);
             });
 
             var b = Task.Run(() =>
             {
-                if (IsStartupIndexProgramsRequired || !_packageRepository.Any())
-                {
-                    Stopwatch.Normal("|Microsoft.Plugin.Program.Main|Win32Program index cost", _packageRepository.IndexPrograms);
-                }
+                Stopwatch.Normal("|Microsoft.Plugin.Program.Main|Win32Program index cost", _packageRepository.IndexPrograms);
             });
 
             Task.WaitAll(a, b);
@@ -72,8 +56,6 @@ namespace Microsoft.Plugin.Program
         public void Save()
         {
             _settingsStorage.Save();
-            _win32ProgramRepository.Save();
-            _packageRepository.Save();
         }
 
         public List<Result> Query(Query query)


### PR DESCRIPTION
## Summary of the Pull Request
Remove Loading and Saving of program plugin cache

## PR Checklist
* [x] Applies to #6048
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed

## Info on Pull Request
This PR removes loading/saving cache to fix following issues : 
1. It will fix the issue #5998, which resulted in missing Packaged app icons when these apps were updated and pt run was disabled.
2. It will fix the issue #5905 with win32 apps not being detected, installed when pt run was disabled. On enabling pt run, it used the previous cache.

## Validation Steps Performed
Manually validated that issues associated with #6048 are resolved.