### PR TITLE
[FancyZones] Fix span accross monitors feature

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/ViewModels/FancyZonesViewModel.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/ViewModels/FancyZonesViewModel.cs
@@ -50,6 +50,7 @@ namespace Microsoft.PowerToys.Settings.UI.Lib.ViewModels
             _restoreSize = Settings.Properties.FancyzonesRestoreSize.Value;
             _useCursorPosEditorStartupScreen = Settings.Properties.UseCursorposEditorStartupscreen.Value;
             _showOnAllMonitors = Settings.Properties.FancyzonesShowOnAllMonitors.Value;
+            _spanZonesAcrossMonitors = Settings.Properties.FancyzonesSpanZonesAcrossMonitors.Value;
             _makeDraggedWindowTransparent = Settings.Properties.FancyzonesMakeDraggedWindowTransparent.Value;
             _highlightOpacity = Settings.Properties.FancyzonesHighlightOpacity.Value;
             _excludedApps = Settings.Properties.FancyzonesExcludedApps.Value;

--- a/src/modules/fancyzones/lib/Settings.h
+++ b/src/modules/fancyzones/lib/Settings.h
@@ -9,7 +9,7 @@ namespace ZonedWindowProperties
     const wchar_t PropertyRestoreSizeID[]   = L"FancyZones_RestoreSize";
     const wchar_t PropertyRestoreOriginID[] = L"FancyZones_RestoreOrigin";
 
-    const wchar_t MultiMonitorDeviceID[]    = L"FancyZones_MultiMonitorDevice";
+    const wchar_t MultiMonitorDeviceID[]    = L"FancyZones#MultiMonitorDevice";
 }
 
 struct Settings


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
Fix Span Zones across monitors feature.
Fix enabling/disabling Span Zones across monitors feature in Settings.

## PR Checklist
* [x] Applies to #6302 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx
