### PR TITLE
[Accessibility][FancyZones Editor] Toggle `show space around zones` CheckBox on Enter

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -268,7 +268,7 @@
                 <ColumnDefinition Width="1*" />
             </Grid.ColumnDefinitions>
             
-            <CheckBox x:Name="spaceAroundSetting" Content="{x:Static props:Resources.Show_Space_Zones}" Style="{StaticResource settingCheckBoxText}" IsChecked="{Binding ShowSpacing}" Grid.Row="0" Grid.Column="0"/>
+            <CheckBox x:Name="spaceAroundSetting" KeyUp="SpaceAroundSetting_KeyUp" Content="{x:Static props:Resources.Show_Space_Zones}" Style="{StaticResource settingCheckBoxText}" IsChecked="{Binding ShowSpacing}" Grid.Row="0" Grid.Column="0"/>
 
             <StackPanel Grid.Row="0" Grid.Column="1" Orientation="Horizontal">
                 <TextBlock x:Name="paddingValue" 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -206,5 +206,13 @@ namespace FancyZonesEditor
 
             model.Delete();
         }
+
+        private void SpaceAroundSetting_KeyUp(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Enter)
+            {
+                spaceAroundSetting.IsChecked = !spaceAroundSetting.IsChecked;
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
**Issue**: “Show space around zones” checkbox does not respond to enter key (should toggle it, same as space)
**Fix**: Enable toggling “Show space around zones” checkbox  on Enter

## PR Checklist
* [x] Applies to #5776 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Validation Steps Performed

_How does someone test & validate?_
 - Open FancyZones Editor
 - Using Tab key navigate to “Show space around zones” checkbox
 - Press Enter Key
 - Observe that checkbox changes it's state