### PR TITLE
Enable localization on all folders under PowerToys root

### DIFF
--- a/.pipelines/build-localization.cmd
+++ b/.pipelines/build-localization.cmd
@@ -18,7 +18,7 @@ set LocalizationXLocPkgVer=2.0.0
 echo Running localization build...
 
 set XLocPath=%NUGET_PACKAGES%\Localization.XLoc.%LocalizationXLocPkgVer%
-set LocProjectDirectory=%RepoRoot%src
+set LocProjectDirectory=%RepoRoot%
 
 rem Run the localization tool on all LocProject.json files in the src directory and it's subdirectories
 dotnet "%XLocPath%\tools\netcore\Microsoft.Localization.XLoc.dll" /f "%LocProjectDirectory%"

--- a/.pipelines/build-localization.cmd
+++ b/.pipelines/build-localization.cmd
@@ -21,7 +21,7 @@ echo Running localization build...
 set XLocPath=%NUGET_PACKAGES%\Localization.XLoc.%LocalizationXLocPkgVer%
 set LocProjectDirectory=%RepoRootWithoutBackslash%
 
-rem Run the localization tool on all LocProject.json files in the src directory and it's subdirectories
+rem Run the localization tool on all LocProject.json files in the src directory and it's subdirectories (directory format must not end with \)
 dotnet "%XLocPath%\tools\netcore\Microsoft.Localization.XLoc.dll" /f "%LocProjectDirectory%"
 
 echo Localization build finished with exit code '%errorlevel%'.

--- a/.pipelines/build-localization.cmd
+++ b/.pipelines/build-localization.cmd
@@ -10,7 +10,8 @@ setlocal
 rem In this sample, the repo root is identical to the script directory path. Adjust the value of the RepoRoot variable accordingly based on your environment.
 rem Again, ensure the RepoRoot variable is set to the real repo root location, otherwise the localization toolset wouldn't work as intended.
 rem Note that the resolved %~dp0 ends with \.
-set RepoRoot=%~dp0..\
+set RepoRootWithoutBackslash=%~dp0..
+set RepoRoot=%RepoRootWithoutBackslash%\
 set OutDir=%RepoRoot%out
 set NUGET_PACKAGES=%RepoRoot%packages
 set LocalizationXLocPkgVer=2.0.0
@@ -18,7 +19,7 @@ set LocalizationXLocPkgVer=2.0.0
 echo Running localization build...
 
 set XLocPath=%NUGET_PACKAGES%\Localization.XLoc.%LocalizationXLocPkgVer%
-set LocProjectDirectory=%RepoRoot%
+set LocProjectDirectory=%RepoRootWithoutBackslash%
 
 rem Run the localization tool on all LocProject.json files in the src directory and it's subdirectories
 dotnet "%XLocPath%\tools\netcore\Microsoft.Localization.XLoc.dll" /f "%LocProjectDirectory%"

--- a/.pipelines/pipeline.user.windows.yml
+++ b/.pipelines/pipeline.user.windows.yml
@@ -41,6 +41,15 @@ restore:
 
 build:
   commands:
+      # Localize the files after the build procedure to avoid existing localized files from getting overwritten. To be moved before the Build PowerToys step once the lcl files have been checked in. Tracked at https://github.com/microsoft/PowerToys/issues/6046
+    - !!buildcommand
+      name: 'Localize Power Toys'
+      command: '.pipelines\build-localization.cmd'
+      artifacts:
+        - from: 'out\loc'
+          to: 'loc'
+          include:
+            - '**/*'
     - !!buildcommand
       name: 'Build Power Toys'
       command: '.pipelines\build.cmd'
@@ -152,15 +161,7 @@ build:
             - 'PowerToysSetup-*.exe'
           signing_options:
             sign_inline: true  # This does signing a soon as this command completes
-    # Localize the files after the build procedure to avoid existing localized files from getting overwritten. To be moved before the Build PowerToys step once the lcl files have been checked in. Tracked at https://github.com/microsoft/PowerToys/issues/6046
-    - !!buildcommand
-      name: 'Localize Power Toys'
-      command: '.pipelines\build-localization.cmd'
-      artifacts:
-        - from: 'out\loc'
-          to: 'loc'
-          include:
-            - '**/*'
+
 
 
 #package:

--- a/.pipelines/pipeline.user.windows.yml
+++ b/.pipelines/pipeline.user.windows.yml
@@ -41,15 +41,6 @@ restore:
 
 build:
   commands:
-      # Localize the files after the build procedure to avoid existing localized files from getting overwritten. To be moved before the Build PowerToys step once the lcl files have been checked in. Tracked at https://github.com/microsoft/PowerToys/issues/6046
-    - !!buildcommand
-      name: 'Localize Power Toys'
-      command: '.pipelines\build-localization.cmd'
-      artifacts:
-        - from: 'out\loc'
-          to: 'loc'
-          include:
-            - '**/*'
     - !!buildcommand
       name: 'Build Power Toys'
       command: '.pipelines\build.cmd'
@@ -161,7 +152,15 @@ build:
             - 'PowerToysSetup-*.exe'
           signing_options:
             sign_inline: true  # This does signing a soon as this command completes
-
+    # Localize the files after the build procedure to avoid existing localized files from getting overwritten. To be moved before the Build PowerToys step once the lcl files have been checked in. Tracked at https://github.com/microsoft/PowerToys/issues/6046
+    - !!buildcommand
+      name: 'Localize Power Toys'
+      command: '.pipelines\build-localization.cmd'
+      artifacts:
+        - from: 'out\loc'
+          to: 'loc'
+          include:
+            - '**/*'
 
 
 #package:


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
Earlier the localization pipeline would read the LocProject.json files only from the `src` folder, but the changes in #6567 indicated that it needs to be enabled in `installer` as well. With the changes in this PR the root folder will be used instead.

## PR Checklist
* [X] Applies to #5779 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

## Validation Steps Performed

_How does someone test & validate?_
- Validated on CDPX pipeline that the localization is done for all projects in `src` and `installer` folders. https://github-private.visualstudio.com/microsoft/_build/results?buildId=11908&view=artifacts&type=publishedArtifacts
