### PR TITLE
Fixing CI with moving NuGet to 5.8 for .NET 5

### DIFF
--- a/.pipelines/ci/templates/build-powertoys-steps.yml
+++ b/.pipelines/ci/templates/build-powertoys-steps.yml
@@ -8,9 +8,9 @@ steps:
   clean: true
 
 - task: NuGetToolInstaller@0
-  displayName: Ensure NuGet 5.5.0
+  displayName: Ensure NuGet 5.8.0
   inputs:
-    versionSpec: 5.5.0
+    versionSpec: 5.8.0
 
 - task: VisualStudioTestPlatformInstaller@1
   displayName: Ensure VSTest Platform

--- a/installer/PowerToysBootstrapper/bootstrapper/bootstrapper.cpp
+++ b/installer/PowerToysBootstrapper/bootstrapper/bootstrapper.cpp
@@ -4,8 +4,8 @@
 #include <common/common.h>
 #include <common/notifications.h>
 #include <common/RcResource.h>
-#include <common/updating/updating.h>
 #include <common/updating/dotnet_installation.h>
+#include <common/updating/installer.h>
 #include <common/version.h>
 #include <common/appMutex.h>
 #include <common/processApi.h>

--- a/installer/PowerToysBootstrapper/bootstrapper/pch.h
+++ b/installer/PowerToysBootstrapper/bootstrapper/pch.h
@@ -20,4 +20,8 @@
 #include <spdlog/sinks/null_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 
+#include <winrt/base.h>
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Foundation.Collections.h>
+
 #include <cxxopts.hpp>

--- a/installer/PowerToysSetupCustomActions/CustomAction.cpp
+++ b/installer/PowerToysSetupCustomActions/CustomAction.cpp
@@ -2,7 +2,7 @@
 
 #include <ProjectTelemetry.h>
 
-#include "../../src/common/updating/updating.h"
+#include "../../src/common/updating/installer.h"
 
 using namespace std;
 

--- a/installer/PowerToysSetupCustomActions/PowerToysSetupCustomActions.vcxproj
+++ b/installer/PowerToysSetupCustomActions/PowerToysSetupCustomActions.vcxproj
@@ -97,8 +97,6 @@
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
-      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">/await /Zc:twoPhase- %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">/await /Zc:twoPhase- %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/src/action_runner/action_runner.cpp
+++ b/src/action_runner/action_runner.cpp
@@ -4,10 +4,12 @@
 #include <Windows.h>
 #include <shellapi.h>
 
+#include <filesystem>
 #include <string_view>
 
 #include <common/common.h>
 #include <common/updating/updating.h>
+#include <common/updating/installer.h>
 #include <common/updating/http_client.h>
 #include <common/updating/dotnet_installation.h>
 

