### PR TITLE
[Keyboard Manager] Disable single keys using the none selection in the key remapper

### DIFF
--- a/src/common/keyboard_layout.cpp
+++ b/src/common/keyboard_layout.cpp
@@ -215,6 +215,7 @@ void LayoutMap::LayoutMapImpl::UpdateLayout()
     keyboardLayoutMap[VK_NONCONVERT] = L"IME Non-Convert";
     keyboardLayoutMap[VK_ACCEPT] = L"IME Kana";
     keyboardLayoutMap[VK_MODECHANGE] = L"IME Mode Change";
+    keyboardLayoutMap[CommonSharedConstants::VK_DISABLED] = L"Disabled";
 }
 
 // Function to return the list of key codes in the order for the drop down. It creates it if it doesn't exist
@@ -225,6 +226,7 @@ std::vector<DWORD> LayoutMap::LayoutMapImpl::GetKeyCodeList(const bool isShortcu
     std::vector<DWORD> keyCodes;
     if (!isKeyCodeListGenerated)
     {
+        keyCodes.push_back(CommonSharedConstants::VK_DISABLED);
         // Add character keys
         for (auto& it : unicodeKeys)
         {

--- a/src/common/shared_constants.h
+++ b/src/common/shared_constants.h
@@ -8,4 +8,6 @@ namespace CommonSharedConstants
 
     // Fake key code to represent VK_WIN.
     inline const DWORD VK_WIN_BOTH = 0x104;
+
+    const DWORD VK_DISABLED = DWORD(ULONG_MAX);
 }

--- a/src/modules/keyboardmanager/common/Helpers.h
+++ b/src/modules/keyboardmanager/common/Helpers.h
@@ -48,7 +48,8 @@ namespace KeyboardManagerHelper
         ShortcutAtleast2Keys,
         ShortcutOneActionKey,
         ShortcutNotMoreThanOneActionKey,
-        ShortcutMaxShortcutSizeOneActionKey
+        ShortcutMaxShortcutSizeOneActionKey,
+        MappedFromDisabled
     };
 
     // Enum type to store possible decision for input in the low level hook

--- a/src/modules/keyboardmanager/common/Shortcut.cpp
+++ b/src/modules/keyboardmanager/common/Shortcut.cpp
@@ -79,9 +79,12 @@ bool Shortcut::IsValidShortcut() const
 {
     if (actionKey != NULL)
     {
-        if (winKey != ModifierKey::Disabled || ctrlKey != ModifierKey::Disabled || altKey != ModifierKey::Disabled || shiftKey != ModifierKey::Disabled)
+        if (actionKey != CommonSharedConstants::VK_DISABLED)
         {
-            return true;
+            if (winKey != ModifierKey::Disabled || ctrlKey != ModifierKey::Disabled || altKey != ModifierKey::Disabled || shiftKey != ModifierKey::Disabled)
+            {
+                return true;
+            }
         }
     }
 

--- a/src/modules/keyboardmanager/dll/KeyboardEventHandlers.cpp
+++ b/src/modules/keyboardmanager/dll/KeyboardEventHandlers.cpp
@@ -27,7 +27,7 @@ namespace KeyboardEventHandlers
                 // If mapped to 0x0 then the key is disabled
                 if (remapToKey)
                 {
-                    if (std::get<DWORD>(it->second) == 0x0)
+                    if (std::get<DWORD>(it->second) == CommonSharedConstants::VK_DISABLED)
                     {
                         return 1;
                     }

--- a/src/modules/keyboardmanager/dll/KeyboardEventHandlers.cpp
+++ b/src/modules/keyboardmanager/dll/KeyboardEventHandlers.cpp
@@ -24,7 +24,7 @@ namespace KeyboardEventHandlers
                 // Check if the remap is to a key or a shortcut
                 bool remapToKey = (it->second.index() == 0);
 
-                // If mapped to 0x0 then the key is disabled
+                // If mapped to DWORD(ULONG_MAX) then the key is disabled
                 if (remapToKey)
                 {
                     if (std::get<DWORD>(it->second) == CommonSharedConstants::VK_DISABLED)

--- a/src/modules/keyboardmanager/ui/BufferValidationHelpers.cpp
+++ b/src/modules/keyboardmanager/ui/BufferValidationHelpers.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 #include "BufferValidationHelpers.h"
 #include <keyboardmanager/common/KeyboardManagerConstants.h>
+#include <common\shared_constants.h>
 
 namespace BufferValidationHelpers
 {
@@ -19,6 +20,11 @@ namespace BufferValidationHelpers
                 {
                     errorType = KeyboardManagerHelper::ErrorType::MapToSameKey;
                 }
+            }
+            //If attempting to remap "Disabled" to something
+            if (colIndex == 0 && keyCodeList[selectedKeyIndex] == CommonSharedConstants::VK_DISABLED)
+            {
+                errorType = KeyboardManagerHelper::ErrorType::MappedFromDisabled;
             }
 
             // If one column is shortcut and other is key no warning required


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
The UI option to map an arbitrary single key to "none" (ie disabling it) was shown at the top of the options but was not functional. The backend to handle a Arbitrary key ---> None/null already existed but was not exposed. This pull requests essentially just turns on that functionality. It does not implement any new UI.

## PR Checklist
* [x] Directly applies to #2215. Also, indirectly addresses #1196.
* [x] CLA signed.
* [x] KeyboardManagerTest passed.
* [x] Does not require documentation to be updated. Except maybe to mention that it is a feature in the keyboard manager [overview](https://github.com/microsoft/PowerToys/wiki/Keyboard-Manager-Overview).

* [x] There was discussion within #2215 and #6209 but I don't think I have directly discussed this with core contributors.

## Info on Pull Request

_What does this include?_
This pull request changes the buffer validation to allow the selection of "Disabled". It adds the key and some logic to validate when it is okay to have it in the key remapping,

## Validation Steps Performed

_How does someone test & validate?_
Disabled is interpreted as just a key with key code DWORD(ULONG_MAX) so it does not have issues with the existing code that checks for null.
## Possible improvements/Next steps

The interaction with shortcuts seems a bit unsteady. It seems to work, but I suspect that is just the other code handling it gracefully.