### PR TITLE
[Localization] Unreachable input box in FancyZones Editor fix.

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -54,7 +54,7 @@
             <Setter Property="Foreground" Value="Black"/>
             <Setter Property="FontSize" Value="14"/>
             <Setter Property="LineHeight" Value="20" />
-            <Setter Property="Margin" Value="40,10,0,0" />
+            <Setter Property="Margin" Value="7,10,0,0" />
             <Setter Property="TextAlignment" Value="Left" />
         </Style>
         <Style x:Key="settingCheckBoxText" TargetType="CheckBox">
@@ -258,13 +258,37 @@
             </TabItem>
         </TabControl>
 
-		<StackPanel Orientation="Horizontal" Margin="10,4,0,8">
-			<CheckBox x:Name="spaceAroundSetting" Content="{x:Static props:Resources.Show_Space_Zones}" Style="{StaticResource settingCheckBoxText}" IsChecked="{Binding ShowSpacing}"/>
-            <TextBlock x:Name="paddingValue" Text="{x:Static props:Resources.Space_Around_Zones}" Style="{StaticResource settingText}" IsEnabled="{Binding ShowSpacing}" />
-			<TextBox AutomationProperties.LabeledBy="{Binding ElementName=paddingValue}" Text="{Binding Path=Spacing,Mode=TwoWay}" Style="{StaticResource textBox}" MinWidth="32" IsEnabled="{Binding ShowSpacing}"/>
-            <TextBlock x:Name="sensitivityRadiusValue"  Text="{x:Static props:Resources.Distance_adjacent_zones}" Style="{StaticResource settingText}"/>
-			<TextBox AutomationProperties.LabeledBy="{Binding ElementName=sensitivityRadiusValue}" Text="{Binding Path=SensitivityRadius,Mode=TwoWay}" Style="{StaticResource textBox}" MinWidth="40"/>
-		</StackPanel>
+		<Grid Margin="10,4,10,8" >
+            <Grid.RowDefinitions>
+                <RowDefinition Height="1*" />
+                <RowDefinition Height="1*" />
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="1*" />
+                <ColumnDefinition Width="1*" />
+            </Grid.ColumnDefinitions>
+            
+            <CheckBox x:Name="spaceAroundSetting" Content="{x:Static props:Resources.Show_Space_Zones}" Style="{StaticResource settingCheckBoxText}" IsChecked="{Binding ShowSpacing}" Grid.Row="0" Grid.Column="0"/>
+
+            <StackPanel Grid.Row="1" Grid.Column="0" Orientation="Horizontal">
+                <TextBlock x:Name="paddingValue" 
+                           Text="{x:Static props:Resources.Space_Around_Zones}" 
+                           Style="{StaticResource settingText}" 
+                           IsEnabled="{Binding ShowSpacing}" 
+                           MaxWidth="{Binding Path=SettingsTextMaxWidth, ElementName=MainWindow1}" 
+                           TextWrapping="Wrap"/>
+                <TextBox AutomationProperties.LabeledBy="{Binding ElementName=paddingValue}" Text="{Binding Path=Spacing,Mode=TwoWay}" Style="{StaticResource textBox}" MinWidth="32" IsEnabled="{Binding ShowSpacing}" />
+            </StackPanel>
+
+            <StackPanel Grid.Row="0" Grid.Column="1" Orientation="Horizontal">
+                <TextBlock x:Name="sensitivityRadiusValue"
+                           Text="{x:Static props:Resources.Distance_adjacent_zones}" 
+                           Style="{StaticResource settingText}" 
+                           MaxWidth="{Binding Path=SettingsTextMaxWidth, ElementName=MainWindow1}" 
+                           TextWrapping="Wrap"/>
+			    <TextBox AutomationProperties.LabeledBy="{Binding ElementName=sensitivityRadiusValue}" Text="{Binding Path=SensitivityRadius,Mode=TwoWay}" Style="{StaticResource textBox}" MinWidth="40"/>
+            </StackPanel>
+        </Grid>
 
 		<StackPanel Orientation="Horizontal" Margin="0,10,0,16">
 			<Button x:Name="EditCustomButton" Content="{x:Static props:Resources.Edit_Selected_Layout}" Padding="8" Style="{StaticResource secondaryButton}" Click="EditLayout_Click"/>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -270,7 +270,7 @@
             
             <CheckBox x:Name="spaceAroundSetting" Content="{x:Static props:Resources.Show_Space_Zones}" Style="{StaticResource settingCheckBoxText}" IsChecked="{Binding ShowSpacing}" Grid.Row="0" Grid.Column="0"/>
 
-            <StackPanel Grid.Row="1" Grid.Column="0" Orientation="Horizontal">
+            <StackPanel Grid.Row="0" Grid.Column="1" Orientation="Horizontal">
                 <TextBlock x:Name="paddingValue" 
                            Text="{x:Static props:Resources.Space_Around_Zones}" 
                            Style="{StaticResource settingText}" 
@@ -280,7 +280,7 @@
                 <TextBox AutomationProperties.LabeledBy="{Binding ElementName=paddingValue}" Text="{Binding Path=Spacing,Mode=TwoWay}" Style="{StaticResource textBox}" MinWidth="32" IsEnabled="{Binding ShowSpacing}" />
             </StackPanel>
 
-            <StackPanel Grid.Row="0" Grid.Column="1" Orientation="Horizontal">
+            <StackPanel Grid.Row="1" Grid.Column="0" Orientation="Horizontal">
                 <TextBlock x:Name="sensitivityRadiusValue"
                            Text="{x:Static props:Resources.Distance_adjacent_zones}" 
                            Style="{StaticResource settingText}" 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -26,6 +26,14 @@ namespace FancyZonesEditor
 
         public int WrapPanelItemSize { get; set; } = 262;
 
+        public double SettingsTextMaxWidth
+        {
+            get
+            {
+                return (Width / 2) - 60;
+            }
+        }
+
         public MainWindow()
         {
             InitializeComponent();


### PR DESCRIPTION
## Summary of the Pull Request

Changed text position in the main editor window.  Wrap text in case if it won't fit into the line width.

## PR Checklist
* [x] Applies to #7634 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed

## Info on Pull Request

![Снимок1 (3)](https://user-images.githubusercontent.com/8949536/97701798-0a5ee900-1abf-11eb-9bfb-44d4114839da.PNG)

![Снимок (2)](https://user-images.githubusercontent.com/8949536/97701687-d97eb400-1abe-11eb-8c8c-c12d29248a64.PNG)

![Снимок3 (2)](https://user-images.githubusercontent.com/8949536/97701907-30848900-1abf-11eb-84e6-f6b864677204.PNG)

## Validation Steps Performed

For testing, you can set desired values for  `Space_Around_Zones` or  `Distance_adjacent_zones` in the resource file.