### PR TITLE
[Settings] Switch focus to last Image Size ListViewItem on adding new size

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI.Library/ViewModels/ImageResizerViewModel.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Library/ViewModels/ImageResizerViewModel.cs
@@ -86,6 +86,8 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
         private bool _keepDateModified;
         private int _encoderGuidId;
 
+        public bool IsListViewFocusRequested { get; set; }
+
         public bool IsEnabled
         {
             get
@@ -257,6 +259,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             imageSizes.Add(newSize);
             _advancedSizes = imageSizes;
             SavesImageSizes(imageSizes);
+
+            // Set the focus requested flag to indicate that an add operation has occurred during the ContainerContentChanging event
+            IsListViewFocusRequested = true;
         }
 
         public void DeleteImageSize(int id)

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
@@ -65,7 +65,8 @@
                       SelectionMode="None"
                       ScrollViewer.HorizontalScrollMode="Enabled"
                       ScrollViewer.HorizontalScrollBarVisibility="Auto"
-                      ScrollViewer.IsHorizontalRailEnabled="True">
+                      ScrollViewer.IsHorizontalRailEnabled="True"
+                      ContainerContentChanging="ImagesSizesListView_ContainerContentChanging">
 
                 <ListView.ItemContainerStyle>
                     <Style TargetType="ListViewItem">

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Linq;
 using Microsoft.PowerToys.Settings.UI.Library;
 using Microsoft.PowerToys.Settings.UI.Library.Utilities;
 using Microsoft.PowerToys.Settings.UI.Library.ViewModels;
@@ -43,6 +44,19 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             }
             catch
             {
+            }
+        }
+
+        private void ImagesSizesListView_ContainerContentChanging(ListViewBase sender, ContainerContentChangingEventArgs args)
+        {
+            if (ViewModel.IsListViewFocusRequested)
+            {
+                // Set focus to the last item in the ListView
+                int size = ImagesSizesListView.Items.Count;
+                ((ListViewItem)ImagesSizesListView.ContainerFromIndex(size - 1)).Focus(FocusState.Programmatic);
+
+                // Reset the focus requested flag
+                ViewModel.IsListViewFocusRequested = false;
             }
         }
     }


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
This PR adds code to switch the tab focus to the new ListViewItem when the Add Size button is pressed.
The logic needs to happen in ContainerContentChanging and not the Button_Click handler as the ListView doesn't get updated immediately after `ViewModel.AddRow` is called.

**Note:** This PR only makes the focus change mentioned in the issue and not the "announcement after successful add/delete" feedback on the issue.
## PR Checklist
* [X] Applies to #7047
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [X] Tests passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx


## Validation Steps Performed

_How does someone test & validate?_
Turn on Narrator
- Tab through the Image Resizer page till the Add Sizes button and press it
- Validate that Narrator reads out the new item in the ListView and it focus is on that element
- Move focus to the remove button and press it
- Validate that narrator reads out the adjacent element and focus is on it.