### PR TITLE
Fix Accessibility issues of the Image Resizer settings page

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -483,6 +483,9 @@
   <data name="ImageResizer_Height_Property.AutomationProperties.Name" xml:space="preserve">
     <value>Image Resizer Height Property</value>
   </data>
+  <data name="ImageResizer_Size_Property.AutomationProperties.Name" xml:space="preserve">
+    <value>Image Resizer Size Property</value>
+  </data>
   <data name="ImageResizer_Times_Symbol.AutomationProperties.Name" xml:space="preserve">
     <value>Times Symbol</value>
   </data>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -472,7 +472,7 @@
     <value>Image Size</value>
   </data>
   <data name="ImageResizer_Name.AutomationProperties.Name" xml:space="preserve">
-    <value>Image Resizer Name</value>
+    <value>Image Resizer Configuration Name</value>
   </data>
   <data name="ImageResizer_AddSizeButton.Label" xml:space="preserve">
     <value>Add size</value>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -480,6 +480,9 @@
   <data name="ImageResizer_Width_Property.AutomationProperties.Name" xml:space="preserve">
     <value>Image Resizer Width Property</value>
   </data>
+  <data name="ImageResizer_Times_Symbol.AutomationProperties.Name" xml:space="preserve">
+    <value>Times Symbol</value>
+  </data>
   <data name="ImageResizer_AddSizeButton.Label" xml:space="preserve">
     <value>Add size</value>
   </data>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -472,22 +472,25 @@
     <value>Image Size</value>
   </data>
   <data name="ImageResizer_Name.AutomationProperties.Name" xml:space="preserve">
-    <value>Image Resizer Configuration Name</value>
+    <value>Configuration Name</value>
   </data>
   <data name="ImageResizer_Fit_Property.AutomationProperties.Name" xml:space="preserve">
-    <value>Image Resizer Fit Property</value>
+    <value>Fit Property</value>
   </data>
   <data name="ImageResizer_Width_Property.AutomationProperties.Name" xml:space="preserve">
-    <value>Image Resizer Width Property</value>
+    <value>Width Property</value>
   </data>
   <data name="ImageResizer_Height_Property.AutomationProperties.Name" xml:space="preserve">
-    <value>Image Resizer Height Property</value>
+    <value>Height Property</value>
   </data>
   <data name="ImageResizer_Size_Property.AutomationProperties.Name" xml:space="preserve">
-    <value>Image Resizer Size Property</value>
+    <value>Size Property</value>
   </data>
   <data name="ImageResizer_Times_Symbol.AutomationProperties.Name" xml:space="preserve">
     <value>Times Symbol</value>
+  </data>
+  <data name="RemoveButton.AutomationProperties.Name" xml:space="preserve">
+    <value>Remove</value>
   </data>
   <data name="ImageResizer_AddSizeButton.Label" xml:space="preserve">
     <value>Add size</value>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -495,6 +495,9 @@
   <data name="RemoveButton.AutomationProperties.Name" xml:space="preserve">
     <value>Remove</value>
   </data>
+  <data name="ImageResizer_Image.AutomationProperties.Name" xml:space="preserve">
+    <value>Image Resizer</value>
+  </data>
   <data name="ImageResizer_AddSizeButton.Label" xml:space="preserve">
     <value>Add size</value>
   </data>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -468,6 +468,9 @@
   <data name="ImageResizer_EnableToggle.Header" xml:space="preserve">
     <value>Enable Image Resizer</value>
   </data>
+  <data name="ImagesSizesListView.AutomationProperties.Name" xml:space="preserve">
+    <value>Image Size</value>
+  </data>
   <data name="ImageResizer_AddSizeButton.Label" xml:space="preserve">
     <value>Add size</value>
   </data>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -471,6 +471,9 @@
   <data name="ImagesSizesListView.AutomationProperties.Name" xml:space="preserve">
     <value>Image Size</value>
   </data>
+  <data name="ImageResizer_Configurations.AutomationProperties.Name" xml:space="preserve">
+    <value>Configurations</value>
+  </data>
   <data name="ImageResizer_Name.AutomationProperties.Name" xml:space="preserve">
     <value>Configuration Name</value>
   </data>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -477,6 +477,9 @@
   <data name="ImageResizer_Fit_Property.AutomationProperties.Name" xml:space="preserve">
     <value>Image Resizer Fit Property</value>
   </data>
+  <data name="ImageResizer_Width_Property.AutomationProperties.Name" xml:space="preserve">
+    <value>Image Resizer Width Property</value>
+  </data>
   <data name="ImageResizer_AddSizeButton.Label" xml:space="preserve">
     <value>Add size</value>
   </data>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -471,6 +471,9 @@
   <data name="ImagesSizesListView.AutomationProperties.Name" xml:space="preserve">
     <value>Image Size</value>
   </data>
