### PR TITLE
[Keyboard Manager] Fix crash on closing and reopening Type UI

### DIFF
--- a/src/modules/keyboardmanager/common/KeyboardManagerState.cpp
+++ b/src/modules/keyboardmanager/common/KeyboardManagerState.cpp
@@ -240,7 +240,6 @@ void KeyboardManagerState::UpdateDetectShortcutUI()
     auto detectedShortcutCopy = detectedShortcut;
     currentShortcut_lock.unlock();
     detectedShortcut_lock.unlock();
-
     // Since this function is invoked from the back-end thread, in order to update the UI the dispatcher must be used.
     currentShortcutUI1.as<StackPanel>().Dispatcher().RunAsync(Windows::UI::Core::CoreDispatcherPriority::Normal, [this, detectedShortcutCopy]() {
         std::vector<hstring> shortcut = detectedShortcutCopy.GetKeyVector(keyboardMap);
@@ -419,6 +418,7 @@ void KeyboardManagerState::RegisterKeyDelay(
     {
         throw std::invalid_argument("This key was already registered.");
     }
+
     keyDelays[key] = std::make_unique<KeyDelay>(key, onShortPress, onLongPressDetected, onLongPressReleased);
 }
 
@@ -431,6 +431,13 @@ void KeyboardManagerState::UnregisterKeyDelay(DWORD key)
     {
         throw std::invalid_argument("The key was not previously registered.");
     }
+}
+
+// Function to clear all the registered key delays
+void KeyboardManagerState::ClearRegisteredKeyDelays()
+{
+    std::lock_guard l(keyDelays_mutex);
+    keyDelays.clear();
 }
 
 bool KeyboardManagerState::HandleKeyDelayEvent(LowlevelKeyboardEvent* ev)

--- a/src/modules/keyboardmanager/common/KeyboardManagerState.h
+++ b/src/modules/keyboardmanager/common/KeyboardManagerState.h
@@ -185,6 +185,9 @@ public:
     // NOTE*: the virtual key should represent the original, unmapped virtual key.
     void UnregisterKeyDelay(DWORD key);
 
+    // Function to clear all the registered key delays
+    void ClearRegisteredKeyDelays();
+
     // Handle a key event, for a delayed key.
     bool HandleKeyDelayEvent(LowlevelKeyboardEvent* ev);
 

--- a/src/modules/keyboardmanager/ui/EditKeyboardWindow.cpp
+++ b/src/modules/keyboardmanager/ui/EditKeyboardWindow.cpp
@@ -338,6 +338,7 @@ void createEditKeyboardWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMan
     hwndLock.lock();
     hwndEditKeyboardNativeWindow = nullptr;
     keyboardManagerState.ResetUIState();
+    keyboardManagerState.ClearRegisteredKeyDelays();
 
     // Cannot be done in WM_DESTROY because that causes crashes due to fatal app exit
     xamlBridge.ClearXamlIslands();

--- a/src/modules/keyboardmanager/ui/EditShortcutsWindow.cpp
+++ b/src/modules/keyboardmanager/ui/EditShortcutsWindow.cpp
@@ -322,6 +322,7 @@ void createEditShortcutsWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMa
     hwndLock.lock();
     hwndEditShortcutsNativeWindow = nullptr;
     keyboardManagerState.ResetUIState();
+    keyboardManagerState.ClearRegisteredKeyDelays();
 
     // Cannot be done in WM_DESTROY because that causes crashes due to fatal app exit
     xamlBridge.ClearXamlIslands();

--- a/src/modules/keyboardmanager/ui/ShortcutControl.cpp
+++ b/src/modules/keyboardmanager/ui/ShortcutControl.cpp
@@ -264,10 +264,7 @@ void ShortcutControl::createDetectShortcutWindow(winrt::Windows::Foundation::IIn
     StackPanel linkedShortcutStackPanel = KeyboardManagerHelper::getSiblingElement(sender).as<StackPanel>();
 
     auto unregisterKeys = [&keyboardManagerState]() {
-        std::thread t1(&KeyboardManagerState::UnregisterKeyDelay, &keyboardManagerState, VK_ESCAPE);
-        std::thread t2(&KeyboardManagerState::UnregisterKeyDelay, &keyboardManagerState, VK_RETURN);
-        t1.detach();
-        t2.detach();
+        keyboardManagerState.ClearRegisteredKeyDelays();
     };
 
     auto selectDetectedShortcutAndResetKeys = [&keyboardManagerState](DWORD key) {

--- a/src/modules/keyboardmanager/ui/SingleKeyRemapControl.cpp
+++ b/src/modules/keyboardmanager/ui/SingleKeyRemapControl.cpp
@@ -198,10 +198,7 @@ void SingleKeyRemapControl::createDetectKeyWindow(winrt::Windows::Foundation::II
     ComboBox linkedRemapDropDown = KeyboardManagerHelper::getSiblingElement(sender).as<ComboBox>();
 
     auto unregisterKeys = [&keyboardManagerState]() {
-        std::thread t1(&KeyboardManagerState::UnregisterKeyDelay, &keyboardManagerState, VK_ESCAPE);
-        std::thread t2(&KeyboardManagerState::UnregisterKeyDelay, &keyboardManagerState, VK_RETURN);
-        t1.detach();
-        t2.detach();
+        keyboardManagerState.ClearRegisteredKeyDelays();
     };
 
     auto onPressEnter = [linkedRemapDropDown,


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
This PR fixes a crash that would occur if you open close a KBM window while on the Type screen and re-open the Type window (easy to reproduce). It could also be possible to reproduce this if you're computer is running slow and you quickly close and re-open the Type window (hard to reproduce).

The exception was occurring because the RegisterKeyDelay method throws an exception if a key delay is already registered for that key (currently we use KeyDelay for Esc and Enter on the Type screen for hold enter/esc to dismiss). On closing the entire KBM window directly, the logic for unregistering the key delay handlers was not getting executed, so code has been added to clear these handlers on exiting either of the windows.

In the Type buttons the logic for unregistering the key delay was done by spawning two different threads however since this is a quick operation it makes more sense to perform it immediately as thread spawning cost would be higher, and this could also lead to the hard to repro scenario mentioned above.

## PR Checklist
* [X] Applies to #6555 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [X] Tests passed


## Validation Steps Performed

_How does someone test & validate?_
- Open Remap key window. Click Type, and close the Remap key window. Reopen Remap key and click Type again.
- Open Remap shortcuts window. Click Type, and close the Remap key window. Reopen Remap key and click Type again.