### PR TITLE
[FancyZones] Adjust template tab non-highlighted color

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -42,7 +42,7 @@
         <Style x:Key="tabText" TargetType="TextBlock">
             <Setter Property="FontFamily" Value="Segoe UI" />
             <Setter Property="FontWeight" Value="SemiBold" />
-            <Setter Property="Foreground" Value="#C4C4C4"/>
+            <Setter Property="Foreground" Value="#767676"/>
             <Setter Property="FontSize" Value="14"/>
             <Setter Property="LineHeight" Value="20" />
             <Setter Property="Margin" Value="24,20,0,0" />


### PR DESCRIPTION
## Summary of the Pull Request

FancyZones Editor has two tabs, `Templates` and `Custom` tab, one showing predefined layouts (columns, rows, grid etc.) and other showing user's custom layouts. Active tab is shown in [hex 2A87D7](https://www.colorhexa.com/2a87d7) color, while inactive tab has [hex C4C4C4](https://www.colorhexa.com/c4c4c4). Contrast ratio between inactive tab and white background is not 4.5:1 which is required minimum.

## PR Checklist
* [x] Applies to #7112
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

## Info on Pull Request

Since we want to have some sort of distinction between active and inactive tab, pick shade of gray for inactive that fits accessibility requirements. First one that fulfilled required ratio of 4.5:1 is [hex 767676](https://www.colorhexa.com/767676)

## Validation Steps Performed

1. Open Power Toys App
2. Navigate to Fancy Zone Button and activate it.
3. Navigate to Launch Zones Editor and activate it.
4. Navigate to Custom tab in Choose your layout for this Desktop dialog and verify the text luminosity ratio.

Expected result: luminosity ratio is 4.54:1 (larger than minimal required 4.5:1).
