### PR TITLE
Restart the Launcher if it had crashed when invoked

### DIFF
--- a/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
+++ b/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
@@ -271,6 +271,12 @@ public:
         // For now, hotkeyId will always be zero
         if (m_enabled)
         {
+            if (WaitForSingleObject(m_hProcess, 0) == WAIT_OBJECT_0)
+            {
+                // The process exited, restart it
+                enable();
+            }
+
             SetEvent(m_hEvent);
             return true;
         }


### PR DESCRIPTION
## Summary of the Pull Request

Could apply to issues such as this one #6605. If the Launcher crashes, when we invoke it, nothing happens until it is manually restarted. This PR restarts the launcher if we detect that it crashed or exited somehow.

## PR Checklist
* [x] Applies to #6605
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Validation Steps Performed

Start PT, enable the Launcher, terminate it using the Task Manager and hit the invoke hotkey. The launcher should appear immediately in the Task Manager and should show up on the screen in a few seconds.