--- a/src/common/updating/installer.cpp
+++ b/src/common/updating/installer.cpp
@@ -1,0 +1,204 @@
+#include "pch.h"
+
+#include "installer.h"
+#include "version.h"
+#include <common/common.h>
+#include <common/notifications.h>
+
+#include <msi.h>
+#include <PathCch.h>
+
+#include <winrt/base.h>
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Foundation.Collections.h>
+#include <winrt/Windows.ApplicationModel.h>
+#include <winrt/Windows.Management.Deployment.h>
+
+namespace // Strings in this namespace should not be localized
+{
+    const wchar_t POWER_TOYS_UPGRADE_CODE[] = L"{42B84BF7-5FBF-473B-9C8B-049DC16F7708}";
+
+    const wchar_t DONT_SHOW_AGAIN_RECORD_REGISTRY_PATH[] = L"delete_previous_powertoys_confirm";
+
+    const wchar_t TOAST_TITLE[] = L"PowerToys";
+
+    const wchar_t MSIX_PACKAGE_NAME[] = L"Microsoft.PowerToys";
+    const wchar_t MSIX_PACKAGE_PUBLISHER[] = L"CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US";
+
+    const wchar_t POWERTOYS_EXE_COMPONENT[] = L"{A2C66D91-3485-4D00-B04D-91844E6B345B}";
+}
+
+namespace updating
+{
+    std::wstring get_msi_package_path()
+    {
+        std::wstring package_path;
+        wchar_t GUID_product_string[39];
+        if (const bool found = ERROR_SUCCESS == MsiEnumRelatedProductsW(POWER_TOYS_UPGRADE_CODE, 0, 0, GUID_product_string); !found)
+        {
+            return package_path;
+        }
+
+        if (const bool installed = INSTALLSTATE_DEFAULT == MsiQueryProductStateW(GUID_product_string); !installed)
+        {
+            return package_path;
+        }
+
+        DWORD package_path_size = 0;
+
+        if (const bool has_package_path = ERROR_SUCCESS == MsiGetProductInfoW(GUID_product_string, INSTALLPROPERTY_LOCALPACKAGE, nullptr, &package_path_size); !has_package_path)
+        {
+            return package_path;
+        }
+
+        package_path = std::wstring(++package_path_size, L'\0');
+        if (const bool got_package_path = ERROR_SUCCESS == MsiGetProductInfoW(GUID_product_string, INSTALLPROPERTY_LOCALPACKAGE, package_path.data(), &package_path_size); !got_package_path)
+        {
+            package_path = {};
+            return package_path;
+        }
+
+        package_path.resize(size(package_path) - 1); // trim additional \0 which we got from MsiGetProductInfoW
+
+        return package_path;
+    }
+
+    bool offer_msi_uninstallation(const notifications::strings& strings)
+    {
+        const auto selection = SHMessageBoxCheckW(nullptr,
+                                                  strings.OFFER_UNINSTALL_MSI.c_str(),
+                                                  strings.OFFER_UNINSTALL_MSI_TITLE.c_str(),
+                                                  MB_ICONQUESTION | MB_YESNO,
+                                                  IDNO,
+                                                  DONT_SHOW_AGAIN_RECORD_REGISTRY_PATH);
+        return selection == IDYES;
+    }
+
+    bool uninstall_msi_version(const std::wstring& package_path, const notifications::strings& strings)
+    {
+        const auto uninstall_result = MsiInstallProductW(package_path.c_str(), L"REMOVE=ALL");
+        if (ERROR_SUCCESS == uninstall_result)
+        {
+            return true;
+        }
+        else if (auto system_message = get_last_error_message(uninstall_result); system_message.has_value())
+        {
+            try
+            {
+                ::notifications::show_toast(*system_message, TOAST_TITLE);
+            }
+            catch (...)
+            {
+                updating::notifications::show_uninstallation_error(strings);
+            }
+        }
+        return false;
+    }
+
+    std::optional<std::wstring> get_msi_package_installed_path()
+    {
+        constexpr size_t guid_length = 39;
+        wchar_t product_ID[guid_length];
+        if (const bool found = ERROR_SUCCESS == MsiEnumRelatedProductsW(POWER_TOYS_UPGRADE_CODE, 0, 0, product_ID); !found)
+        {
+            return std::nullopt;
+        }
+
+        if (const bool installed = INSTALLSTATE_DEFAULT == MsiQueryProductStateW(product_ID); !installed)
+        {
+            return std::nullopt;
+        }
+
+        DWORD buf_size = MAX_PATH;
+        wchar_t buf[MAX_PATH];
+        if (ERROR_SUCCESS == MsiGetProductInfoW(product_ID, INSTALLPROPERTY_INSTALLLOCATION, buf, &buf_size) && buf_size)
+        {
+            return buf;
+        }
+
+        DWORD package_path_size = 0;
+
+        if (ERROR_SUCCESS != MsiGetProductInfoW(product_ID, INSTALLPROPERTY_LOCALPACKAGE, nullptr, &package_path_size))
+        {
+            return std::nullopt;
+        }
+        std::wstring package_path(++package_path_size, L'\0');
+
+        if (ERROR_SUCCESS != MsiGetProductInfoW(product_ID, INSTALLPROPERTY_LOCALPACKAGE, package_path.data(), &package_path_size))
+        {
+            return std::nullopt;
+        }
+        package_path.resize(size(package_path) - 1); // trim additional \0 which we got from MsiGetProductInfoW
+
+        wchar_t path[MAX_PATH];
+        DWORD path_size = MAX_PATH;
+        MsiGetComponentPathW(product_ID, POWERTOYS_EXE_COMPONENT, path, &path_size);
+        if (!path_size)
+        {
+            return std::nullopt;
+        }
+        PathCchRemoveFileSpec(path, path_size);
+        return path;
+    }
+
+    std::optional<VersionHelper> get_installed_powertoys_version()
+    {
+        auto installed_path = get_msi_package_installed_path();
+        if (!installed_path)
+        {
+            return std::nullopt;
+        }
+        *installed_path += L"\\PowerToys.exe";
+
+        // Get the version information for the file requested
+        const DWORD fvSize = GetFileVersionInfoSizeW(installed_path->c_str(), nullptr);
+        if (!fvSize)
+        {
+            return std::nullopt;
+        }
+
+        auto pbVersionInfo = std::make_unique<BYTE[]>(fvSize);
+
+        if (!GetFileVersionInfoW(installed_path->c_str(), 0, fvSize, pbVersionInfo.get()))
+        {
+            return std::nullopt;
+        }
+
+        VS_FIXEDFILEINFO* fileInfo = nullptr;
+        UINT fileInfoLen = 0;
+        if (!VerQueryValueW(pbVersionInfo.get(), L"\\", reinterpret_cast<LPVOID*>(&fileInfo), &fileInfoLen))
+        {
+            return std::nullopt;
+        }
+        return VersionHelper{ (fileInfo->dwFileVersionMS >> 16) & 0xffff,
+                              (fileInfo->dwFileVersionMS >> 0) & 0xffff,
+                              (fileInfo->dwFileVersionLS >> 16) & 0xffff };
+    }
+
+    std::future<bool> uninstall_previous_msix_version_async()
+    {
+        winrt::Windows::Management::Deployment::PackageManager package_manager;
+
+        try
+        {
+            auto packages = package_manager.FindPackagesForUser({}, MSIX_PACKAGE_NAME, MSIX_PACKAGE_PUBLISHER);
+            VersionHelper current_version(VERSION_MAJOR, VERSION_MINOR, VERSION_REVISION);
+
+            for (auto package : packages)
+            {
+                VersionHelper msix_version(package.Id().Version().Major, package.Id().Version().Minor, package.Id().Version().Revision);
+
+                if (msix_version < current_version)
+                {
+                    co_await package_manager.RemovePackageAsync(package.Id().FullName());
+                    co_return true;
+                }
+            }
+        }
+        catch (...)
+        {
+        }
+        co_return false;
+    }
+
+}

