### PR TITLE
Possible fix for deserialization error

### DIFF
--- a/src/common/settings_objects.cpp
+++ b/src/common/settings_objects.cpp
@@ -351,7 +351,6 @@ namespace PowerToysSettings
 
     void PowerToyValues::save_to_settings_file()
     {
-        set_version();
         PTSettingsHelper::save_module_settings(_name, m_json);
     }
 

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/PowerLauncherSettings.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/PowerLauncherSettings.cs
@@ -2,9 +2,6 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
-using System.IO;
-using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -19,16 +16,8 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
 
         public PowerLauncherSettings()
         {
-            try
-            {
-                Version = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).ProductVersion;
-            }
-            catch (FileNotFoundException)
-            {
-                Version = "1.0";
-            }
-
             Properties = new PowerLauncherProperties();
+            Version = "1";
             Name = ModuleName;
         }
 

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/PowerLauncherSettings.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/PowerLauncherSettings.cs
@@ -25,7 +25,7 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
             }
             catch (FileNotFoundException)
             {
-                Version = "1";
+                Version = "1.0";
             }
 
             Properties = new PowerLauncherProperties();

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/PowerLauncherSettings.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/PowerLauncherSettings.cs
@@ -2,6 +2,9 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -16,8 +19,16 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
 
         public PowerLauncherSettings()
         {
+            try
+            {
+                Version = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).ProductVersion;
+            }
+            catch (FileNotFoundException)
+            {
+                Version = "1";
+            }
+
             Properties = new PowerLauncherProperties();
-            Version = "1";
             Name = ModuleName;
         }
 

--- a/src/modules/launcher/PowerLauncher/SettingsWatcher.cs
+++ b/src/modules/launcher/PowerLauncher/SettingsWatcher.cs
@@ -50,7 +50,7 @@ namespace PowerLauncher
                     retryCount++;
                     if (!SettingsUtils.SettingsExists(PowerLauncherSettings.ModuleName))
                     {
-                        Log.Info("|SettingsWatcher.OverloadSettings|PT Run settings.json was missing, creating a new one");
+                        Log.Info("|SettingsWatcher.OverloadSettings| PT Run settings.json was missing, creating a new one");
                         var defaultSettings = new PowerLauncherSettings();
                         defaultSettings.Save();
                     }

--- a/src/modules/launcher/PowerLauncher/SettingsWatcher.cs
+++ b/src/modules/launcher/PowerLauncher/SettingsWatcher.cs
@@ -109,7 +109,7 @@ namespace PowerLauncher
                 }
                 catch (JsonException e)
                 {
-                    Log.Exception($"|SettingsWatcher.OverloadSettings| Failed to Deserealize PowerToys settings, {e.Message}", e);
+                    Log.Exception($"|SettingsWatcher.OverloadSettings| Failed to Deserialize PowerToys settings, {e.Message}", e);
                 }
             }
 

--- a/src/modules/launcher/PowerLauncher/SettingsWatcher.cs
+++ b/src/modules/launcher/PowerLauncher/SettingsWatcher.cs
@@ -5,13 +5,17 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Text.Json;
 using System.Threading;
 using System.Windows.Input;
 using Microsoft.PowerToys.Settings.UI.Lib;
+using Newtonsoft.Json;
 using Wox.Core.Plugin;
 using Wox.Infrastructure.Hotkey;
+using Wox.Infrastructure.Logger;
 using Wox.Infrastructure.UserSettings;
 using Wox.Plugin;
+using JsonException = System.Text.Json.JsonException;
 
 namespace PowerLauncher
 {
@@ -46,8 +50,7 @@ namespace PowerLauncher
                     retryCount++;
                     if (!SettingsUtils.SettingsExists(PowerLauncherSettings.ModuleName))
                     {
-                        Debug.WriteLine("PT Run settings.json was missing, creating a new one");
-
+                        Log.Info("|SettingsWatcher.OverloadSettings|PT Run settings.json was missing, creating a new one");
                         var defaultSettings = new PowerLauncherSettings();
                         defaultSettings.Save();
                     }
@@ -103,6 +106,10 @@ namespace PowerLauncher
 
                     Thread.Sleep(1000);
                     Debug.WriteLine(e.Message);
+                }
+                catch (JsonException e)
+                {
+                    Log.Exception($"|SettingsWatcher.OverloadSettings| Failed to Deserealize PowerToys settings, {e.Message}", e);
                 }
             }
 

--- a/src/modules/launcher/PowerLauncher/SettingsWatcher.cs
+++ b/src/modules/launcher/PowerLauncher/SettingsWatcher.cs
@@ -102,14 +102,18 @@ namespace PowerLauncher
                     if (retryCount > MaxRetries)
                     {
                         retry = false;
+                        Log.Exception($"|SettingsWatcher.OverloadSettings| IO Exception, {e.Message}", e);
                     }
 
                     Thread.Sleep(1000);
-                    Debug.WriteLine(e.Message);
                 }
                 catch (JsonException e)
                 {
-                    Log.Exception($"|SettingsWatcher.OverloadSettings| Failed to Deserialize PowerToys settings, {e.Message}", e);
+                    if (retryCount > MaxRetries)
+                    {
+                        retry = false;
+                        Log.Exception($"|SettingsWatcher.OverloadSettings| Failed to Deserialize PowerToys settings, {e.Message}", e);
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary of the Pull Request
Possible fix for deserialization error and fix for correct settings version.

## PR Checklist
* [x] Applies to #5897 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed

## Info on Pull Request
I hit this error only once. The issue seemed to be happening because of race condition between the setting's IPC and the file watcher. The following set of events is happening. 
1. Runner accesses `settings.json` file to write updated content. 
2. This triggers FileSystemWatcher, which causes a file read of incompletely written `settings.json`. Since the JSON is incorrectly formatted, it causes a Deserialization error.

This PR has the following changes :
1. This PR tries to do a possible fix for the Deserialization issue by handling the error and retrying the file read for a `MaxRetries` number of times. 
2. Logging has been improved.
3. The `settings.json` was getting stored with version=1.0 rather than the current Powertoys version. This has been fixed in this PR.