### PR TITLE
[KBM] Moved unregistering of key delays to always run on the dispatcher thread to avoid mutex re-entrancy

### DIFF
--- a/src/modules/keyboardmanager/common/KeyDelay.cpp
+++ b/src/modules/keyboardmanager/common/KeyDelay.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 #include "KeyDelay.h"
 
+// NOTE: The destructor should never be called on the DelayThread, i.e. from any of shortPress, longPress or longPressReleased, as it will re-enter the mutex. Even if the mutex is removed it will deadlock because of the join statement
 KeyDelay::~KeyDelay()
 {
     std::unique_lock<std::mutex> l(_queueMutex);

--- a/src/modules/keyboardmanager/ui/ShortcutControl.cpp
+++ b/src/modules/keyboardmanager/ui/ShortcutControl.cpp
@@ -355,6 +355,7 @@ void ShortcutControl::createDetectShortcutWindow(winrt::Windows::Foundation::IIn
         onAccept();
     });
 
+    // NOTE: UnregisterKeys should never be called on the DelayThread, as it will re-enter the mutex. To avoid this it is run on the dispatcher thread
     keyboardManagerState.RegisterKeyDelay(
         VK_RETURN,
         selectDetectedShortcutAndResetKeys,
@@ -409,6 +410,7 @@ void ShortcutControl::createDetectShortcutWindow(winrt::Windows::Foundation::IIn
         onCancel();
     });
 
+    // NOTE: UnregisterKeys should never be called on the DelayThread, as it will re-enter the mutex. To avoid this it is run on the dispatcher thread
     keyboardManagerState.RegisterKeyDelay(
         VK_ESCAPE,
         selectDetectedShortcutAndResetKeys,

--- a/src/modules/keyboardmanager/ui/SingleKeyRemapControl.cpp
+++ b/src/modules/keyboardmanager/ui/SingleKeyRemapControl.cpp
@@ -269,6 +269,7 @@ void SingleKeyRemapControl::createDetectKeyWindow(winrt::Windows::Foundation::II
         onAccept();
     });
 
+    // NOTE: UnregisterKeys should never be called on the DelayThread, as it will re-enter the mutex. To avoid this it is run on the dispatcher thread
     keyboardManagerState.RegisterKeyDelay(
         VK_RETURN,
         std::bind(&KeyboardManagerState::SelectDetectedRemapKey, &keyboardManagerState, std::placeholders::_1),
@@ -313,6 +314,7 @@ void SingleKeyRemapControl::createDetectKeyWindow(winrt::Windows::Foundation::II
         onCancel();
     });
 
+    // NOTE: UnregisterKeys should never be called on the DelayThread, as it will re-enter the mutex. To avoid this it is run on the dispatcher thread
     keyboardManagerState.RegisterKeyDelay(
         VK_ESCAPE,
         std::bind(&KeyboardManagerState::SelectDetectedRemapKey, &keyboardManagerState, std::placeholders::_1),

--- a/src/modules/keyboardmanager/ui/SingleKeyRemapControl.cpp
+++ b/src/modules/keyboardmanager/ui/SingleKeyRemapControl.cpp
@@ -281,41 +281,47 @@ void SingleKeyRemapControl::createDetectKeyWindow(winrt::Windows::Foundation::II
                     onPressEnter();
                 });
         },
-        [onReleaseEnter](DWORD) {
-            onReleaseEnter();
+        [onReleaseEnter, detectRemapKeyBox](DWORD) {
+            detectRemapKeyBox.Dispatcher().RunAsync(
+                Windows::UI::Core::CoreDispatcherPriority::Normal,
+                [onReleaseEnter]() {
+                    onReleaseEnter();
+                });
         });
 
     TextBlock cancelButtonText;
     cancelButtonText.Text(GET_RESOURCE_STRING(IDS_CANCEL_BUTTON));
+
+    auto onCancel = [&keyboardManagerState,
+                     detectRemapKeyBox,
+                     unregisterKeys] {
+        detectRemapKeyBox.Hide();
+
+        // Reset the keyboard manager UI state
+        keyboardManagerState.ResetUIState();
+        // Revert UI state back to Edit Keyboard window
+        keyboardManagerState.SetUIState(KeyboardManagerUIState::EditKeyboardWindowActivated, EditKeyboardWindowHandle);
+        unregisterKeys();
+    };
 
     Button cancelButton;
     cancelButton.HorizontalAlignment(HorizontalAlignment::Stretch);
     cancelButton.Margin({ 2, 2, 2, 2 });
     cancelButton.Content(cancelButtonText);
     // Cancel button
-    cancelButton.Click([detectRemapKeyBox, unregisterKeys, &keyboardManagerState](winrt::Windows::Foundation::IInspectable const& sender, RoutedEventArgs const&) {
-        // Reset the keyboard manager UI state
-        keyboardManagerState.ResetUIState();
-        // Revert UI state back to Edit Keyboard window
-        keyboardManagerState.SetUIState(KeyboardManagerUIState::EditKeyboardWindowActivated, EditKeyboardWindowHandle);
-        unregisterKeys();
-        detectRemapKeyBox.Hide();
+    cancelButton.Click([onCancel](winrt::Windows::Foundation::IInspectable const& sender, RoutedEventArgs const&) {
+        onCancel();
     });
 
     keyboardManagerState.RegisterKeyDelay(
         VK_ESCAPE,
         std::bind(&KeyboardManagerState::SelectDetectedRemapKey, &keyboardManagerState, std::placeholders::_1),
-        [&keyboardManagerState, detectRemapKeyBox, unregisterKeys](DWORD) {
+        [onCancel, detectRemapKeyBox](DWORD) {
             detectRemapKeyBox.Dispatcher().RunAsync(
                 Windows::UI::Core::CoreDispatcherPriority::Normal,
-                [detectRemapKeyBox] {
-                    detectRemapKeyBox.Hide();
+                [onCancel] {
+                    onCancel();
                 });
-
-            keyboardManagerState.ResetUIState();
-            // Revert UI state back to Edit Keyboard window
-            keyboardManagerState.SetUIState(KeyboardManagerUIState::EditKeyboardWindowActivated, EditKeyboardWindowHandle);
-            unregisterKeys();
         },
         nullptr);
 


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

This PR fixes a crash which occurs on using the Enter/Esc accessible keys for closing the Type UI.
Repro steps on master/0.23 are:
- Open Remap key/shortcut window
- Click Type
- Hold Enter/Esc.

## PR Checklist
* [X] Applies to #6955 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [X] Tests passed

## Info on Pull Request

_What does this include?_
- On closing the Type window we terminate the KeyDelay thread and delete the object by calling the destructor (`clear` is called on the `std::map` that stores them`). When we click the OK/Cancel button, this gets executed on the UI(dispatcher) thread, but when executed from the KeyDelay object this was getting called from the Delay thread. This causes re-entrancy on the queueMutex as it already has a lock on the mutex when it calls any of the shortPress, longPress or longPressRelease handlers, leading to a crash.
- Even if we remove the mutex usage in the destructor, it would result in a deadlock because the delay thread would wait on the delay thread `join` call. If we remove the `join` call we would run into other issues since the object deletion is occurring mid-execution of the method.
- In 0.21 separate threads were being created for this, which could lead to difficult to catch crashes due to multithreaded delete statements without locks, and the reason for using separate threads wasn't documented.
- To fix the issues mentioned above, the code was modified such that it runs on the UI thread in all cases. Comments have been added to document the reason for this.


## Validation Steps Performed

_How does someone test & validate?_
Do the following on both Remap a key window and Remap shortcuts window on both columns
- Open the Type UI
- Type some key/shortcut
- Close the Type window by pressing the OK button
- Repeat above steps, but close the window using the Cancel button
- Repeat above steps, but close the window by holding Enter (this was earlier crashing)
- Repeat above steps, but close the window by holding Esc (this was earlier crashing)
Validate that no crashes occur and that the key/shortcut is loaded into the drop downs as expected for OK/Enter and ignored for Cancel/Esc.