### PR TITLE
[FancyZones] Add name property for delete button

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -239,7 +239,15 @@
                                                HorizontalAlignment="Stretch" 
                                                LastChildFill="True">
                                         <DockPanel DockPanel.Dock="Top" LastChildFill="True" >
-                                            <Button x:Name="DeleteButton" Visibility="{Binding Converter={StaticResource ModelToVisibilityConverter}}" DockPanel.Dock="Right" MaxHeight="10" Click="OnDelete" Padding="8,4,8,4" Margin="0,0,8,0" BorderThickness="0" Background="#f2f2f2">
+                                            <Button x:Name="DeleteButton" AutomationProperties.Name="{x:Static props:Resources.Custom_Layout_Delete_Button}"
+                                                    Visibility="{Binding Converter={StaticResource ModelToVisibilityConverter}}"
+                                                    DockPanel.Dock="Right"
+                                                    MaxHeight="10"
+                                                    Click="OnDelete"
+                                                    Padding="8,4,8,4"
+                                                    Margin="0,0,8,0"
+                                                    BorderThickness="0"
+                                                    Background="#f2f2f2">
                                                 <Image Source="images/Delete.png" />
                                             </Button>
                                             <TextBlock DockPanel.Dock="Top" 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
@@ -142,6 +142,15 @@ namespace FancyZonesEditor.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Delete custom layout.
+        /// </summary>
+        public static string Custom_Layout_Delete_Button {
+            get {
+                return ResourceManager.GetString("Custom_Layout_Delete_Button", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Custom table layout creator.
         /// </summary>
         public static string Custom_Table_Layout {

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
@@ -132,7 +132,7 @@
   <data name="Grid_Layout_Editor" xml:space="preserve">
     <value>Grid layout editor</value>
   </data>
-	<data name="Choose_Layout" xml:space="preserve">
+  <data name="Choose_Layout" xml:space="preserve">
     <value>Choose your layout for this desktop</value>
   </data>
   <data name="Crash_Report_Message_Box_Text_Part1" xml:space="preserve">
@@ -185,5 +185,8 @@
   </data>
   <data name="Zone_Count_Increment" xml:space="preserve">
     <value>Increment number of zones in template layout</value>
+  </data>
+  <data name="Custom_Layout_Delete_Button" xml:space="preserve">
+    <value>Delete custom layout</value>
   </data>
 </root>


### PR DESCRIPTION
## Summary of the Pull Request

User's custom layouts shown in FancyZones Editor can be deleted by clicking on small delete button in top right corner of the layout preview. This delete button is lacking accessibility name, and therefore cannot be announced by narrator.

## PR Checklist
* [x] Applies to #7086
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA


## Validation Steps Performed

1. Open PowerToys Settings application.
2. Navigate to FancyZones present at the left side of the pane and activate it.
3. Navigate to 'Launch Zone Editor' present at the right side of the pane and activate it.
4. Navigate to Custom tab in Choose your layout for this Desktop dialog and activate it.
5. Run Accessibility Insights for Windows tool.

Expected result: Delete button is focusable element and it has valid descriptive name.

![DeleteButton](https://user-images.githubusercontent.com/57061786/98372652-63d69300-203e-11eb-8e74-7c55f7cb8c63.png)

