### PR TITLE
Remove flicker on relaunch

### DIFF
--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml
@@ -22,7 +22,6 @@
         Closing="OnClosing"
         Background="Transparent"
         LocationChanged="OnLocationChanged"
-        Activated="OnActivated"
         Deactivated="OnDeactivated"
         IsVisibleChanged="OnVisibilityChanged"
         Visibility="{Binding MainWindowVisibility, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -161,14 +161,6 @@ namespace PowerLauncher
             _settings.WindowLeft = Left;
         }
 
-        private void OnActivated(object sender, EventArgs e)
-        {
-            if (_settings.ClearInputOnLaunch)
-            {
-                _viewModel.ClearQueryCommand.Execute(null);
-            }
-        }
-
         private void OnDeactivated(object sender, EventArgs e)
         {
             if (_settings.HideWhenDeactivated)

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -166,7 +166,10 @@ namespace PowerLauncher
             if (_settings.HideWhenDeactivated)
             {
                 // (this.FindResource("OutroStoryboard") as Storyboard).Begin();
-                Hide();
+                if (_viewModel.MainWindowVisibility != Visibility.Collapsed)
+                {
+                    _viewModel.ToggleWox();
+                }
             }
         }
 

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -166,10 +166,7 @@ namespace PowerLauncher
             if (_settings.HideWhenDeactivated)
             {
                 // (this.FindResource("OutroStoryboard") as Storyboard).Begin();
-                if (_viewModel.MainWindowVisibility != Visibility.Collapsed)
-                {
-                    _viewModel.ToggleWox();
-                }
+                _viewModel.Hide();
             }
         }
 

--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -735,7 +735,7 @@ namespace PowerLauncher.ViewModel
             }
             else
             {
-                if (_settings.ClearInputOnLaunch)
+                if (_settings.ClearInputOnLaunch && Results.Visibility == Visibility.Visible)
                 {
                     ClearQueryCommand.Execute(null);
                     Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.ApplicationIdle, new Action(() =>

--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Windows.Threading;
 using interop;
 using Microsoft.PowerLauncher.Telemetry;
 using Microsoft.PowerToys.Telemetry;
@@ -734,7 +735,19 @@ namespace PowerLauncher.ViewModel
             }
             else
             {
-                MainWindowVisibility = Visibility.Collapsed;
+                if (_settings.ClearInputOnLaunch)
+                {
+                    ClearQueryCommand.Execute(null);
+                    Results.Results.NotifyChanges();
+                }
+
+                Task.Run(() =>
+                {
+                    Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.ApplicationIdle, new Action(() =>
+                    {
+                        MainWindowVisibility = Visibility.Collapsed;
+                    }));
+                });
             }
         }
 

--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -741,13 +741,10 @@ namespace PowerLauncher.ViewModel
                     Results.Results.NotifyChanges();
                 }
 
-                Task.Run(() =>
+                Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.ApplicationIdle, new Action(() =>
                 {
-                    Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.ApplicationIdle, new Action(() =>
-                    {
-                        MainWindowVisibility = Visibility.Collapsed;
-                    }));
-                });
+                    MainWindowVisibility = Visibility.Collapsed;
+                }));
             }
         }
 

--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -131,7 +131,7 @@ namespace PowerLauncher.ViewModel
                 }
                 else
                 {
-                    MainWindowVisibility = Visibility.Collapsed;
+                    Hide();
                 }
             });
 
@@ -203,7 +203,7 @@ namespace PowerLauncher.ViewModel
                         // SelectedItem returns null if selection is empty.
                         if (result != null && result.Action != null)
                         {
-                            MainWindowVisibility = Visibility.Collapsed;
+                            Hide();
 
                             Application.Current.Dispatcher.Invoke(() =>
                             {
@@ -747,6 +747,14 @@ namespace PowerLauncher.ViewModel
                 {
                     MainWindowVisibility = Visibility.Collapsed;
                 }
+            }
+        }
+
+        public void Hide()
+        {
+            if (MainWindowVisibility != Visibility.Collapsed)
+            {
+                ToggleWox();
             }
         }
 

--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -727,7 +727,7 @@ namespace PowerLauncher.ViewModel
             });
         }
 
-        private void ToggleWox()
+        public void ToggleWox()
         {
             if (MainWindowVisibility != Visibility.Visible)
             {

--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -738,7 +738,6 @@ namespace PowerLauncher.ViewModel
                 if (_settings.ClearInputOnLaunch)
                 {
                     ClearQueryCommand.Execute(null);
-                    Results.Results.NotifyChanges();
                     Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.ApplicationIdle, new Action(() =>
                     {
                         MainWindowVisibility = Visibility.Collapsed;

--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -739,12 +739,15 @@ namespace PowerLauncher.ViewModel
                 {
                     ClearQueryCommand.Execute(null);
                     Results.Results.NotifyChanges();
+                    Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.ApplicationIdle, new Action(() =>
+                    {
+                        MainWindowVisibility = Visibility.Collapsed;
+                    }));
                 }
-
-                Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.ApplicationIdle, new Action(() =>
+                else
                 {
                     MainWindowVisibility = Visibility.Collapsed;
-                }));
+                }
             }
         }
 


### PR DESCRIPTION
## Summary of the Pull Request
Fix flicker on launching PT run when `clear_input_on_launch` is enabled and query before last hide was not empty.

## PR Checklist
* [x] Applies to #5616 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed

## Info on Pull Request
This PR makes following changes to fix this issue : 
1. Removes the code to clear searchbox and list view from `OnActivated` function to toggle function of hotkey manager.
2. Set `MainWindowVisibility` as `Visibility.Collapsed` when all dispatcher events have been processed. WPF application was being collapsed just after setting List view visibility to hidden, which prevented List view UI changes to be propagted as it was already hidden. These changes took place when List View was visible in next launch, causing flicker.

Note : The flicker is sometimes present if you hide and unhide very quickly.
## Validation Steps Performed
Manually validated that flicker is not observed on launcher PT Run when `clear_input_on_launch` is enabled.