### PR TITLE
Remove Drop Down from combo box name as it is redundant

### DIFF
--- a/src/modules/keyboardmanager/dll/Resources.resx
+++ b/src/modules/keyboardmanager/dll/Resources.resx
@@ -265,7 +265,7 @@
     <value>Unexpected error</value>
   </data>
   <data name="Key_DropDown_Combobox" xml:space="preserve">
-    <value>Key Drop Down</value>
+    <value>Key</value>
   </data>
   <data name="Add_Key_Remap_Button" xml:space="preserve">
     <value>Add Key Remap</value>


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
Remove redundant part from a Combobox name.

## PR Checklist
* [X] Applies to #7088
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

## Validation Steps Performed

_How does someone test & validate?_
Check with the Narrator if combobox in Remap keys/Remap shortcuts windows have correct names that is they should not contain redundant `Drop Down`. As an alternative Accessibility Insight can be used. 
![image](https://user-images.githubusercontent.com/17161067/96128915-989f7080-0efe-11eb-89cc-599d46188b7f.png)

