### PR TITLE
Add in verbose error message and telemetry for SetWindowsHookEx failure

### DIFF
--- a/src/common/common.cpp
+++ b/src/common/common.cpp
@@ -11,12 +11,6 @@
 #pragma comment(lib, "advapi32.lib")
 #pragma comment(lib, "shlwapi.lib")
 
-namespace localized_strings
-{
-    const wchar_t LAST_ERROR_FORMAT_STRING[] = L"%s failed with error %d: %s";
-    const wchar_t LAST_ERROR_TITLE_STRING[] = L"Error";
-}
-
 std::optional<RECT> get_window_pos(HWND hwnd)
 {
     RECT window;
@@ -91,7 +85,7 @@ std::optional<std::wstring> get_last_error_message(const DWORD dw)
     return message;
 }
 
-void show_last_error_message(LPCWSTR lpszFunction, DWORD dw)
+void show_last_error_message(LPCWSTR lpszFunction, DWORD dw, LPCWSTR errorTitle)
 {
     const auto system_message = get_last_error_message(dw);
     if (!system_message.has_value())
@@ -107,7 +101,7 @@ void show_last_error_message(LPCWSTR lpszFunction, DWORD dw)
                          lpszFunction,
                          dw,
                          system_message->c_str());
-        MessageBoxW(NULL, (LPCTSTR)lpDisplayBuf, localized_strings::LAST_ERROR_TITLE_STRING, MB_OK);
+        MessageBoxW(NULL, (LPCTSTR)lpDisplayBuf, errorTitle, MB_OK | MB_ICONERROR);
         LocalFree(lpDisplayBuf);
     }
 }

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -6,6 +6,13 @@
 #include <memory>
 #include <vector>
 
+
+namespace localized_strings
+{
+    const wchar_t LAST_ERROR_FORMAT_STRING[] = L"%s failed with error %d: %s";
+    const wchar_t LAST_ERROR_TITLE_STRING[] = L"Error";
+}
+
 // Gets position of given window.
 std::optional<RECT> get_window_pos(HWND hwnd);
 
@@ -16,7 +23,7 @@ bool is_system_window(HWND hwnd, const char* class_name);
 int run_message_loop(const bool until_idle = false, const std::optional<uint32_t> timeout_seconds = {});
 
 std::optional<std::wstring> get_last_error_message(const DWORD dw);
-void show_last_error_message(LPCWSTR lpszFunction, DWORD dw);
+void show_last_error_message(LPCWSTR lpszFunction, DWORD dw, LPCWSTR errorTitle = localized_strings::LAST_ERROR_TITLE_STRING);
 
 enum WindowState
 {

--- a/src/common/interop/KeyboardHook.cpp
+++ b/src/common/interop/KeyboardHook.cpp
@@ -4,6 +4,7 @@
 #include <msclr\marshal.h>
 #include <msclr\marshal_cppstd.h>
 #include <common/debug_control.h>
+#include <common/common.h>
 
 using namespace interop;
 using namespace System::Runtime::InteropServices;
@@ -46,7 +47,8 @@ void KeyboardHook::Start()
             0);
         if (hookHandle == nullptr)
         {
-            throw std::exception("SetWindowsHookEx failed.");
+            DWORD errorCode = GetLastError();
+            show_last_error_message(L"SetWindowsHookEx", errorCode, L"PowerToys - Interop");
         }
     }
 }

--- a/src/modules/fancyzones/dll/dllmain.cpp
+++ b/src/modules/fancyzones/dll/dllmain.cpp
@@ -82,10 +82,8 @@ public:
                 s_llKeyboardHook = SetWindowsHookEx(WH_KEYBOARD_LL, LowLevelKeyboardProc, GetModuleHandle(NULL), NULL);
                 if (!s_llKeyboardHook)
                 {
-                    MessageBoxW(NULL,
-                                GET_RESOURCE_STRING(IDS_KEYBOARD_LISTENER_ERROR).c_str(),
-                                GET_RESOURCE_STRING(IDS_POWERTOYS_FANCYZONES).c_str(),
-                                MB_OK | MB_ICONERROR);
+                    DWORD errorCode = GetLastError();
+                    show_last_error_message(L"SetWindowsHookEx", errorCode, GET_RESOURCE_STRING(IDS_POWERTOYS_FANCYZONES).c_str());
                 }
             }
 

