### PR TITLE
[Keyboard Manager] Fix focusable elements should have different names accessibility issue

### DIFF
--- a/src/modules/keyboardmanager/dll/Resources.resx
+++ b/src/modules/keyboardmanager/dll/Resources.resx
@@ -276,10 +276,7 @@
   <data name="Delete_Remapping_Button" xml:space="preserve">
     <value>Delete Remapping</value>
   </data>
-  <data name="Remapped_To" xml:space="preserve">
-    <value>Remapped To</value>
-  </data>
-  <data name="Target_Application" xml:space="preserve">
-    <value>For Target Application </value>
+  <data name="AutomationProperties_Row" xml:space="preserve">
+    <value>Row </value>
   </data>
 </root>

--- a/src/modules/keyboardmanager/ui/EditKeyboardWindow.cpp
+++ b/src/modules/keyboardmanager/ui/EditKeyboardWindow.cpp
@@ -217,18 +217,11 @@ void createEditKeyboardWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMan
     keyRemapTable.ColumnDefinitions().Append(removeColumn);
     keyRemapTable.RowDefinitions().Append(RowDefinition());
 
-    ListView keyRemapListView;
-    keyRemapListView.CanDragItems(false);
-    keyRemapListView.CanReorderItems(false);
-    keyRemapListView.IsSwipeEnabled(false);
-    keyRemapListView.SelectionMode(ListViewSelectionMode::None);
-
     // First header textblock in the header row of the keys remap table
     TextBlock originalKeyRemapHeader;
     originalKeyRemapHeader.Text(GET_RESOURCE_STRING(IDS_EDITKEYBOARD_SOURCEHEADER));
     originalKeyRemapHeader.FontWeight(Text::FontWeights::Bold());
     originalKeyRemapHeader.Margin({ 0, 0, 0, 10 });
-    keyRemapListView.Items().Append(box_value(L"LMAO"));
 
     // Second header textblock in the header row of the keys remap table
     TextBlock newKeyRemapHeader;
@@ -312,7 +305,6 @@ void createEditKeyboardWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMan
     StackPanel mappingsPanel;
     mappingsPanel.Children().Append(keyRemapInfoHeader);
     mappingsPanel.Children().Append(keyRemapInfoExample);
-    mappingsPanel.Children().Append(keyRemapListView);
     mappingsPanel.Children().Append(keyRemapTable);
     mappingsPanel.Children().Append(addRemapKey);
 

--- a/src/modules/keyboardmanager/ui/EditKeyboardWindow.cpp
+++ b/src/modules/keyboardmanager/ui/EditKeyboardWindow.cpp
@@ -217,11 +217,18 @@ void createEditKeyboardWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMan
     keyRemapTable.ColumnDefinitions().Append(removeColumn);
     keyRemapTable.RowDefinitions().Append(RowDefinition());
 
+    ListView keyRemapListView;
+    keyRemapListView.CanDragItems(false);
+    keyRemapListView.CanReorderItems(false);
+    keyRemapListView.IsSwipeEnabled(false);
+    keyRemapListView.SelectionMode(ListViewSelectionMode::None);
+
     // First header textblock in the header row of the keys remap table
     TextBlock originalKeyRemapHeader;
     originalKeyRemapHeader.Text(GET_RESOURCE_STRING(IDS_EDITKEYBOARD_SOURCEHEADER));
     originalKeyRemapHeader.FontWeight(Text::FontWeights::Bold());
     originalKeyRemapHeader.Margin({ 0, 0, 0, 10 });
+    keyRemapListView.Items().Append(box_value(L"LMAO"));
 
     // Second header textblock in the header row of the keys remap table
     TextBlock newKeyRemapHeader;
@@ -305,6 +312,7 @@ void createEditKeyboardWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMan
     StackPanel mappingsPanel;
     mappingsPanel.Children().Append(keyRemapInfoHeader);
     mappingsPanel.Children().Append(keyRemapInfoExample);
+    mappingsPanel.Children().Append(keyRemapListView);
     mappingsPanel.Children().Append(keyRemapTable);
     mappingsPanel.Children().Append(addRemapKey);
 

--- a/src/modules/keyboardmanager/ui/KeyDropDownControl.cpp
+++ b/src/modules/keyboardmanager/ui/KeyDropDownControl.cpp
@@ -36,13 +36,14 @@ void KeyDropDownControl::SetDefaultProperties(bool isShortcut)
     // Attach flyout to the drop down
     warningFlyout.as<Flyout>().Content(warningMessage.as<TextBlock>());
     dropDown.as<ComboBox>().ContextFlyout().SetAttachedFlyout((FrameworkElement)dropDown.as<ComboBox>(), warningFlyout.as<Flyout>());
