### PR TITLE
fix missing fragment portion of LocalPath

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/SearchHelper/WindowsSearchAPI.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/SearchHelper/WindowsSearchAPI.cs
@@ -58,7 +58,10 @@ namespace Microsoft.Plugin.Indexer.SearchHelper
                     continue;
                 }
 
-                var uri_path = new Uri((string)oleDBResult.FieldData[0]);
+                // # is URI syntax for the fragment component, need to be encoded so LocalPath returns complete path
+                var string_path = ((string)oleDBResult.FieldData[0]).Replace("#", "%23", StringComparison.OrdinalIgnoreCase);
+                var uri_path = new Uri(string_path);
+
                 var result = new SearchResult
                 {
                     Path = uri_path.LocalPath,


### PR DESCRIPTION
## Summary of the Pull Request

Indexer does not return the complete path to files and folders where the name contains the '#' symbol.

## PR Checklist
* [x] Applies to #4759 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #4759
* [x] Tests added/passed
* [ ] Requires documentation to be updated

## Info on Pull Request

In the URI make up, the '#' symbol is the syntax to indicate the fragment part of the URI:
![image](https://user-images.githubusercontent.com/26427004/91670168-5690ba00-eb5e-11ea-83f8-8923e2bb3ecd.png)

We replace the symbol with the encoded syntax %23 so it is escaped and LocalPath property returns the full path.

## Validation Steps Performed

1. Create folder called 'C# In Depth'
2. Create file called 'Transitioning from C# to F#'
3. Search in PT Run for the newly created file e.g. 'transitioning'

Before PR:
![image](https://user-images.githubusercontent.com/26427004/91777137-5feb5680-ec32-11ea-8a63-a43a3cb664c7.png)


After:
![image](https://user-images.githubusercontent.com/26427004/91776692-3c73dc00-ec31-11ea-872b-8fabf160fa67.png)
