### PR TITLE
[Image Resizer] Upgraded to .NET Core 3.1

### DIFF
--- a/PowerToys.sln
+++ b/PowerToys.sln
@@ -135,11 +135,11 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "KeyboardManager", "src\modu
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "imageresizer", "imageresizer", "{6C7F47CC-2151-44A3-A546-41C70025132C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImageResizerUI", "src\modules\imageresizer\ui\ImageResizerUI.csproj", "{2BE46397-4DFA-414C-9BD4-41E4BBF8CB34}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ImageResizerUI", "src\modules\imageresizer\ui\ImageResizerUI.csproj", "{2BE46397-4DFA-414C-9BD4-41E4BBF8CB34}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ImageResizerExt", "src\modules\imageresizer\dll\ImageResizerExt.vcxproj", "{0B43679E-EDFA-4DA0-AD30-F4628B308B1B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImageResizerUITest", "src\modules\imageresizer\tests\ImageResizerUITest.csproj", "{E0CC7526-D85E-43AC-844F-D5DF0D2F5AB8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ImageResizerUITest", "src\modules\imageresizer\tests\ImageResizerUITest.csproj", "{E0CC7526-D85E-43AC-844F-D5DF0D2F5AB8}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "KeyboardManagerUI", "src\modules\keyboardmanager\ui\KeyboardManagerUI.vcxproj", "{EAF23649-EF6E-478B-980E-81FAD96CCA2A}"
 EndProject

--- a/installer/PowerToysSetup/Product.wxs
+++ b/installer/PowerToysSetup/Product.wxs
@@ -492,14 +492,11 @@
         <File Source="$(var.BinX64Dir)modules\$(var.ImageResizerProjectName)\ImageResizer.exe">
           <netfx:NativeImage Id="ImageResizer.exe" Platform="all" Priority="0" />
         </File>
-        <File Source="$(var.BinX64Dir)modules\$(var.ImageResizerProjectName)\GalaSoft.MvvmLight.dll" />
-        <File Source="$(var.BinX64Dir)modules\$(var.ImageResizerProjectName)\GalaSoft.MvvmLight.Platform.dll" />
-        <File Source="$(var.BinX64Dir)modules\$(var.ImageResizerProjectName)\GalaSoft.MvvmLight.Extras.dll" />
-        <File Source="$(var.BinX64Dir)modules\$(var.ImageResizerProjectName)\System.Windows.Interactivity.dll">
-          <!-- NB: Needed since it's only referenced in XAML. -->
-          <netfx:NativeImage Id="Interactivity" Platform="all" Priority="0"/>
-        </File>
         <File Source="$(var.BinX64Dir)modules\$(var.ImageResizerProjectName)\Newtonsoft.Json.dll" />
+        <File Source="$(var.BinX64Dir)modules\$(var.ImageResizerProjectName)\ImageResizer.dll" />
+        <File Source="$(var.BinX64Dir)modules\$(var.ImageResizerProjectName)\ImageResizer.deps.json" />
+        <File Source="$(var.BinX64Dir)modules\$(var.ImageResizerProjectName)\ImageResizer.runtimeconfig.json" />
+        <File Id="Module_ImageResizer_Microsoft_Xaml_Behaviors" Source="$(var.BinX64Dir)modules\$(var.ImageResizerProjectName)\Microsoft.Xaml.Behaviors.dll" />
         <File Source="$(var.BinX64Dir)modules\$(var.ImageResizerProjectName)\ImageResizerExt.dll" KeyPath="yes" />		  
         <File Id="ImageResizer_interop" Source="$(var.BinX64Dir)modules\$(var.ImageResizerProjectName)\PowerToysInterop.dll" />
 

--- a/src/modules/imageresizer/tests/App.config
+++ b/src/modules/imageresizer/tests/App.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
-  </startup>
-</configuration>

--- a/src/modules/imageresizer/tests/ImageResizerUITest.csproj
+++ b/src/modules/imageresizer/tests/ImageResizerUITest.csproj
@@ -1,114 +1,44 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\..\Version.props" />
-  <!-- We don't have GenerateAssemblyInfo task until we use .net core, so we generate it with WriteLinesToFile -->
+  
   <PropertyGroup>
