### PR TITLE
Settings accessibility issues with clipping on large text

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
@@ -50,7 +50,6 @@
                           IsOn="{Binding IsEnabled, Mode=TwoWay}"/>
 
             <Custom:HotkeySettingsControl x:Uid="ColorPicker_ActivationShortcut"
-                                          Width="240"
                                           HorizontalAlignment="Left"
                                           Margin="{StaticResource MediumTopMargin}"
                                           HotkeySettings="{x:Bind Path=ViewModel.ActivationShortcut, Mode=TwoWay}"

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
@@ -50,11 +50,12 @@
                           IsOn="{Binding IsEnabled, Mode=TwoWay}"/>
 
             <Custom:HotkeySettingsControl x:Uid="ColorPicker_ActivationShortcut"
-                                          HorizontalAlignment="Left"
                                           Margin="{StaticResource MediumTopMargin}"
                                           HotkeySettings="{x:Bind Path=ViewModel.ActivationShortcut, Mode=TwoWay}"
                                           Keys="Win, Ctrl, Alt, Shift"
                                           Enabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"
+                                          HorizontalAlignment="Left"
+                                          MinWidth="240"
                                           />
 
             <TextBlock x:Uid="ShortcutGuide_Appearance_Behavior"
@@ -62,10 +63,11 @@
                        Foreground="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToForegroundConverter}}"/>
         
             <ComboBox x:Uid="ColorPicker_CopiedColorRepresentation"
-                          SelectedIndex="{Binding CopiedColorRepresentationIndex, Mode=TwoWay}"
-                          Margin="{StaticResource SmallTopMargin}"
-                          Width="240"
-                          IsEnabled="{Binding IsEnabled}">
+                      SelectedIndex="{Binding CopiedColorRepresentationIndex, Mode=TwoWay}"
+                      Margin="{StaticResource SmallTopMargin}"
+                      IsEnabled="{Binding IsEnabled}"
+                      HorizontalAlignment="Left"
+                      MinWidth="240">
                 <ComboBoxItem Content="HEX - #FFAA00"/>
                 <ComboBoxItem Content="RGB - rgb(100, 50, 75)"/>
                 <ComboBoxItem Content="CMYK - cmyk(100%, 50%, 75%, 0%)"/>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -77,11 +77,12 @@
 
             <CustomControls:HotkeySettingsControl 
                 x:Uid="FancyZones_HotkeyEditorControl"
-                HorizontalAlignment="Left"
                 Margin="{StaticResource SmallTopMargin}"
                 HotkeySettings="{x:Bind Path=ViewModel.EditorHotkey, Mode=TwoWay}"
                 Keys="Win, Ctrl, Alt, Shift"
                 Enabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"
+                HorizontalAlignment="Left"
+                MinWidth="240"
                 />
 
             <CheckBox x:Uid="FancyZones_ShiftDragCheckBoxControl_Header"
@@ -165,7 +166,7 @@
                 <Slider x:Uid="FancyZones_HighlightOpacity"
                     Minimum="0"
                     Maximum="100"
-                    Width="240"
+                    MinWidth="240"
                     IsThumbToolTipEnabled="False"
                     Value="{x:Bind Mode=TwoWay, Path=ViewModel.HighlightOpacity}"
                     HorizontalAlignment="Left"
@@ -233,7 +234,6 @@
                     <Flyout>
                         <muxc:ColorPicker x:Name="FancyZones_InActiveColorPicker"
                               Margin="0,6,0,0"
-                              HorizontalAlignment="Left"
                               IsColorSliderVisible="True"
                               IsColorChannelTextInputVisible="True"
                               IsHexInputVisible="True"
@@ -284,12 +284,14 @@
                      Margin="{StaticResource SmallTopMargin}"
                      Text="{x:Bind Mode=TwoWay, Path=ViewModel.ExcludedApps}"
                      IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"
-                     HorizontalAlignment="Left"
                      ScrollViewer.VerticalScrollBarVisibility ="Visible"
                      ScrollViewer.VerticalScrollMode="Enabled"
                      ScrollViewer.IsVerticalRailEnabled="True"
                      TextWrapping="Wrap"
