### PR TITLE
Handle exception in Packaged program loading at startup

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/PackageWrapper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/PackageWrapper.cs
@@ -49,9 +49,9 @@ namespace Microsoft.Plugin.Program.Programs
             {
                 path = package.InstalledLocation.Path;
             }
-            catch (Exception e) when (e is ArgumentException || e is FileNotFoundException)
+            catch (Exception e) when (e is ArgumentException || e is FileNotFoundException || e is DirectoryNotFoundException)
             {
-                ProgramLogger.LogException($"PackageWrapper", "GetWrapperFromPackage", "package.InstalledLocation.Path", $"Exception {package.Id.Name}", e);
+                ProgramLogger.LogException($"PackageWrapper", "GetWrapperFromPackage", "Path could not be determined", $"Exception {package.Id.Name}", e);
                 return new PackageWrapper(
                     package.Id.Name,
                     package.Id.FullName,

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/PackagemanagerWrapper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/PackagemanagerWrapper.cs
@@ -2,9 +2,11 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Security.Principal;
 using Windows.Management.Deployment;
+using Wox.Infrastructure.Logger;
 using Package = Windows.ApplicationModel.Package;
 
 namespace Microsoft.Plugin.Program.Programs
@@ -18,6 +20,7 @@ namespace Microsoft.Plugin.Program.Programs
             _packageManager = new PackageManager();
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "We want to catch all exception to prevent error in a program from affecting loading of program plugin.")]
         public IEnumerable<IPackage> FindPackagesForCurrentUser()
         {
             List<PackageWrapper> packages = new List<PackageWrapper>();
@@ -29,7 +32,14 @@ namespace Microsoft.Plugin.Program.Programs
                 var m = _packageManager.FindPackagesForUser(id);
                 foreach (Package p in m)
                 {
-                    packages.Add(PackageWrapper.GetWrapperFromPackage(p));
+                    try
+                    {
+                        packages.Add(PackageWrapper.GetWrapperFromPackage(p));
+                    }
+                    catch (Exception e)
+                    {
+                        Log.Error(nameof(PackageManagerWrapper), e.Message, nameof(FindPackagesForCurrentUser));
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary of the Pull Request
This PR adds code to fix the loading of program plugin due to failure in Packaged app load at startup.

## PR Checklist
* [x] Applies to #6673, #6665 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed

## Info on Pull Request
This PR contains the following changes : 
1. Added exception handling for `DirectoryNotFoundException` when Packaged app is not found at location returned by PackageManager. This was the cause of issue #6673 as this exception was not handled before.
2. Added a try-catch to handle all exceptions when adding a new packaged app in `PackagemanagerWrapper.` All exceptions should be caught here because an issue in one program should not affect loading of entire program plugin.
 
## Validation Steps Performed
1. Manually validated that throwing any exception while creating a packaged app does not result in failure in loading program plugin. 
2. MSI containing this PR changes were shared with users and they reported that the error was resolved.