### PR TITLE
[fxcop] Settings UI

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI.Runner/MainWindow.xaml.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Runner/MainWindow.xaml.cs
@@ -44,21 +44,21 @@ namespace Microsoft.PowerToys.Settings.UI.Runner
             if (shellPage != null)
             {
                 // send IPC Message
-                shellPage.SetDefaultSndMessageCallback(msg =>
+                ShellPage.SetDefaultSndMessageCallback(msg =>
                 {
                     // IPC Manager is null when launching runner directly
                     Program.GetTwoWayIPCManager()?.Send(msg);
                 });
 
                 // send IPC Message
-                shellPage.SetRestartAdminSndMessageCallback(msg =>
+                ShellPage.SetRestartAdminSndMessageCallback(msg =>
                 {
                     Program.GetTwoWayIPCManager().Send(msg);
                     System.Windows.Application.Current.Shutdown(); // close application
                 });
 
                 // send IPC Message
-                shellPage.SetCheckForUpdatesMessageCallback(msg =>
+                ShellPage.SetCheckForUpdatesMessageCallback(msg =>
                 {
                     Program.GetTwoWayIPCManager().Send(msg);
                 });
@@ -83,8 +83,8 @@ namespace Microsoft.PowerToys.Settings.UI.Runner
                     }
                 };
 
-                shellPage.SetElevationStatus(Program.IsElevated);
-                shellPage.SetIsUserAnAdmin(Program.IsUserAnAdmin);
+                ShellPage.SetElevationStatus(Program.IsElevated);
+                ShellPage.SetIsUserAnAdmin(Program.IsUserAnAdmin);
                 shellPage.Refresh();
             }
 

--- a/src/core/Microsoft.PowerToys.Settings.UI/Activation/ActivationHandler.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Activation/ActivationHandler.cs
@@ -20,10 +20,9 @@ namespace Microsoft.PowerToys.Settings.UI.Activation
     internal abstract class ActivationHandler<T> : ActivationHandler
         where T : class
     {
-        [SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "Warning is intended for library code.")]
         public override async Task HandleAsync(object args)
         {
-            await HandleInternalAsync(args as T);
+            await HandleInternalAsync(args as T).ConfigureAwait(false);
         }
 
         public override bool CanHandle(object args)

--- a/src/core/Microsoft.PowerToys.Settings.UI/Activation/ActivationHandler.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Activation/ActivationHandler.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 
 namespace Microsoft.PowerToys.Settings.UI.Activation
@@ -15,10 +16,11 @@ namespace Microsoft.PowerToys.Settings.UI.Activation
         public abstract Task HandleAsync(object args);
     }
 
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:File may only contain a single type", Justification = "abstract T and abstract")]
+    [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1402:File may only contain a single type", Justification = "abstract T and abstract")]
     internal abstract class ActivationHandler<T> : ActivationHandler
         where T : class
     {
+        [SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "Warning is intended for library code.")]
         public override async Task HandleAsync(object args)
         {
             await HandleInternalAsync(args as T);

--- a/src/core/Microsoft.PowerToys.Settings.UI/Activation/DefaultActivationHandler.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Activation/DefaultActivationHandler.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Microsoft.PowerToys.Settings.UI.Services;
 using Windows.ApplicationModel.Activation;
@@ -18,6 +19,7 @@ namespace Microsoft.PowerToys.Settings.UI.Activation
             this.navElement = navElement;
         }
 
+        [SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "Warning is intended for library code.")]
         protected override async Task HandleInternalAsync(IActivatedEventArgs args)
         {
             // When the navigation stack isn't restored, navigate to the first page and configure

--- a/src/core/Microsoft.PowerToys.Settings.UI/Activation/DefaultActivationHandler.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Activation/DefaultActivationHandler.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Microsoft.PowerToys.Settings.UI.Services;
 using Windows.ApplicationModel.Activation;
@@ -19,7 +18,6 @@ namespace Microsoft.PowerToys.Settings.UI.Activation
             this.navElement = navElement;
         }
 
-        [SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "Warning is intended for library code.")]
         protected override async Task HandleInternalAsync(IActivatedEventArgs args)
         {
             // When the navigation stack isn't restored, navigate to the first page and configure
@@ -31,7 +29,7 @@ namespace Microsoft.PowerToys.Settings.UI.Activation
             }
 
             NavigationService.Navigate(navElement, arguments);
-            await Task.CompletedTask;
+            await Task.CompletedTask.ConfigureAwait(false);
         }
 
         protected override bool CanHandleInternal(IActivatedEventArgs args)

--- a/src/core/Microsoft.PowerToys.Settings.UI/App.xaml.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/App.xaml.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.PowerToys.Settings.UI.Helpers;
 using Microsoft.Toolkit.Win32.UI.XamlHost;
 
 namespace Microsoft.PowerToys.Settings.UI
@@ -15,7 +16,7 @@ namespace Microsoft.PowerToys.Settings.UI
             // Hide the Xaml Island window
             var coreWindow = Windows.UI.Core.CoreWindow.GetForCurrentThread();
             var coreWindowInterop = Interop.GetInterop(coreWindow);
-            Interop.ShowWindow(coreWindowInterop.WindowHandle, Interop.SW_HIDE);
+            NativeMethods.ShowWindow(coreWindowInterop.WindowHandle, Interop.SW_HIDE);
         }
     }
 }

--- a/src/core/Microsoft.PowerToys.Settings.UI/Behaviors/NavigationViewHeaderBehavior.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Behaviors/NavigationViewHeaderBehavior.cs
@@ -30,12 +30,12 @@ namespace Microsoft.PowerToys.Settings.UI.Behaviors
 
         public static NavigationViewHeaderMode GetHeaderMode(Page item)
         {
-            return (NavigationViewHeaderMode)item.GetValue(HeaderModeProperty);
+            return (NavigationViewHeaderMode)item?.GetValue(HeaderModeProperty);
         }
 
         public static void SetHeaderMode(Page item, NavigationViewHeaderMode value)
         {
-            item.SetValue(HeaderModeProperty, value);
+            item?.SetValue(HeaderModeProperty, value);
         }
 
         public static readonly DependencyProperty HeaderModeProperty =
@@ -43,12 +43,12 @@ namespace Microsoft.PowerToys.Settings.UI.Behaviors
 
         public static object GetHeaderContext(Page item)
         {
-            return item.GetValue(HeaderContextProperty);
+            return item?.GetValue(HeaderContextProperty);
         }
 
         public static void SetHeaderContext(Page item, object value)
         {
-            item.SetValue(HeaderContextProperty, value);
+            item?.SetValue(HeaderContextProperty, value);
         }
 
         public static readonly DependencyProperty HeaderContextProperty =
@@ -56,12 +56,12 @@ namespace Microsoft.PowerToys.Settings.UI.Behaviors
 
         public static DataTemplate GetHeaderTemplate(Page item)
         {
-            return (DataTemplate)item.GetValue(HeaderTemplateProperty);
+            return (DataTemplate)item?.GetValue(HeaderTemplateProperty);
         }
 
         public static void SetHeaderTemplate(Page item, DataTemplate value)
         {
-            item.SetValue(HeaderTemplateProperty, value);
+            item?.SetValue(HeaderTemplateProperty, value);
         }
 
         public static readonly DependencyProperty HeaderTemplateProperty =

--- a/src/core/Microsoft.PowerToys.Settings.UI/Controls/HotkeySettingsControl.xaml.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Controls/HotkeySettingsControl.xaml.cs
@@ -110,7 +110,7 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
             hook.Dispose();
         }
 
