### PR TITLE
[PowerToys Run] Fix mouse click handler for PowerToys Run results

### DIFF
--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml
@@ -98,7 +98,7 @@
     </Grid> 
     <Window.InputBindings>
         <KeyBinding Key="Escape" Command="{Binding EscCommand}" />
-        <KeyBinding Key="Enter" Command="{Binding OpenResultCommand}" />
+        <KeyBinding Key="Enter" Command="{Binding OpenResultWithKeyboardCommand}" />
         <KeyBinding Modifiers="Alt" Key="F4" Command="{Binding IgnoreCommand}" />
     </Window.InputBindings>
 </Window>

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -110,7 +110,7 @@ namespace PowerLauncher
                 if (result is ResultViewModel resultVM)
                 {
                     _viewModel.Results.SelectedItem = resultVM;
-                    _viewModel.OpenResultCommand.Execute(null);
+                    _viewModel.OpenResultWithMouseCommand.Execute(null);
                 }
             }
         }

--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -118,6 +118,60 @@ namespace PowerLauncher.ViewModel
             }
         }
 
+        private void OpenResultsEvent(object index, bool isMouseClick)
+        {
+            var results = SelectedResults;
+
+            if (index != null)
+            {
+                results.SelectedIndex = int.Parse(index.ToString(), CultureInfo.InvariantCulture);
+            }
+
+            if (results.SelectedItem != null)
+            {
+                bool executeResultRequired = false;
+
+                if (isMouseClick)
+                {
+                    executeResultRequired = true;
+                }
+                else
+                {
+                    // If there is a context button selected fire the action for that button instead, and the main command will not be executed
+                    executeResultRequired = !results.SelectedItem.ExecuteSelectedContextButton();
+                }
+
+                if (executeResultRequired)
+                {
+                    var result = results.SelectedItem.Result;
+
+                    // SelectedItem returns null if selection is empty.
+                    if (result != null && result.Action != null)
+                    {
+                        MainWindowVisibility = Visibility.Collapsed;
+
+                        Application.Current.Dispatcher.Invoke(() =>
+                        {
+                            result.Action(new ActionContext
+                            {
+                                SpecialKeyState = KeyboardHelper.CheckModifiers(),
+                            });
+                        });
+
+                        if (SelectedIsFromQueryResults())
+                        {
+                            _userSelectedRecord.Add(result);
+                            _history.Add(result.OriginQuery.RawQuery);
+                        }
+                        else
+                        {
+                            SelectedResults = Results;
+                        }
+                    }
+                }
+            }
+        }
+
         private void InitializeKeyCommands()
         {
             IgnoreCommand = new RelayCommand(_ => { });
@@ -181,49 +235,14 @@ namespace PowerLauncher.ViewModel
                 Process.Start("https://aka.ms/PowerToys/");
             });
 
-            OpenResultCommand = new RelayCommand(index =>
+            OpenResultWithKeyboardCommand = new RelayCommand(index =>
             {
-                var results = SelectedResults;
+                OpenResultsEvent(index, false);
+            });
 
-                if (index != null)
-                {
-                    results.SelectedIndex = int.Parse(index.ToString(), CultureInfo.InvariantCulture);
-                }
-
-                if (results.SelectedItem != null)
-                {
-                    // If there is a context button selected fire the action for that button before the main command.
-                    bool didExecuteContextButton = results.SelectedItem.ExecuteSelectedContextButton();
-
-                    if (!didExecuteContextButton)
-                    {
-                        var result = results.SelectedItem.Result;
-
-                        // SelectedItem returns null if selection is empty.
-                        if (result != null && result.Action != null)
-                        {
-                            MainWindowVisibility = Visibility.Collapsed;
-
-                            Application.Current.Dispatcher.Invoke(() =>
-                            {
-                                result.Action(new ActionContext
-                                {
-                                    SpecialKeyState = KeyboardHelper.CheckModifiers(),
-                                });
-                            });
-
-                            if (SelectedIsFromQueryResults())
-                            {
-                                _userSelectedRecord.Add(result);
-                                _history.Add(result.OriginQuery.RawQuery);
-                            }
-                            else
-                            {
-                                SelectedResults = Results;
-                            }
-                        }
-                    }
-                }
+            OpenResultWithMouseCommand = new RelayCommand(index =>
+            {
+                OpenResultsEvent(index, true);
             });
 
             LoadContextMenuCommand = new RelayCommand(_ =>
@@ -391,7 +410,9 @@ namespace PowerLauncher.ViewModel
 
         public ICommand LoadHistoryCommand { get; set; }
 
-        public ICommand OpenResultCommand { get; set; }
+        public ICommand OpenResultWithKeyboardCommand { get; set; }
+
+        public ICommand OpenResultWithMouseCommand { get; set; }
 
         public ICommand ClearQueryCommand { get; set; }
 


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
This PR fixes the scenario mentioned in #3886 where left clicking a result while a context menu item has tab focus results in the context menu item getting executed.

## PR Checklist
* [X] Applies to #3886 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [X] Tests passed

## Info on Pull Request

_What does this include?_
- Modified the OpenResultCommand to use a function which takes a boolean argument `isMouseClick`. The command has been split into two commands i.e. OpenResultWithKeyboardCommand and OpenResultWithMouseCommand.
- `OpenResultCommand` reference in the MainWindow InputBindings has been replaced with the Keyboard variant
- `OpenResultCommand` reference in the MainWindow `SuggestionsList_PreviewMouseLeftButtonUp` event handler has been replaced with the Mouse variant
- If the `isMouseClick` argument is true, the step for executing the selected context menu button is skipped

## Validation Steps Performed

_How does someone test & validate?_
Manually validated with the following steps:
- Click a result normally with mouse
- Click each of the context menu buttons normally with mouse
- Select result/context menu items and run them with keyboard navigation and Enter
- Click a result with mouse while a context menu has tab focus
- Click a context menu item with mouse while another has tab focus
- Click a context menu item with mouse while result has focus