### PR TITLE
PowerRename: Add Lookbehind

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -1244,6 +1244,7 @@ LOGMSG
 logon
 LOGPIXELSX
 LOn
+lookbehind
 lowlevel
 lowlevelkb
 LOWORD

--- a/src/core/Microsoft.PowerToys.Settings.UI.Library/PowerRenameLocalProperties.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Library/PowerRenameLocalProperties.cs
@@ -16,6 +16,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             MaxMRUSize = 0;
             ShowIcon = false;
             ExtendedContextMenuOnly = false;
+            UseBoostLib = false;
         }
 
         private int _maxSize;
@@ -47,6 +48,8 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         public bool ShowIcon { get; set; }
 
         public bool ExtendedContextMenuOnly { get; set; }
+
+        public bool UseBoostLib { get; set; }
 
         public string ToJsonString()
         {

--- a/src/core/Microsoft.PowerToys.Settings.UI.Library/PowerRenameProperties.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Library/PowerRenameProperties.cs
@@ -15,6 +15,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             MaxMRUSize = new IntProperty();
             ShowIcon = new BoolProperty();
             ExtendedContextMenuOnly = new BoolProperty();
+            UseBoostLib = new BoolProperty();
             Enabled = new BoolProperty();
         }
 
@@ -34,5 +35,8 @@ namespace Microsoft.PowerToys.Settings.UI.Library
 
         [JsonPropertyName("bool_show_extended_menu")]
         public BoolProperty ExtendedContextMenuOnly { get; set; }
+
+        [JsonPropertyName("bool_use_boost_lib")]
+        public BoolProperty UseBoostLib { get; set; }
     }
 }

--- a/src/core/Microsoft.PowerToys.Settings.UI.Library/PowerRenameSettings.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Library/PowerRenameSettings.cs
@@ -35,6 +35,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             Properties.MaxMRUSize.Value = localProperties.MaxMRUSize;
             Properties.ShowIcon.Value = localProperties.ShowIcon;
             Properties.ExtendedContextMenuOnly.Value = localProperties.ExtendedContextMenuOnly;
+            Properties.UseBoostLib.Value = localProperties.UseBoostLib;
 
             Version = "1";
             Name = ModuleName;

--- a/src/core/Microsoft.PowerToys.Settings.UI.Library/ViewModels/PowerRenameViewModel.cs
+++ b/src/core/Microsoft.PowerToys.Settings.UI.Library/ViewModels/PowerRenameViewModel.cs
@@ -67,6 +67,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             _powerRenameRestoreFlagsOnLaunch = Settings.Properties.PersistState.Value;
             _powerRenameMaxDispListNumValue = Settings.Properties.MaxMRUSize.Value;
             _autoComplete = Settings.Properties.MRUEnabled.Value;
+            _powerRenameUseBoostLib = Settings.Properties.UseBoostLib.Value;
             _powerRenameEnabled = GeneralSettingsConfig.Enabled.PowerRename;
         }
 
@@ -76,6 +77,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
         private bool _powerRenameRestoreFlagsOnLaunch;
         private int _powerRenameMaxDispListNumValue;
         private bool _autoComplete;
+        private bool _powerRenameUseBoostLib;
 
         public bool IsEnabled
         {
@@ -194,6 +196,24 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
                 {
                     _powerRenameMaxDispListNumValue = value;
                     Settings.Properties.MaxMRUSize.Value = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        public bool UseBoostLib
+        {
+            get
+            {
+                return _powerRenameUseBoostLib;
+            }
+
+            set
+            {
+                if (value != _powerRenameUseBoostLib)
+                {
+                    _powerRenameUseBoostLib = value;
+                    Settings.Properties.UseBoostLib.Value = value;
                     RaisePropertyChanged();
                 }
             }

--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -817,4 +817,10 @@
   <data name="FancyZones_WindowBehavior_GroupSettings.Text" xml:space="preserve">
     <value>Window behavior</value>
   </data>
+  <data name="PowerRename_BehaviorHeader.Text" xml:space="preserve">
+    <value>Behavior</value>
+  </data>
+  <data name="PowerRename_Toggle_UseBoostLib.Content" xml:space="preserve">
+    <value>Use Boost Library, provides extended features but may behave different</value>
+  </data>
 </root>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -821,6 +821,7 @@
     <value>Behavior</value>
   </data>
   <data name="PowerRename_Toggle_UseBoostLib.Content" xml:space="preserve">
-    <value>Use Boost Library (provides extended features but may use different regex syntax)</value>
+    <value>Use Boost library (provides extended features but may use different regex syntax)</value>
+    <comment>Boost is a product name, should not be translated</comment>
   </data>
 </root>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -821,6 +821,6 @@
     <value>Behavior</value>
   </data>
   <data name="PowerRename_Toggle_UseBoostLib.Content" xml:space="preserve">
-    <value>Use Boost Library, provides extended features but may behave different</value>
+    <value>Use Boost Library (provides extended features but may use different regex syntax)</value>
   </data>
 </root>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerRenamePage.xaml
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Views/PowerRenamePage.xaml
@@ -90,6 +90,15 @@
                           Margin="0, 17, 0, 0" 
                           IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.RestoreFlagsOnLaunch}"
                           IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"/>
+
+            <TextBlock x:Uid="PowerRename_BehaviorHeader"
+                       Style="{StaticResource SettingsGroupTitleStyle}"
+                       Foreground="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToForegroundConverter}}"/>
+
+            <CheckBox x:Uid="PowerRename_Toggle_UseBoostLib"
+                      Margin="{StaticResource SmallTopMargin}"
+                      IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.UseBoostLib}"
+                      IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"/>
         </StackPanel>
 
 

--- a/src/modules/powerrename/UWPui/PowerRenameUWPUI.vcxproj
+++ b/src/modules/powerrename/UWPui/PowerRenameUWPUI.vcxproj
@@ -146,6 +146,8 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="..\..\..\..\packages\boost.1.72.0.0\build\boost.targets" Condition="Exists('..\..\..\..\packages\boost.1.72.0.0\build\boost.targets')" />
+    <Import Project="..\..\..\..\packages\boost_regex-vc142.1.72.0.0\build\boost_regex-vc142.targets" Condition="Exists('..\..\..\..\packages\boost_regex-vc142.1.72.0.0\build\boost_regex-vc142.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -153,5 +155,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\packages\boost.1.72.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\boost.1.72.0.0\build\boost.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\packages\boost_regex-vc142.1.72.0.0\build\boost_regex-vc142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\boost_regex-vc142.1.72.0.0\build\boost_regex-vc142.targets'))" />
   </Target>
 </Project>

--- a/src/modules/powerrename/UWPui/packages.config
+++ b/src/modules/powerrename/UWPui/packages.config
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="boost" version="1.72.0.0" targetFramework="native" />
+  <package id="boost_regex-vc142" version="1.72.0.0" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.200729.8" targetFramework="native" />
 </packages>

--- a/src/modules/powerrename/dll/PowerRenameExt.vcxproj
+++ b/src/modules/powerrename/dll/PowerRenameExt.vcxproj
@@ -218,6 +218,8 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="..\..\..\..\packages\boost.1.72.0.0\build\boost.targets" Condition="Exists('..\..\..\..\packages\boost.1.72.0.0\build\boost.targets')" />
+    <Import Project="..\..\..\..\packages\boost_regex-vc142.1.72.0.0\build\boost_regex-vc142.targets" Condition="Exists('..\..\..\..\packages\boost_regex-vc142.1.72.0.0\build\boost_regex-vc142.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -225,5 +227,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\packages\boost.1.72.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\boost.1.72.0.0\build\boost.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\packages\boost_regex-vc142.1.72.0.0\build\boost_regex-vc142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\boost_regex-vc142.1.72.0.0\build\boost_regex-vc142.targets'))" />
   </Target>
 </Project>

--- a/src/modules/powerrename/dll/Resources.resx
+++ b/src/modules/powerrename/dll/Resources.resx
@@ -145,6 +145,7 @@
     <value>Only show the PowerRename menu item on the extended context menu (Shift + Right-click).</value>
   </data>
   <data name="Use_Boost_Lib" xml:space="preserve">
-    <value>Use Boost Library, provides extended features but may behave different.</value>
+    <value>Use Boost library (provides extended features but may use different regex syntax).</value>
+    <comment>Boost is a product name, should not be translated</comment>
   </data>
 </root>

--- a/src/modules/powerrename/dll/Resources.resx
+++ b/src/modules/powerrename/dll/Resources.resx
@@ -144,4 +144,7 @@
   <data name="Extended_Menu_Info" xml:space="preserve">
     <value>Only show the PowerRename menu item on the extended context menu (Shift + Right-click).</value>
   </data>
+  <data name="Use_Boost_Lib" xml:space="preserve">
+    <value>Use Boost Library, provides extended features but may behave different.</value>
+  </data>
 </root>

--- a/src/modules/powerrename/dll/dllmain.cpp
+++ b/src/modules/powerrename/dll/dllmain.cpp
@@ -234,6 +234,11 @@ public:
             GET_RESOURCE_STRING(IDS_EXTENDED_MENU_INFO),
             CSettingsInstance().GetExtendedContextMenuOnly());
 
