### PR TITLE
[fxcop] Settings UI unit tests

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/Microsoft.PowerToys.Settings.UI.UnitTests.csproj
+++ b/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/Microsoft.PowerToys.Settings.UI.UnitTests.csproj
@@ -24,6 +24,11 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers">
+        <Version>3.3.0</Version>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/ModelsTests/BasePTModuleSettingsTest.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/ModelsTests/BasePTModuleSettingsTest.cs
@@ -21,8 +21,8 @@ namespace CommonLibTest
         // https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-migrate-from-newtonsoft-how-to.
         // Test also fails when the attributes are not initialized i.e they have null values.
         [TestMethod]
-        [Obsolete]
-        public void ToJsonString_ShouldReturnValidJSONOfModel_WhenSuccessful()
+        [ObsoleteAttribute("This test method is obsolete.", true)]
+        public void ToJsonStringShouldReturnValidJSONOfModelWhenSuccessful()
         {
             //Mock Disk access
             string saveContent = string.Empty;

--- a/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/ModelsTests/HelperTest.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/ModelsTests/HelperTest.cs
@@ -24,7 +24,7 @@ namespace CommonLibTest
         }
 
         [TestMethod]
-        public void Helper_CompareVersions_ShouldBeEqual_WhenSuccessful()
+        public void HelperCompareVersionsShouldBeEqualWhenSuccessful()
         {
             TestStringsAreEqual("v0.0.0", "v0.0.0");
             TestStringsAreEqual("v0.1.1", "v0.1.1");
@@ -33,7 +33,7 @@ namespace CommonLibTest
         }
 
         [TestMethod]
-        public void Helper_CompareVersions_ShouldBeSmaller_WhenSuccessful()
+        public void HelperCompareVersionsShouldBeSmallerWhenSuccessful()
         {
             TestStringIsSmaller("v0.0.0", "v0.0.1");
             TestStringIsSmaller("v0.0.0", "v0.1.0");
@@ -47,28 +47,28 @@ namespace CommonLibTest
 
         [TestMethod]
         [ExpectedException(typeof(FormatException))]
-        public void Helper_CompareVersions_ShouldThrowBadFormat_WhenNoVersionString()
+        public void HelperCompareVersionsShouldThrowBadFormatWhenNoVersionString()
         {
             Helper.CompareVersions("v0.0.1", string.Empty);
         }
 
         [TestMethod]
         [ExpectedException(typeof(FormatException))]
-        public void Helper_CompareVersions_ShouldThrowBadFormat_WhenShortVersionString()
+        public void HelperCompareVersionsShouldThrowBadFormatWhenShortVersionString()
         {
             Helper.CompareVersions("v0.0.1", "v0.1");
         }
 
         [TestMethod]
         [ExpectedException(typeof(FormatException))]
-        public void Helper_CompareVersions_ShouldThrowBadFormat_WhenLongVersionString()
+        public void HelperCompareVersionsShouldThrowBadFormatWhenLongVersionString()
         {
             Helper.CompareVersions("v0.0.1", "v0.0.0.1");
         }
 
         [TestMethod]
         [ExpectedException(typeof(FormatException))]
-        public void Helper_CompareVersions_ShouldThrowBadFormat_WhenItIsNotAVersionString()
+        public void HelperCompareVersionsShouldThrowBadFormatWhenItIsNotAVersionString()
         {
             Helper.CompareVersions("v0.0.1", "HelloWorld");
         }

--- a/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/ModelsTests/SettingsRepositoryTest.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/ModelsTests/SettingsRepositoryTest.cs
@@ -15,7 +15,7 @@ namespace CommonLibTest
     [TestClass]
     public class SettingsRepositoryTest
     {
-        private Task<SettingsRepository<GeneralSettings>> GetSettingsRepository(ISettingsUtils settingsUtils)
+        private static Task<SettingsRepository<GeneralSettings>> GetSettingsRepository(ISettingsUtils settingsUtils)
         {
 
             return Task.Run(() =>

--- a/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/ModelsTests/SettingsUtilsTests.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/ModelsTests/SettingsUtilsTests.cs
@@ -21,7 +21,7 @@ namespace CommonLibTest
 
 
         [TestMethod]
-        public void SaveSettings_SaveSettingsToFile_WhenFilePathExists()
+        public void SaveSettingsSaveSettingsToFileWhenFilePathExists()
         {
             // Arrange
             var mockIOProvider = IIOProviderMocks.GetMockIOProviderForSaveLoadExists();
@@ -41,7 +41,7 @@ namespace CommonLibTest
         }
 
         [TestMethod]
-        public void SaveSettings_ShouldCreateFile_WhenFilePathIsNotFound()
+        public void SaveSettingsShouldCreateFileWhenFilePathIsNotFound()
         {
             // Arrange
             var mockIOProvider = IIOProviderMocks.GetMockIOProviderForSaveLoadExists();
@@ -59,7 +59,7 @@ namespace CommonLibTest
         }
 
         [TestMethod]
-        public void SettingsFolderExists_ShouldReturnFalse_WhenFilePathIsNotFound()
+        public void SettingsFolderExistsShouldReturnFalseWhenFilePathIsNotFound()
         {
             // Arrange
             var mockIOProvider = IIOProviderMocks.GetMockIOProviderForSaveLoadExists();

--- a/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/ViewModelTests/FancyZones.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/ViewModelTests/FancyZones.cs
@@ -25,14 +25,14 @@ namespace ViewModelTests
         private Mock<ISettingsUtils> mockFancyZonesSettingsUtils;
 
         [TestInitialize]
-        public void SetUp_StubSettingUtils()
+        public void SetUpStubSettingUtils()
         {
             mockGeneralSettingsUtils = ISettingsUtilsMocks.GetStubSettingsUtils<GeneralSettings>();
             mockFancyZonesSettingsUtils = ISettingsUtilsMocks.GetStubSettingsUtils<FancyZonesSettings>();
         }
 
         [TestMethod]
-        public void IsEnabled_ShouldDisableModule_WhenSuccessful()
+        public void IsEnabledShouldDisableModuleWhenSuccessful()
         {
             Func<string, int> SendMockIPCConfigMSG = msg =>
             {
@@ -50,7 +50,7 @@ namespace ViewModelTests
         }
 
         [TestMethod]
-        public void ShiftDrag_ShouldSetValue2False_WhenSuccessful()
+        public void ShiftDragShouldSetValue2FalseWhenSuccessful()
         {
             // Assert
             Func<string, int> SendMockIPCConfigMSG = msg =>
@@ -69,7 +69,7 @@ namespace ViewModelTests
         }
 
         [TestMethod]
-        public void OverrideSnapHotkeys_ShouldSetValue2True_WhenSuccessful()
+        public void OverrideSnapHotkeysShouldSetValue2TrueWhenSuccessful()
         {
             // Assert
             Func<string, int> SendMockIPCConfigMSG = msg =>
@@ -88,7 +88,7 @@ namespace ViewModelTests
         }
 
         [TestMethod]
-        public void MoveWindowsBasedOnPosition_ShouldSetValue2True_WhenSuccessful()
+        public void MoveWindowsBasedOnPositionShouldSetValue2TrueWhenSuccessful()
         {
             // Assert
             Func<string, int> SendMockIPCConfigMSG = msg =>
@@ -107,7 +107,7 @@ namespace ViewModelTests
         }
 
         [TestMethod]
-        public void ZoneSetChangeFlashZones_ShouldSetValue2False_WhenSuccessful()
+        public void ZoneSetChangeFlashZonesShouldSetValue2FalseWhenSuccessful()
         {
             // Assert
             Func<string, int> SendMockIPCConfigMSG = msg =>
@@ -126,7 +126,7 @@ namespace ViewModelTests
         }
 
         [TestMethod]
-        public void MouseSwitch_ShouldSetValue2True_WhenSuccessful()
+        public void MouseSwitchShouldSetValue2TrueWhenSuccessful()
         {
             // Assert
             Func<string, int> SendMockIPCConfigMSG = msg =>
@@ -145,7 +145,7 @@ namespace ViewModelTests
         }
 
         [TestMethod]
-        public void DisplayChangeMoveWindows_ShouldSetValue2True_WhenSuccessful()
+        public void DisplayChangeMoveWindowsShouldSetValue2TrueWhenSuccessful()
         {
             // Assert
             Func<string, int> SendMockIPCConfigMSG = msg =>
@@ -164,7 +164,7 @@ namespace ViewModelTests
         }
 
         [TestMethod]
-        public void ZoneSetChangeMoveWindows_ShouldSetValue2True_WhenSuccessful()
+        public void ZoneSetChangeMoveWindowsShouldSetValue2TrueWhenSuccessful()
         {
             // Assert
             Func<string, int> SendMockIPCConfigMSG = msg =>
@@ -183,7 +183,7 @@ namespace ViewModelTests
         }
 
         [TestMethod]
-        public void AppLastZoneMoveWindows_ShouldSetValue2True_WhenSuccessful()
+        public void AppLastZoneMoveWindowsShouldSetValue2TrueWhenSuccessful()
         {
             // Assert
             Func<string, int> SendMockIPCConfigMSG = msg =>
@@ -201,7 +201,7 @@ namespace ViewModelTests
             viewModel.AppLastZoneMoveWindows = true;
         }
 
-        public void OpenWindowOnActiveMonitor_ShouldSetValue2True_WhenSuccessful()
+        public void OpenWindowOnActiveMonitorShouldSetValue2TrueWhenSuccessful()
         {
             // Assert
             Func<string, int> SendMockIPCConfigMSG = msg =>
@@ -220,7 +220,7 @@ namespace ViewModelTests
         }
 
         [TestMethod]
-        public void RestoreSize_ShouldSetValue2True_WhenSuccessful()
+        public void RestoreSizeShouldSetValue2TrueWhenSuccessful()
         {
             // Assert
             Func<string, int> SendMockIPCConfigMSG = msg =>
@@ -239,7 +239,7 @@ namespace ViewModelTests
         }
 
         [TestMethod]
-        public void UseCursorPosEditorStartupScreen_ShouldSetValue2False_WhenSuccessful()
+        public void UseCursorPosEditorStartupScreenShouldSetValue2FalseWhenSuccessful()
         {
             // Assert
             Func<string, int> SendMockIPCConfigMSG = msg =>
@@ -258,7 +258,7 @@ namespace ViewModelTests
         }
 
         [TestMethod]
-        public void ShowOnAllMonitors_ShouldSetValue2True_WhenSuccessful()
+        public void ShowOnAllMonitorsShouldSetValue2TrueWhenSuccessful()
         {
             // Assert
             Func<string, int> SendMockIPCConfigMSG = msg =>
@@ -277,7 +277,7 @@ namespace ViewModelTests
         }
 
         [TestMethod]
-        public void ZoneHighlightColor_ShouldSetColorValue2White_WhenSuccessful()
+        public void ZoneHighlightColorShouldSetColorValue2WhiteWhenSuccessful()
         {
             // Assert
             Func<string, int> SendMockIPCConfigMSG = msg =>
@@ -296,7 +296,7 @@ namespace ViewModelTests
         }
 
         [TestMethod]
-        public void ZoneBorderColor_ShouldSetColorValue2White_WhenSuccessful()
+        public void ZoneBorderColorShouldSetColorValue2WhiteWhenSuccessful()
         {
             // Assert
             Func<string, int> SendMockIPCConfigMSG = msg =>
@@ -315,7 +315,7 @@ namespace ViewModelTests
         }
 
         [TestMethod]
-        public void ZoneInActiveColor_ShouldSetColorValue2White_WhenSuccessful()
+        public void ZoneInActiveColorShouldSetColorValue2WhiteWhenSuccessful()
         {
             // Assert
             Func<string, int> SendMockIPCConfigMSG = msg =>
@@ -334,7 +334,7 @@ namespace ViewModelTests
         }
 
         [TestMethod]
-        public void ExcludedApps_ShouldSetColorValue2White_WhenSuccessful()
+        public void ExcludedAppsShouldSetColorValue2WhiteWhenSuccessful()
         {
             // Assert
             Func<string, int> SendMockIPCConfigMSG = msg =>
@@ -353,7 +353,7 @@ namespace ViewModelTests
         }
 
         [TestMethod]
-        public void HighlightOpacity_ShouldSetOpacityValueTo60_WhenSuccessful()
+        public void HighlightOpacityShouldSetOpacityValueTo60WhenSuccessful()
         {
             // Assert
             Func<string, int> SendMockIPCConfigMSG = msg =>
@@ -369,11 +369,6 @@ namespace ViewModelTests
 
             // act
             viewModel.HighlightOpacity = 60;
-        }
-
-        private string ToRGBHex(Color color)
-        {
-            return "#" + color.R.ToString("X2") + color.G.ToString("X2") + color.B.ToString("X2");
         }
     }
 }

--- a/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/ViewModelTests/General.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/ViewModelTests/General.cs
@@ -17,18 +17,18 @@ namespace ViewModelTests
     [TestClass]
     public class General
     {
-        public const string generalSettings_file_name = "Test\\GenealSettings";
+        public const string generalSettingsFileName = "Test\\GenealSettings";
 
         private Mock<ISettingsUtils> mockGeneralSettingsUtils;
 
         [TestInitialize]
-        public void SetUp_StubSettingUtils()
+        public void SetUpStubSettingUtils()
         {
             mockGeneralSettingsUtils = ISettingsUtilsMocks.GetStubSettingsUtils<GeneralSettings>();
         }
 
         [TestMethod]
-        public void IsElevated_ShouldUpdateRunasAdminStatusAttrs_WhenSuccessful()
+        public void IsElevatedShouldUpdateRunasAdminStatusAttrsWhenSuccessful()
         {
             // Arrange
             Func<string, int> SendMockIPCConfigMSG = msg => { return 0; };
@@ -44,7 +44,7 @@ namespace ViewModelTests
                 SendMockIPCConfigMSG,
                 SendRestartAdminIPCMessage,
                 SendCheckForUpdatesIPCMessage,
-                generalSettings_file_name);
+                generalSettingsFileName);
 
             Assert.AreEqual(viewModel.RunningAsUserDefaultText, viewModel.RunningAsText);
             Assert.IsFalse(viewModel.IsElevated);
@@ -58,7 +58,7 @@ namespace ViewModelTests
         }
 
         [TestMethod]
-        public void Startup_ShouldEnableRunOnStartUp_WhenSuccessful()
+        public void StartupShouldEnableRunOnStartUpWhenSuccessful()
         {
             // Assert
             Func<string, int> SendMockIPCConfigMSG = msg =>
@@ -81,7 +81,7 @@ namespace ViewModelTests
                 SendMockIPCConfigMSG,
                 SendRestartAdminIPCMessage,
                 SendCheckForUpdatesIPCMessage,
-                generalSettings_file_name);
+                generalSettingsFileName);
             Assert.IsFalse(viewModel.Startup);
 
             // act
@@ -89,7 +89,7 @@ namespace ViewModelTests
         }
 
         [TestMethod]
-        public void RunElevated_ShouldEnableAlwaysRunElevated_WhenSuccessful()
+        public void RunElevatedShouldEnableAlwaysRunElevatedWhenSuccessful()
         {
             // Assert
             Func<string, int> SendMockIPCConfigMSG = msg =>
@@ -113,7 +113,7 @@ namespace ViewModelTests
                 SendMockIPCConfigMSG,
                 SendRestartAdminIPCMessage,
                 SendCheckForUpdatesIPCMessage,
-                generalSettings_file_name);
+                generalSettingsFileName);
 
             Assert.IsFalse(viewModel.RunElevated);
 
