### PR TITLE
Changed default theme in settings to be consistent with that of shortcut guide

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/ShortcutGuideProperties.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/ShortcutGuideProperties.cs
@@ -12,7 +12,7 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
         {
             OverlayOpacity = new IntProperty(90);
             PressTime = new IntProperty(900);
-            Theme = new StringProperty("light");
+            Theme = new StringProperty("system");
         }
 
         [JsonPropertyName("overlay_opacity")]

--- a/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/ViewModelTests/ShortcutGuide.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/ViewModelTests/ShortcutGuide.cs
@@ -62,7 +62,8 @@ namespace ViewModelTests
 
             // Arrange
             ShortcutGuideViewModel viewModel = new ShortcutGuideViewModel(SettingsRepository<GeneralSettings>.GetInstance(mockGeneralSettingsUtils.Object), SettingsRepository<ShortcutGuideSettings>.GetInstance(mockShortcutGuideSettingsUtils.Object), SendMockIPCConfigMSG, ShortCutGuideTestFolderName);
-            Assert.AreEqual(1, viewModel.ThemeIndex);
+            // Initialize shortcut guide settings theme to 'system' to be in sync with shortcut_guide.h.
+            Assert.AreEqual(2, viewModel.ThemeIndex);
 
             // Act
             viewModel.ThemeIndex = 0;


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

When the settings.json file of shortcut guide does not exist, the runner starts shortcut guide with it's default configurations (ie. the ones present in shortcut_guide.cpp and shortcut_guide.h so it has it's background theme set to system). However, when settings starts off, it tries to get the configurations from the settings.json file of shortcut guide, but since the file does not exist, it creates a new file with it's default configurations of shortcut guide (and the default theme in the settings process for shortcut guide is light). 

## PR Checklist
* [x] Applies to #3629
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

This PR changes the defaut theme property of shortcut guide settings to 'system' instead of 'light'.
Ideally this information should be communicated to the runner once a new file has been created so that both the powertoy and settings are in sync with the configurations, even if they don't have the same default configurations. This would be taken care as a part of issue #6823 where instead of having the settings process save the file directly, it can communicate this change to the runner so that all the modules are aware of the change and they can save the setting. This is how it is done in all the cases except when the file does not exist. This case should also be unified to behave like the rest.

## Validation Steps Performed

_How does someone test & validate?_

* Delete the shortcutguide folder in appdata/local/microsoft/powertoys
* start powertoys and open settings, we now observe that the shortcut guide theme follows the system default theme and that the system default radio button is checked.
* Also the theme that gets created is "theme":{"value":"system"}}.
