### PR TITLE
[KBM] Prevent keyboard manager crash when index is not found

### DIFF
--- a/src/modules/keyboardmanager/ui/ShortcutControl.cpp
+++ b/src/modules/keyboardmanager/ui/ShortcutControl.cpp
@@ -105,6 +105,7 @@ void ShortcutControl::AddNewShortcutControlRow(Grid& parent, std::vector<std::ve
         UIElementCollection children = parent.Children();
         uint32_t index;
         children.IndexOf(targetAppTextBox, index);
+        Sleep(5000);
         uint32_t lastIndexInRow = index + ((KeyboardManagerConstants::ShortcutTableColCount - 1) - KeyboardManagerConstants::ShortcutTableTargetAppColIndex);
         // Calculate row index in the buffer from the grid child index (first set of children are header elements and then three children in each row)
         int rowIndex = (lastIndexInRow - KeyboardManagerConstants::ShortcutTableHeaderCount) / KeyboardManagerConstants::ShortcutTableColCount;

--- a/src/modules/keyboardmanager/ui/ShortcutControl.cpp
+++ b/src/modules/keyboardmanager/ui/ShortcutControl.cpp
@@ -177,7 +177,14 @@ void ShortcutControl::AddNewShortcutControlRow(Grid& parent, std::vector<std::ve
         uint32_t index;
         // Get index of delete button
         UIElementCollection children = parent.Children();
-        children.IndexOf(currentButton, index);
+        bool indexFound = children.IndexOf(currentButton, index);
+
+        // IndexOf could fail if the the row got deleted and the button handler was invoked twice. In this case it should return
+        if (!indexFound)
+        {
+            return;
+        }
+
         uint32_t lastIndexInRow = index + ((KeyboardManagerConstants::ShortcutTableColCount - 1) - KeyboardManagerConstants::ShortcutTableRemoveColIndex);
         // Change the row index of elements appearing after the current row, as we will delete the row definition
         for (uint32_t i = lastIndexInRow + 1; i < children.Size(); i++)

--- a/src/modules/keyboardmanager/ui/ShortcutControl.cpp
+++ b/src/modules/keyboardmanager/ui/ShortcutControl.cpp
@@ -104,11 +104,23 @@ void ShortcutControl::AddNewShortcutControlRow(Grid& parent, std::vector<std::ve
         // Get index of targetAppTextBox button
         UIElementCollection children = parent.Children();
         uint32_t index;
-        children.IndexOf(targetAppTextBox, index);
-        Sleep(5000);
+        bool indexFound = children.IndexOf(targetAppTextBox, index);
+
+        // IndexOf could fail if the the row got deleted after LostFocus handler was invoked. In this case it should return
+        if (!indexFound)
+        {
+            return;
+        }
+
         uint32_t lastIndexInRow = index + ((KeyboardManagerConstants::ShortcutTableColCount - 1) - KeyboardManagerConstants::ShortcutTableTargetAppColIndex);
         // Calculate row index in the buffer from the grid child index (first set of children are header elements and then three children in each row)
         int rowIndex = (lastIndexInRow - KeyboardManagerConstants::ShortcutTableHeaderCount) / KeyboardManagerConstants::ShortcutTableColCount;
+
+        // rowIndex could be out of bounds if the the row got deleted after LostFocus handler was invoked. In this case it should return
+        if (rowIndex >= keyboardRemapControlObjects.size())
+        {
+            return;
+        }
 
         // Validate both set of drop downs
         KeyDropDownControl::ValidateShortcutFromDropDownList(parent, keyboardRemapControlObjects[rowIndex][0]->getShortcutControl(), keyboardRemapControlObjects[rowIndex][0]->shortcutDropDownStackPanel.as<StackPanel>(), 0, ShortcutControl::shortcutRemapBuffer, keyboardRemapControlObjects[rowIndex][0]->keyDropDownControlObjects, targetAppTextBox, false, false);

--- a/src/modules/keyboardmanager/ui/SingleKeyRemapControl.cpp
+++ b/src/modules/keyboardmanager/ui/SingleKeyRemapControl.cpp
@@ -138,7 +138,14 @@ void SingleKeyRemapControl::AddNewControlKeyRemapRow(Grid& parent, std::vector<s
         uint32_t index;
         // Get index of delete button
         UIElementCollection children = parent.Children();
-        children.IndexOf(currentButton, index);
+        bool indexFound = children.IndexOf(currentButton, index);
+
+        // IndexOf could fail if the the row got deleted and the button handler was invoked twice. In this case it should return
+        if (!indexFound)
+        {
+            return;
+        }
+
         uint32_t lastIndexInRow = index + ((KeyboardManagerConstants::RemapTableColCount - 1) - KeyboardManagerConstants::RemapTableRemoveColIndex);
         // Change the row index of elements appearing after the current row, as we will delete the row definition
         for (uint32_t i = lastIndexInRow + 1; i < children.Size(); i++)


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
This PR prevents Keyboard Manager from crashing in the target app textbox LostFocus handler due to a InvalidPointerRead exception.

To repro the exception easily, add `Sleep(5000)` in the handler like in this commit https://github.com/microsoft/PowerToys/commit/7064482e989c004170f07180ea83233ac7c449d7 and follow the steps in the gif. When this is done the WinRT error `input data cannot be processed in the non-chronological order` will also appear in the VS output.

![kbmShortcutCrashRepro](https://user-images.githubusercontent.com/32061677/92646616-8dbc4500-f29b-11ea-902a-3761d5794197.gif)

The exception seems to occur if a user manages to press the delete and invoke LostFocus at the same time. Without the artificial `Sleep` this could happen if someone's system is running slow and hanging for some reason (most likely external to PowerToys).

## PR Checklist
* [X] Applies to #6483 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [X] Tests passed

## Info on Pull Request

_What does this include?_
- The [`IndexOf`](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.uielementcollection.indexof?view=winrt-19041#Windows_UI_Xaml_Controls_UIElementCollection_IndexOf_Windows_UI_Xaml_UIElement_System_UInt32__) method can fail if the element was not found in the collection. For this we should check the return value, and if it is false that means the element was not found. As mentioned above this could occur if the row got deleted before the LostFocus handler completed execution.
- An extra safeguard was added for the part where element in the vector was accessed, however while testing with the above repro the execution never went into that block.
- Added similar IndexOf safeguards in the Delete button handlers.

## Validation Steps Performed

_How does someone test & validate?_
- Add `Sleep(5000)` as in this commit https://github.com/microsoft/PowerToys/commit/7064482e989c004170f07180ea83233ac7c449d7 and repro with the steps in the gif, i.e. add 3 remap rows, and set focus to the bottom target app textbox and then press the Delete buttons and other textboxes. With the changes in this PR the app will not crash.
