### PR TITLE
[FancyZones] Set 3-zones PriorityGrid as default layout

### DIFF
--- a/src/modules/fancyzones/lib/FancyZonesData.cpp
+++ b/src/modules/fancyzones/lib/FancyZonesData.cpp
@@ -106,7 +106,8 @@ void FancyZonesData::AddDevice(const std::wstring& deviceId)
         wil::unique_cotaskmem_string guidString;
         if (result == S_OK && SUCCEEDED(StringFromCLSID(guid, &guidString)))
         {
-            deviceInfoMap[deviceId] = DeviceInfoData{ ZoneSetData{ guidString.get(), ZoneSetLayoutType::PriorityGrid }, true, 16, 3 };
+            DeviceInfoData defaultDeviceInfoData{ ZoneSetData{ guidString.get(), ZoneSetLayoutType::PriorityGrid }, true, 16, 3 };
+            deviceInfoMap[deviceId] = std::move(defaultDeviceInfoData);
         }
         else
         {
@@ -130,11 +131,7 @@ void FancyZonesData::CloneDeviceInfo(const std::wstring& source, const std::wstr
     }
 
     // Clone information from source device if destination device is uninitialized (Blank).
-    auto& destInfo = deviceInfoMap[destination];
-    if (destInfo.activeZoneSet.type == FancyZonesDataTypes::ZoneSetLayoutType::Blank)
-    {
-        destInfo = deviceInfoMap[source];
-    }
+    deviceInfoMap[destination] = deviceInfoMap[source];
 }
 
 void FancyZonesData::UpdatePrimaryDesktopData(const std::wstring& desktopId)

--- a/src/modules/fancyzones/lib/FancyZonesData.cpp
+++ b/src/modules/fancyzones/lib/FancyZonesData.cpp
@@ -95,11 +95,23 @@ std::optional<FancyZonesDataTypes::CustomZoneSetData> FancyZonesData::FindCustom
 
 void FancyZonesData::AddDevice(const std::wstring& deviceId)
 {
+    using namespace FancyZonesDataTypes;
+
     std::scoped_lock lock{ dataLock };
     if (!deviceInfoMap.contains(deviceId))
     {
         // Creates default entry in map when ZoneWindow is created
-        deviceInfoMap[deviceId] = FancyZonesDataTypes::DeviceInfoData{ FancyZonesDataTypes::ZoneSetData{ NonLocalizable::NullStr, FancyZonesDataTypes::ZoneSetLayoutType::Blank } };
+        GUID guid;
+        auto result{ CoCreateGuid(&guid) };
+        wil::unique_cotaskmem_string guidString;
+        if (result == S_OK && SUCCEEDED(StringFromCLSID(guid, &guidString)))
+        {
+            deviceInfoMap[deviceId] = DeviceInfoData{ ZoneSetData{ guidString.get(), ZoneSetLayoutType::PriorityGrid }, true, 16, 3 };
+        }
+        else
+        {
+            deviceInfoMap[deviceId] = DeviceInfoData{ ZoneSetData{ NonLocalizable::NullStr, ZoneSetLayoutType::Blank } };
+        }
     }
 }
 

--- a/src/modules/fancyzones/lib/FancyZonesData.cpp
+++ b/src/modules/fancyzones/lib/FancyZonesData.cpp
@@ -106,7 +106,11 @@ void FancyZonesData::AddDevice(const std::wstring& deviceId)
         wil::unique_cotaskmem_string guidString;
         if (result == S_OK && SUCCEEDED(StringFromCLSID(guid, &guidString)))
         {
-            DeviceInfoData defaultDeviceInfoData{ ZoneSetData{ guidString.get(), ZoneSetLayoutType::PriorityGrid }, true, 16, 3 };
+            constexpr bool defaultShowSpacing{ true };
+            constexpr int defaultSpacing{ 16 };
+            constexpr int defaultZoneCount{ 3 };
+            const ZoneSetData zoneSetData{ guidString.get(), ZoneSetLayoutType::PriorityGrid };
+            DeviceInfoData defaultDeviceInfoData{ zoneSetData, defaultShowSpacing, defaultSpacing, defaultZoneCount };
             deviceInfoMap[deviceId] = std::move(defaultDeviceInfoData);
         }
         else

