### PR TITLE
[FancyZones] Enable to manually zone child windows

### DIFF
--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -346,11 +346,12 @@ FancyZones::VirtualDesktopInitialize() noexcept
 
 bool FancyZones::ShouldProcessNewWindow(HWND window) noexcept
 {
+    using namespace FancyZonesUtils;
     // Avoid processing splash screens, already stamped (zoned) windows, or those windows
     // that belong to excluded applications list.
     if (IsSplashScreen(window) ||
         (reinterpret_cast<size_t>(::GetProp(window, ZonedWindowProperties::PropertyMultipleZoneID)) != 0) ||
-        !FancyZonesUtils::IsInterestingWindow(window, m_settings->GetSettings()->excludedAppsArray))
+        !IsInterestingWindow(window, m_settings->GetSettings()->excludedAppsArray, NewlyCreatedWindow::Yes))
     {
         return false;
     }

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -351,7 +351,7 @@ bool FancyZones::ShouldProcessNewWindow(HWND window) noexcept
     // that belong to excluded applications list.
     if (IsSplashScreen(window) ||
         (reinterpret_cast<size_t>(::GetProp(window, ZonedWindowProperties::PropertyMultipleZoneID)) != 0) ||
-        !IsInterestingWindow(window, m_settings->GetSettings()->excludedAppsArray, NewlyCreatedWindow::Yes))
+        !IsCandidateForLastKnownZone(window, m_settings->GetSettings()->excludedAppsArray))
     {
         return false;
     }
