### PR TITLE
Fix KBM Settings page Property related and screen reader Accessibility issues

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -218,6 +218,9 @@
   <data name="KeyboardManager_TargetAppIcon.AutomationProperties.Name" xml:space="preserve">
     <value>For Target Application</value>
   </data>
+  <data name="KeyboardManager_Image.AutomationProperties.Name" xml:space="preserve">
+    <value>Keyboard Manager</value>
+  </data>
   <data name="ColorPicker_Description.Text" xml:space="preserve">
     <value>Quick and simple system-wide color picker.</value>
   </data>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -209,13 +209,13 @@
   <data name="KeyboardManager_RemappedShortcutsListItem.AutomationProperties.Name" xml:space="preserve">
     <value>Shortcut Remapping</value>
   </data>
-  <data name="KeyboardManager_RemappingIcon.AutomationProperties.Name" xml:space="preserve">
+  <data name="KeyboardManager_RemappedTo.AutomationProperties.Name" xml:space="preserve">
     <value>Remapped to</value>
   </data>
-  <data name="KeyboardManager_ShortcutRemappingIcon.AutomationProperties.Name" xml:space="preserve">
+  <data name="KeyboardManager_ShortcutRemappedTo.AutomationProperties.Name" xml:space="preserve">
     <value>Remapped to</value>
   </data>
-  <data name="KeyboardManager_TargetAppIcon.AutomationProperties.Name" xml:space="preserve">
+  <data name="KeyboardManager_TargetApp.AutomationProperties.Name" xml:space="preserve">
     <value>For Target Application</value>
   </data>
   <data name="KeyboardManager_Image.AutomationProperties.Name" xml:space="preserve">

--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -209,6 +209,15 @@
   <data name="KeyboardManager_RemappedShortcutsListItem.AutomationProperties.Name" xml:space="preserve">
     <value>Shortcut Remapping</value>
   </data>
+  <data name="KeyboardManager_RemappingIcon.AutomationProperties.Name" xml:space="preserve">
+    <value>Remapped to</value>
+  </data>
+  <data name="KeyboardManager_ShortcutRemappingIcon.AutomationProperties.Name" xml:space="preserve">
+    <value>Remapped to</value>
+  </data>
+  <data name="KeyboardManager_TargetAppIcon.AutomationProperties.Name" xml:space="preserve">
+    <value>For Target Application</value>
+  </data>
   <data name="ColorPicker_Description.Text" xml:space="preserve">
     <value>Quick and simple system-wide color picker.</value>
   </data>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -197,6 +197,12 @@
     <value>Remap shortcuts</value>
     <comment>Keyboard Manager remap shortcuts header</comment>
   </data>
+  <data name="RemapKeysList.AutomationProperties.Name" xml:space="preserve">
+    <value>Current Key Remappings</value>
+  </data>
+  <data name="KeyboardManager_RemappedKeysListItem.AutomationProperties.Name" xml:space="preserve">
+    <value>Key Remapping</value>
+  </data>
   <data name="ColorPicker_Description.Text" xml:space="preserve">
     <value>Quick and simple system-wide color picker.</value>
   </data>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -200,6 +200,9 @@
   <data name="RemapKeysList.AutomationProperties.Name" xml:space="preserve">
     <value>Current Key Remappings</value>
   </data>
+  <data name="RemapShortcutsList.AutomationProperties.Name" xml:space="preserve">
+    <value>Current Shortcut Remappings</value>
+  </data>
   <data name="KeyboardManager_RemappedKeysListItem.AutomationProperties.Name" xml:space="preserve">
     <value>Key Remapping</value>
   </data>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -203,6 +203,9 @@
   <data name="KeyboardManager_RemappedKeysListItem.AutomationProperties.Name" xml:space="preserve">
     <value>Key Remapping</value>
   </data>
+  <data name="KeyboardManager_RemappedShortcutsListItem.AutomationProperties.Name" xml:space="preserve">
+    <value>Shortcut Remapping</value>
+  </data>
   <data name="ColorPicker_Description.Text" xml:space="preserve">
     <value>Quick and simple system-wide color picker.</value>
   </data>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/KeyboardManagerPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/KeyboardManagerPage.xaml
