### PR TITLE
common: fix trim functions for wchar_t

### DIFF
--- a/src/common/string_utils.h
+++ b/src/common/string_utils.h
@@ -5,27 +5,38 @@
 #include <algorithm>
 
 template<typename CharT>
-inline constexpr std::basic_string_view<CharT> default_trim_arg()
+struct default_trim_arg
 {
-    return reinterpret_cast<CharT*>(" \t\r\n");
-}
+};
 
-template <typename CharT>
-inline std::basic_string_view<CharT> left_trim(std::basic_string_view<CharT> s, const std::basic_string_view<CharT> chars_to_trim = default_trim_arg<CharT>())
+template<>
+struct default_trim_arg<char>
+{
+    static inline constexpr std::string_view value = " \t\r\n";
+};
+
+template<>
+struct default_trim_arg<wchar_t>
+{
+    static inline constexpr std::wstring_view value = L" \t\r\n";
+};
+
+template<typename CharT>
+inline std::basic_string_view<CharT> left_trim(std::basic_string_view<CharT> s, const std::basic_string_view<CharT> chars_to_trim = default_trim_arg<CharT>::value)
 {
     s.remove_prefix(std::min<size_t>(s.find_first_not_of(chars_to_trim), size(s)));
     return s;
 }
 
 template<typename CharT>
-inline std::basic_string_view<CharT> right_trim(std::basic_string_view<CharT> s, const std::basic_string_view<CharT> chars_to_trim = default_trim_arg<CharT>())
+inline std::basic_string_view<CharT> right_trim(std::basic_string_view<CharT> s, const std::basic_string_view<CharT> chars_to_trim = default_trim_arg<CharT>::value)
 {
     s.remove_suffix(std::min<size_t>(size(s) - s.find_last_not_of(chars_to_trim) - 1, size(s)));
     return s;
 }
 
 template<typename CharT>
-inline std::basic_string_view<CharT> trim(std::basic_string_view<CharT> s, const std::basic_string_view<CharT> chars_to_trim = default_trim_arg<CharT>())
+inline std::basic_string_view<CharT> trim(std::basic_string_view<CharT> s, const std::basic_string_view<CharT> chars_to_trim = default_trim_arg<CharT>::value)
 {
     return left_trim(right_trim(s, chars_to_trim), chars_to_trim);
 }


### PR DESCRIPTION
Noticed a bug in string_utils. reinterpret-casting char string literal as wchar_t string literal will trim `ठ਍` instead of the space symbols.