-    // To set the accessible name of the combo-box
+    // To set the accessible name of the combo-box (by default index 1)
     SetAccessibleNameForComboBox(dropDown.as<ComboBox>(), 1);
 }
 
 // Function to set accessible name for combobox
 void KeyDropDownControl::SetAccessibleNameForComboBox(ComboBox dropDown, int index)
 {
+    // Display name with drop down index (where this indexing will start from 1) - Used by narrator
     dropDown.SetValue(Automation::AutomationProperties::NameProperty(), box_value(GET_RESOURCE_STRING(IDS_KEY_DROPDOWN_COMBOBOX) + L" " + std::to_wstring(index)));
 }
 
@@ -159,7 +160,7 @@ std::pair<KeyboardManagerHelper::ErrorType, int> KeyDropDownControl::ValidateSho
             for (uint32_t i = dropDownIndex + 1; i < keyDropDownControlObjects.size(); i++)
             {
                 // Update accessible name (row index will become i-1 for this element, so the display name would be i (display name indexing from 1)
-                SetAccessibleNameForComboBox(keyDropDownControlObjects[i]->GetComboBox(), i);            
+                SetAccessibleNameForComboBox(keyDropDownControlObjects[i]->GetComboBox(), i);
             }
 
             parent.Children().RemoveAt(dropDownIndex);

--- a/src/modules/keyboardmanager/ui/KeyDropDownControl.cpp
+++ b/src/modules/keyboardmanager/ui/KeyDropDownControl.cpp
@@ -67,7 +67,8 @@ void KeyDropDownControl::SetSelectionHandler(Grid& table, StackPanel singleKeyCo
         bool indexFound = table.Children().IndexOf(singleKeyControl, controlIndex);
         if (indexFound)
         {
-            int rowIndex = (controlIndex - KeyboardManagerConstants::RemapTableHeaderCount) / KeyboardManagerConstants::RemapTableColCount;
+            // GetRow will give the row index including the table header
+            int rowIndex = table.GetRow(singleKeyControl) - 1;
 
             // Validate current remap selection
             KeyboardManagerHelper::ErrorType errorType = BufferValidationHelpers::ValidateAndUpdateKeyBufferElement(rowIndex, colIndex, selectedKeyIndex, keyCodeList, singleKeyRemapBuffer);
@@ -109,14 +110,8 @@ std::pair<KeyboardManagerHelper::ErrorType, int> KeyDropDownControl::ValidateSho
 
     if (controlIindexFound)
     {
-        if (isSingleKeyWindow)
-        {
-            rowIndex = (controlIndex - KeyboardManagerConstants::RemapTableHeaderCount) / KeyboardManagerConstants::RemapTableColCount;
-        }
-        else
-        {
-            rowIndex = (controlIndex - KeyboardManagerConstants::ShortcutTableHeaderCount) / KeyboardManagerConstants::ShortcutTableColCount;
-        }
+        // GetRow will give the row index including the table header
+        rowIndex = table.GetRow(shortcutControl) - 1;
 
         std::vector<int32_t> selectedIndices = GetSelectedIndicesFromStackPanel(parent);
 

--- a/src/modules/keyboardmanager/ui/KeyDropDownControl.h
+++ b/src/modules/keyboardmanager/ui/KeyDropDownControl.h
@@ -45,6 +45,9 @@ private:
     // Function to check if the layout has changed and accordingly update the drop down list
     void CheckAndUpdateKeyboardLayout(ComboBox currentDropDown, bool isShortcut);
 
+    // Function to set accessible name for combobox
+    static void SetAccessibleNameForComboBox(ComboBox dropDown, int index);
+
 public:
     // Pointer to the keyboard manager state
     static KeyboardManagerState* keyboardManagerState;

--- a/src/modules/keyboardmanager/ui/ShortcutControl.h
+++ b/src/modules/keyboardmanager/ui/ShortcutControl.h
@@ -12,6 +12,7 @@ namespace winrt::Windows::UI::Xaml
         struct StackPanel;
         struct Grid;
         struct TextBox;
+        struct Button;
     }
 }
 
@@ -28,7 +29,10 @@ private:
     winrt::Windows::Foundation::IInspectable shortcutControlLayout;
 
     // Function to set the accessible name of the target app text box
-    static void SetAccessibleNameForTextBox(TextBox targetAppTextBox);
+    static void SetAccessibleNameForTextBox(TextBox targetAppTextBox, int rowIndex);
+
+    // Function to set the accessible names for all the controls in a row
+    static void UpdateAccessibleNames(StackPanel sourceColumn, StackPanel mappedToColumn, TextBox targetAppTextBox, Button deleteButton, int rowIndex);
 
 public:
     // Handle to the current Edit Shortcuts Window

--- a/src/modules/keyboardmanager/ui/SingleKeyRemapControl.cpp
+++ b/src/modules/keyboardmanager/ui/SingleKeyRemapControl.cpp
@@ -62,6 +62,14 @@ SingleKeyRemapControl::SingleKeyRemapControl(Grid table, const int colIndex)
     singleKeyRemapControlLayout.as<StackPanel>().UpdateLayout();
 }
 
