### PR TITLE
[ColorPicker] proper Trace::UnregisterProvider(); call

### DIFF
--- a/src/modules/colorPicker/ColorPicker/dllmain.cpp
+++ b/src/modules/colorPicker/ColorPicker/dllmain.cpp
@@ -19,6 +19,7 @@ BOOL APIENTRY DllMain(HMODULE hModule,
         Trace::RegisterProvider();
     case DLL_THREAD_ATTACH:
     case DLL_THREAD_DETACH:
+        break;
     case DLL_PROCESS_DETACH:
         Trace::UnregisterProvider();
         break;


### PR DESCRIPTION
## Summary of the Pull Request

ColorPicker DllMain should call `Trace::UnregisterProvider();` only for DLL_PROCESS_DETACH

