### PR TITLE
Fix throwing when there is no results

### DIFF
--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -536,7 +536,7 @@ namespace PowerLauncher.ViewModel
 
                                     currentCancellationToken.ThrowIfCancellationRequested();
                                     Results.Sort();
-                                    Results.SelectedItem = Results.Results[0];
+                                    Results.SelectedItem = Results.Results.FirstOrDefault();
                                 }
                             }
 
@@ -574,7 +574,7 @@ namespace PowerLauncher.ViewModel
 
                                                         currentCancellationToken.ThrowIfCancellationRequested();
                                                         Results.Sort();
-                                                        Results.SelectedItem = Results.Results[0];
+                                                        Results.SelectedItem = Results.Results.FirstOrDefault();
                                                     }
                                                 }
 


### PR DESCRIPTION
## Summary of the Pull Request

Very small PR: When you type an invalid path in PT Run: `C:DwarfFortress` and there is no result, the code throws an IndexOutOfBounds. This is a safe way to select the first indexed if there is a value. Found this on the current master branch when I made #6933

## PR Checklist
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

Small fix, see summary.

## Validation Steps Performed

When you type an invalid path in PT Run like `C:Folder`, the code wouldn't throw an IndexOutOfBounds anymore, but handle it silently.

## Suggested Labels
* PT Run