### PR TITLE
[PT Run] Updated borderbrush to improve accessibility for dark mode

### DIFF
--- a/src/modules/launcher/PowerLauncher/LauncherControl.xaml
+++ b/src/modules/launcher/PowerLauncher/LauncherControl.xaml
@@ -38,11 +38,21 @@
                                     </Style>
                                 </TextBlock.Style>
                             </TextBlock>
-                            <Border x:Name="border" Background="{TemplateBinding Background}" BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}" SnapsToDevicePixels="True">
-                                <ScrollViewer x:Name="PART_ContentHost" Background="{TemplateBinding Background}" Focusable="false" HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Hidden">
+                            <Border x:Name="border"
+                                    Background="{TemplateBinding Background}"
+                                    BorderThickness="{TemplateBinding BorderThickness}"
+                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                    SnapsToDevicePixels="True">
+                                <ScrollViewer x:Name="PART_ContentHost"
+                                              Background="{TemplateBinding Background}"
+                                              Focusable="false"
+                                              HorizontalScrollBarVisibility="Hidden"
+                                              VerticalScrollBarVisibility="Hidden">
                                     <ScrollViewer.ContentTemplate>
                                         <DataTemplate>
-                                            <Grid Background="{Binding Background, ElementName=PART_ContentHost}" RenderOptions.ClearTypeHint="Enabled" TextOptions.TextFormattingMode="Display">
+                                            <Grid
+                                                Background="{Binding Background, ElementName=PART_ContentHost}"
+                                                RenderOptions.ClearTypeHint="Enabled" TextOptions.TextFormattingMode="Display">
                                                 <ContentPresenter Content="{Binding Path=Content, ElementName=PART_ContentHost}"/>
                                             </Grid>
                                         </DataTemplate>

--- a/src/modules/launcher/PowerLauncher/LauncherControl.xaml
+++ b/src/modules/launcher/PowerLauncher/LauncherControl.xaml
@@ -41,7 +41,7 @@
                             <Border x:Name="border"
                                     Background="{TemplateBinding Background}"
                                     BorderThickness="{TemplateBinding BorderThickness}"
-                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                    BorderBrush="{TemplateBinding DialogBorderBrush}"
                                     SnapsToDevicePixels="True">
                                 <ScrollViewer x:Name="PART_ContentHost"
                                               Background="{TemplateBinding Background}"

--- a/src/modules/launcher/PowerLauncher/LauncherControl.xaml
+++ b/src/modules/launcher/PowerLauncher/LauncherControl.xaml
@@ -26,7 +26,8 @@
                 <Setter.Value>
                     <ControlTemplate TargetType="{x:Type TextBox}">
                         <Grid>
-                            <TextBlock Margin="14, 0, 0, 0" Text="{TemplateBinding Tag}">
+                            <TextBlock Margin="14, 0, 0, 0"
+                                       Text="{TemplateBinding Tag}">
                                 <TextBlock.Style>
                                     <Style TargetType="{x:Type TextBlock}">
                                         <Setter Property="Foreground" Value="Transparent"/>
@@ -41,7 +42,7 @@
                             <Border x:Name="border"
                                     Background="{TemplateBinding Background}"
                                     BorderThickness="{TemplateBinding BorderThickness}"
-                                    BorderBrush="{TemplateBinding DialogBorderBrush}"
+                                    BorderBrush="{TemplateBinding BorderBrush}"
                                     SnapsToDevicePixels="True">
                                 <ScrollViewer x:Name="PART_ContentHost"
                                               Background="{TemplateBinding Background}"
@@ -52,7 +53,8 @@
                                         <DataTemplate>
                                             <Grid
                                                 Background="{Binding Background, ElementName=PART_ContentHost}"
