### PR TITLE
[FancyZones] Update 'span zones across monitors' feature description and add message box warning accordingly 

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -700,7 +700,7 @@
     <value>Microsoft PowerToys is a set of utilities for power users to tune and streamline their Windows experience for greater productivity.</value>
   </data>
   <data name="FancyZones_SpanZonesAcrossMonitorsCheckBoxControl.Content" xml:space="preserve">
-    <value>Allow zones to span across monitors</value>
+    <value>Allow zones to span across monitors (all monitor must have the same DPI scaling)</value>
   </data>
   <data name="ImageResizer_Formatting_ActualHeight.Text" xml:space="preserve">
     <value>Actual height</value>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -700,7 +700,7 @@
     <value>Microsoft PowerToys is a set of utilities for power users to tune and streamline their Windows experience for greater productivity.</value>
   </data>
   <data name="FancyZones_SpanZonesAcrossMonitorsCheckBoxControl.Content" xml:space="preserve">
-    <value>Allow zones to span across monitors (all monitor must have the same DPI scaling)</value>
+    <value>Allow zones to span across monitors (all monitors must have the same DPI scaling)</value>
   </data>
   <data name="ImageResizer_Formatting_ActualHeight.Text" xml:space="preserve">
     <value>Actual height</value>

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 
+#include <common/common.h>
 #include <common/dpi_aware.h>
 #include <common/on_thread_executor.h>
 #include <common/window_helpers.h>
@@ -17,6 +18,8 @@
 #include "MonitorWorkAreaHandler.h"
 
 #include <lib/SecondaryMouseButtonsHook.h>
+
+extern "C" IMAGE_DOS_HEADER __ImageBase;
 
 enum class DisplayChangeType
 {
@@ -627,6 +630,29 @@ void FancyZones::ToggleEditor() noexcept
         m_dpiUnawareThread.submit(OnThreadExecutor::task_t{ [&] {
                               allMonitors = FancyZonesUtils::GetAllMonitorRects<&MONITORINFOEX::rcWork>();
             } }).wait();
+
+        UINT currentDpi = 0;
+        for (const auto& monitor : allMonitors)
+        {
+            UINT dpiX = 0;
+            UINT dpiY = 0;
+            if (GetDpiForMonitor(monitor.first, MDT_EFFECTIVE_DPI, &dpiX, &dpiY) == S_OK)
+            {
+                if (currentDpi == 0)
+                {
+                  currentDpi = dpiX;
+                  continue;
+                }
+                if (currentDpi != dpiX)
+                {
+                    MessageBoxW(NULL,
+                    GET_RESOURCE_STRING(IDS_SPAN_ACROSS_ZONES_WARNING).c_str(),
+                    GET_RESOURCE_STRING(IDS_POWERTOYS_FANCYZONES).c_str(),
+                    MB_OK | MB_ICONWARNING);
+                    break;
+                }
+            }
+        }
 
         for (auto& [monitor, workArea] : allMonitors)
         {

--- a/src/modules/fancyzones/lib/Resources.resx
+++ b/src/modules/fancyzones/lib/Resources.resx
@@ -148,7 +148,7 @@
     <value>Show zones on all monitors while dragging a window</value>
   </data>
   <data name="Setting_Description_Span_Zones_Across_Monitors" xml:space="preserve">
-    <value>Allow zones to span across monitors</value>
+    <value>Allow zones to span across monitors (all monitor must have the same DPI scaling)</value>
   </data>
   <data name="Setting_Description_Make_Dragged_Window_Transparent" xml:space="preserve">
     <value>Make dragged window transparent</value>

--- a/src/modules/fancyzones/lib/Resources.resx
+++ b/src/modules/fancyzones/lib/Resources.resx
@@ -148,7 +148,7 @@
     <value>Show zones on all monitors while dragging a window</value>
   </data>
   <data name="Setting_Description_Span_Zones_Across_Monitors" xml:space="preserve">
-    <value>Allow zones to span across monitors (all monitor must have the same DPI scaling)</value>
+    <value>Allow zones to span across monitors (all monitors must have the same DPI scaling)</value>
   </data>
   <data name="Setting_Description_Make_Dragged_Window_Transparent" xml:space="preserve">
     <value>Make dragged window transparent</value>
@@ -214,6 +214,6 @@
     <value>PowerToys - FancyZones</value>
   </data>
   <data name="Span_Across_Zones_Warning" xml:space="preserve">
-    <value>With 'Allow zones to span across monitors' setting ON, all monitor must have the same DPI scaling</value>
+    <value>With 'Allow zones to span across monitors' setting ON, all monitors must have the same DPI scaling</value>
   </data>
 </root>

--- a/src/modules/fancyzones/lib/Resources.resx
+++ b/src/modules/fancyzones/lib/Resources.resx
@@ -214,6 +214,6 @@
     <value>PowerToys - FancyZones</value>
   </data>
   <data name="Span_Across_Zones_Warning" xml:space="preserve">
-    <value>With 'Allow zones to span across monitors' setting ON, all monitors must have the same DPI scaling</value>
+    <value>The 'Allow zones to span across monitors' option requires all monitors to have the same DPI scaling to work properly.</value>
   </data>
 </root>

--- a/src/modules/fancyzones/lib/Resources.resx
+++ b/src/modules/fancyzones/lib/Resources.resx
@@ -213,4 +213,7 @@
   <data name="Powertoys_FancyZones" xml:space="preserve">
     <value>PowerToys - FancyZones</value>
   </data>
+  <data name="Span_Across_Zones_Warning" xml:space="preserve">
+    <value>With 'Allow zones to span across monitors' setting ON, all monitor must have the same DPI scaling</value>
+  </data>
 </root>


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
Update Span Zones Across Monitors feature description in Settings app to
`Allow zones to span across monitors (all monitor must have the same DPI scaling)`

Add message box with warning on editor launch if monitors DPI's aren't all the same.

## PR Checklist
* [x] Applies to https://github.com/microsoft/PowerToys/issues/6428
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx
