### PR TITLE
Add delay to File System watchers to prevent Calibre installation issue

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program.UnitTests/Storage/ConcurrentQueueEventHandlerTest.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program.UnitTests/Storage/ConcurrentQueueEventHandlerTest.cs
@@ -1,0 +1,106 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Concurrent;
+using Microsoft.Plugin.Program.Storage;
+using NUnit.Framework;
+
+namespace Microsoft.Plugin.Program.UnitTests.Storage
+{
+    [TestFixture]
+    public class ConcurrentQueueEventHandlerTest
+    {
+        [TestCase]
+        public void EventHandlerMustReturnEmptyPathForEmptyQueue()
+        {
+            // Arrange
+            int dequeueDelay = 0;
+            ConcurrentQueue<string> eventHandlingQueue = new ConcurrentQueue<string>();
+
+            // Act
+            string appPath = EventHandler.GetAppPathFromQueue(eventHandlingQueue, dequeueDelay);
+
+            // Assert
+            Assert.IsEmpty(appPath);
+        }
+
+        [TestCase(1)]
+        [TestCase(10)]
+        public void EventHandlerMustReturnPathForConcurrentQueueWithSameFilePaths(int itemCount)
+        {
+            // Arrange
+            int dequeueDelay = 0;
+            string appPath = "appPath";
+            ConcurrentQueue<string> eventHandlingQueue = new ConcurrentQueue<string>();
+            for (int i = 0; i < itemCount; i++)
+            {
+                eventHandlingQueue.Enqueue(appPath);
+            }
+
+            // Act
+            string pathFromQueue = EventHandler.GetAppPathFromQueue(eventHandlingQueue, dequeueDelay);
+
+            // Assert
+            Assert.AreEqual(pathFromQueue, appPath);
+            Assert.AreEqual(eventHandlingQueue.Count, 0);
+        }
+
+        [TestCase(5)]
+        public void EventHandlerMustReturnPathAndRetainDifferentFilePathsInQueue(int itemCount)
+        {
+            // Arrange
+            int dequeueDelay = 0;
+            string firstAppPath = "appPath1";
+            string secondAppPath = "appPath2";
+            ConcurrentQueue<string> eventHandlingQueue = new ConcurrentQueue<string>();
+            for (int i = 0; i < itemCount; i++)
+            {
+                eventHandlingQueue.Enqueue(firstAppPath);
+            }
+
+            for (int i = 0; i < itemCount; i++)
+            {
+                eventHandlingQueue.Enqueue(secondAppPath);
+            }
+
+            // Act
+            string pathFromQueue = EventHandler.GetAppPathFromQueue(eventHandlingQueue, dequeueDelay);
+
+            // Assert
+            Assert.AreEqual(pathFromQueue, firstAppPath);
+            Assert.AreEqual(eventHandlingQueue.Count, itemCount);
+        }
+
+        [TestCase(5)]
+        public void EventHandlerMustReturnPathAndRetainAllPathsAfterEncounteringADifferentPath(int itemCount)
+        {
+            // Arrange
+            int dequeueDelay = 0;
+            string firstAppPath = "appPath1";
+            string secondAppPath = "appPath2";
+            ConcurrentQueue<string> eventHandlingQueue = new ConcurrentQueue<string>();
+            for (int i = 0; i < itemCount; i++)
+            {
+                eventHandlingQueue.Enqueue(firstAppPath);
+            }
+
+            for (int i = 0; i < itemCount; i++)
+            {
+                eventHandlingQueue.Enqueue(secondAppPath);
+            }
+
+            for (int i = 0; i < itemCount; i++)
+            {
+                eventHandlingQueue.Enqueue(firstAppPath);
+            }
+
+            // Act
+            string pathFromQueue = EventHandler.GetAppPathFromQueue(eventHandlingQueue, dequeueDelay);
+
+            // Assert
+            Assert.AreEqual(pathFromQueue, firstAppPath);
+            Assert.AreEqual(eventHandlingQueue.Count, itemCount * 2);
+        }
+    }
+}

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program.UnitTests/Storage/Win32ProgramRepositoryTest.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program.UnitTests/Storage/Win32ProgramRepositoryTest.cs
@@ -200,26 +200,6 @@ namespace Microsoft.Plugin.Program.UnitTests.Storage
         }
 
         [TestCase("path.url")]