-                                                RenderOptions.ClearTypeHint="Enabled" TextOptions.TextFormattingMode="Display">
+                                                RenderOptions.ClearTypeHint="Enabled"
+                                                TextOptions.TextFormattingMode="Display">
                                                 <ContentPresenter Content="{Binding Path=Content, ElementName=PART_ContentHost}"/>
                                             </Grid>
                                         </DataTemplate>

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml
@@ -26,7 +26,6 @@
         Deactivated="OnDeactivated"
         IsVisibleChanged="OnVisibilityChanged"
         Visibility="{Binding MainWindowVisibility, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-        
         d:DataContext="{d:DesignInstance vm:MainViewModel}">
     <Window.Resources>
         <CubicEase x:Key="CubicEaseOut" EasingMode="EaseOut"/>
@@ -59,7 +58,12 @@
             x:Name="SearchBoxBorder" 
             Grid.Row="0" 
             Margin="24,24,24,24">
-            <Rectangle Fill="{DynamicResource SystemChromeLow}" RadiusX="4" RadiusY="4" Stroke="{DynamicResource BorderBrush}" StrokeThickness="1">
+            <Rectangle
+                Fill="{DynamicResource SystemChromeLow}"
+                RadiusX="4"
+                RadiusY="4"
+                Stroke="{DynamicResource DialogBorderBrush}"
+                StrokeThickness="1">
                 <Rectangle.Effect>
                     <DropShadowEffect BlurRadius="32" Opacity="0.28" ShadowDepth="1" />
                 </Rectangle.Effect>
@@ -82,7 +86,12 @@
             <!--<Border.RenderTransform>
                 <TranslateTransform />
             </Border.RenderTransform>-->
-            <Rectangle RadiusX="4" RadiusY="4" Fill="{DynamicResource SystemChromeLow}" Stroke="{DynamicResource BorderBrush}" StrokeThickness="1">
+            <Rectangle
+                RadiusX="4"
+                RadiusY="4"
+                Fill="{DynamicResource SystemChromeLow}"
+                Stroke="{DynamicResource DialogBorderBrush}"
+                StrokeThickness="1">
                 <Rectangle.Effect>
                     <DropShadowEffect BlurRadius="32" Opacity="0.28" ShadowDepth="1" />
                 </Rectangle.Effect>
@@ -93,12 +102,20 @@
                     <TranslateTransform />
                 </local:ResultList.RenderTransform>-->
             </local:ResultList>
-            <Rectangle RadiusX="4" RadiusY="4" Stroke="{DynamicResource SystemChromeLow}" StrokeThickness="1" />
+            <Rectangle
+                RadiusX="4"
+                RadiusY="4"
+                Stroke="{DynamicResource DialogBorderBrush}"
+                StrokeThickness="1" />
         </Grid>
     </Grid> 
     <Window.InputBindings>
-        <KeyBinding Key="Escape" Command="{Binding EscCommand}" />
-        <KeyBinding Key="Enter" Command="{Binding OpenResultWithKeyboardCommand}" />
-        <KeyBinding Modifiers="Alt" Key="F4" Command="{Binding IgnoreCommand}" />
+        <KeyBinding Key="Escape"
+                    Command="{Binding EscCommand}" />
+        <KeyBinding Key="Enter"
+                    Command="{Binding OpenResultWithKeyboardCommand}" />
+        <KeyBinding Modifiers="Alt"
+                    Key="F4"
+                    Command="{Binding IgnoreCommand}" />
     </Window.InputBindings>
 </Window>

--- a/src/modules/launcher/PowerLauncher/ReportWindow.xaml
+++ b/src/modules/launcher/PowerLauncher/ReportWindow.xaml
@@ -40,7 +40,10 @@
                       
                        Foreground="{DynamicResource ControlTextBrushKey}">
                 <Run Text="{x:Static p:Resources.reportWindow_file_bug}"/>
-                <Hyperlink x:Name="RepositoryHyperlink" Click="RepositoryHyperlink_Click"  FontWeight="SemiBold" NavigateUri="https://aka.ms/powerToysReportBug">
+                <Hyperlink x:Name="RepositoryHyperlink"
+                           Click="RepositoryHyperlink_Click"
+                           FontWeight="SemiBold"
+                           NavigateUri="https://aka.ms/powerToysReportBug">
                     <Run Text="{x:Static p:Resources.reportWindow_github_repo}"/>
                 </Hyperlink>
                 <Run Text="{x:Static p:Resources.reportWindow_period}"/>
