### PR TITLE
[chore] disable PowerRename unit tests in CI

### DIFF
--- a/.pipelines/ci/templates/build-powertoys-steps.yml
+++ b/.pipelines/ci/templates/build-powertoys-steps.yml
@@ -96,10 +96,10 @@ steps:
     testAssemblyVer2: |
       **\ImageResizer.Test.dll
       **\KeyboardManagerTest.dll
-      **\PowerRenameUnitTests.dll
       **\UnitTests-CommonLib.dll
       **\PreviewPaneUnitTests.dll #this is the markdown tests
       **\UnitTests-PreviewHandlerCommon.dll
       **\UnitTests-SvgPreviewHandler.dll
       **\powerpreviewTest.dll
       !**\obj\**
+#      **\PowerRenameUnitTests.dll


### PR DESCRIPTION
## Summary of the Pull Request

Some PowerRename unit test are randomly failing. Disable all the PowerRename tests in CI until we can make them reliable.