@@ -122,7 +122,7 @@ namespace ViewModelTests
         }
 
         [TestMethod]
-        public void IsLightThemeRadioButtonChecked_ShouldThemeToLight_WhenSuccessful()
+        public void IsLightThemeRadioButtonCheckedShouldThemeToLightWhenSuccessful()
         {
             // Arrange
             GeneralViewModel viewModel = null;
@@ -146,7 +146,7 @@ namespace ViewModelTests
                 SendMockIPCConfigMSG,
                 SendRestartAdminIPCMessage,
                 SendCheckForUpdatesIPCMessage,
-                generalSettings_file_name);
+                generalSettingsFileName);
             Assert.IsFalse(viewModel.IsLightThemeRadioButtonChecked);
 
             // act
@@ -154,7 +154,7 @@ namespace ViewModelTests
         }
 
         [TestMethod]
-        public void IsDarkThemeRadioButtonChecked_ShouldThemeToDark_WhenSuccessful()
+        public void IsDarkThemeRadioButtonCheckedShouldThemeToDarkWhenSuccessful()
         {
             // Arrange
             // Assert
@@ -177,7 +177,7 @@ namespace ViewModelTests
                 SendMockIPCConfigMSG,
                 SendRestartAdminIPCMessage,
                 SendCheckForUpdatesIPCMessage,
-                generalSettings_file_name);
+                generalSettingsFileName);
             Assert.IsFalse(viewModel.IsDarkThemeRadioButtonChecked);
 
 
@@ -204,7 +204,7 @@ namespace ViewModelTests
             Assert.IsTrue(modules.ColorPicker);
         }
 
-        public int UpdateUIThemeMethod(string themeName)
+        public static int UpdateUIThemeMethod(string themeName)
         {
             return 0;
         }

--- a/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/ViewModelTests/ImageResizer.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/ViewModelTests/ImageResizer.cs
@@ -25,14 +25,14 @@ namespace ViewModelTests
         private Mock<ISettingsUtils> mockImgResizerSettingsUtils;
 
         [TestInitialize]
-        public void SetUp_StubSettingUtils()
+        public void SetUpStubSettingUtils()
         {
             mockGeneralSettingsUtils = ISettingsUtilsMocks.GetStubSettingsUtils<GeneralSettings>();
             mockImgResizerSettingsUtils = ISettingsUtilsMocks.GetStubSettingsUtils<ImageResizerSettings>();
         }
 
         [TestMethod]
-        public void IsEnabled_ShouldEnableModule_WhenSuccessful()
+        public void IsEnabledShouldEnableModuleWhenSuccessful()
         {
             // Assert
             Func<string, int> SendMockIPCConfigMSG = msg =>
@@ -50,7 +50,7 @@ namespace ViewModelTests
         }
 
         [TestMethod]
-        public void JPEGQualityLevel_ShouldSetValueToTen_WhenSuccessful()
+        public void JPEGQualityLevelShouldSetValueToTenWhenSuccessful()
         {
             // arrange
             var mockIOProvider = IIOProviderMocks.GetMockIOProviderForSaveLoadExists();
@@ -67,7 +67,7 @@ namespace ViewModelTests
         }
 
         [TestMethod]
-        public void PngInterlaceOption_ShouldSetValueToTen_WhenSuccessful()
+        public void PngInterlaceOptionShouldSetValueToTenWhenSuccessful()
         {
             // arrange
             var mockIOProvider = IIOProviderMocks.GetMockIOProviderForSaveLoadExists();
@@ -84,7 +84,7 @@ namespace ViewModelTests
         }
 
         [TestMethod]
-        public void TiffCompressOption_ShouldSetValueToTen_WhenSuccessful()
+        public void TiffCompressOptionShouldSetValueToTenWhenSuccessful()
         {
             // arrange
             var mockIOProvider = IIOProviderMocks.GetMockIOProviderForSaveLoadExists();
@@ -101,7 +101,7 @@ namespace ViewModelTests
         }
 
         [TestMethod]
-        public void FileName_ShouldUpdateValue_WhenSuccessful()
+        public void FileNameShouldUpdateValueWhenSuccessful()
         {
             // arrange
             var mockIOProvider = IIOProviderMocks.GetMockIOProviderForSaveLoadExists();
@@ -119,7 +119,7 @@ namespace ViewModelTests
         }
 
         [TestMethod]
-        public void KeepDateModified_ShouldUpdateValue_WhenSuccessful()
+        public void KeepDateModifiedShouldUpdateValueWhenSuccessful()
         {
             // arrange
             var settingUtils = ISettingsUtilsMocks.GetStubSettingsUtils<ImageResizerSettings>();
@@ -142,7 +142,7 @@ namespace ViewModelTests
         }
 
         [TestMethod]
-        public void Encoder_ShouldUpdateValue_WhenSuccessful()
+        public void EncoderShouldUpdateValueWhenSuccessful()
         {
             // arrange
             var mockIOProvider = IIOProviderMocks.GetMockIOProviderForSaveLoadExists();
@@ -160,7 +160,7 @@ namespace ViewModelTests
         }
 
         [TestMethod]
-        public void AddRow_ShouldAddEmptyImageSize_WhenSuccessful()
+        public void AddRowShouldAddEmptyImageSizeWhenSuccessful()
         {
             // arrange
             var mockSettingsUtils = ISettingsUtilsMocks.GetStubSettingsUtils<ImageResizerSettings>();
@@ -176,7 +176,7 @@ namespace ViewModelTests
         }
 
         [TestMethod]
-        public void DeleteImageSize_ShouldDeleteImageSize_WhenSuccessful()
+        public void DeleteImageSizeShouldDeleteImageSizeWhenSuccessful()
         {
             // arrange
             var mockSettingsUtils = ISettingsUtilsMocks.GetStubSettingsUtils<ImageResizerSettings>();
@@ -194,7 +194,7 @@ namespace ViewModelTests
         }
 
         [TestMethod]