@@ -59,8 +62,6 @@
                  TextWrapping="Wrap">
             </TextBox>
 
-       
-        
         <RichTextBox x:Name="ErrorTextbox" 
                      Grid.Row="3"
                      BorderBrush="{DynamicResource ScrollBarThumbBackground}"

--- a/src/modules/launcher/PowerLauncher/ResultList.xaml
+++ b/src/modules/launcher/PowerLauncher/ResultList.xaml
@@ -21,7 +21,11 @@
                 <Setter Property="Control.Template">
                     <Setter.Value>
                         <ControlTemplate>
-                            <Rectangle Margin="2" StrokeDashArray="1 2" SnapsToDevicePixels="true" StrokeThickness="1" Stroke="{DynamicResource ControlTextBrushKey}"/>
+                            <Rectangle Margin="2"
+                                       StrokeDashArray="1 2"
+                                       SnapsToDevicePixels="true"
+                                       StrokeThickness="1"
+                                       Stroke="{DynamicResource ControlTextBrushKey}"/>
                         </ControlTemplate>
                     </Setter.Value>
                 </Setter>
@@ -38,8 +42,19 @@
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="{x:Type Button}">
-                            <Border x:Name="border" CornerRadius="4" Background="Transparent" BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="Transparent" SnapsToDevicePixels="true">
-                                <ContentPresenter x:Name="contentPresenter" Focusable="False" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" Margin="{TemplateBinding Padding}" RecognizesAccessKey="True" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                            <Border x:Name="border"
+                                    CornerRadius="2"
+                                    Background="Transparent"
+                                    BorderThickness="{TemplateBinding BorderThickness}"
+                                    BorderBrush="Transparent"
+                                    SnapsToDevicePixels="true">
+                                <ContentPresenter x:Name="contentPresenter"
+                                                  Focusable="False"
+                                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                  Margin="{TemplateBinding Padding}"
+                                                  RecognizesAccessKey="True"
+                                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                                  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
                             </Border>
                             <ControlTemplate.Triggers>
                                 <Trigger Property="IsDefaulted" Value="true">
@@ -72,8 +87,16 @@
                     <Setter.Value>
                         <ControlTemplate TargetType="{x:Type ListViewItem}">
                             <Grid Background="Transparent">
-                                <Border x:Name="HighlightBorder" BorderThickness="0" Background="{DynamicResource SystemChromeLow}" BorderBrush="Transparent" SnapsToDevicePixels="true"/>
-                                <ContentPresenter x:Name="contentPresenter" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" Margin="{TemplateBinding Padding}" RecognizesAccessKey="True" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                                <Border x:Name="HighlightBorder"
+                                        BorderThickness="0"
+                                        Background="{DynamicResource SystemChromeLow}"
+                                        BorderBrush="Transparent"
+                                        SnapsToDevicePixels="true"/>
+                                <ContentPresenter x:Name="contentPresenter"
+                                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                  Margin="{TemplateBinding Padding}" RecognizesAccessKey="True"
+                                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                                  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
                             </Grid>
                             <ControlTemplate.Triggers>
                                 <!-- Setting the opacity of the highlight border to improve the contrast of the AccentColorbrush when selected. In UWP we could call a different brush, in WPF we need to play with the opacity of the WindowGlassBrush-->
@@ -100,8 +123,18 @@
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="{x:Type ListViewItem}">
-                            <Border x:Name="border" CornerRadius="4" Background="Transparent" BorderBrush="Transparent" SnapsToDevicePixels="true">
-                                <ContentPresenter x:Name="contentPresenter" Focusable="False" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" Margin="{TemplateBinding Padding}" RecognizesAccessKey="True" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                            <Border x:Name="border"
+                                    CornerRadius="4"
+                                    Background="Transparent"
+                                    BorderBrush="Transparent"
+                                    SnapsToDevicePixels="true">
+                                <ContentPresenter x:Name="contentPresenter"
+                                                  Focusable="False"
+                                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                  Margin="{TemplateBinding Padding}"
+                                                  RecognizesAccessKey="True"
+                                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                                  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
                             </Border>
                             <ControlTemplate.Triggers>
                                 <Trigger Property="IsMouseOver" Value="true">
@@ -137,8 +170,16 @@
                     <Setter.Value>
                         <ControlTemplate TargetType="{x:Type ToolTip}" >
                             <Grid Margin="8,2" >
-                                <Rectangle Fill="{DynamicResource ToolTipBackgroundBrushKey}" RadiusX="4" RadiusY="4" Stroke="{DynamicResource ToolTipBorderBrushKey}" StrokeThickness="1"/>
-                                <ContentPresenter Margin="4" HorizontalAlignment="Center" VerticalAlignment="Top" />
+                                <Rectangle
+                                    Fill="{DynamicResource ToolTipBackgroundBrushKey}"
+                                    RadiusX="4"
+                                    RadiusY="4"
+                                    Stroke="{DynamicResource ToolTipBorderBrushKey}"
+                                    StrokeThickness="1"/>
+                                <ContentPresenter
+                                    Margin="4"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Top" />
                             </Grid>
                         </ControlTemplate>
                     </Setter.Value>
@@ -174,8 +215,7 @@
                         Width="642" 
                         Background="Transparent"
                         ToolTipService.BetweenShowDelay="0"
-                        ToolTipService.InitialShowDelay="1000"
-                        >
+                        ToolTipService.InitialShowDelay="1000">
                         <Behaviors:Interaction.Triggers>
                             <Behaviors:EventTrigger EventName="MouseEnter">
                                 <Behaviors:InvokeCommandAction Command="{Binding ActivateContextButtonsHoverCommand}"/>
@@ -211,9 +251,34 @@
                                 </StackPanel>
                             </ToolTip>
                         </Grid.ToolTip>
-                        <Image AutomationProperties.Name="{x:Static p:Resources.AppIcon}" x:Name="AppIcon" Height="36" MaxWidth="56" Grid.RowSpan="2" Margin="-6,-2,0,0" HorizontalAlignment="Center" Source="{Binding Image}" />
-                        <TextBlock AutomationProperties.Name="{x:Static p:Resources.Title}" x:Name="Title" Grid.Column="1" Text="{Binding Result.Title}" FontWeight="SemiBold" FontSize="20" Margin="0,0,0,-2" VerticalAlignment="Bottom" RenderOptions.ClearTypeHint="Enabled"/>
-                        <TextBlock AutomationProperties.Name="{x:Static p:Resources.Subtitle}" x:Name="Path" Grid.Column="1" Text= "{Binding Result.SubTitle}" Grid.Row="1" Foreground="{DynamicResource SecondaryTextForeground}" Margin="0,2,0,0" VerticalAlignment="Top" RenderOptions.ClearTypeHint="Enabled"/>
+                        <Image
+                            AutomationProperties.Name="{x:Static p:Resources.AppIcon}"
+                               x:Name="AppIcon"
+                               Height="36"
+                               MaxWidth="56"
+                               Grid.RowSpan="2"
+                               Margin="-6,-2,0,0"
+                               HorizontalAlignment="Center"
+                               Source="{Binding Image}" />
+                        <TextBlock
+                            AutomationProperties.Name="{x:Static p:Resources.Title}"
+                            x:Name="Title" Grid.Column="1"
+                            Text="{Binding Result.Title}"
+                            FontWeight="SemiBold"
+                            FontSize="20"
+                            Margin="0,0,0,-2"
+                            VerticalAlignment="Bottom"
+                            RenderOptions.ClearTypeHint="Enabled"/>
+                        <TextBlock
+                            AutomationProperties.Name="{x:Static p:Resources.Subtitle}"
+                            x:Name="Path"
+                            Grid.Column="1"
+                            Text= "{Binding Result.SubTitle}"
+                            Grid.Row="1"
+                            Foreground="{DynamicResource SecondaryTextForeground}"
+                            Margin="0,2,0,0"
+                            VerticalAlignment="Top"
+                            RenderOptions.ClearTypeHint="Enabled"/>
                         <ListView      
                             AutomationProperties.Name="{x:Static p:Resources.ContextMenuItemsCollection}"
                             HorizontalAlignment="Right" 
