### PR TITLE
[FancyZones] Enable keyboard accessibility for template and custom layout items

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -211,7 +211,10 @@
                                 <Border Margin="8" 
                                         BorderBrush="{Binding Path=IsSelected, Converter={StaticResource BooleanToBrushConverter}}"
                                         Style="{StaticResource templateBackground}" 
-                                        MouseDown="LayoutItem_Click">
+                                        MouseDown="LayoutItem_Click"
+                                        Focusable="True"
+                                        FocusManager.GotFocus="LayoutItem_Focused"
+                                        KeyDown="LayoutItem_Apply">
                                     <DockPanel Margin="0,20,0,0" 
                                                VerticalAlignment="Stretch" 
                                                HorizontalAlignment="Stretch" 
@@ -244,7 +247,10 @@
                                 <Border Margin="8"
                                         BorderBrush="{Binding Path=IsSelected, Converter={StaticResource BooleanToBrushConverter}}" 
                                         Style="{StaticResource templateBackground}" 
-                                        MouseDown="LayoutItem_Click">
+                                        MouseDown="LayoutItem_Click"
+                                        Focusable="True"
+                                        FocusManager.GotFocus="LayoutItem_Focused"
+                                        KeyDown="LayoutItem_Apply">
                                     <DockPanel Margin="0,20,0,0" 
                                                VerticalAlignment="Stretch" 
                                                HorizontalAlignment="Stretch" 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -84,6 +84,21 @@ namespace FancyZonesEditor
             Select(((Border)sender).DataContext as LayoutModel);
         }
 
+        private void LayoutItem_Focused(object sender, RoutedEventArgs e)
+        {
+            Select(((Border)sender).DataContext as LayoutModel);
+        }
+
+        private void LayoutItem_Apply(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Return || e.Key == Key.Space)
+            {
+                // When certain layout item (template or custom) is focused through keyboard and user
+                // presses Enter or Space key, layout will be applied.
+                Apply();
+            }
+        }
+
         private void Select(LayoutModel newSelection)
         {
             if (EditorOverlay.Current.DataContext is LayoutModel currentSelection)
@@ -154,6 +169,11 @@ namespace FancyZonesEditor
         }
 
         private void Apply_Click(object sender, RoutedEventArgs e)
+        {
+            Apply();
+        }
+
+        private void Apply()
         {
             EditorOverlay mainEditor = EditorOverlay.Current;
 


### PR DESCRIPTION
## Summary of the Pull Request

Template and custom layout items are now accessible through keyboard, either by navigating by `Tab` or through keyboard arrows. When certain layout is focused through keyboard, and user presses `Enter` or `Space` key, layout will be applied.

## PR Checklist
* [x] Applies to #7089
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

## Validation Steps Performed

1. Open PowerToys Settings App.
2. Navigate to FancyZones menu item and activate it.
3. Navigate to Launch Zone Editor button and activate it. Choose your layout for this desktop window will open.
4. Try accessing one of Focus/Column/Rows/Grid/Power Grid menu items using keyboard (`Tab` or keyboard arrows).
5. Press `Enter` or `Space` key.
6. Open FancyZones Editor again, and do the same with custom layouts.

Expected result: Layout items (both template and custom) are accessible through keyboard.
