### PR TITLE
[FancyZones] Fix stuck chrome tab when merging into existing window

### DIFF
--- a/src/modules/fancyzones/lib/WindowMoveHandler.cpp
+++ b/src/modules/fancyzones/lib/WindowMoveHandler.cpp
@@ -209,10 +209,10 @@ void WindowMoveHandler::MoveSizeEnd(HWND window, POINT const& ptScreen, const st
         auto zoneWindow = std::move(m_zoneWindowMoveSize);
         ResetWindowTransparency();
 
-        bool hasNoVisibleOwnoer = FancyZonesUtils::HasNoVisibleOwner(window);
+        bool hasNoVisibleOwner = FancyZonesUtils::HasNoVisibleOwner(window);
         bool isStandardWindow = FancyZonesUtils::IsStandardWindow(window);
 
-        if ((isStandardWindow == false && hasNoVisibleOwnoer == false &&
+        if ((isStandardWindow == false && hasNoVisibleOwner == true &&
              m_moveSizeWindowInfo.standardWindow == true && m_moveSizeWindowInfo.noVisibleOwner == true) ||
              FancyZonesUtils::IsWindowMaximized(window))
         {

--- a/src/modules/fancyzones/lib/WindowMoveHandler.cpp
+++ b/src/modules/fancyzones/lib/WindowMoveHandler.cpp
@@ -67,8 +67,8 @@ void WindowMoveHandler::MoveSizeStart(HWND window, HMONITOR monitor, POINT const
         return;
     }
 
-    m_moveSizeWindowInfo.noVisibleOwner = FancyZonesUtils::HasNoVisibleOwner(window);
-    m_moveSizeWindowInfo.standardWindow = FancyZonesUtils::IsStandardWindow(window);
+    m_moveSizeWindowInfo.hasNoVisibleOwner = FancyZonesUtils::HasNoVisibleOwner(window);
+    m_moveSizeWindowInfo.isStandardWindow = FancyZonesUtils::IsStandardWindow(window);
     m_inMoveSize = true;
 
     auto iter = zoneWindowMap.find(monitor);
@@ -213,7 +213,7 @@ void WindowMoveHandler::MoveSizeEnd(HWND window, POINT const& ptScreen, const st
         bool isStandardWindow = FancyZonesUtils::IsStandardWindow(window);
 
         if ((isStandardWindow == false && hasNoVisibleOwner == true &&
-             m_moveSizeWindowInfo.standardWindow == true && m_moveSizeWindowInfo.noVisibleOwner == true) ||
+             m_moveSizeWindowInfo.isStandardWindow == true && m_moveSizeWindowInfo.hasNoVisibleOwner == true) ||
              FancyZonesUtils::IsWindowMaximized(window))
         {
             // Abort the zoning, this is a Chromium based tab that is merged back with an existing window

--- a/src/modules/fancyzones/lib/WindowMoveHandler.h
+++ b/src/modules/fancyzones/lib/WindowMoveHandler.h
@@ -52,9 +52,9 @@ private:
     struct MoveSizeWindowInfo
     {
         // True if from the styles the window looks like a standard window
-        bool standardWindow = false;
+        bool isStandardWindow = false;
         // True if the window is a top-level window that does not have a visible owner
-        bool noVisibleOwner = false;
+        bool hasNoVisibleOwner = false;
     };
 
     void WarnIfElevationIsRequired(HWND window) noexcept;


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
Fix for #3536. This was fixed [(PR)](https://github.com/microsoft/PowerToys/pull/6549) but broken later with [this change](https://github.com/microsoft/PowerToys/commit/3d36779e19d3f2470585c3789b3cd9d728f4e8ec#diff-ff7794bdc47c8ebd8c1cecabe2f532fc).

## PR Checklist
* [x] Applies to #3536 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Validation Steps Performed

_How does someone test & validate?_
Manually tested zoning and merging chrome tabs 