### PR TITLE
[FancyZones] Align zone numbers between Editor and FancyZonesLib

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/Settings.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/Settings.cs
@@ -404,15 +404,15 @@ namespace FancyZonesEditor
                 _gridModel.ColumnPercents.Add(((_multiplier * (col + 1)) / cols) - ((_multiplier * col) / cols));
             }
 
-            int index = ZoneCount - 1;
-            for (int col = cols - 1; col >= 0; col--)
+            int index = 0;
+            for (int row = 0; row < rows; row++)
             {
-                for (int row = rows - 1; row >= 0; row--)
+                for (int col = 0; col < cols; col++)
                 {
-                    _gridModel.CellChildMap[row, col] = index--;
-                    if (index < 0)
+                    _gridModel.CellChildMap[row, col] = index++;
+                    if (index == ZoneCount)
                     {
-                        index = 0;
+                        index--;
                     }
                 }
             }

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -1183,10 +1183,9 @@ bool FancyZones::OnSnapHotkeyBasedOnPosition(HWND window, DWORD vkCode) noexcept
                 auto zoneSet = workArea->ActiveZoneSet();
                 if (zoneSet)
                 {
-                    auto zones = zoneSet->GetZones();
-                    for (size_t i = 0; i < zones.size(); i++)
+                    const auto& zones = zoneSet->GetZones();
+                    for (const auto& [zoneId, zone] : zones)
                     {
-                        const auto& zone = zones[i];
                         RECT zoneRect = zone->GetZoneRect();
 
                         zoneRect.left += monitorRect.left;
@@ -1195,7 +1194,7 @@ bool FancyZones::OnSnapHotkeyBasedOnPosition(HWND window, DWORD vkCode) noexcept
                         zoneRect.bottom += monitorRect.top;
 
                         zoneRects.emplace_back(zoneRect);
-                        zoneRectsInfo.emplace_back(i, workArea);
+                        zoneRectsInfo.emplace_back(zoneId, workArea);
                     }
                 }
             }
@@ -1228,10 +1227,9 @@ bool FancyZones::OnSnapHotkeyBasedOnPosition(HWND window, DWORD vkCode) noexcept
             auto zoneSet = workArea->ActiveZoneSet();
             if (zoneSet)
             {
-                auto zones = zoneSet->GetZones();
-                for (size_t i = 0; i < zones.size(); i++)
+                const auto& zones = zoneSet->GetZones();
+                for (const auto& [zoneId, zone] : zones)
                 {
-                    const auto& zone = zones[i];
                     RECT zoneRect = zone->GetZoneRect();
 
                     zoneRect.left += currentMonitorRect.left;
@@ -1240,7 +1238,7 @@ bool FancyZones::OnSnapHotkeyBasedOnPosition(HWND window, DWORD vkCode) noexcept
                     zoneRect.bottom += currentMonitorRect.top;
 
                     zoneRects.emplace_back(zoneRect);
-                    zoneRectsInfo.emplace_back(i, workArea);
+                    zoneRectsInfo.emplace_back(zoneId, workArea);
                 }
             }
         }

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -1183,7 +1183,7 @@ bool FancyZones::OnSnapHotkeyBasedOnPosition(HWND window, DWORD vkCode) noexcept
                 auto zoneSet = workArea->ActiveZoneSet();
                 if (zoneSet)
                 {
-                    const auto& zones = zoneSet->GetZones();
+                    const auto zones = zoneSet->GetZones();
                     for (const auto& [zoneId, zone] : zones)
                     {
                         RECT zoneRect = zone->GetZoneRect();
@@ -1227,7 +1227,7 @@ bool FancyZones::OnSnapHotkeyBasedOnPosition(HWND window, DWORD vkCode) noexcept
             auto zoneSet = workArea->ActiveZoneSet();
             if (zoneSet)
             {
-                const auto& zones = zoneSet->GetZones();
+                const auto zones = zoneSet->GetZones();
                 for (const auto& [zoneId, zone] : zones)
                 {
                     RECT zoneRect = zone->GetZoneRect();

--- a/src/modules/fancyzones/lib/Zone.cpp
+++ b/src/modules/fancyzones/lib/Zone.cpp
@@ -135,7 +135,7 @@ RECT Zone::ComputeActualZoneRect(HWND window, HWND zoneWindow) const noexcept
 
 winrt::com_ptr<IZone> MakeZone(const RECT& zoneRect, const size_t zoneId) noexcept
 {
-    if (ValidateZoneRect(zoneRect) && zoneId > 0)
+    if (ValidateZoneRect(zoneRect) && zoneId >= 0)
     {
         return winrt::make_self<Zone>(zoneRect, zoneId);
     }

--- a/src/modules/fancyzones/lib/ZoneSet.cpp
+++ b/src/modules/fancyzones/lib/ZoneSet.cpp
@@ -318,7 +318,7 @@ ZoneSet::MoveWindowIntoZoneByIndexSet(HWND window, HWND workAreaWindow, const st
         if (m_zones.contains(id))
         {
             const auto& zone = m_zones.at(id);
-            const RECT& newSize = zone->ComputeActualZoneRect(window, workAreaWindow);
+            const RECT newSize = zone->ComputeActualZoneRect(window, workAreaWindow);
             if (!sizeEmpty)
             {
                 size.left = min(size.left, newSize.left);
@@ -903,18 +903,21 @@ std::vector<size_t> ZoneSet::GetCombinedZoneRange(const std::vector<size_t>& ini
 
     for (size_t zoneId : combinedZones)
     {
-        const RECT& rect = m_zones.at(zoneId)->GetZoneRect();
-        if (boundingRectEmpty)
+        if (m_zones.contains(zoneId))
         {
-            boundingRect = rect;
-            boundingRectEmpty = false;
-        }
-        else
-        {
-            boundingRect.left = min(boundingRect.left, rect.left);
-            boundingRect.top = min(boundingRect.top, rect.top);
-            boundingRect.right = max(boundingRect.right, rect.right);
-            boundingRect.bottom = max(boundingRect.bottom, rect.bottom);
+            const RECT rect = m_zones.at(zoneId)->GetZoneRect();
+            if (boundingRectEmpty)
+            {
+                boundingRect = rect;
+                boundingRectEmpty = false;
+            }
+            else
+            {
+                boundingRect.left = min(boundingRect.left, rect.left);
+                boundingRect.top = min(boundingRect.top, rect.top);
+                boundingRect.right = max(boundingRect.right, rect.right);
+                boundingRect.bottom = max(boundingRect.bottom, rect.bottom);
+            }
         }
     }
 
@@ -922,7 +925,7 @@ std::vector<size_t> ZoneSet::GetCombinedZoneRange(const std::vector<size_t>& ini
     {
         for (const auto& [zoneId, zone] : m_zones)
         {
-            const RECT& rect = zone->GetZoneRect();
+            const RECT rect = zone->GetZoneRect();
             if (boundingRect.left <= rect.left && rect.right <= boundingRect.right &&
                 boundingRect.top <= rect.top && rect.bottom <= boundingRect.bottom)
             {

--- a/src/modules/fancyzones/lib/ZoneSet.cpp
+++ b/src/modules/fancyzones/lib/ZoneSet.cpp
@@ -344,14 +344,14 @@ ZoneSet::MoveWindowIntoZoneByDirectionAndIndex(HWND window, HWND workAreaWindow,
     // The window was not assigned to any zone here
     if (indexSet.size() == 0)
     {
-        MoveWindowIntoZoneByIndex(window, workAreaWindow, vkCode == VK_LEFT ? numZones : 1);
+        MoveWindowIntoZoneByIndex(window, workAreaWindow, vkCode == VK_LEFT ? numZones - 1 : 0);
         return true;
     }
 
     size_t oldId = indexSet[0];
 
     // We reached the edge
-    if ((vkCode == VK_LEFT && oldId == 1) || (vkCode == VK_RIGHT && oldId == numZones))
+    if ((vkCode == VK_LEFT && oldId == 0) || (vkCode == VK_RIGHT && oldId == numZones - 1))
     {
         if (!cycle)
         {
@@ -360,7 +360,7 @@ ZoneSet::MoveWindowIntoZoneByDirectionAndIndex(HWND window, HWND workAreaWindow,
         }
         else
         {
-            MoveWindowIntoZoneByIndex(window, workAreaWindow, vkCode == VK_LEFT ? numZones : 1);
+            MoveWindowIntoZoneByIndex(window, workAreaWindow, vkCode == VK_LEFT ? numZones - 1 : 0);
             return true;
         }
     }
@@ -385,9 +385,7 @@ ZoneSet::MoveWindowIntoZoneByDirectionAndPosition(HWND window, HWND workAreaWind
         return false;
     }
 
-    // Initialize (m_zones.size() + 1) vector of bools
-    // as usedZoneIndices[0] not used -> zoneIds have values in [1..m_zones.size()]
-    std::vector<bool> usedZoneIndices(m_zones.size() + 1, false);
+    std::vector<bool> usedZoneIndices(m_zones.size(), false);
     for (size_t id : GetZoneIndexSetFromWindow(window))
     {
         usedZoneIndices[id] = true;
@@ -598,7 +596,7 @@ bool ZoneSet::CalculateFocusLayout(Rect workArea, int zoneCount) noexcept
 
     for (int i = 0; i < zoneCount; i++)
     {
-        auto zone = MakeZone(focusZoneRect, m_zones.size() + 1);
+        auto zone = MakeZone(focusZoneRect, m_zones.size());
         if (zone)
         {
             AddZone(zone);
@@ -655,7 +653,7 @@ bool ZoneSet::CalculateColumnsAndRowsLayout(Rect workArea, FancyZonesDataTypes::
         }
 
 
-        auto zone = MakeZone(RECT{ left, top, right, bottom }, m_zones.size() + 1);
+        auto zone = MakeZone(RECT{ left, top, right, bottom }, m_zones.size());
         if (zone)
         {
             AddZone(zone);
@@ -722,15 +720,15 @@ bool ZoneSet::CalculateGridLayout(Rect workArea, FancyZonesDataTypes::ZoneSetLay
         gridLayoutInfo.cellChildMap()[i] = std::vector<int>(columns);
     }
 
-    int index = zoneCount - 1;
-    for (int col = columns - 1; col >= 0; col--)
+    int index = 0;
+    for (int row = 0; row < rows; row++)
     {
-        for (int row = rows - 1; row >= 0; row--)
+        for (int col = 0; col < columns; col++)
         {
-            gridLayoutInfo.cellChildMap()[row][col] = index--;
-            if (index < 0)
+            gridLayoutInfo.cellChildMap()[row][col] = index++;
+            if (index == zoneCount)
             {
-                index = 0;
+                index--;
             }
         }
     }
@@ -775,7 +773,7 @@ bool ZoneSet::CalculateCustomLayout(Rect workArea, int spacing) noexcept
                 DPIAware::Convert(m_config.Monitor, x, y);
                 DPIAware::Convert(m_config.Monitor, width, height);
 
-                auto zone = MakeZone(RECT{ x, y, x + width, y + height }, m_zones.size() + 1);
+                auto zone = MakeZone(RECT{ x, y, x + width, y + height }, m_zones.size());
                 if (zone)
                 {
                     AddZone(zone);
@@ -858,7 +856,7 @@ bool ZoneSet::CalculateGridZones(Rect workArea, FancyZonesDataTypes::GridLayoutI
                 long right = columnInfo[maxCol].End;
                 long bottom = rowInfo[maxRow].End;
 
-                auto zone = MakeZone(RECT{ left, top, right, bottom }, i + 1);
+                auto zone = MakeZone(RECT{ left, top, right, bottom }, i);
                 if (zone)
                 {
                     AddZone(zone);

--- a/src/modules/fancyzones/lib/ZoneSet.cpp
+++ b/src/modules/fancyzones/lib/ZoneSet.cpp
@@ -115,7 +115,7 @@ public:
     {
     }
 
-    ZoneSet(ZoneSetConfig const& config, std::map<size_t, winrt::com_ptr<IZone>> zones):
+    ZoneSet(ZoneSetConfig const& config, ZonesMap zones) :
         m_config(config),
         m_zones(zones)
     {

--- a/src/modules/fancyzones/lib/ZoneSet.cpp
+++ b/src/modules/fancyzones/lib/ZoneSet.cpp
@@ -130,7 +130,7 @@ public:
     ZonesFromPoint(POINT pt) const noexcept;
     IFACEMETHODIMP_(std::vector<size_t>)
     GetZoneIndexSetFromWindow(HWND window) const noexcept;
-    std::map<size_t, winrt::com_ptr<IZone>>
+    IFACEMETHODIMP_(ZonesMap)
     GetZones()const noexcept override { return m_zones; }
     IFACEMETHODIMP_(void)
     MoveWindowIntoZoneByIndex(HWND window, HWND workAreaWindow, size_t index) noexcept;
@@ -159,7 +159,7 @@ private:
     bool CalculateCustomLayout(Rect workArea, int spacing) noexcept;
     bool CalculateGridZones(Rect workArea, FancyZonesDataTypes::GridLayoutInfo gridLayoutInfo, int spacing);
 
-    std::map<size_t, winrt::com_ptr<IZone>> m_zones;
+    ZonesMap m_zones;
     std::map<HWND, std::vector<size_t>> m_windowIndexSet;
 
     // Needed for ExtendWindowByDirectionAndPosition

--- a/src/modules/fancyzones/lib/ZoneSet.cpp
+++ b/src/modules/fancyzones/lib/ZoneSet.cpp
@@ -217,8 +217,18 @@ ZoneSet::ZonesFromPoint(POINT pt) const noexcept
     {
         for (size_t j = i + 1; j < capturedZones.size(); ++j)
         {
-            const auto& rectI = m_zones.at(capturedZones[i])->GetZoneRect();
-            const auto& rectJ = m_zones.at(capturedZones[j])->GetZoneRect();
+            RECT rectI;
+            RECT rectJ;
+            try
+            {
+                rectI = m_zones.at(capturedZones[i])->GetZoneRect();
+                rectJ = m_zones.at(capturedZones[j])->GetZoneRect();
+            }
+            catch (std::out_of_range)
+            {
+                return {};
+            }
+
             if (max(rectI.top, rectJ.top) + m_config.SensitivityRadius < min(rectI.bottom, rectJ.bottom) &&
                 max(rectI.left, rectJ.left) + m_config.SensitivityRadius < min(rectI.right, rectJ.right))
             {
@@ -237,8 +247,17 @@ ZoneSet::ZonesFromPoint(POINT pt) const noexcept
         size_t smallestIdx = 0;
         for (size_t i = 1; i < capturedZones.size(); ++i)
         {
-            const auto& rectS = m_zones.at(capturedZones[smallestIdx])->GetZoneRect();
-            const auto& rectI = m_zones.at(capturedZones[i])->GetZoneRect();
+            RECT rectS;
+            RECT rectI;
+            try
+            {
+                rectS = m_zones.at(capturedZones[smallestIdx])->GetZoneRect();
+                rectI = m_zones.at(capturedZones[i])->GetZoneRect();
+            }
+            catch (std::out_of_range)
+            {
+                return {};
+            }
             int smallestSize = (rectS.bottom - rectS.top) * (rectS.right - rectS.left);
             int iSize = (rectI.bottom - rectI.top) * (rectI.right - rectI.left);
 

--- a/src/modules/fancyzones/lib/ZoneSet.h
+++ b/src/modules/fancyzones/lib/ZoneSet.h
@@ -45,7 +45,7 @@ interface __declspec(uuid("{E4839EB7-669D-49CF-84A9-71A2DFD851A3}")) IZoneSet : 
     /**
      * @returns Array of zone objects (defining coordinates of the zone) inside this zone layout.
      */
-    IFACEMETHOD_(std::vector<winrt::com_ptr<IZone>>, GetZones)() const = 0;
+    virtual std::map<size_t, winrt::com_ptr<IZone>> GetZones() const = 0;
     /**
      * Assign window to the zone based on zone index inside zone layout.
      *

--- a/src/modules/fancyzones/lib/ZoneSet.h
+++ b/src/modules/fancyzones/lib/ZoneSet.h
@@ -6,13 +6,15 @@ namespace FancyZonesDataTypes
 {
     enum class ZoneSetLayoutType;
 }
-
 /**
  * Class representing single zone layout. ZoneSet is responsible for actual calculation of rectangle coordinates
  * (whether is grid or canvas layout) and moving windows through them.
  */
 interface __declspec(uuid("{E4839EB7-669D-49CF-84A9-71A2DFD851A3}")) IZoneSet : public IUnknown
 {
+    // Mapping zone id to zone
+    using ZonesMap = std::map<size_t, winrt::com_ptr<IZone>>;
+
     /**
      * @returns Unique identifier of zone layout.
      */
@@ -45,7 +47,7 @@ interface __declspec(uuid("{E4839EB7-669D-49CF-84A9-71A2DFD851A3}")) IZoneSet : 
     /**
      * @returns Array of zone objects (defining coordinates of the zone) inside this zone layout.
      */
-    virtual std::map<size_t, winrt::com_ptr<IZone>> GetZones() const = 0;
+    IFACEMETHOD_(ZonesMap, GetZones) () const = 0;
     /**
      * Assign window to the zone based on zone index inside zone layout.
      *

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -69,7 +69,7 @@ namespace ZoneWindowUtils
                          COLORREF hostZoneBorderColor,
                          COLORREF hostZoneHighlightColor,
                          int hostZoneHighlightOpacity,
-                         std::map<size_t, winrt::com_ptr<IZone>> zones,
+                         IZoneSet::ZonesMap zones,
                          std::vector<size_t> highlightZone,
                          bool flashMode)
     {
@@ -621,7 +621,7 @@ void ZoneWindow::OnPaint(HDC hdc) noexcept
     COLORREF hostZoneBorderColor{};
     COLORREF hostZoneHighlightColor{};
     int hostZoneHighlightOpacity{};
-    std::map<size_t, winrt::com_ptr<IZone>> zones{};
+    IZoneSet::ZonesMap zones;
     std::vector<size_t> highlightZone = m_highlightZone;
     bool flashMode = m_flashMode;
 

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -69,7 +69,7 @@ namespace ZoneWindowUtils
                          COLORREF hostZoneBorderColor,
                          COLORREF hostZoneHighlightColor,
                          int hostZoneHighlightOpacity,
-                         std::vector<winrt::com_ptr<IZone>> zones,
+                         std::map<size_t, winrt::com_ptr<IZone>> zones,
                          std::vector<size_t> highlightZone,
                          bool flashMode)
     {
@@ -621,7 +621,7 @@ void ZoneWindow::OnPaint(HDC hdc) noexcept
     COLORREF hostZoneBorderColor{};
     COLORREF hostZoneHighlightColor{};
     int hostZoneHighlightOpacity{};
-    std::vector<winrt::com_ptr<IZone>> zones{};
+    std::map<size_t, winrt::com_ptr<IZone>> zones{};
     std::vector<size_t> highlightZone = m_highlightZone;
     bool flashMode = m_flashMode;
 

--- a/src/modules/fancyzones/lib/ZoneWindowDrawing.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindowDrawing.cpp
@@ -115,7 +115,7 @@ namespace ZoneWindowDrawing
                            COLORREF zoneBorderColor,
                            COLORREF highlightColor,
                            int zoneOpacity,
-                           const std::map<size_t, winrt::com_ptr<IZone>>& zones,
+                           const IZoneSet::ZonesMap& zones,
                            const std::vector<size_t>& highlightZones,
                            bool flashMode) noexcept
     {

--- a/src/modules/fancyzones/lib/ZoneWindowDrawing.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindowDrawing.cpp
@@ -155,7 +155,11 @@ namespace ZoneWindowDrawing
         {
             colorHighlight.fill = highlightColor;
             colorHighlight.border = zoneBorderColor;
-            DrawZone(hdc, colorHighlight, zones.at(zoneId), flashMode);
+
+            if (zones.contains(zoneId))
+            {
+                DrawZone(hdc, colorHighlight, zones.at(zoneId), flashMode);
+            }
         }
     }
 }

--- a/src/modules/fancyzones/lib/ZoneWindowDrawing.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindowDrawing.cpp
@@ -98,7 +98,7 @@ namespace
 
         if (!flashMode)
         {
-            DrawIndex(hdc, zoneRect, zone->Id());
+            DrawIndex(hdc, zoneRect, zone->Id() + 1);
         }
     }
 }

--- a/src/modules/fancyzones/lib/ZoneWindowDrawing.h
+++ b/src/modules/fancyzones/lib/ZoneWindowDrawing.h
@@ -7,6 +7,7 @@
 
 #include "util.h"
 #include "Zone.h"
+#include "ZoneSet.h"
 
 namespace ZoneWindowDrawing
 {
@@ -25,7 +26,7 @@ namespace ZoneWindowDrawing
                            COLORREF zoneBorderColor,
                            COLORREF highlightColor,
                            int zoneOpacity,
-                           const std::map<size_t, winrt::com_ptr<IZone>>& zones,
+                           const IZoneSet::ZonesMap& zones,
                            const std::vector<size_t>& highlightZones,
                            bool flashMode) noexcept;
 }

--- a/src/modules/fancyzones/lib/ZoneWindowDrawing.h
+++ b/src/modules/fancyzones/lib/ZoneWindowDrawing.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <map>
 #include <vector>
 #include <wil\resource.h>
 #include <winrt/base.h>
@@ -24,7 +25,7 @@ namespace ZoneWindowDrawing
                            COLORREF zoneBorderColor,
                            COLORREF highlightColor,
                            int zoneOpacity,
-                           const std::vector<winrt::com_ptr<IZone>>& zones,
+                           const std::map<size_t, winrt::com_ptr<IZone>>& zones,
                            const std::vector<size_t>& highlightZones,
                            bool flashMode) noexcept;
 }

--- a/src/modules/fancyzones/tests/UnitTests/ZoneSet.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/ZoneSet.Spec.cpp
@@ -91,8 +91,8 @@ namespace FancyZonesUnitTests
                 m_set->AddZone(zone);
                 auto zones = m_set->GetZones();
                 Assert::AreEqual((size_t)1, zones.size());
-                compareZones(zone, zones[0]);
-                Assert::AreEqual(zoneId, zones[0]->Id());
+                compareZones(zone, zones[zoneId]);
+                Assert::AreEqual(zoneId, zones[zoneId]->Id());
             }
 
             TEST_METHOD (AddManyEqual)
@@ -105,8 +105,8 @@ namespace FancyZonesUnitTests
                     m_set->AddZone(zone);
                     auto zones = m_set->GetZones();
                     Assert::AreEqual(i + 1, zones.size());
-                    compareZones(zone, zones[i]);
-                    Assert::AreEqual(zoneId, zones[i]->Id());
+                    compareZones(zone, zones[zoneId]);
+                    Assert::AreEqual(zoneId, zones[zoneId]->Id());
                 }
             }
 
@@ -124,8 +124,8 @@ namespace FancyZonesUnitTests
                     m_set->AddZone(zone);
                     auto zones = m_set->GetZones();
                     Assert::AreEqual(i + 1, zones.size());
-                    compareZones(zone, zones[i]);
-                    Assert::AreEqual(zoneId, zones[i]->Id());
+                    compareZones(zone, zones[zoneId]);
+                    Assert::AreEqual(zoneId, zones[zoneId]->Id());
                 }
             }
 
@@ -369,14 +369,14 @@ namespace FancyZonesUnitTests
                 m_set->AddZone(zone3);
 
                 HWND window = Mocks::Window();
-                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0);
-                Assert::IsTrue(std::vector<size_t>{ 0 } == m_set->GetZoneIndexSetFromWindow(window));
-
                 m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 1);
                 Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window));
 
                 m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 2);
                 Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window));
+
+                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 3);
+                Assert::IsTrue(std::vector<size_t>{ 3 } == m_set->GetZoneIndexSetFromWindow(window));
             }
 
             TEST_METHOD (MoveWindowIntoZoneByIndexSeveralTimesSameIndex)
@@ -390,10 +390,10 @@ namespace FancyZonesUnitTests
                 m_set->AddZone(zone3);
 
                 HWND window = Mocks::Window();
-                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0);
-                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0);
-                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0);
-                Assert::IsTrue(std::vector<size_t>{ 0 } == m_set->GetZoneIndexSetFromWindow(window));
+                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 2);
+                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 2);
+                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 2);
+                Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window));
             }
 
             TEST_METHOD (MoveWindowIntoZoneByPointEmpty)
@@ -420,7 +420,7 @@ namespace FancyZonesUnitTests
                 auto window = Mocks::Window();
                 m_set->MoveWindowIntoZoneByPoint(window, Mocks::Window(), POINT{ 50, 50 });
 
-                Assert::IsTrue(std::vector<size_t>{ 0 } == m_set->GetZoneIndexSetFromWindow(window));
+                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window));
             }
 
             TEST_METHOD (MoveWindowIntoZoneByPointInnerPointOverlappingZones)
@@ -433,7 +433,7 @@ namespace FancyZonesUnitTests
                 auto window = Mocks::Window();
                 m_set->MoveWindowIntoZoneByPoint(window, Mocks::Window(), POINT{ 50, 50 });
 
-                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window));
+                Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window));
             }
 
             TEST_METHOD (MoveWindowIntoZoneByPointDropAddWindow)
@@ -447,11 +447,11 @@ namespace FancyZonesUnitTests
                 m_set->AddZone(zone1);
                 m_set->AddZone(zone2);
 
-                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0);
+                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 1);
 
                 m_set->MoveWindowIntoZoneByPoint(window, Mocks::Window(), POINT{ 50, 50 });
 
-                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window));
+                Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window));
             }
 
             TEST_METHOD (MoveWindowIntoZoneByPointDropAddWindowToSameZone)
@@ -469,7 +469,7 @@ namespace FancyZonesUnitTests
 
                 m_set->MoveWindowIntoZoneByPoint(window, Mocks::Window(), POINT{ 50, 50 });
 
-                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window));
+                Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window));
             }
 
             TEST_METHOD (MoveWindowIntoZoneByPointSeveralZonesWithSameWindow)
@@ -485,11 +485,11 @@ namespace FancyZonesUnitTests
                 m_set->AddZone(zone2);
                 m_set->AddZone(zone3);
 
-                m_set->MoveWindowIntoZoneByIndexSet(window, Mocks::Window(), { 0, 1, 2 });
+                m_set->MoveWindowIntoZoneByIndexSet(window, Mocks::Window(), { 1, 2, 3 });
 
                 m_set->MoveWindowIntoZoneByPoint(window, Mocks::Window(), POINT{ 50, 50 });
 
-                Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window));
+                Assert::IsTrue(std::vector<size_t>{ 3 } == m_set->GetZoneIndexSetFromWindow(window));
             }
     };
 
@@ -535,14 +535,14 @@ namespace FancyZonesUnitTests
             {
                 HWND window = Mocks::Window();
                 m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_RIGHT, true);
-                Assert::IsTrue(std::vector<size_t>{ 0 } == m_set->GetZoneIndexSetFromWindow(window));
+                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window));
             }
 
             TEST_METHOD (MoveLeftNoZones)
             {
                 HWND window = Mocks::Window();
                 m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_LEFT, true);
-                Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window));
+                Assert::IsTrue(std::vector<size_t>{ 3 } == m_set->GetZoneIndexSetFromWindow(window));
             }
 
             TEST_METHOD (MoveRightTwice)
@@ -550,7 +550,7 @@ namespace FancyZonesUnitTests
                 HWND window = Mocks::Window();
                 m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_RIGHT, true);
                 m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_RIGHT, true);
-                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window));
+                Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window));
             }
 
             TEST_METHOD (MoveLeftTwice)
@@ -558,7 +558,7 @@ namespace FancyZonesUnitTests
                 HWND window = Mocks::Window();
                 m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_LEFT, true);
                 m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_LEFT, true);
-                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window));
+                Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window));
             }
 
             TEST_METHOD (MoveRightMoreThanZonesCount)
@@ -569,7 +569,7 @@ namespace FancyZonesUnitTests
                     m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_RIGHT, true);
                 }
 
-                Assert::IsTrue(std::vector<size_t>{ 0 } == m_set->GetZoneIndexSetFromWindow(window));
+                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window));
             }
 
             TEST_METHOD (MoveLeftMoreThanZonesCount)
@@ -580,131 +580,131 @@ namespace FancyZonesUnitTests
                     m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_LEFT, true);
                 }
 
-                Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window));
+                Assert::IsTrue(std::vector<size_t>{ 3 } == m_set->GetZoneIndexSetFromWindow(window));
             }
 
             TEST_METHOD (MoveWindowIntoZoneByDirectionRight)
             {
                 HWND window = Mocks::Window();
-                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0);
-                m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_RIGHT, true);
-                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window));
-
+                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 1);
                 m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_RIGHT, true);
                 Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window));
+
+                m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_RIGHT, true);
+                Assert::IsTrue(std::vector<size_t>{ 3 } == m_set->GetZoneIndexSetFromWindow(window));
             }
 
             TEST_METHOD (MoveRightWithSameWindowAdded)
-            {
-                HWND window = Mocks::Window();
-                m_set->MoveWindowIntoZoneByIndexSet(window, Mocks::Window(), { 0, 1 });
-
-                Assert::IsTrue(std::vector<size_t>{ 0, 1 } == m_set->GetZoneIndexSetFromWindow(window));
-
-                m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_RIGHT, true);
-                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window));
-
-                m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_RIGHT, true);
-                Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window));
-            }
-
-            TEST_METHOD (MoveRightWithDifferentWindowsAdded)
-            {
-                HWND window1 = Mocks::Window();
-                HWND window2 = Mocks::Window();
-                m_set->MoveWindowIntoZoneByIndex(window1, Mocks::Window(), { 0 });
-                m_set->MoveWindowIntoZoneByIndex(window2, Mocks::Window(), { 1 });
-
-                Assert::IsTrue(std::vector<size_t>{ 0 } == m_set->GetZoneIndexSetFromWindow(window1));
-                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window2));
-
-                m_set->MoveWindowIntoZoneByDirectionAndIndex(window1, Mocks::Window(), VK_RIGHT, true);
-
-                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window1));
-                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window2));
-
-                m_set->MoveWindowIntoZoneByDirectionAndIndex(window1, Mocks::Window(), VK_RIGHT, true);
-
-                Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window1));
-                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window2));
-            }
-
-            TEST_METHOD (MoveWindowIntoZoneByDirectionLeft)
-            {
-                HWND window = Mocks::Window();
-                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 2);
-                m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_LEFT, true);
-                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window));
-
-                m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_LEFT, true);
-                Assert::IsTrue(std::vector<size_t>{ 0 } == m_set->GetZoneIndexSetFromWindow(window));
-            }
-
-            TEST_METHOD (MoveLeftWithSameWindowAdded)
             {
                 HWND window = Mocks::Window();
                 m_set->MoveWindowIntoZoneByIndexSet(window, Mocks::Window(), { 1, 2 });
 
                 Assert::IsTrue(std::vector<size_t>{ 1, 2 } == m_set->GetZoneIndexSetFromWindow(window));
 
-                m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_LEFT, true);
-                Assert::IsTrue(std::vector<size_t>{ 0 } == m_set->GetZoneIndexSetFromWindow(window));
+                m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_RIGHT, true);
+                Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window));
 
+                m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_RIGHT, true);
+                Assert::IsTrue(std::vector<size_t>{ 3 } == m_set->GetZoneIndexSetFromWindow(window));
+            }
+
+            TEST_METHOD (MoveRightWithDifferentWindowsAdded)
+            {
+                HWND window1 = Mocks::Window();
+                HWND window2 = Mocks::Window();
+                m_set->MoveWindowIntoZoneByIndex(window1, Mocks::Window(), { 1 });
+                m_set->MoveWindowIntoZoneByIndex(window2, Mocks::Window(), { 2 });
+
+                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window1));
+                Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window2));
+
+                m_set->MoveWindowIntoZoneByDirectionAndIndex(window1, Mocks::Window(), VK_RIGHT, true);
+
+                Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window1));
+                Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window2));
+
+                m_set->MoveWindowIntoZoneByDirectionAndIndex(window1, Mocks::Window(), VK_RIGHT, true);
+
+                Assert::IsTrue(std::vector<size_t>{ 3 } == m_set->GetZoneIndexSetFromWindow(window1));
+                Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window2));
+            }
+
+            TEST_METHOD (MoveWindowIntoZoneByDirectionLeft)
+            {
+                HWND window = Mocks::Window();
+                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 3);
                 m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_LEFT, true);
                 Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window));
+
+                m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_LEFT, true);
+                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window));
+            }
+
+            TEST_METHOD (MoveLeftWithSameWindowAdded)
+            {
+                HWND window = Mocks::Window();
+                m_set->MoveWindowIntoZoneByIndexSet(window, Mocks::Window(), { 2, 3 });
+
+                Assert::IsTrue(std::vector<size_t>{ 2, 3 } == m_set->GetZoneIndexSetFromWindow(window));
+
+                m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_LEFT, true);
+                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window));
+
+                m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_LEFT, true);
+                Assert::IsTrue(std::vector<size_t>{ 3 } == m_set->GetZoneIndexSetFromWindow(window));
             }
 
             TEST_METHOD (MoveLeftWithDifferentWindowsAdded)
             {
                 HWND window1 = Mocks::Window();
                 HWND window2 = Mocks::Window();
-                m_set->MoveWindowIntoZoneByIndex(window1, Mocks::Window(), 1);
-                m_set->MoveWindowIntoZoneByIndex(window2, Mocks::Window(), 2);
+                m_set->MoveWindowIntoZoneByIndex(window1, Mocks::Window(), 2);
+                m_set->MoveWindowIntoZoneByIndex(window2, Mocks::Window(), 3);
 
-                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window1));
+                Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window1));
+                Assert::IsTrue(std::vector<size_t>{ 3 } == m_set->GetZoneIndexSetFromWindow(window2));
+
+                m_set->MoveWindowIntoZoneByDirectionAndIndex(window2, Mocks::Window(), VK_LEFT, true);
+                Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window1));
                 Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window2));
 
                 m_set->MoveWindowIntoZoneByDirectionAndIndex(window2, Mocks::Window(), VK_LEFT, true);
-                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window1));
+                Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window1));
                 Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window2));
-
-                m_set->MoveWindowIntoZoneByDirectionAndIndex(window2, Mocks::Window(), VK_LEFT, true);
-                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window1));
-                Assert::IsTrue(std::vector<size_t>{ 0 } == m_set->GetZoneIndexSetFromWindow(window2));
             }
 
             TEST_METHOD (MoveWindowIntoZoneByDirectionWrapAroundRight)
             {
                 HWND window = Mocks::Window();
-                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 2);
+                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 3);
                 m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_RIGHT, true);
-                Assert::IsTrue(std::vector<size_t>{ 0 } == m_set->GetZoneIndexSetFromWindow(window));
+                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window));
             }
 
             TEST_METHOD (MoveWindowIntoZoneByDirectionWrapAroundLeft)
             {
                 HWND window = Mocks::Window();
-                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0);
+                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 1);
                 m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_LEFT, true);
-                Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window));
+                Assert::IsTrue(std::vector<size_t>{ 3 } == m_set->GetZoneIndexSetFromWindow(window));
             }
 
             TEST_METHOD (MoveSecondWindowIntoSameZone)
             {
                 HWND window1 = Mocks::Window();
-                m_set->MoveWindowIntoZoneByIndex(window1, Mocks::Window(), 0);
+                m_set->MoveWindowIntoZoneByIndex(window1, Mocks::Window(), 1);
 
                 HWND window2 = Mocks::Window();
                 m_set->MoveWindowIntoZoneByDirectionAndIndex(window2, Mocks::Window(), VK_RIGHT, true);
 
-                Assert::IsTrue(std::vector<size_t>{ 0 } == m_set->GetZoneIndexSetFromWindow(window1));
-                Assert::IsTrue(std::vector<size_t>{ 0 } == m_set->GetZoneIndexSetFromWindow(window2));
+                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window1));
+                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window2));
             }
 
             TEST_METHOD (MoveRightMoreThanZoneCountReturnsFalse)
             {
                 HWND window = Mocks::Window();
-                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0);
+                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 1);
                 for (size_t i = 0; i < m_set->GetZones().size() - 1; ++i)
                 {
                     m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_RIGHT, false);
@@ -716,7 +716,7 @@ namespace FancyZonesUnitTests
             TEST_METHOD (MoveLeftMoreThanZoneCountReturnsFalse)
             {
                 HWND window = Mocks::Window();
-                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 2);
+                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 3);
                 for (size_t i = 0; i < m_set->GetZones().size() - 1; ++i)
                 {
                     m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_LEFT, false);
@@ -771,12 +771,12 @@ namespace FancyZonesUnitTests
                     auto zones = set->GetZones();
                     Assert::AreEqual(expectedCount, zones.size());
 
-                    int zoneId = 0;
+                    int zoneId = 1;
                     for (const auto& zone : zones)
                     {
                         Assert::IsTrue(set->IsZoneEmpty(zoneId));
 
-                        const auto& zoneRect = zone->GetZoneRect();
+                        const auto& zoneRect = zone.second->GetZoneRect();
                         Assert::IsTrue(zoneRect.left >= 0, L"left border is less than zero");
                         Assert::IsTrue(zoneRect.top >= 0, L"top border is less than zero");
 

--- a/src/modules/fancyzones/tests/UnitTests/ZoneSet.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/ZoneSet.Spec.cpp
@@ -85,7 +85,7 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (AddOne)
             {
-                constexpr size_t zoneId = 1;
+                constexpr size_t zoneId = 0;
                 winrt::com_ptr<IZone> zone = MakeZone({ 0, 0, 100, 100 }, zoneId);
                 Assert::IsNotNull(zone.get());
                 m_set->AddZone(zone);
@@ -99,7 +99,7 @@ namespace FancyZonesUnitTests
             {
                 for (size_t i = 0; i < 1024; i++)
                 {
-                    size_t zoneId = i + 1;
+                    size_t zoneId = i;
                     winrt::com_ptr<IZone> zone = MakeZone({ 0, 0, 100, 100 }, zoneId);
                     Assert::IsNotNull(zone.get());
                     m_set->AddZone(zone);
@@ -114,7 +114,7 @@ namespace FancyZonesUnitTests
             {
                 for (size_t i = 0; i < 1024; i++)
                 {
-                    size_t zoneId = i + 1;
+                    size_t zoneId = i;
                     int left = rand() % 10;
                     int top = rand() % 10;
                     int right = left + 1 + rand() % 100;
@@ -133,13 +133,6 @@ namespace FancyZonesUnitTests
             {
                 winrt::com_ptr<IZone> zone = MakeZone({ 0, 0, 0, 0 }, 1);
                 Assert::IsNotNull(zone.get());
-            }
-
-            TEST_METHOD (MakeZoneWithInvalidId)
-            {
-                constexpr size_t invalidZoneId = 0;
-                winrt::com_ptr<IZone> zone = MakeZone({ 0, 0, 0, 0 }, invalidZoneId);
-                Assert::IsNull(zone.get());
             }
 
             TEST_METHOD (MakeZoneFromInvalidRectWidth)
@@ -361,39 +354,39 @@ namespace FancyZonesUnitTests
             TEST_METHOD (MoveWindowIntoZoneByIndexSeveralTimesSameWindow)
             {
                 // Add a couple of zones.
-                winrt::com_ptr<IZone> zone1 = MakeZone({ 0, 0, 100, 100 }, 1);
-                winrt::com_ptr<IZone> zone2 = MakeZone({ 1, 1, 101, 101 }, 2);
-                winrt::com_ptr<IZone> zone3 = MakeZone({ 2, 2, 102, 102 }, 3);
+                winrt::com_ptr<IZone> zone1 = MakeZone({ 0, 0, 100, 100 }, 0);
+                winrt::com_ptr<IZone> zone2 = MakeZone({ 1, 1, 101, 101 }, 1);
+                winrt::com_ptr<IZone> zone3 = MakeZone({ 2, 2, 102, 102 }, 2);
                 m_set->AddZone(zone1);
                 m_set->AddZone(zone2);
                 m_set->AddZone(zone3);
 
                 HWND window = Mocks::Window();
+                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0);
+                Assert::IsTrue(std::vector<size_t>{ 0 } == m_set->GetZoneIndexSetFromWindow(window));
+
                 m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 1);
                 Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window));
 
                 m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 2);
                 Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window));
-
-                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 3);
-                Assert::IsTrue(std::vector<size_t>{ 3 } == m_set->GetZoneIndexSetFromWindow(window));
             }
 
             TEST_METHOD (MoveWindowIntoZoneByIndexSeveralTimesSameIndex)
             {
                 // Add a couple of zones.
-                winrt::com_ptr<IZone> zone1 = MakeZone({ 0, 0, 100, 100 }, 1);
-                winrt::com_ptr<IZone> zone2 = MakeZone({ 1, 1, 101, 101 }, 2);
-                winrt::com_ptr<IZone> zone3 = MakeZone({ 2, 2, 102, 102 }, 3);
+                winrt::com_ptr<IZone> zone1 = MakeZone({ 0, 0, 100, 100 }, 0);
+                winrt::com_ptr<IZone> zone2 = MakeZone({ 1, 1, 101, 101 }, 1);
+                winrt::com_ptr<IZone> zone3 = MakeZone({ 2, 2, 102, 102 }, 2);
                 m_set->AddZone(zone1);
                 m_set->AddZone(zone2);
                 m_set->AddZone(zone3);
 
                 HWND window = Mocks::Window();
-                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 2);
-                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 2);
-                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 2);
-                Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window));
+                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0);
+                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0);
+                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0);
+                Assert::IsTrue(std::vector<size_t>{ 0 } == m_set->GetZoneIndexSetFromWindow(window));
             }
 
             TEST_METHOD (MoveWindowIntoZoneByPointEmpty)
@@ -414,8 +407,21 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (MoveWindowIntoZoneByPointInnerPoint)
             {
-                winrt::com_ptr<IZone> zone1 = MakeZone({ 0, 0, 100, 100 }, 1);
+                winrt::com_ptr<IZone> zone1 = MakeZone({ 0, 0, 100, 100 }, 0);
                 m_set->AddZone(zone1);
+
+                auto window = Mocks::Window();
+                m_set->MoveWindowIntoZoneByPoint(window, Mocks::Window(), POINT{ 50, 50 });
+
+                Assert::IsTrue(std::vector<size_t>{ 0 } == m_set->GetZoneIndexSetFromWindow(window));
+            }
+
+            TEST_METHOD (MoveWindowIntoZoneByPointInnerPointOverlappingZones)
+            {
+                winrt::com_ptr<IZone> zone1 = MakeZone({ 0, 0, 100, 100 }, 0);
+                winrt::com_ptr<IZone> zone2 = MakeZone({ 10, 10, 90, 90 }, 1);
+                m_set->AddZone(zone1);
+                m_set->AddZone(zone2);
 
                 auto window = Mocks::Window();
                 m_set->MoveWindowIntoZoneByPoint(window, Mocks::Window(), POINT{ 50, 50 });
@@ -423,35 +429,22 @@ namespace FancyZonesUnitTests
                 Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window));
             }
 
-            TEST_METHOD (MoveWindowIntoZoneByPointInnerPointOverlappingZones)
-            {
-                winrt::com_ptr<IZone> zone1 = MakeZone({ 0, 0, 100, 100 }, 1);
-                winrt::com_ptr<IZone> zone2 = MakeZone({ 10, 10, 90, 90 }, 2);
-                m_set->AddZone(zone1);
-                m_set->AddZone(zone2);
-
-                auto window = Mocks::Window();
-                m_set->MoveWindowIntoZoneByPoint(window, Mocks::Window(), POINT{ 50, 50 });
-
-                Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window));
-            }
-
             TEST_METHOD (MoveWindowIntoZoneByPointDropAddWindow)
             {
                 const auto window = Mocks::Window();
                 const auto zoneWindow = Mocks::Window();
 
-                winrt::com_ptr<IZone> zone1 = MakeZone({ 0, 0, 100, 100 }, 1);
-                winrt::com_ptr<IZone> zone2 = MakeZone({ 10, 10, 90, 90 }, 2);
+                winrt::com_ptr<IZone> zone1 = MakeZone({ 0, 0, 100, 100 }, 0);
+                winrt::com_ptr<IZone> zone2 = MakeZone({ 10, 10, 90, 90 }, 1);
 
                 m_set->AddZone(zone1);
                 m_set->AddZone(zone2);
 
-                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 1);
+                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0);
 
                 m_set->MoveWindowIntoZoneByPoint(window, Mocks::Window(), POINT{ 50, 50 });
 
-                Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window));
+                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window));
             }
 
             TEST_METHOD (MoveWindowIntoZoneByPointDropAddWindowToSameZone)
@@ -459,8 +452,8 @@ namespace FancyZonesUnitTests
                 const auto window = Mocks::Window();
                 const auto zoneWindow = Mocks::Window();
 
-                winrt::com_ptr<IZone> zone1 = MakeZone({ 0, 0, 100, 100 }, 1);
-                winrt::com_ptr<IZone> zone2 = MakeZone({ 10, 10, 90, 90 }, 2);
+                winrt::com_ptr<IZone> zone1 = MakeZone({ 0, 0, 100, 100 }, 0);
+                winrt::com_ptr<IZone> zone2 = MakeZone({ 10, 10, 90, 90 }, 1);
 
                 m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 1);
 
@@ -469,7 +462,7 @@ namespace FancyZonesUnitTests
 
                 m_set->MoveWindowIntoZoneByPoint(window, Mocks::Window(), POINT{ 50, 50 });
 
-                Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window));
+                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window));
             }
 
             TEST_METHOD (MoveWindowIntoZoneByPointSeveralZonesWithSameWindow)
@@ -477,19 +470,19 @@ namespace FancyZonesUnitTests
                 const auto window = Mocks::Window();
                 const auto zoneWindow = Mocks::Window();
 
-                winrt::com_ptr<IZone> zone1 = MakeZone({ 0, 0, 100, 100 }, 1);
-                winrt::com_ptr<IZone> zone2 = MakeZone({ 10, 10, 90, 90 }, 2);
-                winrt::com_ptr<IZone> zone3 = MakeZone({ 20, 20, 80, 80 }, 3);
+                winrt::com_ptr<IZone> zone1 = MakeZone({ 0, 0, 100, 100 }, 0);
+                winrt::com_ptr<IZone> zone2 = MakeZone({ 10, 10, 90, 90 }, 1);
+                winrt::com_ptr<IZone> zone3 = MakeZone({ 20, 20, 80, 80 }, 2);
 
                 m_set->AddZone(zone1);
                 m_set->AddZone(zone2);
                 m_set->AddZone(zone3);
 
-                m_set->MoveWindowIntoZoneByIndexSet(window, Mocks::Window(), { 1, 2, 3 });
+                m_set->MoveWindowIntoZoneByIndexSet(window, Mocks::Window(), { 0, 1, 2 });
 
                 m_set->MoveWindowIntoZoneByPoint(window, Mocks::Window(), POINT{ 50, 50 });
 
-                Assert::IsTrue(std::vector<size_t>{ 3 } == m_set->GetZoneIndexSetFromWindow(window));
+                Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window));
             }
     };
 
@@ -507,9 +500,9 @@ namespace FancyZonesUnitTests
                 m_set = MakeZoneSet(config);
 
                 // Add a couple of zones.
-                m_zone1 = MakeZone({ 0, 0, 100, 100 }, 1);
-                m_zone2 = MakeZone({ 0, 0, 100, 100 }, 2);
-                m_zone3 = MakeZone({ 0, 0, 100, 100 }, 3);
+                m_zone1 = MakeZone({ 0, 0, 100, 100 }, 0);
+                m_zone2 = MakeZone({ 0, 0, 100, 100 }, 1);
+                m_zone3 = MakeZone({ 0, 0, 100, 100 }, 2);
                 m_set->AddZone(m_zone1);
                 m_set->AddZone(m_zone2);
                 m_set->AddZone(m_zone3);
@@ -535,14 +528,14 @@ namespace FancyZonesUnitTests
             {
                 HWND window = Mocks::Window();
                 m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_RIGHT, true);
-                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window));
+                Assert::IsTrue(std::vector<size_t>{ 0 } == m_set->GetZoneIndexSetFromWindow(window));
             }
 
             TEST_METHOD (MoveLeftNoZones)
             {
                 HWND window = Mocks::Window();
                 m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_LEFT, true);
-                Assert::IsTrue(std::vector<size_t>{ 3 } == m_set->GetZoneIndexSetFromWindow(window));
+                Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window));
             }
 
             TEST_METHOD (MoveRightTwice)
@@ -550,7 +543,7 @@ namespace FancyZonesUnitTests
                 HWND window = Mocks::Window();
                 m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_RIGHT, true);
                 m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_RIGHT, true);
-                Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window));
+                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window));
             }
 
             TEST_METHOD (MoveLeftTwice)
@@ -558,7 +551,7 @@ namespace FancyZonesUnitTests
                 HWND window = Mocks::Window();
                 m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_LEFT, true);
                 m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_LEFT, true);
-                Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window));
+                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window));
             }
 
             TEST_METHOD (MoveRightMoreThanZonesCount)
@@ -569,7 +562,7 @@ namespace FancyZonesUnitTests
                     m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_RIGHT, true);
                 }
 
-                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window));
+                Assert::IsTrue(std::vector<size_t>{ 0 } == m_set->GetZoneIndexSetFromWindow(window));
             }
 
             TEST_METHOD (MoveLeftMoreThanZonesCount)
@@ -580,131 +573,131 @@ namespace FancyZonesUnitTests
                     m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_LEFT, true);
                 }
 
-                Assert::IsTrue(std::vector<size_t>{ 3 } == m_set->GetZoneIndexSetFromWindow(window));
+                Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window));
             }
 
             TEST_METHOD (MoveWindowIntoZoneByDirectionRight)
             {
                 HWND window = Mocks::Window();
-                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 1);
+                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0);
                 m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_RIGHT, true);
-                Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window));
+                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window));
 
                 m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_RIGHT, true);
-                Assert::IsTrue(std::vector<size_t>{ 3 } == m_set->GetZoneIndexSetFromWindow(window));
+                Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window));
             }
 
             TEST_METHOD (MoveRightWithSameWindowAdded)
             {
                 HWND window = Mocks::Window();
-                m_set->MoveWindowIntoZoneByIndexSet(window, Mocks::Window(), { 1, 2 });
+                m_set->MoveWindowIntoZoneByIndexSet(window, Mocks::Window(), { 0, 1 });
 
-                Assert::IsTrue(std::vector<size_t>{ 1, 2 } == m_set->GetZoneIndexSetFromWindow(window));
+                Assert::IsTrue(std::vector<size_t>{ 0, 1 } == m_set->GetZoneIndexSetFromWindow(window));
+
+                m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_RIGHT, true);
+                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window));
 
                 m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_RIGHT, true);
                 Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window));
-
-                m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_RIGHT, true);
-                Assert::IsTrue(std::vector<size_t>{ 3 } == m_set->GetZoneIndexSetFromWindow(window));
             }
 
             TEST_METHOD (MoveRightWithDifferentWindowsAdded)
             {
                 HWND window1 = Mocks::Window();
                 HWND window2 = Mocks::Window();
-                m_set->MoveWindowIntoZoneByIndex(window1, Mocks::Window(), { 1 });
-                m_set->MoveWindowIntoZoneByIndex(window2, Mocks::Window(), { 2 });
+                m_set->MoveWindowIntoZoneByIndex(window1, Mocks::Window(), { 0 });
+                m_set->MoveWindowIntoZoneByIndex(window2, Mocks::Window(), { 1 });
+
+                Assert::IsTrue(std::vector<size_t>{ 0 } == m_set->GetZoneIndexSetFromWindow(window1));
+                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window2));
+
+                m_set->MoveWindowIntoZoneByDirectionAndIndex(window1, Mocks::Window(), VK_RIGHT, true);
 
                 Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window1));
-                Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window2));
+                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window2));
 
                 m_set->MoveWindowIntoZoneByDirectionAndIndex(window1, Mocks::Window(), VK_RIGHT, true);
 
                 Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window1));
-                Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window2));
-
-                m_set->MoveWindowIntoZoneByDirectionAndIndex(window1, Mocks::Window(), VK_RIGHT, true);
-
-                Assert::IsTrue(std::vector<size_t>{ 3 } == m_set->GetZoneIndexSetFromWindow(window1));
-                Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window2));
+                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window2));
             }
 
             TEST_METHOD (MoveWindowIntoZoneByDirectionLeft)
             {
                 HWND window = Mocks::Window();
-                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 3);
-                m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_LEFT, true);
-                Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window));
-
+                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 2);
                 m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_LEFT, true);
                 Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window));
+
+                m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_LEFT, true);
+                Assert::IsTrue(std::vector<size_t>{ 0 } == m_set->GetZoneIndexSetFromWindow(window));
             }
 
             TEST_METHOD (MoveLeftWithSameWindowAdded)
             {
                 HWND window = Mocks::Window();
-                m_set->MoveWindowIntoZoneByIndexSet(window, Mocks::Window(), { 2, 3 });
+                m_set->MoveWindowIntoZoneByIndexSet(window, Mocks::Window(), { 1, 2 });
 
-                Assert::IsTrue(std::vector<size_t>{ 2, 3 } == m_set->GetZoneIndexSetFromWindow(window));
-
-                m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_LEFT, true);
-                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window));
+                Assert::IsTrue(std::vector<size_t>{ 1, 2 } == m_set->GetZoneIndexSetFromWindow(window));
 
                 m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_LEFT, true);
-                Assert::IsTrue(std::vector<size_t>{ 3 } == m_set->GetZoneIndexSetFromWindow(window));
+                Assert::IsTrue(std::vector<size_t>{ 0 } == m_set->GetZoneIndexSetFromWindow(window));
+
+                m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_LEFT, true);
+                Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window));
             }
 
             TEST_METHOD (MoveLeftWithDifferentWindowsAdded)
             {
                 HWND window1 = Mocks::Window();
                 HWND window2 = Mocks::Window();
-                m_set->MoveWindowIntoZoneByIndex(window1, Mocks::Window(), 2);
-                m_set->MoveWindowIntoZoneByIndex(window2, Mocks::Window(), 3);
+                m_set->MoveWindowIntoZoneByIndex(window1, Mocks::Window(), 1);
+                m_set->MoveWindowIntoZoneByIndex(window2, Mocks::Window(), 2);
 
-                Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window1));
-                Assert::IsTrue(std::vector<size_t>{ 3 } == m_set->GetZoneIndexSetFromWindow(window2));
-
-                m_set->MoveWindowIntoZoneByDirectionAndIndex(window2, Mocks::Window(), VK_LEFT, true);
-                Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window1));
+                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window1));
                 Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window2));
 
                 m_set->MoveWindowIntoZoneByDirectionAndIndex(window2, Mocks::Window(), VK_LEFT, true);
-                Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window1));
+                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window1));
                 Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window2));
+
+                m_set->MoveWindowIntoZoneByDirectionAndIndex(window2, Mocks::Window(), VK_LEFT, true);
+                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window1));
+                Assert::IsTrue(std::vector<size_t>{ 0 } == m_set->GetZoneIndexSetFromWindow(window2));
             }
 
             TEST_METHOD (MoveWindowIntoZoneByDirectionWrapAroundRight)
             {
                 HWND window = Mocks::Window();
-                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 3);
+                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 2);
                 m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_RIGHT, true);
-                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window));
+                Assert::IsTrue(std::vector<size_t>{ 0 } == m_set->GetZoneIndexSetFromWindow(window));
             }
 
             TEST_METHOD (MoveWindowIntoZoneByDirectionWrapAroundLeft)
             {
                 HWND window = Mocks::Window();
-                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 1);
+                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0);
                 m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_LEFT, true);
-                Assert::IsTrue(std::vector<size_t>{ 3 } == m_set->GetZoneIndexSetFromWindow(window));
+                Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window));
             }
 
             TEST_METHOD (MoveSecondWindowIntoSameZone)
             {
                 HWND window1 = Mocks::Window();
-                m_set->MoveWindowIntoZoneByIndex(window1, Mocks::Window(), 1);
+                m_set->MoveWindowIntoZoneByIndex(window1, Mocks::Window(), 0);
 
                 HWND window2 = Mocks::Window();
                 m_set->MoveWindowIntoZoneByDirectionAndIndex(window2, Mocks::Window(), VK_RIGHT, true);
 
-                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window1));
-                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window2));
+                Assert::IsTrue(std::vector<size_t>{ 0 } == m_set->GetZoneIndexSetFromWindow(window1));
+                Assert::IsTrue(std::vector<size_t>{ 0 } == m_set->GetZoneIndexSetFromWindow(window2));
             }
 
             TEST_METHOD (MoveRightMoreThanZoneCountReturnsFalse)
             {
                 HWND window = Mocks::Window();
-                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 1);
+                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0);
                 for (size_t i = 0; i < m_set->GetZones().size() - 1; ++i)
                 {
                     m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_RIGHT, false);
@@ -716,7 +709,7 @@ namespace FancyZonesUnitTests
             TEST_METHOD (MoveLeftMoreThanZoneCountReturnsFalse)
             {
                 HWND window = Mocks::Window();
-                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 3);
+                m_set->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 2);
                 for (size_t i = 0; i < m_set->GetZones().size() - 1; ++i)
                 {
                     m_set->MoveWindowIntoZoneByDirectionAndIndex(window, Mocks::Window(), VK_LEFT, false);
@@ -771,7 +764,7 @@ namespace FancyZonesUnitTests
                     auto zones = set->GetZones();
                     Assert::AreEqual(expectedCount, zones.size());
 
-                    int zoneId = 1;
+                    int zoneId = 0;
                     for (const auto& zone : zones)
                     {
                         Assert::IsTrue(set->IsZoneEmpty(zoneId));

--- a/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
@@ -537,7 +537,7 @@ namespace FancyZonesUnitTests
             Assert::AreEqual(expected, actual);
 
             const auto zoneSet = zoneWindow->ActiveZoneSet();
-            zoneSet->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 1);
+            zoneSet->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0);
             const auto actualZoneIndexSet = zoneSet->GetZoneIndexSetFromWindow(window);
             Assert::IsFalse(std::vector<size_t>{} == actualZoneIndexSet);
         }
@@ -593,7 +593,7 @@ namespace FancyZonesUnitTests
             Assert::AreEqual(expected, actual);
 
             const auto zoneSet = zoneWindow->ActiveZoneSet();
-            zoneSet->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 1);
+            zoneSet->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0);
             const auto actualZoneIndex = zoneSet->GetZoneIndexSetFromWindow(window);
             Assert::IsFalse(std::vector<size_t>{} == actualZoneIndex); // with invalid point zone remains the same
         }
@@ -706,7 +706,7 @@ namespace FancyZonesUnitTests
 
             auto zone = MakeZone(RECT{ 0, 0, 100, 100 }, 1);
             zoneWindow->ActiveZoneSet()->AddZone(zone);
-            zoneWindow->MoveWindowIntoZoneByIndex(window, 1);
+            zoneWindow->MoveWindowIntoZoneByIndex(window, 0);
 
             //fill app zone history map
             Assert::IsTrue(m_fancyZonesData.SetAppLastZones(window, deviceId, Helpers::GuidToString(zoneSetId), { 2 }));

--- a/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
@@ -537,7 +537,7 @@ namespace FancyZonesUnitTests
             Assert::AreEqual(expected, actual);
 
             const auto zoneSet = zoneWindow->ActiveZoneSet();
-            zoneSet->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0);
+            zoneSet->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 1);
             const auto actualZoneIndexSet = zoneSet->GetZoneIndexSetFromWindow(window);
             Assert::IsFalse(std::vector<size_t>{} == actualZoneIndexSet);
         }
@@ -593,7 +593,7 @@ namespace FancyZonesUnitTests
             Assert::AreEqual(expected, actual);
 
             const auto zoneSet = zoneWindow->ActiveZoneSet();
-            zoneSet->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0);
+            zoneSet->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 1);
             const auto actualZoneIndex = zoneSet->GetZoneIndexSetFromWindow(window);
             Assert::IsFalse(std::vector<size_t>{} == actualZoneIndex); // with invalid point zone remains the same
         }
@@ -620,7 +620,7 @@ namespace FancyZonesUnitTests
             Assert::AreEqual((size_t)1, actualAppZoneHistory.size());
             const auto& appHistoryArray = actualAppZoneHistory.begin()->second;
             Assert::AreEqual((size_t)1, appHistoryArray.size());
-            Assert::IsTrue(std::vector<size_t>{ 0 } == appHistoryArray[0].zoneIndexSet);
+            Assert::IsTrue(std::vector<size_t>{ 1 } == appHistoryArray[0].zoneIndexSet);
         }
 
         TEST_METHOD(MoveWindowIntoZoneByDirectionManyTimes)
@@ -637,7 +637,7 @@ namespace FancyZonesUnitTests
             Assert::AreEqual((size_t)1, actualAppZoneHistory.size());
             const auto& appHistoryArray = actualAppZoneHistory.begin()->second;
             Assert::AreEqual((size_t)1, appHistoryArray.size());
-            Assert::IsTrue(std::vector<size_t>{ 2 } == appHistoryArray[0].zoneIndexSet);
+            Assert::IsTrue(std::vector<size_t>{ 3 } == appHistoryArray[0].zoneIndexSet);
         }
 
         TEST_METHOD(SaveWindowProcessToZoneIndexNullptrWindow)
@@ -706,7 +706,7 @@ namespace FancyZonesUnitTests
 
             auto zone = MakeZone(RECT{ 0, 0, 100, 100 }, 1);
             zoneWindow->ActiveZoneSet()->AddZone(zone);
-            zoneWindow->MoveWindowIntoZoneByIndex(window, 0);
+            zoneWindow->MoveWindowIntoZoneByIndex(window, 1);
 
             //fill app zone history map
             Assert::IsTrue(m_fancyZonesData.SetAppLastZones(window, deviceId, Helpers::GuidToString(zoneSetId), { 2 }));

--- a/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
@@ -620,7 +620,7 @@ namespace FancyZonesUnitTests
             Assert::AreEqual((size_t)1, actualAppZoneHistory.size());
             const auto& appHistoryArray = actualAppZoneHistory.begin()->second;
             Assert::AreEqual((size_t)1, appHistoryArray.size());
-            Assert::IsTrue(std::vector<size_t>{ 1 } == appHistoryArray[0].zoneIndexSet);
+            Assert::IsTrue(std::vector<size_t>{ 0 } == appHistoryArray[0].zoneIndexSet);
         }
 
         TEST_METHOD(MoveWindowIntoZoneByDirectionManyTimes)
@@ -637,7 +637,7 @@ namespace FancyZonesUnitTests
             Assert::AreEqual((size_t)1, actualAppZoneHistory.size());
             const auto& appHistoryArray = actualAppZoneHistory.begin()->second;
             Assert::AreEqual((size_t)1, appHistoryArray.size());
-            Assert::IsTrue(std::vector<size_t>{ 3 } == appHistoryArray[0].zoneIndexSet);
+            Assert::IsTrue(std::vector<size_t>{ 2 } == appHistoryArray[0].zoneIndexSet);
         }
 
         TEST_METHOD(SaveWindowProcessToZoneIndexNullptrWindow)


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
Fix misaligned zone numbers between Editor and FancyZonesLib.
Cycle zone by zoneId on win+arrow
Update zone drawing logic

## PR Checklist
* [x] Applies to #6734 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx
