### PR TITLE
removed temp files check

### DIFF
--- a/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
@@ -93,28 +93,12 @@ namespace FancyZonesUnitTests
             m_parentUniqueId << L"DELA026#5&10a58c63&0&UID16777488_" << m_monitorInfo.rcMonitor.right << "_" << m_monitorInfo.rcMonitor.bottom << "_{61FA9FC0-26A6-4B37-A834-491C148DFC57}";
             m_uniqueId << L"DELA026#5&10a58c63&0&UID16777488_" << m_monitorInfo.rcMonitor.right << "_" << m_monitorInfo.rcMonitor.bottom << "_{39B25DD2-130D-4B5D-8851-4791D66B1539}";
 
-            Assert::IsFalse(m_fancyZonesData.activeZoneSetTmpFileName.empty());
-            Assert::IsFalse(m_fancyZonesData.appliedZoneSetTmpFileName.empty());
-            Assert::IsFalse(m_fancyZonesData.deletedCustomZoneSetsTmpFileName.empty());
-
-            Assert::IsFalse(std::filesystem::exists(m_fancyZonesData.activeZoneSetTmpFileName));
-            Assert::IsFalse(std::filesystem::exists(m_fancyZonesData.appliedZoneSetTmpFileName));
-            Assert::IsFalse(std::filesystem::exists(m_fancyZonesData.deletedCustomZoneSetsTmpFileName));
-
             m_fancyZonesData.SetSettingsModulePath(L"FancyZonesUnitTests");
             m_fancyZonesData.clear_data();
 
             auto guid = Helpers::StringToGuid(L"{39B25DD2-130D-4B5D-8851-4791D66B1539}");
             Assert::IsTrue(guid.has_value());
             m_virtualDesktopGuid = *guid;
-        }
-
-        TEST_METHOD_CLEANUP(Cleanup)
-        {
-            //cleanup temp files if were created
-            std::filesystem::remove(m_fancyZonesData.activeZoneSetTmpFileName);
-            std::filesystem::remove(m_fancyZonesData.appliedZoneSetTmpFileName);
-            std::filesystem::remove(m_fancyZonesData.deletedCustomZoneSetsTmpFileName);
         }
 
         TEST_METHOD(CreateZoneWindow)
@@ -457,24 +441,8 @@ namespace FancyZonesUnitTests
 
             m_uniqueId << L"DELA026#5&10a58c63&0&UID16777488_" << m_monitorInfo.rcMonitor.right << "_" << m_monitorInfo.rcMonitor.bottom << "_{39B25DD2-130D-4B5D-8851-4791D66B1539}";
 
-            Assert::IsFalse(m_fancyZonesData.activeZoneSetTmpFileName.empty());
-            Assert::IsFalse(m_fancyZonesData.appliedZoneSetTmpFileName.empty());
-            Assert::IsFalse(m_fancyZonesData.deletedCustomZoneSetsTmpFileName.empty());
-
-            Assert::IsFalse(std::filesystem::exists(m_fancyZonesData.activeZoneSetTmpFileName));
-            Assert::IsFalse(std::filesystem::exists(m_fancyZonesData.appliedZoneSetTmpFileName));
-            Assert::IsFalse(std::filesystem::exists(m_fancyZonesData.deletedCustomZoneSetsTmpFileName));
-
             m_fancyZonesData.SetSettingsModulePath(L"FancyZonesUnitTests");
             m_fancyZonesData.clear_data();
-        }
-
-        TEST_METHOD_CLEANUP(Cleanup)
-        {
-            //cleanup temp files if were created
-            std::filesystem::remove(m_fancyZonesData.activeZoneSetTmpFileName);
-            std::filesystem::remove(m_fancyZonesData.appliedZoneSetTmpFileName);
-            std::filesystem::remove(m_fancyZonesData.deletedCustomZoneSetsTmpFileName);
         }
 
     public:


### PR DESCRIPTION
## Summary of the Pull Request

Verified that `ZoneWindowCreationUnitTests` and `ZoneWindowUnitTests` don't use temp files `FancyZonesActiveZoneSets.json`, `FancyZonesAppliedZoneSets.json`, `FancyZonesDeletedCustomZoneSets.json`, so checks could be removed as unnecessary.

## PR Checklist
* [x] Applies to #7441
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx
