### PR TITLE
Fixed a stack overflow

### DIFF
--- a/src/modules/fancyzones/lib/WindowMoveHandler.cpp
+++ b/src/modules/fancyzones/lib/WindowMoveHandler.cpp
@@ -291,7 +291,13 @@ void WindowMoveHandlerPrivate::MoveSizeUpdate(HMONITOR monitor, POINT const& ptS
         // We'll get here if the user presses/releases shift while dragging.
         // Restart the drag on the ZoneWindow that m_windowMoveSize is on
         MoveSizeStart(m_windowMoveSize, monitor, ptScreen, zoneWindowMap);
-        MoveSizeUpdate(monitor, ptScreen, zoneWindowMap);
+
+        // m_dragEnabled could get set to false if we're moving an elevated window.
+        // In that case do not proceed.
+        if (m_dragEnabled)
+        {
+            MoveSizeUpdate(monitor, ptScreen, zoneWindowMap);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary of the Pull Request

This should fix issue #5856
Credits to @gurnec for proposing the fix.

## PR Checklist
* [x] Applies to #5856
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

Checks whether drag got disabled by the call to `WarnIfElevationIsRequired`.

## Validation Steps Performed

* Disable the first two options in FZ settings.
* Start dragging task manager.
* Check that FZ is still working by dragging a non-elevated window.