@@ -239,14 +304,32 @@
                             </ItemsControl.ItemsPanel>
                             <ListView.ItemTemplate>
                                 <DataTemplate>
-                                    <Button AutomationProperties.Name="{x:Static p:Resources.ContextMenuItem}" Style="{StaticResource IconButtonStyle}" Command="{Binding Command}" VerticalAlignment="Center" Height="42" Width="42" BorderThickness="1" >
+                                    <Button
+                                        AutomationProperties.Name="{x:Static p:Resources.ContextMenuItem}"
+                                        Style="{StaticResource IconButtonStyle}"
+                                        Command="{Binding Command}"
+                                        VerticalAlignment="Center"
+                                        Height="42"
+                                        Width="42"
+                                        BorderThickness="1" >
                                         <ToolTipService.ToolTip>
                                             <ToolTip >
-                                                <TextBlock AutomationProperties.Name="{x:Static p:Resources.ContextMenuItemAdditionalInformation}" Text="{Binding Title}" Foreground="{DynamicResource ToolTipForegroundBrushKey}" Margin="8,5" FontSize="12" RenderOptions.ClearTypeHint="Enabled"/>
+                                                <TextBlock
+                                                    AutomationProperties.Name="{x:Static p:Resources.ContextMenuItemAdditionalInformation}"
+                                                    Text="{Binding Title}"
+                                                    Foreground="{DynamicResource ToolTipForegroundBrushKey}"
+                                                    Margin="8,5"
+                                                    FontSize="12"
+                                                    RenderOptions.ClearTypeHint="Enabled"/>
                                             </ToolTip>
                                         </ToolTipService.ToolTip>
                                         <Button.Content>
-                                            <TextBlock AutomationProperties.Name="{x:Static p:Resources.ContextMenuIcon}" FontFamily="{Binding FontFamily}" FontSize="16" Text="{Binding Glyph}" RenderOptions.ClearTypeHint="Enabled"/>
+                                            <TextBlock
+                                                AutomationProperties.Name="{x:Static p:Resources.ContextMenuIcon}"
+                                                FontFamily="{Binding FontFamily}"
+                                                FontSize="16"
+                                                Text="{Binding Glyph}"
+                                                RenderOptions.ClearTypeHint="Enabled"/>
                                         </Button.Content>
                                     </Button>
                                 </DataTemplate>

--- a/src/modules/launcher/PowerLauncher/Themes/Dark.xaml
+++ b/src/modules/launcher/PowerLauncher/Themes/Dark.xaml
@@ -3,7 +3,8 @@
                     xmlns:markup="clr-namespace:MahApps.Metro.Markup;assembly=MahApps.Metro"
                     xmlns:markupWithAssembly="clr-namespace:MahApps.Metro.Markup;assembly=MahApps.Metro"
                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                    xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options" xmlns:system="clr-namespace:System;assembly=System.Runtime"
+                    xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
+                    xmlns:system="clr-namespace:System;assembly=System.Runtime"
                     mc:Ignorable="options">
 
     <!--  Metadata  -->
@@ -28,7 +29,7 @@
     <SolidColorBrush x:Key="ControlTextBrushKey" Color="White" />
     <SolidColorBrush x:Key="SecondaryTextForeground" Color="#FFa1a1a1" />
     <SolidColorBrush x:Key="InactiveSelectionHighlightBrushKey" Color="White" />
-    <SolidColorBrush x:Key="BorderBrush" Color="Transparent" />
+    <SolidColorBrush x:Key="DialogBorderBrush" Color="#FF373737" />
     
     <SolidColorBrush x:Key="ScrollBarThumbBackground" Color="#FF7a7a7a" />
     <Color x:Key="ScrollBarThumbPointerOver">#FF767676</Color>

