### PR TITLE
[FancyZones] Adjust colors of secondary buttons to maintain 3:1 contrast ratio against white background

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditorWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditorWindow.xaml
@@ -70,7 +70,7 @@
             <Setter Property="FontSize" Value="14"/>
             <Setter Property="Padding" Value="0,5,0,5"/>
             <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="Background" Value="#F2F2F2"/>
+            <Setter Property="Background" Value="#949494"/>
             <Setter Property="Margin" Value="16,10,0,0" />
             <Setter Property="Width" Value="239"/>
             <Setter Property="Height" Value="32"/>
@@ -154,7 +154,7 @@
             <Setter Property="Margin" Value="16,12,0,0"/>
         </Style>
         <Style x:Key="textBox" TargetType="TextBox">
-            <Setter Property="BorderBrush" Value="#cccccc"/>
+            <Setter Property="BorderBrush" Value="#949494"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="FontFamily" Value="SegoeUI"/>
             <Setter Property="FontWeight" Value="Regular"/>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditorWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditorWindow.xaml
@@ -66,11 +66,11 @@
         <Style x:Key="secondaryButton" TargetType="Button">
             <Setter Property="FontFamily" Value="Segoe UI" />
             <Setter Property="FontWeight" Value="SemiBold" />
-            <Setter Property="Foreground" Value="Black"/>
+            <Setter Property="Foreground" Value="White"/>
             <Setter Property="FontSize" Value="14"/>
             <Setter Property="Padding" Value="0,5,0,5"/>
             <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="Background" Value="#949494"/>
+            <Setter Property="Background" Value="#767676"/>
             <Setter Property="Margin" Value="16,10,0,0" />
             <Setter Property="Width" Value="239"/>
             <Setter Property="Height" Value="32"/>
@@ -85,7 +85,7 @@
             </Setter>
             <Style.Triggers>
                 <Trigger Property="IsMouseOver" Value="True">
-                    <Setter Property="Background" Value="#BCBCBD"/>
+                    <Setter Property="Background" Value="#5D5D5D"/>
                 </Trigger>
             </Style.Triggers>
         </Style>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditorWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditorWindow.xaml
@@ -64,11 +64,11 @@
         <Style x:Key="secondaryButton" TargetType="Button">
             <Setter Property="FontFamily" Value="Segoe UI" />
             <Setter Property="FontWeight" Value="SemiBold" />
-            <Setter Property="Foreground" Value="Black"/>
+            <Setter Property="Foreground" Value="White"/>
             <Setter Property="FontSize" Value="14"/>
             <Setter Property="Padding" Value="0,5,0,5"/>
             <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="Background" Value="#949494"/>
+            <Setter Property="Background" Value="#767676"/>
             <Setter Property="Width" Value="239"/>
             <Setter Property="Height" Value="32"/>
             <Setter Property="Template">
@@ -82,7 +82,7 @@
             </Setter>
             <Style.Triggers>
                 <Trigger Property="IsMouseOver" Value="True">
-                    <Setter Property="Background" Value="#BCBCBD"/>
+                    <Setter Property="Background" Value="#5D5D5D"/>
                 </Trigger>
             </Style.Triggers>
         </Style>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditorWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditorWindow.xaml
@@ -68,7 +68,7 @@
             <Setter Property="FontSize" Value="14"/>
             <Setter Property="Padding" Value="0,5,0,5"/>
             <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="Background" Value="#F2F2F2"/>
+            <Setter Property="Background" Value="#949494"/>
             <Setter Property="Width" Value="239"/>
             <Setter Property="Height" Value="32"/>
             <Setter Property="Template">
@@ -151,7 +151,7 @@
             <Setter Property="Margin" Value="0,12,0,0"/>
         </Style>
         <Style x:Key="textBox" TargetType="TextBox">
-            <Setter Property="BorderBrush" Value="#cccccc"/>
+            <Setter Property="BorderBrush" Value="#949494"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="FontFamily" Value="SegoeUI"/>
             <Setter Property="FontWeight" Value="Regular"/>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -75,11 +75,11 @@
         <Style x:Key="secondaryButton" TargetType="Button">
             <Setter Property="FontFamily" Value="Segoe UI" />
             <Setter Property="FontWeight" Value="SemiBold" />
-            <Setter Property="Foreground" Value="Black"/>
+            <Setter Property="Foreground" Value="White"/>
             <Setter Property="FontSize" Value="14"/>
             <Setter Property="Padding" Value="0,5,0,5"/>
             <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="Background" Value="#949494"/>
+            <Setter Property="Background" Value="#767676"/>
             <Setter Property="Margin" Value="16,0,0,0" />
             <Setter Property="Width" Value="378"/>
             <Setter Property="Height" Value="32"/>
@@ -94,7 +94,7 @@
             </Setter>
             <Style.Triggers>
                 <Trigger Property="IsMouseOver" Value="True">
-                    <Setter Property="Background" Value="#BCBCBD"/>
+                    <Setter Property="Background" Value="#5D5D5D"/>
                 </Trigger>
             </Style.Triggers>
         </Style>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -79,7 +79,7 @@
             <Setter Property="FontSize" Value="14"/>
             <Setter Property="Padding" Value="0,5,0,5"/>
             <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="Background" Value="#F2F2F2"/>
+            <Setter Property="Background" Value="#949494"/>
             <Setter Property="Margin" Value="16,0,0,0" />
             <Setter Property="Width" Value="378"/>
             <Setter Property="Height" Value="32"/>


### PR DESCRIPTION
## Summary of the Pull Request

Use [hex 949494](https://www.colorhexa.com/949494) color for secondary buttons and custom layout name box, to achieve 3:1 contrast ratio against white background.

## PR Checklist
* [x] Applies to #7032 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

## Validation Steps Performed

1. Open PowerToys App
2. Navigate to FancyZones Button and activate it.
3. Navigate to Launch Zones Editor and activate it.
4. Navigate to Custom tab in Choose your layout for this Desktop dialog and select it.
5. Navigate to Create new custom item and select it
6. Navigate to Edit Selected layout element and activate it.
7. Navigate to 'Name' edit field boundary and verify its luminosity ratio.

Expected result: Luminosity ratio is 3:1.
