### PR TITLE
[PT Run] Handle theme at startup

### DIFF
--- a/src/modules/launcher/PowerLauncher/SettingsWatcher.cs
+++ b/src/modules/launcher/PowerLauncher/SettingsWatcher.cs
@@ -9,7 +9,6 @@ using System.Threading;
 using System.Windows.Input;
 using ManagedCommon;
 using Microsoft.PowerToys.Settings.UI.Library;
-using Microsoft.PowerToys.Settings.UI.Library.Utilities;
 using PowerLauncher.Helper;
 using Wox.Core.Plugin;
 using Wox.Infrastructure.Hotkey;
@@ -43,6 +42,9 @@ namespace PowerLauncher
 
             // Load initial settings file
             OverloadSettings();
+
+            // Apply theme at startup
+            _themeManager.ChangeTheme(_settings.Theme, _settings.Theme == Theme.System);
         }
 
         public void CreateSettingsIfNotExists()


### PR DESCRIPTION
## Summary of the Pull Request

Apply correct theme at startup.

## PR Checklist
* [x] Applies to #7754
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #7754
## Info on Pull Request

At first run theme is handled as system instead of user set Dark/Light.

## Validation Steps Performed

- Set Windows color Dark
- Set PT Run color Light
- Reboot
- Invoke PT Run
- PT Run color is Light