### PR TITLE
Fixing Settings Util tests. 

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/ModelsTests/SettingsUtilsTests.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/ModelsTests/SettingsUtilsTests.cs
@@ -48,7 +48,7 @@ namespace CommonLibTest
             BasePTSettingsTest actual_json = SettingsUtils.GetSettings<BasePTSettingsTest>(file_name);
 
             // Assert
-            Assert.IsTrue(actual_json.Equals(actual_json));
+            Assert.AreEqual(expected_json.ToJsonString(), actual_json.ToJsonString());
         }
 
         [TestMethod]
@@ -70,7 +70,7 @@ namespace CommonLibTest
             BasePTSettingsTest actual_json = SettingsUtils.GetSettings<BasePTSettingsTest>(file_name);
 
             // Assert
-            Assert.IsTrue(actual_json.Equals(actual_json));
+            Assert.AreEqual(expected_json.ToJsonString(), actual_json.ToJsonString());
         }
 
         [TestMethod]


### PR DESCRIPTION
1) the same variables (actual_json) are being compared against each other.
2) BasePTSettingsTest doesn't override equals to Equals compares the objects. This change compares the json strings directly.

## Summary of the Pull Request
These unit tests weren't actually running the expected test.  Performing the proper check. 

_What is this about?_

## PR Checklist
* [ ] Applies to #xxx
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

## Validation Steps Performed

_How does someone test & validate?_
