### PR TITLE
[fxcop] Settings UI runner

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI.Library/Utilities/Logger.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Library/Utilities/Logger.cs
@@ -32,6 +32,11 @@ namespace Microsoft.PowerToys.Settings.UI.Library.Utilities
             Log(message, "INFO");
         }
 
+        public static void LogError(string message)
+        {
+            Log(message, "ERROR");
+        }
+
         public static void LogError(string message, Exception e)
         {
             Log(

--- a/src/core/Microsoft.PowerToys.Settings.UI.Library/Utilities/Logger.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Library/Utilities/Logger.cs
@@ -35,6 +35,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library.Utilities
         public static void LogError(string message)
         {
             Log(message, "ERROR");
+#if DEBUG
+            Debugger.Break();
+#endif
         }
 
         public static void LogError(string message, Exception e)
@@ -47,6 +50,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library.Utilities
                 "Stack trace: " + Environment.NewLine +
                 e?.StackTrace,
                 "ERROR");
+#if DEBUG
+            Debugger.Break();
+#endif
         }
 
         private static void Log(string message, string type)

--- a/src/core/Microsoft.PowerToys.Settings.UI.Runner/MainWindow.xaml.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Runner/MainWindow.xaml.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics;
 using System.Windows;
 using Microsoft.PowerLauncher.Telemetry;
 using Microsoft.PowerToys.Settings.UI.Library.Utilities;
@@ -80,9 +79,6 @@ namespace Microsoft.PowerToys.Settings.UI.Runner
                         else
                         {
                             Logger.LogError("Failed to parse JSON from IPC message.");
-#if DEBUG
-                            Debugger.Break();
-#endif
                         }
                     }
                 };

--- a/src/core/Microsoft.PowerToys.Settings.UI.Runner/MainWindow.xaml.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Runner/MainWindow.xaml.cs
@@ -67,16 +67,13 @@ namespace Microsoft.PowerToys.Settings.UI.Runner
                 {
                     if (ShellPage.ShellHandler.IPCResponseHandleList != null)
                     {
-                        try
+                        var success = JsonObject.TryParse(msg, out JsonObject json);
+                        if (success)
                         {
-                            JsonObject json = JsonObject.Parse(msg);
                             foreach (Action<JsonObject> handle in ShellPage.ShellHandler.IPCResponseHandleList)
                             {
                                 handle(json);
                             }
-                        }
-                        catch (Exception)
-                        {
                         }
                     }
                 };

--- a/src/core/Microsoft.PowerToys.Settings.UI.Runner/Microsoft.PowerToys.Settings.UI.Runner.csproj
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Runner/Microsoft.PowerToys.Settings.UI.Runner.csproj
@@ -69,6 +69,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VCRTForwarders.140" Version="1.0.6" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers">
+      <Version>3.3.0</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/core/Microsoft.PowerToys.Settings.UI.Runner/Program.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Runner/Program.cs
@@ -13,7 +13,7 @@ using Windows.UI.Popups;
 
 namespace Microsoft.PowerToys.Settings.UI.Runner
 {
-    public class Program
+    public static class Program
     {
         // Quantity of arguments
         private const int ArgumentsQty = 5;
@@ -37,9 +37,9 @@ namespace Microsoft.PowerToys.Settings.UI.Runner
                 App app = new App();
                 app.InitializeComponent();
 
-                if (args.Length >= ArgumentsQty)
+                if (args != null && args.Length >= ArgumentsQty)
                 {
-                    int.TryParse(args[2], out int powerToysPID);
+                    _ = int.TryParse(args[2], out int powerToysPID);
                     PowerToysPID = powerToysPID;
 
                     if (args[4] == "true")


### PR DESCRIPTION
## Summary of the Pull Request

Adding FxCop to the Microsoft.PowerToys.Settings.UI.Runner.csproj project, and fixing the resulting warnings and errors.

## PR Checklist
* [x] Applies to #5129 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
![image](https://user-images.githubusercontent.com/16506055/96929971-d573e600-146f-11eb-90dc-c82c77ab2fc1.png)
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

Minor changes to the Settings.UI.Runner project to enable FxCop. Includes marking Program class as static, checking if args is null, using (discarding) the return result of TryParse and changing Json.Parse to Json.TryParse on WindowsXamlHost_ChildChanged.

## Validation Steps Performed

Ensure unit tests pass on Debug & Release mode, and manually validate settings functionality for Debug & Release builds.