### PR TITLE
Catch security and unauthorized access exception while trying to read from file

### DIFF
--- a/src/modules/launcher/Wox.Infrastructure/FileSystemHelper/FileWrapper.cs
+++ b/src/modules/launcher/Wox.Infrastructure/FileSystemHelper/FileWrapper.cs
@@ -2,7 +2,9 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.IO;
+using System.Security;
 using Wox.Infrastructure.Logger;
 
 namespace Wox.Infrastructure.FileSystemHelper
@@ -19,9 +21,9 @@ namespace Wox.Infrastructure.FileSystemHelper
             {
                 return File.ReadAllLines(path);
             }
-            catch (IOException ex)
+            catch (System.Exception ex) when (ex is SecurityException || ex is UnauthorizedAccessException || ex is IOException)
             {
-                Log.Info($"File {path} is being accessed by another process| {ex.Message}", GetType());
+                Log.Info($"Unable to read File: {path}| {ex.Message}", GetType());
 
                 return new string[] { string.Empty };
             }


### PR DESCRIPTION

## Summary of the Pull Request

_What is this about?_

This PR fixes the issue where PT Run crashed when a steam game was being installed.

## PR Checklist
* [x] Applies to #6896
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

Security exceptions and unauthorized access exceptions are caught while trying to create all programs as the file may not be accessible. This catch block is also there for the internet shortcut programs, however they are being read before using the FileSystem wrapper which does not catch the security and unauthorized access exceptions. This PR catches those exceptions and logs it.

## Validation Steps Performed

_How does someone test & validate?_

- Changed the security permissions required to access a url file and removed read permissions for the current user.
- tried to rename /index the file.
- the exception is caught.
![image](https://user-images.githubusercontent.com/28739210/95245709-596b7400-07c8-11eb-8726-c3bec2890edb.png)
![image](https://user-images.githubusercontent.com/28739210/95245397-ec57de80-07c7-11eb-8ae6-74487410b85e.png)