-    <AssemblyTitle>ImageResizerUITest</AssemblyTitle>
-    <AssemblyCompany>Microsoft Corp.</AssemblyCompany>
-    <AssemblyCopyright>Copyright (C) 2020 Microsoft Corp.</AssemblyCopyright>
-  </PropertyGroup>
-  <ItemGroup>
-    <AssemblyVersionFiles Include="Generated Files\AssemblyInfo.cs" />
-  </ItemGroup>
-  <Target Name="GenerateAssemblyInfo" BeforeTargets="PrepareForBuild">
-    <ItemGroup>
-      <HeaderLines Include="// Copyright (c) Microsoft Corporation" />
-      <HeaderLines Include="// The Microsoft Corporation licenses this file to you under the MIT license." />
-      <HeaderLines Include="// See the LICENSE file in the project root for more information." />
-      <HeaderLines Include="#pragma warning disable SA1516" />
-      <HeaderLines Include="using System.Reflection%3b" />
-      <HeaderLines Include="using System.Runtime.InteropServices%3b" />
-      <HeaderLines Include="using System.Windows%3b" />
-      <HeaderLines Include="[assembly: AssemblyTitle(&quot;$(AssemblyTitle)&quot;)]" />
-      <HeaderLines Include="[assembly: AssemblyDescription(&quot;&quot;)]" />
-      <HeaderLines Include="[assembly: AssemblyConfiguration(&quot;&quot;)]" />
-      <HeaderLines Include="[assembly: AssemblyCompany(&quot;$(AssemblyCompany)&quot;)]" />
-      <HeaderLines Include="[assembly: AssemblyCopyright(&quot;$(AssemblyCopyright)&quot;)]" />
-      <HeaderLines Include="[assembly: AssemblyProduct(&quot;$(AssemblyTitle)&quot;)]" />
-      <HeaderLines Include="[assembly: AssemblyTrademark(&quot;&quot;)]" />
-      <HeaderLines Include="[assembly: AssemblyCulture(&quot;&quot;)]" />
-      <HeaderLines Include="[assembly: ComVisible(false)]" />
-      <HeaderLines Include="[assembly: AssemblyVersion(&quot;$(Version).0&quot;)]" />
-      <HeaderLines Include="[assembly: AssemblyFileVersion(&quot;$(Version).0&quot;)]" />
-    </ItemGroup>
-    <WriteLinesToFile File="Generated Files\AssemblyInfo.cs" Lines="@(HeaderLines)" Overwrite="true" Encoding="Unicode" WriteOnlyWhenDifferent="true" />
-  </Target>
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">x64</Platform>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <ProjectGuid>{E0CC7526-D85E-43AC-844F-D5DF0D2F5AB8}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ImageResizer</RootNamespace>
     <AssemblyName>ImageResizer.Test</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile>
-    </TargetFrameworkProfile>
+    <AssemblyCompany>Microsoft Corp.</AssemblyCompany>
+    <AssemblyCopyright>Copyright (C) 2020 Microsoft Corp.</AssemblyCopyright>
+    <Version>$(Version).0</Version>
+    <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\modules\ImageResizer\$(AssemblyName)\</OutputPath>
+    <CodeAnalysisRuleSet>..\..\..\codeAnalysis\Rules.ruleset</CodeAnalysisRuleSet>
+    <Platforms>x64</Platforms>
+  </PropertyGroup>
+  
+  <PropertyGroup>
+    <Platform Condition="'$(Platform)'==''">x64</Platform>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IntermediateOutputPath>$(SolutionDir)$(Platform)\$(Configuration)\obj\$(AssemblyName)\</IntermediateOutputPath>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\modules\ImageResizer\$(AssemblyName)\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-    <CodeAnalysisRuleSet>..\..\..\codeAnalysis\Rules.ruleset</CodeAnalysisRuleSet>
+    
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\modules\ImageResizer\$(AssemblyName)\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-    <CodeAnalysisRuleSet>..\..\..\codeAnalysis\Rules.ruleset</CodeAnalysisRuleSet>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
+  
   <ItemGroup>
-    <Reference Include="PresentationCore" />
-    <Reference Include="System" />
-    <Reference Include="WindowsBase" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\ui\ImageResizerUI.csproj">
-      <Project>{2be46397-4dfa-414c-9bd4-41e4bbf8cb34}</Project>
-      <Name>ImageResizerUI</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\ui\ImageResizerUI.csproj" />
   </ItemGroup>
   <ItemGroup>
     <AdditionalFiles Include="..\..\..\codeAnalysis\StyleCop.json">
       <Link>StyleCop.json</Link>
     </AdditionalFiles>
-    <None Include="..\..\..\..\.editorconfig">
-      <Link>.editorconfig</Link>
-    </None>
-    <None Include="App.config">
-      <SubType>Designer</SubType>
-    </None>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\codeAnalysis\GlobalSuppressions.cs">
-      <Link>GlobalSuppressions.cs</Link>
-    </Compile>
-    <Compile Include="Generated Files\AssemblyInfo.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Models\CustomSizeTests.cs" />
-    <Compile Include="Models\ResizeSizeTests.cs" />
-    <Compile Include="Models\ResizeBatchTests.cs" />
-    <Compile Include="Models\ResizeOperationTests.cs" />
-    <Compile Include="Properties\AppFixture.cs" />
-    <Compile Include="Properties\SettingsTests.cs" />
-    <Compile Include="Test\AssertEx.cs" />
-    <Compile Include="Test\BitmapSourceExtensions.cs" />
-    <Compile Include="Test\TestDirectory.cs" />
-    <Compile Include="Views\TimeRemainingConverterTests.cs" />
+    <Compile Include="..\codeAnalysis\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Test.gif">
@@ -131,33 +61,18 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers">
-      <Version>3.3.0</Version>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Moq">
-      <Version>4.14.5</Version>
-    </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers">
-      <Version>1.1.118</Version>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Moq" Version="4.14.5" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="System.ValueTuple">
-      <Version>4.5.0</Version>
-    </PackageReference>
-    <PackageReference Include="xunit">
-      <Version>2.4.1</Version>
-    </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio">
-      <Version>2.4.3</Version>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/modules/imageresizer/ui/App.config
+++ b/src/modules/imageresizer/ui/App.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
-  </startup>
-</configuration>

