### PR TITLE
Allow embedded images in SVGs to be displayed

### DIFF
--- a/src/modules/previewpane/UnitTests-PreviewHandlerCommon/WebBrowserExtUnitTests.cs
+++ b/src/modules/previewpane/UnitTests-PreviewHandlerCommon/WebBrowserExtUnitTests.cs
@@ -46,7 +46,6 @@ namespace UnitTests_PreviewHandlerCommon
             var actualFlags = (int)extendedSite.InvokeMember(DISPIDAMBIENTDLCONTROL, BindingFlags.InvokeMethod, null, null, null, null, null, null);
 
             // Assert
-            Assert.IsTrue((actualFlags & (int)WebBrowserDownloadControlFlags.DLIMAGES) == 0);
             Assert.IsTrue((actualFlags & (int)WebBrowserDownloadControlFlags.VIDEOS) == 0);
             Assert.IsTrue((actualFlags & (int)WebBrowserDownloadControlFlags.BGSOUNDS) == 0);
             Assert.IsTrue((actualFlags & (int)WebBrowserDownloadControlFlags.DOWNLOADONLY) == 0);

--- a/src/modules/previewpane/common/controls/WebBrowserExt.cs
+++ b/src/modules/previewpane/common/controls/WebBrowserExt.cs
@@ -54,6 +54,7 @@ namespace PreviewHandlerCommon
                 if (name.Equals(DISPIDAMBIENTDLCONTROL))
                 {
                     result = Convert.ToInt32(
+                        WebBrowserDownloadControlFlags.DLIMAGES |
                         WebBrowserDownloadControlFlags.PRAGMA_NO_CACHE |
                         WebBrowserDownloadControlFlags.FORCEOFFLINE |
                         WebBrowserDownloadControlFlags.NO_CLIENTPULL |


### PR DESCRIPTION
Add DLIMAGES to WebBrowserExt ambient control flags to allow display of img links in SVGs.  We still specify FORCEOFFLINE so we are not actually performing a download.  This is to target SVGs with xlink base64 encoded data.
