### PR TITLE
[VideoConferenceMute] Add camera overlay image preview to settings

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -517,7 +517,7 @@ Disabling this module or closing PowerToys will unmute the microphone and camera
   </data>
   <data name="VideoConference_SelectedMicrophone.Header" xml:space="preserve">
     <value>Selected microphone</value>
-  </data>  
+  </data>
   <data name="VideoConference_CameraOverlayImagePathHeader.Text" xml:space="preserve">
     <value>Camera overlay image</value>
   </data>
@@ -823,7 +823,7 @@ Disabling this module or closing PowerToys will unmute the microphone and camera
   </data>
   <data name="VideoConference_Microphone.Text" xml:space="preserve">
     <value>Microphone</value>
-  </data>  
+  </data>
   <data name="VideoConference_Toolbar.Text" xml:space="preserve">
     <value>Toolbar</value>
   </data>
@@ -841,5 +841,14 @@ Disabling this module or closing PowerToys will unmute the microphone and camera
   </data>
   <data name="FileExplorerPreview_PreviewPane_GroupSettings.Text" xml:space="preserve">
     <value>Preview Pane</value>
+  </data>
+  <data name="VideoConference_CameraOverlayImageAlt.AutomationProperties.Name" xml:space="preserve">
+    <value>Camera overlay image preview</value>
+  </data>
+  <data name="VideoConference_CameraOverlayImageBrowse.Content" xml:space="preserve">
+    <value>Browse</value>
+  </data>
+  <data name="VideoConference_CameraOverlayImageClear.Content" xml:space="preserve">
+    <value>Clear</value>
   </data>
 </root>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/VideoConference.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/VideoConference.xaml
@@ -107,24 +107,29 @@
             <TextBlock x:Uid="VideoConference_CameraOverlayImagePathHeader"
                        Margin="{StaticResource SmallTopMargin}"/>
 
-            <Border CornerRadius="4" Background="Yellow"
+            <Border CornerRadius="4"
                     HorizontalAlignment="Left"
                     Margin="{StaticResource XXSmallTopMargin}">
-                        <Image Width="240"
-                               Source="{Binding Mode=OneWay, Path=CameraImageOverlayPath}"/>
+                <Image Width="240"
+                       x:Uid="VideoConference_CameraOverlayImageAlt"
+                       ToolTipService.ToolTip="{Binding Mode=OneWay, Path=CameraImageOverlayPath}"
+                       Source="{Binding Mode=OneWay, Path=CameraImageOverlayPath}"/>
             </Border>
 
-            <StackPanel Orientation="Horizontal" Padding="0" Spacing="4" Margin="{StaticResource XXSmallTopMargin}">
-                <Button
-                        Height="32"
+            <StackPanel Orientation="Horizontal"
+                        Padding="0"
+                        Spacing="8"
+                        Margin="{StaticResource SmallTopMargin}">
+                <Button Height="32"
                         IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"
-                        Content="Browse"
+                        x:Uid="VideoConference_CameraOverlayImageBrowse"
                         Command="{Binding Mode=OneWay, Path=SelectOverlayImage}"
                         HorizontalContentAlignment="Left"
                         HorizontalAlignment="Left" />
+                
                 <Button IsEnabled="{Binding Mode=TwoWay, Path=IsEnabled}"
                         Height="32"
-                        Content="Clear"
+                        x:Uid="VideoConference_CameraOverlayImageClear"
                         Command="{Binding Mode=OneWay, Path=ClearOverlayImage}"
                         HorizontalAlignment="Left" />
             </StackPanel>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/VideoConference.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/VideoConference.xaml
@@ -107,15 +107,22 @@
             <TextBlock x:Uid="VideoConference_CameraOverlayImagePathHeader"
                        Margin="{StaticResource SmallTopMargin}"/>
 
+            <Border CornerRadius="4" Background="Yellow"
+                    HorizontalAlignment="Left"
+                    Margin="{StaticResource XXSmallTopMargin}">
+                        <Image Width="240"
+                               Source="{Binding Mode=OneWay, Path=CameraImageOverlayPath}"/>
+            </Border>
+
             <StackPanel Orientation="Horizontal" Padding="0" Spacing="4" Margin="{StaticResource XXSmallTopMargin}">
-                <Button Width="240"
+                <Button
                         Height="32"
                         IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"
-                        Content="{Binding Mode=TwoWay, Path=CameraImageOverlayPath}"
+                        Content="Browse"
                         Command="{Binding Mode=OneWay, Path=SelectOverlayImage}"
                         HorizontalContentAlignment="Left"
                         HorizontalAlignment="Left" />
-                <Button IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"
+                <Button IsEnabled="{Binding Mode=TwoWay, Path=IsEnabled}"
                         Height="32"
                         Content="Clear"
                         Command="{Binding Mode=OneWay, Path=ClearOverlayImage}"


### PR DESCRIPTION
## Summary of the Pull Request
This PR adds an image preview of the camera overlay image in settings. It tries to replicate the Windows 10 Settings UX when setting a new background.
- The path is shown when hovering over the image.
- Moved the Browse and Clear text to the resources file.
- The image provides feedback when using Narrator, meeting accessibility needs.

**Known 'issues':**
- The clear button is always enabled. If there's no image set, it should be disabled.
- When switching between images, there's a short flickering.

Both issues can be resolved by setting a default camera overlay image, tracked in issue https://github.com/microsoft/PowerToys/issues/6314#issuecomment-686401452. (@enricogior Do you want me to export those concepts and include them in the solution? Let me know what resolution you'd need.

![VideoConfImage2](https://user-images.githubusercontent.com/9866362/96111704-db9f1b00-0ee1-11eb-8de7-66475438db36.gif)


## PR Checklist
* [X] Applies to #6374 #6314
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx
