### PR TITLE
Assert.AreEqual switched cases

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/ViewModelTests/ImageResizer.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/ViewModelTests/ImageResizer.cs
@@ -172,7 +172,7 @@ namespace ViewModelTests
             viewModel.AddRow();
 
             // Assert
-            Assert.AreEqual(viewModel.Sizes.Count, sizeOfOriginalArray + 1);
+            Assert.AreEqual(sizeOfOriginalArray + 1, viewModel.Sizes.Count);
         }
 
         [TestMethod]
@@ -189,7 +189,7 @@ namespace ViewModelTests
             viewModel.DeleteImageSize(0);
 
             // Assert
-            Assert.AreEqual(viewModel.Sizes.Count, sizeOfOriginalArray - 1);
+            Assert.AreEqual(sizeOfOriginalArray - 1, viewModel.Sizes.Count);
             Assert.IsFalse(viewModel.Sizes.Contains(deleteCandidate));
         }
 

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program.UnitTests/Programs/UWPTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program.UnitTests/Programs/UWPTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Plugin.Program.UnitTests.Programs
             var applications = UWP.All();
 
             // Assert
-            Assert.AreEqual(applications.Length, 2);
+            Assert.AreEqual(2, applications.Length);
             Assert.IsTrue(applications.FindAll(x => x.Name == "DevelopmentApp").Length > 0);
             Assert.IsTrue(applications.FindAll(x => x.Name == "PackagedApp").Length > 0);
         }
@@ -70,7 +70,7 @@ namespace Microsoft.Plugin.Program.UnitTests.Programs
             var applications = UWP.All();
 
             // Assert
-            Assert.AreEqual(applications.Length, 1);
+            Assert.AreEqual(1, applications.Length);
             Assert.IsTrue(applications.FindAll(x => x.Name == "PackagedApp").Length > 0);
         }
 
@@ -89,7 +89,7 @@ namespace Microsoft.Plugin.Program.UnitTests.Programs
             var applications = UWP.All();
 
             // Assert
-            Assert.AreEqual(applications.Length, 0);
+            Assert.AreEqual(0, applications.Length);
         }
     }
 }

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program.UnitTests/Programs/Win32Tests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program.UnitTests/Programs/Win32Tests.cs
@@ -247,7 +247,7 @@ namespace Microsoft.Plugin.Program.UnitTests.Programs
             Win32Program[] apps = Win32Program.DeduplicatePrograms(prgms.AsParallel());
 
             // Assert
-            Assert.AreEqual(apps.Length, 1);
+            Assert.AreEqual(1, apps.Length);
         }
 
         [Test]
@@ -264,7 +264,7 @@ namespace Microsoft.Plugin.Program.UnitTests.Programs
             Win32Program[] apps = Win32Program.DeduplicatePrograms(prgms.AsParallel());
 
             // Assert
-            Assert.AreEqual(apps.Length, 1);
+            Assert.AreEqual(1, apps.Length);
         }
 
         [Test]
@@ -280,7 +280,7 @@ namespace Microsoft.Plugin.Program.UnitTests.Programs
             Win32Program[] apps = Win32Program.DeduplicatePrograms(prgms.AsParallel());
 
             // Assert
-            Assert.AreEqual(apps.Length, 1);
+            Assert.AreEqual(1, apps.Length);
         }
 
         [Test]
@@ -297,7 +297,7 @@ namespace Microsoft.Plugin.Program.UnitTests.Programs
             Win32Program[] apps = Win32Program.DeduplicatePrograms(prgms.AsParallel());
 
             // Assert
-            Assert.AreEqual(apps.Length, 1);
+            Assert.AreEqual(1, apps.Length);
             Assert.IsTrue(!string.IsNullOrEmpty(apps[0].LnkResolvedPath));
         }
 
@@ -316,7 +316,7 @@ namespace Microsoft.Plugin.Program.UnitTests.Programs
             Win32Program[] apps = Win32Program.DeduplicatePrograms(prgms.AsParallel());
 
             // Assert
-            Assert.AreEqual(apps.Length, 3);
+            Assert.AreEqual(3, apps.Length);
         }
 
         [Test]
@@ -425,10 +425,10 @@ namespace Microsoft.Plugin.Program.UnitTests.Programs
             List<ContextMenuResult> contextMenuResults = _pinnedWebpage.ContextMenus(mock.Object);
 
             // Assert
-            Assert.AreEqual(contextMenuResults.Count, 3);
-            Assert.AreEqual(contextMenuResults[0].Title, Properties.Resources.wox_plugin_program_run_as_administrator);
-            Assert.AreEqual(contextMenuResults[1].Title, Properties.Resources.wox_plugin_program_open_containing_folder);
-            Assert.AreEqual(contextMenuResults[2].Title, Properties.Resources.wox_plugin_program_open_in_console);
+            Assert.AreEqual(3, contextMenuResults.Count);
+            Assert.AreEqual(Properties.Resources.wox_plugin_program_run_as_administrator, contextMenuResults[0].Title);
+            Assert.AreEqual(Properties.Resources.wox_plugin_program_open_containing_folder, contextMenuResults[1].Title);
+            Assert.AreEqual(Properties.Resources.wox_plugin_program_open_in_console, contextMenuResults[2].Title);
         }
 
         [Test]
@@ -441,9 +441,9 @@ namespace Microsoft.Plugin.Program.UnitTests.Programs
             List<ContextMenuResult> contextMenuResults = _dummyInternetShortcutApp.ContextMenus(mock.Object);
 
             // Assert
-            Assert.AreEqual(contextMenuResults.Count, 2);
-            Assert.AreEqual(contextMenuResults[0].Title, Properties.Resources.wox_plugin_program_open_containing_folder);
-            Assert.AreEqual(contextMenuResults[1].Title, Properties.Resources.wox_plugin_program_open_in_console);
+            Assert.AreEqual(2, contextMenuResults.Count);
+            Assert.AreEqual(Properties.Resources.wox_plugin_program_open_containing_folder, contextMenuResults[0].Title);
+            Assert.AreEqual(Properties.Resources.wox_plugin_program_open_in_console, contextMenuResults[1].Title);
         }
 
         [Test]
@@ -456,10 +456,10 @@ namespace Microsoft.Plugin.Program.UnitTests.Programs
             List<ContextMenuResult> contextMenuResults = _chrome.ContextMenus(mock.Object);
 
             // Assert
-            Assert.AreEqual(contextMenuResults.Count, 3);
-            Assert.AreEqual(contextMenuResults[0].Title, Properties.Resources.wox_plugin_program_run_as_administrator);
-            Assert.AreEqual(contextMenuResults[1].Title, Properties.Resources.wox_plugin_program_open_containing_folder);
-            Assert.AreEqual(contextMenuResults[2].Title, Properties.Resources.wox_plugin_program_open_in_console);
+            Assert.AreEqual(3, contextMenuResults.Count);
+            Assert.AreEqual(Properties.Resources.wox_plugin_program_run_as_administrator, contextMenuResults[0].Title);
+            Assert.AreEqual(Properties.Resources.wox_plugin_program_open_containing_folder, contextMenuResults[1].Title);
+            Assert.AreEqual(Properties.Resources.wox_plugin_program_open_in_console, contextMenuResults[2].Title);
         }
 
         [Test]
@@ -472,10 +472,10 @@ namespace Microsoft.Plugin.Program.UnitTests.Programs
             List<ContextMenuResult> contextMenuResults = _cmdRunCommand.ContextMenus(mock.Object);
 
             // Assert
-            Assert.AreEqual(contextMenuResults.Count, 3);
-            Assert.AreEqual(contextMenuResults[0].Title, Properties.Resources.wox_plugin_program_run_as_administrator);
-            Assert.AreEqual(contextMenuResults[1].Title, Properties.Resources.wox_plugin_program_open_containing_folder);
-            Assert.AreEqual(contextMenuResults[2].Title, Properties.Resources.wox_plugin_program_open_in_console);
+            Assert.AreEqual(3, contextMenuResults.Count);
+            Assert.AreEqual(Properties.Resources.wox_plugin_program_run_as_administrator, contextMenuResults[0].Title);
+            Assert.AreEqual(Properties.Resources.wox_plugin_program_open_containing_folder, contextMenuResults[1].Title);
+            Assert.AreEqual(Properties.Resources.wox_plugin_program_open_in_console, contextMenuResults[2].Title);
         }
 
         [Test]
@@ -488,10 +488,10 @@ namespace Microsoft.Plugin.Program.UnitTests.Programs
             List<ContextMenuResult> contextMenuResults = _dummyAppRefApp.ContextMenus(mock.Object);
 
             // Assert
-            Assert.AreEqual(contextMenuResults.Count, 3);
-            Assert.AreEqual(contextMenuResults[0].Title, Properties.Resources.wox_plugin_program_run_as_administrator);
-            Assert.AreEqual(contextMenuResults[1].Title, Properties.Resources.wox_plugin_program_open_containing_folder);
-            Assert.AreEqual(contextMenuResults[2].Title, Properties.Resources.wox_plugin_program_open_in_console);
+            Assert.AreEqual(3, contextMenuResults.Count);
+            Assert.AreEqual(Properties.Resources.wox_plugin_program_run_as_administrator, contextMenuResults[0].Title);
+            Assert.AreEqual(Properties.Resources.wox_plugin_program_open_containing_folder, contextMenuResults[1].Title);
+            Assert.AreEqual(Properties.Resources.wox_plugin_program_open_in_console, contextMenuResults[2].Title);
         }
 
         [Test]
@@ -504,10 +504,10 @@ namespace Microsoft.Plugin.Program.UnitTests.Programs
             List<ContextMenuResult> contextMenuResults = _dummyShortcutApp.ContextMenus(mock.Object);
 
             // Assert
-            Assert.AreEqual(contextMenuResults.Count, 3);
-            Assert.AreEqual(contextMenuResults[0].Title, Properties.Resources.wox_plugin_program_run_as_administrator);
-            Assert.AreEqual(contextMenuResults[1].Title, Properties.Resources.wox_plugin_program_open_containing_folder);
-            Assert.AreEqual(contextMenuResults[2].Title, Properties.Resources.wox_plugin_program_open_in_console);
+            Assert.AreEqual(3, contextMenuResults.Count);
+            Assert.AreEqual(Properties.Resources.wox_plugin_program_run_as_administrator, contextMenuResults[0].Title);
+            Assert.AreEqual(Properties.Resources.wox_plugin_program_open_containing_folder, contextMenuResults[1].Title);
+            Assert.AreEqual(Properties.Resources.wox_plugin_program_open_in_console, contextMenuResults[2].Title);
         }
 
         [Test]
@@ -520,9 +520,9 @@ namespace Microsoft.Plugin.Program.UnitTests.Programs
             List<ContextMenuResult> contextMenuResults = _dummyFolderApp.ContextMenus(mock.Object);
 
             // Assert
-            Assert.AreEqual(contextMenuResults.Count, 2);
-            Assert.AreEqual(contextMenuResults[0].Title, Properties.Resources.wox_plugin_program_open_containing_folder);
-            Assert.AreEqual(contextMenuResults[1].Title, Properties.Resources.wox_plugin_program_open_in_console);
+            Assert.AreEqual(2, contextMenuResults.Count);
+            Assert.AreEqual(Properties.Resources.wox_plugin_program_open_containing_folder, contextMenuResults[0].Title);
+            Assert.AreEqual(Properties.Resources.wox_plugin_program_open_in_console, contextMenuResults[1].Title);
         }
 
         [Test]
@@ -535,9 +535,9 @@ namespace Microsoft.Plugin.Program.UnitTests.Programs
             List<ContextMenuResult> contextMenuResults = _dummyGenericFileApp.ContextMenus(mock.Object);
 
             // Assert
-            Assert.AreEqual(contextMenuResults.Count, 2);
-            Assert.AreEqual(contextMenuResults[0].Title, Properties.Resources.wox_plugin_program_open_containing_folder);
-            Assert.AreEqual(contextMenuResults[1].Title, Properties.Resources.wox_plugin_program_open_in_console);
+            Assert.AreEqual(2, contextMenuResults.Count);
+            Assert.AreEqual(Properties.Resources.wox_plugin_program_open_containing_folder, contextMenuResults[0].Title);
+            Assert.AreEqual(Properties.Resources.wox_plugin_program_open_in_console, contextMenuResults[1].Title);
         }
 
         [Test]

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program.UnitTests/Storage/ConcurrentQueueEventHandlerTest.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program.UnitTests/Storage/ConcurrentQueueEventHandlerTest.cs
@@ -42,8 +42,8 @@ namespace Microsoft.Plugin.Program.UnitTests.Storage
             string pathFromQueue = EventHandler.GetAppPathFromQueue(eventHandlingQueue, dequeueDelay);
 
             // Assert
-            Assert.AreEqual(pathFromQueue, appPath);
-            Assert.AreEqual(eventHandlingQueue.Count, 0);
+            Assert.AreEqual(appPath, pathFromQueue);
+            Assert.AreEqual(0, eventHandlingQueue.Count);
         }
 
         [TestCase(5)]
@@ -68,8 +68,8 @@ namespace Microsoft.Plugin.Program.UnitTests.Storage
             string pathFromQueue = EventHandler.GetAppPathFromQueue(eventHandlingQueue, dequeueDelay);
 
             // Assert
-            Assert.AreEqual(pathFromQueue, firstAppPath);
-            Assert.AreEqual(eventHandlingQueue.Count, itemCount);
+            Assert.AreEqual(firstAppPath, pathFromQueue);
+            Assert.AreEqual(itemCount, eventHandlingQueue.Count);
         }
 
         [TestCase(5)]
@@ -99,8 +99,8 @@ namespace Microsoft.Plugin.Program.UnitTests.Storage
             string pathFromQueue = EventHandler.GetAppPathFromQueue(eventHandlingQueue, dequeueDelay);
 
             // Assert
-            Assert.AreEqual(pathFromQueue, firstAppPath);
-            Assert.AreEqual(eventHandlingQueue.Count, itemCount * 2);
+            Assert.AreEqual(firstAppPath, pathFromQueue);
+            Assert.AreEqual(itemCount * 2, eventHandlingQueue.Count);
         }
     }
 }

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program.UnitTests/Storage/Win32ProgramRepositoryTest.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program.UnitTests/Storage/Win32ProgramRepositoryTest.cs
@@ -63,13 +63,13 @@ namespace Microsoft.Plugin.Program.UnitTests.Storage
             // Act
             win32ProgramRepository.Add(item1);
 
-            Assert.AreEqual(win32ProgramRepository.Count(), 1);
+            Assert.AreEqual(1, win32ProgramRepository.Count());
 
             // To add an item with the same hashCode, ie, same name, exename and fullPath
             win32ProgramRepository.Add(item2);
 
             // Assert, count still remains 1 because they are duplicate items
-            Assert.AreEqual(win32ProgramRepository.Count(), 1);
+            Assert.AreEqual(1, win32ProgramRepository.Count());
         }
 
         [TestCase("path.appref-ms")]
@@ -83,8 +83,8 @@ namespace Microsoft.Plugin.Program.UnitTests.Storage
             _fileSystemMocks[0].Raise(m => m.Created += null, e);
 
             // Assert
-            Assert.AreEqual(win32ProgramRepository.Count(), 1);
-            Assert.AreEqual(win32ProgramRepository.ElementAt(0).AppType, Win32Program.ApplicationType.ApprefApplication);
+            Assert.AreEqual(1, win32ProgramRepository.Count());
+            Assert.AreEqual(Win32Program.ApplicationType.ApprefApplication, win32ProgramRepository.ElementAt(0).AppType);
         }
 
         [TestCase("directory", "path.appref-ms")]
@@ -102,7 +102,7 @@ namespace Microsoft.Plugin.Program.UnitTests.Storage
             _fileSystemMocks[0].Raise(m => m.Deleted += null, e);
 
             // Assert
-            Assert.AreEqual(win32ProgramRepository.Count(), 0);
+            Assert.AreEqual(0, win32ProgramRepository.Count());
         }
 
         [TestCase("directory", "oldpath.appref-ms", "newpath.appref-ms")]
@@ -123,7 +123,7 @@ namespace Microsoft.Plugin.Program.UnitTests.Storage
             _fileSystemMocks[0].Raise(m => m.Renamed += null, e);
 
             // Assert
-            Assert.AreEqual(win32ProgramRepository.Count(), 1);
+            Assert.AreEqual(1, win32ProgramRepository.Count());
             Assert.IsTrue(win32ProgramRepository.Contains(newitem));
             Assert.IsFalse(win32ProgramRepository.Contains(olditem));
         }
@@ -144,8 +144,8 @@ namespace Microsoft.Plugin.Program.UnitTests.Storage
             _fileSystemMocks[0].Raise(m => m.Created += null, e);
 
             // Assert
-            Assert.AreEqual(win32ProgramRepository.Count(), 1);
-            Assert.AreEqual(win32ProgramRepository.ElementAt(0).AppType, Win32Program.ApplicationType.Win32Application);
+            Assert.AreEqual(1, win32ProgramRepository.Count());
+            Assert.AreEqual(Win32Program.ApplicationType.Win32Application, win32ProgramRepository.ElementAt(0).AppType);
         }
 
         [TestCase("directory", "path.exe")]
@@ -168,7 +168,7 @@ namespace Microsoft.Plugin.Program.UnitTests.Storage
             _fileSystemMocks[0].Raise(m => m.Deleted += null, e);
 
             // Assert
-            Assert.AreEqual(win32ProgramRepository.Count(), 0);
+            Assert.AreEqual(0, win32ProgramRepository.Count());
         }
 
         [TestCase("directory", "oldpath.appref-ms", "newpath.appref-ms")]
@@ -194,7 +194,7 @@ namespace Microsoft.Plugin.Program.UnitTests.Storage
             _fileSystemMocks[0].Raise(m => m.Renamed += null, e);
 
             // Assert
-            Assert.AreEqual(win32ProgramRepository.Count(), 1);
+            Assert.AreEqual(1, win32ProgramRepository.Count());
             Assert.IsTrue(win32ProgramRepository.Contains(newitem));
             Assert.IsFalse(win32ProgramRepository.Contains(olditem));
         }
@@ -217,7 +217,7 @@ namespace Microsoft.Plugin.Program.UnitTests.Storage
             _fileSystemMocks[0].Raise(m => m.Created += null, e);
 
             // Assert
-            Assert.AreEqual(win32ProgramRepository.Count(), 0);
+            Assert.AreEqual(0, win32ProgramRepository.Count());
         }
 
         [TestCase("path.exe")]
@@ -245,7 +245,7 @@ namespace Microsoft.Plugin.Program.UnitTests.Storage
             _fileSystemMocks[0].Raise(m => m.Changed += null, e);
 
             // Assert
-            Assert.AreEqual(win32ProgramRepository.Count(), 0);
+            Assert.AreEqual(0, win32ProgramRepository.Count());
         }
 
         [TestCase("directory", "path.url")]
@@ -268,7 +268,7 @@ namespace Microsoft.Plugin.Program.UnitTests.Storage
             _fileSystemMocks[0].Raise(m => m.Deleted += null, e);
 
             // Assert
-            Assert.AreEqual(win32ProgramRepository.Count(), 0);
+            Assert.AreEqual(0, win32ProgramRepository.Count());
         }
 
         [TestCase("directory", "oldpath.url", "newpath.url")]
@@ -294,7 +294,7 @@ namespace Microsoft.Plugin.Program.UnitTests.Storage
             _fileSystemMocks[0].Raise(m => m.Renamed += null, e);
 
             // Assert
-            Assert.AreEqual(win32ProgramRepository.Count(), 1);
+            Assert.AreEqual(1, win32ProgramRepository.Count());
             Assert.IsTrue(win32ProgramRepository.Contains(newitem));
             Assert.IsFalse(win32ProgramRepository.Contains(olditem));
         }
@@ -326,7 +326,7 @@ namespace Microsoft.Plugin.Program.UnitTests.Storage
             _fileSystemMocks[0].Raise(m => m.Deleted += null, e);
 
             // Assert
-            Assert.AreEqual(win32ProgramRepository.Count(), 0);
+            Assert.AreEqual(0, win32ProgramRepository.Count());
         }
 
         [TestCase("directory", "oldpath.lnk", "path.lnk")]
@@ -365,7 +365,7 @@ namespace Microsoft.Plugin.Program.UnitTests.Storage
             _fileSystemMocks[0].Raise(m => m.Renamed += null, e);
 
             // Assert
-            Assert.AreEqual(win32ProgramRepository.Count(), 1);
+            Assert.AreEqual(1, win32ProgramRepository.Count());
             Assert.IsTrue(win32ProgramRepository.Contains(newitem));
             Assert.IsFalse(win32ProgramRepository.Contains(olditem));
         }

--- a/src/modules/launcher/Wox.Test/MainViewModelTest.cs
+++ b/src/modules/launcher/Wox.Test/MainViewModelTest.cs
@@ -22,7 +22,7 @@ namespace Wox.Test
             string autoCompleteText = MainViewModel.GetAutoCompleteText(index, input, query);
 
             // Assert
-            Assert.AreEqual(autoCompleteText, string.Empty);
+            Assert.AreEqual(string.Empty, autoCompleteText);
         }
 
         [Test]
@@ -37,7 +37,7 @@ namespace Wox.Test
             string autoCompleteText = MainViewModel.GetAutoCompleteText(index, input, query);
 
             // Assert