-        public void UpdateWidthAndHeight_ShouldUpateSize_WhenCorrectValuesAreProvided()
+        public void UpdateWidthAndHeightShouldUpateSizeWhenCorrectValuesAreProvided()
         {
             // arrange
             ImageSize imageSize = new ImageSize()

--- a/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/ViewModelTests/KeyboardManager.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/ViewModelTests/KeyboardManager.cs
@@ -26,7 +26,7 @@ namespace ViewModelTests
         }
 
         [TestMethod]
-        public void CombineShortcutLists_ShouldReturnEmptyList_WhenBothArgumentsAreEmptyLists()
+        public void CombineShortcutListsShouldReturnEmptyListWhenBothArgumentsAreEmptyLists()
         {
             // arrange
             var firstList = new List<KeysDataModel>();
@@ -38,11 +38,11 @@ namespace ViewModelTests
             // Assert
             var expectedResult = new List<AppSpecificKeysDataModel>();
 
-            Assert.AreEqual(expectedResult.Count(), result.Count());
+            Assert.AreEqual(expectedResult.Count, result.Count);
         }
 
         [TestMethod]
-        public void CombineShortcutLists_ShouldReturnListWithOneAllAppsEntry_WhenFirstArgumentHasOneEntryAndSecondArgumentIsEmpty()
+        public void CombineShortcutListsShouldReturnListWithOneAllAppsEntryWhenFirstArgumentHasOneEntryAndSecondArgumentIsEmpty()
         {
             // arrange
             var firstList = new List<KeysDataModel>();
@@ -63,12 +63,12 @@ namespace ViewModelTests
             expectedEntry.TargetApp = "All Apps";
             expectedResult.Add(expectedEntry);
             var x = expectedResult[0].Equals(result[0]);
-            Assert.AreEqual(expectedResult.Count(), result.Count());
+            Assert.AreEqual(expectedResult.Count, result.Count);
             Assert.IsTrue(expectedResult[0].Compare(result[0]));
         }
 
         [TestMethod]
-        public void CombineShortcutLists_ShouldReturnListWithOneAppSpecificEntry_WhenFirstArgumentIsEmptyAndSecondArgumentHasOneEntry()
+        public void CombineShortcutListsShouldReturnListWithOneAppSpecificEntryWhenFirstArgumentIsEmptyAndSecondArgumentHasOneEntry()
         {
             // arrange
             var firstList = new List<KeysDataModel>();
@@ -90,12 +90,12 @@ namespace ViewModelTests
             expectedEntry.TargetApp = entry.TargetApp;
             expectedResult.Add(expectedEntry);
 
-            Assert.AreEqual(expectedResult.Count(), result.Count());
+            Assert.AreEqual(expectedResult.Count, result.Count);
             Assert.IsTrue(expectedResult[0].Compare(result[0]));
         }
 
         [TestMethod]
-        public void CombineShortcutLists_ShouldReturnListWithOneAllAppsEntryAndOneAppSpecificEntry_WhenFirstArgumentHasOneEntryAndSecondArgumentHasOneEntry()
+        public void CombineShortcutListsShouldReturnListWithOneAllAppsEntryAndOneAppSpecificEntryWhenFirstArgumentHasOneEntryAndSecondArgumentHasOneEntry()
         {
             // arrange
             var firstList = new List<KeysDataModel>();
@@ -126,7 +126,7 @@ namespace ViewModelTests
             expectedSecondEntry.TargetApp = secondListEntry.TargetApp;
             expectedResult.Add(expectedSecondEntry);
 
-            Assert.AreEqual(expectedResult.Count(), result.Count());
+            Assert.AreEqual(expectedResult.Count, result.Count);
             Assert.IsTrue(expectedResult[0].Compare(result[0]));
             Assert.IsTrue(expectedResult[1].Compare(result[1]));
         }

--- a/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/ViewModelTests/PowerLauncherViewModelTest.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/ViewModelTests/PowerLauncherViewModelTest.cs
@@ -16,7 +16,9 @@ namespace ViewModelTests
         {
             public int TimesSent { get; set; }
 
-            public void OnSend(PowerLauncherSettings settings)
+            // PowerLauncherSettings is unused, but required according to SendCallback's signature.
+            // Naming parameter with discard symbol to suppress FxCop warnings.
+            public void OnSend(PowerLauncherSettings _)
             {
                 TimesSent++;
             }
@@ -36,7 +38,7 @@ namespace ViewModelTests
         }
 
         [TestMethod]
-        public void SearchPreference_ShouldUpdatePreferences()
+        public void SearchPreferenceShouldUpdatePreferences()
         {
             viewModel.SearchResultPreference = "SearchOptionsAreNotValidated";
             viewModel.SearchTypePreference = "SearchOptionsAreNotValidated";
@@ -46,17 +48,23 @@ namespace ViewModelTests
             Assert.IsTrue(mockSettings.Properties.SearchTypePreference == "SearchOptionsAreNotValidated");
         }
 
-        public void AssertHotkeySettings(HotkeySettings setting, bool win, bool ctrl, bool alt, bool shift, int code)
+        public static void AssertHotkeySettings(HotkeySettings setting, bool win, bool ctrl, bool alt, bool shift, int code)
         {
-            Assert.AreEqual(win, setting.Win);
-            Assert.AreEqual(ctrl, setting.Ctrl);
-            Assert.AreEqual(alt, setting.Alt);
-            Assert.AreEqual(shift, setting.Shift);
-            Assert.AreEqual(code, setting.Code);
+            if (setting != null)
+            {
+                Assert.AreEqual(win, setting.Win);
+                Assert.AreEqual(ctrl, setting.Ctrl);
+                Assert.AreEqual(alt, setting.Alt);
+                Assert.AreEqual(shift, setting.Shift);
+                Assert.AreEqual(code, setting.Code);
+            } else
+            {
+                Assert.Fail("setting parameter is null");
+            }
         }
 
         [TestMethod]
