### PR TITLE
Change Settings' Resources.resw to use the name PowerRename consistently. 

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -687,7 +687,7 @@
     <comment>do not loc the product name</comment>
   </data>
   <data name="PowerRename_Image.AutomationProperties.Name" xml:space="preserve">
-    <value>Power Rename</value>
+    <value>PowerRename</value>
   </data>
   <data name="About_ShortcutGuide.Text" xml:space="preserve">
     <value>About Shortcut Guide</value>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -688,6 +688,7 @@
   </data>
   <data name="PowerRename_Image.AutomationProperties.Name" xml:space="preserve">
     <value>PowerRename</value>
+    <comment>do not loc</comment>
   </data>
   <data name="About_ShortcutGuide.Text" xml:space="preserve">
     <value>About Shortcut Guide</value>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -684,6 +684,7 @@
   </data>
   <data name="About_PowerRename.Text" xml:space="preserve">
     <value>About PowerRename</value>
+    <comment>do not loc the product name</comment>
   </data>
   <data name="PowerRename_Image.AutomationProperties.Name" xml:space="preserve">
     <value>Power Rename</value>

--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -683,7 +683,7 @@
     <value>PowerToys Run</value>
   </data>
   <data name="About_PowerRename.Text" xml:space="preserve">
-    <value>About Power Rename</value>
+    <value>About PowerRename</value>
   </data>
   <data name="PowerRename_Image.AutomationProperties.Name" xml:space="preserve">
     <value>Power Rename</value>


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

PowerRename Settings page uses "PowerRename" and "Power Rename" inconsistently 

## PR Checklist
* [x] Applies to #8059
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #8059 

## Info on Pull Request

_What does this include?_

Changes "Power Rename" to "PowerRename" in PowerRename Settings' Description

## Validation Steps Performed

*Not required*
