### PR TITLE
fix low-level kb hook disabling macro

### DIFF
--- a/src/modules/fancyzones/lib/GenericKeyHook.h
+++ b/src/modules/fancyzones/lib/GenericKeyHook.h
@@ -2,6 +2,7 @@
 
 #include "pch.h"
 #include <functional>
+#include <common/debug_control.h>
 
 template<int... keys>
 class GenericKeyHook

--- a/src/runner/centralized_kb_hook.cpp
+++ b/src/runner/centralized_kb_hook.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 #include "centralized_kb_hook.h"
-#include "common/common.h"
+#include <common/common.h>
+#include <common/debug_control.h>
 
 namespace CentralizedKeyboardHook
 {


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
- we didn't include the `common/debug_control.h` file on 2 occasions which defines the `DISABLE_LOWLEVEL_HOOKS_WHEN_DEBUGGED` macro.