--- a/src/modules/fancyzones/tests/UnitTests/Util.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/Util.cpp
@@ -86,6 +86,7 @@ DWORD WINAPI ThreadProc(LPVOID lpParam)
     if (RegisterDLLWindowClass((LPCWSTR)creator->getWindowClassName().c_str(), creator) != 0)
     {
         auto hWnd = CreateWindowEx(0, (LPCWSTR)creator->getWindowClassName().c_str(), (LPCWSTR)creator->getTitle().c_str(), WS_EX_APPWINDOW, CW_USEDEFAULT, CW_USEDEFAULT, 10, 10, nullptr, nullptr, creator->getHInstance(), NULL);
+        SetWindowPos(hWnd, HWND_TOPMOST, 10, 10, 100, 100, SWP_SHOWWINDOW);
         creator->setHwnd(hWnd);
         creator->setCondition(true);
 

--- a/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
@@ -116,21 +116,33 @@ namespace FancyZonesUnitTests
         {
             auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId.str(), {}, false);
             testZoneWindow(zoneWindow);
-            Assert::IsNull(zoneWindow->ActiveZoneSet());
+
+            auto* activeZoneSet{ zoneWindow->ActiveZoneSet() };
+            Assert::IsNotNull(activeZoneSet);
+            Assert::AreEqual(static_cast<int>(activeZoneSet->LayoutType()), static_cast<int>(FancyZonesDataTypes::ZoneSetLayoutType::PriorityGrid));
+            Assert::AreEqual(activeZoneSet->GetZones().size(), static_cast<size_t>(3));
         }
 
         TEST_METHOD(CreateZoneWindowNoHinst)
         {
             auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), {}, m_monitor, m_uniqueId.str(), {}, false);
             testZoneWindow(zoneWindow);
-            Assert::IsNull(zoneWindow->ActiveZoneSet());
+
+            auto* activeZoneSet{ zoneWindow->ActiveZoneSet() };
+            Assert::IsNotNull(activeZoneSet);
+            Assert::AreEqual(static_cast<int>(activeZoneSet->LayoutType()), static_cast<int>(FancyZonesDataTypes::ZoneSetLayoutType::PriorityGrid));
+            Assert::AreEqual(activeZoneSet->GetZones().size(), static_cast<size_t>(3));
         }
 
         TEST_METHOD(CreateZoneWindowNoHinstFlashZones)
         {
             auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), {}, m_monitor, m_uniqueId.str(), {}, false);
             testZoneWindow(zoneWindow);
-            Assert::IsNull(zoneWindow->ActiveZoneSet());
+
+            auto* activeZoneSet{ zoneWindow->ActiveZoneSet() };
+            Assert::IsNotNull(activeZoneSet);
+            Assert::AreEqual(static_cast<int>(activeZoneSet->LayoutType()), static_cast<int>(FancyZonesDataTypes::ZoneSetLayoutType::PriorityGrid));
+            Assert::AreEqual(activeZoneSet->GetZones().size(), static_cast<size_t>(3));
         }
 
         TEST_METHOD(CreateZoneWindowNoMonitor)
@@ -156,7 +168,11 @@ namespace FancyZonesUnitTests
 
             Assert::IsNotNull(zoneWindow.get());
             Assert::AreEqual(expectedUniqueId.c_str(), zoneWindow->UniqueId().c_str());
-            Assert::IsNull(zoneWindow->ActiveZoneSet());
+
+            auto* activeZoneSet{ zoneWindow->ActiveZoneSet() };
+            Assert::IsNotNull(activeZoneSet);
+            Assert::AreEqual(static_cast<int>(activeZoneSet->LayoutType()), static_cast<int>(FancyZonesDataTypes::ZoneSetLayoutType::PriorityGrid));
+            Assert::AreEqual(activeZoneSet->GetZones().size(), static_cast<size_t>(3));
         }
 
         TEST_METHOD(CreateZoneWindowNoDesktopId)
