### PR TITLE
[FancyZones Editor][Accessibility] Remove Left/Right Window Commands

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/EditorOverlay.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/EditorOverlay.xaml.cs
@@ -95,6 +95,8 @@ namespace FancyZonesEditor
             _mainWindow.ShowActivated = true;
             _mainWindow.Topmost = true;
             _mainWindow.Show();
+            _mainWindow.LeftWindowCommands = null;
+            _mainWindow.RightWindowCommands = null;
 
             // window is set to topmost to make sure it shows on top of PowerToys settings page
             // we can reset topmost flag now

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -166,12 +166,17 @@ namespace FancyZonesEditor
             }
 
             window.Owner = EditorOverlay.Current;
+
             window.DataContext = model;
             window.Show();
+
             if (isGrid)
             {
                 (window as GridEditorWindow).NameTextBox().Focus();
             }
+
+            window.LeftWindowCommands = null;
+            window.RightWindowCommands = null;
         }
 
         private void Apply_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
Screen reader is reading Left/Right Window Commands elements of the Metro Window. To prevent this, remove them.

## PR Checklist
* [x] Applies to #7072
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Validation Steps Performed

_How does someone test & validate?_
 - Open FancyZones Editor
 - Click Edit Selected item
 - Turn on Narrator
 - Navigate through window elements using arrow keys
 - Observe that there are no hidden elements in top left corner of the screen, i.e. Narrator doesn't narrate them

Do the same for both Grid and Custom editor windows