--- a/src/modules/launcher/PowerLauncher/Themes/HighContrast1.xaml
+++ b/src/modules/launcher/PowerLauncher/Themes/HighContrast1.xaml
@@ -3,7 +3,8 @@
                     xmlns:markup="clr-namespace:MahApps.Metro.Markup;assembly=MahApps.Metro"
                     xmlns:markupWithAssembly="clr-namespace:MahApps.Metro.Markup;assembly=MahApps.Metro"
                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                    xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options" xmlns:system="clr-namespace:System;assembly=System.Runtime"
+                    xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
+                    xmlns:system="clr-namespace:System;assembly=System.Runtime"
                     mc:Ignorable="options">
 
     <!--  Metadata  -->
@@ -28,7 +29,7 @@
     <SolidColorBrush x:Key="ControlTextBrushKey" Color="#FFffff00" />
     <SolidColorBrush x:Key="SecondaryTextForeground" Color="#FF008000" />
     <SolidColorBrush x:Key="InactiveSelectionHighlightBrushKey" Color="#FFFFFFFF" />
-    <SolidColorBrush x:Key="BorderBrush" Color="White" />
+    <SolidColorBrush x:Key="DialogBorderBrush" Color="#FF373737" />
     
     <SolidColorBrush x:Key="ScrollBarThumbBackground" Color="White" />
     <Color x:Key="ScrollBarThumbPointerOver">#FF008000</Color>

--- a/src/modules/launcher/PowerLauncher/Themes/HighContrast2.xaml
+++ b/src/modules/launcher/PowerLauncher/Themes/HighContrast2.xaml
@@ -3,7 +3,8 @@
                     xmlns:markup="clr-namespace:MahApps.Metro.Markup;assembly=MahApps.Metro"
                     xmlns:markupWithAssembly="clr-namespace:MahApps.Metro.Markup;assembly=MahApps.Metro"
                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                    xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options" xmlns:system="clr-namespace:System;assembly=System.Runtime"
+                    xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
+                    xmlns:system="clr-namespace:System;assembly=System.Runtime"
                     mc:Ignorable="options">
 
     <!--  Metadata  -->
@@ -28,7 +29,7 @@
     <SolidColorBrush x:Key="ControlTextBrushKey" Color="#FF00ff00" />
     <SolidColorBrush x:Key="SecondaryTextForeground" Color="#FFc0c0c0" />
     <SolidColorBrush x:Key="InactiveSelectionHighlightBrushKey" Color="#FFFFFFFF" />
-    <SolidColorBrush x:Key="BorderBrush" Color="White" />
+    <SolidColorBrush x:Key="DialogBorderBrush" Color="White" />
     
     <SolidColorBrush x:Key="ScrollBarThumbBackground" Color="White" />
     <Color x:Key="ScrollBarThumbPointerOver">#FF0000ff</Color>

--- a/src/modules/launcher/PowerLauncher/Themes/HighContrastBlack.xaml
+++ b/src/modules/launcher/PowerLauncher/Themes/HighContrastBlack.xaml
@@ -3,7 +3,8 @@
                     xmlns:markup="clr-namespace:MahApps.Metro.Markup;assembly=MahApps.Metro"
                     xmlns:markupWithAssembly="clr-namespace:MahApps.Metro.Markup;assembly=MahApps.Metro"
                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                    xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options" xmlns:system="clr-namespace:System;assembly=System.Runtime"
+                    xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
+                    xmlns:system="clr-namespace:System;assembly=System.Runtime"
                     mc:Ignorable="options">
 
     <!--  Metadata  -->
@@ -28,7 +29,8 @@
     <SolidColorBrush x:Key="ControlTextBrushKey" Color="White" />
     <SolidColorBrush x:Key="SecondaryTextForeground" Color="#FF3ff23f" />
     <SolidColorBrush x:Key="InactiveSelectionHighlightBrushKey" Color="White" />