-        public void Hotkeys_ShouldUpdateHotkeys()
+        public void HotkeysShouldUpdateHotkeys()
         {
             var openPowerLauncher = new HotkeySettings();
             openPowerLauncher.Win = true;
@@ -104,7 +112,7 @@ namespace ViewModelTests
         }
 
         [TestMethod]
-        public void Override_ShouldUpdateOverrides()
+        public void OverrideShouldUpdateOverrides()
         {
             viewModel.OverrideWinRKey = true;
             viewModel.OverrideWinSKey = false;
@@ -116,7 +124,7 @@ namespace ViewModelTests
         }
 
         [TestMethod]
-        public void DriveDetectionViewModel_WhenSet_MustUpdateOverrides()
+        public void DriveDetectionViewModelWhenSetMustUpdateOverrides()
         {
             // Act
             viewModel.DisableDriveDetectionWarning = true;

--- a/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/ViewModelTests/PowerPreview.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/ViewModelTests/PowerPreview.cs
@@ -21,13 +21,13 @@ namespace ViewModelTests
         private Mock<ISettingsUtils> mockPowerPreviewSettingsUtils;
 
         [TestInitialize]
-        public void SetUp_StubSettingUtils()
+        public void SetUpStubSettingUtils()
         {
             mockPowerPreviewSettingsUtils = ISettingsUtilsMocks.GetStubSettingsUtils<PowerPreviewSettings>();
         }
 
         [TestMethod]
-        public void SVGRenderIsEnabled_ShouldPrevHandler_WhenSuccessful()
+        public void SVGRenderIsEnabledShouldPrevHandlerWhenSuccessful()
         {
             // Assert
             Func<string, int> SendMockIPCConfigMSG = msg =>
@@ -45,7 +45,7 @@ namespace ViewModelTests
         }
 
         [TestMethod]
-        public void SVGThumbnailIsEnabled_ShouldPrevHandler_WhenSuccessful()
+        public void SVGThumbnailIsEnabledShouldPrevHandlerWhenSuccessful()
         {
             // Assert
             Func<string, int> SendMockIPCConfigMSG = msg =>
@@ -63,7 +63,7 @@ namespace ViewModelTests
         }
 
         [TestMethod]
-        public void MDRenderIsEnabled_ShouldPrevHandler_WhenSuccessful()
+        public void MDRenderIsEnabledShouldPrevHandlerWhenSuccessful()
         {
             // Assert
             Func<string, int> SendMockIPCConfigMSG = msg =>

--- a/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/ViewModelTests/PowerRename.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/ViewModelTests/PowerRename.cs
@@ -17,21 +17,21 @@ namespace ViewModelTests
     public class PowerRename
     {
         public const string ModuleName = PowerRenameSettings.ModuleName;
-        public const string generalSettings_file_name = "Test\\PowerRename";
+        public const string generalSettingsFileName = "Test\\PowerRename";
 
         private Mock<ISettingsUtils> mockGeneralSettingsUtils;
 
         private Mock<ISettingsUtils> mockPowerRenamePropertiesUtils;
 
         [TestInitialize]
-        public void SetUp_StubSettingUtils()
+        public void SetUpStubSettingUtils()
         {
             mockGeneralSettingsUtils = ISettingsUtilsMocks.GetStubSettingsUtils<GeneralSettings>();
             mockPowerRenamePropertiesUtils = ISettingsUtilsMocks.GetStubSettingsUtils<PowerRenameLocalProperties>();
         }
 
         [TestMethod]
-        public void IsEnabled_ShouldEnableModule_WhenSuccessful()
+        public void IsEnabledShouldEnableModuleWhenSuccessful()
         {
             // Assert
             Func<string, int> SendMockIPCConfigMSG = msg =>
@@ -42,14 +42,14 @@ namespace ViewModelTests
             };
 
             // arrange
-            PowerRenameViewModel viewModel = new PowerRenameViewModel(mockPowerRenamePropertiesUtils.Object, SettingsRepository<GeneralSettings>.GetInstance(mockGeneralSettingsUtils.Object), SendMockIPCConfigMSG, generalSettings_file_name);
+            PowerRenameViewModel viewModel = new PowerRenameViewModel(mockPowerRenamePropertiesUtils.Object, SettingsRepository<GeneralSettings>.GetInstance(mockGeneralSettingsUtils.Object), SendMockIPCConfigMSG, generalSettingsFileName);
 
             // act
             viewModel.IsEnabled = true;
         }
 
         [TestMethod]
-        public void MRUEnabled_ShouldSetValue2True_WhenSuccessful()
+        public void MRUEnabledShouldSetValue2TrueWhenSuccessful()
         {
             // Assert
             Func<string, int> SendMockIPCConfigMSG = msg =>
@@ -60,7 +60,7 @@ namespace ViewModelTests
             };
 
             // arrange
-            PowerRenameViewModel viewModel = new PowerRenameViewModel(mockPowerRenamePropertiesUtils.Object, SettingsRepository<GeneralSettings>.GetInstance(mockGeneralSettingsUtils.Object), SendMockIPCConfigMSG, generalSettings_file_name);
+            PowerRenameViewModel viewModel = new PowerRenameViewModel(mockPowerRenamePropertiesUtils.Object, SettingsRepository<GeneralSettings>.GetInstance(mockGeneralSettingsUtils.Object), SendMockIPCConfigMSG, generalSettingsFileName);
 
             // act
             viewModel.MRUEnabled = true;
@@ -70,7 +70,7 @@ namespace ViewModelTests
         public void WhenIsEnabledIsOffAndMRUEnabledIsOffGlobalAndMruShouldBeOff()
         {
             Func<string, int> SendMockIPCConfigMSG = msg => { return 0; };
-            PowerRenameViewModel viewModel = new PowerRenameViewModel(mockPowerRenamePropertiesUtils.Object, SettingsRepository<GeneralSettings>.GetInstance(mockGeneralSettingsUtils.Object), SendMockIPCConfigMSG, generalSettings_file_name);
+            PowerRenameViewModel viewModel = new PowerRenameViewModel(mockPowerRenamePropertiesUtils.Object, SettingsRepository<GeneralSettings>.GetInstance(mockGeneralSettingsUtils.Object), SendMockIPCConfigMSG, generalSettingsFileName);
 
             viewModel.IsEnabled = false;
             viewModel.MRUEnabled = false;
@@ -82,7 +82,7 @@ namespace ViewModelTests
         public void WhenIsEnabledIsOffAndMRUEnabledIsOnGlobalAndMruShouldBeOff()
         {
             Func<string, int> SendMockIPCConfigMSG = msg => { return 0; };
-            PowerRenameViewModel viewModel = new PowerRenameViewModel(mockPowerRenamePropertiesUtils.Object, SettingsRepository<GeneralSettings>.GetInstance(mockGeneralSettingsUtils.Object), SendMockIPCConfigMSG, generalSettings_file_name);
+            PowerRenameViewModel viewModel = new PowerRenameViewModel(mockPowerRenamePropertiesUtils.Object, SettingsRepository<GeneralSettings>.GetInstance(mockGeneralSettingsUtils.Object), SendMockIPCConfigMSG, generalSettingsFileName);
 
             viewModel.IsEnabled = false;
             viewModel.MRUEnabled = true;
@@ -94,7 +94,7 @@ namespace ViewModelTests
         public void WhenIsEnabledIsOnAndMRUEnabledIsOffGlobalAndMruShouldBeOff()
         {
             Func<string, int> SendMockIPCConfigMSG = msg => { return 0; };
-            PowerRenameViewModel viewModel = new PowerRenameViewModel(mockPowerRenamePropertiesUtils.Object, SettingsRepository<GeneralSettings>.GetInstance(mockGeneralSettingsUtils.Object), SendMockIPCConfigMSG, generalSettings_file_name);
+            PowerRenameViewModel viewModel = new PowerRenameViewModel(mockPowerRenamePropertiesUtils.Object, SettingsRepository<GeneralSettings>.GetInstance(mockGeneralSettingsUtils.Object), SendMockIPCConfigMSG, generalSettingsFileName);
 
             viewModel.IsEnabled = true;
             viewModel.MRUEnabled = false;
@@ -106,7 +106,7 @@ namespace ViewModelTests
         public void WhenIsEnabledIsOnAndMRUEnabledIsOnGlobalAndMruShouldBeOn()
         {
             Func<string, int> SendMockIPCConfigMSG = msg => { return 0; };
-            PowerRenameViewModel viewModel = new PowerRenameViewModel(mockPowerRenamePropertiesUtils.Object, SettingsRepository<GeneralSettings>.GetInstance(mockGeneralSettingsUtils.Object), SendMockIPCConfigMSG, generalSettings_file_name);
+            PowerRenameViewModel viewModel = new PowerRenameViewModel(mockPowerRenamePropertiesUtils.Object, SettingsRepository<GeneralSettings>.GetInstance(mockGeneralSettingsUtils.Object), SendMockIPCConfigMSG, generalSettingsFileName);
 
             viewModel.IsEnabled = true;
             viewModel.MRUEnabled = true;
@@ -115,7 +115,7 @@ namespace ViewModelTests
         }
 
         [TestMethod]
-        public void EnabledOnContextMenu_ShouldSetValue2True_WhenSuccessful()
+        public void EnabledOnContextMenuShouldSetValue2TrueWhenSuccessful()
         {
             // Assert
             Func<string, int> SendMockIPCConfigMSG = msg =>
@@ -126,14 +126,14 @@ namespace ViewModelTests
             };
 
             // arrange
-            PowerRenameViewModel viewModel = new PowerRenameViewModel(mockPowerRenamePropertiesUtils.Object, SettingsRepository<GeneralSettings>.GetInstance(mockGeneralSettingsUtils.Object), SendMockIPCConfigMSG, generalSettings_file_name);
+            PowerRenameViewModel viewModel = new PowerRenameViewModel(mockPowerRenamePropertiesUtils.Object, SettingsRepository<GeneralSettings>.GetInstance(mockGeneralSettingsUtils.Object), SendMockIPCConfigMSG, generalSettingsFileName);
 
             // act
             viewModel.EnabledOnContextMenu = true;
         }
 
         [TestMethod]
-        public void EnabledOnContextExtendedMenu_ShouldSetValue2True_WhenSuccessful()
+        public void EnabledOnContextExtendedMenuShouldSetValue2TrueWhenSuccessful()
         {
             // Assert
             Func<string, int> SendMockIPCConfigMSG = msg =>
@@ -144,14 +144,14 @@ namespace ViewModelTests
             };
 
             // arrange
-            PowerRenameViewModel viewModel = new PowerRenameViewModel(mockPowerRenamePropertiesUtils.Object, SettingsRepository<GeneralSettings>.GetInstance(mockGeneralSettingsUtils.Object), SendMockIPCConfigMSG, generalSettings_file_name);
+            PowerRenameViewModel viewModel = new PowerRenameViewModel(mockPowerRenamePropertiesUtils.Object, SettingsRepository<GeneralSettings>.GetInstance(mockGeneralSettingsUtils.Object), SendMockIPCConfigMSG, generalSettingsFileName);
 
             // act
             viewModel.EnabledOnContextMenu = true;
         }
 
         [TestMethod]
-        public void RestoreFlagsOnLaunch_ShouldSetValue2True_WhenSuccessful()
+        public void RestoreFlagsOnLaunchShouldSetValue2TrueWhenSuccessful()
         {
             // Assert
             Func<string, int> SendMockIPCConfigMSG = msg =>
@@ -162,14 +162,14 @@ namespace ViewModelTests
             };
 
             // arrange
-            PowerRenameViewModel viewModel = new PowerRenameViewModel(mockPowerRenamePropertiesUtils.Object, SettingsRepository<GeneralSettings>.GetInstance(mockGeneralSettingsUtils.Object), SendMockIPCConfigMSG, generalSettings_file_name);
+            PowerRenameViewModel viewModel = new PowerRenameViewModel(mockPowerRenamePropertiesUtils.Object, SettingsRepository<GeneralSettings>.GetInstance(mockGeneralSettingsUtils.Object), SendMockIPCConfigMSG, generalSettingsFileName);
 
             // act
             viewModel.RestoreFlagsOnLaunch = true;
         }
 
         [TestMethod]
-        public void MaxDispListNum_ShouldSetMaxSuggListTo20_WhenSuccessful()
+        public void MaxDispListNumShouldSetMaxSuggListTo20WhenSuccessful()
         {
             // Assert
             Func<string, int> SendMockIPCConfigMSG = msg =>
@@ -180,7 +180,7 @@ namespace ViewModelTests
             };
 
             // arrange
-            PowerRenameViewModel viewModel = new PowerRenameViewModel(mockPowerRenamePropertiesUtils.Object, SettingsRepository<GeneralSettings>.GetInstance(mockGeneralSettingsUtils.Object), SendMockIPCConfigMSG, generalSettings_file_name);
+            PowerRenameViewModel viewModel = new PowerRenameViewModel(mockPowerRenamePropertiesUtils.Object, SettingsRepository<GeneralSettings>.GetInstance(mockGeneralSettingsUtils.Object), SendMockIPCConfigMSG, generalSettingsFileName);
 
             // act
             viewModel.MaxDispListNum = 20;

--- a/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/ViewModelTests/ShortcutGuide.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/ViewModelTests/ShortcutGuide.cs
@@ -23,14 +23,14 @@ namespace ViewModelTests
         private Mock<ISettingsUtils> mockShortcutGuideSettingsUtils;
 
         [TestInitialize]
-        public void SetUp_StubSettingUtils()
+        public void SetUpStubSettingUtils()
         {
             mockGeneralSettingsUtils = ISettingsUtilsMocks.GetStubSettingsUtils<GeneralSettings>();
             mockShortcutGuideSettingsUtils = ISettingsUtilsMocks.GetStubSettingsUtils<ShortcutGuideSettings>();
         }
 
         [TestMethod]
-        public void IsEnabled_ShouldEnableModule_WhenSuccessful()
+        public void IsEnabledShouldEnableModuleWhenSuccessful()
         {
             // Assert
             // Initialize mock function of sending IPC message.
@@ -49,7 +49,7 @@ namespace ViewModelTests
         }
 
         [TestMethod]
-        public void ThemeIndex_ShouldSetThemeToDark_WhenSuccessful()
+        public void ThemeIndexShouldSetThemeToDarkWhenSuccessful()
         {
             // Assert
             // Initialize mock function of sending IPC message.
@@ -70,7 +70,7 @@ namespace ViewModelTests
         }
 
         [TestMethod]
-        public void PressTime_ShouldSetPressTimeToOneHundred_WhenSuccessful()
+        public void PressTimeShouldSetPressTimeToOneHundredWhenSuccessful()
         {
             // Assert
             // Initialize mock function of sending IPC message.
@@ -90,7 +90,7 @@ namespace ViewModelTests
         }
 
         [TestMethod]
-        public void OverlayOpacity_ShouldSeOverlayOpacityToOneHundred_WhenSuccessful()
+        public void OverlayOpacityShouldSeOverlayOpacityToOneHundredWhenSuccessful()
         {
             // Assert
             // Initialize mock function of sending IPC message.


### PR DESCRIPTION
## Summary of the Pull Request

Adding FxCop to the Microsoft.PowerToys.Settings.UI.UnitTests.csproj project, and fixing the resulting warnings and errors. 

## PR Checklist
* [x] Applies to #5129 
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
![image](https://user-images.githubusercontent.com/16506055/94972939-50745d00-04bf-11eb-8a18-8f224a5af494.png)
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

Changes made to fix the warnings and errors include: changing method naming conventions, adding message for deprecated methods, marking non-instance-accessing methods as static, removing unused code, replacing usage of Count() method for Lists with the more efficient Count property, renaming unused arguments, validating arguments for public methods.

## Validation Steps Performed

Check there are no fxcop warnings and the related tests pass.
