### PR TITLE
Fix for ArgumentOutOfRange Exception in Result List

### DIFF
--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -507,6 +507,7 @@ namespace PowerLauncher.ViewModel
 
                                     currentCancellationToken.ThrowIfCancellationRequested();
                                     Results.Sort();
+                                    Results.SelectedItem = Results.Results[0];
                                 }
                             }
 
@@ -544,6 +545,7 @@ namespace PowerLauncher.ViewModel
 
                                                         currentCancellationToken.ThrowIfCancellationRequested();
                                                         Results.Sort();
+                                                        Results.SelectedItem = Results.Results[0];
                                                     }
                                                 }
 
@@ -599,7 +601,6 @@ namespace PowerLauncher.ViewModel
                     if (!isDelayedInvoke)
                     {
                         Results.SelectedIndex = 0;
-                        Results.SelectedItem = Results.Results[0];
                     }
                 }
                 else


### PR DESCRIPTION
## Summary of the Pull Request
Fix for ArgumentOutOfRange Exception caused to race condition in `Result` list.

## PR Checklist
* [x] Applies to #6544 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed

## Info on Pull Request
The issue is caused due to race condition in `Results` List. `Results.SelectedItem = Results.Results[0]` is required because it activates context menu, and context menu of the first item needs to be activated by default. It was called in `UpdateResultsListViewAfterQuery` function. But we can't use a lock inside `UpdateResultsListViewAfterQuery` as it runs on UI thread and would end up blocking it. Hence, to fix this issue `Results.SelectedItem` was moved to synchronized block in `QueryResults` function.

Note : The issue is not hit frequently but the information in call stack gives a clear indication of the underlying cause. 

## Validation Steps Performed
Validated that the cause of error is resolved based on the call stack in the issue.