+        settings.add_bool_toggle(
+            L"bool_use_boost_lib",
+            GET_RESOURCE_STRING(IDS_USE_BOOST_LIB),
+            CSettingsInstance().GetUseBoostLib());
+
         return settings.serialize_to_buffer(buffer, buffer_size);
     }
 
@@ -252,6 +257,7 @@ public:
             CSettingsInstance().SetMaxMRUSize(values.get_int_value(L"int_max_mru_size").value());
             CSettingsInstance().SetShowIconOnMenu(values.get_bool_value(L"bool_show_icon_on_menu").value());
             CSettingsInstance().SetExtendedContextMenuOnly(values.get_bool_value(L"bool_show_extended_menu").value());
+            CSettingsInstance().SetUseBoostLib(values.get_bool_value(L"bool_use_boost_lib").value());
             CSettingsInstance().Save();
 
             Trace::SettingsChanged();

--- a/src/modules/powerrename/dll/packages.config
+++ b/src/modules/powerrename/dll/packages.config
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="boost" version="1.72.0.0" targetFramework="native" />
+  <package id="boost_regex-vc142" version="1.72.0.0" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.200729.8" targetFramework="native" />
 </packages>

--- a/src/modules/powerrename/lib/PowerRenameLib.vcxproj
+++ b/src/modules/powerrename/lib/PowerRenameLib.vcxproj
@@ -189,6 +189,8 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="..\..\..\..\packages\boost.1.72.0.0\build\boost.targets" Condition="Exists('..\..\..\..\packages\boost.1.72.0.0\build\boost.targets')" />
+    <Import Project="..\..\..\..\packages\boost_regex-vc142.1.72.0.0\build\boost_regex-vc142.targets" Condition="Exists('..\..\..\..\packages\boost_regex-vc142.1.72.0.0\build\boost_regex-vc142.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -196,5 +198,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\packages\boost.1.72.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\boost.1.72.0.0\build\boost.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\packages\boost_regex-vc142.1.72.0.0\build\boost_regex-vc142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\boost_regex-vc142.1.72.0.0\build\boost_regex-vc142.targets'))" />
   </Target>
 </Project>

--- a/src/modules/powerrename/lib/PowerRenameRegEx.cpp
+++ b/src/modules/powerrename/lib/PowerRenameRegEx.cpp
@@ -3,6 +3,7 @@
 #include <regex>
 #include <string>
 #include <algorithm>
+#include <boost/regex.hpp>
 
 
 using namespace std;
@@ -206,6 +207,20 @@ HRESULT CPowerRenameRegEx::Replace(_In_ PCWSTR source, _Outptr_ PWSTR* result)
 
             if (m_flags & UseRegularExpressions)
             {
+                if (_useBoostLib)
+                {
+                    boost::wregex pattern(m_searchTerm, (!(m_flags & CaseSensitive)) ? boost::regex::icase | boost::regex::ECMAScript : boost::regex::ECMAScript);
+                    if (m_flags & MatchAllOccurences)
+                    {
+                        res = boost::regex_replace(wstring(source), pattern, replaceTerm);
+                    }
+                    else
+                    {
+                        res = boost::regex_replace(wstring(source), pattern, replaceTerm, boost::regex_constants::format_first_only);
+                    }
+                }
+                else
+                {
                 std::wregex pattern(m_searchTerm, (!(m_flags & CaseSensitive)) ? regex_constants::icase | regex_constants::ECMAScript : regex_constants::ECMAScript);
                 if (m_flags & MatchAllOccurences)
                 {
@@ -215,6 +230,7 @@ HRESULT CPowerRenameRegEx::Replace(_In_ PCWSTR source, _Outptr_ PWSTR* result)
                 {
                     res = regex_replace(wstring(source), pattern, replaceTerm, regex_constants::format_first_only);
                 }
+            }
             }
             else
             {

--- a/src/modules/powerrename/lib/PowerRenameRegEx.cpp
+++ b/src/modules/powerrename/lib/PowerRenameRegEx.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include "PowerRenameRegEx.h"
+#include "Settings.h"
 #include <regex>
 #include <string>
 #include <algorithm>
@@ -179,7 +180,8 @@ CPowerRenameRegEx::CPowerRenameRegEx(bool useBoostLib) :
     SHStrDup(L"", &m_searchTerm);
     SHStrDup(L"", &m_replaceTerm);
 
-    _useBoostLib = useBoostLib;
+    CSettingsInstance().Load();
+    _useBoostLib = CSettingsInstance().GetUseBoostLib();
 }
 
 CPowerRenameRegEx::~CPowerRenameRegEx()

--- a/src/modules/powerrename/lib/PowerRenameRegEx.cpp
+++ b/src/modules/powerrename/lib/PowerRenameRegEx.cpp
@@ -159,11 +159,11 @@ IFACEMETHODIMP CPowerRenameRegEx::PutFlags(_In_ DWORD flags)
     return S_OK;
 }
 
