### PR TITLE
Pulling custom logger out of Program plugin

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Logger/ProgramLogger.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Logger/ProgramLogger.cs
@@ -7,10 +7,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Security;
-using NLog;
-using NLog.Config;
-using NLog.Targets;
-using Wox.Infrastructure;
+using Wox.Infrastructure.Logger;
 
 namespace Microsoft.Plugin.Program.Logger
 {
@@ -21,32 +18,6 @@ namespace Microsoft.Plugin.Program.Logger
     /// </summary>
     internal static class ProgramLogger
     {
-        public const string DirectoryName = "Logs";
-
-        static ProgramLogger()
-        {
-            var path = Path.Combine(Constant.DataDirectory, DirectoryName, Constant.Version);
-            if (!Directory.Exists(path))
-            {
-                Directory.CreateDirectory(path);
-            }
-
-            var configuration = new LoggingConfiguration();
-            using (var target = new FileTarget())
-            {
-                configuration.AddTarget("file", target);
-                target.FileName = path.Replace(@"\", "/", StringComparison.Ordinal) + "/${shortdate}.txt";
-#if DEBUG
-                var rule = new LoggingRule("*", LogLevel.Debug, target);
-#else
-                var rule = new LoggingRule("*", LogLevel.Error, target);
-#endif
-                configuration.LoggingRules.Add(rule);
-            }
-
-            LogManager.Configuration = configuration;
-        }
-
         /// <summary>
         /// Logs an exception
         /// </summary>
@@ -55,45 +26,26 @@ namespace Microsoft.Plugin.Program.Logger
         {
             Debug.WriteLine($"ERROR{classname}|{callingMethodName}|{loadingProgramPath}|{interpretationMessage}");
 
-            var logger = LogManager.GetLogger(string.Empty);
-
-            var innerExceptionNumber = 1;
-
             var possibleResolution = "Not yet known";
             var errorStatus = "UNKNOWN";
 
-            logger.Error("------------- BEGIN Microsoft.Plugin.Program exception -------------");
-
-            do
+            if (IsKnownWinProgramError(e, callingMethodName) || IsKnownUWPProgramError(e, callingMethodName))
             {
-                if (IsKnownWinProgramError(e, callingMethodName) || IsKnownUWPProgramError(e, callingMethodName))
-                {
-                    possibleResolution = "Can be ignored and Wox should still continue, however the program may not be loaded";
-                    errorStatus = "KNOWN";
-                }
-
-                var calledMethod = e.TargetSite != null ? e.TargetSite.ToString() : e.StackTrace;
-
-                calledMethod = string.IsNullOrEmpty(calledMethod) ? "Not available" : calledMethod;
-
-                logger.Error($"\nException full name: {e.GetType().FullName}"
-                             + $"\nError status: {errorStatus}"
-                             + $"\nClass name: {classname}"
-                             + $"\nCalling method: {callingMethodName}"
-                             + $"\nProgram path: {loadingProgramPath}"
-                             + $"\nInnerException number: {innerExceptionNumber}"
-                             + $"\nException message: {e.Message}"
-                             + $"\nException error type: HResult {e.HResult}"
-                             + $"\nException thrown in called method: {calledMethod}"
-                             + $"\nPossible interpretation of the error: {interpretationMessage}"
-                             + $"\nPossible resolution: {possibleResolution}");
-
-                innerExceptionNumber++;
-                e = e.InnerException;
+                possibleResolution = "Can be ignored and Wox should still continue, however the program may not be loaded";
+                errorStatus = "KNOWN";
             }
-            while (e != null);
 
-            logger.Error("------------- END Microsoft.Plugin.Program exception -------------");
+            var calledMethod = e.TargetSite != null ? e.TargetSite.ToString() : e.StackTrace;
+
+            calledMethod = string.IsNullOrEmpty(calledMethod) ? "Not available" : calledMethod;
+            var msg = $"Error status: {errorStatus}"
+                         + $"\nProgram path: {loadingProgramPath}"
+                         + $"\nException thrown in called method: {calledMethod}"
+                         + $"\nPossible interpretation of the error: {interpretationMessage}"
+                         + $"\nPossible resolution: {possibleResolution}";
+
+            // removed looping logic since that is inside Log class
+            Log.Exception(classname, msg, e, callingMethodName);
         }
 
         /// <summary>
@@ -103,12 +55,10 @@ namespace Microsoft.Plugin.Program.Logger
         [MethodImpl(MethodImplOptions.Synchronized)]
         internal static void LogException(string message, Exception e)
         {
-            // Index 0 is always empty.
             var parts = message.Split('|');
             if (parts.Length < 4)
             {
-                var logger = LogManager.GetLogger(string.Empty);
-                logger.Error(e, $"fail to log exception in program logger, parts length is too small: {parts.Length}, message: {message}");
+                Log.Exception($"|ProgramLogger|LogException|Fail to log exception in program logger, parts length is too small: {parts.Length}, message: {message}", e);
             }
 
             var classname = parts[1];


### PR DESCRIPTION
## Summary of the Pull Request

Program plugin has logging but it implemented its own logger.

This pipes all the existing logging to the new logger.

Here is an example of a piped result

```
2020-09-17 10:26:18.0344|ERROR|Win32.LnkProgram|-------------------------- Begin exception --------------------------
2020-09-17 10:26:18.0540|ERROR|Win32.LnkProgram|Error status: KNOWN
Program path: C:\ProgramData\Microsoft\Windows\Start Menu\Programs\Accessories\Windows Media Player.lnk
Exception thrown in called method: Void GetDescription(System.Text.StringBuilder, Int32)
Possible interpretation of the error: An unexpected error occurred in the calling method LnkProgram
Possible resolution: Can be ignored and Wox should still continue, however the program may not be loaded
2020-09-17 10:26:18.0738|ERROR|Win32.LnkProgram|Exception full name:
 <System.Runtime.InteropServices.COMException>
2020-09-17 10:26:18.0926|ERROR|Win32.LnkProgram|Exception message:
 <Error HRESULT E_FAIL has been returned from a call to a COM component.>
2020-09-17 10:26:18.1229|ERROR|Win32.LnkProgram|Exception stack trace:
 <   at Microsoft.Plugin.Program.Programs.ShellLinkHelper.IShellLinkW.GetDescription(StringBuilder pszName, Int32 cchMaxName)
   at Microsoft.Plugin.Program.Programs.ShellLinkHelper.RetrieveTargetPath(String path) in C:\Users\crutkas\source\repos\ptMain\src\modules\launcher\Plugins\Microsoft.Plugin.Program\Programs\ShellLinkHelper.cs:line 163
   at Microsoft.Plugin.Program.Programs.Win32Program.LnkProgram(String path) in C:\Users\crutkas\source\repos\ptMain\src\modules\launcher\Plugins\Microsoft.Plugin.Program\Programs\Win32Program.cs:line 445>
2020-09-17 10:26:18.1395|ERROR|Win32.LnkProgram|Exception source:
 <Microsoft.Plugin.Program>
2020-09-17 10:26:18.1558|ERROR|Win32.LnkProgram|Exception target site:
 <Void GetDescription(System.Text.StringBuilder, Int32)>
2020-09-17 10:26:18.1966|ERROR|Win32.LnkProgram|Exception HResult:
 <-2147467259>
2020-09-17 10:26:18.2166|ERROR|Win32.LnkProgram|-------------------------- End exception --------------------------
```

## PR Checklist
* [ ] Applies to #6669
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

## Validation Steps Performed

_How does someone test & validate?_
