### PR TITLE
[PT Run] Log file not created

### DIFF
--- a/src/modules/launcher/PowerLauncher/ReportWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/ReportWindow.xaml.cs
@@ -42,9 +42,9 @@ namespace PowerLauncher
         {
             string path = Log.CurrentLogDirectory;
             var directory = new DirectoryInfo(path);
-            var log = directory.GetFiles().OrderByDescending(f => f.LastWriteTime).First();
+            var log = directory.GetFiles().OrderByDescending(f => f.LastWriteTime).FirstOrDefault();
 
-            LogFilePathBox.Text = log.FullName;
+            LogFilePathBox.Text = log?.FullName;
 
             StringBuilder content = new StringBuilder();
             content.AppendLine(ErrorReporting.RuntimeInfo());

--- a/src/modules/launcher/Wox.Plugin/Logger/Log.cs
+++ b/src/modules/launcher/Wox.Plugin/Logger/Log.cs
@@ -41,8 +41,8 @@ namespace Wox.Plugin.Logger
             var rule = new LoggingRule("*", LogLevel.Info, target);
 #endif
             configuration.LoggingRules.Add(rule);
-            LogManager.Configuration = configuration;
             target.Dispose();
+            LogManager.Configuration = configuration;
         }
 
         private static void LogInternalException(string message, System.Exception e, Type fullClassName, [CallerMemberName] string methodName = "", [CallerFilePath] string sourceFilePath = "", [CallerLineNumber] int sourceLineNumber = 0)


### PR DESCRIPTION
## Summary of the Pull Request

In master and 0.25.0 PT Run log file is not created.

## PR Checklist
* [x] Applies to #7834
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #7834

## Info on Pull Request

PT Run log file is not created.

## Validation Steps Performed

After PT Run startup the log file is created in `C:\Users\david\AppData\Local\Microsoft\PowerToys\PowerToys Run\Logs`.