@@ -1032,7 +1032,7 @@ void FancyZones::UpdateWindowsPositions() noexcept
 void FancyZones::CycleActiveZoneSet(DWORD vkCode) noexcept
 {
     auto window = GetForegroundWindow();
-    if (FancyZonesUtils::IsInterestingWindow(window, m_settings->GetSettings()->excludedAppsArray))
+    if (FancyZonesUtils::IsCandidateForZoning(window, m_settings->GetSettings()->excludedAppsArray))
     {
         const HMONITOR monitor = MonitorFromWindow(window, MONITOR_DEFAULTTONULL);
         if (monitor)
@@ -1249,7 +1249,7 @@ bool FancyZones::OnSnapHotkeyBasedOnPosition(HWND window, DWORD vkCode) noexcept
 bool FancyZones::OnSnapHotkey(DWORD vkCode) noexcept
 {
     auto window = GetForegroundWindow();
-    if (FancyZonesUtils::IsInterestingWindow(window, m_settings->GetSettings()->excludedAppsArray))
+    if (FancyZonesUtils::IsCandidateForZoning(window, m_settings->GetSettings()->excludedAppsArray))
     {
         if (m_settings->GetSettings()->moveWindowsBasedOnPosition)
         {

--- a/src/modules/fancyzones/lib/WindowMoveHandler.cpp
+++ b/src/modules/fancyzones/lib/WindowMoveHandler.cpp
@@ -172,7 +172,7 @@ bool WindowMoveHandler::MoveWindowIntoZoneByDirectionAndPosition(HWND window, DW
 
 void WindowMoveHandlerPrivate::MoveSizeStart(HWND window, HMONITOR monitor, POINT const& ptScreen, const std::unordered_map<HMONITOR, winrt::com_ptr<IZoneWindow>>& zoneWindowMap) noexcept
 {
-    if (!FancyZonesUtils::IsInterestingWindow(window, m_settings->GetSettings()->excludedAppsArray) || WindowMoveHandlerUtils::IsCursorTypeIndicatingSizeEvent())
+    if (!FancyZonesUtils::IsCandidateForZoning(window, m_settings->GetSettings()->excludedAppsArray) || WindowMoveHandlerUtils::IsCursorTypeIndicatingSizeEvent())
     {
         return;
     }
@@ -297,7 +297,7 @@ void WindowMoveHandlerPrivate::MoveSizeUpdate(HMONITOR monitor, POINT const& ptS
 
 void WindowMoveHandlerPrivate::MoveSizeEnd(HWND window, POINT const& ptScreen, const std::unordered_map<HMONITOR, winrt::com_ptr<IZoneWindow>>& zoneWindowMap) noexcept
 {
-    if (window != m_windowMoveSize && !FancyZonesUtils::IsInterestingWindow(window, m_settings->GetSettings()->excludedAppsArray))
+    if (window != m_windowMoveSize && !FancyZonesUtils::IsCandidateForZoning(window, m_settings->GetSettings()->excludedAppsArray))
     {
         return;
     }

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -307,7 +307,11 @@ IFACEMETHODIMP ZoneWindow::MoveSizeEnd(HWND window, POINT const& ptScreen) noexc
         MapWindowPoints(nullptr, m_window.get(), &ptClient, 1);
         m_activeZoneSet->MoveWindowIntoZoneByIndexSet(window, m_window.get(), m_highlightZone);
 
-        SaveWindowProcessToZoneIndex(window);
+        auto windowInfo = FancyZonesUtils::GetFancyZonesWindowInfo(window);
+        if (windowInfo.noVisibleOwner)
+        {
+            SaveWindowProcessToZoneIndex(window);
+        }
     }
     Trace::ZoneWindow::MoveSizeEnd(m_activeZoneSet);
 
@@ -338,7 +342,11 @@ ZoneWindow::MoveWindowIntoZoneByDirectionAndIndex(HWND window, DWORD vkCode, boo
     {
         if (m_activeZoneSet->MoveWindowIntoZoneByDirectionAndIndex(window, m_window.get(), vkCode, cycle))
         {
-            SaveWindowProcessToZoneIndex(window);
+            auto windowInfo = FancyZonesUtils::GetFancyZonesWindowInfo(window);
+            if (windowInfo.noVisibleOwner)
+            {
+                SaveWindowProcessToZoneIndex(window);
+            }
             return true;
         }
     }

--- a/src/modules/fancyzones/lib/util.h
+++ b/src/modules/fancyzones/lib/util.h
@@ -15,12 +15,6 @@ namespace FancyZonesUtils
         std::wstring processPath;
     };
 
-    enum class NewlyCreatedWindow
-    {
-        No = 0,
-        Yes
-    };
-
     struct Rect
     {
         Rect() {}

--- a/src/modules/fancyzones/lib/util.h
+++ b/src/modules/fancyzones/lib/util.h
@@ -188,9 +188,9 @@ namespace FancyZonesUtils
     void SizeWindowToRect(HWND window, RECT rect) noexcept;
 
     FancyZonesWindowInfo GetFancyZonesWindowInfo(HWND window);
-    bool IsInterestingWindow(HWND window,
-                             const std::vector<std::wstring>& excludedApps,
-                             NewlyCreatedWindow newlyCreatedWindow = NewlyCreatedWindow::No) noexcept;
+    bool IsCandidateForLastKnownZone(HWND window, const std::vector<std::wstring>& excludedApps) noexcept;
+    bool IsCandidateForZoning(HWND window, const std::vector<std::wstring>& excludedApps) noexcept;
+
     bool IsWindowMaximized(HWND window) noexcept;
     void SaveWindowSizeAndOrigin(HWND window) noexcept;
     void RestoreWindowSize(HWND window) noexcept;

--- a/src/modules/fancyzones/lib/util.h
+++ b/src/modules/fancyzones/lib/util.h
@@ -15,6 +15,12 @@ namespace FancyZonesUtils
         std::wstring processPath;
     };
 
+    enum class NewlyCreatedWindow
+    {
+        No = 0,
+        Yes
+    };
+
     struct Rect
     {
         Rect() {}
@@ -181,7 +187,10 @@ namespace FancyZonesUtils
     void OrderMonitors(std::vector<std::pair<HMONITOR, RECT>>& monitorInfo);
     void SizeWindowToRect(HWND window, RECT rect) noexcept;
 
-    bool IsInterestingWindow(HWND window, const std::vector<std::wstring>& excludedApps) noexcept;
+    FancyZonesWindowInfo GetFancyZonesWindowInfo(HWND window);
+    bool IsInterestingWindow(HWND window,
+                             const std::vector<std::wstring>& excludedApps,
+                             NewlyCreatedWindow newlyCreatedWindow = NewlyCreatedWindow::No) noexcept;
     bool IsWindowMaximized(HWND window) noexcept;
     void SaveWindowSizeAndOrigin(HWND window) noexcept;
     void RestoreWindowSize(HWND window) noexcept;


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
Enable manual (using hotkey and shift+drag) zoning of child windows and do not keep them in zone app history.

## PR Checklist
* [x] Applies to #1445 ~#2834~
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx
