### PR TITLE
[Settings] Add AppxBundlePlatform to remove warning

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI/Microsoft.PowerToys.Settings.UI.csproj
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Microsoft.PowerToys.Settings.UI.csproj
@@ -10,6 +10,7 @@
     <AssemblyCopyright>Copyright (C) 2020 Microsoft Corp.</AssemblyCopyright>
     <AssemblyProduct>PowerToys</AssemblyProduct>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <AppxBundlePlatforms>x64</AppxBundlePlatforms>
   </PropertyGroup>
   <ItemGroup>
     <AssemblyVersionFiles Include="Generated Files\AssemblyInfo.cs" />


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
This PR adds the AppxBundlePlatforms property as x64 to remove the warning that it is not set, as per this stackoverflow thread https://stackoverflow.com/questions/57643594/appx4001-warning.

The warning appears because the AppxBundle target is disabled in the solution (as it is a xaml islands project we don't want to deploy the UWP app). By adding this property we can suppress the warning without any user impact.
## PR Checklist
* [X] Applies to #5100 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [X] Tests passed


## Validation Steps Performed

_How does someone test & validate?_
- Validated that the warning mentioned in #5100 does not appear while building Settings.UI (UWP)
- Validated that PowerToys runs and all pages in Settings appear correctly when running from VS and from local MSI.