### PR TITLE
[FancyZones] Clone parent data only for new VD

### DIFF
--- a/src/modules/fancyzones/lib/FancyZonesData.cpp
+++ b/src/modules/fancyzones/lib/FancyZonesData.cpp
@@ -213,7 +213,6 @@ void FancyZonesData::CloneDeviceInfo(const std::wstring& source, const std::wstr
         return;
     }
 
-    // Clone information from source device if destination device is uninitialized (Blank).
     deviceInfoMap[destination] = deviceInfoMap[source];
 }
 

--- a/src/modules/fancyzones/lib/FancyZonesData.cpp
+++ b/src/modules/fancyzones/lib/FancyZonesData.cpp
@@ -171,7 +171,7 @@ std::optional<FancyZonesDataTypes::CustomZoneSetData> FancyZonesData::FindCustom
     return it != end(customZoneSetsMap) ? std::optional{ it->second } : std::nullopt;
 }
 
-void FancyZonesData::AddDevice(const std::wstring& deviceId)
+bool FancyZonesData::AddDevice(const std::wstring& deviceId)
 {
     using namespace FancyZonesDataTypes;
 
@@ -192,7 +192,11 @@ void FancyZonesData::AddDevice(const std::wstring& deviceId)
         {
             deviceInfoMap[deviceId] = DeviceInfoData{ ZoneSetData{ NonLocalizable::NullStr, ZoneSetLayoutType::Blank } };
         }
+
+        return true;
     }
+
+    return false;
 }
 
 void FancyZonesData::CloneDeviceInfo(const std::wstring& source, const std::wstring& destination)

--- a/src/modules/fancyzones/lib/FancyZonesData.h
+++ b/src/modules/fancyzones/lib/FancyZonesData.h
@@ -58,7 +58,7 @@ public:
         return appZoneHistoryMap;
     }
 
-    void AddDevice(const std::wstring& deviceId);
+    bool AddDevice(const std::wstring& deviceId);
     void CloneDeviceInfo(const std::wstring& source, const std::wstring& destination);
     void UpdatePrimaryDesktopData(const std::wstring& desktopId);
     void RemoveDeletedDesktops(const std::vector<std::wstring>& activeDesktops);

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -444,8 +444,8 @@ ZoneWindow::ClearSelectedZones() noexcept
 void ZoneWindow::InitializeZoneSets(const std::wstring& parentUniqueId) noexcept
 {
     // If there is not defined zone layout for this work area, created default entry.
-    FancyZonesDataInstance().AddDevice(m_uniqueId);
-    if (!parentUniqueId.empty())
+    bool deviceAdded = FancyZonesDataInstance().AddDevice(m_uniqueId);
+    if (deviceAdded && !parentUniqueId.empty())
     {
         FancyZonesDataInstance().CloneDeviceInfo(parentUniqueId, m_uniqueId);
     }

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -443,8 +443,8 @@ ZoneWindow::ClearSelectedZones() noexcept
 
 void ZoneWindow::InitializeZoneSets(const std::wstring& parentUniqueId) noexcept
 {
-    // If there is not defined zone layout for this work area, created default entry.
     bool deviceAdded = FancyZonesDataInstance().AddDevice(m_uniqueId);
+    // If the device has been added, check if it should inherit the parent's layout
     if (deviceAdded && !parentUniqueId.empty())
     {
         FancyZonesDataInstance().CloneDeviceInfo(parentUniqueId, m_uniqueId);


### PR DESCRIPTION
## Summary of the Pull Request

Don't overwrite the VD layout for existing devices.
FancyZonesData::AddDevice() now returns a bool: true if the desktop has been added to the device list, false if it was already present.

## PR Checklist
* [x] Applies to https://github.com/microsoft/PowerToys/issues/6967


## Validation Steps Performed

- Assign a layout to the primary desktop
- Create a VD and assign a different layout
- Quit PT
- Restart PT
- Verify that both the VD didn't have the layout reset to the same layout as the primary desktop

