### PR TITLE
[FancyZones Editor][Accessibility] Default focused elements in all FancyZones Editor windows

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditorWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditorWindow.xaml
@@ -176,7 +176,7 @@
         </Style>
 
     </Window.Resources>
-    <StackPanel>
+    <StackPanel FocusManager.FocusedElement="{Binding ElementName=newZoneButton}">
         <TextBlock Name="windowEditorDialogTitle" Text="{x:Static props:Resources.Custom_Layout_Creator}" Style="{StaticResource titleText}"  />
         <Button x:Name="newZoneButton" AutomationProperties.LabeledBy="{Binding ElementName=newZoneName}" Width="496" Height="136" Style="{StaticResource newZoneButton}" Click="OnAddZone">
             <StackPanel>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditorWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditorWindow.xaml
@@ -179,7 +179,7 @@
 
         <TextBlock Text="{x:Static props:Resources.Note_Custom_Table}" Style="{StaticResource textLabel}" TextWrapping="Wrap" />
         <TextBlock x:Name="customLayoutName" Text="{x:Static props:Resources.Name}" Style="{StaticResource textLabel}" />
-        <TextBox Text="{Binding Name}" AutomationProperties.LabeledBy="{Binding ElementName=customLayoutName}" Style="{StaticResource textBox}" />
+        <TextBox Name="customLayoutNameTextBox" Text="{Binding Name}" GotFocus="NameTextBox_GotFocus" AutomationProperties.LabeledBy="{Binding ElementName=customLayoutName}" Style="{StaticResource textBox}" />
 <!--        
         <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
             <CheckBox x:Name="showGridSetting" VerticalAlignment="Center" HorizontalAlignment="Center" IsChecked="True" Margin="21,4,0,0"/>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditorWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditorWindow.xaml.cs
@@ -38,5 +38,15 @@ namespace FancyZonesEditor
         }
 
         private GridLayoutModel _stashedModel;
+
+        private void NameTextBox_GotFocus(object sender, RoutedEventArgs e)
+        {
+            customLayoutNameTextBox.CaretIndex = customLayoutNameTextBox.Text.Length;
+        }
+
+        public System.Windows.Controls.TextBox NameTextBox()
+        {
+            return customLayoutNameTextBox;
+        }
     }
 }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -187,8 +187,8 @@
             </ControlTemplate.Triggers>
         </ControlTemplate>
     </Window.Resources>
-    
-    <StackPanel>
+
+    <StackPanel FocusManager.FocusedElement="{Binding ElementName=decrementZones}">
 
         <TextBlock Name="DialogTitle" Text="{x:Static props:Resources.Choose_Layout}" Style="{StaticResource titleText}" />
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -154,9 +154,11 @@ namespace FancyZonesEditor
             mainEditor.Edit();
 
             EditorWindow window;
+            bool isGrid = false;
             if (model is GridLayoutModel)
             {
                 window = new GridEditorWindow();
+                isGrid = true;
             }
             else
             {
@@ -166,6 +168,10 @@ namespace FancyZonesEditor
             window.Owner = EditorOverlay.Current;
             window.DataContext = model;
             window.Show();
+            if (isGrid)
+            {
+                (window as GridEditorWindow).NameTextBox().Focus();
+            }
         }
 
         private void Apply_Click(object sender, RoutedEventArgs e)

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -724,7 +724,7 @@ void FancyZones::ToggleEditor() noexcept
     sei.fMask = { SEE_MASK_NOCLOSEPROCESS | SEE_MASK_FLAG_NO_UI };
     sei.lpFile = NonLocalizable::FZEditorExecutablePath;
     sei.lpParameters = params.c_str();
-    sei.nShow = SW_SHOWNORMAL;
+    sei.nShow = SW_SHOWDEFAULT;
     ShellExecuteEx(&sei);
     Trace::FancyZones::EditorLaunched(1);
 


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
First interactive element is now focused by default when each FZ Editor window is shown.

## PR Checklist
* [x] Applies to #7077
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Validation Steps Performed

_How does someone test & validate?_
Open FancyZones
Open FancyZones Editor
Navigate from one Editor window to another (Edit Selected Layout window - both Grid and Custom)
Observe that every window has focused element on opening, either by pressing Enter and observing the behavior, or if shown "focused dotted rectangle" for specific window element