### PR TITLE
Fix inconsistency in the color of QueryTextBox

### DIFF
--- a/src/modules/launcher/PowerLauncher/LauncherControl.xaml
+++ b/src/modules/launcher/PowerLauncher/LauncherControl.xaml
@@ -9,7 +9,7 @@
     d:DesignWidth="720">
     <UserControl.Resources>
         <Style x:Key="QueryTextBoxStyle" TargetType="{x:Type TextBox}">
-            <Setter Property="Background" Value="{DynamicResource SystemChromeLow}" />
+            <Setter Property="Background" Value="Transparent" />
             <Setter Property="BorderThickness" Value="0" />
             <Setter Property="Foreground" Value="{DynamicResource ControlTextBrushKey}"/>
             <Setter Property="CaretBrush" Value="{DynamicResource ControlTextBrushKey}"/>
@@ -102,11 +102,12 @@
             x:Name="AutoCompleteTextBlock"
             x:FieldModifier="public"
             Opacity="0.6"            
-            Canvas.ZIndex="0" 
+            Canvas.ZIndex="-1" 
             Margin="24, 0, 14, 0"
             VerticalAlignment="Center"
             FontSize="24"
             Foreground="{DynamicResource TextControlPlaceholderForeground}"
+            Background="{DynamicResource SystemChromeLow}"
             RenderOptions.ClearTypeHint="Enabled"
          />
         <TextBlock


### PR DESCRIPTION
## Summary of the Pull Request
Fix inconsistency in the color of QueryTextBox

## PR Checklist
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed

## Info on Pull Request
The color of the QueryTextBox text was different when autocomplete text suggestion was available as show below : 

#### Search text without autocomplete text
![Issue2-2](https://user-images.githubusercontent.com/10995909/91619807-ff62cd80-e942-11ea-88a5-cb4250097f1d.png)

#### Search text with autocomplete text
![Issue2-1](https://user-images.githubusercontent.com/10995909/91619798-fb36b000-e942-11ea-942f-687538f5de98.png)

This issue was happening because of changes made in #6049, where `AutoCompleteTextBlock` was placed on top on `QueryTextBox` causing the lighter color of the former to be visible. This PR makes the following changes to fix this issue. 
1. Set z-index of `AutoCompleteTextBlock` to be strictly less than `QueryTextBox`. 
2. Set background color of `AutoCompleteTextBlock` to `SystemChromeLow` and of `QueryTextBox` to `transparent`.

## Validation Steps Performed
Manually validated that color inconsistency is not present in QueryTextBox