### PR TITLE
[PT Run] Fix for argument out of range exception

### DIFF
--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -14,6 +14,7 @@ using PowerLauncher.Helper;
 using PowerLauncher.ViewModel;
 using Wox.Infrastructure.UserSettings;
 using KeyEventArgs = System.Windows.Input.KeyEventArgs;
+using Log = Wox.Infrastructure.Logger.Log;
 using Screen = System.Windows.Forms.Screen;
 
 namespace PowerLauncher
@@ -300,7 +301,20 @@ namespace PowerLauncher
             _viewModel.Results.SelectedItem = (ResultViewModel)listview.SelectedItem;
             if (e.AddedItems.Count > 0 && e.AddedItems[0] != null)
             {
-                listview.ScrollIntoView(e.AddedItems[0]);
+                try
+                {
+                    listview.ScrollIntoView(e.AddedItems[0]);
+                }
+                catch (ArgumentOutOfRangeException ex)
+                {
+                    // Due to virtualization being enabled for the listview, the layout system updates elements in a deferred manner using an algorithm that balances performance and concurrency.
+                    // Hence, there can be a situation where the element index that we want to scroll into view is out of range for it's parent control.
+                    // To mitigate this we use the UpdateLayout function, which forces layout update to ensure that the parent element contains the latest properties.
+                    // However, it has a performance impact and is therefore not called each time.
+                    Log.Exception("MainWindow", "The parent element layout is not updated yet", ex, "SuggestionsList_SelectionChanged");
+                    listview.UpdateLayout();
+                    listview.ScrollIntoView(e.AddedItems[0]);
+                }
             }
 
             // To populate the AutoCompleteTextBox as soon as the selection is changed or set.


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

This PR fixes the ArgumentOutOfRange Exception thrown by the listview.ScrollIntoview() function.

## PR Checklist
* [x] Applies to #6081
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

* An Argument Out of Range Exception was being thrown by the listview.ScrollIntoView function.
* This was happening because of the parent element not being updated as the layout update happens in a deferred manner by an algorithm which optimizes for performance and concurrency.
* To mitigate this issue, it was suggested in the documentation to call the `UpdateLayout` function before calling `scrollIntoView` if there are many elements being added or removed. However, the issue with this is that there is a performance impact and not ideal to do it for minor additions or deletions.

Hence, the following changes have been made - 
* Add a try-catch block to catch the `ArgumentOutOfRange` exception.
* To ensure that there are no user facing implications, to call `UpdateLayout` and then scroll to the added items. This way, the user sees the elements as expected.
* This way there is no performance impact whenever a selection is modified.

## Validation Steps Performed

_How does someone test & validate?_

Added a throw statement in the try block and ensured that the code works as expected.
```
throw new ArgumentOutOfRangeException(nameof(sender));
```