-                     AcceptsReturn="True"/>
+                     AcceptsReturn="True"
+                     HorizontalAlignment="Left"
+                     MinWidth="240"
+                     MinHeight="160" />
         </StackPanel>
 
         <RelativePanel x:Name="SidePanel" 

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -76,7 +76,6 @@
                        Foreground="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToForegroundConverter}}"/>
 
             <CustomControls:HotkeySettingsControl 
-                Width="240"
                 x:Uid="FancyZones_HotkeyEditorControl"
                 HorizontalAlignment="Left"
                 Margin="{StaticResource SmallTopMargin}"
@@ -285,8 +284,6 @@
                      Margin="{StaticResource SmallTopMargin}"
                      Text="{x:Bind Mode=TwoWay, Path=ViewModel.ExcludedApps}"
                      IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"
-                     Width="375"
-                     Height="160"
                      HorizontalAlignment="Left"
                      ScrollViewer.VerticalScrollBarVisibility ="Visible"
                      ScrollViewer.VerticalScrollMode="Enabled"

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml
@@ -51,10 +51,13 @@
 
         <StackPanel Orientation="Vertical" 
                     x:Name="GeneralView">
-            <TextBlock x:Uid="Admin_Mode" FontWeight="SemiBold"
+            <TextBlock x:Uid="Admin_Mode" 
+                       FontWeight="SemiBold"
+                       TextWrapping="Wrap"
                        Style="{StaticResource SubtitleTextBlockStyle}"/>
 
             <TextBlock Text="{x:Bind Mode=TwoWay, Path=ViewModel.RunningAsText}"
+                       TextWrapping="Wrap"
                        Margin="{StaticResource SmallTopMargin}"/>
 
             <Button x:Uid="GeneralPage_RestartAsAdmin_Button"
@@ -66,6 +69,7 @@
 
             <TextBlock x:Uid="General_RunAsAdminRequired"
                        Foreground="{ThemeResource SystemControlErrorTextForegroundBrush}"
+                       TextWrapping="Wrap"
                        Visibility="{Binding Mode=TwoWay, Path=IsElevated, Converter={StaticResource BoolToVisibilityConverter}}"
                        Margin="0,24,0,-8" />
 
@@ -75,7 +79,7 @@
                           IsOn="{Binding Mode=TwoWay, Path=RunElevated}"/>
 
             <HyperlinkButton NavigateUri="https://aka.ms/powertoysDetectedElevatedHelp">
-                <TextBlock x:Uid="GeneralPage_ToggleSwitch_AlwaysRunElevated_Link" />
+                <TextBlock x:Uid="GeneralPage_ToggleSwitch_AlwaysRunElevated_Link" TextWrapping="Wrap" />
             </HyperlinkButton>
 
 

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
@@ -149,7 +149,7 @@
                             <muxc:NumberBox Name="ImageResizer_Width_Property"
                                             x:Uid="ImageResizer_Width_Property"
                                             Value="{x:Bind Path=Width, Mode=TwoWay}" 
-                                            Width="68"
+                                            MinWidth="68"
                                             SpinButtonPlacementMode="Compact"
                                             VerticalAlignment="Center"
                                             Margin="{StaticResource SmallTopMargin}"/>
@@ -167,7 +167,7 @@
                             <muxc:NumberBox Name="ImageResizer_Height_Property"
                                             x:Uid="ImageResizer_Height_Property"
                                             Value="{x:Bind Path=Height, Mode=TwoWay}" 
-                                            Width="68"
+                                            MinWidth="68"
                                             VerticalAlignment="Center"
                                             SpinButtonPlacementMode="Compact"
                                             Opacity="{x:Bind Path=ExtraBoxOpacity, Mode=OneWay}"
@@ -177,7 +177,7 @@
                             <ComboBox Name="ImageResizer_Size_Property"
                                       x:Uid="ImageResizer_Size_Property"
                                       SelectedIndex="{Binding Path=Unit, Mode=TwoWay}"
-                                      Width="120"
+                                      MinWidth="120"
                                       VerticalAlignment="Center"
                                       Margin="{StaticResource SmallTopMargin}">
                                 <ComboBoxItem x:Uid="ImageResizer_Sizes_Units_CM" />
@@ -220,7 +220,7 @@
 
             <ComboBox x:Uid="ImageResizer_FallBackEncoderText"
                           SelectedIndex="{x:Bind Path=ViewModel.Encoder, Mode=TwoWay}"
-                          Width="240"
+                          MinWidth="240"
                           Margin="{StaticResource SmallTopMargin}"
                           IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}">
                 <ComboBoxItem x:Uid="ImageResizer_FallbackEncoder_PNG" />
@@ -235,7 +235,7 @@
                             Minimum="0"
                             Maximum="100"
                             Value="{x:Bind Mode=TwoWay, Path=ViewModel.JPEGQualityLevel}"
-                            Width="240"
+                            MinWidth="240"
                             Margin="{StaticResource SmallTopMargin}"
                             SpinButtonPlacementMode="Compact"
                             HorizontalAlignment="Left"
@@ -245,7 +245,7 @@
 
             <ComboBox x:Uid="ImageResizer_PNGInterlacing"
                           SelectedIndex="{x:Bind Mode=TwoWay, Path=ViewModel.PngInterlaceOption}"
-                          Width="240"
+                          MinWidth="240"
                           Margin="{StaticResource SmallTopMargin}"
                           IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}">
                 <ComboBoxItem x:Uid="Default"/>
@@ -255,7 +255,7 @@
 
             <ComboBox x:Uid="ImageResizer_TIFFCompression"
                           SelectedIndex="{x:Bind Mode=TwoWay, Path=ViewModel.TiffCompressOption}"
-                          Width="240"
+                          MinWidth="240"
                           Margin="{StaticResource SmallTopMargin}"
                           IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}">
                 <ComboBoxItem x:Uid="ImageResizer_ENCODER_TIFF_Default"/>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
@@ -90,7 +90,35 @@
                         <Setter Property="Template">
                             <Setter.Value>
                                 <ControlTemplate TargetType="ListViewItem">
