### PR TITLE
Use task delay instead of thread sleep

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program.UnitTests/Storage/ConcurrentQueueEventHandlerTest.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program.UnitTests/Storage/ConcurrentQueueEventHandlerTest.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Concurrent;
+using System.Threading.Tasks;
 using Microsoft.Plugin.Program.Storage;
 using NUnit.Framework;
 
@@ -12,14 +13,14 @@ namespace Microsoft.Plugin.Program.UnitTests.Storage
     public class ConcurrentQueueEventHandlerTest
     {
         [TestCase]
-        public void EventHandlerMustReturnEmptyPathForEmptyQueue()
+        public async Task EventHandlerMustReturnEmptyPathForEmptyQueueAsync()
         {
             // Arrange
             int dequeueDelay = 0;
             ConcurrentQueue<string> eventHandlingQueue = new ConcurrentQueue<string>();
 
             // Act
-            string appPath = EventHandler.GetAppPathFromQueue(eventHandlingQueue, dequeueDelay);
+            string appPath = await EventHandler.GetAppPathFromQueueAsync(eventHandlingQueue, dequeueDelay).ConfigureAwait(false);
 
             // Assert
             Assert.IsEmpty(appPath);
@@ -27,7 +28,7 @@ namespace Microsoft.Plugin.Program.UnitTests.Storage
 
         [TestCase(1)]
         [TestCase(10)]
-        public void EventHandlerMustReturnPathForConcurrentQueueWithSameFilePaths(int itemCount)
+        public async Task EventHandlerMustReturnPathForConcurrentQueueWithSameFilePathsAsync(int itemCount)
         {
             // Arrange
             int dequeueDelay = 0;
@@ -39,7 +40,7 @@ namespace Microsoft.Plugin.Program.UnitTests.Storage
             }
 
             // Act
-            string pathFromQueue = EventHandler.GetAppPathFromQueue(eventHandlingQueue, dequeueDelay);
+            string pathFromQueue = await EventHandler.GetAppPathFromQueueAsync(eventHandlingQueue, dequeueDelay).ConfigureAwait(false);
 
             // Assert
             Assert.AreEqual(appPath, pathFromQueue);
@@ -47,7 +48,7 @@ namespace Microsoft.Plugin.Program.UnitTests.Storage
         }
 
         [TestCase(5)]
-        public void EventHandlerMustReturnPathAndRetainDifferentFilePathsInQueue(int itemCount)
+        public async Task EventHandlerMustReturnPathAndRetainDifferentFilePathsInQueueAsync(int itemCount)
         {
             // Arrange
             int dequeueDelay = 0;
@@ -65,7 +66,7 @@ namespace Microsoft.Plugin.Program.UnitTests.Storage
             }
 
             // Act
-            string pathFromQueue = EventHandler.GetAppPathFromQueue(eventHandlingQueue, dequeueDelay);
+            string pathFromQueue = await EventHandler.GetAppPathFromQueueAsync(eventHandlingQueue, dequeueDelay).ConfigureAwait(false);
 
             // Assert
             Assert.AreEqual(firstAppPath, pathFromQueue);
@@ -73,7 +74,7 @@ namespace Microsoft.Plugin.Program.UnitTests.Storage
         }
 
         [TestCase(5)]
-        public void EventHandlerMustReturnPathAndRetainAllPathsAfterEncounteringADifferentPath(int itemCount)
+        public async Task EventHandlerMustReturnPathAndRetainAllPathsAfterEncounteringADifferentPathAsync(int itemCount)
         {
             // Arrange
             int dequeueDelay = 0;
@@ -96,7 +97,7 @@ namespace Microsoft.Plugin.Program.UnitTests.Storage
             }
 
             // Act
-            string pathFromQueue = EventHandler.GetAppPathFromQueue(eventHandlingQueue, dequeueDelay);
+            string pathFromQueue = await EventHandler.GetAppPathFromQueueAsync(eventHandlingQueue, dequeueDelay).ConfigureAwait(false);
 
             // Assert
             Assert.AreEqual(firstAppPath, pathFromQueue);

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Storage/EventHandler.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Storage/EventHandler.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.Collections.Concurrent;
-using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.Plugin.Program.Storage
 {
@@ -12,7 +12,7 @@ namespace Microsoft.Plugin.Program.Storage
     {
         // To obtain the path of the app when multiple events are added to the Concurrent queue across multiple threads.
         // On the first occurence of a different file path, the existing app path is to be returned without removing any more elements from the queue.
-        public static string GetAppPathFromQueue(ConcurrentQueue<string> eventHandlingQueue, int dequeueDelay)
+        public static async Task<string> GetAppPathFromQueueAsync(ConcurrentQueue<string> eventHandlingQueue, int dequeueDelay)
         {
             if (eventHandlingQueue == null)
             {
@@ -36,7 +36,7 @@ namespace Microsoft.Plugin.Program.Storage
                 }
 
                 // This delay has been added to account for the delay in events being triggered during app installation.
-                Thread.Sleep(dequeueDelay);
+                await Task.Delay(dequeueDelay).ConfigureAwait(false);
             }
 
             return previousAppPath;

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Storage/Win32ProgramRepository.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Storage/Win32ProgramRepository.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
 using System.IO;
-using System.Threading;
 using System.Threading.Tasks;
 using Wox.Infrastructure.Logger;
 using Wox.Infrastructure.Storage;
@@ -40,26 +39,26 @@ namespace Microsoft.Plugin.Program.Storage
             InitializeFileSystemWatchers();
 
             // This task would always run in the background trying to dequeue file paths from the queue at regular intervals.
-            Task.Run(() =>
-            {
-                while (true)
-                {
-                    int dequeueDelay = 500;
-                    string appPath = EventHandler.GetAppPathFromQueue(commonEventHandlingQueue, dequeueDelay);
+            _ = Task.Run(async () =>
+              {
+                  while (true)
+                  {
+                      int dequeueDelay = 500;
+                      string appPath = await EventHandler.GetAppPathFromQueueAsync(commonEventHandlingQueue, dequeueDelay).ConfigureAwait(false);
 
-                    // To allow for the installation process to finish.
-                    Thread.Sleep(5000);
+                      // To allow for the installation process to finish.
+                      await Task.Delay(5000).ConfigureAwait(false);
 
-                    if (!string.IsNullOrEmpty(appPath))
-                    {
-                        Programs.Win32Program app = Programs.Win32Program.GetAppFromPath(appPath);
-                        if (app != null)
-                        {
-                            Add(app);
-                        }
-                    }
-                }
-            }).ConfigureAwait(false);
+                      if (!string.IsNullOrEmpty(appPath))
+                      {
+                          Programs.Win32Program app = Programs.Win32Program.GetAppFromPath(appPath);
+                          if (app != null)
+                          {
+                              Add(app);
+                          }
+                      }
+                  }
+              }).ConfigureAwait(false);
         }
 
         private void InitializeFileSystemWatchers()

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Storage/Win32ProgramRepository.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Storage/Win32ProgramRepository.cs
@@ -40,25 +40,25 @@ namespace Microsoft.Plugin.Program.Storage
 
             // This task would always run in the background trying to dequeue file paths from the queue at regular intervals.
             _ = Task.Run(async () =>
-              {
-                  while (true)
-                  {
-                      int dequeueDelay = 500;
-                      string appPath = await EventHandler.GetAppPathFromQueueAsync(commonEventHandlingQueue, dequeueDelay).ConfigureAwait(false);
+            {
+                while (true)
+                {
+                    int dequeueDelay = 500;
+                    string appPath = await EventHandler.GetAppPathFromQueueAsync(commonEventHandlingQueue, dequeueDelay).ConfigureAwait(false);
 
-                      // To allow for the installation process to finish.
-                      await Task.Delay(5000).ConfigureAwait(false);
+                    // To allow for the installation process to finish.
+                    await Task.Delay(5000).ConfigureAwait(false);
 
-                      if (!string.IsNullOrEmpty(appPath))
-                      {
-                          Programs.Win32Program app = Programs.Win32Program.GetAppFromPath(appPath);
-                          if (app != null)
-                          {
-                              Add(app);
-                          }
-                      }
-                  }
-              }).ConfigureAwait(false);
+                    if (!string.IsNullOrEmpty(appPath))
+                    {
+                        Programs.Win32Program app = Programs.Win32Program.GetAppFromPath(appPath);
+                        if (app != null)
+                        {
+                            Add(app);
+                        }
+                    }
+                }
+            }).ConfigureAwait(false);
         }
 
         private void InitializeFileSystemWatchers()


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

To prevent PT Run from immediately acting on an app which is installed, a delay of 5 seconds was added before working on any event sent by the file system watcher. However, this was done using a `Thread.Sleep` instead of `Task.Delay`. 

The `Thread.Sleep` blocks the thread whereas `Task.Delay` works based on a timer and schedules the thread to run after that given delay. This would improve the performance as a thread is not blocked anymore doing nothing.

## PR Checklist
* [x] Applies to #7208 (I'm not sure if it contributes majorly to the delay because a new thread from the thread pool is assigned to a new task and therefore that thread is stalled and not the main thread)
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Validation Steps Performed

_How does someone test & validate?_

All unit tests pass.
Installed calibre multiple times and ensured that it is installed as expected.
