### PR TITLE
Fix Null Reference exception in PT Settings

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/ViewModels/PowerLauncherViewModel.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/ViewModels/PowerLauncherViewModel.cs
@@ -22,41 +22,36 @@ namespace Microsoft.PowerToys.Settings.UI.Lib.ViewModels
 
         public PowerLauncherViewModel(Func<string, int> ipcMSGCallBackFunc, int defaultKeyCode)
         {
-            try
+            // set the callback functions value to hangle outgoing IPC message.
+            SendConfigMSG = ipcMSGCallBackFunc;
+
+            callback = (PowerLauncherSettings settings) =>
             {
-                callback = (PowerLauncherSettings settings) =>
-                {
-                    // Propagate changes to Power Launcher through IPC
-                    SendConfigMSG(
-                        string.Format("{{ \"powertoys\": {{ \"{0}\": {1} }} }}", PowerLauncherSettings.ModuleName, JsonSerializer.Serialize(settings)));
-                };
-                if (SettingsUtils.SettingsExists(PowerLauncherSettings.ModuleName))
-                {
-                    settings = SettingsUtils.GetSettings<PowerLauncherSettings>(PowerLauncherSettings.ModuleName);
-                }
-                else
-                {
-                    settings = new PowerLauncherSettings();
-                    settings.Properties.OpenPowerLauncher.Alt = true;
-                    settings.Properties.OpenPowerLauncher.Code = defaultKeyCode;
-                    settings.Properties.MaximumNumberOfResults = 4;
-                    callback(settings);
-                }
+                // Propagate changes to Power Launcher through IPC
+                SendConfigMSG(
+                    string.Format("{{ \"powertoys\": {{ \"{0}\": {1} }} }}", PowerLauncherSettings.ModuleName, JsonSerializer.Serialize(settings)));
+            };
 
-                if (SettingsUtils.SettingsExists())
-                {
-                    generalSettings = SettingsUtils.GetSettings<GeneralSettings>();
-                }
-                else
-                {
-                    generalSettings = new GeneralSettings();
-                }
-
-                // set the callback functions value to hangle outgoing IPC message.
-                SendConfigMSG = ipcMSGCallBackFunc;
+            if (SettingsUtils.SettingsExists(PowerLauncherSettings.ModuleName))
+            {
+                settings = SettingsUtils.GetSettings<PowerLauncherSettings>(PowerLauncherSettings.ModuleName);
             }
-            catch
+            else
             {
+                settings = new PowerLauncherSettings();
+                settings.Properties.OpenPowerLauncher.Alt = true;
+                settings.Properties.OpenPowerLauncher.Code = defaultKeyCode;
+                settings.Properties.MaximumNumberOfResults = 4;
+                callback(settings);
+            }
+
+            if (SettingsUtils.SettingsExists())
+            {
+                generalSettings = SettingsUtils.GetSettings<GeneralSettings>();
+            }
+            else
+            {
+                generalSettings = new GeneralSettings();
             }
         }
 


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

There was a null reference exception in the PT Run settings page which was causing it to crash.

## PR Checklist
* [x] Applies to #6457
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

Steps to repro the bug:
* Delete the settings.json file inside the PowerToys Run folder.
* Launch settings and try to open the PT Run settings page, it would cause settings to crash.

Reason as to why this was happening:
* The `sendConfigMSG` was being accessed in the callback without being initialized.
* This entire block of code was encapsulated in a try-catch block, hence the `generalSettings` variable was not being initialized. 
* When the page was loaded, the toggle switch got it's value from a binding to the `EnablePowerLauncher` variable which was set to `generalSettings.Enabled.PowerLauncher` but since this generalSettings was not initialized, a null reference exception was thrown.

Steps to fix it:
* The `sendConfigMSG` variable is initialized before being accessed in the callback. 
* The generic try-catch block was removed because there should not be any exceptions thrown. We are checking the existence of the settings file before accessing it, like done in the other view model files.

## Validation Steps Performed

_How does someone test & validate?_

* Deleted the settings.json file and ensured that settings does not crash.
* All settings test pass.
