### PR TITLE
[PowerRename] Fix tests inconsistency, improve test performance

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -2267,6 +2267,7 @@ tif
 TILEDWINDOW
 timeinfo
 Timeline
+timeunion
 timeutil
 titlecase
 tlb
@@ -2342,6 +2343,7 @@ UIPI
 UIs
 uk
 ul
+ULARGE
 ULLONG
 ulong
 unchecks

--- a/src/modules/powerrename/dll/PowerRenameExt.cpp
+++ b/src/modules/powerrename/dll/PowerRenameExt.cpp
@@ -122,9 +122,9 @@ HRESULT CPowerRenameMenu::InvokeCommand(_In_ LPCMINVOKECOMMANDINFO pici)
         (LOWORD(pici->lpVerb) == 0))
     {
         Trace::Invoked();
+        hr = E_OUTOFMEMORY;
         InvokeStruct* pInvokeData = new (std::nothrow) InvokeStruct;
-        hr = pInvokeData ? S_OK : E_OUTOFMEMORY;
-        if (SUCCEEDED(hr))
+        if (pInvokeData)
         {
             pInvokeData->hwndParent = pici->hwnd;
             hr = CoMarshalInterThreadInterfaceInStream(__uuidof(m_spdo), m_spdo, &(pInvokeData->pstrm));
@@ -248,8 +248,8 @@ HRESULT __stdcall CPowerRenameMenu::Invoke(IShellItemArray* psiItemArray, IBindC
 #endif
     Trace::Invoked();
     InvokeStruct* pInvokeData = new (std::nothrow) InvokeStruct;
-    HRESULT hr = pInvokeData ? S_OK : E_OUTOFMEMORY;
-    if (SUCCEEDED(hr))
+    HRESULT hr = E_OUTOFMEMORY;
+    if (pInvokeData)
     {
         pInvokeData->hwndParent = nullptr;
         hr = CoMarshalInterThreadInterfaceInStream(__uuidof(psiItemArray), psiItemArray, &(pInvokeData->pstrm));

--- a/src/modules/powerrename/dll/PowerRenameExt.cpp
+++ b/src/modules/powerrename/dll/PowerRenameExt.cpp
@@ -122,8 +122,8 @@ HRESULT CPowerRenameMenu::InvokeCommand(_In_ LPCMINVOKECOMMANDINFO pici)
         (LOWORD(pici->lpVerb) == 0))
     {
         Trace::Invoked();
-        hr = E_OUTOFMEMORY;
         InvokeStruct* pInvokeData = new (std::nothrow) InvokeStruct;
+        hr = E_OUTOFMEMORY;
         if (pInvokeData)
         {
             pInvokeData->hwndParent = pici->hwnd;

--- a/src/modules/powerrename/dll/dllmain.cpp
+++ b/src/modules/powerrename/dll/dllmain.cpp
@@ -123,9 +123,10 @@ STDAPI DllCanUnloadNow(void)
 //
 STDAPI DllGetClassObject(_In_ REFCLSID clsid, _In_ REFIID riid, _Outptr_ void** ppv)
 {
+    HRESULT hr = E_FAIL;
     *ppv = NULL;
     CPowerRenameClassFactory* pClassFactory = new CPowerRenameClassFactory(clsid);
-    HRESULT hr = pClassFactory->QueryInterface(riid, ppv);
+    hr = pClassFactory->QueryInterface(riid, ppv);
     pClassFactory->Release();
     return hr;
 }

--- a/src/modules/powerrename/lib/Helpers.cpp
+++ b/src/modules/powerrename/lib/Helpers.cpp
@@ -189,7 +189,7 @@ HRESULT GetDatedFileName(_Out_ PWSTR result, UINT cchMax, _In_ PCWSTR source, SY
 {
     std::locale::global(std::locale(""));
     HRESULT hr = E_INVALIDARG;     
-    if ((source && wcslen(source) > 0))
+    if (source && wcslen(source) > 0)
     {
         std::wstring res(source);
         wchar_t replaceTerm[MAX_PATH] = { 0 };
@@ -346,7 +346,7 @@ HRESULT _ParseEnumItems(_In_ IEnumShellItems* pesi, _In_ IPowerRenameManager* ps
 HRESULT EnumerateDataObject(_In_ IUnknown* dataSource, _In_ IPowerRenameManager* psrm)
 {
     CComPtr<IShellItemArray> spsia;
-    HRESULT hr = E_FAIL; 
+    HRESULT hr = E_FAIL;
     if (SUCCEEDED(_GetShellItemArrayFromDataOject(dataSource, &spsia)))
     {
         CComPtr<IEnumShellItems> spesi;

--- a/src/modules/powerrename/lib/Helpers.cpp
+++ b/src/modules/powerrename/lib/Helpers.cpp
@@ -9,7 +9,7 @@ namespace fs = std::filesystem;
 
 HRESULT GetTrimmedFileName(_Out_ PWSTR result, UINT cchMax, _In_ PCWSTR source)
 {
-    HRESULT hr = (source && wcslen(source) > 0) ? S_OK : E_INVALIDARG;
+    HRESULT hr = source ? S_OK : E_INVALIDARG;
     if (SUCCEEDED(hr))
     {
         PWSTR newName = nullptr;
@@ -38,7 +38,7 @@ HRESULT GetTrimmedFileName(_Out_ PWSTR result, UINT cchMax, _In_ PCWSTR source)
 HRESULT GetTransformedFileName(_Out_ PWSTR result, UINT cchMax, _In_ PCWSTR source, DWORD flags)
 {
     std::locale::global(std::locale(""));
-    HRESULT hr = (source && wcslen(source) > 0 && flags) ? S_OK : E_INVALIDARG;
+    HRESULT hr = (source && flags) ? S_OK : E_INVALIDARG;
     if (SUCCEEDED(hr))
     {
         if (flags & Uppercase)

--- a/src/modules/powerrename/lib/Helpers.cpp
+++ b/src/modules/powerrename/lib/Helpers.cpp
@@ -169,7 +169,7 @@ HRESULT GetTransformedFileName(_Out_ PWSTR result, UINT cchMax, _In_ PCWSTR sour
     return hr;
 }
 
-bool isFileAttributesUsed(_In_ PCWSTR source) 
+bool isFileTimeUsed(_In_ PCWSTR source) 
 {
     bool used = false;
     std::wstring patterns[] = { L"(([^\\$]|^)(\\$\\$)*)\\$Y", L"(([^\\$]|^)(\\$\\$)*)\\$M", L"(([^\\$]|^)(\\$\\$)*)\\$D", 

--- a/src/modules/powerrename/lib/Helpers.cpp
+++ b/src/modules/powerrename/lib/Helpers.cpp
@@ -185,7 +185,7 @@ bool isFileAttributesUsed(_In_ PCWSTR source)
     return used;
 }
 
-HRESULT GetDatedFileName(_Out_ PWSTR result, UINT cchMax, _In_ PCWSTR source, SYSTEMTIME LocalTime)
+HRESULT GetDatedFileName(_Out_ PWSTR result, UINT cchMax, _In_ PCWSTR source, SYSTEMTIME fileTime)
 {
     std::locale::global(std::locale(""));
     HRESULT hr = (source && wcslen(source) > 0) ? S_OK : E_INVALIDARG;     
@@ -201,72 +201,72 @@ HRESULT GetDatedFileName(_Out_ PWSTR result, UINT cchMax, _In_ PCWSTR source, SY
             StringCchCopy(localeName, LOCALE_NAME_MAX_LENGTH, L"en_US");
         }
 
-        StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%04d"), L"$01", LocalTime.wYear);
+        StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%04d"), L"$01", fileTime.wYear);
         res = regex_replace(res, std::wregex(L"(([^\\$]|^)(\\$\\$)*)\\$YYYY"), replaceTerm);
 
-        StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%02d"), L"$01", (LocalTime.wYear % 100));
+        StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%02d"), L"$01", (fileTime.wYear % 100));
         res = regex_replace(res, std::wregex(L"(([^\\$]|^)(\\$\\$)*)\\$YY"), replaceTerm);
 
-        StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%d"), L"$01", (LocalTime.wYear % 10));
+        StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%d"), L"$01", (fileTime.wYear % 10));
         res = regex_replace(res, std::wregex(L"(([^\\$]|^)(\\$\\$)*)\\$Y"), replaceTerm);
         
-        GetDateFormatEx(localeName, NULL, &LocalTime, L"MMMM", formattedDate, MAX_PATH, NULL);
+        GetDateFormatEx(localeName, NULL, &fileTime, L"MMMM", formattedDate, MAX_PATH, NULL);
         formattedDate[0] = towupper(formattedDate[0]);
         StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%s"), L"$01", formattedDate);
         res = regex_replace(res, std::wregex(L"(([^\\$]|^)(\\$\\$)*)\\$MMMM"), replaceTerm);
         
-        GetDateFormatEx(localeName, NULL, &LocalTime, L"MMM", formattedDate, MAX_PATH, NULL);
+        GetDateFormatEx(localeName, NULL, &fileTime, L"MMM", formattedDate, MAX_PATH, NULL);
         formattedDate[0] = towupper(formattedDate[0]);
         StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%s"), L"$01", formattedDate);
         res = regex_replace(res, std::wregex(L"(([^\\$]|^)(\\$\\$)*)\\$MMM"), replaceTerm);
                 
-        StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%02d"), L"$01", LocalTime.wMonth);
+        StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%02d"), L"$01", fileTime.wMonth);
         res = regex_replace(res, std::wregex(L"(([^\\$]|^)(\\$\\$)*)\\$MM"), replaceTerm);
 
-        StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%d"), L"$01", LocalTime.wMonth);
+        StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%d"), L"$01", fileTime.wMonth);
         res = regex_replace(res, std::wregex(L"(([^\\$]|^)(\\$\\$)*)\\$M"), replaceTerm);
 
-        GetDateFormatEx(localeName, NULL, &LocalTime, L"dddd", formattedDate, MAX_PATH, NULL);
+        GetDateFormatEx(localeName, NULL, &fileTime, L"dddd", formattedDate, MAX_PATH, NULL);
         formattedDate[0] = towupper(formattedDate[0]);
         StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%s"), L"$01", formattedDate);
         res = regex_replace(res, std::wregex(L"(([^\\$]|^)(\\$\\$)*)\\$DDDD"), replaceTerm);
         
-        GetDateFormatEx(localeName, NULL, &LocalTime, L"ddd", formattedDate, MAX_PATH, NULL);
+        GetDateFormatEx(localeName, NULL, &fileTime, L"ddd", formattedDate, MAX_PATH, NULL);
         formattedDate[0] = towupper(formattedDate[0]);
         StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%s"), L"$01", formattedDate);
         res = regex_replace(res, std::wregex(L"(([^\\$]|^)(\\$\\$)*)\\$DDD"), replaceTerm);
 
-        StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%02d"), L"$01", LocalTime.wDay);
+        StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%02d"), L"$01", fileTime.wDay);
         res = regex_replace(res, std::wregex(L"(([^\\$]|^)(\\$\\$)*)\\$DD"), replaceTerm);
 
-        StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%d"), L"$01", LocalTime.wDay);
+        StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%d"), L"$01", fileTime.wDay);
         res = regex_replace(res, std::wregex(L"(([^\\$]|^)(\\$\\$)*)\\$D"), replaceTerm);
 
-        StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%02d"), L"$01", LocalTime.wHour);
+        StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%02d"), L"$01", fileTime.wHour);
         res = regex_replace(res, std::wregex(L"(([^\\$]|^)(\\$\\$)*)\\$hh"), replaceTerm);
 
-        StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%d"), L"$01", LocalTime.wHour);
+        StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%d"), L"$01", fileTime.wHour);
         res = regex_replace(res, std::wregex(L"(([^\\$]|^)(\\$\\$)*)\\$h"), replaceTerm);
 
-        StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%02d"), L"$01", LocalTime.wMinute);
+        StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%02d"), L"$01", fileTime.wMinute);
         res = regex_replace(res, std::wregex(L"(([^\\$]|^)(\\$\\$)*)\\$mm"), replaceTerm);
 
-        StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%d"), L"$01", LocalTime.wMinute);
+        StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%d"), L"$01", fileTime.wMinute);
         res = regex_replace(res, std::wregex(L"(([^\\$]|^)(\\$\\$)*)\\$m"), replaceTerm);
 
-        StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%02d"), L"$01", LocalTime.wSecond);
+        StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%02d"), L"$01", fileTime.wSecond);
         res = regex_replace(res, std::wregex(L"(([^\\$]|^)(\\$\\$)*)\\$ss"), replaceTerm);
 
-        StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%d"), L"$01", LocalTime.wSecond);
+        StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%d"), L"$01", fileTime.wSecond);
         res = regex_replace(res, std::wregex(L"(([^\\$]|^)(\\$\\$)*)\\$s"), replaceTerm);
 
-        StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%03d"), L"$01", LocalTime.wMilliseconds);
+        StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%03d"), L"$01", fileTime.wMilliseconds);
         res = regex_replace(res, std::wregex(L"(([^\\$]|^)(\\$\\$)*)\\$fff"), replaceTerm);
 
-        StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%02d"), L"$01", LocalTime.wMilliseconds/10);
+        StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%02d"), L"$01", fileTime.wMilliseconds/10);
         res = regex_replace(res, std::wregex(L"(([^\\$]|^)(\\$\\$)*)\\$ff"), replaceTerm);
 
-        StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%d"), L"$01", LocalTime.wMilliseconds/100);
+        StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%d"), L"$01", fileTime.wMilliseconds/100);
         res = regex_replace(res, std::wregex(L"(([^\\$]|^)(\\$\\$)*)\\$f"), replaceTerm);
 
         hr = StringCchCopy(result, cchMax, res.c_str());

--- a/src/modules/powerrename/lib/Helpers.cpp
+++ b/src/modules/powerrename/lib/Helpers.cpp
@@ -9,8 +9,8 @@ namespace fs = std::filesystem;
 
 HRESULT GetTrimmedFileName(_Out_ PWSTR result, UINT cchMax, _In_ PCWSTR source)
 {
-    HRESULT hr = source ? S_OK : E_INVALIDARG;
-    if (SUCCEEDED(hr))
+    HRESULT hr = E_INVALIDARG;
+    if (source)
     {
         PWSTR newName = nullptr;
         hr = SHStrDup(source, &newName);
@@ -38,8 +38,8 @@ HRESULT GetTrimmedFileName(_Out_ PWSTR result, UINT cchMax, _In_ PCWSTR source)
 HRESULT GetTransformedFileName(_Out_ PWSTR result, UINT cchMax, _In_ PCWSTR source, DWORD flags)
 {
     std::locale::global(std::locale(""));
-    HRESULT hr = (source && flags) ? S_OK : E_INVALIDARG;
-    if (SUCCEEDED(hr))
+    HRESULT hr = E_INVALIDARG;
+    if (source && flags)
     {
         if (flags & Uppercase)
         {
@@ -188,8 +188,8 @@ bool isFileTimeUsed(_In_ PCWSTR source)
 HRESULT GetDatedFileName(_Out_ PWSTR result, UINT cchMax, _In_ PCWSTR source, SYSTEMTIME fileTime)
 {
     std::locale::global(std::locale(""));
-    HRESULT hr = (source && wcslen(source) > 0) ? S_OK : E_INVALIDARG;     
-    if (SUCCEEDED(hr))
+    HRESULT hr = E_INVALIDARG;     
+    if ((source && wcslen(source) > 0))
     {
         std::wstring res(source);
         wchar_t replaceTerm[MAX_PATH] = { 0 };
@@ -346,12 +346,11 @@ HRESULT _ParseEnumItems(_In_ IEnumShellItems* pesi, _In_ IPowerRenameManager* ps
 HRESULT EnumerateDataObject(_In_ IUnknown* dataSource, _In_ IPowerRenameManager* psrm)
 {
     CComPtr<IShellItemArray> spsia;
-    HRESULT hr = _GetShellItemArrayFromDataOject(dataSource, &spsia);
-    if (SUCCEEDED(hr))
+    HRESULT hr = E_FAIL; 
+    if (SUCCEEDED(_GetShellItemArrayFromDataOject(dataSource, &spsia)))
     {
         CComPtr<IEnumShellItems> spesi;
-        hr = spsia->EnumItems(&spesi);
-        if (SUCCEEDED(hr))
+        if (SUCCEEDED(spsia->EnumItems(&spesi)))
         {
             hr = _ParseEnumItems(spesi, psrm);
         }

--- a/src/modules/powerrename/lib/Helpers.h
+++ b/src/modules/powerrename/lib/Helpers.h
@@ -5,7 +5,7 @@
 
 HRESULT GetTrimmedFileName(_Out_ PWSTR result, UINT cchMax, _In_ PCWSTR source);
 HRESULT GetTransformedFileName(_Out_ PWSTR result, UINT cchMax, _In_ PCWSTR source, DWORD flags);
-HRESULT GetDatedFileName(_Out_ PWSTR result, UINT cchMax, _In_ PCWSTR source, SYSTEMTIME LocalTime);
+HRESULT GetDatedFileName(_Out_ PWSTR result, UINT cchMax, _In_ PCWSTR source, SYSTEMTIME fileTime);
 bool isFileAttributesUsed(_In_ PCWSTR source);
 bool DataObjectContainsRenamableItem(_In_ IUnknown* dataSource);
 HRESULT EnumerateDataObject(_In_ IUnknown* pdo, _In_ IPowerRenameManager* psrm);

--- a/src/modules/powerrename/lib/Helpers.h
+++ b/src/modules/powerrename/lib/Helpers.h
@@ -6,7 +6,7 @@
 HRESULT GetTrimmedFileName(_Out_ PWSTR result, UINT cchMax, _In_ PCWSTR source);
 HRESULT GetTransformedFileName(_Out_ PWSTR result, UINT cchMax, _In_ PCWSTR source, DWORD flags);
 HRESULT GetDatedFileName(_Out_ PWSTR result, UINT cchMax, _In_ PCWSTR source, SYSTEMTIME fileTime);
-bool isFileAttributesUsed(_In_ PCWSTR source);
+bool isFileTimeUsed(_In_ PCWSTR source);
 bool DataObjectContainsRenamableItem(_In_ IUnknown* dataSource);
 HRESULT EnumerateDataObject(_In_ IUnknown* pdo, _In_ IPowerRenameManager* psrm);
 BOOL GetEnumeratedFileName(

--- a/src/modules/powerrename/lib/PowerRenameInterfaces.h
+++ b/src/modules/powerrename/lib/PowerRenameInterfaces.h
@@ -44,7 +44,7 @@ public:
     IFACEMETHOD(PutReplaceTerm)(_In_ PCWSTR replaceTerm) = 0;
     IFACEMETHOD(GetFlags)(_Out_ DWORD* flags) = 0;
     IFACEMETHOD(PutFlags)(_In_ DWORD flags) = 0;
-    IFACEMETHOD(Replace)(_In_ PCWSTR source, _Outptr_ PWSTR* result) = 0;
+    IFACEMETHOD(Replace)(_In_ SYSTEMTIME LocalTime, _In_ PCWSTR source, _Outptr_ PWSTR* result) = 0;
 };
 
 interface __declspec(uuid("C7F59201-4DE1-4855-A3A2-26FC3279C8A5")) IPowerRenameItem : public IUnknown

--- a/src/modules/powerrename/lib/PowerRenameInterfaces.h
+++ b/src/modules/powerrename/lib/PowerRenameInterfaces.h
@@ -44,7 +44,7 @@ public:
     IFACEMETHOD(PutReplaceTerm)(_In_ PCWSTR replaceTerm) = 0;
     IFACEMETHOD(GetFlags)(_Out_ DWORD* flags) = 0;
     IFACEMETHOD(PutFlags)(_In_ DWORD flags) = 0;
-    IFACEMETHOD(Replace)(_In_ PCWSTR source, _Outptr_ PWSTR * result, _In_ SYSTEMTIME LocalTime) = 0;
+    IFACEMETHOD(Replace)(_In_ PCWSTR source, _Outptr_ PWSTR * result, _In_ SYSTEMTIME LocalTime, _In_ bool useFileAttributes) = 0;
 };
 
 interface __declspec(uuid("C7F59201-4DE1-4855-A3A2-26FC3279C8A5")) IPowerRenameItem : public IUnknown

--- a/src/modules/powerrename/lib/PowerRenameInterfaces.h
+++ b/src/modules/powerrename/lib/PowerRenameInterfaces.h
@@ -44,7 +44,7 @@ public:
     IFACEMETHOD(PutReplaceTerm)(_In_ PCWSTR replaceTerm) = 0;
     IFACEMETHOD(GetFlags)(_Out_ DWORD* flags) = 0;
     IFACEMETHOD(PutFlags)(_In_ DWORD flags) = 0;
-    IFACEMETHOD(Replace)(_In_ SYSTEMTIME LocalTime, _In_ PCWSTR source, _Outptr_ PWSTR* result) = 0;
+    IFACEMETHOD(Replace)(_In_ PCWSTR source, _Outptr_ PWSTR * result, _In_ SYSTEMTIME LocalTime) = 0;
 };
 
 interface __declspec(uuid("C7F59201-4DE1-4855-A3A2-26FC3279C8A5")) IPowerRenameItem : public IUnknown

--- a/src/modules/powerrename/lib/PowerRenameInterfaces.h
+++ b/src/modules/powerrename/lib/PowerRenameInterfaces.h
@@ -44,14 +44,14 @@ public:
     IFACEMETHOD(PutReplaceTerm)(_In_ PCWSTR replaceTerm) = 0;
     IFACEMETHOD(GetFlags)(_Out_ DWORD* flags) = 0;
     IFACEMETHOD(PutFlags)(_In_ DWORD flags) = 0;
-    IFACEMETHOD(Replace)(_In_ PCWSTR source, _Outptr_ PWSTR * result, _In_ SYSTEMTIME LocalTime, _In_ bool useFileAttributes) = 0;
+    IFACEMETHOD(Replace)(_In_ PCWSTR source, _Outptr_ PWSTR* result, _In_ SYSTEMTIME fileTime, _In_ bool useFileAttributes) = 0;
 };
 
 interface __declspec(uuid("C7F59201-4DE1-4855-A3A2-26FC3279C8A5")) IPowerRenameItem : public IUnknown
 {
 public:
     IFACEMETHOD(GetPath)(_Outptr_ PWSTR* path) = 0;
-    IFACEMETHOD(GetDate)(_Outptr_ SYSTEMTIME* date) = 0;
+    IFACEMETHOD(GetTime)(_Outptr_ SYSTEMTIME* time) = 0;
     IFACEMETHOD(GetShellItem)(_Outptr_ IShellItem** ppsi) = 0;
     IFACEMETHOD(GetOriginalName)(_Outptr_ PWSTR* originalName) = 0;
     IFACEMETHOD(GetNewName)(_Outptr_ PWSTR* newName) = 0;

--- a/src/modules/powerrename/lib/PowerRenameInterfaces.h
+++ b/src/modules/powerrename/lib/PowerRenameInterfaces.h
@@ -31,6 +31,7 @@ public:
     IFACEMETHOD(OnSearchTermChanged)(_In_ PCWSTR searchTerm) = 0;
     IFACEMETHOD(OnReplaceTermChanged)(_In_ PCWSTR replaceTerm) = 0;
     IFACEMETHOD(OnFlagsChanged)(_In_ DWORD flags) = 0;
+    IFACEMETHOD(OnFileTimeChanged)(_In_ SYSTEMTIME fileTime) = 0;
 };
 
 interface __declspec(uuid("E3ED45B5-9CE0-47E2-A595-67EB950B9B72")) IPowerRenameRegEx : public IUnknown
@@ -44,7 +45,9 @@ public:
     IFACEMETHOD(PutReplaceTerm)(_In_ PCWSTR replaceTerm) = 0;
     IFACEMETHOD(GetFlags)(_Out_ DWORD* flags) = 0;
     IFACEMETHOD(PutFlags)(_In_ DWORD flags) = 0;
-    IFACEMETHOD(Replace)(_In_ PCWSTR source, _Outptr_ PWSTR* result, _In_ SYSTEMTIME fileTime, _In_ bool useFileAttributes) = 0;
+    IFACEMETHOD(PutFileTime)(_In_ SYSTEMTIME fileTime) = 0;
+    IFACEMETHOD(ResetFileTime)() = 0;
+    IFACEMETHOD(Replace)(_In_ PCWSTR source, _Outptr_ PWSTR* result) = 0;
 };
 
 interface __declspec(uuid("C7F59201-4DE1-4855-A3A2-26FC3279C8A5")) IPowerRenameItem : public IUnknown

--- a/src/modules/powerrename/lib/PowerRenameItem.cpp
+++ b/src/modules/powerrename/lib/PowerRenameItem.cpp
@@ -42,11 +42,11 @@ IFACEMETHODIMP CPowerRenameItem::GetPath(_Outptr_ PWSTR* path)
     return hr;
 }
 
-IFACEMETHODIMP CPowerRenameItem::GetDate(_Outptr_ SYSTEMTIME* date)
+IFACEMETHODIMP CPowerRenameItem::GetTime(_Outptr_ SYSTEMTIME* time)
 {
     CSRWSharedAutoLock lock(&m_lock);
-    HRESULT hr = m_isDateParsed ? S_OK : E_FAIL ;
-    if (!m_isDateParsed)
+    HRESULT hr = m_isTimeParsed ? S_OK : E_FAIL ;
+    if (!m_isTimeParsed)
     {
         HANDLE hFile = CreateFileW(m_path, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);
         if (hFile != INVALID_HANDLE_VALUE)
@@ -59,8 +59,8 @@ IFACEMETHODIMP CPowerRenameItem::GetDate(_Outptr_ SYSTEMTIME* date)
                 {
                     if (SystemTimeToTzSpecificLocalTime(NULL, &SystemTime, &LocalTime))
                     {
-                        m_date = LocalTime;
-                        m_isDateParsed = true;
+                        m_time = LocalTime;
+                        m_isTimeParsed = true;
                         hr = S_OK;
                     }
                 }
@@ -68,7 +68,7 @@ IFACEMETHODIMP CPowerRenameItem::GetDate(_Outptr_ SYSTEMTIME* date)
         }
         CloseHandle(hFile);
     }
-    *date = m_date;
+    *time = m_time;
     return hr;
 }
 

--- a/src/modules/powerrename/lib/PowerRenameItem.cpp
+++ b/src/modules/powerrename/lib/PowerRenameItem.cpp
@@ -46,6 +46,7 @@ IFACEMETHODIMP CPowerRenameItem::GetTime(_Outptr_ SYSTEMTIME* time)
 {
     CSRWSharedAutoLock lock(&m_lock);
     HRESULT hr = E_FAIL ;
+
     if (m_isTimeParsed)
     {
         hr = S_OK;
@@ -224,6 +225,7 @@ HRESULT CPowerRenameItem::s_CreateInstance(_In_opt_ IShellItem* psi, _In_ REFIID
     HRESULT hr = E_OUTOFMEMORY;
     if (newRenameItem)
     {
+        hr = S_OK ;
         if (psi != nullptr)
         {
             hr = newRenameItem->_Init(psi);

--- a/src/modules/powerrename/lib/PowerRenameItem.cpp
+++ b/src/modules/powerrename/lib/PowerRenameItem.cpp
@@ -34,8 +34,8 @@ IFACEMETHODIMP CPowerRenameItem::GetPath(_Outptr_ PWSTR* path)
 {
     *path = nullptr;
     CSRWSharedAutoLock lock(&m_lock);
-    HRESULT hr = m_path ? S_OK : E_FAIL;
-    if (SUCCEEDED(hr))
+    HRESULT hr = E_FAIL;
+    if (m_path)
     {
         hr = SHStrDup(m_path, path);
     }
@@ -45,8 +45,12 @@ IFACEMETHODIMP CPowerRenameItem::GetPath(_Outptr_ PWSTR* path)
 IFACEMETHODIMP CPowerRenameItem::GetTime(_Outptr_ SYSTEMTIME* time)
 {
     CSRWSharedAutoLock lock(&m_lock);
-    HRESULT hr = m_isTimeParsed ? S_OK : E_FAIL ;
-    if (!m_isTimeParsed)
+    HRESULT hr = E_FAIL ;
+    if (m_isTimeParsed)
+    {
+        hr = S_OK;
+    }
+    else
     {
         HANDLE hFile = CreateFileW(m_path, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);
         if (hFile != INVALID_HANDLE_VALUE)
@@ -80,8 +84,8 @@ IFACEMETHODIMP CPowerRenameItem::GetShellItem(_Outptr_ IShellItem** ppsi)
 IFACEMETHODIMP CPowerRenameItem::GetOriginalName(_Outptr_ PWSTR* originalName)
 {
     CSRWSharedAutoLock lock(&m_lock);
-    HRESULT hr = m_originalName ? S_OK : E_FAIL;
-    if (SUCCEEDED(hr))
+    HRESULT hr = E_FAIL;
+    if (m_originalName)
     {
         hr = SHStrDup(m_originalName, originalName);
     }
@@ -217,8 +221,8 @@ HRESULT CPowerRenameItem::s_CreateInstance(_In_opt_ IShellItem* psi, _In_ REFIID
     *resultInterface = nullptr;
 
     CPowerRenameItem *newRenameItem = new CPowerRenameItem();
-    HRESULT hr = newRenameItem ? S_OK : E_OUTOFMEMORY;
-    if (SUCCEEDED(hr))
+    HRESULT hr = E_OUTOFMEMORY;
+    if (newRenameItem)
     {
         if (psi != nullptr)
         {

--- a/src/modules/powerrename/lib/PowerRenameItem.cpp
+++ b/src/modules/powerrename/lib/PowerRenameItem.cpp
@@ -104,8 +104,8 @@ IFACEMETHODIMP CPowerRenameItem::PutNewName(_In_opt_ PCWSTR newName)
 IFACEMETHODIMP CPowerRenameItem::GetNewName(_Outptr_ PWSTR* newName)
 {
     CSRWSharedAutoLock lock(&m_lock);
-    HRESULT hr = m_newName ? S_OK : E_FAIL;
-    if (SUCCEEDED(hr))
+    HRESULT hr = S_OK;
+    if (m_newName)
     {
         hr = SHStrDup(m_newName, newName);
     }

--- a/src/modules/powerrename/lib/PowerRenameItem.h
+++ b/src/modules/powerrename/lib/PowerRenameItem.h
@@ -15,7 +15,7 @@ public:
 
     // IPowerRenameItem
     IFACEMETHODIMP GetPath(_Outptr_ PWSTR* path);
-    IFACEMETHODIMP GetDate(_Outptr_ SYSTEMTIME* date);
+    IFACEMETHODIMP GetTime(_Outptr_ SYSTEMTIME* time);
     IFACEMETHODIMP GetShellItem(_Outptr_ IShellItem** ppsi);
     IFACEMETHODIMP GetOriginalName(_Outptr_ PWSTR* originalName);
     IFACEMETHODIMP PutNewName(_In_opt_ PCWSTR newName);
@@ -50,7 +50,7 @@ protected:
 
     bool        m_selected = true;
     bool        m_isFolder = false;
-    bool        m_isDateParsed = false;
+    bool        m_isTimeParsed = false;
     bool        m_canRename = true;
     int         m_id = -1;
     int         m_iconIndex = -1;
@@ -59,7 +59,7 @@ protected:
     PWSTR       m_path = nullptr;
     PWSTR       m_originalName = nullptr;
     PWSTR       m_newName = nullptr;
-    SYSTEMTIME  m_date = {0};
+    SYSTEMTIME  m_time = {0};
     CSRWLock    m_lock;
     long        m_refCount = 0;
 };

--- a/src/modules/powerrename/lib/PowerRenameItem.h
+++ b/src/modules/powerrename/lib/PowerRenameItem.h
@@ -59,7 +59,7 @@ protected:
     PWSTR       m_path = nullptr;
     PWSTR       m_originalName = nullptr;
     PWSTR       m_newName = nullptr;
-    SYSTEMTIME  m_date;
+    SYSTEMTIME  m_date = {0};
     CSRWLock    m_lock;
     long        m_refCount = 0;
 };

--- a/src/modules/powerrename/lib/PowerRenameManager.cpp
+++ b/src/modules/powerrename/lib/PowerRenameManager.cpp
@@ -898,14 +898,14 @@ DWORD WINAPI CPowerRenameManager::s_regexWorkerThread(_In_ void* pv)
                                 }
 
                                 PWSTR replaceTerm = nullptr;
-                                SYSTEMTIME LocalTime = {0};
+                                SYSTEMTIME fileTime = {0};
 
-                                if (!useFileAttributes || SUCCEEDED(spItem->GetDate(&LocalTime)))
+                                if (!useFileAttributes || SUCCEEDED(spItem->GetTime(&fileTime)))
                                 {
                                     PWSTR newName = nullptr;
                                     // Failure here means we didn't match anything or had nothing to match
                                     // Call put_newName with null in that case to reset it
-                                    spRenameRegEx->Replace(sourceName, &newName, LocalTime, useFileAttributes);
+                                    spRenameRegEx->Replace(sourceName, &newName, fileTime, useFileAttributes);
 
                                     wchar_t resultName[MAX_PATH] = { 0 };
 

--- a/src/modules/powerrename/lib/PowerRenameManager.cpp
+++ b/src/modules/powerrename/lib/PowerRenameManager.cpp
@@ -891,8 +891,6 @@ DWORD WINAPI CPowerRenameManager::s_regexWorkerThread(_In_ void* pv)
                     PWSTR currentNewName = nullptr;
                     winrt::check_hresult(spItem->GetNewName(&currentNewName));
 
-                    //winrt::check_hresult(E_INVALIDARG);
-
                     wchar_t sourceName[MAX_PATH] = { 0 };
                     if (flags & NameOnly)
                     {
@@ -1026,7 +1024,7 @@ DWORD WINAPI CPowerRenameManager::s_regexWorkerThread(_In_ void* pv)
     }
     catch (...)
     {
-        MessageBox(NULL, L"RegexWorkerThread failed to execute.\nPlease report the bug to https://aka.ms/powerToysReportBug", L"PowerToys Settings Error", MB_OK);
+        MessageBox(NULL, L"RegexWorkerThread failed to execute.\nPlease report the bug to https://aka.ms/powerToysReportBug", L"PowerRename Error", MB_OK);
     }
 
     return 0;

--- a/src/modules/powerrename/lib/PowerRenameManager.cpp
+++ b/src/modules/powerrename/lib/PowerRenameManager.cpp
@@ -890,27 +890,24 @@ DWORD WINAPI CPowerRenameManager::s_regexWorkerThread(_In_ void* pv)
                                     StringCchCopy(sourceName, ARRAYSIZE(sourceName), originalName);
                                 }
 
-                                wchar_t newReplaceTerm[MAX_PATH] = { 0 };
                                 PWSTR replaceTerm = nullptr;
-                                SYSTEMTIME LocalTime;
+                                SYSTEMTIME LocalTime = {0};
 
                                 if (SUCCEEDED(spRenameRegEx->GetReplaceTerm(&replaceTerm)) && isFileAttributesUsed(replaceTerm))
                                 {
                                     if (SUCCEEDED(spItem->GetDate(&LocalTime)))
                                     {
-                                        if (SUCCEEDED(GetDatedFileName(newReplaceTerm, ARRAYSIZE(newReplaceTerm), replaceTerm, LocalTime)))
-                                        {
-                                            spRenameRegEx->PutReplaceTerm(newReplaceTerm);
-                                        }
+                                        //if (SUCCEEDED(GetDatedFileName(newReplaceTerm, ARRAYSIZE(newReplaceTerm), replaceTerm, LocalTime)))
+                                        //{
+                                            // OK
+                                        //}
                                     }
                                 }
 
                                 PWSTR newName = nullptr;
                                 // Failure here means we didn't match anything or had nothing to match
                                 // Call put_newName with null in that case to reset it
-                                spRenameRegEx->Replace(sourceName, &newName);
-
-                                spRenameRegEx->PutReplaceTerm(replaceTerm);
+                                spRenameRegEx->Replace(LocalTime, sourceName, &newName);
 
                                 wchar_t resultName[MAX_PATH] = { 0 };
 

--- a/src/modules/powerrename/lib/PowerRenameManager.cpp
+++ b/src/modules/powerrename/lib/PowerRenameManager.cpp
@@ -836,7 +836,7 @@ DWORD WINAPI CPowerRenameManager::s_regexWorkerThread(_In_ void* pv)
 
                     PWSTR replaceTerm = nullptr;
                     bool useFileTime = false;
-                    if (SUCCEEDED(spRenameRegEx->GetReplaceTerm(&replaceTerm)) && isFileAttributesUsed(replaceTerm))
+                    if (SUCCEEDED(spRenameRegEx->GetReplaceTerm(&replaceTerm)) && isFileTimeUsed(replaceTerm))
                     {
                             useFileTime = true;
                     }
@@ -913,8 +913,12 @@ DWORD WINAPI CPowerRenameManager::s_regexWorkerThread(_In_ void* pv)
                                     // Call put_newName with null in that case to reset it
                                     spRenameRegEx->Replace(sourceName, &newName);
 
-                                    spRenameRegEx->ResetFileTime();
-
+                                    // fileTime is a file specific value, to be removed after Replace operation
+                                    if (useFileTime)
+                                    {
+                                        spRenameRegEx->ResetFileTime();
+                                    }
+                                    
                                     wchar_t resultName[MAX_PATH] = { 0 };
 
                                     PWSTR newNameToUse = nullptr;

--- a/src/modules/powerrename/lib/PowerRenameManager.cpp
+++ b/src/modules/powerrename/lib/PowerRenameManager.cpp
@@ -907,7 +907,7 @@ DWORD WINAPI CPowerRenameManager::s_regexWorkerThread(_In_ void* pv)
                                 PWSTR newName = nullptr;
                                 // Failure here means we didn't match anything or had nothing to match
                                 // Call put_newName with null in that case to reset it
-                                spRenameRegEx->Replace(LocalTime, sourceName, &newName);
+                                spRenameRegEx->Replace(sourceName, &newName, LocalTime);
 
                                 wchar_t resultName[MAX_PATH] = { 0 };
 

--- a/src/modules/powerrename/lib/PowerRenameManager.cpp
+++ b/src/modules/powerrename/lib/PowerRenameManager.cpp
@@ -426,8 +426,8 @@ HRESULT CPowerRenameManager::s_CreateInstance(_Outptr_ IPowerRenameManager** pps
 {
     *ppsrm = nullptr;
     CPowerRenameManager *psrm = new CPowerRenameManager();
-    HRESULT hr = psrm ? S_OK : E_OUTOFMEMORY;
-    if (SUCCEEDED(hr))
+    HRESULT hr = E_OUTOFMEMORY;
+    if (psrm)
     {
         hr = psrm->_Init();
         if (SUCCEEDED(hr))
@@ -652,8 +652,8 @@ HRESULT CPowerRenameManager::_PerformFileOperation()
 HRESULT CPowerRenameManager::_CreateFileOpWorkerThread()
 {
     WorkerThreadData* pwtd = new WorkerThreadData;
-    HRESULT hr = pwtd ? S_OK : E_OUTOFMEMORY;
-    if (SUCCEEDED(hr))
+    HRESULT hr = E_OUTOFMEMORY;
+    if (pwtd)
     {
         pwtd->hwndManager = m_hwndMessage;
         pwtd->startEvent = m_startRegExWorkerEvent;
@@ -798,8 +798,8 @@ HRESULT CPowerRenameManager::_PerformRegExRename()
 HRESULT CPowerRenameManager::_CreateRegExWorkerThread()
 {
     WorkerThreadData* pwtd = new WorkerThreadData;
-    HRESULT hr = pwtd ? S_OK : E_OUTOFMEMORY;
-    if (SUCCEEDED(hr))
+    HRESULT hr = E_OUTOFMEMORY;
+    if (pwtd)
     {
         pwtd->hwndManager = m_hwndMessage;
         pwtd->startEvent = m_startRegExWorkerEvent;

--- a/src/modules/powerrename/lib/PowerRenameManager.cpp
+++ b/src/modules/powerrename/lib/PowerRenameManager.cpp
@@ -660,8 +660,12 @@ HRESULT CPowerRenameManager::_CreateFileOpWorkerThread()
         pwtd->cancelEvent = nullptr;
         pwtd->spsrm = this;
         m_fileOpWorkerThreadHandle = CreateThread(nullptr, 0, s_fileOpWorkerThread, pwtd, 0, nullptr);
-        hr = (m_fileOpWorkerThreadHandle) ? S_OK : E_FAIL;
-        if (FAILED(hr))
+        hr = E_FAIL;
+        if (m_fileOpWorkerThreadHandle)
+        {
+            hr = S_OK;
+        }
+        else
         {
             delete pwtd;
         }
@@ -807,8 +811,12 @@ HRESULT CPowerRenameManager::_CreateRegExWorkerThread()
         pwtd->hwndParent = m_hwndParent;
         pwtd->spsrm = this;
         m_regExWorkerThreadHandle = CreateThread(nullptr, 0, s_regexWorkerThread, pwtd, 0, nullptr);
-        hr = (m_regExWorkerThreadHandle) ? S_OK : E_FAIL;
-        if (FAILED(hr))
+        hr = E_FAIL;
+        if (m_regExWorkerThreadHandle)
+        {
+            hr = S_OK;
+        }
+        else
         {
             delete pwtd;
         }

--- a/src/modules/powerrename/lib/PowerRenameManager.h
+++ b/src/modules/powerrename/lib/PowerRenameManager.h
@@ -46,6 +46,7 @@ public:
     IFACEMETHODIMP OnSearchTermChanged(_In_ PCWSTR searchTerm);
     IFACEMETHODIMP OnReplaceTermChanged(_In_ PCWSTR replaceTerm);
     IFACEMETHODIMP OnFlagsChanged(_In_ DWORD flags);
+    IFACEMETHODIMP OnFileTimeChanged(_In_ SYSTEMTIME fileTime);
 
     static HRESULT s_CreateInstance(_Outptr_ IPowerRenameManager** ppsrm);
 

--- a/src/modules/powerrename/lib/PowerRenameRegEx.cpp
+++ b/src/modules/powerrename/lib/PowerRenameRegEx.cpp
@@ -243,7 +243,15 @@ HRESULT CPowerRenameRegEx::Replace(_In_ PCWSTR source, _Outptr_ PWSTR* result)
 
             std::wstring sourceToUse(source);
             std::wstring searchTerm(m_searchTerm);
-            std::wstring replaceTerm((m_useFileTime && !fileTimeErrorOccurred) ? wstring(newReplaceTerm) : (m_replaceTerm ? wstring(m_replaceTerm) : wstring(L"")));
+            std::wstring replaceTerm(L"");
+            if (m_useFileTime && !fileTimeErrorOccurred)
+            {
+                replaceTerm = wstring(newReplaceTerm);
+            }
+            else if (m_replaceTerm)
+            {
+                replaceTerm = wstring(m_replaceTerm);
+            }
 
             replaceTerm = regex_replace(replaceTerm, std::wregex(L"(([^\\$]|^)(\\$\\$)*)\\$[0]"), L"$1$$$0");
             replaceTerm = regex_replace(replaceTerm, std::wregex(L"(([^\\$]|^)(\\$\\$)*)\\$([1-9])"), L"$1$0$4");

--- a/src/modules/powerrename/lib/PowerRenameRegEx.cpp
+++ b/src/modules/powerrename/lib/PowerRenameRegEx.cpp
@@ -189,7 +189,7 @@ CPowerRenameRegEx::~CPowerRenameRegEx()
     CoTaskMemFree(m_replaceTerm);
 }
 
-HRESULT CPowerRenameRegEx::Replace(_In_ PCWSTR source, _Outptr_ PWSTR* result, _In_ SYSTEMTIME LocalTime, _In_ bool useFileAttributes)
+HRESULT CPowerRenameRegEx::Replace(_In_ PCWSTR source, _Outptr_ PWSTR* result, _In_ SYSTEMTIME fileTime, _In_ bool useFileAttributes)
 {
     *result = nullptr;
 
@@ -204,13 +204,13 @@ HRESULT CPowerRenameRegEx::Replace(_In_ PCWSTR source, _Outptr_ PWSTR* result, _
             wchar_t newReplaceTerm[MAX_PATH] = { 0 };
             if (useFileAttributes)
             {
-                if (FAILED(GetDatedFileName(newReplaceTerm, ARRAYSIZE(newReplaceTerm), m_replaceTerm, LocalTime)))
+                if (FAILED(GetDatedFileName(newReplaceTerm, ARRAYSIZE(newReplaceTerm), m_replaceTerm, fileTime)))
                     useFileAttributes = false;
             }
 
             std::wstring sourceToUse(source);
             std::wstring searchTerm(m_searchTerm);
-            std::wstring replaceTerm(m_replaceTerm ? (useFileAttributes ? wstring(newReplaceTerm) : wstring(m_replaceTerm)) : wstring(L""));
+            std::wstring replaceTerm(useFileAttributes ? wstring(newReplaceTerm) : (m_replaceTerm ? wstring(m_replaceTerm) : wstring(L"")));
 
             replaceTerm = regex_replace(replaceTerm, std::wregex(L"(([^\\$]|^)(\\$\\$)*)\\$[0]"), L"$1$$$0");
             replaceTerm = regex_replace(replaceTerm, std::wregex(L"(([^\\$]|^)(\\$\\$)*)\\$([1-9])"), L"$1$0$4");

--- a/src/modules/powerrename/lib/PowerRenameRegEx.cpp
+++ b/src/modules/powerrename/lib/PowerRenameRegEx.cpp
@@ -173,7 +173,7 @@ IFACEMETHODIMP CPowerRenameRegEx::PutFileTime(_In_ SYSTEMTIME fileTime)
     SystemTimeToFileTime(&m_fileTime, &ft1.fileTime);
     SystemTimeToFileTime(&fileTime, &ft2.fileTime);
 
-    if(ft2.ul.QuadPart != ft1.ul.QuadPart)
+    if (ft2.ul.QuadPart != ft1.ul.QuadPart)
     {
         m_fileTime = fileTime;
         m_useFileTime = true;

--- a/src/modules/powerrename/lib/PowerRenameRegEx.cpp
+++ b/src/modules/powerrename/lib/PowerRenameRegEx.cpp
@@ -154,7 +154,7 @@ IFACEMETHODIMP CPowerRenameRegEx::PutFlags(_In_ DWORD flags)
     if (m_flags != flags)
     {
         m_flags = flags;
-        _OnFileTimeChanged();
+        _OnFlagsChanged();
     }
     return S_OK;
 }
@@ -177,7 +177,7 @@ IFACEMETHODIMP CPowerRenameRegEx::PutFileTime(_In_ SYSTEMTIME fileTime)
     {
         m_fileTime = fileTime;
         m_useFileTime = true;
-        _OnFlagsChanged();
+        _OnFileTimeChanged();
     }
     return S_OK;
 }

--- a/src/modules/powerrename/lib/PowerRenameRegEx.cpp
+++ b/src/modules/powerrename/lib/PowerRenameRegEx.cpp
@@ -201,17 +201,17 @@ HRESULT CPowerRenameRegEx::Replace(_In_ SYSTEMTIME LocalTime, _In_ PCWSTR source
         try
         {
             // TODO: creating the regex could be costly.  May want to cache this.
-            bool isFileAttributesUsedValue = isFileAttributesUsed(m_replaceTerm ? m_replaceTerm : L"");
+            bool useFileAttributes = isFileAttributesUsed(m_replaceTerm ? m_replaceTerm : L"");
             wchar_t newReplaceTerm[MAX_PATH] = { 0 };
-            if (isFileAttributesUsedValue)
+            if (useFileAttributes)
             {
                 if (FAILED(GetDatedFileName(newReplaceTerm, ARRAYSIZE(newReplaceTerm), m_replaceTerm, LocalTime)))
-                    isFileAttributesUsedValue = false;
+                    useFileAttributes = false;
             }
 
             std::wstring sourceToUse(source);
             std::wstring searchTerm(m_searchTerm);
-            std::wstring replaceTerm(m_replaceTerm ? (isFileAttributesUsedValue ? wstring(newReplaceTerm) : wstring(m_replaceTerm)) : wstring(L""));
+            std::wstring replaceTerm(m_replaceTerm ? (useFileAttributes ? wstring(newReplaceTerm) : wstring(m_replaceTerm)) : wstring(L""));
 
             replaceTerm = regex_replace(replaceTerm, std::wregex(L"(([^\\$]|^)(\\$\\$)*)\\$[0]"), L"$1$$$0");
             replaceTerm = regex_replace(replaceTerm, std::wregex(L"(([^\\$]|^)(\\$\\$)*)\\$([1-9])"), L"$1$0$4");

--- a/src/modules/powerrename/lib/PowerRenameRegEx.cpp
+++ b/src/modules/powerrename/lib/PowerRenameRegEx.cpp
@@ -189,7 +189,7 @@ CPowerRenameRegEx::~CPowerRenameRegEx()
     CoTaskMemFree(m_replaceTerm);
 }
 
-HRESULT CPowerRenameRegEx::Replace(_In_ SYSTEMTIME LocalTime, _In_ PCWSTR source, _Outptr_ PWSTR* result)
+HRESULT CPowerRenameRegEx::Replace(_In_ PCWSTR source, _Outptr_ PWSTR* result, _In_ SYSTEMTIME LocalTime)
 {
     *result = nullptr;
 

--- a/src/modules/powerrename/lib/PowerRenameRegEx.cpp
+++ b/src/modules/powerrename/lib/PowerRenameRegEx.cpp
@@ -226,9 +226,13 @@ HRESULT CPowerRenameRegEx::Replace(_In_ PCWSTR source, _Outptr_ PWSTR* result)
     *result = nullptr;
 
     CSRWSharedAutoLock lock(&m_lock);
-    HRESULT hr = (source && wcslen(source) > 0 && m_searchTerm && wcslen(m_searchTerm) > 0) ? S_OK : E_INVALIDARG;
+    HRESULT hr = (source && wcslen(source) > 0) ? S_OK : E_INVALIDARG;
     if (SUCCEEDED(hr))
     {
+        if (!(m_searchTerm && wcslen(m_searchTerm) > 0))
+        {
+            return hr;
+        }
         wstring res = source;
         try
         {

--- a/src/modules/powerrename/lib/PowerRenameRegEx.cpp
+++ b/src/modules/powerrename/lib/PowerRenameRegEx.cpp
@@ -189,7 +189,7 @@ CPowerRenameRegEx::~CPowerRenameRegEx()
     CoTaskMemFree(m_replaceTerm);
 }
 
-HRESULT CPowerRenameRegEx::Replace(_In_ PCWSTR source, _Outptr_ PWSTR* result, _In_ SYSTEMTIME LocalTime)
+HRESULT CPowerRenameRegEx::Replace(_In_ PCWSTR source, _Outptr_ PWSTR* result, _In_ SYSTEMTIME LocalTime, _In_ bool useFileAttributes)
 {
     *result = nullptr;
 
@@ -201,7 +201,6 @@ HRESULT CPowerRenameRegEx::Replace(_In_ PCWSTR source, _Outptr_ PWSTR* result, _
         try
         {
             // TODO: creating the regex could be costly.  May want to cache this.
-            bool useFileAttributes = isFileAttributesUsed(m_replaceTerm ? m_replaceTerm : L"");
             wchar_t newReplaceTerm[MAX_PATH] = { 0 };
             if (useFileAttributes)
             {

--- a/src/modules/powerrename/lib/PowerRenameRegEx.cpp
+++ b/src/modules/powerrename/lib/PowerRenameRegEx.cpp
@@ -76,8 +76,8 @@ IFACEMETHODIMP CPowerRenameRegEx::UnAdvise(_In_ DWORD cookie)
 IFACEMETHODIMP CPowerRenameRegEx::GetSearchTerm(_Outptr_ PWSTR* searchTerm)
 {
     *searchTerm = nullptr;
-    HRESULT hr = m_searchTerm ? S_OK : E_FAIL;
-    if (SUCCEEDED(hr))
+    HRESULT hr = S_OK;
+    if (m_searchTerm)
     {
         CSRWSharedAutoLock lock(&m_lock);
         hr = SHStrDup(m_searchTerm, searchTerm);
@@ -88,8 +88,8 @@ IFACEMETHODIMP CPowerRenameRegEx::GetSearchTerm(_Outptr_ PWSTR* searchTerm)
 IFACEMETHODIMP CPowerRenameRegEx::PutSearchTerm(_In_ PCWSTR searchTerm)
 {
     bool changed = false;
-    HRESULT hr = searchTerm ? S_OK : E_INVALIDARG;
-    if (SUCCEEDED(hr))
+    HRESULT hr = S_OK;
+    if (searchTerm)
     {
         CSRWExclusiveAutoLock lock(&m_lock);
         if (m_searchTerm == nullptr || lstrcmp(searchTerm, m_searchTerm) != 0)
@@ -111,8 +111,8 @@ IFACEMETHODIMP CPowerRenameRegEx::PutSearchTerm(_In_ PCWSTR searchTerm)
 IFACEMETHODIMP CPowerRenameRegEx::GetReplaceTerm(_Outptr_ PWSTR* replaceTerm)
 {
     *replaceTerm = nullptr;
-    HRESULT hr = m_replaceTerm ? S_OK : E_FAIL;
-    if (SUCCEEDED(hr))
+    HRESULT hr = S_OK;
+    if (m_replaceTerm)
     {
         CSRWSharedAutoLock lock(&m_lock);
         hr = SHStrDup(m_replaceTerm, replaceTerm);
@@ -123,8 +123,8 @@ IFACEMETHODIMP CPowerRenameRegEx::GetReplaceTerm(_Outptr_ PWSTR* replaceTerm)
 IFACEMETHODIMP CPowerRenameRegEx::PutReplaceTerm(_In_ PCWSTR replaceTerm)
 {
     bool changed = false;
-    HRESULT hr = replaceTerm ? S_OK : E_INVALIDARG;
-    if (SUCCEEDED(hr))
+    HRESULT hr = S_OK;
+    if (replaceTerm)
     {
         CSRWExclusiveAutoLock lock(&m_lock);
         if (m_replaceTerm == nullptr || lstrcmp(replaceTerm, m_replaceTerm) != 0)
@@ -196,8 +196,8 @@ HRESULT CPowerRenameRegEx::s_CreateInstance(_Outptr_ IPowerRenameRegEx** renameR
     *renameRegEx = nullptr;
 
     CPowerRenameRegEx *newRenameRegEx = new CPowerRenameRegEx();
-    HRESULT hr = newRenameRegEx ? S_OK : E_OUTOFMEMORY;
-    if (SUCCEEDED(hr))
+    HRESULT hr = E_OUTOFMEMORY;
+    if (newRenameRegEx)
     {
         hr = newRenameRegEx->QueryInterface(IID_PPV_ARGS(renameRegEx));
         newRenameRegEx->Release();

--- a/src/modules/powerrename/lib/PowerRenameRegEx.h
+++ b/src/modules/powerrename/lib/PowerRenameRegEx.h
@@ -25,7 +25,7 @@ public:
     IFACEMETHODIMP PutReplaceTerm(_In_ PCWSTR replaceTerm);
     IFACEMETHODIMP GetFlags(_Out_ DWORD* flags);
     IFACEMETHODIMP PutFlags(_In_ DWORD flags);
-    IFACEMETHODIMP Replace(_In_ PCWSTR source, _Outptr_ PWSTR* result, _In_ SYSTEMTIME LocalTime, _In_ bool useFileAttributes);
+    IFACEMETHODIMP Replace(_In_ PCWSTR source, _Outptr_ PWSTR* result, _In_ SYSTEMTIME fileTime, _In_ bool useFileAttributes);
 
     static HRESULT s_CreateInstance(_Outptr_ IPowerRenameRegEx **renameRegEx);
 

--- a/src/modules/powerrename/lib/PowerRenameRegEx.h
+++ b/src/modules/powerrename/lib/PowerRenameRegEx.h
@@ -25,7 +25,7 @@ public:
     IFACEMETHODIMP PutReplaceTerm(_In_ PCWSTR replaceTerm);
     IFACEMETHODIMP GetFlags(_Out_ DWORD* flags);
     IFACEMETHODIMP PutFlags(_In_ DWORD flags);
-    IFACEMETHODIMP Replace(_In_ PCWSTR source, _Outptr_ PWSTR* result, _In_ SYSTEMTIME LocalTime);
+    IFACEMETHODIMP Replace(_In_ PCWSTR source, _Outptr_ PWSTR* result, _In_ SYSTEMTIME LocalTime, _In_ bool useFileAttributes);
 
     static HRESULT s_CreateInstance(_Outptr_ IPowerRenameRegEx **renameRegEx);
 

--- a/src/modules/powerrename/lib/PowerRenameRegEx.h
+++ b/src/modules/powerrename/lib/PowerRenameRegEx.h
@@ -25,7 +25,7 @@ public:
     IFACEMETHODIMP PutReplaceTerm(_In_ PCWSTR replaceTerm);
     IFACEMETHODIMP GetFlags(_Out_ DWORD* flags);
     IFACEMETHODIMP PutFlags(_In_ DWORD flags);
-    IFACEMETHODIMP Replace(_In_ PCWSTR source, _Outptr_ PWSTR* result);
+    IFACEMETHODIMP Replace(_In_ SYSTEMTIME LocalTime, _In_ PCWSTR source, _Outptr_ PWSTR* result);
 
     static HRESULT s_CreateInstance(_Outptr_ IPowerRenameRegEx **renameRegEx);
 

--- a/src/modules/powerrename/lib/PowerRenameRegEx.h
+++ b/src/modules/powerrename/lib/PowerRenameRegEx.h
@@ -25,7 +25,7 @@ public:
     IFACEMETHODIMP PutReplaceTerm(_In_ PCWSTR replaceTerm);
     IFACEMETHODIMP GetFlags(_Out_ DWORD* flags);
     IFACEMETHODIMP PutFlags(_In_ DWORD flags);
-    IFACEMETHODIMP Replace(_In_ SYSTEMTIME LocalTime, _In_ PCWSTR source, _Outptr_ PWSTR* result);
+    IFACEMETHODIMP Replace(_In_ PCWSTR source, _Outptr_ PWSTR* result, _In_ SYSTEMTIME LocalTime);
 
     static HRESULT s_CreateInstance(_Outptr_ IPowerRenameRegEx **renameRegEx);
 

--- a/src/modules/powerrename/lib/PowerRenameRegEx.h
+++ b/src/modules/powerrename/lib/PowerRenameRegEx.h
@@ -25,7 +25,9 @@ public:
     IFACEMETHODIMP PutReplaceTerm(_In_ PCWSTR replaceTerm);
     IFACEMETHODIMP GetFlags(_Out_ DWORD* flags);
     IFACEMETHODIMP PutFlags(_In_ DWORD flags);
-    IFACEMETHODIMP Replace(_In_ PCWSTR source, _Outptr_ PWSTR* result, _In_ SYSTEMTIME fileTime, _In_ bool useFileAttributes);
+    IFACEMETHODIMP PutFileTime(_In_ SYSTEMTIME fileTime);
+    IFACEMETHODIMP ResetFileTime();
+    IFACEMETHODIMP Replace(_In_ PCWSTR source, _Outptr_ PWSTR* result);
 
     static HRESULT s_CreateInstance(_Outptr_ IPowerRenameRegEx **renameRegEx);
 
@@ -36,6 +38,7 @@ protected:
     void _OnSearchTermChanged();
     void _OnReplaceTermChanged();
     void _OnFlagsChanged();
+    void _OnFileTimeChanged();
 
     size_t _Find(std::wstring data, std::wstring toSearch, bool caseInsensitive, size_t pos);
 
@@ -43,6 +46,9 @@ protected:
     DWORD m_flags = DEFAULT_FLAGS;
     PWSTR m_searchTerm = nullptr;
     PWSTR m_replaceTerm = nullptr;
+
+    SYSTEMTIME m_fileTime = {0};
+    bool m_useFileTime = false;
 
     CSRWLock m_lock;
     CSRWLock m_lockEvents;

--- a/src/modules/powerrename/lib/Settings.cpp
+++ b/src/modules/powerrename/lib/Settings.cpp
@@ -312,8 +312,8 @@ HRESULT CRenameMRU::CreateInstance(_In_ const std::wstring& filePath, _In_ const
 {
     *ppUnk = nullptr;
     unsigned int maxMRUSize = CSettingsInstance().GetMaxMRUSize();
-    HRESULT hr = maxMRUSize > 0 ? S_OK : E_FAIL;
-    if (SUCCEEDED(hr))
+    HRESULT hr = E_FAIL;
+    if (maxMRUSize > 0)
     {
         CRenameMRU* renameMRU = new CRenameMRU(maxMRUSize, filePath, regPath);
         hr = renameMRU ? S_OK : E_OUTOFMEMORY;

--- a/src/modules/powerrename/lib/Settings.cpp
+++ b/src/modules/powerrename/lib/Settings.cpp
@@ -316,11 +316,12 @@ HRESULT CRenameMRU::CreateInstance(_In_ const std::wstring& filePath, _In_ const
     if (maxMRUSize > 0)
     {
         CRenameMRU* renameMRU = new CRenameMRU(maxMRUSize, filePath, regPath);
-        hr = renameMRU ? S_OK : E_OUTOFMEMORY;
-        if (SUCCEEDED(hr))
+        hr = E_OUTOFMEMORY;
+        if (renameMRU)
         {
             renameMRU->QueryInterface(IID_PPV_ARGS(ppUnk));
             renameMRU->Release();
+            hr = S_OK;
         }
     }
 

--- a/src/modules/powerrename/ui/PowerRenameUI.cpp
+++ b/src/modules/powerrename/ui/PowerRenameUI.cpp
@@ -120,8 +120,8 @@ HRESULT CPowerRenameUI::s_CreateInstance(_In_ IPowerRenameManager* psrm, _In_opt
 {
     *ppsrui = nullptr;
     CPowerRenameUI* prui = new CPowerRenameUI();
-    HRESULT hr = prui ? S_OK : E_OUTOFMEMORY;
-    if (SUCCEEDED(hr))
+    HRESULT hr = E_OUTOFMEMORY;
+    if (prui)
     {
         // Pass the IPowerRenameManager to the IPowerRenameUI so it can subscribe to events
         hr = prui->_Initialize(psrm, dataSource, enableDragDrop);

--- a/src/modules/powerrename/unittests/MockPowerRenameItem.cpp
+++ b/src/modules/powerrename/unittests/MockPowerRenameItem.cpp
@@ -1,14 +1,14 @@
 #include "pch.h"
 #include "MockPowerRenameItem.h"
 
-HRESULT CMockPowerRenameItem::CreateInstance(_In_opt_ PCWSTR path, _In_opt_ PCWSTR originalName, _In_ UINT depth, _In_ bool isFolder, _Outptr_ IPowerRenameItem** ppItem)
+HRESULT CMockPowerRenameItem::CreateInstance(_In_opt_ PCWSTR path, _In_opt_ PCWSTR originalName, _In_ UINT depth, _In_ bool isFolder, _In_ SYSTEMTIME LocalTime, _Outptr_ IPowerRenameItem** ppItem)
 {
     *ppItem = nullptr;
     CMockPowerRenameItem* newItem = new CMockPowerRenameItem();
     HRESULT hr = newItem ? S_OK : E_OUTOFMEMORY;
     if (SUCCEEDED(hr))
     {
-        newItem->Init(path, originalName, depth, isFolder);
+        newItem->Init(path, originalName, depth, isFolder, LocalTime);
         hr = newItem->QueryInterface(IID_PPV_ARGS(ppItem));
         newItem->Release();
     }
@@ -16,7 +16,7 @@ HRESULT CMockPowerRenameItem::CreateInstance(_In_opt_ PCWSTR path, _In_opt_ PCWS
     return hr;
 }
 
-void CMockPowerRenameItem::Init(_In_opt_ PCWSTR path, _In_opt_ PCWSTR originalName, _In_ UINT depth, _In_ bool isFolder)
+void CMockPowerRenameItem::Init(_In_opt_ PCWSTR path, _In_opt_ PCWSTR originalName, _In_ UINT depth, _In_ bool isFolder, _In_ SYSTEMTIME LocalTime)
 {
     if (path != nullptr)
     {
@@ -30,4 +30,5 @@ void CMockPowerRenameItem::Init(_In_opt_ PCWSTR path, _In_opt_ PCWSTR originalNa
 
     m_depth = depth;
     m_isFolder = isFolder;
+    m_date = LocalTime;
 }

--- a/src/modules/powerrename/unittests/MockPowerRenameItem.cpp
+++ b/src/modules/powerrename/unittests/MockPowerRenameItem.cpp
@@ -31,4 +31,5 @@ void CMockPowerRenameItem::Init(_In_opt_ PCWSTR path, _In_opt_ PCWSTR originalNa
     m_depth = depth;
     m_isFolder = isFolder;
     m_date = LocalTime;
+    m_isDateParsed = true;
 }

--- a/src/modules/powerrename/unittests/MockPowerRenameItem.cpp
+++ b/src/modules/powerrename/unittests/MockPowerRenameItem.cpp
@@ -1,14 +1,14 @@
 #include "pch.h"
 #include "MockPowerRenameItem.h"
 
-HRESULT CMockPowerRenameItem::CreateInstance(_In_opt_ PCWSTR path, _In_opt_ PCWSTR originalName, _In_ UINT depth, _In_ bool isFolder, _In_ SYSTEMTIME LocalTime, _Outptr_ IPowerRenameItem** ppItem)
+HRESULT CMockPowerRenameItem::CreateInstance(_In_opt_ PCWSTR path, _In_opt_ PCWSTR originalName, _In_ UINT depth, _In_ bool isFolder, _In_ SYSTEMTIME time, _Outptr_ IPowerRenameItem** ppItem)
 {
     *ppItem = nullptr;
     CMockPowerRenameItem* newItem = new CMockPowerRenameItem();
     HRESULT hr = newItem ? S_OK : E_OUTOFMEMORY;
     if (SUCCEEDED(hr))
     {
-        newItem->Init(path, originalName, depth, isFolder, LocalTime);
+        newItem->Init(path, originalName, depth, isFolder, time);
         hr = newItem->QueryInterface(IID_PPV_ARGS(ppItem));
         newItem->Release();
     }
@@ -16,7 +16,7 @@ HRESULT CMockPowerRenameItem::CreateInstance(_In_opt_ PCWSTR path, _In_opt_ PCWS
     return hr;
 }
 
-void CMockPowerRenameItem::Init(_In_opt_ PCWSTR path, _In_opt_ PCWSTR originalName, _In_ UINT depth, _In_ bool isFolder, _In_ SYSTEMTIME LocalTime)
+void CMockPowerRenameItem::Init(_In_opt_ PCWSTR path, _In_opt_ PCWSTR originalName, _In_ UINT depth, _In_ bool isFolder, _In_ SYSTEMTIME time)
 {
     if (path != nullptr)
     {
@@ -30,6 +30,6 @@ void CMockPowerRenameItem::Init(_In_opt_ PCWSTR path, _In_opt_ PCWSTR originalNa
 
     m_depth = depth;
     m_isFolder = isFolder;
-    m_date = LocalTime;
-    m_isDateParsed = true;
+    m_time = time;
+    m_isTimeParsed = true;
 }

--- a/src/modules/powerrename/unittests/MockPowerRenameItem.cpp
+++ b/src/modules/powerrename/unittests/MockPowerRenameItem.cpp
@@ -5,8 +5,8 @@ HRESULT CMockPowerRenameItem::CreateInstance(_In_opt_ PCWSTR path, _In_opt_ PCWS
 {
     *ppItem = nullptr;
     CMockPowerRenameItem* newItem = new CMockPowerRenameItem();
-    HRESULT hr = newItem ? S_OK : E_OUTOFMEMORY;
-    if (SUCCEEDED(hr))
+    HRESULT hr = E_OUTOFMEMORY;
+    if (newItem)
     {
         newItem->Init(path, originalName, depth, isFolder, time);
         hr = newItem->QueryInterface(IID_PPV_ARGS(ppItem));

--- a/src/modules/powerrename/unittests/MockPowerRenameItem.h
+++ b/src/modules/powerrename/unittests/MockPowerRenameItem.h
@@ -7,6 +7,6 @@ class CMockPowerRenameItem :
     public CPowerRenameItem
 {
 public:
-    static HRESULT CreateInstance(_In_opt_ PCWSTR path, _In_opt_ PCWSTR originalName, _In_ UINT depth, _In_ bool isFolder, _Outptr_ IPowerRenameItem** ppItem);
-    void Init(_In_opt_ PCWSTR path, _In_opt_ PCWSTR originalName, _In_ UINT depth, _In_ bool isFolder);
+    static HRESULT CreateInstance(_In_opt_ PCWSTR path, _In_opt_ PCWSTR originalName, _In_ UINT depth, _In_ bool isFolder, _In_ SYSTEMTIME LocalTime, _Outptr_ IPowerRenameItem** ppItem);
+    void Init(_In_opt_ PCWSTR path, _In_opt_ PCWSTR originalName, _In_ UINT depth, _In_ bool isFolder, _In_ SYSTEMTIME LocalTime);
 };

--- a/src/modules/powerrename/unittests/MockPowerRenameItem.h
+++ b/src/modules/powerrename/unittests/MockPowerRenameItem.h
@@ -7,6 +7,6 @@ class CMockPowerRenameItem :
     public CPowerRenameItem
 {
 public:
-    static HRESULT CreateInstance(_In_opt_ PCWSTR path, _In_opt_ PCWSTR originalName, _In_ UINT depth, _In_ bool isFolder, _In_ SYSTEMTIME LocalTime, _Outptr_ IPowerRenameItem** ppItem);
-    void Init(_In_opt_ PCWSTR path, _In_opt_ PCWSTR originalName, _In_ UINT depth, _In_ bool isFolder, _In_ SYSTEMTIME LocalTime);
+    static HRESULT CreateInstance(_In_opt_ PCWSTR path, _In_opt_ PCWSTR originalName, _In_ UINT depth, _In_ bool isFolder, _In_ SYSTEMTIME time, _Outptr_ IPowerRenameItem** ppItem);
+    void Init(_In_opt_ PCWSTR path, _In_opt_ PCWSTR originalName, _In_ UINT depth, _In_ bool isFolder, _In_ SYSTEMTIME time);
 };

--- a/src/modules/powerrename/unittests/MockPowerRenameManagerEvents.cpp
+++ b/src/modules/powerrename/unittests/MockPowerRenameManagerEvents.cpp
@@ -81,8 +81,8 @@ HRESULT CMockPowerRenameManagerEvents::s_CreateInstance(_In_ IPowerRenameManager
 {
     *ppsrui = nullptr;
     CMockPowerRenameManagerEvents* events = new CMockPowerRenameManagerEvents();
-    HRESULT hr = events != nullptr ? S_OK : E_OUTOFMEMORY;
-    if (SUCCEEDED(hr))
+    HRESULT hr = E_OUTOFMEMORY;
+    if (events != nullptr)
     {
         hr = events->QueryInterface(IID_PPV_ARGS(ppsrui));
         events->Release();

--- a/src/modules/powerrename/unittests/MockPowerRenameRegExEvents.cpp
+++ b/src/modules/powerrename/unittests/MockPowerRenameRegExEvents.cpp
@@ -66,8 +66,8 @@ HRESULT CMockPowerRenameRegExEvents::s_CreateInstance(_Outptr_ IPowerRenameRegEx
 {
     *ppsrree = nullptr;
     CMockPowerRenameRegExEvents* psrree = new CMockPowerRenameRegExEvents();
-    HRESULT hr = psrree ? S_OK : E_OUTOFMEMORY;
-    if (SUCCEEDED(hr))
+    HRESULT hr = E_OUTOFMEMORY;
+    if (psrree)
     {
         hr = psrree->QueryInterface(IID_PPV_ARGS(ppsrree));
         psrree->Release();

--- a/src/modules/powerrename/unittests/MockPowerRenameRegExEvents.cpp
+++ b/src/modules/powerrename/unittests/MockPowerRenameRegExEvents.cpp
@@ -56,6 +56,12 @@ IFACEMETHODIMP CMockPowerRenameRegExEvents::OnFlagsChanged(_In_ DWORD flags)
     return S_OK;
 }
 
+IFACEMETHODIMP CMockPowerRenameRegExEvents::OnFileTimeChanged(_In_ SYSTEMTIME fileTime)
+{
+    m_fileTime = fileTime;
+    return S_OK;
+}
+
 HRESULT CMockPowerRenameRegExEvents::s_CreateInstance(_Outptr_ IPowerRenameRegExEvents** ppsrree)
 {
     *ppsrree = nullptr;

--- a/src/modules/powerrename/unittests/MockPowerRenameRegExEvents.h
+++ b/src/modules/powerrename/unittests/MockPowerRenameRegExEvents.h
@@ -18,6 +18,7 @@ public:
     IFACEMETHODIMP OnSearchTermChanged(_In_ PCWSTR searchTerm);
     IFACEMETHODIMP OnReplaceTermChanged(_In_ PCWSTR replaceTerm);
     IFACEMETHODIMP OnFlagsChanged(_In_ DWORD flags);
+    IFACEMETHODIMP OnFileTimeChanged(_In_ SYSTEMTIME fileTime);
 
     static HRESULT s_CreateInstance(_Outptr_ IPowerRenameRegExEvents** ppsrree);
 
@@ -35,5 +36,6 @@ public:
     PWSTR m_searchTerm = nullptr;
     PWSTR m_replaceTerm = nullptr;
     DWORD m_flags = 0;
+    SYSTEMTIME m_fileTime = { 0 };
     long m_refCount;
 };

--- a/src/modules/powerrename/unittests/PowerRenameManagerTests.cpp
+++ b/src/modules/powerrename/unittests/PowerRenameManagerTests.cpp
@@ -84,6 +84,7 @@ namespace PowerRenameManagerTests
             renRegEx->PutFlags(flags);
             renRegEx->PutSearchTerm(searchTerm.c_str());
             renRegEx->PutReplaceTerm(replaceTerm.c_str());
+            renRegEx->PutFileTime(fileTime);
 
             // Perform the rename
             bool replaceSuccess = false;

--- a/src/modules/powerrename/unittests/PowerRenameManagerTests.cpp
+++ b/src/modules/powerrename/unittests/PowerRenameManagerTests.cpp
@@ -84,7 +84,6 @@ namespace PowerRenameManagerTests
             renRegEx->PutFlags(flags);
             renRegEx->PutSearchTerm(searchTerm.c_str());
             renRegEx->PutReplaceTerm(replaceTerm.c_str());
-            renRegEx->PutFileTime(fileTime);
 
             // Perform the rename
             bool replaceSuccess = false;

--- a/src/modules/powerrename/unittests/PowerRenameManagerTests.cpp
+++ b/src/modules/powerrename/unittests/PowerRenameManagerTests.cpp
@@ -32,7 +32,7 @@ namespace PowerRenameManagerTests
             int depth;
         };
 
-        void RenameHelper(_In_ rename_pairs * renamePairs, _In_ int numPairs, _In_ std::wstring searchTerm, _In_ std::wstring replaceTerm, SYSTEMTIME LocalTime, _In_ DWORD flags)
+        void RenameHelper(_In_ rename_pairs * renamePairs, _In_ int numPairs, _In_ std::wstring searchTerm, _In_ std::wstring replaceTerm, SYSTEMTIME fileTime, _In_ DWORD flags)
         {
             // Create a single item (in a temp directory) and verify rename works as expected
             CTestFileHelper testFileHelper;
@@ -63,7 +63,7 @@ namespace PowerRenameManagerTests
                                                      renamePairs[i].originalName.c_str(),
                                                      renamePairs[i].depth,
                                                      !renamePairs[i].isFile,
-                                                     LocalTime,
+                                                     fileTime,
                                                      &item);
 
                 int itemId = 0;
@@ -312,26 +312,26 @@ namespace PowerRenameManagerTests
         TEST_METHOD (VerifyFileAttributesMonthandDayNames)
         {
             std::locale::global(std::locale(""));
-            SYSTEMTIME LocalTime = { 2020, 1, 3, 1, 15, 6, 42, 453 };
+            SYSTEMTIME fileTime = { 2020, 1, 3, 1, 15, 6, 42, 453 };
             wchar_t localeName[LOCALE_NAME_MAX_LENGTH];
             wchar_t result[MAX_PATH] = L"bar";
             wchar_t formattedDate[MAX_PATH];
             if (GetUserDefaultLocaleName(localeName, LOCALE_NAME_MAX_LENGTH) == 0)
                 StringCchCopy(localeName, LOCALE_NAME_MAX_LENGTH, L"en_US");
 
-            GetDateFormatEx(localeName, NULL, &LocalTime, L"MMM", formattedDate, MAX_PATH, NULL);
+            GetDateFormatEx(localeName, NULL, &fileTime, L"MMM", formattedDate, MAX_PATH, NULL);
             formattedDate[0] = towupper(formattedDate[0]);
             StringCchPrintf(result, MAX_PATH, TEXT("%s%s"), result, formattedDate);
 
-            GetDateFormatEx(localeName, NULL, &LocalTime, L"MMMM", formattedDate, MAX_PATH, NULL);
+            GetDateFormatEx(localeName, NULL, &fileTime, L"MMMM", formattedDate, MAX_PATH, NULL);
             formattedDate[0] = towupper(formattedDate[0]);
             StringCchPrintf(result, MAX_PATH, TEXT("%s-%s"), result, formattedDate);
 
-            GetDateFormatEx(localeName, NULL, &LocalTime, L"ddd", formattedDate, MAX_PATH, NULL);
+            GetDateFormatEx(localeName, NULL, &fileTime, L"ddd", formattedDate, MAX_PATH, NULL);
             formattedDate[0] = towupper(formattedDate[0]);
             StringCchPrintf(result, MAX_PATH, TEXT("%s-%s"), result, formattedDate);
 
-            GetDateFormatEx(localeName, NULL, &LocalTime, L"dddd", formattedDate, MAX_PATH, NULL);
+            GetDateFormatEx(localeName, NULL, &fileTime, L"dddd", formattedDate, MAX_PATH, NULL);
             formattedDate[0] = towupper(formattedDate[0]);
             StringCchPrintf(result, MAX_PATH, TEXT("%s-%s"), result, formattedDate);
 

--- a/src/modules/powerrename/unittests/PowerRenameRegExBoostTests.cpp
+++ b/src/modules/powerrename/unittests/PowerRenameRegExBoostTests.cpp
@@ -414,7 +414,7 @@ TEST_METHOD(VerifyLookbehind)
     }
 }
 
-TEST_METHOD (VerifyEventsFire)
+TEST_METHOD(VerifyEventsFire)
 {
     CComPtr<IPowerRenameRegEx> renameRegEx;
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);

--- a/src/modules/powerrename/unittests/PowerRenameRegExBoostTests.cpp
+++ b/src/modules/powerrename/unittests/PowerRenameRegExBoostTests.cpp
@@ -37,7 +37,7 @@ TEST_METHOD(GeneralReplaceTest)
     PWSTR result = nullptr;
     Assert::IsTrue(renameRegEx->PutSearchTerm(L"foo") == S_OK);
     Assert::IsTrue(renameRegEx->PutReplaceTerm(L"big") == S_OK);
-    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result, SYSTEMTIME{0}) == S_OK);
+    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result, SYSTEMTIME{0}, false) == S_OK);
     Assert::IsTrue(wcscmp(result, L"bigbar") == 0);
     CoTaskMemFree(result);
 }
@@ -49,7 +49,7 @@ TEST_METHOD(ReplaceNoMatch)
     PWSTR result = nullptr;
     Assert::IsTrue(renameRegEx->PutSearchTerm(L"notfound") == S_OK);
     Assert::IsTrue(renameRegEx->PutReplaceTerm(L"big") == S_OK);
-    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result, SYSTEMTIME{0}) == S_OK);
+    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result, SYSTEMTIME{0}, false) == S_OK);
     Assert::IsTrue(wcscmp(result, L"foobar") == 0);
     CoTaskMemFree(result);
 }
@@ -59,7 +59,7 @@ TEST_METHOD(ReplaceNoSearchOrReplaceTerm)
     CComPtr<IPowerRenameRegEx> renameRegEx;
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     PWSTR result = nullptr;
-    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result, SYSTEMTIME{0}) != S_OK);
+    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result, SYSTEMTIME{0}, false) != S_OK);
     Assert::IsTrue(result == nullptr);
     CoTaskMemFree(result);
 }
@@ -70,7 +70,7 @@ TEST_METHOD(ReplaceNoReplaceTerm)
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     PWSTR result = nullptr;
     Assert::IsTrue(renameRegEx->PutSearchTerm(L"foo") == S_OK);
-    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result, SYSTEMTIME{0}) == S_OK);
+    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result, SYSTEMTIME{0}, false) == S_OK);
     Assert::IsTrue(wcscmp(result, L"bar") == 0);
     CoTaskMemFree(result);
 }
@@ -82,7 +82,7 @@ TEST_METHOD(ReplaceEmptyStringReplaceTerm)
     PWSTR result = nullptr;
     Assert::IsTrue(renameRegEx->PutSearchTerm(L"foo") == S_OK);
     Assert::IsTrue(renameRegEx->PutReplaceTerm(L"") == S_OK);
-    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result, SYSTEMTIME{0}) == S_OK);
+    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result, SYSTEMTIME{0}, false) == S_OK);
     Assert::IsTrue(wcscmp(result, L"bar") == 0);
     CoTaskMemFree(result);
 }
@@ -115,7 +115,7 @@ TEST_METHOD(VerifyCaseSensitiveSearch)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}, false) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -139,7 +139,7 @@ TEST_METHOD(VerifyReplaceFirstOnly)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}, false) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -163,7 +163,7 @@ TEST_METHOD(VerifyReplaceAll)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}, false) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -188,7 +188,7 @@ TEST_METHOD(VerifyReplaceAllCaseInsensitive)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}, false) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -212,7 +212,7 @@ TEST_METHOD(VerifyReplaceFirstOnlyUseRegEx)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}, false) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -236,7 +236,7 @@ TEST_METHOD(VerifyReplaceAllUseRegEx)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}, false) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -260,7 +260,7 @@ TEST_METHOD(VerifyReplaceAllUseRegExCaseSensitive)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}, false) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -285,7 +285,7 @@ TEST_METHOD(VerifyMatchAllWildcardUseRegEx)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}, false) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -302,7 +302,7 @@ void VerifyReplaceFirstWildcard(SearchReplaceExpected sreTable[], int tableSize,
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}, false) == S_OK);
         Assert::AreEqual(sreTable[i].expected, result);
         CoTaskMemFree(result);
     }
@@ -381,7 +381,7 @@ TEST_METHOD(VerifyHandleCapturingGroups)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}, false) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -408,7 +408,7 @@ TEST_METHOD(VerifyLookbehind)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}, false) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }

--- a/src/modules/powerrename/unittests/PowerRenameRegExBoostTests.cpp
+++ b/src/modules/powerrename/unittests/PowerRenameRegExBoostTests.cpp
@@ -37,7 +37,7 @@ TEST_METHOD(GeneralReplaceTest)
     PWSTR result = nullptr;
     Assert::IsTrue(renameRegEx->PutSearchTerm(L"foo") == S_OK);
     Assert::IsTrue(renameRegEx->PutReplaceTerm(L"big") == S_OK);
-    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result, SYSTEMTIME{0}, false) == S_OK);
+    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result) == S_OK);
     Assert::IsTrue(wcscmp(result, L"bigbar") == 0);
     CoTaskMemFree(result);
 }
@@ -49,7 +49,7 @@ TEST_METHOD(ReplaceNoMatch)
     PWSTR result = nullptr;
     Assert::IsTrue(renameRegEx->PutSearchTerm(L"notfound") == S_OK);
     Assert::IsTrue(renameRegEx->PutReplaceTerm(L"big") == S_OK);
-    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result, SYSTEMTIME{0}, false) == S_OK);
+    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result) == S_OK);
     Assert::IsTrue(wcscmp(result, L"foobar") == 0);
     CoTaskMemFree(result);
 }
@@ -59,7 +59,7 @@ TEST_METHOD(ReplaceNoSearchOrReplaceTerm)
     CComPtr<IPowerRenameRegEx> renameRegEx;
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     PWSTR result = nullptr;
-    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result, SYSTEMTIME{0}, false) != S_OK);
+    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result) != S_OK);
     Assert::IsTrue(result == nullptr);
     CoTaskMemFree(result);
 }
@@ -70,7 +70,7 @@ TEST_METHOD(ReplaceNoReplaceTerm)
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     PWSTR result = nullptr;
     Assert::IsTrue(renameRegEx->PutSearchTerm(L"foo") == S_OK);
-    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result, SYSTEMTIME{0}, false) == S_OK);
+    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result) == S_OK);
     Assert::IsTrue(wcscmp(result, L"bar") == 0);
     CoTaskMemFree(result);
 }
@@ -82,7 +82,7 @@ TEST_METHOD(ReplaceEmptyStringReplaceTerm)
     PWSTR result = nullptr;
     Assert::IsTrue(renameRegEx->PutSearchTerm(L"foo") == S_OK);
     Assert::IsTrue(renameRegEx->PutReplaceTerm(L"") == S_OK);
-    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result, SYSTEMTIME{0}, false) == S_OK);
+    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result) == S_OK);
     Assert::IsTrue(wcscmp(result, L"bar") == 0);
     CoTaskMemFree(result);
 }
