### PR TITLE
[FancyZones] Add descriptive name for zone increment/decrement buttons

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -185,9 +185,9 @@
             <TabItem Header="{x:Static props:Resources.Templates}" Template="{StaticResource myTabs}">
                 <StackPanel>
                     <StackPanel Margin="0,15,0,8" Orientation="Horizontal" HorizontalAlignment="Center">
-                        <Button x:Name="decrementZones" Width="40" Height="40" Content="-" Style="{StaticResource spinnerButton}" Click="DecrementZones_Click"/>
+                        <Button x:Name="decrementZones" Width="40" Height="40" AutomationProperties.Name="{x:Static props:Resources.Zone_Count_Decrement}" Content="-" Style="{StaticResource spinnerButton}" Click="DecrementZones_Click"/>
                         <TextBlock x:Name="zoneCount" Text="{Binding ZoneCount}" Style="{StaticResource zoneCount}"/>
-                        <Button x:Name="incrementZones" Width="40" Height="40" Content="+" Style="{StaticResource spinnerButton}" Click="IncrementZones_Click"/>
+                        <Button x:Name="incrementZones" Width="40" Height="40" AutomationProperties.Name="{x:Static props:Resources.Zone_Count_Increment}" Content="+" Style="{StaticResource spinnerButton}" Click="IncrementZones_Click"/>
                     </StackPanel>
                     <ItemsControl ItemsSource="{Binding DefaultModels}" Margin="8,0,0,0">
                         <ItemsControl.ItemsPanel>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
@@ -239,5 +239,23 @@ namespace FancyZonesEditor.Properties {
                 return ResourceManager.GetString("Templates", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Decrement number of zones in template layout.
+        /// </summary>
+        public static string Zone_Count_Decrement {
+            get {
+                return ResourceManager.GetString("Zone_Count_Decrement", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Increment number of zones in template layout.
+        /// </summary>
+        public static string Zone_Count_Increment {
+            get {
+                return ResourceManager.GetString("Zone_Count_Increment", resourceCulture);
+            }
+        }
     }
 }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
@@ -177,4 +177,10 @@
   <data name="Templates" xml:space="preserve">
     <value>Templates</value>
   </data>
+  <data name="Zone_Count_Decrement" xml:space="preserve">
+    <value>Decrement number of zones in template layout</value>
+  </data>
+  <data name="Zone_Count_Increment" xml:space="preserve">
+    <value>Increment number of zones in template layout</value>
+  </data>
 </root>


### PR DESCRIPTION
## Summary of the Pull Request

Buttons for incrementing and decrementing number of zones within template layout are simply announced by narrator as "-" and "+" button. Add more descriptive announcement for these buttons:
1. Decrement number of zones in template layout
2. Increment number of zones in template layout

## PR Checklist
* [x] Applies to #7095 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

## Validation Steps Performed

1. Launch Accessibility Insights for Windows tool.
2. Open PowerToys Settings App.
3. Navigate to FancyZones menu item and activate it.
4. Navigate to 'Launch Zone Editor' button and activate it. 'Choose your layout for this desktop' window will open.
5. Verify the name defined for '+/-' buttons using Accessiblity Insights for Windows tool.
6. Turn on Narrator and verify.

Expected result:
![DecrementNumberOfZones](https://user-images.githubusercontent.com/57061786/98240105-3b309980-1f69-11eb-9694-3dd67ff5da7b.png)
![IncrementNumberOfZones](https://user-images.githubusercontent.com/57061786/98240116-3d92f380-1f69-11eb-9634-f83b2ccfb845.png)