+  <data name="ImageResizer_Name.AutomationProperties.Name" xml:space="preserve">
+    <value>Image Resizer Name</value>
+  </data>
   <data name="ImageResizer_AddSizeButton.Label" xml:space="preserve">
     <value>Add size</value>
   </data>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -474,6 +474,9 @@
   <data name="ImageResizer_Name.AutomationProperties.Name" xml:space="preserve">
     <value>Image Resizer Configuration Name</value>
   </data>
+  <data name="ImageResizer_Fit_Property.AutomationProperties.Name" xml:space="preserve">
+    <value>Image Resizer Fit Property</value>
+  </data>
   <data name="ImageResizer_AddSizeButton.Label" xml:space="preserve">
     <value>Add size</value>
   </data>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -480,6 +480,9 @@
   <data name="ImageResizer_Width_Property.AutomationProperties.Name" xml:space="preserve">
     <value>Image Resizer Width Property</value>
   </data>
+  <data name="ImageResizer_Height_Property.AutomationProperties.Name" xml:space="preserve">
+    <value>Image Resizer Height Property</value>
+  </data>
   <data name="ImageResizer_Times_Symbol.AutomationProperties.Name" xml:space="preserve">
     <value>Times Symbol</value>
   </data>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
@@ -1,4 +1,4 @@
-﻿<Page
+﻿  <Page
     x:Class="Microsoft.PowerToys.Settings.UI.Views.ImageResizerPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -58,6 +58,7 @@
                        Foreground="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToForegroundConverter}}"/>
 
             <ListView x:Name="ImagesSizesListView" 
+                      x:Uid="ImagesSizesListView"
                       ItemsSource="{x:Bind ViewModel.Sizes, Mode=TwoWay}"
                       Padding="0"
                       IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
@@ -97,7 +97,9 @@
                 <ListView.ItemTemplate>
                     <DataTemplate x:Name="SingleLineDataTemplate" x:DataType="models:ImageSize" >
                         <StackPanel Orientation="Horizontal" Height="48" Padding="0" Spacing="4">
-                            <TextBox Text="{x:Bind Path=Name, Mode=TwoWay}" 
+                            <TextBox Name="ImageResizer_Name"
+                                     x:Uid="ImageResizer_Name"
+                                     Text="{x:Bind Path=Name, Mode=TwoWay}" 
                                      Width="90"
                                      VerticalAlignment="Center"
                                      Height="34"

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
@@ -160,6 +160,7 @@
                                 <ComboBoxItem x:Uid="ImageResizer_Sizes_Units_Pixels" />
                             </ComboBox>
                             <Button x:Name="RemoveButton"
+                                    x:Uid="RemoveButton"
                                     Background="Transparent"
                                     FontFamily="Segoe MDL2 Assets"
                                     Height="34"

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
@@ -336,7 +336,7 @@
                     HorizontalAlignment="Left"
                     Margin="{StaticResource SmallTopBottomMargin}"
                     RelativePanel.Below="DescriptionPanel">
-                <Image Source="ms-appx:///Assets/Modules/ImageResizer.png" />
+                <Image x:Uid="ImageResizer_Image" Source="ms-appx:///Assets/Modules/ImageResizer.png" />
             </Border>
 
             <StackPanel x:Name="LinksPanel"

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
@@ -255,10 +255,12 @@
                       HorizontalAlignment="Left"
                       MinWidth="240"
                       IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"
-                      Margin="{StaticResource SmallTopMargin}">
+                      Margin="{StaticResource SmallTopMargin}"
+                      AutomationProperties.LabeledBy="{Binding ElementName=ImageResizer_FilenameFormatHeader}">
                 <TextBox.Header>
                     <StackPanel Orientation="Horizontal">
-                        <TextBlock x:Uid="ImageResizer_FilenameFormatHeader"
+                        <TextBlock Name="ImageResizer_FilenameFormatHeader"
+                            x:Uid="ImageResizer_FilenameFormatHeader"
                             Margin="0,0,0,0"
                             Foreground="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToForegroundConverter}}"/>
                         <TextBlock Text="&#xE946;"

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
@@ -136,7 +136,9 @@
                                        Opacity="{x:Bind Path=ExtraBoxOpacity, Mode=OneWay}"                                    
                                        Width="25"/>
 
