### PR TITLE
[PT runner] Misplaced 'return' statement fix.

### DIFF
--- a/src/runner/settings_window.cpp
+++ b/src/runner/settings_window.cpp
@@ -100,9 +100,9 @@ std::optional<std::wstring> dispatch_json_action_to_module(const json::JsonObjec
             const auto element = powertoy_element.Value().Stringify();
             modules().at(name)->call_custom_action(element.c_str());
         }
-
-        return result;
     }
+
+    return result;
 }
 
 void send_json_config_to_module(const std::wstring& module_key, const std::wstring& settings)


### PR DESCRIPTION
## Summary of the Pull Request

The return statement was not correctly placed in the [runner/settings_window.cpp](https://github.com/microsoft/PowerToys/blob/274c009f208a02515b6d5d405692b2e01bf439e5/src/runner/settings_window.cpp#L104). It's been taken out of the loop.

## PR Checklist
* [x] Applies to #7199
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