@@ -115,7 +115,7 @@ TEST_METHOD(VerifyCaseSensitiveSearch)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}, false) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -139,7 +139,7 @@ TEST_METHOD(VerifyReplaceFirstOnly)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}, false) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -163,7 +163,7 @@ TEST_METHOD(VerifyReplaceAll)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}, false) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -188,7 +188,7 @@ TEST_METHOD(VerifyReplaceAllCaseInsensitive)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}, false) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -212,7 +212,7 @@ TEST_METHOD(VerifyReplaceFirstOnlyUseRegEx)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}, false) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -236,7 +236,7 @@ TEST_METHOD(VerifyReplaceAllUseRegEx)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}, false) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -260,7 +260,7 @@ TEST_METHOD(VerifyReplaceAllUseRegExCaseSensitive)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}, false) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -285,7 +285,7 @@ TEST_METHOD(VerifyMatchAllWildcardUseRegEx)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}, false) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -302,7 +302,7 @@ void VerifyReplaceFirstWildcard(SearchReplaceExpected sreTable[], int tableSize,
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}, false) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
         Assert::AreEqual(sreTable[i].expected, result);
         CoTaskMemFree(result);
     }
@@ -381,7 +381,7 @@ TEST_METHOD(VerifyHandleCapturingGroups)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}, false) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -408,13 +408,13 @@ TEST_METHOD(VerifyLookbehind)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}, false) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
 }
 