-HRESULT CPowerRenameRegEx::s_CreateInstance(_Outptr_ IPowerRenameRegEx** renameRegEx, bool useBoostLib)
+HRESULT CPowerRenameRegEx::s_CreateInstance(_Outptr_ IPowerRenameRegEx** renameRegEx)
 {
     *renameRegEx = nullptr;
 
-    CPowerRenameRegEx *newRenameRegEx = new CPowerRenameRegEx(useBoostLib);
+    CPowerRenameRegEx *newRenameRegEx = new CPowerRenameRegEx();
     HRESULT hr = newRenameRegEx ? S_OK : E_OUTOFMEMORY;
     if (SUCCEEDED(hr))
     {
@@ -173,7 +173,7 @@ HRESULT CPowerRenameRegEx::s_CreateInstance(_Outptr_ IPowerRenameRegEx** renameR
     return hr;
 }
 
-CPowerRenameRegEx::CPowerRenameRegEx(bool useBoostLib) :
+CPowerRenameRegEx::CPowerRenameRegEx() :
     m_refCount(1)
 {
     // Init to empty strings

--- a/src/modules/powerrename/lib/PowerRenameRegEx.cpp
+++ b/src/modules/powerrename/lib/PowerRenameRegEx.cpp
@@ -180,7 +180,6 @@ CPowerRenameRegEx::CPowerRenameRegEx() :
     SHStrDup(L"", &m_searchTerm);
     SHStrDup(L"", &m_replaceTerm);
 
-    CSettingsInstance().Load();
     _useBoostLib = CSettingsInstance().GetUseBoostLib();
 }
 

--- a/src/modules/powerrename/lib/PowerRenameRegEx.h
+++ b/src/modules/powerrename/lib/PowerRenameRegEx.h
@@ -39,6 +39,7 @@ protected:
 
     size_t _Find(std::wstring data, std::wstring toSearch, bool caseInsensitive, size_t pos);
 
+    bool _useBoostLib = false;
     DWORD m_flags = DEFAULT_FLAGS;
     PWSTR m_searchTerm = nullptr;
     PWSTR m_replaceTerm = nullptr;

--- a/src/modules/powerrename/lib/PowerRenameRegEx.h
+++ b/src/modules/powerrename/lib/PowerRenameRegEx.h
@@ -27,10 +27,10 @@ public:
     IFACEMETHODIMP PutFlags(_In_ DWORD flags);
     IFACEMETHODIMP Replace(_In_ PCWSTR source, _Outptr_ PWSTR* result);
 
-    static HRESULT s_CreateInstance(_Outptr_ IPowerRenameRegEx **renameRegEx, bool useBoostLib = false);
+    static HRESULT s_CreateInstance(_Outptr_ IPowerRenameRegEx **renameRegEx);
 
 protected:
-    CPowerRenameRegEx(bool useBoostLib = false);
+    CPowerRenameRegEx();
     virtual ~CPowerRenameRegEx();
 
     void _OnSearchTermChanged();

--- a/src/modules/powerrename/lib/PowerRenameRegEx.h
+++ b/src/modules/powerrename/lib/PowerRenameRegEx.h
@@ -27,10 +27,10 @@ public:
     IFACEMETHODIMP PutFlags(_In_ DWORD flags);
     IFACEMETHODIMP Replace(_In_ PCWSTR source, _Outptr_ PWSTR* result);
 
-    static HRESULT s_CreateInstance(_Outptr_ IPowerRenameRegEx **renameRegEx);
+    static HRESULT s_CreateInstance(_Outptr_ IPowerRenameRegEx **renameRegEx, bool useBoostLib = false);
 
 protected:
-    CPowerRenameRegEx();
+    CPowerRenameRegEx(bool useBoostLib = false);
     virtual ~CPowerRenameRegEx();
 
     void _OnSearchTermChanged();

--- a/src/modules/powerrename/lib/Settings.cpp
+++ b/src/modules/powerrename/lib/Settings.cpp
@@ -31,6 +31,7 @@ namespace
     const wchar_t c_mruEnabled[] = L"MRUEnabled";
     const wchar_t c_mruList[] = L"MRUList";
     const wchar_t c_insertionIdx[] = L"InsertionIdx";
+    const wchar_t c_useBoostLib[] = L"UseBoostLib";
 
     unsigned int GetRegNumber(const std::wstring& valueName, unsigned int defaultValue)
     {
@@ -414,6 +415,7 @@ void CSettings::Save()
     jsonData.SetNamedValue(c_maxMRUSize,              json::value(settings.maxMRUSize));
     jsonData.SetNamedValue(c_searchText,              json::value(settings.searchText));
     jsonData.SetNamedValue(c_replaceText,             json::value(settings.replaceText));
+    jsonData.SetNamedValue(c_useBoostLib,             json::value(settings.useBoostLib));
 
     json::to_file(jsonFilePath, jsonData);
     GetSystemTimeAsFileTime(&lastLoadedTime);
@@ -457,6 +459,7 @@ void CSettings::MigrateFromRegistry()
     settings.flags                   = GetRegNumber(c_flags, 0);
     settings.searchText              = GetRegString(c_searchText, L"");
     settings.replaceText             = GetRegString(c_replaceText, L"");
+    settings.useBoostLib             = false; // Never existed in registry, disabled by default.
 }
 
 void CSettings::ParseJson()
@@ -498,6 +501,10 @@ void CSettings::ParseJson()
             if (json::has(jsonSettings, c_replaceText, json::JsonValueType::String))
             {
                 settings.replaceText = jsonSettings.GetNamedString(c_replaceText);
+            }
+            if (json::has(jsonSettings, c_useBoostLib, json::JsonValueType::Boolean))
+            {
+                settings.useBoostLib = jsonSettings.GetNamedBoolean(c_useBoostLib);
             }
         }
         catch (const winrt::hresult_error&) { }

--- a/src/modules/powerrename/lib/Settings.h
+++ b/src/modules/powerrename/lib/Settings.h
@@ -51,6 +51,16 @@ public:
         settings.persistState = persistState;
     }
 
+    inline bool GetUseBoostLib() const
+    {
+        return settings.useBoostLib;
+    }
+
+    inline void SetUseBoostLib(bool useBoostLib)
+    {
+        settings.useBoostLib = useBoostLib;
+    }
+
     inline bool GetMRUEnabled() const
     {
         return settings.MRUEnabled;
@@ -114,6 +124,7 @@ private:
         bool showIconOnMenu{ true };
         bool extendedContextMenuOnly{ false }; // Disabled by default.
         bool persistState{ true };
+        bool useBoostLib{ false }; // Disabled by default.
         bool MRUEnabled{ true };
         unsigned int maxMRUSize{ 10 };
         unsigned int flags{ 0 };

--- a/src/modules/powerrename/lib/packages.config
+++ b/src/modules/powerrename/lib/packages.config
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="boost" version="1.72.0.0" targetFramework="native" />
+  <package id="boost_regex-vc142" version="1.72.0.0" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.200729.8" targetFramework="native" />
 </packages>

--- a/src/modules/powerrename/lib/trace.cpp
+++ b/src/modules/powerrename/lib/trace.cpp
@@ -85,5 +85,6 @@ void Trace::SettingsChanged() noexcept
         TraceLoggingBoolean(CSettingsInstance().GetPersistState(), "PersistState"),
         TraceLoggingBoolean(CSettingsInstance().GetMRUEnabled(), "IsMRUEnabled"),
         TraceLoggingUInt64(CSettingsInstance().GetMaxMRUSize(), "MaxMRUSize"),
+        TraceLoggingBoolean(CSettingsInstance().GetUseBoostLib(), "UseBoostLib"),
         TraceLoggingUInt64(CSettingsInstance().GetFlags(), "Flags"));
 }

--- a/src/modules/powerrename/testapp/PowerRenameTest.vcxproj
+++ b/src/modules/powerrename/testapp/PowerRenameTest.vcxproj
@@ -202,6 +202,8 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="..\..\..\..\packages\boost.1.72.0.0\build\boost.targets" Condition="Exists('..\..\..\..\packages\boost.1.72.0.0\build\boost.targets')" />
+    <Import Project="..\..\..\..\packages\boost_regex-vc142.1.72.0.0\build\boost_regex-vc142.targets" Condition="Exists('..\..\..\..\packages\boost_regex-vc142.1.72.0.0\build\boost_regex-vc142.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -209,5 +211,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\packages\boost.1.72.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\boost.1.72.0.0\build\boost.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\packages\boost_regex-vc142.1.72.0.0\build\boost_regex-vc142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\boost_regex-vc142.1.72.0.0\build\boost_regex-vc142.targets'))" />
   </Target>
 </Project>

--- a/src/modules/powerrename/testapp/packages.config
+++ b/src/modules/powerrename/testapp/packages.config
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="boost" version="1.72.0.0" targetFramework="native" />
+  <package id="boost_regex-vc142" version="1.72.0.0" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.200729.8" targetFramework="native" />
 </packages>

--- a/src/modules/powerrename/unittests/PowerRenameLibUnitTests.vcxproj
+++ b/src/modules/powerrename/unittests/PowerRenameLibUnitTests.vcxproj
@@ -196,6 +196,7 @@
     <ClCompile Include="MockPowerRenameItem.cpp" />
     <ClCompile Include="MockPowerRenameManagerEvents.cpp" />
     <ClCompile Include="MockPowerRenameRegExEvents.cpp" />
+    <ClCompile Include="PowerRenameRegExBoostTests.cpp" />
     <ClCompile Include="PowerRenameManagerTests.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(CIBuild)'!='true'">Create</PrecompiledHeader>

--- a/src/modules/powerrename/unittests/PowerRenameLibUnitTests.vcxproj
+++ b/src/modules/powerrename/unittests/PowerRenameLibUnitTests.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.props')" />
   <ItemGroup Label="ProjectConfigurations">
@@ -217,6 +217,8 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="..\..\..\..\packages\boost.1.72.0.0\build\boost.targets" Condition="Exists('..\..\..\..\packages\boost.1.72.0.0\build\boost.targets')" />
+    <Import Project="..\..\..\..\packages\boost_regex-vc142.1.72.0.0\build\boost_regex-vc142.targets" Condition="Exists('..\..\..\..\packages\boost_regex-vc142.1.72.0.0\build\boost_regex-vc142.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -224,5 +226,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\packages\boost.1.72.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\boost.1.72.0.0\build\boost.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\packages\boost_regex-vc142.1.72.0.0\build\boost_regex-vc142.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\boost_regex-vc142.1.72.0.0\build\boost_regex-vc142.targets'))" />
   </Target>
 </Project>

--- a/src/modules/powerrename/unittests/PowerRenameLibUnitTests.vcxproj.filters
+++ b/src/modules/powerrename/unittests/PowerRenameLibUnitTests.vcxproj.filters
@@ -8,6 +8,7 @@
     <ClCompile Include="pch.cpp" />
     <ClCompile Include="PowerRenameRegExTests.cpp" />
     <ClCompile Include="TestFileHelper.cpp" />
+    <ClCompile Include="PowerRenameRegExBoostTests.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="MockPowerRenameItem.h" />

--- a/src/modules/powerrename/unittests/PowerRenameRegExBoostTests.cpp
+++ b/src/modules/powerrename/unittests/PowerRenameRegExBoostTests.cpp
@@ -351,7 +351,7 @@ TEST_METHOD(VerifyReplaceFirstWildNoFlags)
 
 TEST_METHOD(VerifyHandleCapturingGroups)
 {
-    // This differs from the Standard Library: Boost does not recognize $xyz as $x and "yz".
+    // This differs from the Standard Library: Boost does not recognize $123 as $1 and "23".
     // To use a capturing group followed by numbers as replacement curly braces are needed.
     CComPtr<IPowerRenameRegEx> renameRegEx;
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);

--- a/src/modules/powerrename/unittests/PowerRenameRegExBoostTests.cpp
+++ b/src/modules/powerrename/unittests/PowerRenameRegExBoostTests.cpp
@@ -341,26 +341,27 @@ TEST_METHOD(VerifyReplaceFirstWildNoFlags)
 TEST_METHOD(VerifyHandleCapturingGroups)
 {
     // This differs from the Standard Library: Boost does not recognize $xyz as $x and "yz".
-    // - 1st test: Boost does not replace $223 to bar23
-    // - 2nd test: Boost does not replace $123 to foo23
-    // - 5th test: Boost does not replace $12 to foo2
-    // - 6th test: Boost does not replace $10 to foo0
-    // - 8th test: Boost does not replace $11 to foo1
+    // To use a capturing group followed by numbers as replacement curly braces are needed.
     CComPtr<IPowerRenameRegEx> renameRegEx;
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx, true) == S_OK);
     DWORD flags = MatchAllOccurences | UseRegularExpressions | CaseSensitive;
     Assert::IsTrue(renameRegEx->PutFlags(flags) == S_OK);
 
     SearchReplaceExpected sreTable[] = {
-        //search, replace, test, result //
+        //search, replace, test, result
         { L"(foo)(bar)", L"$1_$002_$223_$001021_$00001", L"foobar", L"foo_$002__$001021_$00001" },
+        { L"(foo)(bar)", L"$1_$002_${2}23_$001021_$00001", L"foobar", L"foo_$002_bar23_$001021_$00001" },
         { L"(foo)(bar)", L"_$1$2_$123$040", L"foobar", L"_foobar_$040" },
+        { L"(foo)(bar)", L"_$1$2_${1}23$040", L"foobar", L"_foobar_foo23$040" },
         { L"(foo)(bar)", L"$$$1", L"foobar", L"$foo" },
         { L"(foo)(bar)", L"$$1", L"foobar", L"$1" },
         { L"(foo)(bar)", L"$12", L"foobar", L"" },
+        { L"(foo)(bar)", L"${1}2", L"foobar", L"foo2" },
         { L"(foo)(bar)", L"$10", L"foobar", L"" },
+        { L"(foo)(bar)", L"${1}0", L"foobar", L"foo0" },
         { L"(foo)(bar)", L"$01", L"foobar", L"$01" },
         { L"(foo)(bar)", L"$$$11", L"foobar", L"$" },
+        { L"(foo)(bar)", L"$$${1}1", L"foobar", L"$foo1" },
         { L"(foo)(bar)", L"$$$$113a", L"foobar", L"$$113a" },
     };
 

--- a/src/modules/powerrename/unittests/PowerRenameRegExBoostTests.cpp
+++ b/src/modules/powerrename/unittests/PowerRenameRegExBoostTests.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include "CppUnitTest.h"
+#include "powerrename/lib/Settings.h"
 #include <PowerRenameInterfaces.h>
 #include <PowerRenameRegEx.h>
 #include "MockPowerRenameRegExEvents.h"
@@ -19,10 +20,20 @@ namespace PowerRenameRegExBoostTests
     TEST_CLASS(SimpleTests)
     {
     public:
+TEST_CLASS_INITIALIZE(ClassInitialize)
+{
+    CSettingsInstance().SetUseBoostLib(true);
+}
+
+TEST_CLASS_CLEANUP(ClassCleanup)
+{
+    CSettingsInstance().SetUseBoostLib(false);
+}
+
 TEST_METHOD(GeneralReplaceTest)
 {
     CComPtr<IPowerRenameRegEx> renameRegEx;
-    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx, true) == S_OK);
+    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     PWSTR result = nullptr;
     Assert::IsTrue(renameRegEx->PutSearchTerm(L"foo") == S_OK);
     Assert::IsTrue(renameRegEx->PutReplaceTerm(L"big") == S_OK);
@@ -34,7 +45,7 @@ TEST_METHOD(GeneralReplaceTest)
 TEST_METHOD(ReplaceNoMatch)
 {
     CComPtr<IPowerRenameRegEx> renameRegEx;
-    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx, true) == S_OK);
+    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     PWSTR result = nullptr;
     Assert::IsTrue(renameRegEx->PutSearchTerm(L"notfound") == S_OK);
     Assert::IsTrue(renameRegEx->PutReplaceTerm(L"big") == S_OK);
@@ -46,7 +57,7 @@ TEST_METHOD(ReplaceNoMatch)
 TEST_METHOD(ReplaceNoSearchOrReplaceTerm)
 {
     CComPtr<IPowerRenameRegEx> renameRegEx;
-    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx, true) == S_OK);
+    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     PWSTR result = nullptr;
     Assert::IsTrue(renameRegEx->Replace(L"foobar", &result) != S_OK);
     Assert::IsTrue(result == nullptr);
@@ -56,7 +67,7 @@ TEST_METHOD(ReplaceNoSearchOrReplaceTerm)
 TEST_METHOD(ReplaceNoReplaceTerm)
 {
     CComPtr<IPowerRenameRegEx> renameRegEx;
-    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx, true) == S_OK);
+    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     PWSTR result = nullptr;
     Assert::IsTrue(renameRegEx->PutSearchTerm(L"foo") == S_OK);
     Assert::IsTrue(renameRegEx->Replace(L"foobar", &result) == S_OK);
@@ -67,7 +78,7 @@ TEST_METHOD(ReplaceNoReplaceTerm)
 TEST_METHOD(ReplaceEmptyStringReplaceTerm)
 {
     CComPtr<IPowerRenameRegEx> renameRegEx;
-    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx, true) == S_OK);
+    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     PWSTR result = nullptr;
     Assert::IsTrue(renameRegEx->PutSearchTerm(L"foo") == S_OK);
     Assert::IsTrue(renameRegEx->PutReplaceTerm(L"") == S_OK);
@@ -79,7 +90,7 @@ TEST_METHOD(ReplaceEmptyStringReplaceTerm)
 TEST_METHOD(VerifyDefaultFlags)
 {
     CComPtr<IPowerRenameRegEx> renameRegEx;
-    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx, true) == S_OK);
+    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     DWORD flags = 0;
     Assert::IsTrue(renameRegEx->GetFlags(&flags) == S_OK);
     Assert::IsTrue(flags == MatchAllOccurences);
@@ -88,7 +99,7 @@ TEST_METHOD(VerifyDefaultFlags)
 TEST_METHOD(VerifyCaseSensitiveSearch)
 {
     CComPtr<IPowerRenameRegEx> renameRegEx;
-    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx, true) == S_OK);
+    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     DWORD flags = CaseSensitive;
     Assert::IsTrue(renameRegEx->PutFlags(flags) == S_OK);
 
@@ -113,7 +124,7 @@ TEST_METHOD(VerifyCaseSensitiveSearch)
 TEST_METHOD(VerifyReplaceFirstOnly)
 {
     CComPtr<IPowerRenameRegEx> renameRegEx;
-    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx, true) == S_OK);
+    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     DWORD flags = 0;
     Assert::IsTrue(renameRegEx->PutFlags(flags) == S_OK);
 
@@ -137,7 +148,7 @@ TEST_METHOD(VerifyReplaceFirstOnly)
 TEST_METHOD(VerifyReplaceAll)
 {
     CComPtr<IPowerRenameRegEx> renameRegEx;
-    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx, true) == S_OK);
+    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     DWORD flags = MatchAllOccurences;
     Assert::IsTrue(renameRegEx->PutFlags(flags) == S_OK);
 
@@ -161,7 +172,7 @@ TEST_METHOD(VerifyReplaceAll)
 TEST_METHOD(VerifyReplaceAllCaseInsensitive)
 {
     CComPtr<IPowerRenameRegEx> renameRegEx;
-    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx, true) == S_OK);
+    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     DWORD flags = MatchAllOccurences | CaseSensitive;
     Assert::IsTrue(renameRegEx->PutFlags(flags) == S_OK);
 
@@ -186,7 +197,7 @@ TEST_METHOD(VerifyReplaceAllCaseInsensitive)
 TEST_METHOD(VerifyReplaceFirstOnlyUseRegEx)
 {
     CComPtr<IPowerRenameRegEx> renameRegEx;
-    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx, true) == S_OK);
+    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     DWORD flags = UseRegularExpressions;
     Assert::IsTrue(renameRegEx->PutFlags(flags) == S_OK);
 
@@ -210,7 +221,7 @@ TEST_METHOD(VerifyReplaceFirstOnlyUseRegEx)
 TEST_METHOD(VerifyReplaceAllUseRegEx)
 {
     CComPtr<IPowerRenameRegEx> renameRegEx;
-    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx, true) == S_OK);
+    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     DWORD flags = MatchAllOccurences | UseRegularExpressions;
     Assert::IsTrue(renameRegEx->PutFlags(flags) == S_OK);
 
@@ -234,7 +245,7 @@ TEST_METHOD(VerifyReplaceAllUseRegEx)
 TEST_METHOD(VerifyReplaceAllUseRegExCaseSensitive)
 {
     CComPtr<IPowerRenameRegEx> renameRegEx;
-    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx, true) == S_OK);
+    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     DWORD flags = MatchAllOccurences | UseRegularExpressions | CaseSensitive;
     Assert::IsTrue(renameRegEx->PutFlags(flags) == S_OK);
 
@@ -258,7 +269,7 @@ TEST_METHOD(VerifyReplaceAllUseRegExCaseSensitive)
 TEST_METHOD(VerifyMatchAllWildcardUseRegEx)
 {
     CComPtr<IPowerRenameRegEx> renameRegEx;
-    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx, true) == S_OK);
+    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     DWORD flags = MatchAllOccurences | UseRegularExpressions;
     Assert::IsTrue(renameRegEx->PutFlags(flags) == S_OK);
 
@@ -283,7 +294,7 @@ TEST_METHOD(VerifyMatchAllWildcardUseRegEx)
 void VerifyReplaceFirstWildcard(SearchReplaceExpected sreTable[], int tableSize, DWORD flags)
 {
     CComPtr<IPowerRenameRegEx> renameRegEx;
-    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx, true) == S_OK);
+    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     Assert::IsTrue(renameRegEx->PutFlags(flags) == S_OK);
 
     for (int i = 0; i < tableSize; i++)
@@ -343,7 +354,7 @@ TEST_METHOD(VerifyHandleCapturingGroups)
     // This differs from the Standard Library: Boost does not recognize $xyz as $x and "yz".
     // To use a capturing group followed by numbers as replacement curly braces are needed.
     CComPtr<IPowerRenameRegEx> renameRegEx;
-    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx, true) == S_OK);
+    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     DWORD flags = MatchAllOccurences | UseRegularExpressions | CaseSensitive;
     Assert::IsTrue(renameRegEx->PutFlags(flags) == S_OK);
 
