### PR TITLE
[README] [Fix] Links to File Explorer addons is a bit misleading

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ For a video overview of PowerToys, including install steps and a walkthrough of 
 
 ### File Explorer Add-ons
 
-[<img align="left" src="https://aka.ms/powerToysPowerPreviewImageSmall" />](https://aka.ms/PowerToysOverview_FileExplorerAddOns) [File Explorer](https://aka.ms/PowerToysOverview_FileExplorerAddOns) add-ons will enable SVG icon rendering and Preview Pane additions for File Explorer. 
+[<img align="left" src="https://aka.ms/powerToysPowerPreviewImageSmall" />](https://aka.ms/PowerToysOverview_FileExplorerAddOns) [File Explorer add-ons](https://aka.ms/PowerToysOverview_FileExplorerAddOns) will enable SVG icon rendering and Preview Pane additions for File Explorer. 
 
 Preview Pane is an existing feature in the File Explorer.  To enable it, you just click the View tab in the ribbon and then click "Preview Pane". PowerToys will now enable two types of files to be previewed: Markdown (.md) & SVG (.svg)
 <br/>


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

Changes this:

![image](https://user-images.githubusercontent.com/67918878/98457159-188dc300-21ab-11eb-85e1-4b44e41a0287.png)

To this:

![image](https://user-images.githubusercontent.com/67918878/98457176-20e5fe00-21ab-11eb-9841-bac1ccc55064.png)


## PR Checklist
* [x] Resolves #7922
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

