### PR TITLE
[PowerToys Run] Fixed wrong name logged in Program Plugin

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Main.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Plugin.Program
 
             var b = Task.Run(() =>
             {
-                Stopwatch.Normal("|Microsoft.Plugin.Program.Main|Win32Program index cost", _packageRepository.IndexPrograms);
+                Stopwatch.Normal("|Microsoft.Plugin.Program.Main|Package index cost", _packageRepository.IndexPrograms);
             });
 
             Task.WaitAll(a, b);


### PR DESCRIPTION
## Summary of the Pull Request

Fixes the duplicate Win32Program Index cost rule, when one is actually for indexing the packages (UWP applications)

Previously.
![image](https://user-images.githubusercontent.com/16852398/95785662-71665a80-0cd6-11eb-8fa9-9b4594ec37cc.png)


## PR Checklist
* [ ] Applies to #xxx
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Validation Steps Performed

- Run the application and view the logs are not duplicate anymore :)