### PR TITLE
[FancyZones] Refactor Zone class

### DIFF
--- a/src/modules/fancyzones/lib/Zone.cpp
+++ b/src/modules/fancyzones/lib/Zone.cpp
@@ -9,8 +9,6 @@
 #include "Settings.h"
 #include "util.h"
 
-#include "common/monitors.h"
-
 namespace
 {
     bool ValidateZoneRect(const RECT& rect)
@@ -19,67 +17,68 @@ namespace
         int height = rect.bottom - rect.top;
         return rect.left >= 0 && rect.right >= 0 && rect.top >= 0 && rect.bottom >= 0 && width >= 0 && height >= 0;
     }
+
+    BOOL CALLBACK saveDisplayToVector(HMONITOR monitor, HDC hdc, LPRECT rect, LPARAM data)
+    {
+        reinterpret_cast<std::vector<HMONITOR>*>(data)->emplace_back(monitor);
+        return true;
+    }
+
+    bool allMonitorsHaveSameDpiScaling()
+    {
+        std::vector<HMONITOR> monitors;
+        EnumDisplayMonitors(NULL, NULL, saveDisplayToVector, reinterpret_cast<LPARAM>(&monitors));
+
+        if (monitors.size() < 2)
+        {
+            return true;
+        }
+
+        UINT firstMonitorDpiX;
+        UINT firstMonitorDpiY;
+
+        if (S_OK != GetDpiForMonitor(monitors[0], MDT_EFFECTIVE_DPI, &firstMonitorDpiX, &firstMonitorDpiY))
+        {
+            return false;
+        }
+
+        for (int i = 1; i < monitors.size(); i++)
+        {
+            UINT iteratedMonitorDpiX;
+            UINT iteratedMonitorDpiY;
+
+            if (S_OK != GetDpiForMonitor(monitors[i], MDT_EFFECTIVE_DPI, &iteratedMonitorDpiX, &iteratedMonitorDpiY) ||
+                iteratedMonitorDpiX != firstMonitorDpiX)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
 }
 
 struct Zone : winrt::implements<Zone, IZone>
 {
 public:
-    Zone(RECT zoneRect) :
-        m_zoneRect(zoneRect)
+    Zone(RECT zoneRect, const size_t zoneId) :
+        m_zoneRect(zoneRect),
+        m_id(zoneId)
     {
     }
 
-    IFACEMETHODIMP_(RECT) GetZoneRect() noexcept { return m_zoneRect; }
-    IFACEMETHODIMP_(void) SetId(size_t id) noexcept { m_id = id; }
-    IFACEMETHODIMP_(size_t) Id() noexcept { return m_id; }
-    IFACEMETHODIMP_(RECT) ComputeActualZoneRect(HWND window, HWND zoneWindow) noexcept;
+    IFACEMETHODIMP_(RECT) GetZoneRect() const noexcept { return m_zoneRect; }
+    IFACEMETHODIMP_(size_t) Id() const noexcept { return m_id; }
+    IFACEMETHODIMP_(RECT) ComputeActualZoneRect(HWND window, HWND zoneWindow) const noexcept;
 
 private:
     RECT m_zoneRect{};
-    size_t m_id{};
+    const size_t m_id{};
     std::map<HWND, RECT> m_windows{};
 };
 
-static BOOL CALLBACK saveDisplayToVector(HMONITOR monitor, HDC hdc, LPRECT rect, LPARAM data)
-{
-    reinterpret_cast<std::vector<HMONITOR>*>(data)->emplace_back(monitor);
-    return true;
-}
-
-bool allMonitorsHaveSameDpiScaling()
-{
-    std::vector<HMONITOR> monitors;
-    EnumDisplayMonitors(NULL, NULL, saveDisplayToVector, reinterpret_cast<LPARAM>(&monitors));
-
-    if (monitors.size() < 2)
-    {
-        return true;
-    }
-
-    UINT firstMonitorDpiX;
-    UINT firstMonitorDpiY;
-
-    if (S_OK != GetDpiForMonitor(monitors[0], MDT_EFFECTIVE_DPI, &firstMonitorDpiX, &firstMonitorDpiY))
-    {
-        return false;
-    }
-
-    for (int i = 1; i < monitors.size(); i++)
-    {
-        UINT iteratedMonitorDpiX;
-        UINT iteratedMonitorDpiY;
-
-        if (S_OK != GetDpiForMonitor(monitors[i], MDT_EFFECTIVE_DPI, &iteratedMonitorDpiX, &iteratedMonitorDpiY) ||
-            iteratedMonitorDpiX != firstMonitorDpiX)
-        {
-            return false;
-        }
-    }
-
-    return true;
-}
-
-RECT Zone::ComputeActualZoneRect(HWND window, HWND zoneWindow) noexcept
+RECT Zone::ComputeActualZoneRect(HWND window, HWND zoneWindow) const noexcept
 {
     // Take care of 1px border
     RECT newWindowRect = m_zoneRect;
@@ -130,11 +129,11 @@ RECT Zone::ComputeActualZoneRect(HWND window, HWND zoneWindow) noexcept
     return newWindowRect;
 }
 
-winrt::com_ptr<IZone> MakeZone(const RECT& zoneRect) noexcept
+winrt::com_ptr<IZone> MakeZone(const RECT& zoneRect, const size_t zoneId) noexcept
 {
-    if (ValidateZoneRect(zoneRect))
+    if (ValidateZoneRect(zoneRect) && zoneId > 0)
     {
-        return winrt::make_self<Zone>(zoneRect);
+        return winrt::make_self<Zone>(zoneRect, zoneId);
     }
     else
     {

--- a/src/modules/fancyzones/lib/Zone.h
+++ b/src/modules/fancyzones/lib/Zone.h
@@ -8,15 +8,11 @@ interface __declspec(uuid("{8228E934-B6EF-402A-9892-15A1441BF8B0}")) IZone : pub
     /**
      * @returns Zone coordinates (top-left and bottom-right corner) represented as RECT structure.
      */
-    IFACEMETHOD_(RECT, GetZoneRect)() = 0;
-    /**
-     * @param   id Zone identifier.
-     */
-    IFACEMETHOD_(void, SetId)(size_t id) = 0;
+    IFACEMETHOD_(RECT, GetZoneRect)() const = 0;
     /**
      * @returns Zone identifier.
      */
-    IFACEMETHOD_(size_t, Id)() = 0;
+    IFACEMETHOD_(size_t, Id)() const = 0;
     /**
      * Compute the coordinates of the rectangle to which a window should be resized.
      *
@@ -25,8 +21,8 @@ interface __declspec(uuid("{8228E934-B6EF-402A-9892-15A1441BF8B0}")) IZone : pub
      *                     current monitor desktop work area.
      * @returns a RECT structure, describing global coordinates to which a window should be resized
      */
-    IFACEMETHOD_(RECT, ComputeActualZoneRect)(HWND window, HWND zoneWindow) = 0;
+    IFACEMETHOD_(RECT, ComputeActualZoneRect)(HWND window, HWND zoneWindow) const = 0;
 
 };
 
-winrt::com_ptr<IZone> MakeZone(const RECT& zoneRect) noexcept;
+winrt::com_ptr<IZone> MakeZone(const RECT& zoneRect, const size_t zoneId) noexcept;

--- a/src/modules/fancyzones/lib/ZoneSet.cpp
+++ b/src/modules/fancyzones/lib/ZoneSet.cpp
@@ -178,9 +178,6 @@ IFACEMETHODIMP ZoneSet::AddZone(winrt::com_ptr<IZone> zone) noexcept
 {
     m_zones.emplace_back(zone);
 
-    // Important not to set Id 0 since we store it in the HWND using SetProp.
-    // SetProp(0) doesn't really work.
-    zone->SetId(m_zones.size());
     return S_OK;
 }
 
@@ -603,7 +600,7 @@ bool ZoneSet::CalculateFocusLayout(Rect workArea, int zoneCount) noexcept
 
     for (int i = 0; i < zoneCount; i++)
     {
-        auto zone = MakeZone(focusZoneRect);
+        auto zone = MakeZone(focusZoneRect, m_zones.size() + 1);
         if (zone)
         {
             AddZone(zone);
@@ -660,7 +657,7 @@ bool ZoneSet::CalculateColumnsAndRowsLayout(Rect workArea, FancyZonesDataTypes::
         }
 
 
-        auto zone = MakeZone(RECT{ left, top, right, bottom });
+        auto zone = MakeZone(RECT{ left, top, right, bottom }, m_zones.size() + 1);
         if (zone)
         {
             AddZone(zone);
@@ -780,7 +777,7 @@ bool ZoneSet::CalculateCustomLayout(Rect workArea, int spacing) noexcept
                 DPIAware::Convert(m_config.Monitor, x, y);
                 DPIAware::Convert(m_config.Monitor, width, height);
 
-                auto zone = MakeZone(RECT{ x, y, x + width, y + height });
+                auto zone = MakeZone(RECT{ x, y, x + width, y + height }, m_zones.size() + 1);
                 if (zone)
                 {
                     AddZone(zone);
@@ -863,7 +860,7 @@ bool ZoneSet::CalculateGridZones(Rect workArea, FancyZonesDataTypes::GridLayoutI
                 long right = columnInfo[maxCol].End;
                 long bottom = rowInfo[maxRow].End;
 
-                auto zone = MakeZone(RECT{ left, top, right, bottom });
+                auto zone = MakeZone(RECT{ left, top, right, bottom }, i + 1);
                 if (zone)
                 {
                     AddZone(zone);

--- a/src/modules/fancyzones/lib/ZoneSet.cpp
+++ b/src/modules/fancyzones/lib/ZoneSet.cpp
@@ -860,7 +860,7 @@ bool ZoneSet::CalculateGridZones(Rect workArea, FancyZonesDataTypes::GridLayoutI
                 long right = columnInfo[maxCol].End;
                 long bottom = rowInfo[maxRow].End;
 
-                auto zone = MakeZone(RECT{ left, top, right, bottom }, i + 1);
+                auto zone = MakeZone(RECT{ left, top, right, bottom }, m_zones.size() + 1);
                 if (zone)
                 {
                     AddZone(zone);

--- a/src/modules/fancyzones/tests/UnitTests/Zone.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/Zone.Spec.cpp
@@ -22,7 +22,7 @@ namespace FancyZonesUnitTests
     public:
         TEST_METHOD(TestCreateZone)
         {
-            winrt::com_ptr<IZone> zone = MakeZone(m_zoneRect);
+            winrt::com_ptr<IZone> zone = MakeZone(m_zoneRect, 1);
             Assert::IsNotNull(&zone);
             CustomAssert::AreEqual(m_zoneRect, zone->GetZoneRect());
         }
@@ -30,18 +30,17 @@ namespace FancyZonesUnitTests
         TEST_METHOD(TestCreateZoneZeroRect)
         {
             RECT zoneRect{ 0, 0, 0, 0 };
-            winrt::com_ptr<IZone> zone = MakeZone(zoneRect);
+            winrt::com_ptr<IZone> zone = MakeZone(zoneRect, 1);
             Assert::IsNotNull(&zone);
             CustomAssert::AreEqual(zoneRect, zone->GetZoneRect());
         }
 
         TEST_METHOD(GetSetId)
         {
-            winrt::com_ptr<IZone> zone = MakeZone(m_zoneRect);
+            constexpr size_t zoneId = 123;
+            winrt::com_ptr<IZone> zone = MakeZone(m_zoneRect, zoneId);
 
-            constexpr size_t id = 10;
-            zone->SetId(id);
-            Assert::AreEqual(zone->Id(), id);
+            Assert::AreEqual(zone->Id(), zoneId);
         }
     };
 }

--- a/src/modules/fancyzones/tests/UnitTests/ZoneSet.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/ZoneSet.Spec.cpp
@@ -85,40 +85,28 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (AddOne)
             {
-                winrt::com_ptr<IZone> zone = MakeZone({ 0, 0, 100, 100 });
+                constexpr size_t zoneId = 1;
+                winrt::com_ptr<IZone> zone = MakeZone({ 0, 0, 100, 100 }, zoneId);
                 Assert::IsNotNull(zone.get());
                 m_set->AddZone(zone);
                 auto zones = m_set->GetZones();
                 Assert::AreEqual((size_t)1, zones.size());
                 compareZones(zone, zones[0]);
-                Assert::AreEqual((size_t)1, zones[0]->Id());
-            }
-
-            TEST_METHOD (AddManySame)
-            {
-                winrt::com_ptr<IZone> zone = MakeZone({ 0, 0, 100, 100 });
-                Assert::IsNotNull(zone.get());
-                for (size_t i = 0; i < 1024; i++)
-                {
-                    m_set->AddZone(zone);
-                    auto zones = m_set->GetZones();
-                    Assert::AreEqual(i + 1, zones.size());
-                    compareZones(zone, zones[i]);
-                    Assert::AreEqual(i + 1, zones[i]->Id());
-                }
+                Assert::AreEqual(zoneId, zones[0]->Id());
             }
 
             TEST_METHOD (AddManyEqual)
             {
                 for (size_t i = 0; i < 1024; i++)
                 {
-                    winrt::com_ptr<IZone> zone = MakeZone({ 0, 0, 100, 100 });
+                    size_t zoneId = i + 1;
+                    winrt::com_ptr<IZone> zone = MakeZone({ 0, 0, 100, 100 }, zoneId);
                     Assert::IsNotNull(zone.get());
                     m_set->AddZone(zone);
                     auto zones = m_set->GetZones();
                     Assert::AreEqual(i + 1, zones.size());
                     compareZones(zone, zones[i]);
-                    Assert::AreEqual(i + 1, zones[i]->Id());
+                    Assert::AreEqual(zoneId, zones[i]->Id());
                 }
             }
 
@@ -126,41 +114,49 @@ namespace FancyZonesUnitTests
             {
                 for (size_t i = 0; i < 1024; i++)
                 {
+                    size_t zoneId = i + 1;
                     int left = rand() % 10;
                     int top = rand() % 10;
                     int right = left + 1 + rand() % 100;
                     int bottom = top + 1 + rand() % 100;
-                    winrt::com_ptr<IZone> zone = MakeZone({ left, top, right, bottom });
+                    winrt::com_ptr<IZone> zone = MakeZone({ left, top, right, bottom }, zoneId);
                     Assert::IsNotNull(zone.get());
                     m_set->AddZone(zone);
                     auto zones = m_set->GetZones();
                     Assert::AreEqual(i + 1, zones.size());
                     compareZones(zone, zones[i]);
-                    Assert::AreEqual(i + 1, zones[i]->Id());
+                    Assert::AreEqual(zoneId, zones[i]->Id());
                 }
             }
 
             TEST_METHOD (MakeZoneFromZeroRect)
             {
-                winrt::com_ptr<IZone> zone = MakeZone({ 0, 0, 0, 0 });
+                winrt::com_ptr<IZone> zone = MakeZone({ 0, 0, 0, 0 }, 1);
                 Assert::IsNotNull(zone.get());
+            }
+
+            TEST_METHOD (MakeZoneWithInvalidId)
+            {
+                constexpr size_t invalidZoneId = 0;
+                winrt::com_ptr<IZone> zone = MakeZone({ 0, 0, 0, 0 }, invalidZoneId);
+                Assert::IsNull(zone.get());
             }
 
             TEST_METHOD (MakeZoneFromInvalidRectWidth)
             {
-                winrt::com_ptr<IZone> zone = MakeZone({ 100, 100, 99, 101 });
+                winrt::com_ptr<IZone> zone = MakeZone({ 100, 100, 99, 101 }, 1);
                 Assert::IsNull(zone.get());
             }
 
             TEST_METHOD (MakeZoneFromInvalidRectHeight)
             {
-                winrt::com_ptr<IZone> zone = MakeZone({ 100, 100, 101, 99 });
+                winrt::com_ptr<IZone> zone = MakeZone({ 100, 100, 101, 99 }, 1);
                 Assert::IsNull(zone.get());
             }
 
             TEST_METHOD (MakeZoneFromInvalidRectCoords)
             {
-                winrt::com_ptr<IZone> zone = MakeZone({ -1, -1, -1, -1 });
+                winrt::com_ptr<IZone> zone = MakeZone({ -1, -1, -1, -1 }, 1);
                 Assert::IsNull(zone.get());
             }
 
@@ -173,7 +169,7 @@ namespace FancyZonesUnitTests
             TEST_METHOD (ZoneFromPointInner)
             {
                 const int left = 0, top = 0, right = 100, bottom = 100;
-                winrt::com_ptr<IZone> expected = MakeZone({ left, top, right, bottom });
+                winrt::com_ptr<IZone> expected = MakeZone({ left, top, right, bottom }, 1);
                 m_set->AddZone(expected);
 
                 for (int i = left + 1; i < right; i++)
@@ -190,7 +186,7 @@ namespace FancyZonesUnitTests
             TEST_METHOD (ZoneFromPointBorder)
             {
                 const int left = 0, top = 0, right = 100, bottom = 100;
-                winrt::com_ptr<IZone> expected = MakeZone({ left, top, right, bottom });
+                winrt::com_ptr<IZone> expected = MakeZone({ left, top, right, bottom }, 1);
                 m_set->AddZone(expected);
 
                 for (int i = left; i < right; i++)
@@ -224,7 +220,7 @@ namespace FancyZonesUnitTests
             TEST_METHOD (ZoneFromPointOuter)
             {
                 const int left = 0, top = 0, right = 100, bottom = 100;
-                winrt::com_ptr<IZone> zone = MakeZone({ left, top, right, bottom });
+                winrt::com_ptr<IZone> zone = MakeZone({ left, top, right, bottom }, 1);
                 m_set->AddZone(zone);
 
                 auto actual = m_set->ZonesFromPoint(POINT{ 200, 200 });
@@ -233,13 +229,13 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (ZoneFromPointOverlapping)
             {
-                winrt::com_ptr<IZone> zone1 = MakeZone({ 0, 0, 100, 100 });
+                winrt::com_ptr<IZone> zone1 = MakeZone({ 0, 0, 100, 100 }, 1);
                 m_set->AddZone(zone1);
-                winrt::com_ptr<IZone> zone2 = MakeZone({ 10, 10, 90, 90 });
+                winrt::com_ptr<IZone> zone2 = MakeZone({ 10, 10, 90, 90 }, 2);
                 m_set->AddZone(zone2);
-                winrt::com_ptr<IZone> zone3 = MakeZone({ 10, 10, 150, 150 });
+                winrt::com_ptr<IZone> zone3 = MakeZone({ 10, 10, 150, 150 }, 3);
                 m_set->AddZone(zone3);
-                winrt::com_ptr<IZone> zone4 = MakeZone({ 10, 10, 50, 50 });
+                winrt::com_ptr<IZone> zone4 = MakeZone({ 10, 10, 50, 50 }, 4);
                 m_set->AddZone(zone4);
 
                 // zone4 is expected because it's the smallest one, and it's considered to be inside
@@ -252,13 +248,13 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (ZoneFromPointMultizoneHorizontal)
             {
-                winrt::com_ptr<IZone> zone1 = MakeZone({ 0, 0, 100, 100 });
+                winrt::com_ptr<IZone> zone1 = MakeZone({ 0, 0, 100, 100 }, 1);
                 m_set->AddZone(zone1);
-                winrt::com_ptr<IZone> zone2 = MakeZone({ 100, 0, 200, 100 });
+                winrt::com_ptr<IZone> zone2 = MakeZone({ 100, 0, 200, 100 }, 2);
                 m_set->AddZone(zone2);
-                winrt::com_ptr<IZone> zone3 = MakeZone({ 0, 100, 100, 200 });
+                winrt::com_ptr<IZone> zone3 = MakeZone({ 0, 100, 100, 200 }, 3);
                 m_set->AddZone(zone3);
-                winrt::com_ptr<IZone> zone4 = MakeZone({ 100, 100, 200, 200 });
+                winrt::com_ptr<IZone> zone4 = MakeZone({ 100, 100, 200, 200 }, 4);
                 m_set->AddZone(zone4);
 
                 auto actual = m_set->ZonesFromPoint(POINT{ 50, 100 });
@@ -269,13 +265,13 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (ZoneFromPointMultizoneVertical)
             {
-                winrt::com_ptr<IZone> zone1 = MakeZone({ 0, 0, 100, 100 });
+                winrt::com_ptr<IZone> zone1 = MakeZone({ 0, 0, 100, 100 }, 1);
                 m_set->AddZone(zone1);
-                winrt::com_ptr<IZone> zone2 = MakeZone({ 100, 0, 200, 100 });
+                winrt::com_ptr<IZone> zone2 = MakeZone({ 100, 0, 200, 100 }, 2);
                 m_set->AddZone(zone2);
-                winrt::com_ptr<IZone> zone3 = MakeZone({ 0, 100, 100, 200 });
+                winrt::com_ptr<IZone> zone3 = MakeZone({ 0, 100, 100, 200 }, 3);
                 m_set->AddZone(zone3);
-                winrt::com_ptr<IZone> zone4 = MakeZone({ 100, 100, 200, 200 });
+                winrt::com_ptr<IZone> zone4 = MakeZone({ 100, 100, 200, 200 }, 4);
                 m_set->AddZone(zone4);
 
                 auto actual = m_set->ZonesFromPoint(POINT{ 100, 50 });
@@ -286,13 +282,13 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (ZoneFromPointMultizoneQuad)
             {
-                winrt::com_ptr<IZone> zone1 = MakeZone({ 0, 0, 100, 100 });
+                winrt::com_ptr<IZone> zone1 = MakeZone({ 0, 0, 100, 100 }, 1);
                 m_set->AddZone(zone1);
-                winrt::com_ptr<IZone> zone2 = MakeZone({ 100, 0, 200, 100 });
+                winrt::com_ptr<IZone> zone2 = MakeZone({ 100, 0, 200, 100 }, 2);
                 m_set->AddZone(zone2);
-                winrt::com_ptr<IZone> zone3 = MakeZone({ 0, 100, 100, 200 });
+                winrt::com_ptr<IZone> zone3 = MakeZone({ 0, 100, 100, 200 }, 3);
                 m_set->AddZone(zone3);
-                winrt::com_ptr<IZone> zone4 = MakeZone({ 100, 100, 200, 200 });
+                winrt::com_ptr<IZone> zone4 = MakeZone({ 100, 100, 200, 200 }, 4);
                 m_set->AddZone(zone4);
 
                 auto actual = m_set->ZonesFromPoint(POINT{ 100, 100 });
@@ -305,7 +301,7 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (ZoneIndexFromWindowUnknown)
             {
-                winrt::com_ptr<IZone> zone = MakeZone({ 0, 0, 100, 100 });
+                winrt::com_ptr<IZone> zone = MakeZone({ 0, 0, 100, 100 }, 1);
                 HWND window = Mocks::Window();
                 HWND zoneWindow = Mocks::Window();
                 m_set->AddZone(zone);
@@ -317,7 +313,7 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (ZoneIndexFromWindowNull)
             {
-                winrt::com_ptr<IZone> zone = MakeZone({ 0, 0, 100, 100 });
+                winrt::com_ptr<IZone> zone = MakeZone({ 0, 0, 100, 100 }, 1);
                 HWND window = Mocks::Window();
                 HWND zoneWindow = Mocks::Window();
                 m_set->AddZone(zone);
@@ -329,9 +325,9 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (MoveWindowIntoZoneByIndex)
             {
-                winrt::com_ptr<IZone> zone1 = MakeZone({ 0, 0, 100, 100 });
-                winrt::com_ptr<IZone> zone2 = MakeZone({ 0, 0, 100, 100 });
-                winrt::com_ptr<IZone> zone3 = MakeZone({ 0, 0, 100, 100 });
+                winrt::com_ptr<IZone> zone1 = MakeZone({ 0, 0, 100, 100 }, 1);
+                winrt::com_ptr<IZone> zone2 = MakeZone({ 0, 0, 100, 100 }, 2);
+                winrt::com_ptr<IZone> zone3 = MakeZone({ 0, 0, 100, 100 }, 3);
                 m_set->AddZone(zone1);
                 m_set->AddZone(zone2);
                 m_set->AddZone(zone3);
@@ -349,9 +345,9 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (MoveWindowIntoZoneByIndexWithInvalidIndex)
             {
-                winrt::com_ptr<IZone> zone1 = MakeZone({ 0, 0, 100, 100 });
-                winrt::com_ptr<IZone> zone2 = MakeZone({ 0, 0, 100, 100 });
-                winrt::com_ptr<IZone> zone3 = MakeZone({ 0, 0, 100, 100 });
+                winrt::com_ptr<IZone> zone1 = MakeZone({ 0, 0, 100, 100 }, 1);
+                winrt::com_ptr<IZone> zone2 = MakeZone({ 0, 0, 100, 100 }, 2);
+                winrt::com_ptr<IZone> zone3 = MakeZone({ 0, 0, 100, 100 }, 3);
                 m_set->AddZone(zone1);
                 m_set->AddZone(zone2);
                 m_set->AddZone(zone3);
@@ -364,9 +360,9 @@ namespace FancyZonesUnitTests
             TEST_METHOD (MoveWindowIntoZoneByIndexSeveralTimesSameWindow)
             {
                 // Add a couple of zones.
-                winrt::com_ptr<IZone> zone1 = MakeZone({ 0, 0, 100, 100 });
-                winrt::com_ptr<IZone> zone2 = MakeZone({ 1, 1, 101, 101 });
-                winrt::com_ptr<IZone> zone3 = MakeZone({ 2, 2, 102, 102 });
+                winrt::com_ptr<IZone> zone1 = MakeZone({ 0, 0, 100, 100 }, 1);
+                winrt::com_ptr<IZone> zone2 = MakeZone({ 1, 1, 101, 101 }, 2);
+                winrt::com_ptr<IZone> zone3 = MakeZone({ 2, 2, 102, 102 }, 3);
                 m_set->AddZone(zone1);
                 m_set->AddZone(zone2);
                 m_set->AddZone(zone3);
@@ -385,9 +381,9 @@ namespace FancyZonesUnitTests
             TEST_METHOD (MoveWindowIntoZoneByIndexSeveralTimesSameIndex)
             {
                 // Add a couple of zones.
-                winrt::com_ptr<IZone> zone1 = MakeZone({ 0, 0, 100, 100 });
-                winrt::com_ptr<IZone> zone2 = MakeZone({ 1, 1, 101, 101 });
-                winrt::com_ptr<IZone> zone3 = MakeZone({ 2, 2, 102, 102 });
+                winrt::com_ptr<IZone> zone1 = MakeZone({ 0, 0, 100, 100 }, 1);
+                winrt::com_ptr<IZone> zone2 = MakeZone({ 1, 1, 101, 101 }, 2);
+                winrt::com_ptr<IZone> zone3 = MakeZone({ 2, 2, 102, 102 }, 3);
                 m_set->AddZone(zone1);
                 m_set->AddZone(zone2);
                 m_set->AddZone(zone3);
@@ -406,7 +402,7 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (MoveWindowIntoZoneByPointOuterPoint)
             {
-                winrt::com_ptr<IZone> zone1 = MakeZone({ 0, 0, 100, 100 });
+                winrt::com_ptr<IZone> zone1 = MakeZone({ 0, 0, 100, 100 }, 1);
                 m_set->AddZone(zone1);
 
                 auto window = Mocks::Window();
@@ -417,7 +413,7 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (MoveWindowIntoZoneByPointInnerPoint)
             {
-                winrt::com_ptr<IZone> zone1 = MakeZone({ 0, 0, 100, 100 });
+                winrt::com_ptr<IZone> zone1 = MakeZone({ 0, 0, 100, 100 }, 1);
                 m_set->AddZone(zone1);
 
                 auto window = Mocks::Window();
@@ -428,8 +424,8 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (MoveWindowIntoZoneByPointInnerPointOverlappingZones)
             {
-                winrt::com_ptr<IZone> zone1 = MakeZone({ 0, 0, 100, 100 });
-                winrt::com_ptr<IZone> zone2 = MakeZone({ 10, 10, 90, 90 });
+                winrt::com_ptr<IZone> zone1 = MakeZone({ 0, 0, 100, 100 }, 1);
+                winrt::com_ptr<IZone> zone2 = MakeZone({ 10, 10, 90, 90 }, 2);
                 m_set->AddZone(zone1);
                 m_set->AddZone(zone2);
 
@@ -444,8 +440,8 @@ namespace FancyZonesUnitTests
                 const auto window = Mocks::Window();
                 const auto zoneWindow = Mocks::Window();
 
-                winrt::com_ptr<IZone> zone1 = MakeZone({ 0, 0, 100, 100 });
-                winrt::com_ptr<IZone> zone2 = MakeZone({ 10, 10, 90, 90 });
+                winrt::com_ptr<IZone> zone1 = MakeZone({ 0, 0, 100, 100 }, 1);
+                winrt::com_ptr<IZone> zone2 = MakeZone({ 10, 10, 90, 90 }, 2);
 
                 m_set->AddZone(zone1);
                 m_set->AddZone(zone2);
@@ -462,8 +458,8 @@ namespace FancyZonesUnitTests
                 const auto window = Mocks::Window();
                 const auto zoneWindow = Mocks::Window();
 
-                winrt::com_ptr<IZone> zone1 = MakeZone({ 0, 0, 100, 100 });
-                winrt::com_ptr<IZone> zone2 = MakeZone({ 10, 10, 90, 90 });
+                winrt::com_ptr<IZone> zone1 = MakeZone({ 0, 0, 100, 100 }, 1);
+                winrt::com_ptr<IZone> zone2 = MakeZone({ 10, 10, 90, 90 }, 2);
 
                 m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 1);
 
@@ -480,9 +476,9 @@ namespace FancyZonesUnitTests
                 const auto window = Mocks::Window();
                 const auto zoneWindow = Mocks::Window();
 
-                winrt::com_ptr<IZone> zone1 = MakeZone({ 0, 0, 100, 100 });
-                winrt::com_ptr<IZone> zone2 = MakeZone({ 10, 10, 90, 90 });
-                winrt::com_ptr<IZone> zone3 = MakeZone({ 20, 20, 80, 80 });
+                winrt::com_ptr<IZone> zone1 = MakeZone({ 0, 0, 100, 100 }, 1);
+                winrt::com_ptr<IZone> zone2 = MakeZone({ 10, 10, 90, 90 }, 2);
+                winrt::com_ptr<IZone> zone3 = MakeZone({ 20, 20, 80, 80 }, 3);
 
                 m_set->AddZone(zone1);
                 m_set->AddZone(zone2);
@@ -510,9 +506,9 @@ namespace FancyZonesUnitTests
                 m_set = MakeZoneSet(config);
 
                 // Add a couple of zones.
-                m_zone1 = MakeZone({ 0, 0, 100, 100 });
-                m_zone2 = MakeZone({ 0, 0, 100, 100 });
-                m_zone3 = MakeZone({ 0, 0, 100, 100 });
+                m_zone1 = MakeZone({ 0, 0, 100, 100 }, 1);
+                m_zone2 = MakeZone({ 0, 0, 100, 100 }, 2);
+                m_zone3 = MakeZone({ 0, 0, 100, 100 }, 3);
                 m_set->AddZone(m_zone1);
                 m_set->AddZone(m_zone2);
                 m_set->AddZone(m_zone3);

--- a/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
@@ -657,7 +657,7 @@ namespace FancyZonesUnitTests
             Assert::IsNotNull(zoneWindow->ActiveZoneSet());
 
             auto window = Mocks::WindowCreate(m_hInst);
-            auto zone = MakeZone(RECT{ 0, 0, 100, 100 });
+            auto zone = MakeZone(RECT{ 0, 0, 100, 100 }, 1);
             zoneWindow->ActiveZoneSet()->AddZone(zone);
 
             zoneWindow->SaveWindowProcessToZoneIndex(window);
@@ -684,7 +684,7 @@ namespace FancyZonesUnitTests
             Assert::IsTrue(std::vector<size_t>{ 0 } == appHistoryArray1[0].zoneIndexSet);
 
             // add zone without window
-            const auto zone = MakeZone(RECT{ 0, 0, 100, 100 });
+            const auto zone = MakeZone(RECT{ 0, 0, 100, 100 }, 1);
             zoneWindow->ActiveZoneSet()->AddZone(zone);
 
             zoneWindow->SaveWindowProcessToZoneIndex(window);
@@ -704,7 +704,7 @@ namespace FancyZonesUnitTests
             const auto deviceId = zoneWindow->UniqueId();
             const auto zoneSetId = zoneWindow->ActiveZoneSet()->Id();
 
-            auto zone = MakeZone(RECT{ 0, 0, 100, 100 });
+            auto zone = MakeZone(RECT{ 0, 0, 100, 100 }, 1);
             zoneWindow->ActiveZoneSet()->AddZone(zone);
             zoneWindow->MoveWindowIntoZoneByIndex(window, 0);
 
@@ -737,7 +737,7 @@ namespace FancyZonesUnitTests
             SetWindowPos(window, nullptr, 150, 150, originalWidth, originalHeight, SWP_SHOWWINDOW);
             SetWindowLong(window, GWL_STYLE, GetWindowLong(window, GWL_STYLE) & ~WS_SIZEBOX);
 
-            auto zone = MakeZone(RECT{ 50, 50, 300, 300 });
+            auto zone = MakeZone(RECT{ 50, 50, 300, 300 }, 1);
             zoneWindow->ActiveZoneSet()->AddZone(zone);
 
             zoneWindow->MoveWindowIntoZoneByDirectionAndIndex(window, VK_LEFT, true);


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
In order to properly fix #6734 i.e. to match zone numbers between editor and engine and to be able to Win+ windows in zone-numbers-order, some refactoring was needed in Zone class. Zone Id will be used for iterating through zones on Win+arrow as iteration through zones based on their creation order is not reliable (e.g. creating custom grid layout - splitting and merging cells - doesn't give correct order all the time)

Pass zoneId on zone creaton and make it const
Refactor IZone and Zone - move static methods to anonymous namespace and make methods const
Remove SetId

## PR Checklist
* [x] Applies to #7049 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Validation Steps Performed

_How does someone test & validate?_
Tested manually