### PR TITLE
[FancyZones] Responsive drawing

### DIFF
--- a/src/common/on_thread_executor.cpp
+++ b/src/common/on_thread_executor.cpp
@@ -16,6 +16,14 @@ std::future<void> OnThreadExecutor::submit(task_t task)
     return future;
 }
 
+void OnThreadExecutor::cancel()
+{
+    std::lock_guard lock{ _task_mutex };
+    _task_queue = {};
+    _task_cv.notify_one();
+}
+
+
 void OnThreadExecutor::worker_thread()
 {
     while (!_shutdown_request)

--- a/src/common/on_thread_executor.h
+++ b/src/common/on_thread_executor.h
@@ -18,6 +18,7 @@ public:
     OnThreadExecutor();
     ~OnThreadExecutor();
     std::future<void> submit(task_t task);
+    void cancel();
 
 private:
     void worker_thread();

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -195,11 +195,13 @@ ZoneWindow::ZoneWindow(HINSTANCE hinstance)
 
     Gdiplus::GdiplusStartupInput gdiplusStartupInput;
     Gdiplus::GdiplusStartup(&gdiplusToken, &gdiplusStartupInput, NULL);
+    m_paintExecutor.submit(OnThreadExecutor::task_t{ []() { BufferedPaintInit(); } });
 }
 
 ZoneWindow::~ZoneWindow()
 {
     Gdiplus::GdiplusShutdown(gdiplusToken);
+    m_paintExecutor.submit(OnThreadExecutor::task_t{ []() { BufferedPaintUnInit(); } });
 }
 
 bool ZoneWindow::Init(IZoneWindowHost* host, HINSTANCE hinstance, HMONITOR monitor, const std::wstring& uniqueId, const std::wstring& parentUniqueId, bool flashZones)

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -60,7 +60,7 @@ namespace ZoneWindowUtils
         return result;
     }
 
-    void PaintZoneWindowAsync(HDC hdc,
+    void PaintZoneWindow(HDC hdc,
                               HWND window,
                               bool hasActiveZoneSet,
                               COLORREF hostZoneColor,
@@ -598,9 +598,13 @@ LRESULT ZoneWindow::WndProc(UINT message, WPARAM wparam, LPARAM lparam) noexcept
         return 1;
 
     case WM_PRINTCLIENT:
-    case WM_PAINT:
     {
         OnPaint(reinterpret_cast<HDC>(wparam));
+    }
+    break;
+    case WM_PAINT:
+    {
+        OnPaint(NULL);
     }
     break;
 
@@ -636,17 +640,17 @@ void ZoneWindow::OnPaint(HDC hdc) noexcept
 
     OnThreadExecutor::task_t task{
         [=]() {
-        ZoneWindowUtils::PaintZoneWindowAsync(hdc,
-                                              window,
-                                              hasActiveZoneSet,
-                                              hostZoneColor,
-                                              hostZoneBorderColor,
-                                              hostZoneHighlightColor,
-                                              hostZoneHighlightOpacity,
-                                              zones,
-                                              highlightZone,
-                                              flashMode,
-                                              drawHints);
+        ZoneWindowUtils::PaintZoneWindow(hdc,
+                                         window,
+                                         hasActiveZoneSet,
+                                         hostZoneColor,
+                                         hostZoneBorderColor,
+                                         hostZoneHighlightColor,
+                                         hostZoneHighlightOpacity,
+                                         zones,
+                                         highlightZone,
+                                         flashMode,
+                                         drawHints);
         } };
 
     if (m_animating)

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -61,16 +61,16 @@ namespace ZoneWindowUtils
     }
 
     void PaintZoneWindow(HDC hdc,
-                              HWND window,
-                              bool hasActiveZoneSet,
-                              COLORREF hostZoneColor,
-                              COLORREF hostZoneBorderColor,
-                              COLORREF hostZoneHighlightColor,
-                              int hostZoneHighlightOpacity,
-                              std::vector<winrt::com_ptr<IZone>> zones,
-                              std::vector<size_t> highlightZone,
-                              bool flashMode,
-                              bool drawHints)
+                         HWND window,
+                         bool hasActiveZoneSet,
+                         COLORREF hostZoneColor,
+                         COLORREF hostZoneBorderColor,
+                         COLORREF hostZoneHighlightColor,
+                         int hostZoneHighlightOpacity,
+                         std::vector<winrt::com_ptr<IZone>> zones,
+                         std::vector<size_t> highlightZone,
+                         bool flashMode,
+                         bool drawHints)
     {
         PAINTSTRUCT ps;
         HDC oldHdc = hdc;


### PR DESCRIPTION
## Summary of the Pull Request

This PR is the first step towards making the graphics of FZ more responsive. With this PR, dragging a window around will not stutter. There's still a small delay when the zone window is first shown.

## PR Checklist
* [x] Applies to #4073
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

We had stuttering because we didn't quickly return control to the OS in the mouse hook. This PR mostly takes care of that by offloading drawing (which is slow) to another thread.

## Validation Steps Performed

Check that the dragged window doesn't stutter when it moves across zones. Ideally this should be checked on a fast monitor and with a zone layout with many (>20) rows/columns.