@@ -47,7 +47,9 @@
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
-                <FontIcon Glyph="&#xE72A;"
+                <FontIcon Name="KeyboardManager_RemappingIcon"
+                          x:Uid="KeyboardManager_RemappingIcon"
+                          Glyph="&#xE72A;"
                           Grid.Column="1"
                           FontSize="14"
                           VerticalAlignment="Center" 
@@ -116,7 +118,9 @@
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
-                <FontIcon Glyph="&#xE72A;"
+                <FontIcon Name="KeyboardManager_ShortcutRemappingIcon"
+                          x:Uid="KeyboardManager_ShortcutRemappingIcon"
+                          Glyph="&#xE72A;"
                           Grid.Column="1"
                           FontSize="14"
                           VerticalAlignment="Center" 
@@ -150,7 +154,9 @@
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
-                <FontIcon Glyph="&#xE72A;"
+                <FontIcon Name="KeyboardManager_TargetAppIcon"
+                          x:Uid="KeyboardManager_TargetAppIcon"
+                          Glyph="&#xE72A;"
                           Grid.Column="3"
                           FontSize="14"
                           VerticalAlignment="Center" 

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/KeyboardManagerPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/KeyboardManagerPage.xaml
@@ -47,14 +47,14 @@
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
-                <FontIcon Name="KeyboardManager_RemappingIcon"
-                          x:Uid="KeyboardManager_RemappingIcon"
-                          Glyph="&#xE72A;"
+                <FontIcon Glyph="&#xE72A;"
                           Grid.Column="1"
                           FontSize="14"
                           VerticalAlignment="Center" 
                           Margin="5,0,5,0"/>
                 <ItemsControl
+                    Name="KeyboardManager_RemappedTo"
+                    x:Uid="KeyboardManager_RemappedTo"
                     ItemsSource="{x:Bind GetNewRemapKeys()}"
                     Grid.Column="2">
                     <ItemsControl.ItemsPanel>
@@ -118,14 +118,13 @@
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
-                <FontIcon Name="KeyboardManager_ShortcutRemappingIcon"
-                          x:Uid="KeyboardManager_ShortcutRemappingIcon"
-                          Glyph="&#xE72A;"
+                <FontIcon Glyph="&#xE72A;"
                           Grid.Column="1"
                           FontSize="14"
                           VerticalAlignment="Center" 
                           Margin="5,0,5,0"/>
-                <ItemsControl
+                <ItemsControl Name="KeyboardManager_ShortcutRemappedTo"
+                    x:Uid="KeyboardManager_ShortcutRemappedTo"
                     ItemsSource="{x:Bind GetNewRemapKeys()}"
                     Grid.Column="2">
                     <ItemsControl.ItemsPanel>
@@ -154,14 +153,14 @@
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
-                <FontIcon Name="KeyboardManager_TargetAppIcon"
-                          x:Uid="KeyboardManager_TargetAppIcon"
-                          Glyph="&#xE72A;"
+                <FontIcon Glyph="&#xE72A;"
                           Grid.Column="3"
                           FontSize="14"
                           VerticalAlignment="Center" 
                           Margin="5,0,5,0"/>
                 <Border
+                    Name="KeyboardManager_TargetApp"
+                    x:Uid="KeyboardManager_TargetApp"
                     Background="{ThemeResource SystemAccentColor}"
                     Grid.Column="4"
                     CornerRadius="4"

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/KeyboardManagerPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/KeyboardManagerPage.xaml
@@ -15,7 +15,8 @@
     <Page.Resources>
         <local:VisibleIfNotEmpty x:Key="visibleIfNotEmptyConverter" />
         <DataTemplate x:Name="KeysListViewTemplate" x:DataType="Lib:KeysDataModel">
-            <StackPanel Name="KeyboardManager_RemappedKeysListItem" 
+            <StackPanel 
+                Name="KeyboardManager_RemappedKeysListItem" 
                 x:Uid="KeyboardManager_RemappedKeysListItem"
                 Orientation="Horizontal"
                 Height="56">
