### PR TITLE
autoupdate improvements

### DIFF
--- a/installer/PowerToysBootstrapper/bootstrapper/bootstrapper.rc
+++ b/installer/PowerToysBootstrapper/bootstrapper/bootstrapper.rc
@@ -8,7 +8,7 @@ IDR_BIN_ICON BIN "../../../src/runner/svgs/icon.ico"
 
 STRINGTABLE
 BEGIN
-    IDS_DOTNET_CORE_DOWNLOAD_FAILURE "Couldn't download .NET Core Desktop Runtime 3.1.3, please install it manually."
+    IDS_DOTNET_CORE_DOWNLOAD_FAILURE "Couldn't download .NET Core Desktop Runtime 3.1, please install it manually."
     IDS_DOTNET_CORE_DOWNLOAD_FAILURE_TITLE "PowerToys installation error"
 END
 

--- a/installer/PowerToysBootstrapper/bootstrapper/pch.h
+++ b/installer/PowerToysBootstrapper/bootstrapper/pch.h
@@ -11,3 +11,5 @@
 #include <Msi.h>
 
 #include <unordered_set>
+#include <tuple>
+#include <sstream>

--- a/installer/PowerToysSetup/Product.wxs
+++ b/installer/PowerToysSetup/Product.wxs
@@ -70,7 +70,8 @@
     <Property Id="INSTALLSTARTMENUSHORTCUT" Value="1"/>
     <Property Id="CREATESCHEDULEDTASK" Value="1"/>
     <Property Id="WixShellExecTarget" Value="[#action_runner.exe]" />
-    
+    <Property Id="SKIPDOTNETINSTALL" Value="0"/>
+        
     <Property Id ="EXISTINGPOWERRENAMEEXTPATH">
       <RegistrySearch Id="ExistingExtPath" Root="HKCR" Key="CLSID\{0440049F-D1DC-4E46-B27B-98393D79486B}\InprocServer32" Type="raw"/>
     </Property>
@@ -96,7 +97,7 @@
       </Custom>
       
       <Custom Action="InstallDotNet" After="InstallFinalize">
-        NOT Installed
+        NOT Installed and (SKIPDOTNETINSTALL = 0)
       </Custom>
 
       <Custom Action="TerminateProcesses" Before="InstallValidate" />

--- a/src/action_runner/action_runner.rc
+++ b/src/action_runner/action_runner.rc
@@ -4,7 +4,7 @@
 
 STRINGTABLE
 BEGIN
-    IDS_DOTNET_CORE_DOWNLOAD_FAILURE "Couldn't download .NET Core Desktop Runtime 3.1.3, please install it manually."
+    IDS_DOTNET_CORE_DOWNLOAD_FAILURE "Couldn't download .NET Core Desktop Runtime 3.1, please install it manually."
     IDS_DOTNET_CORE_DOWNLOAD_FAILURE_TITLE "PowerToys installation error"
 END
 

