### PR TITLE
FZ: fix nullptr crash

### DIFF
--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -616,7 +616,7 @@ void FancyZones::ToggleEditor() noexcept
     winrt::com_ptr<IZoneWindow> zoneWindow;
 
     std::shared_lock readLock(m_lock);
-    
+
     if (m_settings->GetSettings()->spanZonesAcrossMonitors)
     {
         zoneWindow = m_workAreaHandler.GetWorkArea(m_currentDesktopId, NULL);
@@ -625,7 +625,7 @@ void FancyZones::ToggleEditor() noexcept
     {
         zoneWindow = m_workAreaHandler.GetWorkArea(m_currentDesktopId, monitor);
     }
-    
+
     if (!zoneWindow)
     {
         return;
@@ -639,7 +639,8 @@ void FancyZones::ToggleEditor() noexcept
 
         m_dpiUnawareThread.submit(OnThreadExecutor::task_t{ [&] {
                               allMonitors = FancyZonesUtils::GetAllMonitorRects<&MONITORINFOEX::rcWork>();
-            } }).wait();
+                          } })
+            .wait();
 
         UINT currentDpi = 0;
         for (const auto& monitor : allMonitors)
@@ -650,15 +651,15 @@ void FancyZones::ToggleEditor() noexcept
             {
                 if (currentDpi == 0)
                 {
-                  currentDpi = dpiX;
-                  continue;
+                    currentDpi = dpiX;
+                    continue;
                 }
                 if (currentDpi != dpiX)
                 {
                     MessageBoxW(NULL,
-                    GET_RESOURCE_STRING(IDS_SPAN_ACROSS_ZONES_WARNING).c_str(),
-                    GET_RESOURCE_STRING(IDS_POWERTOYS_FANCYZONES).c_str(),
-                    MB_OK | MB_ICONWARNING);
+                                GET_RESOURCE_STRING(IDS_SPAN_ACROSS_ZONES_WARNING).c_str(),
+                                GET_RESOURCE_STRING(IDS_POWERTOYS_FANCYZONES).c_str(),
+                                MB_OK | MB_ICONWARNING);
                     break;
                 }
             }
@@ -693,8 +694,9 @@ void FancyZones::ToggleEditor() noexcept
         mi.cbSize = sizeof(mi);
 
         m_dpiUnawareThread.submit(OnThreadExecutor::task_t{ [&] {
-            GetMonitorInfo(monitor, &mi);
-            } }).wait();
+                              GetMonitorInfo(monitor, &mi);
+                          } })
+            .wait();
 
         const auto x = mi.rcWork.left;
         const auto y = mi.rcWork.top;