@@ -83,7 +84,9 @@
             </StackPanel>
         </DataTemplate>
         <DataTemplate x:Name="ShortcutKeysListViewTemplate" x:DataType="Lib:AppSpecificKeysDataModel">
-            <StackPanel
+            <StackPanel 
+                Name="KeyboardManager_RemappedShortcutsListItem" 
+                x:Uid="KeyboardManager_RemappedShortcutsListItem"
                 Orientation="Horizontal"
                 Height="56">
                 <ItemsControl

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/KeyboardManagerPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/KeyboardManagerPage.xaml
@@ -344,7 +344,7 @@
                     HorizontalAlignment="Left"
                     Margin="{StaticResource SmallTopBottomMargin}"
                     RelativePanel.Below="DescriptionPanel">
-                <Image Source="ms-appx:///Assets/Modules/KBM.png" />
+                <Image x:Uid="KeyboardManager_Image" Source="ms-appx:///Assets/Modules/KBM.png" />
             </Border>
 
             <StackPanel x:Name="LinksPanel"

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/KeyboardManagerPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/KeyboardManagerPage.xaml
@@ -285,6 +285,7 @@
                     />
 
             <ListView x:Name="RemapShortcutsList"
+                      x:Uid="RemapShortcutsList"
                       extensions:ListViewExtensions.AlternateColor="{ThemeResource SystemControlBackgroundListLowBrush}"
                       ItemsSource="{x:Bind Path=ViewModel.RemapShortcuts, Mode=OneWay}"
                       ItemTemplate="{StaticResource ShortcutKeysListViewTemplate}"

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/KeyboardManagerPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/KeyboardManagerPage.xaml
@@ -15,7 +15,8 @@
     <Page.Resources>
         <local:VisibleIfNotEmpty x:Key="visibleIfNotEmptyConverter" />
         <DataTemplate x:Name="KeysListViewTemplate" x:DataType="Lib:KeysDataModel">
-            <StackPanel
+            <StackPanel Name="KeyboardManager_RemappedKeysListItem" 
+                x:Uid="KeyboardManager_RemappedKeysListItem"
                 Orientation="Horizontal"
                 Height="56">
                 <ItemsControl
@@ -238,6 +239,7 @@
                     IsEnabled="{x:Bind Path=ViewModel.Enabled, Mode=OneWay}"/>
 
             <ListView x:Name="RemapKeysList"
+                      x:Uid="RemapKeysList"
                       extensions:ListViewExtensions.AlternateColor="{ThemeResource SystemControlBackgroundListLowBrush}"
                       ItemsSource="{x:Bind Path=ViewModel.RemapKeys, Mode=OneWay}"
                       ItemTemplate="{StaticResource KeysListViewTemplate}"


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

This PR fixes the property related accessibility issues and screen reader related issues of the KBM settings page.

## PR Checklist
* [x] Applies to #5621, #5624 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

The following changes have been made in this PR - 
1. Accessible names have been added to the key remapping list and shortcut remapping lists.
2. Accessible names have been added to the individual list items as well. Without these two changes the name was set to the item source which was Microsoft.Settings.UI.Lib.KeysDataModel etc, this was causing a property related issue. The screen reader was also reading out this (Microsoft.Settings.UI.Lib.KeysDataModel) value on navigating to the list. These issues have been fixed now.
3. The arrow icons were not being read out previously. If we had the following remapping `A -> B`, A and B were being read out but not the arrow. Now it has been modified such that it is read out as `A **remapped to** B`. 
4. Similarly for shortcut remappings, `Ctrl B -> Ctrl C -> All Apps`, it was previously reading out only the keys, now it reads out ` Ctrl B **remapped to** Ctrl C **for target application** All apps`.
5. The image on the right was previously being read as image or graphic based on the screen reader. An accessible name has been added now.

## Validation Steps Performed

_How does someone test & validate?_

* Run Accessibility insights and only the xaml islands issues show up.
* Navigate using a screen reader and ensure that all the components are being read out as expected.