--- a/src/modules/fancyzones/dll/dllmain.cpp
+++ b/src/modules/fancyzones/dll/dllmain.cpp
@@ -85,7 +85,7 @@ public:
                     DWORD errorCode = GetLastError();
                     show_last_error_message(L"SetWindowsHookEx", errorCode, GET_RESOURCE_STRING(IDS_POWERTOYS_FANCYZONES).c_str());
                     auto errorMessage = get_last_error_message(errorCode);
-                    Trace::FancyZones::Exception(errorCode, errorMessage.has_value() ? errorMessage.value() : L"", L"enable.SetWindowsHookEx");
+                    Trace::FancyZones::Error(errorCode, errorMessage.has_value() ? errorMessage.value() : L"", L"enable.SetWindowsHookEx");
                 }
             }
 

--- a/src/modules/fancyzones/dll/dllmain.cpp
+++ b/src/modules/fancyzones/dll/dllmain.cpp
@@ -84,6 +84,8 @@ public:
                 {
                     DWORD errorCode = GetLastError();
                     show_last_error_message(L"SetWindowsHookEx", errorCode, GET_RESOURCE_STRING(IDS_POWERTOYS_FANCYZONES).c_str());
+                    auto errorMessage = get_last_error_message(errorCode);
+                    Trace::FancyZones::Exception(errorCode, errorMessage.has_value() ? errorMessage.value() : L"", L"enable.SetWindowsHookEx");
                 }
             }
 

--- a/src/modules/fancyzones/lib/trace.cpp
+++ b/src/modules/fancyzones/lib/trace.cpp
@@ -213,12 +213,12 @@ void Trace::FancyZones::EditorLaunched(int value) noexcept
         TraceLoggingInt32(value, EditorLaunchValueKey));
 }
 
-// Log if an exception occurs in FZ
-void Trace::FancyZones::Exception(const DWORD errorCode, std::wstring errorMessage, std::wstring methodName) noexcept
+// Log if an error occurs in FZ
+void Trace::FancyZones::Error(const DWORD errorCode, std::wstring errorMessage, std::wstring methodName) noexcept
 {
     TraceLoggingWrite(
         g_hProvider,
-        "FancyZones_Exception",
+        "FancyZones_Error",
         ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
         TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE),
         TraceLoggingValue(methodName.c_str(), "MethodName"),

--- a/src/modules/fancyzones/lib/trace.cpp
+++ b/src/modules/fancyzones/lib/trace.cpp
@@ -213,6 +213,19 @@ void Trace::FancyZones::EditorLaunched(int value) noexcept
         TraceLoggingInt32(value, EditorLaunchValueKey));
 }
 
+// Log if an exception occurs in FZ
+void Trace::FancyZones::Exception(const DWORD errorCode, std::wstring errorMessage, std::wstring methodName) noexcept
+{
+    TraceLoggingWrite(
+        g_hProvider,
+        "FancyZones_Exception",
+        ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
+        TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE),
+        TraceLoggingValue(methodName.c_str(), "MethodName"),
+        TraceLoggingValue(errorCode, "ErrorCode"),
+        TraceLoggingValue(errorMessage.c_str(), "ErrorMessage"));
+}
+
 void Trace::SettingsChanged(const Settings& settings) noexcept
 {
     const auto& editorHotkey = settings.editorHotkey;

--- a/src/modules/fancyzones/lib/trace.h
+++ b/src/modules/fancyzones/lib/trace.h
@@ -16,6 +16,7 @@ public:
         static void OnKeyDown(DWORD vkCode, bool win, bool control, bool inMoveSize) noexcept;
         static void DataChanged() noexcept;
         static void EditorLaunched(int value) noexcept;
+        static void Exception(const DWORD errorCode, std::wstring errorMessage, std::wstring methodName) noexcept;
     };
 
     static void SettingsChanged(const Settings& settings) noexcept;

