### PR TITLE
Fix issue with autocomplete text not getting cleared 

### DIFF
--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -318,20 +318,21 @@ namespace PowerLauncher
 
         private void QueryTextBox_TextChanged(object sender, TextChangedEventArgs e)
         {
+            var textBox = (TextBox)sender;
+            var text = textBox.Text;
+
+            if (string.IsNullOrEmpty(text))
+            {
+                SearchBox.AutoCompleteTextBlock.Text = string.Empty;
+            }
+
             if (_isTextSetProgrammatically)
             {
-                var textBox = (TextBox)sender;
                 textBox.SelectionStart = textBox.Text.Length;
                 _isTextSetProgrammatically = false;
             }
             else
             {
-                var text = ((TextBox)sender).Text;
-                if (string.IsNullOrEmpty(text))
-                {
-                    SearchBox.AutoCompleteTextBlock.Text = string.Empty;
-                }
-
                 _viewModel.QueryText = text;
                 _viewModel.Query();
             }


### PR DESCRIPTION
## Summary of the Pull Request
Autocomplete text was not getting cleared when `Clear the Previous Query on Launch` option is enabled. 

## PR Checklist
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed

## Info on Pull Request
The issue was happening because the code path for clearing query programmatically didn't set autocomplete text to empty.

## Validation Steps Performed
Manually validated that autocomplete text is cleared. 