### PR TITLE
[FancyZones] Add AutomationProperties.Name to focusable elements

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditorWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditorWindow.xaml
@@ -1,4 +1,5 @@
 ﻿<local:EditorWindow x:Class="FancyZonesEditor.CanvasEditorWindow"
+        AutomationProperties.Name="CanvasEditorWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -166,14 +167,14 @@
     </Window.Resources>
     <StackPanel>
         <TextBlock Name="windowEditorDialogTitle" Text="{x:Static props:Resources.Custom_Layout_Creator}" Style="{StaticResource titleText}"  />
-        <Button x:Name="newZoneButton" Width="496" Height="136" Style="{StaticResource newZoneButton}" Click="OnAddZone">
+        <Button x:Name="newZoneButton" AutomationProperties.Name="newZoneButton" Width="496" Height="136" Style="{StaticResource newZoneButton}" Click="OnAddZone">
             <StackPanel>
-                <TextBlock x:Name="newSoneName" Text="{x:Static props:Resources.Add_zone}" Style="{StaticResource templateTitleText}"  />
+                <TextBlock x:Name="newZoneName" Text="{x:Static props:Resources.Add_zone}" Style="{StaticResource templateTitleText}"  />
                 <TextBlock HorizontalAlignment="Center" Text="+" Margin="0,-40,0,0"/>
             </StackPanel>
         </Button>
         <TextBlock Text="{x:Static props:Resources.Name}" Style="{StaticResource textLabel}" />
-        <TextBox Text="{Binding Name}" Width="496" Style="{StaticResource textBox}" />
+        <TextBox Text="{Binding Name}" AutomationProperties.Name="newLayoutName" Width="496" Style="{StaticResource textBox}" />
         <!--
         <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
             <CheckBox x:Name="showGridSetting" VerticalAlignment="Center" HorizontalAlignment="Center" IsChecked="True" Margin="16,4,0,0"/>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditorWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditorWindow.xaml
@@ -1,5 +1,5 @@
 ﻿<local:EditorWindow x:Class="FancyZonesEditor.CanvasEditorWindow"
-        AutomationProperties.Name="CanvasEditorWindow"
+        AutomationProperties.Name="{x:Static props:Resources.Canvs_Layout_Editor}"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -167,14 +167,14 @@
     </Window.Resources>
     <StackPanel>
         <TextBlock Name="windowEditorDialogTitle" Text="{x:Static props:Resources.Custom_Layout_Creator}" Style="{StaticResource titleText}"  />
-        <Button x:Name="newZoneButton" AutomationProperties.Name="newZoneButton" Width="496" Height="136" Style="{StaticResource newZoneButton}" Click="OnAddZone">
+        <Button x:Name="newZoneButton" AutomationProperties.LabeledBy="{Binding ElementName=newZoneName}" Width="496" Height="136" Style="{StaticResource newZoneButton}" Click="OnAddZone">
             <StackPanel>
                 <TextBlock x:Name="newZoneName" Text="{x:Static props:Resources.Add_zone}" Style="{StaticResource templateTitleText}"  />
                 <TextBlock HorizontalAlignment="Center" Text="+" Margin="0,-40,0,0"/>
             </StackPanel>
         </Button>
-        <TextBlock Text="{x:Static props:Resources.Name}" Style="{StaticResource textLabel}" />
-        <TextBox Text="{Binding Name}" AutomationProperties.Name="newLayoutName" Width="496" Style="{StaticResource textBox}" />
+        <TextBlock x:Name="customLayoutName" Text="{x:Static props:Resources.Name}" Style="{StaticResource textLabel}" />
+        <TextBox Text="{Binding Name}" AutomationProperties.LabeledBy="{Binding ElementName=customLayoutName}" Width="496" Style="{StaticResource textBox}" />
         <!--
         <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
             <CheckBox x:Name="showGridSetting" VerticalAlignment="Center" HorizontalAlignment="Center" IsChecked="True" Margin="16,4,0,0"/>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditorWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditorWindow.xaml
