### PR TITLE
[PowerRename] fix build warning

### DIFF
--- a/src/modules/powerrename/UWPui/resource.h
+++ b/src/modules/powerrename/UWPui/resource.h
@@ -2,12 +2,3 @@
 // Microsoft Visual C++ generated include file.
 // Used by PowerRenameUWPUI.rc
 
-//////////////////////////////
-// Non-localizable
-
-#define FILE_DESCRIPTION "PowerToys PowerRenameUWPUI"
-#define INTERNAL_NAME "PowerRenameUWPUI"
-#define ORIGINAL_FILENAME "PowerRenameUWPUI.exe"
-
-// Non-localizable
-//////////////////////////////


### PR DESCRIPTION


## Summary of the Pull Request

Fix a build warning:
![image](https://user-images.githubusercontent.com/3206696/91546830-5e184f00-e923-11ea-9ff8-a989b33d329b.png)

## Info on Pull Request

PowerRenameUWPUI uses the resources from powerrename\dll\Resources.resx, the fix removes the duplicated definitions

## Validation Steps Performed

Build the `PowerRenameUWPUI` project and verify that the `PowerRenameUWPUI.exe`'s properties are set correctly

![image](https://user-images.githubusercontent.com/3206696/91546968-8e5fed80-e923-11ea-992d-b4207708969c.png)