--- a/src/modules/fancyzones/lib/trace.h
+++ b/src/modules/fancyzones/lib/trace.h
@@ -16,7 +16,7 @@ public:
         static void OnKeyDown(DWORD vkCode, bool win, bool control, bool inMoveSize) noexcept;
         static void DataChanged() noexcept;
         static void EditorLaunched(int value) noexcept;
-        static void Exception(const DWORD errorCode, std::wstring errorMessage, std::wstring methodName) noexcept;
+        static void Error(const DWORD errorCode, std::wstring errorMessage, std::wstring methodName) noexcept;
     };
 
     static void SettingsChanged(const Settings& settings) noexcept;

--- a/src/modules/keyboardmanager/common/trace.cpp
+++ b/src/modules/keyboardmanager/common/trace.cpp
@@ -131,3 +131,16 @@ void Trace::ShortcutRemapInvoked(bool isShortcutToShortcut, bool isAppSpecific) 
         }
     }
 }
+
+// Log if an exception occurs in KBM
+void Trace::Exception(const DWORD errorCode, std::wstring errorMessage, std::wstring methodName) noexcept
+{
+    TraceLoggingWrite(
+        g_hProvider,
+        "KeyboardManager_Exception",
+        ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
+        TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE),
+        TraceLoggingValue(methodName.c_str(), "MethodName"),
+        TraceLoggingValue(errorCode, "ErrorCode"),
+        TraceLoggingValue(errorMessage.c_str(), "ErrorMessage"));
+}

--- a/src/modules/keyboardmanager/common/trace.cpp
+++ b/src/modules/keyboardmanager/common/trace.cpp
@@ -132,12 +132,12 @@ void Trace::ShortcutRemapInvoked(bool isShortcutToShortcut, bool isAppSpecific) 
     }
 }
 
-// Log if an exception occurs in KBM
-void Trace::Exception(const DWORD errorCode, std::wstring errorMessage, std::wstring methodName) noexcept
+// Log if an error occurs in KBM
+void Trace::Error(const DWORD errorCode, std::wstring errorMessage, std::wstring methodName) noexcept
 {
     TraceLoggingWrite(
         g_hProvider,
-        "KeyboardManager_Exception",
+        "KeyboardManager_Error",
         ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
         TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE),
         TraceLoggingValue(methodName.c_str(), "MethodName"),

--- a/src/modules/keyboardmanager/common/trace.h
+++ b/src/modules/keyboardmanager/common/trace.h
@@ -24,6 +24,6 @@ public:
     // Log if a shortcut remap has been invoked
     static void ShortcutRemapInvoked(bool isShortcutToShortcut, bool isAppSpecific) noexcept;
     
-    // Log if an exception occurs in KBM
-    static void Exception(const DWORD errorCode, std::wstring errorMessage, std::wstring methodName) noexcept;
+    // Log if an error occurs in KBM
+    static void Error(const DWORD errorCode, std::wstring errorMessage, std::wstring methodName) noexcept;
 };

--- a/src/modules/keyboardmanager/common/trace.h
+++ b/src/modules/keyboardmanager/common/trace.h
@@ -23,4 +23,7 @@ public:
 
     // Log if a shortcut remap has been invoked
     static void ShortcutRemapInvoked(bool isShortcutToShortcut, bool isAppSpecific) noexcept;
+    
+    // Log if an exception occurs in KBM
+    static void Exception(const DWORD errorCode, std::wstring errorMessage, std::wstring methodName) noexcept;
 };

