### PR TITLE
Corrected querytext display on action keyword

### DIFF
--- a/src/modules/launcher/PowerLauncher/ViewModel/ResultViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/ResultViewModel.cs
@@ -272,8 +272,7 @@ namespace PowerLauncher.ViewModel
 
         public string SearchBoxDisplayText()
         {
-            var display = string.IsNullOrEmpty(Result.QueryTextDisplay) ? Result.Title : Result.QueryTextDisplay;
-            return display;
+            return Result.QueryTextDisplay;
         }
 
         public override string ToString()

--- a/src/modules/launcher/Wox.Core/Plugin/PluginManager.cs
+++ b/src/modules/launcher/Wox.Core/Plugin/PluginManager.cs
@@ -172,6 +172,7 @@ namespace Wox.Core.Plugin
                     if (results != null)
                     {
                         UpdatePluginMetadata(results, metadata, query);
+                        UpdateResultWithActionKeyword(results, query);
                     }
                 });
                 metadata.QueryCount += 1;
@@ -183,6 +184,23 @@ namespace Wox.Core.Plugin
                 Log.Exception($"|PluginManager.QueryForPlugin|Exception for plugin <{pair.Metadata.Name}> when query <{query}>", e);
                 return new List<Result>();
             }
+        }
+
+        private static List<Result> UpdateResultWithActionKeyword(List<Result> results, Query query)
+        {
+            foreach (Result result in results)
+            {
+                if (!string.IsNullOrEmpty(result.QueryTextDisplay))
+                {
+                    result.QueryTextDisplay = string.Format("{0} {1}", query.ActionKeyword, result.QueryTextDisplay);
+                }
+                else
+                {
+                    result.QueryTextDisplay = string.Format("{0} {1}", query.ActionKeyword, result.Title);
+                }
+            }
+
+            return results;
         }
 
         public static void UpdatePluginMetadata(List<Result> results, PluginMetadata metadata, Query query)

--- a/src/modules/launcher/Wox.Test/PluginManagerTest.cs
+++ b/src/modules/launcher/Wox.Test/PluginManagerTest.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Moq;
+using NUnit.Framework;
+using Wox.Core.Plugin;
+using Wox.Plugin;
+
+namespace Wox.Test
+{
+    [TestFixture]
+    public class PluginManagerTest
+    {
+        [Test]
+        public void QueryForPlugin_SetsActionKeyword_WhenQueryTextDisplayIsSet()
+        {
+            // Arrange
+            var actionKeyword = ">";
+            var title = "dummyTitle";
+            var queryTextDisplay = "dummyQueryTextDisplay";
+            var query = new Query
+            {
+                ActionKeyword = actionKeyword,
+            };
+            var metadata = new PluginMetadata
+            {
+                ID = "dummyName",
+                IcoPath = "dummyIcoPath",
+                ExecuteFileName = "dummyExecuteFileName",
+                PluginDirectory = "dummyPluginDirectory",
+            };
+            var result = new Result()
+            {
+                QueryTextDisplay = queryTextDisplay,
+                Title = title,
+            };
+            var results = new List<Result>() { result };
+            var pluginMock = new Mock<IPlugin>();
+            pluginMock.Setup(r => r.Query(query)).Returns(results);
+            var pluginPair = new PluginPair
+            {
+                Plugin = pluginMock.Object,
+                Metadata = metadata,
+            };
+
+            // Act
+            var queryOutput = PluginManager.QueryForPlugin(pluginPair, query);
+
+            // Assert
+            Assert.AreEqual(string.Format("{0} {1}", ">", queryTextDisplay), queryOutput[0].QueryTextDisplay);
+        }
+
+        [TestCase("")]
+        [TestCase(null)]
+        public void QueryForPlugin_SetsActionKeyword_WhenQueryTextDisplayIsEmpty(string queryTextDisplay)
+        {
+            // Arrange
+            var actionKeyword = ">";
+            var title = "dummyTitle";
+            var query = new Query
+            {
+                ActionKeyword = actionKeyword,
+            };
+            var metadata = new PluginMetadata
+            {
+                ID = "dummyName",
+                IcoPath = "dummyIcoPath",
+                ExecuteFileName = "dummyExecuteFileName",
+                PluginDirectory = "dummyPluginDirectory",
+            };
+            var result = new Result()
+            {
+                QueryTextDisplay = queryTextDisplay,
+                Title = title,
+            };
+            var results = new List<Result>() { result };
+            var pluginMock = new Mock<IPlugin>();
+            pluginMock.Setup(r => r.Query(query)).Returns(results);
+            var pluginPair = new PluginPair
+            {
+                Plugin = pluginMock.Object,
+                Metadata = metadata,
+            };
+
+            // Act
+            var queryOutput = PluginManager.QueryForPlugin(pluginPair, query);
+
+            // Assert
+            Assert.AreEqual(string.Format("{0} {1}", ">", title), queryOutput[0].QueryTextDisplay);
+        }
+    }
+}


### PR DESCRIPTION
## Summary of the Pull Request
Fix for action keyword disappearing in search box when scrolling through results.

## PR Checklist
* [x] Applies to #2576 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed

## Validation Steps Performed
Manually validated that action keyword is present in textbox when scrolling through results. 

![2576](https://user-images.githubusercontent.com/10995909/92163951-5fe18700-ede9-11ea-873e-7c4e7f97228d.gif)
