### PR TITLE
Getting version numbers set by the build farm

### DIFF
--- a/src/Version.props
+++ b/src/Version.props
@@ -1,6 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <Version>0.21.2</Version>
+    <Version>0.0.1</Version>
+    <DevEnvironment>Local</DevEnvironment>
   </PropertyGroup>
 </Project>

--- a/src/modules/previewpane/SvgPreviewHandler/SvgPreviewControl.cs
+++ b/src/modules/previewpane/SvgPreviewHandler/SvgPreviewControl.cs
@@ -48,7 +48,7 @@ namespace Microsoft.PowerToys.PreviewHandler.Svg
                 {
                     _infoBarAdded = false;
                     string svgData = null;
-                    using (var stream = new StreamWrapper(dataSource as IStream))
+                    using (var stream = new ReadonlyStream(dataSource as IStream))
                     {
                         using (var reader = new StreamReader(stream))
                         {

--- a/src/modules/previewpane/SvgThumbnailProvider/SvgThumbnailProvider.cs
+++ b/src/modules/previewpane/SvgThumbnailProvider/SvgThumbnailProvider.cs
@@ -222,7 +222,7 @@ namespace SvgThumbnailProvider
             }
 
             string svgData = null;
-            using (var stream = new StreamWrapper(this.Stream as IStream))
+            using (var stream = new ReadonlyStream(this.Stream as IStream))
             {
                 using (var reader = new StreamReader(stream))
                 {

--- a/src/modules/previewpane/UnitTests-PreviewHandlerCommon/FormHandlerControlTests.cs
+++ b/src/modules/previewpane/UnitTests-PreviewHandlerCommon/FormHandlerControlTests.cs
@@ -58,7 +58,7 @@ namespace UnitTests_PreviewHandlerCommon
             using (var testFormHandlerControl = new TestFormControl())
             {
                 // Act
-                var handle = testFormHandlerControl.GetHandle();
+                var handle = testFormHandlerControl.Handle;
 
                 // Assert
                 Assert.AreEqual(testFormHandlerControl.Handle, handle);

--- a/src/modules/previewpane/UnitTests-PreviewHandlerCommon/PreviewHandlerBaseTests.cs
+++ b/src/modules/previewpane/UnitTests-PreviewHandlerCommon/PreviewHandlerBaseTests.cs
@@ -19,6 +19,11 @@ namespace UnitTests_PreviewHandlerCommon
 
         public class TestPreviewHandler : PreviewHandlerBase
         {
+            public TestPreviewHandler()
+            {
+                Initialize();
+            }
+
             public override void DoPreview()
             {
                 throw new NotImplementedException();
@@ -291,7 +296,7 @@ namespace UnitTests_PreviewHandlerCommon
             // Arrange
             var previewControlHandle = new IntPtr(5);
             var mockPreviewControl = new Mock<IPreviewHandlerControl>();
-            mockPreviewControl.Setup(x => x.GetHandle())
+            mockPreviewControl.Setup(x => x.GetWindowHandle())
                 .Returns(previewControlHandle);
 
             previewHandlerControl = mockPreviewControl.Object;

--- a/src/modules/previewpane/UnitTests-PreviewHandlerCommon/StreamWrapperTests.cs
+++ b/src/modules/previewpane/UnitTests-PreviewHandlerCommon/StreamWrapperTests.cs
@@ -26,7 +26,7 @@ namespace UnitTests_PreviewHandlerCommon
             // Act
             try
             {
-                var streamWrapper = new StreamWrapper(stream);
+                var streamWrapper = new ReadonlyStream(stream);
             }
             catch (ArgumentNullException ex)
             {
@@ -44,7 +44,7 @@ namespace UnitTests_PreviewHandlerCommon
             var streamMock = new Mock<IStream>();
 
             // Act
-            var streamWrapper = new StreamWrapper(streamMock.Object);
+            var streamWrapper = new ReadonlyStream(streamMock.Object);
 
             // Assert
             Assert.AreEqual(streamWrapper.CanRead, true);
@@ -57,7 +57,7 @@ namespace UnitTests_PreviewHandlerCommon
             var streamMock = new Mock<IStream>();
 
             // Act
-            var streamWrapper = new StreamWrapper(streamMock.Object);
+            var streamWrapper = new ReadonlyStream(streamMock.Object);
 
             // Assert
             Assert.AreEqual(streamWrapper.CanSeek, true);
@@ -70,7 +70,7 @@ namespace UnitTests_PreviewHandlerCommon
             var streamMock = new Mock<IStream>();
 
             // Act
-            var streamWrapper = new StreamWrapper(streamMock.Object);
+            var streamWrapper = new ReadonlyStream(streamMock.Object);
 
             // Assert
             Assert.AreEqual(streamWrapper.CanWrite, false);
@@ -89,7 +89,7 @@ namespace UnitTests_PreviewHandlerCommon
 
             stremMock
                 .Setup(x => x.Stat(out stat, It.IsAny<int>()));
-            var streamWrapper = new StreamWrapper(stremMock.Object);
+            var streamWrapper = new ReadonlyStream(stremMock.Object);
 
             // Act
             var actualLength = streamWrapper.Length;
@@ -113,7 +113,7 @@ namespace UnitTests_PreviewHandlerCommon
                 {
                     Marshal.WriteInt64(plibNewPosition, currPosition);
                 });
-            var streamWrapper = new StreamWrapper(stremMock.Object);
+            var streamWrapper = new ReadonlyStream(stremMock.Object);
 
             // Act
             var actualPosition = streamWrapper.Position;
@@ -131,7 +131,7 @@ namespace UnitTests_PreviewHandlerCommon
             int expectedDwOrigin = 0; // STREAM_SEEK_SET
             var stremMock = new Mock<IStream>();
 
-            var streamWrapper = new StreamWrapper(stremMock.Object)
+            var streamWrapper = new ReadonlyStream(stremMock.Object)
             {
                 // Act
                 Position = positionToSet,
@@ -168,7 +168,7 @@ namespace UnitTests_PreviewHandlerCommon
             }
 
             var stremMock = new Mock<IStream>();
-            var streamWrapper = new StreamWrapper(stremMock.Object);
+            var streamWrapper = new ReadonlyStream(stremMock.Object);
 
             // Act
             streamWrapper.Seek(offset, origin);
@@ -191,7 +191,7 @@ namespace UnitTests_PreviewHandlerCommon
                     Marshal.WriteInt64(plibNewPosition, position);
                 });
 
-            var streamWrapper = new StreamWrapper(stremMock.Object);
+            var streamWrapper = new ReadonlyStream(stremMock.Object);
 
             // Act
             var actualPosition = streamWrapper.Seek(0, SeekOrigin.Begin);
@@ -212,7 +212,7 @@ namespace UnitTests_PreviewHandlerCommon
             var stremMock = new Mock<IStream>();
             ArgumentOutOfRangeException exception = null;
 
-            var streamWrapper = new StreamWrapper(stremMock.Object);
+            var streamWrapper = new ReadonlyStream(stremMock.Object);
 
             // Act
             try
@@ -252,7 +252,7 @@ namespace UnitTests_PreviewHandlerCommon
                    Marshal.WriteInt32(bytesReadPtr, count);
                });
 
-            var streamWrapper = new StreamWrapper(stremMock.Object);
+            var streamWrapper = new ReadonlyStream(stremMock.Object);
 
             // Act
             var bytesRead = streamWrapper.Read(inputBuffer, offset, count);
@@ -267,7 +267,7 @@ namespace UnitTests_PreviewHandlerCommon
         {
             // Arrange
             var stremMock = new Mock<IStream>();
-            var streamWrapper = new StreamWrapper(stremMock.Object);
+            var streamWrapper = new ReadonlyStream(stremMock.Object);
             NotImplementedException exception = null;
 
             // Act
@@ -289,7 +289,7 @@ namespace UnitTests_PreviewHandlerCommon
         {
             // Arrange
             var stremMock = new Mock<IStream>();
-            var streamWrapper = new StreamWrapper(stremMock.Object);
+            var streamWrapper = new ReadonlyStream(stremMock.Object);
             NotImplementedException exception = null;
 
             // Act
@@ -311,7 +311,7 @@ namespace UnitTests_PreviewHandlerCommon
         {
             // Arrange
             var stremMock = new Mock<IStream>();
-            var streamWrapper = new StreamWrapper(stremMock.Object);
+            var streamWrapper = new ReadonlyStream(stremMock.Object);
             NotImplementedException exception = null;
 
             // Act

--- a/src/modules/previewpane/common/PreviewHandlerCommon.csproj
+++ b/src/modules/previewpane/common/PreviewHandlerCommon.csproj
@@ -110,6 +110,7 @@
     <Compile Include="cominterop\IViewObject.cs" />
     <Compile Include="cominterop\LOGFONT.cs" />
     <Compile Include="cominterop\MSG.cs" />
+    <Compile Include="cominterop\NativeMethods.cs" />
     <Compile Include="cominterop\RECT.cs" />
     <Compile Include="controls\WebBrowserDownloadControlFlags.cs" />
     <Compile Include="controls\WebBrowserExt.cs">
@@ -129,7 +130,7 @@
     <Compile Include="handlers\PreviewHandlerBase.cs" />
     <Compile Include="handlers\StreamBasedPreviewHandler.cs" />
     <Compile Include="examplehandler\TestCustomHandler.cs" />
-    <Compile Include="Utilities\StreamWrapper.cs" />
+    <Compile Include="Utilities\ReadonlyStream.cs" />
   </ItemGroup>
   <ItemGroup>
     <AdditionalFiles Include="..\..\..\codeAnalysis\StyleCop.json">
@@ -137,6 +138,11 @@
     </AdditionalFiles>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers">
+      <Version>3.3.0</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="StyleCop.Analyzers">
       <Version>1.1.118</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/modules/previewpane/common/cominterop/COLORREF.cs
+++ b/src/modules/previewpane/common/cominterop/COLORREF.cs
@@ -11,12 +11,13 @@ namespace Common.ComInterlop
     /// The COLORREF value is used to specify an RGB color.
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1815:Override equals and operator equals on value types", Justification = "Interop")]
     public struct COLORREF
     {
         /// <summary>
-        /// Stores an RGB color value in a 32 bit integer.
+        /// Gets or sets stores an RGB color value in a 32 bit integer.
         /// </summary>
-        public uint Dword;
+        public uint Dword { get; set; }
 
         /// <summary>
         /// Gets RGB value stored in <see cref="Dword"/> in <see cref="Color"/> structure.
@@ -26,9 +27,9 @@ namespace Common.ComInterlop
             get
             {
                 return Color.FromArgb(
-                    (int)(0x000000FFU & this.Dword),
-                    (int)(0x0000FF00U & this.Dword) >> 8,
-                    (int)(0x00FF0000U & this.Dword) >> 16);
+                    (int)(0x000000FFU & Dword),
+                    (int)(0x0000FF00U & Dword) >> 8,
+                    (int)(0x00FF0000U & Dword) >> 16);
             }
         }
     }

--- a/src/modules/previewpane/common/cominterop/IThumbnailProvider.cs
+++ b/src/modules/previewpane/common/cominterop/IThumbnailProvider.cs
@@ -10,10 +10,11 @@ namespace Common.ComInterlop
     /// <summary>
     /// Specifies the alpha type of the image.
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "Interop")]
     public enum WTS_ALPHATYPE : int
     {
         /// <summary>
-        /// he bitmap is an unknown format. The Shell tries nonetheless to detect whether the image has an alpha channel.
+        /// The bitmap is an unknown format. The Shell tries nonetheless to detect whether the image has an alpha channel.
         /// </summary>
         WTSAT_UNKNOWN = 0,
 

--- a/src/modules/previewpane/common/cominterop/LOGFONT.cs
+++ b/src/modules/previewpane/common/cominterop/LOGFONT.cs
@@ -10,79 +10,86 @@ namespace Common.ComInterlop
     /// Defines the attributes of a font.
     /// </summary>
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1815:Override equals and operator equals on value types", Justification = "Interop")]
     public struct LOGFONT
     {
         /// <summary>
-        /// Value of type INT that specifies the height, in logical units, of the font's character cell or character.
+        /// Gets or sets value of type INT that specifies the height, in logical units, of the font's character cell or character.
         /// </summary>
-        public int LfHeight;
+        public int LfHeight { get; set; }
 
         /// <summary>
-        /// Value of type INT that specifies the width, in logical units, of characters in the font.
+        /// Gets or sets value of type INT that specifies the width, in logical units, of characters in the font.
         /// </summary>
-        public int LfWidth;
+        public int LfWidth { get; set; }
 
         /// <summary>
-        /// Value of type INT that contains the angle, in tenths of degrees, between the escapement vector and the x-axis of the device. The escapement
+        /// Gets or sets value of type INT that contains the angle, in tenths of degrees, between the escapement vector and the x-axis of the device. The escapement
         /// vector is parallel to the base line of a row of text.
         /// </summary>
-        public int LfEscapement;
+        public int LfEscapement { get; set; }
 
         /// <summary>
-        /// Value of type INT that specifies the angle, in tenths of degrees, between each character's base line and the x-axis of the device.
+        /// Gets or sets value of type INT that specifies the angle, in tenths of degrees, between each character's base line and the x-axis of the device.
         /// </summary>
-        public int LfOrientation;
+        public int LfOrientation { get; set; }
 
         /// <summary>
-        /// Value of type INT that specifies the weight of the font in the range from 0 through 1000.
+        /// Gets or sets value of type INT that specifies the weight of the font in the range from 0 through 1000.
         /// </summary>
-        public int LfWeight;
+        public int LfWeight { get; set; }
 
         /// <summary>
-        /// Value of type BYTE that specifies an italic font if set to TRUE.
+        /// Gets or sets value of type BYTE that specifies an italic font if set to TRUE.
         /// </summary>
-        public byte LfItalic;
+        public byte LfItalic { get; set; }
 
         /// <summary>
-        /// Value of type BYTE that specifies an underlined font if set to TRUE.
+        /// Gets or sets value of type BYTE that specifies an underlined font if set to TRUE.
         /// </summary>
-        public byte LfUnderline;
+        public byte LfUnderline { get; set; }
 
         /// <summary>
-        /// Value of type BYTE that specifies a strikeout font if set to TRUE.
+        /// Gets or sets value of type BYTE that specifies a strikeout font if set to TRUE.
         /// </summary>
-        public byte LfStrikeOut;
+        public byte LfStrikeOut { get; set; }
 
         /// <summary>
-        /// Value of type BYTE that specifies the character set.
+        /// Gets or sets value of type BYTE that specifies the character set.
         /// </summary>
-        public byte LfCharSet;
+        public byte LfCharSet { get; set; }
 
         /// <summary>
-        /// Value of type BYTE that specifies the output precision. The output precision defines how closely the output must match the requested
+        /// Gets or sets value of type BYTE that specifies the output precision. The output precision defines how closely the output must match the requested
         /// font's height, width, character orientation, escapement, pitch, and font type.
         /// </summary>
-        public byte LfOutPrecision;
+        public byte LfOutPrecision { get; set; }
 
         /// <summary>
-        /// Value of type BYTE that specifies the clipping precision. The clipping precision defines how to clip characters that are partially outside the clipping region.
+        /// Gets or sets value of type BYTE that specifies the clipping precision. The clipping precision defines how to clip characters that are partially outside the clipping region.
         /// </summary>
-        public byte LfClipPrecision;
+        public byte LfClipPrecision { get; set; }
 
         /// <summary>
-        /// Value of type BYTE that specifies the output quality. The output quality defines how carefully the GDI must attempt to match the logical-font attributes to those of an actual physical font.
+        /// Gets or sets value of type BYTE that specifies the output quality. The output quality defines how carefully the GDI must attempt to match the logical-font attributes to those of an actual physical font.
         /// </summary>
-        public byte LfQuality;
+        public byte LfQuality { get; set; }
 
         /// <summary>
-        /// Value of type BYTE that specifies the pitch and family of the font.
+        /// Gets or sets value of type BYTE that specifies the pitch and family of the font.
         /// </summary>
-        public byte LfPitchAndFamily;
+        public byte LfPitchAndFamily { get; set; }
 
         /// <summary>
-        /// Array of wide characters that contains a null-terminated string that specifies the typeface name of the font. The length of the string must not exceed 32 characters, including the NULL terminator.
+        /// Gets or sets array of wide characters that contains a null-terminated string that specifies the typeface name of the font. The length of the string must not exceed 32 characters, including the NULL terminator.
         /// </summary>
+        public string LfFaceName
+        {
+            get { return _lfFaceName; }
+            set { _lfFaceName = value; }
+        }
+
         [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)]
-        public string LfFaceName;
+        private string _lfFaceName;
     }
 }

--- a/src/modules/previewpane/common/cominterop/MSG.cs
+++ b/src/modules/previewpane/common/cominterop/MSG.cs
@@ -11,41 +11,42 @@ namespace Common.ComInterlop
     /// Contains message information from a thread's message queue.
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1815:Override equals and operator equals on value types", Justification = "Interop")]
     public struct MSG
     {
         /// <summary>
-        /// A handle to the window whose window procedure receives the message. This member is NULL when the message is a thread message.
+        /// Gets or sets a handle to the window whose window procedure receives the message. This member is NULL when the message is a thread message.
         /// </summary>
-        public IntPtr Hwnd;
+        public IntPtr Hwnd { get; set; }
 
         /// <summary>
-        /// The message identifier. Applications can only use the low word; the high word is reserved by the system.
+        /// Gets or sets the message identifier. Applications can only use the low word; the high word is reserved by the system.
         /// </summary>
-        public int Message;
+        public int Message { get; set; }
 
         /// <summary>
-        /// Additional information about the message. The exact meaning depends on the value of the message member.
+        /// Gets or sets additional information about the message. The exact meaning depends on the value of the message member.
         /// </summary>
-        public IntPtr WParam;
+        public IntPtr WParam { get; set; }
 
         /// <summary>
-        /// Additional information about the message. The exact meaning depends on the value of the message member.
+        /// Gets or sets additional information about the message. The exact meaning depends on the value of the message member.
         /// </summary>
-        public IntPtr LParam;
+        public IntPtr LParam { get; set; }
 
         /// <summary>
-        /// The time at which the message was posted.
+        /// Gets or sets the time at which the message was posted.
         /// </summary>
-        public int Time;
+        public int Time { get; set; }
 
         /// <summary>
-        /// The x coordinate of cursor position, in screen coordinates, when the message was posted.
+        /// Gets or sets the x coordinate of cursor position, in screen coordinates, when the message was posted.
         /// </summary>
-        public int PtX;
+        public int PtX { get; set; }
 
         /// <summary>
-        /// The y coordinate of cursor position, in screen coordinates, when the message was posted.
+        /// Gets or sets the y coordinate of cursor position, in screen coordinates, when the message was posted.
         /// </summary>
-        public int PtY;
+        public int PtY { get; set; }
     }
 }