-                                    <ListViewItemPresenter CheckBrush="{ThemeResource ListViewItemCheckBrush}" ContentMargin="{TemplateBinding Padding}" CheckMode="{ThemeResource ListViewItemCheckMode}" ContentTransitions="{TemplateBinding ContentTransitions}" CheckBoxBrush="{ThemeResource ListViewItemCheckBoxBrush}" DragForeground="{ThemeResource ListViewItemDragForeground}" DragOpacity="{ThemeResource ListViewItemDragThemeOpacity}" DragBackground="{ThemeResource ListViewItemDragBackground}" DisabledOpacity="{ThemeResource ListViewItemDisabledThemeOpacity}" FocusVisualPrimaryBrush="{TemplateBinding FocusVisualPrimaryBrush}" FocusVisualSecondaryThickness="{TemplateBinding FocusVisualSecondaryThickness}" FocusBorderBrush="{ThemeResource ListViewItemFocusBorderBrush}" FocusVisualMargin="{TemplateBinding FocusVisualMargin}" FocusVisualPrimaryThickness="{TemplateBinding FocusVisualPrimaryThickness}" FocusSecondaryBorderBrush="{ThemeResource ListViewItemFocusSecondaryBorderBrush}" FocusVisualSecondaryBrush="{TemplateBinding FocusVisualSecondaryBrush}" HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" Control.IsTemplateFocusTarget="True" PointerOverForeground="{ThemeResource ListViewItemForegroundPointerOver}" PressedBackground="{ThemeResource ListViewItemBackgroundPressed}" PlaceholderBackground="{ThemeResource ListViewItemPlaceholderBackground}" PointerOverBackground="{ThemeResource ListViewItemBackgroundPointerOver}" ReorderHintOffset="{ThemeResource ListViewItemReorderHintThemeOffset}" SelectedPressedBackground="{ThemeResource ListViewItemBackgroundSelectedPressed}" SelectionCheckMarkVisualEnabled="{ThemeResource ListViewItemSelectionCheckMarkVisualEnabled}" SelectedForeground="{ThemeResource ListViewItemForegroundSelected}" SelectedPointerOverBackground="{ThemeResource ListViewItemBackgroundSelectedPointerOver}" SelectedBackground="{ThemeResource ListViewItemBackgroundSelected}" VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                                    <ListViewItemPresenter 
+                                        CheckBrush="{ThemeResource ListViewItemCheckBrush}" 
+                                        ContentMargin="{TemplateBinding Padding}" 
+                                        CheckMode="{ThemeResource ListViewItemCheckMode}" 
+                                        ContentTransitions="{TemplateBinding ContentTransitions}" 
+                                        CheckBoxBrush="{ThemeResource ListViewItemCheckBoxBrush}" 
+                                        DragForeground="{ThemeResource ListViewItemDragForeground}" 
+                                        DragOpacity="{ThemeResource ListViewItemDragThemeOpacity}" 
+                                        DragBackground="{ThemeResource ListViewItemDragBackground}" 
+                                        DisabledOpacity="{ThemeResource ListViewItemDisabledThemeOpacity}" 
+                                        FocusVisualPrimaryBrush="{TemplateBinding FocusVisualPrimaryBrush}" 
+                                        FocusVisualSecondaryThickness="{TemplateBinding FocusVisualSecondaryThickness}" 
+                                        FocusBorderBrush="{ThemeResource ListViewItemFocusBorderBrush}" 
+                                        FocusVisualMargin="{TemplateBinding FocusVisualMargin}" 
+                                        FocusVisualPrimaryThickness="{TemplateBinding FocusVisualPrimaryThickness}" 
+                                        FocusSecondaryBorderBrush="{ThemeResource ListViewItemFocusSecondaryBorderBrush}" 
+                                        FocusVisualSecondaryBrush="{TemplateBinding FocusVisualSecondaryBrush}" 
+                                        HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" 
+                                        Control.IsTemplateFocusTarget="True" 
+                                        PointerOverForeground="{ThemeResource ListViewItemForegroundPointerOver}" 
+                                        PressedBackground="{ThemeResource ListViewItemBackgroundPressed}"
+                                        PlaceholderBackground="{ThemeResource ListViewItemPlaceholderBackground}" 
+                                        PointerOverBackground="{ThemeResource ListViewItemBackgroundPointerOver}" ReorderHintOffset="{ThemeResource ListViewItemReorderHintThemeOffset}" 
+                                        SelectedPressedBackground="{ThemeResource ListViewItemBackgroundSelectedPressed}" 
+                                        SelectionCheckMarkVisualEnabled="{ThemeResource ListViewItemSelectionCheckMarkVisualEnabled}" 
+                                        SelectedForeground="{ThemeResource ListViewItemForegroundSelected}" 
+                                        SelectedPointerOverBackground="{ThemeResource ListViewItemBackgroundSelectedPointerOver}" 
+                                        SelectedBackground="{ThemeResource ListViewItemBackgroundSelected}" 
+                                        VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"/>
                                 </ControlTemplate>
                             </Setter.Value>
                         </Setter>
@@ -99,13 +127,12 @@
                 </ListView.ItemContainerStyle>
                 <ListView.ItemTemplate>
                     <DataTemplate x:Name="SingleLineDataTemplate" x:DataType="models:ImageSize" >
-                        <StackPanel Name="ImageResizer_Configurations" x:Uid="ImageResizer_Configurations" Orientation="Horizontal" Height="48" Padding="0" Spacing="4">
+                        <StackPanel Name="ImageResizer_Configurations" x:Uid="ImageResizer_Configurations" Orientation="Horizontal" Padding="0" Spacing="4">
                             <TextBox Name="ImageResizer_Name"
                                      x:Uid="ImageResizer_Name"
                                      Text="{x:Bind Path=Name, Mode=TwoWay}" 
                                      Width="90"
                                      VerticalAlignment="Center"
-                                     Height="34"
                                      Margin="{StaticResource SmallTopMargin}"/>
 
                             <ComboBox Name="ImageResizer_Fit_Property"
@@ -113,7 +140,6 @@
                                       SelectedIndex="{x:Bind Path=Fit, Mode=TwoWay}"
                                       Width="90"
                                       VerticalAlignment="Center"
-                                      Height="34"
                                       Margin="{StaticResource SmallTopMargin}">
                                 <ComboBoxItem x:Uid="ImageResizer_Sizes_Fit_Fill" />
                                 <ComboBoxItem x:Uid="ImageResizer_Sizes_Fit_Fit" />
@@ -124,7 +150,6 @@
                                             x:Uid="ImageResizer_Width_Property"
                                             Value="{x:Bind Path=Width, Mode=TwoWay}" 
                                             Width="68"
-                                            Height="34"
                                             SpinButtonPlacementMode="Compact"
                                             VerticalAlignment="Center"
                                             Margin="{StaticResource SmallTopMargin}"/>
@@ -143,7 +168,6 @@
                                             x:Uid="ImageResizer_Height_Property"
                                             Value="{x:Bind Path=Height, Mode=TwoWay}" 
                                             Width="68"
-                                            Height="34"
                                             VerticalAlignment="Center"
                                             SpinButtonPlacementMode="Compact"
                                             Opacity="{x:Bind Path=ExtraBoxOpacity, Mode=OneWay}"
@@ -154,7 +178,6 @@
                                       x:Uid="ImageResizer_Size_Property"
                                       SelectedIndex="{Binding Path=Unit, Mode=TwoWay}"
                                       Width="120"
-                                      Height="34"
                                       VerticalAlignment="Center"
                                       Margin="{StaticResource SmallTopMargin}">
                                 <ComboBoxItem x:Uid="ImageResizer_Sizes_Units_CM" />
@@ -166,7 +189,6 @@
                                     x:Uid="RemoveButton"
                                     Background="Transparent"
                                     FontFamily="Segoe MDL2 Assets"
-                                    Height="34"
                                     Width="34"
                                     Content="&#xE74D;"
                                     VerticalAlignment="Center"
@@ -183,7 +205,6 @@
             <StackPanel Orientation="Horizontal">
                 <AppBarButton Icon="Add"
                               x:Name="AddSizeButton"
-                              Width="560"
                               Style="{StaticResource AddItemAppBarButtonStyle}"
                               IsEnabled="{x:Bind Mode=TwoWay, Path=ViewModel.IsEnabled}" 
                               x:Uid="ImageResizer_AddSizeButton"

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
@@ -54,21 +54,18 @@
                        Foreground="{x:Bind Mode=OneWay, Path=ViewModel.EnablePowerLauncher, Converter={StaticResource ModuleEnabledToForegroundConverter}}"/>
 
             <CustomControls:HotkeySettingsControl x:Uid="PowerLauncher_OpenPowerLauncher"
-                                                  Width="240"
                                                   HorizontalAlignment="Left"
                                                   Margin="{StaticResource SmallTopMargin}"
                                                   HotkeySettings="{x:Bind Path=ViewModel.OpenPowerLauncher, Mode=TwoWay}"
                                                   Keys="Win, Ctrl, Alt, Shift"
                                                   Enabled="{x:Bind Mode=OneWay, Path=ViewModel.EnablePowerLauncher}"/>
             <!--<Custom:HotkeySettingsControl x:Uid="PowerLauncher_OpenFileLocation"
-                                          Width="320"
                                           HorizontalAlignment="Left"
                                           Margin="{StaticResource SmallTopMargin}"
                                           HotkeySettings="{Binding Path=ViewModel.OpenFileLocation, Mode=TwoWay}"
                                           IsEnabled="False"
                                         />
             <Custom:HotkeySettingsControl x:Uid="PowerLauncher_CopyPathLocation"
-                                          Width="320"
                                           HorizontalAlignment="Left"
                                           Margin="{StaticResource SmallTopMargin}"
                                           HotkeySettings="{Binding Path=ViewModel.CopyPathLocation, Mode=TwoWay}"
@@ -76,7 +73,6 @@
                                           IsEnabled="False"
                                         />
             <Custom:HotkeySettingsControl x:Uid="PowerLauncher_OpenConsole"
-                                          Width="320"
                                           HorizontalAlignment="Left"
                                           Margin="{StaticResource SmallTopMargin}"
                                           HotkeySettings="{Binding Path=ViewModel.OpenConsole, Mode=TwoWay}"

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
@@ -55,6 +55,7 @@
 
             <CustomControls:HotkeySettingsControl x:Uid="PowerLauncher_OpenPowerLauncher"
                                                   HorizontalAlignment="Left"
