### PR TITLE
Modernized unique pointer construction

### DIFF
--- a/src/modules/keyboardmanager/ui/KeyDropDownControl.cpp
+++ b/src/modules/keyboardmanager/ui/KeyDropDownControl.cpp
@@ -309,7 +309,7 @@ ComboBox KeyDropDownControl::GetComboBox()
 // Function to add a drop down to the shortcut stack panel
 void KeyDropDownControl::AddDropDown(Grid table, StackPanel shortcutControl, StackPanel parent, const int colIndex, RemapBuffer& shortcutRemapBuffer, std::vector<std::unique_ptr<KeyDropDownControl>>& keyDropDownControlObjects, TextBox targetApp, bool isHybridControl, bool isSingleKeyWindow, bool ignoreWarning)
 {
-    keyDropDownControlObjects.push_back(std::move(std::unique_ptr<KeyDropDownControl>(new KeyDropDownControl(true, ignoreWarning, colIndex == 1))));
+    keyDropDownControlObjects.emplace_back(std::make_unique<KeyDropDownControl>(true, ignoreWarning, colIndex == 1));
     parent.Children().Append(keyDropDownControlObjects[keyDropDownControlObjects.size() - 1]->GetComboBox());
     keyDropDownControlObjects[keyDropDownControlObjects.size() - 1]->SetSelectionHandler(table, shortcutControl, parent, colIndex, shortcutRemapBuffer, keyDropDownControlObjects, targetApp, isHybridControl, isSingleKeyWindow);
     parent.UpdateLayout();

--- a/src/modules/keyboardmanager/ui/ShortcutControl.cpp
+++ b/src/modules/keyboardmanager/ui/ShortcutControl.cpp
@@ -72,8 +72,8 @@ void ShortcutControl::AddNewShortcutControlRow(Grid& parent, std::vector<std::ve
 
     // Create new ShortcutControl objects dynamically so that we does not get destructed
     std::vector<std::unique_ptr<ShortcutControl>> newrow;
-    newrow.push_back(std::move(std::unique_ptr<ShortcutControl>(new ShortcutControl(parent, 0, targetAppTextBox))));
-    newrow.push_back(std::move(std::unique_ptr<ShortcutControl>(new ShortcutControl(parent, 1, targetAppTextBox))));
+    newrow.emplace_back(std::make_unique<ShortcutControl>(parent, 0, targetAppTextBox));
+    newrow.emplace_back(std::make_unique<ShortcutControl>(parent, 1, targetAppTextBox));
     keyboardRemapControlObjects.push_back(std::move(newrow));
 
     // Add to grid

--- a/src/modules/keyboardmanager/ui/SingleKeyRemapControl.cpp
+++ b/src/modules/keyboardmanager/ui/SingleKeyRemapControl.cpp
@@ -29,7 +29,7 @@ SingleKeyRemapControl::SingleKeyRemapControl(Grid table, const int colIndex)
     // Key column
     if (colIndex == 0)
     {
-        keyDropDownControlObjects.push_back(std::move(std::unique_ptr<KeyDropDownControl>(new KeyDropDownControl(false))));
+        keyDropDownControlObjects.emplace_back(std::make_unique<KeyDropDownControl>(false));
         singleKeyRemapControlLayout.as<StackPanel>().Children().Append(keyDropDownControlObjects[0]->GetComboBox());
         // Set selection handler for the drop down
         keyDropDownControlObjects[0]->SetSelectionHandler(table, singleKeyRemapControlLayout.as<StackPanel>(), colIndex, singleKeyRemapBuffer);
@@ -76,8 +76,8 @@ void SingleKeyRemapControl::AddNewControlKeyRemapRow(Grid& parent, std::vector<s
 {
     // Create new SingleKeyRemapControl objects dynamically so that we does not get destructed
     std::vector<std::unique_ptr<SingleKeyRemapControl>> newrow;
-    newrow.push_back(std::move(std::unique_ptr<SingleKeyRemapControl>(new SingleKeyRemapControl(parent, 0))));
-    newrow.push_back(std::move(std::unique_ptr<SingleKeyRemapControl>(new SingleKeyRemapControl(parent, 1))));
+    newrow.emplace_back(std::make_unique<SingleKeyRemapControl>(parent, 0));
+    newrow.push_back(std::make_unique<SingleKeyRemapControl>(parent, 1));
     keyboardRemapControlObjects.push_back(std::move(newrow));
 
     // Add to grid

--- a/src/modules/keyboardmanager/ui/SingleKeyRemapControl.cpp
+++ b/src/modules/keyboardmanager/ui/SingleKeyRemapControl.cpp
@@ -77,7 +77,7 @@ void SingleKeyRemapControl::AddNewControlKeyRemapRow(Grid& parent, std::vector<s
     // Create new SingleKeyRemapControl objects dynamically so that we does not get destructed
     std::vector<std::unique_ptr<SingleKeyRemapControl>> newrow;
     newrow.emplace_back(std::make_unique<SingleKeyRemapControl>(parent, 0));
-    newrow.push_back(std::make_unique<SingleKeyRemapControl>(parent, 1));
+    newrow.emplace_back(std::make_unique<SingleKeyRemapControl>(parent, 1));
     keyboardRemapControlObjects.push_back(std::move(newrow));
 
     // Add to grid


### PR DESCRIPTION
## Summary of the Pull Request
Modernized construction of unique pointers to proper C++17 conventions.

## PR Checklist
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

It simply changes from `vector.push_back(std::move(std::unique_ptr(new T)));` to `vector.emplace_back(std::make_unique<T>());`
## Validation Steps Performed

Have not been able to test, since I wrote this while on Linux and it doesn't compile on Linux. passed CI CD

Closes #6985 