### PR TITLE
[FancyZones] Introduce several fallback scenarios when obtaining GUID for current virtual desktop

### DIFF
--- a/src/modules/fancyzones/lib/VirtualDesktopUtils.cpp
+++ b/src/modules/fancyzones/lib/VirtualDesktopUtils.cpp
@@ -79,20 +79,34 @@ namespace VirtualDesktopUtils
 
     bool GetCurrentVirtualDesktopId(GUID* desktopId)
     {
-        if (!GetDesktopIdFromCurrentSession(desktopId))
+        // Explorer persists current virtual desktop identifier to registry on a per session basis, but only
+        // after first virtual desktop switch happens. If the user hasn't switched virtual desktops in this
+        // session, value in registry will be empty.
+        if (GetDesktopIdFromCurrentSession(desktopId))
         {
-            // Explorer persists current virtual desktop identifier to registry on a per session basis,
-            // but only after first virtual desktop switch happens. If the user hasn't switched virtual
-            // desktops (only primary desktop) in this session value in registry will be empty.
-            // If this value is empty take first element from array of virtual desktops (not kept per session).
-            std::vector<GUID> ids{};
-            if (!GetVirtualDesktopIds(ids) || ids.empty())
-            {
-                return false;
-            }
-            *desktopId = ids[0];
+            return true;
         }
-        return true;
+        // First fallback scenario is to try obtaining virtual desktop id through IVirtualDesktopManager
+        // interface. Use foreground window (the window with which the user is currently working) to determine
+        // current virtual desktop.
+        else if (GetWindowDesktopId(GetForegroundWindow(), desktopId))
+        {
+            return true;
+        }
+        // Second fallback scenario is to get array of virtual desktops stored in registry, but not kept per
+        // session. Note that we are taking first element from virtual desktop array, which is primary desktop.
+        // If user has more than one virtual desktop, one of previous functions should return correct value,
+        // as desktop switch occured in current session.
+        else
+        {
+            std::vector<GUID> ids{};
+            if (GetVirtualDesktopIds(ids) && ids.size() > 0)
+            {
+                *desktopId = ids[0];
+                return true;
+            }
+        }
+        return false;
     }
 
     bool GetVirtualDesktopIds(HKEY hKey, std::vector<GUID>& ids)


### PR DESCRIPTION
## Summary of the Pull Request

On a clean machine there is no information about virtual desktops in registry. Introduce several fallback scenarios when acquiring information about current virtual desktop to make sure we always have up to date information, and eliminate scenario of 0000 GUID appearing.

## PR Checklist
* [X] Applies to #6475
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

## Info on Pull Request

When acquiring information about virtual desktop try following things:
1. Get desktop identifier from current session (from registry `Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\SessionInfo\\<session-idx>\\VirtualDesktops`)
2. Use `IVirtualDesktopManager` [interface](https://docs.microsoft.com/en-us/windows/win32/api/shobjidl_core/nf-shobjidl_core-ivirtualdesktopmanager-getwindowdesktopid) and currently active window (foreground window).
3. Get array of virtual desktops from registry (not kept per session) `Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\VirtualDesktops\\VirtualDesktopIDs`

## Validation Steps Performed

1. Delete virtual desktop info from registry (both from current session info and from array). This information can be found on paths from above.
2. Make sure that _During zone layout changes, windows assign to a zone will match new size/positions_ and _Keep windows in their zones when the screen resolution changes_ are ON.
3. Start PowerToys, and check information in `C:\Users\<user-name>\AppData\Local\Microsoft\PowerToys\FancyZones\zones-settings.json`. There should be valid virtual desktop information.
4. Assign window to a zone, and modify taskbar position and zone layout. Assigned window position and size should be updated on every change.
5. Create new virtual desktop, and perform same checks. 
