### PR TITLE
FxCop and StyleCop for SVG thumbnail

### DIFF
--- a/installer/PowerToysSetup/Product.wxs
+++ b/installer/PowerToysSetup/Product.wxs
@@ -438,18 +438,18 @@
         </RegistryKey>
         <!-- Registry Key for Class Registration of Svg Thumbnail Provider -->
         <RegistryKey Root="HKCR" Key="CLSID\{36B27788-A8BB-4698-A756-DF9F11F64F84}">
-            <RegistryValue Type="string" Value="SvgThumbnailProvider.SvgThumbnailProvider" />
+            <RegistryValue Type="string" Value="Microsoft.PowerToys.ThumbnailHandler.Svg.SvgThumbnailProvider" />
             <RegistryValue Type="string" Name="DisplayName" Value="Svg Thumbnail Provider" />
             <RegistryValue Type="string" Name="AppID" Value="{CF142243-F059-45AF-8842-DBBE9783DB14}" />
             <RegistryValue Type="string" Key="Implemented Categories\{62C8FE65-4EBB-45e7-B440-6E39B2CDBF29}" Value=""/>
             <RegistryValue Type="string" Key="InprocServer32" Value="mscoree.dll" />
             <RegistryValue Type="string" Key="InprocServer32" Name="Assembly" Value="SvgThumbnailProvider, Version=$(var.Version).0, Culture=neutral" />
-            <RegistryValue Type="string" Key="InprocServer32" Name="Class" Value="SvgThumbnailProvider.SvgThumbnailProvider" />
+            <RegistryValue Type="string" Key="InprocServer32" Name="Class" Value="Microsoft.PowerToys.ThumbnailHandler.Svg.SvgThumbnailProvider" />
             <RegistryValue Type="string" Key="InprocServer32" Name="RuntimeVersion" Value="v4.0.30319" />
             <RegistryValue Type="string" Key="InprocServer32" Name="ThreadingModel" Value="Both" />
             <RegistryValue Type="string" Key="InprocServer32" Name="CodeBase" Value="file:///[FileExplorerPreviewInstallFolder]SvgThumbnailProvider.dll" />
             <RegistryValue Type="string" Key="InprocServer32\$(var.Version).0" Name="Assembly" Value="SvgThumbnailProvider, Version=$(var.Version).0, Culture=neutral" />
-            <RegistryValue Type="string" Key="InprocServer32\$(var.Version).0" Name="Class" Value="SvgThumbnailProvider.SvgThumbnailProvider" />
+            <RegistryValue Type="string" Key="InprocServer32\$(var.Version).0" Name="Class" Value="Microsoft.PowerToys.ThumbnailHandler.Svg.SvgThumbnailProvider" />
             <RegistryValue Type="string" Key="InprocServer32\$(var.Version).0" Name="RuntimeVersion" Value="v4.0.30319" />
             <RegistryValue Type="string" Key="InprocServer32\$(var.Version).0" Name="CodeBase" Value="file:///[FileExplorerPreviewInstallFolder]SvgThumbnailProvider.dll" />
         </RegistryKey>

--- a/src/modules/previewpane/SvgThumbnailProvider/SvgThumbnailProvider.cs
+++ b/src/modules/previewpane/SvgThumbnailProvider/SvgThumbnailProvider.cs
@@ -1,23 +1,24 @@
 ﻿// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+using System;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.ComTypes;
+using System.Windows.Forms;
+using Common;
+using Common.ComInterlop;
+using Common.Utilities;
+using Microsoft.PowerToys.Telemetry;
+using PreviewHandlerCommon;
 
