### PR TITLE
Fix for null reference exception

### DIFF
--- a/src/modules/launcher/PowerLauncher/App.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/App.xaml.cs
@@ -173,13 +173,17 @@ namespace PowerLauncher
                     Log.Info("|App.OnExit| Start PowerToys Run Exit----------------------------------------------------  ");
                     if (disposing)
                     {
-                        _themeManager.ThemeChanged -= OnThemeChanged;
-                        API.SaveAppAllSettings();
+                        if (_themeManager != null)
+                        {
+                            _themeManager.ThemeChanged -= OnThemeChanged;
+                        }
+
+                        API?.SaveAppAllSettings();
                         PluginManager.Dispose();
-                        _mainWindow.Dispose();
-                        API.Dispose();
-                        _mainVM.Dispose();
-                        _themeManager.Dispose();
+                        _mainWindow?.Dispose();
+                        API?.Dispose();
+                        _mainVM?.Dispose();
+                        _themeManager?.Dispose();
                         _disposed = true;
                     }
 


### PR DESCRIPTION
## Summary of the Pull Request
Fix null reference exception in Powertoys `Dispose` function.

## PR Checklist
* [x] Applies to #6499 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed

## Info on Pull Request
PowerLauncher listens for `WM_CLOSE` event from runner to gracefully shut down WPF application. If the callback is invoked during `OnStartup` call in `App.xaml.xs`, `NullReferenceException` would be thrown since objects are not initialized.

Steps to repro : 
1. Call `Dispose` method right before [this](https://github.com/microsoft/PowerToys/blob/master/src/modules/launcher/PowerLauncher/App.xaml.cs#L83) line. 

## Validation Steps Performed
Manually validated that powertoys exits without any crash using above repro steps.