### PR TITLE
Fix duplicate zone drawing

### DIFF
--- a/src/modules/fancyzones/lib/Settings.h
+++ b/src/modules/fancyzones/lib/Settings.h
@@ -30,7 +30,7 @@ struct Settings
     bool showZonesOnAllMonitors = false;
     bool spanZonesAcrossMonitors = false;
     bool makeDraggedWindowTransparent = true;
-    std::wstring zoneColor = L"#F5FCFF";
+    std::wstring zoneColor = L"#AACDFF";
     std::wstring zoneBorderColor = L"#FFFFFF";
     std::wstring zoneHighlightColor = L"#008CFF";
     int zoneHighlightOpacity = 50;

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -71,8 +71,7 @@ namespace ZoneWindowUtils
                          int hostZoneHighlightOpacity,
                          std::vector<winrt::com_ptr<IZone>> zones,
                          std::vector<size_t> highlightZone,
-                         bool flashMode,
-                         bool drawHints)
+                         bool flashMode)
     {
         PAINTSTRUCT ps;
         HDC oldHdc = hdc;
@@ -99,8 +98,7 @@ namespace ZoneWindowUtils
                                                      hostZoneHighlightOpacity,
                                                      zones,
                                                      highlightZone,
-                                                     flashMode,
-                                                     drawHints);
+                                                     flashMode);
             }
 
             EndBufferedPaint(bufferedPaint, TRUE);
@@ -170,7 +168,6 @@ private:
     std::wstring m_uniqueId; // Parsed deviceId + resolution + virtualDesktopId
     wil::unique_hwnd m_window{}; // Hidden tool window used to represent current monitor desktop work area.
     HWND m_windowMoveSize{};
-    bool m_drawHints{};
     bool m_flashMode{};
     winrt::com_ptr<IZoneSet> m_activeZoneSet;
     std::vector<winrt::com_ptr<IZoneSet>> m_zoneSets;
@@ -266,7 +263,6 @@ bool ZoneWindow::Init(IZoneWindowHost* host, HINSTANCE hinstance, HMONITOR monit
 IFACEMETHODIMP ZoneWindow::MoveSizeEnter(HWND window) noexcept
 {
     m_windowMoveSize = window;
-    m_drawHints = true;
     m_highlightZone = {};
     m_initialHighlightZone = {};
     ShowZoneWindow();
@@ -477,7 +473,6 @@ ZoneWindow::HideZoneWindow() noexcept
         ShowWindow(m_window.get(), SW_HIDE);
         m_keyLast = 0;
         m_windowMoveSize = nullptr;
-        m_drawHints = false;
         m_highlightZone = {};
     }
 }
@@ -629,7 +624,6 @@ void ZoneWindow::OnPaint(HDC hdc) noexcept
     std::vector<winrt::com_ptr<IZone>> zones{};
     std::vector<size_t> highlightZone = m_highlightZone;
     bool flashMode = m_flashMode;
-    bool drawHints = m_drawHints;
 
     if (hasActiveZoneSet)
     {
@@ -651,8 +645,7 @@ void ZoneWindow::OnPaint(HDC hdc) noexcept
                                          hostZoneHighlightOpacity,
                                          zones,
                                          highlightZone,
-                                         flashMode,
-                                         drawHints);
+                                         flashMode);
         } };
 
     if (m_animating)

--- a/src/modules/fancyzones/lib/ZoneWindowDrawing.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindowDrawing.cpp
@@ -114,11 +114,9 @@ namespace ZoneWindowDrawing
                            int zoneOpacity,
                            const std::vector<winrt::com_ptr<IZone>>& zones,
                            const std::vector<size_t>& highlightZones,
-                           bool flashMode,
-                           bool drawHints) noexcept
+                           bool flashMode) noexcept
     {
         //                                 { fillAlpha, fill, borderAlpha, border, thickness }
-        ColorSetting const colorHints{ OpacitySettingToAlpha(zoneOpacity), RGB(81, 92, 107), 255, RGB(104, 118, 138), -2 };
         ColorSetting colorViewer{ OpacitySettingToAlpha(zoneOpacity), 0, 255, RGB(40, 50, 60), -2 };
         ColorSetting colorHighlight{ OpacitySettingToAlpha(zoneOpacity), 0, 255, 0, -2 };
         ColorSetting const colorFlash{ OpacitySettingToAlpha(zoneOpacity), RGB(81, 92, 107), 200, RGB(104, 118, 138), -2 };
@@ -145,10 +143,7 @@ namespace ZoneWindowDrawing
                 {
                     DrawZone(hdc, colorFlash, zone, zones, flashMode);
                 }
-                else if (drawHints)
-                {
-                    DrawZone(hdc, colorHints, zone, zones, flashMode);
-                }
+                else
                 {
                     colorViewer.fill = zoneColor;
                     colorViewer.border = zoneBorderColor;

--- a/src/modules/fancyzones/lib/ZoneWindowDrawing.h
+++ b/src/modules/fancyzones/lib/ZoneWindowDrawing.h
@@ -26,6 +26,5 @@ namespace ZoneWindowDrawing
                            int zoneOpacity,
                            const std::vector<winrt::com_ptr<IZone>>& zones,
                            const std::vector<size_t>& highlightZones,
-                           bool flashMode,
-                           bool drawHints) noexcept;
+                           bool flashMode) noexcept;
 }


### PR DESCRIPTION
## Summary of the Pull Request

Right now we're drawing all zones twice most of the time. See issue #7279

## PR Checklist
* [x] Applies to #7279
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

Removed `drawHints` because it was not used and buggy anyway.

## Validation Steps Performed

Check that zones are colored properly.
