### PR TITLE
[Run] Fix autosuggest

### DIFF
--- a/src/modules/launcher/Wox.Core/Plugin/PluginManager.cs
+++ b/src/modules/launcher/Wox.Core/Plugin/PluginManager.cs
@@ -194,13 +194,14 @@ namespace Wox.Core.Plugin
         {
             foreach (Result result in results)
             {
-                if (!string.IsNullOrEmpty(result.QueryTextDisplay))
+                if (string.IsNullOrEmpty(result.QueryTextDisplay))
+                {
+                    result.QueryTextDisplay = result.Title;
+                }
+
+                if (!string.IsNullOrEmpty(query.ActionKeyword))
                 {
                     result.QueryTextDisplay = string.Format("{0} {1}", query.ActionKeyword, result.QueryTextDisplay);
-                }
-                else
-                {
-                    result.QueryTextDisplay = string.Format("{0} {1}", query.ActionKeyword, result.Title);
                 }
             }
 

--- a/src/modules/launcher/Wox.Test/PluginManagerTest.cs
+++ b/src/modules/launcher/Wox.Test/PluginManagerTest.cs
@@ -15,13 +15,18 @@ namespace Wox.Test
     [TestFixture]
     public class PluginManagerTest
     {
-        [Test]
-        public void QueryForPlugin_SetsActionKeyword_WhenQueryTextDisplayIsSet()
+        [TestCase(">", "dummyQueryText", "dummyTitle", "> dummyQueryText")]
+        [TestCase(">", null, "dummyTitle", "> dummyTitle")]
+        [TestCase(">", "", "dummyTitle", "> dummyTitle")]
+        [TestCase("", "dummyQueryText", "dummyTitle", "dummyQueryText")]
+        [TestCase("", null, "dummyTitle", "dummyTitle")]
+        [TestCase("", "", "dummyTitle", "dummyTitle")]
+        [TestCase(null, "dummyQueryText", "dummyTitle", "dummyQueryText")]
+        [TestCase(null, null, "dummyTitle", "dummyTitle")]
+        [TestCase(null, "", "dummyTitle", "dummyTitle")]
+        public void QueryForPlugin_SetsActionKeyword_WhenQueryTextDisplayIsEmpty(string actionKeyword, string queryTextDisplay, string title, string expectedResult)
         {
             // Arrange
-            var actionKeyword = ">";
-            var title = "dummyTitle";
-            var queryTextDisplay = "dummyQueryTextDisplay";
             var query = new Query
             {
                 ActionKeyword = actionKeyword,
@@ -51,46 +56,7 @@ namespace Wox.Test
             var queryOutput = PluginManager.QueryForPlugin(pluginPair, query);
 
             // Assert
-            Assert.AreEqual(string.Format("{0} {1}", ">", queryTextDisplay), queryOutput[0].QueryTextDisplay);
-        }
-
-        [TestCase("")]
-        [TestCase(null)]
-        public void QueryForPlugin_SetsActionKeyword_WhenQueryTextDisplayIsEmpty(string queryTextDisplay)
-        {
-            // Arrange
-            var actionKeyword = ">";
-            var title = "dummyTitle";
-            var query = new Query
-            {
-                ActionKeyword = actionKeyword,
-            };
-            var metadata = new PluginMetadata
-            {
-                ID = "dummyName",
-                IcoPath = "dummyIcoPath",
-                ExecuteFileName = "dummyExecuteFileName",
-                PluginDirectory = "dummyPluginDirectory",
-            };
-            var result = new Result()
-            {
-                QueryTextDisplay = queryTextDisplay,
-                Title = title,
-            };
-            var results = new List<Result>() { result };
-            var pluginMock = new Mock<IPlugin>();
-            pluginMock.Setup(r => r.Query(query)).Returns(results);
-            var pluginPair = new PluginPair
-            {
-                Plugin = pluginMock.Object,
-                Metadata = metadata,
-            };
-
-            // Act
-            var queryOutput = PluginManager.QueryForPlugin(pluginPair, query);
-
-            // Assert
-            Assert.AreEqual(string.Format("{0} {1}", ">", title), queryOutput[0].QueryTextDisplay);
+            Assert.AreEqual(expectedResult, queryOutput[0].QueryTextDisplay);
         }
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request
Fix issue in autosuggest due to incorrect text from `UpdateResultWithActionKeyword` when action keyword is not present.

## PR Checklist
* [ ] Applies to #xxx
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request
Autosuggest was broken because `UpdateResultWithActionKeyword` returned an empty space at the beginning when the actionkeyword was not present, resulting in an incorrect match with the query. For example, If "Mail" is queried and no action keyword is present, `UpdateResultWithActionKeyword` returns " Mail".

## Validation Steps Performed
Manually validated that autosuggest works as expected.