### PR TITLE
[FancyZones Editor] Crash with big 'Space around zones' values

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/LayoutPreview.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/LayoutPreview.xaml.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
@@ -171,8 +172,8 @@ namespace FancyZonesEditor
                             maxCol++;
                         }
 
-                        rect.Width = colInfo[maxCol].End - left;
-                        rect.Height = rowInfo[maxRow].End - top;
+                        rect.Width = Math.Max(0, colInfo[maxCol].End - left);
+                        rect.Height = Math.Max(0, rowInfo[maxRow].End - top);
                         rect.StrokeThickness = 1;
                         rect.Stroke = Brushes.DarkGray;
                         rect.Fill = Brushes.LightGray;


### PR DESCRIPTION
## Summary of the Pull Request

Fix Editor crash with big `Space around zones` value.

## PR Checklist
* [x] Applies to #6814 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed

## Info on Pull Request

Use `Math.Max` to prevent negative width and height.

## Validation Steps Performed

1. Select grid layout.
2. Set some big enough `Space around zones` value (for 1920x1080 display and 3 zones 700 is enough).
3. Click Apply.
4. Open editor.
