### PR TITLE
[FancyZones Editor] Reset layout

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -445,7 +445,7 @@
         </Grid>
 
 		<StackPanel Orientation="Horizontal" Margin="0,10,0,16">
-            <Button x:Name="ResetButton" Content="{x:Static props:Resources.Reset_Layout}" Padding="8" Style="{StaticResource secondaryButton}" Click="ResetButton_Click"/>
+            <Button x:Name="ResetButton" Content="{x:Static props:Resources.Reset_Layout}" Padding="8" Style="{StaticResource secondaryButton}" Click="Reset_Click"/>
             <Button x:Name="EditCustomButton" Content="{x:Static props:Resources.Edit_Selected_Layout}" Padding="8" Style="{StaticResource secondaryButton}" Click="EditLayout_Click"/>
             <Button x:Name="ApplyCustomButton" Content="{x:Static props:Resources.Apply}" Padding="8" Style="{StaticResource primaryButton}" Click="Apply_Click"/>
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -90,7 +90,7 @@
             <Setter Property="BorderThickness" Value="0"/>
             <Setter Property="Background" Value="#767676"/>
             <Setter Property="Margin" Value="16,0,0,0" />
-            <Setter Property="Width" Value="245"/>
+            <Setter Property="Width" Value="200"/>
             <Setter Property="Height" Value="32"/>
             <Setter Property="FocusVisualStyle" Value="{DynamicResource customButtonFocusVisualStyle}" />
             <Setter Property="Template">
@@ -117,7 +117,7 @@
             <Setter Property="BorderThickness" Value="0"/>
             <Setter Property="Background" Value="#0078D7"/>
             <Setter Property="Margin" Value="16,0,0,0" />
-            <Setter Property="Width" Value="245"/>
+            <Setter Property="Width" Value="220"/>
             <Setter Property="Height" Value="32"/>
             <Setter Property="FocusVisualStyle" Value="{DynamicResource customButtonFocusVisualStyle}" />
             <Setter Property="Template">
@@ -445,6 +445,7 @@
         </Grid>
 
 		<StackPanel Orientation="Horizontal" Margin="0,10,0,16">
+            <Button x:Name="ResetButton" Content="{x:Static props:Resources.Reset_Layout}" Padding="8" Style="{StaticResource secondaryButton}" Click="ResetButton_Click"/>
             <Button x:Name="EditCustomButton" Content="{x:Static props:Resources.Edit_Selected_Layout}" Padding="8" Style="{StaticResource secondaryButton}" Click="EditLayout_Click"/>
             <Button x:Name="ApplyCustomButton" Content="{x:Static props:Resources.Apply}" Padding="8" Style="{StaticResource primaryButton}" Click="Apply_Click"/>
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -193,6 +193,7 @@ namespace FancyZonesEditor
         {
             LayoutModel.SerializeDeletedCustomZoneSets();
             App.Overlay.CloseLayoutWindow();
+            App.Current.Shutdown();
         }
 
         private void OnInitialized(object sender, EventArgs e)

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -244,7 +244,7 @@ namespace FancyZonesEditor
             this.Close();
         }
 
-        private void ResetButton_Click(object sender, RoutedEventArgs e)
+        private void Reset_Click(object sender, RoutedEventArgs e)
         {
             var overlay = App.Overlay;
             MainWindowSettingsModel settings = ((App)Application.Current).MainWindowSettings;

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -242,5 +242,28 @@ namespace FancyZonesEditor
         {
             this.Close();
         }
+
+        private void ResetButton_Click(object sender, RoutedEventArgs e)
+        {
+            var overlay = App.Overlay;
+            MainWindowSettingsModel settings = ((App)Application.Current).MainWindowSettings;
+
+            if (overlay.CurrentDataContext is LayoutModel model)
+            {
+                model.IsSelected = false;
+                model.IsApplied = false;
+            }
+
+            overlay.CurrentLayoutSettings.ZonesetUuid = settings.BlankModel.Uuid;
+            overlay.CurrentLayoutSettings.Type = LayoutType.Blank;
+            overlay.CurrentDataContext = settings.BlankModel;
+
+            App.FancyZonesEditorIO.SerializeAppliedLayouts();
+
+            if (!overlay.MultiMonitorMode)
+            {
+                Close();
+            }
+        }
     }
 }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/CanvasLayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/CanvasLayoutModel.cs
