### PR TITLE
Fix settings UpgradeSettingsConfiguration code path

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/SettingsUtils.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/SettingsUtils.cs
@@ -72,7 +72,7 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
                 T deserializedSettings = GetFile<T>(powertoy, fileName);
 
                 // IF the file needs to be modified, to save the new configurations accordingly.
-                if (!deserializedSettings.UpgradeSettingsConfiguration())
+                if (deserializedSettings.UpgradeSettingsConfiguration())
                 {
                     SaveSettings(deserializedSettings.ToJsonString(), powertoy, fileName);
                 }


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
This fixes the code path for upgradeconfiguration. The function was getting executed if the return value was false, whereas based on the actual return values it should have been for true. This was causing an infinite loop in KBM's filewatcher where it would keep trying to load the profile as the file watcher code was re-saving the file.
## PR Checklist
* [ ] Applies to #xxx
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

## Validation Steps Performed

_How does someone test & validate?_
Tests passed, and KBM settings no longer glitched out.