@@ -168,8 +184,11 @@ namespace FancyZonesUnitTests
             const std::wstring expectedWorkArea = std::to_wstring(m_monitorInfo.rcMonitor.right) + L"_" + std::to_wstring(m_monitorInfo.rcMonitor.bottom);
             Assert::IsNotNull(zoneWindow.get());
             Assert::IsTrue(zoneWindow->UniqueId().empty());
-            Assert::IsNull(zoneWindow->ActiveZoneSet());
-            Assert::IsNull(zoneWindow->ActiveZoneSet());
+
+            auto* activeZoneSet{ zoneWindow->ActiveZoneSet() };
+            Assert::IsNotNull(activeZoneSet);
+            Assert::AreEqual(static_cast<int>(activeZoneSet->LayoutType()), static_cast<int>(FancyZonesDataTypes::ZoneSetLayoutType::PriorityGrid));
+            Assert::AreEqual(activeZoneSet->GetZones().size(), static_cast<size_t>(3));
         }
 
         TEST_METHOD(CreateZoneWindowWithActiveZoneTmpFile)
@@ -373,12 +392,12 @@ namespace FancyZonesUnitTests
 
             Assert::IsNotNull(actualZoneWindow->ActiveZoneSet());
             const auto actualZoneSet = actualZoneWindow->ActiveZoneSet()->GetZones();
-            Assert::AreEqual((size_t)zoneCount, actualZoneSet.size());
+            Assert::AreEqual((size_t)3, actualZoneSet.size());
 
             Assert::IsTrue(m_fancyZonesData.GetDeviceInfoMap().contains(m_uniqueId.str()));
             auto currentDeviceInfo = m_fancyZonesData.GetDeviceInfoMap().at(m_uniqueId.str());
-            Assert::AreEqual(zoneCount, currentDeviceInfo.zoneCount);
-            Assert::AreEqual(spacing, currentDeviceInfo.spacing);
+            Assert::AreEqual(3, currentDeviceInfo.zoneCount);
+            Assert::AreEqual(16, currentDeviceInfo.spacing);
             Assert::AreEqual(static_cast<int>(type), static_cast<int>(currentDeviceInfo.activeZoneSet.type));
         }
 
@@ -401,16 +420,15 @@ namespace FancyZonesUnitTests
             // newWorkArea = false - zoneWindow won't be cloned from parent
             auto actualZoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId.str(), {}, false);
 
-            Assert::IsNull(actualZoneWindow->ActiveZoneSet());
+            Assert::IsNotNull(actualZoneWindow->ActiveZoneSet());
 
             Assert::IsTrue(m_fancyZonesData.GetDeviceInfoMap().contains(m_uniqueId.str()));
             auto currentDeviceInfo = m_fancyZonesData.GetDeviceInfoMap().at(m_uniqueId.str());
             // default values
-            Assert::AreEqual(false, currentDeviceInfo.showSpacing);
-            Assert::AreEqual(0, currentDeviceInfo.zoneCount);
-            Assert::AreEqual(0, currentDeviceInfo.spacing);
-            Assert::AreEqual(std::wstring{ L"null" }, currentDeviceInfo.activeZoneSet.uuid);
-            Assert::AreEqual(static_cast<int>(ZoneSetLayoutType::Blank), static_cast<int>(currentDeviceInfo.activeZoneSet.type));
+            Assert::AreEqual(true, currentDeviceInfo.showSpacing);
+            Assert::AreEqual(3, currentDeviceInfo.zoneCount);
+            Assert::AreEqual(16, currentDeviceInfo.spacing);
+            Assert::AreEqual(static_cast<int>(ZoneSetLayoutType::PriorityGrid), static_cast<int>(currentDeviceInfo.activeZoneSet.type));
         }
     };
 
@@ -599,14 +617,6 @@ namespace FancyZonesUnitTests
             Assert::IsFalse(std::vector<size_t>{} == actualZoneIndex); // with invalid point zone remains the same
         }
 