--- a/src/common/UnitTests-CommonLib/UnitTestsVersionHelper.cpp
+++ b/src/common/UnitTests-CommonLib/UnitTestsVersionHelper.cpp
@@ -4,11 +4,20 @@
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
+namespace Microsoft::VisualStudio::CppUnitTestFramework
+{
+    template<>
+    inline std::wstring ToString<VersionHelper>(const VersionHelper& v)
+    {
+        return v.toWstring();
+    }
+}
+
 namespace UnitTestsVersionHelper
 {
-    const int MAJOR_VERSION_0 = 0;
-    const int MINOR_VERSION_12 = 12;
-    const int REVISION_VERSION_0 = 0;
+    const size_t MAJOR_VERSION_0 = 0;
+    const size_t MINOR_VERSION_12 = 12;
+    const size_t REVISION_VERSION_0 = 0;
 
     TEST_CLASS (UnitTestsVersionHelper)
     {
@@ -23,9 +32,9 @@ namespace UnitTestsVersionHelper
         }
         TEST_METHOD (integerConstructorShouldProperlyInitializationWithDifferentVersionNumbers)
         {
-            const int testcaseMajor = 2;
-            const int testcaseMinor = 25;
-            const int testcaseRevision = 1;
+            const size_t testcaseMajor = 2;
+            const size_t testcaseMinor = 25;
+            const size_t testcaseRevision = 1;
             VersionHelper sut(testcaseMajor, testcaseMinor, testcaseRevision);
 
             Assert::AreEqual(testcaseMajor, sut.major);
@@ -36,17 +45,77 @@ namespace UnitTestsVersionHelper
         {
             VersionHelper sut("v0.12.3");
 
-            Assert::AreEqual(0, sut.major);
-            Assert::AreEqual(12, sut.minor);
-            Assert::AreEqual(3, sut.revision);
+            Assert::AreEqual(0ull, sut.major);
+            Assert::AreEqual(12ull, sut.minor);
+            Assert::AreEqual(3ull, sut.revision);
         }
         TEST_METHOD (stringConstructorShouldProperlyInitializationWithDifferentVersionNumbers)
         {
             VersionHelper sut("v2.25.1");
 
-            Assert::AreEqual(2, sut.major);
-            Assert::AreEqual(25, sut.minor);
-            Assert::AreEqual(1, sut.revision);
+            Assert::AreEqual(2ull, sut.major);
+            Assert::AreEqual(25ull, sut.minor);
+            Assert::AreEqual(1ull, sut.revision);
+        }
+        TEST_METHOD (emptyStringNotAccepted)
+        {
+            Assert::ExpectException<std::logic_error>([] {
+                VersionHelper sut("");
+            });
+        }
+        TEST_METHOD (invalidStringNotAccepted1)
+        {
+            Assert::ExpectException<std::logic_error>([] {
+                VersionHelper sut("v2a.");
+            });
+        }
+        TEST_METHOD (invalidStringNotAccepted2)
+        {
+            Assert::ExpectException<std::logic_error>([] {
+                VersionHelper sut("12abc2vv.0");
+            });
+        }
+        TEST_METHOD (invalidStringNotAccepted3)
+        {
+            Assert::ExpectException<std::logic_error>([] {
+                VersionHelper sut("123");
+            });
+        }
+        TEST_METHOD (invalidStringNotAccepted4)
+        {
+            Assert::ExpectException<std::logic_error>([] {
+                VersionHelper sut("v1v2v3");
+            });
+        }
+        TEST_METHOD (invalidStringNotAccepted5)
+        {
+            Assert::ExpectException<std::logic_error>([] {
+                VersionHelper sut("v.1.2.3v");
+            });
+        }
+        TEST_METHOD (partialVersionStringNotAccepted1)
+        {
+            Assert::ExpectException<std::logic_error>([] {
+                VersionHelper sut("v1.");
+            });
+        }
+        TEST_METHOD (partialVersionStringNotAccepted2)
+        {
+            Assert::ExpectException<std::logic_error>([] {
+                VersionHelper sut("v1.2");
+            });
+        }
+        TEST_METHOD (partialVersionStringNotAccepted3)
+        {
+            Assert::ExpectException<std::logic_error>([] {
+                VersionHelper sut("v1.2.");
+            });
+        }
+        TEST_METHOD (parsedWithoutLeadingV)
+        {
+            VersionHelper expected{ 12ull, 13ull, 111ull };
+            VersionHelper actual("12.13.111");
+            Assert::AreEqual(actual, expected);
         }
         TEST_METHOD (whenMajorVersionIsGreaterComparisonOperatorShouldReturnProperValue)
         {

--- a/src/common/VersionHelper.cpp
+++ b/src/common/VersionHelper.cpp
@@ -1,30 +1,32 @@
 #include "pch.h"
 #include "VersionHelper.h"
 
+#include "string_utils.h"
+
 #include <algorithm>
 #include <sstream>
 
 VersionHelper::VersionHelper(std::string str)
 {
-    std::replace(str.begin(), str.end(), '.', ' ');
-    std::replace(str.begin(), str.end(), 'v', ' ');
-    std::stringstream ss;
+    // Remove whitespaces chars and a leading 'v'
+    str = left_trim(trim(str), "v");
+    // Replace '.' with spaces
+    replace_chars(str, ".", ' ');
 
-    ss << str;
-
-    std::string temp;
-    ss >> temp;
-    std::stringstream(temp) >> major;
-    ss >> temp;
-    std::stringstream(temp) >> minor;
-    ss >> temp;
-    std::stringstream(temp) >> revision;
+    std::istringstream ss{ str };
+    ss >> major;
+    ss >> minor;
+    ss >> revision;
+    if (ss.fail() || !ss.eof())
+    {
+        throw std::logic_error("VersionHelper: couldn't parse the supplied version string");
+    }
 }
 
-VersionHelper::VersionHelper(int major, int minor, int revision) :
-    major(major),
-    minor(minor),
-    revision(revision)
+VersionHelper::VersionHelper(const size_t major, const size_t minor, const size_t revision) :
+    major{ major },
+    minor{ minor },
+    revision{ revision }
 {
 }
 

--- a/src/common/VersionHelper.h
+++ b/src/common/VersionHelper.h
@@ -6,13 +6,13 @@
 struct VersionHelper
 {
     VersionHelper(std::string str);
-    VersionHelper(int major, int minor, int revision);
+    VersionHelper(const size_t major, const size_t minor, const size_t revision);
 
     auto operator<=>(const VersionHelper&) const = default;
 
-    int major;
-    int minor;
-    int revision;
+    size_t major;
+    size_t minor;
+    size_t revision;
 
     std::wstring toWstring() const;
 };

--- a/src/common/common.vcxproj
+++ b/src/common/common.vcxproj
@@ -138,6 +138,7 @@
     <ClInclude Include="os-detect.h" />
     <ClInclude Include="RestartManagement.h" />
     <ClInclude Include="shared_constants.h" />
+    <ClInclude Include="string_utils.h" />
     <ClInclude Include="timeutil.h" />
     <ClInclude Include="two_way_pipe_message_ipc.h" />
     <ClInclude Include="VersionHelper.h" />

--- a/src/common/common.vcxproj.filters
+++ b/src/common/common.vcxproj.filters
@@ -131,11 +131,14 @@
     </ClInclude>
     <ClInclude Include="comUtils.h">
       <Filter>Header Files</Filter>
-    </ClInclude>    
+    </ClInclude>
     <ClInclude Include="LowlevelKeyboardEvent.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="WinHookEvent.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="string_utils.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/common/d2d_svg.cpp
+++ b/src/common/d2d_svg.cpp
@@ -34,10 +34,10 @@ D2DSVG& D2DSVG::resize(int x, int y, int width, int height, float fill, float ma
     transform = transform * D2D1::Matrix3x2F::Translation((width - svg_width) / 2.0f, (height - svg_height) / 2.0f);
     float h_scale = fill * height / svg_height;
     float v_scale = fill * width / svg_width;
-    used_scale = min(h_scale, v_scale);
+    used_scale = std::min(h_scale, v_scale);
     if (max_scale > 0)
     {
-        used_scale = min(used_scale, max_scale);
+        used_scale = std::min(used_scale, max_scale);
     }
     transform = transform * D2D1::Matrix3x2F::Scale(used_scale, used_scale, D2D1::Point2F(width / 2.0f, height / 2.0f));
     transform = transform * D2D1::Matrix3x2F::Translation((float)x, (float)y);

--- a/src/common/pch.h
+++ b/src/common/pch.h
@@ -1,3 +1,4 @@
+#define NOMINMAX
 #include <winrt/base.h>
 #include <winrt/Windows.Foundation.Collections.h>
 #include <Windows.h>

--- a/src/common/string_utils.h
+++ b/src/common/string_utils.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <string_view>
+#include <string>
+#include <algorithm>
+
+constexpr inline std::string_view default_trim_arg = " \t\r\n";
+
+inline std::string_view left_trim(std::string_view s, const std::string_view chars_to_trim = default_trim_arg)
+{
+    s.remove_prefix(std::min(s.find_first_not_of(chars_to_trim), size(s)));
+    return s;
+}
+
+inline std::string_view right_trim(std::string_view s, const std::string_view chars_to_trim = default_trim_arg)
+{
+    s.remove_suffix(std::min(size(s) - s.find_last_not_of(chars_to_trim) - 1, size(s)));
+    return s;
+}
+
+inline std::string_view trim(std::string_view s, const std::string_view chars_to_trim = default_trim_arg)
+{
+    return left_trim(right_trim(s, chars_to_trim), chars_to_trim);
+}
+
+inline void replace_chars(std::string& s, const std::string_view chars_to_replace, const char replacement_char)
+{
+    for (const char c : chars_to_replace)
+    {
+        std::replace(begin(s), end(s), c, replacement_char);
+    }
+}

--- a/src/common/updating/dotnet_installation.cpp
+++ b/src/common/updating/dotnet_installation.cpp
@@ -20,7 +20,7 @@ namespace updating
         return runtimes->find(DESKTOP_DOTNET_RUNTIME_STRING) != std::string::npos;
     }
 
-    bool install_dotnet()
+    bool install_dotnet(const bool silent)
     {
         const wchar_t DOTNET_DESKTOP_DOWNLOAD_LINK[] = L"https://download.visualstudio.microsoft.com/download/pr/3eb7efa1-96c6-4e97-bb9f-563ecf595f8a/7efd9c1cdd74df8fb0a34c288138a84f/windowsdesktop-runtime-3.1.6-win-x64.exe";
         const wchar_t DOTNET_DESKTOP_FILENAME[] = L"windowsdesktop-runtime.exe";
@@ -52,7 +52,9 @@ namespace updating
         sei.fMask = { SEE_MASK_NOASYNC | SEE_MASK_NOCLOSEPROCESS | SEE_MASK_NO_CONSOLE };
         sei.lpFile = dotnet_download_path.c_str();
         sei.nShow = SW_SHOWNORMAL;
-        sei.lpParameters = L"/install /passive";
+        std::wstring dotnet_flags = L"/install ";
+        dotnet_flags += silent ? L"/quiet" : L"/passive";
+        sei.lpParameters = dotnet_flags.c_str();
         if (ShellExecuteExW(&sei) != TRUE)
         {
             return false;

--- a/src/common/updating/dotnet_installation.h
+++ b/src/common/updating/dotnet_installation.h
@@ -3,5 +3,5 @@
 namespace updating
 {
     bool dotnet_is_installed();
-    bool install_dotnet();
+    bool install_dotnet(const bool silent = false);
 }


### PR DESCRIPTION
## Summary of the Pull Request
- add --help and --skip_dotnet_install commands
- do not accept invalid input in VersionHelper and add negative unit tests
- do not specify patch version of .net core in the notification msgs

## PR Checklist
* [x] Applies to #6069,#5770
* [x] Tests added/passed

## Info on Pull Request

Regarding #6069, it's a tentative fix, however, it looks like it'll fix it. We generate "old -> new" version toast using `current_version_to_next_version`. It's only used by the following functions (not taking error msg into account):
  1. `show_available`
  2. `show_visit_github` 
  3. `show_version_ready`

Let's find out how they're used:
  1. is called inside `check_new_version_available`, which shouldn't display a toast if `get_new_github_version_info_async` return nothing.
  2. is called by `try_autoupdate`, which again returns if `check_new_version_available` returned nothing.
  3. is also called by try_autoupdate, same as above.

We'd expect many bug reports regarding false-positive update notifications if `get_new_github_version_info_async` worked incorrectly in the majority of cases, so it's either a subtle bug in that function, or the update notification was somehow snoozed and resurfaced later.

`VersionHelper` could accept invalid input w/o indicating any error, thus leading to unitialized version fileds. Perhaps Github rarely doesn't send the tag, so we observe this issue.

If we still experience the issue, we'll need to ask a user which able to experience it to delete their `update_state.json` or use "check for updates" button, so we can reliably reproduce and debug it.


## Validation Steps Performed

- installed PT on a clean machine w/ and w/o `--skip_dotnet_install` flag
- unit tests passed
