### PR TITLE
previewpane: use RAII for FileExplorerPreviewSettings classes to avoi…

### DIFF
--- a/src/modules/previewpane/powerpreview/powerpreview.h
+++ b/src/modules/previewpane/powerpreview/powerpreview.h
@@ -21,7 +21,7 @@ private:
     std::wstring m_moduleName;
     //contains the non localized key of the powertoy
     std::wstring app_key;
-    std::vector<FileExplorerPreviewSettings*> m_fileExplorerModules;
+    std::vector<std::unique_ptr<FileExplorerPreviewSettings>> m_fileExplorerModules;
 
     // Function to check if the registry states need to be updated
     bool is_registry_update_required();

--- a/src/modules/previewpane/powerpreview/preview_handler.h
+++ b/src/modules/previewpane/powerpreview/preview_handler.h
@@ -11,8 +11,8 @@ namespace PowerPreviewSettings
         static const LPCWSTR preview_handlers_subkey;
 
     public:
-        PreviewHandlerSettings(bool toggleSettingEnabled, const std::wstring& toggleSettingName, const std::wstring& toggleSettingDescription, LPCWSTR clsid, const std::wstring& registryValueData, RegistryWrapperIface* registryWrapper) :
-            FileExplorerPreviewSettings(toggleSettingEnabled, toggleSettingName, toggleSettingDescription, clsid, registryValueData, registryWrapper)
+        PreviewHandlerSettings(bool toggleSettingEnabled, const std::wstring& toggleSettingName, const std::wstring& toggleSettingDescription, LPCWSTR clsid, const std::wstring& registryValueData, std::unique_ptr<RegistryWrapperIface> registryWrapper) :
+            FileExplorerPreviewSettings(toggleSettingEnabled, toggleSettingName, toggleSettingDescription, clsid, registryValueData, std::move(registryWrapper))
         {
         }
 

--- a/src/modules/previewpane/powerpreview/settings.cpp
+++ b/src/modules/previewpane/powerpreview/settings.cpp
@@ -12,22 +12,14 @@ namespace PowerPreviewSettings
     extern "C" IMAGE_DOS_HEADER __ImageBase;
 
     // Base Settings Class Implementation
-    FileExplorerPreviewSettings::FileExplorerPreviewSettings(bool toggleSettingEnabled, const std::wstring& toggleSettingName, const std::wstring& toggleSettingDescription, LPCWSTR clsid, const std::wstring& registryValueData, RegistryWrapperIface* registryWrapper) :
+    FileExplorerPreviewSettings::FileExplorerPreviewSettings(bool toggleSettingEnabled, const std::wstring& toggleSettingName, const std::wstring& toggleSettingDescription, LPCWSTR clsid, const std::wstring& registryValueData, std::unique_ptr<RegistryWrapperIface> registryWrapper) :
         m_toggleSettingEnabled(toggleSettingEnabled),
         m_toggleSettingName(toggleSettingName),
         m_toggleSettingDescription(toggleSettingDescription),
         m_clsid(clsid),
         m_registryValueData(registryValueData),
-        m_registryWrapper(registryWrapper)
+        m_registryWrapper(std::move(registryWrapper))
     {
-    }
-
-    FileExplorerPreviewSettings::~FileExplorerPreviewSettings()
-    {
-        if (this->m_registryWrapper != NULL)
-        {
-            delete this->m_registryWrapper;
-        }
     }
 
     bool FileExplorerPreviewSettings::GetToggleSettingState() const

--- a/src/modules/previewpane/powerpreview/settings.h
+++ b/src/modules/previewpane/powerpreview/settings.h
@@ -18,11 +18,10 @@ namespace PowerPreviewSettings
         LPCWSTR m_clsid;
 
     protected:
-        RegistryWrapperIface* m_registryWrapper;
+        std::unique_ptr<RegistryWrapperIface> m_registryWrapper;
 
     public:
-        FileExplorerPreviewSettings(bool toggleSettingEnabled, const std::wstring& toggleSettingName, const std::wstring& toggleSettingDescription, LPCWSTR clsid, const std::wstring& registryValueData, RegistryWrapperIface* registryWrapper);
-        ~FileExplorerPreviewSettings();
+        FileExplorerPreviewSettings(bool toggleSettingEnabled, const std::wstring& toggleSettingName, const std::wstring& toggleSettingDescription, LPCWSTR clsid, const std::wstring& registryValueData, std::unique_ptr<RegistryWrapperIface>);
 
         virtual bool GetToggleSettingState() const;
         virtual void UpdateToggleSettingState(bool state);

--- a/src/modules/previewpane/powerpreview/thumbnail_provider.h
+++ b/src/modules/previewpane/powerpreview/thumbnail_provider.h
@@ -11,8 +11,8 @@ namespace PowerPreviewSettings
         LPCWSTR thumbnail_provider_subkey;
 
     public:
-        ThumbnailProviderSettings(bool toggleSettingEnabled, const std::wstring& toggleSettingName, const std::wstring& toggleSettingDescription, LPCWSTR clsid, const std::wstring& registryValueData, RegistryWrapperIface* registryWrapper, LPCWSTR subkey) :
-            FileExplorerPreviewSettings(toggleSettingEnabled, toggleSettingName, toggleSettingDescription, clsid, registryValueData, registryWrapper), thumbnail_provider_subkey(subkey)
+        ThumbnailProviderSettings(bool toggleSettingEnabled, const std::wstring& toggleSettingName, const std::wstring& toggleSettingDescription, LPCWSTR clsid, const std::wstring& registryValueData, std::unique_ptr<RegistryWrapperIface> registryWrapper, LPCWSTR subkey) :
+            FileExplorerPreviewSettings(toggleSettingEnabled, toggleSettingName, toggleSettingDescription, clsid, registryValueData, std::move(registryWrapper)), thumbnail_provider_subkey(subkey)
         {
         }
 

--- a/src/modules/previewpane/powerpreviewTest/FileExplorerPreviewSettingsTest.cpp
+++ b/src/modules/previewpane/powerpreviewTest/FileExplorerPreviewSettingsTest.cpp
@@ -417,7 +417,7 @@ namespace FileExplorerPreviewSettingsTest
                 L"valid-description",
                 L"valid-guid",
                 L"valid-handler",
-                registryMock);
+                std::unique_ptr<RegistryWrapperIface>(registryMock));
         }
 
         ThumbnailProviderSettings GetThumbnailProviderSettingsObject(bool defaultState, RegistryWrapperIface* registryMock)
@@ -428,7 +428,7 @@ namespace FileExplorerPreviewSettingsTest
                 L"valid-description",
                 L"valid-guid",
                 L"valid-handler",
-                registryMock,
+                std::unique_ptr<RegistryWrapperIface>(registryMock),
                 L"valid-subkey");
         }
 


### PR DESCRIPTION
…d memory leaks
## Summary of the Pull Request
objects stored in `m_fileExplorerModules` were leaked before.

## PR Checklist
* [x] Applies to #7418 

## Validation Steps Performed

- unit tests passed