### PR TITLE
[PT Run] Add null check in SelectPrevTabItem

### DIFF
--- a/src/modules/launcher/PowerLauncher/ViewModel/ResultsViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/ResultsViewModel.cs
@@ -174,7 +174,7 @@ namespace PowerLauncher.ViewModel
             {
                 // Tabbing backwards should highlight the last item of the previous row
                 SelectPrevResult();
-                SelectedItem.SelectLastContextButton();
+                SelectedItem?.SelectLastContextButton();
             }
         }
 


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
This PR fixes a null reference exception which occurs if you try to Shift+Tab on the launcher window when there are no results/no query.

## PR Checklist
* [X] Applies to #7122 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [X] Tests passed

## Validation Steps Performed

_How does someone test & validate?_
- Validated that exception is not thrown on pressing Shift+Tab on empty launcher search box
- Validated that Shift+Tab works as expected when there are results