-TEST_METHOD(VerifyEventsFire)
+TEST_METHOD (VerifyEventsFire)
 {
     CComPtr<IPowerRenameRegEx> renameRegEx;
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
@@ -427,6 +427,8 @@ TEST_METHOD(VerifyEventsFire)
     Assert::IsTrue(renameRegEx->PutFlags(flags) == S_OK);
     Assert::IsTrue(renameRegEx->PutSearchTerm(L"FOO") == S_OK);
     Assert::IsTrue(renameRegEx->PutReplaceTerm(L"BAR") == S_OK);
+    Assert::IsTrue(renameRegEx->PutFileTime(SYSTEMTIME{0}) == S_OK);
+    Assert::IsTrue(renameRegEx->ResetFileTime() == S_OK);
     Assert::IsTrue(lstrcmpi(L"FOO", mockEvents->m_searchTerm) == 0);
     Assert::IsTrue(lstrcmpi(L"BAR", mockEvents->m_replaceTerm) == 0);
     Assert::IsTrue(flags == mockEvents->m_flags);

--- a/src/modules/powerrename/unittests/PowerRenameRegExBoostTests.cpp
+++ b/src/modules/powerrename/unittests/PowerRenameRegExBoostTests.cpp
@@ -59,7 +59,7 @@ TEST_METHOD(ReplaceNoSearchOrReplaceTerm)
     CComPtr<IPowerRenameRegEx> renameRegEx;
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     PWSTR result = nullptr;
-    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result) != S_OK);
+    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result) == S_OK);
     Assert::IsTrue(result == nullptr);
     CoTaskMemFree(result);
 }