--- a/src/modules/imageresizer/ui/App.xaml
+++ b/src/modules/imageresizer/ui/App.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:m="clr-namespace:ImageResizer.Models"
-             xmlns:sys="clr-namespace:System;assembly=mscorlib"
+             xmlns:sys="clr-namespace:System;assembly=System.Runtime"
              xmlns:v="clr-namespace:ImageResizer.Views">
 
     <Application.Resources>

--- a/src/modules/imageresizer/ui/App.xaml.cs
+++ b/src/modules/imageresizer/ui/App.xaml.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Text;
 using System.Windows;
-using GalaSoft.MvvmLight.Threading;
 using ImageResizer.Models;
 using ImageResizer.Properties;
 using ImageResizer.Utilities;
@@ -19,7 +18,6 @@ namespace ImageResizer
         static App()
         {
             Console.InputEncoding = Encoding.Unicode;
-            DispatcherHelper.Initialize();
         }
 
         protected override void OnStartup(StartupEventArgs e)

--- a/src/modules/imageresizer/ui/Helpers/Observable.cs
+++ b/src/modules/imageresizer/ui/Helpers/Observable.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace ImageResizer.Helpers
+{
+    public class Observable : INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        protected void Set<T>(ref T storage, T value, [CallerMemberName] string propertyName = null)
+        {
+            if (Equals(storage, value))
+            {
+                return;
+            }
+
+            storage = value;
+            OnPropertyChanged(propertyName);
+        }
+
+        protected void OnPropertyChanged(string propertyName) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/src/modules/imageresizer/ui/Helpers/RelayCommand.cs
+++ b/src/modules/imageresizer/ui/Helpers/RelayCommand.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Windows.Input;
+
+namespace ImageResizer.Helpers
+{
+    public class RelayCommand : ICommand
+    {
+        private readonly Action _execute;
+        private readonly Func<bool> _canExecute;
+
+        public event EventHandler CanExecuteChanged;
+
+        public RelayCommand(Action execute)
+            : this(execute, null)
+        {
+        }
+
+        public RelayCommand(Action execute, Func<bool> canExecute)
+        {
+            _execute = execute ?? throw new ArgumentNullException(nameof(execute));
+            _canExecute = canExecute;
+        }
+
+        public bool CanExecute(object parameter) => _canExecute == null || _canExecute();
+
+        public void Execute(object parameter) => _execute();
+
+        public void OnCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:File may only contain a single type", Justification = "abstract T and abstract")]
+    public class RelayCommand<T> : ICommand
+    {
+        private readonly Action<T> execute;
+
+        private readonly Func<T, bool> canExecute;
+
+        public event EventHandler CanExecuteChanged;
+
+        public RelayCommand(Action<T> execute)
+            : this(execute, null)
+        {
+        }
+
+        public RelayCommand(Action<T> execute, Func<T, bool> canExecute)
+        {
+            this.execute = execute ?? throw new ArgumentNullException(nameof(execute));
+            this.canExecute = canExecute;
+        }
+
+        public bool CanExecute(object parameter) => canExecute == null || canExecute((T)parameter);
+
+        public void Execute(object parameter) => execute((T)parameter);
+
+        public void OnCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/src/modules/imageresizer/ui/ImageResizerUI.csproj
+++ b/src/modules/imageresizer/ui/ImageResizerUI.csproj
@@ -1,4 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+  <Import Project="..\..\..\Version.props" />
+  
   <PropertyGroup>
     <AssemblyTitle>ImageResizer</AssemblyTitle>
     <AssemblyCompany>Microsoft Corp.</AssemblyCompany>
@@ -8,8 +10,9 @@
     <UseWPF>true</UseWPF>
     <Platforms>x64</Platforms>
   </PropertyGroup>
+  
   <PropertyGroup>
-    <Platform Condition=" '$(Platform)' == '' ">x64</Platform>
+    <Platform Condition="'$(Platform)'==''">x64</Platform>
     <ProjectGuid>{2BE46397-4DFA-414C-9BD4-41E4BBF8CB34}</ProjectGuid>
     <OutputType>WinExe</OutputType>
     <RootNamespace>ImageResizer</RootNamespace>
@@ -19,39 +22,21 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IntermediateOutputPath>$(SolutionDir)$(Platform)\$(Configuration)\obj\$(AssemblyName)\</IntermediateOutputPath>
   </PropertyGroup>
+  
   <PropertyGroup>
     <ApplicationIcon>Resources\ImageResizer.ico</ApplicationIcon>
     <NeutralLanguage>en-US</NeutralLanguage>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+  
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
-  <Import Project="..\..\..\Version.props" />
-  <Target Name="GenerateAssemblyInfo" BeforeTargets="PrepareForBuild">
-    <ItemGroup>
-      <HeaderLines Include="// Copyright (c) Microsoft Corporation" />
-      <HeaderLines Include="// The Microsoft Corporation licenses this file to you under the MIT license." />
-      <HeaderLines Include="// See the LICENSE file in the project root for more information." />
-      <HeaderLines Include="#pragma warning disable SA1516" />
-      <HeaderLines Include="using System.Reflection%3b" />
-      <HeaderLines Include="using System.Resources%3b" />
-      <HeaderLines Include="using System.Runtime.InteropServices%3b" />
-      <HeaderLines Include="using System.Windows%3b" />
-      <HeaderLines Include="[assembly: AssemblyTitle(&quot;$(AssemblyTitle)&quot;)]" />
-      <HeaderLines Include="[assembly: AssemblyDescription(&quot;&quot;)]" />
-      <HeaderLines Include="[assembly: AssemblyConfiguration(&quot;&quot;)]" />
-      <HeaderLines Include="[assembly: AssemblyCompany(&quot;$(AssemblyCompany)&quot;)]" />
-      <HeaderLines Include="[assembly: AssemblyCopyright(&quot;$(AssemblyCopyright)&quot;)]" />
-      <HeaderLines Include="[assembly: AssemblyProduct(&quot;$(AssemblyTitle)&quot;)]" />
-      <HeaderLines Include="[assembly: AssemblyTrademark(&quot;&quot;)]" />
-      <HeaderLines Include="[assembly: AssemblyCulture(&quot;&quot;)]" />
-      <HeaderLines Include="[assembly: ComVisible(false)]" />
-      <HeaderLines Include="[assembly: ThemeInfo(ResourceDictionaryLocation.None, ResourceDictionaryLocation.SourceAssembly)]" />
-      <HeaderLines Include="[assembly: AssemblyVersion(&quot;$(Version).0&quot;)]" />
-      <HeaderLines Include="[assembly: AssemblyFileVersion(&quot;$(Version).0&quot;)]" />
-    </ItemGroup>
-    <WriteLinesToFile File="Generated Files\AssemblyInfo.cs" Lines="@(HeaderLines)" Overwrite="true" Encoding="Unicode" WriteOnlyWhenDifferent="true" />
-  </Target>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+  
   <ItemGroup>
     <Compile Include="..\codeAnalysis\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />
   </ItemGroup>

--- a/src/modules/imageresizer/ui/ImageResizerUI.csproj
+++ b/src/modules/imageresizer/ui/ImageResizerUI.csproj
@@ -14,7 +14,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>ImageResizer</RootNamespace>
     <AssemblyName>ImageResizer</AssemblyName>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IntermediateOutputPath>$(SolutionDir)$(Platform)\$(Configuration)\obj\$(AssemblyName)\</IntermediateOutputPath>
@@ -53,13 +53,6 @@
     <WriteLinesToFile File="Generated Files\AssemblyInfo.cs" Lines="@(HeaderLines)" Overwrite="true" Encoding="Unicode" WriteOnlyWhenDifferent="true" />
   </Target>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualBasic" />
-    <Reference Include="System.Xaml" />
-    <Reference Include="WindowsBase" />
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
-  </ItemGroup>
-  <ItemGroup>
     <Compile Include="..\codeAnalysis\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -83,7 +76,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="MvvmLightLibs" Version="5.4.1.1" />
+    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.19" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>

--- a/src/modules/imageresizer/ui/ImageResizerUI.csproj
+++ b/src/modules/imageresizer/ui/ImageResizerUI.csproj
@@ -1,16 +1,32 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <Import Project="..\..\..\Version.props" />
-  <!-- We don't have GenerateAssemblyInfo task until we use .net core, so we generate it with WriteLinesToFile -->
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
     <AssemblyTitle>ImageResizer</AssemblyTitle>
     <AssemblyCompany>Microsoft Corp.</AssemblyCompany>
     <AssemblyCopyright>Copyright (C) 2019 Microsoft Corp.</AssemblyCopyright>
+    <CodeAnalysisRuleSet>..\..\..\codeAnalysis\Rules.ruleset</CodeAnalysisRuleSet>
+    <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\modules\ImageResizer</OutputPath>
+    <UseWPF>true</UseWPF>
+    <Platforms>x64</Platforms>
   </PropertyGroup>
-  <ItemGroup>
-    <AssemblyVersionFiles Include="Generated Files\AssemblyInfo.cs" />
-  </ItemGroup>
+  <PropertyGroup>
+    <Platform Condition=" '$(Platform)' == '' ">x64</Platform>
+    <ProjectGuid>{2BE46397-4DFA-414C-9BD4-41E4BBF8CB34}</ProjectGuid>
+    <OutputType>WinExe</OutputType>
+    <RootNamespace>ImageResizer</RootNamespace>
+    <AssemblyName>ImageResizer</AssemblyName>
+    <TargetFramework>net472</TargetFramework>
+    <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <IntermediateOutputPath>$(SolutionDir)$(Platform)\$(Configuration)\obj\$(AssemblyName)\</IntermediateOutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <ApplicationIcon>Resources\ImageResizer.ico</ApplicationIcon>
+    <NeutralLanguage>en-US</NeutralLanguage>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+  <Import Project="..\..\..\Version.props" />
   <Target Name="GenerateAssemblyInfo" BeforeTargets="PrepareForBuild">
     <ItemGroup>
       <HeaderLines Include="// Copyright (c) Microsoft Corporation" />
@@ -30,163 +46,32 @@
       <HeaderLines Include="[assembly: AssemblyTrademark(&quot;&quot;)]" />
       <HeaderLines Include="[assembly: AssemblyCulture(&quot;&quot;)]" />
       <HeaderLines Include="[assembly: ComVisible(false)]" />
-      <HeaderLines Include="[assembly: NeutralResourcesLanguage(&quot;en-US&quot;)]" />
       <HeaderLines Include="[assembly: ThemeInfo(ResourceDictionaryLocation.None, ResourceDictionaryLocation.SourceAssembly)]" />
       <HeaderLines Include="[assembly: AssemblyVersion(&quot;$(Version).0&quot;)]" />
       <HeaderLines Include="[assembly: AssemblyFileVersion(&quot;$(Version).0&quot;)]" />
     </ItemGroup>
     <WriteLinesToFile File="Generated Files\AssemblyInfo.cs" Lines="@(HeaderLines)" Overwrite="true" Encoding="Unicode" WriteOnlyWhenDifferent="true" />
   </Target>
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">x64</Platform>
-    <ProjectGuid>{2BE46397-4DFA-414C-9BD4-41E4BBF8CB34}</ProjectGuid>
-    <OutputType>WinExe</OutputType>
-    <RootNamespace>ImageResizer</RootNamespace>
-    <AssemblyName>ImageResizer</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <WarningLevel>4</WarningLevel>
-    <TargetFrameworkProfile>
-    </TargetFrameworkProfile>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <IntermediateOutputPath>$(SolutionDir)$(Platform)\$(Configuration)\obj\$(AssemblyName)\</IntermediateOutputPath>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
-    <PlatformTarget>x64</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\modules\ImageResizer</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-    <CodeAnalysisRuleSet>..\..\..\codeAnalysis\Rules.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
-    <PlatformTarget>x64</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\modules\ImageResizer</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-    <CodeAnalysisRuleSet>..\..\..\codeAnalysis\Rules.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-  <PropertyGroup>
-    <ApplicationIcon>Resources\ImageResizer.ico</ApplicationIcon>
-  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualBasic" />
-    <Reference Include="System" />
     <Reference Include="System.Xaml" />
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
   </ItemGroup>
   <ItemGroup>
-    <ApplicationDefinition Include="App.xaml">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-    </ApplicationDefinition>
-    <Compile Include="..\codeAnalysis\GlobalSuppressions.cs">
-      <Link>GlobalSuppressions.cs</Link>
-    </Compile>
-    <Compile Include="Extensions\BitmapEncoderExtensions.cs" />
-    <Compile Include="Extensions\ICollectionExtensions.cs" />
-    <Compile Include="Extensions\TimeSpanExtensions.cs" />
-    <Compile Include="Models\AdvancedSettings.cs" />
-    <Compile Include="Models\ResizeError.cs" />
-    <Compile Include="Properties\Settings.cs" />
-    <Compile Include="Models\CustomSize.cs" />
-    <Compile Include="Properties\InternalsVisibleTo.cs" />
-    <Compile Include="Models\ResizeBatch.cs" />
-    <Compile Include="Models\ResizeFit.cs" />
-    <Compile Include="Models\ResizeOperation.cs" />
-    <Compile Include="Models\ResizeSize.cs" />
-    <Compile Include="Models\ResizeUnit.cs" />
-    <Compile Include="Utilities\MathHelpers.cs" />
-    <Compile Include="Utilities\NativeMethods.cs" />
-    <Compile Include="ViewModels\AdvancedViewModel.cs" />
-    <Compile Include="ViewModels\InputViewModel.cs" />
-    <Compile Include="ViewModels\ITabViewModel.cs" />
-    <Compile Include="Views\AutoDoubleValidationRule.cs" />
-    <Compile Include="Views\BoolValueConverter.cs" />
-    <Compile Include="Views\ContainerFormatConverter.cs" />
-    <Compile Include="Views\AutoDoubleConverter.cs" />
-    <Compile Include="Views\IMainView.cs" />
-    <Compile Include="ViewModels\MainViewModel.cs" />
-    <Compile Include="ViewModels\ProgressViewModel.cs" />
-    <Compile Include="ViewModels\ResultsViewModel.cs" />
-    <Compile Include="Views\AdvancedWindow.xaml.cs">
-      <DependentUpon>AdvancedWindow.xaml</DependentUpon>
-    </Compile>
-    <Compile Include="Views\TiffCompressOptionConverter.cs" />
-    <Compile Include="Views\EnumValueConverter.cs" />
-    <Compile Include="Views\ProgressPage.xaml.cs">
-      <DependentUpon>ProgressPage.xaml</DependentUpon>
-    </Compile>
-    <Compile Include="Views\ResizeUnitConverter.cs" />
-    <Compile Include="Views\ResultsPage.xaml.cs">
-      <DependentUpon>ResultsPage.xaml</DependentUpon>
-    </Compile>
-    <Compile Include="Views\TimeRemainingConverter.cs" />
-    <Page Include="Views\AdvancedWindow.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Page Include="Views\InputPage.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Page Include="Views\MainWindow.xaml">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-    </Page>
-    <Compile Include="App.xaml.cs">
-      <DependentUpon>App.xaml</DependentUpon>
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Views\InputPage.xaml.cs">
-      <DependentUpon>InputPage.xaml</DependentUpon>
-    </Compile>
-    <Compile Include="Views\MainWindow.xaml.cs">
-      <DependentUpon>MainWindow.xaml</DependentUpon>
-      <SubType>Code</SubType>
-    </Compile>
-    <Page Include="Views\ProgressPage.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Page Include="Views\ResultsPage.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
+    <Compile Include="..\codeAnalysis\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Generated Files\AssemblyInfo.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Properties\Resources.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>Resources.resx</DependentUpon>
-    </Compile>
-    <EmbeddedResource Include="Properties\Resources.resx">
+    <EmbeddedResource Update="Properties\Resources.resx">
       <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
       <SubType>Designer</SubType>
-    </EmbeddedResource>    
+    </EmbeddedResource>
     <EmbeddedResource Include="Properties\Resources.*.resx" />
   </ItemGroup>
   <ItemGroup>
     <AdditionalFiles Include="..\..\..\codeAnalysis\StyleCop.json" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="App.config" />
   </ItemGroup>
   <ItemGroup>
     <Resource Include="Resources\ImageResizer.ico" />
@@ -195,31 +80,16 @@
     <Resource Include="Resources\ImageResizer.png" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers">
-      <Version>3.3.0</Version>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="MvvmLightLibs">
-      <Version>5.4.1.1</Version>
-    </PackageReference>
-    <PackageReference Include="Newtonsoft.Json">
-      <Version>12.0.3</Version>
-    </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers">
-      <Version>1.1.118</Version>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    <PackageReference Include="MvvmLightLibs" Version="5.4.1.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\common\interop\interop.vcxproj">
-      <Project>{f055103b-f80b-4d0c-bf48-057c55620033}</Project>
-      <Name>interop</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\..\..\common\interop\interop.vcxproj" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <TargetFrameworkSDKToolsDirectory Condition=" '$(Platform)' == 'x64'">$(TargetFrameworkSDKToolsDirectory)$(Platform)\</TargetFrameworkSDKToolsDirectory>
-  </PropertyGroup>
 </Project>

--- a/src/modules/imageresizer/ui/ImageResizerUI.csproj
+++ b/src/modules/imageresizer/ui/ImageResizerUI.csproj
@@ -7,6 +7,8 @@
     <AssemblyCopyright>Copyright (C) 2019 Microsoft Corp.</AssemblyCopyright>
     <CodeAnalysisRuleSet>..\..\..\codeAnalysis\Rules.ruleset</CodeAnalysisRuleSet>
     <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\modules\ImageResizer</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <UseWPF>true</UseWPF>
     <Platforms>x64</Platforms>
   </PropertyGroup>
@@ -30,10 +32,12 @@
   
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Optimize>true</Optimize>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Optimize>false</Optimize>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   
@@ -69,5 +73,12 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\common\interop\interop.vcxproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Update="Properties\Resources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Resources.resx</DependentUpon>
+    </Compile>
   </ItemGroup>
 </Project>

--- a/src/modules/imageresizer/ui/Models/ResizeSize.cs
+++ b/src/modules/imageresizer/ui/Models/ResizeSize.cs
@@ -4,14 +4,14 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using GalaSoft.MvvmLight;
+using ImageResizer.Helpers;
 using ImageResizer.Properties;
 using Newtonsoft.Json;
 
 namespace ImageResizer.Models
 {
     [JsonObject(MemberSerialization.OptIn)]
-    public class ResizeSize : ObservableObject
+    public class ResizeSize : Observable
     {
         private static readonly IDictionary<string, string> _tokens = new Dictionary<string, string>
         {
@@ -45,7 +45,7 @@ namespace ImageResizer.Models
         public virtual string Name
         {
             get => _name;
-            set => Set(nameof(Name), ref _name, ReplaceTokens(value));
+            set => Set(ref _name, ReplaceTokens(value));
         }
 
         [JsonProperty(PropertyName = "fit")]
@@ -54,7 +54,8 @@ namespace ImageResizer.Models
             get => _fit;
             set
             {
-                if (Set(nameof(Fit), ref _fit, value))
+                Set(ref _fit, value);
+                if (!Equals(_fit, value))
                 {
                     UpdateShowHeight();
                 }
@@ -65,14 +66,14 @@ namespace ImageResizer.Models
         public double Width
         {
             get => _width;
-            set => Set(nameof(Width), ref _width, value);
+            set => Set(ref _width, value);
         }
 
         [JsonProperty(PropertyName = "height")]
         public double Height
         {
             get => _height;
-            set => Set(nameof(Height), ref _height, value);
+            set => Set(ref _height, value);
         }
 
         public bool ShowHeight
@@ -87,7 +88,8 @@ namespace ImageResizer.Models
             get => _unit;
             set
             {
-                if (Set(nameof(Unit), ref _unit, value))
+                Set(ref _unit, value);
+                if (!Equals(_unit, value))
                 {
                     UpdateShowHeight();
                 }
@@ -113,7 +115,6 @@ namespace ImageResizer.Models
 
         private void UpdateShowHeight()
             => Set(
-                nameof(ShowHeight),
                 ref _showHeight,
                 Fit == ResizeFit.Stretch || Unit != ResizeUnit.Percent);
 

--- a/src/modules/imageresizer/ui/Properties/Settings.cs
+++ b/src/modules/imageresizer/ui/Properties/Settings.cs
@@ -2,6 +2,7 @@
 // The Brice Lambson licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.  Code forked from Brice Lambson's https://github.com/bricelam/ImageResizer/
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -65,14 +66,14 @@ namespace ImageResizer.Properties
         public string FileNameFormat
             => _fileNameFormat
                 ?? (_fileNameFormat = FileName
-                    .Replace("{", "{{")
-                    .Replace("}", "}}")
-                    .Replace("%1", "{0}")
-                    .Replace("%2", "{1}")
-                    .Replace("%3", "{2}")
-                    .Replace("%4", "{3}")
-                    .Replace("%5", "{4}")
-                    .Replace("%6", "{5}"));
+                    .Replace("{", "{{", StringComparison.OrdinalIgnoreCase)
+                    .Replace("}", "}}", StringComparison.OrdinalIgnoreCase)
+                    .Replace("%1", "{0}", StringComparison.OrdinalIgnoreCase)
+                    .Replace("%2", "{1}", StringComparison.OrdinalIgnoreCase)
+                    .Replace("%3", "{2}", StringComparison.OrdinalIgnoreCase)
+                    .Replace("%4", "{3}", StringComparison.OrdinalIgnoreCase)
+                    .Replace("%5", "{4}", StringComparison.OrdinalIgnoreCase)
+                    .Replace("%6", "{5}", StringComparison.OrdinalIgnoreCase));
 
         public ResizeSize SelectedSize
         {

--- a/src/modules/imageresizer/ui/ViewModels/AdvancedViewModel.cs
+++ b/src/modules/imageresizer/ui/ViewModels/AdvancedViewModel.cs
@@ -7,14 +7,13 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Windows.Input;
 using System.Windows.Media.Imaging;
-using GalaSoft.MvvmLight;
-using GalaSoft.MvvmLight.Command;
+using ImageResizer.Helpers;
 using ImageResizer.Models;
 using ImageResizer.Properties;
 
 namespace ImageResizer.ViewModels
 {
-    public class AdvancedViewModel : ViewModelBase
+    public class AdvancedViewModel : Observable
     {
         private static Dictionary<Guid, string> InitEncoderMap()
         {

--- a/src/modules/imageresizer/ui/ViewModels/InputViewModel.cs
+++ b/src/modules/imageresizer/ui/ViewModels/InputViewModel.cs
@@ -4,15 +4,14 @@
 // ShowAdvancedCommand = new RelayCommand(ShowAdvanced);
 
 using System.Windows.Input;
-using GalaSoft.MvvmLight;
-using GalaSoft.MvvmLight.Command;
+using ImageResizer.Helpers;
 using ImageResizer.Models;
 using ImageResizer.Properties;
 using ImageResizer.Views;
 
 namespace ImageResizer.ViewModels
 {
-    public class InputViewModel : ViewModelBase
+    public class InputViewModel : Observable
     {
         private readonly ResizeBatch _batch;
         private readonly MainViewModel _mainViewModel;

--- a/src/modules/imageresizer/ui/ViewModels/MainViewModel.cs
+++ b/src/modules/imageresizer/ui/ViewModels/MainViewModel.cs
@@ -4,15 +4,14 @@
 
 using System.Collections.Generic;
 using System.Windows.Input;
-using GalaSoft.MvvmLight;
-using GalaSoft.MvvmLight.Command;
+using ImageResizer.Helpers;
 using ImageResizer.Models;
 using ImageResizer.Properties;
 using ImageResizer.Views;
 
 namespace ImageResizer.ViewModels
 {
-    public class MainViewModel : ViewModelBase
+    public class MainViewModel : Observable
     {
         private readonly Settings _settings;
         private readonly ResizeBatch _batch;
@@ -32,13 +31,13 @@ namespace ImageResizer.ViewModels
         public object CurrentPage
         {
             get => _currentPage;
-            set => Set(nameof(CurrentPage), ref _currentPage, value);
+            set => Set(ref _currentPage, value);
         }
 
         public double Progress
         {
             get => _progress;
-            set => Set(nameof(Progress), ref _progress, value);
+            set => Set(ref _progress, value);
         }
 
         public void Load(IMainView view)

--- a/src/modules/imageresizer/ui/ViewModels/ProgressViewModel.cs
+++ b/src/modules/imageresizer/ui/ViewModels/ProgressViewModel.cs
@@ -8,14 +8,13 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Input;
-using GalaSoft.MvvmLight;
-using GalaSoft.MvvmLight.Command;
+using ImageResizer.Helpers;
 using ImageResizer.Models;
 using ImageResizer.Views;
 
 namespace ImageResizer.ViewModels
 {
-    public class ProgressViewModel : ViewModelBase, IDisposable
+    public class ProgressViewModel : Observable, IDisposable
     {
         private readonly MainViewModel _mainViewModel;
         private readonly ResizeBatch _batch;
@@ -43,13 +42,13 @@ namespace ImageResizer.ViewModels
         public double Progress
         {
             get => _progress;
-            set => Set(nameof(Progress), ref _progress, value);
+            set => Set(ref _progress, value);
         }
 
         public TimeSpan TimeRemaining
         {
             get => _timeRemaining;
-            set => Set(nameof(TimeRemaining), ref _timeRemaining, value);
+            set => Set(ref _timeRemaining, value);
         }
 
         public ICommand StartCommand { get; }

--- a/src/modules/imageresizer/ui/ViewModels/ResultsViewModel.cs
+++ b/src/modules/imageresizer/ui/ViewModels/ResultsViewModel.cs
@@ -4,14 +4,13 @@
 
 using System.Collections.Generic;
 using System.Windows.Input;
-using GalaSoft.MvvmLight;
-using GalaSoft.MvvmLight.Command;
+using ImageResizer.Helpers;
 using ImageResizer.Models;
 using ImageResizer.Views;
 
 namespace ImageResizer.ViewModels
 {
-    public class ResultsViewModel : ViewModelBase
+    public class ResultsViewModel : Observable
     {
         private readonly IMainView _mainView;
 

--- a/src/modules/imageresizer/ui/Views/MainWindow.xaml
+++ b/src/modules/imageresizer/ui/Views/MainWindow.xaml
@@ -1,7 +1,7 @@
 ﻿<Window x:Class="ImageResizer.Views.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
+        xmlns:behaviors="http://schemas.microsoft.com/xaml/behaviors"
         xmlns:local="clr-namespace:ImageResizer.Views"
         xmlns:p="clr-namespace:ImageResizer.Properties"
         xmlns:vm="clr-namespace:ImageResizer.ViewModels"
@@ -29,10 +29,10 @@
         <TaskbarItemInfo ProgressState="Normal" ProgressValue="{Binding Progress}"/>
     </Window.TaskbarItemInfo>
 
-    <i:Interaction.Triggers>
-        <i:EventTrigger EventName="Loaded">
-            <i:InvokeCommandAction Command="{Binding LoadCommand}" CommandParameter="{Binding ElementName=_this}"/>
-        </i:EventTrigger>
-    </i:Interaction.Triggers>
+    <behaviors:Interaction.Triggers>
+        <behaviors:EventTrigger EventName="Loaded">
+            <behaviors:InvokeCommandAction Command="{Binding LoadCommand}" CommandParameter="{Binding ElementName=_this}"/>
+        </behaviors:EventTrigger>
+    </behaviors:Interaction.Triggers>
 
 </Window>

--- a/src/modules/imageresizer/ui/Views/ProgressPage.xaml
+++ b/src/modules/imageresizer/ui/Views/ProgressPage.xaml
@@ -1,7 +1,7 @@
 ﻿<UserControl x:Class="ImageResizer.Views.ProgressPage"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
+             xmlns:behaviors="http://schemas.microsoft.com/xaml/behaviors"
              xmlns:local="clr-namespace:ImageResizer.Views"
              xmlns:p="clr-namespace:ImageResizer.Properties"
              MinWidth="350">
@@ -10,11 +10,11 @@
         <local:TimeRemainingConverter x:Key="TimeRemainingConverter"/>
     </UserControl.Resources>
 
-    <i:Interaction.Triggers>
-        <i:EventTrigger EventName="Loaded">
-            <i:InvokeCommandAction Command="{Binding StartCommand}"/>
-        </i:EventTrigger>
-    </i:Interaction.Triggers>
+    <behaviors:Interaction.Triggers>
+        <behaviors:EventTrigger EventName="Loaded">
+            <behaviors:InvokeCommandAction Command="{Binding StartCommand}"/>
+        </behaviors:EventTrigger>
+    </behaviors:Interaction.Triggers>
 
     <StackPanel>
         <TextBlock Margin="11,11,11,0"


### PR DESCRIPTION
## Summary of the Pull Request

I have upgraded Image Resizer to .NET Core 3.1

## PR Checklist
* [x] Applies to #776
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #776

## Info on Pull Request

- Migrated project to SDK Style
- Removed MvvmLight
- Upgraded ImageResizerUI and ImageResizerUITest to .NET Core 3.1
- Performed usage tests
- Performed update and install tests

## Validation Steps Performed

Check if everything is fine in Product.wxs,  ImageResizerUI.csproj, ImageResizerUITest.csproj