-            Assert.AreEqual(autoCompleteText, string.Empty);
+            Assert.AreEqual(string.Empty, autoCompleteText);
         }
 
         [Test]
@@ -52,7 +52,7 @@ namespace Wox.Test
             string autoCompleteText = MainViewModel.GetAutoCompleteText(index, input, query);
 
             // Assert
-            Assert.AreEqual(autoCompleteText, string.Empty);
+            Assert.AreEqual(string.Empty, autoCompleteText);
         }
 
         [Test]
@@ -67,7 +67,7 @@ namespace Wox.Test
             string autoCompleteText = MainViewModel.GetAutoCompleteText(index, input, query);
 
             // Assert
-            Assert.AreEqual(autoCompleteText, string.Empty);
+            Assert.AreEqual(string.Empty, autoCompleteText);
         }
 
         [Test]
@@ -82,7 +82,7 @@ namespace Wox.Test
             string autoCompleteText = MainViewModel.GetAutoCompleteText(index, input, query);
 
             // Assert
-            Assert.AreEqual(autoCompleteText, string.Empty);
+            Assert.AreEqual(string.Empty, autoCompleteText);
         }
 
         [Test]
@@ -98,7 +98,7 @@ namespace Wox.Test
             string autoCompleteText = MainViewModel.GetAutoCompleteText(index, input, query);
 
             // Assert
-            Assert.AreEqual(autoCompleteText, expectedAutoCompleteText);
+            Assert.AreEqual(expectedAutoCompleteText, autoCompleteText);
         }
 
         [Test]
@@ -114,7 +114,7 @@ namespace Wox.Test
             string autoCompleteText = MainViewModel.GetAutoCompleteText(index, input, query);
 
             // Assert
-            Assert.AreEqual(autoCompleteText, expectedAutoCompleteText);
+            Assert.AreEqual(expectedAutoCompleteText, autoCompleteText);
         }
 
         [Test]
@@ -129,7 +129,7 @@ namespace Wox.Test
             string autoCompleteText = MainViewModel.GetSearchText(index, input, query);
 
             // Assert
-            Assert.AreEqual(autoCompleteText, string.Empty);
+            Assert.AreEqual(string.Empty, autoCompleteText);
         }
 
         [Test]
@@ -144,7 +144,7 @@ namespace Wox.Test
             string autoCompleteText = MainViewModel.GetSearchText(index, input, query);
 
             // Assert
-            Assert.AreEqual(autoCompleteText, string.Empty);
+            Assert.AreEqual(string.Empty, autoCompleteText);
         }
 
         [Test]
@@ -159,7 +159,7 @@ namespace Wox.Test
             string autoCompleteText = MainViewModel.GetSearchText(index, input, query);
 
             // Assert
-            Assert.AreEqual(autoCompleteText, input);
+            Assert.AreEqual(input, autoCompleteText);
         }
 
         [Test]
@@ -174,7 +174,7 @@ namespace Wox.Test
             string autoCompleteText = MainViewModel.GetSearchText(index, input, query);
 
             // Assert
-            Assert.AreEqual(autoCompleteText, input);
+            Assert.AreEqual(input, autoCompleteText);
         }
 
         [Test]
@@ -190,7 +190,7 @@ namespace Wox.Test
             string autoCompleteText = MainViewModel.GetSearchText(index, input, query);
 
             // Assert
-            Assert.AreEqual(autoCompleteText, expectedAutoCompleteText);
+            Assert.AreEqual(expectedAutoCompleteText, autoCompleteText);
         }
 
         [Test]
@@ -205,7 +205,7 @@ namespace Wox.Test
             string autoCompleteText = MainViewModel.GetSearchText(index, input, query);
 
             // Assert
-            Assert.AreEqual(autoCompleteText, input);
+            Assert.AreEqual(input, autoCompleteText);
         }
     }
 }

--- a/src/modules/launcher/Wox.Test/Plugins/FolderPluginTest.cs
+++ b/src/modules/launcher/Wox.Test/Plugins/FolderPluginTest.cs
@@ -26,9 +26,9 @@ namespace Wox.Test.Plugins
             List<ContextMenuResult> contextMenuResults = contextMenuLoader.LoadContextMenus(result);
 
             // Assert
-            Assert.AreEqual(contextMenuResults.Count, 2);
-            Assert.AreEqual(contextMenuResults[0].Title, Microsoft.Plugin.Folder.Properties.Resources.Microsoft_plugin_folder_copy_path);
-            Assert.AreEqual(contextMenuResults[1].Title, Microsoft.Plugin.Folder.Properties.Resources.Microsoft_plugin_folder_open_in_console);
+            Assert.AreEqual(2, contextMenuResults.Count);
+            Assert.AreEqual(Microsoft.Plugin.Folder.Properties.Resources.Microsoft_plugin_folder_copy_path, contextMenuResults[0].Title);
+            Assert.AreEqual(Microsoft.Plugin.Folder.Properties.Resources.Microsoft_plugin_folder_open_in_console, contextMenuResults[1].Title);
         }
 
         [Test]
@@ -45,10 +45,10 @@ namespace Wox.Test.Plugins
             List<ContextMenuResult> contextMenuResults = contextMenuLoader.LoadContextMenus(result);
 
             // Assert
-            Assert.AreEqual(contextMenuResults.Count, 3);
-            Assert.AreEqual(contextMenuResults[0].Title, Microsoft.Plugin.Folder.Properties.Resources.Microsoft_plugin_folder_open_containing_folder);
-            Assert.AreEqual(contextMenuResults[1].Title, Microsoft.Plugin.Folder.Properties.Resources.Microsoft_plugin_folder_copy_path);
-            Assert.AreEqual(contextMenuResults[2].Title, Microsoft.Plugin.Folder.Properties.Resources.Microsoft_plugin_folder_open_in_console);
+            Assert.AreEqual(3, contextMenuResults.Count);
+            Assert.AreEqual(Microsoft.Plugin.Folder.Properties.Resources.Microsoft_plugin_folder_open_containing_folder, contextMenuResults[0].Title);
+            Assert.AreEqual(Microsoft.Plugin.Folder.Properties.Resources.Microsoft_plugin_folder_copy_path, contextMenuResults[1].Title);
+            Assert.AreEqual(Microsoft.Plugin.Folder.Properties.Resources.Microsoft_plugin_folder_open_in_console, contextMenuResults[2].Title);
         }
     }
 }

--- a/src/modules/launcher/Wox.Test/Plugins/ResultTest.cs
+++ b/src/modules/launcher/Wox.Test/Plugins/ResultTest.cs
@@ -22,7 +22,7 @@ namespace Wox.Test.Plugins
             res.ToolTipData = new ToolTipData(toolTipText, string.Empty);
 
             // Assert
-            Assert.AreEqual(res.ToolTipVisibility, Visibility.Visible);
+            Assert.AreEqual(Visibility.Visible, res.ToolTipVisibility);
         }
 
         [Test]
@@ -32,7 +32,7 @@ namespace Wox.Test.Plugins
             Result res = new Result();
 
             // Assert
-            Assert.AreEqual(res.ToolTipVisibility, Visibility.Collapsed);
+            Assert.AreEqual(Visibility.Collapsed, res.ToolTipVisibility);
         }
     }
 }

