### PR TITLE
[KBM] Change declaration order of _delayThread member in KeyDelay

### DIFF
--- a/src/modules/keyboardmanager/common/KeyDelay.h
+++ b/src/modules/keyboardmanager/common/KeyDelay.h
@@ -63,7 +63,6 @@ private:
     // Also checks for overflow conditions.
     bool CheckIfMillisHaveElapsed(DWORD64 first, DWORD64 last, DWORD64 duration);
 
-    std::thread _delayThread;
     bool _quit;
     KeyDelayState _state;
 
@@ -85,6 +84,9 @@ private:
 
     // Virtual Key provided in the constructor. Passed to callback functions.
     DWORD _key;
+
+    // Declare _delayThread after all other members so that it is the last to be initialized by the constructor
+    std::thread _delayThread;
 
     static const DWORD64 LONG_PRESS_DELAY_MILLIS = 900;
     static const DWORD64 ON_HOLD_WAIT_TIMEOUT_MILLIS = 50;


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
Move `_delayThread` declaration to occur after all the members of the KeyDelay class. The reason for this being there could be cases where the thread starts before the other members are initialized, causing failures such as the mtx_do_lock exception in the linked issue as a result of the mutex not being initialized before the thread starts. (See highlighted point in the docs below)
These cpp docs https://en.cppreference.com/w/cpp/language/constructor mention the following:

**Initialization order**
The order of member initializers in the list is irrelevant: the actual order of initialization is as follows:

1) If the constructor is for the most-derived class, virtual bases are initialized in the order in which they appear in depth-first left-to-right traversal of the base class declarations (left-to-right refers to the appearance in base-specifier lists)
2) Then, direct bases are initialized in left-to-right order as they appear in this class's base-specifier list
3) **Then, non-static data member are initialized in order of declaration in the class definition.**
4) Finally, the body of the constructor is executed
(Note: if initialization order was controlled by the appearance in the member initializer lists of different constructors, then the destructor wouldn't be able to ensure that the order of destruction is the reverse of the order of construction)


## PR Checklist
* [X] Applies to #6504 (might fix the issue, but we don't have a proper repro, apart from the accidental repro that @ryanbodrug-microsoft got
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [X] Tests passed

## Validation Steps Performed

_How does someone test & validate?_
Built the solution, and pressed the Type button in KBM, didnt see a crash (doesn't validate that the bug is fixed).