--- a/src/modules/keyboardmanager/dll/dllmain.cpp
+++ b/src/modules/keyboardmanager/dll/dllmain.cpp
@@ -366,7 +366,7 @@ public:
                 DWORD errorCode = GetLastError();
                 show_last_error_message(L"SetWindowsHookEx", errorCode, L"PowerToys - Keyboard Manager");
                 auto errorMessage = get_last_error_message(errorCode);
-                Trace::Exception(errorCode, errorMessage.has_value() ? errorMessage.value() : L"", L"start_lowlevel_keyboard_hook.SetWindowsHookEx");
+                Trace::Error(errorCode, errorMessage.has_value() ? errorMessage.value() : L"", L"start_lowlevel_keyboard_hook.SetWindowsHookEx");
             }
         }
     }

--- a/src/modules/keyboardmanager/dll/dllmain.cpp
+++ b/src/modules/keyboardmanager/dll/dllmain.cpp
@@ -365,6 +365,8 @@ public:
             {
                 DWORD errorCode = GetLastError();
                 show_last_error_message(L"SetWindowsHookEx", errorCode, L"PowerToys - Keyboard Manager");
+                auto errorMessage = get_last_error_message(errorCode);
+                Trace::Exception(errorCode, errorMessage.has_value() ? errorMessage.value() : L"", L"start_lowlevel_keyboard_hook.SetWindowsHookEx");
             }
         }
     }

