### PR TITLE
Add exception handling in win32 program

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32Program.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32Program.cs
@@ -330,6 +330,7 @@ namespace Microsoft.Plugin.Program.Programs
             return ExecutableName;
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Any error in CreateWin32Program should not prevent other programs from loading.")]
         private static Win32Program CreateWin32Program(string path)
         {
             try
@@ -355,76 +356,92 @@ namespace Microsoft.Plugin.Program.Programs
 
                 return new Win32Program() { Valid = false, Enabled = false };
             }
+            catch (Exception e)
+            {
+                ProgramLogger.Exception($"|An unexpected error occurred in the calling method CreateWin32Program at {path}", e, MethodBase.GetCurrentMethod().DeclaringType, path);
+
+                return new Win32Program() { Valid = false, Enabled = false };
+            }
         }
 
         // This function filters Internet Shortcut programs
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Any error in InternetShortcutProgram should not prevent other programs from loading.")]
         private static Win32Program InternetShortcutProgram(string path)
         {
-            string[] lines = FileWrapper.ReadAllLines(path);
-            string iconPath = string.Empty;
-            string urlPath = string.Empty;
-            bool validApp = false;
-
-            Regex internetShortcutURLPrefixes = new Regex(@"^steam:\/\/(rungameid|run)\/|^com\.epicgames\.launcher:\/\/apps\/");
-
-            const string urlPrefix = "URL=";
-            const string iconFilePrefix = "IconFile=";
-
-            foreach (string line in lines)
-            {
-                if (line.StartsWith(urlPrefix, StringComparison.OrdinalIgnoreCase))
-                {
-                    urlPath = line.Substring(urlPrefix.Length);
-
-                    try
-                    {
-                        Uri uri = new Uri(urlPath);
-                    }
-                    catch (UriFormatException e)
-                    {
-                        // To catch the exception if the uri cannot be parsed.
-                        // Link to watson crash: https://watsonportal.microsoft.com/Failure?FailureSearchText=5f871ea7-e886-911f-1b31-131f63f6655b
-                        ProgramLogger.Exception($"url could not be parsed", e, MethodBase.GetCurrentMethod().DeclaringType, urlPath);
-                        return new Win32Program() { Valid = false, Enabled = false };
-                    }
-
-                    // To filter out only those steam shortcuts which have 'run' or 'rungameid' as the hostname
-                    if (internetShortcutURLPrefixes.Match(urlPath).Success)
-                    {
-                        validApp = true;
-                    }
-                }
-
-                if (line.StartsWith(iconFilePrefix, StringComparison.OrdinalIgnoreCase))
-                {
-                    iconPath = line.Substring(iconFilePrefix.Length);
-                }
-            }
-
-            if (!validApp)
-            {
-                return new Win32Program() { Valid = false, Enabled = false };
-            }
-
             try
             {
-                var p = new Win32Program
+                string[] lines = FileWrapper.ReadAllLines(path);
+                string iconPath = string.Empty;
+                string urlPath = string.Empty;
+                bool validApp = false;
+
+                Regex internetShortcutURLPrefixes = new Regex(@"^steam:\/\/(rungameid|run)\/|^com\.epicgames\.launcher:\/\/apps\/");
+
+                const string urlPrefix = "URL=";
+                const string iconFilePrefix = "IconFile=";
+
+                foreach (string line in lines)
                 {
-                    Name = Path.GetFileNameWithoutExtension(path),
-                    ExecutableName = Path.GetFileName(path),
-                    IcoPath = iconPath,
-                    FullPath = urlPath,
-                    UniqueIdentifier = path,
-                    ParentDirectory = Directory.GetParent(path).FullName,
-                    Valid = true,
-                    Enabled = true,
-                    AppType = ApplicationType.InternetShortcutApplication,
-                };
-                return p;
+                    if (line.StartsWith(urlPrefix, StringComparison.OrdinalIgnoreCase))
+                    {
+                        urlPath = line.Substring(urlPrefix.Length);
+
+                        try
+                        {
+                            Uri uri = new Uri(urlPath);
+                        }
+                        catch (UriFormatException e)
+                        {
+                            // To catch the exception if the uri cannot be parsed.
+                            // Link to watson crash: https://watsonportal.microsoft.com/Failure?FailureSearchText=5f871ea7-e886-911f-1b31-131f63f6655b
+                            ProgramLogger.Exception($"url could not be parsed", e, MethodBase.GetCurrentMethod().DeclaringType, urlPath);
+                            return new Win32Program() { Valid = false, Enabled = false };
+                        }
+
+                        // To filter out only those steam shortcuts which have 'run' or 'rungameid' as the hostname
+                        if (internetShortcutURLPrefixes.Match(urlPath).Success)
+                        {
+                            validApp = true;
+                        }
+                    }
+
+                    if (line.StartsWith(iconFilePrefix, StringComparison.OrdinalIgnoreCase))
+                    {
+                        iconPath = line.Substring(iconFilePrefix.Length);
+                    }
+                }
+
+                if (!validApp)
+                {
+                    return new Win32Program() { Valid = false, Enabled = false };
+                }
+
+                try
+                {
+                    var p = new Win32Program
+                    {
+                        Name = Path.GetFileNameWithoutExtension(path),
+                        ExecutableName = Path.GetFileName(path),
+                        IcoPath = iconPath,
+                        FullPath = urlPath,
+                        UniqueIdentifier = path,
+                        ParentDirectory = Directory.GetParent(path).FullName,
+                        Valid = true,
+                        Enabled = true,
+                        AppType = ApplicationType.InternetShortcutApplication,
+                    };
+                    return p;
+                }
+                catch (Exception e) when (e is SecurityException || e is UnauthorizedAccessException)
+                {
+                    ProgramLogger.Exception($"|Permission denied when trying to load the program from {path}", e, MethodBase.GetCurrentMethod().DeclaringType, path);
+
+                    return new Win32Program() { Valid = false, Enabled = false };
+                }
             }
