### PR TITLE
[FancyZones] Remove migration from registry logic and delete registry data if present

### DIFF
--- a/src/modules/fancyzones/lib/FancyZonesData.cpp
+++ b/src/modules/fancyzones/lib/FancyZonesData.cpp
@@ -62,22 +62,16 @@ namespace
 
     bool DeleteRegistryKey(HKEY hKeyRoot, LPTSTR lpSubKey)
     {
-        // First, see if we can delete the key without having
-        // to recurse.
-        auto result = RegDeleteKey(hKeyRoot, lpSubKey);
-
-        if (result == ERROR_SUCCESS)
+        // First, see if we can delete the key without having to recurse.
+        if (ERROR_SUCCESS == RegDeleteKey(hKeyRoot, lpSubKey))
         {
             return true;
         }
 
         HKEY hKey;
-        result = RegOpenKeyEx(hKeyRoot, lpSubKey, 0, KEY_READ, &hKey);
-
-        if (result != ERROR_SUCCESS)
+        if (ERROR_SUCCESS != RegOpenKeyEx(hKeyRoot, lpSubKey, 0, KEY_READ, &hKey))
         {
-            // Error opening key
-            return FALSE;
+            return false;
         }
 
         // Check for an ending slash and add one if it is missing.
@@ -95,7 +89,7 @@ namespace
         DWORD dwSize = MAX_PATH;
         TCHAR szName[MAX_PATH];
         FILETIME ftWrite;
-        result = RegEnumKeyEx(hKey, 0, szName, &dwSize, NULL, NULL, NULL, &ftWrite);
+        auto result = RegEnumKeyEx(hKey, 0, szName, &dwSize, NULL, NULL, NULL, &ftWrite);
 
         if (result == ERROR_SUCCESS)
         {
@@ -120,9 +114,7 @@ namespace
         RegCloseKey(hKey);
 
         // Try again to delete the root key.
-        result = RegDeleteKey(hKeyRoot, lpSubKey);
-
-        if (result == ERROR_SUCCESS)
+        if (ERROR_SUCCESS == RegDeleteKey(hKeyRoot, lpSubKey))
         {
             return true;
         }
@@ -136,10 +128,8 @@ namespace
         StringCchPrintf(key, ARRAYSIZE(key), L"%s", NonLocalizable::RegistryPath);
 
         HKEY hKey;
-        auto result = RegOpenKeyEx(HKEY_CURRENT_USER, key, 0, KEY_READ, &hKey);
-        if (result == ERROR_FILE_NOT_FOUND)
+        if (ERROR_FILE_NOT_FOUND == RegOpenKeyEx(HKEY_CURRENT_USER, key, 0, KEY_READ, &hKey))
         {
-            // Key not found
             return true;
         }
         else

--- a/src/modules/fancyzones/lib/FancyZonesData.cpp
+++ b/src/modules/fancyzones/lib/FancyZonesData.cpp
@@ -20,7 +20,6 @@
 namespace NonLocalizable
 {
     const wchar_t FancyZonesStr[] = L"FancyZones";
-    const wchar_t LayoutsStr[] = L"Layouts";
     const wchar_t NullStr[] = L"null";
 
     const wchar_t FancyZonesDataFile[] = L"zones-settings.json";
@@ -59,6 +58,94 @@ namespace
         });
 
         return tmpDirPath;
+    }
+
+    bool DeleteRegistryKey(HKEY hKeyRoot, LPTSTR lpSubKey)
+    {
+        // First, see if we can delete the key without having
+        // to recurse.
+        auto result = RegDeleteKey(hKeyRoot, lpSubKey);
+
+        if (result == ERROR_SUCCESS)
+        {
+            return true;
+        }
+
+        HKEY hKey;
+        result = RegOpenKeyEx(hKeyRoot, lpSubKey, 0, KEY_READ, &hKey);
+
+        if (result != ERROR_SUCCESS)
+        {
+            // Error opening key
+            return FALSE;
+        }
+
+        // Check for an ending slash and add one if it is missing.
+        LPTSTR lpEnd = lpSubKey + lstrlen(lpSubKey);
+
+        if (*(lpEnd - 1) != TEXT('\\'))
+        {
+            *lpEnd = TEXT('\\');
+            lpEnd++;
+            *lpEnd = TEXT('\0');
+        }
+
+        // Enumerate the keys
+
+        DWORD dwSize = MAX_PATH;
+        TCHAR szName[MAX_PATH];
+        FILETIME ftWrite;
+        result = RegEnumKeyEx(hKey, 0, szName, &dwSize, NULL, NULL, NULL, &ftWrite);
+
+        if (result == ERROR_SUCCESS)
+        {
+            do
+            {
+                *lpEnd = TEXT('\0');
+                StringCchCat(lpSubKey, MAX_PATH * 2, szName);
+
+                if (!DeleteRegistryKey(hKeyRoot, lpSubKey))
+                {
+                    break;
+                }
+
+                dwSize = MAX_PATH;
+                result = RegEnumKeyEx(hKey, 0, szName, &dwSize, NULL, NULL, NULL, &ftWrite);
+            } while (result == ERROR_SUCCESS);
+        }
+
+        lpEnd--;
+        *lpEnd = TEXT('\0');
+
+        RegCloseKey(hKey);
+
+        // Try again to delete the root key.
+        result = RegDeleteKey(hKeyRoot, lpSubKey);
+
+        if (result == ERROR_SUCCESS)
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    bool DeleteFancyZonesRegistryData()
+    {
+        wchar_t key[256];
+        StringCchPrintf(key, ARRAYSIZE(key), L"%s", NonLocalizable::RegistryPath);
+
+        HKEY hKey;
+        auto result = RegOpenKeyEx(HKEY_CURRENT_USER, key, 0, KEY_READ, &hKey);
+        if (result == ERROR_FILE_NOT_FOUND)
+        {
+            // Key not found
+            return true;
+        }
+        else
+        {
+            return DeleteRegistryKey(HKEY_CURRENT_USER, key);
+        }
     }
 }
 
