### PR TITLE
[FZ Editor] Improved a function in GridData.cs

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridData.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridData.cs
@@ -1028,23 +1028,12 @@ namespace FancyZonesEditor
             int totalDiff = total - 10000;
             if (totalDiff != 0)
             {
-                int perLineDiff = totalDiff / percents.Count;
-                int lastLineDiff = totalDiff - (perLineDiff * (percents.Count - 1));
-
-                for (int i = 0; i < percents.Count - 1 && perLineDiff != 0; i++)
+                for (int i = 0; i < percents.Count; i++)
                 {
-                    int percent = percents[i] - perLineDiff;
-                    if (percent < 0)
-                    {
-                        percent = 0;
-                    }
-
-                    percents[i] = percent;
-                    info[i].Percent = percent;
+                    int diffFraction = (totalDiff * (i + 1) / percents.Count) - (totalDiff * i / percents.Count);
+                    info[i].Percent -= diffFraction;
+                    percents[i] = info[i].Percent;
                 }
-
-                info[percents.Count - 1].Percent -= lastLineDiff;
-                percents[percents.Count - 1] -= lastLineDiff;
             }
         }
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridData.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridData.cs
@@ -1025,15 +1025,13 @@ namespace FancyZonesEditor
                 total += info[i].Percent;
             }
 
-            int totalDiff = total - 10000;
-            if (totalDiff != 0)
+            int prefixTotal = 0;
+            for (int i = 0; i < percents.Count; i++)
             {
-                for (int i = 0; i < percents.Count; i++)
-                {
-                    int diffFraction = (totalDiff * (i + 1) / percents.Count) - (totalDiff * i / percents.Count);
-                    info[i].Percent -= diffFraction;
-                    percents[i] = info[i].Percent;
-                }
+                int first = prefixTotal * 10000 / total;
+                prefixTotal += info[i].Percent;
+                int last = prefixTotal * 10000 / total;
+                percents[i] = info[i].Percent = last - first;
             }
         }
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridData.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridData.cs
@@ -12,6 +12,9 @@ namespace FancyZonesEditor
 {
     public class GridData
     {
+        // The sum of row/column percents should be equal to this number
+        private const int _multiplier = 10000;
+
         public class ResizeInfo
         {
             public ResizeInfo()
@@ -70,7 +73,7 @@ namespace FancyZonesEditor
                     total += info[i].Percent;
                 }
 
-                int diff = total - 10000;
+                int diff = total - _multiplier;
                 if (diff != 0)
                 {
                     TotalPercent -= diff;
@@ -1028,9 +1031,9 @@ namespace FancyZonesEditor
             int prefixTotal = 0;
             for (int i = 0; i < percents.Count; i++)
             {
-                int first = prefixTotal * 10000 / total;
+                int first = prefixTotal * _multiplier / total;
                 prefixTotal += info[i].Percent;
-                int last = prefixTotal * 10000 / total;
+                int last = prefixTotal * _multiplier / total;
                 percents[i] = info[i].Percent = last - first;
             }
         }


### PR DESCRIPTION
## Summary of the Pull Request

This should fix the problem described in #5319

## PR Checklist
* [x] Applies to #5319
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

Make sure that the sum of numbers after the call to `FixAccuracyError` is exactly 10000,
This PR won't fix existing layouts whose sum of percent values is not 10000. Perhaps I should also add this to the PR?

## Validation Steps Performed

Follow the scenario described in the issue.