--- a/src/common/updating/installer.h
+++ b/src/common/updating/installer.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <string>
+#include <optional>
+#include <future>
+
+#include "notifications.h"
+#include "../VersionHelper.h"
+
+namespace updating
+{
+    std::wstring get_msi_package_path();
+    bool uninstall_msi_version(const std::wstring& package_path, const notifications::strings&);
+    bool offer_msi_uninstallation(const notifications::strings&);
+    std::optional<std::wstring> get_msi_package_installed_path();
+
+    std::optional<VersionHelper> get_installed_powertoys_version();
+    std::future<bool> uninstall_previous_msix_version_async();
+}

--- a/src/common/updating/notifications.h
+++ b/src/common/updating/notifications.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 namespace updating
 {
     struct new_version_download_info;

--- a/src/common/updating/updating.cpp
+++ b/src/common/updating/updating.cpp
@@ -6,99 +6,28 @@
 #include "notifications.h"
 #include "updating.h"
 
-#include <msi.h>
 #include <common/common.h>
 #include <common/json.h>
 #include <common/settings_helpers.h>
 #include <common/winstore.h>
 #include <common/notifications.h>
 
-#include <winrt/Windows.Management.Deployment.h>
+#include <winrt/base.h>
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.Networking.Connectivity.h>
 
 #include "VersionHelper.h"
-#include <PathCch.h>
 
 namespace // Strings in this namespace should not be localized
 {
-    const wchar_t POWER_TOYS_UPGRADE_CODE[] = L"{42B84BF7-5FBF-473B-9C8B-049DC16F7708}";
-    const wchar_t POWERTOYS_EXE_COMPONENT[] = L"{A2C66D91-3485-4D00-B04D-91844E6B345B}";
-    const wchar_t DONT_SHOW_AGAIN_RECORD_REGISTRY_PATH[] = L"delete_previous_powertoys_confirm";
     const wchar_t LATEST_RELEASE_ENDPOINT[] = L"https://api.github.com/repos/microsoft/PowerToys/releases/latest";
-    const wchar_t MSIX_PACKAGE_NAME[] = L"Microsoft.PowerToys";
-    const wchar_t MSIX_PACKAGE_PUBLISHER[] = L"CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US";
 
     const size_t MAX_DOWNLOAD_ATTEMPTS = 3;
-    const wchar_t TOAST_TITLE[] = L"PowerToys";
 }
 
 namespace updating
 {
-    std::wstring get_msi_package_path()
-    {
-        std::wstring package_path;
-        wchar_t GUID_product_string[39];
-        if (const bool found = ERROR_SUCCESS == MsiEnumRelatedProductsW(POWER_TOYS_UPGRADE_CODE, 0, 0, GUID_product_string); !found)
-        {
-            return package_path;
-        }
-
-        if (const bool installed = INSTALLSTATE_DEFAULT == MsiQueryProductStateW(GUID_product_string); !installed)
-        {
-            return package_path;
-        }
-
-        DWORD package_path_size = 0;
-
-        if (const bool has_package_path = ERROR_SUCCESS == MsiGetProductInfoW(GUID_product_string, INSTALLPROPERTY_LOCALPACKAGE, nullptr, &package_path_size); !has_package_path)
-        {
-            return package_path;
-        }
-
-        package_path = std::wstring(++package_path_size, L'\0');
-        if (const bool got_package_path = ERROR_SUCCESS == MsiGetProductInfoW(GUID_product_string, INSTALLPROPERTY_LOCALPACKAGE, package_path.data(), &package_path_size); !got_package_path)
-        {
-            package_path = {};
-            return package_path;
-        }
-
-        package_path.resize(size(package_path) - 1); // trim additional \0 which we got from MsiGetProductInfoW
-
-        return package_path;
-    }
-
-    bool offer_msi_uninstallation(const notifications::strings& strings)
-    {
-        const auto selection = SHMessageBoxCheckW(nullptr,
-                                                  strings.OFFER_UNINSTALL_MSI.c_str(),
-                                                  strings.OFFER_UNINSTALL_MSI_TITLE.c_str(),
-                                                  MB_ICONQUESTION | MB_YESNO,
-                                                  IDNO,
-                                                  DONT_SHOW_AGAIN_RECORD_REGISTRY_PATH);
-        return selection == IDYES;
-    }
-
-    bool uninstall_msi_version(const std::wstring& package_path, const notifications::strings& strings)
-    {
-        const auto uninstall_result = MsiInstallProductW(package_path.c_str(), L"REMOVE=ALL");
-        if (ERROR_SUCCESS == uninstall_result)
-        {
-            return true;
-        }
-        else if (auto system_message = get_last_error_message(uninstall_result); system_message.has_value())
-        {
-            try
-            {
-                ::notifications::show_toast(*system_message, TOAST_TITLE);
-            }
-            catch (...)
-            {
-                updating::notifications::show_uninstallation_error(strings);
-            }
-        }
-        return false;
-    }
-
     std::future<std::optional<new_version_download_info>> get_new_github_version_info_async()
     {
         // If the current version starts with 0.0.*, it means we're on a local build from a farm and shouldn't check for updates.
@@ -151,32 +80,6 @@ namespace updating
         {
             co_return std::nullopt;
         }
-    }
-
-    std::future<bool> uninstall_previous_msix_version_async()
-    {
-        winrt::Windows::Management::Deployment::PackageManager package_manager;
-
-        try
-        {
-            auto packages = package_manager.FindPackagesForUser({}, MSIX_PACKAGE_NAME, MSIX_PACKAGE_PUBLISHER);
-            VersionHelper current_version(VERSION_MAJOR, VERSION_MINOR, VERSION_REVISION);
-
-            for (auto package : packages)
-            {
-                VersionHelper msix_version(package.Id().Version().Major, package.Id().Version().Minor, package.Id().Version().Revision);
-
-                if (msix_version < current_version)
-                {
-                    co_await package_manager.RemovePackageAsync(package.Id().FullName());
-                    co_return true;
-                }
-            }
-        }
-        catch (...)
-        {
-        }
-        co_return false;
     }
 
     bool could_be_costly_connection()
@@ -281,85 +184,5 @@ namespace updating
         }
 
         co_return new_version->installer_filename;
-    }
-
-    std::optional<std::wstring> get_msi_package_installed_path()
-    {
-        constexpr size_t guid_length = 39;
-        wchar_t product_ID[guid_length];
-        if (const bool found = ERROR_SUCCESS == MsiEnumRelatedProductsW(POWER_TOYS_UPGRADE_CODE, 0, 0, product_ID); !found)
-        {
-            return std::nullopt;
-        }
-
-        if (const bool installed = INSTALLSTATE_DEFAULT == MsiQueryProductStateW(product_ID); !installed)
-        {
-            return std::nullopt;
-        }
-
-        DWORD buf_size = MAX_PATH;
-        wchar_t buf[MAX_PATH];
-        if (ERROR_SUCCESS == MsiGetProductInfoW(product_ID, INSTALLPROPERTY_INSTALLLOCATION, buf, &buf_size) && buf_size)
-        {
-            return buf;
-        }
-
-        DWORD package_path_size = 0;
-
-        if (ERROR_SUCCESS != MsiGetProductInfoW(product_ID, INSTALLPROPERTY_LOCALPACKAGE, nullptr, &package_path_size))
-        {
-            return std::nullopt;
-        }
-        std::wstring package_path(++package_path_size, L'\0');
-
-        if (ERROR_SUCCESS != MsiGetProductInfoW(product_ID, INSTALLPROPERTY_LOCALPACKAGE, package_path.data(), &package_path_size))
-        {
-            return std::nullopt;
-        }
-        package_path.resize(size(package_path) - 1); // trim additional \0 which we got from MsiGetProductInfoW
-
-        wchar_t path[MAX_PATH];
-        DWORD path_size = MAX_PATH;
-        MsiGetComponentPathW(product_ID, POWERTOYS_EXE_COMPONENT, path, &path_size);
-        if (!path_size)
-        {
-            return std::nullopt;
-        }
-        PathCchRemoveFileSpec(path, path_size);
-        return path;
-    }
-
-    std::optional<VersionHelper> get_installed_powertoys_version()
-    {
-        auto installed_path = get_msi_package_installed_path();
-        if (!installed_path)
-        {
-            return std::nullopt;
-        }
-        *installed_path += L"\\PowerToys.exe";
-
-        // Get the version information for the file requested
-        const DWORD fvSize = GetFileVersionInfoSizeW(installed_path->c_str(), nullptr);
-        if (!fvSize)
-        {
-            return std::nullopt;
-        }
-
-        auto pbVersionInfo = std::make_unique<BYTE[]>(fvSize);
-
-        if (!GetFileVersionInfoW(installed_path->c_str(), 0, fvSize, pbVersionInfo.get()))
-        {
-            return std::nullopt;
-        }
-
-        VS_FIXEDFILEINFO* fileInfo = nullptr;
-        UINT fileInfoLen = 0;
-        if (!VerQueryValueW(pbVersionInfo.get(), L"\\", reinterpret_cast<LPVOID*>(&fileInfo), &fileInfoLen))
-        {
-            return std::nullopt;
-        }
-        return VersionHelper{ (fileInfo->dwFileVersionMS >> 16) & 0xffff,
-                              (fileInfo->dwFileVersionMS >> 0) & 0xffff,
-                              (fileInfo->dwFileVersionLS >> 16) & 0xffff };
     }
 }