@@ -371,9 +458,9 @@ bool FancyZonesData::SetAppLastZones(HWND window, const std::wstring& deviceId, 
     std::unordered_map<DWORD, HWND> processIdToHandleMap{};
     processIdToHandleMap[processId] = window;
     FancyZonesDataTypes::AppZoneHistoryData data{ .processIdToHandleMap = processIdToHandleMap,
-                                                    .zoneSetUuid = zoneSetId,
-                                                    .deviceId = deviceId,
-                                                    .zoneIndexSet = zoneIndexSet };
+                                                  .zoneSetUuid = zoneSetId,
+                                                  .deviceId = deviceId,
+                                                  .zoneIndexSet = zoneIndexSet };
 
     if (appZoneHistoryMap.contains(processPath))
     {
@@ -463,7 +550,6 @@ void FancyZonesData::LoadFancyZonesData()
 {
     if (!std::filesystem::exists(zonesSettingsFileName))
     {
-        MigrateCustomZoneSetsFromRegistry();
         SaveFancyZonesData();
     }
     else
@@ -474,118 +560,18 @@ void FancyZonesData::LoadFancyZonesData()
         deviceInfoMap = JSONHelpers::ParseDeviceInfos(fancyZonesDataJSON);
         customZoneSetsMap = JSONHelpers::ParseCustomZoneSets(fancyZonesDataJSON);
     }
+
+    DeleteFancyZonesRegistryData();
 }
 
 void FancyZonesData::SaveFancyZonesData() const
 {
     std::scoped_lock lock{ dataLock };
     JSONHelpers::SaveFancyZonesData(zonesSettingsFileName,
-									appZoneHistoryFileName,
-									deviceInfoMap,
-									customZoneSetsMap,
-									appZoneHistoryMap);
-}
-
-void FancyZonesData::MigrateCustomZoneSetsFromRegistry()
-{
-    std::scoped_lock lock{ dataLock };
-    wchar_t key[256];
-    StringCchPrintf(key, ARRAYSIZE(key), L"%s\\%s", NonLocalizable::RegistryPath, NonLocalizable::LayoutsStr);
-    HKEY hkey;
-    if (RegOpenKeyExW(HKEY_CURRENT_USER, key, 0, KEY_ALL_ACCESS, &hkey) == ERROR_SUCCESS)
-    {
-        BYTE data[256];
-        DWORD dataSize = ARRAYSIZE(data);
-        wchar_t value[256]{};
-        DWORD valueLength = ARRAYSIZE(value);
-        DWORD i = 0;
-        while (RegEnumValueW(hkey, i++, value, &valueLength, nullptr, nullptr, reinterpret_cast<BYTE*>(&data), &dataSize) == ERROR_SUCCESS)
-        {
-            FancyZonesDataTypes::CustomZoneSetData zoneSetData;
-            zoneSetData.name = std::wstring{ value };
-            zoneSetData.type = static_cast<FancyZonesDataTypes::CustomLayoutType>(data[2]);
-
-            GUID guid;
-            auto result = CoCreateGuid(&guid);
-            if (result != S_OK)
-            {
-                continue;
-            }
-            wil::unique_cotaskmem_string guidString;
-            if (!SUCCEEDED(StringFromCLSID(guid, &guidString)))
-            {
-                continue;
-            }
-
-            std::wstring uuid = guidString.get();
-
-            switch (zoneSetData.type)
-            {
-            case FancyZonesDataTypes::CustomLayoutType::Grid:
-            {
-                // Visit https://github.com/microsoft/PowerToys/blob/v0.14.0/src/modules/fancyzones/editor/FancyZonesEditor/Models/GridLayoutModel.cs#L183
-                // To see how custom Grid layout was packed in registry
-                int j = 5;
-                FancyZonesDataTypes::GridLayoutInfo zoneSetInfo(FancyZonesDataTypes::GridLayoutInfo::Minimal{ .rows = data[j++], .columns = data[j++] });
-
-                for (int row = 0; row < zoneSetInfo.rows(); row++, j += 2)
-                {
-                    zoneSetInfo.rowsPercents()[row] = data[j] * 256 + data[j + 1];
-                }
-
-                for (int col = 0; col < zoneSetInfo.columns(); col++, j += 2)
-                {
-                    zoneSetInfo.columnsPercents()[col] = data[j] * 256 + data[j + 1];
-                }
-
-                for (int row = 0; row < zoneSetInfo.rows(); row++)
-                {
-                    for (int col = 0; col < zoneSetInfo.columns(); col++)
-                    {
-                        zoneSetInfo.cellChildMap()[row][col] = data[j++];
-                    }
-                }
-                zoneSetData.info = zoneSetInfo;
-                break;
-            }
-            case FancyZonesDataTypes::CustomLayoutType::Canvas:
-            {
-                // Visit https://github.com/microsoft/PowerToys/blob/v0.14.0/src/modules/fancyzones/editor/FancyZonesEditor/Models/CanvasLayoutModel.cs#L128
-                // To see how custom Canvas layout was packed in registry
-                int j = 5;
-                FancyZonesDataTypes::CanvasLayoutInfo info;
-                info.lastWorkAreaWidth = data[j] * 256 + data[j + 1];
-                j += 2;
-                info.lastWorkAreaHeight = data[j] * 256 + data[j + 1];
-                j += 2;
-
-                int count = data[j++];
-                info.zones.reserve(count);
-                while (count-- > 0)
-                {
-                    int x = data[j] * 256 + data[j + 1];
-                    j += 2;
-                    int y = data[j] * 256 + data[j + 1];
-                    j += 2;
-                    int width = data[j] * 256 + data[j + 1];
-                    j += 2;
-                    int height = data[j] * 256 + data[j + 1];
-                    j += 2;
-                    info.zones.push_back(FancyZonesDataTypes::CanvasLayoutInfo::Rect{
-                        x, y, width, height });
-                }
-                zoneSetData.info = info;
-                break;
-            }
-            default:
-                continue;
-            }
-            customZoneSetsMap[uuid] = zoneSetData;
-
-            valueLength = ARRAYSIZE(value);
-            dataSize = ARRAYSIZE(data);
-        }
-    }
+                                    appZoneHistoryFileName,
+                                    deviceInfoMap,
+                                    customZoneSetsMap,
+                                    appZoneHistoryMap);
 }
 
 void FancyZonesData::RemoveDesktopAppZoneHistory(const std::wstring& desktopId)

--- a/src/modules/fancyzones/lib/FancyZonesData.h
+++ b/src/modules/fancyzones/lib/FancyZonesData.h
@@ -116,7 +116,6 @@ private:
     void ParseCustomZoneSetFromTmpFile(std::wstring_view tmpFilePath);
     void ParseDeletedCustomZoneSetsFromTmpFile(std::wstring_view tmpFilePath);
 
-    void MigrateCustomZoneSetsFromRegistry();
     void RemoveDesktopAppZoneHistory(const std::wstring& desktopId);
 
     // Maps app path to app's zone history data


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
Do not migrate custom layouts from registry on first PowerToys run. Also, if FancyZones registry data is present in registry, delete it.

## PR Checklist
* [x] Applies to https://github.com/microsoft/PowerToys/issues/6659
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Validation Steps Performed

_How does someone test & validate?_
Scenario #1
1. Delete FancyZones JSON files
2. Confirm that there is some FancyZones data present in registry (Layouts subkey)
3, Start PowerToys
4. Open FancyZones JSON files and confirm that no data was migrated from registry

Scenario #2
1. Start PT with FZ enabled
2. (If there was any FZ data in registry) Confirm that SuperFancyZones registry key is deleted 