### PR TITLE
Tweaked KBM comment, removed redundant assignment, and avoid sending key up for one case when not necessary

### DIFF
--- a/src/modules/keyboardmanager/dll/KeyboardEventHandlers.cpp
+++ b/src/modules/keyboardmanager/dll/KeyboardEventHandlers.cpp
@@ -386,9 +386,20 @@ namespace KeyboardEventHandlers
                     {
                         // 1 for releasing new key and original shortcut modifiers except the one released and dummy key
                         key_count = dest_size + src_size - 2 + KeyboardManagerConstants::DUMMY_KEY_EVENT_SIZE;
+                        bool isTargetKeyPressed = false;
+
                         // Do not send Disable key up
                         if (std::get<DWORD>(it->second.targetShortcut) == CommonSharedConstants::VK_DISABLED)
                         {
+                            key_count--;
+                        }
+                        else if (ii.GetVirtualKeyState(KeyboardManagerHelper::FilterArtificialKeys(std::get<DWORD>(it->second.targetShortcut))))
+                        {
+                            isTargetKeyPressed = true;
+                        }
+                        else
+                        {
+                            isTargetKeyPressed = false;
                             key_count--;
                         }
 
@@ -397,7 +408,7 @@ namespace KeyboardEventHandlers
 
                         // Release new key state
                         int i = 0;
-                        if (std::get<DWORD>(it->second.targetShortcut) != CommonSharedConstants::VK_DISABLED)
+                        if (std::get<DWORD>(it->second.targetShortcut) != CommonSharedConstants::VK_DISABLED && isTargetKeyPressed)
                         {
                             KeyboardManagerHelper::SetKeyEvent(keyEventList, i, INPUT_KEYBOARD, (WORD)KeyboardManagerHelper::FilterArtificialKeys(std::get<DWORD>(it->second.targetShortcut)), KEYEVENTF_KEYUP, KeyboardManagerConstants::KEYBOARDMANAGER_SHORTCUT_FLAG);
                             i++;
@@ -503,7 +514,7 @@ namespace KeyboardEventHandlers
                                 KeyboardManagerHelper::SetKeyEvent(keyEventList, i, INPUT_KEYBOARD, (WORD)KeyboardManagerHelper::FilterArtificialKeys(std::get<DWORD>(it->second.targetShortcut)), KEYEVENTF_KEYUP, KeyboardManagerConstants::KEYBOARDMANAGER_SHORTCUT_FLAG);
                                 i++;
 
-                                // Set original shortcut key down state except the action key and the released modifier
+                                // Set original shortcut key down state except the action key
                                 KeyboardManagerHelper::SetModifierKeyEvents(it->first, it->second.winKeyInvoked, keyEventList, i, true, KeyboardManagerConstants::KEYBOARDMANAGER_SHORTCUT_FLAG);
 
                                 // Send a dummy key event to prevent modifier press+release from being triggered. Example: Win+A->V, press Shift+Win+A and release A, since Win will be pressed here we need to send a dummy event after it

--- a/src/modules/keyboardmanager/dll/KeyboardEventHandlers.cpp
+++ b/src/modules/keyboardmanager/dll/KeyboardEventHandlers.cpp
@@ -542,8 +542,6 @@ namespace KeyboardEventHandlers
                     {
                         if (remapToShortcut)
                         {
-                            it->second.isShortcutInvoked = true;
-
                             // Modifier state reset might be required for this key depending on the target shortcut action key - ex: Ctrl+A -> Win+Caps
                             if (std::get<Shortcut>(it->second.targetShortcut).GetCtrlKey() == NULL && std::get<Shortcut>(it->second.targetShortcut).GetAltKey() == NULL && std::get<Shortcut>(it->second.targetShortcut).GetShiftKey() == NULL)
                             {


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
This PR makes the tweaks mentioned in the title, found when writing the documentation for KBM.

- Corrected a comment
- Removed redundant assignment to isShortcutInvoked
- Send key up for target key only if it is pressed (since action key can be released without resetting the state).

## PR Checklist
* [X] Applies to #7337 
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [X] Tests passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

## Validation Steps Performed

_How does someone test & validate?_
Tests passed. This should be sufficient.
For extra validate, try remapping Win+Ctrl+A->B and check that pressing Win+Ctrl+A, releasing A, Ctrl, then Win works fine and start menu doesn't appear. Also check that pressing Win+Ctrl+A then releasing Win while Ctrl+A is still held selects all text in text editor.