-        private void KeyEventHandler(int key, bool matchValue, int matchValueCode, string matchValueText)
+        private void KeyEventHandler(int key, bool matchValue, int matchValueCode)
         {
             switch ((Windows.System.VirtualKey)key)
             {
@@ -230,7 +230,7 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
         {
             await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
             {
-                KeyEventHandler(key, true, key, Library.Utilities.Helper.GetKeyName((uint)key));
+                KeyEventHandler(key, true, key);
 
                 // Tab and Shift+Tab are accessible keys and should not be displayed in the hotkey control.
                 if (internalSettings.Code > 0 && !internalSettings.IsAccessibleShortcut())
@@ -245,7 +245,7 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
         {
             await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
             {
-                KeyEventHandler(key, false, 0, string.Empty);
+                KeyEventHandler(key, false, 0);
             });
         }
 

--- a/src/core/Microsoft.PowerToys.Settings.UI/Controls/HotkeySettingsControl.xaml.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Controls/HotkeySettingsControl.xaml.cs
@@ -15,9 +15,9 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
     {
         private readonly UIntPtr ignoreKeyEventFlag = (UIntPtr)0x5555;
 
-        private bool _shiftKeyDownOnEntering = false;
+        private bool _shiftKeyDownOnEntering;
 
-        private bool _shiftToggled = false;
+        private bool _shiftToggled;
 
         public string Header { get; set; }
 
@@ -30,7 +30,7 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
                 typeof(HotkeySettingsControl),
                 null);
 
-        private bool _enabled = false;
+        private bool _enabled;
 
         public bool Enabled
         {

--- a/src/core/Microsoft.PowerToys.Settings.UI/Controls/HotkeySettingsControl.xaml.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Controls/HotkeySettingsControl.xaml.cs
@@ -11,7 +11,7 @@ using Windows.UI.Xaml.Controls;
 
 namespace Microsoft.PowerToys.Settings.UI.Controls
 {
-    public sealed partial class HotkeySettingsControl : UserControl
+    public sealed partial class HotkeySettingsControl : UserControl, IDisposable
     {
         private readonly UIntPtr ignoreKeyEventFlag = (UIntPtr)0x5555;
 
@@ -73,6 +73,7 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
         private HotkeySettings lastValidSettings;
         private HotkeySettingsControlHook hook;
         private bool _isActive;
+        private bool disposedValue;
 
         public HotkeySettings HotkeySettings
         {
@@ -277,6 +278,29 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
 
             HotkeyTextBox.Text = hotkeySettings.ToString();
             _isActive = false;
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    // TODO: dispose managed state (managed objects)
+                    hook.Dispose();
+                }
+
+                // TODO: free unmanaged resources (unmanaged objects) and override finalizer
+                // TODO: set large fields to null
+                disposedValue = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/core/Microsoft.PowerToys.Settings.UI/Converters/ModuleEnabledToForegroundConverter.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Converters/ModuleEnabledToForegroundConverter.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Globalization;
 using Microsoft.PowerToys.Settings.UI.Library;
 using Microsoft.PowerToys.Settings.UI.Library.Utilities;
 using Windows.UI.Xaml;
@@ -22,10 +23,14 @@ namespace Microsoft.PowerToys.Settings.UI.Converters
             bool isEnabled = (bool)value;
 
             var defaultTheme = new Windows.UI.ViewManagement.UISettings();
-            var uiTheme = defaultTheme.GetColorValue(Windows.UI.ViewManagement.UIColorType.Background).ToString();
-            selectedTheme = SettingsRepository<GeneralSettings>.GetInstance(settingsUtils).SettingsConfig.Theme.ToLower();
 
-            if (selectedTheme == "dark" || (selectedTheme == "system" && uiTheme == "#FF000000"))
+            // Using InvariantCulture as this is an internal string and expected to be in hexadecimal
+            var uiTheme = defaultTheme.GetColorValue(Windows.UI.ViewManagement.UIColorType.Background).ToString(CultureInfo.InvariantCulture);
+
+            // Normalize strings to uppercase according to Fxcop
+            selectedTheme = SettingsRepository<GeneralSettings>.GetInstance(settingsUtils).SettingsConfig.Theme.ToUpperInvariant();
+
+            if (selectedTheme == "DARK" || (selectedTheme == "SYSTEM" && uiTheme == "#FF000000"))
             {
                 // DARK
                 if (isEnabled)

--- a/src/core/Microsoft.PowerToys.Settings.UI/Helpers/NativeMethods.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Helpers/NativeMethods.cs
@@ -13,5 +13,8 @@ namespace Microsoft.PowerToys.Settings.UI.Helpers
 
         [DllImport("user32.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.StdCall, SetLastError = true)]
         internal static extern short GetAsyncKeyState(int vKey);
+
+        [DllImport("user32.dll")]
+        public static extern bool ShowWindow(System.IntPtr hWnd, int nCmdShow);
     }
 }

--- a/src/core/Microsoft.PowerToys.Settings.UI/Helpers/NavHelper.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Helpers/NavHelper.cs
@@ -19,12 +19,12 @@ namespace Microsoft.PowerToys.Settings.UI.Helpers
         // NavHelper.SetNavigateTo(navigationViewItem, typeof(MainPage));
         public static Type GetNavigateTo(NavigationViewItem item)
         {
-            return (Type)item.GetValue(NavigateToProperty);
+            return (Type)item?.GetValue(NavigateToProperty);
         }
 
         public static void SetNavigateTo(NavigationViewItem item, Type value)
         {
-            item.SetValue(NavigateToProperty, value);
+            item?.SetValue(NavigateToProperty, value);
         }
 
         public static readonly DependencyProperty NavigateToProperty =

--- a/src/core/Microsoft.PowerToys.Settings.UI/Helpers/NavHelper.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Helpers/NavHelper.cs
@@ -8,7 +8,7 @@ using Windows.UI.Xaml;
 
 namespace Microsoft.PowerToys.Settings.UI.Helpers
 {
-    public class NavHelper
+    public static class NavHelper
     {
         // This helper class allows to specify the page that will be shown when you click on a NavigationViewItem
         //

--- a/src/core/Microsoft.PowerToys.Settings.UI/Interop.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Interop.cs
@@ -23,9 +23,6 @@ namespace Microsoft.PowerToys.Settings.UI
             }
         }
 
-        [DllImport("user32.dll")]
-        public static extern bool ShowWindow(System.IntPtr hWnd, int nCmdShow);
-
         [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1310:Field names should not contain underscore", Justification = "Interop naming consistancy")]
         public const int SW_HIDE = 0;
     }

--- a/src/core/Microsoft.PowerToys.Settings.UI/Microsoft.PowerToys.Settings.UI.csproj
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Microsoft.PowerToys.Settings.UI.csproj
@@ -201,6 +201,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers">
+      <Version>3.3.0</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <PRIResource Include="Strings\*\Resources.resw" />

--- a/src/core/Microsoft.PowerToys.Settings.UI/Services/ActivationService.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Services/ActivationService.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -32,6 +33,7 @@ namespace Microsoft.PowerToys.Settings.UI.Services
             this.defaultNavItem = defaultNavItem;
         }
 
+        [SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "Warning is intended for library code.")]
         public async Task ActivateAsync(object activationArgs)
         {
             if (IsInteractive(activationArgs))
@@ -64,11 +66,13 @@ namespace Microsoft.PowerToys.Settings.UI.Services
             }
         }
 
+        [SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "Warning is intended for library code.")]
         private static async Task InitializeAsync()
         {
             await Task.CompletedTask;
         }
 
+        [SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "Warning is intended for library code.")]
         private async Task HandleActivationAsync(object activationArgs)
         {
             var activationHandler = GetActivationHandlers()
@@ -89,6 +93,7 @@ namespace Microsoft.PowerToys.Settings.UI.Services
             }
         }
 
+        [SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "Warning is intended for library code.")]
         private static async Task StartupAsync()
         {
             await Task.CompletedTask;

--- a/src/core/Microsoft.PowerToys.Settings.UI/Services/ActivationService.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Services/ActivationService.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -33,14 +32,13 @@ namespace Microsoft.PowerToys.Settings.UI.Services
             this.defaultNavItem = defaultNavItem;
         }
 