+// Function to set the accessible names for all the controls in a row
+void SingleKeyRemapControl::UpdateAccessibleNames(StackPanel sourceColumn, StackPanel mappedToColumn, Button deleteButton, int rowIndex)
+{
+    sourceColumn.SetValue(Automation::AutomationProperties::NameProperty(), box_value(GET_RESOURCE_STRING(IDS_AUTOMATIONPROPERTIES_ROW) + std::to_wstring(rowIndex) + L", " + GET_RESOURCE_STRING(IDS_EDITKEYBOARD_SOURCEHEADER)));
+    mappedToColumn.SetValue(Automation::AutomationProperties::NameProperty(), box_value(GET_RESOURCE_STRING(IDS_AUTOMATIONPROPERTIES_ROW) + std::to_wstring(rowIndex) + L", " + GET_RESOURCE_STRING(IDS_EDITKEYBOARD_TARGETHEADER)));
+    deleteButton.SetValue(Automation::AutomationProperties::NameProperty(), box_value(GET_RESOURCE_STRING(IDS_AUTOMATIONPROPERTIES_ROW) + std::to_wstring(rowIndex) + L", " + GET_RESOURCE_STRING(IDS_DELETE_REMAPPING_BUTTON)));
+}
+
 // Function to add a new row to the remap keys table. If the originalKey and newKey args are provided, then the displayed remap keys are set to those values.
 void SingleKeyRemapControl::AddNewControlKeyRemapRow(Grid& parent, std::vector<std::vector<std::unique_ptr<SingleKeyRemapControl>>>& keyboardRemapControlObjects, const DWORD originalKey, const std::variant<DWORD, Shortcut> newKey)
 {
@@ -90,8 +98,6 @@ void SingleKeyRemapControl::AddNewControlKeyRemapRow(Grid& parent, std::vector<s
     parent.SetRow(arrowIcon, parent.RowDefinitions().Size() - 1);
     parent.Children().Append(arrowIcon);
 
-    // To set the accessible name of the arrow icon by setting the accessible name of the remapped key
-    keyboardRemapControlObjects[keyboardRemapControlObjects.size() - 1][1]->getSingleKeyRemapControl().SetValue(Automation::AutomationProperties::NameProperty(), box_value(GET_RESOURCE_STRING(IDS_REMAPPED_TO)));
     // SingleKeyRemapControl for the new remap key
     parent.Children().Append(keyboardRemapControlObjects[keyboardRemapControlObjects.size() - 1][1]->getSingleKeyRemapControl());
 
@@ -154,6 +160,17 @@ void SingleKeyRemapControl::AddNewControlKeyRemapRow(Grid& parent, std::vector<s
             parent.SetRow(children.GetAt(i).as<FrameworkElement>(), elementRowIndex - 1);
         }
 
+        // Update accessible names for each row after the deleted row
+        for (uint32_t i = lastIndexInRow + 1; i < children.Size(); i += KeyboardManagerConstants::RemapTableColCount)
+        {
+            // Get row index from grid
+            int32_t elementRowIndex = parent.GetRow(children.GetAt(i).as<FrameworkElement>());
+            StackPanel sourceCol = children.GetAt(i + KeyboardManagerConstants::RemapTableOriginalColIndex).as<StackPanel>();
+            StackPanel targetCol = children.GetAt(i + KeyboardManagerConstants::RemapTableNewColIndex).as<StackPanel>();
+            Button delButton = children.GetAt(i + KeyboardManagerConstants::RemapTableRemoveColIndex).as<Button>();
+            UpdateAccessibleNames(sourceCol, targetCol, delButton, elementRowIndex);
+        }
+
         for (int i = 0; i < KeyboardManagerConstants::RemapTableColCount; i++)
         {
             parent.Children().RemoveAt(lastIndexInRow - i);
@@ -174,6 +191,9 @@ void SingleKeyRemapControl::AddNewControlKeyRemapRow(Grid& parent, std::vector<s
     parent.SetRow(deleteRemapKeys, parent.RowDefinitions().Size() - 1);
     parent.Children().Append(deleteRemapKeys);
     parent.UpdateLayout();
+
+    // Set accessible names
+    UpdateAccessibleNames(keyboardRemapControlObjects[keyboardRemapControlObjects.size() - 1][0]->getSingleKeyRemapControl(), keyboardRemapControlObjects[keyboardRemapControlObjects.size() - 1][1]->getSingleKeyRemapControl(), deleteRemapKeys, parent.RowDefinitions().Size() - 1);
 }
 
 // Function to return the stack panel element of the SingleKeyRemapControl. This is the externally visible UI element which can be used to add it to other layouts

--- a/src/modules/keyboardmanager/ui/SingleKeyRemapControl.h
+++ b/src/modules/keyboardmanager/ui/SingleKeyRemapControl.h
@@ -10,6 +10,7 @@ namespace winrt::Windows::UI::Xaml
     {
         struct StackPanel;
         struct Grid;
+        struct Button;
     }
 }
 
@@ -24,6 +25,9 @@ private:
 
     // Stack panel for the drop downs to display the selected shortcut for the hybrid case
     winrt::Windows::Foundation::IInspectable hybridDropDownStackPanel;
+
+    // Function to set the accessible names for all the controls in a row
+    static void UpdateAccessibleNames(StackPanel sourceColumn, StackPanel mappedToColumn, Button deleteButton, int rowIndex);
 
 public:
     // Vector to store dynamically allocated KeyDropDownControl objects to avoid early destruction


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
This PR adds code to dynamically update the AutomationProperties.Name for each row/column pair in the grid in Remap Keys/Shortcuts. This solves the accessibility issue as sibling elements will always have different names.
The names for each stackpanel/textbox/button was given as `Row {rowNum}, ColumnName`, to make it uniform.

- The PR also makes a two line change to clean up some code for calculating rowIndex to be more scalable for future changes (using Grid.GetRow rather than manually calculating row index).

## PR Checklist
* [X] Applies to #6671
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [X] Tests passed

## Info on Pull Request

_What does this include?_
Remap Keys
- The stackpanel in the first column for each row is given the name "Row {rowNum}, Key:"
- The stackpanel in the second column for each row is given the name "Row {rowNum}, Mapped To:" (the old `Remapped to` string was removed so that the format is standardized to use the column name).
- The delete button for each row is given the name "Row {rowNum}, Delete Remapping"

Remap Shortcuts
- The stackpanel in the first column for each row is given the name "Row {rowNum}, Shortcut:"
- The stackpanel in the second column for each row is given the name "Row {rowNum}, Mapped To:" (the old `Remapped to` string was removed so that the format is standardized to use the column name).
- The textbox for target app for each row is given the name "Row {rowNum}, Target App:" along with the code which was added in #6379 for adding in All Apps depending on if the box is empty. (the `For target application` string was removed so that the format is standardized to use the column name).
- The delete button for each row is given the name "Row {rowNum}, Delete Remapping"

In both the windows above, the accessible names are set on initialization when the row is created, and in the Delete button handler, when a row is deleted, the accessible names for the rows after that row are updated (since the row index would change). We don't need to add extra logic for updating existing rows when a new row is added since rows only get added at the end.

- In the KeyDropDownControl file, the ComboBox was named "Key Drop Down {index}", and this is initialized to 1 (for the first drop down in shortcut controls, and for the only drop down in single key controls). A different value is set in the AddDropDown method to the number of drop downs (Since when this gets called a drop down is added only at the end). When a drop down is deleted, all the drop downs after it are updated (since the index changes).

- As part of code cleanup, two areas where rowIndex was calculated in KeyDropDownControl were changed to use Grid.GetRow rather than manually calculating it (making the code futureproof).

## Validation Steps Performed

_How does someone test & validate?_
- Run accessibility insights on the Remap keys and remap shortcuts window and validate the above issue doesn't appear.
- Validate with Narrator that the correct indexes are setting on adding/deleting rows, and adding/deleting drop downs.
- Validate remappings are applied correctly on adding/removing rows