### PR TITLE
[FancyZones] Add custom announcement to tab items

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -193,7 +193,7 @@
         <TextBlock Name="DialogTitle" Text="{x:Static props:Resources.Choose_Layout}" Style="{StaticResource titleText}" />
 
         <TabControl BorderThickness="0" x:Name="TemplateTab" AutomationProperties.LabeledBy="{Binding ElementName=DialogTitle}" SelectedIndex="{Binding IsCustomLayoutActive, Mode=OneWay, Converter={StaticResource BooleanToIntConverter}}">
-            <TabItem Header="{x:Static props:Resources.Templates}" Template="{StaticResource myTabs}">
+            <TabItem Header="{x:Static props:Resources.Templates}" Template="{StaticResource myTabs}" AutomationProperties.Name="{x:Static props:Resources.Tab_Item_Templates}">
                 <StackPanel>
                     <StackPanel Margin="0,15,0,8" Orientation="Horizontal" HorizontalAlignment="Center">
                         <Button x:Name="decrementZones" Width="40" Height="40" AutomationProperties.Name="{x:Static props:Resources.Zone_Count_Decrement}" Content="-" Style="{StaticResource spinnerButton}" Click="DecrementZones_Click"/>
@@ -234,7 +234,7 @@
             </TabItem>
             
             
-            <TabItem Header="{x:Static props:Resources.Custom}" Template="{StaticResource myTabs}">
+            <TabItem Header="{x:Static props:Resources.Custom}" Template="{StaticResource myTabs}" AutomationProperties.Name="{x:Static props:Resources.Tab_Item_Custom}">
                 <StackPanel>
                     <ItemsControl ItemsSource="{Binding CustomModels}" Margin="8,8,0,0">
                         <ItemsControl.ItemsPanel>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
@@ -295,6 +295,24 @@ namespace FancyZonesEditor.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Custom tab selected, press ctrl + tab to switch to Templates.
+        /// </summary>
+        public static string Tab_Item_Custom {
+            get {
+                return ResourceManager.GetString("Tab_Item_Custom", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Templates tab selected, press ctrl + tab to switch to Custom.
+        /// </summary>
+        public static string Tab_Item_Templates {
+            get {
+                return ResourceManager.GetString("Tab_Item_Templates", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Columns.
         /// </summary>
         public static string Template_Layout_Columns {

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
@@ -220,4 +220,10 @@
   <data name="Template_Layout_Rows" xml:space="preserve">
     <value>Rows</value>
   </data>
+  <data name="Tab_Item_Custom" xml:space="preserve">
+    <value>Custom tab selected, press ctrl + tab to switch to Templates</value>
+  </data>
+  <data name="Tab_Item_Templates" xml:space="preserve">
+    <value>Templates tab selected, press ctrl + tab to switch to Custom</value>
+  </data>
 </root>


### PR DESCRIPTION
## Summary of the Pull Request

Add custom, localized string which should be announced when user selects templates or custom tab. User can switch between those two by pressing ctrl + tab.

## PR Checklist
* [x] Applies to #7076
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA

## Validation Steps Performed

1. Open PowerToys Settings application.
2. Navigate to FancyZones present at the left side of the pane and activate it.
3. Navigate to 'Launch Zone Editor' present at the right side of the pane and activate it.
4. Choose your layout for this desktop utility dialog will get open.
5. Navigate to Template and Custom tab items using Tab key.
