### PR TITLE
[Fix Build farm]Fix ImageResizer Loc and change C# language version in ColorPicker to 8.0

### DIFF
--- a/UnitTest-ColorPickerUI/UnitTest-ColorPickerUI.csproj
+++ b/UnitTest-ColorPickerUI/UnitTest-ColorPickerUI.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>UnitTest_ColorPickerUI</RootNamespace>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <OutputType>Library</OutputType>
   </PropertyGroup>
 

--- a/src/modules/colorPicker/ColorPickerUI/ColorPickerUI.csproj
+++ b/src/modules/colorPicker/ColorPickerUI/ColorPickerUI.csproj
@@ -62,7 +62,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>true</Prefer32Bit>
@@ -73,7 +73,7 @@
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>true</Prefer32Bit>

--- a/src/modules/colorPicker/ColorPickerUI/Helpers/ColorHelper.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/ColorHelper.cs
@@ -28,7 +28,7 @@ namespace ColorPicker.Helpers
             {
                 return (color.GetHue(), 0d, lightness);
             }
-            else if (lightness is > 0d and <= 0.5d)
+            else if (lightness > 0d && lightness <= 0.5d)
             {
                 return (color.GetHue(), (max - min) / (max + min), lightness);
             }

--- a/src/modules/imageresizer/ui/ImageResizerUI.csproj
+++ b/src/modules/imageresizer/ui/ImageResizerUI.csproj
@@ -50,7 +50,6 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
       <SubType>Designer</SubType>
     </EmbeddedResource>
-    <EmbeddedResource Include="Properties\Resources.*.resx" />
   </ItemGroup>
   <ItemGroup>
     <AdditionalFiles Include="..\..\..\codeAnalysis\StyleCop.json" />


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
Since ImageResizerUI is now a .NET Core project, `<EmbeddedResource Include="Properties\Resources.*.resx" />` is not required as .NET Core projects automatically include all the files in the Properties folder.
The version of VS in CDPX pipeline doesn't support C# 9.0, so this has been downgraded to 8.0 and use of `is <` and `and` features has been removed.

Errors on the build farm:
```
"S:\src\modules\imageresizer\ui\ImageResizerUI.csproj" (default target) (33) ->
[INFO] [6297]        (CheckForDuplicateItems target) -> 
[INFO] [6298]          C:\Program Files\dotnet\sdk\3.1.200\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultItems.targets(306,5): error NETSDK1022: Duplicate 'EmbeddedResource' items were included. The .NET SDK includes 'EmbeddedResource' items from your project directory by default. You can either remove these items from your project file, or set the 'EnableDefaultEmbeddedResourceItems' property to 'false' if you want to explicitly include them in your project file. For more information, see https://aka.ms/sdkimplicititems. The duplicate items were: 'Properties\Resources.cs.resx'; 'Properties\Resources.de.resx'; 'Properties\Resources.es.resx'; 'Properties\Resources.fr.resx'; 'Properties\Resources.hu.resx'; 'Properties\Resources.it.resx'; 'Properties\Resources.ja.resx'; 'Properties\Resources.ko.resx'; 'Properties\Resources.nl.resx'; 'Properties\Resources.pl.resx'; 'Properties\Resources.pt-BR.resx'; 'Properties\Resources.pt-PT.resx'; 'Properties\Resources.ru.resx'; 'Properties\Resources.sv.resx'; 'Properties\Resources.tr.resx'; 'Properties\Resources.zh-Hans.resx'; 'Properties\Resources.zh-Hant.resx' [S:\src\modules\imageresizer\ui\ImageResizerUI.csproj]
[INFO] [6299]        "S:\PowerToys.sln" (default target) (1) ->
[INFO] [6300]        "S:\src\runner\runner.vcxproj.metaproj" (default target) (2) ->
[INFO] [6301]        "S:\src\modules\colorPicker\ColorPickerUI\ColorPickerUI.csproj" (default target) (23) ->
[INFO] [6302]        "S:\src\modules\colorPicker\ColorPickerUI\ColorPickerUI_yxr1rklh_wpftmp.csproj" (_CompileTemporaryAssembly target) (60) ->
[INFO] [6303]        (CoreCompile target) -> 
[INFO] [6304]          CSC : error CS1617: Invalid option '9.0' for /langversion. Use '/langversion:?' to list supported values. [S:\src\modules\colorPicker\ColorPickerUI\ColorPickerUI_yxr1rklh_wpftmp.csproj]
[INFO] [6305]
```

## PR Checklist
* [ ] Applies to #xxx
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [X] Tests passed

## Info on Pull Request

_What does this include?_

## Validation Steps Performed

_How does someone test & validate?_
Validated on pipeline https://github-private.visualstudio.com/microsoft/_build/results?buildId=14311&view=results and tested the MSI