### PR TITLE
[Image Resizer] Fluent UI and theming support

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -1356,6 +1356,7 @@ MMI
 mockapi
 MODECHANGE
 moderncop
+modernwpf
 modulekey
 MONITORINFO
 MONITORINFOEX

--- a/installer/PowerToysSetup/Product.wxs
+++ b/installer/PowerToysSetup/Product.wxs
@@ -485,12 +485,16 @@
         <File Source="$(var.BinX64Dir)modules\$(var.ImageResizerProjectName)\ImageResizer.exe">
           <netfx:NativeImage Id="ImageResizer.exe" Platform="all" Priority="0" />
         </File>
+        <File Source="$(var.BinX64Dir)modules\$(var.ImageResizerProjectName)\ImageResizerExt.dll" KeyPath="yes" />	
         <File Source="$(var.BinX64Dir)modules\$(var.ImageResizerProjectName)\Newtonsoft.Json.dll" />
         <File Source="$(var.BinX64Dir)modules\$(var.ImageResizerProjectName)\ImageResizer.dll" />
         <File Source="$(var.BinX64Dir)modules\$(var.ImageResizerProjectName)\ImageResizer.deps.json" />
         <File Source="$(var.BinX64Dir)modules\$(var.ImageResizerProjectName)\ImageResizer.runtimeconfig.json" />
+        <File Id="Module_ImageResizer_ControlzEX" Source="$(var.BinX64Dir)modules\$(var.ImageResizerProjectName)\ControlzEx.dll" />
+        <File Id="Module_ImageResizer_ModernWpf_Controls" Source="$(var.BinX64Dir)modules\$(var.ImageResizerProjectName)\ModernWpf.Controls.dll" />
+        <File Id="Module_ImageResizer_ModernWpf" Source="$(var.BinX64Dir)modules\$(var.ImageResizerProjectName)\ModernWpf.dll" />
+        <File Id="Module_ImageResizer_System_Text_Json" Source="$(var.BinX64Dir)modules\$(var.ImageResizerProjectName)\System.Text.Json.dll" />
         <File Id="Module_ImageResizer_Microsoft_Xaml_Behaviors" Source="$(var.BinX64Dir)modules\$(var.ImageResizerProjectName)\Microsoft.Xaml.Behaviors.dll" />
-        <File Source="$(var.BinX64Dir)modules\$(var.ImageResizerProjectName)\ImageResizerExt.dll" KeyPath="yes" />		  
         <File Id="ImageResizer_interop" Source="$(var.BinX64Dir)modules\$(var.ImageResizerProjectName)\PowerToysInterop.dll" />
         <File Id="ImageResizer_System.IO.Abstractions.dll" Source="$(var.BinX64Dir)modules\$(var.ImageResizerProjectName)\System.IO.Abstractions.dll" />
 

--- a/src/modules/imageresizer/tests/Properties/AppFixture.cs
+++ b/src/modules/imageresizer/tests/Properties/AppFixture.cs
@@ -26,6 +26,7 @@ namespace ImageResizer.Properties
             {
                 if (disposing)
                 {
+                    _imageResizerApp.Dispose();
                     _imageResizerApp = null;
                 }
 

--- a/src/modules/imageresizer/ui/App.xaml
+++ b/src/modules/imageresizer/ui/App.xaml
@@ -3,74 +3,83 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:m="clr-namespace:ImageResizer.Models"
              xmlns:sys="clr-namespace:System;assembly=System.Runtime"
-             xmlns:v="clr-namespace:ImageResizer.Views">
+             xmlns:v="clr-namespace:ImageResizer.Views"
+             xmlns:ui="http://schemas.modernwpf.com/2019">
 
     <Application.Resources>
-        <ObjectDataProvider x:Key="ResizeFitValues"
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ui:ThemeResources />
+                <ui:XamlControlsResources />
+                <!-- Other merged dictionaries here -->
+            </ResourceDictionary.MergedDictionaries>
+
+            <ObjectDataProvider x:Key="ResizeFitValues"
                             MethodName="GetValues"
                             ObjectType="sys:Enum">
-            <ObjectDataProvider.MethodParameters>
-                <x:Type Type="{x:Type m:ResizeFit}"/>
-            </ObjectDataProvider.MethodParameters>
-        </ObjectDataProvider>
-        <ObjectDataProvider x:Key="ResizeUnitValues"
+                <ObjectDataProvider.MethodParameters>
+                    <x:Type Type="{x:Type m:ResizeFit}"/>
+                </ObjectDataProvider.MethodParameters>
+            </ObjectDataProvider>
+            <ObjectDataProvider x:Key="ResizeUnitValues"
                             MethodName="GetValues"
                             ObjectType="sys:Enum">
-            <ObjectDataProvider.MethodParameters>
-                <x:Type Type="{x:Type m:ResizeUnit}"/>
-            </ObjectDataProvider.MethodParameters>
-        </ObjectDataProvider>
-        <v:EnumValueConverter x:Key="EnumValueConverter"/>
-        <v:AutoDoubleConverter x:Key="AutoDoubleConverter"/>
-        <v:BoolValueConverter x:Key="BoolValueConverter"/>
-        <v:VisibilityBoolConverter x:Key="VisibilityBoolConverter"/>
-        <Style x:Key="MainInstructionTextBlockStyle" TargetType="TextBlock">
-            <Setter Property="FontSize" Value="12pt"/>
-            <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.HotTrackColor}}"/>
-        </Style>
-        <Style TargetType="TextBox">
-            <Setter Property="VerticalContentAlignment" Value="Center"/>
-        </Style>
-        <Style x:Key="AccessibleComboBoxStyle" TargetType="ComboBoxItem">
-            <Setter Property="Template">
-                <Setter.Value>
-                    <ControlTemplate TargetType="{x:Type ComboBoxItem}">
-                        <Border Name="SelectedItemBorder"
+                <ObjectDataProvider.MethodParameters>
+                    <x:Type Type="{x:Type m:ResizeUnit}"/>
+                </ObjectDataProvider.MethodParameters>
+            </ObjectDataProvider>
+            <v:EnumValueConverter x:Key="EnumValueConverter"/>
+            <v:AutoDoubleConverter x:Key="AutoDoubleConverter"/>
+            <v:BoolValueConverter x:Key="BoolValueConverter"/>
+            <v:VisibilityBoolConverter x:Key="VisibilityBoolConverter"/>
+            <Style x:Key="MainInstructionTextBlockStyle" TargetType="TextBlock">
+                <Setter Property="FontSize" Value="12pt"/>
+                <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.HotTrackColor}}"/>
+            </Style>
+            <Style TargetType="TextBox">
+                <Setter Property="VerticalContentAlignment" Value="Center"/>
+            </Style>
+            <Style x:Key="AccessibleComboBoxStyle" TargetType="ComboBoxItem">
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="{x:Type ComboBoxItem}">
+                            <Border Name="SelectedItemBorder"
                                 Padding="2"
                                 SnapsToDevicePixels="true">
-                            <ContentPresenter />
-                        </Border>
-                        <ControlTemplate.Triggers>
-                            <Trigger Property="IsSelected" Value="true">
-                                <Setter TargetName="SelectedItemBorder"
+                                <ContentPresenter />
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsSelected" Value="true">
+                                    <Setter TargetName="SelectedItemBorder"
                                         Property="Background"
                                         Value="#FF91b9d8"/>
-                                <Setter Property="Foreground"
+                                    <Setter Property="Foreground"
                                         Value="Black" />
-                            </Trigger>
-                            <Trigger Property="IsHighlighted" Value="true">
-                                <Setter TargetName="SelectedItemBorder"
+                                </Trigger>
+                                <Trigger Property="IsHighlighted" Value="true">
+                                    <Setter TargetName="SelectedItemBorder"
                                         Property="Background"
                                         Value="#FFdadada" />
-                                <Setter Property="Foreground"
+                                    <Setter Property="Foreground"
                                         Value="Black" />
-                            </Trigger>
-                            <MultiTrigger>
-                                <MultiTrigger.Conditions>
-                                    <Condition Property="IsSelected" Value="true" />
-                                    <Condition Property="IsHighlighted" Value="true" />
-                                </MultiTrigger.Conditions>
-                                <Setter TargetName="SelectedItemBorder"
+                                </Trigger>
+                                <MultiTrigger>
+                                    <MultiTrigger.Conditions>
+                                        <Condition Property="IsSelected" Value="true" />
+                                        <Condition Property="IsHighlighted" Value="true" />
+                                    </MultiTrigger.Conditions>
+                                    <Setter TargetName="SelectedItemBorder"
                                         Property="Background"
                                         Value="#FF619ccb"/>
-                                <Setter Property="Foreground"
+                                    <Setter Property="Foreground"
                                         Value="Black" />
-                            </MultiTrigger>
-                        </ControlTemplate.Triggers>
-                    </ControlTemplate>
-                </Setter.Value>
-            </Setter>
-        </Style>
-    </Application.Resources>
+                                </MultiTrigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
 
+        </ResourceDictionary>
+    </Application.Resources>
 </Application>

--- a/src/modules/imageresizer/ui/App.xaml
+++ b/src/modules/imageresizer/ui/App.xaml
@@ -11,7 +11,6 @@
             <ResourceDictionary.MergedDictionaries>
                 <ui:ThemeResources />
                 <ui:XamlControlsResources />
-                <!-- Other merged dictionaries here -->
             </ResourceDictionary.MergedDictionaries>
 
             <ObjectDataProvider x:Key="ResizeFitValues"
@@ -21,6 +20,7 @@
                     <x:Type Type="{x:Type m:ResizeFit}"/>
                 </ObjectDataProvider.MethodParameters>
             </ObjectDataProvider>
+            
             <ObjectDataProvider x:Key="ResizeUnitValues"
                             MethodName="GetValues"
                             ObjectType="sys:Enum">
@@ -28,58 +28,11 @@
                     <x:Type Type="{x:Type m:ResizeUnit}"/>
                 </ObjectDataProvider.MethodParameters>
             </ObjectDataProvider>
+            
             <v:EnumValueConverter x:Key="EnumValueConverter"/>
             <v:AutoDoubleConverter x:Key="AutoDoubleConverter"/>
             <v:BoolValueConverter x:Key="BoolValueConverter"/>
             <v:VisibilityBoolConverter x:Key="VisibilityBoolConverter"/>