-        [SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "Warning is intended for library code.")]
         public async Task ActivateAsync(object activationArgs)
         {
             if (IsInteractive(activationArgs))
             {
                 // Initialize services that you need before app activation
                 // take into account that the splash screen is shown while this code runs.
-                await InitializeAsync();
+                await InitializeAsync().ConfigureAwait(false);
 
                 // Do not repeat app initialization when the Window already has content,
                 // just ensure that the window is active
@@ -53,7 +51,7 @@ namespace Microsoft.PowerToys.Settings.UI.Services
 
             // Depending on activationArgs one of ActivationHandlers or DefaultActivationHandler
             // will navigate to the first page
-            await HandleActivationAsync(activationArgs);
+            await HandleActivationAsync(activationArgs).ConfigureAwait(false);
             lastActivationArgs = activationArgs;
 
             if (IsInteractive(activationArgs))
@@ -62,17 +60,15 @@ namespace Microsoft.PowerToys.Settings.UI.Services
                 Window.Current.Activate();
 
                 // Tasks after activation
-                await StartupAsync();
+                await StartupAsync().ConfigureAwait(false);
             }
         }
 
-        [SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "Warning is intended for library code.")]
         private static async Task InitializeAsync()
         {
-            await Task.CompletedTask;
+            await Task.CompletedTask.ConfigureAwait(false);
         }
 