--- a/src/modules/powerrename/unittests/PowerRenameRegExBoostTests.cpp
+++ b/src/modules/powerrename/unittests/PowerRenameRegExBoostTests.cpp
@@ -37,7 +37,7 @@ TEST_METHOD(GeneralReplaceTest)
     PWSTR result = nullptr;
     Assert::IsTrue(renameRegEx->PutSearchTerm(L"foo") == S_OK);
     Assert::IsTrue(renameRegEx->PutReplaceTerm(L"big") == S_OK);
-    Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, L"foobar", &result) == S_OK);
+    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result, SYSTEMTIME{0}) == S_OK);
     Assert::IsTrue(wcscmp(result, L"bigbar") == 0);
     CoTaskMemFree(result);
 }
@@ -49,7 +49,7 @@ TEST_METHOD(ReplaceNoMatch)
     PWSTR result = nullptr;
     Assert::IsTrue(renameRegEx->PutSearchTerm(L"notfound") == S_OK);
     Assert::IsTrue(renameRegEx->PutReplaceTerm(L"big") == S_OK);
-    Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, L"foobar", &result) == S_OK);
+    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result, SYSTEMTIME{0}) == S_OK);
     Assert::IsTrue(wcscmp(result, L"foobar") == 0);
     CoTaskMemFree(result);
 }
