### PR TITLE
[KBM] Move Focus to Type button in new row on Adding a remap

### DIFF
--- a/src/modules/keyboardmanager/ui/EditKeyboardWindow.cpp
+++ b/src/modules/keyboardmanager/ui/EditKeyboardWindow.cpp
@@ -15,6 +15,7 @@
 #include "keyboardmanager/common/KeyboardManagerState.h"
 #include "common/common.h"
 #include "LoadingAndSavingRemappingHelper.h"
+#include "UIHelpers.h"
 extern "C" IMAGE_DOS_HEADER __ImageBase;
 
 using namespace winrt::Windows::Foundation;
@@ -304,8 +305,12 @@ void createEditKeyboardWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMan
     addRemapKey.Margin({ 10, 10, 0, 25 });
     addRemapKey.Click([&](winrt::Windows::Foundation::IInspectable const& sender, RoutedEventArgs const&) {
         SingleKeyRemapControl::AddNewControlKeyRemapRow(keyRemapTable, keyboardRemapControlObjects);
+
         // Whenever a remap is added move to the bottom of the screen
         scrollViewer.ChangeView(nullptr, scrollViewer.ScrollableHeight(), nullptr);
+
+        // Set focus to the first Type Button in the newly added row
+        UIHelpers::SetFocusOnTypeButtonInLastRow(keyRemapTable, KeyboardManagerConstants::RemapTableColCount);
     });
 
     // Set accessible name for the addRemapKey button

--- a/src/modules/keyboardmanager/ui/EditShortcutsWindow.cpp
+++ b/src/modules/keyboardmanager/ui/EditShortcutsWindow.cpp
@@ -13,6 +13,7 @@
 #include <keyboardmanager/common/KeyboardManagerState.h>
 #include "common/common.h"
 #include "LoadingAndSavingRemappingHelper.h"
+#include "UIHelpers.h"
 extern "C" IMAGE_DOS_HEADER __ImageBase;
 
 using namespace winrt::Windows::Foundation;
@@ -291,8 +292,12 @@ void createEditShortcutsWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMa
     addShortcut.Margin({ 10, 0, 0, 25 });
     addShortcut.Click([&](winrt::Windows::Foundation::IInspectable const& sender, RoutedEventArgs const&) {
         ShortcutControl::AddNewShortcutControlRow(shortcutTable, keyboardRemapControlObjects);
+
         // Whenever a remap is added move to the bottom of the screen
         scrollViewer.ChangeView(nullptr, scrollViewer.ScrollableHeight(), nullptr);
+
+        // Set focus to the first Type Button in the newly added row
+        UIHelpers::SetFocusOnTypeButtonInLastRow(shortcutTable, KeyboardManagerConstants::ShortcutTableColCount);
     });
 
     // Set accessible name for the add shortcut button

--- a/src/modules/keyboardmanager/ui/KeyboardManagerUI.vcxproj
+++ b/src/modules/keyboardmanager/ui/KeyboardManagerUI.vcxproj
@@ -124,6 +124,7 @@
     <ClCompile Include="ShortcutControl.cpp" />
     <ClCompile Include="SingleKeyRemapControl.cpp" />
     <ClCompile Include="Styles.cpp" />
+    <ClCompile Include="UIHelpers.cpp" />
     <ClCompile Include="XamlBridge.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -137,6 +138,7 @@
     <ClInclude Include="pch.h" />
     <ClInclude Include="ShortcutControl.h" />
     <ClInclude Include="SingleKeyRemapControl.h" />
+    <ClInclude Include="UIHelpers.h" />
     <ClInclude Include="XamlBridge.h" />
   </ItemGroup>
   <ItemGroup>

--- a/src/modules/keyboardmanager/ui/KeyboardManagerUI.vcxproj.filters
+++ b/src/modules/keyboardmanager/ui/KeyboardManagerUI.vcxproj.filters
@@ -34,6 +34,9 @@
     <ClCompile Include="BufferValidationHelpers.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="UIHelpers.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Dialog.h">
@@ -67,6 +70,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="BufferValidationHelpers.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="UIHelpers.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/modules/keyboardmanager/ui/UIHelpers.cpp
+++ b/src/modules/keyboardmanager/ui/UIHelpers.cpp
@@ -1,0 +1,18 @@
+#include "pch.h"
+#include "UIHelpers.h"
+
+namespace UIHelpers
+{
+    // This method sets focus to the first Type button on the last row of the Grid
+    void SetFocusOnTypeButtonInLastRow(Grid& parent, long colCount)
+    {
+        // First element in the last row (StackPanel)
+        StackPanel firstElementInLastRow = parent.Children().GetAt(parent.Children().Size() - colCount).as<StackPanel>();
+
+        // Type button is the first child in the StackPanel
+        Button firstTypeButtonInLastRow = firstElementInLastRow.Children().GetAt(0).as<Button>();
+
+        // Set programmatic focus on the button
+        firstTypeButtonInLastRow.Focus(FocusState::Programmatic);
+    }
+}

--- a/src/modules/keyboardmanager/ui/UIHelpers.h
+++ b/src/modules/keyboardmanager/ui/UIHelpers.h
@@ -1,0 +1,8 @@
+#pragma once
+
+// This namespace contains UI methods that are to be used for both KBM windows
+namespace UIHelpers
+{
+    // This method sets focus to the first Type button on the last row of the Grid
+    void SetFocusOnTypeButtonInLastRow(Grid& parent, long colCount);
+}


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
This PR adds logic so that after the Add remap button is pressed the keyboard focus is moved to the Type button on the new row.

## PR Checklist
* [X] Applies to #7067 
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [X] Tests passed

## Info on Pull Request

_What does this include?_
- A new namespace UIHelpers has been added for any common UI operations to be done on both the windows.

## Validation Steps Performed

_How does someone test & validate?_
- Tab to the Add remap button and press Enter to add a row. Validate that focus is on the Type button of the new row. This should be validated on both windows.
- Use Narrator and validate that the details of the row are read out on adding the remapping.