@@ -1,5 +1,5 @@
 ﻿<local:EditorWindow x:Class="FancyZonesEditor.CanvasEditorWindow"
-        AutomationProperties.Name="{x:Static props:Resources.Canvs_Layout_Editor}"
+        AutomationProperties.Name="{x:Static props:Resources.Canvas_Layout_Editor}"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -1,5 +1,6 @@
 <Controls:MetroWindow x:Class="FancyZonesEditor.MainWindow"
         x:Name="MainWindow1"
+        AutomationProperties.Name="MainWindow1"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -180,7 +181,7 @@
 
         <TextBlock Name="dialog_Title" Text="{x:Static props:Resources.Choose_Layout}" Style="{StaticResource titleText}"  />
 
-        <TabControl BorderThickness="0" x:Name="TemplateTab" SelectedIndex="{Binding IsCustomLayoutActive, Mode=OneWay, Converter={StaticResource BooleanToIntConverter}}">
+        <TabControl BorderThickness="0" x:Name="TemplateTab" AutomationProperties.Name="TemplateTab" SelectedIndex="{Binding IsCustomLayoutActive, Mode=OneWay, Converter={StaticResource BooleanToIntConverter}}">
             <TabItem Header="{x:Static props:Resources.Templates}" Template="{StaticResource myTabs}">
                 <StackPanel>
                     <StackPanel Margin="0,15,0,8" Orientation="Horizontal" HorizontalAlignment="Center">
@@ -260,9 +261,9 @@
 		<StackPanel Orientation="Horizontal" Margin="10,4,0,8">
 			<CheckBox x:Name="spaceAroundSetting" Content="{x:Static props:Resources.Show_Space_Zones}" Style="{StaticResource settingCheckBoxText}" IsChecked="{Binding ShowSpacing}"/>
 			<TextBlock Text="{x:Static props:Resources.Space_Around_Zones}" Style="{StaticResource settingText}" IsEnabled="{Binding ShowSpacing}" />
-			<TextBox x:Name="paddingValue" Text="{Binding Path=Spacing,Mode=TwoWay}" Style="{StaticResource textBox}" MinWidth="32" IsEnabled="{Binding ShowSpacing}"/>
+			<TextBox x:Name="paddingValue" AutomationProperties.Name="paddingValue" Text="{Binding Path=Spacing,Mode=TwoWay}" Style="{StaticResource textBox}" MinWidth="32" IsEnabled="{Binding ShowSpacing}"/>
 			<TextBlock Text="{x:Static props:Resources.Distance_adjacent_zones}" Style="{StaticResource settingText}"/>
-			<TextBox x:Name="sensitivityRadiusValue" Text="{Binding Path=SensitivityRadius,Mode=TwoWay}" Style="{StaticResource textBox}" MinWidth="40"/>
+			<TextBox x:Name="sensitivityRadiusValue" AutomationProperties.Name="sensitivityRadiusValue" Text="{Binding Path=SensitivityRadius,Mode=TwoWay}" Style="{StaticResource textBox}" MinWidth="40"/>
 		</StackPanel>
 
 		<StackPanel Orientation="Horizontal" Margin="0,10,0,16">

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -1,6 +1,6 @@
 <Controls:MetroWindow x:Class="FancyZonesEditor.MainWindow"
         x:Name="MainWindow1"
-        AutomationProperties.Name="{x:Static props:Resources.Fancy_Zones_Main_Editor_Window}"
+        AutomationProperties.Name="{x:Static props:Resources.Fancy_Zones_Main_Editor}"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -1,6 +1,6 @@
 <Controls:MetroWindow x:Class="FancyZonesEditor.MainWindow"
         x:Name="MainWindow1"
