### PR TITLE
EnumerateFileSystemInfos uses EnumerationOptions 

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder.UnitTests/InternalQueryFolderTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder.UnitTests/InternalQueryFolderTests.cs
@@ -42,8 +42,8 @@ namespace Microsoft.Plugin.Folder.UnitTests
             queryFileSystemInfoMock.Setup(r => r.Exists(It.IsAny<string>()))
                 .Returns<string>(path => ContainsDirectory(path));
 
-            queryFileSystemInfoMock.Setup(r => r.MatchFileSystemInfo(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<SearchOption>()))
-                .Returns<string, string, SearchOption>(MatchFileSystemInfo);
+            queryFileSystemInfoMock.Setup(r => r.MatchFileSystemInfo(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()))
+                .Returns<string, string, bool>(MatchFileSystemInfo);
 
             _queryFileSystemInfoMock = queryFileSystemInfoMock;
         }
@@ -66,25 +66,23 @@ namespace Microsoft.Plugin.Folder.UnitTests
             return trimEnd;
         }
 
-        private static IEnumerable<DisplayFileInfo> MatchFileSystemInfo(string search, string incompleteName, SearchOption searchOption)
+        private static IEnumerable<DisplayFileInfo> MatchFileSystemInfo(string search, string incompleteName, bool isRecursive)
         {
             Func<string, bool> folderSearchFunc;
             Func<string, bool> fileSearchFunc;
-            switch (searchOption)
+            switch (isRecursive)
             {
-                case SearchOption.TopDirectoryOnly:
+                case false:
                     folderSearchFunc = s => s.Equals(search, StringComparison.CurrentCultureIgnoreCase);
 
                     var regexSearch = TrimDirectoryEnd(search);
 
                     fileSearchFunc = s => Regex.IsMatch(s, $"^{Regex.Escape(regexSearch)}[^\\\\]*$");
                     break;
-                case SearchOption.AllDirectories:
+                case true:
                     folderSearchFunc = s => s.StartsWith(search, StringComparison.CurrentCultureIgnoreCase);
                     fileSearchFunc = s => s.StartsWith(search, StringComparison.CurrentCultureIgnoreCase);
                     break;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(searchOption), searchOption, null);
             }
 
             var directories = DirectoryExist.Where(s => folderSearchFunc(s))

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/IQueryFileSystemInfo.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/IQueryFileSystemInfo.cs
@@ -10,6 +10,6 @@ namespace Microsoft.Plugin.Folder.Sources
 {
     public interface IQueryFileSystemInfo : IDirectoryWrapper
     {
-        IEnumerable<DisplayFileInfo> MatchFileSystemInfo(string search, string incompleteName, SearchOption searchOption);
+        IEnumerable<DisplayFileInfo> MatchFileSystemInfo(string search, string incompleteName, bool isRecursive);
     }
 }

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/QueryFileSystemInfo.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/QueryFileSystemInfo.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Plugin.Folder.Sources
             var directoryInfo = new DirectoryInfo(search);
             var fileSystemInfos = directoryInfo.EnumerateFileSystemInfos(incompleteName, new EnumerationOptions()
             {
-                MatchType = MatchType.Simple,
+                MatchType = MatchType.Win32,
                 RecurseSubdirectories = isRecursive,
                 IgnoreInaccessible = true,
                 ReturnSpecialDirectories = false,

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/QueryInternalDirectory.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/QueryInternalDirectory.cs
@@ -36,15 +36,10 @@ namespace Microsoft.Plugin.Folder.Sources
             return search.Any(c => SpecialSearchChars.Contains(c));
         }
 
-        public static SearchOption GetSearchOptions(string query)
+        public static bool RecursiveSearch(string query)
         {
             // give the ability to search all folder when it contains a >
-            if (query.Any(c => c.Equals('>')))
-            {
-                return SearchOption.AllDirectories;
-            }
-
-            return SearchOption.TopDirectoryOnly;
+            return query.Any(c => c.Equals('>'));
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1308:Normalize strings to uppercase", Justification = "Do not want to change the behavior of the application, but want to enforce static analysis")]
@@ -99,9 +94,9 @@ namespace Microsoft.Plugin.Folder.Sources
             }
 
             var (search, incompleteName) = processed;
-            var searchOption = GetSearchOptions(incompleteName);
+            var isRecursive = RecursiveSearch(incompleteName);
 
-            if (searchOption == SearchOption.AllDirectories)
+            if (isRecursive)
             {
                 // match everything before and after search term using supported wildcard '*', ie. *searchterm*
                 if (string.IsNullOrEmpty(incompleteName))
@@ -117,7 +112,7 @@ namespace Microsoft.Plugin.Folder.Sources
             yield return new CreateOpenCurrentFolderResult(search);
 
             // Note: Take 1000 is so that you don't search the whole system before you discard
-            var lookup = _queryFileSystemInfo.MatchFileSystemInfo(search, incompleteName, searchOption)
+            var lookup = _queryFileSystemInfo.MatchFileSystemInfo(search, incompleteName, isRecursive)
                 .Take(1000)
                 .ToLookup(r => r.Type);
 


### PR DESCRIPTION
## Summary of the Pull Request

Changed EnumerateFileSystemInfos to EnumerationOptions we don't have to catch the exceptions ourself. See #6922 for more information.

## PR Checklist
* [x] Applies to #6922
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #6922

## Info on Pull Request

Other querying of fileSystem.

## Validation Steps Performed

It doesn't break any tests.

## Suggested tags
* Product-Launcher

