### PR TITLE
Fix Docker desktop not found in program plugin issue

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32Program.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32Program.cs
@@ -756,7 +756,9 @@ namespace Microsoft.Plugin.Program.Programs
         private static ParallelQuery<Win32Program> DesktopPrograms(IList<string> suffixes)
         {
             var directory1 = Environment.GetFolderPath(Environment.SpecialFolder.Desktop);
-            List<string> indexLocation = new List<string>() { directory1 };
+            var directory2 = Environment.GetFolderPath(Environment.SpecialFolder.CommonDesktopDirectory);
+
+            List<string> indexLocation = new List<string>() { directory1, directory2 };
 
             return IndexPath(suffixes, indexLocation);
         }

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32Program.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32Program.cs
@@ -746,8 +746,8 @@ namespace Microsoft.Plugin.Program.Programs
 
         private static ParallelQuery<Win32Program> StartMenuPrograms(IList<string> suffixes)
         {
-            var directory1 = Environment.GetFolderPath(Environment.SpecialFolder.Programs);
-            var directory2 = Environment.GetFolderPath(Environment.SpecialFolder.CommonPrograms);
+            var directory1 = Environment.GetFolderPath(Environment.SpecialFolder.StartMenu);
+            var directory2 = Environment.GetFolderPath(Environment.SpecialFolder.CommonStartMenu);
             List<string> indexLocation = new List<string>() { directory1, directory2 };
 
             return IndexPath(suffixes, indexLocation);

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Storage/Win32ProgramFileSystemWatchers.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Storage/Win32ProgramFileSystemWatchers.cs
@@ -28,8 +28,8 @@ namespace Microsoft.Plugin.Program.Storage
         {
             string[] paths = new string[]
                             {
-                               Environment.GetFolderPath(Environment.SpecialFolder.Programs),
-                               Environment.GetFolderPath(Environment.SpecialFolder.CommonPrograms),
+                               Environment.GetFolderPath(Environment.SpecialFolder.StartMenu),
+                               Environment.GetFolderPath(Environment.SpecialFolder.CommonStartMenu),
                                Environment.GetFolderPath(Environment.SpecialFolder.Desktop),
                             };
             return paths;

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Storage/Win32ProgramFileSystemWatchers.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Storage/Win32ProgramFileSystemWatchers.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Plugin.Program.Storage
                                Environment.GetFolderPath(Environment.SpecialFolder.StartMenu),
                                Environment.GetFolderPath(Environment.SpecialFolder.CommonStartMenu),
                                Environment.GetFolderPath(Environment.SpecialFolder.Desktop),
+                               Environment.GetFolderPath(Environment.SpecialFolder.CommonDesktopDirectory),
                             };
             return paths;
         }


### PR DESCRIPTION
## Summary of the Pull Request
Fix for `Docker` application not showing up in PT Run.

## PR Checklist
* [x] Applies to #4151 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed

## Info on Pull Request
The issue was happening because docker installs .lnk at location `C:\ProgramData\Microsoft\Windows\Start Menu`, which is not indexed by program plugin. 

Steps to repro : 
1. While installing `Docker` desktop, uncheck `Add shortcut to desktop` on Configuration screen.

The following locations needs to be indexed by program plugin to match start menu search : 
1. `StartMenu` : Added with this PR.
2. `Programs` : A subfolder of `StartMenu`, and will be indexed by program plugin during indexing of `StartMenu`
3. `CommonStartMenu` : Added with this PR. 
4. `CommonPrograms` : A subfolder of `CommonStartMenu` , and will be indexed by program plugin during indexing of `CommonStartMenu`.
5. User Desktop : This location is indexed by program plugin.
6. Public Desktop : Added with this PR.

## Validation Steps Performed
Manually validated that Docker application is indexed by program plugin and shows up in query.