### PR TITLE
ImageResizer: fix Color contrast of ComboBox

### DIFF
--- a/src/modules/imageresizer/ui/App.xaml
+++ b/src/modules/imageresizer/ui/App.xaml
@@ -30,6 +30,46 @@
         <Style TargetType="TextBox">
             <Setter Property="VerticalContentAlignment" Value="Center"/>
         </Style>
+        <Style x:Key="AccessibleComboBoxStyle" TargetType="ComboBoxItem">
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="{x:Type ComboBoxItem}">
+                        <Border Name="SelectedItemBorder"
+                                Padding="2"
+                                SnapsToDevicePixels="true">
+                            <ContentPresenter />
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsSelected" Value="true">
+                                <Setter TargetName="SelectedItemBorder"
+                                        Property="Background"
+                                        Value="#FF91b9d8"/>
+                                <Setter Property="Foreground"
+                                        Value="Black" />
+                            </Trigger>
+                            <Trigger Property="IsHighlighted" Value="true">
+                                <Setter TargetName="SelectedItemBorder"
+                                        Property="Background"
+                                        Value="#FFdadada" />
+                                <Setter Property="Foreground"
+                                        Value="Black" />
+                            </Trigger>
+                            <MultiTrigger>
+                                <MultiTrigger.Conditions>
+                                    <Condition Property="IsSelected" Value="true" />
+                                    <Condition Property="IsHighlighted" Value="true" />
+                                </MultiTrigger.Conditions>
+                                <Setter TargetName="SelectedItemBorder"
+                                        Property="Background"
+                                        Value="#FF619ccb"/>
+                                <Setter Property="Foreground"
+                                        Value="Black" />
+                            </MultiTrigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
     </Application.Resources>
 
 </Application>

--- a/src/modules/imageresizer/ui/Views/InputPage.xaml
+++ b/src/modules/imageresizer/ui/Views/InputPage.xaml
@@ -55,7 +55,8 @@
                         <ComboBox Height="23"
                                   Margin="5,0,0,0"
                                   ItemsSource="{Binding Source={StaticResource ResizeFitValues}}"
-                                  SelectedItem="{Binding Fit}">
+                                  SelectedItem="{Binding Fit}"
+                                  ItemContainerStyle="{StaticResource AccessibleComboBoxStyle}">
                             <ComboBox.ItemTemplate>
                                 <DataTemplate DataType="{x:Type m:ResizeFit}">
                                     <ContentPresenter Content="{Binding Converter={StaticResource EnumValueConverter}}"/>
@@ -97,7 +98,8 @@
                         <ComboBox Height="23"
                                   Margin="7,0,0,0"
                                   ItemsSource="{Binding Source={StaticResource ResizeUnitValues}}"
-                                  SelectedItem="{Binding Unit}">
+                                  SelectedItem="{Binding Unit}"
+                                  ItemContainerStyle="{StaticResource AccessibleComboBoxStyle}">
                             <ComboBox.ItemTemplate>
                                 <DataTemplate DataType="{x:Type m:ResizeUnit}">
                                     <ContentPresenter Content="{Binding Converter={StaticResource EnumValueConverter}}"/>


### PR DESCRIPTION
## Summary of the Pull Request

I've changed ComboBox item colors to high contrast. I wasn't able to use the same approach as in #7781 to employ `SystemColors` because of "resource not found" error, so they're hardcoded. Tagging @niels9001 for visibility, perhaps he can suggest a solution for that 🙂 .

## PR Checklist
* [x] Applies to #7094

## Validation Steps Performed

![image](https://user-images.githubusercontent.com/1828123/97874706-72fdce00-1d2a-11eb-8fce-4cfb7ca7fd3c.png)