@@ -120,10 +120,16 @@ namespace FancyZonesEditor.Models
         {
             AddCustomLayout(this);
 
+            var canvasRect = CanvasRect;
+            if (canvasRect.Width == 0 || canvasRect.Height == 0)
+            {
+                canvasRect = App.Overlay.WorkArea;
+            }
+
             CanvasLayoutInfo layoutInfo = new CanvasLayoutInfo
             {
-                RefWidth = (int)CanvasRect.Width,
-                RefHeight = (int)CanvasRect.Height,
+                RefWidth = (int)canvasRect.Width,
+                RefHeight = (int)canvasRect.Height,
                 Zones = new Zone[Zones.Count],
             };
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutSettings.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutSettings.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using FancyZonesEditor.Models;
 
 namespace FancyZonesEditor
@@ -15,8 +16,6 @@ namespace FancyZonesEditor
         public static int DefaultZoneCount => 3;
 
         public static int DefaultSensitivityRadius => 20;
-
-        public string DeviceId { get; set; } = string.Empty;
 
         public string ZonesetUuid { get; set; } = string.Empty;
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/MainWindowSettingsModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/MainWindowSettingsModel.cs
@@ -46,9 +46,6 @@ namespace FancyZonesEditor
         public static readonly string RegistryPath = "SOFTWARE\\SuperFancyZones";
         public static readonly string FullRegistryPath = "HKEY_CURRENT_USER\\" + RegistryPath;
 
-        private const string LayoutTypeBlankStr = "blank";
-        private const string NullUuidStr = "null";
-
         // hard coded data for all the "Priority Grid" configurations that are unique to "Grid"
         private static readonly byte[][] _priorityData = new byte[][]
         {
@@ -364,6 +361,16 @@ namespace FancyZonesEditor
 
         private static ObservableCollection<LayoutModel> _customModels;
 
+        public CanvasLayoutModel BlankModel
+        {
+            get
+            {
+                return _blankModel;
+            }
+        }
+
+        private CanvasLayoutModel _blankModel = new CanvasLayoutModel(string.Empty, LayoutType.Blank);
+
         public static bool IsPredefinedLayout(LayoutModel model)
         {
             return model.Type != LayoutType.Custom;
@@ -379,7 +386,11 @@ namespace FancyZonesEditor
             LayoutSettings currentApplied = App.Overlay.CurrentLayoutSettings;
 
             // set new layout
-            if (currentApplied.Type == LayoutType.Custom)
+            if (currentApplied.Type == LayoutType.Blank)
+            {
+                foundModel = BlankModel;
+            }
+            else if (currentApplied.Type == LayoutType.Custom)
             {
                 foreach (LayoutModel model in MainWindowSettingsModel.CustomModels)
                 {

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/MainWindowSettingsModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/MainWindowSettingsModel.cs
@@ -417,7 +417,7 @@ namespace FancyZonesEditor
 
             if (foundModel == null)
             {
-                foundModel = DefaultModels[0];
+                foundModel = DefaultModels[4]; // PriorityGrid
             }
 
             foundModel.IsSelected = true;

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
@@ -349,6 +349,15 @@ namespace FancyZonesEditor.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Reset.
+        /// </summary>
+        public static string Reset_Layout {
+            get {
+                return ResourceManager.GetString("Reset_Layout", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Save and apply.
         /// </summary>
         public static string Save_Apply {

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
@@ -349,7 +349,7 @@ namespace FancyZonesEditor.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Reset.
+        ///   Looks up a localized string similar to Reset layout.
         /// </summary>
         public static string Reset_Layout {
             get {

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
@@ -255,5 +255,6 @@
   </data>
   <data name="Reset_Layout" xml:space="preserve">
     <value>Reset</value>
+    <comment>as in Reset to a blank value</comment.
   </data>
 </root>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
@@ -253,4 +253,7 @@
   <data name="Error_Monitor_Match_Not_Found" xml:space="preserve">
     <value>Match not found ({0})</value>
   </data>
+  <data name="Reset_Layout" xml:space="preserve">
+    <value>Reset</value>
+  </data>
 </root>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
@@ -254,7 +254,7 @@
     <value>Match not found ({0})</value>
   </data>
   <data name="Reset_Layout" xml:space="preserve">
-    <value>Reset</value>
+    <value>Reset layout</value>
     <comment>as in Reset to a blank value</comment>
   </data>
 </root>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
@@ -255,6 +255,6 @@
   </data>
   <data name="Reset_Layout" xml:space="preserve">
     <value>Reset</value>
-    <comment>as in Reset to a blank value</comment.
+    <comment>as in Reset to a blank value</comment>
   </data>
 </root>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
@@ -319,7 +319,6 @@ namespace FancyZonesEditor.Utils
                                 {
                                     monitors[monitorIndex].Settings = new LayoutSettings
                                     {
-                                        DeviceId = deviceId,
                                         ZonesetUuid = zonesetData.GetProperty(ActiveZoneSetJsonTag).GetProperty(UuidJsonTag).GetString(),
                                         ShowSpacing = zonesetData.GetProperty(EditorShowSpacingJsonTag).GetBoolean(),
                                         Spacing = zonesetData.GetProperty(EditorSpacingJsonTag).GetInt32(),
@@ -340,7 +339,6 @@ namespace FancyZonesEditor.Utils
                                 // one zoneset for all desktops
                                 App.Overlay.Monitors[App.Overlay.CurrentDesktop].Settings = new LayoutSettings
                                 {
-                                    DeviceId = deviceId,
                                     ZonesetUuid = zonesetData.GetProperty(ActiveZoneSetJsonTag).GetProperty(UuidJsonTag).GetString(),
                                     ShowSpacing = zonesetData.GetProperty(EditorShowSpacingJsonTag).GetBoolean(),
                                     Spacing = zonesetData.GetProperty(EditorSpacingJsonTag).GetInt32(),
@@ -527,7 +525,7 @@ namespace FancyZonesEditor.Utils
 
                 applied.AppliedZonesets.Add(new AppliedZoneSet
                 {
-                    DeviceId = zoneset.DeviceId,
+                    DeviceId = monitor.Device.Id,
                     ActiveZoneset = activeZoneSet,
                     EditorShowSpacing = zoneset.ShowSpacing,
                     EditorSpacing = zoneset.Spacing,

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
@@ -57,6 +57,9 @@ namespace FancyZonesEditor.Utils
         private const string AppliedZoneSetsTmpFileName = "FancyZonesAppliedZoneSets.json";
         private const string DeletedCustomZoneSetsTmpFileName = "FancyZonesDeletedCustomZoneSets.json";
 
+        // Non-localizable string: Multi-monitor id
+        private const string MultiMonitorId = "FancyZones#MultiMonitorDevice";
+
         private readonly IFileSystem _fileSystem = new FileSystem();
 
         private JsonSerializerOptions _options = new JsonSerializerOptions
@@ -334,7 +337,7 @@ namespace FancyZonesEditor.Utils
                         }
                         else
                         {
-                            bool isLayoutMultiMonitor = deviceId.StartsWith("FancyZones#MultiMonitorDevice");
+                            bool isLayoutMultiMonitor = deviceId.StartsWith(MultiMonitorId);
                             if (isLayoutMultiMonitor)
                             {
                                 // one zoneset for all desktops
@@ -347,6 +350,8 @@ namespace FancyZonesEditor.Utils
                                     ZoneCount = zonesetData.GetProperty(EditorZoneCountJsonTag).GetInt32(),
                                     SensitivityRadius = zonesetData.GetProperty(EditorSensitivityRadiusJsonTag).GetInt32(),
                                 };
+
+                                App.Overlay.Monitors[App.Overlay.CurrentDesktop].Device.Id = deviceId;
 
                                 break;
                             }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
@@ -28,6 +28,7 @@ namespace FancyZonesEditor.Utils
         private const string EditorZoneCountJsonTag = "editor-zone-count";
         private const string EditorSensitivityRadiusJsonTag = "editor-sensitivity-radius";
 
+        private const string BlankJsonTag = "blank";
         private const string FocusJsonTag = "focus";
         private const string ColumnsJsonTag = "columns";
         private const string RowsJsonTag = "rows";
@@ -613,6 +614,8 @@ namespace FancyZonesEditor.Utils
         {
             switch (type)
             {
+                case LayoutType.Blank:
+                    return BlankJsonTag;
                 case LayoutType.Focus:
                     return FocusJsonTag;
                 case LayoutType.Rows:

--- a/src/modules/fancyzones/lib/JsonHelpers.cpp
+++ b/src/modules/fancyzones/lib/JsonHelpers.cpp
@@ -619,10 +619,7 @@ namespace JSONHelpers
 
         for (const auto& [deviceID, deviceData] : deviceInfoMap)
         {
-            if (deviceData.activeZoneSet.type != FancyZonesDataTypes::ZoneSetLayoutType::Blank)
-            {
-                DeviceInfosJSON.Append(DeviceInfoJSON::DeviceInfoJSON::ToJson(DeviceInfoJSON{ deviceID, deviceData }));
-            }
+            DeviceInfosJSON.Append(DeviceInfoJSON::DeviceInfoJSON::ToJson(DeviceInfoJSON{ deviceID, deviceData }));
         }
 
         return DeviceInfosJSON;

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -390,7 +390,7 @@ void ZoneWindow::CalculateZoneSet() noexcept
 
     const auto& activeZoneSet = deviceInfoData->activeZoneSet;
 
-    if (activeZoneSet.uuid.empty() || activeZoneSet.type == FancyZonesDataTypes::ZoneSetLayoutType::Blank)
+    if (activeZoneSet.uuid.empty())
     {
         return;
     }


### PR DESCRIPTION
## Summary of the Pull Request

Allow resetting layout on the selected monitor.  

## PR Checklist
* [x] Applies to #192
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

Added `Reset` button that helps to deselect applied or default layout on the selected monitor.
After resetting the layout has the `Blank` type.  All other layout settings (zones count, spacing, etc.) remain the same and are saved as usual.

![Capture (Small) (1)](https://user-images.githubusercontent.com/8949536/99540486-9d08ee80-29c0-11eb-92aa-bddcf5bb6b73.PNG)

![Capture (Small)](https://user-images.githubusercontent.com/8949536/99540311-67fc9c00-29c0-11eb-8a9f-16588b4255a1.PNG)


![Image 2020-11-18 at 5 09 47 PM](https://user-images.githubusercontent.com/8949536/99540837-1accfa00-29c1-11eb-8952-15f665be54d4.png)


## Validation Steps Performed

* Reset layout with `Allow zones to span across monitors` selected.
* Reset layout with `Allow zones to span across monitors` deselected.
* Verify after resetting:
  * no layout marked as selected (blue border)
  * no layout marked as applied (blue background)
  * layouts are saved and applied correctly