--- a/src/modules/previewpane/common/cominterop/NativeMethods.cs
+++ b/src/modules/previewpane/common/cominterop/NativeMethods.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace PreviewHandlerCommon.ComInterop
+{
+    /// <summary>
+    /// Interop methods
+    /// </summary>
+    internal class NativeMethods
+    {
+        /// <summary>
+        /// Changes the parent window of the specified child window.
+        /// </summary>
+        /// <param name="hWndChild">A handle to the child window.</param>
+        /// <param name="hWndNewParent">A handle to the new parent window.</param>
+        /// <returns>If the function succeeds, the return value is a handle to the previous parent window and NULL in case of failure.</returns>
+        [DllImport("user32.dll")]
+        public static extern IntPtr SetParent(IntPtr hWndChild, IntPtr hWndNewParent);
+
+        /// <summary>
+        /// Retrieves the handle to the window that has the keyboard focus, if the window is attached to the calling thread's message queue.
+        /// </summary>
+        /// <returns>The return value is the handle to the window with the keyboard focus. If the calling thread's message queue does not have an associated window with the keyboard focus, the return value is NULL.</returns>
+        [DllImport("user32.dll", CharSet = CharSet.Auto)]
+        public static extern IntPtr GetFocus();
+
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern int GetWindowLong(IntPtr hWnd, int nIndex);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern int SetWindowLong(IntPtr hWnd, int nIndex, int dwNewLong);
+    }
+}

--- a/src/modules/previewpane/common/cominterop/RECT.cs
+++ b/src/modules/previewpane/common/cominterop/RECT.cs
@@ -11,27 +11,28 @@ namespace Common.ComInterlop
     /// The RECT structure defines a rectangle by the coordinates of its upper-left and lower-right corners.
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1815:Override equals and operator equals on value types", Justification = "Interop")]
     public struct RECT
     {
         /// <summary>
-        /// Specifies the x-coordinate of the upper-left corner of the rectangle.
+        /// Gets or sets specifies the x-coordinate of the upper-left corner of the rectangle.
         /// </summary>
-        public int Left;
+        public int Left { get; set; }
 
         /// <summary>
-        /// Specifies the y-coordinate of the upper-left corner of the rectangle.
+        /// Gets or sets specifies the y-coordinate of the upper-left corner of the rectangle.
         /// </summary>
-        public int Top;
+        public int Top { get; set; }
 
         /// <summary>
-        /// Specifies the x-coordinate of the lower-right corner of the rectangle.
+        /// Gets or sets specifies the x-coordinate of the lower-right corner of the rectangle.
         /// </summary>
-        public int Right;
+        public int Right { get; set; }
 
         /// <summary>
-        /// Specifies the y-coordinate of the lower-right corner of the rectangle.
+        /// Gets or sets specifies the y-coordinate of the lower-right corner of the rectangle.
         /// </summary>
-        public int Bottom;
+        public int Bottom { get; set; }
 
         /// <summary>
         /// Creates a <see cref="Rectangle" /> structure with the edge locations specified in the struct.
@@ -39,7 +40,7 @@ namespace Common.ComInterlop
         /// <returns>Return a <see cref="Rectangle"/>.</returns>
         public Rectangle ToRectangle()
         {
-            return Rectangle.FromLTRB(this.Left, this.Top, this.Right, this.Bottom);
+            return Rectangle.FromLTRB(Left, Top, Right, Bottom);
         }
     }
 }

--- a/src/modules/previewpane/common/controls/IPreviewHandlerControl.cs
+++ b/src/modules/previewpane/common/controls/IPreviewHandlerControl.cs
@@ -47,7 +47,7 @@ namespace Common
         /// Gets the HWND of the control window.
         /// </summary>
         /// <returns>Pointer to the window handle.</returns>
-        IntPtr GetHandle();
+        IntPtr GetWindowHandle();
 
         /// <summary>
         /// Hide the preview and free any resource used for the preview.

--- a/src/modules/previewpane/common/controls/WebBrowserDownloadControlFlags.cs
+++ b/src/modules/previewpane/common/controls/WebBrowserDownloadControlFlags.cs
@@ -9,6 +9,7 @@ using System;
 /// Values of flags are defined in mshtmdid.h in distributed Windows Sdk.
 /// </summary>
 [Flags]
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "Interop, keeping stuff in sync")]
 public enum WebBrowserDownloadControlFlags : int
 {
     /// <summary>

--- a/src/modules/previewpane/common/controls/WebBrowserExt.cs
+++ b/src/modules/previewpane/common/controls/WebBrowserExt.cs
@@ -51,7 +51,8 @@ namespace PreviewHandlerCommon
             public object InvokeMember(string name, BindingFlags invokeAttr, Binder binder, object target, object[] args, ParameterModifier[] modifiers, CultureInfo culture, string[] namedParameters)
             {
                 object result;
-                if (name.Equals(DISPIDAMBIENTDLCONTROL))
+
+                if (name != null && name.Equals(DISPIDAMBIENTDLCONTROL, StringComparison.CurrentCulture))
                 {
                     result = Convert.ToInt32(
                         WebBrowserDownloadControlFlags.DLIMAGES |
@@ -65,11 +66,11 @@ namespace PreviewHandlerCommon
                         WebBrowserDownloadControlFlags.NO_DLACTIVEXCTLS |
                         WebBrowserDownloadControlFlags.NO_RUNACTIVEXCTLS |
                         WebBrowserDownloadControlFlags.NO_BEHAVIORS |
-                        WebBrowserDownloadControlFlags.SILENT);
+                        WebBrowserDownloadControlFlags.SILENT, CultureInfo.CurrentCulture);
                 }
                 else
                 {
-                    result = this.GetType().InvokeMember(name, invokeAttr, binder, target, args, modifiers, culture, namedParameters);
+                    result = GetType().InvokeMember(name, invokeAttr, binder, target, args, modifiers, culture, namedParameters);
                 }
 
                 return result;

--- a/src/modules/previewpane/common/examplehandler/CustomControlTest.cs
+++ b/src/modules/previewpane/common/examplehandler/CustomControlTest.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.IO;
 using System.Windows.Forms;
 
@@ -24,7 +25,7 @@ namespace Common
                 WebBrowser browser = new WebBrowser();
 
                 browser.DocumentText = "Test";
-                browser.Navigate(filePath);
+                browser.Navigate(new Uri(filePath));
                 browser.Dock = DockStyle.Fill;
                 browser.IsWebBrowserContextMenuEnabled = false;
                 this.Controls.Add(browser);

--- a/src/modules/previewpane/common/examplehandler/TestCustomHandler.cs
+++ b/src/modules/previewpane/common/examplehandler/TestCustomHandler.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Runtime.InteropServices;
 
 namespace Common
@@ -12,21 +13,50 @@ namespace Common
     [Guid("22a1a8e8-e929-4732-90ce-91eaff38b614")]
     [ClassInterface(ClassInterfaceType.None)]
     [ComVisible(true)]
-    public class TestCustomHandler : FileBasedPreviewHandler
+    public class TestCustomHandler : FileBasedPreviewHandler, IDisposable
     {
-        private CustomControlTest previewHandlerControl;
+        private CustomControlTest _previewHandlerControl;
+        private bool disposedValue;
 
         /// <inheritdoc />
         public override void DoPreview()
         {
-            this.previewHandlerControl.DoPreview(this.FilePath);
+            _previewHandlerControl.DoPreview(FilePath);
         }
 
         /// <inheritdoc />
         protected override IPreviewHandlerControl CreatePreviewHandlerControl()
         {
-            this.previewHandlerControl = new CustomControlTest();
-            return this.previewHandlerControl;
+            _previewHandlerControl = new CustomControlTest();
+
+            return _previewHandlerControl;
+        }
+
+        /// <summary>
+        /// Disposes objects
+        /// </summary>
+        /// <param name="disposing">Is Disposing</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    _previewHandlerControl.Dispose();
+                }
+
+                // TODO: free unmanaged resources (unmanaged objects) and override finalizer
+                // TODO: set large fields to null
+                disposedValue = true;
+            }
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/modules/previewpane/common/handlers/PreviewHandlerBase.cs
+++ b/src/modules/previewpane/common/handlers/PreviewHandlerBase.cs
@@ -46,7 +46,14 @@ namespace Common
         /// </summary>
         public PreviewHandlerBase()
         {
-            this.previewControl = this.CreatePreviewHandlerControl();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PreviewHandlerBase"/> class.
+        /// </summary>
+        public void Initialize()
+        {
+            previewControl = CreatePreviewHandlerControl();
         }
 
         /// <inheritdoc />
@@ -107,7 +114,7 @@ namespace Common
         /// <inheritdoc />
         public void GetWindow(out IntPtr phwnd)
         {
-            phwnd = this.previewControl.GetHandle();
+            phwnd = this.previewControl.GetWindowHandle();
         }
 
         /// <inheritdoc />

--- a/tools/build/versionSetting.ps1
+++ b/tools/build/versionSetting.ps1
@@ -1,0 +1,41 @@
+[CmdletBinding()]
+Param(
+  [Parameter(Mandatory=$True,Position=1)]
+  [string]$versionNumber = "0.0.1",
+
+  [Parameter(Mandatory=$True,Position=2)]
+  [AllowEmptyString()]
+  [string]$DevEnvironment = "Local"
+)
+
+Write-Host $PSScriptRoot
+$versionRegex = "(\d+)\.(\d+)\.(\d+)"
+
+if($versionNumber -match $versionRegEx)
+{
+  $buildDayOfYear = (Get-Date).DayofYear;
+  $buildTime = Get-Date -Format HH;
+  # $buildTime = Get-Date -Format HHmmss;
+  # $buildYear = Get-Date -Format yy;
+  # $revision = [string]::Format("{0}{1}{2}", $buildYear, $buildDayOfYear, $buildTime )
+
+  # max UInt16, 65535
+  #$revision = [string]::Format("{0}{1}", $buildDayOfYear, $buildTime )
+  #Write-Host "Revision" $revision
+
+  $versionNumber = [int]::Parse($matches[1]).ToString() + "." + [int]::Parse($matches[2]).ToString() + "." + [int]::Parse($matches[3]).ToString() # + "." + $revision
+  Write-Host "Version Number" $versionNumber
+}
+else{
+	throw "Build format does not match the expected pattern (buildName_w.x.y.z)"
+}
+
+$verPropWriteFileLocation = $PSScriptRoot + '/../../src/Version.props';
+$verPropReadFileLocation = $verPropWriteFileLocation;
+
+[XML]$verProps = Get-Content $verPropReadFileLocation
+$verProps.Project.PropertyGroup.Version = $versionNumber;
+$verProps.Project.PropertyGroup.DevEnvironment = $DevEnvironment;
+
+Write-Host "xml" $verProps.Project.PropertyGroup.Version 
+$verProps.Save($verPropWriteFileLocation);


### PR DESCRIPTION
## Summary of the Pull Request

Marking as draft until i can prove the farm worked e2e

Since i did a bad branch with #6777, recopied

As outlined in https://github.com/microsoft/PowerToys/wiki/Versioning, we are moving the versioning e2e on the build farm.  From now on there is a single spot that will set the version number and all local dev builds will be 0.0.1

This also sets up the start of having application titles / systray and other spots with the dev environment.  After doing a bit of investigation, this will require a bit more work.

This is also the start of #873 which then will let us start shifting to allow a more complete revision number.  As this has pretty wide reaching changes, i'm just getting the build farm up and functional with this PR.

The script runs local as well as on the farm due to the relative path.

For the farm, this was done by adding in an additional step to execute the PowerShell script and pass in the var's set in ADO.

## PR Checklist
* [ ] Applies to #873* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

## Validation Steps Performed

_How does someone test & validate?_
