### PR TITLE
[FancyZones editor] Rudimentary crash handler

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/App.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/App.xaml.cs
@@ -3,7 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
 using FancyZonesEditor.Models;
@@ -25,6 +30,8 @@ namespace FancyZonesEditor
 
         private void OnStartup(object sender, StartupEventArgs e)
         {
+            AppDomain.CurrentDomain.UnhandledException += OnUnhandledException;
+
             RunnerHelper.WaitForPowerToysRunner(Settings.PowerToysPID, () =>
             {
                 Environment.Exit(0);
@@ -65,6 +72,97 @@ namespace FancyZonesEditor
             EditorOverlay overlay = new EditorOverlay();
             overlay.Show();
             overlay.DataContext = foundModel;
+        }
+
+        private void OnUnhandledException(object sender, UnhandledExceptionEventArgs args)
+        {
+            var fileStream = File.OpenWrite("FZEditorCrash.log");
+            var sw = new StreamWriter(fileStream);
+            sw.Write(FormatException((Exception)args.ExceptionObject));
+            fileStream.Close();
+        }
+
+        private string FormatException(Exception ex)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine();
+            sb.AppendLine("## Exception");
+            sb.AppendLine();
+            sb.AppendLine("```");
+
+            var exlist = new List<StringBuilder>();
+
+            while (ex != null)
+            {
+                var exsb = new StringBuilder();
+                exsb.Append(ex.GetType().FullName);
+                exsb.Append(": ");
+                exsb.AppendLine(ex.Message);
+                if (ex.Source != null)
+                {
+                    exsb.Append("   Source: ");
+                    exsb.AppendLine(ex.Source);
+                }
+
+                if (ex.TargetSite != null)
+                {
+                    exsb.Append("   TargetAssembly: ");
+                    exsb.AppendLine(ex.TargetSite.Module.Assembly.ToString());
+                    exsb.Append("   TargetModule: ");
+                    exsb.AppendLine(ex.TargetSite.Module.ToString());
+                    exsb.Append("   TargetSite: ");
+                    exsb.AppendLine(ex.TargetSite.ToString());
+                }
+
+                exsb.AppendLine(ex.StackTrace);
+                exlist.Add(exsb);
+
+                ex = ex.InnerException;
+            }
+
+            foreach (var result in exlist.Select(o => o.ToString()).Reverse())
+            {
+                sb.AppendLine(result);
+            }
+
+            sb.AppendLine("```");
+            sb.AppendLine();
+
+            sb.AppendLine("## Environment");
+            sb.AppendLine($"* Command Line: {Environment.CommandLine}");
+            sb.AppendLine($"* Timestamp: {DateTime.Now.ToString(CultureInfo.InvariantCulture)}");
+            sb.AppendLine($"* OS Version: {Environment.OSVersion.VersionString}");
+            sb.AppendLine($"* IntPtr Length: {IntPtr.Size}");
+            sb.AppendLine($"* x64: {Environment.Is64BitOperatingSystem}");
+            sb.AppendLine($"* CLR Version: {Environment.Version}");
+            sb.AppendLine($"* Installed .NET Framework: ");
+
+            sb.AppendLine();
+            sb.AppendLine("## Assemblies - " + AppDomain.CurrentDomain.FriendlyName);
+            sb.AppendLine();
+            foreach (var ass in AppDomain.CurrentDomain.GetAssemblies().OrderBy(o => o.GlobalAssemblyCache ? 50 : 0))
+            {
+                sb.Append("* ");
+                sb.Append(ass.FullName);
+                sb.Append(" (");
+
+                if (ass.IsDynamic)
+                {
+                    sb.Append("dynamic assembly doesn't has location");
+                }
+                else if (string.IsNullOrEmpty(ass.Location))
+                {
+                    sb.Append("location is null or empty");
+                }
+                else
+                {
+                    sb.Append(ass.Location);
+                }
+
+                sb.AppendLine(")");
+            }
+
+            return sb.ToString();
         }
     }
 }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/App.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/App.xaml.cs
@@ -80,7 +80,7 @@ namespace FancyZonesEditor
             var sw = new StreamWriter(fileStream);
             sw.Write(FormatException((Exception)args.ExceptionObject));
             fileStream.Close();
-            MessageBox.Show("FancyZones editor crash log written to " + Path.GetFullPath(fileStream.Name));
+            MessageBox.Show("Error logged to " + Path.GetFullPath(fileStream.Name) + "\nPlease report the bug to https://aka.ms/powerToysReportBug", "FancyZones Editor Error");
         }
 
         private string FormatException(Exception ex)

--- a/src/modules/fancyzones/editor/FancyZonesEditor/App.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/App.xaml.cs
@@ -80,6 +80,7 @@ namespace FancyZonesEditor
             var sw = new StreamWriter(fileStream);
             sw.Write(FormatException((Exception)args.ExceptionObject));
             fileStream.Close();
+            MessageBox.Show("FancyZones editor crash log written to " + Path.GetFullPath(fileStream.Name));
         }
 
         private string FormatException(Exception ex)
@@ -135,9 +136,6 @@ namespace FancyZonesEditor
             sb.AppendLine($"* IntPtr Length: {IntPtr.Size}");
             sb.AppendLine($"* x64: {Environment.Is64BitOperatingSystem}");
             sb.AppendLine($"* CLR Version: {Environment.Version}");
-            sb.AppendLine($"* Installed .NET Framework: ");
-
-            sb.AppendLine();
             sb.AppendLine("## Assemblies - " + AppDomain.CurrentDomain.FriendlyName);
             sb.AppendLine();
             foreach (var ass in AppDomain.CurrentDomain.GetAssemblies().OrderBy(o => o.GlobalAssemblyCache ? 50 : 0))

--- a/src/modules/fancyzones/editor/FancyZonesEditor/App.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/App.xaml.cs
@@ -76,7 +76,7 @@ namespace FancyZonesEditor
 
         private void OnUnhandledException(object sender, UnhandledExceptionEventArgs args)
         {
-            var fileStream = File.OpenWrite("FZEditorCrash.log");
+            var fileStream = File.OpenWrite("FZEditorCrashLog.txt");
             var sw = new StreamWriter(fileStream);
             sw.Write(FormatException((Exception)args.ExceptionObject));
             fileStream.Close();


### PR DESCRIPTION
## Summary of the Pull Request

This PR implements a crash handler for the FancyZones editor. It writes a log file and shows a message box telling the user that a crash occurred, and where the log file is located.

## PR Checklist
* [ ] Applies to #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Validation Steps Performed

The easiest way to crash the editor is to set zone spacing to some large value (e.g. 10000).
