### PR TITLE
[FancyZones] Update primary desktop data on virtual desktop switch

### DIFF
--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -898,9 +898,12 @@ void FancyZones::OnDisplayChange(DisplayChangeType changeType) noexcept
         if (changeType == DisplayChangeType::Initialization)
         {
             std::vector<std::wstring> ids{};
-            if (VirtualDesktopUtils::GetVirtualDesktopIds(ids) && !ids.empty())
+            if (VirtualDesktopUtils::GetVirtualDesktopIds(ids))
             {
-                FancyZonesDataInstance().UpdatePrimaryDesktopData(ids[0]);
+                if (ids.size() > 0)
+                {
+                    FancyZonesDataInstance().UpdatePrimaryDesktopData(ids[0]);
+                }
                 FancyZonesDataInstance().RemoveDeletedDesktops(ids);
             }
         }
@@ -1312,6 +1315,10 @@ void FancyZones::RegisterVirtualDesktopUpdates(std::vector<GUID>& ids) noexcept
     std::vector<std::wstring> active{};
     if (VirtualDesktopUtils::GetVirtualDesktopIds(active))
     {
+        if (active.size() > 0)
+        {
+            FancyZonesDataInstance().UpdatePrimaryDesktopData(active[0]);
+        }
         FancyZonesDataInstance().RemoveDeletedDesktops(active);
     }
 }

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -898,12 +898,9 @@ void FancyZones::OnDisplayChange(DisplayChangeType changeType) noexcept
         if (changeType == DisplayChangeType::Initialization)
         {
             std::vector<std::wstring> ids{};
-            if (VirtualDesktopUtils::GetVirtualDesktopIds(ids))
+            if (VirtualDesktopUtils::GetVirtualDesktopIds(ids) && ids.size() > 0)
             {
-                if (ids.size() > 0)
-                {
-                    FancyZonesDataInstance().UpdatePrimaryDesktopData(ids[0]);
-                }
+                FancyZonesDataInstance().UpdatePrimaryDesktopData(ids[0]);
                 FancyZonesDataInstance().RemoveDeletedDesktops(ids);
             }
         }
@@ -1313,12 +1310,9 @@ void FancyZones::RegisterVirtualDesktopUpdates(std::vector<GUID>& ids) noexcept
 
     m_workAreaHandler.RegisterUpdates(ids);
     std::vector<std::wstring> active{};
-    if (VirtualDesktopUtils::GetVirtualDesktopIds(active))
+    if (VirtualDesktopUtils::GetVirtualDesktopIds(active) && active.size() > 0)
     {
-        if (active.size() > 0)
-        {
-            FancyZonesDataInstance().UpdatePrimaryDesktopData(active[0]);
-        }
+        FancyZonesDataInstance().UpdatePrimaryDesktopData(active[0]);
         FancyZonesDataInstance().RemoveDeletedDesktops(active);
     }
 }

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -898,7 +898,7 @@ void FancyZones::OnDisplayChange(DisplayChangeType changeType) noexcept
         if (changeType == DisplayChangeType::Initialization)
         {
             std::vector<std::wstring> ids{};
-            if (VirtualDesktopUtils::GetVirtualDesktopIds(ids) && ids.size() > 0)
+            if (VirtualDesktopUtils::GetVirtualDesktopIds(ids) && !ids.empty())
             {
                 FancyZonesDataInstance().UpdatePrimaryDesktopData(ids[0]);
                 FancyZonesDataInstance().RemoveDeletedDesktops(ids);
@@ -1310,7 +1310,7 @@ void FancyZones::RegisterVirtualDesktopUpdates(std::vector<GUID>& ids) noexcept
 
     m_workAreaHandler.RegisterUpdates(ids);
     std::vector<std::wstring> active{};
-    if (VirtualDesktopUtils::GetVirtualDesktopIds(active) && active.size() > 0)
+    if (VirtualDesktopUtils::GetVirtualDesktopIds(active) && !active.empty())
     {
         FancyZonesDataInstance().UpdatePrimaryDesktopData(active[0]);
         FancyZonesDataInstance().RemoveDeletedDesktops(active);

--- a/src/modules/fancyzones/lib/FancyZonesData.cpp
+++ b/src/modules/fancyzones/lib/FancyZonesData.cpp
@@ -262,16 +262,17 @@ void FancyZonesData::RemoveDeletedDesktops(const std::vector<std::wstring>& acti
     for (auto it = std::begin(deviceInfoMap); it != std::end(deviceInfoMap);)
     {
         std::wstring desktopId = ExtractVirtualDesktopId(it->first);
-        auto foundId = active.find(desktopId);
-        if (foundId == std::end(active))
+        if (desktopId != NonLocalizable::DefaultGuid)
         {
-            RemoveDesktopAppZoneHistory(desktopId);
-            it = deviceInfoMap.erase(it);
+            auto foundId = active.find(desktopId);
+            if (foundId == std::end(active))
+            {
+                RemoveDesktopAppZoneHistory(desktopId);
+                it = deviceInfoMap.erase(it);
+                continue;
+            }
         }
-        else
-        {
-            ++it;
-        }
+        ++it;
     }
     SaveFancyZonesData();
 }

--- a/src/modules/fancyzones/lib/VirtualDesktopUtils.cpp
+++ b/src/modules/fancyzones/lib/VirtualDesktopUtils.cpp
@@ -86,17 +86,10 @@ namespace VirtualDesktopUtils
         {
             return true;
         }
-        // First fallback scenario is to try obtaining virtual desktop id through IVirtualDesktopManager
-        // interface. Use foreground window (the window with which the user is currently working) to determine
-        // current virtual desktop.
-        else if (GetWindowDesktopId(GetForegroundWindow(), desktopId))
-        {
-            return true;
-        }
-        // Second fallback scenario is to get array of virtual desktops stored in registry, but not kept per
-        // session. Note that we are taking first element from virtual desktop array, which is primary desktop.
-        // If user has more than one virtual desktop, one of previous functions should return correct value,
-        // as desktop switch occurred in current session.
+        // Fallback scenario is to get array of virtual desktops stored in registry, but not kept per session.
+        // Note that we are taking first element from virtual desktop array, which is primary desktop.
+        // If user has more than one virtual desktop, previous function should return correct value, as desktop
+        // switch occurred in current session.
         else
         {
             std::vector<GUID> ids{};


### PR DESCRIPTION
## Summary of the Pull Request

1. If user never made a new virtual desktop, there will be no information about virtual desktop id in the registry, and zeroed-GUID will be used. Migrate persisted information for zeroed-GUID in primary desktop when virtual desktop switch occurs. 
2. Don't use `IVirtualDesktopManager::GetWindowDesktopId` on `GetForegroundWindow` during initialization. If PowerToys start right away when system starts, `GetForegroundWindow` might not contain valid HWND, and we could end up with zeroed-GUID.

## PR Checklist
* [x] Applies to: https://github.com/microsoft/PowerToys/issues/7790
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

## Validation Steps Performed

1. Clear the registry (both _Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\SessionInfo\\<id>\\VirtualDesktops_ and _Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\VirtualDesktops_) and persisted FancyZones settings (_C:\Users\<user-name>\AppData\Local\Microsoft\PowerToys\FancyZones_), reboot the machine.
2. Start PowerToys and apply either template or custom layout on primary desktop.
3. Verify that layout information is persisted, and zeroed GUID is used to define primary desktop.
4. Create new virtual desktop.
5. Verify that layout information for primary desktop is preserved, but GUID is updated to the real one.
