### PR TITLE
[KBM] Ignore IME keys while checking keyboard state for Shortcut Remaps

### DIFF
--- a/src/modules/keyboardmanager/common/Shortcut.cpp
+++ b/src/modules/keyboardmanager/common/Shortcut.cpp
@@ -656,7 +656,7 @@ bool IgnoreKeyCode(DWORD key)
     bool isOEMSpecific = in_range(key, 0x92, 0x96) || equals(key, 0xE1) || in_range(key, 0xE3, 0xE4) || equals(key, 0xE6) || in_range(key, 0xE9, 0xF5);
 
     // IME keys. Ignore these key codes as some of them are used by IME keyboards. More information at https://github.com/microsoft/PowerToys/issues/6951
-    bool isIME = in_range(key, VK_KANA, 0x1A) + in_range(key, VK_CONVERT, VK_MODECHANGE) + equals(key, VK_PROCESSKEY);
+    bool isIME = in_range(key, VK_KANA, 0x1A) || in_range(key, VK_CONVERT, VK_MODECHANGE) || equals(key, VK_PROCESSKEY);
 
     if (isUndefined || isReserved || isUnassigned || isOEMSpecific || isIME)
     {

--- a/src/modules/keyboardmanager/common/Shortcut.cpp
+++ b/src/modules/keyboardmanager/common/Shortcut.cpp
@@ -652,8 +652,11 @@ bool IgnoreKeyCode(DWORD key)
     // Unassigned keys
     bool isUnassigned = in_range(key, 0x88, 0x8F) || in_range(key, 0x97, 0x9F) || in_range(key, 0xD8, 0xDA) || equals(key, 0xE8);
 
-    //OEM Specific keys. Ignore these key codes as some of them are used by IME keyboards. More information at https://github.com/microsoft/PowerToys/issues/5225
+    // OEM Specific keys. Ignore these key codes as some of them are used by IME keyboards. More information at https://github.com/microsoft/PowerToys/issues/5225
     bool isOEMSpecific = in_range(key, 0x92, 0x96) || equals(key, 0xE1) || in_range(key, 0xE3, 0xE4) || equals(key, 0xE6) || in_range(key, 0xE9, 0xF5);
+
+    // IME keys. Ignore these key codes as some of them are used by IME keyboards. More information at https://github.com/microsoft/PowerToys/issues/6951
+    bool isIME = in_range(key, VK_KANA, 0x1A) + in_range(key, VK_CONVERT, VK_MODECHANGE) + equals(key, VK_PROCESSKEY);
 
     if (isUndefined || isReserved || isUnassigned || isOEMSpecific)
     {

--- a/src/modules/keyboardmanager/common/Shortcut.cpp
+++ b/src/modules/keyboardmanager/common/Shortcut.cpp
@@ -658,7 +658,7 @@ bool IgnoreKeyCode(DWORD key)
     // IME keys. Ignore these key codes as some of them are used by IME keyboards. More information at https://github.com/microsoft/PowerToys/issues/6951
     bool isIME = in_range(key, VK_KANA, 0x1A) + in_range(key, VK_CONVERT, VK_MODECHANGE) + equals(key, VK_PROCESSKEY);
 
-    if (isUndefined || isReserved || isUnassigned || isOEMSpecific)
+    if (isUndefined || isReserved || isUnassigned || isOEMSpecific || isIME)
     {
         return true;
     }


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
As mentioned in the comment at https://github.com/microsoft/PowerToys/issues/6951#issuecomment-706626338, it was found that VK_KANJI sometimes gets set and doesn't get released while pressing Alt+` on Japanese IME. To prevent this from blocking shortcut remaps, this PR adds all the IME related keys as per the [Virtual Key Codes doc](https://docs.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes) to the ignore list.

## PR Checklist
* [X] Applies to #6951 https://github.com/microsoft/PowerToys/issues/6951#issuecomment-706626338
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [X] Tests passed


## Validation Steps Performed

_How does someone test & validate?_
- Add some shortcut to shortcut remapping
- Switch to Japanese IME keyboard layout
- Open a text editor, and do the following steps:
    - Press Alt
    - Press ` (At this point the Japanese IME should get changed)
    - Release Alt
    - Release `
    - Press the shortcut you remapped (earlier this wouldn't work until you hit and release Alt+` normally again)