### PR TITLE
Fix logging string format

### DIFF
--- a/src/modules/launcher/Wox.Infrastructure/Storage/BinaryStorage`1.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Storage/BinaryStorage`1.cs
@@ -44,7 +44,7 @@ namespace Wox.Infrastructure.Storage
                 if (File.Exists(FilePath))
                 {
                     File.Delete(FilePath);
-                    Log.Info($"|BinaryStorage.TryLoad|Deleting cached data| <{FilePath}>");
+                    Log.Info($"|BinaryStorage.TryLoad|Deleting cached data at <{FilePath}>");
                 }
             }
 
@@ -133,7 +133,7 @@ namespace Wox.Infrastructure.Storage
             }
 
             _storageHelper.Close();
-            Log.Info($"|BinaryStorage.Save|Saving cached data| <{FilePath}>");
+            Log.Info($"|BinaryStorage.Save|Saving cached data at <{FilePath}>");
         }
     }
 }

--- a/src/modules/launcher/Wox.Infrastructure/Storage/JsonStorage`1.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Storage/JsonStorage`1.cs
@@ -51,7 +51,7 @@ namespace Wox.Infrastructure.Storage
                 if (File.Exists(FilePath))
                 {
                     File.Delete(FilePath);
-                    Log.Info($"|JsonStorage.TryLoad|Deleting cached data|<{FilePath}>");
+                    Log.Info($"|JsonStorage.TryLoad|Deleting cached data at <{FilePath}>");
                 }
             }
 
@@ -123,11 +123,11 @@ namespace Wox.Infrastructure.Storage
                 string serialized = JsonConvert.SerializeObject(_data, Formatting.Indented);
                 File.WriteAllText(FilePath, serialized);
                 _storageHelper.Close();
-                Log.Info($"|JsonStorage.Save|Saving cached data| <{FilePath}>");
+                Log.Info($"|JsonStorage.Save|Saving cached data at <{FilePath}>");
             }
             catch (IOException e)
             {
-                Log.Error($"|JsonStorage.Save|Error in saving data| <{FilePath}>", e.Message);
+                Log.Error($"|JsonStorage.Save|Error in saving data at <{FilePath}>", e.Message);
             }
         }
     }


### PR DESCRIPTION
## Summary of the Pull Request
Fix string format of `Log.Info` function

## PR Checklist
* [x] Applies to #6709 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed

## Info on Pull Request
`Log.Info` accepts string containing two token seperated by `|`. The caching code instead provides 3 tokens which result in following error messages: 
`2020-09-11 16:41:04.2053|FATAL|FaultyLogger|Wrong logger message format <|JsonStorage.Save|Saving cached data| <C:\Users\divyan\AppData\Local\Microsoft\PowerToys\PowerToys Run\Settings\Settings.json>>`



## Validation Steps Performed
Manually validated that logs are written correctly. 

The following logs are generated after changes : 
```
2020-09-18 11:56:49.2215|INFO|JsonStorage.Save|Saving cached data at <C:\Users\divyan\AppData\Local\Microsoft\PowerToys\PowerToys Run\Settings\Settings.json>
2020-09-18 11:56:49.2499|INFO|JsonStorage.Save|Saving cached data at <C:\Users\divyan\AppData\Local\Microsoft\PowerToys\PowerToys Run\Settings\Plugins\Microsoft.Plugin.Folder\FolderSettings.json>
2020-09-18 11:56:49.2809|INFO|JsonStorage.Save|Saving cached data at <C:\Users\divyan\AppData\Local\Microsoft\PowerToys\PowerToys Run\Settings\Plugins\Microsoft.Plugin.Indexer\IndexerSettings.json>
2020-09-18 11:56:49.3336|INFO|JsonStorage.Save|Saving cached data at <C:\Users\divyan\AppData\Local\Microsoft\PowerToys\PowerToys Run\Settings\Plugins\Microsoft.Plugin.Program\ProgramPluginSettings.json>
2020-09-18 11:56:49.3671|INFO|JsonStorage.Save|Saving cached data at <C:\Users\divyan\AppData\Local\Microsoft\PowerToys\PowerToys Run\Settings\Plugins\Microsoft.Plugin.Shell\ShellPluginSettings.json>
2020-09-18 11:56:49.3955|INFO|JsonStorage.Save|Saving cached data at <C:\Users\divyan\AppData\Local\Microsoft\PowerToys\PowerToys Run\Settings\Plugins\Microsoft.Plugin.Uri\UriSettings.json>
```