### PR TITLE
[Settings] Fix tabbing issues on KBM settings page

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/KeyboardManagerPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/KeyboardManagerPage.xaml
@@ -14,6 +14,9 @@
 
     <Page.Resources>
         <local:VisibleIfNotEmpty x:Key="visibleIfNotEmptyConverter" />
+        <Style TargetType="ListViewItem" x:Name="KeysListViewContainerStyle">
+            <Setter Property="IsTabStop" Value="False"/>
+        </Style>
         <DataTemplate x:Name="KeysListViewTemplate" x:DataType="Lib:KeysDataModel">
             <StackPanel
                 Orientation="Horizontal"
@@ -252,6 +255,7 @@
                       IsSwipeEnabled="False"
                       Visibility="{x:Bind Path=ViewModel.RemapKeys, Mode=OneWay, Converter={StaticResource visibleIfNotEmptyConverter}}"
                       IsEnabled="{x:Bind Path=ViewModel.Enabled, Mode=OneWay}"
+                      ItemContainerStyle="{StaticResource KeysListViewContainerStyle}"
                       />
 
             <!--<AppBarButton x:Uid="KeyboardManager_RemapKeyboardButton"
@@ -297,6 +301,7 @@
                       ScrollViewer.HorizontalScrollMode="Enabled"
                       ScrollViewer.HorizontalScrollBarVisibility="Visible"
                       ScrollViewer.IsHorizontalRailEnabled="True"
+                      ItemContainerStyle="{StaticResource KeysListViewContainerStyle}"
                       />
 
             <!--<AppBarButton x:Uid="KeyboardManager_RemapShortcutsButton"

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/KeyboardManagerPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/KeyboardManagerPage.xaml
@@ -22,7 +22,8 @@
                 Orientation="Horizontal"
                 Height="56">
                 <ItemsControl
-                    ItemsSource="{x:Bind GetOriginalKeys()}">
+                    ItemsSource="{x:Bind GetOriginalKeys()}"
+                    IsTabStop="False">
                     <ItemsControl.ItemsPanel>
                         <ItemsPanelTemplate>
                             <StackPanel Orientation="Horizontal"/>
@@ -55,7 +56,8 @@
                           Margin="5,0,5,0"/>
                 <ItemsControl
                     ItemsSource="{x:Bind GetNewRemapKeys()}"
-                    Grid.Column="2">
+                    Grid.Column="2"
+                    IsTabStop="False">
                     <ItemsControl.ItemsPanel>
                         <ItemsPanelTemplate>
                             <StackPanel Orientation="Horizontal"/>
@@ -89,7 +91,8 @@
                 Orientation="Horizontal"
                 Height="56">
                 <ItemsControl
-                    ItemsSource="{x:Bind GetOriginalKeys()}">
+                    ItemsSource="{x:Bind GetOriginalKeys()}"
+                    IsTabStop="False">
                     <ItemsControl.ItemsPanel>
                         <ItemsPanelTemplate>
                             <StackPanel Orientation="Horizontal"/>
@@ -122,7 +125,8 @@
                           Margin="5,0,5,0"/>
                 <ItemsControl
                     ItemsSource="{x:Bind GetNewRemapKeys()}"
-                    Grid.Column="2">
+                    Grid.Column="2"
+                    IsTabStop="False">
                     <ItemsControl.ItemsPanel>
                         <ItemsPanelTemplate>
                             <StackPanel Orientation="Horizontal"/>


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
This PR removes the tab stops on the ListViews in the KBM settings page.

## PR Checklist
* [X] Applies to #5623
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [X] Tests passed

## Info on Pull Request

_What does this include?_
- As described on this comment https://github.com/microsoft/microsoft-ui-xaml/issues/3229#issuecomment-686086315 on the WinUI repo, in order to remove the tab stop from the ListView we have to set IsTabStop to false on the ItemContainerStyle for the ListViewItems.
- After doing this there was still an issue of extra tabs being required to reach the next control, even though the listview items did not explicitly get focus. This was happening because of the ItemsControl elements used in each row. This was resolved by settings IsTabStop to false for both of these controls.

## Validation Steps Performed

_How does someone test & validate?_
- Tab through all the elements on the KBM settings page.