### PR TITLE
[Launcher] Make searchbox text selectable

### DIFF
--- a/src/modules/launcher/PowerLauncher/LauncherControl.xaml
+++ b/src/modules/launcher/PowerLauncher/LauncherControl.xaml
@@ -26,17 +26,6 @@
                 <Setter.Value>
                     <ControlTemplate TargetType="{x:Type TextBox}">
                         <Grid>
-                            <Border x:Name="border" Background="{TemplateBinding Background}" BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}" SnapsToDevicePixels="True">
-                                <ScrollViewer x:Name="PART_ContentHost" Background="{TemplateBinding Background}" Focusable="false" HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Hidden">
-                                    <ScrollViewer.ContentTemplate>
-                                        <DataTemplate>
-                                            <Grid Background="{Binding Background, ElementName=PART_ContentHost}" RenderOptions.ClearTypeHint="Enabled" TextOptions.TextFormattingMode="Display">
-                                                <ContentPresenter Content="{Binding Path=Content, ElementName=PART_ContentHost}"/>
-                                            </Grid>
-                                        </DataTemplate>
-                                    </ScrollViewer.ContentTemplate>
-                                </ScrollViewer>
-                            </Border>
                             <TextBlock Margin="14, 0, 0, 0" Text="{TemplateBinding Tag}">
                                 <TextBlock.Style>
                                     <Style TargetType="{x:Type TextBlock}">
@@ -49,6 +38,17 @@
                                     </Style>
                                 </TextBlock.Style>
                             </TextBlock>
+                            <Border x:Name="border" Background="{TemplateBinding Background}" BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}" SnapsToDevicePixels="True">
+                                <ScrollViewer x:Name="PART_ContentHost" Background="{TemplateBinding Background}" Focusable="false" HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Hidden">
+                                    <ScrollViewer.ContentTemplate>
+                                        <DataTemplate>
+                                            <Grid Background="{Binding Background, ElementName=PART_ContentHost}" RenderOptions.ClearTypeHint="Enabled" TextOptions.TextFormattingMode="Display">
+                                                <ContentPresenter Content="{Binding Path=Content, ElementName=PART_ContentHost}"/>
+                                            </Grid>
+                                        </DataTemplate>
+                                    </ScrollViewer.ContentTemplate>
+                                </ScrollViewer>
+                            </Border>
                         </Grid>
                         <ControlTemplate.Triggers>
                             <Trigger Property="IsEnabled" Value="false">


### PR DESCRIPTION
## Summary of the Pull Request
The placeholder textblock that we use to show predictive text was blocking the textbox, showing the actual typed in query. That's the reason why this text was not selectable. Now that the text is selectable the query is easier to empty (select all, backspace) or to cut / copy.

End-result:

![SelectSearch](https://user-images.githubusercontent.com/9866362/92305352-b0421b80-ef86-11ea-9aea-1bb99f96caf4.gif)


## PR Checklist
* [X] Applies to #6331
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA