### PR TITLE
Use en-Us locale when using ToUpper()

### DIFF
--- a/tools/build/convert-resx-to-rc.ps1
+++ b/tools/build/convert-resx-to-rc.ps1
@@ -109,13 +109,14 @@ Foreach-Object {
             # Each line of the resgen text file is of the form ResourceName=ResourceValue with no spaces.
             $content = $line -split "=", 2
 
+            $culture = [System.Globalization.CultureInfo]::GetCultureInfo('en-US')
             # Each resource is named as IDS_ResxResourceName, in uppercase
-            $lineInRCFormat = "IDS_" + $content[0].ToUpper() + " L`"" + $content[1] + "`""
+            $lineInRCFormat = "IDS_" + $content[0].ToUpper($culture) + " L`"" + $content[1] + "`""
             $newLinesForRCFile = $newLinesForRCFile + "`r`n    " + $lineInRCFormat
 
             # Resource header file needs to be updated only for one language
             if (!$headerFileUpdated) {
-                $lineInHeaderFormat = "#define IDS_" + $content[0].ToUpper() + " " + $count.ToString()
+                $lineInHeaderFormat = "#define IDS_" + $content[0].ToUpper($culture) + " " + $count.ToString()
                 $newLinesForHeaderFile = $newLinesForHeaderFile + "`r`n" + $lineInHeaderFormat
                 $count++
             }


### PR DESCRIPTION
## Summary of the Pull Request

Using ToUpper() in file generation script works different in some languages of Windows.
Use default English locale to avoid errors.

## PR Checklist
* [x] Applies to #6172 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

## Validation Steps Performed

_How does someone test & validate?_
