### PR TITLE
[Settings] Added recursive delete for IOProvider DeleteDirectory to prevent crash on non-empty directory

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/Utilities/SystemIOProvider.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/Utilities/SystemIOProvider.cs
@@ -16,7 +16,7 @@ namespace Microsoft.PowerToys.Settings.UI.Lib.Utilities
 
         public void DeleteDirectory(string path)
         {
-            Directory.Delete(path, true);
+            Directory.Delete(path, recursive: true);
         }
 
         public bool DirectoryExists(string path)

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/Utilities/SystemIOProvider.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/Utilities/SystemIOProvider.cs
@@ -16,7 +16,7 @@ namespace Microsoft.PowerToys.Settings.UI.Lib.Utilities
 
         public void DeleteDirectory(string path)
         {
-            Directory.Delete(path);
+            Directory.Delete(path, true);
         }
 
         public bool DirectoryExists(string path)


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
As per the arguments of the [`Directory.Delete` method](https://docs.microsoft.com/en-us/dotnet/api/system.io.directory.delete?view=netcore-3.1) the `recursive` bool argument has been set to `true` so that the directory can be deleted even if it is not empty.

## PR Checklist
* [X] Applies to #6811 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [X] Tests passed

## Validation Steps Performed

_How does someone test & validate?_
- Make a corrupted PT Run settings file so that a JsonException occurs while PT Run reads it.
- PT Run should not crash when it tries to delete the settings and replace it.