--- a/src/modules/launcher/Wox.Test/Plugins/WindowsIndexerTest.cs
+++ b/src/modules/launcher/Wox.Test/Plugins/WindowsIndexerTest.cs
@@ -53,7 +53,7 @@ namespace Wox.Test.Plugins
 
             // Assert
             Assert.IsNotNull(queryHelper);
-            Assert.AreEqual(queryHelper.QueryMaxResults, maxCount);
+            Assert.AreEqual(maxCount, queryHelper.QueryMaxResults);
         }
 
         [Test]
@@ -281,11 +281,11 @@ namespace Wox.Test.Plugins
             List<ContextMenuResult> contextMenuItems = contextMenuLoader.LoadContextMenus(result);
 
             // Assert
-            Assert.AreEqual(contextMenuItems.Count, 4);
-            Assert.AreEqual(contextMenuItems[0].Title, Microsoft.Plugin.Indexer.Properties.Resources.Microsoft_plugin_indexer_open_containing_folder);
-            Assert.AreEqual(contextMenuItems[1].Title, Microsoft.Plugin.Indexer.Properties.Resources.Microsoft_plugin_indexer_run_as_administrator);
-            Assert.AreEqual(contextMenuItems[2].Title, Microsoft.Plugin.Indexer.Properties.Resources.Microsoft_plugin_indexer_copy_path);
-            Assert.AreEqual(contextMenuItems[3].Title, Microsoft.Plugin.Indexer.Properties.Resources.Microsoft_plugin_indexer_open_in_console);
+            Assert.AreEqual(4, contextMenuItems.Count);
+            Assert.AreEqual(Microsoft.Plugin.Indexer.Properties.Resources.Microsoft_plugin_indexer_open_containing_folder, contextMenuItems[0].Title);
+            Assert.AreEqual(Microsoft.Plugin.Indexer.Properties.Resources.Microsoft_plugin_indexer_run_as_administrator, contextMenuItems[1].Title);
+            Assert.AreEqual(Microsoft.Plugin.Indexer.Properties.Resources.Microsoft_plugin_indexer_copy_path, contextMenuItems[2].Title);
+            Assert.AreEqual(Microsoft.Plugin.Indexer.Properties.Resources.Microsoft_plugin_indexer_open_in_console, contextMenuItems[3].Title);
         }
 
         [TestCase("item.pdf")]
@@ -309,10 +309,10 @@ namespace Wox.Test.Plugins
             List<ContextMenuResult> contextMenuItems = contextMenuLoader.LoadContextMenus(result);
 
             // Assert
-            Assert.AreEqual(contextMenuItems.Count, 3);
-            Assert.AreEqual(contextMenuItems[0].Title, Microsoft.Plugin.Indexer.Properties.Resources.Microsoft_plugin_indexer_open_containing_folder);
-            Assert.AreEqual(contextMenuItems[1].Title, Microsoft.Plugin.Indexer.Properties.Resources.Microsoft_plugin_indexer_copy_path);
-            Assert.AreEqual(contextMenuItems[2].Title, Microsoft.Plugin.Indexer.Properties.Resources.Microsoft_plugin_indexer_open_in_console);
+            Assert.AreEqual(3, contextMenuItems.Count);
+            Assert.AreEqual(Microsoft.Plugin.Indexer.Properties.Resources.Microsoft_plugin_indexer_open_containing_folder, contextMenuItems[0].Title);
+            Assert.AreEqual(Microsoft.Plugin.Indexer.Properties.Resources.Microsoft_plugin_indexer_copy_path, contextMenuItems[1].Title);
+            Assert.AreEqual(Microsoft.Plugin.Indexer.Properties.Resources.Microsoft_plugin_indexer_open_in_console, contextMenuItems[2].Title);
         }
 
         [TestCase("C:/DummyFolder")]
@@ -334,9 +334,9 @@ namespace Wox.Test.Plugins
             List<ContextMenuResult> contextMenuItems = contextMenuLoader.LoadContextMenus(result);
 
             // Assert
-            Assert.AreEqual(contextMenuItems.Count, 2);
-            Assert.AreEqual(contextMenuItems[0].Title, Microsoft.Plugin.Indexer.Properties.Resources.Microsoft_plugin_indexer_copy_path);
-            Assert.AreEqual(contextMenuItems[1].Title, Microsoft.Plugin.Indexer.Properties.Resources.Microsoft_plugin_indexer_open_in_console);
+            Assert.AreEqual(2, contextMenuItems.Count);
+            Assert.AreEqual(Microsoft.Plugin.Indexer.Properties.Resources.Microsoft_plugin_indexer_copy_path, contextMenuItems[0].Title);
+            Assert.AreEqual(Microsoft.Plugin.Indexer.Properties.Resources.Microsoft_plugin_indexer_open_in_console, contextMenuItems[1].Title);
         }
 
         [TestCase(0, false, ExpectedResult = true)]

--- a/src/modules/launcher/Wox.Test/ResultsViewModelTest.cs
+++ b/src/modules/launcher/Wox.Test/ResultsViewModelTest.cs
@@ -25,7 +25,7 @@ namespace Wox.Test
             rvm.SelectedItem = selectedItem;
 
             // Assert
-            Assert.AreEqual(selectedItem.ContextMenuSelectedIndex, ResultViewModel.NoSelectionIndex);
+            Assert.AreEqual(ResultViewModel.NoSelectionIndex, selectedItem.ContextMenuSelectedIndex);
         }
 
         [Test]
@@ -45,7 +45,7 @@ namespace Wox.Test
             rvm.SelectNextContextMenuItem();
 
             // Assert
-            Assert.AreEqual(selectedItem.ContextMenuSelectedIndex, 0);
+            Assert.AreEqual(0, selectedItem.ContextMenuSelectedIndex);
         }
 
         [Test]
@@ -65,7 +65,7 @@ namespace Wox.Test
             rvm.SelectNextContextMenuItem();
 
             // Assert
-            Assert.AreEqual(selectedItem.ContextMenuSelectedIndex, 0);
+            Assert.AreEqual(0, selectedItem.ContextMenuSelectedIndex);
         }
 
         [Test]
@@ -96,7 +96,7 @@ namespace Wox.Test
             rvm.SelectPreviousContextMenuItem();
 
             // Assert
-            Assert.AreEqual(selectedItem.ContextMenuSelectedIndex, 1);
+            Assert.AreEqual(1, selectedItem.ContextMenuSelectedIndex);
         }
 
         [Test]
@@ -117,7 +117,7 @@ namespace Wox.Test
             rvm.SelectPreviousContextMenuItem();
 
             // Assert
-            Assert.AreEqual(selectedItem.ContextMenuSelectedIndex, ResultViewModel.NoSelectionIndex);
+            Assert.AreEqual(ResultViewModel.NoSelectionIndex, selectedItem.ContextMenuSelectedIndex);
         }
 
         [Test]

--- a/src/modules/previewpane/PreviewPaneUnitTests/HTMLParsingExtensionTest.cs
+++ b/src/modules/previewpane/PreviewPaneUnitTests/HTMLParsingExtensionTest.cs
@@ -31,7 +31,8 @@ namespace PreviewPaneUnitTests
             string html = Markdown.ToHtml(mdString, markdownPipeline);
 
             // Assert