-        public void Win32ProgramRepositoryMustCallOnAppChangedForUrlAppsWhenChangedEventIsRaised(string path)
-        {
-            // Arrange
-            Win32ProgramRepository win32ProgramRepository = new Win32ProgramRepository(_fileSystemWatchers, new BinaryStorage<IList<Win32Program>>("Win32"), _settings, _pathsToWatch);
-            FileSystemEventArgs e = new FileSystemEventArgs(WatcherChangeTypes.Changed, "directory", path);
-
-            // File.ReadAllLines must be mocked for url applications
-            var mockFile = new Mock<IFileWrapper>();
-            mockFile.Setup(m => m.ReadAllLines(It.IsAny<string>())).Returns(new string[] { "URL=steam://rungameid/1258080", "IconFile=iconFile" });
-            Win32Program.FileWrapper = mockFile.Object;
-
-            // Act
-            _fileSystemMocks[0].Raise(m => m.Changed += null, e);
-
-            // Assert
-            Assert.AreEqual(win32ProgramRepository.Count(), 1);
-            Assert.AreEqual(win32ProgramRepository.ElementAt(0).AppType, Win32Program.ApplicationType.InternetShortcutApplication); // Internet Shortcut Application
-        }
-
-        [TestCase("path.url")]
         public void Win32ProgramRepositoryMustNotCreateUrlAppWhenCreatedEventIsRaised(string path)
         {
             // We are handing internet shortcut apps using the Changed event instead
@@ -317,26 +297,6 @@ namespace Microsoft.Plugin.Program.UnitTests.Storage
             Assert.AreEqual(win32ProgramRepository.Count(), 1);
             Assert.IsTrue(win32ProgramRepository.Contains(newitem));
             Assert.IsFalse(win32ProgramRepository.Contains(olditem));
-        }
-
-        [TestCase("path.lnk")]
-        public void Win32ProgramRepositoryMustCallOnAppCreatedForLnkAppsWhenCreatedEventIsRaised(string path)
-        {
-            // Arrange
-            Win32ProgramRepository win32ProgramRepository = new Win32ProgramRepository(_fileSystemWatchers, new BinaryStorage<IList<Win32Program>>("Win32"), _settings, _pathsToWatch);
-            FileSystemEventArgs e = new FileSystemEventArgs(WatcherChangeTypes.Created, "directory", path);
-
-            // ShellLinkHelper must be mocked for lnk applications
-            var mockShellLink = new Mock<IShellLinkHelper>();
-            mockShellLink.Setup(m => m.RetrieveTargetPath(It.IsAny<string>())).Returns(string.Empty);
-            Win32Program.Helper = mockShellLink.Object;
-
-            // Act
-            _fileSystemMocks[0].Raise(m => m.Created += null, e);
-
-            // Assert
-            Assert.AreEqual(win32ProgramRepository.Count(), 1);
-            Assert.AreEqual(win32ProgramRepository.ElementAt(0).AppType, Win32Program.ApplicationType.Win32Application);
         }
 
         [TestCase("directory", "path.lnk")]

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/ShellLinkHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/ShellLinkHelper.cs
@@ -174,6 +174,9 @@ namespace Microsoft.Plugin.Program.Programs
                 }
             }
 
+            // To release unmanaged memory
+            Marshal.ReleaseComObject(link);
+
             return target;
         }
     }

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Storage/EventHandler.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Storage/EventHandler.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+
+namespace Microsoft.Plugin.Program.Storage
+{
+    public static class EventHandler
+    {
+        // To obtain the path of the app when multiple events are added to the Concurrent queue across multiple threads.
+        // On the first occurence of a different file path, the existing app path is to be returned without removing any more elements from the queue.
+        public static string GetAppPathFromQueue(ConcurrentQueue<string> eventHandlingQueue, int dequeueDelay)
+        {
+            if (eventHandlingQueue == null)
+            {
+                throw new ArgumentNullException(nameof(eventHandlingQueue));
+            }
+
+            string previousAppPath = string.Empty;
+
+            // To obtain the last event associated with a particular app.
+            while (eventHandlingQueue.TryPeek(out string currentAppPath))
+            {
+                if (string.IsNullOrEmpty(previousAppPath) || previousAppPath.Equals(currentAppPath, StringComparison.OrdinalIgnoreCase))
+                {
+                    // To dequeue a path only if it is the first one in the queue or if the path was the same as thre previous one (to avoid trying to create apps on duplicate events)
+                    previousAppPath = currentAppPath;
+                    eventHandlingQueue.TryDequeue(out _);
+                }
+                else
+                {
+                    break;
+                }
+
+                // This delay has been added to account for the delay in events being triggered during app installation.
+                Thread.Sleep(dequeueDelay);
+            }
+
+            return previousAppPath;
+        }
+    }
+}


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

This PR adds a delay to the File System watchers so that we don't try to get information about an app even before it is installed, which was leading to the Calibre not being installed issue.

## PR Checklist
* [x] Applies to #6429
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

The following approach has been taken for lnk and url files, both of which we try to get a handle on or open on installation.
When an app is installed, multiple events are created, they are of type `Created` and `Changed`.
The `Changed` events are triggered after the `created` events.

Previously, we were trying to immediately get a handle on the app as soon as it was created, however, this was before the installation process was complete. (Apps are created and written to in chunks, leading to a lot of events being triggered before the installation process is over). There is no way to tell that the installation process is complete, other than to wait for the last event (again which we have no idea that it is the last event).

To improve the handling of such cases, instead of immediately acting on getting an event, we instead put it in a queue. The background task keeps dequeueing the elements at regular intervals of 5 seconds. Once it dequeues an element, it waits for 0.5 a second to allow the addition of any more events to the queue. This way, after we reach the last event for a particular file, we wait for 5 more seconds before trying to get a handle on the app. 

Also added a line of code to release unmanaged memory.

## Validation Steps Performed

_How does someone test & validate?_

* Installed calibre numerous times and validated that it installs as expected.
* Also installed some epic games and validated that they install.
* Added unit tests for the dequeue logic.