-        [SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "Warning is intended for library code.")]
         private async Task HandleActivationAsync(object activationArgs)
         {
             var activationHandler = GetActivationHandlers()
@@ -80,7 +76,7 @@ namespace Microsoft.PowerToys.Settings.UI.Services
 
             if (activationHandler != null)
             {
-                await activationHandler.HandleAsync(activationArgs);
+                await activationHandler.HandleAsync(activationArgs).ConfigureAwait(false);
             }
 
             if (IsInteractive(activationArgs))
@@ -88,15 +84,14 @@ namespace Microsoft.PowerToys.Settings.UI.Services
                 var defaultHandler = new DefaultActivationHandler(defaultNavItem);
                 if (defaultHandler.CanHandle(activationArgs))
                 {
-                    await defaultHandler.HandleAsync(activationArgs);
+                    await defaultHandler.HandleAsync(activationArgs).ConfigureAwait(false);
                 }
             }
         }
 
-        [SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "Warning is intended for library code.")]
         private static async Task StartupAsync()
         {
-            await Task.CompletedTask;
+            await Task.CompletedTask.ConfigureAwait(false);
         }
 
         private static IEnumerable<ActivationHandler> GetActivationHandlers()

--- a/src/core/Microsoft.PowerToys.Settings.UI/Services/ActivationService.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Services/ActivationService.cs
@@ -64,7 +64,7 @@ namespace Microsoft.PowerToys.Settings.UI.Services
             }
         }
 
-        private async Task InitializeAsync()
+        private static async Task InitializeAsync()
         {
             await Task.CompletedTask;
         }
@@ -89,17 +89,17 @@ namespace Microsoft.PowerToys.Settings.UI.Services
             }
         }
 
-        private async Task StartupAsync()
+        private static async Task StartupAsync()
         {
             await Task.CompletedTask;
         }
 
-        private IEnumerable<ActivationHandler> GetActivationHandlers()
+        private static IEnumerable<ActivationHandler> GetActivationHandlers()
         {
             yield break;
         }
 
-        private bool IsInteractive(object args)
+        private static bool IsInteractive(object args)
         {
             return args is IActivatedEventArgs;
         }

--- a/src/core/Microsoft.PowerToys.Settings.UI/ViewModels/ShellViewModel.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/ViewModels/ShellViewModel.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
@@ -78,6 +79,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             args.Handled = result;
         }
 
+        [SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "Warning is intended for library code.")]
         private async void OnLoaded()
         {
             // Keyboard accelerators are added here to avoid showing 'Alt + left' tooltip on the page.

--- a/src/core/Microsoft.PowerToys.Settings.UI/ViewModels/ShellViewModel.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/ViewModels/ShellViewModel.cs
@@ -114,7 +114,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                             .FirstOrDefault(menuItem => IsMenuItemForPageType(menuItem, e.SourcePageType));
         }
 
-        private bool IsMenuItemForPageType(WinUI.NavigationViewItem menuItem, Type sourcePageType)
+        private static bool IsMenuItemForPageType(WinUI.NavigationViewItem menuItem, Type sourcePageType)
         {
             var pageType = menuItem.GetValue(NavHelper.NavigateToProperty) as Type;
             return pageType == sourcePageType;

--- a/src/core/Microsoft.PowerToys.Settings.UI/ViewModels/ShellViewModel.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/ViewModels/ShellViewModel.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
@@ -79,14 +78,13 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             args.Handled = result;
         }
 