-namespace SvgThumbnailProvider
+namespace Microsoft.PowerToys.ThumbnailHandler.Svg
 {
-    using System;
-    using System.Drawing;
-    using System.Drawing.Drawing2D;
-    using System.Drawing.Imaging;
-    using System.IO;
-    using System.Linq;
-    using System.Runtime.InteropServices;
-    using System.Runtime.InteropServices.ComTypes;
-    using System.Windows.Forms;
-    using Common;
-    using Common.ComInterlop;
-    using Common.Utilities;
-    using Microsoft.PowerToys.Telemetry;
-    using PreviewHandlerCommon;
+
 
     /// <summary>
     /// SVG Thumbnail Provider.
@@ -64,7 +65,7 @@ namespace SvgThumbnailProvider
                 {
                     deviceContextHandle = graphics.GetHdc();
 
-                    IViewObject viewObject = browser.ActiveXInstance as IViewObject;
+                    IViewObject viewObject = browser?.ActiveXInstance as IViewObject;
                     viewObject.Draw(1, -1, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, deviceContextHandle, ref rect, IntPtr.Zero, IntPtr.Zero, 0);
                 }
                 finally
@@ -100,30 +101,16 @@ namespace SvgThumbnailProvider
             // Wrap the SVG content in HTML in IE Edge mode so we can ensure
             // we render properly.
             string wrappedContent = WrapSVGInHTML(content);
-            WebBrowserExt browser = new WebBrowserExt();
-            browser.Dock = DockStyle.Fill;
-            browser.IsWebBrowserContextMenuEnabled = false;
-            browser.ScriptErrorsSuppressed = true;
-            browser.ScrollBarsEnabled = false;
-            browser.AllowNavigation = false;
-            browser.Width = (int)cx;
-            browser.Height = (int)cx;
-            browser.DocumentText = wrappedContent;
-
-            // Wait for the browser to render the content.
-            while (browser.IsBusy || browser.ReadyState != WebBrowserReadyState.Complete)
+            using (WebBrowserExt browser = new WebBrowserExt())
             {
-                Application.DoEvents();
-            }
-
-            // Check size of the rendered SVG.
-            var svg = browser.Document.GetElementsByTagName("svg").Cast<HtmlElement>().FirstOrDefault();
-            if (svg != null)
-            {
-                // Update the size of the browser control to fit the SVG
-                // in the visible viewport.
-                browser.Width = svg.OffsetRectangle.Width;
-                browser.Height = svg.OffsetRectangle.Height;
+                browser.Dock = DockStyle.Fill;
+                browser.IsWebBrowserContextMenuEnabled = false;
+                browser.ScriptErrorsSuppressed = true;
+                browser.ScrollBarsEnabled = false;
+                browser.AllowNavigation = false;
+                browser.Width = (int)cx;
+                browser.Height = (int)cx;
+                browser.DocumentText = wrappedContent;
 
                 // Wait for the browser to render the content.
                 while (browser.IsBusy || browser.ReadyState != WebBrowserReadyState.Complete)
@@ -131,16 +118,32 @@ namespace SvgThumbnailProvider
                     Application.DoEvents();
                 }
 
-                // Capture the image of the SVG from the browser.
-                thumbnail = GetBrowserContentImage(browser, svg.OffsetRectangle, Color.White);
-                if (thumbnail.Width != cx && thumbnail.Height != cx)
+                // Check size of the rendered SVG.
+                var svg = browser.Document.GetElementsByTagName("svg").Cast<HtmlElement>().FirstOrDefault();
+                if (svg != null)
                 {
-                    // We are not the appropriate size for caller.  Resize now while
-                    // respecting the aspect ratio.
-                    float scale = Math.Min((float)cx / thumbnail.Width, (float)cx / thumbnail.Height);
-                    int scaleWidth = (int)(thumbnail.Width * scale);
-                    int scaleHeight = (int)(thumbnail.Height * scale);
-                    thumbnail = ResizeImage(thumbnail, scaleWidth, scaleHeight);
+                    // Update the size of the browser control to fit the SVG
+                    // in the visible viewport.
+                    browser.Width = svg.OffsetRectangle.Width;
+                    browser.Height = svg.OffsetRectangle.Height;
+
+                    // Wait for the browser to render the content.
+                    while (browser.IsBusy || browser.ReadyState != WebBrowserReadyState.Complete)
+                    {
+                        Application.DoEvents();
+                    }
+
+                    // Capture the image of the SVG from the browser.
+                    thumbnail = GetBrowserContentImage(browser, svg.OffsetRectangle, Color.White);
+                    if (thumbnail.Width != cx && thumbnail.Height != cx)
+                    {
+                        // We are not the appropriate size for caller.  Resize now while
+                        // respecting the aspect ratio.
+                        float scale = Math.Min((float)cx / thumbnail.Width, (float)cx / thumbnail.Height);
+                        int scaleWidth = (int)(thumbnail.Width * scale);
+                        int scaleHeight = (int)(thumbnail.Height * scale);
+                        thumbnail = ResizeImage(thumbnail, scaleWidth, scaleHeight);
+                    }
                 }
             }
 