@@ -389,7 +400,7 @@ TEST_METHOD(VerifyLookbehind)
     };
 
     CComPtr<IPowerRenameRegEx> renameRegEx;
-    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx, true) == S_OK);
+    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     Assert::IsTrue(renameRegEx->PutFlags(UseRegularExpressions) == S_OK);
 
     for (int i = 0; i < ARRAYSIZE(sreTable); i++)
@@ -406,7 +417,7 @@ TEST_METHOD(VerifyLookbehind)
 TEST_METHOD(VerifyEventsFire)
 {
     CComPtr<IPowerRenameRegEx> renameRegEx;
-    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx, true) == S_OK);
+    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     CMockPowerRenameRegExEvents* mockEvents = new CMockPowerRenameRegExEvents();
     CComPtr<IPowerRenameRegExEvents> regExEvents;
     Assert::IsTrue(mockEvents->QueryInterface(IID_PPV_ARGS(&regExEvents)) == S_OK);

--- a/src/modules/powerrename/unittests/PowerRenameRegExBoostTests.cpp
+++ b/src/modules/powerrename/unittests/PowerRenameRegExBoostTests.cpp
@@ -1,0 +1,425 @@
+#include "pch.h"
+#include "CppUnitTest.h"
+#include <PowerRenameInterfaces.h>
+#include <PowerRenameRegEx.h>
+#include "MockPowerRenameRegExEvents.h"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace PowerRenameRegExBoostTests
+{
+    struct SearchReplaceExpected
+    {
+        PCWSTR search;
+        PCWSTR replace;
+        PCWSTR test;
+        PCWSTR expected;
+    };
+
+    TEST_CLASS(SimpleTests)
+    {
+    public:
+TEST_METHOD(GeneralReplaceTest)
+{
+    CComPtr<IPowerRenameRegEx> renameRegEx;
+    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx, true) == S_OK);
+    PWSTR result = nullptr;
+    Assert::IsTrue(renameRegEx->PutSearchTerm(L"foo") == S_OK);
+    Assert::IsTrue(renameRegEx->PutReplaceTerm(L"big") == S_OK);
+    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result) == S_OK);
+    Assert::IsTrue(wcscmp(result, L"bigbar") == 0);
+    CoTaskMemFree(result);
+}
+
+TEST_METHOD(ReplaceNoMatch)
+{
+    CComPtr<IPowerRenameRegEx> renameRegEx;
+    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx, true) == S_OK);
+    PWSTR result = nullptr;
+    Assert::IsTrue(renameRegEx->PutSearchTerm(L"notfound") == S_OK);
+    Assert::IsTrue(renameRegEx->PutReplaceTerm(L"big") == S_OK);
+    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result) == S_OK);
+    Assert::IsTrue(wcscmp(result, L"foobar") == 0);
+    CoTaskMemFree(result);
+}
+
+TEST_METHOD(ReplaceNoSearchOrReplaceTerm)
+{
+    CComPtr<IPowerRenameRegEx> renameRegEx;
+    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx, true) == S_OK);
+    PWSTR result = nullptr;
+    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result) != S_OK);
+    Assert::IsTrue(result == nullptr);
+    CoTaskMemFree(result);
+}
+
+TEST_METHOD(ReplaceNoReplaceTerm)
+{
+    CComPtr<IPowerRenameRegEx> renameRegEx;
+    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx, true) == S_OK);
+    PWSTR result = nullptr;
+    Assert::IsTrue(renameRegEx->PutSearchTerm(L"foo") == S_OK);
+    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result) == S_OK);
+    Assert::IsTrue(wcscmp(result, L"bar") == 0);
+    CoTaskMemFree(result);
+}
+
+TEST_METHOD(ReplaceEmptyStringReplaceTerm)
+{
+    CComPtr<IPowerRenameRegEx> renameRegEx;
+    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx, true) == S_OK);
+    PWSTR result = nullptr;
+    Assert::IsTrue(renameRegEx->PutSearchTerm(L"foo") == S_OK);
+    Assert::IsTrue(renameRegEx->PutReplaceTerm(L"") == S_OK);
+    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result) == S_OK);
+    Assert::IsTrue(wcscmp(result, L"bar") == 0);
+    CoTaskMemFree(result);
+}
+
+TEST_METHOD(VerifyDefaultFlags)
+{
+    CComPtr<IPowerRenameRegEx> renameRegEx;
+    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx, true) == S_OK);
+    DWORD flags = 0;
+    Assert::IsTrue(renameRegEx->GetFlags(&flags) == S_OK);
+    Assert::IsTrue(flags == MatchAllOccurences);
+}
+
+TEST_METHOD(VerifyCaseSensitiveSearch)
+{
+    CComPtr<IPowerRenameRegEx> renameRegEx;
+    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx, true) == S_OK);
+    DWORD flags = CaseSensitive;
+    Assert::IsTrue(renameRegEx->PutFlags(flags) == S_OK);
+
+    SearchReplaceExpected sreTable[] = {
+        { L"Foo", L"Foo", L"FooBar", L"FooBar" },
+        { L"Foo", L"boo", L"FooBar", L"booBar" },
+        { L"Foo", L"boo", L"foobar", L"foobar" },
+        { L"123", L"654", L"123456", L"654456" },
+    };
+
+    for (int i = 0; i < ARRAYSIZE(sreTable); i++)
+    {
+        PWSTR result = nullptr;
+        Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
+        Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
+        CoTaskMemFree(result);
+    }
+}
+
+TEST_METHOD(VerifyReplaceFirstOnly)
+{
+    CComPtr<IPowerRenameRegEx> renameRegEx;
+    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx, true) == S_OK);
+    DWORD flags = 0;
+    Assert::IsTrue(renameRegEx->PutFlags(flags) == S_OK);
+
+    SearchReplaceExpected sreTable[] = {
+        { L"B", L"BB", L"ABA", L"ABBA" },
+        { L"B", L"A", L"ABBBA", L"AABBA" },
+        { L"B", L"BBB", L"ABABAB", L"ABBBABAB" },
+    };
+
+    for (int i = 0; i < ARRAYSIZE(sreTable); i++)
+    {
+        PWSTR result = nullptr;
+        Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
+        Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
+        CoTaskMemFree(result);
+    }
+}
+
+TEST_METHOD(VerifyReplaceAll)
+{
+    CComPtr<IPowerRenameRegEx> renameRegEx;
+    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx, true) == S_OK);
+    DWORD flags = MatchAllOccurences;
+    Assert::IsTrue(renameRegEx->PutFlags(flags) == S_OK);
+
+    SearchReplaceExpected sreTable[] = {
+        { L"B", L"BB", L"ABA", L"ABBA" },
+        { L"B", L"A", L"ABBBA", L"AAAAA" },
+        { L"B", L"BBB", L"ABABAB", L"ABBBABBBABBB" },
+    };
+
+    for (int i = 0; i < ARRAYSIZE(sreTable); i++)
+    {
+        PWSTR result = nullptr;
+        Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
+        Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
+        CoTaskMemFree(result);
+    }
+}
+
+TEST_METHOD(VerifyReplaceAllCaseInsensitive)
+{
+    CComPtr<IPowerRenameRegEx> renameRegEx;
+    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx, true) == S_OK);
+    DWORD flags = MatchAllOccurences | CaseSensitive;
+    Assert::IsTrue(renameRegEx->PutFlags(flags) == S_OK);
+
+    SearchReplaceExpected sreTable[] = {
+        { L"B", L"BB", L"ABA", L"ABBA" },
+        { L"B", L"A", L"ABBBA", L"AAAAA" },
+        { L"B", L"BBB", L"ABABAB", L"ABBBABBBABBB" },
+        { L"b", L"BBB", L"AbABAb", L"ABBBABABBB" },
+    };
+
+    for (int i = 0; i < ARRAYSIZE(sreTable); i++)
+    {
+        PWSTR result = nullptr;
+        Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
+        Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
+        CoTaskMemFree(result);
+    }
+}
+
+TEST_METHOD(VerifyReplaceFirstOnlyUseRegEx)
+{
+    CComPtr<IPowerRenameRegEx> renameRegEx;
+    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx, true) == S_OK);
+    DWORD flags = UseRegularExpressions;
+    Assert::IsTrue(renameRegEx->PutFlags(flags) == S_OK);
+
+    SearchReplaceExpected sreTable[] = {
+        { L"B", L"BB", L"ABA", L"ABBA" },
+        { L"B", L"A", L"ABBBA", L"AABBA" },
+        { L"B", L"BBB", L"ABABAB", L"ABBBABAB" },
+    };
+
+    for (int i = 0; i < ARRAYSIZE(sreTable); i++)
+    {
+        PWSTR result = nullptr;
+        Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
+        Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
+        CoTaskMemFree(result);
+    }
+}
+
+TEST_METHOD(VerifyReplaceAllUseRegEx)
+{
+    CComPtr<IPowerRenameRegEx> renameRegEx;
+    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx, true) == S_OK);
+    DWORD flags = MatchAllOccurences | UseRegularExpressions;
+    Assert::IsTrue(renameRegEx->PutFlags(flags) == S_OK);
+
+    SearchReplaceExpected sreTable[] = {
+        { L"B", L"BB", L"ABA", L"ABBA" },
+        { L"B", L"A", L"ABBBA", L"AAAAA" },
+        { L"B", L"BBB", L"ABABAB", L"ABBBABBBABBB" },
+    };
+
+    for (int i = 0; i < ARRAYSIZE(sreTable); i++)
+    {
+        PWSTR result = nullptr;
+        Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
+        Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
+        CoTaskMemFree(result);
+    }
+}
+
+TEST_METHOD(VerifyReplaceAllUseRegExCaseSensitive)
+{
+    CComPtr<IPowerRenameRegEx> renameRegEx;
+    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx, true) == S_OK);
+    DWORD flags = MatchAllOccurences | UseRegularExpressions | CaseSensitive;
+    Assert::IsTrue(renameRegEx->PutFlags(flags) == S_OK);
+
+    SearchReplaceExpected sreTable[] = {
+        { L"B", L"BB", L"ABA", L"ABBA" },
+        { L"B", L"A", L"ABBBA", L"AAAAA" },
+        { L"b", L"BBB", L"AbABAb", L"ABBBABABBB" },
+    };
+
+    for (int i = 0; i < ARRAYSIZE(sreTable); i++)
+    {
+        PWSTR result = nullptr;
+        Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
+        Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
+        CoTaskMemFree(result);
+    }
+}
+
+TEST_METHOD(VerifyMatchAllWildcardUseRegEx)
+{
+    CComPtr<IPowerRenameRegEx> renameRegEx;
+    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx, true) == S_OK);
+    DWORD flags = MatchAllOccurences | UseRegularExpressions;
+    Assert::IsTrue(renameRegEx->PutFlags(flags) == S_OK);
+
+    // This differs from the Standard Library: .* has two matches (all and nothing).
+    SearchReplaceExpected sreTable[] = {
+        //search, replace, test, result
+        { L".*", L"Foo", L"AAAAAA", L"FooFoo" },
+        { L".+", L"Foo", L"AAAAAA", L"Foo" },
+    };
+
+    for (int i = 0; i < ARRAYSIZE(sreTable); i++)
+    {
+        PWSTR result = nullptr;
+        Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
+        Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
+        CoTaskMemFree(result);
+    }
+}
+
+void VerifyReplaceFirstWildcard(SearchReplaceExpected sreTable[], int tableSize, DWORD flags)
+{
+    CComPtr<IPowerRenameRegEx> renameRegEx;
+    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx, true) == S_OK);
+    Assert::IsTrue(renameRegEx->PutFlags(flags) == S_OK);
+
+    for (int i = 0; i < tableSize; i++)
+    {
+        PWSTR result = nullptr;
+        Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
+        Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
+        Assert::AreEqual(sreTable[i].expected, result);
+        CoTaskMemFree(result);
+    }
+}
+
+TEST_METHOD(VerifyReplaceFirstWildCardUseRegex)
+{
+    SearchReplaceExpected sreTable[] = {
+        //search, replace, test, result
+        { L".*", L"Foo", L"AAAAAA", L"Foo" },
+    };
+    VerifyReplaceFirstWildcard(sreTable, ARRAYSIZE(sreTable), UseRegularExpressions);
+}
+
+TEST_METHOD(VerifyReplaceFirstWildCardUseRegexMatchAllOccurrences)
+{
+    // This differs from the Standard Library: .* has two matches (all and nothing).
+    SearchReplaceExpected sreTable[] = {
+        //search, replace, test, result
+        { L".*", L"Foo", L"AAAAAA", L"FooFoo" },
+        { L".+", L"Foo", L"AAAAAA", L"Foo" },
+    };
+    VerifyReplaceFirstWildcard(sreTable, ARRAYSIZE(sreTable), UseRegularExpressions | MatchAllOccurences);
+}
+
+TEST_METHOD(VerifyReplaceFirstWildCardMatchAllOccurrences)
+{
+    SearchReplaceExpected sreTable[] = {
+        //search, replace, test, result
+        { L".*", L"Foo", L"AAAAAA", L"AAAAAA" },
+        { L".*", L"Foo", L".*", L"Foo" },
+        { L".*", L"Foo", L".*Bar.*", L"FooBarFoo" },
+    };
+    VerifyReplaceFirstWildcard(sreTable, ARRAYSIZE(sreTable), MatchAllOccurences);
+}
+
+TEST_METHOD(VerifyReplaceFirstWildNoFlags)
+{
+    SearchReplaceExpected sreTable[] = {
+        //search, replace, test, result
+        { L".*", L"Foo", L"AAAAAA", L"AAAAAA" },
+        { L".*", L"Foo", L".*", L"Foo" },
+    };
+    VerifyReplaceFirstWildcard(sreTable, ARRAYSIZE(sreTable), 0);
+}
+
+TEST_METHOD(VerifyHandleCapturingGroups)
+{
+    // This differs from the Standard Library: Boost does not recognize $xyz as $x and "yz".
+    // - 1st test: Boost does not replace $223 to bar23
+    // - 2nd test: Boost does not replace $123 to foo23
+    // - 5th test: Boost does not replace $12 to foo2
+    // - 6th test: Boost does not replace $10 to foo0
+    // - 8th test: Boost does not replace $11 to foo1
+    CComPtr<IPowerRenameRegEx> renameRegEx;
+    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx, true) == S_OK);
+    DWORD flags = MatchAllOccurences | UseRegularExpressions | CaseSensitive;
+    Assert::IsTrue(renameRegEx->PutFlags(flags) == S_OK);
+
+    SearchReplaceExpected sreTable[] = {
+        //search, replace, test, result //
+        { L"(foo)(bar)", L"$1_$002_$223_$001021_$00001", L"foobar", L"foo_$002__$001021_$00001" },
+        { L"(foo)(bar)", L"_$1$2_$123$040", L"foobar", L"_foobar_$040" },
+        { L"(foo)(bar)", L"$$$1", L"foobar", L"$foo" },
+        { L"(foo)(bar)", L"$$1", L"foobar", L"$1" },
+        { L"(foo)(bar)", L"$12", L"foobar", L"" },
+        { L"(foo)(bar)", L"$10", L"foobar", L"" },
+        { L"(foo)(bar)", L"$01", L"foobar", L"$01" },
+        { L"(foo)(bar)", L"$$$11", L"foobar", L"$" },
+        { L"(foo)(bar)", L"$$$$113a", L"foobar", L"$$113a" },
+    };
+
+    for (int i = 0; i < ARRAYSIZE(sreTable); i++)
+    {
+        PWSTR result = nullptr;
+        Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
+        Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
+        CoTaskMemFree(result);
+    }
+}
+
+TEST_METHOD(VerifyLookbehind)
+{
+    SearchReplaceExpected sreTable[] = {
+        //search, replace, test, result
+        { L"(?<=E12).*", L"Foo", L"AAE12BBB", L"AAE12Foo" },
+        { L"(?<=E12).+", L"Foo", L"AAE12BBB", L"AAE12Foo" },
+        { L"(?<=E\\d\\d).+", L"Foo", L"AAE12BBB", L"AAE12Foo" },
+        { L"(?<!E12).*", L"Foo", L"AAE12BBB", L"Foo" },
+        { L"(?<!E12).+", L"Foo", L"AAE12BBB", L"Foo" },
+        { L"(?<!E\\d\\d).+", L"Foo", L"AAE12BBB", L"Foo" },
+    };
+
+    CComPtr<IPowerRenameRegEx> renameRegEx;
+    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx, true) == S_OK);
+    Assert::IsTrue(renameRegEx->PutFlags(UseRegularExpressions) == S_OK);
+
+    for (int i = 0; i < ARRAYSIZE(sreTable); i++)
+    {
+        PWSTR result = nullptr;
+        Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
+        Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
+        CoTaskMemFree(result);
+    }
+}
+
+TEST_METHOD(VerifyEventsFire)
+{
+    CComPtr<IPowerRenameRegEx> renameRegEx;
+    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx, true) == S_OK);
+    CMockPowerRenameRegExEvents* mockEvents = new CMockPowerRenameRegExEvents();
+    CComPtr<IPowerRenameRegExEvents> regExEvents;
+    Assert::IsTrue(mockEvents->QueryInterface(IID_PPV_ARGS(&regExEvents)) == S_OK);
+    DWORD cookie = 0;
+    Assert::IsTrue(renameRegEx->Advise(regExEvents, &cookie) == S_OK);
+    DWORD flags = MatchAllOccurences | UseRegularExpressions | CaseSensitive;
+    Assert::IsTrue(renameRegEx->PutFlags(flags) == S_OK);
+    Assert::IsTrue(renameRegEx->PutSearchTerm(L"FOO") == S_OK);
+    Assert::IsTrue(renameRegEx->PutReplaceTerm(L"BAR") == S_OK);
+    Assert::IsTrue(lstrcmpi(L"FOO", mockEvents->m_searchTerm) == 0);
+    Assert::IsTrue(lstrcmpi(L"BAR", mockEvents->m_replaceTerm) == 0);
+    Assert::IsTrue(flags == mockEvents->m_flags);
+    Assert::IsTrue(renameRegEx->UnAdvise(cookie) == S_OK);
+    mockEvents->Release();
+}
+};
+}

