### PR TITLE
[KBM] Avoid checking reserved/unassigned/oem-specific/undefined key codes during shortcut remaps

### DIFF
--- a/src/modules/keyboardmanager/common/Shortcut.cpp
+++ b/src/modules/keyboardmanager/common/Shortcut.cpp
@@ -613,25 +613,51 @@ bool Shortcut::CheckModifiersKeyboardState(InputInterface& ii) const
     return true;
 }
 
+bool in_range(DWORD key, DWORD a, DWORD b)
+{
+    return (key >= a && key <= b);
+}
+
+bool equals(DWORD key, DWORD a)
+{
+    return (key == a);
+}
+
 // Function to check if the key code is to be ignored
 bool IgnoreKeyCode(DWORD key)
 {
+    // Ignore mouse buttons. Keeping this could cause a remapping to fail if a mouse button is also pressed at the same time
     switch (key)
     {
-        // Ignore mouse buttons. Keeping this could cause a remapping to fail if a mouse button is also pressed at the same time
     case VK_LBUTTON:
     case VK_RBUTTON:
     case VK_MBUTTON:
     case VK_XBUTTON1:
     case VK_XBUTTON2:
-        // Ignore these key codes as they are reserved. Used by IME keyboards. More information at https://github.com/microsoft/PowerToys/issues/5225
-    case 0xF0:
-    case 0xF1:
-    case 0xF2:
         return true;
     }
 
-    return false;
+    // As per docs: https://docs.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes
+    // Undefined keys
+    bool isUndefined = equals(key, 0x07) || in_range(key, 0x0E, 0x0F) || in_range(key, 0x3A, 0x40);
+
+    // Reserved keys
+    bool isReserved = in_range(key, 0x0A, 0x0B) || equals(key, 0x5E) || in_range(key, 0xB8, 0xB9) || in_range(key, 0xC1, 0xD7) || equals(key, 0xE0) || equals(key, VK_NONAME);
+
+    // Unassigned keys
+    bool isUnassigned = in_range(key, 0x88, 0x8F) || in_range(key, 0x97, 0x9F) || in_range(key, 0xD8, 0xDA) || equals(key, 0xE8);
+
+    //OEM Specific keys. Ignore these key codes as some of them are used by IME keyboards. More information at https://github.com/microsoft/PowerToys/issues/5225
+    bool isOEMSpecific = in_range(key, 0x92, 0x96) || equals(key, 0xE1) || in_range(key, 0xE3, 0xE4) || equals(key, 0xE6) || in_range(key, 0xE9, 0xF5);
+
+    if (isUndefined || isReserved || isUnassigned || isOEMSpecific)
+    {
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 // Function to check if any keys are pressed down except those in the shortcut

--- a/src/modules/keyboardmanager/common/Shortcut.cpp
+++ b/src/modules/keyboardmanager/common/Shortcut.cpp
@@ -613,11 +613,13 @@ bool Shortcut::CheckModifiersKeyboardState(InputInterface& ii) const
     return true;
 }
 
+// Helper method for checking if a key is in a range for cleaner code
 bool in_range(DWORD key, DWORD a, DWORD b)
 {
     return (key >= a && key <= b);
 }
 
+// Helper method for checking if a key is equal to a value for cleaner code
 bool equals(DWORD key, DWORD a)
 {
     return (key == a);


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
This PR tweaks the code that checks keys to be ignored during shortcut remaps to be more generic. Rather than ignoring the few problematic codes as issues are created (so far 0xF0, 0xF1, 0xF2, 0xF3), the PR ignores any key codes mentioned as unassigned, reserved, undefined or oem-specific on the official docs at https://docs.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes, similar to the fix done for shortcut guide at #6025

## PR Checklist
* [X] Applies to #6951 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [X] Tests passed

## Validation Steps Performed

_How does someone test & validate?_
- Validate that shortcut to shortcut remappings work on En-US
- Validate on Japanese language that even after pressing Shift+Caps, Alt+Caps, Ctrl+Caps or Alt+` the shortcut remaps still work.