### PR TITLE
Fix Tab Trap in SettingsHotkey Custom Control

### DIFF
--- a/src/common/interop/KeyboardHook.cpp
+++ b/src/common/interop/KeyboardHook.cpp
@@ -1,6 +1,5 @@
 #include "pch.h"
 #include "KeyboardHook.h"
-#include "interop.h"
 #include <exception>
 #include <msclr\marshal.h>
 #include <msclr\marshal_cppstd.h>

--- a/src/common/interop/KeyboardHook.cpp
+++ b/src/common/interop/KeyboardHook.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include "KeyboardHook.h"
+#include "interop.h"
 #include <exception>
 #include <msclr\marshal.h>
 #include <msclr\marshal_cppstd.h>
@@ -10,9 +11,6 @@ using namespace interop;
 using namespace System::Runtime::InteropServices;
 using namespace System;
 using namespace System::Diagnostics;
-
-// A keyboard event sent with this value in the extra Information field should be ignored by the hook so that it can be captured by the system instead.
-const int IGNORE_FLAG = 0x5555;
 
 KeyboardHook::KeyboardHook(
     KeyboardEventCallback ^ keyboardEventCallback,
@@ -66,7 +64,7 @@ LRESULT __clrcall KeyboardHook::HookProc(int nCode, WPARAM wParam, LPARAM lParam
 
         ev->dwExtraInfo = reinterpret_cast<KBDLLHOOKSTRUCT*>(lParam)->dwExtraInfo;
 
-        if ((filterKeyboardEvent != nullptr && !filterKeyboardEvent->Invoke(ev)) || (ev->dwExtraInfo == IGNORE_FLAG))
+        if ((filterKeyboardEvent != nullptr && !filterKeyboardEvent->Invoke(ev)) || (ev->dwExtraInfo == interop::Constants::IGNORE_KEYEVENT_FLAG))
         {
             return CallNextHookEx(hookHandle, nCode, wParam, lParam);
         }

--- a/src/common/interop/KeyboardHook.cpp
+++ b/src/common/interop/KeyboardHook.cpp
@@ -61,7 +61,6 @@ LRESULT __clrcall KeyboardHook::HookProc(int nCode, WPARAM wParam, LPARAM lParam
         KeyboardEvent ^ ev = gcnew KeyboardEvent();
         ev->message = wParam;
         ev->key = reinterpret_cast<KBDLLHOOKSTRUCT*>(lParam)->vkCode;
-
         ev->dwExtraInfo = reinterpret_cast<KBDLLHOOKSTRUCT*>(lParam)->dwExtraInfo;
 
         // Ignore the keyboard hook if either the ignore flag is set or if the FilterkeyboardEvent returns false.

--- a/src/common/interop/KeyboardHook.cpp
+++ b/src/common/interop/KeyboardHook.cpp
@@ -64,6 +64,7 @@ LRESULT __clrcall KeyboardHook::HookProc(int nCode, WPARAM wParam, LPARAM lParam
 
         ev->dwExtraInfo = reinterpret_cast<KBDLLHOOKSTRUCT*>(lParam)->dwExtraInfo;
 
+        // Ignore the keyboard hook if either the ignore flag is set or if the FilterkeyboardEvent returns false.
         if ((filterKeyboardEvent != nullptr && !filterKeyboardEvent->Invoke(ev)) || (ev->dwExtraInfo == interop::Constants::IGNORE_KEYEVENT_FLAG))
         {
             return CallNextHookEx(hookHandle, nCode, wParam, lParam);

--- a/src/common/interop/KeyboardHook.cpp
+++ b/src/common/interop/KeyboardHook.cpp
@@ -63,8 +63,8 @@ LRESULT __clrcall KeyboardHook::HookProc(int nCode, WPARAM wParam, LPARAM lParam
         ev->key = reinterpret_cast<KBDLLHOOKSTRUCT*>(lParam)->vkCode;
         ev->dwExtraInfo = reinterpret_cast<KBDLLHOOKSTRUCT*>(lParam)->dwExtraInfo;
 
-        // Ignore the keyboard hook if either the ignore flag is set or if the FilterkeyboardEvent returns false.
-        if ((filterKeyboardEvent != nullptr && !filterKeyboardEvent->Invoke(ev)) || (ev->dwExtraInfo == interop::Constants::IGNORE_KEYEVENT_FLAG))
+        // Ignore the keyboard hook if the FilterkeyboardEvent returns false.
+        if ((filterKeyboardEvent != nullptr && !filterKeyboardEvent->Invoke(ev)))
         {
             return CallNextHookEx(hookHandle, nCode, wParam, lParam);
         }

--- a/src/common/interop/KeyboardHook.h
+++ b/src/common/interop/KeyboardHook.h
@@ -10,6 +10,7 @@ public
     {
         WPARAM message;
         int key;
+        DWORD dwExtraInfo;
     };
 
 public

--- a/src/common/interop/interop.h
+++ b/src/common/interop/interop.h
@@ -127,9 +127,6 @@ public
     {
     public:
         literal int VK_WIN_BOTH = CommonSharedConstants::VK_WIN_BOTH;
-
-        // A keyboard event sent with this value in the extra Information field should be ignored by the hook so that it can be captured by the system instead.
-        literal DWORD IGNORE_KEYEVENT_FLAG = 0x5555;
         
         static String^ PowerLauncherSharedEvent()
         {

--- a/src/common/interop/interop.h
+++ b/src/common/interop/interop.h
@@ -127,6 +127,9 @@ public
     {
     public:
         literal int VK_WIN_BOTH = CommonSharedConstants::VK_WIN_BOTH;
+
+        // A keyboard event sent with this value in the extra Information field should be ignored by the hook so that it can be captured by the system instead.
+        literal DWORD IGNORE_KEYEVENT_FLAG = 0x5555;
         
         static String^ PowerLauncherSharedEvent()
         {

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/HotkeySettings.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/HotkeySettings.cs
@@ -10,6 +10,8 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
 {
     public class HotkeySettings
     {
+        private const int VKTAB = 0x09;
+
         public HotkeySettings()
         {
             Win = false;
@@ -101,8 +103,8 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
         public bool IsValid()
         {
             // Tab and Shift+Tab are not valid settings to meet the accessibility criteria.
-            if ((!Alt && !Ctrl && !Win && Shift && Code == 0x09)
-                || (!Alt && !Ctrl && !Win && !Shift && Code == 0x09))
+            if ((!Alt && !Ctrl && !Win && Shift && Code == VKTAB)
+                || (!Alt && !Ctrl && !Win && !Shift && Code == VKTAB))
             {
                 return false;
             }

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/HotkeySettings.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/HotkeySettings.cs
@@ -102,9 +102,7 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
 
         public bool IsValid()
         {
-            // Tab and Shift+Tab are not valid settings to meet the accessibility criteria.
-            if ((!Alt && !Ctrl && !Win && Shift && Code == VKTAB)
-                || (!Alt && !Ctrl && !Win && !Shift && Code == VKTAB))
+            if (IsAccessibleShortcut())
             {
                 return false;
             }
@@ -115,6 +113,18 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
         public bool IsEmpty()
         {
             return !Alt && !Ctrl && !Win && !Shift && Code == 0;
+        }
+
+        public bool IsAccessibleShortcut()
+        {
+            // Shift+Tab and Tab are accessible shortcuts
+            if ((!Alt && !Ctrl && !Win && Shift && Code == VKTAB)
+                || (!Alt && !Ctrl && !Win && !Shift && Code == VKTAB))
+            {
+                return true;
+            }
+
+            return false;
         }
     }
 }

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/HotkeySettings.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/HotkeySettings.cs
@@ -100,6 +100,13 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
 
         public bool IsValid()
         {
+            // Tab and Shift+Tab are not valid settings to meet the accessibility criteria.
+            if ((!Alt && !Ctrl && !Win && Shift && Code == 0x09)
+                || (!Alt && !Ctrl && !Win && !Shift && Code == 0x09))
+            {
+                return false;
+            }
+
             return (Alt || Ctrl || Win || Shift) && Code != 0;
         }
 

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/HotkeySettingsControlHook.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/HotkeySettingsControlHook.cs
@@ -22,12 +22,17 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
         private KeyEvent _keyUp;
         private IsActive _isActive;
 
-        public HotkeySettingsControlHook(KeyEvent keyDown, KeyEvent keyUp, IsActive isActive)
+        private FilterAccessibleKeyboardEvents _filterKeyboardEvent;
+
+        public delegate bool FilterAccessibleKeyboardEvents(int key);
+
+        public HotkeySettingsControlHook(KeyEvent keyDown, KeyEvent keyUp, IsActive isActive, FilterAccessibleKeyboardEvents filterAccessibleKeyboardEvents)
         {
             _keyDown = keyDown;
             _keyUp = keyUp;
             _isActive = isActive;
-            _hook = new KeyboardHook(HotkeySettingsHookCallback, IsActive, null);
+            _filterKeyboardEvent = filterAccessibleKeyboardEvents;
+            _hook = new KeyboardHook(HotkeySettingsHookCallback, IsActive, FilterKeyboardEvents);
             _hook.Start();
         }
 
@@ -49,6 +54,11 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
                     _keyUp(ev.key);
                     break;
             }
+        }
+
+        private bool FilterKeyboardEvents(KeyboardEvent ev)
+        {
+            return _filterKeyboardEvent(ev.key);
         }
 
         public void Dispose()

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/HotkeySettingsControlHook.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/HotkeySettingsControlHook.cs
@@ -11,7 +11,7 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
 
     public delegate bool IsActive();
 
-    public delegate bool FilterAccessibleKeyboardEvents(int key, UIntPtr ignoreExtraInfoEvent);
+    public delegate bool FilterAccessibleKeyboardEvents(int key, UIntPtr extraInfo);
 
     public class HotkeySettingsControlHook
     {
@@ -27,11 +27,8 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
 
         private FilterAccessibleKeyboardEvents _filterKeyboardEvent;
 
-        private UIntPtr _ignoreKeyEventFlag;
-
         public HotkeySettingsControlHook(KeyEvent keyDown, KeyEvent keyUp, IsActive isActive, FilterAccessibleKeyboardEvents filterAccessibleKeyboardEvents)
         {
-            _ignoreKeyEventFlag = (UIntPtr)interop.Constants.IGNORE_KEYEVENT_FLAG;
             _keyDown = keyDown;
             _keyUp = keyUp;
             _isActive = isActive;
@@ -62,7 +59,7 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
 
         private bool FilterKeyboardEvents(KeyboardEvent ev)
         {
-            return _filterKeyboardEvent(ev.key, _ignoreKeyEventFlag);
+            return _filterKeyboardEvent(ev.key, (UIntPtr)ev.dwExtraInfo);
         }
 
         public void Dispose()

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/HotkeySettingsControlHook.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/HotkeySettingsControlHook.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using interop;
 
 namespace Microsoft.PowerToys.Settings.UI.Lib
@@ -9,6 +10,8 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
     public delegate void KeyEvent(int key);
 
     public delegate bool IsActive();
+
+    public delegate bool FilterAccessibleKeyboardEvents(int key, UIntPtr ignoreExtraInfoEvent);
 
     public class HotkeySettingsControlHook
     {
@@ -24,10 +27,11 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
 
         private FilterAccessibleKeyboardEvents _filterKeyboardEvent;
 
-        public delegate bool FilterAccessibleKeyboardEvents(int key);
+        private UIntPtr _ignoreKeyEventFlag;
 
         public HotkeySettingsControlHook(KeyEvent keyDown, KeyEvent keyUp, IsActive isActive, FilterAccessibleKeyboardEvents filterAccessibleKeyboardEvents)
         {
+            _ignoreKeyEventFlag = (UIntPtr)interop.Constants.IGNORE_KEYEVENT_FLAG;
             _keyDown = keyDown;
             _keyUp = keyUp;
             _isActive = isActive;
@@ -58,7 +62,7 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
 
         private bool FilterKeyboardEvents(KeyboardEvent ev)
         {
-            return _filterKeyboardEvent(ev.key);
+            return _filterKeyboardEvent(ev.key, _ignoreKeyEventFlag);
         }
 
         public void Dispose()

--- a/src/core/Microsoft.PowerToys.Settings.UI/Controls/HotkeySettingsControl.xaml.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Controls/HotkeySettingsControl.xaml.cs
@@ -176,7 +176,7 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
                         {
                             ki = new NativeKeyboardHelper.KEYBDINPUT
                             {
-                                wVk = 0x10,
+                                wVk = (int)Windows.System.VirtualKey.Shift,
                                 dwFlags = (uint)NativeKeyboardHelper.KeyEventF.KeyDown,
 
                                 // Any keyevent with the extraInfo set to this value will be ignored by the keyboard hook and sent to the system instead.
@@ -220,7 +220,7 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
                         {
                             ki = new NativeKeyboardHelper.KEYBDINPUT
                             {
-                                wVk = 0x10,
+                                wVk = (int)Windows.System.VirtualKey.Shift,
                                 dwFlags = (uint)NativeKeyboardHelper.KeyEventF.KeyUp,
                                 dwExtraInfo = ignoreKeyEventFlag,
                             },
@@ -276,7 +276,7 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
             _shiftToggled = false;
 
             // To keep track of the shift key, whether it was pressed on entering.
-            if ((NativeMethods.GetAsyncKeyState(VKSHIFT) & 0x8000) != 0)
+            if ((NativeMethods.GetAsyncKeyState((int)Windows.System.VirtualKey.Shift) & 0x8000) != 0)
             {
                 _shiftKeyDownOnEntering = true;
             }

--- a/src/core/Microsoft.PowerToys.Settings.UI/Controls/HotkeySettingsControl.xaml.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Controls/HotkeySettingsControl.xaml.cs
@@ -146,13 +146,13 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
             if (key == 0x09)
             {
                 // TODO: Others should not be pressed
-                if (!internalSettings.Shift && !_shiftKeyDownOnEntering)
+                if (!internalSettings.Shift && !_shiftKeyDownOnEntering && !internalSettings.Win && !internalSettings.Alt && !internalSettings.Ctrl)
                 {
                     return false;
                 }
 
                 // shift was not pressed while entering but it was pressed while leaving the hotkey
-                else if (internalSettings.Shift && !_shiftKeyDownOnEntering)
+                else if (internalSettings.Shift && !_shiftKeyDownOnEntering && !internalSettings.Win && !internalSettings.Alt && !internalSettings.Ctrl)
                 {
                     internalSettings.Shift = false;
 
@@ -178,13 +178,13 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
                 }
 
                 // Shift was pressed on entering and remained pressed
-                else if (!internalSettings.Shift && _shiftKeyDownOnEntering && !_shiftToggled)
+                else if (!internalSettings.Shift && _shiftKeyDownOnEntering && !_shiftToggled && !internalSettings.Win && !internalSettings.Alt && !internalSettings.Ctrl)
                 {
                     return false;
                 }
 
                 // Shift was pressed on entering but it was released and later pressed again
-                else if (internalSettings.Shift && _shiftKeyDownOnEntering && _shiftToggled)
+                else if (internalSettings.Shift && _shiftKeyDownOnEntering && _shiftToggled && !internalSettings.Win && !internalSettings.Alt && !internalSettings.Ctrl)
                 {
                     internalSettings.Shift = false;
 
@@ -192,7 +192,7 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
                 }
 
                 // Shift was pressed on entering and was later released
-                else if (!internalSettings.Shift && _shiftKeyDownOnEntering && _shiftToggled)
+                else if (!internalSettings.Shift && _shiftKeyDownOnEntering && _shiftToggled && !internalSettings.Win && !internalSettings.Alt && !internalSettings.Ctrl)
                 {
                     NativeKeyboardHelper.INPUT inputShift = new NativeKeyboardHelper.INPUT
                     {

--- a/src/core/Microsoft.PowerToys.Settings.UI/Controls/HotkeySettingsControl.xaml.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Controls/HotkeySettingsControl.xaml.cs
@@ -15,6 +15,8 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
     {
         private const int VKSHIFT = 0x10;
 
+        private readonly UIntPtr ignoreKeyEventFlag = (UIntPtr)0x5555;
+
         private bool _shiftKeyDownOnEntering = false;
 
         private bool _shiftToggled = false;
@@ -144,8 +146,14 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
             }
         }
 
-        private bool FilterAccessibleKeyboardEvents(int key, UIntPtr extraInfoIgnoreKeyEvent)
+        private bool FilterAccessibleKeyboardEvents(int key, UIntPtr extraInfo)
         {
+            // A keyboard event sent with this value in the extra Information field should be ignored by the hook so that it can be captured by the system instead.
+            if (extraInfo == ignoreKeyEventFlag)
+            {
+                return false;
+            }
+
             // If the current key press is tab, based on the other keys ignore the key press so as to shift focus out of the hotkey control.
             if ((Windows.System.VirtualKey)key == Windows.System.VirtualKey.Tab)
             {
@@ -172,7 +180,7 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
                                 dwFlags = (uint)NativeKeyboardHelper.KeyEventF.KeyDown,
 
                                 // Any keyevent with the extraInfo set to this value will be ignored by the keyboard hook and sent to the system instead.
-                                dwExtraInfo = (UIntPtr)extraInfoIgnoreKeyEvent,
+                                dwExtraInfo = ignoreKeyEventFlag,
                             },
                         },
                     };
@@ -214,7 +222,7 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
                             {
                                 wVk = 0x10,
                                 dwFlags = (uint)NativeKeyboardHelper.KeyEventF.KeyUp,
-                                dwExtraInfo = (UIntPtr)extraInfoIgnoreKeyEvent,
+                                dwExtraInfo = ignoreKeyEventFlag,
                             },
                         },
                     };

--- a/src/core/Microsoft.PowerToys.Settings.UI/Controls/HotkeySettingsControl.xaml.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Controls/HotkeySettingsControl.xaml.cs
@@ -13,8 +13,6 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
 {
     public sealed partial class HotkeySettingsControl : UserControl
     {
-        private const int VKSHIFT = 0x10;
-
         private readonly UIntPtr ignoreKeyEventFlag = (UIntPtr)0x5555;
 
         private bool _shiftKeyDownOnEntering = false;

--- a/src/core/Microsoft.PowerToys.Settings.UI/Controls/HotkeySettingsControl.xaml.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Controls/HotkeySettingsControl.xaml.cs
@@ -230,14 +230,12 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
             await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
             {
                 KeyEventHandler(key, true, key, Lib.Utilities.Helper.GetKeyName((uint)key));
-                if (internalSettings.Code > 0)
+
+                // Tab and Shift+Tab are accessible keys and should not be displayed in the hotkey control.
+                if (internalSettings.Code > 0 && !internalSettings.IsAccessibleShortcut())
                 {
-                    // Display all key presses except Tab and Shift+Tab.
-                    if (!internalSettings.IsAccessibleShortcut())
-                    {
-                        HotkeyTextBox.Text = internalSettings.ToString();
-                        lastValidSettings = internalSettings.Clone();
-                    }
+                    HotkeyTextBox.Text = internalSettings.ToString();
+                    lastValidSettings = internalSettings.Clone();
                 }
             });
         }

--- a/src/core/Microsoft.PowerToys.Settings.UI/Controls/HotkeySettingsControl.xaml.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Controls/HotkeySettingsControl.xaml.cs
@@ -71,6 +71,7 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
         private HotkeySettings hotkeySettings;
         private HotkeySettings internalSettings;
         private HotkeySettings lastValidSettings;
+        private HotkeySettings latestSettings;
         private HotkeySettingsControlHook hook;
         private bool _isActive;
 
@@ -236,8 +237,13 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
                 KeyEventHandler(key, true, key, Lib.Utilities.Helper.GetKeyName((uint)key));
                 if (internalSettings.Code > 0)
                 {
-                    lastValidSettings = internalSettings.Clone();
-                    HotkeyTextBox.Text = lastValidSettings.ToString();
+                    latestSettings = internalSettings.Clone();
+
+                    if (latestSettings != null && (latestSettings.IsValid() || latestSettings.IsEmpty()))
+                    {
+                        HotkeyTextBox.Text = latestSettings.ToString();
+                        lastValidSettings = latestSettings.Clone();
+                    }
                 }
             });
         }

--- a/src/core/Microsoft.PowerToys.Settings.UI/Controls/HotkeySettingsControl.xaml.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Controls/HotkeySettingsControl.xaml.cs
@@ -73,7 +73,6 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
         private HotkeySettings hotkeySettings;
         private HotkeySettings internalSettings;
         private HotkeySettings lastValidSettings;
-        private HotkeySettings latestSettings;
         private HotkeySettingsControlHook hook;
         private bool _isActive;
 
@@ -245,12 +244,11 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
                 KeyEventHandler(key, true, key, Lib.Utilities.Helper.GetKeyName((uint)key));
                 if (internalSettings.Code > 0)
                 {
-                    latestSettings = internalSettings.Clone();
-
-                    if (latestSettings != null && (latestSettings.IsValid() || latestSettings.IsEmpty()))
+                    // Display all key presses except Tab and Shift+Tab.
+                    if (!internalSettings.IsAccessibleShortcut())
                     {
-                        HotkeyTextBox.Text = latestSettings.ToString();
-                        lastValidSettings = latestSettings.Clone();
+                        HotkeyTextBox.Text = internalSettings.ToString();
+                        lastValidSettings = internalSettings.Clone();
                     }
                 }
             });

--- a/src/core/Microsoft.PowerToys.Settings.UI/Controls/HotkeySettingsControl.xaml.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Controls/HotkeySettingsControl.xaml.cs
@@ -141,7 +141,7 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
             }
         }
 
-        private bool FilterAccessibleKeyboardEvents(int key)
+        private bool FilterAccessibleKeyboardEvents(int key, UIntPtr extraInfoIgnoreKeyEvent)
         {
             if (key == 0x09)
             {
@@ -165,7 +165,7 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
                             {
                                 wVk = 0x10,
                                 dwFlags = (uint)NativeKeyboardHelper.KeyEventF.KeyDown,
-                                dwExtraInfo = (UIntPtr)0x5555,
+                                dwExtraInfo = (UIntPtr)extraInfoIgnoreKeyEvent,
                             },
                         },
                     };
@@ -203,7 +203,7 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
                             {
                                 wVk = 0x10,
                                 dwFlags = (uint)NativeKeyboardHelper.KeyEventF.KeyUp,
-                                dwExtraInfo = (UIntPtr)0x5555,
+                                dwExtraInfo = (UIntPtr)extraInfoIgnoreKeyEvent,
                             },
                         },
                     };

--- a/src/core/Microsoft.PowerToys.Settings.UI/Helpers/NativeKeyboardHelper.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Helpers/NativeKeyboardHelper.cs
@@ -1,0 +1,86 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.PowerToys.Settings.UI.Helpers
+{
+    internal static class NativeKeyboardHelper
+    {
+        [StructLayout(LayoutKind.Sequential)]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1307:Accessible fields should begin with upper-case letter", Justification = "Matching Native Structure")]
+        internal struct INPUT
+        {
+            internal INPUTTYPE type;
+            internal InputUnion data;
+
+            internal static int Size
+            {
+                get { return Marshal.SizeOf(typeof(INPUT)); }
+            }
+        }
+
+        [StructLayout(LayoutKind.Explicit)]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1307:Accessible fields should begin with upper-case letter", Justification = "Matching Native Structure")]
+        internal struct InputUnion
+        {
+            [FieldOffset(0)]
+            internal MOUSEINPUT mi;
+            [FieldOffset(0)]
+            internal KEYBDINPUT ki;
+            [FieldOffset(0)]
+            internal HARDWAREINPUT hi;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1307:Accessible fields should begin with upper-case letter", Justification = "Matching Native Structure")]
+        internal struct MOUSEINPUT
+        {
+            internal int dx;
+            internal int dy;
+            internal int mouseData;
+            internal uint dwFlags;
+            internal uint time;
+            internal UIntPtr dwExtraInfo;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1307:Accessible fields should begin with upper-case letter", Justification = "Matching Native Structure")]
+        internal struct KEYBDINPUT
+        {
+            internal short wVk;
+            internal short wScan;
+            internal uint dwFlags;
+            internal int time;
+            internal UIntPtr dwExtraInfo;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1307:Accessible fields should begin with upper-case letter", Justification = "Matching Native Structure")]
+        internal struct HARDWAREINPUT
+        {
+            internal int uMsg;
+            internal short wParamL;
+            internal short wParamH;
+        }
+
+        internal enum INPUTTYPE : uint
+        {
+            INPUT_MOUSE = 0,
+            INPUT_KEYBOARD = 1,
+            INPUT_HARDWARE = 2,
+        }
+
+        [Flags]
+        internal enum KeyEventF
+        {
+            KeyDown = 0x0000,
+            ExtendedKey = 0x0001,
+            KeyUp = 0x0002,
+            Unicode = 0x0004,
+            Scancode = 0x0008,
+        }
+    }
+}

--- a/src/core/Microsoft.PowerToys.Settings.UI/Helpers/NativeMethods.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Helpers/NativeMethods.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+namespace Microsoft.PowerToys.Settings.UI.Helpers
+{
+    internal static class NativeMethods
+    {
+        [DllImport("user32.dll")]
+        internal static extern uint SendInput(uint nInputs, NativeKeyboardHelper.INPUT[] pInputs, int cbSize);
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.StdCall, SetLastError = true)]
+        internal static extern short GetAsyncKeyState(int vKey);
+    }
+}

--- a/src/core/Microsoft.PowerToys.Settings.UI/Microsoft.PowerToys.Settings.UI.csproj
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Microsoft.PowerToys.Settings.UI.csproj
@@ -102,6 +102,8 @@
     <Compile Include="Generated Files\AssemblyInfo.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="Helpers\NativeKeyboardHelper.cs" />
+    <Compile Include="Helpers\NativeMethods.cs" />
     <Compile Include="Helpers\NavHelper.cs" />
     <Compile Include="Helpers\Observable.cs" />
     <Compile Include="Helpers\RelayCommand.cs" />


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

This PR fixes the tab trap in the settings hotkey control by ignoring shift+tab and Tab key presses.

## PR Checklist
* [x] Applies to #6110, #7056.
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

The following changes have been made in this PR - 
* The `FilterKeyboardEvent` function has been added so that the hotkey can ignore some key presses.
* We have the information of the shift key when it was entering the control and whether it was modified in between. The following cases have been handled -
1. When shift was never pressed while entering or within the control and tab was pressed, in this case simply ignore the tab key press.
2. When shift was pressed while entering but it was released in between then the system still thinks that the shift key is pressed, therefore simulate a shift key up event and ignore the tab that was pressed, therefore simulating a tab key press.
3. When shift was pressed while entering and remained pressed while leaving, simply ignoring the tab key press will suffice as the system already knows that shift is pressed.
4. When shift was not pressed while entering but shift was pressed within the control, as the system does not know that the shift key was pressed, send a shift key down event and ignore the tab key press to simulate shift+tab.

A couple of other things that had to be kept in mind - 
* If the shift key press was used only to get focus out of the control, then reset the shift status within the control to not being pressed.
* Send inputs with the extra info flag, with the same value as that used within the keyboard hook so as to ignore any key event that was sent with that information. This was the hook does not end up consuming it's own inputs.

* The lastValidSettings is not always valid and therefore another variable was added called latestsettings. The code was modified so that both the variables now perform as the name suggests. Otherwise, the hotkey control was not setting the correct hotkey while losing focus.

## Validation Steps Performed

_How does someone test & validate?_

* Validated that tab, shift-tab with multiple modified combinations work as expected.