-            Assert.AreEqual(html, "<table class=\"table table-striped table-bordered\">\n<thead>\n<tr>\n<th>A</th>\n<th>B</th>\n</tr>\n</thead>\n</table>\n");
+            const string expected = "<table class=\"table table-striped table-bordered\">\n<thead>\n<tr>\n<th>A</th>\n<th>B</th>\n</tr>\n</thead>\n</table>\n";
+            Assert.AreEqual(expected, html);
         }
 
         [TestMethod]
@@ -46,7 +47,8 @@ namespace PreviewPaneUnitTests
             string html = Markdown.ToHtml(mdString, markdownPipeline);
 
             // Assert
-            Assert.AreEqual(html, "<blockquote class=\"blockquote\">\n<p>Blockquotes.</p>\n</blockquote>\n");
+            const string expected = "<blockquote class=\"blockquote\">\n<p>Blockquotes.</p>\n</blockquote>\n";
+            Assert.AreEqual(expected, html);
         }
 
         [TestMethod]
@@ -61,7 +63,8 @@ namespace PreviewPaneUnitTests
             string html = Markdown.ToHtml(mdString, markdownPipeline);
 
             // Assert
-            Assert.AreEqual(html, "<p><img src=\"#\" class=\"img-fluid\" alt=\"text\" title=\"Figure\" /></p>\n");
+            const string expected = "<p><img src=\"#\" class=\"img-fluid\" alt=\"text\" title=\"Figure\" /></p>\n";
+            Assert.AreEqual(expected, html);
         }
 
         [TestMethod]
@@ -76,7 +79,8 @@ namespace PreviewPaneUnitTests
             string html = Markdown.ToHtml(mdString, markdownPipeline);
 
             // Assert
-            Assert.AreEqual(html, "<figure class=\"figure\">\n<figcaption class=\"figure-caption\">This is a caption</figcaption>\n</figure>\n");
+            const string expected = "<figure class=\"figure\">\n<figcaption class=\"figure-caption\">This is a caption</figcaption>\n</figure>\n";
+            Assert.AreEqual(expected, html);
         }
 
         [TestMethod]
@@ -92,8 +96,9 @@ namespace PreviewPaneUnitTests
             string html = Markdown.ToHtml(mdString, markdownPipeline);
 
             // Assert
-            Assert.AreEqual(count, 1);
-            Assert.AreEqual(html, "<p><img src=\"#\" class=\"img-fluid\" alt=\"text\" title=\"Figure\" /></p>\n");
+            Assert.AreEqual(1, count);
+            const string expected = "<p><img src=\"#\" class=\"img-fluid\" alt=\"text\" title=\"Figure\" /></p>\n";
+            Assert.AreEqual(expected, html);
         }
     }
 }

--- a/src/modules/previewpane/PreviewPaneUnitTests/MarkdownPreviewHandlerTest.cs
+++ b/src/modules/previewpane/PreviewPaneUnitTests/MarkdownPreviewHandlerTest.cs
@@ -23,7 +23,7 @@ namespace PreviewPaneUnitTests
                 markdownPreviewHandlerControl.DoPreview<string>("HelperFiles/MarkdownWithExternalImage.txt");
 
                 // Assert
-                Assert.AreEqual(markdownPreviewHandlerControl.Controls.Count, 2);
+                Assert.AreEqual(2, markdownPreviewHandlerControl.Controls.Count);
                 Assert.IsInstanceOfType(markdownPreviewHandlerControl.Controls[0], typeof(WebBrowserExt));
             }
         }
@@ -38,7 +38,7 @@ namespace PreviewPaneUnitTests
                 markdownPreviewHandlerControl.DoPreview<string>("HelperFiles/MarkdownWithExternalImage.txt");
 
                 // Assert
-                Assert.AreEqual(markdownPreviewHandlerControl.Controls.Count, 2);
+                Assert.AreEqual(2, markdownPreviewHandlerControl.Controls.Count);
                 Assert.IsInstanceOfType(markdownPreviewHandlerControl.Controls[1], typeof(RichTextBox));
             }
         }
@@ -53,7 +53,7 @@ namespace PreviewPaneUnitTests
                 markdownPreviewHandlerControl.DoPreview<string>("HelperFiles/MarkdownWithHTMLImageTag.txt");
 
                 // Assert
-                Assert.AreEqual(markdownPreviewHandlerControl.Controls.Count, 2);
+                Assert.AreEqual(2, markdownPreviewHandlerControl.Controls.Count);
                 Assert.IsInstanceOfType(markdownPreviewHandlerControl.Controls[1], typeof(RichTextBox));
             }
         }
@@ -68,7 +68,7 @@ namespace PreviewPaneUnitTests
                 markdownPreviewHandlerControl.DoPreview<string>("HelperFiles/MarkdownWithScript.txt");
 
                 // Assert
-                Assert.AreEqual(markdownPreviewHandlerControl.Controls.Count, 1);
+                Assert.AreEqual(1, markdownPreviewHandlerControl.Controls.Count);
                 Assert.IsInstanceOfType(markdownPreviewHandlerControl.Controls[0], typeof(WebBrowserExt));
             }
         }
@@ -85,11 +85,11 @@ namespace PreviewPaneUnitTests
                 // Assert
                 Assert.IsInstanceOfType(markdownPreviewHandlerControl.Controls[0], typeof(WebBrowserExt));
                 Assert.IsNotNull(((WebBrowser)markdownPreviewHandlerControl.Controls[0]).DocumentText);
-                Assert.AreEqual(((WebBrowser)markdownPreviewHandlerControl.Controls[0]).Dock, DockStyle.Fill);
-                Assert.AreEqual(((WebBrowser)markdownPreviewHandlerControl.Controls[0]).IsWebBrowserContextMenuEnabled, false);
-                Assert.AreEqual(((WebBrowser)markdownPreviewHandlerControl.Controls[0]).ScriptErrorsSuppressed, true);
-                Assert.AreEqual(((WebBrowser)markdownPreviewHandlerControl.Controls[0]).ScrollBarsEnabled, true);
-                Assert.AreEqual(((WebBrowser)markdownPreviewHandlerControl.Controls[0]).AllowNavigation, false);
+                Assert.AreEqual(DockStyle.Fill, ((WebBrowser)markdownPreviewHandlerControl.Controls[0]).Dock);
+                Assert.AreEqual(false, ((WebBrowser)markdownPreviewHandlerControl.Controls[0]).IsWebBrowserContextMenuEnabled);
+                Assert.AreEqual(true, ((WebBrowser)markdownPreviewHandlerControl.Controls[0]).ScriptErrorsSuppressed);
+                Assert.AreEqual(true, ((WebBrowser)markdownPreviewHandlerControl.Controls[0]).ScrollBarsEnabled);
+                Assert.AreEqual(false, ((WebBrowser)markdownPreviewHandlerControl.Controls[0]).AllowNavigation);
             }
         }
 
@@ -105,10 +105,10 @@ namespace PreviewPaneUnitTests
                 // Assert
                 Assert.IsInstanceOfType(markdownPreviewHandlerControl.Controls[1], typeof(RichTextBox));
                 Assert.IsNotNull(((RichTextBox)markdownPreviewHandlerControl.Controls[1]).Text);
-                Assert.AreEqual(((RichTextBox)markdownPreviewHandlerControl.Controls[1]).Dock, DockStyle.Top);
-                Assert.AreEqual(((RichTextBox)markdownPreviewHandlerControl.Controls[1]).BorderStyle, BorderStyle.None);
-                Assert.AreEqual(((RichTextBox)markdownPreviewHandlerControl.Controls[1]).BackColor, Color.LightYellow);
-                Assert.AreEqual(((RichTextBox)markdownPreviewHandlerControl.Controls[1]).Multiline, true);
+                Assert.AreEqual(DockStyle.Top, ((RichTextBox)markdownPreviewHandlerControl.Controls[1]).Dock);
+                Assert.AreEqual(BorderStyle.None, ((RichTextBox)markdownPreviewHandlerControl.Controls[1]).BorderStyle);
+                Assert.AreEqual(Color.LightYellow, ((RichTextBox)markdownPreviewHandlerControl.Controls[1]).BackColor);
+                Assert.AreEqual(true, ((RichTextBox)markdownPreviewHandlerControl.Controls[1]).Multiline);
             }
         }
     }

--- a/src/modules/previewpane/UnitTests-PreviewHandlerCommon/FileBasedPreviewHandlerTests.cs
+++ b/src/modules/previewpane/UnitTests-PreviewHandlerCommon/FileBasedPreviewHandlerTests.cs
@@ -38,7 +38,7 @@ namespace PreviewHandlerCommonUnitTests
             fileBasedPreviewHandler.Initialize(filePath, grfMode);
 
             // Assert
-            Assert.AreEqual(fileBasedPreviewHandler.FilePath, filePath);
+            Assert.AreEqual(filePath, fileBasedPreviewHandler.FilePath);
         }
     }
 }

--- a/src/modules/previewpane/UnitTests-PreviewHandlerCommon/StreamBasedPreviewHandlerTests.cs
+++ b/src/modules/previewpane/UnitTests-PreviewHandlerCommon/StreamBasedPreviewHandlerTests.cs
@@ -39,7 +39,7 @@ namespace PreviewHandlerCommonUnitTests
             streamBasedPreviewHandler.Initialize(stream, grfMode);
 
             // Assert
-            Assert.AreEqual(streamBasedPreviewHandler.Stream, stream);
+            Assert.AreEqual(stream, streamBasedPreviewHandler.Stream);
         }
     }
 }

--- a/src/modules/previewpane/UnitTests-PreviewHandlerCommon/StreamWrapperTests.cs
+++ b/src/modules/previewpane/UnitTests-PreviewHandlerCommon/StreamWrapperTests.cs
@@ -50,7 +50,7 @@ namespace PreviewHandlerCommonUnitTests
             using (var streamWrapper = new ReadonlyStream(streamMock.Object))
             {
                 // Assert
-                Assert.AreEqual(streamWrapper.CanRead, true);
+                Assert.AreEqual(true, streamWrapper.CanRead);
             }
         }
 
@@ -64,7 +64,7 @@ namespace PreviewHandlerCommonUnitTests
             using (var streamWrapper = new ReadonlyStream(streamMock.Object))
             {
                 // Assert
-                Assert.AreEqual(streamWrapper.CanSeek, true);
+                Assert.AreEqual(true, streamWrapper.CanSeek);
             }
         }
 
@@ -78,7 +78,7 @@ namespace PreviewHandlerCommonUnitTests
             using (var streamWrapper = new ReadonlyStream(streamMock.Object))
             {
                 // Assert
-                Assert.AreEqual(streamWrapper.CanWrite, false);
+                Assert.AreEqual(false, streamWrapper.CanWrite);
             }
         }
 
@@ -101,7 +101,7 @@ namespace PreviewHandlerCommonUnitTests
                 var actualLength = streamWrapper.Length;
 
                 // Assert
-                Assert.AreEqual(actualLength, streamLength);
+                Assert.AreEqual(streamLength, actualLength);
             }
         }
 
@@ -127,7 +127,7 @@ namespace PreviewHandlerCommonUnitTests
                 var actualPosition = streamWrapper.Position;
 
                 // Assert
-                Assert.AreEqual(actualPosition, currPosition);
+                Assert.AreEqual(currPosition, actualPosition);
                 streamMock.Verify(_ => _.Seek(It.Is<long>(offset => offset == expectedOffset), It.Is<int>(dworigin => dworigin == expectedDwOrigin), It.IsAny<IntPtr>()), Times.Once);
             }
         }
@@ -207,7 +207,7 @@ namespace PreviewHandlerCommonUnitTests
                 var actualPosition = streamWrapper.Seek(0, SeekOrigin.Begin);
 
                 // Assert
-                Assert.AreEqual(position, actualPosition);
+                Assert.AreEqual(actualPosition, position);
             }
         }
 

--- a/src/modules/previewpane/UnitTests-SvgPreviewHandler/SvgPreviewControlTests.cs
+++ b/src/modules/previewpane/UnitTests-SvgPreviewHandler/SvgPreviewControlTests.cs
@@ -28,7 +28,7 @@ namespace SvgPreviewHandlerUnitTests
                 svgPreviewControl.DoPreview(GetMockStream("<svg></svg>"));
 
                 // Assert
-                Assert.AreEqual(svgPreviewControl.Controls.Count, 1);
+                Assert.AreEqual(1, svgPreviewControl.Controls.Count);
                 Assert.IsInstanceOfType(svgPreviewControl.Controls[0], typeof(WebBrowserExt));
             }
         }
@@ -57,7 +57,7 @@ namespace SvgPreviewHandlerUnitTests
                 svgPreviewControl.DoPreview(GetMockStream("<svg></svg>"));
 
                 // Assert
-                Assert.AreEqual(((WebBrowser)svgPreviewControl.Controls[0]).IsWebBrowserContextMenuEnabled, false);
+                Assert.AreEqual(false, ((WebBrowser)svgPreviewControl.Controls[0]).IsWebBrowserContextMenuEnabled);
             }
         }
 
@@ -71,7 +71,7 @@ namespace SvgPreviewHandlerUnitTests
                 svgPreviewControl.DoPreview(GetMockStream("<svg></svg>"));
 
                 // Assert
-                Assert.AreEqual(((WebBrowser)svgPreviewControl.Controls[0]).Dock, DockStyle.Fill);
+                Assert.AreEqual(DockStyle.Fill, ((WebBrowser)svgPreviewControl.Controls[0]).Dock);
             }
         }
 
@@ -85,7 +85,7 @@ namespace SvgPreviewHandlerUnitTests
                 svgPreviewControl.DoPreview(GetMockStream("<svg></svg>"));
 
                 // Assert
-                Assert.AreEqual(((WebBrowser)svgPreviewControl.Controls[0]).ScriptErrorsSuppressed, true);
+                Assert.AreEqual(true, ((WebBrowser)svgPreviewControl.Controls[0]).ScriptErrorsSuppressed);
             }
         }
 
@@ -99,7 +99,7 @@ namespace SvgPreviewHandlerUnitTests
                 svgPreviewControl.DoPreview(GetMockStream("<svg></svg>"));
 
                 // Assert
-                Assert.AreEqual(((WebBrowser)svgPreviewControl.Controls[0]).ScrollBarsEnabled, true);
+                Assert.AreEqual(true, ((WebBrowser)svgPreviewControl.Controls[0]).ScrollBarsEnabled);
             }
         }
 
