### PR TITLE
[Settings] Add null check for WindowsXamlHost_ChildChanged handler to prevent NullRefException

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI.Runner/MainWindow.xaml.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Runner/MainWindow.xaml.cs
@@ -30,6 +30,12 @@ namespace Microsoft.PowerToys.Settings.UI.Runner
 
         private void WindowsXamlHost_ChildChanged(object sender, EventArgs e)
         {
+            // If sender is null, it could lead to a NullReferenceException. This might occur on restarting as admin (check https://github.com/microsoft/PowerToys/issues/7393 for details)
+            if (sender == null)
+            {
+                return;
+            }
+
             // Hook up x:Bind source.
             WindowsXamlHost windowsXamlHost = sender as WindowsXamlHost;
             ShellPage shellPage = windowsXamlHost.GetUwpInternalObject() as ShellPage;


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
This PR adds a null check to the `sender` in the ChildChanged handler. According the the stack trace from Watson, the crash occurred when the user pressed Restart as Admin.

## PR Checklist
* [X] Applies to #7393 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [X] Tests passed


## Validation Steps Performed

_How does someone test & validate?_
No repro steps, but according to the trace it could happen on pressing Restart as admin.
Validate manually that settings normally works fine and restart as admin works.