@@ -59,7 +59,7 @@ TEST_METHOD(ReplaceNoSearchOrReplaceTerm)
     CComPtr<IPowerRenameRegEx> renameRegEx;
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     PWSTR result = nullptr;
-    Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, L"foobar", &result) != S_OK);
+    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result, SYSTEMTIME{0}) != S_OK);
     Assert::IsTrue(result == nullptr);
     CoTaskMemFree(result);
 }
@@ -70,7 +70,7 @@ TEST_METHOD(ReplaceNoReplaceTerm)
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     PWSTR result = nullptr;
     Assert::IsTrue(renameRegEx->PutSearchTerm(L"foo") == S_OK);
-    Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, L"foobar", &result) == S_OK);
+    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result, SYSTEMTIME{0}) == S_OK);
     Assert::IsTrue(wcscmp(result, L"bar") == 0);
     CoTaskMemFree(result);
 }
@@ -82,7 +82,7 @@ TEST_METHOD(ReplaceEmptyStringReplaceTerm)
     PWSTR result = nullptr;
     Assert::IsTrue(renameRegEx->PutSearchTerm(L"foo") == S_OK);
     Assert::IsTrue(renameRegEx->PutReplaceTerm(L"") == S_OK);
-    Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, L"foobar", &result) == S_OK);
+    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result, SYSTEMTIME{0}) == S_OK);
     Assert::IsTrue(wcscmp(result, L"bar") == 0);
     CoTaskMemFree(result);
 }
@@ -115,7 +115,7 @@ TEST_METHOD(VerifyCaseSensitiveSearch)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -139,7 +139,7 @@ TEST_METHOD(VerifyReplaceFirstOnly)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -163,7 +163,7 @@ TEST_METHOD(VerifyReplaceAll)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -188,7 +188,7 @@ TEST_METHOD(VerifyReplaceAllCaseInsensitive)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -212,7 +212,7 @@ TEST_METHOD(VerifyReplaceFirstOnlyUseRegEx)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -236,7 +236,7 @@ TEST_METHOD(VerifyReplaceAllUseRegEx)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -260,7 +260,7 @@ TEST_METHOD(VerifyReplaceAllUseRegExCaseSensitive)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -285,7 +285,7 @@ TEST_METHOD(VerifyMatchAllWildcardUseRegEx)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -302,7 +302,7 @@ void VerifyReplaceFirstWildcard(SearchReplaceExpected sreTable[], int tableSize,
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}) == S_OK);
         Assert::AreEqual(sreTable[i].expected, result);
         CoTaskMemFree(result);
     }
@@ -381,7 +381,7 @@ TEST_METHOD(VerifyHandleCapturingGroups)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -408,7 +408,7 @@ TEST_METHOD(VerifyLookbehind)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }

--- a/src/modules/powerrename/unittests/PowerRenameRegExBoostTests.cpp
+++ b/src/modules/powerrename/unittests/PowerRenameRegExBoostTests.cpp
@@ -37,7 +37,7 @@ TEST_METHOD(GeneralReplaceTest)
     PWSTR result = nullptr;
     Assert::IsTrue(renameRegEx->PutSearchTerm(L"foo") == S_OK);
     Assert::IsTrue(renameRegEx->PutReplaceTerm(L"big") == S_OK);
-    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result) == S_OK);
+    Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, L"foobar", &result) == S_OK);
     Assert::IsTrue(wcscmp(result, L"bigbar") == 0);
     CoTaskMemFree(result);
 }
@@ -49,7 +49,7 @@ TEST_METHOD(ReplaceNoMatch)
     PWSTR result = nullptr;
     Assert::IsTrue(renameRegEx->PutSearchTerm(L"notfound") == S_OK);
     Assert::IsTrue(renameRegEx->PutReplaceTerm(L"big") == S_OK);
-    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result) == S_OK);
+    Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, L"foobar", &result) == S_OK);
     Assert::IsTrue(wcscmp(result, L"foobar") == 0);
     CoTaskMemFree(result);
 }
@@ -59,7 +59,7 @@ TEST_METHOD(ReplaceNoSearchOrReplaceTerm)
     CComPtr<IPowerRenameRegEx> renameRegEx;
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     PWSTR result = nullptr;
-    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result) != S_OK);
+    Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, L"foobar", &result) != S_OK);
     Assert::IsTrue(result == nullptr);
     CoTaskMemFree(result);
 }
@@ -70,7 +70,7 @@ TEST_METHOD(ReplaceNoReplaceTerm)
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     PWSTR result = nullptr;
     Assert::IsTrue(renameRegEx->PutSearchTerm(L"foo") == S_OK);
-    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result) == S_OK);
+    Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, L"foobar", &result) == S_OK);
     Assert::IsTrue(wcscmp(result, L"bar") == 0);
     CoTaskMemFree(result);
 }
@@ -82,7 +82,7 @@ TEST_METHOD(ReplaceEmptyStringReplaceTerm)
     PWSTR result = nullptr;
     Assert::IsTrue(renameRegEx->PutSearchTerm(L"foo") == S_OK);
     Assert::IsTrue(renameRegEx->PutReplaceTerm(L"") == S_OK);
-    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result) == S_OK);
+    Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, L"foobar", &result) == S_OK);
     Assert::IsTrue(wcscmp(result, L"bar") == 0);
     CoTaskMemFree(result);
 }
@@ -115,7 +115,7 @@ TEST_METHOD(VerifyCaseSensitiveSearch)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -139,7 +139,7 @@ TEST_METHOD(VerifyReplaceFirstOnly)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -163,7 +163,7 @@ TEST_METHOD(VerifyReplaceAll)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -188,7 +188,7 @@ TEST_METHOD(VerifyReplaceAllCaseInsensitive)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -212,7 +212,7 @@ TEST_METHOD(VerifyReplaceFirstOnlyUseRegEx)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -236,7 +236,7 @@ TEST_METHOD(VerifyReplaceAllUseRegEx)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -260,7 +260,7 @@ TEST_METHOD(VerifyReplaceAllUseRegExCaseSensitive)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -285,7 +285,7 @@ TEST_METHOD(VerifyMatchAllWildcardUseRegEx)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -302,7 +302,7 @@ void VerifyReplaceFirstWildcard(SearchReplaceExpected sreTable[], int tableSize,
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, sreTable[i].test, &result) == S_OK);
         Assert::AreEqual(sreTable[i].expected, result);
         CoTaskMemFree(result);
     }
@@ -381,7 +381,7 @@ TEST_METHOD(VerifyHandleCapturingGroups)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -408,7 +408,7 @@ TEST_METHOD(VerifyLookbehind)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }

--- a/src/modules/powerrename/unittests/PowerRenameRegExTests.cpp
+++ b/src/modules/powerrename/unittests/PowerRenameRegExTests.cpp
@@ -31,7 +31,7 @@ TEST_METHOD(GeneralReplaceTest)
     PWSTR result = nullptr;
     Assert::IsTrue(renameRegEx->PutSearchTerm(L"foo") == S_OK);
     Assert::IsTrue(renameRegEx->PutReplaceTerm(L"big") == S_OK);
-    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result, SYSTEMTIME{0}) == S_OK);
+    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result, SYSTEMTIME{0}, false) == S_OK);
     Assert::IsTrue(wcscmp(result, L"bigbar") == 0);
     CoTaskMemFree(result);
 }
@@ -43,7 +43,7 @@ TEST_METHOD(ReplaceNoMatch)
     PWSTR result = nullptr;
     Assert::IsTrue(renameRegEx->PutSearchTerm(L"notfound") == S_OK);
     Assert::IsTrue(renameRegEx->PutReplaceTerm(L"big") == S_OK);
-    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result, SYSTEMTIME{0}) == S_OK);
+    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result, SYSTEMTIME{0}, false) == S_OK);
     Assert::IsTrue(wcscmp(result, L"foobar") == 0);
     CoTaskMemFree(result);
 }
@@ -53,7 +53,7 @@ TEST_METHOD(ReplaceNoSearchOrReplaceTerm)
     CComPtr<IPowerRenameRegEx> renameRegEx;
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     PWSTR result = nullptr;
-    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result, SYSTEMTIME{0}) != S_OK);
+    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result, SYSTEMTIME{0}, false) != S_OK);
     Assert::IsTrue(result == nullptr);
     CoTaskMemFree(result);
 }
@@ -64,7 +64,7 @@ TEST_METHOD(ReplaceNoReplaceTerm)
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     PWSTR result = nullptr;
     Assert::IsTrue(renameRegEx->PutSearchTerm(L"foo") == S_OK);
-    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result, SYSTEMTIME{0}) == S_OK);
+    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result, SYSTEMTIME{0}, false) == S_OK);
     Assert::IsTrue(wcscmp(result, L"bar") == 0);
     CoTaskMemFree(result);
 }
@@ -76,7 +76,7 @@ TEST_METHOD(ReplaceEmptyStringReplaceTerm)
     PWSTR result = nullptr;
     Assert::IsTrue(renameRegEx->PutSearchTerm(L"foo") == S_OK);
     Assert::IsTrue(renameRegEx->PutReplaceTerm(L"") == S_OK);
-    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result, SYSTEMTIME{0}) == S_OK);
+    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result, SYSTEMTIME{0}, false) == S_OK);
     Assert::IsTrue(wcscmp(result, L"bar") == 0);
     CoTaskMemFree(result);
 }
@@ -109,7 +109,7 @@ TEST_METHOD(VerifyCaseSensitiveSearch)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}, false) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -133,7 +133,7 @@ TEST_METHOD(VerifyReplaceFirstOnly)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}, false) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -157,7 +157,7 @@ TEST_METHOD(VerifyReplaceAll)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}, false) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -182,7 +182,7 @@ TEST_METHOD(VerifyReplaceAllCaseInsensitive)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}, false) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -206,7 +206,7 @@ TEST_METHOD(VerifyReplaceFirstOnlyUseRegEx)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}, false) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -230,7 +230,7 @@ TEST_METHOD(VerifyReplaceAllUseRegEx)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}, false) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -254,7 +254,7 @@ TEST_METHOD(VerifyReplaceAllUseRegExCaseSensitive)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}, false) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -276,7 +276,7 @@ TEST_METHOD(VerifyMatchAllWildcardUseRegEx)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}, false) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -293,7 +293,7 @@ void VerifyReplaceFirstWildcard(SearchReplaceExpected sreTable[], int tableSize,
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}, false) == S_OK);
         Assert::AreEqual(sreTable[i].expected, result);
         CoTaskMemFree(result);
     }
@@ -363,7 +363,7 @@ TEST_METHOD(VerifyHandleCapturingGroups)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}, false) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -386,7 +386,7 @@ TEST_METHOD (VerifyFileAttributesNoPadding)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{ 2020, 7, 3, 22, 15, 6, 42, 453 }) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{ 2020, 7, 3, 22, 15, 6, 42, 453 }, true) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -409,7 +409,7 @@ TEST_METHOD (VerifyFileAttributesPadding)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{ 2020, 7, 3, 22, 15, 6, 42, 453 }) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{ 2020, 7, 3, 22, 15, 6, 42, 453 }, true) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -423,26 +423,26 @@ TEST_METHOD (VerifyFileAttributesMonthandDayNames)
     Assert::IsTrue(renameRegEx->PutFlags(flags) == S_OK);
 
     std::locale::global(std::locale(""));
-    SYSTEMTIME LocalTime = { 2020, 1, 3, 1, 15, 6, 42, 453 };
+    SYSTEMTIME fileTime = { 2020, 1, 3, 1, 15, 6, 42, 453 };
     wchar_t localeName[LOCALE_NAME_MAX_LENGTH];
     wchar_t result[MAX_PATH] = L"bar";
     wchar_t formattedDate[MAX_PATH];
     if (GetUserDefaultLocaleName(localeName, LOCALE_NAME_MAX_LENGTH) == 0)
         StringCchCopy(localeName, LOCALE_NAME_MAX_LENGTH, L"en_US");
 
-    GetDateFormatEx(localeName, NULL, &LocalTime, L"MMM", formattedDate, MAX_PATH, NULL);
+    GetDateFormatEx(localeName, NULL, &fileTime, L"MMM", formattedDate, MAX_PATH, NULL);
     formattedDate[0] = towupper(formattedDate[0]);
     StringCchPrintf(result, MAX_PATH, TEXT("%s%s"), result, formattedDate);
 
-    GetDateFormatEx(localeName, NULL, &LocalTime, L"MMMM", formattedDate, MAX_PATH, NULL);
+    GetDateFormatEx(localeName, NULL, &fileTime, L"MMMM", formattedDate, MAX_PATH, NULL);
     formattedDate[0] = towupper(formattedDate[0]);
     StringCchPrintf(result, MAX_PATH, TEXT("%s-%s"), result, formattedDate);
 
-    GetDateFormatEx(localeName, NULL, &LocalTime, L"ddd", formattedDate, MAX_PATH, NULL);
+    GetDateFormatEx(localeName, NULL, &fileTime, L"ddd", formattedDate, MAX_PATH, NULL);
     formattedDate[0] = towupper(formattedDate[0]);
     StringCchPrintf(result, MAX_PATH, TEXT("%s-%s"), result, formattedDate);
 
-    GetDateFormatEx(localeName, NULL, &LocalTime, L"dddd", formattedDate, MAX_PATH, NULL);
+    GetDateFormatEx(localeName, NULL, &fileTime, L"dddd", formattedDate, MAX_PATH, NULL);
     formattedDate[0] = towupper(formattedDate[0]);
     StringCchPrintf(result, MAX_PATH, TEXT("%s-%s"), result, formattedDate);
 
@@ -456,7 +456,7 @@ TEST_METHOD (VerifyFileAttributesMonthandDayNames)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{ 2020, 1, 3, 1, 15, 6, 42, 453 }) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{ 2020, 1, 3, 1, 15, 6, 42, 453 }, true) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -480,7 +480,7 @@ TEST_METHOD(VerifyLookbehindFails)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}) == E_FAIL);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}, false) == E_FAIL);
         Assert::AreEqual(sreTable[i].expected, result);
         CoTaskMemFree(result);
     }

--- a/src/modules/powerrename/unittests/PowerRenameRegExTests.cpp
+++ b/src/modules/powerrename/unittests/PowerRenameRegExTests.cpp
@@ -53,7 +53,7 @@ TEST_METHOD(ReplaceNoSearchOrReplaceTerm)
     CComPtr<IPowerRenameRegEx> renameRegEx;
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     PWSTR result = nullptr;
-    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result) != S_OK);
+    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result) == S_OK);
     Assert::IsTrue(result == nullptr);
     CoTaskMemFree(result);
 }

--- a/src/modules/powerrename/unittests/PowerRenameRegExTests.cpp
+++ b/src/modules/powerrename/unittests/PowerRenameRegExTests.cpp
@@ -31,7 +31,7 @@ TEST_METHOD(GeneralReplaceTest)
     PWSTR result = nullptr;
     Assert::IsTrue(renameRegEx->PutSearchTerm(L"foo") == S_OK);
     Assert::IsTrue(renameRegEx->PutReplaceTerm(L"big") == S_OK);
-    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result, SYSTEMTIME{0}, false) == S_OK);
+    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result) == S_OK);
     Assert::IsTrue(wcscmp(result, L"bigbar") == 0);
     CoTaskMemFree(result);
 }
@@ -43,7 +43,7 @@ TEST_METHOD(ReplaceNoMatch)
     PWSTR result = nullptr;
     Assert::IsTrue(renameRegEx->PutSearchTerm(L"notfound") == S_OK);
     Assert::IsTrue(renameRegEx->PutReplaceTerm(L"big") == S_OK);
-    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result, SYSTEMTIME{0}, false) == S_OK);
+    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result) == S_OK);
     Assert::IsTrue(wcscmp(result, L"foobar") == 0);
     CoTaskMemFree(result);
 }
@@ -53,7 +53,7 @@ TEST_METHOD(ReplaceNoSearchOrReplaceTerm)
     CComPtr<IPowerRenameRegEx> renameRegEx;
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     PWSTR result = nullptr;
-    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result, SYSTEMTIME{0}, false) != S_OK);
+    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result) != S_OK);
     Assert::IsTrue(result == nullptr);
     CoTaskMemFree(result);
 }
@@ -64,7 +64,7 @@ TEST_METHOD(ReplaceNoReplaceTerm)
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     PWSTR result = nullptr;
     Assert::IsTrue(renameRegEx->PutSearchTerm(L"foo") == S_OK);
-    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result, SYSTEMTIME{0}, false) == S_OK);
+    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result) == S_OK);
     Assert::IsTrue(wcscmp(result, L"bar") == 0);
     CoTaskMemFree(result);
 }
@@ -76,7 +76,7 @@ TEST_METHOD(ReplaceEmptyStringReplaceTerm)
     PWSTR result = nullptr;
     Assert::IsTrue(renameRegEx->PutSearchTerm(L"foo") == S_OK);
     Assert::IsTrue(renameRegEx->PutReplaceTerm(L"") == S_OK);
-    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result, SYSTEMTIME{0}, false) == S_OK);
+    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result) == S_OK);
     Assert::IsTrue(wcscmp(result, L"bar") == 0);
     CoTaskMemFree(result);
 }
@@ -109,7 +109,7 @@ TEST_METHOD(VerifyCaseSensitiveSearch)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}, false) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -133,7 +133,7 @@ TEST_METHOD(VerifyReplaceFirstOnly)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}, false) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -157,7 +157,7 @@ TEST_METHOD(VerifyReplaceAll)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}, false) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -182,7 +182,7 @@ TEST_METHOD(VerifyReplaceAllCaseInsensitive)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}, false) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -206,7 +206,7 @@ TEST_METHOD(VerifyReplaceFirstOnlyUseRegEx)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}, false) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -230,7 +230,7 @@ TEST_METHOD(VerifyReplaceAllUseRegEx)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}, false) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -254,7 +254,7 @@ TEST_METHOD(VerifyReplaceAllUseRegExCaseSensitive)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}, false) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -276,7 +276,7 @@ TEST_METHOD(VerifyMatchAllWildcardUseRegEx)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}, false) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -293,7 +293,7 @@ void VerifyReplaceFirstWildcard(SearchReplaceExpected sreTable[], int tableSize,
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}, false) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
         Assert::AreEqual(sreTable[i].expected, result);
         CoTaskMemFree(result);
     }
@@ -363,7 +363,7 @@ TEST_METHOD(VerifyHandleCapturingGroups)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}, false) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -386,7 +386,8 @@ TEST_METHOD (VerifyFileAttributesNoPadding)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{ 2020, 7, 3, 22, 15, 6, 42, 453 }, true) == S_OK);
+        Assert::IsTrue(renameRegEx->PutFileTime(SYSTEMTIME{ 2020, 7, 3, 22, 15, 6, 42, 453 }) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -409,7 +410,8 @@ TEST_METHOD (VerifyFileAttributesPadding)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{ 2020, 7, 3, 22, 15, 6, 42, 453 }, true) == S_OK);
+        Assert::IsTrue(renameRegEx->PutFileTime(SYSTEMTIME{ 2020, 7, 3, 22, 15, 6, 42, 453 }) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -456,7 +458,8 @@ TEST_METHOD (VerifyFileAttributesMonthandDayNames)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{ 2020, 1, 3, 1, 15, 6, 42, 453 }, true) == S_OK);
+        Assert::IsTrue(renameRegEx->PutFileTime(fileTime) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -480,7 +483,7 @@ TEST_METHOD(VerifyLookbehindFails)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}, false) == E_FAIL);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == E_FAIL);
         Assert::AreEqual(sreTable[i].expected, result);
         CoTaskMemFree(result);
     }
@@ -499,6 +502,8 @@ TEST_METHOD(VerifyEventsFire)
     Assert::IsTrue(renameRegEx->PutFlags(flags) == S_OK);
     Assert::IsTrue(renameRegEx->PutSearchTerm(L"FOO") == S_OK);
     Assert::IsTrue(renameRegEx->PutReplaceTerm(L"BAR") == S_OK);
+    Assert::IsTrue(renameRegEx->PutFileTime(SYSTEMTIME{ 0 }) == S_OK);
+    Assert::IsTrue(renameRegEx->ResetFileTime() == S_OK);
     Assert::IsTrue(lstrcmpi(L"FOO", mockEvents->m_searchTerm) == 0);
     Assert::IsTrue(lstrcmpi(L"BAR", mockEvents->m_replaceTerm) == 0);
     Assert::IsTrue(flags == mockEvents->m_flags);

--- a/src/modules/powerrename/unittests/PowerRenameRegExTests.cpp
+++ b/src/modules/powerrename/unittests/PowerRenameRegExTests.cpp
@@ -31,7 +31,7 @@ TEST_METHOD(GeneralReplaceTest)
     PWSTR result = nullptr;
     Assert::IsTrue(renameRegEx->PutSearchTerm(L"foo") == S_OK);
     Assert::IsTrue(renameRegEx->PutReplaceTerm(L"big") == S_OK);
