### PR TITLE
[PR Template] Automatic issue linking in PR templates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@
 _What is this about?_
 
 ## PR Checklist
-* [ ] Applies to #xxx
+* [ ] Closes #xxx
 * [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
 * [ ] Tests added/passed
 * [ ] Requires documentation to be updated

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,7 @@ _What is this about?_
 
 ## PR Checklist
 * [ ] Closes #xxx
+<!--Use "Applies to #xxx" if the PR is not a complete solution to the issue-->
 * [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
 * [ ] Tests added/passed
 * [ ] Requires documentation to be updated


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
Changes `Applies to #x` to `Closes #x`

## PR Checklist
* [x] Applies to https://github.com/microsoft/PowerToys/issues/7733#issuecomment-719958891
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* ~Tests added/passed~
* ~Requires documentation to be updated~
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: _None_

## Info on Pull Request

_What does this include?_

GitHub will automatically link the issue to PR which was not the case when it was `Applies to`.

msftbot can then add the `In-Progress` label to the issue when a PR is linked to it.