@@ -166,7 +169,7 @@ namespace SvgThumbnailProvider
                     {0}
                   </body>
                 </html>";
-            return string.Format(html, svg);
+            return string.Format(CultureInfo.CurrentCulture, html, svg);
         }
 
         /// <summary>
@@ -178,8 +181,11 @@ namespace SvgThumbnailProvider
         /// <returns>The resized image.</returns>
         public static Bitmap ResizeImage(Image image, int width, int height)
         {
-            if (width <= 0 || height <= 0 ||
-                width > MaxThumbnailSize || height > MaxThumbnailSize)
+            if (width <= 0 || 
+                height <= 0 ||
+                width > MaxThumbnailSize || 
+                height > MaxThumbnailSize ||
+                image == null)
             {
                 return null;
             }
@@ -232,11 +238,13 @@ namespace SvgThumbnailProvider
 
             if (svgData != null)
             {
-                Bitmap thumbnail = GetThumbnail(svgData, cx);
-                if (thumbnail != null && thumbnail.Size.Width > 0 && thumbnail.Size.Height > 0)
+                using (Bitmap thumbnail = GetThumbnail(svgData, cx))
                 {
-                    phbmp = thumbnail.GetHbitmap();
-                    pdwAlpha = WTS_ALPHATYPE.WTSAT_RGB;
+                    if (thumbnail != null && thumbnail.Size.Width > 0 && thumbnail.Size.Height > 0)
+                    {
+                        phbmp = thumbnail.GetHbitmap();
+                        pdwAlpha = WTS_ALPHATYPE.WTSAT_RGB;
+                    }
                 }
             }
         }

--- a/src/modules/previewpane/SvgThumbnailProvider/SvgThumbnailProvider.cs
+++ b/src/modules/previewpane/SvgThumbnailProvider/SvgThumbnailProvider.cs
@@ -10,7 +10,6 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
 using System.Windows.Forms;
-using Common;
 using Common.ComInterlop;
 using Common.Utilities;
 using Microsoft.PowerToys.Telemetry;
