### PR TITLE
To catch URI Format Exception in PT Run

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32Program.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32Program.cs
@@ -376,7 +376,17 @@ namespace Microsoft.Plugin.Program.Programs
                 if (line.StartsWith(urlPrefix, StringComparison.OrdinalIgnoreCase))
                 {
                     urlPath = line.Substring(urlPrefix.Length);
-                    Uri uri = new Uri(urlPath);
+
+                    try
+                    {
+                        Uri uri = new Uri(urlPath);
+                    }
+                    catch (UriFormatException e)
+                    {
+                        // To catch the exception if the uri cannot be parsed.
+                        ProgramLogger.LogException($"|Win32Program|InternetShortcutProgram|{urlPath}|url could not be parsed", e);
+                        return new Win32Program() { Valid = false, Enabled = false };
+                    }
 
                     // To filter out only those steam shortcuts which have 'run' or 'rungameid' as the hostname
                     if (internetShortcutURLPrefixes.Match(urlPath).Success)

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32Program.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32Program.cs
@@ -384,6 +384,7 @@ namespace Microsoft.Plugin.Program.Programs
                     catch (UriFormatException e)
                     {
                         // To catch the exception if the uri cannot be parsed.
+                        // Link to watson crash: https://watsonportal.microsoft.com/Failure?FailureSearchText=5f871ea7-e886-911f-1b31-131f63f6655b
                         ProgramLogger.LogException($"|Win32Program|InternetShortcutProgram|{urlPath}|url could not be parsed", e);
                         return new Win32Program() { Valid = false, Enabled = false };
                     }


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

This PR catches the URI Format Exception in PT Run when an internet shortcut program with an incorrect uri is created.

## PR Checklist
* [x] Applies to #6515
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

This crash was observed in watson: https://github.com/microsoft/PowerToys/issues/6515.
When an internet shortcut program (steam or epic games app) is installed with an incorrect url, this exception is thrown. The following changes catch this exception and return an invalid program so that it does not get added to PT Run.

Based on the following references, the url='url' is always in a single line. Hence an incorrect uri format is the only cause of this exception.

## Validation Steps Performed

_How does someone test & validate?_

Added a throw new UriFormatException() in the try block and ensured that the application does not crash.