-        TEST_METHOD(MoveWindowIntoZoneByIndexNoActiveZoneSet)
-        {
-            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId.str(), {}, false);
-            Assert::IsNull(zoneWindow->ActiveZoneSet());
-
-            zoneWindow->MoveWindowIntoZoneByIndex(Mocks::Window(), 0);
-        }
-
         TEST_METHOD(MoveWindowIntoZoneByIndex)
         {
             PrepareFZData();
@@ -616,14 +626,6 @@ namespace FancyZonesUnitTests
             zoneWindow->MoveWindowIntoZoneByIndex(Mocks::Window(), 0);
 
             const auto actual = zoneWindow->ActiveZoneSet();
-        }
-
-        TEST_METHOD(MoveWindowIntoZoneByDirectionNoActiveZoneSet)
-        {
-            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId.str(), {}, false);
-            Assert::IsNull(zoneWindow->ActiveZoneSet());
-
-            zoneWindow->MoveWindowIntoZoneByIndex(Mocks::Window(), 0);
         }
 
         TEST_METHOD(MoveWindowIntoZoneByDirectionAndIndex)
@@ -658,17 +660,6 @@ namespace FancyZonesUnitTests
             const auto& appHistoryArray = actualAppZoneHistory.begin()->second;
             Assert::AreEqual((size_t)1, appHistoryArray.size());
             Assert::IsTrue(std::vector<size_t>{ 2 } == appHistoryArray[0].zoneIndexSet);
-        }
-
-        TEST_METHOD(SaveWindowProcessToZoneIndexNoActiveZoneSet)
-        {
-            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId.str(), {}, false);
-            Assert::IsNull(zoneWindow->ActiveZoneSet());
-
-            zoneWindow->SaveWindowProcessToZoneIndex(Mocks::Window());
-
-            const auto actualAppZoneHistory = m_fancyZonesData.GetAppZoneHistoryMap();
-            Assert::IsTrue(actualAppZoneHistory.empty());
         }
 
         TEST_METHOD(SaveWindowProcessToZoneIndexNullptrWindow)

--- a/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
@@ -392,12 +392,12 @@ namespace FancyZonesUnitTests
 
             Assert::IsNotNull(actualZoneWindow->ActiveZoneSet());
             const auto actualZoneSet = actualZoneWindow->ActiveZoneSet()->GetZones();
-            Assert::AreEqual((size_t)3, actualZoneSet.size());
+            Assert::AreEqual((size_t)zoneCount, actualZoneSet.size());
 
             Assert::IsTrue(m_fancyZonesData.GetDeviceInfoMap().contains(m_uniqueId.str()));
             auto currentDeviceInfo = m_fancyZonesData.GetDeviceInfoMap().at(m_uniqueId.str());
-            Assert::AreEqual(3, currentDeviceInfo.zoneCount);
-            Assert::AreEqual(16, currentDeviceInfo.spacing);
+            Assert::AreEqual(zoneCount, currentDeviceInfo.zoneCount);
+            Assert::AreEqual(spacing, currentDeviceInfo.spacing);
             Assert::AreEqual(static_cast<int>(type), static_cast<int>(currentDeviceInfo.activeZoneSet.type));
         }
 
@@ -472,22 +472,6 @@ namespace FancyZonesUnitTests
             std::filesystem::remove(m_fancyZonesData.deletedCustomZoneSetsTmpFileName);
         }
 
