### PR TITLE
[Accessibility][FancyZones Editor] Close Edit Canvas Layout and Edit Grid Layout windows by pressing Esc

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditorWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditorWindow.xaml.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Windows;
+using System.Windows.Input;
 using FancyZonesEditor.Models;
 
 namespace FancyZonesEditor
@@ -15,6 +16,9 @@ namespace FancyZonesEditor
         public CanvasEditorWindow()
         {
             InitializeComponent();
+
+            KeyUp += CanvasEditorWindow_KeyUp;
+
             _model = EditorOverlay.Current.DataContext as CanvasLayoutModel;
             _stashedModel = (CanvasLayoutModel)_model.Clone();
         }
@@ -39,6 +43,14 @@ namespace FancyZonesEditor
         {
             base.OnCancel(sender, e);
             _stashedModel.RestoreTo(_model);
+        }
+
+        private void CanvasEditorWindow_KeyUp(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Escape)
+            {
+                OnCancel(sender, null);
+            }
         }
 
         private int _offset = 100;

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditorWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditorWindow.xaml.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Windows;
+using System.Windows.Input;
 using FancyZonesEditor.Models;
 
 namespace FancyZonesEditor
@@ -15,6 +16,9 @@ namespace FancyZonesEditor
         public GridEditorWindow()
         {
             InitializeComponent();
+
+            KeyUp += GridEditorWindow_KeyUp;
+
             _stashedModel = (GridLayoutModel)(EditorOverlay.Current.DataContext as GridLayoutModel).Clone();
         }
 
@@ -23,6 +27,14 @@ namespace FancyZonesEditor
             base.OnCancel(sender, e);
             GridLayoutModel model = EditorOverlay.Current.DataContext as GridLayoutModel;
             _stashedModel.RestoreTo(model);
+        }
+
+        private void GridEditorWindow_KeyUp(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Escape)
+            {
+                OnCancel(sender, null);
+            }
         }
 
         private GridLayoutModel _stashedModel;


### PR DESCRIPTION


## Summary of the Pull Request

_What is this about?_
Enable Closing Edit Canvas Layout and Edit Grid Layout windows by pressing Esc button. 

 Navigating to 'Close' button using e.g. Tab button requires bigger rework of these windows. As complete rework of Editor is planned, this will probably be part of that work.

## PR Checklist
* [x] Applies to #7113
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Validation Steps Performed

_How does someone test & validate?_
Scenario 1:
Open Power Toys App
Navigate to Fancy Zone Button and activate it.
Navigate to Launch Zones Editor and activate it.
Navigate to Custom tab in Choose your layout for this Desktop dialog and select it.
Navigate to Create new custom item and selet it
Navigate to Edit Selected layout element and activate it.
Press Esc button and confirm that Edit Selected Layout window is closed

Scenario 2:
Open Power Toys App
Navigate to Fancy Zone Button and activate it.
Navigate to Launch Zones Editor and activate it.
Navigate to Priority Grid layout and Select it.
Navigate to Edit Selected layout element and activate it.
Press Esc button and confirm that Edit Selected Layout window is closed
