### PR TITLE
[Launcher] Kill the Launcher immediately

### DIFF
--- a/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
+++ b/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
@@ -294,12 +294,16 @@ public:
     void terminateProcess()
     {
         DWORD processID = GetProcessId(m_hProcess);
+        TerminateProcess(m_hProcess, 1);
+        // Temporarily disable sending a message to close
+        /*
         EnumWindows(&requestMainWindowClose, processID);
         const DWORD result = WaitForSingleObject(m_hProcess, MAX_WAIT_MILLISEC);
         if (result == WAIT_TIMEOUT || result == WAIT_FAILED)
         {
             TerminateProcess(m_hProcess, 1);
         }
+        */
     }
 };
 

--- a/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
+++ b/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
@@ -11,7 +11,7 @@ extern "C" IMAGE_DOS_HEADER __ImageBase;
 
 namespace
 {
-    const wchar_t POWER_LAUNCHER_PID_SHARED_FILE[] = L"Local\\3cbfbad4-199b-4e2c-9825-942d5d3d3c74";
+    const wchar_t POWER_LAUNCHER_PID_SHARED_FILE[] = L"Local\\PowerLauncherPidSharedFile-3cbfbad4-199b-4e2c-9825-942d5d3d3c74";
     const wchar_t JSON_KEY_PROPERTIES[] = L"properties";
     const wchar_t JSON_KEY_WIN[] = L"win";
     const wchar_t JSON_KEY_ALT[] = L"alt";
@@ -315,7 +315,7 @@ void Microsoft_Launcher::init_settings()
         // Load and parse the settings file for this PowerToy.
         PowerToysSettings::PowerToyValues settings =
             PowerToysSettings::PowerToyValues::load_from_settings_file(get_name());
-        
+
         parse_hotkey(settings);
     }
     catch (std::exception ex)
@@ -339,7 +339,7 @@ void Microsoft_Launcher::parse_hotkey(PowerToysSettings::PowerToyValues& setting
     {
         m_hotkey.key = 0;
     }
-}    
+}
 
 extern "C" __declspec(dllexport) PowertoyModuleIface* __cdecl powertoy_create()
 {


### PR DESCRIPTION
## Summary of the Pull Request

This is a temporary fix to close the Launcher immediately when the PowerToy is disabled, or PowerToys exits cleanly/is restarted as admin.

## PR Checklist
* [x] Applies to #5860
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

Don't wait for Launcher to exit when it's sent a message, because right now it doesn't seem to react to it. We should keep looking for a proper way to fix this.

## Validation Steps Performed

Scenario 1: Disable Launcher. It should quit immediately.
Scenario 2: Restart PT as admin. The launcher will keep the old instance of PowerToys.exe running for 10 more seconds. When it finally quits, the launcher will also quit and so it needs to be restarted manually. This PR also fixed this bug.