### PR TITLE
[PT Run] Folder path starting with backslash

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/Path/FolderHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/Path/FolderHelper.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Plugin.Folder.Sources
             }
 
             // Absolute path of system drive: \Windows\System32
-            if (search.Length > 2 && search[0] == '\\' && search[1] != '\\')
+            if (search[0] == '\\' && (search.Length == 1 || search[1] != '\\'))
             {
                 search = Path.Combine(Path.GetPathRoot(Environment.SystemDirectory), search.Substring(1));
             }

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/Path/FolderHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/Path/FolderHelper.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.IO;
 using System.Linq;
 
 namespace Microsoft.Plugin.Folder.Sources
@@ -75,6 +76,17 @@ namespace Microsoft.Plugin.Folder.Sources
 
         public static string Expand(string search)
         {
+            if (search == null)
+            {
+                throw new ArgumentNullException(nameof(search));
+            }
+
+            // Absolute path of system drive: \Windows\System32
+            if (search.Length > 2 && search[0] == '\\' && search[1] != '\\')
+            {
+                search = Path.Combine(Path.GetPathRoot(Environment.SystemDirectory), search.Substring(1));
+            }
+
             return Environment.ExpandEnvironmentVariables(search);
         }
     }


### PR DESCRIPTION
## Summary of the Pull Request

Support for path starting with backslash: **an absolute path from the root of the current drive**
https://docs.microsoft.com/en-us/dotnet/standard/io/file-path-formats

## PR Checklist
* [x] Applies to #3911
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #3911

## Info on Pull Request

Support for path starting with backslash
The **\** is replaced with Windows drive (in most cases C:\)

## Validation Steps Performed

- Open PT Run
- Type a path that starts with backslash (e.g. \windows\system32)
- Press enter