### PR TITLE
Fix settings changes that were made in PR #6620

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/ViewModels/GeneralViewModel.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/ViewModels/GeneralViewModel.cs
@@ -15,8 +15,6 @@ namespace Microsoft.PowerToys.Settings.UI.Lib.ViewModels
     {
         private GeneralSettings GeneralSettingsConfig { get; set; }
 
-        private readonly ISettingsUtils _settingsUtils;
-
         public ButtonClickCommand CheckFoUpdatesEventHandler { get; set; }
 
         public ButtonClickCommand RestartElevatedButtonEventHandler { get; set; }
@@ -35,11 +33,10 @@ namespace Microsoft.PowerToys.Settings.UI.Lib.ViewModels
 
         private string _settingsConfigFileFolder = string.Empty;
 
-        public GeneralViewModel(ISettingsUtils settingsUtils, ISettingsRepository<GeneralSettings> settingsRepository, string runAsAdminText, string runAsUserText, bool isElevated, bool isAdmin, Func<string, int> updateTheme, Func<string, int> ipcMSGCallBackFunc, Func<string, int> ipcMSGRestartAsAdminMSGCallBackFunc, Func<string, int> ipcMSGCheckForUpdatesCallBackFunc, string configFileSubfolder = "")
+        public GeneralViewModel(ISettingsRepository<GeneralSettings> settingsRepository, string runAsAdminText, string runAsUserText, bool isElevated, bool isAdmin, Func<string, int> updateTheme, Func<string, int> ipcMSGCallBackFunc, Func<string, int> ipcMSGRestartAsAdminMSGCallBackFunc, Func<string, int> ipcMSGCheckForUpdatesCallBackFunc, string configFileSubfolder = "")
         {
             CheckFoUpdatesEventHandler = new ButtonClickCommand(CheckForUpdates_Click);
             RestartElevatedButtonEventHandler = new ButtonClickCommand(Restart_Elevated);
-            _settingsUtils = settingsUtils ?? throw new ArgumentNullException(nameof(settingsUtils));
 
             // To obtain the general settings configuration of PowerToys if it exists, else to create a new file and return the default configurations.
             GeneralSettingsConfig = settingsRepository.SettingsConfig;
@@ -344,10 +341,9 @@ namespace Microsoft.PowerToys.Settings.UI.Lib.ViewModels
         // callback function to launch the URL to check for updates.
         private void CheckForUpdates_Click()
         {
-            GeneralSettings settings = _settingsUtils.GetSettings<GeneralSettings>(_settingsConfigFileFolder);
-            settings.CustomActionName = "check_for_updates";
+            GeneralSettingsConfig.CustomActionName = "check_for_updates";
 
-            OutGoingGeneralSettings outsettings = new OutGoingGeneralSettings(settings);
+            OutGoingGeneralSettings outsettings = new OutGoingGeneralSettings(GeneralSettingsConfig);
             GeneralSettingsCustomAction customaction = new GeneralSettingsCustomAction(outsettings);
 
             SendCheckForUpdatesConfigMSG(customaction.ToString());
@@ -355,10 +351,9 @@ namespace Microsoft.PowerToys.Settings.UI.Lib.ViewModels
 
         public void Restart_Elevated()
         {
-            GeneralSettings settings = _settingsUtils.GetSettings<GeneralSettings>(_settingsConfigFileFolder);
-            settings.CustomActionName = "restart_elevation";
+            GeneralSettingsConfig.CustomActionName = "restart_elevation";
 
-            OutGoingGeneralSettings outsettings = new OutGoingGeneralSettings(settings);
+            OutGoingGeneralSettings outsettings = new OutGoingGeneralSettings(GeneralSettingsConfig);
             GeneralSettingsCustomAction customaction = new GeneralSettingsCustomAction(outsettings);
 
             SendRestartAsAdminConfigMSG(customaction.ToString());

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/ViewModels/ImageResizerViewModel.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/ViewModels/ImageResizerViewModel.cs
@@ -19,7 +19,8 @@ namespace Microsoft.PowerToys.Settings.UI.Lib.ViewModels
 
         private ImageResizerSettings Settings { get; set; }
 
-        private const string ModuleName = ImageResizerSettings.ModuleName;
+        // NOTE: Not using ImageResizerSettings.ModuleName ("Image Resizer") to be backward compatible.
+        private const string ModuleName = "ImageResizer";
 
         private Func<string, int> SendConfigMSG { get; }
 

--- a/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/ViewModelTests/General.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/ViewModelTests/General.cs
@@ -35,7 +35,6 @@ namespace ViewModelTests
             Func<string, int> SendRestartAdminIPCMessage = msg => { return 0; };
             Func<string, int> SendCheckForUpdatesIPCMessage = msg => { return 0; };
             GeneralViewModel viewModel = new GeneralViewModel(
-                new Mock<ISettingsUtils>().Object,
                 SettingsRepository<GeneralSettings>.GetInstance(mockGeneralSettingsUtils.Object),
                 "GeneralSettings_RunningAsAdminText",
                 "GeneralSettings_RunningAsUserText",
@@ -73,7 +72,6 @@ namespace ViewModelTests
             Func<string, int> SendRestartAdminIPCMessage = msg => { return 0; };
             Func<string, int> SendCheckForUpdatesIPCMessage = msg => { return 0; };
             GeneralViewModel viewModel = new GeneralViewModel(
-                new Mock<ISettingsUtils>().Object,
                 SettingsRepository<GeneralSettings>.GetInstance(mockGeneralSettingsUtils.Object),
                 "GeneralSettings_RunningAsAdminText",
                 "GeneralSettings_RunningAsUserText",
@@ -106,7 +104,6 @@ namespace ViewModelTests
 
             // Arrange
             GeneralViewModel viewModel = new GeneralViewModel(
-                new Mock<ISettingsUtils>().Object,
                 SettingsRepository<GeneralSettings>.GetInstance(mockGeneralSettingsUtils.Object),
                 "GeneralSettings_RunningAsAdminText",
                 "GeneralSettings_RunningAsUserText",
@@ -140,7 +137,6 @@ namespace ViewModelTests
             Func<string, int> SendRestartAdminIPCMessage = msg => { return 0; };
             Func<string, int> SendCheckForUpdatesIPCMessage = msg => { return 0; };
             viewModel = new GeneralViewModel(
-                new Mock<ISettingsUtils>().Object,
                 SettingsRepository<GeneralSettings>.GetInstance(mockGeneralSettingsUtils.Object),
                 "GeneralSettings_RunningAsAdminText",
                 "GeneralSettings_RunningAsUserText",
@@ -172,7 +168,6 @@ namespace ViewModelTests
             Func<string, int> SendRestartAdminIPCMessage = msg => { return 0; };
             Func<string, int> SendCheckForUpdatesIPCMessage = msg => { return 0; };
             GeneralViewModel viewModel = new GeneralViewModel(
-                new Mock<ISettingsUtils>().Object,
                 SettingsRepository<GeneralSettings>.GetInstance(mockGeneralSettingsUtils.Object),
                 "GeneralSettings_RunningAsAdminText",
                 "GeneralSettings_RunningAsUserText",

--- a/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/ViewModelTests/ImageResizer.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/ViewModelTests/ImageResizer.cs
@@ -18,8 +18,7 @@ namespace ViewModelTests
     [TestClass]
     public class ImageResizer
     {
-        // To have a consistent name.
-        public const string Module = ImageResizerSettings.ModuleName;
+        public const string Module = "ImageResizer";
 
         private Mock<ISettingsUtils> mockGeneralSettingsUtils;
 

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml.cs
@@ -36,7 +36,6 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             var settingsUtils = new SettingsUtils(new SystemIOProvider());
 
             ViewModel = new GeneralViewModel(
-                settingsUtils,
                 SettingsRepository<GeneralSettings>.GetInstance(settingsUtils),
                 loader.GetString("GeneralSettings_RunningAsAdminText"),
                 loader.GetString("GeneralSettings_RunningAsUserText"),


### PR DESCRIPTION
## Summary of the Pull Request

This PR fixes and complements the changes made in PR #6620.

_What is this about?_

## PR Checklist
* [ ] Applies to #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

The following changes have been made in this PR - 
1. GeneralViewModel did not require ISettingsUtils to be passed because the information was already encapsulated in settingsRepository. Hence, it has been removed.
2. All the module names were unified in 6620 using <PT>Settings.ModuleName, however the ImageResizerSetttings.ModuleName is "Image Resizer" and the name of the settings folder is "ImageResizer" (Without the space). This change would create a new folder and make img resizer backward incompatible. Hence, the name has been reset to "ImageResizer".

## Validation Steps Performed

_How does someone test & validate?_

* All tests pass.
* Validated that restart as admin and check for updates functionalities work as expected.
* Validated that there is only one image resizer folder "ImageResizer".