-            <Style x:Key="MainInstructionTextBlockStyle" TargetType="TextBlock">
-                <Setter Property="FontSize" Value="12pt"/>
-                <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.HotTrackColor}}"/>
-            </Style>
-            <Style TargetType="TextBox">
-                <Setter Property="VerticalContentAlignment" Value="Center"/>
-            </Style>
-            <Style x:Key="AccessibleComboBoxStyle" TargetType="ComboBoxItem">
-                <Setter Property="Template">
-                    <Setter.Value>
-                        <ControlTemplate TargetType="{x:Type ComboBoxItem}">
-                            <Border Name="SelectedItemBorder"
-                                Padding="2"
-                                SnapsToDevicePixels="true">
-                                <ContentPresenter />
-                            </Border>
-                            <ControlTemplate.Triggers>
-                                <Trigger Property="IsSelected" Value="true">
-                                    <Setter TargetName="SelectedItemBorder"
-                                        Property="Background"
-                                        Value="#FF91b9d8"/>
-                                    <Setter Property="Foreground"
-                                        Value="Black" />
-                                </Trigger>
-                                <Trigger Property="IsHighlighted" Value="true">
-                                    <Setter TargetName="SelectedItemBorder"
-                                        Property="Background"
-                                        Value="#FFdadada" />
-                                    <Setter Property="Foreground"
-                                        Value="Black" />
-                                </Trigger>
-                                <MultiTrigger>
-                                    <MultiTrigger.Conditions>
-                                        <Condition Property="IsSelected" Value="true" />
-                                        <Condition Property="IsHighlighted" Value="true" />
-                                    </MultiTrigger.Conditions>
-                                    <Setter TargetName="SelectedItemBorder"
-                                        Property="Background"
-                                        Value="#FF619ccb"/>
-                                    <Setter Property="Foreground"
-                                        Value="Black" />
-                                </MultiTrigger>
-                            </ControlTemplate.Triggers>
-                        </ControlTemplate>
-                    </Setter.Value>
-                </Setter>
-            </Style>
-
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/src/modules/imageresizer/ui/App.xaml.cs
+++ b/src/modules/imageresizer/ui/App.xaml.cs
@@ -13,11 +13,10 @@ using ImageResizer.Views;
 
 namespace ImageResizer
 {
-#pragma warning disable CA1001 // Types that own disposable fields should be disposable
-    public partial class App : Application
-#pragma warning restore CA1001 // Types that own disposable fields should be disposable
+    public partial class App : Application, IDisposable
     {
         private ThemeManager _themeManager;
+        private bool _isDisposed;
 
         static App()
         {
@@ -44,6 +43,28 @@ namespace ImageResizer
             NativeMethods.INPUT[] inputs = new NativeMethods.INPUT[] { input };
             _ = NativeMethods.SendInput(1, inputs, NativeMethods.INPUT.Size);
             NativeMethods.SetForegroundWindow(hWnd);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_isDisposed)
+            {
+                if (disposing)
+                {
+                    _themeManager.Dispose();
+                }
+
+                // TODO: free unmanaged resources (unmanaged objects) and override finalizer
+                // TODO: set large fields to null
+                _isDisposed = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/modules/imageresizer/ui/App.xaml.cs
+++ b/src/modules/imageresizer/ui/App.xaml.cs
@@ -51,7 +51,7 @@ namespace ImageResizer
             {
                 if (disposing)
                 {
-                    _themeManager.Dispose();
+                    _themeManager?.Dispose();
                 }
 
                 // TODO: free unmanaged resources (unmanaged objects) and override finalizer

--- a/src/modules/imageresizer/ui/App.xaml.cs
+++ b/src/modules/imageresizer/ui/App.xaml.cs
@@ -13,8 +13,12 @@ using ImageResizer.Views;
 
 namespace ImageResizer
 {
+#pragma warning disable CA1001 // Types that own disposable fields should be disposable
     public partial class App : Application
+#pragma warning restore CA1001 // Types that own disposable fields should be disposable
     {
+        private ThemeManager _themeManager;
+
         static App()
         {
             Console.InputEncoding = Encoding.Unicode;
@@ -27,6 +31,8 @@ namespace ImageResizer
             // TODO: Add command-line parameters that can be used in lieu of the input page (issue #14)
             var mainWindow = new MainWindow(new MainViewModel(batch, Settings.Default));
             mainWindow.Show();
+
+            _themeManager = new ThemeManager(this);
 
             // Temporary workaround for issue #1273
             BecomeForegroundWindow(new System.Windows.Interop.WindowInteropHelper(mainWindow).Handle);

--- a/src/modules/imageresizer/ui/ImageResizerUI.csproj
+++ b/src/modules/imageresizer/ui/ImageResizerUI.csproj
@@ -61,7 +61,7 @@
     <Resource Include="Resources\ImageResizer.png" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MahApps.Metro" Version="2.3.3" />
+    <PackageReference Include="ControlzEx" Version="4.4.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/modules/imageresizer/ui/ImageResizerUI.csproj
+++ b/src/modules/imageresizer/ui/ImageResizerUI.csproj
@@ -61,10 +61,12 @@
     <Resource Include="Resources\ImageResizer.png" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="MahApps.Metro" Version="2.3.3" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.19" />
+    <PackageReference Include="ModernWpfUI" Version="0.9.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>

--- a/src/modules/imageresizer/ui/Properties/Resources.Designer.cs
+++ b/src/modules/imageresizer/ui/Properties/Resources.Designer.cs
@@ -259,7 +259,7 @@ namespace ImageResizer.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to © 2019 Brice Lambson. All rights reserved..
+        ///   Looks up a localized string similar to © 2020 Brice Lambson. All rights reserved..
         /// </summary>
         public static string Copyright {
             get {
@@ -286,7 +286,7 @@ namespace ImageResizer.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to _Select a size..
+        ///   Looks up a localized string similar to _Select a size.
         /// </summary>
         public static string Input_Content {
             get {

--- a/src/modules/imageresizer/ui/Properties/Resources.Designer.cs
+++ b/src/modules/imageresizer/ui/Properties/Resources.Designer.cs
@@ -232,7 +232,7 @@ namespace ImageResizer.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Advanced Options.
+        ///   Looks up a localized string similar to Settings.
         /// </summary>
         public static string Advanced_Title {
             get {
@@ -268,7 +268,7 @@ namespace ImageResizer.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Image Resizer for Windows.
+        ///   Looks up a localized string similar to Image Resizer.
         /// </summary>
         public static string ImageResizer {
             get {
@@ -313,15 +313,6 @@ namespace ImageResizer.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Resize your pictures.
-        /// </summary>
-        public static string Input_MainInstruction {
-            get {
-                return ResourceManager.GetString("Input_MainInstruction", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to R_esize the original pictures (don&apos;t create copies).
         /// </summary>
         public static string Input_Replace {
@@ -340,7 +331,7 @@ namespace ImageResizer.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Advanced options....
+        ///   Looks up a localized string similar to Settings.
         /// </summary>
         public static string Input_ShowAdvanced {
             get {

--- a/src/modules/imageresizer/ui/Properties/Resources.Designer.cs
+++ b/src/modules/imageresizer/ui/Properties/Resources.Designer.cs
@@ -124,6 +124,15 @@ namespace ImageResizer.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Filename.
+        /// </summary>
+        public static string Advanced_FileName_Tooltip {
+            get {
+                return ResourceManager.GetString("Advanced_FileName_Tooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Original filename.
         /// </summary>
         public static string Advanced_FileNameToken1 {
@@ -376,6 +385,15 @@ namespace ImageResizer.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Apply settings.
+        /// </summary>
+        public static string OK_Tooltip {
+            get {
+                return ResourceManager.GetString("OK_Tooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Phone.
         /// </summary>
         public static string Phone {
@@ -525,6 +543,15 @@ namespace ImageResizer.Properties {
         public static string Progress_TimeRemaining_Seconds {
             get {
                 return ResourceManager.GetString("Progress_TimeRemaining_Seconds", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Resize pictures.
+        /// </summary>
+        public static string Resize_Tooltip {
+            get {
+                return ResourceManager.GetString("Resize_Tooltip", resourceCulture);
             }
         }
         

--- a/src/modules/imageresizer/ui/Properties/Resources.Designer.cs
+++ b/src/modules/imageresizer/ui/Properties/Resources.Designer.cs
@@ -106,6 +106,15 @@ namespace ImageResizer.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Fallback encoder.
+        /// </summary>
+        public static string Advanced_FallbackEncoder_Name {
+            get {
+                return ResourceManager.GetString("Advanced_FallbackEncoder_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to File.
         /// </summary>
         public static string Advanced_File {
@@ -126,9 +135,9 @@ namespace ImageResizer.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Filename.
         /// </summary>
-        public static string Advanced_FileName_Tooltip {
+        public static string Advanced_FileName_Name {
             get {
-                return ResourceManager.GetString("Advanced_FileName_Tooltip", resourceCulture);
+                return ResourceManager.GetString("Advanced_FileName_Name", resourceCulture);
             }
         }
         
@@ -205,6 +214,15 @@ namespace ImageResizer.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to JPEG quality level.
+        /// </summary>
+        public static string Advanced_JpegQualityLevel_Name {
+            get {
+                return ResourceManager.GetString("Advanced_JpegQualityLevel_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to _Use original date modified.
         /// </summary>
         public static string Advanced_KeepDateModified {
@@ -223,6 +241,15 @@ namespace ImageResizer.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to PNG interlacing.
+        /// </summary>
+        public static string Advanced_PngInterlaceOption_Name {
+            get {
+                return ResourceManager.GetString("Advanced_PngInterlaceOption_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Sizes.
         /// </summary>
         public static string Advanced_Sizes {
@@ -237,6 +264,15 @@ namespace ImageResizer.Properties {
         public static string Advanced_TiffCompressOption {
             get {
                 return ResourceManager.GetString("Advanced_TiffCompressOption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to TIFF compression.
+        /// </summary>
+        public static string Advanced_TiffCompressOption_Name {
+            get {
+                return ResourceManager.GetString("Advanced_TiffCompressOption_Name", resourceCulture);
             }
         }
         

--- a/src/modules/imageresizer/ui/Properties/Resources.Designer.cs
+++ b/src/modules/imageresizer/ui/Properties/Resources.Designer.cs
@@ -790,6 +790,15 @@ namespace ImageResizer.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Times Symbol.
+        /// </summary>
+        public static string Times_Symbol {
+            get {
+                return ResourceManager.GetString("Times_Symbol", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Unit.
         /// </summary>
         public static string Unit {

--- a/src/modules/imageresizer/ui/Properties/Resources.Designer.cs
+++ b/src/modules/imageresizer/ui/Properties/Resources.Designer.cs
@@ -277,6 +277,15 @@ namespace ImageResizer.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Height.
+        /// </summary>
+        public static string Height {
+            get {
+                return ResourceManager.GetString("Height", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Image Resizer.
         /// </summary>
         public static string ImageResizer {
@@ -556,6 +565,15 @@ namespace ImageResizer.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Resize type.
+        /// </summary>
+        public static string Resize_Type {
+            get {
+                return ResourceManager.GetString("Resize_Type", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Fill.
         /// </summary>
         public static string ResizeFit_Fill {
@@ -736,6 +754,15 @@ namespace ImageResizer.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unit.
+        /// </summary>
+        public static string Unit {
+            get {
+                return ResourceManager.GetString("Unit", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Value must be between &apos;{0}&apos; and &apos;{1}&apos;..
         /// </summary>
         public static string ValueMustBeBetween {
@@ -750,6 +777,15 @@ namespace ImageResizer.Properties {
         public static string Version {
             get {
                 return ResourceManager.GetString("Version", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Width.
+        /// </summary>
+        public static string Width {
+            get {
+                return ResourceManager.GetString("Width", resourceCulture);
             }
         }
     }

--- a/src/modules/imageresizer/ui/Properties/Resources.resx
+++ b/src/modules/imageresizer/ui/Properties/Resources.resx
@@ -189,6 +189,9 @@
   <data name="Copyright" xml:space="preserve">
     <value>© 2020 Brice Lambson. All rights reserved.</value>
   </data>
+  <data name="Height" xml:space="preserve">
+    <value>Height</value>
+  </data>
   <data name="ImageResizer" xml:space="preserve">
     <value>Image Resizer</value>
   </data>
@@ -312,6 +315,9 @@
   <data name="Resize_Tooltip" xml:space="preserve">
     <value>Resize pictures</value>
   </data>
+  <data name="Resize_Type" xml:space="preserve">
+    <value>Resize type</value>
+  </data>
   <data name="Results_Close" xml:space="preserve">
     <value>Close</value>
   </data>
@@ -342,10 +348,16 @@
   <data name="TiffCompressOption_Zip" xml:space="preserve">
     <value>Zip</value>
   </data>
+  <data name="Unit" xml:space="preserve">
+    <value>Unit</value>
+  </data>
   <data name="ValueMustBeBetween" xml:space="preserve">
     <value>Value must be between '{0}' and '{1}'.</value>
   </data>
   <data name="Version" xml:space="preserve">
     <value>Version</value>
+  </data>
+  <data name="Width" xml:space="preserve">
+    <value>Width</value>
   </data>
 </root>

--- a/src/modules/imageresizer/ui/Properties/Resources.resx
+++ b/src/modules/imageresizer/ui/Properties/Resources.resx
@@ -159,6 +159,9 @@
   <data name="Advanced_FileNameTokens" xml:space="preserve">
     <value>The following parameters can be used.</value>
   </data>
+  <data name="Advanced_FileName_Tooltip" xml:space="preserve">
+    <value>Filename</value>
+  </data>
   <data name="Advanced_JpegQualityLevel" xml:space="preserve">
     <value>_JPEG quality level:</value>
   </data>
@@ -221,6 +224,9 @@
   </data>
   <data name="OK" xml:space="preserve">
     <value>OK</value>
+  </data>
+  <data name="OK_Tooltip" xml:space="preserve">
+    <value>Apply settings</value>
   </data>
   <data name="Phone" xml:space="preserve">
     <value>Phone</value>
@@ -302,6 +308,9 @@
   </data>
   <data name="ResizeUnit_Pixel" xml:space="preserve">
     <value>Pixels</value>
+  </data>
+  <data name="Resize_Tooltip" xml:space="preserve">
+    <value>Resize pictures</value>
   </data>
   <data name="Results_Close" xml:space="preserve">
     <value>Close</value>

--- a/src/modules/imageresizer/ui/Properties/Resources.resx
+++ b/src/modules/imageresizer/ui/Properties/Resources.resx
@@ -125,9 +125,11 @@
   </data>
   <data name="Advanced_DeleteSize" xml:space="preserve">
     <value>Delete</value>
+    <comment>remove a file</comment>
   </data>
   <data name="Advanced_Encoding" xml:space="preserve">
     <value>Encoding</value>
+    <comment>encoding a file to a different format</comment>
   </data>
   <data name="Advanced_FallbackEncoder" xml:space="preserve">
     <value>_Fallback encoder:</value>
@@ -137,6 +139,7 @@
   </data>
   <data name="Advanced_File" xml:space="preserve">
     <value>File</value>
+    <comment>as in file name</comment>
   </data>
   <data name="Advanced_FileName" xml:space="preserve">
     <value>_Filename:</value>
@@ -206,6 +209,7 @@
   </data>
   <data name="ImageResizer" xml:space="preserve">
     <value>Image Resizer</value>
+    <comment>Product name, do not loc</comment>
   </data>
   <data name="Input_Auto" xml:space="preserve">
     <value>(auto)</value>

--- a/src/modules/imageresizer/ui/Properties/Resources.resx
+++ b/src/modules/imageresizer/ui/Properties/Resources.resx
@@ -201,9 +201,6 @@
   <data name="Input_IgnoreOrientation" xml:space="preserve">
     <value>Ign_ore the orientation of pictures</value>
   </data>
-  <data name="Input_MainInstruction" xml:space="preserve">
-    <value>Resize your pictures</value>
-  </data>
   <data name="Input_Replace" xml:space="preserve">
     <value>R_esize the original pictures (don't create copies)</value>
   </data>

--- a/src/modules/imageresizer/ui/Properties/Resources.resx
+++ b/src/modules/imageresizer/ui/Properties/Resources.resx
@@ -132,6 +132,9 @@
   <data name="Advanced_FallbackEncoder" xml:space="preserve">
     <value>_Fallback encoder:</value>
   </data>
+  <data name="Advanced_FallbackEncoder_Name" xml:space="preserve">
+    <value>Fallback encoder</value>
+  </data>
   <data name="Advanced_File" xml:space="preserve">
     <value>File</value>
   </data>
@@ -159,11 +162,14 @@
   <data name="Advanced_FileNameTokens" xml:space="preserve">
     <value>The following parameters can be used.</value>
   </data>
-  <data name="Advanced_FileName_Tooltip" xml:space="preserve">
+  <data name="Advanced_FileName_Name" xml:space="preserve">
     <value>Filename</value>
   </data>
   <data name="Advanced_JpegQualityLevel" xml:space="preserve">
     <value>_JPEG quality level:</value>
+  </data>
+  <data name="Advanced_JpegQualityLevel_Name" xml:space="preserve">
+    <value>JPEG quality level</value>
   </data>
   <data name="Advanced_KeepDateModified" xml:space="preserve">
     <value>_Use original date modified</value>
@@ -171,11 +177,17 @@
   <data name="Advanced_PngInterlaceOption" xml:space="preserve">
     <value>_PNG interlacing:</value>
   </data>
+  <data name="Advanced_PngInterlaceOption_Name" xml:space="preserve">
+    <value>PNG interlacing</value>
+  </data>
   <data name="Advanced_Sizes" xml:space="preserve">
     <value>Sizes</value>
   </data>
   <data name="Advanced_TiffCompressOption" xml:space="preserve">
     <value>_TIFF compression:</value>
+  </data>
+  <data name="Advanced_TiffCompressOption_Name" xml:space="preserve">
+    <value>TIFF compression</value>
   </data>
   <data name="Advanced_Title" xml:space="preserve">
     <value>Settings</value>

--- a/src/modules/imageresizer/ui/Properties/Resources.resx
+++ b/src/modules/imageresizer/ui/Properties/Resources.resx
@@ -184,7 +184,7 @@
     <value>Cancel</value>
   </data>
   <data name="Copyright" xml:space="preserve">
-    <value>© 2019 Brice Lambson. All rights reserved.</value>
+    <value>© 2020 Brice Lambson. All rights reserved.</value>
   </data>
   <data name="ImageResizer" xml:space="preserve">
     <value>Image Resizer</value>
@@ -193,7 +193,7 @@
     <value>(auto)</value>
   </data>
   <data name="Input_Content" xml:space="preserve">
-    <value>_Select a size.</value>
+    <value>_Select a size</value>
   </data>
   <data name="Input_Custom" xml:space="preserve">
     <value>Custom</value>

--- a/src/modules/imageresizer/ui/Properties/Resources.resx
+++ b/src/modules/imageresizer/ui/Properties/Resources.resx
@@ -360,6 +360,9 @@
   <data name="TiffCompressOption_Zip" xml:space="preserve">
     <value>Zip</value>
   </data>
+  <data name="Times_Symbol" xml:space="preserve">
+    <value>Times Symbol</value>
+  </data>
   <data name="Unit" xml:space="preserve">
     <value>Unit</value>
   </data>

--- a/src/modules/imageresizer/ui/Themes/Dark.xaml
+++ b/src/modules/imageresizer/ui/Themes/Dark.xaml
@@ -15,8 +15,8 @@
     <system:String x:Key="Theme.ColorScheme">Accent1</system:String>
     <Color x:Key="Theme.PrimaryAccentColor">Black</Color>
 
-    <SolidColorBrush x:Key="SecondaryBackgroundBrush" Color="#FF3a3a3a" />
-    <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FF333333" />
+    <SolidColorBrush x:Key="SecondaryBackgroundBrush" Color="#FF1f1f1f" />
+    <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FF000000" />
     <SolidColorBrush x:Key="WindowBorderBrush" Color="#FF535353"/>
     <SolidColorBrush x:Key="TitleBarSecondaryForegroundBrush" Color="#FF9a9a9a"/>
 
@@ -25,5 +25,5 @@
 
     <SolidColorBrush x:Key="ColorControlBackgroundBrush" Color="#FF454545"/>
     <SolidColorBrush x:Key="PrimaryForegroundBrush" Color="#FFFFFFFF" />
-    <SolidColorBrush x:Key="SecondaryForegroundBrush" Color="#FF6b6b6b" />
+    <SolidColorBrush x:Key="SecondaryForegroundBrush" Color="#FF999999" />
 </ResourceDictionary>

--- a/src/modules/imageresizer/ui/Themes/Dark.xaml
+++ b/src/modules/imageresizer/ui/Themes/Dark.xaml
@@ -1,0 +1,29 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:markup="clr-namespace:MahApps.Metro.Markup;assembly=MahApps.Metro"
+                    xmlns:markupWithAssembly="clr-namespace:MahApps.Metro.Markup;assembly=MahApps.Metro"
+                    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                    xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
+                    xmlns:system="clr-namespace:System;assembly=System.Runtime"
+                    mc:Ignorable="options">
+
+    <!--  Metadata  -->
+    <system:String x:Key="Theme.Name">Dark.Accent1</system:String>
+    <system:String x:Key="Theme.Origin">PowerToysImageResizer</system:String>
+    <system:String x:Key="Theme.DisplayName">Accent1 (Dark)</system:String>
+    <system:String x:Key="Theme.BaseColorScheme">Dark</system:String>
+    <system:String x:Key="Theme.ColorScheme">Accent1</system:String>
+    <Color x:Key="Theme.PrimaryAccentColor">Black</Color>
+
+    <SolidColorBrush x:Key="SecondaryBackgroundBrush" Color="#FF3a3a3a" />
+    <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FF333333" />
+    <SolidColorBrush x:Key="WindowBorderBrush" Color="#FF535353"/>
+    <SolidColorBrush x:Key="TitleBarSecondaryForegroundBrush" Color="#FF9a9a9a"/>
+
+    <SolidColorBrush x:Key="ListViewPointerOverBrush" Color="#FF242424"/>
+    <SolidColorBrush x:Key="ListViewPressedBrush" Color="#FF333333"/>
+
+    <SolidColorBrush x:Key="ColorControlBackgroundBrush" Color="#FF454545"/>
+    <SolidColorBrush x:Key="PrimaryForegroundBrush" Color="#FFFFFFFF" />
+    <SolidColorBrush x:Key="SecondaryForegroundBrush" Color="#FF6b6b6b" />
+</ResourceDictionary>

--- a/src/modules/imageresizer/ui/Themes/Dark.xaml
+++ b/src/modules/imageresizer/ui/Themes/Dark.xaml
@@ -19,4 +19,5 @@
     <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FF000000" />
     <SolidColorBrush x:Key="PrimaryForegroundBrush" Color="#FFFFFFFF" />
     <SolidColorBrush x:Key="SecondaryForegroundBrush" Color="#FF999999" />
+    <SolidColorBrush x:Key="PrimaryBorderBrush" Color="Transparent"/>
 </ResourceDictionary>

--- a/src/modules/imageresizer/ui/Themes/Dark.xaml
+++ b/src/modules/imageresizer/ui/Themes/Dark.xaml
@@ -15,8 +15,8 @@
     <system:String x:Key="Theme.ColorScheme">Accent1</system:String>
     <Color x:Key="Theme.PrimaryAccentColor">Black</Color>
 
-    <SolidColorBrush x:Key="SecondaryBackgroundBrush" Color="#FF1f1f1f" />
-    <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FF000000" />
+    <SolidColorBrush x:Key="SecondaryBackgroundBrush" Color="#FF3a3a3a" />
+    <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FF333333" />
     <SolidColorBrush x:Key="PrimaryForegroundBrush" Color="#FFFFFFFF" />
     <SolidColorBrush x:Key="SecondaryForegroundBrush" Color="#FF999999" />
     <SolidColorBrush x:Key="PrimaryBorderBrush" Color="Transparent"/>

--- a/src/modules/imageresizer/ui/Themes/Dark.xaml
+++ b/src/modules/imageresizer/ui/Themes/Dark.xaml
@@ -17,13 +17,6 @@
 
     <SolidColorBrush x:Key="SecondaryBackgroundBrush" Color="#FF1f1f1f" />
     <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FF000000" />
-    <SolidColorBrush x:Key="WindowBorderBrush" Color="#FF535353"/>
-    <SolidColorBrush x:Key="TitleBarSecondaryForegroundBrush" Color="#FF9a9a9a"/>
-
-    <SolidColorBrush x:Key="ListViewPointerOverBrush" Color="#FF242424"/>
-    <SolidColorBrush x:Key="ListViewPressedBrush" Color="#FF333333"/>
-
-    <SolidColorBrush x:Key="ColorControlBackgroundBrush" Color="#FF454545"/>
     <SolidColorBrush x:Key="PrimaryForegroundBrush" Color="#FFFFFFFF" />
     <SolidColorBrush x:Key="SecondaryForegroundBrush" Color="#FF999999" />
 </ResourceDictionary>

--- a/src/modules/imageresizer/ui/Themes/Dark.xaml
+++ b/src/modules/imageresizer/ui/Themes/Dark.xaml
@@ -1,11 +1,6 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:markup="clr-namespace:MahApps.Metro.Markup;assembly=MahApps.Metro"
-                    xmlns:markupWithAssembly="clr-namespace:MahApps.Metro.Markup;assembly=MahApps.Metro"
-                    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                    xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
-                    xmlns:system="clr-namespace:System;assembly=System.Runtime"
-                    mc:Ignorable="options">
+                    xmlns:system="clr-namespace:System;assembly=System.Runtime">
 
     <!--  Metadata  -->
     <system:String x:Key="Theme.Name">Dark.Accent1</system:String>

--- a/src/modules/imageresizer/ui/Themes/HighContrast1.xaml
+++ b/src/modules/imageresizer/ui/Themes/HighContrast1.xaml
@@ -19,5 +19,5 @@
     <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FF000000" />
     <SolidColorBrush x:Key="PrimaryForegroundBrush" Color="#FFffff00" />
     <SolidColorBrush x:Key="SecondaryForegroundBrush" Color="#FF00ff00" />
-    <SolidColorBrush x:Key="PrimaryBorderBrush" Color="Transparent"/>
+    <SolidColorBrush x:Key="PrimaryBorderBrush" Color="#FFffff00"/>
 </ResourceDictionary>

--- a/src/modules/imageresizer/ui/Themes/HighContrast1.xaml
+++ b/src/modules/imageresizer/ui/Themes/HighContrast1.xaml
@@ -1,0 +1,29 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:markup="clr-namespace:MahApps.Metro.Markup;assembly=MahApps.Metro"
+                    xmlns:markupWithAssembly="clr-namespace:MahApps.Metro.Markup;assembly=MahApps.Metro"
+                    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                    xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
+                    xmlns:system="clr-namespace:System;assembly=System.Runtime"
+                    mc:Ignorable="options">
+
+    <!--  Metadata  -->
+    <system:String x:Key="Theme.Name">HighContrast.Accent2</system:String>
+    <system:String x:Key="Theme.Origin">PowerToysImageResizer</system:String>
+    <system:String x:Key="Theme.DisplayName">Accent2 (HighContrast)</system:String>
+    <system:String x:Key="Theme.BaseColorScheme">HighContrast</system:String>
+    <system:String x:Key="Theme.ColorScheme">Accent2</system:String>
+    <Color x:Key="Theme.PrimaryAccentColor">White</Color>
+
+    <SolidColorBrush x:Key="SecondaryBackgroundBrush" Color="#FF3a3a3a" />
+    <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FF333333" />
+    <SolidColorBrush x:Key="WindowBorderBrush" Color="#FFffff00"/>
+    <SolidColorBrush x:Key="TitleBarSecondaryForegroundBrush" Color="#FF9a9a9a"/>
+
+    <SolidColorBrush x:Key="ListViewPointerOverBrush" Color="#FF242424"/>
+    <SolidColorBrush x:Key="ListViewPressedBrush" Color="#FF333333"/>
+
+    <SolidColorBrush x:Key="ColorControlBackgroundBrush" Color="#FF454545"/>
+    <SolidColorBrush x:Key="PrimaryForegroundBrush" Color="#FFffff00" />
+    <SolidColorBrush x:Key="SecondaryForegroundBrush" Color="#FF00ff00" />
+</ResourceDictionary>

--- a/src/modules/imageresizer/ui/Themes/HighContrast1.xaml
+++ b/src/modules/imageresizer/ui/Themes/HighContrast1.xaml
@@ -19,4 +19,5 @@
     <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FF000000" />
     <SolidColorBrush x:Key="PrimaryForegroundBrush" Color="#FFffff00" />
     <SolidColorBrush x:Key="SecondaryForegroundBrush" Color="#FF00ff00" />
+    <SolidColorBrush x:Key="PrimaryBorderBrush" Color="Transparent"/>
 </ResourceDictionary>

--- a/src/modules/imageresizer/ui/Themes/HighContrast1.xaml
+++ b/src/modules/imageresizer/ui/Themes/HighContrast1.xaml
@@ -15,15 +15,8 @@
     <system:String x:Key="Theme.ColorScheme">Accent2</system:String>
     <Color x:Key="Theme.PrimaryAccentColor">White</Color>
 
-    <SolidColorBrush x:Key="SecondaryBackgroundBrush" Color="#FF3a3a3a" />
-    <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FF333333" />
-    <SolidColorBrush x:Key="WindowBorderBrush" Color="#FFffff00"/>
-    <SolidColorBrush x:Key="TitleBarSecondaryForegroundBrush" Color="#FF9a9a9a"/>
-
-    <SolidColorBrush x:Key="ListViewPointerOverBrush" Color="#FF242424"/>
-    <SolidColorBrush x:Key="ListViewPressedBrush" Color="#FF333333"/>
-
-    <SolidColorBrush x:Key="ColorControlBackgroundBrush" Color="#FF454545"/>
+    <SolidColorBrush x:Key="SecondaryBackgroundBrush" Color="#FF1f1f1f" />
+    <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FF000000" />
     <SolidColorBrush x:Key="PrimaryForegroundBrush" Color="#FFffff00" />
     <SolidColorBrush x:Key="SecondaryForegroundBrush" Color="#FF00ff00" />
 </ResourceDictionary>

--- a/src/modules/imageresizer/ui/Themes/HighContrast1.xaml
+++ b/src/modules/imageresizer/ui/Themes/HighContrast1.xaml
@@ -1,11 +1,6 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:markup="clr-namespace:MahApps.Metro.Markup;assembly=MahApps.Metro"
-                    xmlns:markupWithAssembly="clr-namespace:MahApps.Metro.Markup;assembly=MahApps.Metro"
-                    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                    xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
-                    xmlns:system="clr-namespace:System;assembly=System.Runtime"
-                    mc:Ignorable="options">
+                    xmlns:system="clr-namespace:System;assembly=System.Runtime">
 
     <!--  Metadata  -->
     <system:String x:Key="Theme.Name">HighContrast.Accent2</system:String>

--- a/src/modules/imageresizer/ui/Themes/HighContrast1.xaml
+++ b/src/modules/imageresizer/ui/Themes/HighContrast1.xaml
@@ -15,8 +15,8 @@
     <system:String x:Key="Theme.ColorScheme">Accent2</system:String>
     <Color x:Key="Theme.PrimaryAccentColor">White</Color>
 
-    <SolidColorBrush x:Key="SecondaryBackgroundBrush" Color="#FF1f1f1f" />
-    <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FF000000" />
+    <SolidColorBrush x:Key="SecondaryBackgroundBrush" Color="#FF3a3a3a" />
+    <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FF333333" />
     <SolidColorBrush x:Key="PrimaryForegroundBrush" Color="#FFffff00" />
     <SolidColorBrush x:Key="SecondaryForegroundBrush" Color="#FF00ff00" />
     <SolidColorBrush x:Key="PrimaryBorderBrush" Color="#FFffff00"/>

--- a/src/modules/imageresizer/ui/Themes/HighContrast2.xaml
+++ b/src/modules/imageresizer/ui/Themes/HighContrast2.xaml
@@ -1,11 +1,6 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:markup="clr-namespace:MahApps.Metro.Markup;assembly=MahApps.Metro"
-                    xmlns:markupWithAssembly="clr-namespace:MahApps.Metro.Markup;assembly=MahApps.Metro"
-                    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                    xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
-                    xmlns:system="clr-namespace:System;assembly=System.Runtime"
-                    mc:Ignorable="options">
+                    xmlns:system="clr-namespace:System;assembly=System.Runtime">
 
     <!--  Metadata  -->
     <system:String x:Key="Theme.Name">HighContrast.Accent3</system:String>

--- a/src/modules/imageresizer/ui/Themes/HighContrast2.xaml
+++ b/src/modules/imageresizer/ui/Themes/HighContrast2.xaml
@@ -20,5 +20,5 @@
     <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FF000000" />
     <SolidColorBrush x:Key="PrimaryForegroundBrush" Color="#FF00ff00" />
     <SolidColorBrush x:Key="SecondaryForegroundBrush" Color="#FFc0c0c0" />
-    <SolidColorBrush x:Key="PrimaryBorderBrush" Color="Transparent"/>
+    <SolidColorBrush x:Key="PrimaryBorderBrush" Color="#FF00ff00"/>
 </ResourceDictionary>

--- a/src/modules/imageresizer/ui/Themes/HighContrast2.xaml
+++ b/src/modules/imageresizer/ui/Themes/HighContrast2.xaml
@@ -1,0 +1,30 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:markup="clr-namespace:MahApps.Metro.Markup;assembly=MahApps.Metro"
+                    xmlns:markupWithAssembly="clr-namespace:MahApps.Metro.Markup;assembly=MahApps.Metro"
+                    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                    xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
+                    xmlns:system="clr-namespace:System;assembly=System.Runtime"
+                    mc:Ignorable="options">
+
+    <!--  Metadata  -->
+    <system:String x:Key="Theme.Name">HighContrast.Accent3</system:String>
+    <system:String x:Key="Theme.Origin">PowerToysImageResizer</system:String>
+    <system:String x:Key="Theme.DisplayName">Accent3 (HighContrast)</system:String>
+    <system:String x:Key="Theme.BaseColorScheme">HighContrast</system:String>
+    <system:String x:Key="Theme.ColorScheme">Accent3</system:String>
+    <Color x:Key="Theme.PrimaryAccentColor">White</Color>
+
+    <SolidColorBrush x:Key="SecondaryBackgroundBrush" Color="#FF3a3a3a" />
+    <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FF333333" />
+    <SolidColorBrush x:Key="WindowBorderBrush" Color="#FF00ff00"/>
+    <SolidColorBrush x:Key="TitleBarSecondaryForegroundBrush" Color="#FF9a9a9a"/>
+
+    <SolidColorBrush x:Key="ListViewPointerOverBrush" Color="#FF242424"/>
+    <SolidColorBrush x:Key="ListViewPressedBrush" Color="#FF333333"/>
+
+    <SolidColorBrush x:Key="ColorControlBackgroundBrush" Color="#FF454545"/>
+
+    <SolidColorBrush x:Key="PrimaryForegroundBrush" Color="#FF00ff00" />
+    <SolidColorBrush x:Key="SecondaryForegroundBrush" Color="#FFc0c0c0" />
+</ResourceDictionary>

--- a/src/modules/imageresizer/ui/Themes/HighContrast2.xaml
+++ b/src/modules/imageresizer/ui/Themes/HighContrast2.xaml
@@ -15,16 +15,9 @@
     <system:String x:Key="Theme.ColorScheme">Accent3</system:String>
     <Color x:Key="Theme.PrimaryAccentColor">White</Color>
 
-    <SolidColorBrush x:Key="SecondaryBackgroundBrush" Color="#FF3a3a3a" />
-    <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FF333333" />
-    <SolidColorBrush x:Key="WindowBorderBrush" Color="#FF00ff00"/>
-    <SolidColorBrush x:Key="TitleBarSecondaryForegroundBrush" Color="#FF9a9a9a"/>
 
-    <SolidColorBrush x:Key="ListViewPointerOverBrush" Color="#FF242424"/>
-    <SolidColorBrush x:Key="ListViewPressedBrush" Color="#FF333333"/>
-
-    <SolidColorBrush x:Key="ColorControlBackgroundBrush" Color="#FF454545"/>
-
+    <SolidColorBrush x:Key="SecondaryBackgroundBrush" Color="#FF1f1f1f" />
+    <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FF000000" />
     <SolidColorBrush x:Key="PrimaryForegroundBrush" Color="#FF00ff00" />
     <SolidColorBrush x:Key="SecondaryForegroundBrush" Color="#FFc0c0c0" />
 </ResourceDictionary>

--- a/src/modules/imageresizer/ui/Themes/HighContrast2.xaml
+++ b/src/modules/imageresizer/ui/Themes/HighContrast2.xaml
@@ -16,8 +16,8 @@
     <Color x:Key="Theme.PrimaryAccentColor">White</Color>
 
 
-    <SolidColorBrush x:Key="SecondaryBackgroundBrush" Color="#FF1f1f1f" />
-    <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FF000000" />
+    <SolidColorBrush x:Key="SecondaryBackgroundBrush" Color="#FF3a3a3a" />
+    <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FF333333" />
     <SolidColorBrush x:Key="PrimaryForegroundBrush" Color="#FF00ff00" />
     <SolidColorBrush x:Key="SecondaryForegroundBrush" Color="#FFc0c0c0" />
     <SolidColorBrush x:Key="PrimaryBorderBrush" Color="#FF00ff00"/>

--- a/src/modules/imageresizer/ui/Themes/HighContrast2.xaml
+++ b/src/modules/imageresizer/ui/Themes/HighContrast2.xaml
@@ -20,4 +20,5 @@
     <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FF000000" />
     <SolidColorBrush x:Key="PrimaryForegroundBrush" Color="#FF00ff00" />
     <SolidColorBrush x:Key="SecondaryForegroundBrush" Color="#FFc0c0c0" />
+    <SolidColorBrush x:Key="PrimaryBorderBrush" Color="Transparent"/>
 </ResourceDictionary>

--- a/src/modules/imageresizer/ui/Themes/HighContrastBlack.xaml
+++ b/src/modules/imageresizer/ui/Themes/HighContrastBlack.xaml
@@ -15,8 +15,8 @@
     <system:String x:Key="Theme.ColorScheme">Accent4</system:String>
     <Color x:Key="Theme.PrimaryAccentColor">White</Color>
 
-    <SolidColorBrush x:Key="SecondaryBackgroundBrush" Color="#FF1f1f1f" />
-    <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FF000000" />
+    <SolidColorBrush x:Key="SecondaryBackgroundBrush" Color="#FF3a3a3a" />
+    <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FF333333" />
     <SolidColorBrush x:Key="PrimaryForegroundBrush" Color="#FFffffff" />
     <SolidColorBrush x:Key="SecondaryForegroundBrush" Color="#FF1aebff" />
     <SolidColorBrush x:Key="PrimaryBorderBrush" Color="White"/>

--- a/src/modules/imageresizer/ui/Themes/HighContrastBlack.xaml
+++ b/src/modules/imageresizer/ui/Themes/HighContrastBlack.xaml
@@ -15,16 +15,8 @@
     <system:String x:Key="Theme.ColorScheme">Accent4</system:String>
     <Color x:Key="Theme.PrimaryAccentColor">White</Color>
 
-    <SolidColorBrush x:Key="SecondaryBackgroundBrush" Color="#FF3a3a3a" />
-    <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FF333333" />
-    <SolidColorBrush x:Key="WindowBorderBrush" Color="#FFffffff"/>
-    <SolidColorBrush x:Key="TitleBarSecondaryForegroundBrush" Color="#FF9a9a9a"/>
-
-    <SolidColorBrush x:Key="ListViewPointerOverBrush" Color="#FF242424"/>
-    <SolidColorBrush x:Key="ListViewPressedBrush" Color="#FF333333"/>
-
-    <SolidColorBrush x:Key="ColorControlBackgroundBrush" Color="#FF454545"/>
-
+    <SolidColorBrush x:Key="SecondaryBackgroundBrush" Color="#FF1f1f1f" />
+    <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FF000000" />
     <SolidColorBrush x:Key="PrimaryForegroundBrush" Color="#FFffffff" />
     <SolidColorBrush x:Key="SecondaryForegroundBrush" Color="#FF1aebff" />
 </ResourceDictionary>

--- a/src/modules/imageresizer/ui/Themes/HighContrastBlack.xaml
+++ b/src/modules/imageresizer/ui/Themes/HighContrastBlack.xaml
@@ -1,0 +1,30 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:markup="clr-namespace:MahApps.Metro.Markup;assembly=MahApps.Metro"
+                    xmlns:markupWithAssembly="clr-namespace:MahApps.Metro.Markup;assembly=MahApps.Metro"
+                    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                    xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
+                    xmlns:system="clr-namespace:System;assembly=System.Runtime"
+                    mc:Ignorable="options">
+
+    <!--  Metadata  -->
+    <system:String x:Key="Theme.Name">HighContrast.Accent4</system:String>
+    <system:String x:Key="Theme.Origin">PowerToysImageResizer</system:String>
+    <system:String x:Key="Theme.DisplayName">Accent4 (HighContrast)</system:String>
+    <system:String x:Key="Theme.BaseColorScheme">HighContrast</system:String>
+    <system:String x:Key="Theme.ColorScheme">Accent4</system:String>
+    <Color x:Key="Theme.PrimaryAccentColor">White</Color>
+
+    <SolidColorBrush x:Key="SecondaryBackgroundBrush" Color="#FF3a3a3a" />
+    <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FF333333" />
+    <SolidColorBrush x:Key="WindowBorderBrush" Color="#FFffffff"/>
+    <SolidColorBrush x:Key="TitleBarSecondaryForegroundBrush" Color="#FF9a9a9a"/>
+
+    <SolidColorBrush x:Key="ListViewPointerOverBrush" Color="#FF242424"/>
+    <SolidColorBrush x:Key="ListViewPressedBrush" Color="#FF333333"/>
+
+    <SolidColorBrush x:Key="ColorControlBackgroundBrush" Color="#FF454545"/>
+
+    <SolidColorBrush x:Key="PrimaryForegroundBrush" Color="#FFffffff" />
+    <SolidColorBrush x:Key="SecondaryForegroundBrush" Color="#FF1aebff" />
+</ResourceDictionary>

--- a/src/modules/imageresizer/ui/Themes/HighContrastBlack.xaml
+++ b/src/modules/imageresizer/ui/Themes/HighContrastBlack.xaml
@@ -19,4 +19,5 @@
     <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FF000000" />
     <SolidColorBrush x:Key="PrimaryForegroundBrush" Color="#FFffffff" />
     <SolidColorBrush x:Key="SecondaryForegroundBrush" Color="#FF1aebff" />
+    <SolidColorBrush x:Key="PrimaryBorderBrush" Color="Transparent"/>
 </ResourceDictionary>

--- a/src/modules/imageresizer/ui/Themes/HighContrastBlack.xaml
+++ b/src/modules/imageresizer/ui/Themes/HighContrastBlack.xaml
@@ -19,5 +19,5 @@
     <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FF000000" />
     <SolidColorBrush x:Key="PrimaryForegroundBrush" Color="#FFffffff" />
     <SolidColorBrush x:Key="SecondaryForegroundBrush" Color="#FF1aebff" />
-    <SolidColorBrush x:Key="PrimaryBorderBrush" Color="Transparent"/>
+    <SolidColorBrush x:Key="PrimaryBorderBrush" Color="White"/>
 </ResourceDictionary>

--- a/src/modules/imageresizer/ui/Themes/HighContrastBlack.xaml
+++ b/src/modules/imageresizer/ui/Themes/HighContrastBlack.xaml
@@ -1,12 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:markup="clr-namespace:MahApps.Metro.Markup;assembly=MahApps.Metro"
-                    xmlns:markupWithAssembly="clr-namespace:MahApps.Metro.Markup;assembly=MahApps.Metro"
-                    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                    xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
-                    xmlns:system="clr-namespace:System;assembly=System.Runtime"
-                    mc:Ignorable="options">
-
+                    xmlns:system="clr-namespace:System;assembly=System.Runtime">
+    
     <!--  Metadata  -->
     <system:String x:Key="Theme.Name">HighContrast.Accent4</system:String>
     <system:String x:Key="Theme.Origin">PowerToysImageResizer</system:String>

--- a/src/modules/imageresizer/ui/Themes/HighContrastWhite.xaml
+++ b/src/modules/imageresizer/ui/Themes/HighContrastWhite.xaml
@@ -1,0 +1,30 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:markup="clr-namespace:MahApps.Metro.Markup;assembly=MahApps.Metro"
+                    xmlns:markupWithAssembly="clr-namespace:MahApps.Metro.Markup;assembly=MahApps.Metro"
+                    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                    xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
+                    xmlns:system="clr-namespace:System;assembly=System.Runtime"
+                    mc:Ignorable="options">
+
+    <!--  Metadata  -->
+    <system:String x:Key="Theme.Name">HighContrast.Accent5</system:String>
+    <system:String x:Key="Theme.Origin">PowerToysImageResizer</system:String>
+    <system:String x:Key="Theme.DisplayName">Accent5 (HighContrast)</system:String>
+    <system:String x:Key="Theme.BaseColorScheme">HighContrast</system:String>
+    <system:String x:Key="Theme.ColorScheme">Accent5</system:String>
+    <Color x:Key="Theme.PrimaryAccentColor">White</Color>
+
+    <SolidColorBrush x:Key="SecondaryBackgroundBrush" Color="#FFededed" />
+    <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FFe5e5e5" />
+    <SolidColorBrush x:Key="WindowBorderBrush" Color="Black"/>
+    <SolidColorBrush x:Key="TitleBarSecondaryForegroundBrush" Color="#FF949494"/>
+
+    <SolidColorBrush x:Key="ListViewPointerOverBrush" Color="#e9e9e9"/>
+    <SolidColorBrush x:Key="ListViewPressedBrush" Color="#FFe5e5e5"/>
+
+    <SolidColorBrush x:Key="ColorControlBackgroundBrush" Color="#FFf9f9f9"/>
+
+    <SolidColorBrush x:Key="PrimaryForegroundBrush" Color="#FF000000" />
+    <SolidColorBrush x:Key="SecondaryForegroundBrush" Color="#FF37006e" />
+</ResourceDictionary>

--- a/src/modules/imageresizer/ui/Themes/HighContrastWhite.xaml
+++ b/src/modules/imageresizer/ui/Themes/HighContrastWhite.xaml
@@ -15,16 +15,8 @@
     <system:String x:Key="Theme.ColorScheme">Accent5</system:String>
     <Color x:Key="Theme.PrimaryAccentColor">White</Color>
 
-    <SolidColorBrush x:Key="SecondaryBackgroundBrush" Color="#FFededed" />
+    <SolidColorBrush x:Key="SecondaryBackgroundBrush" Color="#FFe6e6e6" />
     <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FFFFFFFF" />
-    <SolidColorBrush x:Key="WindowBorderBrush" Color="Black"/>
-    <SolidColorBrush x:Key="TitleBarSecondaryForegroundBrush" Color="#FF949494"/>
-
-    <SolidColorBrush x:Key="ListViewPointerOverBrush" Color="#e9e9e9"/>
-    <SolidColorBrush x:Key="ListViewPressedBrush" Color="#FFe5e5e5"/>
-
-    <SolidColorBrush x:Key="ColorControlBackgroundBrush" Color="#FFf9f9f9"/>
-
     <SolidColorBrush x:Key="PrimaryForegroundBrush" Color="#FF000000" />
-    <SolidColorBrush x:Key="SecondaryForegroundBrush" Color="#FF37006e" />
+    <SolidColorBrush x:Key="SecondaryForegroundBrush" Color="#FF7d7d7d" />
 </ResourceDictionary>

--- a/src/modules/imageresizer/ui/Themes/HighContrastWhite.xaml
+++ b/src/modules/imageresizer/ui/Themes/HighContrastWhite.xaml
@@ -19,5 +19,5 @@
     <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FFFFFFFF" />
     <SolidColorBrush x:Key="PrimaryForegroundBrush" Color="#FF000000" />
     <SolidColorBrush x:Key="SecondaryForegroundBrush" Color="#FF7d7d7d" />
-    <SolidColorBrush x:Key="PrimaryBorderBrush" Color="Transparent"/>
+    <SolidColorBrush x:Key="PrimaryBorderBrush" Color="Black"/>
 </ResourceDictionary>

--- a/src/modules/imageresizer/ui/Themes/HighContrastWhite.xaml
+++ b/src/modules/imageresizer/ui/Themes/HighContrastWhite.xaml
@@ -15,9 +15,9 @@
     <system:String x:Key="Theme.ColorScheme">Accent5</system:String>
     <Color x:Key="Theme.PrimaryAccentColor">White</Color>
 
-    <SolidColorBrush x:Key="SecondaryBackgroundBrush" Color="#FFe6e6e6" />
-    <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FFFFFFFF" />
+    <SolidColorBrush x:Key="SecondaryBackgroundBrush" Color="#FFe5e5e5" />
+    <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FFf7f7f7" />
     <SolidColorBrush x:Key="PrimaryForegroundBrush" Color="#FF000000" />
-    <SolidColorBrush x:Key="SecondaryForegroundBrush" Color="#FF7d7d7d" />
+    <SolidColorBrush x:Key="SecondaryForegroundBrush" Color="#FF676666" />
     <SolidColorBrush x:Key="PrimaryBorderBrush" Color="Black"/>
 </ResourceDictionary>

--- a/src/modules/imageresizer/ui/Themes/HighContrastWhite.xaml
+++ b/src/modules/imageresizer/ui/Themes/HighContrastWhite.xaml
@@ -19,4 +19,5 @@
     <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FFFFFFFF" />
     <SolidColorBrush x:Key="PrimaryForegroundBrush" Color="#FF000000" />
     <SolidColorBrush x:Key="SecondaryForegroundBrush" Color="#FF7d7d7d" />
+    <SolidColorBrush x:Key="PrimaryBorderBrush" Color="Transparent"/>
 </ResourceDictionary>

--- a/src/modules/imageresizer/ui/Themes/HighContrastWhite.xaml
+++ b/src/modules/imageresizer/ui/Themes/HighContrastWhite.xaml
@@ -16,7 +16,7 @@
     <Color x:Key="Theme.PrimaryAccentColor">White</Color>
 
     <SolidColorBrush x:Key="SecondaryBackgroundBrush" Color="#FFededed" />
-    <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FFe5e5e5" />
+    <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FFFFFFFF" />
     <SolidColorBrush x:Key="WindowBorderBrush" Color="Black"/>
     <SolidColorBrush x:Key="TitleBarSecondaryForegroundBrush" Color="#FF949494"/>
 

--- a/src/modules/imageresizer/ui/Themes/HighContrastWhite.xaml
+++ b/src/modules/imageresizer/ui/Themes/HighContrastWhite.xaml
@@ -16,7 +16,7 @@
     <Color x:Key="Theme.PrimaryAccentColor">White</Color>
 
     <SolidColorBrush x:Key="SecondaryBackgroundBrush" Color="#FFe5e5e5" />
-    <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FFf7f7f7" />
+    <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FFf5f5f5" />
     <SolidColorBrush x:Key="PrimaryForegroundBrush" Color="#FF000000" />
     <SolidColorBrush x:Key="SecondaryForegroundBrush" Color="#FF676666" />
     <SolidColorBrush x:Key="PrimaryBorderBrush" Color="Black"/>

--- a/src/modules/imageresizer/ui/Themes/HighContrastWhite.xaml
+++ b/src/modules/imageresizer/ui/Themes/HighContrastWhite.xaml
@@ -1,11 +1,6 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:markup="clr-namespace:MahApps.Metro.Markup;assembly=MahApps.Metro"
-                    xmlns:markupWithAssembly="clr-namespace:MahApps.Metro.Markup;assembly=MahApps.Metro"
-                    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                    xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
-                    xmlns:system="clr-namespace:System;assembly=System.Runtime"
-                    mc:Ignorable="options">
+                    xmlns:system="clr-namespace:System;assembly=System.Runtime">
 
     <!--  Metadata  -->
     <system:String x:Key="Theme.Name">HighContrast.Accent5</system:String>

--- a/src/modules/imageresizer/ui/Themes/Light.xaml
+++ b/src/modules/imageresizer/ui/Themes/Light.xaml
@@ -1,11 +1,6 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:markup="clr-namespace:MahApps.Metro.Markup;assembly=MahApps.Metro"
-                    xmlns:markupWithAssembly="clr-namespace:MahApps.Metro.Markup;assembly=MahApps.Metro"
-                    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                    xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
-                    xmlns:system="clr-namespace:System;assembly=System.Runtime"
-                    mc:Ignorable="options">
+                    xmlns:system="clr-namespace:System;assembly=System.Runtime">
 
     <!--  Metadata  -->
     <system:String x:Key="Theme.Name">Light.Accent1</system:String>

--- a/src/modules/imageresizer/ui/Themes/Light.xaml
+++ b/src/modules/imageresizer/ui/Themes/Light.xaml
@@ -15,9 +15,9 @@
     <system:String x:Key="Theme.ColorScheme">Accent1</system:String>
     <Color x:Key="Theme.PrimaryAccentColor">White</Color>
 
-    <SolidColorBrush x:Key="SecondaryBackgroundBrush" Color="#FFe6e6e6" />
-    <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FFFFFFFF" />
+    <SolidColorBrush x:Key="SecondaryBackgroundBrush" Color="#FFe5e5e5" />
+    <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FFf7f7f7" />
     <SolidColorBrush x:Key="PrimaryForegroundBrush" Color="#FF000000" />
-    <SolidColorBrush x:Key="SecondaryForegroundBrush" Color="#FF7d7d7d" />
+    <SolidColorBrush x:Key="SecondaryForegroundBrush" Color="#FF676666" />
     <SolidColorBrush x:Key="PrimaryBorderBrush" Color="Transparent"/>
 </ResourceDictionary>

--- a/src/modules/imageresizer/ui/Themes/Light.xaml
+++ b/src/modules/imageresizer/ui/Themes/Light.xaml
@@ -16,7 +16,7 @@
     <Color x:Key="Theme.PrimaryAccentColor">White</Color>
 
     <SolidColorBrush x:Key="SecondaryBackgroundBrush" Color="#FFededed" />
-    <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FFe5e5e5" />
+    <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FFFFFFFF" />
     <SolidColorBrush x:Key="WindowBorderBrush" Color="#FFf7f7f7"/>
     <SolidColorBrush x:Key="TitleBarSecondaryForegroundBrush" Color="#FF949494"/>
 

--- a/src/modules/imageresizer/ui/Themes/Light.xaml
+++ b/src/modules/imageresizer/ui/Themes/Light.xaml
@@ -19,4 +19,5 @@
     <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FFFFFFFF" />
     <SolidColorBrush x:Key="PrimaryForegroundBrush" Color="#FF000000" />
     <SolidColorBrush x:Key="SecondaryForegroundBrush" Color="#FF7d7d7d" />
+    <SolidColorBrush x:Key="PrimaryBorderBrush" Color="Transparent"/>
 </ResourceDictionary>

--- a/src/modules/imageresizer/ui/Themes/Light.xaml
+++ b/src/modules/imageresizer/ui/Themes/Light.xaml
@@ -15,16 +15,8 @@
     <system:String x:Key="Theme.ColorScheme">Accent1</system:String>
     <Color x:Key="Theme.PrimaryAccentColor">White</Color>
 
-    <SolidColorBrush x:Key="SecondaryBackgroundBrush" Color="#FFededed" />
+    <SolidColorBrush x:Key="SecondaryBackgroundBrush" Color="#FFe6e6e6" />
     <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FFFFFFFF" />
-    <SolidColorBrush x:Key="WindowBorderBrush" Color="#FFf7f7f7"/>
-    <SolidColorBrush x:Key="TitleBarSecondaryForegroundBrush" Color="#FF949494"/>
-
-    <SolidColorBrush x:Key="ListViewPointerOverBrush" Color="#e9e9e9"/>
-    <SolidColorBrush x:Key="ListViewPressedBrush" Color="#FFe5e5e5"/>
-
-    <SolidColorBrush x:Key="ColorControlBackgroundBrush" Color="#FFf9f9f9"/>
-
     <SolidColorBrush x:Key="PrimaryForegroundBrush" Color="#FF000000" />
-    <SolidColorBrush x:Key="SecondaryForegroundBrush" Color="#FF949494" />
+    <SolidColorBrush x:Key="SecondaryForegroundBrush" Color="#FF7d7d7d" />
 </ResourceDictionary>

--- a/src/modules/imageresizer/ui/Themes/Light.xaml
+++ b/src/modules/imageresizer/ui/Themes/Light.xaml
@@ -16,7 +16,7 @@
     <Color x:Key="Theme.PrimaryAccentColor">White</Color>
 
     <SolidColorBrush x:Key="SecondaryBackgroundBrush" Color="#FFe5e5e5" />
-    <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FFf7f7f7" />
+    <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FFf5f5f5" />
     <SolidColorBrush x:Key="PrimaryForegroundBrush" Color="#FF000000" />
     <SolidColorBrush x:Key="SecondaryForegroundBrush" Color="#FF676666" />
     <SolidColorBrush x:Key="PrimaryBorderBrush" Color="Transparent"/>

--- a/src/modules/imageresizer/ui/Themes/Light.xaml
+++ b/src/modules/imageresizer/ui/Themes/Light.xaml
@@ -1,0 +1,30 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:markup="clr-namespace:MahApps.Metro.Markup;assembly=MahApps.Metro"
+                    xmlns:markupWithAssembly="clr-namespace:MahApps.Metro.Markup;assembly=MahApps.Metro"
+                    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                    xmlns:options="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
+                    xmlns:system="clr-namespace:System;assembly=System.Runtime"
+                    mc:Ignorable="options">
+
+    <!--  Metadata  -->
+    <system:String x:Key="Theme.Name">Light.Accent1</system:String>
+    <system:String x:Key="Theme.Origin">PowerToysImageResizer</system:String>
+    <system:String x:Key="Theme.DisplayName">Accent1 (Light)</system:String>
+    <system:String x:Key="Theme.BaseColorScheme">Light</system:String>
+    <system:String x:Key="Theme.ColorScheme">Accent1</system:String>
+    <Color x:Key="Theme.PrimaryAccentColor">White</Color>
+
+    <SolidColorBrush x:Key="SecondaryBackgroundBrush" Color="#FFededed" />
+    <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FFe5e5e5" />
+    <SolidColorBrush x:Key="WindowBorderBrush" Color="#FFf7f7f7"/>
+    <SolidColorBrush x:Key="TitleBarSecondaryForegroundBrush" Color="#FF949494"/>
+
+    <SolidColorBrush x:Key="ListViewPointerOverBrush" Color="#e9e9e9"/>
+    <SolidColorBrush x:Key="ListViewPressedBrush" Color="#FFe5e5e5"/>
+
+    <SolidColorBrush x:Key="ColorControlBackgroundBrush" Color="#FFf9f9f9"/>
+
+    <SolidColorBrush x:Key="PrimaryForegroundBrush" Color="#FF000000" />
+    <SolidColorBrush x:Key="SecondaryForegroundBrush" Color="#FF949494" />
+</ResourceDictionary>

--- a/src/modules/imageresizer/ui/Utilities/CustomLibraryThemeProvider.cs
+++ b/src/modules/imageresizer/ui/Utilities/CustomLibraryThemeProvider.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using ControlzEx.Theming;
+
+namespace ImageResizer.Utilities
+{
+    public class CustomLibraryThemeProvider : LibraryThemeProvider
+    {
+        public static readonly CustomLibraryThemeProvider DefaultInstance = new CustomLibraryThemeProvider();
+
+        public CustomLibraryThemeProvider()
+            : base(true)
+        {
+        }
+
+        /// <inheritdoc />
+        public override void FillColorSchemeValues(Dictionary<string, string> values, RuntimeThemeColorValues colorValues)
+        {
+        }
+    }
+}

--- a/src/modules/imageresizer/ui/Utilities/ThemeManager.cs
+++ b/src/modules/imageresizer/ui/Utilities/ThemeManager.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
 using System;
 using System.Linq;
 using System.Windows;
 using ControlzEx.Theming;
-using MahApps.Metro.Theming;
 using Microsoft.Win32;
 
 namespace ImageResizer.Utilities
@@ -39,27 +39,27 @@ namespace ImageResizer.Utilities
             ControlzEx.Theming.ThemeManager.Current.AddLibraryTheme(
                 new LibraryTheme(
                     highContrastOneThemeUri,
-                    MahAppsLibraryThemeProvider.DefaultInstance));
+                    CustomLibraryThemeProvider.DefaultInstance));
             ControlzEx.Theming.ThemeManager.Current.AddLibraryTheme(
                 new LibraryTheme(
                     highContrastTwoThemeUri,
-                    MahAppsLibraryThemeProvider.DefaultInstance));
+                    CustomLibraryThemeProvider.DefaultInstance));
             ControlzEx.Theming.ThemeManager.Current.AddLibraryTheme(
                 new LibraryTheme(
                     highContrastBlackThemeUri,
-                    MahAppsLibraryThemeProvider.DefaultInstance));
+                    CustomLibraryThemeProvider.DefaultInstance));
             ControlzEx.Theming.ThemeManager.Current.AddLibraryTheme(
                 new LibraryTheme(
                     highContrastWhiteThemeUri,
-                    MahAppsLibraryThemeProvider.DefaultInstance));
+                    CustomLibraryThemeProvider.DefaultInstance));
             ControlzEx.Theming.ThemeManager.Current.AddLibraryTheme(
                 new LibraryTheme(
                     lightThemeUri,
-                    MahAppsLibraryThemeProvider.DefaultInstance));
+                    CustomLibraryThemeProvider.DefaultInstance));
             ControlzEx.Theming.ThemeManager.Current.AddLibraryTheme(
                 new LibraryTheme(
                     darkThemeUri,
-                    MahAppsLibraryThemeProvider.DefaultInstance));
+                    CustomLibraryThemeProvider.DefaultInstance));
 
             ResetTheme();
             ControlzEx.Theming.ThemeManager.Current.ThemeSyncMode = ThemeSyncMode.SyncWithAppMode;

--- a/src/modules/imageresizer/ui/Utilities/ThemeManager.cs
+++ b/src/modules/imageresizer/ui/Utilities/ThemeManager.cs
@@ -1,0 +1,201 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+using System.Linq;
+using System.Windows;
+using ControlzEx.Theming;
+using MahApps.Metro.Theming;
+using Microsoft.Win32;
+
+namespace ImageResizer.Utilities
+{
+    public class ThemeManager : IDisposable
+    {
+        private readonly Application _app;
+        private const string LightTheme = "Light.Accent1";
+        private const string DarkTheme = "Dark.Accent1";
+        private const string HighContrastOneTheme = "HighContrast.Accent2";
+        private const string HighContrastTwoTheme = "HighContrast.Accent3";
+        private const string HighContrastBlackTheme = "HighContrast.Accent4";
+        private const string HighContrastWhiteTheme = "HighContrast.Accent5";
+
+        private Theme currentTheme;
+        private bool _disposed;
+
+        public event ThemeChangedHandler ThemeChanged;
+
+        public ThemeManager(Application app)
+        {
+            _app = app;
+
+            Uri highContrastOneThemeUri = new Uri("pack://application:,,,/Themes/HighContrast1.xaml");
+            Uri highContrastTwoThemeUri = new Uri("pack://application:,,,/Themes/HighContrast2.xaml");
+            Uri highContrastBlackThemeUri = new Uri("pack://application:,,,/Themes/HighContrastWhite.xaml");
+            Uri highContrastWhiteThemeUri = new Uri("pack://application:,,,/Themes/HighContrastBlack.xaml");
+            Uri lightThemeUri = new Uri("pack://application:,,,/Themes/Light.xaml");
+            Uri darkThemeUri = new Uri("pack://application:,,,/Themes/Dark.xaml");
+
+            ControlzEx.Theming.ThemeManager.Current.AddLibraryTheme(
+                new LibraryTheme(
+                    highContrastOneThemeUri,
+                    MahAppsLibraryThemeProvider.DefaultInstance));
+            ControlzEx.Theming.ThemeManager.Current.AddLibraryTheme(
+                new LibraryTheme(
+                    highContrastTwoThemeUri,
+                    MahAppsLibraryThemeProvider.DefaultInstance));
+            ControlzEx.Theming.ThemeManager.Current.AddLibraryTheme(
+                new LibraryTheme(
+                    highContrastBlackThemeUri,
+                    MahAppsLibraryThemeProvider.DefaultInstance));
+            ControlzEx.Theming.ThemeManager.Current.AddLibraryTheme(
+                new LibraryTheme(
+                    highContrastWhiteThemeUri,
+                    MahAppsLibraryThemeProvider.DefaultInstance));
+            ControlzEx.Theming.ThemeManager.Current.AddLibraryTheme(
+                new LibraryTheme(
+                    lightThemeUri,
+                    MahAppsLibraryThemeProvider.DefaultInstance));
+            ControlzEx.Theming.ThemeManager.Current.AddLibraryTheme(
+                new LibraryTheme(
+                    darkThemeUri,
+                    MahAppsLibraryThemeProvider.DefaultInstance));
+
+            ResetTheme();
+            ControlzEx.Theming.ThemeManager.Current.ThemeSyncMode = ThemeSyncMode.SyncWithAppMode;
+            ControlzEx.Theming.ThemeManager.Current.ThemeChanged += Current_ThemeChanged;
+            SystemParameters.StaticPropertyChanged += SystemParameters_StaticPropertyChanged;
+        }
+
+        private void SystemParameters_StaticPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(SystemParameters.HighContrast))
+            {
+                ResetTheme();
+            }
+        }
+
+        public Theme GetCurrentTheme()
+        {
+            return currentTheme;
+        }
+
+        private static Theme GetHighContrastBaseType()
+        {
+            string registryKey = @"HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Themes";
+            string theme = (string)Registry.GetValue(registryKey, "CurrentTheme", string.Empty);
+            theme = theme.Split('\\').Last().Split('.').First().ToString();
+
+            switch (theme)
+            {
+                case "hc1":
+                    return Theme.HighContrastOne;
+                case "hc2":
+                    return Theme.HighContrastTwo;
+                case "hcwhite":
+                    return Theme.HighContrastWhite;
+                case "hcblack":
+                    return Theme.HighContrastBlack;
+                default:
+                    return Theme.None;
+            }
+        }
+
+        private void ResetTheme()
+        {
+            if (SystemParameters.HighContrast)
+            {
+                Theme highContrastBaseType = GetHighContrastBaseType();
+                ChangeTheme(highContrastBaseType);
+            }
+            else
+            {
+                string baseColor = WindowsThemeHelper.GetWindowsBaseColor();
+                ChangeTheme((Theme)Enum.Parse(typeof(Theme), baseColor));
+            }
+        }
+
+        private void ChangeTheme(Theme theme)
+        {
+            Theme oldTheme = currentTheme;
+            if (theme == currentTheme)
+            {
+                return;
+            }
+
+            if (theme == Theme.HighContrastOne)
+            {
+                ControlzEx.Theming.ThemeManager.Current.ChangeTheme(_app, HighContrastOneTheme);
+                currentTheme = Theme.HighContrastOne;
+            }
+            else if (theme == Theme.HighContrastTwo)
+            {
+                ControlzEx.Theming.ThemeManager.Current.ChangeTheme(_app, HighContrastTwoTheme);
+                currentTheme = Theme.HighContrastTwo;
+            }
+            else if (theme == Theme.HighContrastWhite)
+            {
+                ControlzEx.Theming.ThemeManager.Current.ChangeTheme(_app, HighContrastWhiteTheme);
+                currentTheme = Theme.HighContrastWhite;
+            }
+            else if (theme == Theme.HighContrastBlack)
+            {
+                ControlzEx.Theming.ThemeManager.Current.ChangeTheme(_app, HighContrastBlackTheme);
+                currentTheme = Theme.HighContrastBlack;
+            }
+            else if (theme == Theme.Light)
+            {
+                ControlzEx.Theming.ThemeManager.Current.ChangeTheme(_app, LightTheme);
+                currentTheme = Theme.Light;
+            }
+            else if (theme == Theme.Dark)
+            {
+                ControlzEx.Theming.ThemeManager.Current.ChangeTheme(_app, DarkTheme);
+                currentTheme = Theme.Dark;
+            }
+            else
+            {
+                currentTheme = Theme.None;
+            }
+
+            ThemeChanged?.Invoke(oldTheme, currentTheme);
+        }
+
+        private void Current_ThemeChanged(object sender, ThemeChangedEventArgs e)
+        {
+            ResetTheme();
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    ControlzEx.Theming.ThemeManager.Current.ThemeChanged -= Current_ThemeChanged;
+                    SystemParameters.StaticPropertyChanged -= SystemParameters_StaticPropertyChanged;
+                    _disposed = true;
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+    }
+
+    public delegate void ThemeChangedHandler(Theme oldTheme, Theme newTheme);
+
+    public enum Theme
+    {
+        None,
+        Light,
+        Dark,
+        HighContrastOne,
+        HighContrastTwo,
+        HighContrastBlack,
+        HighContrastWhite,
+    }
+}

--- a/src/modules/imageresizer/ui/ViewModels/ProgressViewModel.cs
+++ b/src/modules/imageresizer/ui/ViewModels/ProgressViewModel.cs
@@ -81,7 +81,7 @@ namespace ImageResizer.ViewModels
             }
             else
             {
-                _mainView.Close();
+               // _mainView.Close();
             }
         }
 

--- a/src/modules/imageresizer/ui/ViewModels/ProgressViewModel.cs
+++ b/src/modules/imageresizer/ui/ViewModels/ProgressViewModel.cs
@@ -81,7 +81,7 @@ namespace ImageResizer.ViewModels
             }
             else
             {
-               // _mainView.Close();
+                _mainView.Close();
             }
         }
 

--- a/src/modules/imageresizer/ui/Views/AdvancedWindow.xaml
+++ b/src/modules/imageresizer/ui/Views/AdvancedWindow.xaml
@@ -65,6 +65,7 @@
                                              Text="{Binding Name}"/>
                                     <ComboBox Grid.Column="1"
                                               Margin="8,0,0,0"
+                                              Width="90"
                                               ItemsSource="{Binding Source={StaticResource ResizeFitValues}}"
                                               AutomationProperties.Name="{x:Static p:Resources.Resize_Type}"
                                               SelectedItem="{Binding Fit}">
@@ -91,16 +92,20 @@
                                         </TextBox.Text>
                                     </TextBox>
                                     <TextBlock Grid.Column="3"
-                                               Margin="8,0,0,0"
+                                               Foreground="{DynamicResource PrimaryForegroundBrush}"
+                                               Name="Times_Symbol"
+                                               AutomationProperties.Name="{x:Static p:Resources.Times_Symbol}"
                                                VerticalAlignment="Center"
-                                               Visibility="{Binding ShowHeight,Converter={StaticResource BoolValueConverter}}">
-                                    </TextBlock>
+                                               Text="&#xE711;"
+                                               FontFamily="Segoe MDL2 Assets"
+                                               Width="25"
+                                               TextAlignment="Center"
+                                               Visibility="{Binding ShowHeight,Converter={StaticResource BoolValueConverter}}"/>
                                     <TextBox Grid.Column="4"
                                              Width="56"
                                              MaxWidth="56"
                                              TextWrapping="Wrap"
                                              AutomationProperties.Name="{x:Static p:Resources.Height}"
-                                             Margin="8,0,0,0"
                                              Visibility="{Binding ShowHeight,Converter={StaticResource BoolValueConverter}}">
                                         <TextBox.Text>
                                             <Binding Converter="{StaticResource AutoDoubleConverter}"
@@ -114,6 +119,7 @@
                                     </TextBox>
                                     <ComboBox Grid.Column="5"
                                               Margin="8,0,0,0"
+                                              MinWidth="120"
                                               ItemsSource="{Binding Source={StaticResource ResizeUnitValues}}"
                                               AutomationProperties.Name="{x:Static p:Resources.Unit}"
                                               SelectedItem="{Binding Unit}">
@@ -159,6 +165,7 @@
                            Target="{Binding ElementName=_fallbackEncoderComboBox}"/>
                     <ComboBox Grid.Column="1"
                               HorizontalAlignment="Left"
+                              MinWidth="148"
                               ItemsSource="{Binding Encoders}"
                               AutomationProperties.Name="{x:Static p:Resources.Advanced_FallbackEncoder_Name}"
                               Name="_fallbackEncoderComboBox"
@@ -177,6 +184,7 @@
                     <TextBox Grid.Row="1"
                              Grid.Column="1"
                              Width="56"
+                             MinWidth="148"
                              TextWrapping="Wrap"
                              AutomationProperties.Name="{x:Static p:Resources.Advanced_JpegQualityLevel_Name}"
                              Margin="0,8,0,0"
@@ -191,6 +199,7 @@
                     <ComboBox Grid.Row="2"
                               Grid.Column="1"
                               Margin="0,8,0,0"
+                              MinWidth="148"
                               HorizontalAlignment="Left"
                               AutomationProperties.Name="{x:Static p:Resources.Advanced_PngInterlaceOption_Name}"
                               ItemsSource="{Binding Source={StaticResource PngInterlaceOptionValues}}"
@@ -209,6 +218,7 @@
                            Target="{Binding ElementName=_tiffCompressComboBox}"/>
                     <ComboBox Grid.Row="3"
                               Grid.Column="1"
+                              MinWidth="148"
                               Margin="0,8,0,0"
                               HorizontalAlignment="Left"
                               AutomationProperties.Name="{x:Static p:Resources.Advanced_TiffCompressOption_Name}"
@@ -257,7 +267,9 @@
                                Target="{Binding ElementName=fileNameTextBox}"/>
                         <TextBox Grid.Column="1"
                                  Height="23"
+                                MinWidth="240"
                                  TabIndex="0"
+                                 HorizontalAlignment="Left"
                                  TextWrapping="Wrap"
                                  Name="fileNameTextBox"
                                  AutomationProperties.Name="{x:Static p:Resources.Advanced_FileName_Name}"

--- a/src/modules/imageresizer/ui/Views/AdvancedWindow.xaml
+++ b/src/modules/imageresizer/ui/Views/AdvancedWindow.xaml
@@ -61,6 +61,7 @@
                                     <TextBox Width="96"
                                              MaxWidth="96"
                                              TextWrapping="Wrap"
+                                             AutomationProperties.Name="{Binding Name}"
                                              Text="{Binding Name}"/>
                                     <ComboBox Grid.Column="1"
                                               Margin="8,0,0,0"
@@ -128,6 +129,7 @@
                                             Grid.Column="6"
                                             Margin="8,0,0,0"
                                             VerticalAlignment="Center"
+                                            AutomationProperties.Name="{x:Static p:Resources.Advanced_DeleteSize}"
                                             ToolTip="{x:Static p:Resources.Advanced_DeleteSize}" 
                                             Command="{Binding DataContext.RemoveSizeCommand,ElementName=_this}"
                                             CommandParameter="{Binding}" />
@@ -158,6 +160,7 @@
                     <ComboBox Grid.Column="1"
                               HorizontalAlignment="Left"
                               ItemsSource="{Binding Encoders}"
+                              AutomationProperties.Name="{x:Static p:Resources.Advanced_FallbackEncoder_Name}"
                               Name="_fallbackEncoderComboBox"
                               SelectedItem="{Binding Settings.FallbackEncoder}">
                         <ComboBox.ItemTemplate>
@@ -175,6 +178,7 @@
                              Grid.Column="1"
                              Width="56"
                              TextWrapping="Wrap"
+                             AutomationProperties.Name="{x:Static p:Resources.Advanced_JpegQualityLevel_Name}"
                              Margin="0,8,0,0"
                              HorizontalAlignment="Left"
                              Name="_jpegQualityLevelTextBox"
@@ -188,6 +192,7 @@
                               Grid.Column="1"
                               Margin="0,8,0,0"
                               HorizontalAlignment="Left"
+                              AutomationProperties.Name="{x:Static p:Resources.Advanced_PngInterlaceOption_Name}"
                               ItemsSource="{Binding Source={StaticResource PngInterlaceOptionValues}}"
                               Name="_pngInterlaceComboBox"
                               SelectedItem="{Binding Settings.PngInterlaceOption}">
@@ -206,6 +211,7 @@
                               Grid.Column="1"
                               Margin="0,8,0,0"
                               HorizontalAlignment="Left"
+                              AutomationProperties.Name="{x:Static p:Resources.Advanced_TiffCompressOption_Name}"
                               ItemsSource="{Binding Source={StaticResource TiffCompressOptionValues}}"
                               Name="_tiffCompressComboBox"
                               SelectedItem="{Binding Settings.TiffCompressOption}">
@@ -254,7 +260,7 @@
                                  TabIndex="0"
                                  TextWrapping="Wrap"
                                  Name="fileNameTextBox"
-                                 AutomationProperties.Name="{x:Static p:Resources.Advanced_FileName_Tooltip}"
+                                 AutomationProperties.Name="{x:Static p:Resources.Advanced_FileName_Name}"
                                  Text="{Binding Settings.FileName}"/>
                     </Grid>
                     <Separator Margin="0,12,0,0"/>

--- a/src/modules/imageresizer/ui/Views/AdvancedWindow.xaml
+++ b/src/modules/imageresizer/ui/Views/AdvancedWindow.xaml
@@ -41,11 +41,11 @@
             <RowDefinition/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
-        <TabControl>
+        <TabControl Style="{StaticResource TabControlPivotStyle}">
             <TabItem Header="{x:Static p:Resources.Advanced_Sizes}">
-                <StackPanel Margin="12">
+                <StackPanel Margin="0,12,0,12">
                     <!-- TODO: Allow these to be drag-and-drop reordered (issue #15) -->
-                    <ItemsControl Grid.IsSharedSizeScope="True" ItemsSource="{Binding Settings.Sizes}">
+                    <ItemsControl Grid.IsSharedSizeScope="True" TabIndex="0" ItemsSource="{Binding Settings.Sizes}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate DataType="m:ResizeSize">
                                 <Grid Margin="0,0,0,8">
@@ -131,15 +131,13 @@
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
-                    <TextBlock>
-                        <local:AccessibleHyperlink ControlType="Button" Command="{Binding AddSizeCommand}">
-                            <Run Text="{x:Static p:Resources.Advanced_CreateSize}"/>
-                        </local:AccessibleHyperlink>
-                    </TextBlock>
+                    <Button Margin="0,12,0,0"
+                            Command="{Binding AddSizeCommand}"
+                            Content="{x:Static p:Resources.Advanced_CreateSize}"/>
                 </StackPanel>
             </TabItem>
             <TabItem Header="{x:Static p:Resources.Advanced_Encoding}">
-                <Grid Margin="12" VerticalAlignment="Top">
+                <Grid Margin="0,12,0,12" VerticalAlignment="Top">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto"/>
                         <ColumnDefinition/>
@@ -216,7 +214,7 @@
                 </Grid>
             </TabItem>
             <TabItem Header="{x:Static p:Resources.Advanced_File}">
-                <StackPanel Margin="12,8">
+                <StackPanel Margin="0,12,0,12">
                     <TextBlock Text="{x:Static p:Resources.Advanced_FileNameTokens}"/>
                     <TextBlock Margin="0,8,0,0">
                         <Run Text="%1 -"/>
@@ -243,14 +241,16 @@
                             <ColumnDefinition/>
                         </Grid.ColumnDefinitions>
                         <Label HorizontalAlignment="Left"
+                               x:Name="fileNameTextBoxLabel"
                                Content="{x:Static p:Resources.Advanced_FileName}"
                                Padding="0,4,4,0"
-                               Target="{Binding ElementName=_fileNameTextBox}"/>
+                               Target="{Binding ElementName=fileNameTextBox}"/>
                         <TextBox Grid.Column="1"
                                  Height="23"
-                                 TabIndex="1"
+                                 TabIndex="0"
                                  TextWrapping="Wrap"
-                                 Name="_fileNameTextBox"
+                                 Name="fileNameTextBox"
+                                 AutomationProperties.Name="{x:Static p:Resources.Advanced_FileName_Tooltip}"
                                  Text="{Binding Settings.FileName}"/>
                     </Grid>
                     <Separator Margin="0,12,0,0"/>
@@ -269,12 +269,16 @@
                     HorizontalAlignment="Right"
                     Orientation="Horizontal">
                 <Button MinWidth="76"
-                    Click="HandleAcceptClick"
-                    Style="{StaticResource AccentButtonStyle}"
-                    Content="{x:Static p:Resources.OK}"
-                    IsDefault="True"/>
+                        TabIndex="100"
+                        Click="HandleAcceptClick"
+                        Style="{StaticResource AccentButtonStyle}"
+                        Content="{x:Static p:Resources.OK}"
+                        AutomationProperties.Name="{x:Static p:Resources.OK_Tooltip}"
+                        IsDefault="True"/>
+
                 <Button MinWidth="76"
                     Margin="8,0,0,0"
+                    TabIndex="101"
                     Content="{x:Static p:Resources.Cancel}"
                     IsCancel="True"/>
             </StackPanel>

--- a/src/modules/imageresizer/ui/Views/AdvancedWindow.xaml
+++ b/src/modules/imageresizer/ui/Views/AdvancedWindow.xaml
@@ -5,9 +5,12 @@
         xmlns:m="clr-namespace:ImageResizer.Models"
         xmlns:p="clr-namespace:ImageResizer.Properties"
         xmlns:sys="clr-namespace:System;assembly=mscorlib"
+        xmlns:ui="http://schemas.modernwpf.com/2019"
         MinWidth="390"
         MinHeight="340"
-        Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"
+        ui:WindowHelper.UseModernWindowStyle="True"
+        ui:TitleBar.IsIconVisible="True"
+        Background="{DynamicResource PrimaryBackgroundBrush}"
         Name="_this"
         ResizeMode="NoResize"
         SizeToContent="WidthAndHeight"
@@ -33,19 +36,19 @@
         <local:ContainerFormatConverter x:Key="ContainerFormatConverter"/>
     </Window.Resources>
 
-    <Grid Margin="11">
+    <Grid Margin="0">
         <Grid.RowDefinitions>
             <RowDefinition/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <TabControl>
             <TabItem Header="{x:Static p:Resources.Advanced_Sizes}">
-                <StackPanel Margin="11">
+                <StackPanel Margin="12">
                     <!-- TODO: Allow these to be drag-and-drop reordered (issue #15) -->
                     <ItemsControl Grid.IsSharedSizeScope="True" ItemsSource="{Binding Settings.Sizes}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate DataType="m:ResizeSize">
-                                <Grid Margin="0,0,0,7">
+                                <Grid Margin="0,0,0,8">
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition SharedSizeGroup="0"/>
                                         <ColumnDefinition SharedSizeGroup="1"/>
@@ -55,10 +58,12 @@
                                         <ColumnDefinition SharedSizeGroup="5"/>
                                         <ColumnDefinition SharedSizeGroup="6"/>
                                     </Grid.ColumnDefinitions>
-                                    <TextBox Width="66" Text="{Binding Name}"/>
+                                    <TextBox Width="96"
+                                             MaxWidth="96"
+                                             TextWrapping="Wrap"
+                                             Text="{Binding Name}"/>
                                     <ComboBox Grid.Column="1"
-                                              Height="23"
-                                              Margin="5,0,0,0"
+                                              Margin="8,0,0,0"
                                               ItemsSource="{Binding Source={StaticResource ResizeFitValues}}"
                                               SelectedItem="{Binding Fit}">
                                         <ComboBox.ItemTemplate>
@@ -68,9 +73,10 @@
                                         </ComboBox.ItemTemplate>
                                     </ComboBox>
                                     <TextBox Grid.Column="2"
-                                             Width="43"
-                                             Height="23"
-                                             Margin="7,0,0,0">
+                                             Width="56"
+                                             MaxWidth="56"
+                                             TextWrapping="Wrap"
+                                             Margin="8,0,0,0">
                                         <TextBox.Text>
                                             <Binding Converter="{StaticResource AutoDoubleConverter}"
                                                      Path="Width"
@@ -82,15 +88,15 @@
                                         </TextBox.Text>
                                     </TextBox>
                                     <TextBlock Grid.Column="3"
-                                               Margin="5,0,0,0"
+                                               Margin="8,0,0,0"
                                                VerticalAlignment="Center"
                                                Visibility="{Binding ShowHeight,Converter={StaticResource BoolValueConverter}}">
-                                        ×
                                     </TextBlock>
                                     <TextBox Grid.Column="4"
-                                             Width="43"
-                                             Height="23"
-                                             Margin="5,0,0,0"
+                                             Width="56"
+                                             MaxWidth="56"
+                                             TextWrapping="Wrap"
+                                             Margin="8,0,0,0"
                                              Visibility="{Binding ShowHeight,Converter={StaticResource BoolValueConverter}}">
                                         <TextBox.Text>
                                             <Binding Converter="{StaticResource AutoDoubleConverter}"
@@ -103,8 +109,7 @@
                                         </TextBox.Text>
                                     </TextBox>
                                     <ComboBox Grid.Column="5"
-                                              Height="23"
-                                              Margin="7,0,0,0"
+                                              Margin="8,0,0,0"
                                               ItemsSource="{Binding Source={StaticResource ResizeUnitValues}}"
                                               SelectedItem="{Binding Unit}">
                                         <ComboBox.ItemTemplate>
@@ -113,11 +118,15 @@
                                             </DataTemplate>
                                         </ComboBox.ItemTemplate>
                                     </ComboBox>
-                                    <TextBlock Grid.Column="6" Margin="5,0,0,0" VerticalAlignment="Center">
-                                        <local:AccessibleHyperlink ControlType="Button"  Command="{Binding DataContext.RemoveSizeCommand,ElementName=_this}" CommandParameter="{Binding}">
-                                            <Run Text="{x:Static p:Resources.Advanced_DeleteSize}"/>
-                                        </local:AccessibleHyperlink>
-                                    </TextBlock>
+                                    <Button Content="&#xE107;"
+                                            FontFamily="Segoe MDL2 Assets"
+                                            Background="Transparent"
+                                            Grid.Column="6"
+                                            Margin="8,0,0,0"
+                                            VerticalAlignment="Center"
+                                            ToolTip="{x:Static p:Resources.Advanced_DeleteSize}" 
+                                            Command="{Binding DataContext.RemoveSizeCommand,ElementName=_this}"
+                                            CommandParameter="{Binding}" />
                                 </Grid>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
@@ -130,7 +139,7 @@
                 </StackPanel>
             </TabItem>
             <TabItem Header="{x:Static p:Resources.Advanced_Encoding}">
-                <Grid Margin="11" VerticalAlignment="Top">
+                <Grid Margin="12" VerticalAlignment="Top">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto"/>
                         <ColumnDefinition/>
@@ -142,10 +151,9 @@
                         <RowDefinition/>
                     </Grid.RowDefinitions>
                     <Label Content="{x:Static p:Resources.Advanced_FallbackEncoder}"
-                           Padding="0,5,5,0"
+                           Padding="0,8,8,0"
                            Target="{Binding ElementName=_fallbackEncoderComboBox}"/>
                     <ComboBox Grid.Column="1"
-                              Height="23"
                               HorizontalAlignment="Left"
                               ItemsSource="{Binding Encoders}"
                               Name="_fallbackEncoderComboBox"
@@ -157,27 +165,26 @@
                         </ComboBox.ItemTemplate>
                     </ComboBox>
                     <Label Grid.Row="1"
-                           Margin="0,7,0,0"
+                           Margin="0,8,0,0"
                            Content="{x:Static p:Resources.Advanced_JpegQualityLevel}"
-                           Padding="0,5,5,0"
+                           Padding="0,8,8,0"
                            Target="{Binding ElementName=_jpegQualityLevelTextBox}"/>
                     <TextBox Grid.Row="1"
                              Grid.Column="1"
-                             Width="34"
-                             Height="23"
-                             Margin="0,7,0,0"
+                             Width="56"
+                             TextWrapping="Wrap"
+                             Margin="0,8,0,0"
                              HorizontalAlignment="Left"
                              Name="_jpegQualityLevelTextBox"
                              Text="{Binding Settings.JpegQualityLevel,ValidatesOnExceptions=True,ValidatesOnDataErrors=True}"/>
                     <Label Grid.Row="2"
-                           Margin="0,7,0,0"
+                           Margin="0,8,0,0"
                            Content="{x:Static p:Resources.Advanced_PngInterlaceOption}"
-                           Padding="0,5,5,0"
+                           Padding="0,8,8,0"
                            Target="{Binding ElementName=_pngInterlaceComboBox}"/>
                     <ComboBox Grid.Row="2"
                               Grid.Column="1"
-                              Height="23"
-                              Margin="0,7,0,0"
+                              Margin="0,8,0,0"
                               HorizontalAlignment="Left"
                               ItemsSource="{Binding Source={StaticResource PngInterlaceOptionValues}}"
                               Name="_pngInterlaceComboBox"
@@ -189,14 +196,13 @@
                         </ComboBox.ItemTemplate>
                     </ComboBox>
                     <Label Grid.Row="3"
-                           Margin="0,7,0,0"
+                           Margin="0,8,0,0"
                            Content="{x:Static p:Resources.Advanced_TiffCompressOption}"
-                           Padding="0,5,5,0"
+                           Padding="0,8,8,0"
                            Target="{Binding ElementName=_tiffCompressComboBox}"/>
                     <ComboBox Grid.Row="3"
                               Grid.Column="1"
-                              Height="23"
-                              Margin="0,7,0,0"
+                              Margin="0,8,0,0"
                               HorizontalAlignment="Left"
                               ItemsSource="{Binding Source={StaticResource TiffCompressOptionValues}}"
                               Name="_tiffCompressComboBox"
@@ -210,9 +216,9 @@
                 </Grid>
             </TabItem>
             <TabItem Header="{x:Static p:Resources.Advanced_File}">
-                <StackPanel Margin="11,9">
+                <StackPanel Margin="12,8">
                     <TextBlock Text="{x:Static p:Resources.Advanced_FileNameTokens}"/>
-                    <TextBlock Margin="9,5,0,0">
+                    <TextBlock Margin="0,8,0,0">
                         <Run Text="%1 -"/>
                         <Run Text="{x:Static p:Resources.Advanced_FileNameToken1}"/>
                         <LineBreak/>
@@ -231,42 +237,46 @@
                         <Run>%6 -</Run>
                         <Run Text="{x:Static p:Resources.Advanced_FileNameToken6}"/>
                     </TextBlock>
-                    <Grid Margin="0,7,0,0">
+                    <Grid Margin="0,8,0,0">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto"/>
                             <ColumnDefinition/>
                         </Grid.ColumnDefinitions>
                         <Label HorizontalAlignment="Left"
                                Content="{x:Static p:Resources.Advanced_FileName}"
-                               Padding="0,5,5,0"
+                               Padding="0,4,4,0"
                                Target="{Binding ElementName=_fileNameTextBox}"/>
                         <TextBox Grid.Column="1"
                                  Height="23"
+                                 TextWrapping="Wrap"
                                  Name="_fileNameTextBox"
                                  Text="{Binding Settings.FileName}"/>
                     </Grid>
-                    <Separator Margin="0,11,0,0"/>
-                    <CheckBox Margin="0,11,0,0"
+                    <Separator Margin="0,12,0,0"/>
+                    <CheckBox Margin="0,12,0,0"
                               Content="{x:Static p:Resources.Advanced_KeepDateModified}"
                               IsChecked="{Binding Settings.KeepDateModified}"/>
                 </StackPanel>
             </TabItem>
         </TabControl>
-        <StackPanel Grid.Row="1"
-                    Margin="0,11,0,0"
+        <Border Grid.Row="1"
+                Margin="0,24,0,0"
+                Background="{DynamicResource SecondaryBackgroundBrush}"
+                Padding="12">
+
+            <StackPanel 
                     HorizontalAlignment="Right"
                     Orientation="Horizontal">
-            <Button Height="23"
-                    MinWidth="75"
+                <Button MinWidth="76"
                     Click="HandleAcceptClick"
+                    Style="{StaticResource AccentButtonStyle}"
                     Content="{x:Static p:Resources.OK}"
                     IsDefault="True"/>
-            <Button Height="23"
-                    MinWidth="75"
-                    Margin="7,0,0,0"
+                <Button MinWidth="76"
+                    Margin="8,0,0,0"
                     Content="{x:Static p:Resources.Cancel}"
                     IsCancel="True"/>
-        </StackPanel>
+            </StackPanel>
+        </Border>
     </Grid>
-
 </Window>

--- a/src/modules/imageresizer/ui/Views/AdvancedWindow.xaml
+++ b/src/modules/imageresizer/ui/Views/AdvancedWindow.xaml
@@ -248,6 +248,7 @@
                                Target="{Binding ElementName=_fileNameTextBox}"/>
                         <TextBox Grid.Column="1"
                                  Height="23"
+                                 TabIndex="1"
                                  TextWrapping="Wrap"
                                  Name="_fileNameTextBox"
                                  Text="{Binding Settings.FileName}"/>

--- a/src/modules/imageresizer/ui/Views/AdvancedWindow.xaml
+++ b/src/modules/imageresizer/ui/Views/AdvancedWindow.xaml
@@ -6,7 +6,7 @@
         xmlns:p="clr-namespace:ImageResizer.Properties"
         xmlns:sys="clr-namespace:System;assembly=mscorlib"
         xmlns:ui="http://schemas.modernwpf.com/2019"
-        MinWidth="390"
+        MinWidth="560"
         MinHeight="340"
         ui:WindowHelper.UseModernWindowStyle="True"
         ui:TitleBar.IsIconVisible="True"
@@ -65,6 +65,7 @@
                                     <ComboBox Grid.Column="1"
                                               Margin="8,0,0,0"
                                               ItemsSource="{Binding Source={StaticResource ResizeFitValues}}"
+                                              AutomationProperties.Name="{x:Static p:Resources.Resize_Type}"
                                               SelectedItem="{Binding Fit}">
                                         <ComboBox.ItemTemplate>
                                             <DataTemplate DataType="{x:Type m:ResizeFit}">
@@ -76,6 +77,7 @@
                                              Width="56"
                                              MaxWidth="56"
                                              TextWrapping="Wrap"
+                                             AutomationProperties.Name="{x:Static p:Resources.Width}"
                                              Margin="8,0,0,0">
                                         <TextBox.Text>
                                             <Binding Converter="{StaticResource AutoDoubleConverter}"
@@ -96,6 +98,7 @@
                                              Width="56"
                                              MaxWidth="56"
                                              TextWrapping="Wrap"
+                                             AutomationProperties.Name="{x:Static p:Resources.Height}"
                                              Margin="8,0,0,0"
                                              Visibility="{Binding ShowHeight,Converter={StaticResource BoolValueConverter}}">
                                         <TextBox.Text>
@@ -111,6 +114,7 @@
                                     <ComboBox Grid.Column="5"
                                               Margin="8,0,0,0"
                                               ItemsSource="{Binding Source={StaticResource ResizeUnitValues}}"
+                                              AutomationProperties.Name="{x:Static p:Resources.Unit}"
                                               SelectedItem="{Binding Unit}">
                                         <ComboBox.ItemTemplate>
                                             <DataTemplate DataType="{x:Type m:ResizeUnit}">
@@ -262,6 +266,8 @@
         </TabControl>
         <Border Grid.Row="1"
                 Margin="0,24,0,0"
+                BorderBrush="{DynamicResource PrimaryBorderBrush}"
+                BorderThickness="0,1,0,0"
                 Background="{DynamicResource SecondaryBackgroundBrush}"
                 Padding="12">
 

--- a/src/modules/imageresizer/ui/Views/AdvancedWindow.xaml
+++ b/src/modules/imageresizer/ui/Views/AdvancedWindow.xaml
@@ -6,6 +6,7 @@
         xmlns:p="clr-namespace:ImageResizer.Properties"
         xmlns:sys="clr-namespace:System;assembly=mscorlib"
         xmlns:ui="http://schemas.modernwpf.com/2019"
+        ContentRendered="WindowContentRendered"
         MinWidth="560"
         MinHeight="340"
         ui:WindowHelper.UseModernWindowStyle="True"

--- a/src/modules/imageresizer/ui/Views/AdvancedWindow.xaml.cs
+++ b/src/modules/imageresizer/ui/Views/AdvancedWindow.xaml.cs
@@ -25,5 +25,11 @@ namespace ImageResizer.Views
             Process.Start(e.Uri.ToString());
             e.Handled = true;
         }
+
+        // Fix for black outline WPF bug when a window uses custom chrome. More info here https://stackoverflow.com/questions/29207331/wpf-window-with-custom-chrome-has-unwanted-outline-on-right-and-bottom
+        private void WindowContentRendered(object sender, System.EventArgs e)
+        {
+            InvalidateVisual();
+        }
     }
 }

--- a/src/modules/imageresizer/ui/Views/InputPage.xaml
+++ b/src/modules/imageresizer/ui/Views/InputPage.xaml
@@ -4,17 +4,17 @@
              xmlns:local="clr-namespace:ImageResizer.Views"
              xmlns:m="clr-namespace:ImageResizer.Models"
              xmlns:p="clr-namespace:ImageResizer.Properties"
+             xmlns:ui="http://schemas.modernwpf.com/2019"
              MinWidth="350">
 
     <StackPanel Background="{DynamicResource PrimaryBackgroundBrush}">
-        <TextBlock Margin="11,11,11,0"
-                   Style="{StaticResource MainInstructionTextBlockStyle}"
-                   Text="{x:Static p:Resources.Input_MainInstruction}"/>
-        <Label Margin="11,11,11,0"
+        <Label Margin="12,12,12,0"
+               FontSize="16"
                Content="{x:Static p:Resources.Input_Content}"
                Target="{Binding ElementName=_selectedSizeListBox}"/>
-        <ListBox Margin="20,0,11,0"
+        <ListBox Margin="12,12,12,0"
                  BorderThickness="0"
+                 Background="Transparent"
                  ItemsSource="{Binding Settings.AllSizes}"
                  Name="_selectedSizeListBox"
                  SelectedIndex="{Binding Settings.SelectedSizeIndex}">
@@ -23,8 +23,9 @@
                     <Setter Property="Template">
                         <Setter.Value>
                             <ControlTemplate TargetType="ListBoxItem">
-                                <RadioButton Margin="0,7,0,0"
-                                             VerticalContentAlignment="Center"
+                                <RadioButton Margin="0,4,0,0"
+                                             VerticalAlignment="Center"
+                                             VerticalContentAlignment="Top"
                                              Focusable="False"
                                              IsChecked="{Binding IsSelected,RelativeSource={RelativeSource TemplatedParent}}">
                                     <ContentPresenter/>
@@ -37,35 +38,33 @@
             <ListBox.Resources>
                 <DataTemplate DataType="{x:Type m:ResizeSize}">
                     <StackPanel Orientation="Horizontal">
-                        <TextBlock Text="{Binding Name}"/>
-                        <TextBlock Text=" ("/>
+                        <TextBlock Text="{Binding Name}" FontWeight="Bold"/>
+                        <TextBlock Text="(" Margin="4,0,0,0"/>
                         <TextBlock Text="{Binding Fit,Converter={StaticResource EnumValueConverter},ConverterParameter=ThirdPersonSingular}"/>
-                        <TextBlock Text=" "/>
-                        <TextBlock Text="{Binding Width,Converter={StaticResource AutoDoubleConverter},ConverterParameter=Auto}"/>
-                        <TextBlock Text=" × " Visibility="{Binding ShowHeight,Converter={StaticResource BoolValueConverter}}"/>
-                        <TextBlock Text="{Binding Height,Converter={StaticResource AutoDoubleConverter},ConverterParameter=Auto}" Visibility="{Binding ShowHeight,Converter={StaticResource BoolValueConverter}}"/>
-                        <TextBlock Text=" "/>
-                        <TextBlock Text="{Binding Unit,Converter={StaticResource EnumValueConverter},ConverterParameter=ToLower}"/>
+                        <TextBlock Text="{Binding Width,Converter={StaticResource AutoDoubleConverter},ConverterParameter=Auto}" Margin="4,0,0,0"/>
+                        <TextBlock Text="x" Visibility="{Binding ShowHeight,Converter={StaticResource BoolValueConverter}}" Margin="4,0,0,0"/>
+                        <TextBlock Text="{Binding Height,Converter={StaticResource AutoDoubleConverter},ConverterParameter=Auto}" Visibility="{Binding ShowHeight,Converter={StaticResource BoolValueConverter}}" Margin="4,0,0,0"/>
+                        <TextBlock Text="{Binding Unit,Converter={StaticResource EnumValueConverter},ConverterParameter=ToLower}" Margin="4,0,0,0"/>
                         <TextBlock Text=")"/>
                     </StackPanel>
                 </DataTemplate>
                 <DataTemplate DataType="{x:Type m:CustomSize}">
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock VerticalAlignment="Center" Text="{Binding Name}"/>
-                        <ComboBox Height="23"
-                                  Margin="5,0,0,0"
+                    <StackPanel Orientation="Horizontal" Margin="0,-8,0,0">
+                        <TextBlock VerticalAlignment="Center" Text="{Binding Name}" FontWeight="Bold"/>
+                        <ComboBox 
+                                  Margin="8,0,0,0"
                                   ItemsSource="{Binding Source={StaticResource ResizeFitValues}}"
-                                  SelectedItem="{Binding Fit}"
-                                  ItemContainerStyle="{StaticResource AccessibleComboBoxStyle}">
+                                  SelectedItem="{Binding Fit}">
                             <ComboBox.ItemTemplate>
                                 <DataTemplate DataType="{x:Type m:ResizeFit}">
                                     <ContentPresenter Content="{Binding Converter={StaticResource EnumValueConverter}}"/>
                                 </DataTemplate>
                             </ComboBox.ItemTemplate>
                         </ComboBox>
-                        <TextBox Width="43"
-                                 Height="23"
-                                 Margin="7,0,0,0">
+                        <TextBox Width="56"
+                                 Style="{StaticResource DefaultTextBoxStyle}"
+                                 TextWrapping="Wrap"
+                                 Margin="8,0,0,0">
                             <TextBox.Text>
                                 <Binding Converter="{StaticResource AutoDoubleConverter}"
                                          Path="Width"
@@ -76,14 +75,14 @@
                                 </Binding>
                             </TextBox.Text>
                         </TextBox>
-                        <TextBlock Margin="5,0,0,0"
+                        <TextBlock Margin="8,0,0,0"
                                    VerticalAlignment="Center"
                                    Visibility="{Binding ShowHeight,Converter={StaticResource BoolValueConverter}}">
-                            ×
                         </TextBlock>
-                        <TextBox Width="43"
-                                 Height="23"
-                                 Margin="5,0,0,0"
+                        <TextBox Width="56"
+                                 Style="{StaticResource DefaultTextBoxStyle}"
+                                 Margin="0,0,0,0"
+                                 TextWrapping="Wrap"
                                  Visibility="{Binding ShowHeight,Converter={StaticResource BoolValueConverter}}">
                             <TextBox.Text>
                                 <Binding Converter="{StaticResource AutoDoubleConverter}"
@@ -95,11 +94,11 @@
                                 </Binding>
                             </TextBox.Text>
                         </TextBox>
-                        <ComboBox Height="23"
-                                  Margin="7,0,0,0"
+                        <ComboBox 
+                                  Margin="8,0,0,0"
                                   ItemsSource="{Binding Source={StaticResource ResizeUnitValues}}"
                                   SelectedItem="{Binding Unit}"
-                                  ItemContainerStyle="{StaticResource AccessibleComboBoxStyle}">
+                                  >
                             <ComboBox.ItemTemplate>
                                 <DataTemplate DataType="{x:Type m:ResizeUnit}">
                                     <ContentPresenter Content="{Binding Converter={StaticResource EnumValueConverter}}"/>
@@ -110,22 +109,20 @@
                 </DataTemplate>
             </ListBox.Resources>
         </ListBox>
-        <CheckBox Margin="11,11,11,0"
+        <CheckBox Margin="12,24,12,0"
                   Content="{x:Static p:Resources.Input_ShrinkOnly}"
                   IsChecked="{Binding Settings.ShrinkOnly}"/>
         <!-- TODO: This option doesn't make much sense when resizing into a directory. We should swap it for an option
                    to overwrite any files in the directory instead (issue #88) -->
-        <CheckBox Margin="11,7,11,0"
+        <CheckBox Margin="12,4,12,0"
                   Content="{x:Static p:Resources.Input_Replace}"
                   IsChecked="{Binding Settings.Replace}"/>
-        <CheckBox Margin="11,7,11,0"
+        <CheckBox Margin="12,4,12,0"
                   Content="{x:Static p:Resources.Input_IgnoreOrientation}"
                   IsChecked="{Binding Settings.IgnoreOrientation}"/>
-        <Border Margin="0,11,0,0"
-                Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"
-                BorderBrush="{DynamicResource {x:Static SystemColors.ControlLightBrushKey}}"
-                BorderThickness="0,1,0,0"
-                Padding="11,11">
+        <Border Margin="0,24,0,0"
+                Background="{DynamicResource SecondaryBackgroundBrush}"
+                Padding="12">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition/>
@@ -133,26 +130,26 @@
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
 
-                <TextBlock x:Name="AdvancedSettingsTextBlock"
-                           VerticalAlignment="Center"
-                           Visibility="{Binding ShowAdvancedSettings, Converter={StaticResource BoolValueConverter}}"
-                           IsEnabled="{Binding Visibility,ElementName=AdvancedSettingsTextBlock, Converter={StaticResource VisibilityBoolConverter}}"
-                           Focusable="{Binding Visibility,ElementName=AdvancedSettingsTextBlock, Converter={StaticResource VisibilityBoolConverter}}">
-                    <local:AccessibleHyperlink ControlType="Button" Command="{Binding ShowAdvancedCommand}">
-                        <Run Text="{x:Static p:Resources.Input_ShowAdvanced}"/>
-                    </local:AccessibleHyperlink>
-                </TextBlock>
-                
+                <Button Content="&#xE115;"
+                        FontFamily="Segoe MDL2 Assets"
+                        Style="{StaticResource DefaultButtonStyle}"
+                        FontSize="16"
+                        ToolTip="{x:Static p:Resources.Input_ShowAdvanced}"
+                        Background="Transparent"
+                        Command="{Binding ShowAdvancedCommand}"
+                        />
+                <!-- Visibility="{Binding ShowAdvancedSettings, Converter={StaticResource BoolValueConverter}}" -->
                 <Button Grid.Column="1"
-                        Height="23"
-                        MinWidth="75"
+                        Style="{StaticResource AccentButtonStyle}"
+                        MinWidth="76"
                         Command="{Binding ResizeCommand}"
                         Content="{x:Static p:Resources.Input_Resize}"
                         IsDefault="True"/>
+                
                 <Button Grid.Column="2"
-                        Height="23"
-                        MinWidth="75"
-                        Margin="7,0,0,0"
+                        Style="{StaticResource DefaultButtonStyle}"
+                        MinWidth="76"
+                        Margin="12,0,0,0"
                         Command="{Binding CancelCommand}"
                         Content="{x:Static p:Resources.Cancel}"
                         IsCancel="True"/>

--- a/src/modules/imageresizer/ui/Views/InputPage.xaml
+++ b/src/modules/imageresizer/ui/Views/InputPage.xaml
@@ -12,12 +12,15 @@
                FontSize="16"
                Content="{x:Static p:Resources.Input_Content}"
                Target="{Binding ElementName=_selectedSizeListBox}"/>
+        
         <ListBox Margin="12,12,12,0"
                  BorderThickness="0"
                  Background="Transparent"
+                 AutomationProperties.Name="Sizes listbox"
                  ItemsSource="{Binding Settings.AllSizes}"
                  Name="_selectedSizeListBox"
                  SelectedIndex="{Binding Settings.SelectedSizeIndex}">
+            
             <ListBox.ItemContainerStyle>
                 <Style TargetType="ListBoxItem">
                     <Setter Property="Template">
@@ -26,6 +29,7 @@
                                 <RadioButton Margin="0,4,0,0"
                                              VerticalAlignment="Center"
                                              VerticalContentAlignment="Top"
+                                             AutomationProperties.Name="{Binding Name}"
                                              Focusable="False"
                                              IsChecked="{Binding IsSelected,RelativeSource={RelativeSource TemplatedParent}}">
                                     <ContentPresenter/>
@@ -33,26 +37,30 @@
                             </ControlTemplate>
                         </Setter.Value>
                     </Setter>
+                    <Setter Property="AutomationProperties.Name" Value="{Binding Name}"/>
                 </Style>
             </ListBox.ItemContainerStyle>
+            
             <ListBox.Resources>
                 <DataTemplate DataType="{x:Type m:ResizeSize}">
                     <StackPanel Orientation="Horizontal">
-                        <TextBlock Text="{Binding Name}" FontWeight="Bold"/>
-                        <TextBlock Text="(" Margin="4,0,0,0"/>
-                        <TextBlock Text="{Binding Fit,Converter={StaticResource EnumValueConverter},ConverterParameter=ThirdPersonSingular}"/>
-                        <TextBlock Text="{Binding Width,Converter={StaticResource AutoDoubleConverter},ConverterParameter=Auto}" Margin="4,0,0,0"/>
-                        <TextBlock Text="x" Visibility="{Binding ShowHeight,Converter={StaticResource BoolValueConverter}}" Margin="4,0,0,0"/>
-                        <TextBlock Text="{Binding Height,Converter={StaticResource AutoDoubleConverter},ConverterParameter=Auto}" Visibility="{Binding ShowHeight,Converter={StaticResource BoolValueConverter}}" Margin="4,0,0,0"/>
-                        <TextBlock Text="{Binding Unit,Converter={StaticResource EnumValueConverter},ConverterParameter=ToLower}" Margin="4,0,0,0"/>
-                        <TextBlock Text=")"/>
+                        <TextBlock Text="{Binding Name}" FontWeight="Bold" Foreground="{DynamicResource PrimaryForegroundBrush}"/>
+                        <TextBlock Text="(" Margin="4,0,0,0" Foreground="{DynamicResource SecondaryForegroundBrush}"/>
+                        <TextBlock Text="{Binding Fit,Converter={StaticResource EnumValueConverter},ConverterParameter=ThirdPersonSingular}" Foreground="{DynamicResource SecondaryForegroundBrush}"/>
+                        <TextBlock Text="{Binding Width,Converter={StaticResource AutoDoubleConverter},ConverterParameter=Auto}" Margin="4,0,0,0" Foreground="{DynamicResource SecondaryForegroundBrush}"/>
+                        <TextBlock Text="x" Visibility="{Binding ShowHeight,Converter={StaticResource BoolValueConverter}}" Margin="4,0,0,0" Foreground="{DynamicResource SecondaryForegroundBrush}"/>
+                        <TextBlock Text="{Binding Height,Converter={StaticResource AutoDoubleConverter},ConverterParameter=Auto}" Visibility="{Binding ShowHeight,Converter={StaticResource BoolValueConverter}}" Margin="4,0,0,0" Foreground="{DynamicResource SecondaryForegroundBrush}"/>
+                        <TextBlock Text="{Binding Unit,Converter={StaticResource EnumValueConverter},ConverterParameter=ToLower}" Margin="4,0,0,0" Foreground="{DynamicResource SecondaryForegroundBrush}"/>
+                        <TextBlock Text=")" Foreground="{DynamicResource SecondaryForegroundBrush}"/>
                     </StackPanel>
                 </DataTemplate>
+                
                 <DataTemplate DataType="{x:Type m:CustomSize}">
                     <StackPanel Orientation="Horizontal" Margin="0,-8,0,0">
-                        <TextBlock VerticalAlignment="Center" Text="{Binding Name}" FontWeight="Bold"/>
-                        <ComboBox 
-                                  Margin="8,0,0,0"
+                        <TextBlock VerticalAlignment="Center"
+                                   Text="{Binding Name}"
+                                   FontWeight="Bold"/>
+                        <ComboBox Margin="8,0,0,0"
                                   ItemsSource="{Binding Source={StaticResource ResizeFitValues}}"
                                   SelectedItem="{Binding Fit}">
                             <ComboBox.ItemTemplate>
@@ -77,8 +85,8 @@
                         </TextBox>
                         <TextBlock Margin="8,0,0,0"
                                    VerticalAlignment="Center"
-                                   Visibility="{Binding ShowHeight,Converter={StaticResource BoolValueConverter}}">
-                        </TextBlock>
+                                   Visibility="{Binding ShowHeight,Converter={StaticResource BoolValueConverter}}"/>
+
                         <TextBox Width="56"
                                  Style="{StaticResource DefaultTextBoxStyle}"
                                  Margin="0,0,0,0"
@@ -94,11 +102,9 @@
                                 </Binding>
                             </TextBox.Text>
                         </TextBox>
-                        <ComboBox 
-                                  Margin="8,0,0,0"
+                        <ComboBox Margin="8,0,0,0"
                                   ItemsSource="{Binding Source={StaticResource ResizeUnitValues}}"
-                                  SelectedItem="{Binding Unit}"
-                                  >
+                                  SelectedItem="{Binding Unit}">
                             <ComboBox.ItemTemplate>
                                 <DataTemplate DataType="{x:Type m:ResizeUnit}">
                                     <ContentPresenter Content="{Binding Converter={StaticResource EnumValueConverter}}"/>
@@ -109,6 +115,7 @@
                 </DataTemplate>
             </ListBox.Resources>
         </ListBox>
+        
         <CheckBox Margin="12,24,12,0"
                   Content="{x:Static p:Resources.Input_ShrinkOnly}"
                   IsChecked="{Binding Settings.ShrinkOnly}"/>
@@ -117,9 +124,11 @@
         <CheckBox Margin="12,4,12,0"
                   Content="{x:Static p:Resources.Input_Replace}"
                   IsChecked="{Binding Settings.Replace}"/>
+        
         <CheckBox Margin="12,4,12,0"
                   Content="{x:Static p:Resources.Input_IgnoreOrientation}"
                   IsChecked="{Binding Settings.IgnoreOrientation}"/>
+        
         <Border Margin="0,24,0,0"
                 Background="{DynamicResource SecondaryBackgroundBrush}"
                 Padding="12">
@@ -134,18 +143,20 @@
                         FontFamily="Segoe MDL2 Assets"
                         Style="{StaticResource DefaultButtonStyle}"
                         FontSize="16"
+                        Margin="-10,0,0,0"
+                        AutomationProperties.Name="{x:Static p:Resources.Input_ShowAdvanced}"
                         ToolTip="{x:Static p:Resources.Input_ShowAdvanced}"
                         Background="Transparent"
-                        Command="{Binding ShowAdvancedCommand}"
-                        />
+                        Command="{Binding ShowAdvancedCommand}"/>
                 <!-- Visibility="{Binding ShowAdvancedSettings, Converter={StaticResource BoolValueConverter}}" -->
                 <Button Grid.Column="1"
                         Style="{StaticResource AccentButtonStyle}"
                         MinWidth="76"
                         Command="{Binding ResizeCommand}"
+                        AutomationProperties.Name="{x:Static p:Resources.Resize_Tooltip}"
                         Content="{x:Static p:Resources.Input_Resize}"
                         IsDefault="True"/>
-                
+
                 <Button Grid.Column="2"
                         Style="{StaticResource DefaultButtonStyle}"
                         MinWidth="76"
@@ -156,5 +167,4 @@
             </Grid>
         </Border>
     </StackPanel>
-
 </UserControl>

--- a/src/modules/imageresizer/ui/Views/InputPage.xaml
+++ b/src/modules/imageresizer/ui/Views/InputPage.xaml
@@ -115,6 +115,7 @@
                                    Text="&#xE711;"
                                    FontFamily="Segoe MDL2 Assets"
                                    Width="25"
+                                   Foreground="{DynamicResource PrimaryForegroundBrush}"
                                    Name="Times_Symbol"
                                    AutomationProperties.Name="{x:Static p:Resources.Times_Symbol}"
                                    TextAlignment="Center"

--- a/src/modules/imageresizer/ui/Views/InputPage.xaml
+++ b/src/modules/imageresizer/ui/Views/InputPage.xaml
@@ -111,8 +111,13 @@
                                 </Binding>
                             </TextBox.Text>
                         </TextBox>
-                        <TextBlock Margin="8,0,0,0"
-                                   VerticalAlignment="Center"
+                        <TextBlock VerticalAlignment="Center"
+                                   Text="&#xE711;"
+                                   FontFamily="Segoe MDL2 Assets"
+                                   Width="25"
+                                   Name="Times_Symbol"
+                                   AutomationProperties.Name="{x:Static p:Resources.Times_Symbol}"
+                                   TextAlignment="Center"
                                    Visibility="{Binding ShowHeight,Converter={StaticResource BoolValueConverter}}"/>
 
                         <TextBox Width="56"

--- a/src/modules/imageresizer/ui/Views/InputPage.xaml
+++ b/src/modules/imageresizer/ui/Views/InputPage.xaml
@@ -83,6 +83,7 @@
                     <StackPanel Orientation="Horizontal" Margin="0,-8,0,0">
                         <TextBlock VerticalAlignment="Center"
                                    Text="{Binding Name}"
+                                   Foreground="{DynamicResource PrimaryForegroundBrush}"
                                    FontWeight="Bold"/>
                         <ComboBox Margin="8,0,0,0"
                                   ItemsSource="{Binding Source={StaticResource ResizeFitValues}}"

--- a/src/modules/imageresizer/ui/Views/InputPage.xaml
+++ b/src/modules/imageresizer/ui/Views/InputPage.xaml
@@ -37,7 +37,7 @@
                Content="{x:Static p:Resources.Input_Content}"
                Target="{Binding ElementName=_selectedSizeListBox}"/>
         
-        <ListBox Margin="12,12,12,0"
+        <ListBox Margin="12,24,12,0"
                  BorderThickness="0"
                  Background="Transparent"
                  AutomationProperties.Name="Sizes listbox"
@@ -87,6 +87,7 @@
                         <ComboBox Margin="8,0,0,0"
                                   ItemsSource="{Binding Source={StaticResource ResizeFitValues}}"
                                   Style="{StaticResource DisabledWhenUnselectedComboBoxStyle}"
+                                  AutomationProperties.Name="{x:Static p:Resources.Resize_Type}"
                                   SelectedItem="{Binding Fit}">
                             <ComboBox.ItemTemplate>
                                 <DataTemplate DataType="{x:Type m:ResizeFit}">
@@ -97,6 +98,7 @@
                         <TextBox Width="56"
                                  TextWrapping="Wrap"
                                  Style="{StaticResource DisabledWhenUnselectedTextBoxStyle}"
+                                 AutomationProperties.Name="{x:Static p:Resources.Width}"
                                  Margin="8,0,0,0">
                             <TextBox.Text>
                                 <Binding Converter="{StaticResource AutoDoubleConverter}"
@@ -115,6 +117,7 @@
                         <TextBox Width="56"
                                  Style="{StaticResource DisabledWhenUnselectedTextBoxStyle}"
                                  TextWrapping="Wrap"
+                                 AutomationProperties.Name="{x:Static p:Resources.Height}"
                                  Visibility="{Binding ShowHeight,Converter={StaticResource BoolValueConverter}}">
                             <TextBox.Text>
                                 <Binding Converter="{StaticResource AutoDoubleConverter}"
@@ -129,6 +132,7 @@
                         <ComboBox Margin="8,0,0,0"
                                   ItemsSource="{Binding Source={StaticResource ResizeUnitValues}}"
                                   Style="{StaticResource DisabledWhenUnselectedComboBoxStyle}"
+                                  AutomationProperties.Name="{x:Static p:Resources.Unit}"
                                   SelectedItem="{Binding Unit}">
                             <ComboBox.ItemTemplate>
                                 <DataTemplate DataType="{x:Type m:ResizeUnit}">
@@ -141,7 +145,7 @@
             </ListBox.Resources>
         </ListBox>
         
-        <CheckBox Margin="12,24,12,0"
+        <CheckBox Margin="12,36,12,0"
                   Content="{x:Static p:Resources.Input_ShrinkOnly}"
                   IsChecked="{Binding Settings.ShrinkOnly}"/>
         <!-- TODO: This option doesn't make much sense when resizing into a directory. We should swap it for an option
@@ -156,6 +160,8 @@
         
         <Border Margin="0,24,0,0"
                 Background="{DynamicResource SecondaryBackgroundBrush}"
+                BorderBrush="{DynamicResource PrimaryBorderBrush}"
+                BorderThickness="0,1,0,0"
                 Padding="12">
             <Grid>
                 <Grid.ColumnDefinitions>
@@ -168,7 +174,7 @@
                         FontFamily="Segoe MDL2 Assets"
                         Style="{StaticResource DefaultButtonStyle}"
                         FontSize="16"
-                        Margin="-10,0,0,0"
+                        Margin="-6,0,0,0"
                         AutomationProperties.Name="{x:Static p:Resources.Input_ShowAdvanced}"
                         ToolTip="{x:Static p:Resources.Input_ShowAdvanced}"
                         Background="Transparent"

--- a/src/modules/imageresizer/ui/Views/InputPage.xaml
+++ b/src/modules/imageresizer/ui/Views/InputPage.xaml
@@ -68,11 +68,11 @@
             <ListBox.Resources>
                 <DataTemplate DataType="{x:Type m:ResizeSize}">
                     <StackPanel Orientation="Horizontal">
-                        <TextBlock Text="{Binding Name}" FontWeight="Bold" Foreground="{DynamicResource PrimaryForegroundBrush}"/>
+                        <TextBlock Text="{Binding Name}" FontWeight="SemiBold" Foreground="{DynamicResource PrimaryForegroundBrush}"/>
                         <TextBlock Text="(" Margin="4,0,0,0" Foreground="{DynamicResource SecondaryForegroundBrush}"/>
                         <TextBlock Text="{Binding Fit,Converter={StaticResource EnumValueConverter},ConverterParameter=ThirdPersonSingular}" Foreground="{DynamicResource SecondaryForegroundBrush}"/>
                         <TextBlock Text="{Binding Width,Converter={StaticResource AutoDoubleConverter},ConverterParameter=Auto}" Margin="4,0,0,0" Foreground="{DynamicResource SecondaryForegroundBrush}"/>
-                        <TextBlock Text="x" Visibility="{Binding ShowHeight,Converter={StaticResource BoolValueConverter}}" Margin="4,0,0,0" Foreground="{DynamicResource SecondaryForegroundBrush}"/>
+                        <TextBlock Text="&#xE711;" FontSize="11" FontFamily="Segoe MDL2 Assets" Visibility="{Binding ShowHeight,Converter={StaticResource BoolValueConverter}}" Margin="4,5,0,0" Foreground="{DynamicResource SecondaryForegroundBrush}"/>
                         <TextBlock Text="{Binding Height,Converter={StaticResource AutoDoubleConverter},ConverterParameter=Auto}" Visibility="{Binding ShowHeight,Converter={StaticResource BoolValueConverter}}" Margin="4,0,0,0" Foreground="{DynamicResource SecondaryForegroundBrush}"/>
                         <TextBlock Text="{Binding Unit,Converter={StaticResource EnumValueConverter},ConverterParameter=ToLower}" Margin="4,0,0,0" Foreground="{DynamicResource SecondaryForegroundBrush}"/>
                         <TextBlock Text=")" Foreground="{DynamicResource SecondaryForegroundBrush}"/>
@@ -84,7 +84,7 @@
                         <TextBlock VerticalAlignment="Center"
                                    Text="{Binding Name}"
                                    Foreground="{DynamicResource PrimaryForegroundBrush}"
-                                   FontWeight="Bold"/>
+                                   FontWeight="SemiBold"/>
                         <ComboBox Margin="8,0,0,0"
                                   ItemsSource="{Binding Source={StaticResource ResizeFitValues}}"
                                   Style="{StaticResource DisabledWhenUnselectedComboBoxStyle}"
@@ -115,7 +115,7 @@
                                    Text="&#xE711;"
                                    FontFamily="Segoe MDL2 Assets"
                                    Width="25"
-                                   Foreground="{DynamicResource PrimaryForegroundBrush}"
+                                   Foreground="{DynamicResource SecondaryForegroundBrush}"
                                    Name="Times_Symbol"
                                    AutomationProperties.Name="{x:Static p:Resources.Times_Symbol}"
                                    TextAlignment="Center"

--- a/src/modules/imageresizer/ui/Views/InputPage.xaml
+++ b/src/modules/imageresizer/ui/Views/InputPage.xaml
@@ -179,8 +179,10 @@
                         AutomationProperties.Name="{x:Static p:Resources.Input_ShowAdvanced}"
                         ToolTip="{x:Static p:Resources.Input_ShowAdvanced}"
                         Background="Transparent"
-                        Command="{Binding ShowAdvancedCommand}"/>
-                <!-- Visibility="{Binding ShowAdvancedSettings, Converter={StaticResource BoolValueConverter}}" -->
+                        Command="{Binding ShowAdvancedCommand}"
+                        Visibility="{Binding ShowAdvancedSettings, Converter={StaticResource BoolValueConverter}}"
+                        />
+
                 <Button Grid.Column="1"
                         Style="{StaticResource AccentButtonStyle}"
                         MinWidth="76"

--- a/src/modules/imageresizer/ui/Views/InputPage.xaml
+++ b/src/modules/imageresizer/ui/Views/InputPage.xaml
@@ -6,7 +6,7 @@
              xmlns:p="clr-namespace:ImageResizer.Properties"
              MinWidth="350">
 
-    <StackPanel>
+    <StackPanel Background="{DynamicResource PrimaryBackgroundBrush}">
         <TextBlock Margin="11,11,11,0"
                    Style="{StaticResource MainInstructionTextBlockStyle}"
                    Text="{x:Static p:Resources.Input_MainInstruction}"/>

--- a/src/modules/imageresizer/ui/Views/InputPage.xaml
+++ b/src/modules/imageresizer/ui/Views/InputPage.xaml
@@ -6,7 +6,31 @@
              xmlns:p="clr-namespace:ImageResizer.Properties"
              xmlns:ui="http://schemas.modernwpf.com/2019"
              MinWidth="350">
-
+    <UserControl.Resources>
+        <Style x:Key="DisabledWhenUnselectedComboBoxStyle" TargetType="ComboBox" BasedOn="{StaticResource DefaultComboBoxStyle}">
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding IsSelected, RelativeSource={RelativeSource AncestorType=ListBoxItem}}" Value="True">
+                    <Setter Property="IsEnabled" Value="True"/>
+                </DataTrigger>
+                <DataTrigger Binding="{Binding IsSelected, RelativeSource={RelativeSource AncestorType=ListBoxItem}}" Value="False">
+                    <Setter Property="IsEnabled" Value="False"/>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+        <Style x:Key="DisabledWhenUnselectedTextBoxStyle" TargetType="TextBox" BasedOn="{StaticResource DefaultTextBoxStyle}">
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding IsSelected, RelativeSource={RelativeSource AncestorType=ListBoxItem}}" Value="True">
+                    <Setter Property="IsEnabled" Value="True"/>
+                </DataTrigger>
+                <DataTrigger Binding="{Binding IsSelected, RelativeSource={RelativeSource AncestorType=ListBoxItem}}" Value="False">
+                    <Setter Property="IsEnabled" Value="False"/>
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+    </UserControl.Resources>
+    
+    
+    
     <StackPanel Background="{DynamicResource PrimaryBackgroundBrush}">
         <Label Margin="12,12,12,0"
                FontSize="16"
@@ -62,6 +86,7 @@
                                    FontWeight="Bold"/>
                         <ComboBox Margin="8,0,0,0"
                                   ItemsSource="{Binding Source={StaticResource ResizeFitValues}}"
+                                  Style="{StaticResource DisabledWhenUnselectedComboBoxStyle}"
                                   SelectedItem="{Binding Fit}">
                             <ComboBox.ItemTemplate>
                                 <DataTemplate DataType="{x:Type m:ResizeFit}">
@@ -70,8 +95,8 @@
                             </ComboBox.ItemTemplate>
                         </ComboBox>
                         <TextBox Width="56"
-                                 Style="{StaticResource DefaultTextBoxStyle}"
                                  TextWrapping="Wrap"
+                                 Style="{StaticResource DisabledWhenUnselectedTextBoxStyle}"
                                  Margin="8,0,0,0">
                             <TextBox.Text>
                                 <Binding Converter="{StaticResource AutoDoubleConverter}"
@@ -88,8 +113,7 @@
                                    Visibility="{Binding ShowHeight,Converter={StaticResource BoolValueConverter}}"/>
 
                         <TextBox Width="56"
-                                 Style="{StaticResource DefaultTextBoxStyle}"
-                                 Margin="0,0,0,0"
+                                 Style="{StaticResource DisabledWhenUnselectedTextBoxStyle}"
                                  TextWrapping="Wrap"
                                  Visibility="{Binding ShowHeight,Converter={StaticResource BoolValueConverter}}">
                             <TextBox.Text>
@@ -104,6 +128,7 @@
                         </TextBox>
                         <ComboBox Margin="8,0,0,0"
                                   ItemsSource="{Binding Source={StaticResource ResizeUnitValues}}"
+                                  Style="{StaticResource DisabledWhenUnselectedComboBoxStyle}"
                                   SelectedItem="{Binding Unit}">
                             <ComboBox.ItemTemplate>
                                 <DataTemplate DataType="{x:Type m:ResizeUnit}">

--- a/src/modules/imageresizer/ui/Views/MainWindow.xaml
+++ b/src/modules/imageresizer/ui/Views/MainWindow.xaml
@@ -16,8 +16,7 @@
         ui:WindowHelper.UseModernWindowStyle="True"
         ui:TitleBar.IsIconVisible="True"
         ui:TitleBar.Background="{DynamicResource PrimaryBackgroundBrush}"
-        AutomationProperties.Name="Image Resizer"
-        >
+        AutomationProperties.Name="{x:Static p:Resources.ImageResizer}">
 
     <Window.Resources>
         <DataTemplate DataType="{x:Type vm:InputViewModel}">

--- a/src/modules/imageresizer/ui/Views/MainWindow.xaml
+++ b/src/modules/imageresizer/ui/Views/MainWindow.xaml
@@ -1,6 +1,7 @@
 ﻿<Window x:Class="ImageResizer.Views.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:ui="http://schemas.modernwpf.com/2019"
         xmlns:behaviors="http://schemas.microsoft.com/xaml/behaviors"
         xmlns:local="clr-namespace:ImageResizer.Views"
         xmlns:p="clr-namespace:ImageResizer.Properties"
@@ -11,7 +12,11 @@
         ResizeMode="NoResize"
         SizeToContent="WidthAndHeight"
         Title="{x:Static p:Resources.ImageResizer}"
-        WindowStartupLocation="CenterScreen">
+        WindowStartupLocation="CenterScreen"
+        ui:WindowHelper.UseModernWindowStyle="True"
+        ui:TitleBar.IsIconVisible="True"
+        ui:TitleBar.Background="{DynamicResource PrimaryBackgroundBrush}"
+        >
 
     <Window.Resources>
         <DataTemplate DataType="{x:Type vm:InputViewModel}">

--- a/src/modules/imageresizer/ui/Views/MainWindow.xaml
+++ b/src/modules/imageresizer/ui/Views/MainWindow.xaml
@@ -16,6 +16,7 @@
         ui:WindowHelper.UseModernWindowStyle="True"
         ui:TitleBar.IsIconVisible="True"
         ui:TitleBar.Background="{DynamicResource PrimaryBackgroundBrush}"
+        AutomationProperties.Name="Image Resizer"
         >
 
     <Window.Resources>

--- a/src/modules/imageresizer/ui/Views/ProgressPage.xaml
+++ b/src/modules/imageresizer/ui/Views/ProgressPage.xaml
@@ -31,6 +31,7 @@
                 Padding="12,12">
             <StackPanel HorizontalAlignment="Right" Orientation="Horizontal">
                 <Button MinWidth="76"
+                        Style="{StaticResource AccentButtonStyle}"
                         Command="{Binding StopCommand}"
                         Content="{x:Static p:Resources.Progress_Stop}"
                         IsCancel="True"/>

--- a/src/modules/imageresizer/ui/Views/ProgressPage.xaml
+++ b/src/modules/imageresizer/ui/Views/ProgressPage.xaml
@@ -4,6 +4,7 @@
              xmlns:behaviors="http://schemas.microsoft.com/xaml/behaviors"
              xmlns:local="clr-namespace:ImageResizer.Views"
              xmlns:p="clr-namespace:ImageResizer.Properties"
+             Background="{DynamicResource PrimaryBackgroundBrush}"
              MinWidth="350">
 
     <UserControl.Resources>
@@ -17,27 +18,23 @@
     </behaviors:Interaction.Triggers>
 
     <StackPanel>
-        <TextBlock Margin="11,11,11,0"
-                   Style="{StaticResource MainInstructionTextBlockStyle}"
+        <TextBlock Margin="12,12,12,0"
+                   FontSize="16"
                    Text="{x:Static p:Resources.Progress_MainInstruction}"/>
-        <TextBlock Margin="11,11,11,0" Text="{Binding TimeRemaining,Converter={StaticResource TimeRemainingConverter}}"/>
-        <ProgressBar Height="15"
-                     Margin="11,11,11,0"
+        <TextBlock Margin="12,12,12,0" Text="{Binding TimeRemaining,Converter={StaticResource TimeRemainingConverter}}"/>
+        <ProgressBar Height="16"
+                     Margin="12,12,12,0"
                      Value="{Binding Progress}"
                      Maximum="1"/>
-        <Border Margin="0,11,0,0"
-                Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"
-                BorderBrush="{DynamicResource {x:Static SystemColors.ControlLightBrushKey}}"
-                BorderThickness="0,1,0,0"
-                Padding="11,11">
+        <Border Margin="0,12,0,0"
+                Background="{DynamicResource SecondaryBackgroundBrush}"
+                Padding="12,12">
             <StackPanel HorizontalAlignment="Right" Orientation="Horizontal">
-                <Button Height="23"
-                        MinWidth="75"
+                <Button MinWidth="76"
                         Command="{Binding StopCommand}"
                         Content="{x:Static p:Resources.Progress_Stop}"
                         IsCancel="True"/>
             </StackPanel>
         </Border>
     </StackPanel>
-
 </UserControl>

--- a/src/modules/imageresizer/ui/Views/ProgressPage.xaml
+++ b/src/modules/imageresizer/ui/Views/ProgressPage.xaml
@@ -20,14 +20,19 @@
     <StackPanel>
         <TextBlock Margin="12,12,12,0"
                    FontSize="16"
+                   Foreground="{DynamicResource PrimaryForegroundBrush}"
                    Text="{x:Static p:Resources.Progress_MainInstruction}"/>
-        <TextBlock Margin="12,12,12,0" Text="{Binding TimeRemaining,Converter={StaticResource TimeRemainingConverter}}"/>
+        <TextBlock Margin="12,12,12,0"
+                   Foreground="{DynamicResource PrimaryForegroundBrush}"
+                   Text="{Binding TimeRemaining,Converter={StaticResource TimeRemainingConverter}}"/>
         <ProgressBar Height="16"
                      Margin="12,12,12,0"
                      Value="{Binding Progress}"
                      Maximum="1"/>
         <Border Margin="0,12,0,0"
                 Background="{DynamicResource SecondaryBackgroundBrush}"
+                BorderBrush="{DynamicResource PrimaryBorderBrush}"
+                BorderThickness="0,1,0,0"
                 Padding="12,12">
             <StackPanel HorizontalAlignment="Right" Orientation="Horizontal">
                 <Button MinWidth="76"

--- a/src/modules/imageresizer/ui/Views/ResultsPage.xaml
+++ b/src/modules/imageresizer/ui/Views/ResultsPage.xaml
@@ -2,21 +2,22 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:p="clr-namespace:ImageResizer.Properties"
-             MinWidth="350">
+             MinWidth="350"
+             Background="{DynamicResource PrimaryBackgroundBrush}">
 
     <StackPanel>
-        <TextBlock Margin="11,11,11,0"
-                   Style="{StaticResource MainInstructionTextBlockStyle}"
+        <TextBlock Margin="12,12,12,0"
+                   FontSize="16"
                    Text="{x:Static p:Resources.Results_MainInstruction}"/>
         <ScrollViewer MaxWidth="363"
                       MaxHeight="350"
                       HorizontalAlignment="Stretch"
                       VerticalScrollBarVisibility="Auto">
-            <ItemsControl Margin="11,4,11,0" ItemsSource="{Binding Errors}">
+            <ItemsControl Margin="12,4,12,0" ItemsSource="{Binding Errors}">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate DataType="ResizeError">
                         <StackPanel>
-                            <TextBlock Margin="0,7,0,0"
+                            <TextBlock Margin="0,8,0,0"
                                        FontWeight="Bold"
                                        Text="{Binding File}"/>
                             <TextBlock Text="{Binding Error}" TextWrapping="Wrap"/>
@@ -25,14 +26,13 @@
                 </ItemsControl.ItemTemplate>
             </ItemsControl>
         </ScrollViewer>
-        <Border Margin="0,11,0,0"
-                Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"
+        <Border Margin="0,12,0,0"
+                Background="{DynamicResource SecondaryBackgroundBrush}"
                 BorderBrush="{DynamicResource {x:Static SystemColors.ControlLightBrushKey}}"
                 BorderThickness="0,1,0,0"
-                Padding="11,11">
+                Padding="12,12">
             <StackPanel HorizontalAlignment="Right" Orientation="Horizontal">
-                <Button Height="23"
-                        MinWidth="75"
+                <Button MinWidth="76"
                         Command="{Binding CloseCommand}"
                         Content="{x:Static p:Resources.Results_Close}"
                         IsCancel="True"
@@ -40,5 +40,4 @@
             </StackPanel>
         </Border>
     </StackPanel>
-
 </UserControl>

--- a/src/modules/imageresizer/ui/Views/ResultsPage.xaml
+++ b/src/modules/imageresizer/ui/Views/ResultsPage.xaml
@@ -8,6 +8,7 @@
     <StackPanel>
         <TextBlock Margin="12,12,12,0"
                    FontSize="16"
+                   Foreground="{DynamicResource PrimaryForegroundBrush}"
                    Text="{x:Static p:Resources.Results_MainInstruction}"/>
         <ScrollViewer MaxWidth="363"
                       MaxHeight="350"
@@ -28,7 +29,7 @@
         </ScrollViewer>
         <Border Margin="0,12,0,0"
                 Background="{DynamicResource SecondaryBackgroundBrush}"
-                BorderBrush="{DynamicResource {x:Static SystemColors.ControlLightBrushKey}}"
+                BorderBrush="{DynamicResource PrimaryBorderBrush}"
                 BorderThickness="0,1,0,0"
                 Padding="12,12">
             <StackPanel HorizontalAlignment="Right" Orientation="Horizontal">


### PR DESCRIPTION
## Summary of the Pull Request

# UX
- It now adopts Fluent Design, and uses ModernWPF to mimic the WinUI look and feel. Theming support has been added as well (including all versions of high contrast)
In that sense, it addresses #1053 but I wouldn't close it since we need a bigger UI refresh to adopt WinUI and really rethink the UI logic.
- Added DataTriggers that will disable the input boxes when the custom radiobutton is not selected.

Impression:

![ImageResizerFluent](https://user-images.githubusercontent.com/9866362/98482671-28d18c80-2203-11eb-875f-dd381b7cc599.gif)

Dark vs. light vs. high contrast
![image](https://user-images.githubusercontent.com/9866362/98482899-bbbef680-2204-11eb-8da2-948f11447e24.png)

Settings
![image](https://user-images.githubusercontent.com/9866362/98482943-fa54b100-2204-11eb-8026-08c43d43637c.png)

Progress view
![image](https://user-images.githubusercontent.com/9866362/98482970-2f610380-2205-11eb-9963-651c1823c938.png)




# Accessibility 
Solves various narrator/accessibility insights issues by setting the AutomationProperties.Name values:
#7062, #7059, #7055, #7034, #7038, #7041, #7045

This does introduce a new issue on the Settings page that I do not know how to solve. These items are part of a ListView, so it makes sense that they all have the name AutomationProperties.Name. The other issue is with using a Segoe MDL2 Glyph as the content on the delete button:

![image](https://user-images.githubusercontent.com/9866362/98483124-33d9ec00-2206-11eb-9214-2f0d553bf873.png)


## PR Checklist
* [X] Applies to #1053 #7062, #7059, #7055, #7034, #7038, #7041, #7045
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA