### PR TITLE
interop: fix possible crash in keyboardhook

### DIFF
--- a/src/common/interop/KeyboardHook.h
+++ b/src/common/interop/KeyboardHook.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cinttypes>
+
 using namespace System::Threading;
 using namespace System::Collections::Generic;
 
@@ -10,7 +12,7 @@ public
     {
         WPARAM message;
         int key;
-        DWORD dwExtraInfo;
+        uint64_t dwExtraInfo;
     };
 
 public

--- a/src/common/interop/interop.vcxproj
+++ b/src/common/interop/interop.vcxproj
@@ -98,6 +98,8 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <MultiProcessorCompilation Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</MultiProcessorCompilation>
       <MultiProcessorCompilation Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</MultiProcessorCompilation>
+      <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</TreatWarningAsError>
+      <TreatWarningAsError Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</TreatWarningAsError>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary of the Pull Request
- size of `DWORD dwExtraInfo` was 4 bytes, and on x64 arch pointer size is 8 bytes. [We've stored a pointer in `dwExtraInfo` member](https://github.com/microsoft/PowerToys/blob/cfe2bbd75e35a17436d7ebf6e8a125dec4d5cb40/src/common/interop/KeyboardHook.cpp#L63), which will crash if the system allocator would want to supply us with pages from a higher virtual memory space half.
- treat warnings as errors

## PR Checklist
* [x] Applies to #7419

## Validation Steps Performed

- tested that keyboard manager still works
