### PR TITLE
[Accessibility] [FancyZones Editor] Associate Name label with textbox

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditorWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditorWindow.xaml
@@ -166,8 +166,8 @@
         <TextBlock Name="windowEditorDialogTitle" Text="{x:Static props:Resources.Custom_Table_Layout}" Style="{StaticResource titleText}"  />
 
         <TextBlock Text="{x:Static props:Resources.Note_Custom_Table}" Style="{StaticResource textLabel}" TextWrapping="Wrap" />
-        <TextBlock Text="{x:Static props:Resources.Name}" Style="{StaticResource textLabel}" />
-        <TextBox Text="{Binding Name}" Style="{StaticResource textBox}" />
+        <TextBlock x:Name="customLayoutName" Text="{x:Static props:Resources.Name}" Style="{StaticResource textLabel}" />
+        <TextBox Text="{Binding Name}" AutomationProperties.LabeledBy="{Binding ElementName=customLayoutName}" Style="{StaticResource textBox}" />
 <!--        
         <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
             <CheckBox x:Name="showGridSetting" VerticalAlignment="Center" HorizontalAlignment="Center" IsChecked="True" Margin="21,4,0,0"/>


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
Bind *Name* label with associated textbox for GridEditorWindow. Issue says CanvasEditorWindow, however, that one is already bind correctly.

## PR Checklist
* [x] Applies to #7108 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Validation Steps Performed

_How does someone test & validate?_
Open FancyZones Editor
Select e.g. PriorityGrid layout
Click "Edit Selected Layout"
Press Win+Ctrl+Enter to turn on the Narrator
Navigate to "Custom layout 1" text box
Observe that Narrator says "*Name* edit Custom layout 1"   