### PR TITLE
Remove unneeded variable for GetLastError();

### DIFF
--- a/src/common/common.cpp
+++ b/src/common/common.cpp
@@ -479,7 +479,7 @@ bool check_user_is_admin()
     };
 
     HANDLE hToken;
-    DWORD dwSize = 0, dwResult = 0;
+    DWORD dwSize = 0;
     PTOKEN_GROUPS pGroupInfo;
     SID_IDENTIFIER_AUTHORITY SIDAuth = SECURITY_NT_AUTHORITY;
     PSID pSID = NULL;
@@ -493,8 +493,7 @@ bool check_user_is_admin()
     // Call GetTokenInformation to get the buffer size.
     if (!GetTokenInformation(hToken, TokenGroups, NULL, dwSize, &dwSize))
     {
-        dwResult = GetLastError();
-        if (dwResult != ERROR_INSUFFICIENT_BUFFER)
+        if (GetLastError() != ERROR_INSUFFICIENT_BUFFER)
         {
             return true;
         }


### PR DESCRIPTION
No other usage of GetLastError has the result assigned to a variable first in this code, so it is better if we make check_user_is_admin the same in that regard.

## Summary of the Pull Request

GetLastError() is no longer assigned to a variable in check_user_is_admin

## PR Checklist
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [X] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

GetLastError() is no longer assigned to a variable in check_user_is_admin
## Validation Steps Performed

Passed unit tests