### PR TITLE
[fxcop] Settings UI library (part 3) - exception handling

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/GeneralSettings.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/GeneralSettings.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.PowerToys.Settings.UI.Lib.Interface;
@@ -53,6 +54,7 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
         [JsonPropertyName("download_updates_automatically")]
         public bool AutoDownloadUpdates { get; set; }
 
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Any error from calling interop code should not prevent the program from loading.")]
         public GeneralSettings()
         {
             Packaged = false;
@@ -66,8 +68,9 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
             {
                 PowertoysVersion = DefaultPowertoysVersion();
             }
-            catch
+            catch (Exception e)
             {
+                Logger.LogError("Exception encountered when getting PowerToys version", e);
                 PowertoysVersion = "v0.0.0";
             }
 

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/SettingsUtils.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/SettingsUtils.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using Microsoft.PowerToys.Settings.UI.Lib.Interface;
 using Microsoft.PowerToys.Settings.UI.Lib.Utilities;
@@ -100,6 +101,7 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
         }
 
         // Save settings to a json file.
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "General exceptions will be logged until we can better understand runtime exception scenarios")]
         public void SaveSettings(string jsonSettings, string powertoy = DefaultModuleName, string fileName = DefaultFileName)
         {
             try
@@ -114,8 +116,9 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
                     _ioProvider.WriteAllText(GetSettingsPath(powertoy, fileName), jsonSettings);
                 }
             }
-            catch
+            catch (Exception e)
             {
+                Logger.LogError($"Exception encountered while saving {powertoy} settings.", e);
             }
         }
 

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/SettingsUtils.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/SettingsUtils.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Text.Json;
 using Microsoft.PowerToys.Settings.UI.Lib.Interface;
 using Microsoft.PowerToys.Settings.UI.Lib.Utilities;
@@ -119,6 +120,12 @@ namespace Microsoft.PowerToys.Settings.UI.Lib
             catch (Exception e)
             {
                 Logger.LogError($"Exception encountered while saving {powertoy} settings.", e);
+#if DEBUG
+                if (e is ArgumentException || e is ArgumentNullException || e is PathTooLongException)
+                {
+                    throw e;
+                }
+#endif
             }
         }
 

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/Utilities/Logger.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/Utilities/Logger.cs
@@ -27,6 +27,11 @@ namespace Microsoft.PowerToys.Settings.UI.Lib.Utilities
             Trace.AutoFlush = true;
         }
 
