### PR TITLE
Fixed scaling Accessibility issues in Settings

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -285,7 +285,7 @@
                      Margin="{StaticResource SmallTopMargin}"
                      Text="{x:Bind Mode=TwoWay, Path=ViewModel.ExcludedApps}"
                      IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"
-                     Width="370"
+                     Width="375"
                      Height="160"
                      HorizontalAlignment="Left"
                      ScrollViewer.VerticalScrollBarVisibility ="Visible"

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -285,7 +285,7 @@
                      Margin="{StaticResource SmallTopMargin}"
                      Text="{x:Bind Mode=TwoWay, Path=ViewModel.ExcludedApps}"
                      IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"
-                     Width="380"
+                     Width="370"
                      Height="160"
                      HorizontalAlignment="Left"
                      ScrollViewer.VerticalScrollBarVisibility ="Visible"

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
@@ -64,7 +64,7 @@
                       IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"
                       SelectionMode="None"
                       ScrollViewer.HorizontalScrollMode="Enabled"
-                      ScrollViewer.HorizontalScrollBarVisibility="Visible"
+                      ScrollViewer.HorizontalScrollBarVisibility="Auto"
                       ScrollViewer.IsHorizontalRailEnabled="True">
 
                 <ListView.ItemContainerStyle>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
@@ -62,7 +62,10 @@
                       ItemsSource="{x:Bind ViewModel.Sizes, Mode=TwoWay}"
                       Padding="0"
                       IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"
-                      SelectionMode="None">
+                      SelectionMode="None"
+                      ScrollViewer.HorizontalScrollMode="Enabled"
+                      ScrollViewer.HorizontalScrollBarVisibility="Visible"
+                      ScrollViewer.IsHorizontalRailEnabled="True">
 
                 <ListView.ItemContainerStyle>
                     <Style TargetType="ListViewItem">


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

## PR Checklist
* [x] Applies to #6773
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

The following changes have been made in this PR - 
1. A horizontal scroll bar has been added for the img resizer configurations. Previously there was no scroll bar and the components couldn't be accessed when the width of settings was reduced.
2. Reduced the width of the FZ text box because it was being cut.

## Validation Steps Performed

_How does someone test & validate?_

Before:
![image](https://user-images.githubusercontent.com/28739210/93950114-7cd9ed80-fcf7-11ea-992d-5c479390fec5.png)

After
![image](https://user-images.githubusercontent.com/28739210/93950120-7fd4de00-fcf7-11ea-9da1-d8351633d223.png)


Before:
![image](https://user-images.githubusercontent.com/28739210/93950125-8400fb80-fcf7-11ea-948d-41eddc5bf811.png)

After:
![image](https://user-images.githubusercontent.com/28739210/93950176-aabf3200-fcf7-11ea-8992-ad4e4e910c01.png)

