### PR TITLE
[FancyZones] Allow negative spacing between zones up to -10

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/Settings.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/Settings.cs
@@ -54,6 +54,8 @@ namespace FancyZonesEditor
         public const ushort _blankCustomModelId = 0xFFFA;
         public const ushort _lastDefinedId = _blankCustomModelId;
 
+        private const int MaxNegativeSpacing = -10;
+
         // Localizable strings
         private const string ErrorMessageBoxTitle = "FancyZones Editor Error";
         private const string ErrorParsingDeviceInfo = "Error parsing device info data.";
@@ -209,7 +211,7 @@ namespace FancyZonesEditor
             {
                 if (_spacing != value)
                 {
-                    _spacing = Math.Max(0, value);
+                    _spacing = Math.Max(MaxNegativeSpacing, value);
                     FirePropertyChanged();
                 }
             }

--- a/src/modules/fancyzones/lib/Zone.cpp
+++ b/src/modules/fancyzones/lib/Zone.cpp
@@ -15,7 +15,11 @@ namespace
     {
         int width  = rect.right - rect.left;
         int height = rect.bottom - rect.top;
-        return rect.left >= 0 && rect.right >= 0 && rect.top >= 0 && rect.bottom >= 0 && width >= 0 && height >= 0;
+        return rect.left   >= ZoneConstants::MAX_NEGATIVE_SPACING &&
+               rect.right  >= ZoneConstants::MAX_NEGATIVE_SPACING &&
+               rect.top    >= ZoneConstants::MAX_NEGATIVE_SPACING &&
+               rect.bottom >= ZoneConstants::MAX_NEGATIVE_SPACING &&
+               width >= 0 && height >= 0;
     }
 
     BOOL CALLBACK saveDisplayToVector(HMONITOR monitor, HDC hdc, LPRECT rect, LPARAM data)

--- a/src/modules/fancyzones/lib/Zone.h
+++ b/src/modules/fancyzones/lib/Zone.h
@@ -1,5 +1,10 @@
 #pragma once
 
+namespace ZoneConstants
+{
+    constexpr int MAX_NEGATIVE_SPACING = -10;
+}
+
 /**
  * Class representing one zone inside applied zone layout, which is basically wrapper around rectangle structure.
  */

--- a/src/modules/fancyzones/tests/UnitTests/ZoneSet.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/ZoneSet.Spec.cpp
@@ -156,7 +156,8 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (MakeZoneFromInvalidRectCoords)
             {
-                winrt::com_ptr<IZone> zone = MakeZone({ -1, -1, -1, -1 }, 1);
+                const int invalid = ZoneConstants::MAX_NEGATIVE_SPACING - 1;
+                winrt::com_ptr<IZone> zone = MakeZone({ invalid, invalid, invalid, invalid }, 1);
                 Assert::IsNull(zone.get());
             }
 
@@ -846,9 +847,9 @@ namespace FancyZonesUnitTests
                     }
                 }
 
-                TEST_METHOD (NegativeSpacing)
+                TEST_METHOD (LargeNegativeSpacing)
                 {
-                    const int spacing = -1;
+                    const int spacing = ZoneConstants::MAX_NEGATIVE_SPACING - 1;
                     const int zoneCount = 10;
 
                     for (int type = static_cast<int>(ZoneSetLayoutType::Focus); type < static_cast<int>(ZoneSetLayoutType::Custom); type++)


### PR DESCRIPTION
## Summary of the Pull Request

Allow negative spacing between zones, which will essentially result with overlapping windows. Maximum supported value is -10, although this can be changed.

## PR Checklist
* [x] Applies to #7160
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed

## Info on Pull Request

Introduce negative spacing functionality both to core FancyZones (lib) and to FancyZones Editor.

## Validation Steps Performed

Set negative spacing for some grid layout in editor, and perform few of the main FancyZones features (shift + drag, win + arrow etc.).
