### PR TITLE
Replace deprecated C headers with their C++ equivalent

### DIFF
--- a/src/modules/keyboardmanager/ui/pch.h
+++ b/src/modules/keyboardmanager/ui/pch.h
@@ -2,8 +2,8 @@
 // Do not define WIN32_LEAN_AND_MEAN as WinUI doesn't work when it is defined
 #include <unknwn.h>
 #include <windows.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cstdlib>
+#include <cstring>
 #include <thread>
 #include <winrt/Windows.system.h>
 #include <winrt/windows.ui.xaml.hosting.h>

--- a/tools/CleanUp_tool/main.cpp
+++ b/tools/CleanUp_tool/main.cpp
@@ -1,6 +1,6 @@
 #include <windows.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cstdlib>
+#include <cstring>
 #include <shlwapi.h>
 #include <shlobj.h>
 


### PR DESCRIPTION
To remove warnings about deprecated headers and for more robust C++, this replaces the deprecated C header with its C++ equivalent.

## Summary of the Pull Request

Replaces deprecated C headers with their C++ equivalent.

## PR Checklist
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [X] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

Replaces deprecated C headers with their C++ equivalent.

## Validation Steps Performed
Passed all Unit Tests
