### PR TITLE
[FancyZones] Screen enumeration improvement

### DIFF
--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -991,6 +991,7 @@ void FancyZones::UpdateZoneWindows() noexcept
             std::wstring deviceId;
             while (EnumDisplayDevicesW(mi.szDevice, displayDeviceIdxMap[mi.szDevice], &displayDevice, EDD_GET_DEVICE_INTERFACE_NAME))
             {
+                ++displayDeviceIdxMap[mi.szDevice];
                 // Only take active monitors (presented as being "on" by the respective GDI view) and monitors that don't
                 // represent a pseudo device used to mirror application drawing.
                 if (WI_IsFlagSet(displayDevice.StateFlags, DISPLAY_DEVICE_ACTIVE) &&
@@ -998,8 +999,8 @@ void FancyZones::UpdateZoneWindows() noexcept
                 {
                     deviceId = displayDevice.DeviceID;
                     fancyZones->AddZoneWindow(monitor, deviceId);
+                    break;
                 }
-                ++displayDeviceIdxMap[mi.szDevice];
             }
 
             if (deviceId.empty())

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -971,7 +971,7 @@ LRESULT CALLBACK FancyZones::s_WndProc(HWND window, UINT message, WPARAM wparam,
 
 void FancyZones::UpdateZoneWindows() noexcept
 {
-    // Mapping between display device name and device index (operating system identifies each display device in the current session with an index value).
+    // Mapping between display device name and device index (operating system identifies each display device with an index value).
     std::unordered_map<std::wstring, DWORD> displayDeviceIdxMap;
     struct capture
     {

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -977,7 +977,7 @@ void FancyZones::UpdateZoneWindows() noexcept
         if (GetMonitorInfo(monitor, &mi))
         {
             DISPLAY_DEVICE displayDevice;
-            displayDevice.cb = sizeof(DISPLAY_DEVICE);
+            displayDevice.cb = sizeof(displayDevice);
 
             std::wstring deviceId;
             bool validMonitor = true;

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -26,24 +26,26 @@ using namespace FancyZonesUtils;
 
 namespace ZoneWindowUtils
 {
-    std::wstring GenerateUniqueId(HMONITOR monitor, PCWSTR deviceId, PCWSTR virtualDesktopId)
+    std::wstring GenerateUniqueId(HMONITOR monitor, const std::wstring& deviceId, const std::wstring& virtualDesktopId)
     {
-        wchar_t uniqueId[256]{}; // Parsed deviceId + resolution + virtualDesktopId
-
         MONITORINFOEXW mi;
         mi.cbSize = sizeof(mi);
-        if (virtualDesktopId && GetMonitorInfo(monitor, &mi))
+        if (!virtualDesktopId.empty() && GetMonitorInfo(monitor, &mi))
         {
-            wchar_t parsedId[256]{};
-            ParseDeviceId(deviceId, parsedId, 256);
-
             Rect const monitorRect(mi.rcMonitor);
-            StringCchPrintf(uniqueId, ARRAYSIZE(uniqueId), L"%s_%d_%d_%s", parsedId, monitorRect.width(), monitorRect.height(), virtualDesktopId);
+            // Unique identifier format: <parsed-device-id>_<width>_<height>_<virtual-desktop-id>
+            return ParseDeviceId(deviceId) +
+                   L'_' +
+                   std::to_wstring(monitorRect.width()) +
+                   L'_' +
+                   std::to_wstring(monitorRect.height()) +
+                   L'_' +
+                   virtualDesktopId;
         }
-        return std::wstring{ uniqueId };
+        return {};
     }
 
-    std::wstring GenerateUniqueIdAllMonitorsArea(PCWSTR virtualDesktopId)
+    std::wstring GenerateUniqueIdAllMonitorsArea(const std::wstring& virtualDesktopId)
     {
         std::wstring result{ ZonedWindowProperties::MultiMonitorDeviceID };
 

--- a/src/modules/fancyzones/lib/ZoneWindow.h
+++ b/src/modules/fancyzones/lib/ZoneWindow.h
@@ -4,8 +4,8 @@
 
 namespace ZoneWindowUtils
 {
-    std::wstring GenerateUniqueId(HMONITOR monitor, PCWSTR deviceId, PCWSTR virtualDesktopId);
-    std::wstring GenerateUniqueIdAllMonitorsArea(PCWSTR virtualDesktopId);
+    std::wstring GenerateUniqueId(HMONITOR monitor, const std::wstring& devideId, const std::wstring& virtualDesktopId);
+    std::wstring GenerateUniqueIdAllMonitorsArea(const std::wstring& virtualDesktopId);
 }
 
 /**

--- a/src/modules/fancyzones/lib/util.cpp
+++ b/src/modules/fancyzones/lib/util.cpp
@@ -45,7 +45,7 @@ namespace FancyZonesUtils
         // We're interested in the unique part between the first and last #'s
         // Example input: \\?\DISPLAY#DELA026#5&10a58c63&0&UID16777488#{e6f07b5f-ee97-4a90-b076-33f57bf4eaa7}
         // Example output: DELA026#5&10a58c63&0&UID16777488
-        const std::wstring defaultDeviceId = L"FallbackDevice";
+        static const std::wstring defaultDeviceId = L"FallbackDevice";
         if (deviceId.empty())
         {
             return defaultDeviceId;

--- a/src/modules/fancyzones/lib/util.cpp
+++ b/src/modules/fancyzones/lib/util.cpp
@@ -40,6 +40,30 @@ namespace
 
 namespace FancyZonesUtils
 {
+    std::wstring ParseDeviceId(const std::wstring& deviceId)
+    {
+        // We're interested in the unique part between the first and last #'s
+        // Example input: \\?\DISPLAY#DELA026#5&10a58c63&0&UID16777488#{e6f07b5f-ee97-4a90-b076-33f57bf4eaa7}
+        // Example output: DELA026#5&10a58c63&0&UID16777488
+        const std::wstring defaultDeviceId = L"FallbackDevice";
+        if (deviceId.empty())
+        {
+            return defaultDeviceId;
+        }
+
+        size_t start = deviceId.find(L'#');
+        size_t end = deviceId.rfind(L'#');
+        if (start != std::wstring::npos && end != std::wstring::npos && start != end)
+        {
+            size_t size = end - (start + 1);
+            return deviceId.substr(start + 1, size);
+        }
+        else
+        {
+            return defaultDeviceId;
+        }
+    }
+
     typedef BOOL(WINAPI* GetDpiForMonitorInternalFunc)(HMONITOR, UINT, UINT*, UINT*);
     UINT GetDpiForMonitor(HMONITOR monitor) noexcept
     {

--- a/src/modules/fancyzones/lib/util.h
+++ b/src/modules/fancyzones/lib/util.h
@@ -103,34 +103,6 @@ namespace FancyZonesUtils
             return fallbackColor;
         }
     }
-    
-    inline void ParseDeviceId(PCWSTR deviceId, PWSTR parsedId, size_t size)
-    {
-        // We're interested in the unique part between the first and last #'s
-        // Example input: \\?\DISPLAY#DELA026#5&10a58c63&0&UID16777488#{e6f07b5f-ee97-4a90-b076-33f57bf4eaa7}
-        // Example output: DELA026#5&10a58c63&0&UID16777488
-        const std::wstring defaultDeviceId = L"FallbackDevice";
-        if (!deviceId)
-        {
-            StringCchCopy(parsedId, size, defaultDeviceId.c_str());
-            return;
-        }
-        wchar_t buffer[256];
-        StringCchCopy(buffer, 256, deviceId);
-
-        PWSTR pszStart = wcschr(buffer, L'#');
-        PWSTR pszEnd = wcsrchr(buffer, L'#');
-        if (pszStart && pszEnd && (pszStart != pszEnd))
-        {
-            pszStart++; // skip past the first #
-            *pszEnd = '\0';
-            StringCchCopy(parsedId, size, pszStart);
-        }
-        else
-        {
-            StringCchCopy(parsedId, size, defaultDeviceId.c_str());
-        }
-    }
 
     inline BYTE OpacitySettingToAlpha(int opacity)
     {
@@ -184,6 +156,8 @@ namespace FancyZonesUtils
 
         return result;
     }
+
+    std::wstring ParseDeviceId(const std::wstring& deviceId);
 
     UINT GetDpiForMonitor(HMONITOR monitor) noexcept;
     void OrderMonitors(std::vector<std::pair<HMONITOR, RECT>>& monitorInfo);

--- a/src/modules/fancyzones/tests/UnitTests/Util.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/Util.Spec.cpp
@@ -45,10 +45,10 @@ namespace FancyZonesUnitTests
             // We're interested in the unique part between the first and last #'s
             // Example input: \\?\DISPLAY#DELA026#5&10a58c63&0&UID16777488#{e6f07b5f-ee97-4a90-b076-33f57bf4eaa7}
             // Example output: DELA026#5&10a58c63&0&UID16777488
-            PCWSTR input = L"\\\\?\\DISPLAY#DELA026#5&10a58c63&0&UID16777488#{e6f07b5f-ee97-4a90-b076-33f57bf4eaa7}";
-            wchar_t output[256]{};
-            ParseDeviceId(input, output, ARRAYSIZE(output));
-            Assert::AreEqual(0, wcscmp(output, L"DELA026#5&10a58c63&0&UID16777488"));
+            const std::wstring input = L"\\\\?\\DISPLAY#DELA026#5&10a58c63&0&UID16777488#{e6f07b5f-ee97-4a90-b076-33f57bf4eaa7}";
+            const std::wstring actual = ParseDeviceId(input);
+            const std::wstring expected = L"DELA026#5&10a58c63&0&UID16777488";
+            Assert::AreEqual(expected, actual);
         }
 
         TEST_METHOD(TestParseInvalidDeviceId)
@@ -56,10 +56,10 @@ namespace FancyZonesUnitTests
             // We're interested in the unique part between the first and last #'s
             // Example input: \\?\DISPLAY#DELA026#5&10a58c63&0&UID16777488#{e6f07b5f-ee97-4a90-b076-33f57bf4eaa7}
             // Example output: DELA026#5&10a58c63&0&UID16777488
-            PCWSTR input = L"AnInvalidDeviceId";
-            wchar_t output[256]{};
-            ParseDeviceId(input, output, ARRAYSIZE(output));
-            Assert::AreEqual(0, wcscmp(output, L"FallbackDevice"));
+            const std::wstring input = L"AnInvalidDeviceId";
+            const std::wstring actual = ParseDeviceId(input);
+            const std::wstring expected = L"FallbackDevice";
+            Assert::AreEqual(expected, actual);
         }
 
         TEST_METHOD(TestMonitorOrdering01)

--- a/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
@@ -160,7 +160,7 @@ namespace FancyZonesUnitTests
         TEST_METHOD(CreateZoneWindowNoDeviceId)
         {
             // Generate unique id without device id
-            std::wstring uniqueId = ZoneWindowUtils::GenerateUniqueId(m_monitor, nullptr, m_virtualDesktopId.c_str());
+            std::wstring uniqueId = ZoneWindowUtils::GenerateUniqueId(m_monitor, {}, m_virtualDesktopId);
             auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, uniqueId, {}, false);
 
             const std::wstring expectedWorkArea = std::to_wstring(m_monitorInfo.rcMonitor.right) + L"_" + std::to_wstring(m_monitorInfo.rcMonitor.bottom);
@@ -178,7 +178,7 @@ namespace FancyZonesUnitTests
         TEST_METHOD(CreateZoneWindowNoDesktopId)
         {
             // Generate unique id without virtual desktop id
-            std::wstring uniqueId = ZoneWindowUtils::GenerateUniqueId(m_monitor, m_deviceId.c_str(), nullptr);
+            std::wstring uniqueId = ZoneWindowUtils::GenerateUniqueId(m_monitor, m_deviceId, {});
             auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, uniqueId, {}, false);
 
             const std::wstring expectedWorkArea = std::to_wstring(m_monitorInfo.rcMonitor.right) + L"_" + std::to_wstring(m_monitorInfo.rcMonitor.bottom);


### PR DESCRIPTION
## Summary of the Pull Request

Improve current procedure for enumeration screens (work areas) which does not take into account possibility that we have more than one [display](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-enumdisplaydevicesa) per [monitor](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-enumdisplaymonitors).

## PR Checklist
* [X] Applies to #6321
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

## Validation Steps Performed

Extensive regression testing as this affects every possible monitor / display configuration.