--- a/src/common/updating/updating.h
+++ b/src/common/updating/updating.h
@@ -11,14 +11,6 @@
 
 namespace updating
 {
-    std::wstring get_msi_package_path();
-    bool uninstall_msi_version(const std::wstring& package_path, const notifications::strings&);
-    bool offer_msi_uninstallation(const notifications::strings&);
-    std::optional<std::wstring> get_msi_package_installed_path();
-    std::optional<VersionHelper> get_installed_powertoys_version();
-
-    std::future<bool> uninstall_previous_msix_version_async();
-
     struct new_version_download_info
     {
         winrt::Windows::Foundation::Uri release_page_uri;

--- a/src/common/updating/updating.vcxproj
+++ b/src/common/updating/updating.vcxproj
@@ -175,6 +175,7 @@
   <ItemGroup>
     <ClInclude Include="dotnet_installation.h" />
     <ClInclude Include="http_client.h" />
+    <ClInclude Include="installer.h" />
     <ClInclude Include="notifications.h" />
     <ClInclude Include="updating.h" />
     <ClInclude Include="pch.h" />
@@ -182,6 +183,7 @@
   <ItemGroup>
     <ClCompile Include="dotnet_installation.cpp" />
     <ClCompile Include="http_client.cpp" />
+    <ClCompile Include="installer.cpp" />
     <ClCompile Include="notifications.cpp" />
     <ClCompile Include="updating.cpp" />
     <ClCompile Include="pch.cpp">

--- a/src/common/updating/updating.vcxproj.filters
+++ b/src/common/updating/updating.vcxproj.filters
@@ -30,6 +30,9 @@
     <ClInclude Include="notifications.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="installer.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp">
@@ -45,6 +48,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="notifications.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="installer.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -17,6 +17,7 @@
 #include <common/processApi.h>
 #include <common/RestartManagement.h>
 #include <common/toast_dont_show_again.h>
+#include <common/updating/installer.h>
 #include <common/updating/updating.h>
 #include <common/winstore.h>
 
@@ -33,7 +34,7 @@
 #if _DEBUG && _WIN64
 #include "unhandled_exception_handler.h"
 #endif
-#include <common\settings_helpers.h>
+#include <common/settings_helpers.h>
 #include <common/logger/logger.h>
 
 extern "C" IMAGE_DOS_HEADER __ImageBase;

--- a/src/runner/update_utils.cpp
+++ b/src/runner/update_utils.cpp
@@ -8,6 +8,7 @@
 #include "update_utils.h"
 
 #include <common/timeutil.h>
+#include <common/updating/installer.h>
 #include <common/updating/updating.h>
 #include <runner/general_settings.h>
 


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

talked to Matteo Pagani, this should be the fix. Net 5.0 requires NuGet 5.8. If you're using an older version, you will get that error

## PR Checklist
* [ ] Applies to #8141
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

## Validation Steps Performed

_How does someone test & validate?_
