### PR TITLE
Display Drive detection warning only for multiple drives

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/DriveDetection/DriveInfoWrapper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/DriveDetection/DriveInfoWrapper.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IO;
+using System.Linq;
 
 namespace Microsoft.Plugin.Indexer.DriveDetection
 {
@@ -12,7 +13,8 @@ namespace Microsoft.Plugin.Indexer.DriveDetection
 
         private static int GetDriveInfo()
         {
-            return DriveInfo.GetDrives().Length;
+            // To ignore removable type drives, CD ROMS, no root partitions which may not be formatted and only return the fixed drives in the system.
+            return DriveInfo.GetDrives().Where(d => d.DriveType == DriveType.Fixed).Count();
         }
 
         public int GetDriveCount() => DriveCount;

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/DriveDetection/DriveInfoWrapper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/DriveDetection/DriveInfoWrapper.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using Microsoft.Plugin.Indexer.Interface;
+
+namespace Microsoft.Plugin.Indexer.DriveDetection
+{
+    public class DriveInfoWrapper : IDriveInfoWrapper
+    {
+        private static readonly int DriveCount = GetDriveInfo();
+
+        private static int GetDriveInfo()
+        {
+            return DriveInfo.GetDrives().Length;
+        }
+
+        public int GetDriveCount() => DriveCount;
+    }
+}

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/DriveDetection/DriveInfoWrapper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/DriveDetection/DriveInfoWrapper.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IO;
-using Microsoft.Plugin.Indexer.Interface;
 
 namespace Microsoft.Plugin.Indexer.DriveDetection
 {

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/DriveDetection/IndexerDriveDetection.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/DriveDetection/IndexerDriveDetection.cs
@@ -2,8 +2,6 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.Plugin.Indexer.Interface;
-
 namespace Microsoft.Plugin.Indexer.DriveDetection
 {
     public class IndexerDriveDetection

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/DriveDetection/IndexerDriveDetection.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/DriveDetection/IndexerDriveDetection.cs
@@ -21,7 +21,9 @@ namespace Microsoft.Plugin.Indexer.DriveDetection
             GetEnhancedModeStatus();
         }
 
-        // To display the warning when Enhanced mode is disabled and the Disable Drive detection check box in settings is unchecked
+        // To display the drive detection warning only when enhanced mode is disabled on a system which has multiple drives.
+        // Currently the warning would not be displayed if the enhanced mode is disabled when the user system has only a single fixed drive. However, this warning may be added in the future.
+        // This warning can be disabled by checking the disabled drive detection warning checkbox in settings.
         public bool DisplayWarning()
         {
             return !(IsDriveDetectionWarningCheckBoxSelected || IsEnhancedModeEnabled || (_driveHelper.GetDriveCount() == 1));

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/DriveDetection/IndexerDriveDetection.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/DriveDetection/IndexerDriveDetection.cs
@@ -2,6 +2,8 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Plugin.Indexer.Interface;
+
 namespace Microsoft.Plugin.Indexer.DriveDetection
 {
     public class IndexerDriveDetection
@@ -10,18 +12,21 @@ namespace Microsoft.Plugin.Indexer.DriveDetection
 
         private readonly IRegistryWrapper _registryHelper;
 
+        private readonly IDriveInfoWrapper _driveHelper;
+
         public bool IsDriveDetectionWarningCheckBoxSelected { get; set; }
 
-        public IndexerDriveDetection(IRegistryWrapper registryHelper)
+        public IndexerDriveDetection(IRegistryWrapper registryHelper, IDriveInfoWrapper driveHelper)
         {
             _registryHelper = registryHelper;
+            _driveHelper = driveHelper;
             GetEnhancedModeStatus();
         }
 
         // To display the warning when Enhanced mode is disabled and the Disable Drive detection check box in settings is unchecked
         public bool DisplayWarning()
         {
-            return !(IsDriveDetectionWarningCheckBoxSelected || IsEnhancedModeEnabled);
+            return !(IsDriveDetectionWarningCheckBoxSelected || IsEnhancedModeEnabled || (_driveHelper.GetDriveCount() == 1));
         }
 
         // To look up the registry entry for enhanced search

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Interface/IDriveInfoWrapper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Interface/IDriveInfoWrapper.cs
@@ -2,7 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace Microsoft.Plugin.Indexer.Interface
+namespace Microsoft.Plugin.Indexer
 {
     public interface IDriveInfoWrapper
     {

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Interface/IDriveInfoWrapper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Interface/IDriveInfoWrapper.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.Plugin.Indexer.Interface
+{
+    public interface IDriveInfoWrapper
+    {
+        int GetDriveCount();
+    }
+}

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Main.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Plugin.Indexer
         private readonly WindowsSearchAPI _api = new WindowsSearchAPI(_search);
 
         // To obtain information regarding the drives that are indexed
-        private readonly IndexerDriveDetection _driveDetection = new IndexerDriveDetection(new RegistryWrapper());
+        private readonly IndexerDriveDetection _driveDetection = new IndexerDriveDetection(new RegistryWrapper(), new DriveInfoWrapper());
 
         // Reserved keywords in oleDB
         private readonly string reservedStringPattern = @"^[\/\\\$\%]+$|^.*[<>].*$";

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Properties/Resources.Designer.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Properties/Resources.Designer.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Plugin.Indexer.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Warning: Not all drives are indexed..
+        ///   Looks up a localized string similar to Warning: Not all files are indexed..
         /// </summary>
         public static string Microsoft_plugin_indexer_drivedetectionwarning {
             get {

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Properties/Resources.resx
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Properties/Resources.resx
@@ -136,7 +136,7 @@
     <value>Path</value>
   </data>
   <data name="Microsoft_plugin_indexer_drivedetectionwarning" xml:space="preserve">
-    <value>Warning: Not all drives are indexed.</value>
+    <value>Warning: Not all files are indexed.</value>
   </data>
   <data name="Microsoft_plugin_indexer_disable_warning_in_settings" xml:space="preserve">
     <value>Click to go to Windows Search settings to fix.</value>

--- a/src/modules/launcher/Wox.Test/Plugins/WindowsIndexerTest.cs
+++ b/src/modules/launcher/Wox.Test/Plugins/WindowsIndexerTest.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Plugin.Indexer;
 using Microsoft.Plugin.Indexer.DriveDetection;
-using Microsoft.Plugin.Indexer.Interface;
 using Microsoft.Plugin.Indexer.SearchHelper;
 using Microsoft.Search.Interop;
 using Moq;

--- a/src/modules/launcher/Wox.Test/Plugins/WindowsIndexerTest.cs
+++ b/src/modules/launcher/Wox.Test/Plugins/WindowsIndexerTest.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Plugin.Indexer;
 using Microsoft.Plugin.Indexer.DriveDetection;
+using Microsoft.Plugin.Indexer.Interface;
 using Microsoft.Plugin.Indexer.SearchHelper;
 using Microsoft.Search.Interop;
 using Moq;
@@ -348,17 +349,21 @@ namespace Wox.Test.Plugins
             Assert.AreEqual(Microsoft.Plugin.Indexer.Properties.Resources.Microsoft_plugin_indexer_open_in_console, contextMenuItems[1].Title);
         }
 
-        [TestCase(0, false, ExpectedResult = true)]
-        [TestCase(0, true, ExpectedResult = false)]
-        [TestCase(1, false, ExpectedResult = false)]
-        [TestCase(1, true, ExpectedResult = false)]
-        public bool DriveDetectionMustDisplayWarningWhenEnhancedModeIsOffAndWhenWarningIsNotDisabled(int enhancedModeStatus, bool disableWarningCheckBoxStatus)
+        [TestCase(0, 2, false, ExpectedResult = true)]
+        [TestCase(0, 3, true, ExpectedResult = false)]
+        [TestCase(1, 2, false, ExpectedResult = false)]
+        [TestCase(1, 4, true, ExpectedResult = false)]
+        [TestCase(0, 1, false, ExpectedResult = false)]
+        public bool DriveDetectionMustDisplayWarningWhenEnhancedModeIsOffAndWhenWarningIsNotDisabled(int enhancedModeStatus, int driveCount, bool disableWarningCheckBoxStatus)
         {
             // Arrange
             var mockRegistry = new Mock<IRegistryWrapper>();
             mockRegistry.Setup(r => r.GetHKLMRegistryValue(It.IsAny<string>(), It.IsAny<string>())).Returns(enhancedModeStatus); // Enhanced mode is disabled
 
-            IndexerDriveDetection driveDetection = new IndexerDriveDetection(mockRegistry.Object);
+            var mockDriveInfo = new Mock<IDriveInfoWrapper>();
+            mockDriveInfo.Setup(d => d.GetDriveCount()).Returns(driveCount);
+
+            IndexerDriveDetection driveDetection = new IndexerDriveDetection(mockRegistry.Object, mockDriveInfo.Object);
             driveDetection.IsDriveDetectionWarningCheckBoxSelected = disableWarningCheckBoxStatus;
 
             // Act & Assert


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

The Drive detection warning for the indexer plugin should not be displayed when there is only a single drive on the system.

## PR Checklist
* [x] Applies to #7487, partially to #5117
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

Added an additional check where the drive detection warning is not displayed when there is only one drive on the system.

## Validation Steps Performed

_How does someone test & validate?_

Tested it manually as well as added unit tests for the same.