### PR TITLE
Added kill context (control+delete) to programs.

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/UWPApplication.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/UWPApplication.cs
@@ -191,6 +191,33 @@ namespace Microsoft.Plugin.Program.Programs
                 },
             });
 
+            if (Process.GetProcessesByName(Name).Any())
+            {
+                contextMenus.Add(
+                    new ContextMenuResult
+                    {
+                        PluginName = Assembly.GetExecutingAssembly().GetName().Name,
+                        Title = Properties.Resources.wox_plugin_program_kill_application,
+                        Glyph = "\xE945",
+                        FontFamily = "Segoe MDL2 Assets",
+                        AcceleratorKey = Key.Delete,
+                        AcceleratorModifiers = ModifierKeys.Control,
+                        Action = _ =>
+                        {
+                            try
+                            {
+                                Wox.Infrastructure.Helper.KillProcess(Name);
+                                return true;
+                            }
+                            catch (Exception e)
+                            {
+                                Log.Exception($"|Microsoft.Plugin.Program.Win32.ContextMenu| Failed to kill {Name}, {e.Message}", e);
+                                return false;
+                            }
+                        },
+                    });
+            }
+
             return contextMenus;
         }
 

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32Program.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32Program.cs
@@ -321,6 +321,33 @@ namespace Microsoft.Plugin.Program.Programs
                     },
                 });
 
+            if (Process.GetProcessesByName(Name).Any())
+            {
+                contextMenus.Add(
+                    new ContextMenuResult
+                    {
+                        PluginName = Assembly.GetExecutingAssembly().GetName().Name,
+                        Title = Properties.Resources.wox_plugin_program_kill_application,
+                        Glyph = "\xE945",
+                        FontFamily = "Segoe MDL2 Assets",
+                        AcceleratorKey = Key.Delete,
+                        AcceleratorModifiers = ModifierKeys.Control,
+                        Action = _ =>
+                        {
+                            try
+                            {
+                                Wox.Infrastructure.Helper.KillProcess(Name);
+                                return true;
+                            }
+                            catch (Exception e)
+                            {
+                                Log.Exception($"|Microsoft.Plugin.Program.Win32.ContextMenu| Failed to kill {Name}, {e.Message}", e);
+                                return false;
+                            }
+                        },
+                    });
+            }
+
             return contextMenus;
         }
 

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Properties/Resources.Designer.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Properties/Resources.Designer.cs
@@ -160,6 +160,15 @@ namespace Microsoft.Plugin.Program.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Kill all application with name (Ctrl+Delete).
+        /// </summary>
+        public static string wox_plugin_program_kill_application {
+            get {
+                return ResourceManager.GetString("wox_plugin_program_kill_application", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Open containing folder (Ctrl+Shift+E).
         /// </summary>
         public static string wox_plugin_program_open_containing_folder {

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Properties/Resources.resx
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Properties/Resources.resx
@@ -123,6 +123,9 @@
   <data name="wox_plugin_program_open_containing_folder" xml:space="preserve">
     <value>Open containing folder (Ctrl+Shift+E)</value>
   </data>
+  <data name="wox_plugin_program_kill_application" xml:space="preserve">
+    <value>Kill all application with name (Ctrl+Delete)</value>
+  </data>
   <data name="wox_plugin_program_open_in_console" xml:space="preserve">
     <value>Open path in console (Ctrl+Shift+C)</value>
   </data>

--- a/src/modules/launcher/Wox.Infrastructure/Helper.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Helper.cs
@@ -3,8 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Wox.Infrastructure.Logger;
@@ -108,6 +110,33 @@ namespace Wox.Infrastructure
             };
 
             return Process.Start(processStartInfo);
+        }
+
+        public static void KillProcess(string name)
+        {
+            var chromeDriverProcesses = Process.GetProcessesByName(name)
+                .Where(r => r.MainModule != null)
+                .ToArray();
+
+            var exceptions = new List<System.Exception>();
+
+            foreach (var process in chromeDriverProcesses)
+            {
+                try
+                {
+                    process.Kill();
+                }
+                catch (System.Exception e)
+                {
+                    Log.Exception($"|Wox.Infrastructure.Helpers|Failed to kill {name}, {e.Message}", e);
+                    exceptions.Add(e);
+                }
+            }
+
+            if (exceptions.Any())
+            {
+                throw new AggregateException(exceptions);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request

Adds a kill program in the context menu. Was a request, see #6084

## PR Checklist
* [x] Applies to #6084
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [x] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

I chose the lightning symbol for the kill, but I'm not sure if that is the right one. Icons I have found that could also apply

* **![LightningBolt](https://docs.microsoft.com/en-us/windows/uwp/design/style/images/segoe-mdl/e945.png) LightningBolt**
* ![Delete](https://docs.microsoft.com/en-us/windows/uwp/design/style/images/segoe-mdl/e74d.png) Delete
* ![EraseTool](https://docs.microsoft.com/en-us/windows/uwp/design/style/images/segoe-mdl/e75c.png) EraseTool
* ![PowerButton](https://docs.microsoft.com/en-us/windows/uwp/design/style/images/segoe-mdl/e7e8.png) PowerButton
* ![EndPoint](https://docs.microsoft.com/en-us/windows/uwp/design/style/images/segoe-mdl/e81b.png) EndPoint
* ![StatusCircleErrorX](https://docs.microsoft.com/en-us/windows/uwp/design/style/images/segoe-mdl/f13d.png) StatusCircleErrorX
* ![StatusCircleBlock](https://docs.microsoft.com/en-us/windows/uwp/design/style/images/segoe-mdl/f140.png) StatusCircleBlock
* ![CancelMedium](https://docs.microsoft.com/en-us/windows/uwp/design/style/images/segoe-mdl/f78a.png) CancelMedium

## Validation Steps Performed

Try the feature yourself. Search an program and kill it with the shortcut (control+delete) or click the button.

## Documentation update:

https://github.com/microsoft/PowerToys/wiki/PowerToys-Run-Overview#14-keyboard-shortcuts Add following markdown:

`|Ctrl+Delete | (Only applicable to applications) Kills every application with this name |`

## Propesed tags:

* Product-Launcher
* Run-Plugin