+        public static void LogInfo(string message)
+        {
+            Log(message, "INFO");
+        }
+
         public static void LogError(string message, Exception e)
         {
             Log(

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/Utilities/Logger.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/Utilities/Logger.cs
@@ -20,7 +20,7 @@ namespace Microsoft.PowerToys.Settings.UI.Lib.Utilities
                 Directory.CreateDirectory(ApplicationLogPath);
             }
 
-            var logFilePath = Path.Combine(ApplicationLogPath, "Log_" + DateTime.Now.ToString(@"yyyy-MM-dd", CultureInfo.CurrentCulture) + ".txt");
+            var logFilePath = Path.Combine(ApplicationLogPath, "Log_" + DateTime.Now.ToString(@"yyyy-MM-dd", CultureInfo.InvariantCulture) + ".txt");
 
             Trace.Listeners.Add(new TextWriterTraceListener(logFilePath));
 

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/Utilities/Logger.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/Utilities/Logger.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+
+namespace Microsoft.PowerToys.Settings.UI.Lib.Utilities
+{
+    public static class Logger
+    {
+        private static readonly string ApplicationLogPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Microsoft\\PowerToys\\Settings Logs");
+
+        static Logger()
+        {
+            if (!Directory.Exists(ApplicationLogPath))
+            {
+                Directory.CreateDirectory(ApplicationLogPath);
+            }
+
+            var logFilePath = Path.Combine(ApplicationLogPath, "Log_" + DateTime.Now.ToString(@"yyyy-MM-dd", CultureInfo.CurrentCulture) + ".txt");
+
+            Trace.Listeners.Add(new TextWriterTraceListener(logFilePath));
+
+            Trace.AutoFlush = true;
+        }
+
+        public static void LogError(string message, Exception e)
+        {
+            Log(
+                message + Environment.NewLine +
+                e?.Message + Environment.NewLine +
+                "Inner exception: " + Environment.NewLine +
+                e?.InnerException?.Message + Environment.NewLine +
+                "Stack trace: " + Environment.NewLine +
+                e?.StackTrace,
+                "ERROR");
+        }
+
+        private static void Log(string message, string type)
+        {
+            Trace.WriteLine(type + ": " + DateTime.Now.TimeOfDay);
+            Trace.Indent();
+            Trace.WriteLine(GetCallerInfo());
+            Trace.WriteLine(message);
+            Trace.Unindent();
+        }
+
+        private static string GetCallerInfo()
+        {
+            StackTrace stackTrace = new StackTrace();
+
+            var methodName = stackTrace.GetFrame(3)?.GetMethod();
+            var className = methodName?.DeclaringType.Name;
+            return "[Method]: " + methodName?.Name + " [Class]: " + className;
+        }
+    }
+}

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/ViewModels/FancyZonesViewModel.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/ViewModels/FancyZonesViewModel.cs
@@ -8,6 +8,7 @@ using System.Globalization;
 using System.Runtime.CompilerServices;
 using Microsoft.PowerToys.Settings.UI.Lib.Helpers;
 using Microsoft.PowerToys.Settings.UI.Lib.Interface;
+using Microsoft.PowerToys.Settings.UI.Lib.Utilities;
 using Microsoft.PowerToys.Settings.UI.Lib.ViewModels.Commands;
 
 namespace Microsoft.PowerToys.Settings.UI.Lib.ViewModels
@@ -542,19 +543,21 @@ namespace Microsoft.PowerToys.Settings.UI.Lib.ViewModels
 
         private static string ToRGBHex(string color)
         {
-            try
+            // Using InvariantCulture as these are expected to be hex codes.
+            bool success = int.TryParse(
+                color.Replace("#", string.Empty),
+                System.Globalization.NumberStyles.HexNumber,
+                CultureInfo.InvariantCulture,
+                out int argb);
+
+            if (success)
             {
-                // Using InvariantCulture as these are expected to be hex codes.
-                int argb = int.Parse(
-                    color.Replace("#", string.Empty),
-                    System.Globalization.NumberStyles.HexNumber,
-                    CultureInfo.InvariantCulture);
                 Color clr = Color.FromArgb(argb);
                 return "#" + clr.R.ToString("X2", CultureInfo.InvariantCulture) +
                     clr.G.ToString("X2", CultureInfo.InvariantCulture) +
                     clr.B.ToString("X2", CultureInfo.InvariantCulture);
             }
-            catch (Exception)
+            else
             {
                 return "#FFFFFF";
             }

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/ViewModels/GeneralViewModel.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/ViewModels/GeneralViewModel.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Globalization;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Microsoft.PowerToys.Settings.UI.Lib.Helpers;
 using Microsoft.PowerToys.Settings.UI.Lib.Interface;
@@ -236,6 +236,7 @@ namespace Microsoft.PowerToys.Settings.UI.Lib.ViewModels
             }
         }
 
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "This may throw if the XAML page is not initialized in tests (https://github.com/microsoft/PowerToys/pull/2676)")]
         public bool IsDarkThemeRadioButtonChecked
         {
             get
@@ -253,8 +254,9 @@ namespace Microsoft.PowerToys.Settings.UI.Lib.ViewModels
                     {
                         UpdateUIThemeCallBack(GeneralSettingsConfig.Theme);
                     }
-                    catch
+                    catch (Exception e)
                     {
+                        Logger.LogError("Exception encountered when changing Settings theme", e);
                     }
 
                     NotifyPropertyChanged();
@@ -262,6 +264,7 @@ namespace Microsoft.PowerToys.Settings.UI.Lib.ViewModels
             }
         }
 
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "This may throw if the XAML page is not initialized in tests (https://github.com/microsoft/PowerToys/pull/2676)")]
         public bool IsLightThemeRadioButtonChecked
         {
             get
@@ -279,8 +282,9 @@ namespace Microsoft.PowerToys.Settings.UI.Lib.ViewModels
                     {
                         UpdateUIThemeCallBack(GeneralSettingsConfig.Theme);
                     }
-                    catch
+                    catch (Exception e)
                     {
+                        Logger.LogError("Exception encountered when changing Settings theme", e);
                     }
 
                     NotifyPropertyChanged();
@@ -288,6 +292,7 @@ namespace Microsoft.PowerToys.Settings.UI.Lib.ViewModels
             }
         }
 
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "This may throw if the XAML page is not initialized in tests (https://github.com/microsoft/PowerToys/pull/2676)")]
         public bool IsSystemThemeRadioButtonChecked
         {
             get
@@ -305,8 +310,9 @@ namespace Microsoft.PowerToys.Settings.UI.Lib.ViewModels
                     {
                         UpdateUIThemeCallBack(GeneralSettingsConfig.Theme);
                     }
-                    catch
+                    catch (Exception e)
                     {
+                        Logger.LogError("Exception encountered when changing Settings theme", e);
                     }
 
                     NotifyPropertyChanged();

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/ViewModels/ImageResizerViewModel.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/ViewModels/ImageResizerViewModel.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Linq;
 using Microsoft.PowerToys.Settings.UI.Lib.Helpers;
 using Microsoft.PowerToys.Settings.UI.Lib.Interface;
@@ -45,6 +46,12 @@ namespace Microsoft.PowerToys.Settings.UI.Lib.ViewModels
             catch (Exception e)
             {
                 Logger.LogError($"Exception encountered while reading {ModuleName} settings.", e);
+#if DEBUG
+                if (e is ArgumentException || e is ArgumentNullException || e is PathTooLongException)
+                {
+                    throw e;
+                }
+#endif
                 Settings = new ImageResizerSettings();
                 _settingsUtils.SaveSettings(Settings.ToJsonString(), ModuleName);
             }

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/ViewModels/ImageResizerViewModel.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/ViewModels/ImageResizerViewModel.cs
@@ -5,9 +5,11 @@
 using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.PowerToys.Settings.UI.Lib.Helpers;
 using Microsoft.PowerToys.Settings.UI.Lib.Interface;
+using Microsoft.PowerToys.Settings.UI.Lib.Utilities;
 
 namespace Microsoft.PowerToys.Settings.UI.Lib.ViewModels
 {
@@ -23,6 +25,7 @@ namespace Microsoft.PowerToys.Settings.UI.Lib.ViewModels
 
         private Func<string, int> SendConfigMSG { get; }
 
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Exceptions should not crash the program but will be logged until we can understand common exception scenarios")]
         public ImageResizerViewModel(ISettingsUtils settingsUtils, ISettingsRepository<GeneralSettings> settingsRepository, Func<string, int> ipcMSGCallBackFunc)
         {
             _settingsUtils = settingsUtils ?? throw new ArgumentNullException(nameof(settingsUtils));
@@ -39,8 +42,9 @@ namespace Microsoft.PowerToys.Settings.UI.Lib.ViewModels
             {
                 Settings = _settingsUtils.GetSettings<ImageResizerSettings>(ModuleName);
             }
-            catch
+            catch (Exception e)
             {
+                Logger.LogError($"Exception encountered while reading {ModuleName} settings.", e);
                 Settings = new ImageResizerSettings();
                 _settingsUtils.SaveSettings(Settings.ToJsonString(), ModuleName);
             }

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/ViewModels/KeyboardManagerViewModel.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/ViewModels/KeyboardManagerViewModel.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -58,8 +59,20 @@ namespace Microsoft.PowerToys.Settings.UI.Lib.ViewModels
 
             if (_settingsUtils.SettingsExists(PowerToyName))
             {
-                // Todo: Be more resilient while reading and saving settings.
-                Settings = _settingsUtils.GetSettings<KeyboardManagerSettings>(PowerToyName);
+                try
+                {
+                    Settings = _settingsUtils.GetSettings<KeyboardManagerSettings>(PowerToyName);
+                }
+                catch (Exception e)
+                {
+                    Logger.LogError($"Exception encountered while reading {PowerToyName} settings.", e);
+#if DEBUG
+                    if (e is ArgumentException || e is ArgumentNullException || e is PathTooLongException)
+                    {
+                        throw e;
+                    }
+#endif
+                }
 
                 // Load profile.
                 if (!LoadProfile())

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/ViewModels/KeyboardManagerViewModel.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/ViewModels/KeyboardManagerViewModel.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -182,6 +182,7 @@ namespace Microsoft.PowerToys.Settings.UI.Lib.ViewModels
             OnPropertyChanged(nameof(RemapShortcuts));
         }
 
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Exceptions here (especially mutex errors) should not halt app execution, but they will be logged.")]
         public bool LoadProfile()
         {
             var success = true;
@@ -221,9 +222,10 @@ namespace Microsoft.PowerToys.Settings.UI.Lib.ViewModels
                     }
                 }
             }
-            catch (Exception)
+            catch (Exception e)
             {
                 // Failed to load the configuration.
+                Logger.LogError($"Exception encountered when loading {PowerToyName} profile", e);
                 success = false;
             }
 

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/ViewModels/PowerRenameViewModel.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/ViewModels/PowerRenameViewModel.cs
@@ -3,9 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Microsoft.PowerToys.Settings.UI.Lib.Helpers;
 using Microsoft.PowerToys.Settings.UI.Lib.Interface;
+using Microsoft.PowerToys.Settings.UI.Lib.Utilities;
 
 namespace Microsoft.PowerToys.Settings.UI.Lib.ViewModels
 {
@@ -23,6 +25,7 @@ namespace Microsoft.PowerToys.Settings.UI.Lib.ViewModels
 
         private Func<string, int> SendConfigMSG { get; }
 
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Exceptions should not crash the program but will be logged until we can understand common exception scenarios")]
         public PowerRenameViewModel(ISettingsUtils settingsUtils, ISettingsRepository<GeneralSettings> settingsRepository, Func<string, int> ipcMSGCallBackFunc, string configFileSubfolder = "")
         {
             // Update Settings file folder:
@@ -41,8 +44,9 @@ namespace Microsoft.PowerToys.Settings.UI.Lib.ViewModels
                 PowerRenameLocalProperties localSettings = _settingsUtils.GetSettings<PowerRenameLocalProperties>(GetSettingsSubPath(), "power-rename-settings.json");
                 Settings = new PowerRenameSettings(localSettings);
             }
-            catch
+            catch (Exception e)
             {
+                Logger.LogError($"Exception encountered while reading {ModuleName} settings.", e);
                 PowerRenameLocalProperties localSettings = new PowerRenameLocalProperties();
                 Settings = new PowerRenameSettings(localSettings);
                 _settingsUtils.SaveSettings(localSettings.ToJsonString(), GetSettingsSubPath(), "power-rename-settings.json");

--- a/src/core/Microsoft.PowerToys.Settings.UI.Lib/ViewModels/PowerRenameViewModel.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Lib/ViewModels/PowerRenameViewModel.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Runtime.CompilerServices;
 using Microsoft.PowerToys.Settings.UI.Lib.Helpers;
 using Microsoft.PowerToys.Settings.UI.Lib.Interface;
@@ -47,6 +48,12 @@ namespace Microsoft.PowerToys.Settings.UI.Lib.ViewModels
             catch (Exception e)
             {
                 Logger.LogError($"Exception encountered while reading {ModuleName} settings.", e);
+#if DEBUG
+                if (e is ArgumentException || e is ArgumentNullException || e is PathTooLongException)
+                {
+                    throw e;
+                }
+#endif
                 PowerRenameLocalProperties localSettings = new PowerRenameLocalProperties();
                 Settings = new PowerRenameSettings(localSettings);
                 _settingsUtils.SaveSettings(localSettings.ToJsonString(), GetSettingsSubPath(), "power-rename-settings.json");

--- a/src/modules/colorPicker/ColorPickerUI/Settings/UserSettings.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Settings/UserSettings.cs
@@ -6,7 +6,6 @@ using System;
 using System.ComponentModel.Composition;
 using System.IO;
 using System.Threading;
-using ColorPicker.Helpers;
 using Microsoft.PowerToys.Settings.UI.Lib;
 using Microsoft.PowerToys.Settings.UI.Lib.Utilities;
 
@@ -60,7 +59,7 @@ namespace ColorPicker.Settings
 
                             if (!_settingsUtils.SettingsExists(ColorPickerModuleName))
                             {
-                                ColorPicker.Helpers.Logger.LogInfo("ColorPicker settings.json was missing, creating a new one");
+                                Logger.LogInfo("ColorPicker settings.json was missing, creating a new one");
                                 var defaultColorPickerSettings = new ColorPickerSettings();
                                 defaultColorPickerSettings.Save(_settingsUtils);
                             }
@@ -82,7 +81,7 @@ namespace ColorPicker.Settings
                                 retry = false;
                             }
 
-                            ColorPicker.Helpers.Logger.LogError("Failed to read changed settings", ex);
+                            Logger.LogError("Failed to read changed settings", ex);
                             Thread.Sleep(500);
                         }
 #pragma warning disable CA1031 // Do not catch general exception types
@@ -94,7 +93,7 @@ namespace ColorPicker.Settings
                                 retry = false;
                             }
 
-                            ColorPicker.Helpers.Logger.LogError("Failed to read changed settings", ex);
+                            Logger.LogError("Failed to read changed settings", ex);
                             Thread.Sleep(500);
                         }
                     }