-    Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, L"foobar", &result) == S_OK);
+    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result, SYSTEMTIME{0}) == S_OK);
     Assert::IsTrue(wcscmp(result, L"bigbar") == 0);
     CoTaskMemFree(result);
 }
@@ -43,7 +43,7 @@ TEST_METHOD(ReplaceNoMatch)
     PWSTR result = nullptr;
     Assert::IsTrue(renameRegEx->PutSearchTerm(L"notfound") == S_OK);
     Assert::IsTrue(renameRegEx->PutReplaceTerm(L"big") == S_OK);
-    Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, L"foobar", &result) == S_OK);
+    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result, SYSTEMTIME{0}) == S_OK);
     Assert::IsTrue(wcscmp(result, L"foobar") == 0);
     CoTaskMemFree(result);
 }
@@ -53,7 +53,7 @@ TEST_METHOD(ReplaceNoSearchOrReplaceTerm)
     CComPtr<IPowerRenameRegEx> renameRegEx;
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     PWSTR result = nullptr;
-    Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, L"foobar", &result) != S_OK);
+    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result, SYSTEMTIME{0}) != S_OK);
     Assert::IsTrue(result == nullptr);
     CoTaskMemFree(result);
 }
@@ -64,7 +64,7 @@ TEST_METHOD(ReplaceNoReplaceTerm)
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     PWSTR result = nullptr;
     Assert::IsTrue(renameRegEx->PutSearchTerm(L"foo") == S_OK);
-    Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, L"foobar", &result) == S_OK);
+    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result, SYSTEMTIME{0}) == S_OK);
     Assert::IsTrue(wcscmp(result, L"bar") == 0);
     CoTaskMemFree(result);
 }
@@ -76,7 +76,7 @@ TEST_METHOD(ReplaceEmptyStringReplaceTerm)
     PWSTR result = nullptr;
     Assert::IsTrue(renameRegEx->PutSearchTerm(L"foo") == S_OK);
     Assert::IsTrue(renameRegEx->PutReplaceTerm(L"") == S_OK);
-    Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, L"foobar", &result) == S_OK);
+    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result, SYSTEMTIME{0}) == S_OK);
     Assert::IsTrue(wcscmp(result, L"bar") == 0);
     CoTaskMemFree(result);
 }
@@ -109,7 +109,7 @@ TEST_METHOD(VerifyCaseSensitiveSearch)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -133,7 +133,7 @@ TEST_METHOD(VerifyReplaceFirstOnly)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -157,7 +157,7 @@ TEST_METHOD(VerifyReplaceAll)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -182,7 +182,7 @@ TEST_METHOD(VerifyReplaceAllCaseInsensitive)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -206,7 +206,7 @@ TEST_METHOD(VerifyReplaceFirstOnlyUseRegEx)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -230,7 +230,7 @@ TEST_METHOD(VerifyReplaceAllUseRegEx)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -254,7 +254,7 @@ TEST_METHOD(VerifyReplaceAllUseRegExCaseSensitive)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -276,7 +276,7 @@ TEST_METHOD(VerifyMatchAllWildcardUseRegEx)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -293,7 +293,7 @@ void VerifyReplaceFirstWildcard(SearchReplaceExpected sreTable[], int tableSize,
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}) == S_OK);
         Assert::AreEqual(sreTable[i].expected, result);
         CoTaskMemFree(result);
     }
@@ -363,7 +363,7 @@ TEST_METHOD(VerifyHandleCapturingGroups)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -386,7 +386,7 @@ TEST_METHOD (VerifyFileAttributesNoPadding)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{ 2020, 7, 3, 22, 15, 6, 42, 453 }, sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{ 2020, 7, 3, 22, 15, 6, 42, 453 }) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -409,7 +409,7 @@ TEST_METHOD (VerifyFileAttributesPadding)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{ 2020, 7, 3, 22, 15, 6, 42, 453 }, sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{ 2020, 7, 3, 22, 15, 6, 42, 453 }) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -456,7 +456,7 @@ TEST_METHOD (VerifyFileAttributesMonthandDayNames)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{ 2020, 1, 3, 1, 15, 6, 42, 453 }, sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{ 2020, 1, 3, 1, 15, 6, 42, 453 }) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -480,7 +480,7 @@ TEST_METHOD(VerifyLookbehindFails)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, sreTable[i].test, &result) == E_FAIL);
+        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result, SYSTEMTIME{0}) == E_FAIL);
         Assert::AreEqual(sreTable[i].expected, result);
         CoTaskMemFree(result);
     }

--- a/src/modules/powerrename/unittests/PowerRenameRegExTests.cpp
+++ b/src/modules/powerrename/unittests/PowerRenameRegExTests.cpp
@@ -374,6 +374,7 @@ TEST_METHOD (VerifyFileAttributesNoPadding)
     CComPtr<IPowerRenameRegEx> renameRegEx;
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     DWORD flags = MatchAllOccurences | UseRegularExpressions ;
+    SYSTEMTIME fileTime = SYSTEMTIME{ 2020, 7, 3, 22, 15, 6, 42, 453 };
     Assert::IsTrue(renameRegEx->PutFlags(flags) == S_OK);
 
     SearchReplaceExpected sreTable[] = {
@@ -386,7 +387,7 @@ TEST_METHOD (VerifyFileAttributesNoPadding)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->PutFileTime(SYSTEMTIME{ 2020, 7, 3, 22, 15, 6, 42, 453 }) == S_OK);
+        Assert::IsTrue(renameRegEx->PutFileTime(fileTime) == S_OK);
         Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
@@ -399,7 +400,7 @@ TEST_METHOD (VerifyFileAttributesPadding)
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     DWORD flags = MatchAllOccurences | UseRegularExpressions;
     Assert::IsTrue(renameRegEx->PutFlags(flags) == S_OK);
-
+    SYSTEMTIME fileTime = SYSTEMTIME{ 2020, 7, 3, 22, 15, 6, 42, 453 };
     SearchReplaceExpected sreTable[] = {
         //search, replace, test, result
         { L"foo", L"bar$YYYY-$MM-$DD-$hh-$mm-$ss-$fff", L"foo", L"bar2020-07-22-15-06-42-453" },
@@ -410,7 +411,7 @@ TEST_METHOD (VerifyFileAttributesPadding)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->PutFileTime(SYSTEMTIME{ 2020, 7, 3, 22, 15, 6, 42, 453 }) == S_OK);
+        Assert::IsTrue(renameRegEx->PutFileTime(fileTime) == S_OK);
         Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);

--- a/src/modules/powerrename/unittests/PowerRenameRegExTests.cpp
+++ b/src/modules/powerrename/unittests/PowerRenameRegExTests.cpp
@@ -31,7 +31,7 @@ TEST_METHOD(GeneralReplaceTest)
     PWSTR result = nullptr;
     Assert::IsTrue(renameRegEx->PutSearchTerm(L"foo") == S_OK);
     Assert::IsTrue(renameRegEx->PutReplaceTerm(L"big") == S_OK);
-    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result) == S_OK);
+    Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, L"foobar", &result) == S_OK);
     Assert::IsTrue(wcscmp(result, L"bigbar") == 0);
     CoTaskMemFree(result);
 }
@@ -43,7 +43,7 @@ TEST_METHOD(ReplaceNoMatch)
     PWSTR result = nullptr;
     Assert::IsTrue(renameRegEx->PutSearchTerm(L"notfound") == S_OK);
     Assert::IsTrue(renameRegEx->PutReplaceTerm(L"big") == S_OK);
-    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result) == S_OK);
+    Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, L"foobar", &result) == S_OK);
     Assert::IsTrue(wcscmp(result, L"foobar") == 0);
     CoTaskMemFree(result);
 }
@@ -53,7 +53,7 @@ TEST_METHOD(ReplaceNoSearchOrReplaceTerm)
     CComPtr<IPowerRenameRegEx> renameRegEx;
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     PWSTR result = nullptr;
-    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result) != S_OK);
+    Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, L"foobar", &result) != S_OK);
     Assert::IsTrue(result == nullptr);
     CoTaskMemFree(result);
 }
@@ -64,7 +64,7 @@ TEST_METHOD(ReplaceNoReplaceTerm)
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     PWSTR result = nullptr;
     Assert::IsTrue(renameRegEx->PutSearchTerm(L"foo") == S_OK);
-    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result) == S_OK);
+    Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, L"foobar", &result) == S_OK);
     Assert::IsTrue(wcscmp(result, L"bar") == 0);
     CoTaskMemFree(result);
 }
@@ -76,7 +76,7 @@ TEST_METHOD(ReplaceEmptyStringReplaceTerm)
     PWSTR result = nullptr;
     Assert::IsTrue(renameRegEx->PutSearchTerm(L"foo") == S_OK);
     Assert::IsTrue(renameRegEx->PutReplaceTerm(L"") == S_OK);
-    Assert::IsTrue(renameRegEx->Replace(L"foobar", &result) == S_OK);
+    Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, L"foobar", &result) == S_OK);
     Assert::IsTrue(wcscmp(result, L"bar") == 0);
     CoTaskMemFree(result);
 }
@@ -109,7 +109,7 @@ TEST_METHOD(VerifyCaseSensitiveSearch)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -133,7 +133,7 @@ TEST_METHOD(VerifyReplaceFirstOnly)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -157,7 +157,7 @@ TEST_METHOD(VerifyReplaceAll)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -182,7 +182,7 @@ TEST_METHOD(VerifyReplaceAllCaseInsensitive)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -206,7 +206,7 @@ TEST_METHOD(VerifyReplaceFirstOnlyUseRegEx)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -230,7 +230,7 @@ TEST_METHOD(VerifyReplaceAllUseRegEx)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -254,7 +254,7 @@ TEST_METHOD(VerifyReplaceAllUseRegExCaseSensitive)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -276,7 +276,7 @@ TEST_METHOD(VerifyMatchAllWildcardUseRegEx)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -293,7 +293,7 @@ void VerifyReplaceFirstWildcard(SearchReplaceExpected sreTable[], int tableSize,
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, sreTable[i].test, &result) == S_OK);
         Assert::AreEqual(sreTable[i].expected, result);
         CoTaskMemFree(result);
     }
@@ -363,7 +363,100 @@ TEST_METHOD(VerifyHandleCapturingGroups)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
+        CoTaskMemFree(result);
+    }
+}
+
+TEST_METHOD (VerifyFileAttributesNoPadding)
+{
+    CComPtr<IPowerRenameRegEx> renameRegEx;
+    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
+    DWORD flags = MatchAllOccurences | UseRegularExpressions ;
+    Assert::IsTrue(renameRegEx->PutFlags(flags) == S_OK);
+
+    SearchReplaceExpected sreTable[] = {
+        //search, replace, test, result
+        { L"foo", L"bar$YY-$M-$D-$h-$m-$s-$f", L"foo", L"bar20-7-22-15-6-42-4" },
+    };
+
+    for (int i = 0; i < ARRAYSIZE(sreTable); i++)
+    {
+        PWSTR result = nullptr;
+        Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
+        Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{ 2020, 7, 3, 22, 15, 6, 42, 453 }, sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
+        CoTaskMemFree(result);
+    }
+}
+
+TEST_METHOD (VerifyFileAttributesPadding)
+{
+    CComPtr<IPowerRenameRegEx> renameRegEx;
+    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
+    DWORD flags = MatchAllOccurences | UseRegularExpressions;
+    Assert::IsTrue(renameRegEx->PutFlags(flags) == S_OK);
+
+    SearchReplaceExpected sreTable[] = {
+        //search, replace, test, result
+        { L"foo", L"bar$YYYY-$MM-$DD-$hh-$mm-$ss-$fff", L"foo", L"bar2020-07-22-15-06-42-453" },
+    };
+
+    for (int i = 0; i < ARRAYSIZE(sreTable); i++)
+    {
+        PWSTR result = nullptr;
+        Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
+        Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{ 2020, 7, 3, 22, 15, 6, 42, 453 }, sreTable[i].test, &result) == S_OK);
+        Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
+        CoTaskMemFree(result);
+    }
+}
+
+TEST_METHOD (VerifyFileAttributesMonthandDayNames)
+{
+    CComPtr<IPowerRenameRegEx> renameRegEx;
+    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
+    DWORD flags = MatchAllOccurences | UseRegularExpressions;
+    Assert::IsTrue(renameRegEx->PutFlags(flags) == S_OK);
+
+    std::locale::global(std::locale(""));
+    SYSTEMTIME LocalTime = { 2020, 1, 3, 1, 15, 6, 42, 453 };
+    wchar_t localeName[LOCALE_NAME_MAX_LENGTH];
+    wchar_t result[MAX_PATH] = L"bar";
+    wchar_t formattedDate[MAX_PATH];
+    if (GetUserDefaultLocaleName(localeName, LOCALE_NAME_MAX_LENGTH) == 0)
+        StringCchCopy(localeName, LOCALE_NAME_MAX_LENGTH, L"en_US");
+
+    GetDateFormatEx(localeName, NULL, &LocalTime, L"MMM", formattedDate, MAX_PATH, NULL);
+    formattedDate[0] = towupper(formattedDate[0]);
+    StringCchPrintf(result, MAX_PATH, TEXT("%s%s"), result, formattedDate);
+
+    GetDateFormatEx(localeName, NULL, &LocalTime, L"MMMM", formattedDate, MAX_PATH, NULL);
+    formattedDate[0] = towupper(formattedDate[0]);
+    StringCchPrintf(result, MAX_PATH, TEXT("%s-%s"), result, formattedDate);
+
+    GetDateFormatEx(localeName, NULL, &LocalTime, L"ddd", formattedDate, MAX_PATH, NULL);
+    formattedDate[0] = towupper(formattedDate[0]);
+    StringCchPrintf(result, MAX_PATH, TEXT("%s-%s"), result, formattedDate);
+
+    GetDateFormatEx(localeName, NULL, &LocalTime, L"dddd", formattedDate, MAX_PATH, NULL);
+    formattedDate[0] = towupper(formattedDate[0]);
+    StringCchPrintf(result, MAX_PATH, TEXT("%s-%s"), result, formattedDate);
+
+    SearchReplaceExpected sreTable[] = {
+        //search, replace, test, result
+        { L"foo", L"bar$MMM-$MMMM-$DDD-$DDDD", L"foo", result },
+    };
+
+    for (int i = 0; i < ARRAYSIZE(sreTable); i++)
+    {
+        PWSTR result = nullptr;
+        Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
+        Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
+        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{ 2020, 1, 3, 1, 15, 6, 42, 453 }, sreTable[i].test, &result) == S_OK);
         Assert::IsTrue(wcscmp(result, sreTable[i].expected) == 0);
         CoTaskMemFree(result);
     }
@@ -387,7 +480,7 @@ TEST_METHOD(VerifyLookbehindFails)
         PWSTR result = nullptr;
         Assert::IsTrue(renameRegEx->PutSearchTerm(sreTable[i].search) == S_OK);
         Assert::IsTrue(renameRegEx->PutReplaceTerm(sreTable[i].replace) == S_OK);
-        Assert::IsTrue(renameRegEx->Replace(sreTable[i].test, &result) == E_FAIL);
+        Assert::IsTrue(renameRegEx->Replace(SYSTEMTIME{0}, sreTable[i].test, &result) == E_FAIL);
         Assert::AreEqual(sreTable[i].expected, result);
         CoTaskMemFree(result);
     }


### PR DESCRIPTION
## Summary of the Pull Request

Fixes power rename tests which was inconsistently failing.
Increases test performance.
Set `fileTime` as a member of `PowerRenameRegEx` instead of passing it to `Replace()` call

## PR Checklist
* [x] Applies to #6186 
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

## Validation Steps Performed

PowerRename works as expected, especially with file attributes. (like `$YYYY` `$DDDD` `$MM` patterns)
**Also with Search For area and/or Replace With area empty, with different flags**
Tests are passing consistently.