@@ -113,7 +113,7 @@ namespace SvgPreviewHandlerUnitTests
                 svgPreviewControl.DoPreview(GetMockStream("<svg></svg>"));
 
                 // Assert
-                Assert.AreEqual(((WebBrowser)svgPreviewControl.Controls[0]).AllowNavigation, false);
+                Assert.AreEqual(false, ((WebBrowser)svgPreviewControl.Controls[0]).AllowNavigation);
             }
         }
 
@@ -134,13 +134,13 @@ namespace SvgPreviewHandlerUnitTests
 
                 // Assert
                 Assert.IsFalse(string.IsNullOrWhiteSpace(textBox.Text));
-                Assert.AreEqual(svgPreviewControl.Controls.Count, 1);
-                Assert.AreEqual(textBox.Dock, DockStyle.Top);
-                Assert.AreEqual(textBox.BackColor, Color.LightYellow);
+                Assert.AreEqual(1, svgPreviewControl.Controls.Count);
+                Assert.AreEqual(DockStyle.Top, textBox.Dock);
+                Assert.AreEqual(Color.LightYellow, textBox.BackColor);
                 Assert.IsTrue(textBox.Multiline);
                 Assert.IsTrue(textBox.ReadOnly);
-                Assert.AreEqual(textBox.ScrollBars, RichTextBoxScrollBars.None);
-                Assert.AreEqual(textBox.BorderStyle, BorderStyle.None);
+                Assert.AreEqual(RichTextBoxScrollBars.None, textBox.ScrollBars);
+                Assert.AreEqual(BorderStyle.None, textBox.BorderStyle);
             }
         }
 
@@ -165,8 +165,8 @@ namespace SvgPreviewHandlerUnitTests
                 svgPreviewControl.Width += incrementParentControlWidth;
 
                 // Assert
-                Assert.AreEqual(initialParentWidth, initialTextBoxWidth);
-                Assert.AreEqual(finalParentWidth, textBox.Width);
+                Assert.AreEqual(initialTextBoxWidth, initialParentWidth);
+                Assert.AreEqual(textBox.Width, finalParentWidth);
             }
         }
 
@@ -187,7 +187,7 @@ namespace SvgPreviewHandlerUnitTests
                 // Assert
                 Assert.IsInstanceOfType(svgPreviewControl.Controls[0], typeof(RichTextBox));
                 Assert.IsInstanceOfType(svgPreviewControl.Controls[1], typeof(WebBrowserExt));
-                Assert.AreEqual(svgPreviewControl.Controls.Count, 2);
+                Assert.AreEqual(2, svgPreviewControl.Controls.Count);
             }
         }
 
@@ -208,7 +208,7 @@ namespace SvgPreviewHandlerUnitTests
 
                 // Assert
                 Assert.IsInstanceOfType(svgPreviewControl.Controls[0], typeof(WebBrowserExt));
-                Assert.AreEqual(svgPreviewControl.Controls.Count, 1);
+                Assert.AreEqual(1, svgPreviewControl.Controls.Count);
             }
         }
 
@@ -233,8 +233,8 @@ namespace SvgPreviewHandlerUnitTests
                 svgPreviewControl.Width += incrementParentControlWidth;
 
                 // Assert
-                Assert.AreEqual(initialParentWidth, initialTextBoxWidth);
-                Assert.AreEqual(finalParentWidth, textBox.Width);
+                Assert.AreEqual(initialTextBoxWidth, initialParentWidth);
+                Assert.AreEqual(textBox.Width, finalParentWidth);
             }
         }
 

--- a/src/tests/win-app-driver/FancyZonesTests/EditorGridZoneResizeTests.cs
+++ b/src/tests/win-app-driver/FancyZonesTests/EditorGridZoneResizeTests.cs
@@ -176,10 +176,10 @@ namespace PowerToysTests
             Assert.AreEqual(4, zones.Count);
 
             //check splitted zone 
-            Assert.AreEqual(zones[0].Rect.Top, defaultSpacing);
+            Assert.AreEqual(defaultSpacing, zones[0].Rect.Top);
             Assert.IsTrue(Math.Abs(zones[0].Rect.Bottom - splitPos + defaultSpacing / 2) <= 2);
             Assert.IsTrue(Math.Abs(zones[1].Rect.Top - splitPos - defaultSpacing / 2) <= 2);
-            Assert.AreEqual(zones[1].Rect.Bottom, Screen.PrimaryScreen.Bounds.Bottom - defaultSpacing);
+            Assert.AreEqual(Screen.PrimaryScreen.Bounds.Bottom - defaultSpacing, zones[1].Rect.Bottom);
         }
 
         [TestMethod]
@@ -201,10 +201,10 @@ namespace PowerToysTests
             zones = gridEditor.FindElementsByClassName("GridZone");
             Assert.AreEqual(4, zones.Count);
 
-            Assert.AreEqual(zones[0].Rect.Top, defaultSpacing);
+            Assert.AreEqual(defaultSpacing, zones[0].Rect.Top);
             Assert.IsTrue(Math.Abs(zones[0].Rect.Bottom - firstSplitPos + defaultSpacing / 2) <= 2);
             Assert.IsTrue(Math.Abs(zones[1].Rect.Top - firstSplitPos - defaultSpacing / 2) <= 2);
-            Assert.AreEqual(zones[3].Rect.Bottom, Screen.PrimaryScreen.Bounds.Bottom - defaultSpacing);
+            Assert.AreEqual(Screen.PrimaryScreen.Bounds.Bottom - defaultSpacing, zones[3].Rect.Bottom);
 
             //create second split
             int secondSplitPos = zones[3].Rect.Y + zones[3].Rect.Height / 2;
@@ -216,14 +216,14 @@ namespace PowerToysTests
             Assert.AreEqual(5, zones.Count);
 
             //check first split on same position
-            Assert.AreEqual(zones[0].Rect.Top, defaultSpacing);
+            Assert.AreEqual(defaultSpacing, zones[0].Rect.Top);
             Assert.IsTrue(Math.Abs(zones[0].Rect.Bottom - firstSplitPos + defaultSpacing / 2) <= 2);
 
             //check second split
-            Assert.AreEqual(zones[3].Rect.Top, expectedTop);
+            Assert.AreEqual(expectedTop, zones[3].Rect.Top);
             Assert.IsTrue(Math.Abs(zones[3].Rect.Bottom - secondSplitPos + defaultSpacing / 2) <= 2);
             Assert.IsTrue(Math.Abs(zones[4].Rect.Top - secondSplitPos - defaultSpacing / 2) <= 2);
-            Assert.AreEqual(zones[4].Rect.Bottom, Screen.PrimaryScreen.Bounds.Bottom - defaultSpacing);
+            Assert.AreEqual(Screen.PrimaryScreen.Bounds.Bottom - defaultSpacing, zones[4].Rect.Bottom);
         }
 
         [TestMethod]


### PR DESCRIPTION
## Summary of the Pull Request

Assert was switched in these instances, so I changed it to the "expected, actual".

## PR Checklist
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

I started to implement #6920 and I noticed some weird error messages. It looked liked the expected and actual were switched. This repairs it so the values will be in the right method position.

## Validation Steps Performed

Use the tests.