-        AutomationProperties.Name="MainWindow1"
+        AutomationProperties.Name="{x:Static props:Resources.Fancy_Zones_Main_Editor_Window}"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -179,9 +179,9 @@
     
     <StackPanel>
 
-        <TextBlock Name="dialog_Title" Text="{x:Static props:Resources.Choose_Layout}" Style="{StaticResource titleText}"  />
+        <TextBlock Name="DialogTitle" Text="{x:Static props:Resources.Choose_Layout}" Style="{StaticResource titleText}" />
 
-        <TabControl BorderThickness="0" x:Name="TemplateTab" AutomationProperties.Name="TemplateTab" SelectedIndex="{Binding IsCustomLayoutActive, Mode=OneWay, Converter={StaticResource BooleanToIntConverter}}">
+        <TabControl BorderThickness="0" x:Name="TemplateTab" AutomationProperties.LabeledBy="{Binding ElementName=DialogTitle}" SelectedIndex="{Binding IsCustomLayoutActive, Mode=OneWay, Converter={StaticResource BooleanToIntConverter}}">
             <TabItem Header="{x:Static props:Resources.Templates}" Template="{StaticResource myTabs}">
                 <StackPanel>
                     <StackPanel Margin="0,15,0,8" Orientation="Horizontal" HorizontalAlignment="Center">
@@ -260,10 +260,10 @@
 
 		<StackPanel Orientation="Horizontal" Margin="10,4,0,8">
 			<CheckBox x:Name="spaceAroundSetting" Content="{x:Static props:Resources.Show_Space_Zones}" Style="{StaticResource settingCheckBoxText}" IsChecked="{Binding ShowSpacing}"/>
-			<TextBlock Text="{x:Static props:Resources.Space_Around_Zones}" Style="{StaticResource settingText}" IsEnabled="{Binding ShowSpacing}" />
-			<TextBox x:Name="paddingValue" AutomationProperties.Name="paddingValue" Text="{Binding Path=Spacing,Mode=TwoWay}" Style="{StaticResource textBox}" MinWidth="32" IsEnabled="{Binding ShowSpacing}"/>
-			<TextBlock Text="{x:Static props:Resources.Distance_adjacent_zones}" Style="{StaticResource settingText}"/>
-			<TextBox x:Name="sensitivityRadiusValue" AutomationProperties.Name="sensitivityRadiusValue" Text="{Binding Path=SensitivityRadius,Mode=TwoWay}" Style="{StaticResource textBox}" MinWidth="40"/>
+            <TextBlock x:Name="paddingValue" Text="{x:Static props:Resources.Space_Around_Zones}" Style="{StaticResource settingText}" IsEnabled="{Binding ShowSpacing}" />
+			<TextBox AutomationProperties.LabeledBy="{Binding ElementName=paddingValue}" Text="{Binding Path=Spacing,Mode=TwoWay}" Style="{StaticResource textBox}" MinWidth="32" IsEnabled="{Binding ShowSpacing}"/>
+            <TextBlock x:Name="sensitivityRadiusValue"  Text="{x:Static props:Resources.Distance_adjacent_zones}" Style="{StaticResource settingText}"/>
+			<TextBox AutomationProperties.LabeledBy="{Binding ElementName=sensitivityRadiusValue}" Text="{Binding Path=SensitivityRadius,Mode=TwoWay}" Style="{StaticResource textBox}" MinWidth="40"/>
 		</StackPanel>
 
 		<StackPanel Orientation="Horizontal" Margin="0,10,0,16">

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
@@ -88,11 +88,11 @@ namespace FancyZonesEditor.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Canvas layout editor window.
+        ///   Looks up a localized string similar to Canvas layout editor.
         /// </summary>
