### PR TITLE
Fixed KBM shortcut remapping not working after using Japanese IME

### DIFF
--- a/src/modules/keyboardmanager/common/Shortcut.cpp
+++ b/src/modules/keyboardmanager/common/Shortcut.cpp
@@ -613,14 +613,35 @@ bool Shortcut::CheckModifiersKeyboardState(InputInterface& ii) const
     return true;
 }
 
+// Function to check if the key code is to be ignored
+bool IgnoreKeyCode(DWORD key)
+{
+    switch (key)
+    {
+        // Ignore mouse buttons. Keeping this could cause a remapping to fail if a mouse button is also pressed at the same time
+    case VK_LBUTTON:
+    case VK_RBUTTON:
+    case VK_MBUTTON:
+    case VK_XBUTTON1:
+    case VK_XBUTTON2:
+        // Ignore these key codes as they are reserved. Used by IME keyboards. More information at https://github.com/microsoft/PowerToys/issues/5225
+    case 0xF0:
+    case 0xF1:
+    case 0xF2:
+        return true;
+    }
+
+    return false;
+}
+
 // Function to check if any keys are pressed down except those in the shortcut
 bool Shortcut::IsKeyboardStateClearExceptShortcut(InputInterface& ii) const
 {
     // Iterate through all the virtual key codes - 0xFF is set to key down because of the Num Lock
     for (int keyVal = 1; keyVal < 0xFF; keyVal++)
     {
-        // Skip mouse buttons. Keeping this could cause a remapping to fail if a mouse button is also pressed at the same time
-        if (keyVal == VK_LBUTTON || keyVal == VK_RBUTTON || keyVal == VK_MBUTTON || keyVal == VK_XBUTTON1 || keyVal == VK_XBUTTON2)
+        // Ignore problematic key codes
+        if (IgnoreKeyCode(keyVal))
         {
             continue;
         }


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

## PR Checklist
* [X] Applies to #5225
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [X] Tests passed

## Validation Steps Performed

_How does someone test & validate?_
- Add a shortcut remapping and validate that it works normally on en-us
- Switch to Japanese IME and use the Shift+CapsLock, Ctrl+CapsLock, Alt+CapsLock shortcuts
- Validate that shortcut remapping still works