### PR TITLE
[Settings] Changed ImageSize class to parse as double instead of int

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/ImageSize.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/ImageSize.cs
@@ -142,14 +142,17 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
             set
             {
                 double newWidth = -1;
-                double.TryParse(value + string.Empty, out newWidth);
 
-                if (newWidth < 0)
+                if (value < 0 || double.IsNaN(value))
                 {
                     newWidth = 0;
                 }
+                else
+                {
+                    newWidth = value;
+                }
 
-                if (_width != value)
+                if (_width != newWidth)
                 {
                     _width = newWidth;
                     OnPropertyChanged();
@@ -168,14 +171,17 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
             set
             {
                 double newHeight = -1;
-                double.TryParse(value + string.Empty, out newHeight);
 
-                if (newHeight < 0)
+                if (value < 0 || double.IsNaN(value))
                 {
                     newHeight = 0;
                 }
+                else
+                {
+                    newHeight = value;
+                }
 
-                if (_height != value)
+                if (_height != newHeight)
                 {
                     _height = newHeight;
                     OnPropertyChanged();

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/ImageSize.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/ImageSize.cs
@@ -141,8 +141,8 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
 
             set
             {
-                int newWidth = -1;
-                int.TryParse(value + string.Empty, out newWidth);
+                double newWidth = -1;
+                double.TryParse(value + string.Empty, out newWidth);
 
                 if (newWidth < 0)
                 {
@@ -167,8 +167,8 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
 
             set
             {
-                int newHeight = -1;
-                int.TryParse(value + string.Empty, out newHeight);
+                double newHeight = -1;
+                double.TryParse(value + string.Empty, out newHeight);
 
                 if (newHeight < 0)
                 {


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
This PR fixes an issue where decimal values were not accepted for Image sizes. This was supported in the original Image Resizer and in 0.19.

## PR Checklist
* [X] Applies to #5815 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [X] Tests passed

## Info on Pull Request

_What does this include?_
- Since the Width and Height properties are of `double` type, `double.TryParse` has been used instead of `int.TryParse`
- Since `double.TryParse` behaves as per the current culture, it will accept , as decimal point as well for languages which use that if that is the current OS culture

## Validation Steps Performed

_How does someone test & validate?_
- Type decimal value in Image Resizer settings page