-        public static string Canvs_Layout_Editor {
+        public static string Canvas_Layout_Editor {
             get {
-                return ResourceManager.GetString("Canvs_Layout_Editor", resourceCulture);
+                return ResourceManager.GetString("Canvas_Layout_Editor", resourceCulture);
             }
         }
         
@@ -178,11 +178,11 @@ namespace FancyZonesEditor.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to FancyZones main editor window.
+        ///   Looks up a localized string similar to FancyZones main editor.
         /// </summary>
-        public static string Fancy_Zones_Main_Editor_Window {
+        public static string Fancy_Zones_Main_Editor {
             get {
-                return ResourceManager.GetString("Fancy_Zones_Main_Editor_Window", resourceCulture);
+                return ResourceManager.GetString("Fancy_Zones_Main_Editor", resourceCulture);
             }
         }
         

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
@@ -88,6 +88,15 @@ namespace FancyZonesEditor.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Canvas layout editor window.
+        /// </summary>
+        public static string Canvs_Layout_Editor {
+            get {
+                return ResourceManager.GetString("Canvs_Layout_Editor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Choose your layout for this desktop.
         /// </summary>
         public static string Choose_Layout {
@@ -165,6 +174,15 @@ namespace FancyZonesEditor.Properties {
         public static string Fancy_Zones_Editor_App_Title {
             get {
                 return ResourceManager.GetString("Fancy_Zones_Editor_App_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to FancyZones main editor window.
+        /// </summary>
+        public static string Fancy_Zones_Main_Editor_Window {
+            get {
+                return ResourceManager.GetString("Fancy_Zones_Main_Editor_Window", resourceCulture);
             }
         }
         

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
@@ -126,8 +126,8 @@
   <data name="Cancel" xml:space="preserve">
     <value>Cancel</value>
   </data>
-  <data name="Canvs_Layout_Editor" xml:space="preserve">
-    <value>Canvas layout editor window</value>
+  <data name="Canvas_Layout_Editor" xml:space="preserve">
+    <value>Canvas layout editor</value>
   </data>
   <data name="Choose_Layout" xml:space="preserve">
     <value>Choose your layout for this desktop</value>
@@ -156,8 +156,8 @@
   <data name="Fancy_Zones_Editor_App_Title" xml:space="preserve">
     <value>FancyZones Editor</value>
   </data>
-  <data name="Fancy_Zones_Main_Editor_Window" xml:space="preserve">
-    <value>FancyZones main editor window</value>
+  <data name="Fancy_Zones_Main_Editor" xml:space="preserve">
+    <value>FancyZones main editor</value>
   </data>
   <data name="Name" xml:space="preserve">
     <value>Name</value>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
@@ -126,6 +126,9 @@
   <data name="Cancel" xml:space="preserve">
     <value>Cancel</value>
   </data>
+  <data name="Canvs_Layout_Editor" xml:space="preserve">
+    <value>Canvas layout editor window</value>
+  </data>
   <data name="Choose_Layout" xml:space="preserve">
     <value>Choose your layout for this desktop</value>
   </data>
@@ -152,6 +155,9 @@
   </data>
   <data name="Fancy_Zones_Editor_App_Title" xml:space="preserve">
     <value>FancyZones Editor</value>
+  </data>
+  <data name="Fancy_Zones_Main_Editor_Window" xml:space="preserve">
+    <value>FancyZones main editor window</value>
   </data>
   <data name="Name" xml:space="preserve">
     <value>Name</value>


### PR DESCRIPTION
## Summary of the Pull Request

Focusable items should have automation names added due to accessibility reasons.

## PR Checklist
* [x] Applies to #7110 and #7111
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

## Validation Steps Performed

1. Launch Accessibility Insights for Windows tool.
2. Open PowerToys Settings App.
3. Navigate to 'Fancy Zones' menu item and activate it. 'Fancy Zone' pane will open.
4. Navigate to 'Launch Zone Editor' button and activate it. 'Choose your layout for this desktop' window will open.
5. Run the Accessibility Insights for Windows tool.

Expected result: Spacing around zones and distance between adjacent zones text boxes should have names. Same goes for the "main" template tab, which allows You to choose between predefined and custom layouts.