-                            <muxc:NumberBox Value="{x:Bind Path=Height, Mode=TwoWay}" 
+                            <muxc:NumberBox Name="ImageResizer_Height_Property"
+                                            x:Uid="ImageResizer_Height_Property"
+                                            Value="{x:Bind Path=Height, Mode=TwoWay}" 
                                             Width="68"
                                             Height="34"
                                             VerticalAlignment="Center"

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
@@ -117,7 +117,9 @@
                                 <ComboBoxItem x:Uid="ImageResizer_Sizes_Fit_Stretch" />
                             </ComboBox>
 
-                            <muxc:NumberBox Value="{x:Bind Path=Width, Mode=TwoWay}" 
+                            <muxc:NumberBox Name="ImageResizer_Width_Property"
+                                            x:Uid="ImageResizer_Width_Property"
+                                            Value="{x:Bind Path=Width, Mode=TwoWay}" 
                                             Width="68"
                                             Height="34"
                                             SpinButtonPlacementMode="Compact"

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
@@ -147,7 +147,9 @@
                                             IsEnabled="{x:Bind Path=EnableEtraBoxes, Mode=OneWay}"
                                             Margin="{StaticResource SmallTopMargin}"/>
 
-                            <ComboBox SelectedIndex="{Binding Path=Unit, Mode=TwoWay}"
+                            <ComboBox Name="ImageResizer_Size_Property"
+                                      x:Uid="ImageResizer_Size_Property"
+                                      SelectedIndex="{Binding Path=Unit, Mode=TwoWay}"
                                       Width="120"
                                       Height="34"
                                       VerticalAlignment="Center"

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
@@ -207,7 +207,8 @@
                 <ComboBoxItem x:Uid="ImageResizer_FallbackEncoder_GIF" />
             </ComboBox>
 
-            <TextBlock x:Uid="ImageResizer_Encoding"
+            <TextBlock Name="ImageResizer_Encoding"
+                x:Uid="ImageResizer_Encoding"
                 Margin="{StaticResource SmallTopMargin}"
                 Foreground="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToForegroundConverter}}"/>
 
@@ -219,6 +220,7 @@
                             SpinButtonPlacementMode="Compact"
                             HorizontalAlignment="Left"
                             IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"
+                            AutomationProperties.LabeledBy="{Binding ElementName=ImageResizer_Encoding}"
                             />
 
             <ComboBox x:Uid="ImageResizer_PNGInterlacing"

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
@@ -105,7 +105,9 @@
                                      Height="34"
                                      Margin="{StaticResource SmallTopMargin}"/>
 
-                            <ComboBox SelectedIndex="{x:Bind Path=Fit, Mode=TwoWay}"
+                            <ComboBox Name="ImageResizer_Fit_Property"
+                                      x:Uid="ImageResizer_Fit_Property"
+                                      SelectedIndex="{x:Bind Path=Fit, Mode=TwoWay}"
                                       Width="90"
                                       VerticalAlignment="Center"
                                       Height="34"

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
@@ -126,7 +126,9 @@
                                             VerticalAlignment="Center"
                                             Margin="{StaticResource SmallTopMargin}"/>
 
-                            <TextBlock Text="&#xE711;"
+                            <TextBlock Name="ImageResizer_Times_Symbol"
+                                       x:Uid="ImageResizer_Times_Symbol"
+                                       Text="&#xE711;"
                                        FontFamily="Segoe MDL2 Assets"
                                        TextAlignment="Center"
                                        VerticalAlignment="Center"

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
@@ -96,7 +96,7 @@
                 </ListView.ItemContainerStyle>
                 <ListView.ItemTemplate>
                     <DataTemplate x:Name="SingleLineDataTemplate" x:DataType="models:ImageSize" >
-                        <StackPanel Orientation="Horizontal" Height="48" Padding="0" Spacing="4">
+                        <StackPanel Name="ImageResizer_Configurations" x:Uid="ImageResizer_Configurations" Orientation="Horizontal" Height="48" Padding="0" Spacing="4">
                             <TextBox Name="ImageResizer_Name"
                                      x:Uid="ImageResizer_Name"
                                      Text="{x:Bind Path=Name, Mode=TwoWay}" 


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

Accessibility issues of the image resizer settings page are fixed in this PR.

## PR Checklist
* [x] Applies to #5736.
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

The following changes have been made in this PR - 
* Automation properties have been set for all the text blocks, combo boxes and number boxes. (Each commit corresponds to one element's accessibility issue being fixed).
* The Image has more context now.
* The remove button was previously being read out as only button. Now it has been labeled.

## Validation Steps Performed

_How does someone test & validate?_

* Install NVDA (screen reader) and ensure that the correct information is being read out.
* Press Insert+B to read the entire app content.