### PR TITLE
Fix for FileNotFoundException exception in win32 programs

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32Program.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32Program.cs
@@ -484,6 +484,14 @@ namespace Microsoft.Plugin.Program.Programs
 
                 return new Win32Program() { Valid = false, Enabled = false };
             }
+            catch (FileNotFoundException e)
+            {
+                ProgramLogger.LogException(
+                    $"|Win32|ExeProgram|{path}" +
+                                            $"|Unable to locate exe file at {path}", e);
+
+                return new Win32Program() { Valid = false, Enabled = false };
+            }
         }
 
         // Function to get the Win32 application, given the path to the application


### PR DESCRIPTION
## Summary of the Pull Request
Fix for `FileNotFoundException` in Win32 programs.

## PR Checklist
* [x] Applies to #6410, #6425 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed

## Info on Pull Request

The `FileNotFoundException` is being thrown because an external program is creating an `exe` and quickly deleting the file. Creating an `exe` triggers file watcher and this inturn calls the code to add this `exe` in win32 programs. The code tries to fetch file version information, but since it has already been deleted, `FileNotFoundException` is thrown. It would be best to handle this error as it is happening due to an external factor.

Steps to repro : 
1. Put a breakpoint [here](https://github.com/microsoft/PowerToys/blob/master/src/modules/launcher/Wox.Infrastructure/FileSystemHelper/FileVersionInfoWrapper.cs#L20)
2. Paste an exe file on desktop. This will hit breakpoint in step 1. 
3. Delete exe file. 
4. Continue program execution. Error same as in #6410, #6420 will be thrown. 

## Validation Steps Performed
Manually validated that `FileNotFoundException` is handled when above repro steps are followed.