+                                                  MinWidth="240"
                                                   Margin="{StaticResource SmallTopMargin}"
                                                   HotkeySettings="{x:Bind Path=ViewModel.OpenPowerLauncher, Mode=TwoWay}"
                                                   Keys="Win, Ctrl, Alt, Shift"
@@ -124,7 +125,7 @@
 
             <muxc:NumberBox x:Uid="PowerLauncher_MaximumNumberOfResults"
                             Value="{Binding Mode=TwoWay, Path=MaximumNumberOfResults}"
-                            Width="240"
+                            MinWidth="240"
                             SpinButtonPlacementMode="Compact"
                             HorizontalAlignment="Left"
                             Minimum="1"

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerPreviewPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerPreviewPage.xaml
@@ -51,12 +51,14 @@
             <TextBlock x:Uid="FileExplorerPreview_RunAsAdminRequired"
                        Foreground="{ThemeResource SystemControlErrorTextForegroundBrush}"
                        Visibility="{Binding Mode=OneWay, Path=IsElevated, Converter={StaticResource BoolToVisibilityConverter}}"
-                       Margin="{StaticResource SmallBottomMargin}"/>
+                       Margin="{StaticResource SmallBottomMargin}"
+                       TextWrapping="Wrap"/>
 
             <TextBlock x:Uid="FileExplorerPreview_AffectsAllUsers"
                        Foreground="{x:Bind Mode=OneWay, Path=ViewModel.IsElevated, Converter={StaticResource ModuleEnabledToForegroundConverter}}"
                        Margin="{StaticResource SmallBottomMargin}"
-                       FontWeight="SemiBold"/>
+                       FontWeight="SemiBold"
+                       TextWrapping="Wrap"/>
 
             <TextBlock x:Uid="FileExplorerPreview_PreviewPane_GroupSettings"
                        Style="{StaticResource SettingsGroupTitleStyleAsHeader}"
@@ -79,7 +81,8 @@
             <TextBlock x:Uid="FileExplorerPreview_RebootRequired"
                        Foreground="{x:Bind Mode=OneWay, Path=ViewModel.IsElevated, Converter={StaticResource ModuleEnabledToForegroundConverter}}"
                        Margin="{StaticResource SmallTopBottomMargin}"
-                       FontWeight="SemiBold"/>
+                       FontWeight="SemiBold"
+                       TextWrapping="Wrap"/>
 
             <ToggleSwitch x:Uid="FileExplorerPreview_ToggleSwitch_SVG_Thumbnail"
                           Margin="{StaticResource SmallTopMargin}"

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ShortcutGuidePage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ShortcutGuidePage.xaml
@@ -61,7 +61,7 @@
                             SpinButtonPlacementMode="Compact"
                             HorizontalAlignment="Left"
                             Margin="{StaticResource SmallTopMargin}"
-                            Width="240"
+                            MinWidth="240"
                             Value="{x:Bind Mode=TwoWay, Path=ViewModel.PressTime}"
                             IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}" 
                             SmallChange="50" 


### PR DESCRIPTION
## Summary of the Pull Request

When text size is set to 225%, parts of UX would be clipped due to hardcoded values.

## PR Checklist
* [x] Applies to #7068 
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

all instances of Tooltip with hotkey picker are now tweaked to correct. was caused by hardcoded width. bet languages could have also introduced this.
![image](https://user-images.githubusercontent.com/1462282/96800400-1dd0cc80-13ba-11eb-9bfd-4c7994bdbe6b.png)

Fixed exclude app
bet languages could have also introduced this. due to hardcoded width and height
![image](https://user-images.githubusercontent.com/1462282/96800419-2c1ee880-13ba-11eb-8048-81612a226516.png)
![image](https://user-images.githubusercontent.com/1462282/96800428-317c3300-13ba-11eb-9e2f-d12432f764e5.png)

Image Resizer settings:
![image](https://user-images.githubusercontent.com/1462282/96801779-44443700-13bd-11eb-94b7-e2384bd1fbf8.png)


## Validation Steps Performed

follow steps in #7068 