### PR TITLE
[PowerToys Run] Improve startup performance of PT Run's Programs (Win32ProgramRepository) plugin

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32Program.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32Program.cs
@@ -890,16 +890,18 @@ namespace Microsoft.Plugin.Program.Programs
         // Overriding the object.GetHashCode() function to aid in removing duplicates while adding and removing apps from the concurrent dictionary storage
         public override int GetHashCode()
         {
-            return new RemoveDuplicatesComparer().GetHashCode(this);
+            return RemoveDuplicatesComparer.Default.GetHashCode(this);
         }
 
         public override bool Equals(object obj)
         {
-            return obj is Win32Program win && new RemoveDuplicatesComparer().Equals(this, win);
+            return obj is Win32Program win && RemoveDuplicatesComparer.Default.Equals(this, win);
         }
 
         private class RemoveDuplicatesComparer : IEqualityComparer<Win32Program>
         {
+            public static readonly RemoveDuplicatesComparer Default = new RemoveDuplicatesComparer();
+
             public bool Equals(Win32Program app1, Win32Program app2)
             {
                 if (!string.IsNullOrEmpty(app1.Name) && !string.IsNullOrEmpty(app2.Name)
@@ -933,9 +935,8 @@ namespace Microsoft.Plugin.Program.Programs
         // Deduplication code
         public static Win32Program[] DeduplicatePrograms(ParallelQuery<Win32Program> programs)
         {
-            var uniqueExePrograms = programs.Where(x => !(string.IsNullOrEmpty(x.LnkResolvedPath) && ExecutableApplicationExtensions.Contains(Extension(x.FullPath)) && !(x.AppType == ApplicationType.RunCommand)));
-            var uniquePrograms = uniqueExePrograms.Distinct(new RemoveDuplicatesComparer());
-            return uniquePrograms.ToArray();
+            var uniqueExePrograms = programs.Where(x => !(string.IsNullOrEmpty(x.LnkResolvedPath) && ExecutableApplicationExtensions.Contains(Extension(x.FullPath)) && x.AppType != ApplicationType.RunCommand));
+            return new HashSet<Win32Program>(uniqueExePrograms, new RemoveDuplicatesComparer()).ToArray();
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Keeping the process alive but logging the exception")]


### PR DESCRIPTION
## Summary of the Pull Request

I noticed the #7208 which mentioned the slow startup speed of PT Run (Which sometimes is anoying indeed, but it is just a one time hit. So i was curious what it was! In VS I stepped through the Programs.Win32Program.All(_settings); method to see what was slow and i noticed most of the time  was spent on the Deduplicating. So i guessed a set might be faster and validated this.

## PR Checklist
* [X] Applies to #7208
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [X] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

Performance improvement of about x6 on my machine.

## Validation Steps Performed

The following checks i have performed,

- With a debugger break on the entrance / exit of DeduplicatePrograms and let VS show me how long it took to hit the previous breakpoint.

- Use dotTrace to verify the above in Release mode.