### PR TITLE
Fix clipped text

### DIFF
--- a/src/modules/keyboardmanager/ui/EditShortcutsWindow.cpp
+++ b/src/modules/keyboardmanager/ui/EditShortcutsWindow.cpp
@@ -173,7 +173,6 @@ void createEditShortcutsWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMa
     // Third header textblock in the header row of the shortcut table
     TextBlock targetAppHeader;
     targetAppHeader.Text(GET_RESOURCE_STRING(IDS_EDITSHORTCUTS_TARGETAPPHEADER));
-    targetAppHeader.Width(KeyboardManagerConstants::ShortcutTableDropDownWidth);
     targetAppHeader.FontWeight(Text::FontWeights::Bold());
     targetAppHeader.HorizontalAlignment(HorizontalAlignment::Center);
 


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
It fixes clipped text in remap shortcut window. It can be an issue for different languages. For example, one below.
 
![image](https://user-images.githubusercontent.com/17161067/98380401-3515e800-2051-11eb-8033-67f5d8a361c6.png)


## PR Checklist
* [X] Applies to #7856
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_
Remove fixed width on `TextBlock` .

## Validation Steps Performed
![image](https://user-images.githubusercontent.com/17161067/98381719-f2550f80-2052-11eb-83e7-0d442a3b61f6.png)

_How does someone test & validate?_
Ether check Italian version or change length of `EditShortcuts_TargetAppHeader` label in resource file and see that it is not clipped.