### PR TITLE
[Accessibility][FancyZones Editor] Add Grid Layout Editor name property

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditorWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditorWindow.xaml
@@ -1,4 +1,5 @@
 ﻿<local:EditorWindow x:Class="FancyZonesEditor.GridEditorWindow"
+        AutomationProperties.Name="{x:Static props:Resources.Grid_Layout_Editor}"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
@@ -187,6 +187,15 @@ namespace FancyZonesEditor.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Grid layout editor.
+        /// </summary>
+        public static string Grid_Layout_Editor {
+            get {
+                return ResourceManager.GetString("Grid_Layout_Editor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Name.
         /// </summary>
         public static string Name {

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
@@ -129,7 +129,10 @@
   <data name="Canvas_Layout_Editor" xml:space="preserve">
     <value>Canvas layout editor</value>
   </data>
-  <data name="Choose_Layout" xml:space="preserve">
+  <data name="Grid_Layout_Editor" xml:space="preserve">
+    <value>Grid layout editor</value>
+  </data>
+	<data name="Choose_Layout" xml:space="preserve">
     <value>Choose your layout for this desktop</value>
   </data>
   <data name="Crash_Report_Message_Box_Text_Part1" xml:space="preserve">


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
**Issue**:  All windows are missing window titles (it’s just announced as “Window” in NVDA, both when opening and when alt-tabbing)
**Fix**: Added name propery (value: Grid Layout Editor)

## PR Checklist
* [x] Applies to #5776 
![Before](https://user-images.githubusercontent.com/57057282/98133835-5c887b80-1ebe-11eb-8bd8-caf6136f02a7.png)

* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_
**Before**
![image](https://user-images.githubusercontent.com/57057282/98133859-66aa7a00-1ebe-11eb-9b4a-46e7e3a7932b.png)


**After**
![image](https://user-images.githubusercontent.com/57057282/98133887-6c07c480-1ebe-11eb-9842-8047ca301a74.png)

## Validation Steps Performed

_How does someone test & validate?_
 - Open FancyZones Editor
 - Select some of the predefined Layout (e.g. 3-zones Priority Grid)
 - Press Edit Selected Layout
 - Open Accessibility Insights for Windows app and scan Grid Layout Editor window
 - Observe that there is name attribute set (value: Grid Layout Editor)