-            catch (Exception e) when (e is SecurityException || e is UnauthorizedAccessException)
+            catch (Exception e)
             {
-                ProgramLogger.Exception($"|Permission denied when trying to load the program from {path}", e, MethodBase.GetCurrentMethod().DeclaringType, path);
+                ProgramLogger.Exception($"|An unexpected error occurred in the calling method InternetShortcutProgram at {path}", e, MethodBase.GetCurrentMethod().DeclaringType, path);
 
                 return new Win32Program() { Valid = false, Enabled = false };
             }
@@ -433,9 +450,9 @@ namespace Microsoft.Plugin.Program.Programs
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Unsure of what exceptions are caught here while enabling static analysis")]
         private static Win32Program LnkProgram(string path)
         {
-            var program = CreateWin32Program(path);
             try
             {
+                var program = CreateWin32Program(path);
                 const int MAX_PATH = 260;
                 StringBuilder buffer = new StringBuilder(MAX_PATH);
 
@@ -472,13 +489,13 @@ namespace Microsoft.Plugin.Program.Programs
             // Error caused likely due to trying to get the description of the program
             catch (Exception e)
             {
-                ProgramLogger.Exception("An unexpected error occurred in the calling method LnkProgram", e, MethodBase.GetCurrentMethod().DeclaringType, path);
+                ProgramLogger.Exception($"|An unexpected error occurred in the calling method LnkProgram at {path}", e, MethodBase.GetCurrentMethod().DeclaringType, path);
 
-                program.Valid = false;
-                return program;
+                return new Win32Program() { Valid = false, Enabled = false };
             }
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Any error in ExeProgram should not prevent other programs from loading.")]
         private static Win32Program ExeProgram(string path)
         {
             try
@@ -502,6 +519,12 @@ namespace Microsoft.Plugin.Program.Programs
             catch (FileNotFoundException e)
             {
                 ProgramLogger.Exception($"|Unable to locate exe file at {path}", e, MethodBase.GetCurrentMethod().DeclaringType, path);
+
+                return new Win32Program() { Valid = false, Enabled = false };
+            }
+            catch (Exception e)
+            {
+                ProgramLogger.Exception($"|An unexpected error occurred in the calling method ExeProgram at {path}", e, MethodBase.GetCurrentMethod().DeclaringType, path);
 
                 return new Win32Program() { Valid = false, Enabled = false };
             }
@@ -585,6 +608,7 @@ namespace Microsoft.Plugin.Program.Programs
             }
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Minimise the effect of error on other programs")]
         private static IEnumerable<string> ProgramPaths(string directory, IList<string> suffixes, bool recursiveSearch = true)
         {
             if (!Directory.Exists(directory))
@@ -599,41 +623,34 @@ namespace Microsoft.Plugin.Program.Programs
             do
             {
                 var currentDirectory = folderQueue.Dequeue();
-                try
+                foreach (var suffix in suffixes)
                 {
-                    foreach (var suffix in suffixes)
+                    try
                     {
-                        try
-                        {
-                            files.AddRange(Directory.EnumerateFiles(currentDirectory, $"*.{suffix}", SearchOption.TopDirectoryOnly));
-                        }
-                        catch (DirectoryNotFoundException e)
-                        {
-                            ProgramLogger.Exception("|The directory trying to load the program from does not exist", e, MethodBase.GetCurrentMethod().DeclaringType, currentDirectory);
-                        }
+                        files.AddRange(Directory.EnumerateFiles(currentDirectory, $"*.{suffix}", SearchOption.TopDirectoryOnly));
+                    }
+                    catch (Exception e)
+                    {
+                        ProgramLogger.Exception("|The directory trying to load the program from does not exist", e, MethodBase.GetCurrentMethod().DeclaringType, currentDirectory);
                     }
                 }
-                catch (Exception e) when (e is SecurityException || e is UnauthorizedAccessException)
+
+                // If the search is set to be non-recursive, then do not enqueue the child directories.
+                if (!recursiveSearch)
                 {
-                    ProgramLogger.Exception($"|Permission denied when trying to load programs from {currentDirectory}", e, MethodBase.GetCurrentMethod().DeclaringType, currentDirectory);
+                    continue;
                 }
 
                 try
                 {
-                    // If the search is set to be non-recursive, then do not enqueue the child directories.
-                    if (!recursiveSearch)
-                    {
-                        continue;
-                    }
-
                     foreach (var childDirectory in Directory.EnumerateDirectories(currentDirectory, "*", SearchOption.TopDirectoryOnly))
                     {
                         folderQueue.Enqueue(childDirectory);
                     }
                 }
-                catch (Exception e) when (e is SecurityException || e is UnauthorizedAccessException)
+                catch (Exception e)
                 {
-                    ProgramLogger.Exception($"|Permission denied when trying to load programs from {currentDirectory}", e, MethodBase.GetCurrentMethod().DeclaringType, currentDirectory);
+                    ProgramLogger.Exception("|The directory trying to load the program from does not exist", e, MethodBase.GetCurrentMethod().DeclaringType, currentDirectory);
                 }
             }
             while (folderQueue.Any());

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32Program.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32Program.cs
@@ -643,7 +643,7 @@ namespace Microsoft.Plugin.Program.Programs
                 }
                 catch (Exception e)
                 {
-                    ProgramLogger.Exception($"|An unexpected error occurred in the calling method ProgramPaths at {currentDirectory}", e, MethodBase.GetCurrentMethod().DeclaringType, path);
+                    ProgramLogger.Exception($"|An unexpected error occurred in the calling method ProgramPaths at {currentDirectory}", e, MethodBase.GetCurrentMethod().DeclaringType, currentDirectory);
                 }
 
                 try
@@ -665,7 +665,7 @@ namespace Microsoft.Plugin.Program.Programs
                 }
                 catch (Exception e)
                 {
-                    ProgramLogger.Exception($"|An unexpected error occurred in the calling method ProgramPaths at {currentDirectory}", e, MethodBase.GetCurrentMethod().DeclaringType, path);
+                    ProgramLogger.Exception($"|An unexpected error occurred in the calling method ProgramPaths at {currentDirectory}", e, MethodBase.GetCurrentMethod().DeclaringType, currentDirectory);
                 }
             }
             while (folderQueue.Any());


### PR DESCRIPTION
## Summary of the Pull Request
Improving exception handling during indexing of Win32 apps to prevent the error in one application from affecting other programs.

## PR Checklist
* [x] Applies to #6533 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request
This PR contains the following changes :
1. Added a try-catch block for `ProgramPaths` function. This function enumerates all files in the current folder and subfolders. `IOException` was being thrown when trying to call `Directory.EnumerateFiles` on OneDrive virtual folders. All exceptions should be caught here as this function is a bottleneck for a number of functions including `DesktopPrograms`, `StartMenuPrograms`, and `PathEnvironmentPrograms`.
2. Added a try-catch to handle all exceptions when adding a new `InternetShortcutProgram`, `LnkProgram`,`ExeProgram` and `CreateWin32Program`. All exceptions should be caught here because any unhandled exception would propagate to `All` function in `Win32Program.cs`, preventing other win32 programs from loading. 

## Validation Steps Performed
1. Manually validated that the program plugin works as expected.