--- a/src/modules/colorPicker/ColorPickerUI/Settings/UserSettings.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Settings/UserSettings.cs
@@ -60,7 +60,7 @@ namespace ColorPicker.Settings
 
                             if (!_settingsUtils.SettingsExists(ColorPickerModuleName))
                             {
-                                Logger.LogInfo("ColorPicker settings.json was missing, creating a new one");
+                                ColorPicker.Helpers.Logger.LogInfo("ColorPicker settings.json was missing, creating a new one");
                                 var defaultColorPickerSettings = new ColorPickerSettings();
                                 defaultColorPickerSettings.Save(_settingsUtils);
                             }
@@ -82,7 +82,7 @@ namespace ColorPicker.Settings
                                 retry = false;
                             }
 
-                            Logger.LogError("Failed to read changed settings", ex);
+                            ColorPicker.Helpers.Logger.LogError("Failed to read changed settings", ex);
                             Thread.Sleep(500);
                         }
 #pragma warning disable CA1031 // Do not catch general exception types
@@ -94,7 +94,7 @@ namespace ColorPicker.Settings
                                 retry = false;
                             }
 
-                            Logger.LogError("Failed to read changed settings", ex);
+                            ColorPicker.Helpers.Logger.LogError("Failed to read changed settings", ex);
                             Thread.Sleep(500);
                         }
                     }


### PR DESCRIPTION
## Summary of the Pull Request

Fixing FxCop warnings for the Microsoft.PowerToys.Settings.UI.Lib.csproj project, specifically regarding general exception handling in the Settings library code.

## PR Checklist
* [x] Applies to #5129
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
![image](https://user-images.githubusercontent.com/16506055/96511432-f17b4b80-1213-11eb-945b-642f8233108b.png)
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

- Added Logger class under Utilities that is able to log errors to file in %USERPROFILE%\AppData\Local\Microsoft\PowerToys\Settings Logs
- Suppress most instances of FxCop warnings and log exceptions to file

## Validation Steps Performed

Ensure the Library unit tests pass on Debug & Release mode, and manually validate settings functionality for Debug & Release builds.