@@ -18,8 +17,6 @@ using PreviewHandlerCommon;
 
 namespace Microsoft.PowerToys.ThumbnailHandler.Svg
 {
-
-
     /// <summary>
     /// SVG Thumbnail Provider.
     /// </summary>
@@ -181,9 +178,9 @@ namespace Microsoft.PowerToys.ThumbnailHandler.Svg
         /// <returns>The resized image.</returns>
         public static Bitmap ResizeImage(Image image, int width, int height)
         {
-            if (width <= 0 || 
+            if (width <= 0 ||
                 height <= 0 ||
-                width > MaxThumbnailSize || 
+                width > MaxThumbnailSize ||
                 height > MaxThumbnailSize ||
                 image == null)
             {

--- a/src/modules/previewpane/SvgThumbnailProvider/SvgThumbnailProvider.csproj
+++ b/src/modules/previewpane/SvgThumbnailProvider/SvgThumbnailProvider.csproj
@@ -81,10 +81,12 @@
     <StartupObject />
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PlatformTarget>x64</PlatformTarget>
     <OutputPath>..\..\..\..\x64\Debug\modules\FileExplorerPreview\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PlatformTarget>x64</PlatformTarget>
     <OutputPath>..\..\..\..\x64\Release\modules\FileExplorerPreview\</OutputPath>
   </PropertyGroup>
@@ -141,6 +143,8 @@
     <Analyzer Include="..\..\..\..\packages\Microsoft.NetCore.Analyzers.3.3.0\analyzers\dotnet\cs\Microsoft.NetCore.CSharp.Analyzers.dll" />
     <Analyzer Include="..\..\..\..\packages\Microsoft.NetFramework.Analyzers.3.3.0\analyzers\dotnet\cs\Microsoft.NetFramework.Analyzers.dll" />
     <Analyzer Include="..\..\..\..\packages\Microsoft.NetFramework.Analyzers.3.3.0\analyzers\dotnet\cs\Microsoft.NetFramework.CSharp.Analyzers.dll" />
+    <Analyzer Include="..\..\..\..\packages\StyleCop.Analyzers.1.1.118\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
+    <Analyzer Include="..\..\..\..\packages\StyleCop.Analyzers.1.1.118\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/modules/previewpane/SvgThumbnailProvider/SvgThumbnailProvider.csproj
+++ b/src/modules/previewpane/SvgThumbnailProvider/SvgThumbnailProvider.csproj
@@ -1,17 +1,58 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\..\packages\Microsoft.CodeAnalysis.FxCopAnalyzers.3.3.0\build\Microsoft.CodeAnalysis.FxCopAnalyzers.props" Condition="Exists('..\..\..\..\packages\Microsoft.CodeAnalysis.FxCopAnalyzers.3.3.0\build\Microsoft.CodeAnalysis.FxCopAnalyzers.props')" />
+  <Import Project="..\..\..\..\packages\Microsoft.NetFramework.Analyzers.3.3.0\build\Microsoft.NetFramework.Analyzers.props" Condition="Exists('..\..\..\..\packages\Microsoft.NetFramework.Analyzers.3.3.0\build\Microsoft.NetFramework.Analyzers.props')" />
+  <Import Project="..\..\..\..\packages\Microsoft.NetCore.Analyzers.3.3.0\build\Microsoft.NetCore.Analyzers.props" Condition="Exists('..\..\..\..\packages\Microsoft.NetCore.Analyzers.3.3.0\build\Microsoft.NetCore.Analyzers.props')" />
+  <Import Project="..\..\..\..\packages\Microsoft.CodeQuality.Analyzers.3.3.0\build\Microsoft.CodeQuality.Analyzers.props" Condition="Exists('..\..\..\..\packages\Microsoft.CodeQuality.Analyzers.3.3.0\build\Microsoft.CodeQuality.Analyzers.props')" />
+  <Import Project="..\..\..\..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.3.3.0\build\Microsoft.CodeAnalysis.VersionCheckAnalyzer.props" Condition="Exists('..\..\..\..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.3.3.0\build\Microsoft.CodeAnalysis.VersionCheckAnalyzer.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="..\..\..\Version.props" />
+  <ItemGroup>
+    <AssemblyVersionFiles Include="Generated Files\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Target Name="GenerateAssemblyInfo" BeforeTargets="PrepareForBuild">
+    <ItemGroup>
+      <HeaderLines Include="// Copyright (c) Microsoft Corporation" />
+      <HeaderLines Include="// The Microsoft Corporation licenses this file to you under the MIT license." />
+      <HeaderLines Include="// See the LICENSE file in the project root for more information." />
+      <HeaderLines Include="#pragma warning disable SA1516" />
+      <HeaderLines Include="using System.Reflection%3b" />
+      <HeaderLines Include="using System.Resources%3b" />
+      <HeaderLines Include="using System.Runtime.CompilerServices%3b" />
+      <HeaderLines Include="using System.Runtime.InteropServices%3b" />
+      <HeaderLines Include="[assembly: AssemblyTitle(&quot;$(AssemblyTitle)&quot;)]" />
+      <HeaderLines Include="[assembly: AssemblyDescription(&quot;$(AssemblyDescription)&quot;)]" />
+      <HeaderLines Include="[assembly: AssemblyConfiguration(&quot;&quot;)]" />
+      <HeaderLines Include="[assembly: AssemblyCompany(&quot;$(AssemblyCompany)&quot;)]" />
+      <HeaderLines Include="[assembly: AssemblyCopyright(&quot;$(AssemblyCopyright)&quot;)]" />
+      <HeaderLines Include="[assembly: AssemblyProduct(&quot;$(AssemblyProduct)&quot;)]" />
+      <HeaderLines Include="[assembly: AssemblyTrademark(&quot;&quot;)]" />
+      <HeaderLines Include="[assembly: AssemblyCulture(&quot;&quot;)]" />
+      <HeaderLines Include="[assembly: ComVisible(false)]" />
+      <HeaderLines Include="[assembly: NeutralResourcesLanguage(&quot;en-US&quot;)]" />
+      <HeaderLines Include="[assembly: AssemblyVersion(&quot;$(Version).0&quot;)]" />
+      <HeaderLines Include="[assembly: AssemblyFileVersion(&quot;$(Version).0&quot;)]" />
+    </ItemGroup>
+    <WriteLinesToFile File="Generated Files\AssemblyInfo.cs" Lines="@(HeaderLines)" Overwrite="true" Encoding="Unicode" WriteOnlyWhenDifferent="true" />
+  </Target>
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{8FFE09DA-FA4F-4EE1-B3A2-AD5497FBD1AD}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <RootNamespace>SVGThumbnailProvider</RootNamespace>
+    <RootNamespace>Microsoft.PowerToys.ThumbnailHandler.Svg</RootNamespace>
     <AssemblyName>SVGThumbnailProvider</AssemblyName>
+    <AssemblyTitle>SVGThumbnailProvider</AssemblyTitle>
+    <AssemblyDescription>PowerToys SvgPreviewHandler</AssemblyDescription>
+    <AssemblyCompany>Microsoft Corporation</AssemblyCompany>
+    <AssemblyCopyright>Copyright (C) 2020 Microsoft Corporation</AssemblyCopyright>
+    <AssemblyProduct>PowerToys</AssemblyProduct>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>x64</PlatformTarget>
@@ -65,6 +106,9 @@
       <Link>GlobalSuppressions.cs</Link>
     </Compile>
     <Compile Include="SvgThumbnailProvider.cs" />
+    <Compile Include="Generated Files\AssemblyInfo.cs">
+      <SubType>Code</SubType>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\common\ManagedTelemetry\Telemetry\Telemetry.csproj">
@@ -84,5 +128,29 @@
       <Link>StyleCop.json</Link>
     </AdditionalFiles>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\..\..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.3.3.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.VersionCheckAnalyzer.resources.dll" />
+    <Analyzer Include="..\..\..\..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.3.3.0\analyzers\dotnet\Microsoft.CodeAnalysis.VersionCheckAnalyzer.dll" />
+    <Analyzer Include="..\..\..\..\packages\Microsoft.CodeQuality.Analyzers.3.3.0\analyzers\dotnet\cs\Humanizer.dll" />
+    <Analyzer Include="..\..\..\..\packages\Microsoft.CodeQuality.Analyzers.3.3.0\analyzers\dotnet\cs\Microsoft.CodeQuality.Analyzers.dll" />
+    <Analyzer Include="..\..\..\..\packages\Microsoft.CodeQuality.Analyzers.3.3.0\analyzers\dotnet\cs\Microsoft.CodeQuality.CSharp.Analyzers.dll" />
+    <Analyzer Include="..\..\..\..\packages\Microsoft.NetCore.Analyzers.3.3.0\analyzers\dotnet\cs\Microsoft.NetCore.Analyzers.dll" />
+    <Analyzer Include="..\..\..\..\packages\Microsoft.NetCore.Analyzers.3.3.0\analyzers\dotnet\cs\Microsoft.NetCore.CSharp.Analyzers.dll" />
+    <Analyzer Include="..\..\..\..\packages\Microsoft.NetFramework.Analyzers.3.3.0\analyzers\dotnet\cs\Microsoft.NetFramework.Analyzers.dll" />
+    <Analyzer Include="..\..\..\..\packages\Microsoft.NetFramework.Analyzers.3.3.0\analyzers\dotnet\cs\Microsoft.NetFramework.CSharp.Analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\..\..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.3.3.0\build\Microsoft.CodeAnalysis.VersionCheckAnalyzer.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.CodeAnalysis.VersionCheckAnalyzer.3.3.0\build\Microsoft.CodeAnalysis.VersionCheckAnalyzer.props'))" />
+    <Error Condition="!Exists('..\..\..\..\packages\Microsoft.CodeQuality.Analyzers.3.3.0\build\Microsoft.CodeQuality.Analyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.CodeQuality.Analyzers.3.3.0\build\Microsoft.CodeQuality.Analyzers.props'))" />
+    <Error Condition="!Exists('..\..\..\..\packages\Microsoft.NetCore.Analyzers.3.3.0\build\Microsoft.NetCore.Analyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.NetCore.Analyzers.3.3.0\build\Microsoft.NetCore.Analyzers.props'))" />
+    <Error Condition="!Exists('..\..\..\..\packages\Microsoft.NetFramework.Analyzers.3.3.0\build\Microsoft.NetFramework.Analyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.NetFramework.Analyzers.3.3.0\build\Microsoft.NetFramework.Analyzers.props'))" />
+    <Error Condition="!Exists('..\..\..\..\packages\Microsoft.CodeAnalysis.FxCopAnalyzers.3.3.0\build\Microsoft.CodeAnalysis.FxCopAnalyzers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.CodeAnalysis.FxCopAnalyzers.3.3.0\build\Microsoft.CodeAnalysis.FxCopAnalyzers.props'))" />
+  </Target>
 </Project>

--- a/src/modules/previewpane/SvgThumbnailProvider/packages.config
+++ b/src/modules/previewpane/SvgThumbnailProvider/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.CodeAnalysis.FxCopAnalyzers" version="3.3.0" targetFramework="net472" developmentDependency="true" />
+  <package id="Microsoft.CodeAnalysis.VersionCheckAnalyzer" version="3.3.0" targetFramework="net472" developmentDependency="true" />
+  <package id="Microsoft.CodeQuality.Analyzers" version="3.3.0" targetFramework="net472" developmentDependency="true" />
+  <package id="Microsoft.NetCore.Analyzers" version="3.3.0" targetFramework="net472" developmentDependency="true" />
+  <package id="Microsoft.NetFramework.Analyzers" version="3.3.0" targetFramework="net472" developmentDependency="true" />
+</packages>

--- a/src/modules/previewpane/SvgThumbnailProvider/packages.config
+++ b/src/modules/previewpane/SvgThumbnailProvider/packages.config
@@ -5,4 +5,5 @@
   <package id="Microsoft.CodeQuality.Analyzers" version="3.3.0" targetFramework="net472" developmentDependency="true" />
   <package id="Microsoft.NetCore.Analyzers" version="3.3.0" targetFramework="net472" developmentDependency="true" />
   <package id="Microsoft.NetFramework.Analyzers" version="3.3.0" targetFramework="net472" developmentDependency="true" />
+  <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net472" developmentDependency="true" />
 </packages>

--- a/src/modules/previewpane/UnitTests-SvgThumbnailProvider/SvgThumbnailProviderTests.cs
+++ b/src/modules/previewpane/UnitTests-SvgThumbnailProvider/SvgThumbnailProviderTests.cs
@@ -9,6 +9,7 @@ using System.Runtime.InteropServices.ComTypes;
 using System.Text;
 using Common.ComInterlop;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.PowerToys.ThumbnailHandler.Svg;
 using Moq;
 
 namespace SvgThumbnailProviderUnitTests
@@ -25,7 +26,7 @@ namespace SvgThumbnailProviderUnitTests
             svgBuilder.AppendLine("\t</circle>");
             svgBuilder.AppendLine("</svg>");
 
-            Bitmap thumbnail = SvgThumbnailProvider.SvgThumbnailProvider.GetThumbnail(svgBuilder.ToString(), 256);
+            Bitmap thumbnail = SvgThumbnailProvider.GetThumbnail(svgBuilder.ToString(), 256);
             Assert.IsTrue(thumbnail != null);
         }
 
@@ -39,7 +40,7 @@ namespace SvgThumbnailProviderUnitTests
             svgBuilder.AppendLine("\t</circle>");
             svgBuilder.AppendLine("</svg>");
 
-            Bitmap thumbnail = SvgThumbnailProvider.SvgThumbnailProvider.GetThumbnail(svgBuilder.ToString(), 256);
+            Bitmap thumbnail = SvgThumbnailProvider.GetThumbnail(svgBuilder.ToString(), 256);
             Assert.IsTrue(thumbnail != null);
         }
 
@@ -49,21 +50,21 @@ namespace SvgThumbnailProviderUnitTests
             var svgBuilder = new StringBuilder();
             svgBuilder.AppendLine("<p>foo</p>");
 
-            Bitmap thumbnail = SvgThumbnailProvider.SvgThumbnailProvider.GetThumbnail(svgBuilder.ToString(), 256);
+            Bitmap thumbnail = SvgThumbnailProvider.GetThumbnail(svgBuilder.ToString(), 256);
             Assert.IsTrue(thumbnail == null);
         }
 
         [TestMethod]
         public void CheckNoSvgEmptyStringShouldReturnNullBitmap()
         {
-            Bitmap thumbnail = SvgThumbnailProvider.SvgThumbnailProvider.GetThumbnail(string.Empty, 256);
+            Bitmap thumbnail = SvgThumbnailProvider.GetThumbnail(string.Empty, 256);
             Assert.IsTrue(thumbnail == null);
         }
 
         [TestMethod]
         public void CheckNoSvgNullStringShouldReturnNullBitmap()
         {
-            Bitmap thumbnail = SvgThumbnailProvider.SvgThumbnailProvider.GetThumbnail(null, 256);
+            Bitmap thumbnail = SvgThumbnailProvider.GetThumbnail(null, 256);
             Assert.IsTrue(thumbnail == null);
         }
 
@@ -71,7 +72,7 @@ namespace SvgThumbnailProviderUnitTests
         public void CheckZeroSizedThumbnailShouldReturnNullBitmap()
         {
             string content = "<svg></svg>";
-            Bitmap thumbnail = SvgThumbnailProvider.SvgThumbnailProvider.GetThumbnail(content, 0);
+            Bitmap thumbnail = SvgThumbnailProvider.GetThumbnail(content, 0);
             Assert.IsTrue(thumbnail == null);
         }
 
@@ -92,7 +93,7 @@ namespace SvgThumbnailProviderUnitTests
             svgBuilder.AppendLine("</body>");
             svgBuilder.AppendLine("</html>");
 
-            Bitmap thumbnail = SvgThumbnailProvider.SvgThumbnailProvider.GetThumbnail(svgBuilder.ToString(), 256);
+            Bitmap thumbnail = SvgThumbnailProvider.GetThumbnail(svgBuilder.ToString(), 256);
             Assert.IsTrue(thumbnail != null);
         }
 