-    <SolidColorBrush x:Key="BorderBrush" Color="White" />
+    <SolidColorBrush x:Key="DialogBorderBrush" Color="White" />
+    
     <SolidColorBrush x:Key="ScrollBarThumbBackground" Color="White" />
     <Color x:Key="ScrollBarThumbPointerOver">#FF0ca7b6</Color>
     <Color x:Key="ScrollBarThumbPointerPressed">#FF0ca7b6</Color>

--- a/src/modules/launcher/PowerLauncher/Themes/HighContrastWhite.xaml
+++ b/src/modules/launcher/PowerLauncher/Themes/HighContrastWhite.xaml
@@ -3,7 +3,8 @@
                     xmlns:markup="clr-namespace:MahApps.Metro.Markup;assembly=MahApps.Metro"
                     xmlns:markupWithAssembly="clr-namespace:MahApps.Metro.Markup;assembly=MahApps.Metro"
                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                    xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options" xmlns:system="clr-namespace:System;assembly=System.Runtime"
+                    xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
+                    xmlns:system="clr-namespace:System;assembly=System.Runtime"
                     mc:Ignorable="options">
 
     <!--  Metadata  -->
@@ -28,7 +29,8 @@
     <SolidColorBrush x:Key="ControlTextBrushKey" Color="Black" />
     <SolidColorBrush x:Key="SecondaryTextForeground" Color="#FF600000" />
     <SolidColorBrush x:Key="InactiveSelectionHighlightBrushKey" Color="Black" />
-    <SolidColorBrush x:Key="BorderBrush" Color="Black" />
+    <SolidColorBrush x:Key="DialogBorderBrush" Color="Black" />
+    
     <SolidColorBrush x:Key="ScrollBarThumbBackground" Color="Black" />
     <Color x:Key="ScrollBarThumbPointerOver">#FF9a59db</Color>
     <Color x:Key="ScrollBarThumbPointerPressed">#FF9a59db</Color>

--- a/src/modules/launcher/PowerLauncher/Themes/Light.xaml
+++ b/src/modules/launcher/PowerLauncher/Themes/Light.xaml
@@ -3,7 +3,8 @@
                     xmlns:markup="clr-namespace:MahApps.Metro.Markup;assembly=MahApps.Metro"
                     xmlns:markupWithAssembly="clr-namespace:MahApps.Metro.Markup;assembly=MahApps.Metro"
                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                    xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options" xmlns:system="clr-namespace:System;assembly=System.Runtime"
+                    xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
+                    xmlns:system="clr-namespace:System;assembly=System.Runtime"
                     mc:Ignorable="options">
 
     <!--  Metadata  -->
@@ -28,7 +29,8 @@
     <SolidColorBrush x:Key="ControlTextBrushKey" Color="Black" />
     <SolidColorBrush x:Key="SecondaryTextForeground" Color="#FF434343" />
     <SolidColorBrush x:Key="InactiveSelectionHighlightBrushKey" Color="Black" />
-    <SolidColorBrush x:Key="BorderBrush" Color="Transparent" />
+    <SolidColorBrush x:Key="DialogBorderBrush" Color="#FFf7f7f7" />
+    
     <SolidColorBrush x:Key="ScrollBarThumbBackground" Color="#FF7a7a7a" />
     <Color x:Key="ScrollBarThumbPointerOver">#FFa0a0a0</Color>
     <Color x:Key="ScrollBarThumbPointerPressed">#FF747474</Color>


### PR DESCRIPTION
## Summary of the Pull Request

- Updated the BorderBrush with the Windows default border brush so the search box and results list stand out a bit more in dark mode, addressing issue #2428

- Made some of the XAML better readable and maintainable.


Before:
![image](https://user-images.githubusercontent.com/9866362/95256691-6c5f6200-0823-11eb-937a-3def4b4e0453.png)


After:
![image](https://user-images.githubusercontent.com/9866362/95256562-45a12b80-0823-11eb-9b16-2410aa3addb8.png)


## PR Checklist
* [X] Applies to #2428
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [X] Discussed with @crutkas
