### PR TITLE
Fixed the error that Files were named Folder

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Properties/Resources.Designer.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Properties/Resources.Designer.cs
@@ -142,6 +142,15 @@ namespace Microsoft.Plugin.Folder.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to File: {0}.
+        /// </summary>
+        public static string wox_plugin_folder_select_file_result_subtitle {
+            get {
+                return ResourceManager.GetString("wox_plugin_folder_select_file_result_subtitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Use &gt; to search within the directory. Use * to search for file extensions. Or use both &gt;*.
         /// </summary>
         public static string wox_plugin_folder_select_folder_first_result_subtitle {
@@ -165,6 +174,15 @@ namespace Microsoft.Plugin.Folder.Properties {
         public static string wox_plugin_folder_select_folder_OpenFileOrFolder_error_message {
             get {
                 return ResourceManager.GetString("wox_plugin_folder_select_folder_OpenFileOrFolder_error_message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Folder: {0}.
+        /// </summary>
+        public static string wox_plugin_folder_select_folder_result_subtitle {
+            get {
+                return ResourceManager.GetString("wox_plugin_folder_select_folder_result_subtitle", resourceCulture);
             }
         }
     }

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Properties/Resources.Designer.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Properties/Resources.Designer.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Plugin.Folder.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Showing {0} of {1} results.
+        ///   Looks up a localized string similar to Showing {0:N0} of {1:N0} results.
         /// </summary>
         public static string Microsoft_plugin_folder_truncation_warning_subtitle {
             get {

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Properties/Resources.resx
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Properties/Resources.resx
@@ -153,4 +153,10 @@
   <data name="wox_plugin_folder_select_folder_OpenFileOrFolder_error_message" xml:space="preserve">
     <value>Could not start</value>
   </data>
+  <data name="wox_plugin_folder_select_file_result_subtitle" xml:space="preserve">
+    <value>File: {0}</value>
+  </data>
+  <data name="wox_plugin_folder_select_folder_result_subtitle" xml:space="preserve">
+    <value>Folder: {0}</value>
+  </data>
 </root>

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Properties/Resources.resx
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Properties/Resources.resx
@@ -136,7 +136,7 @@
     <value>Warning: Folder Plugin Results truncated.</value>
   </data>
   <data name="Microsoft_plugin_folder_truncation_warning_subtitle" xml:space="preserve">
-    <value>Showing {0} of {1} results</value>
+    <value>Showing {0:N0} of {1:N0} results</value>
   </data>
   <data name="Microsoft_plugin_folder_clipboard_failed" xml:space="preserve">
     <value>Fail to set text in clipboard</value>

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/Result/CreateOpenCurrentFolderResult.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/Result/CreateOpenCurrentFolderResult.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Globalization;
 using Wox.Plugin;
 
 namespace Microsoft.Plugin.Folder.Sources.Result
@@ -27,9 +28,9 @@ namespace Microsoft.Plugin.Folder.Sources.Result
         {
             return new Wox.Plugin.Result
             {
-                Title = $"Open {Search}",
+                Title = Properties.Resources.wox_plugin_folder_select_folder_first_result_title,
                 QueryTextDisplay = Search,
-                SubTitle = $"Folder: Use > to search within the directory. Use * to search for file extensions. Or use both >*.",
+                SubTitle = Properties.Resources.wox_plugin_folder_select_folder_first_result_subtitle,
                 IcoPath = Search,
                 Score = 500,
                 Action = c => _explorerAction.ExecuteSanitized(Search, contextApi),

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/Result/FileItemResult.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/Result/FileItemResult.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Plugin.Folder.Sources.Result
             var result = new Wox.Plugin.Result
             {
                 Title = Title,
-                SubTitle = string.Format(CultureInfo.InvariantCulture, Properties.Resources.wox_plugin_folder_select_file_result_subtitle, FilePath),
+                SubTitle = string.Format(CultureInfo.CurrentCulture, Properties.Resources.wox_plugin_folder_select_file_result_subtitle, FilePath),
                 IcoPath = FilePath,
                 TitleHighlightData = StringMatcher.FuzzySearch(Search, Path.GetFileName(FilePath)).MatchData,
                 Action = c => ExplorerAction.Execute(FilePath, contextApi),

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/Result/FileItemResult.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/Result/FileItemResult.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Globalization;
 using System.IO;
 using Wox.Infrastructure;
 using Wox.Plugin;
@@ -23,7 +24,7 @@ namespace Microsoft.Plugin.Folder.Sources.Result
             var result = new Wox.Plugin.Result
             {
                 Title = Title,
-                SubTitle = "File: " + FilePath,
+                SubTitle = string.Format(CultureInfo.InvariantCulture, Properties.Resources.wox_plugin_folder_select_file_result_subtitle, FilePath),
                 IcoPath = FilePath,
                 TitleHighlightData = StringMatcher.FuzzySearch(Search, Path.GetFileName(FilePath)).MatchData,
                 Action = c => ExplorerAction.Execute(FilePath, contextApi),

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/Result/FileItemResult.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/Result/FileItemResult.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Plugin.Folder.Sources.Result
             var result = new Wox.Plugin.Result
             {
                 Title = Title,
-                SubTitle = "Folder: " + FilePath,
+                SubTitle = "File: " + FilePath,
                 IcoPath = FilePath,
                 TitleHighlightData = StringMatcher.FuzzySearch(Search, Path.GetFileName(FilePath)).MatchData,
                 Action = c => ExplorerAction.Execute(FilePath, contextApi),

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/Result/FolderItemResult.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/Result/FolderItemResult.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Plugin.Folder.Sources.Result
             {
                 Title = Title,
                 IcoPath = Path,
-                SubTitle = string.Format(CultureInfo.InvariantCulture, Properties.Resources.wox_plugin_folder_select_folder_result_subtitle, Subtitle),
+                SubTitle = string.Format(CultureInfo.CurrentCulture, Properties.Resources.wox_plugin_folder_select_folder_result_subtitle, Subtitle),
                 QueryTextDisplay = Path,
                 TitleHighlightData = StringMatcher.FuzzySearch(Search, Title).MatchData,
                 ContextData = new SearchResult { Type = ResultType.Folder, FullPath = Path },

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/Result/FolderItemResult.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/Result/FolderItemResult.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Globalization;
 using Wox.Infrastructure;
 using Wox.Plugin;
 
@@ -36,7 +37,7 @@ namespace Microsoft.Plugin.Folder.Sources.Result
             {
                 Title = Title,
                 IcoPath = Path,
-                SubTitle = "Folder: " + Subtitle,
+                SubTitle = string.Format(CultureInfo.InvariantCulture, Properties.Resources.wox_plugin_folder_select_folder_result_subtitle, Subtitle),
                 QueryTextDisplay = Path,
                 TitleHighlightData = StringMatcher.FuzzySearch(Search, Title).MatchData,
                 ContextData = new SearchResult { Type = ResultType.Folder, FullPath = Path },

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/Result/TruncatedItemResult.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/Result/TruncatedItemResult.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Plugin.Folder.Sources.Result
             {
                 Title = Properties.Resources.Microsoft_plugin_folder_truncation_warning_title,
                 QueryTextDisplay = Search,
-                SubTitle = string.Format(CultureInfo.InvariantCulture, Properties.Resources.Microsoft_plugin_folder_truncation_warning_subtitle, PostTruncationCount, PreTruncationCount),
+                SubTitle = string.Format(CultureInfo.CurrentCulture, Properties.Resources.Microsoft_plugin_folder_truncation_warning_subtitle, PostTruncationCount, PreTruncationCount),
                 IcoPath = WarningIconPath,
             };
         }

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/UserFolderResult.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/UserFolderResult.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Plugin.Folder
             {
                 Title = Title,
                 IcoPath = Path,
-                SubTitle = string.Format(CultureInfo.InvariantCulture, Properties.Resources.wox_plugin_folder_select_folder_result_subtitle, Subtitle),
+                SubTitle = string.Format(CultureInfo.CurrentCulture, Properties.Resources.wox_plugin_folder_select_folder_result_subtitle, Subtitle),
                 QueryTextDisplay = Path,
                 TitleHighlightData = StringMatcher.FuzzySearch(Search, Title).MatchData,
                 ContextData = new SearchResult { Type = ResultType.Folder, FullPath = Path },

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/UserFolderResult.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/UserFolderResult.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Globalization;
 using Microsoft.Plugin.Folder.Sources;
 using Microsoft.Plugin.Folder.Sources.Result;
 using Wox.Infrastructure;
@@ -27,7 +28,7 @@ namespace Microsoft.Plugin.Folder
             {
                 Title = Title,
                 IcoPath = Path,
-                SubTitle = $"Folder: {Subtitle}",
+                SubTitle = string.Format(CultureInfo.InvariantCulture, Properties.Resources.wox_plugin_folder_select_folder_result_subtitle, Subtitle),
                 QueryTextDisplay = Path,
                 TitleHighlightData = StringMatcher.FuzzySearch(Search, Title).MatchData,
                 ContextData = new SearchResult { Type = ResultType.Folder, FullPath = Path },


### PR DESCRIPTION
## Summary of the Pull Request

Repairs that a file is in the subtitle also called file. Introduced in #6600.

## PR Checklist
* [x] Applies to #6028
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed

## Info on Pull Request

Repairs that a file is in the subtitle also called file. This has not been shipped into a version.

## Validation Steps Performed

Query a File with PT Run
