### PR TITLE
Fix runner crashing on launching Keyboard Manager UI

### DIFF
--- a/src/runner/PowerToys.exe.manifest
+++ b/src/runner/PowerToys.exe.manifest
@@ -2,6 +2,8 @@
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
+		<!-- Required for C++ XAML Islands projects that execute from runner (i.e. Keyboard Manager) -->
+		<maxversiontested Id="10.0.18362.0"/>
     </application>
   </compatibility>
 </assembly>

--- a/src/runner/PowerToys.exe.manifest
+++ b/src/runner/PowerToys.exe.manifest
@@ -2,7 +2,7 @@
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
-		<!-- Required for C++ XAML Islands projects that execute from runner (i.e. Keyboard Manager) -->
+		<!-- Required for C++ XAML Islands projects that execute from runner (i.e. Keyboard Manager). More details at https://docs.microsoft.com/en-us/windows/apps/desktop/modernize/host-standard-control-with-xaml-islands-cpp#create-a-desktop-application-project -->
 		<maxversiontested Id="10.0.18362.0"/>
     </application>
   </compatibility>


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
This PR fixes a crash which occurs on launching the keyboard manager UI from settings.

The error message that appears is `Exception thrown at 0x00007FFFA254A799 (KernelBase.dll) in PowerToys.exe: WinRT originate error - 0x8000FFFF : 'WindowsXamlManager and DesktopWindowXamlSource are supported for apps targeting Windows version 10.0.18226.0 and later.  Please check either the application manifest or package manifest and ensure the MaxTestedVersion property is updated.'.
Exception thrown at 0x00007FFFA254A799 in PowerToys.exe: Microsoft C++ exception: winrt::hresult_error at memory location 0x000000A9C3AFCFC8.`

This appears because the `maxVersionTested` attribute (removed in #6095 ) is required in the executable's manifest (in this case in runner), as described here https://docs.microsoft.com/en-us/windows/apps/desktop/modernize/host-standard-control-with-xaml-islands-cpp#create-a-desktop-application-project.
As mentioned on [this part of the same doc](https://docs.microsoft.com/en-us/windows/apps/desktop/modernize/host-standard-control-with-xaml-islands-cpp#use-the-xaml-hosting-api-to-host-a-uwp-control), there is this warning which is a known issue `manifest authoring warning 81010002: Unrecognized Element "maxversiontested" in namespace "urn:schemas-microsoft-com:compatibility.v1"`. I couldn't find a way to suppress or disable this warning, so we will be able to get rid of it only after migrating to WinUI 3.

I have added a comment with details in the manifest file.

## PR Checklist
* [X] Applies to #6183 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

## Validation Steps Performed

_How does someone test & validate?_
Validated that keyboard manager UI gets launched.