### PR TITLE
Updated links under "How to create new PowerToys"

### DIFF
--- a/doc/devdocs/readme.md
+++ b/doc/devdocs/readme.md
@@ -117,8 +117,8 @@ To run and debug PowerToys from Visual Studio when the user is a member of the A
 
 ## How to create new PowerToys
 
-See the instructions on [how to install the PowerToys Module project template](tools/project_template). <br />
-Specifications for the [PowerToys settings API](doc/specs/PowerToys-settings.md).
+See the instructions on [how to install the PowerToys Module project template](/tools/project_template). <br />
+Specifications for the [PowerToys settings API](/doc/devdocs/settings.md).
 
 ## Implementation details
 


### PR DESCRIPTION
## Summary of the Pull Request

The links were 404'ing

## PR Checklist
* [ ] Applies to #xxx
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

Just fixing some invalid links.

## Validation Steps Performed

* Click the links under "How to create new PowerToys" section
* See where it ends up