### PR TITLE
[PT Run] Open folder using shell instead of explorer.exe

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/IShellAction.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/IShellAction.cs
@@ -6,7 +6,7 @@ using Wox.Plugin;
 
 namespace Microsoft.Plugin.Folder.Sources
 {
-    public interface IExplorerAction
+    public interface IShellAction
     {
         bool Execute(string sanitizedPath, IPublicAPI contextApi);
 

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/Result/CreateOpenCurrentFolderResult.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/Result/CreateOpenCurrentFolderResult.cs
@@ -2,26 +2,25 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Globalization;
 using Wox.Plugin;
 
 namespace Microsoft.Plugin.Folder.Sources.Result
 {
     public class CreateOpenCurrentFolderResult : IItemResult
     {
-        private readonly IShellAction _explorerAction;
+        private readonly IShellAction _shellAction;
 
-        public string Search { get; set;  }
+        public string Search { get; set; }
 
         public CreateOpenCurrentFolderResult(string search)
             : this(search, new ShellAction())
         {
         }
 
-        public CreateOpenCurrentFolderResult(string search, IShellAction explorerAction)
+        public CreateOpenCurrentFolderResult(string search, IShellAction shellAction)
         {
             Search = search;
-            _explorerAction = explorerAction;
+            _shellAction = shellAction;
         }
 
         public Wox.Plugin.Result Create(IPublicAPI contextApi)
@@ -33,7 +32,7 @@ namespace Microsoft.Plugin.Folder.Sources.Result
                 SubTitle = Properties.Resources.wox_plugin_folder_select_folder_first_result_subtitle,
                 IcoPath = Search,
                 Score = 500,
-                Action = c => _explorerAction.ExecuteSanitized(Search, contextApi),
+                Action = c => _shellAction.ExecuteSanitized(Search, contextApi),
             };
         }
     }

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/Result/CreateOpenCurrentFolderResult.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/Result/CreateOpenCurrentFolderResult.cs
@@ -9,16 +9,16 @@ namespace Microsoft.Plugin.Folder.Sources.Result
 {
     public class CreateOpenCurrentFolderResult : IItemResult
     {
-        private readonly IExplorerAction _explorerAction;
+        private readonly IShellAction _explorerAction;
 
         public string Search { get; set;  }
 
         public CreateOpenCurrentFolderResult(string search)
-            : this(search, new ExplorerAction())
+            : this(search, new ShellAction())
         {
         }
 
-        public CreateOpenCurrentFolderResult(string search, IExplorerAction explorerAction)
+        public CreateOpenCurrentFolderResult(string search, IShellAction explorerAction)
         {
             Search = search;
             _explorerAction = explorerAction;

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/Result/FileItemResult.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/Result/FileItemResult.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Plugin.Folder.Sources.Result
 {
     public class FileItemResult : IItemResult
     {
-        private static readonly IExplorerAction ExplorerAction = new ExplorerAction();
+        private static readonly IShellAction ExplorerAction = new ShellAction();
 
         public string FilePath { get; set; }
 

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/Result/FileItemResult.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/Result/FileItemResult.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Plugin.Folder.Sources.Result
 {
     public class FileItemResult : IItemResult
     {
-        private static readonly IShellAction ExplorerAction = new ShellAction();
+        private static readonly IShellAction ShellAction = new ShellAction();
 
         public string FilePath { get; set; }
 
@@ -27,7 +27,7 @@ namespace Microsoft.Plugin.Folder.Sources.Result
                 SubTitle = string.Format(CultureInfo.CurrentCulture, Properties.Resources.wox_plugin_folder_select_file_result_subtitle, FilePath),
                 IcoPath = FilePath,
                 TitleHighlightData = StringMatcher.FuzzySearch(Search, Path.GetFileName(FilePath)).MatchData,
-                Action = c => ExplorerAction.Execute(FilePath, contextApi),
+                Action = c => ShellAction.Execute(FilePath, contextApi),
                 ContextData = new SearchResult { Type = ResultType.File, FullPath = FilePath },
             };
             return result;

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/Result/FolderItemResult.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/Result/FolderItemResult.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Plugin.Folder.Sources.Result
 {
     public class FolderItemResult : IItemResult
     {
-        private static readonly IShellAction ExplorerAction = new ShellAction();
+        private static readonly IShellAction ShellAction = new ShellAction();
 
         public FolderItemResult()
         {
@@ -41,7 +41,7 @@ namespace Microsoft.Plugin.Folder.Sources.Result
                 QueryTextDisplay = Path,
                 TitleHighlightData = StringMatcher.FuzzySearch(Search, Title).MatchData,
                 ContextData = new SearchResult { Type = ResultType.Folder, FullPath = Path },
-                Action = c => ExplorerAction.Execute(Path, contextApi),
+                Action = c => ShellAction.Execute(Path, contextApi),
             };
         }
     }

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/Result/FolderItemResult.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/Result/FolderItemResult.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Plugin.Folder.Sources.Result
 {
     public class FolderItemResult : IItemResult
     {
-        private static readonly IExplorerAction ExplorerAction = new ExplorerAction();
+        private static readonly IShellAction ExplorerAction = new ShellAction();
 
         public FolderItemResult()
         {

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/UserFolderResult.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/UserFolderResult.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Plugin.Folder
 {
     public class UserFolderResult : IItemResult
     {
-        private readonly IExplorerAction _explorerAction = new ExplorerAction();
+        private readonly IShellAction _explorerAction = new ShellAction();
 
         public string Search { get; set; }
 

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/UserFolderResult.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/UserFolderResult.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Plugin.Folder
 {
     public class UserFolderResult : IItemResult
     {
-        private readonly IShellAction _explorerAction = new ShellAction();
+        private readonly IShellAction _shellAction = new ShellAction();
 
         public string Search { get; set; }
 
@@ -32,7 +32,7 @@ namespace Microsoft.Plugin.Folder
                 QueryTextDisplay = Path,
                 TitleHighlightData = StringMatcher.FuzzySearch(Search, Title).MatchData,
                 ContextData = new SearchResult { Type = ResultType.Folder, FullPath = Path },
-                Action = c => _explorerAction.Execute(Path, contextApi),
+                Action = c => _shellAction.Execute(Path, contextApi),
             };
         }
     }


### PR DESCRIPTION
## Summary of the Pull Request

Open a folder from PT Run should not use explorer.exe but the shell instead.

## PR Checklist
* [x] Applies to #4622
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #4622

## Info on Pull Request

PT Run is now opening folder using UseShellExecute instead of explorer.exe.

## Validation Steps Performed

- Check that PT Run is still opening folders as expected.
- Replace explorer.exe with an alternative and check that PT run is using the new one.