@@ -105,7 +106,7 @@ namespace SvgThumbnailProviderUnitTests
             svgBuilder.AppendLine("</circle>");
             svgBuilder.AppendLine("</svg>");
 
-            SvgThumbnailProvider.SvgThumbnailProvider provider = new SvgThumbnailProvider.SvgThumbnailProvider();
+            SvgThumbnailProvider provider = new SvgThumbnailProvider();
 
             provider.Initialize(GetMockStream(svgBuilder.ToString()), 0);
 
@@ -134,7 +135,7 @@ namespace SvgThumbnailProviderUnitTests
             svgBuilder.AppendLine("</body>");
             svgBuilder.AppendLine("</html>");
 
-            SvgThumbnailProvider.SvgThumbnailProvider provider = new SvgThumbnailProvider.SvgThumbnailProvider();
+            SvgThumbnailProvider provider = new SvgThumbnailProvider();
 
             provider.Initialize(GetMockStream(svgBuilder.ToString()), 0);
 


### PR DESCRIPTION
## Summary of the Pull Request

Installs and icons change / render.  Changes the WSX as well due to FxCop violation with namespace

![image](https://user-images.githubusercontent.com/1462282/93826783-d5888800-fc1c-11ea-8880-4ca5afa9f88a.png)


## PR Checklist
* [x] Applies to #5129, #6754
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

StyleCop and FxCop

## Validation Steps Performed

_How does someone test & validate?_
