### PR TITLE
Matching ExactName for known Win32 Programs

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program.UnitTests/Programs/Win32Tests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program.UnitTests/Programs/Win32Tests.cs
@@ -63,11 +63,20 @@ namespace Microsoft.Plugin.Program.UnitTests.Programs
             AppType = Win32Program.ApplicationType.Win32Application,
         };
 
-        private static readonly Win32Program _fileExplorer = new Win32Program
+        private static readonly Win32Program _fileExplorerLink = new Win32Program
         {
             Name = "File Explorer",
             ExecutableName = "File Explorer.lnk",
             FullPath = "c:\\users\\powertoys\\appdata\\roaming\\microsoft\\windows\\start menu\\programs\\system tools\\file explorer.lnk",
+            LnkResolvedPath = null,
+            AppType = Win32Program.ApplicationType.Win32Application,
+        };
+
+        private static readonly Win32Program _fileExplorer = new Win32Program
+        {
+            Name = "File Explorer",
+            ExecutableName = "explorer.exe",
+            FullPath = "c:\\windows\\explorer.exe",
             LnkResolvedPath = null,
             AppType = Win32Program.ApplicationType.Win32Application,
         };
@@ -273,7 +282,7 @@ namespace Microsoft.Plugin.Program.UnitTests.Programs
             // Arrange
             List<Win32Program> prgms = new List<Win32Program>
             {
-                _fileExplorer,
+                _fileExplorerLink,
             };
 
             // Act
@@ -401,6 +410,14 @@ namespace Microsoft.Plugin.Program.UnitTests.Programs
         {
             // Even if there is an exact match in the name or exe name, win32 applications should never be filtered
             Assert.IsTrue(_commandPrompt.QueryEqualsNameForRunCommands(query));
+        }
+
+        [TestCase("explorer")]
+        [TestCase("explorer.exe")]
+        public void Win32ApplicationsShouldNotFilterWhenExecutingNameOrNameIsUsed(string query)
+        {
+            // Even if there is an exact match in the name or exe name, win32 applications should never be filtered
+            Assert.IsTrue(_fileExplorer.QueryEqualsNameForRunCommands(query));
         }
 
         [TestCase("cmd")]

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/IProgram.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/IProgram.cs
@@ -20,5 +20,6 @@ namespace Microsoft.Plugin.Program.Programs
         string Description { get; set; }
 
         string Location { get; }
+        bool Enabled { get; set; }
     }
 }

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/IProgram.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/IProgram.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Plugin.Program.Programs
         string Description { get; set; }
 
         string Location { get; }
+
         bool Enabled { get; set; }
     }
 }

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32Program.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32Program.cs
@@ -170,10 +170,12 @@ namespace Microsoft.Plugin.Program.Programs
 
         public bool QueryEqualsNameForRunCommands(string query)
         {
-            if (query != null && AppType == ApplicationType.RunCommand
-                && !query.Equals(Name, StringComparison.OrdinalIgnoreCase))
+            if (query != null && AppType == ApplicationType.RunCommand)
             {
-                return false;
+                if (!query.Equals(Name, StringComparison.OrdinalIgnoreCase) && !query.Equals(ExecutableName, StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
             }
 
             return true;


### PR DESCRIPTION
## Summary of the Pull Request
Windows explorer will show when you type `explorer.exe`. See  #6917 for the interaction.

## PR Checklist
* [x] Applies to  #6917
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed

## Info on Pull Request

Created that it also matches on explorer.exe for explorer.

* Matching explorer.exe also for explorer
* Added unit test
* Optimized multiple iterations for IProgram

## Validation Steps Performed

Try the Plugin `explorer.exe` and see that it has a result. 
