### PR TITLE
[FancyZones] Do not zone window if it merges with other window

### DIFF
--- a/src/modules/fancyzones/lib/WindowMoveHandler.cpp
+++ b/src/modules/fancyzones/lib/WindowMoveHandler.cpp
@@ -173,12 +173,12 @@ bool WindowMoveHandler::MoveWindowIntoZoneByDirectionAndPosition(HWND window, DW
 
 void WindowMoveHandlerPrivate::MoveSizeStart(HWND window, HMONITOR monitor, POINT const& ptScreen, const std::unordered_map<HMONITOR, winrt::com_ptr<IZoneWindow>>& zoneWindowMap) noexcept
 {
-    m_moveSizeStartWindowInfo = FancyZonesUtils::GetFancyZonesWindowInfo(window);
     if (!FancyZonesUtils::IsCandidateForZoning(window, m_settings->GetSettings()->excludedAppsArray) || WindowMoveHandlerUtils::IsCursorTypeIndicatingSizeEvent())
     {
         return;
     }
 
+    m_moveSizeStartWindowInfo = FancyZonesUtils::GetFancyZonesWindowInfo(window);
     m_inMoveSize = true;
 
     auto iter = zoneWindowMap.find(monitor);
@@ -361,7 +361,7 @@ void WindowMoveHandlerPrivate::MoveSizeEnd(HWND window, POINT const& ptScreen, c
         }
         ::RemoveProp(window, ZonedWindowProperties::PropertyMultipleZoneID);
     }
-    
+
     m_inMoveSize = false;
     m_dragEnabled = false;
     m_mouseState = false;

--- a/src/modules/fancyzones/lib/WindowMoveHandler.cpp
+++ b/src/modules/fancyzones/lib/WindowMoveHandler.cpp
@@ -318,11 +318,10 @@ void WindowMoveHandlerPrivate::MoveSizeEnd(HWND window, POINT const& ptScreen, c
     {
         auto zoneWindow = std::move(m_zoneWindowMoveSize);
         ResetWindowTransparency();
+
         auto windowInfo = FancyZonesUtils::GetFancyZonesWindowInfo(window);
-        auto myTie = [](const FancyZonesUtils::FancyZonesWindowInfo& windowInfo) {
-            return std::tie(windowInfo.noVisibleOwner, windowInfo.processPath, windowInfo.standardWindow);
-        };
-        if (myTie(windowInfo) == myTie(m_moveSizeStartWindowInfo))
+        if (windowInfo.standardWindow == m_moveSizeStartWindowInfo.standardWindow &&
+            windowInfo.noVisibleOwner == m_moveSizeStartWindowInfo.noVisibleOwner)
         {
             zoneWindow->MoveSizeEnd(m_windowMoveSize, ptScreen);
         }

--- a/src/modules/fancyzones/lib/WindowMoveHandler.cpp
+++ b/src/modules/fancyzones/lib/WindowMoveHandler.cpp
@@ -320,8 +320,13 @@ void WindowMoveHandlerPrivate::MoveSizeEnd(HWND window, POINT const& ptScreen, c
         ResetWindowTransparency();
 
         auto windowInfo = FancyZonesUtils::GetFancyZonesWindowInfo(window);
-        if (windowInfo.standardWindow == m_moveSizeStartWindowInfo.standardWindow &&
-            windowInfo.noVisibleOwner == m_moveSizeStartWindowInfo.noVisibleOwner)
+
+        if (windowInfo.standardWindow == false && windowInfo.noVisibleOwner == false &&
+          m_moveSizeStartWindowInfo.standardWindow == true && m_moveSizeStartWindowInfo.noVisibleOwner == true)
+        {
+            // Abort the zoning, this is a Chromium based tab that is merged back with an existing window
+        }
+        else
         {
             zoneWindow->MoveSizeEnd(m_windowMoveSize, ptScreen);
         }

--- a/src/modules/fancyzones/lib/pch.h
+++ b/src/modules/fancyzones/lib/pch.h
@@ -21,7 +21,6 @@
 #include <functional>
 #include <unordered_set>
 #include <ShObjIdl.h>
-#include <tuple>
 
 #pragma comment(lib, "windowsapp")
 

--- a/src/modules/fancyzones/lib/pch.h
+++ b/src/modules/fancyzones/lib/pch.h
@@ -21,6 +21,7 @@
 #include <functional>
 #include <unordered_set>
 #include <ShObjIdl.h>
+#include <tuple>
 
 #pragma comment(lib, "windowsapp")
 


### PR DESCRIPTION
e.g. merge Chrome tab into other Chrome window

## Summary of the Pull Request

_What is this about?_
If some of the window properties changed while drag&drop (durring MoveSize* FZ methods), that means that window is merged with other window or changed in some other way. Therefore, that window shouldn't be zoned.

## PR Checklist
* [x] Applies to #3536 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx
