### PR TITLE
[Run] Fix for IndexOutOfBounds exception

### DIFF
--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -500,6 +500,9 @@ namespace PowerLauncher.ViewModel
                     {
                         Thread.Sleep(20);
 
+                        // Keep track of total number of results for telemetry
+                        var numResults = 0;
+
                         // Contains all the plugins for which this raw query is valid
                         var plugins = pluginQueryPairs.Keys.ToList();
 
@@ -535,6 +538,7 @@ namespace PowerLauncher.ViewModel
                                     }
 
                                     currentCancellationToken.ThrowIfCancellationRequested();
+                                    numResults = Results.Results.Count;
                                     Results.Sort();
                                     Results.SelectedItem = Results.Results.FirstOrDefault();
                                 }
@@ -573,6 +577,7 @@ namespace PowerLauncher.ViewModel
                                                         UpdateResultView(results, queryText, currentCancellationToken);
 
                                                         currentCancellationToken.ThrowIfCancellationRequested();
+                                                        numResults = Results.Results.Count;
                                                         Results.Sort();
                                                         Results.SelectedItem = Results.Results.FirstOrDefault();
                                                     }
@@ -598,7 +603,7 @@ namespace PowerLauncher.ViewModel
                         var queryEvent = new LauncherQueryEvent()
                         {
                             QueryTimeMs = queryTimer.ElapsedMilliseconds,
-                            NumResults = Results.Results.Count,
+                            NumResults = numResults,
                             QueryLength = queryText.Length,
                         };
                         PowerToysTelemetry.Log.WriteEvent(queryEvent);

--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -611,7 +611,13 @@ namespace PowerLauncher.ViewModel
                 _currentQuery = _emptyQuery;
                 Results.SelectedItem = null;
                 Results.Visibility = Visibility.Hidden;
-                Results.Clear();
+                Task.Run(() =>
+                {
+                    lock (_addResultsLock)
+                    {
+                        Results.Clear();
+                    }
+                });
             }
         }
 


### PR DESCRIPTION
## Summary of the Pull Request
Fix for `IndexOutOfBoundsException ` exception due to race condition in modifying the underlying list view of `Results`.

## PR Checklist
* [x] Applies to #6954 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request
`IndexOutOfBoundsException` is being thrown while modifying the underlying list view of `Results` in MainViewModel due to following reasons : 
1. `Results` was being indexed without a check on its size. This was fixed in PR #6934.  
2. Another possible cause of this is due to the race condition. The following line modifying Results should be synchronized using locks.
https://github.com/microsoft/PowerToys/blob/c219fe0d1d370158845953c8d33eb8e4d8164ba0/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs#L609-L615

This PR fixes the following issues : 
1. Fixes race condition in clearing `Results`.
2. This PR also fixes a possible issue in telemetry which is generated after query completion. `Results` count was being accessed directly without a lock, and could be incorrect if another query has modified `Results`.

## Validation Steps Performed
Manually validated that race condition is not present for `Results` variable.