--- a/src/modules/powerrename/unittests/PowerRenameRegExTests.cpp
+++ b/src/modules/powerrename/unittests/PowerRenameRegExTests.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include "CppUnitTest.h"
+#include "powerrename/lib/Settings.h"
 #include <PowerRenameInterfaces.h>
 #include <PowerRenameRegEx.h>
 #include "MockPowerRenameRegExEvents.h"
@@ -18,8 +19,14 @@ namespace PowerRenameRegExTests
 
     TEST_CLASS(SimpleTests){
         public:
-            TEST_METHOD(GeneralReplaceTest){
-                CComPtr<IPowerRenameRegEx> renameRegEx;
+TEST_CLASS_INITIALIZE(ClassInitialize)
+{
+    CSettingsInstance().SetUseBoostLib(true);
+}
+
+TEST_METHOD(GeneralReplaceTest)
+{
+    CComPtr<IPowerRenameRegEx> renameRegEx;
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     PWSTR result = nullptr;
     Assert::IsTrue(renameRegEx->PutSearchTerm(L"foo") == S_OK);

--- a/src/modules/powerrename/unittests/PowerRenameRegExTests.cpp
+++ b/src/modules/powerrename/unittests/PowerRenameRegExTests.cpp
@@ -21,7 +21,7 @@ namespace PowerRenameRegExTests
         public:
 TEST_CLASS_INITIALIZE(ClassInitialize)
 {
-    CSettingsInstance().SetUseBoostLib(true);
+    CSettingsInstance().SetUseBoostLib(false);
 }
 
 TEST_METHOD(GeneralReplaceTest)

--- a/src/modules/powerrename/unittests/PowerRenameRegExTests.cpp
+++ b/src/modules/powerrename/unittests/PowerRenameRegExTests.cpp
@@ -362,6 +362,30 @@ TEST_METHOD(VerifyHandleCapturingGroups)
     }
 }
 
+TEST_METHOD(VerifyLookbehindFails)
+{
+    // Standard Library Regex Engine does not support lookbehind, thus test should fail.
+    SearchReplaceExpected sreTable[] = {
+        //search, replace, test, result
+        { L"(?<=E12).*", L"Foo", L"AAAAAA", nullptr },
+        { L"(?<!E12).*", L"Foo", L"AAAAAA", nullptr },
+    };
+
+    CComPtr<IPowerRenameRegEx> renameRegEx;
+    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
+    Assert::IsTrue(renameRegEx->PutFlags(UseRegularExpressions) == S_OK);
+
+    for (int i = 0; i < ARRAYSIZE(sreTable); i++)
+    {
+        PWSTR result = nullptr;
+        Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
+        Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == E_FAIL);
+        Assert::AreEqual(sreTable[i].expected, result);
+        CoTaskMemFree(result);
+    }
+}
+
 TEST_METHOD(VerifyEventsFire)
 {
     CComPtr<IPowerRenameRegEx> renameRegEx;

--- a/src/modules/powerrename/unittests/packages.config
+++ b/src/modules/powerrename/unittests/packages.config
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="boost" version="1.72.0.0" targetFramework="native" />
+  <package id="boost_regex-vc142" version="1.72.0.0" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.200729.8" targetFramework="native" />
 </packages>


### PR DESCRIPTION
## Summary of the Pull Request

Adds the possibility to use Boost Library for Regular Expressions instead of the Standard Library. The Boost library has more features such as Lookbehind.

## PR Checklist
* [x] Applies to #1551
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [x] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #1551 
## Info on Pull Request

* Added Boost Regex Module (with its dependencies) as NuGet dependency.
* `CPowerRenameRegEx` uses library according to property.
* Extended signatures to set the library.

## Validation Steps Performed

_How does someone test & validate?_
