### PR TITLE
[Keyboard Manager] Fix crash in Keyboard Manager by ignoring MapToSameKey warnings on loading

### DIFF
--- a/src/modules/keyboardmanager/ui/KeyDropDownControl.cpp
+++ b/src/modules/keyboardmanager/ui/KeyDropDownControl.cpp
@@ -152,6 +152,7 @@ std::pair<KeyboardManagerHelper::ErrorType, int> KeyDropDownControl::ValidateSho
             validationResult.first = KeyboardManagerHelper::ErrorType::NoError;
         }
 
+        // If the remapping is invalid display an error message
         if (validationResult.first != KeyboardManagerHelper::ErrorType::NoError)
         {
             SetDropDownError(currentDropDown, KeyboardManagerHelper::GetErrorMessage(validationResult.first));

--- a/src/modules/keyboardmanager/ui/KeyDropDownControl.h
+++ b/src/modules/keyboardmanager/ui/KeyDropDownControl.h
@@ -38,6 +38,8 @@ private:
     winrt::Windows::Foundation::IInspectable warningMessage;
     // Stores the flyout attached to the current drop down
     winrt::Windows::Foundation::IInspectable warningFlyout;
+    // Stores whether a key to shortcut warning has to be ignored
+    bool ignoreKeyToShortcutWarning;
 
     // Function to set properties apart from the SelectionChanged event handler
     void SetDefaultProperties(bool isShortcut);
@@ -50,7 +52,8 @@ public:
     static KeyboardManagerState* keyboardManagerState;
 
     // Constructor - the last default parameter should be passed as false only if it originates from Type shortcut or when an old shortcut is reloaded
-    KeyDropDownControl(bool isShortcut)
+    KeyDropDownControl(bool isShortcut, bool fromAddShortcutToControl = false) :
+        ignoreKeyToShortcutWarning(fromAddShortcutToControl)
     {
         SetDefaultProperties(isShortcut);
     }
@@ -71,7 +74,7 @@ public:
     ComboBox GetComboBox();
 
     // Function to add a drop down to the shortcut stack panel
-    static void AddDropDown(winrt::Windows::UI::Xaml::Controls::Grid table, winrt::Windows::UI::Xaml::Controls::StackPanel shortcutControl, winrt::Windows::UI::Xaml::Controls::StackPanel parent, const int colIndex, RemapBuffer& shortcutRemapBuffer, std::vector<std::unique_ptr<KeyDropDownControl>>& keyDropDownControlObjects, winrt::Windows::UI::Xaml::Controls::TextBox targetApp, bool isHybridControl, bool isSingleKeyWindow);
+    static void AddDropDown(winrt::Windows::UI::Xaml::Controls::Grid table, winrt::Windows::UI::Xaml::Controls::StackPanel shortcutControl, winrt::Windows::UI::Xaml::Controls::StackPanel parent, const int colIndex, RemapBuffer& shortcutRemapBuffer, std::vector<std::unique_ptr<KeyDropDownControl>>& keyDropDownControlObjects, winrt::Windows::UI::Xaml::Controls::TextBox targetApp, bool isHybridControl, bool isSingleKeyWindow, bool ignoreWarning = false);
 
     // Function to get the list of key codes from the shortcut combo box stack panel
     static std::vector<int32_t> GetSelectedIndicesFromStackPanel(StackPanel parent);


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
This PR adds in logic to prevent a crash in Keyboard Manager. With the changes in this PR, for Key to Shortcut remappings when they are loaded in on opening the KBM window or when the shortcut is adding from the Type button, the MapToSameKey error will be ignored.

## PR Checklist
* [X] Applies to #6695 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [X] Tests passed

## Info on Pull Request

_What does this include?_
- The crash in #6695 was occurring because of the key to shortcut remapping Shift(left) -> Shift(left) + [. 
- The `AddShortcutToControl` method (which is called while loading existing remappings while starting the remap windows, or from the handler of Type button), adds in the keys sequentially as if a person was entering them (so that the logic for using Type and entering by dropdowns is the same). The issue with this in the above example is that there is an intermediate state of Shift(left) -> Shift(left), which results in a MapToSameKey error.
- With the changes in this PR, when AddShortcutToControl is added and the shortcut is atleast two keys (atleast one modifier), then the MapToSameKey error is ignored for the first execution of the ValidateShortcutSelection handler, after which that state is reset
- Earlier for a user to enter such a mapping, the only way was to do something like Shift -> Ctrl+ [ and then replace Ctrl with Shift. Now a user can directly type Shift+[ from the Type button. The behavior of using the drop down to put Shift first will still lead to a warning since we don't have any way of knowing whether the user will complete it as a shortcut or a key to key mapping.

**Note:** The alternate approach to fixing this was to get rid of the `MapToSameKey` error and instead this error check would be done only on clicking the OK button, and if such a mapping is found it would show the warning "Some remappings could not be applied do you want to continue". The downside of this is a user may have added several remappings like `A`->`A`, `Ctrl`->`Ctrl` etc but they get to know that these are invalid only after pressing OK so it could have a worse UI experience.
To clarify in terms of logic, mapping Shift->Shift is invalid (since it doesnt make sense since you are mapping a key to itself), but Shift->Shift+A is completely valid (if a user wants to orphan their Shift key to use a Shift based shortcut that is fine)

## Validation Steps Performed

_How does someone test & validate?_
- Add Shift(left)->Shift(left) + A shortcut from Type button in the remap key window and save settings
- Reopen Remap key and validate no crash occurs
- Try adding Shift(left) -> Shift(left) +A by drop down and validate that when you enter Shift it shows Remap to same key error. Instead do Ctrl+A and change Ctrl to Shift.
- Use Type button and try adding Shift->Shift (should throw error)
- Add Shift->Shift+A with Type button, change A to None and validate that Remap to same key error occurs
