### PR TITLE
Fix exceptions and incorrect results within the calculator plugin

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Calculator.UnitTest/ExtendedCalculatorParserTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Calculator.UnitTest/ExtendedCalculatorParserTests.cs
@@ -118,9 +118,9 @@ namespace Microsoft.Plugin.Calculator.UnitTests
         [TestCase("sqrt( 36)", true)]
         [TestCase("max 4", false)]
         [TestCase("sin(0)", true)]
-        [TestCase("ln(e)", true)]
         [TestCase("cos", false)]
         [TestCase("abs", false)]
+        [TestCase("1+1.1e3", true)]
         public void InputValid_TestValid_WhenCalled(string input, bool valid)
         {
             // Arrange

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Calculator.UnitTest/ExtendedCalculatorParserTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Calculator.UnitTest/ExtendedCalculatorParserTests.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Plugin.Calculator.UnitTests
 
         [TestCase("42")]
         [TestCase("test")]
+        [TestCase("pi(2)")] // Incorrect input, constant is being treated as a function.
         public void Interpret_NoResult_WhenCalled(string input)
         {
             // Arrange
@@ -60,6 +61,7 @@ namespace Microsoft.Plugin.Calculator.UnitTests
         [TestCase("2+2.11", 4.11D)]
         [TestCase("8.43 + 4.43 - 12.86", 0D)]
         [TestCase("8.43 + 4.43 - 12.8", 0.06D)]
+        [TestCase("exp(5)", 148.413159102577D)]
         public void Interpret_NoErrors_WhenCalledWithRounding(string input, decimal expectedResult)
         {
             // Arrange
@@ -110,8 +112,15 @@ namespace Microsoft.Plugin.Calculator.UnitTests
         [TestCase("((1 * 2)", false)]
         [TestCase("(1 * 2)))", false)]
         [TestCase("abcde", false)]
-        [TestCase("plot( 2 * 3)", true)]
         [TestCase("1 + 2 +", false)]
+        [TestCase("1+2*", false)]
+        [TestCase("1 && 3 &&", false)]
+        [TestCase("sqrt( 36)", true)]
+        [TestCase("max 4", false)]
+        [TestCase("sin(0)", true)]
+        [TestCase("ln(e)", true)]
+        [TestCase("cos", false)]
+        [TestCase("abs", false)]
         public void InputValid_TestValid_WhenCalled(string input, bool valid)
         {
             // Arrange
@@ -121,6 +130,39 @@ namespace Microsoft.Plugin.Calculator.UnitTests
 
             // Assert
             Assert.AreEqual(valid, result);
+        }
+
+        [TestCase("1-1")]
+        [TestCase("sin(0)")]
+        public void Interpret_MustReturnResult_WhenResultIsZero(string input)
+        {
+            // Arrange
+            var engine = new CalculateEngine();
+
+            // Act
+            var result = engine.Interpret(input, CultureInfo.InvariantCulture);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(0.0, result.Result);
+        }
+
+        [TestCase("factorial(5)", 120)]
+        [TestCase("sign(-2)", -1)]
+        [TestCase("sign(2)", +1)]
+        [TestCase("abs(-2)", 2)]
+        [TestCase("abs(2)", 2)]
+        public void Interpret_MustReturnExpectedResult_WhenCalled(string input, decimal expectedResult)
+        {
+            // Arrange
+            var engine = new CalculateEngine();
+
+            // Act
+            var result = engine.Interpret(input, CultureInfo.InvariantCulture);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(expectedResult, result.Result);
         }
     }
 }

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Calculator.UnitTest/ExtendedCalculatorParserTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Calculator.UnitTest/ExtendedCalculatorParserTests.cs
@@ -111,6 +111,7 @@ namespace Microsoft.Plugin.Calculator.UnitTests
         [TestCase("(1 * 2)))", false)]
         [TestCase("abcde", false)]
         [TestCase("plot( 2 * 3)", true)]
+        [TestCase("1 + 2 +", false)]
         public void InputValid_TestValid_WhenCalled(string input, bool valid)
         {
             // Arrange

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Calculator/CalculateEngine.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Calculator/CalculateEngine.cs
@@ -47,7 +47,6 @@ namespace Microsoft.Plugin.Calculator
             {
                 Result = decimalResult,
                 RoundedResult = roundedResult,
-                ValidResult = true,
             };
         }
 

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Calculator/CalculateEngine.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Calculator/CalculateEngine.cs
@@ -47,6 +47,7 @@ namespace Microsoft.Plugin.Calculator
             {
                 Result = decimalResult,
                 RoundedResult = roundedResult,
+                ValidResult = true,
             };
         }
 

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Calculator/CalculateHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Calculator/CalculateHelper.cs
@@ -41,6 +41,13 @@ namespace Microsoft.Plugin.Calculator
                 return false;
             }
 
+            // If the input ends with a binary operator then it is not a valid input to mages and the Interpret function would throw an exception.
+            string trimmedInput = input.TrimEnd();
+            if (trimmedInput.EndsWith('+') || trimmedInput.EndsWith('-') || trimmedInput.EndsWith('*') || trimmedInput.EndsWith('|') || trimmedInput.EndsWith('\\') || trimmedInput.EndsWith('^') || trimmedInput.EndsWith('=') || trimmedInput.EndsWith('&'))
+            {
+                return false;
+            }
+
             return true;
         }
     }

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Calculator/CalculateHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Calculator/CalculateHelper.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Plugin.Calculator
         private static readonly Regex RegValidExpressChar = new Regex(
             @"^(" +
             @"ceil\s*\(|floor\s*\(|exp\s*\(|max\s*\(|min\s*\(|abs\s*\(|log\s*\(|ln\s*\(|sqrt\s*\(|pow\s*\(|" +
-            @"factorial\s*\(|sign\s*\(|round\s*\(|rand\s*\(|exp\s*\(|rand\s*\(|" +
+            @"factorial\s*\(|sign\s*\(|round\s*\(|rand\s*\(|" +
             @"sin\s*\(|cos\s*\(|tan\s*\(|arcsin\s*\(|arccos\s*\(|arctan\s*\(|" +
             @"pi|" +
             @"==|~=|&&|\|\||" +

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Calculator/CalculateHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Calculator/CalculateHelper.cs
@@ -11,10 +11,9 @@ namespace Microsoft.Plugin.Calculator
     {
         private static readonly Regex RegValidExpressChar = new Regex(
             @"^(" +
-            @"ceil|floor|exp|pi|e|max|min|det|abs|log|ln|sqrt|" +
-            @"sin|cos|tan|arcsin|arccos|arctan|" +
-            @"eigval|eigvec|eig|sum|polar|plot|round|sort|real|zeta|" +
-            @"bin2dec|hex2dec|oct2dec|" +
+            @"ceil\s*\(|floor\s*\(|exp\s*\(|pi|e|max\s*\(|min\s*\(|det|abs\s*\(|log\s*\(|ln\s*\(|sqrt\s*\(|pow\s*\(|" +
+            @"factorial\s*\(|sign\s*\(|round\s*\(|rand\s*\(|exp\s*\(|lt\s*\(|gt\s*\(|eq\s*\(|rand\s*\(|" +
+            @"sin\s*\(|cos\s*\(|tan\s*\(|arcsin\s*\(|arccos\s*\(|arctan\s*\(|" +
             @"==|~=|&&|\|\||" +
             @"[ei]|[0-9]|[\+\-\*\/\^\., ""]|[\(\)\|\!\[\]]" +
             @")+$", RegexOptions.Compiled);

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Calculator/CalculateHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Calculator/CalculateHelper.cs
@@ -11,8 +11,8 @@ namespace Microsoft.Plugin.Calculator
     {
         private static readonly Regex RegValidExpressChar = new Regex(
             @"^(" +
-            @"ceil\s*\(|floor\s*\(|exp\s*\(|max\s*\(|min\s*\(|det|abs\s*\(|log\s*\(|ln\s*\(|sqrt\s*\(|pow\s*\(|" +
-            @"factorial\s*\(|sign\s*\(|round\s*\(|rand\s*\(|exp\s*\(|lt\s*\(|gt\s*\(|eq\s*\(|rand\s*\(|" +
+            @"ceil\s*\(|floor\s*\(|exp\s*\(|max\s*\(|min\s*\(|abs\s*\(|log\s*\(|ln\s*\(|sqrt\s*\(|pow\s*\(|" +
+            @"factorial\s*\(|sign\s*\(|round\s*\(|rand\s*\(|exp\s*\(|rand\s*\(|" +
             @"sin\s*\(|cos\s*\(|tan\s*\(|arcsin\s*\(|arccos\s*\(|arctan\s*\(|" +
             @"pi|" +
             @"==|~=|&&|\|\||" +

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Calculator/CalculateHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Calculator/CalculateHelper.cs
@@ -11,9 +11,10 @@ namespace Microsoft.Plugin.Calculator
     {
         private static readonly Regex RegValidExpressChar = new Regex(
             @"^(" +
-            @"ceil\s*\(|floor\s*\(|exp\s*\(|pi|e|max\s*\(|min\s*\(|det|abs\s*\(|log\s*\(|ln\s*\(|sqrt\s*\(|pow\s*\(|" +
+            @"ceil\s*\(|floor\s*\(|exp\s*\(|max\s*\(|min\s*\(|det|abs\s*\(|log\s*\(|ln\s*\(|sqrt\s*\(|pow\s*\(|" +
             @"factorial\s*\(|sign\s*\(|round\s*\(|rand\s*\(|exp\s*\(|lt\s*\(|gt\s*\(|eq\s*\(|rand\s*\(|" +
             @"sin\s*\(|cos\s*\(|tan\s*\(|arcsin\s*\(|arccos\s*\(|arctan\s*\(|" +
+            @"pi|" +
             @"==|~=|&&|\|\||" +
             @"[ei]|[0-9]|[\+\-\*\/\^\., ""]|[\(\)\|\!\[\]]" +
             @")+$", RegexOptions.Compiled);

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Calculator/CalculateHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Calculator/CalculateHelper.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Plugin.Calculator
             @"sin\s*\(|cos\s*\(|tan\s*\(|arcsin\s*\(|arccos\s*\(|arctan\s*\(|" +
             @"pi|" +
             @"==|~=|&&|\|\||" +
-            @"[ei]|[0-9]|[\+\-\*\/\^\., ""]|[\(\)\|\!\[\]]" +
+            @"e|[0-9]|[\+\-\*\/\^\., ""]|[\(\)\|\!\[\]]" +
             @")+$", RegexOptions.Compiled);
 
         public static bool InputValid(string input)

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Calculator/CalculateResult.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Calculator/CalculateResult.cs
@@ -9,15 +9,13 @@ namespace Microsoft.Plugin.Calculator
 {
     public struct CalculateResult : IEquatable<CalculateResult>
     {
-        public bool ValidResult { get; set; }
+        public decimal? Result { get; set; }
 
-        public decimal Result { get; set; }
-
-        public decimal RoundedResult { get; set; }
+        public decimal? RoundedResult { get; set; }
 
         public bool Equals(CalculateResult other)
         {
-            return Result == other.Result && RoundedResult == other.RoundedResult && ValidResult == other.ValidResult;
+            return Result == other.Result && RoundedResult == other.RoundedResult;
         }
 
         public override bool Equals(object obj)
@@ -27,7 +25,7 @@ namespace Microsoft.Plugin.Calculator
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(Result, RoundedResult, ValidResult);
+            return HashCode.Combine(Result, RoundedResult);
         }
 
         public static bool operator ==(CalculateResult left, CalculateResult right)

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Calculator/CalculateResult.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Calculator/CalculateResult.cs
@@ -9,13 +9,15 @@ namespace Microsoft.Plugin.Calculator
 {
     public struct CalculateResult : IEquatable<CalculateResult>
     {
+        public bool ValidResult { get; set; }
+
         public decimal Result { get; set; }
 
         public decimal RoundedResult { get; set; }
 
         public bool Equals(CalculateResult other)
         {
-            return Result == other.Result && RoundedResult == other.RoundedResult;
+            return Result == other.Result && RoundedResult == other.RoundedResult && ValidResult == other.ValidResult;
         }
 
         public override bool Equals(object obj)

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Calculator/CalculateResult.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Calculator/CalculateResult.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Plugin.Calculator
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(Result, RoundedResult);
+            return HashCode.Combine(Result, RoundedResult, ValidResult);
         }
 
         public static bool operator ==(CalculateResult left, CalculateResult right)

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Calculator/ResultHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Calculator/ResultHelper.cs
@@ -17,11 +17,17 @@ namespace Microsoft.Plugin.Calculator
             return CreateResult(result.RoundedResult, iconPath);
         }
 
-        public static Result CreateResult(decimal roundedResult, string iconPath)
+        public static Result CreateResult(decimal? roundedResult, string iconPath)
         {
+            // Return null when the expression is not a valid calculator query.
+            if (roundedResult == null)
+            {
+                return null;
+            }
+
             return new Result
             {
-                Title = roundedResult.ToString(CultureInfo.CurrentCulture),
+                Title = roundedResult?.ToString(CultureInfo.CurrentCulture),
                 IcoPath = iconPath,
                 Score = 300,
                 SubTitle = Properties.Resources.wox_plugin_calculator_copy_number_to_clipboard,
@@ -29,26 +35,29 @@ namespace Microsoft.Plugin.Calculator
             };
         }
 
-        public static bool Action(decimal roundedResult)
+        public static bool Action(decimal? roundedResult)
         {
             var ret = false;
 
-            var thread = new Thread(() =>
+            if (roundedResult != null)
             {
-                try
+                var thread = new Thread(() =>
                 {
-                    Clipboard.SetText(roundedResult.ToString(CultureInfo.CurrentUICulture.NumberFormat));
-                    ret = true;
-                }
-                catch (ExternalException)
-                {
-                    MessageBox.Show(Properties.Resources.wox_plugin_calculator_copy_failed);
-                }
-            });
+                    try
+                    {
+                        Clipboard.SetText(roundedResult?.ToString(CultureInfo.CurrentUICulture.NumberFormat));
+                        ret = true;
+                    }
+                    catch (ExternalException)
+                    {
+                        MessageBox.Show(Properties.Resources.wox_plugin_calculator_copy_failed);
+                    }
+                });
 
-            thread.SetApartmentState(ApartmentState.STA);
-            thread.Start();
-            thread.Join();
+                thread.SetApartmentState(ApartmentState.STA);
+                thread.Start();
+                thread.Join();
+            }
 
             return ret;
         }


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

This PR fixes some incorrect results and exceptions being thrown by the calculator plugin which might be slowing down PT Run.

## PR Checklist
* [x] Applies to #7437
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

The following changes have been made in this PR - 
1. Following the refactoring of the calculator plugin, the searched which resulted in 0 as the result were not working as there was no difference between a default result returned when the input was not valid and a valid input resulting in 0 as the answer. 
The `ValidResult` field has been added to distinguish a valid result from a default result. null couldn't be returned because CalculateResult is a non-nullable type.
Eg: 1-1.
2. Exceptions were being thrown when the user query is not complete, as the queryhelper thinks that the query is valid but the interpreter doesn't. 
Eg: sin, 1+2+
3. When a string corresponding to a function is the user query an exception is thrown because it is not a valid interpreter input.
Eg: Say hypothetically we're seraching for some app named logo, then on entering `log` the calculator plugin would be invoked as there is a match with the regex, however, it is not a valid input to the interpreter.
4. There were some functions such as bin2dec, hex2dec, eigval, etc which are not valid inputs to the mages.interpreter function. hence it has been removed. Otherwise, the calculator helper would think that these inputs are valid as they match the regex but the mages.interpreter function would throw an exception as they are not valid mathematical oparations according to it.

The ideal way to capture a valid input would be using a BNF for a mathematical operation but that cannot be captured in a regex. 

## Validation Steps Performed

_How does someone test & validate?_

Added tests.
Manually validated it