-        [SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "Warning is intended for library code.")]
         private async void OnLoaded()
         {
             // Keyboard accelerators are added here to avoid showing 'Alt + left' tooltip on the page.
             // More info on tracking issue https://github.com/Microsoft/microsoft-ui-xaml/issues/8
             keyboardAccelerators.Add(altLeftKeyboardAccelerator);
             keyboardAccelerators.Add(backKeyboardAccelerator);
-            await Task.CompletedTask;
+            await Task.CompletedTask.ConfigureAwait(false);
         }
 
         private void OnItemInvoked(WinUI.NavigationViewItemInvokedEventArgs args)

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Globalization;
 using Microsoft.PowerToys.Settings.UI.Library;
 using Microsoft.PowerToys.Settings.UI.Library.Utilities;
 using Microsoft.PowerToys.Settings.UI.Library.ViewModels;
@@ -58,16 +59,17 @@ namespace Microsoft.PowerToys.Settings.UI.Views
                     {
                         str = ResourceLoader.GetForCurrentView().GetString("GeneralSettings_VersionIsLatest");
                     }
-                    else if (version != string.Empty)
+                    else if (!string.IsNullOrEmpty(version))
                     {
                         str = ResourceLoader.GetForCurrentView().GetString("GeneralSettings_NewVersionIsAvailable");
-                        if (str != string.Empty)
+                        if (!string.IsNullOrEmpty(str))
                         {
                             str += ": " + version;
                         }
                     }
 
-                    ViewModel.LatestAvailableVersion = string.Format(str);
+                    // Using CurrentCulture since this is user-facing
+                    ViewModel.LatestAvailableVersion = string.Format(CultureInfo.CurrentCulture, str);
                 }
                 catch (Exception)
                 {

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml.cs
@@ -77,7 +77,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             DataContext = ViewModel;
         }
 
-        public int UpdateUIThemeMethod(string themeName)
+        public static int UpdateUIThemeMethod(string themeName)
         {
             switch (themeName.ToUpperInvariant())
             {

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml.cs
@@ -84,7 +84,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
 
         public static int UpdateUIThemeMethod(string themeName)
         {
-            switch (themeName.ToUpperInvariant())
+            switch (themeName?.ToUpperInvariant())
             {
                 case "LIGHT":
                     ShellPage.ShellHandler.RequestedTheme = ElementTheme.Light;
@@ -94,6 +94,9 @@ namespace Microsoft.PowerToys.Settings.UI.Views
                     break;
                 case "SYSTEM":
                     ShellPage.ShellHandler.RequestedTheme = ElementTheme.Default;
+                    break;
+                default:
+                    Logger.LogError($"Unexpected theme name: {themeName}");
                     break;
             }
 

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using Microsoft.PowerToys.Settings.UI.Library;
 using Microsoft.PowerToys.Settings.UI.Library.Utilities;
@@ -28,6 +29,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
         /// Initializes a new instance of the <see cref="GeneralPage"/> class.
         /// General Settings page constructor.
         /// </summary>
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Exceptions from the IPC response handler should be caught and logged.")]
         public GeneralPage()
         {
             InitializeComponent();
@@ -71,8 +73,9 @@ namespace Microsoft.PowerToys.Settings.UI.Views
                     // Using CurrentCulture since this is user-facing
                     ViewModel.LatestAvailableVersion = string.Format(CultureInfo.CurrentCulture, str);
                 }
-                catch (Exception)
+                catch (Exception e)
                 {
+                    Logger.LogError("Exception encountered when reading the version.", e);
                 }
             });
 

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml.cs
@@ -34,7 +34,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
                 Button deleteRowButton = (Button)sender;
 
                 // Using InvariantCulture since this is internal and expected to be numerical
-                int rowNum = int.Parse(deleteRowButton.CommandParameter.ToString(), CultureInfo.InvariantCulture);
+                int rowNum = int.Parse(deleteRowButton?.CommandParameter?.ToString(), CultureInfo.InvariantCulture);
                 ViewModel.DeleteImageSize(rowNum);
             }
             catch (Exception ex)

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Linq;
+using System.Globalization;
 using Microsoft.PowerToys.Settings.UI.Library;
 using Microsoft.PowerToys.Settings.UI.Library.Utilities;
 using Microsoft.PowerToys.Settings.UI.Library.ViewModels;