-        void PrepareFZData()
-        {
-            const auto activeZoneSetTempPath = m_fancyZonesData.activeZoneSetTmpFileName;
-            Assert::IsFalse(std::filesystem::exists(activeZoneSetTempPath));
-
-            const auto type = FancyZonesDataTypes::ZoneSetLayoutType::Columns;
-            const auto expectedZoneSet = FancyZonesDataTypes::ZoneSetData{ Helpers::CreateGuidString(), type };
-            const auto data = FancyZonesDataTypes::DeviceInfoData{ expectedZoneSet, true, 16, 3 };
-            const auto deviceInfo = JSONHelpers::DeviceInfoJSON{ m_uniqueId.str(), data };
-            const auto json = JSONHelpers::DeviceInfoJSON::ToJson(deviceInfo);
-            json::to_file(activeZoneSetTempPath, json);
-            Assert::IsTrue(std::filesystem::exists(activeZoneSetTempPath));
-
-            m_fancyZonesData.ParseDeviceInfoFromTmpFile(activeZoneSetTempPath);
-        }
-
     public:
         TEST_METHOD(MoveSizeEnter)
         {
@@ -543,7 +527,6 @@ namespace FancyZonesUnitTests
 
         TEST_METHOD(MoveSizeEnd)
         {
-            PrepareFZData();
             auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId.str(), {}, false);
 
             const auto window = Mocks::Window();
@@ -561,7 +544,6 @@ namespace FancyZonesUnitTests
 
         TEST_METHOD(MoveSizeEndWindowNotAdded)
         {
-            PrepareFZData();
             auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId.str(), {}, false);
 
             const auto window = Mocks::Window();
@@ -601,7 +583,6 @@ namespace FancyZonesUnitTests
 
         TEST_METHOD(MoveSizeEndInvalidPoint)
         {
-            PrepareFZData();
             auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId.str(), {}, false);
 
             const auto window = Mocks::Window();
@@ -619,7 +600,6 @@ namespace FancyZonesUnitTests
 
         TEST_METHOD(MoveWindowIntoZoneByIndex)
         {
-            PrepareFZData();
             auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId.str(), {}, false);
             Assert::IsNotNull(zoneWindow->ActiveZoneSet());
 
@@ -630,7 +610,6 @@ namespace FancyZonesUnitTests
 
         TEST_METHOD(MoveWindowIntoZoneByDirectionAndIndex)
         {
-            PrepareFZData();
             auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId.str(), {}, false);
             Assert::IsNotNull(zoneWindow->ActiveZoneSet());
 
@@ -646,7 +625,6 @@ namespace FancyZonesUnitTests
 
         TEST_METHOD(MoveWindowIntoZoneByDirectionManyTimes)
         {
-            PrepareFZData();
             auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId.str(), {}, false);
             Assert::IsNotNull(zoneWindow->ActiveZoneSet());
 
@@ -664,7 +642,6 @@ namespace FancyZonesUnitTests
 
         TEST_METHOD(SaveWindowProcessToZoneIndexNullptrWindow)
         {
-            PrepareFZData();
             auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId.str(), {}, false);
             Assert::IsNotNull(zoneWindow->ActiveZoneSet());
 
@@ -676,7 +653,6 @@ namespace FancyZonesUnitTests
 
         TEST_METHOD(SaveWindowProcessToZoneIndexNoWindowAdded)
         {
-            PrepareFZData();
             auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId.str(), {}, false);
             Assert::IsNotNull(zoneWindow->ActiveZoneSet());
 
@@ -692,7 +668,6 @@ namespace FancyZonesUnitTests
 
         TEST_METHOD(SaveWindowProcessToZoneIndexNoWindowAddedWithFilledAppZoneHistory)
         {
-            PrepareFZData();
             auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId.str(), {}, false);
             Assert::IsNotNull(zoneWindow->ActiveZoneSet());
 
@@ -721,7 +696,6 @@ namespace FancyZonesUnitTests
 
         TEST_METHOD(SaveWindowProcessToZoneIndexWindowAdded)
         {
-            PrepareFZData();
             auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId.str(), {}, false);
             Assert::IsNotNull(zoneWindow->ActiveZoneSet());
 
@@ -752,7 +726,6 @@ namespace FancyZonesUnitTests
 
         TEST_METHOD(WhenWindowIsNotResizablePlacingItIntoTheZoneShouldNotResizeIt)
         {
-            PrepareFZData();
             auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId.str(), {}, false);
             Assert::IsNotNull(zoneWindow->ActiveZoneSet());
 


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
Instead of no-layout at FZ startup, now 3-zones PriorityGrid is applied by default.

## PR Checklist
* [x] Applies to #4292
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Validation Steps Performed

_How does someone test & validate?_
1. Delete zone-settings.json file
2. Run FZ
3. Confirm that 3-zone PriorityGrid layout is applied on startup
4. Create new Virtual Desktop
5. Confirm that new Virtual Desktop has 3-zone PriorityGrid
6. Delete VD
7. Change layout on primary desktop to 4-zone Column
8. Create new VD
9. Confirm that new VD has 4-zone Column layout applied (Clone layout from parent feature still works)