### PR TITLE
[FancyZones] Do not zone window if it should be maximized

### DIFF
--- a/src/modules/fancyzones/lib/WindowMoveHandler.cpp
+++ b/src/modules/fancyzones/lib/WindowMoveHandler.cpp
@@ -56,7 +56,6 @@ namespace WindowMoveHandlerUtils
     // MoveSize related window properties
     struct MoveSizeWindowInfo
     {
-        WindowState windowState;
         // True if from the styles the window looks like a standard window
         bool standardWindow = false;
         // True if the window is a top-level window that does not have a visible owner
@@ -194,7 +193,6 @@ void WindowMoveHandlerPrivate::MoveSizeStart(HWND window, HMONITOR monitor, POIN
         return;
     }
 
-    m_moveSizeWindowInfo.windowState = get_window_state(window);
     m_moveSizeWindowInfo.noVisibleOwner = FancyZonesUtils::HasNoVisibleOwner(window);
     m_moveSizeWindowInfo.standardWindow = FancyZonesUtils::IsStandardWindow(window);
     m_inMoveSize = true;
@@ -343,7 +341,7 @@ void WindowMoveHandlerPrivate::MoveSizeEnd(HWND window, POINT const& ptScreen, c
 
         if ((isStandardWindow == false && hasNoVisibleOwnoer == false &&
              m_moveSizeWindowInfo.standardWindow == true && m_moveSizeWindowInfo.noVisibleOwner == true) ||
-            (m_moveSizeWindowInfo.windowState != WindowState::MAXIMIZED && windowState == WindowState::MAXIMIZED))
+            (windowState == WindowState::MAXIMIZED))
         {
             // Abort the zoning, this is a Chromium based tab that is merged back with an existing window
             // or if the window is maximized by Windows when the cursor hits the screen top border

--- a/src/modules/fancyzones/lib/WindowMoveHandler.cpp
+++ b/src/modules/fancyzones/lib/WindowMoveHandler.cpp
@@ -337,11 +337,10 @@ void WindowMoveHandlerPrivate::MoveSizeEnd(HWND window, POINT const& ptScreen, c
 
         bool hasNoVisibleOwnoer = FancyZonesUtils::HasNoVisibleOwner(window);
         bool isStandardWindow = FancyZonesUtils::IsStandardWindow(window);
-        auto windowState = get_window_state(window);
 
         if ((isStandardWindow == false && hasNoVisibleOwnoer == false &&
              m_moveSizeWindowInfo.standardWindow == true && m_moveSizeWindowInfo.noVisibleOwner == true) ||
-            (windowState == WindowState::MAXIMIZED))
+             FancyZonesUtils::IsWindowMaximized(window))
         {
             // Abort the zoning, this is a Chromium based tab that is merged back with an existing window
             // or if the window is maximized by Windows when the cursor hits the screen top border

--- a/src/modules/fancyzones/lib/WindowMoveHandler.cpp
+++ b/src/modules/fancyzones/lib/WindowMoveHandler.cpp
@@ -346,6 +346,7 @@ void WindowMoveHandlerPrivate::MoveSizeEnd(HWND window, POINT const& ptScreen, c
             (m_moveSizeWindowInfo.windowState != WindowState::MAXIMIZED && windowState == WindowState::MAXIMIZED))
         {
             // Abort the zoning, this is a Chromium based tab that is merged back with an existing window
+            // or if the window is maximized by Windows when the cursor hits the screen top border
         }
         else
         {

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -272,8 +272,7 @@ IFACEMETHODIMP ZoneWindow::MoveSizeEnd(HWND window, POINT const& ptScreen) noexc
         MapWindowPoints(nullptr, m_window.get(), &ptClient, 1);
         m_activeZoneSet->MoveWindowIntoZoneByIndexSet(window, m_window.get(), m_highlightZone);
 
-        auto windowInfo = FancyZonesUtils::GetFancyZonesWindowInfo(window);
-        if (windowInfo.noVisibleOwner)
+        if (FancyZonesUtils::HasNoVisibleOwner(window))
         {
             SaveWindowProcessToZoneIndex(window);
         }
@@ -307,8 +306,7 @@ ZoneWindow::MoveWindowIntoZoneByDirectionAndIndex(HWND window, DWORD vkCode, boo
     {
         if (m_activeZoneSet->MoveWindowIntoZoneByDirectionAndIndex(window, m_window.get(), vkCode, cycle))
         {
-            auto windowInfo = FancyZonesUtils::GetFancyZonesWindowInfo(window);
-            if (windowInfo.noVisibleOwner)
+            if (FancyZonesUtils::HasNoVisibleOwner(window))
             {
                 SaveWindowProcessToZoneIndex(window);
             }

--- a/src/modules/fancyzones/lib/util.cpp
+++ b/src/modules/fancyzones/lib/util.cpp
@@ -18,26 +18,6 @@ namespace NonLocalizable
 
 namespace
 {
-    bool HasNoVisibleOwner(HWND window) noexcept
-    {
-        auto owner = GetWindow(window, GW_OWNER);
-        if (owner == nullptr)
-        {
-            return true; // There is no owner at all
-        }
-        if (!IsWindowVisible(owner))
-        {
-            return true; // Owner is invisible
-        }
-        RECT rect;
-        if (!GetWindowRect(owner, &rect))
-        {
-            return false; // Could not get the rect, return true (and filter out the window) just in case
-        }
-        // It is enough that the window is zero-sized in one dimension only.
-        return rect.top == rect.bottom || rect.left == rect.right;
-    }
-
     bool IsZonableByProcessPath(const std::wstring& processPath, const std::vector<std::wstring>& excludedApps)
     {
         // Filter out user specified apps
@@ -201,12 +181,31 @@ namespace FancyZonesUtils
         ::SetWindowPlacement(window, &placement);
     }
 
-    FancyZonesWindowInfo GetFancyZonesWindowInfo(HWND window)
+    bool HasNoVisibleOwner(HWND window) noexcept
     {
-        FancyZonesWindowInfo result;
+        auto owner = GetWindow(window, GW_OWNER);
+        if (owner == nullptr)
+        {
+            return true; // There is no owner at all
+        }
+        if (!IsWindowVisible(owner))
+        {
+            return true; // Owner is invisible
+        }
+        RECT rect;
+        if (!GetWindowRect(owner, &rect))
+        {
+            return false; // Could not get the rect, return true (and filter out the window) just in case
+        }
+        // It is enough that the window is zero-sized in one dimension only.
+        return rect.top == rect.bottom || rect.left == rect.right;
+    }
+
+    bool IsStandardWindow(HWND window)
+    {
         if (GetAncestor(window, GA_ROOT) != window || !IsWindowVisible(window))
         {
-            return result;
+            return false;
         }
         auto style = GetWindowLong(window, GWL_STYLE);
         auto exStyle = GetWindowLong(window, GWL_EXSTYLE);
@@ -217,56 +216,51 @@ namespace FancyZonesUtils
             (style & WS_MINIMIZEBOX) == 0 &&
             (style & WS_MAXIMIZEBOX) == 0)
         {
-            return result;
+            return false;
         }
         if ((style & WS_CHILD) == WS_CHILD ||
             (style & WS_DISABLED) == WS_DISABLED ||
             (exStyle & WS_EX_TOOLWINDOW) == WS_EX_TOOLWINDOW ||
             (exStyle & WS_EX_NOACTIVATE) == WS_EX_NOACTIVATE)
         {
-            return result;
+            return false;
         }
         std::array<char, 256> class_name;
         GetClassNameA(window, class_name.data(), static_cast<int>(class_name.size()));
         if (is_system_window(window, class_name.data()))
         {
-            return result;
+            return false;
         }
         auto process_path = get_process_path(window);
         // Check for Cortana:
         if (strcmp(class_name.data(), "Windows.UI.Core.CoreWindow") == 0 &&
             process_path.ends_with(L"SearchUI.exe"))
         {
-            return result;
+            return false;
         }
-        result.processPath = std::move(process_path);
-        result.standardWindow = true;
-        result.noVisibleOwner = HasNoVisibleOwner(window);
-        return result;
+
+        return true;
     }
 
     bool IsCandidateForLastKnownZone(HWND window, const std::vector<std::wstring>& excludedApps) noexcept
     {
-        auto windowInfo = GetFancyZonesWindowInfo(window);
-        auto zonable = windowInfo.standardWindow && windowInfo.noVisibleOwner;
+        auto zonable = IsStandardWindow(window) && HasNoVisibleOwner(window);
         if (!zonable)
         {
             return false;
         }
 
-        return IsZonableByProcessPath(windowInfo.processPath, excludedApps);
+        return IsZonableByProcessPath(get_process_path(window), excludedApps);
     }
 
     bool IsCandidateForZoning(HWND window, const std::vector<std::wstring>& excludedApps) noexcept
     {
-        auto windowInfo = GetFancyZonesWindowInfo(window);
-
-        if (!windowInfo.standardWindow)
+        if (!IsStandardWindow(window))
         {
             return false;
         }
 
-        return IsZonableByProcessPath(windowInfo.processPath, excludedApps);
+        return IsZonableByProcessPath(get_process_path(window), excludedApps);
     }
 
     bool IsWindowMaximized(HWND window) noexcept

--- a/src/modules/fancyzones/lib/util.h
+++ b/src/modules/fancyzones/lib/util.h
@@ -5,17 +5,6 @@
 
 namespace FancyZonesUtils
 {
-    // Window properties relevant to FancyZones
-    struct FancyZonesWindowInfo
-    {
-        // True if from the styles the window looks like a standard window
-        bool standardWindow = false;
-        // True if the window is a top-level window that does not have a visible owner
-        bool noVisibleOwner = false;
-        // Path to the executable owning the window
-        std::wstring processPath;
-    };
-
     struct Rect
     {
         Rect() {}
@@ -200,7 +189,8 @@ namespace FancyZonesUtils
     void OrderMonitors(std::vector<std::pair<HMONITOR, RECT>>& monitorInfo);
     void SizeWindowToRect(HWND window, RECT rect) noexcept;
 
-    FancyZonesWindowInfo GetFancyZonesWindowInfo(HWND window);
+    bool HasNoVisibleOwner(HWND window) noexcept;
+    bool IsStandardWindow(HWND window);
     bool IsCandidateForLastKnownZone(HWND window, const std::vector<std::wstring>& excludedApps) noexcept;
     bool IsCandidateForZoning(HWND window, const std::vector<std::wstring>& excludedApps) noexcept;
 


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
This prevents Windows' maximize window feature colliding with FZ.
When there is a zone which top edge is touching screen' top edge, trying to maximize the window by dragging it to the top edge of the screen ended up with zoning the window instead of maximizing it.

This PR fixes this.

## PR Checklist
* [x] Applies to #5182 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Validation Steps Performed

_How does someone test & validate?_
1. Disable FZ 'Hold Shift key to activate zones while dragging' option
2. Create custom layout which one of the zones is placed on the screen' top (touching screen' top edge)
3. Try to maximize some window by dragging it to the top of the screen in the area where the zone mention in #2 is touching the top edge of the screen
4. Release the window and confirm that window is maximized