@@ -981,7 +983,7 @@ void FancyZones::UpdateZoneWindows() noexcept
 
     auto callback = [](HMONITOR monitor, HDC, RECT*, LPARAM data) -> BOOL {
         capture* params = reinterpret_cast<capture*>(data);
-        MONITORINFOEX mi{ { .cbSize = sizeof(mi)} };
+        MONITORINFOEX mi{ { .cbSize = sizeof(mi) } };
         if (GetMonitorInfoW(monitor, &mi))
         {
             auto& displayDeviceIdxMap = *(params->displayDeviceIdx);
@@ -1006,8 +1008,8 @@ void FancyZones::UpdateZoneWindows() noexcept
             if (deviceId.empty())
             {
                 deviceId = GetSystemMetrics(SM_REMOTESESSION) ?
-                                L"\\\\?\\DISPLAY#REMOTEDISPLAY#" :
-                                L"\\\\?\\DISPLAY#LOCALDISPLAY#";
+                               L"\\\\?\\DISPLAY#REMOTEDISPLAY#" :
+                               L"\\\\?\\DISPLAY#LOCALDISPLAY#";
 
                 fancyZones->AddZoneWindow(monitor, deviceId);
             }

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -1180,21 +1180,24 @@ bool FancyZones::OnSnapHotkeyBasedOnPosition(HWND window, DWORD vkCode) noexcept
             else
             {
                 auto workArea = m_workAreaHandler.GetWorkArea(m_currentDesktopId, monitor);
-                auto zoneSet = workArea->ActiveZoneSet();
-                if (zoneSet)
+                if (workArea)
                 {
-                    const auto zones = zoneSet->GetZones();
-                    for (const auto& [zoneId, zone] : zones)
+                    auto zoneSet = workArea->ActiveZoneSet();
+                    if (zoneSet)
                     {
-                        RECT zoneRect = zone->GetZoneRect();
+                        const auto zones = zoneSet->GetZones();
+                        for (const auto& [zoneId, zone] : zones)
+                        {
+                            RECT zoneRect = zone->GetZoneRect();
 
-                        zoneRect.left += monitorRect.left;
-                        zoneRect.right += monitorRect.left;
-                        zoneRect.top += monitorRect.top;
-                        zoneRect.bottom += monitorRect.top;
+                            zoneRect.left += monitorRect.left;
+                            zoneRect.right += monitorRect.left;
+                            zoneRect.top += monitorRect.top;
+                            zoneRect.bottom += monitorRect.top;
 
-                        zoneRects.emplace_back(zoneRect);
-                        zoneRectsInfo.emplace_back(zoneId, workArea);
+                            zoneRects.emplace_back(zoneRect);
+                            zoneRectsInfo.emplace_back(zoneId, workArea);
+                        }
                     }
                 }
             }
@@ -1224,21 +1227,24 @@ bool FancyZones::OnSnapHotkeyBasedOnPosition(HWND window, DWORD vkCode) noexcept
         if (currentMonitorRect.top <= currentMonitorRect.bottom)
         {
             auto workArea = m_workAreaHandler.GetWorkArea(m_currentDesktopId, current);
-            auto zoneSet = workArea->ActiveZoneSet();
-            if (zoneSet)
+            if (workArea)
             {
-                const auto zones = zoneSet->GetZones();
-                for (const auto& [zoneId, zone] : zones)
+                auto zoneSet = workArea->ActiveZoneSet();
+                if (zoneSet)
                 {
-                    RECT zoneRect = zone->GetZoneRect();
+                    const auto zones = zoneSet->GetZones();
+                    for (const auto& [zoneId, zone] : zones)
+                    {
+                        RECT zoneRect = zone->GetZoneRect();
 
-                    zoneRect.left += currentMonitorRect.left;
-                    zoneRect.right += currentMonitorRect.left;
-                    zoneRect.top += currentMonitorRect.top;
-                    zoneRect.bottom += currentMonitorRect.top;
+                        zoneRect.left += currentMonitorRect.left;
+                        zoneRect.right += currentMonitorRect.left;
+                        zoneRect.top += currentMonitorRect.top;
+                        zoneRect.bottom += currentMonitorRect.top;
 
-                    zoneRects.emplace_back(zoneRect);
-                    zoneRectsInfo.emplace_back(zoneId, workArea);
+                        zoneRects.emplace_back(zoneRect);
+                        zoneRectsInfo.emplace_back(zoneId, workArea);
+                    }
                 }
             }
         }
@@ -1351,9 +1357,9 @@ bool FancyZones::ShouldProcessSnapHotkey(DWORD vkCode) noexcept
         {
             monitor = MonitorFromWindow(GetForegroundWindow(), MONITOR_DEFAULTTONULL);
         }
-        
+
         auto zoneWindow = m_workAreaHandler.GetWorkArea(m_currentDesktopId, monitor);
-        if (zoneWindow->ActiveZoneSet() != nullptr)
+        if (zoneWindow && zoneWindow->ActiveZoneSet() != nullptr)
         {
             if (vkCode == VK_UP || vkCode == VK_DOWN)
             {


### PR DESCRIPTION
## Summary of the Pull Request

Looks like we crashed before accessing `zoneWindow->ActiveZoneSet()`. `GetWorkArea` could return nullptr, so I've added the checks.
![issue_7479](https://user-images.githubusercontent.com/1828123/97197759-12691100-17bf-11eb-9114-2a351656309b.png)

Also formatted the source.

## PR Checklist
* [x] Applies to #7479

## Validation Steps Performed

I couldn't repro the issue on my machine and [the original reporter didn't respond yet](https://github.com/microsoft/PowerToys/issues/7479#issuecomment-715408740), but we still need to fix the issue.