### PR TITLE
[FancyZonesEditor] Fix different zone indices between editor and engine

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridData.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridData.cs
@@ -474,6 +474,7 @@ namespace FancyZonesEditor
             }
 
             double left, top;
+            int zoneIndex = 1;
             for (int row = 0; row < rows; row++)
             {
                 for (int col = 0; col < cols; col++)
@@ -488,7 +489,7 @@ namespace FancyZonesEditor
                         top = _rowInfo[row].Start;
                         Canvas.SetLeft(zone, left);
                         Canvas.SetTop(zone, top);
-                        zone.LabelID.Content = i + 1;
+                        zone.LabelID.Content = zoneIndex++;
 
                         int maxRow = row;
                         while (((maxRow + 1) < rows) && (cells[maxRow + 1, col] == i))


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
Align zone indices in FZ Editor with FZ engine for custom Grid layouts

## PR Checklist
* [x] Applies to #6734 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Validation Steps Performed

_How does someone test & validate?_
1. Create and apply custom *grid* layout
2. Shift+drag window to show layout preview
3. Observe that zone indices are the same as in FZ Editor