### PR TITLE
Detect potential errors copying metadata and avoid them (#2447)

### DIFF
--- a/src/modules/imageresizer/tests/ImageResizerUITest.csproj
+++ b/src/modules/imageresizer/tests/ImageResizerUITest.csproj
@@ -123,6 +123,9 @@
     <Content Include="Test.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="TestMetadataIssue2447.jpg">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="TestPortrait.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/modules/imageresizer/tests/Models/ResizeOperationTests.cs
+++ b/src/modules/imageresizer/tests/Models/ResizeOperationTests.cs
@@ -31,6 +31,18 @@ namespace ImageResizer.Models
         }
 
         [Fact]
+        public void ExecuteCopiesFrameMetadataExceptWhenMetadataCannotBeCloned()
+        {
+            var operation = new ResizeOperation("TestMetadataIssue2447.jpg", _directory, Settings());
+
+            operation.Execute();
+
+            AssertEx.Image(
+                _directory.File(),
+                image => Assert.Null(((BitmapMetadata)image.Frames[0].Metadata).CameraModel));
+        }
+
+        [Fact]
         public void ExecuteKeepsDateModified()
         {
             var operation = new ResizeOperation("Test.png", _directory, Settings(s => s.KeepDateModified = true));

--- a/src/modules/imageresizer/ui/Models/ResizeOperation.cs
+++ b/src/modules/imageresizer/ui/Models/ResizeOperation.cs
@@ -64,11 +64,25 @@ namespace ImageResizer.Models
 
                 foreach (var originalFrame in decoder.Frames)
                 {
+                    BitmapMetadata metadata = (BitmapMetadata)originalFrame.Metadata;
+                    if (metadata != null)
+                    {
+                        try
+                        {
+                            // Detect whether metadata can copied successfully
+                            _ = metadata.Clone();
+                        }
+                        catch (ArgumentException)
+                        {
+                            metadata = null;
+                        }
+                    }
+
                     encoder.Frames.Add(
                         BitmapFrame.Create(
                             Transform(originalFrame),
                             thumbnail: null,
-                            (BitmapMetadata)originalFrame.Metadata, // TODO: Add an option to strip any metadata that doesn't affect rendering (issue #3)
+                            metadata, // TODO: Add an option to strip any metadata that doesn't affect rendering (issue #3)
                             colorContexts: null));
                 }
 


### PR DESCRIPTION
## Summary of the Pull Request

Detect potential errors copying metadata and avoid them. This fix will allow images with metadata exhibiting this issue to be successfully resized, however the metadata will not be copied across to the resized image.

## PR Checklist
* [x] Applies to #2447 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

* An image with metadata that errors when copying
* A code change that works around the error
* A test that shows how the change avoids the error.

## Validation Steps Performed

One of:
* Run the unit test ExecuteCopiesFrameMetadataExceptWhenMetadataCannotBeCloned
* Run the resizer on the included file TestMetadataIssue2447.jpg
