### PR TITLE
Fixed Visibility OnPropertyChanged getting invoked on clicking away from PT Run

### DIFF
--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -119,10 +119,10 @@ namespace PowerLauncher
         {
             if (e.PropertyName == nameof(MainViewModel.MainWindowVisibility))
             {
-                if (Visibility == System.Windows.Visibility.Visible)
+                if (Visibility == System.Windows.Visibility.Visible && _viewModel.MainWindowVisibility != Visibility.Hidden)
                 {
                     // Not called on first launch
-                    // Additionally called when deactivated by clicking on screen
+                    // Called when window is made visible by hotkey. Not called when the window is deactivated by clicking away
                     UpdatePosition();
                     BringProcessToForeground();
 


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
This PR fixes the issue of the OnPropertyChanged handler for MainWindowVisibility getting invoked when the user clicks away from PT Run. When a user clicks away this is invoked while the window Visibility is Visible and MainWindowVisibility gets changed to Hidden. This was causing a flicker when a user clicked away to another screen because UpdatePosition would get invoked. The rest of the function calls in this handler such as BringProcessToForeground do not make sense either when the window is getting hidden, so a check was added to avoid that scenario.

## PR Checklist
* [X] Applies to #4633
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [X] Tests passed


## Validation Steps Performed

_How does someone test & validate?_
- Run launcher and press the hotkey to show it and hide it. Validate that it gets focus even if an app like explorer was in the foreground.
- Switch mouse focus to another monitor and press Alt+Space to validate the same things above
- Use Alt+Space to make launcher appear and click away on the same monitor. Then hit Alt+Space again and validate everything in the first step
- Use Alt+Space to make launcher appear and click away on a different monitor. Validate that a flicker doesn't occur and hit Alt+Space and repeat first step.