### PR TITLE
Fix prerequisites install script to allow VS Preview versions

### DIFF
--- a/doc/devdocs/readme.md
+++ b/doc/devdocs/readme.md
@@ -57,6 +57,7 @@ Various tools used by PowerToys. Includes the Visual Studio 2019 project templat
 ```shell
 cd "%ProgramFiles(x86)%\Microsoft Visual Studio\2019"
 SET targetFolder="\"
+IF EXIST Preview\NUL (SET targetFolder=Preview)
 IF EXIST Enterprise\NUL (SET targetFolder=Enterprise)
 IF EXIST Professional\NUL (SET targetFolder=Professional)
 IF EXIST Community\NUL (SET targetFolder=Community)


### PR DESCRIPTION
## Summary of the Pull Request

This PR fix the missing `preview` entry in the prerequisites install script

## Picture (without this fix)
<img width="641" alt="2020-09-27 13_16_18-Visual Studio Installer" src="https://user-images.githubusercontent.com/17874713/94363618-b29a2000-00c3-11eb-9d3c-e8903863138e.png">

## PR Checklist
* [ ] Applies to #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [x] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

Only doc change

## Validation Steps Performed

Test changed install script on my PC with Visual Studio 2019 16.8 Preview 3.1 