### PR TITLE
Improved the KB Hook in Color Picker

### DIFF
--- a/src/modules/colorPicker/ColorPickerUI/Keyboard/KeyboardMonitor.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Keyboard/KeyboardMonitor.cs
@@ -62,8 +62,7 @@ namespace ColorPicker.Keyboard
 
         private void Hook_KeyboardPressed(object sender, GlobalKeyboardHookEventArgs e)
         {
-            List<string> currentlyPressedKeys = new List<string>();
-
+            var currentlyPressedKeys = new List<string>();
             var virtualCode = e.KeyboardData.VirtualCode;
 
             // ESC pressed

--- a/src/modules/colorPicker/ColorPickerUI/Keyboard/KeyboardMonitor.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Keyboard/KeyboardMonitor.cs
@@ -21,7 +21,6 @@ namespace ColorPicker.Keyboard
         private readonly AppStateHandler _appStateHandler;
         private readonly IUserSettings _userSettings;
 
-        private List<string> _currentlyPressedKeys = new List<string>();
         private List<string> _activationKeys = new List<string>();
         private GlobalKeyboardHook _keyboardHook;
 
@@ -63,7 +62,7 @@ namespace ColorPicker.Keyboard
 
         private void Hook_KeyboardPressed(object sender, GlobalKeyboardHookEventArgs e)
         {
-            _currentlyPressedKeys.Clear();
+            List<string> currentlyPressedKeys = new List<string>();
 
             var virtualCode = e.KeyboardData.VirtualCode;
 
@@ -76,20 +75,24 @@ namespace ColorPicker.Keyboard
 
             var name = Helper.GetKeyName((uint)virtualCode);
 
-            // Check pressed modifier keys
-            AddModifierKeys();
+            // If the last key pressed is a modifier key, then currentlyPressedKeys cannot possibly match with _activationKeys
+            // because _activationKeys contains exactly 1 non-modifier key. Hence, there's no need to check if `name` is a
+            // modifier key or to do any additional processing on it.
+
+            // Check pressed modifier keys.
+            AddModifierKeys(currentlyPressedKeys);
 
             if (e.KeyboardState == GlobalKeyboardHook.KeyboardState.KeyDown || e.KeyboardState == GlobalKeyboardHook.KeyboardState.SysKeyDown)
             {
-                if (!_currentlyPressedKeys.Contains(name))
+                if (!currentlyPressedKeys.Contains(name))
                 {
-                    _currentlyPressedKeys.Add(name);
+                    currentlyPressedKeys.Add(name);
                 }
             }
 
-            _currentlyPressedKeys.Sort();
+            currentlyPressedKeys.Sort();
 
-            if (ArraysAreSame(_currentlyPressedKeys, _activationKeys))
+            if (ArraysAreSame(currentlyPressedKeys, _activationKeys))
             {
                 _appStateHandler.ShowColorPicker();
             }
@@ -113,26 +116,26 @@ namespace ColorPicker.Keyboard
             return true;
         }
 
-        private void AddModifierKeys()
+        private static void AddModifierKeys(List<string> currentlyPressedKeys)
         {
             if ((GetAsyncKeyState(VK_SHIFT) & 0x8000) != 0)
             {
-                _currentlyPressedKeys.Add("Shift");
+                currentlyPressedKeys.Add("Shift");
             }
 
             if ((GetAsyncKeyState(VK_CONTROL) & 0x8000) != 0)
             {
-                _currentlyPressedKeys.Add("Ctrl");
+                currentlyPressedKeys.Add("Ctrl");
             }
 
             if ((GetAsyncKeyState(VK_MENU) & 0x8000) != 0)
             {
-                _currentlyPressedKeys.Add("Alt");
+                currentlyPressedKeys.Add("Alt");
             }
 
             if ((GetAsyncKeyState(VK_LWIN) & 0x8000) != 0 || (GetAsyncKeyState(VK_RWIN) & 0x8000) != 0)
             {
-                _currentlyPressedKeys.Add("Win");
+                currentlyPressedKeys.Add("Win");
             }
         }
     }

--- a/src/modules/colorPicker/ColorPickerUI/Keyboard/KeyboardMonitor.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Keyboard/KeyboardMonitor.cs
@@ -84,10 +84,7 @@ namespace ColorPicker.Keyboard
 
             if (e.KeyboardState == GlobalKeyboardHook.KeyboardState.KeyDown || e.KeyboardState == GlobalKeyboardHook.KeyboardState.SysKeyDown)
             {
-                if (!currentlyPressedKeys.Contains(name))
-                {
-                    currentlyPressedKeys.Add(name);
-                }
+                currentlyPressedKeys.Add(name);
             }
 
             currentlyPressedKeys.Sort();

--- a/src/modules/colorPicker/ColorPickerUI/Keyboard/KeyboardMonitor.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Keyboard/KeyboardMonitor.cs
@@ -70,6 +70,7 @@ namespace ColorPicker.Keyboard
             {
                 _appStateHandler.HideColorPicker();
                 PowerToysTelemetry.Log.WriteEvent(new ColorPickerCancelledEvent());
+                return;
             }
 
             var name = Helper.GetKeyName((uint)virtualCode);

--- a/src/modules/colorPicker/ColorPickerUI/Win32Apis.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Win32Apis.cs
@@ -17,6 +17,17 @@ namespace ColorPicker
         public const int LlkhfAltdown = KfAltdown >> 8;
         public const int MonitorinfofPrimary = 0x00000001;
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1310:Field names should not contain underscore", Justification = "Interop")]
+        public const int VK_SHIFT = 0x10;
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1310:Field names should not contain underscore", Justification = "Interop")]
+        public const int VK_CONTROL = 0x11;
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1310:Field names should not contain underscore", Justification = "Interop")]
+        public const int VK_MENU = 0x12;
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1310:Field names should not contain underscore", Justification = "Interop")]
+        public const int VK_LWIN = 0x5B;
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1310:Field names should not contain underscore", Justification = "Interop")]
+        public const int VK_RWIN = 0x5C;
+
         public delegate bool MonitorEnumProc(
             IntPtr monitor, IntPtr hdc, IntPtr lprcMonitor, IntPtr lParam);
 
@@ -52,6 +63,9 @@ namespace ColorPicker
 
         [DllImport("user32.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.StdCall, SetLastError = true)]
         internal static extern IntPtr CallNextHookEx(IntPtr idHook, int nCode, IntPtr wParam, IntPtr lParam);
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.StdCall, SetLastError = true)]
+        internal static extern short GetAsyncKeyState(int vKey);
 
         [DllImport("user32.dll", EntryPoint = "SystemParametersInfo")]
         internal static extern bool SystemParametersInfo(int uiAction, int uiParam, IntPtr pvParam, int fWinIni);


### PR DESCRIPTION
## Summary of the Pull Request

This PR should fix #6044 and related issues, without an architectural change proposed in #6060

## PR Checklist
* [x] Applies to #6044 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

Improved the behavior of the KB hook in ColorPicker.

## Validation Steps Performed

#6044 can be reproduced as follows:
* Set the ColorPicker shortcut to the default value `Win + Shift + C`
* Open Task manager
* Click on the desktop
* Press and hold win, whie holding win click on the task manager and then release win.
* Click on the desktop
* Press Shift+C, ColorPicker will open.

Another issue that this PR fixes:

Press the key combo starting with C, and then press `Win + Shift`. ColorPicker will open, but it shouldn't. This PR also takes care of this.
