### PR TITLE
[KBM] Select all text in Target App textbox on getting focus

### DIFF
--- a/src/modules/keyboardmanager/ui/ShortcutControl.cpp
+++ b/src/modules/keyboardmanager/ui/ShortcutControl.cpp
@@ -105,6 +105,12 @@ void ShortcutControl::AddNewShortcutControlRow(Grid& parent, std::vector<std::ve
     targetAppTextBox.PlaceholderText(KeyboardManagerConstants::DefaultAppName);
     targetAppTextBox.Text(targetAppName);
 
+    // GotFocus handler will be called whenever the user tabs into or clicks on the textbox
+    targetAppTextBox.GotFocus([targetAppTextBox](auto const& sender, auto const& e) {
+        // Select all text for accessible purpose
+        targetAppTextBox.SelectAll();
+    });
+
     // LostFocus handler will be called whenever text is updated by a user and then they click something else or tab to another control. Does not get called if Text is updated while the TextBox isn't in focus (i.e. from code)
     targetAppTextBox.LostFocus([&keyboardRemapControlObjects, parent, targetAppTextBox](auto const& sender, auto const& e) {
         // Get index of targetAppTextBox button


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
This PR implements the GotFocus handler for the Target App textbox, such that the text in the textbox is selected on tabbing to it (similar to address bar in Edge)

## PR Checklist
* [X] Applies to #7115 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [X] Tests passed

## Validation Steps Performed

_How does someone test & validate?_
- Open Remap Shortcuts and ensure there is atleast 1 row
- While the textbox is empty, tab/shift+tab/mouse-click into the TextBox and validate that nothing happens
- While the textbox has some multi-char text, tab/shift+tab/mouse-click into the TextBox and validate that the entire text is selected (similar to address bar in Edge/Chrome)