### PR TITLE
[PowerToys Run] Possible fix for dispatcher error

### DIFF
--- a/src/modules/launcher/PowerLauncher/Helper/ErrorReporting.cs
+++ b/src/modules/launcher/PowerLauncher/Helper/ErrorReporting.cs
@@ -12,7 +12,7 @@ namespace PowerLauncher.Helper
 {
     public static class ErrorReporting
     {
-        private static void Report(Exception e)
+        private static void Report(Exception e, bool waitForClose)
         {
             if (e != null)
             {
@@ -20,20 +20,31 @@ namespace PowerLauncher.Helper
                 logger.Fatal(ExceptionFormatter.FormatException(e));
 
                 var reportWindow = new ReportWindow(e);
-                reportWindow.Show();
+
+                if (waitForClose)
+                {
+                    reportWindow.ShowDialog();
+                }
+                else
+                {
+                    reportWindow.Show();
+                }
             }
         }
 
         public static void UnhandledExceptionHandle(object sender, UnhandledExceptionEventArgs e)
         {
             // handle non-ui thread exceptions
-            Report((Exception)e?.ExceptionObject);
+            System.Windows.Application.Current.Dispatcher.Invoke(() =>
+            {
+                Report((Exception)e?.ExceptionObject, true);
+            });
         }
 
         public static void DispatcherUnhandledException(object sender, DispatcherUnhandledExceptionEventArgs e)
         {
             // handle ui thread exceptions
-            Report(e?.Exception);
+            Report(e?.Exception, false);
 
             // prevent application exist, so the user can copy prompted error info
             e.Handled = true;

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -356,15 +356,20 @@ namespace PowerLauncher
                 }
 
                 // (this.FindResource("IntroStoryboard") as Storyboard).Begin();
-                SearchBox.QueryTextBox.Focus();
-                Keyboard.Focus(SearchBox.QueryTextBox);
+                Application.Current.Dispatcher.BeginInvoke(
+                    new Action(
+                    () =>
+                {
+                    SearchBox.QueryTextBox.Focus();
+                    Keyboard.Focus(SearchBox.QueryTextBox);
+
+                    if (!string.IsNullOrEmpty(SearchBox.QueryTextBox.Text))
+                    {
+                        SearchBox.QueryTextBox.SelectAll();
+                    }
+                }), System.Windows.Threading.DispatcherPriority.Normal);
 
                 _settings.ActivateTimes++;
-
-                if (!string.IsNullOrEmpty(SearchBox.QueryTextBox.Text))
-                {
-                    SearchBox.QueryTextBox.SelectAll();
-                }
 
                 // Log the time taken from pressing the hotkey till launcher is visible as separate events depending on if it's the first hotkey invoke or second
                 if (!_coldStateHotkeyPressed)

--- a/src/modules/launcher/PowerLauncher/ViewModel/ResultViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/ResultViewModel.cs
@@ -70,25 +70,30 @@ namespace PowerLauncher.ViewModel
 
         public void ActivateContextButtons(ActivationType activationType)
         {
-            // Result does not contain any context menu items - we don't need to show the context menu ListView at all.
-            if (ContextMenuItems.Count > 0)
-            {
-                AreContextButtonsActive = true;
-            }
-            else
-            {
-                AreContextButtonsActive = false;
-            }
+            System.Windows.Application.Current.Dispatcher.BeginInvoke(
+                    new Action(
+                    () =>
+                    {
+                        // Result does not contain any context menu items - we don't need to show the context menu ListView at all.
+                        if (ContextMenuItems.Count > 0)
+                        {
+                            AreContextButtonsActive = true;
+                        }
+                        else
+                        {
+                            AreContextButtonsActive = false;
+                        }
 
-            if (activationType == ActivationType.Selection)
-            {
-                IsSelected = true;
-                EnableContextMenuAcceleratorKeys();
-            }
-            else if (activationType == ActivationType.Hover)
-            {
-                IsHovered = true;
-            }
+                        if (activationType == ActivationType.Selection)
+                        {
+                            IsSelected = true;
+                            EnableContextMenuAcceleratorKeys();
+                        }
+                        else if (activationType == ActivationType.Hover)
+                        {
+                            IsHovered = true;
+                        }
+                    }), System.Windows.Threading.DispatcherPriority.Normal);
         }
 
         private void DeactivateContextButtonsHoverAction(object sender)
@@ -103,25 +108,30 @@ namespace PowerLauncher.ViewModel
 
         public void DeactivateContextButtons(ActivationType activationType)
         {
-            if (activationType == ActivationType.Selection)
-            {
-                IsSelected = false;
-                DisableContextMenuAcceleratorkeys();
-            }
-            else if (activationType == ActivationType.Hover)
-            {
-                IsHovered = false;
-            }
+            System.Windows.Application.Current.Dispatcher.BeginInvoke(
+                   new Action(
+                   () =>
+                   {
+                       if (activationType == ActivationType.Selection)
+                       {
+                           IsSelected = false;
+                           DisableContextMenuAcceleratorkeys();
+                       }
+                       else if (activationType == ActivationType.Hover)
+                       {
+                           IsHovered = false;
+                       }
 
-            // Result does not contain any context menu items - we don't need to show the context menu ListView at all.
-            if (ContextMenuItems?.Count > 0)
-            {
-                AreContextButtonsActive = IsSelected || IsHovered;
-            }
-            else
-            {
-                AreContextButtonsActive = false;
-            }
+                       // Result does not contain any context menu items - we don't need to show the context menu ListView at all.
+                       if (ContextMenuItems?.Count > 0)
+                       {
+                           AreContextButtonsActive = IsSelected || IsHovered;
+                       }
+                       else
+                       {
+                           AreContextButtonsActive = false;
+                       }
+                   }), System.Windows.Threading.DispatcherPriority.Normal);
         }
 
         public void LoadContextMenu()
@@ -204,7 +214,12 @@ namespace PowerLauncher.ViewModel
         {
             if (ContextMenuSelectedIndex == (ContextMenuItems.Count - 1))
             {
-                ContextMenuSelectedIndex = NoSelectionIndex;
+                System.Windows.Application.Current.Dispatcher.BeginInvoke(
+                       new Action(
+                       () =>
+                       {
+                           ContextMenuSelectedIndex = NoSelectionIndex;
+                       }), System.Windows.Threading.DispatcherPriority.Normal);
                 return false;
             }
 
@@ -220,13 +235,23 @@ namespace PowerLauncher.ViewModel
                 return false;
             }
 
-            ContextMenuSelectedIndex--;
+            System.Windows.Application.Current.Dispatcher.BeginInvoke(
+                   new Action(
+                   () =>
+                   {
+                       ContextMenuSelectedIndex--;
+                   }), System.Windows.Threading.DispatcherPriority.Normal);
             return true;
         }
 
         public void SelectLastContextButton()
         {
-            ContextMenuSelectedIndex = ContextMenuItems.Count - 1;
+            System.Windows.Application.Current.Dispatcher.BeginInvoke(
+                      new Action(
+                      () =>
+                      {
+                          ContextMenuSelectedIndex = ContextMenuItems.Count - 1;
+                      }), System.Windows.Threading.DispatcherPriority.Normal);
         }
 
         public bool HasSelectedContextButton()


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
Based on the information from this stackoverflow post (https://stackoverflow.com/questions/35172613/invalidoperationexception-dispatcher-processing-has-been-suspended-but-message), any code path where a visibility changed event tries to further modify the visual state tree can hit this error. I was unable to repro it, but I have added Dispatcher.BeginInvoke at some possible locations based on the possible repro steps from users in the issue.

I also found that the error reporting window for non-dispatcher exceptions will not work and found that it was fixed on the Wox repo (https://github.com/Wox-launcher/Wox/blob/master/Wox/Helper/ErrorReporting.cs). I had to modify it to use ShowDialog instead of show for the non-dispatcher exceptions because we do not set the exception to be handled, so we have to ensure the user can copy the error message before terminating the PT Run.

## PR Checklist
* [X] Applies to #5658 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

## Info on Pull Request

_What does this include?_

## Validation Steps Performed

_How does someone test & validate?_
