### PR TITLE
ImageResizer: fix hyperlink buttons role

### DIFF
--- a/src/modules/imageresizer/ui/Views/AccessibleHyperlink.cs
+++ b/src/modules/imageresizer/ui/Views/AccessibleHyperlink.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Automation.Peers;
+using System.Windows.Documents;
+
+namespace ImageResizer.Views
+{
+    public class AccessibleHyperlink : Hyperlink
+    {
+        public AutomationControlType ControlType { get; set; }
+
+        protected override AutomationPeer OnCreateAutomationPeer()
+        {
+            var peer = new CustomizableHyperlinkAutomationPeer(this);
+
+            peer.ControlType = ControlType;
+            return peer;
+        }
+    }
+}

--- a/src/modules/imageresizer/ui/Views/AdvancedWindow.xaml
+++ b/src/modules/imageresizer/ui/Views/AdvancedWindow.xaml
@@ -114,18 +114,18 @@
                                         </ComboBox.ItemTemplate>
                                     </ComboBox>
                                     <TextBlock Grid.Column="6" Margin="5,0,0,0" VerticalAlignment="Center">
-                                        <Hyperlink Command="{Binding DataContext.RemoveSizeCommand,ElementName=_this}" CommandParameter="{Binding}">
+                                        <local:AccessibleHyperlink ControlType="Button"  Command="{Binding DataContext.RemoveSizeCommand,ElementName=_this}" CommandParameter="{Binding}">
                                             <Run Text="{x:Static p:Resources.Advanced_DeleteSize}"/>
-                                        </Hyperlink>
+                                        </local:AccessibleHyperlink>
                                     </TextBlock>
                                 </Grid>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
                     <TextBlock>
-                        <Hyperlink Command="{Binding AddSizeCommand}">
+                        <local:AccessibleHyperlink ControlType="Button" Command="{Binding AddSizeCommand}">
                             <Run Text="{x:Static p:Resources.Advanced_CreateSize}"/>
-                        </Hyperlink>
+                        </local:AccessibleHyperlink>
                     </TextBlock>
                 </StackPanel>
             </TabItem>

--- a/src/modules/imageresizer/ui/Views/CustomizableHyperlinkAutomationPeer.cs
+++ b/src/modules/imageresizer/ui/Views/CustomizableHyperlinkAutomationPeer.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Windows.Automation.Peers;
+using System.Windows.Documents;
+
+namespace ImageResizer.Views
+{
+    public class CustomizableHyperlinkAutomationPeer : HyperlinkAutomationPeer
+    {
+        public CustomizableHyperlinkAutomationPeer(Hyperlink owner)
+            : base(owner)
+        {
+        }
+
+        public AutomationControlType ControlType { get; set; }
+
+        protected override AutomationControlType GetAutomationControlTypeCore()
+        {
+            return ControlType;
+        }
+    }
+}

--- a/src/modules/imageresizer/ui/Views/InputPage.xaml
+++ b/src/modules/imageresizer/ui/Views/InputPage.xaml
@@ -133,9 +133,9 @@
                 
                 <TextBlock VerticalAlignment="Center"
                            Visibility="{Binding ShowAdvancedSettings, Converter={StaticResource BoolValueConverter}}">
-                    <Hyperlink Command="{Binding ShowAdvancedCommand}">
+                    <local:AccessibleHyperlink ControlType="Button" Command="{Binding ShowAdvancedCommand}">
                         <Run Text="{x:Static p:Resources.Input_ShowAdvanced}"/>
-                    </Hyperlink>
+                    </local:AccessibleHyperlink>
                 </TextBlock>
                 
                 <Button Grid.Column="1"


### PR DESCRIPTION
## Summary of the Pull Request

fix hyperlink roles by introducing `CustomizableHyperlinkAutomationPeer`

## PR Checklist
* [x] Applies to #7119

## Validation Steps Performed

Accessibility Insights reports those as buttons now.
