### PR TITLE
Fix autocomplete text issue on query change

### DIFF
--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -338,7 +338,7 @@ namespace PowerLauncher
             var text = textBox.Text;
             var autoCompleteText = SearchBox.AutoCompleteTextBlock.Text;
 
-            if (string.IsNullOrEmpty(text) || autoCompleteText.IndexOf(text, StringComparison.InvariantCulture) != 0)
+            if (string.IsNullOrEmpty(text) || autoCompleteText.IndexOf(text, StringComparison.Ordinal) != 0)
             {
                 SearchBox.AutoCompleteTextBlock.Text = string.Empty;
             }

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -336,8 +336,9 @@ namespace PowerLauncher
         {
             var textBox = (TextBox)sender;
             var text = textBox.Text;
+            var autoCompleteText = SearchBox.AutoCompleteTextBlock.Text;
 
-            if (string.IsNullOrEmpty(text))
+            if (string.IsNullOrEmpty(text) || autoCompleteText.IndexOf(text, StringComparison.InvariantCulture) != 0)
             {
                 SearchBox.AutoCompleteTextBlock.Text = string.Empty;
             }

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -338,7 +338,7 @@ namespace PowerLauncher
             var text = textBox.Text;
             var autoCompleteText = SearchBox.AutoCompleteTextBlock.Text;
 
-            if (string.IsNullOrEmpty(text) || autoCompleteText.IndexOf(text, StringComparison.Ordinal) != 0)
+            if (MainViewModel.ShouldAutoCompleteTextBeEmpty(text, autoCompleteText))
             {
                 SearchBox.AutoCompleteTextBlock.Text = string.Empty;
             }

--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -877,7 +877,7 @@ namespace PowerLauncher.ViewModel
             {
                 if (index == 0)
                 {
-                    if (input.IndexOf(query, StringComparison.InvariantCultureIgnoreCase) == 0)
+                    if (input.IndexOf(query, StringComparison.OrdinalIgnoreCase) == 0)
                     {
                         // Use the same case as the input query for the matched portion of the string
                         return query + input.Substring(query.Length);
@@ -894,7 +894,7 @@ namespace PowerLauncher.ViewModel
             {
                 if (index == 0 && !string.IsNullOrEmpty(query))
                 {
-                    if (input.IndexOf(query, StringComparison.InvariantCultureIgnoreCase) == 0)
+                    if (input.IndexOf(query, StringComparison.OrdinalIgnoreCase) == 0)
                     {
                         return query + input.Substring(query.Length);
                     }

--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -871,6 +871,18 @@ namespace PowerLauncher.ViewModel
             }
         }
 
+        public static bool ShouldAutoCompleteTextBeEmpty(string queryText, string autoCompleteText)
+        {
+            if (string.IsNullOrEmpty(autoCompleteText))
+            {
+                return false;
+            }
+            else
+            {
+                return string.IsNullOrEmpty(queryText) || autoCompleteText.IndexOf(queryText, StringComparison.Ordinal) != 0;
+            }
+        }
+
         public static string GetAutoCompleteText(int index, string input, string query)
         {
             if (!string.IsNullOrEmpty(input) && !string.IsNullOrEmpty(query))

--- a/src/modules/launcher/Wox.Test/MainViewModelTest.cs
+++ b/src/modules/launcher/Wox.Test/MainViewModelTest.cs
@@ -207,5 +207,61 @@ namespace Wox.Test
             // Assert
             Assert.AreEqual(input, autoCompleteText);
         }
+
+        [Test]
+        public void ShouldAutoCompleteTextBeEmpty_ShouldReturnFalse_WhenAutoCompleteTextIsEmpty()
+        {
+            // Arrange
+            string queryText = "Te";
+            string autoCompleteText = string.Empty;
+
+            // Act
+            bool result = MainViewModel.ShouldAutoCompleteTextBeEmpty(queryText, autoCompleteText);
+
+            // Assert
+            Assert.AreEqual(false, result);
+        }
+
+        [Test]
+        public void ShouldAutoCompleteTextBeEmpty_ShouldReturnTrue_WhenQueryTextMatchAutoCompleteText()
+        {
+            // Arrange
+            string queryText = "Te";
+            string autoCompleteText = "Teams";
+
+            // Act
+            bool result = MainViewModel.ShouldAutoCompleteTextBeEmpty(queryText, autoCompleteText);
+
+            // Assert
+            Assert.AreEqual(false, result);
+        }
+
+        [Test]
+        public void ShouldAutoCompleteTextBeEmpty_ShouldReturnTrue_WhenQueryTextIsEmpty()
+        {
+            // Arrange
+            string queryText = string.Empty;
+            string autoCompleteText = "Teams";
+
+            // Act
+            bool result = MainViewModel.ShouldAutoCompleteTextBeEmpty(queryText, autoCompleteText);
+
+            // Assert
+            Assert.AreEqual(true, result);
+        }
+
+        [Test]
+        public void ShouldAutoCompleteTextBeEmpty_ShouldReturnTrue_WhenQueryTextDoesNotMatchAutoCompleteText()
+        {
+            // Arrange
+            string queryText = "TE";
+            string autoCompleteText = "Teams";
+
+            // Act
+            bool result = MainViewModel.ShouldAutoCompleteTextBeEmpty(queryText, autoCompleteText);
+
+            // Assert
+            Assert.AreEqual(true, result);
+        }
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request
Fix for autocomplete text is not updating immediately, if typed query text is not a substring of autocomplete text. 

## PR Checklist
* [x] Applies to #7390 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request
Added check to clear autocomplete text, if the current query text is not a substring of autocomplete text.

## Validation Steps Performed
Manually validated that the issue is fixed. 

Before : 
![autocompl_issue](https://user-images.githubusercontent.com/10995909/96518671-3b6a2e80-1220-11eb-93df-79a603b81543.gif)

After:
![autocompl_issue_fixed](https://user-images.githubusercontent.com/10995909/96518637-29888b80-1220-11eb-9886-ef0d1907504e.gif)