@@ -28,7 +29,9 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             try
             {
                 Button deleteRowButton = (Button)sender;
-                int rowNum = int.Parse(deleteRowButton.CommandParameter.ToString());
+
+                // Using InvariantCulture since this is internal and expected to be numerical
+                int rowNum = int.Parse(deleteRowButton.CommandParameter.ToString(), CultureInfo.InvariantCulture);
                 ViewModel.DeleteImageSize(rowNum);
             }
             catch

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml.cs
@@ -56,6 +56,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             }
         }
 
+        [SuppressMessage("Usage", "CA1801:Review unused parameters", Justification = "Params are required for event handler signature requirements.")]
         private void ImagesSizesListView_ContainerContentChanging(ListViewBase sender, ContainerContentChangingEventArgs args)
         {
             if (ViewModel.IsListViewFocusRequested)

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml.cs
@@ -26,20 +26,19 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             DataContext = ViewModel;
         }
 
-        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Exceptions from int.Parse should be caught and logged.")]
         public void DeleteCustomSize(object sender, RoutedEventArgs e)
         {
-            try
-            {
-                Button deleteRowButton = (Button)sender;
+            Button deleteRowButton = (Button)sender;
 
-                // Using InvariantCulture since this is internal and expected to be numerical
-                int rowNum = int.Parse(deleteRowButton?.CommandParameter?.ToString(), CultureInfo.InvariantCulture);
+            // Using InvariantCulture since this is internal and expected to be numerical
+            bool success = int.TryParse(deleteRowButton?.CommandParameter?.ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out int rowNum);
+            if (success)
+            {
                 ViewModel.DeleteImageSize(rowNum);
             }
-            catch (Exception ex)
+            else
             {
-                Logger.LogError("Exception encountered when deleting custom image size.", ex);
+                Logger.LogError("Failed to delete custom image size.");
             }
         }
 

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml.cs
@@ -2,8 +2,10 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Linq;
+using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Linq;
 using Microsoft.PowerToys.Settings.UI.Library;
 using Microsoft.PowerToys.Settings.UI.Library.Utilities;
 using Microsoft.PowerToys.Settings.UI.Library.ViewModels;
@@ -24,6 +26,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             DataContext = ViewModel;
         }
 
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Exceptions from int.Parse should be caught and logged.")]
         public void DeleteCustomSize(object sender, RoutedEventArgs e)
         {
             try
@@ -34,19 +37,22 @@ namespace Microsoft.PowerToys.Settings.UI.Views
                 int rowNum = int.Parse(deleteRowButton.CommandParameter.ToString(), CultureInfo.InvariantCulture);
                 ViewModel.DeleteImageSize(rowNum);
             }
-            catch
+            catch (Exception ex)
             {
+                Logger.LogError("Exception encountered when deleting custom image size.", ex);
             }
         }
 
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "JSON exceptions from saving new settings should be caught and logged.")]
         private void AddSizeButton_Click(object sender, RoutedEventArgs e)
         {
             try
             {
                 ViewModel.AddRow();
             }
-            catch
+            catch (Exception ex)
             {
+                Logger.LogError("Exception encountered when adding a new image size.", ex);
             }
         }
 

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/KeyboardManagerPage.xaml.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/KeyboardManagerPage.xaml.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using Microsoft.PowerToys.Settings.UI.Library;
 using Microsoft.PowerToys.Settings.UI.Library.Utilities;
@@ -58,15 +59,16 @@ namespace Microsoft.PowerToys.Settings.UI.Views
 
         private static void CombineRemappings(List<KeysDataModel> remapKeysList, uint leftKey, uint rightKey, uint combinedKey)
         {
-            KeysDataModel firstRemap = remapKeysList.Find(x => uint.Parse(x.OriginalKeys) == leftKey);
-            KeysDataModel secondRemap = remapKeysList.Find(x => uint.Parse(x.OriginalKeys) == rightKey);
+            // Using InvariantCulture for keys as they are internally represented as numerical values
+            KeysDataModel firstRemap = remapKeysList.Find(x => uint.Parse(x.OriginalKeys, CultureInfo.InvariantCulture) == leftKey);
+            KeysDataModel secondRemap = remapKeysList.Find(x => uint.Parse(x.OriginalKeys, CultureInfo.InvariantCulture) == rightKey);
             if (firstRemap != null && secondRemap != null)
             {
                 if (firstRemap.NewRemapKeys == secondRemap.NewRemapKeys)
                 {
                     KeysDataModel combinedRemap = new KeysDataModel
                     {
-                        OriginalKeys = combinedKey.ToString(),
+                        OriginalKeys = combinedKey.ToString(CultureInfo.InvariantCulture),
                         NewRemapKeys = firstRemap.NewRemapKeys,
                     };
                     remapKeysList.Insert(remapKeysList.IndexOf(firstRemap), combinedRemap);

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/KeyboardManagerPage.xaml.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/KeyboardManagerPage.xaml.cs
@@ -56,7 +56,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             }
         }
 
-        private void CombineRemappings(List<KeysDataModel> remapKeysList, uint leftKey, uint rightKey, uint combinedKey)
+        private static void CombineRemappings(List<KeysDataModel> remapKeysList, uint leftKey, uint rightKey, uint combinedKey)
         {
             KeysDataModel firstRemap = remapKeysList.Find(x => uint.Parse(x.OriginalKeys) == leftKey);
             KeysDataModel secondRemap = remapKeysList.Find(x => uint.Parse(x.OriginalKeys) == rightKey);

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/ShellPage.xaml.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/ShellPage.xaml.cs
@@ -92,7 +92,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
         /// Set Default IPC Message callback function.
         /// </summary>
         /// <param name="implementation">delegate function implementation.</param>
-        public void SetDefaultSndMessageCallback(IPCMessageCallback implementation)
+        public static void SetDefaultSndMessageCallback(IPCMessageCallback implementation)
         {
             DefaultSndMSGCallback = implementation;
         }
@@ -101,7 +101,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
         /// Set restart as admin IPC callback function.
         /// </summary>
         /// <param name="implementation">delegate function implementation.</param>
-        public void SetRestartAdminSndMessageCallback(IPCMessageCallback implementation)
+        public static void SetRestartAdminSndMessageCallback(IPCMessageCallback implementation)
         {
             SndRestartAsAdminMsgCallback = implementation;
         }
@@ -110,17 +110,17 @@ namespace Microsoft.PowerToys.Settings.UI.Views
         /// Set check for updates IPC callback function.
         /// </summary>
         /// <param name="implementation">delegate function implementation.</param>
-        public void SetCheckForUpdatesMessageCallback(IPCMessageCallback implementation)
+        public static void SetCheckForUpdatesMessageCallback(IPCMessageCallback implementation)
         {
             CheckForUpdatesMsgCallback = implementation;
         }
 
-        public void SetElevationStatus(bool isElevated)
+        public static void SetElevationStatus(bool isElevated)
         {
             IsElevated = isElevated;
         }
 
-        public void SetIsUserAnAdmin(bool isAdmin)
+        public static void SetIsUserAnAdmin(bool isAdmin)
         {
             IsUserAnAdmin = isAdmin;
         }

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/VisibleIfNotEmpty.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/VisibleIfNotEmpty.cs
@@ -13,7 +13,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
     {
         public object Convert(object value, Type targetType, object parameter, string language)
         {
-            return (value as IList).Count == 0 ? Visibility.Collapsed : Visibility.Visible;
+            return (value == null) || (value as IList).Count == 0 ? Visibility.Collapsed : Visibility.Visible;
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, string language)


### PR DESCRIPTION
## Summary of the Pull Request

Enable FxCop on the Settings.UI project and fixing the associated warnings.

## PR Checklist
* [x] Applies to #5129 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
![image](https://user-images.githubusercontent.com/16506055/97221069-ad46f880-1789-11eb-80c1-5b9f78185ca2.png)
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

Fixes FxCop warnings including: removing redundant default-value initializations, ensuring Disposable fields are disposed, marking non-instance accessing methods and classes with only static members & methods as static, moving interop methods to NativeMethods class, fixing string-related issues (mainly specifying culture and string normalization), removing unused arguments or suppressing the warning if needed, using safe navigation operator as null argument checks, logging general exceptions that are caught and suppressing ConfigureAwait warnings (which are mostly intended for library code with unpredictable/unspecified execution environments--should be safe to do for UI code).

## Validation Steps Performed

Ensure tests pass and manually validate Settings functionality in Release & Debug builds.