--- a/src/modules/keyboardmanager/dll/dllmain.cpp
+++ b/src/modules/keyboardmanager/dll/dllmain.cpp
@@ -363,7 +363,8 @@ public:
             hook_handle_copy = hook_handle;
             if (!hook_handle)
             {
-                throw std::runtime_error("Cannot install keyboard listener");
+                DWORD errorCode = GetLastError();
+                show_last_error_message(L"SetWindowsHookEx", errorCode, L"PowerToys - Keyboard Manager");
             }
         }
     }

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Properties/Resources.Designer.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Properties/Resources.Designer.cs
@@ -160,15 +160,6 @@ namespace Microsoft.Plugin.Folder.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Please select a folder link.
-        /// </summary>
-        public static string wox_plugin_folder_select_folder_link_warning {
-            get {
-                return ResourceManager.GetString("wox_plugin_folder_select_folder_link_warning", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Could not start.
         /// </summary>
         public static string wox_plugin_folder_select_folder_OpenFileOrFolder_error_message {

--- a/src/modules/launcher/PowerLauncher/Properties/Resources.Designer.cs
+++ b/src/modules/launcher/PowerLauncher/Properties/Resources.Designer.cs
@@ -58,24 +58,6 @@ namespace PowerLauncher.Properties {
             set {
                 resourceCulture = value;
             }
-        }        
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Settings will be reset to default and program will continue to function..
-        /// </summary>
-        public static string deseralization_error_message {
-            get {
-                return ResourceManager.GetString("deseralization_error_message", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Powertoys Run deserialization error.
-        /// </summary>
-        public static string deseralization_error_title {
-            get {
-                return ResourceManager.GetString("deseralization_error_title", resourceCulture);
-            }
         }
         
         /// <summary>
@@ -129,6 +111,24 @@ namespace PowerLauncher.Properties {
         public static string ContextMenuItemsCollection {
             get {
                 return ResourceManager.GetString("ContextMenuItemsCollection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Settings will be reset to default and program will continue to function..
+        /// </summary>
+        public static string deseralization_error_message {
+            get {
+                return ResourceManager.GetString("deseralization_error_message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Powertoys Run deserialization error.
+        /// </summary>
+        public static string deseralization_error_title {
+            get {
+                return ResourceManager.GetString("deseralization_error_title", resourceCulture);
             }
         }
         

--- a/src/modules/shortcut_guide/shortcut_guide.cpp
+++ b/src/modules/shortcut_guide/shortcut_guide.cpp
@@ -228,7 +228,7 @@ void OverlayWindow::enable()
                 DWORD errorCode = GetLastError();
                 show_last_error_message(L"SetWindowsHookEx", errorCode, L"PowerToys - Shortcut Guide");
                 auto errorMessage = get_last_error_message(errorCode);
-                Trace::Exception(errorCode, errorMessage.has_value() ? errorMessage.value() : L"", L"OverlayWindow.enable.SetWindowsHookEx");
+                Trace::Error(errorCode, errorMessage.has_value() ? errorMessage.value() : L"", L"OverlayWindow.enable.SetWindowsHookEx");
             }
         }
         RegisterHotKey(winkey_popup->get_window_handle(), alternative_switch_hotkey_id, alternative_switch_modifier_mask, alternative_switch_vk_code);

--- a/src/modules/shortcut_guide/shortcut_guide.cpp
+++ b/src/modules/shortcut_guide/shortcut_guide.cpp
@@ -227,6 +227,8 @@ void OverlayWindow::enable()
             {
                 DWORD errorCode = GetLastError();
                 show_last_error_message(L"SetWindowsHookEx", errorCode, L"PowerToys - Shortcut Guide");
+                auto errorMessage = get_last_error_message(errorCode);
+                Trace::Exception(errorCode, errorMessage.has_value() ? errorMessage.value() : L"", L"OverlayWindow.enable.SetWindowsHookEx");
             }
         }
         RegisterHotKey(winkey_popup->get_window_handle(), alternative_switch_hotkey_id, alternative_switch_modifier_mask, alternative_switch_vk_code);

--- a/src/modules/shortcut_guide/shortcut_guide.cpp
+++ b/src/modules/shortcut_guide/shortcut_guide.cpp
@@ -6,6 +6,7 @@
 #include <common/common.h>
 #include <common/settings_objects.h>
 #include <common/debug_control.h>
+#include <sstream>
 
 extern "C" IMAGE_DOS_HEADER __ImageBase;
 
@@ -84,8 +85,8 @@ namespace
         // For now, since ShortcutGuide can only disable entire "Windows Controls"
         // group, we require that the window supports all the options.
         result.snappable = ((style & WS_MAXIMIZEBOX) == WS_MAXIMIZEBOX) &&
-                            ((style & WS_MINIMIZEBOX) == WS_MINIMIZEBOX) &&
-                            ((style & WS_THICKFRAME) == WS_THICKFRAME);
+                           ((style & WS_MINIMIZEBOX) == WS_MINIMIZEBOX) &&
+                           ((style & WS_THICKFRAME) == WS_THICKFRAME);
         return result;
     }
 }
@@ -224,7 +225,8 @@ void OverlayWindow::enable()
             hook_handle = SetWindowsHookEx(WH_KEYBOARD_LL, LowLevelKeyboardProc, GetModuleHandle(NULL), NULL);
             if (!hook_handle)
             {
-                MessageBoxW(NULL, L"Cannot install keyboard listener.", L"PowerToys - Shortcut Guide", MB_OK | MB_ICONERROR);
+                DWORD errorCode = GetLastError();
+                show_last_error_message(L"SetWindowsHookEx", errorCode, L"PowerToys - Shortcut Guide");
             }
         }
         RegisterHotKey(winkey_popup->get_window_handle(), alternative_switch_hotkey_id, alternative_switch_modifier_mask, alternative_switch_vk_code);

--- a/src/modules/shortcut_guide/trace.cpp
+++ b/src/modules/shortcut_guide/trace.cpp
@@ -65,3 +65,16 @@ void Trace::SettingsChanged(const int press_delay_time, const int overlay_opacit
         TraceLoggingBoolean(TRUE, "UTCReplace_AppSessionGuid"),
         TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));
 }
+
+// Log if an exception occurs in Shortcut Guide
+void Trace::Exception(const DWORD errorCode, std::wstring errorMessage, std::wstring methodName) noexcept
+{
+    TraceLoggingWrite(
+        g_hProvider,
+        "ShortcutGuide_Exception",
+        ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
+        TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE),
+        TraceLoggingValue(methodName.c_str(), "MethodName"),
+        TraceLoggingValue(errorCode, "ErrorCode"),
+        TraceLoggingValue(errorMessage.c_str(), "ErrorMessage"));
+}

--- a/src/modules/shortcut_guide/trace.cpp
+++ b/src/modules/shortcut_guide/trace.cpp
@@ -66,12 +66,12 @@ void Trace::SettingsChanged(const int press_delay_time, const int overlay_opacit
         TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));
 }
 
-// Log if an exception occurs in Shortcut Guide
-void Trace::Exception(const DWORD errorCode, std::wstring errorMessage, std::wstring methodName) noexcept
+// Log if an error occurs in Shortcut Guide
+void Trace::Error(const DWORD errorCode, std::wstring errorMessage, std::wstring methodName) noexcept
 {
     TraceLoggingWrite(
         g_hProvider,
-        "ShortcutGuide_Exception",
+        "ShortcutGuide_Error",
         ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
         TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE),
         TraceLoggingValue(methodName.c_str(), "MethodName"),

--- a/src/modules/shortcut_guide/trace.h
+++ b/src/modules/shortcut_guide/trace.h
@@ -8,5 +8,5 @@ public:
     static void HideGuide(const __int64 duration_ms, std::vector<int>& key_pressed) noexcept;
     static void EnableShortcutGuide(const bool enabled) noexcept;
     static void SettingsChanged(const int press_delay_time, const int overlay_opacity, const std::wstring& theme) noexcept;
-    static void Exception(const DWORD errorCode, std::wstring errorMessage, std::wstring methodName) noexcept;
+    static void Error(const DWORD errorCode, std::wstring errorMessage, std::wstring methodName) noexcept;
 };

--- a/src/modules/shortcut_guide/trace.h
+++ b/src/modules/shortcut_guide/trace.h
@@ -8,4 +8,5 @@ public:
     static void HideGuide(const __int64 duration_ms, std::vector<int>& key_pressed) noexcept;
     static void EnableShortcutGuide(const bool enabled) noexcept;
     static void SettingsChanged(const int press_delay_time, const int overlay_opacity, const std::wstring& theme) noexcept;
+    static void Exception(const DWORD errorCode, std::wstring errorMessage, std::wstring methodName) noexcept;
 };


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
In #5414 the exceptions that users reported was related to the `SetWindowsHookEx` API failing. As per the docs and after the reaching out to the respective team, the suggestion was to use the `GetLastError` API to get a more detailed error code/message. In this PR I have modified the Message box that we were earlier displaying to show the error code as well as the error message as well, rather than the generic "Cannot install keyboard listener". This will allow us to get more details when users post the issue, since we do not have enough information to figure out the reason right now. The PR also adds telemetry to log this exception for KBM, FZ and SG.

## PR Checklist
* [X] Applies to #5414 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [X] Tests passed

## Info on Pull Request

_What does this include?_
- `show_last_error_message` in common.h was modified to allow a different message box title, with default set to the earlier value.
- In KBM, FZ, SG and interop, when the `SetWindowsHookEx` return value is NULL, `GetLastError` is called along with `show_last_error_message`.
- A telemetry event was added for KBM, FZ and SG, which logs the error code, error message and method name. This is called after `show_last_error_message`, with the method name as the parent function name followed by `SetWindowsHookEx` (for example for SG it is `OverlayWindow.enable.SetWindowsHookEx`).
- As per this comment https://github.com/microsoft/PowerToys/pull/1272#discussion_r379112312 we can't have a generic telemetry event across all modules

## Validation Steps Performed

_How does someone test & validate?_
- Build and run PowerToys
- Modify one of the `SetWindowsHookEx` checks to check non-null and validate that the message box appears.