### PR TITLE
[FancyZones] Replace uniqueId string with uniqueId struct

### DIFF
--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -644,14 +644,23 @@ void FancyZones::ToggleEditor() noexcept
     for (auto& monitor : allMonitors)
     {
         auto monitorId = FancyZonesUtils::GenerateMonitorId(monitor.second, monitor.first, m_currentDesktopId);
-        const auto monitorIdStr = monitorId.Serialize();
+        if (!monitorId.has_value())
+        {
+            continue;
+        }
+
+        const auto monitorIdStr = monitorId->Serialize();
+        if (!monitorIdStr.has_value())
+        {
+            continue;
+        }
 
         if (monitor.first == targetMonitor)
         {
-            params += monitorIdStr + divider; /* Monitor id where the Editor should be opened */
+            params += *monitorIdStr + divider; /* Monitor id where the Editor should be opened */
         }
 
-        monitorsData += monitorIdStr + divider; /* Monitor id */
+        monitorsData += *monitorIdStr + divider; /* Monitor id */
 
         UINT dpiX = 0;
         UINT dpiY = 0;
@@ -888,7 +897,7 @@ void FancyZones::AddZoneWindow(HMONITOR monitor, const std::wstring& deviceId) n
 
     if (m_workAreaHandler.IsNewWorkArea(m_currentDesktopId, monitor))
     {
-        FancyZonesDataTypes::DeviceIdData uniqueId;
+        std::optional<FancyZonesDataTypes::DeviceIdData> uniqueId;
 
         if (monitor)
         {
@@ -899,13 +908,18 @@ void FancyZones::AddZoneWindow(HMONITOR monitor, const std::wstring& deviceId) n
             uniqueId = FancyZonesUtils::GenerateUniqueIdAllMonitorsArea(m_currentDesktopId);
         }
 
+        if (!uniqueId.has_value())
+        {
+            return;
+        }
+
         FancyZonesDataTypes::DeviceIdData parentId{};
         auto parentArea = m_workAreaHandler.GetWorkArea(m_previousDesktopId, monitor);
         if (parentArea)
         {
             parentId = parentArea->UniqueId();
         }
-        auto workArea = MakeZoneWindow(this, m_hinstance, monitor, uniqueId, parentId);
+        auto workArea = MakeZoneWindow(this, m_hinstance, monitor, *uniqueId, parentId);
         if (workArea)
         {
             m_workAreaHandler.AddWorkArea(m_currentDesktopId, monitor, workArea);

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -1270,11 +1270,10 @@ void FancyZones::RegisterVirtualDesktopUpdates(std::vector<GUID>& ids) noexcept
     std::unique_lock writeLock(m_lock);
 
     m_workAreaHandler.RegisterUpdates(ids);
-    std::vector<GUID> active{};
-    if (VirtualDesktopUtils::GetVirtualDesktopIds(active) && !active.empty())
+    if (!ids.empty())
     {
-        FancyZonesDataInstance().UpdatePrimaryDesktopData(active[0]);
-        FancyZonesDataInstance().RemoveDeletedDesktops(active);
+        FancyZonesDataInstance().UpdatePrimaryDesktopData(ids[0]);
+        FancyZonesDataInstance().RemoveDeletedDesktops(ids);
     }
 }
 

--- a/src/modules/fancyzones/lib/FancyZonesData.cpp
+++ b/src/modules/fancyzones/lib/FancyZonesData.cpp
@@ -240,7 +240,7 @@ void FancyZonesData::UpdatePrimaryDesktopData(const GUID& desktopId)
     }
     for (auto& id : toReplace)
     {
-        auto& mapEntry = deviceInfoMap.extract(id);
+        auto mapEntry = deviceInfoMap.extract(id);
         id.virtualDesktopId = desktopId;
         mapEntry.key() = id;
         deviceInfoMap.insert(std::move(mapEntry));

--- a/src/modules/fancyzones/lib/FancyZonesData.cpp
+++ b/src/modules/fancyzones/lib/FancyZonesData.cpp
@@ -4,6 +4,7 @@
 #include "JsonHelpers.h"
 #include "ZoneSet.h"
 #include "Settings.h"
+#include "HashHelpers.h"
 
 #include <common/common.h>
 #include <common/json.h>
@@ -24,7 +25,6 @@ namespace NonLocalizable
 
     const wchar_t FancyZonesDataFile[] = L"zones-settings.json";
     const wchar_t FancyZonesAppZoneHistoryFile[] = L"app-zone-history.json";
-    const wchar_t DefaultGuid[] = L"{00000000-0000-0000-0000-000000000000}";
     const wchar_t RegistryPath[] = L"Software\\SuperFancyZones";
 
     const wchar_t ActiveZoneSetsTmpFileName[] = L"FancyZonesActiveZoneSets.json";
@@ -34,12 +34,6 @@ namespace NonLocalizable
 
 namespace
 {
-    std::wstring ExtractVirtualDesktopId(const std::wstring& deviceId)
-    {
-        // Format: <device-id>_<resolution>_<virtual-desktop-id>
-        return deviceId.substr(deviceId.rfind('_') + 1);
-    }
-
     const std::wstring& GetTempDirPath()
     {
         static std::wstring tmpDirPath;
@@ -157,7 +151,7 @@ FancyZonesData::FancyZonesData()
     deletedCustomZoneSetsTmpFileName = GetTempDirPath() + NonLocalizable::DeletedCustomZoneSetsTmpFileName;
 }
 
-std::optional<FancyZonesDataTypes::DeviceInfoData> FancyZonesData::FindDeviceInfo(const std::wstring& zoneWindowId) const
+std::optional<FancyZonesDataTypes::DeviceInfoData> FancyZonesData::FindDeviceInfo(const FancyZonesDataTypes::DeviceIdData& zoneWindowId) const
 {
     std::scoped_lock lock{ dataLock };
     auto it = deviceInfoMap.find(zoneWindowId);
@@ -171,7 +165,7 @@ std::optional<FancyZonesDataTypes::CustomZoneSetData> FancyZonesData::FindCustom
     return it != end(customZoneSetsMap) ? std::optional{ it->second } : std::nullopt;
 }
 
-bool FancyZonesData::AddDevice(const std::wstring& deviceId)
+bool FancyZonesData::AddDevice(const FancyZonesDataTypes::DeviceIdData& deviceId)
 {
     using namespace FancyZonesDataTypes;
 
@@ -199,7 +193,7 @@ bool FancyZonesData::AddDevice(const std::wstring& deviceId)
     return false;
 }
 
-void FancyZonesData::CloneDeviceInfo(const std::wstring& source, const std::wstring& destination)
+void FancyZonesData::CloneDeviceInfo(const FancyZonesDataTypes::DeviceIdData& source, const FancyZonesDataTypes::DeviceIdData& destination)
 {
     if (source == destination)
     {
@@ -216,7 +210,7 @@ void FancyZonesData::CloneDeviceInfo(const std::wstring& source, const std::wstr
     deviceInfoMap[destination] = deviceInfoMap[source];
 }
 
-void FancyZonesData::UpdatePrimaryDesktopData(const std::wstring& desktopId)
+void FancyZonesData::UpdatePrimaryDesktopData(const GUID& desktopId)
 {
     // Explorer persists current virtual desktop identifier to registry on a per session basis,
     // but only after first virtual desktop switch happens. If the user hasn't switched virtual
@@ -224,50 +218,48 @@ void FancyZonesData::UpdatePrimaryDesktopData(const std::wstring& desktopId)
     // that case (00000000-0000-0000-0000-000000000000).
     // This method will go through all our persisted data with default GUID and update it with
     // valid one.
-    auto replaceDesktopId = [&desktopId](const std::wstring& deviceId) {
-        return deviceId.substr(0, deviceId.rfind('_') + 1) + desktopId;
-    };
+
     std::scoped_lock lock{ dataLock };
     for (auto& [path, perDesktopData] : appZoneHistoryMap)
     {
         for (auto& data : perDesktopData)
         {
-            if (ExtractVirtualDesktopId(data.deviceId) == NonLocalizable::DefaultGuid)
+            if (data.deviceId.virtualDesktopId == GUID_NULL)
             {
-                data.deviceId = replaceDesktopId(data.deviceId);
+                data.deviceId.virtualDesktopId = desktopId;
             }
         }
     }
-    std::vector<std::wstring> toReplace{};
+    std::vector<FancyZonesDataTypes::DeviceIdData> toReplace{};
     for (const auto& [id, data] : deviceInfoMap)
     {
-        if (ExtractVirtualDesktopId(id) == NonLocalizable::DefaultGuid)
+        if (id.virtualDesktopId == GUID_NULL)
         {
             toReplace.push_back(id);
         }
     }
-    for (const auto& id : toReplace)
+    for (auto& id : toReplace)
     {
-        auto mapEntry = deviceInfoMap.extract(id);
-        mapEntry.key() = replaceDesktopId(id);
+        auto& mapEntry = deviceInfoMap.extract(id);
+        id.virtualDesktopId = desktopId;
+        mapEntry.key() = id;
         deviceInfoMap.insert(std::move(mapEntry));
     }
     SaveFancyZonesData();
 }
 
-void FancyZonesData::RemoveDeletedDesktops(const std::vector<std::wstring>& activeDesktops)
+void FancyZonesData::RemoveDeletedDesktops(const std::vector<GUID>& activeDesktops)
 {
-    std::unordered_set<std::wstring> active(std::begin(activeDesktops), std::end(activeDesktops));
+    std::unordered_set<GUID> active(std::begin(activeDesktops), std::end(activeDesktops));
     std::scoped_lock lock{ dataLock };
     for (auto it = std::begin(deviceInfoMap); it != std::end(deviceInfoMap);)
     {
-        std::wstring desktopId = ExtractVirtualDesktopId(it->first);
-        if (desktopId != NonLocalizable::DefaultGuid)
+        if (it->first.virtualDesktopId != GUID_NULL)
         {
-            auto foundId = active.find(desktopId);
+            auto foundId = active.find(it->first.virtualDesktopId);
             if (foundId == std::end(active))
             {
-                RemoveDesktopAppZoneHistory(desktopId);
+                RemoveDesktopAppZoneHistory(it->first.virtualDesktopId);
                 it = deviceInfoMap.erase(it);
                 continue;
             }
@@ -277,7 +269,7 @@ void FancyZonesData::RemoveDeletedDesktops(const std::vector<std::wstring>& acti
     SaveFancyZonesData();
 }
 
-bool FancyZonesData::IsAnotherWindowOfApplicationInstanceZoned(HWND window, const std::wstring_view& deviceId) const
+bool FancyZonesData::IsAnotherWindowOfApplicationInstanceZoned(HWND window, const FancyZonesDataTypes::DeviceIdData& deviceId) const
 {
     std::scoped_lock lock{ dataLock };
     auto processPath = get_process_path(window);
@@ -312,7 +304,7 @@ bool FancyZonesData::IsAnotherWindowOfApplicationInstanceZoned(HWND window, cons
     return false;
 }
 
-void FancyZonesData::UpdateProcessIdToHandleMap(HWND window, const std::wstring_view& deviceId)
+void FancyZonesData::UpdateProcessIdToHandleMap(HWND window, const FancyZonesDataTypes::DeviceIdData& deviceId)
 {
     std::scoped_lock lock{ dataLock };
     auto processPath = get_process_path(window);
@@ -336,7 +328,7 @@ void FancyZonesData::UpdateProcessIdToHandleMap(HWND window, const std::wstring_
     }
 }
 
-std::vector<size_t> FancyZonesData::GetAppLastZoneIndexSet(HWND window, const std::wstring_view& deviceId, const std::wstring_view& zoneSetId) const
+std::vector<size_t> FancyZonesData::GetAppLastZoneIndexSet(HWND window, const FancyZonesDataTypes::DeviceIdData& deviceId, const std::wstring_view& zoneSetId) const
 {
     std::scoped_lock lock{ dataLock };
     auto processPath = get_process_path(window);
@@ -359,7 +351,7 @@ std::vector<size_t> FancyZonesData::GetAppLastZoneIndexSet(HWND window, const st
     return {};
 }
 
-bool FancyZonesData::RemoveAppLastZone(HWND window, const std::wstring_view& deviceId, const std::wstring_view& zoneSetId)
+bool FancyZonesData::RemoveAppLastZone(HWND window, const FancyZonesDataTypes::DeviceIdData& deviceId, const std::wstring_view& zoneSetId)
 {
     std::scoped_lock lock{ dataLock };
     auto processPath = get_process_path(window);
@@ -411,7 +403,7 @@ bool FancyZonesData::RemoveAppLastZone(HWND window, const std::wstring_view& dev
     return false;
 }
 
-bool FancyZonesData::SetAppLastZones(HWND window, const std::wstring& deviceId, const std::wstring& zoneSetId, const std::vector<size_t>& zoneIndexSet)
+bool FancyZonesData::SetAppLastZones(HWND window, const FancyZonesDataTypes::DeviceIdData& deviceId, const std::wstring& zoneSetId, const std::vector<size_t>& zoneIndexSet)
 {
     std::scoped_lock lock{ dataLock };
 
@@ -469,7 +461,7 @@ bool FancyZonesData::SetAppLastZones(HWND window, const std::wstring& deviceId, 
     return true;
 }
 
-void FancyZonesData::SetActiveZoneSet(const std::wstring& deviceId, const FancyZonesDataTypes::ZoneSetData& data)
+void FancyZonesData::SetActiveZoneSet(const FancyZonesDataTypes::DeviceIdData& deviceId, const FancyZonesDataTypes::ZoneSetData& data)
 {
     std::scoped_lock lock{ dataLock };
     auto it = deviceInfoMap.find(deviceId);
@@ -560,14 +552,14 @@ void FancyZonesData::SaveFancyZonesData() const
                                     appZoneHistoryMap);
 }
 
-void FancyZonesData::RemoveDesktopAppZoneHistory(const std::wstring& desktopId)
+void FancyZonesData::RemoveDesktopAppZoneHistory(const GUID& desktopId)
 {
     for (auto it = std::begin(appZoneHistoryMap); it != std::end(appZoneHistoryMap);)
     {
         auto& perDesktopData = it->second;
         for (auto desktopIt = std::begin(perDesktopData); desktopIt != std::end(perDesktopData);)
         {
-            if (ExtractVirtualDesktopId(desktopIt->deviceId) == desktopId)
+            if (desktopIt->deviceId.virtualDesktopId == desktopId)
             {
                 desktopIt = perDesktopData.erase(desktopIt);
             }

--- a/src/modules/fancyzones/lib/FancyZonesData.h
+++ b/src/modules/fancyzones/lib/FancyZonesData.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "JsonHelpers.h"
+#include "HashHelpers.h"
 
 #include <common/settings_helpers.h>
 #include <common/json.h>
@@ -37,11 +38,11 @@ class FancyZonesData
 public:
     FancyZonesData();
 
-    std::optional<FancyZonesDataTypes::DeviceInfoData> FindDeviceInfo(const std::wstring& zoneWindowId) const;
+    std::optional<FancyZonesDataTypes::DeviceInfoData> FindDeviceInfo(const FancyZonesDataTypes::DeviceIdData& zoneWindowId) const;
 
     std::optional<FancyZonesDataTypes::CustomZoneSetData> FindCustomZoneSet(const std::wstring& guid) const;
 
-    inline const std::unordered_map<std::wstring, FancyZonesDataTypes::DeviceInfoData>& GetDeviceInfoMap() const
+    inline const std::unordered_map<FancyZonesDataTypes::DeviceIdData, FancyZonesDataTypes::DeviceInfoData>& GetDeviceInfoMap() const
     {
         std::scoped_lock lock{ dataLock };
         return deviceInfoMap;
@@ -59,18 +60,18 @@ public:
         return appZoneHistoryMap;
     }
 
-    bool AddDevice(const std::wstring& deviceId);
-    void CloneDeviceInfo(const std::wstring& source, const std::wstring& destination);
-    void UpdatePrimaryDesktopData(const std::wstring& desktopId);
-    void RemoveDeletedDesktops(const std::vector<std::wstring>& activeDesktops);
+    bool AddDevice(const FancyZonesDataTypes::DeviceIdData& deviceId);
+    void CloneDeviceInfo(const FancyZonesDataTypes::DeviceIdData& source, const FancyZonesDataTypes::DeviceIdData& destination);
+    void UpdatePrimaryDesktopData(const GUID& desktopId);
+    void RemoveDeletedDesktops(const std::vector<GUID>& activeDesktops);
 
-    bool IsAnotherWindowOfApplicationInstanceZoned(HWND window, const std::wstring_view& deviceId) const;
-    void UpdateProcessIdToHandleMap(HWND window, const std::wstring_view& deviceId);
-    std::vector<size_t> GetAppLastZoneIndexSet(HWND window, const std::wstring_view& deviceId, const std::wstring_view& zoneSetId) const;
-    bool RemoveAppLastZone(HWND window, const std::wstring_view& deviceId, const std::wstring_view& zoneSetId);
-    bool SetAppLastZones(HWND window, const std::wstring& deviceId, const std::wstring& zoneSetId, const std::vector<size_t>& zoneIndexSet);
+    bool IsAnotherWindowOfApplicationInstanceZoned(HWND window, const FancyZonesDataTypes::DeviceIdData& deviceId) const;
+    void UpdateProcessIdToHandleMap(HWND window, const FancyZonesDataTypes::DeviceIdData& deviceId);
+    std::vector<size_t> GetAppLastZoneIndexSet(HWND window, const FancyZonesDataTypes::DeviceIdData& deviceId, const std::wstring_view& zoneSetId) const;
+    bool RemoveAppLastZone(HWND window, const FancyZonesDataTypes::DeviceIdData& deviceId, const std::wstring_view& zoneSetId);
+    bool SetAppLastZones(HWND window, const FancyZonesDataTypes::DeviceIdData& deviceId, const std::wstring& zoneSetId, const std::vector<size_t>& zoneIndexSet);
 
-    void SetActiveZoneSet(const std::wstring& deviceId, const FancyZonesDataTypes::ZoneSetData& zoneSet);
+    void SetActiveZoneSet(const FancyZonesDataTypes::DeviceIdData& deviceId, const FancyZonesDataTypes::ZoneSetData& zoneSet);
 
     void SerializeDeviceInfoToTmpFile(const GUID& currentVirtualDesktop) const;
     void ParseDataFromTmpFiles();
@@ -88,7 +89,7 @@ private:
     friend class FancyZonesUnitTests::ZoneWindowCreationUnitTests;
     friend class FancyZonesUnitTests::ZoneSetCalculateZonesUnitTests;
 
-    inline void SetDeviceInfo(const std::wstring& deviceId, FancyZonesDataTypes::DeviceInfoData data)
+    inline void SetDeviceInfo(const FancyZonesDataTypes::DeviceIdData& deviceId, FancyZonesDataTypes::DeviceInfoData data)
     {
         deviceInfoMap[deviceId] = data;
     }
@@ -117,12 +118,12 @@ private:
     void ParseCustomZoneSetsFromTmpFile(std::wstring_view tmpFilePath);
     void ParseDeletedCustomZoneSetsFromTmpFile(std::wstring_view tmpFilePath);
 
-    void RemoveDesktopAppZoneHistory(const std::wstring& desktopId);
+    void RemoveDesktopAppZoneHistory(const GUID& desktopId);
 
     // Maps app path to app's zone history data
     std::unordered_map<std::wstring, std::vector<FancyZonesDataTypes::AppZoneHistoryData>> appZoneHistoryMap{};
     // Maps device unique ID to device data
-    std::unordered_map<std::wstring, FancyZonesDataTypes::DeviceInfoData> deviceInfoMap{};
+    std::unordered_map<FancyZonesDataTypes::DeviceIdData, FancyZonesDataTypes::DeviceInfoData> deviceInfoMap{};
     // Maps custom zoneset UUID to it's data
     std::unordered_map<std::wstring, FancyZonesDataTypes::CustomZoneSetData> customZoneSetsMap{};
 

--- a/src/modules/fancyzones/lib/FancyZonesDataTypes.cpp
+++ b/src/modules/fancyzones/lib/FancyZonesDataTypes.cpp
@@ -122,7 +122,7 @@ namespace FancyZonesDataTypes
 
     std::wstring DeviceIdData::Serialize() const
     {
-        static std::wstring vdId = L"{00000000-0000-0000-0000-000000000000}";
+        std::wstring vdId = L"{00000000-0000-0000-0000-000000000000}";
         wil::unique_cotaskmem_string virtualDesktopIdStr;
         if (SUCCEEDED(StringFromCLSID(virtualDesktopId, &virtualDesktopIdStr)))
         {
@@ -181,7 +181,7 @@ namespace FancyZonesDataTypes
         }
 
         /*
-        Refer to ZoneWindowUtils::GenerateUniqueId parts contain:
+        Refer to FancyZonesUtils::GenerateUniqueId parts contain:
         1. monitor id [string]
         2. width of device [int]
         3. height of device [int]

--- a/src/modules/fancyzones/lib/FancyZonesDataTypes.h
+++ b/src/modules/fancyzones/lib/FancyZonesDataTypes.h
@@ -42,8 +42,8 @@ namespace FancyZonesDataTypes
         std::wstring monitorId;
 
         bool empty() const;
-        std::wstring Serialize() const;
-        static DeviceIdData Parse(const std::wstring& deviceId);
+        std::optional<std::wstring> Serialize() const;
+        static std::optional<DeviceIdData> Parse(const std::wstring& deviceId);
 
         bool operator==(const DeviceIdData& deviceId) const
         {

--- a/src/modules/fancyzones/lib/FancyZonesDataTypes.h
+++ b/src/modules/fancyzones/lib/FancyZonesDataTypes.h
@@ -6,6 +6,7 @@
 #include <vector>
 #include <optional>
 #include <variant>
+#include <tuple>
 #include <unordered_map>
 
 #include <windef.h>
@@ -30,6 +31,25 @@ namespace FancyZonesDataTypes
     {
         Grid = 0,
         Canvas
+    };
+
+    struct DeviceIdData
+    {
+        std::wstring deviceName;
+        int width;
+        int height;
+        GUID virtualDesktopId;
+        std::wstring monitorId;
+
+        bool empty() const;
+        std::wstring Serialize() const;
+        static DeviceIdData Parse(const std::wstring& deviceId);
+
+        bool operator==(const DeviceIdData& deviceId) const
+        {
+            return std::tie(this->deviceName, this->width, this->height, this->virtualDesktopId, this->monitorId) ==
+                   std::tie(deviceId.deviceName, deviceId.width, deviceId.height, deviceId.virtualDesktopId, deviceId.monitorId);
+        }
     };
 
     struct CanvasLayoutInfo
@@ -104,17 +124,8 @@ namespace FancyZonesDataTypes
         std::unordered_map<DWORD, HWND> processIdToHandleMap; // Maps process id(DWORD) of application to zoned window handle(HWND)
 
         std::wstring zoneSetUuid;
-        std::wstring deviceId;
+        DeviceIdData deviceId;
         std::vector<size_t> zoneIndexSet;
-    };
-
-    struct DeviceIdData
-    {
-        std::wstring deviceName;
-        int width;
-        int height;
-        GUID virtualDesktopId;
-        std::wstring monitorId;
     };
 
     struct DeviceInfoData

--- a/src/modules/fancyzones/lib/FancyZonesLib.vcxproj
+++ b/src/modules/fancyzones/lib/FancyZonesLib.vcxproj
@@ -109,6 +109,7 @@
     <ClInclude Include="FancyZonesWinHookEventIDs.h" />
     <ClInclude Include="GenericKeyHook.h" />
     <ClInclude Include="FancyZonesData.h" />
+    <ClInclude Include="HashHelpers.h" />
     <ClInclude Include="JsonHelpers.h" />
     <ClInclude Include="KeyState.h" />
     <ClInclude Include="MonitorWorkAreaHandler.h" />

--- a/src/modules/fancyzones/lib/FancyZonesLib.vcxproj.filters
+++ b/src/modules/fancyzones/lib/FancyZonesLib.vcxproj.filters
@@ -1,151 +1,54 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <Filter Include="Source Files">
-      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
-      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
-    </Filter>
-    <Filter Include="Header Files">
-      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
-      <Extensions>h;hh;hpp;hxx;hm;inl;inc;ipp;xsd</Extensions>
-    </Filter>
-    <Filter Include="Resource Files">
-      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
-      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
-    </Filter>
-    <Filter Include="Generated Files">
-      <UniqueIdentifier>{093625ff-2415-4c2c-842c-0ee7fcb1d203}</UniqueIdentifier>
-    </Filter>
+    <ClCompile Include="FancyZones.cpp" />
+    <ClCompile Include="FancyZonesDataTypes.cpp" />
+    <ClCompile Include="FancyZonesWinHookEventIDs.cpp" />
+    <ClCompile Include="FancyZonesData.cpp" />
+    <ClCompile Include="JsonHelpers.cpp" />
+    <ClCompile Include="MonitorWorkAreaHandler.cpp" />
+    <ClCompile Include="pch.cpp" />
+    <ClCompile Include="SecondaryMouseButtonsHook.cpp" />
+    <ClCompile Include="Settings.cpp" />
+    <ClCompile Include="trace.cpp" />
+    <ClCompile Include="util.cpp" />
+    <ClCompile Include="VirtualDesktopUtils.cpp" />
+    <ClCompile Include="WindowMoveHandler.cpp" />
+    <ClCompile Include="Zone.cpp" />
+    <ClCompile Include="ZoneSet.cpp" />
+    <ClCompile Include="ZoneWindow.cpp" />
+    <ClCompile Include="ZoneWindowDrawing.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="pch.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="Zone.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="ZoneSet.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="ZoneWindow.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="FancyZones.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="Settings.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="util.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="trace.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="VirtualDesktopUtils.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="WindowMoveHandler.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="FancyZonesWinHookEventIDs.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="SecondaryMouseButtonsHook.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="MonitorWorkAreaHandler.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="GenericKeyHook.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="FancyZonesData.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="JsonHelpers.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="FancyZonesDataTypes.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="Generated Files/resource.h">
-      <Filter>Generated Files</Filter>
-    <ClInclude Include="KeyState.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="ZoneWindowDrawing.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
+    <ClInclude Include="FancyZones.h" />
+    <ClInclude Include="FancyZonesDataTypes.h" />
+    <ClInclude Include="FancyZonesWinHookEventIDs.h" />
+    <ClInclude Include="GenericKeyHook.h" />
+    <ClInclude Include="FancyZonesData.h" />
+    <ClInclude Include="JsonHelpers.h" />
+    <ClInclude Include="KeyState.h" />
+    <ClInclude Include="MonitorWorkAreaHandler.h" />
+    <ClInclude Include="pch.h" />
+    <ClInclude Include="Generated Files/resource.h" />
+    <ClInclude Include="SecondaryMouseButtonsHook.h" />
+    <ClInclude Include="Settings.h" />
+    <ClInclude Include="trace.h" />
+    <ClInclude Include="util.h" />
+    <ClInclude Include="VirtualDesktopUtils.h" />
+    <ClInclude Include="WindowMoveHandler.h" />
+    <ClInclude Include="Zone.h" />
+    <ClInclude Include="ZoneSet.h" />
+    <ClInclude Include="ZoneWindow.h" />
+    <ClInclude Include="ZoneWindowDrawing.h" />
+    <ClInclude Include="HashHelpers.h" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="pch.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="Zone.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="ZoneSet.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="ZoneWindow.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="FancyZones.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="Settings.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="trace.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="util.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="VirtualDesktopUtils.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="WindowMoveHandler.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="FancyZonesWinHookEventIDs.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="SecondaryMouseButtonsHook.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="MonitorWorkAreaHandler.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="FancyZonesData.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="JsonHelpers.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="FancyZonesDataTypes.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="ZoneWindowDrawing.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
+    <ResourceCompile Include="Generated Files/fancyzones.rc" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="resource.base.h" />
+    <None Include="fancyzones.base.rc" />
     <None Include="packages.config" />
-    <None Include="resource.base.h">
-      <Filter>Header Files</Filter>
-    </None>
-    <None Include="fancyzones.base.rc">
-      <Filter>Resource Files</Filter>
-    </None>
-    <None Include="Resources.resx">
-      <Filter>Resource Files</Filter>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
-    <ResourceCompile Include="Generated Files/fancyzones.rc">
-      <Filter>Generated Files</Filter>
-    </ResourceCompile>
+    <None Include="Resources.resx" />
   </ItemGroup>
 </Project>

--- a/src/modules/fancyzones/lib/HashHelpers.h
+++ b/src/modules/fancyzones/lib/HashHelpers.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "FancyZonesDataTypes.h"
+
+namespace std
+{
+    template<>
+    struct hash<GUID>
+    {
+        size_t operator()(const GUID& Value) const
+        {
+            RPC_STATUS status = RPC_S_OK;
+            return ::UuidHash(&const_cast<GUID&>(Value), &status);
+        }
+    };
+
+    template<>
+    struct hash<FancyZonesDataTypes::DeviceIdData>
+    {
+        size_t operator()(const FancyZonesDataTypes::DeviceIdData& Value) const
+        {
+            // TODO(stefan): Implement this
+            return 0;
+        }
+    };
+
+}

--- a/src/modules/fancyzones/lib/HashHelpers.h
+++ b/src/modules/fancyzones/lib/HashHelpers.h
@@ -19,8 +19,11 @@ namespace std
     {
         size_t operator()(const FancyZonesDataTypes::DeviceIdData& Value) const
         {
-            // TODO(stefan): Implement this
-            return 0;
+            size_t deviceNameHash = std::hash<std::wstring>{}(Value.deviceName);
+            RPC_STATUS status = RPC_S_OK;
+            size_t virtualDesktopIdHash = ::UuidHash(&const_cast<GUID&>(Value.virtualDesktopId), &status);
+            size_t monitorIdHash = std::hash<std::wstring>{}(Value.monitorId);
+            return deviceNameHash ^ virtualDesktopIdHash ^ monitorIdHash;
         }
     };
 

--- a/src/modules/fancyzones/lib/JsonHelpers.h
+++ b/src/modules/fancyzones/lib/JsonHelpers.h
@@ -52,7 +52,7 @@ namespace JSONHelpers
         FancyZonesDataTypes::DeviceIdData deviceId;
         FancyZonesDataTypes::DeviceInfoData data;
 
-        static json::JsonObject ToJson(const DeviceInfoJSON& device);
+        static std::optional<json::JsonObject> ToJson(const DeviceInfoJSON& device);
         static std::optional<DeviceInfoJSON> FromJson(const json::JsonObject& device);
     };
 

--- a/src/modules/fancyzones/lib/JsonHelpers.h
+++ b/src/modules/fancyzones/lib/JsonHelpers.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "FancyZonesDataTypes.h"
+#include "HashHelpers.h"
 
 #include <common/json.h>
 
@@ -48,7 +49,7 @@ namespace JSONHelpers
 
     struct DeviceInfoJSON
     {
-        std::wstring deviceId;
+        FancyZonesDataTypes::DeviceIdData deviceId;
         FancyZonesDataTypes::DeviceInfoData data;
 
         static json::JsonObject ToJson(const DeviceInfoJSON& device);
@@ -56,7 +57,7 @@ namespace JSONHelpers
     };
 
     using TAppZoneHistoryMap = std::unordered_map<std::wstring, std::vector<FancyZonesDataTypes::AppZoneHistoryData>>;
-    using TDeviceInfoMap = std::unordered_map<std::wstring, FancyZonesDataTypes::DeviceInfoData>;
+    using TDeviceInfoMap = std::unordered_map<FancyZonesDataTypes::DeviceIdData, FancyZonesDataTypes::DeviceInfoData>;
     using TCustomZoneSetsMap = std::unordered_map<std::wstring, FancyZonesDataTypes::CustomZoneSetData>;
 
     struct AppliedZonesetsJSON

--- a/src/modules/fancyzones/lib/MonitorWorkAreaHandler.h
+++ b/src/modules/fancyzones/lib/MonitorWorkAreaHandler.h
@@ -1,19 +1,8 @@
 #pragma once
 
-interface IZoneWindow;
+#include "HashHelpers.h"
 
-namespace std
-{
-    template<>
-    struct hash<GUID>
-    {
-        size_t operator()(const GUID& Value) const
-        {
-            RPC_STATUS status = RPC_S_OK;
-            return ::UuidHash(&const_cast<GUID&>(Value), &status);
-        }
-    };
-}
+interface IZoneWindow;
 
 class MonitorWorkAreaHandler
 {

--- a/src/modules/fancyzones/lib/VirtualDesktopUtils.cpp
+++ b/src/modules/fancyzones/lib/VirtualDesktopUtils.cpp
@@ -43,14 +43,6 @@ namespace VirtualDesktopUtils
                SUCCEEDED(virtualDesktopManager->GetWindowDesktopId(topLevelWindow, desktopId));
     }
 
-    bool GetZoneWindowDesktopId(IZoneWindow* zoneWindow, GUID* desktopId)
-    {
-        // Format: <device-id>_<resolution>_<virtual-desktop-id>
-        std::wstring uniqueId = zoneWindow->UniqueId();
-        std::wstring virtualDesktopId = uniqueId.substr(uniqueId.rfind('_') + 1);
-        return SUCCEEDED(CLSIDFromString(virtualDesktopId.c_str(), desktopId));
-    }
-
     bool GetDesktopIdFromCurrentSession(GUID* desktopId)
     {
         DWORD sessionId;
@@ -137,24 +129,6 @@ namespace VirtualDesktopUtils
     bool GetVirtualDesktopIds(std::vector<GUID>& ids)
     {
         return GetVirtualDesktopIds(GetVirtualDesktopsRegKey(), ids);
-    }
-
-    bool GetVirtualDesktopIds(std::vector<std::wstring>& ids)
-    {
-        std::vector<GUID> guids{};
-        if (GetVirtualDesktopIds(guids))
-        {
-            for (auto& guid : guids)
-            {
-                wil::unique_cotaskmem_string guidString;
-                if (SUCCEEDED(StringFromCLSID(guid, &guidString)))
-                {
-                    ids.push_back(guidString.get());
-                }
-            }
-            return true;
-        }
-        return false;
     }
 
     HKEY OpenVirtualDesktopsRegKey()

--- a/src/modules/fancyzones/lib/VirtualDesktopUtils.h
+++ b/src/modules/fancyzones/lib/VirtualDesktopUtils.h
@@ -5,10 +5,8 @@
 namespace VirtualDesktopUtils
 {
     bool GetWindowDesktopId(HWND topLevelWindow, GUID* desktopId);
-    bool GetZoneWindowDesktopId(IZoneWindow* zoneWindow, GUID* desktopId);
     bool GetCurrentVirtualDesktopId(GUID* desktopId);
     bool GetVirtualDesktopIds(std::vector<GUID>& ids);
-    bool GetVirtualDesktopIds(std::vector<std::wstring>& ids);
     HKEY GetVirtualDesktopsRegKey();
     void HandleVirtualDesktopUpdates(HWND window, UINT message, HANDLE terminateEvent);
 }

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -31,7 +31,7 @@ public:
     ZoneWindow(HINSTANCE hinstance);
     ~ZoneWindow();
 
-    bool Init(IZoneWindowHost* host, HINSTANCE hinstance, HMONITOR monitor, const std::wstring& uniqueId, const std::wstring& parentUniqueId);
+    bool Init(IZoneWindowHost* host, HINSTANCE hinstance, HMONITOR monitor, const FancyZonesDataTypes::DeviceIdData& uniqueId, const FancyZonesDataTypes::DeviceIdData& parentUniqueId);
 
     IFACEMETHODIMP MoveSizeEnter(HWND window) noexcept;
     IFACEMETHODIMP MoveSizeUpdate(POINT const& ptScreen, bool dragEnabled, bool selectManyZones) noexcept;
@@ -48,7 +48,7 @@ public:
     ExtendWindowByDirectionAndPosition(HWND window, DWORD vkCode) noexcept;
     IFACEMETHODIMP_(void)
     CycleActiveZoneSet(DWORD vkCode) noexcept;
-    IFACEMETHODIMP_(std::wstring)
+    IFACEMETHODIMP_(FancyZonesDataTypes::DeviceIdData)
     UniqueId() noexcept { return { m_uniqueId }; }
     IFACEMETHODIMP_(void)
     SaveWindowProcessToZoneIndex(HWND window) noexcept;
@@ -67,7 +67,7 @@ protected:
     static LRESULT CALLBACK s_WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lparam) noexcept;
 
 private:
-    void InitializeZoneSets(const std::wstring& parentUniqueId) noexcept;
+    void InitializeZoneSets(const FancyZonesDataTypes::DeviceIdData& parentUniqueId) noexcept;
     void CalculateZoneSet() noexcept;
     void UpdateActiveZoneSet(_In_opt_ IZoneSet* zoneSet) noexcept;
     LRESULT WndProc(UINT message, WPARAM wparam, LPARAM lparam) noexcept;
@@ -77,7 +77,7 @@ private:
 
     winrt::com_ptr<IZoneWindowHost> m_host;
     HMONITOR m_monitor{};
-    std::wstring m_uniqueId; // Parsed deviceId + resolution + virtualDesktopId
+    FancyZonesDataTypes::DeviceIdData m_uniqueId; // Parsed deviceId + resolution + virtualDesktopId
     wil::unique_hwnd m_window{}; // Hidden tool window used to represent current monitor desktop work area.
     HWND m_windowMoveSize{};
     winrt::com_ptr<IZoneSet> m_activeZoneSet;
@@ -106,7 +106,7 @@ ZoneWindow::~ZoneWindow()
 {
 }
 
-bool ZoneWindow::Init(IZoneWindowHost* host, HINSTANCE hinstance, HMONITOR monitor, const std::wstring& uniqueId, const std::wstring& parentUniqueId)
+bool ZoneWindow::Init(IZoneWindowHost* host, HINSTANCE hinstance, HMONITOR monitor, const FancyZonesDataTypes::DeviceIdData& uniqueId, const FancyZonesDataTypes::DeviceIdData& parentUniqueId)
 {
     m_host.copy_from(host);
 
@@ -367,7 +367,7 @@ ZoneWindow::ClearSelectedZones() noexcept
 
 #pragma region private
 
-void ZoneWindow::InitializeZoneSets(const std::wstring& parentUniqueId) noexcept
+void ZoneWindow::InitializeZoneSets(const FancyZonesDataTypes::DeviceIdData& parentUniqueId) noexcept
 {
     bool deviceAdded = FancyZonesDataInstance().AddDevice(m_uniqueId);
     // If the device has been added, check if it should inherit the parent's layout
@@ -565,7 +565,7 @@ LRESULT CALLBACK ZoneWindow::s_WndProc(HWND window, UINT message, WPARAM wparam,
                                   DefWindowProc(window, message, wparam, lparam);
 }
 
-winrt::com_ptr<IZoneWindow> MakeZoneWindow(IZoneWindowHost* host, HINSTANCE hinstance, HMONITOR monitor, const std::wstring& uniqueId, const std::wstring& parentUniqueId) noexcept
+winrt::com_ptr<IZoneWindow> MakeZoneWindow(IZoneWindowHost* host, HINSTANCE hinstance, HMONITOR monitor, const FancyZonesDataTypes::DeviceIdData& uniqueId, const FancyZonesDataTypes::DeviceIdData& parentUniqueId) noexcept
 {
     auto self = winrt::make_self<ZoneWindow>(hinstance);
     if (self->Init(host, hinstance, monitor, uniqueId, parentUniqueId))

--- a/src/modules/fancyzones/lib/ZoneWindow.h
+++ b/src/modules/fancyzones/lib/ZoneWindow.h
@@ -2,6 +2,11 @@
 #include "FancyZones.h"
 #include "lib/ZoneSet.h"
 
+namespace FancyZonesDataTypes
+{
+    struct DeviceIdData;
+}
+
 /**
  * Class representing single work area, which is defined by monitor and virtual desktop.
  */
@@ -103,7 +108,7 @@ interface __declspec(uuid("{7F017528-8110-4FB3-BE41-F472969C2560}")) IZoneWindow
     /**
      * @returns Unique work area identifier. Format: <device-id>_<resolution>_<virtual-desktop-id>
      */
-    IFACEMETHOD_(std::wstring, UniqueId)() = 0;
+    IFACEMETHOD_(FancyZonesDataTypes::DeviceIdData, UniqueId)() = 0;
     /**
      * @returns Active zone layout for this work area.
      */
@@ -121,4 +126,4 @@ interface __declspec(uuid("{7F017528-8110-4FB3-BE41-F472969C2560}")) IZoneWindow
 };
 
 winrt::com_ptr<IZoneWindow> MakeZoneWindow(IZoneWindowHost* host, HINSTANCE hinstance, HMONITOR monitor,
-    const std::wstring& uniqueId, const std::wstring& parentUniqueId) noexcept;
+    const FancyZonesDataTypes::DeviceIdData& uniqueId, const FancyZonesDataTypes::DeviceIdData& parentUniqueId) noexcept;

--- a/src/modules/fancyzones/lib/util.cpp
+++ b/src/modules/fancyzones/lib/util.cpp
@@ -387,7 +387,7 @@ namespace FancyZonesUtils
         return SUCCEEDED(CLSIDFromString(str.c_str(), &id));
     }
 
-    FancyZonesDataTypes::DeviceIdData GenerateUniqueId(HMONITOR monitor, const std::wstring& deviceId, const GUID& virtualDesktopId)
+    std::optional<FancyZonesDataTypes::DeviceIdData> GenerateUniqueId(HMONITOR monitor, const std::wstring& deviceId, const GUID& virtualDesktopId)
     {
         MONITORINFOEXW mi;
         mi.cbSize = sizeof(mi);
@@ -395,21 +395,21 @@ namespace FancyZonesUtils
         {
             Rect const monitorRect(mi.rcMonitor);
             // Unique identifier format: <parsed-device-id>_<width>_<height>_<virtual-desktop-id>
-            return { TrimDeviceId(deviceId), monitorRect.width(), monitorRect.height(), virtualDesktopId };
+            return FancyZonesDataTypes::DeviceIdData{ TrimDeviceId(deviceId), monitorRect.width(), monitorRect.height(), virtualDesktopId };
         }
-        return {};
+        return std::nullopt;
     }
 
-    FancyZonesDataTypes::DeviceIdData GenerateUniqueIdAllMonitorsArea(const GUID& virtualDesktopId)
+    std::optional<FancyZonesDataTypes::DeviceIdData> GenerateUniqueIdAllMonitorsArea(const GUID& virtualDesktopId)
     {
         RECT combinedResolution = GetAllMonitorsCombinedRect<&MONITORINFO::rcMonitor>();
         int combinedResolutionWidth = static_cast<int>(combinedResolution.right - combinedResolution.left);
         int combinedResolutionHeight = static_cast<int>(combinedResolution.bottom - combinedResolution.top);
 
-        return { ZonedWindowProperties::MultiMonitorDeviceID, combinedResolutionWidth, combinedResolutionHeight, virtualDesktopId };
+        return FancyZonesDataTypes::DeviceIdData{ ZonedWindowProperties::MultiMonitorDeviceID, combinedResolutionWidth, combinedResolutionHeight, virtualDesktopId };
     }
 
-    FancyZonesDataTypes::DeviceIdData GenerateMonitorId(MONITORINFOEX mi, HMONITOR monitor, const GUID& virtualDesktopId)
+    std::optional<FancyZonesDataTypes::DeviceIdData> GenerateMonitorId(MONITORINFOEX mi, HMONITOR monitor, const GUID& virtualDesktopId)
     {
         DISPLAY_DEVICE displayDevice = { sizeof(displayDevice) };
         PCWSTR deviceId = nullptr;

--- a/src/modules/fancyzones/lib/util.h
+++ b/src/modules/fancyzones/lib/util.h
@@ -1,7 +1,10 @@
 #pragma once
 
-#include "gdiplus.h"
+#include <gdiplus.h>
+
 #include <common/string_utils.h>
+
+#include "FancyZonesDataTypes.h"
 
 namespace FancyZonesDataTypes
 {
@@ -200,13 +203,11 @@ namespace FancyZonesUtils
 
     bool IsValidGuid(const std::wstring& str);
 
-    std::wstring GenerateUniqueId(HMONITOR monitor, const std::wstring& devideId, const std::wstring& virtualDesktopId);
-    std::wstring GenerateUniqueIdAllMonitorsArea(const std::wstring& virtualDesktopId);
-    std::optional<std::wstring> GenerateMonitorId(MONITORINFOEX mi, HMONITOR monitor, const GUID& virtualDesktopId);
+    FancyZonesDataTypes::DeviceIdData GenerateUniqueId(HMONITOR monitor, const std::wstring& devideId, const GUID& virtualDesktopId);
+    FancyZonesDataTypes::DeviceIdData GenerateUniqueIdAllMonitorsArea(const GUID& virtualDesktopId);
+    FancyZonesDataTypes::DeviceIdData GenerateMonitorId(MONITORINFOEX mi, HMONITOR monitor, const GUID& virtualDesktopId);
 
     std::wstring TrimDeviceId(const std::wstring& deviceId);
-    std::optional<FancyZonesDataTypes::DeviceIdData> ParseDeviceId(const std::wstring& deviceId);
-    bool IsValidDeviceId(const std::wstring& str);
 
     RECT PrepareRectForCycling(RECT windowRect, RECT zoneWindowRect, DWORD vkCode) noexcept;
     size_t ChooseNextZoneByPosition(DWORD vkCode, RECT windowRect, const std::vector<RECT>& zoneRects) noexcept;

--- a/src/modules/fancyzones/lib/util.h
+++ b/src/modules/fancyzones/lib/util.h
@@ -203,9 +203,9 @@ namespace FancyZonesUtils
 
     bool IsValidGuid(const std::wstring& str);
 
-    FancyZonesDataTypes::DeviceIdData GenerateUniqueId(HMONITOR monitor, const std::wstring& devideId, const GUID& virtualDesktopId);
-    FancyZonesDataTypes::DeviceIdData GenerateUniqueIdAllMonitorsArea(const GUID& virtualDesktopId);
-    FancyZonesDataTypes::DeviceIdData GenerateMonitorId(MONITORINFOEX mi, HMONITOR monitor, const GUID& virtualDesktopId);
+    std::optional<FancyZonesDataTypes::DeviceIdData> GenerateUniqueId(HMONITOR monitor, const std::wstring& devideId, const GUID& virtualDesktopId);
+    std::optional<FancyZonesDataTypes::DeviceIdData> GenerateUniqueIdAllMonitorsArea(const GUID& virtualDesktopId);
+    std::optional<FancyZonesDataTypes::DeviceIdData> GenerateMonitorId(MONITORINFOEX mi, HMONITOR monitor, const GUID& virtualDesktopId);
 
     std::wstring TrimDeviceId(const std::wstring& deviceId);
 

--- a/src/modules/fancyzones/tests/UnitTests/JsonHelpers.Tests.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/JsonHelpers.Tests.cpp
@@ -88,61 +88,61 @@ namespace FancyZonesUnitTests
         TEST_METHOD (DeviceId)
         {
             const auto deviceId = L"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1539}";
-            Assert::IsTrue(IsValidDeviceId(deviceId));
+            Assert::IsFalse(FancyZonesDataTypes::DeviceIdData::Parse(deviceId).empty());
         }
 
         TEST_METHOD (DeviceIdWithoutHashInName)
         {
             const auto deviceId = L"LOCALDISPLAY_5120_1440_{00000000-0000-0000-0000-000000000000}";
-            Assert::IsTrue(IsValidDeviceId(deviceId));
+            Assert::IsFalse(FancyZonesDataTypes::DeviceIdData::Parse(deviceId).empty());
         }
 
         TEST_METHOD (DeviceIdWithoutHashInNameButWithUnderscores)
         {
             const auto deviceId = L"LOCAL_DISPLAY_5120_1440_{00000000-0000-0000-0000-000000000000}";
-            Assert::IsFalse(IsValidDeviceId(deviceId));
+            Assert::IsTrue(FancyZonesDataTypes::DeviceIdData::Parse(deviceId).empty());
         }
 
         TEST_METHOD (DeviceIdWithUnderscoresInName)
         {
             const auto deviceId = L"Default_Monitor#1&1f0c3c2f&0&UID256_5120_1440_{00000000-0000-0000-0000-000000000000}";
-            Assert::IsTrue(IsValidDeviceId(deviceId));
+            Assert::IsFalse(FancyZonesDataTypes::DeviceIdData::Parse(deviceId).empty());
         }
 
         TEST_METHOD (DeviceIdInvalidFormat)
         {
             const auto deviceId = L"_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1539}";
-            Assert::IsFalse(IsValidDeviceId(deviceId));
+            Assert::IsTrue(FancyZonesDataTypes::DeviceIdData::Parse(deviceId).empty());
         }
 
         TEST_METHOD (DeviceIdInvalidFormat2)
         {
             const auto deviceId = L"AOC2460#4&fe3a015&0&UID65793_19201200_{39B25DD2-130D-4B5D-8851-4791D66B1539}";
-            Assert::IsFalse(IsValidDeviceId(deviceId));
+            Assert::IsTrue(FancyZonesDataTypes::DeviceIdData::Parse(deviceId).empty());
         }
 
         TEST_METHOD (DeviceIdInvalidDecimals)
         {
             const auto deviceId = L"AOC2460#4&fe3a015&0&UID65793_aaaa_1200_{39B25DD2-130D-4B5D-8851-4791D66B1539}";
-            Assert::IsFalse(IsValidDeviceId(deviceId));
+            Assert::IsTrue(FancyZonesDataTypes::DeviceIdData::Parse(deviceId).empty());
         }
 
         TEST_METHOD (DeviceIdInvalidDecimals2)
         {
             const auto deviceId = L"AOC2460#4&fe3a015&0&UID65793_19a0_1200_{39B25DD2-130D-4B5D-8851-4791D66B1539}";
-            Assert::IsFalse(IsValidDeviceId(deviceId));
+            Assert::IsTrue(FancyZonesDataTypes::DeviceIdData::Parse(deviceId).empty());
         }
 
         TEST_METHOD (DeviceIdInvalidDecimals3)
         {
             const auto deviceId = L"AOC2460#4&fe3a015&0&UID65793_1900_120000000000000_{39B25DD2-130D-4B5D-8851-4791D66B1539}";
-            Assert::IsFalse(IsValidDeviceId(deviceId));
+            Assert::IsTrue(FancyZonesDataTypes::DeviceIdData::Parse(deviceId).empty());
         }
 
         TEST_METHOD (DeviceIdInvalidGuid)
         {
             const auto deviceId = L"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-4B5D-8851-4791D66B1539}";
-            Assert::IsFalse(IsValidDeviceId(deviceId));
+            Assert::IsTrue(FancyZonesDataTypes::DeviceIdData::Parse(deviceId).empty());
         }
     };
     TEST_CLASS (ZoneSetLayoutTypeUnitTest)
@@ -701,11 +701,15 @@ namespace FancyZonesUnitTests
     {
         TEST_METHOD (ToJson)
         {
+            DeviceIdData deviceId = { L"AOC2460#4&fe3a015&0&UID65793",
+                                      1920,
+                                      1200,
+                                      { 0X39B25DD2, (short)0X130D, (short)0X4B5D, { 0X88, 0X51, 0X47, 0X91, 0XD6, 0X6B, 0X15, 0X39 } } };
             AppZoneHistoryData data{
-                .zoneSetUuid = L"zoneset-uuid", .deviceId = L"device-id", .zoneIndexSet = { 54321 }
+                .zoneSetUuid = L"zoneset-uuid", .deviceId = deviceId, .zoneIndexSet = { 54321 }
             };
             AppZoneHistoryJSON appZoneHistory{ L"appPath", std::vector<AppZoneHistoryData>{ data } };
-            json::JsonObject expected = json::JsonObject::Parse(L"{\"app-path\": \"appPath\", \"history\":[{\"zone-index-set\": [54321], \"device-id\": \"device-id\", \"zoneset-uuid\": \"zoneset-uuid\"}]}");
+            json::JsonObject expected = json::JsonObject::Parse(L"{\"app-path\": \"appPath\", \"history\":[{\"zone-index-set\": [54321], \"device-id\": \"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1539}\", \"zoneset-uuid\": \"zoneset-uuid\"}]}");
 
             auto actual = AppZoneHistoryJSON::ToJson(appZoneHistory);
             compareJsonObjects(expected, actual);
@@ -713,8 +717,12 @@ namespace FancyZonesUnitTests
 
         TEST_METHOD (FromJson)
         {
+            DeviceIdData deviceId = { L"AOC2460#4&fe3a015&0&UID65793",
+                                      1920,
+                                      1200,
+                                      { 0X39B25DD2, (short)0X130D, (short)0X4B5D, { 0X88, 0X51, 0X47, 0X91, 0XD6, 0X6B, 0X15, 0X39 } } };
             AppZoneHistoryData data{
-                .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502906}", .deviceId = L"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1539}", .zoneIndexSet = { 54321 }
+                .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502906}", .deviceId = deviceId, .zoneIndexSet = { 54321 }
             };
             AppZoneHistoryJSON expected{ L"appPath", std::vector<AppZoneHistoryData>{ data } };
             json::JsonObject json = json::JsonObject::Parse(L"{\"app-path\": \"appPath\", \"history\": [{\"device-id\": \"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1539}\", \"zoneset-uuid\": \"{33A2B101-06E0-437B-A61E-CDBECF502906}\", \"zone-index\": 54321}]}");
@@ -725,7 +733,7 @@ namespace FancyZonesUnitTests
             Assert::AreEqual(expected.appPath.c_str(), actual->appPath.c_str());
             Assert::AreEqual(expected.data.size(), actual->data.size());
             Assert::IsTrue(expected.data[0].zoneIndexSet == actual->data[0].zoneIndexSet);
-            Assert::AreEqual(expected.data[0].deviceId.c_str(), actual->data[0].deviceId.c_str());
+            Assert::AreEqual(expected.data[0].deviceId, actual->data[0].deviceId);
             Assert::AreEqual(expected.data[0].zoneSetUuid.c_str(), actual->data[0].zoneSetUuid.c_str());
         }
 
@@ -745,8 +753,12 @@ namespace FancyZonesUnitTests
 
         TEST_METHOD (FromJsonMissingKeys)
         {
+            DeviceIdData deviceId = { L"AOC2460#4&fe3a015&0&UID65793",
+                                      1920,
+                                      1200,
+                                      { 0X39B25DD2, (short)0X130D, (short)0X4B5D, { 0X88, 0X51, 0X47, 0X91, 0XD6, 0X6B, 0X15, 0X39 } } };
             AppZoneHistoryData data{
-                .zoneSetUuid = L"zoneset-uuid", .deviceId = L"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1539}", .zoneIndexSet = { 54321 }
+                .zoneSetUuid = L"zoneset-uuid", .deviceId = deviceId, .zoneIndexSet = { 54321 }
             };
             AppZoneHistoryJSON appZoneHistory{ L"appPath", std::vector<AppZoneHistoryData>{ data } };
             const auto json = AppZoneHistoryJSON::ToJson(appZoneHistory);
@@ -772,16 +784,24 @@ namespace FancyZonesUnitTests
 
         TEST_METHOD (ToJsonMultipleDesktopAppHistory)
         {
+            DeviceIdData deviceId1 = { L"AOC2460#4&fe3a015&0&UID65793",
+                                      1920,
+                                      1200,
+                                       { 0X39B25DD2, (short)0X130D, (short)0X4B5D, { 0X88, 0X51, 0X47, 0X91, 0XD6, 0X6B, 0X15, 0X39 } } };
+            DeviceIdData deviceId2 = { L"AOC2460#4&fe3a015&0&UID65793",
+                                      1920,
+                                      1400,
+                                       { 0X39B25DD2, (short)0X130D, (short)0X4B5D, { 0X88, 0X51, 0X47, 0X91, 0XD6, 0X6B, 0X15, 0X3A } } };
             AppZoneHistoryData data1{
-                .zoneSetUuid = L"zoneset-uuid1", .deviceId = L"device-id1", .zoneIndexSet = { 54321 }
+                .zoneSetUuid = L"zoneset-uuid1", .deviceId = deviceId1, .zoneIndexSet = { 54321 }
             };
             AppZoneHistoryData data2{
-                .zoneSetUuid = L"zoneset-uuid2", .deviceId = L"device-id2", .zoneIndexSet = { 12345 }
+                .zoneSetUuid = L"zoneset-uuid2", .deviceId = deviceId2, .zoneIndexSet = { 12345 }
             };
             AppZoneHistoryJSON appZoneHistory{
                 L"appPath", std::vector<AppZoneHistoryData>{ data1, data2 }
             };
-            json::JsonObject expected = json::JsonObject::Parse(L"{\"app-path\": \"appPath\", \"history\": [{\"zone-index-set\": [54321], \"device-id\": \"device-id1\", \"zoneset-uuid\": \"zoneset-uuid1\"}, {\"zone-index-set\": [12345], \"device-id\": \"device-id2\", \"zoneset-uuid\": \"zoneset-uuid2\"}]}");
+            json::JsonObject expected = json::JsonObject::Parse(L"{\"app-path\": \"appPath\", \"history\": [{\"zone-index-set\": [54321], \"device-id\": \"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1539}\", \"zoneset-uuid\": \"zoneset-uuid1\"}, {\"zone-index-set\": [12345], \"device-id\": \"AOC2460#4&fe3a015&0&UID65793_1920_1400_{39B25DD2-130D-4B5D-8851-4791D66B153A}\", \"zoneset-uuid\": \"zoneset-uuid2\"}]}");
 
             auto actual = AppZoneHistoryJSON::ToJson(appZoneHistory);
             std::wstring s = actual.Stringify().c_str();
@@ -790,11 +810,19 @@ namespace FancyZonesUnitTests
 
         TEST_METHOD (FromJsonMultipleDesktopAppHistory)
         {
+            DeviceIdData deviceId1 = { L"AOC2460#4&fe3a015&0&UID65793",
+                                       1920,
+                                       1200,
+                                       { 0X39B25DD2, (short)0X130D, (short)0X4B5D, { 0X88, 0X51, 0X47, 0X91, 0XD6, 0X6B, 0X15, 0X39 } } };
+            DeviceIdData deviceId2 = { L"AOC2460#4&fe3a015&0&UID65793",
+                                       1920,
+                                       1200,
+                                       { 0X8a0b9205, (short)0X6128, (short)0X45a2, { 0X93, 0X4a, 0Xb9, 0X7f, 0X5b, 0X27, 0X12, 0X35 } } };
             AppZoneHistoryData data1{
-                .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502906}", .deviceId = L"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1539}", .zoneIndexSet = { 54321 }
+                .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502906}", .deviceId = deviceId1, .zoneIndexSet = { 54321 }
             };
             AppZoneHistoryData data2{
-                .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502906}", .deviceId = L"AOC2460#4&fe3a015&0&UID65793_1920_1200_{8a0b9205-6128-45a2-934a-b97f5b271235}", .zoneIndexSet = { 12345 }
+                .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502906}", .deviceId = deviceId2, .zoneIndexSet = { 12345 }
             };
             AppZoneHistoryJSON expected{
                 L"appPath", std::vector<AppZoneHistoryData>{ data1, data2 }
@@ -810,7 +838,7 @@ namespace FancyZonesUnitTests
             for (size_t i = 0; i < expected.data.size(); ++i)
             {
                 Assert::IsTrue(expected.data[i].zoneIndexSet == actual->data[i].zoneIndexSet);
-                Assert::AreEqual(expected.data[i].deviceId.c_str(), actual->data[i].deviceId.c_str());
+                Assert::AreEqual(expected.data[i].deviceId, actual->data[i].deviceId);
                 Assert::AreEqual(expected.data[i].zoneSetUuid.c_str(), actual->data[i].zoneSetUuid.c_str());
             }
         }
@@ -819,7 +847,11 @@ namespace FancyZonesUnitTests
     TEST_CLASS (DeviceInfoUnitTests)
     {
     private:
-        const std::wstring m_defaultDeviceId = L"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1539}";
+        const DeviceIdData m_defaultDeviceId{ L"AOC2460#4&fe3a015&0&UID65793",
+                                              1920,
+                                              1200,
+                                              { 0X39B25DD2, (short)0X130D, (short)0X4B5D, { 0X88, 0X51, 0X47, 0X91, 0XD6, 0X6B, 0X15, 0X39 } } };
+
         DeviceInfoJSON m_defaultDeviceInfo = DeviceInfoJSON{ m_defaultDeviceId, DeviceInfoData{ ZoneSetData{ L"{33A2B101-06E0-437B-A61E-CDBECF502906}", ZoneSetLayoutType::Custom }, true, 16, 3 } };
         json::JsonObject m_defaultJson = json::JsonObject::Parse(L"{\"device-id\": \"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1539}\", \"active-zoneset\": {\"type\": \"custom\", \"uuid\": \"{33A2B101-06E0-437B-A61E-CDBECF502906}\"}, \"editor-show-spacing\": true, \"editor-spacing\": 16, \"editor-zone-count\": 3}");
 
@@ -842,7 +874,7 @@ namespace FancyZonesUnitTests
             auto actual = DeviceInfoJSON::FromJson(json);
             Assert::IsTrue(actual.has_value());
 
-            Assert::AreEqual(expected.deviceId.c_str(), actual->deviceId.c_str(), L"device id");
+            Assert::AreEqual(expected.deviceId, actual->deviceId, L"device id");
             Assert::AreEqual(expected.data.zoneCount, actual->data.zoneCount, L"zone count");
             Assert::AreEqual((int)expected.data.activeZoneSet.type, (int)actual->data.activeZoneSet.type, L"zone set type");
             Assert::AreEqual(expected.data.activeZoneSet.uuid.c_str(), actual->data.activeZoneSet.uuid.c_str(), L"zone set uuid");
@@ -942,7 +974,10 @@ namespace FancyZonesUnitTests
     {
         TEST_METHOD(SingleDevice)
         {
-            const std::wstring deviceId = L"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1539}";
+            DeviceIdData deviceId{ L"AOC2460#4&fe3a015&0&UID65793",
+                                    1920,
+                                    1200,
+                                   { 0X39B25DD2, (short)0X130D, (short)0X4B5D, { 0X88, 0X51, 0X47, 0X91, 0XD6, 0X6B, 0x15, 0x39 } } };
             const std::wstring zoneUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502906}";
             const ZoneSetLayoutType type = ZoneSetLayoutType::Custom;
             DeviceInfoData data{ ZoneSetData{ zoneUuid, type }, true, 10, 4 };
@@ -971,9 +1006,21 @@ namespace FancyZonesUnitTests
         TEST_METHOD (MultipleDevices)
         {
             TDeviceInfoMap expected;
-            expected.insert(std::make_pair(L"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1539}", DeviceInfoData{ ZoneSetData{ L"{33A2B101-06E0-437B-A61E-CDBECF502906}", ZoneSetLayoutType::Columns }, true, 10, 4 }));
-            expected.insert(std::make_pair(L"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1538}", DeviceInfoData{ ZoneSetData{ L"{33A2B101-06E0-437B-A61E-CDBECF502905}", ZoneSetLayoutType::Rows }, false, 8, 5 }));
-            expected.insert(std::make_pair(L"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1537}", DeviceInfoData{ ZoneSetData{ L"{33A2B101-06E0-437B-A61E-CDBECF502904}", ZoneSetLayoutType::Grid }, true, 9, 6 }));
+            DeviceIdData deviceId1{ L"AOC2460#4&fe3a015&0&UID65793",
+                                    1920,
+                                    1200,
+                                    { 0X39B25DD2, (short)0X130D, (short)0X4B5D, { 0X88, 0X51, 0X47, 0X91, 0XD6, 0X6B, 0X15, 0X39 } } };
+            DeviceIdData deviceId2{ L"AOC2460#4&fe3a015&0&UID65793",
+                                    1920,
+                                    1200,
+                                    { 0X39B25DD2, (short)0X130D, (short)0X4B5D, { 0X88, 0X51, 0X47, 0X91, 0XD6, 0X6B, 0X15, 0X38 } } };
+            DeviceIdData deviceId3{ L"AOC2460#4&fe3a015&0&UID65793",
+                                    1920,
+                                    1200,
+                                    { 0X39B25DD2, (short)0X130D, (short)0X4B5D, { 0X88, 0X51, 0X47, 0X91, 0XD6, 0X6B, 0X15, 0X37 } } };
+            expected.insert(std::make_pair(deviceId1, DeviceInfoData{ ZoneSetData{ L"{33A2B101-06E0-437B-A61E-CDBECF502906}", ZoneSetLayoutType::Columns }, true, 10, 4 }));
+            expected.insert(std::make_pair(deviceId2, DeviceInfoData{ ZoneSetData{ L"{33A2B101-06E0-437B-A61E-CDBECF502905}", ZoneSetLayoutType::Rows }, false, 8, 5 }));
+            expected.insert(std::make_pair(deviceId3, DeviceInfoData{ ZoneSetData{ L"{33A2B101-06E0-437B-A61E-CDBECF502904}", ZoneSetLayoutType::Grid }, true, 9, 6 }));
 
             json::JsonObject json = AppliedZonesetsJSON::ToJson(expected);
             auto actual = AppliedZonesetsJSON::FromJson(json);
@@ -1028,7 +1075,10 @@ namespace FancyZonesUnitTests
     {
     private:
         const std::wstring_view m_moduleName = L"FancyZonesUnitTests";
-        const std::wstring m_defaultDeviceId = L"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1539}";
+        const FancyZonesDataTypes::DeviceIdData m_defaultDeviceId = FancyZonesDataTypes::DeviceIdData{ L"AOC2460#4&fe3a015&0&UID65793",
+                                                                                                       1920,
+                                                                                                       1200,
+                                                                                                       { 0X39B25DD2, 0X130D, 0X4B5D, { 0X88, 0X51, 0X47, 0X91, 0XD6, 0X6B, 0X15, 0X39 } } };
         const std::wstring m_defaultCustomDeviceStr = L"{\"device-id\": \"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1539}\", \"active-zoneset\": {\"type\": \"custom\", \"uuid\": \"{33A2B101-06E0-437B-A61E-CDBECF502906}\"}, \"editor-show-spacing\": true, \"editor-spacing\": 16, \"editor-zone-count\": 3}";
         const json::JsonValue m_defaultCustomDeviceValue = json::JsonValue::Parse(m_defaultCustomDeviceStr);
         const json::JsonObject m_defaultCustomDeviceObj = json::JsonObject::Parse(m_defaultCustomDeviceStr);
@@ -1214,7 +1264,7 @@ namespace FancyZonesUnitTests
                 FancyZonesData data;
                 data.SetSettingsModulePath(m_moduleName);
 
-                const std::wstring deviceId = m_defaultDeviceId;
+                const auto deviceId = m_defaultDeviceId;
                 DeviceInfoData expected{ ZoneSetData{ L"{33A2B101-06E0-437B-A61E-CDBECF502906}", ZoneSetLayoutType::Custom }, true, 16, 3 };
 
                 TDeviceInfoMap expectedDeviceInfoMap;
@@ -1257,7 +1307,7 @@ namespace FancyZonesUnitTests
             TEST_METHOD (AppZoneHistoryParseSingle)
             {
                 const std::wstring expectedAppPath = L"appPath";
-                const std::wstring expectedDeviceId = m_defaultDeviceId;
+                const auto expectedDeviceId = m_defaultDeviceId;
                 const std::wstring expectedZoneSetId = L"{33A2B101-06E0-437B-A61E-CDBECF502906}";
                 const size_t expectedIndex = 54321;
 
@@ -1280,7 +1330,7 @@ namespace FancyZonesUnitTests
                 const auto entryData = entry->second;
                 Assert::AreEqual(expected.data.size(), entryData.size());
                 Assert::AreEqual(expectedZoneSetId.c_str(), entryData[0].zoneSetUuid.c_str());
-                Assert::AreEqual(expectedDeviceId.c_str(), entryData[0].deviceId.c_str());
+                Assert::AreEqual(expectedDeviceId, entryData[0].deviceId);
                 Assert::IsTrue(std::vector<size_t>{ expectedIndex } == entryData[0].zoneIndexSet);
             }
 
@@ -1288,17 +1338,33 @@ namespace FancyZonesUnitTests
             {
                 json::JsonObject json;
                 json::JsonArray zoneHistoryArray;
+                DeviceIdData deviceId1{ L"AOC2460#4&fe3a015&0&UID65793",
+                                        1920,
+                                        1200,
+                                        { 0X39B25DD2, (short)0X130D, (short)0X4B5D, { 0X88, 0X51, 0X47, 0X91, 0XD6, 0X6B, 0X15, 0X39 } } };
+                DeviceIdData deviceId2{ L"AOC2460#4&fe3a015&0&UID65793",
+                                        1920,
+                                        1200,
+                                        { 0X39B25DD2, (short)0X130D, (short)0X4B5D, { 0X88, 0X51, 0X47, 0X91, 0XD6, 0X6B, 0X15, 0X38 } } };
+                DeviceIdData deviceId3{ L"AOC2460#4&fe3a015&0&UID65793",
+                                        1920,
+                                        1200,
+                                        { 0X39B25DD2, (short)0X130D, (short)0X4B5D, { 0X88, 0X51, 0X47, 0X91, 0XD6, 0X6B, 0X15, 0X37 } } };
+                DeviceIdData deviceId4{ L"AOC2460#4&fe3a015&0&UID65793",
+                                        1920,
+                                        1200,
+                                        { 0X39B25DD2, (short)0X130D, (short)0X4B5D, { 0X88, 0X51, 0X47, 0X91, 0XD6, 0X6B, 0X15, 0X36 } } };
                 AppZoneHistoryData data1{
-                    .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502900}", .deviceId = L"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1530}", .zoneIndexSet = { 1 }
+                    .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502900}", .deviceId = deviceId1, .zoneIndexSet = { 1 }
                 };
                 AppZoneHistoryData data2{
-                    .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502901}", .deviceId = L"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1531}", .zoneIndexSet = { 2 }
+                    .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502901}", .deviceId = deviceId2, .zoneIndexSet = { 2 }
                 };
                 AppZoneHistoryData data3{
-                    .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502902}", .deviceId = L"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1532}", .zoneIndexSet = { 3 }
+                    .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502902}", .deviceId = deviceId3, .zoneIndexSet = { 3 }
                 };
                 AppZoneHistoryData data4{
-                    .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502903}", .deviceId = L"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1533}", .zoneIndexSet = { 4 }
+                    .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502903}", .deviceId = deviceId4, .zoneIndexSet = { 4 }
                 };
                 zoneHistoryArray.Append(AppZoneHistoryJSON::ToJson(AppZoneHistoryJSON{ L"app-path-1", std::vector<AppZoneHistoryData>{ data1 } }));
                 zoneHistoryArray.Append(AppZoneHistoryJSON::ToJson(AppZoneHistoryJSON{ L"app-path-2", std::vector<AppZoneHistoryData>{ data2 } }));
@@ -1318,7 +1384,7 @@ namespace FancyZonesUnitTests
 
                     const auto& actual = appZoneHistoryMap.at(expected->appPath);
                     Assert::AreEqual(expected->data.size(), actual.size());
-                    Assert::AreEqual(expected->data[0].deviceId.c_str(), actual[0].deviceId.c_str());
+                    Assert::AreEqual(expected->data[0].deviceId, actual[0].deviceId);
                     Assert::AreEqual(expected->data[0].zoneSetUuid.c_str(), actual[0].zoneSetUuid.c_str());
                     Assert::IsTrue(expected->data[0].zoneIndexSet == actual[0].zoneIndexSet);
 
@@ -1332,20 +1398,36 @@ namespace FancyZonesUnitTests
                 json::JsonArray zoneHistoryArray;
 
                 const auto appPath = L"app-path";
+                DeviceIdData deviceId1{ L"AOC2460#4&fe3a015&0&UID65793",
+                                        1920,
+                                        1200,
+                                        { 0X39B25DD2, (short)0X130D, (short)0X4B5D, { 0X88, 0X51, 0X47, 0X91, 0XD6, 0X6B, 0X15, 0X39 } } };
+                DeviceIdData deviceId2{ L"AOC2460#4&fe3a015&0&UID65793",
+                                        1920,
+                                        1200,
+                                        { 0X39B25DD2, (short)0X130D, (short)0X4B5D, { 0X88, 0X51, 0X47, 0X91, 0XD6, 0X6B, 0X15, 0X38 } } };
+                DeviceIdData deviceId3{ L"AOC2460#4&fe3a015&0&UID65793",
+                                        1920,
+                                        1200,
+                                        { 0X39B25DD2, (short)0X130D, (short)0X4B5D, { 0X88, 0X51, 0X47, 0X91, 0XD6, 0X6B, 0X15, 0X37 } } };
+                DeviceIdData deviceId4{ L"AOC2460#4&fe3a015&0&UID65793",
+                                        1920,
+                                        1200,
+                                        { 0X39B25DD2, (short)0X130D, (short)0X4B5D, { 0X88, 0X51, 0X47, 0X91, 0XD6, 0X6B, 0X15, 0X36 } } };
                 AppZoneHistoryData data1{
-                    .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502900}", .deviceId = L"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1530}", .zoneIndexSet = { 1 }
+                    .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502900}", .deviceId = deviceId1, .zoneIndexSet = { 1 }
                 };
                 zoneHistoryArray.Append(AppZoneHistoryJSON::ToJson(AppZoneHistoryJSON{ appPath, std::vector<AppZoneHistoryData>{ data1 } }));
                 AppZoneHistoryData data2{
-                    .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502901}", .deviceId = L"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1531}", .zoneIndexSet = { 2 }
+                    .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502901}", .deviceId = deviceId2, .zoneIndexSet = { 2 }
                 };
                 zoneHistoryArray.Append(AppZoneHistoryJSON::ToJson(AppZoneHistoryJSON{ appPath, std::vector<AppZoneHistoryData>{ data2 } }));
                 AppZoneHistoryData data3{
-                    .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502902}", .deviceId = L"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1532}", .zoneIndexSet = { 3 }
+                    .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502902}", .deviceId = deviceId3, .zoneIndexSet = { 3 }
                 };
                 zoneHistoryArray.Append(AppZoneHistoryJSON::ToJson(AppZoneHistoryJSON{ appPath, std::vector<AppZoneHistoryData>{ data3 } }));
                 AppZoneHistoryData expected{
-                    .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502903}", .deviceId = L"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1533}", .zoneIndexSet = { 4 }
+                    .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502903}", .deviceId = deviceId4, .zoneIndexSet = { 4 }
                 };
                 zoneHistoryArray.Append(AppZoneHistoryJSON::ToJson(AppZoneHistoryJSON{ appPath, std::vector<AppZoneHistoryData>{ expected } }));
                 json.SetNamedValue(L"app-zone-history", json::JsonValue::Parse(zoneHistoryArray.Stringify()));
@@ -1356,7 +1438,7 @@ namespace FancyZonesUnitTests
 
                 const auto& actual = appZoneHistoryMap.at(appPath);
                 Assert::AreEqual((size_t)1, actual.size());
-                Assert::AreEqual(expected.deviceId.c_str(), actual[0].deviceId.c_str());
+                Assert::AreEqual(expected.deviceId, actual[0].deviceId);
                 Assert::AreEqual(expected.zoneSetUuid.c_str(), actual[0].zoneSetUuid.c_str());
                 Assert::IsTrue(expected.zoneIndexSet == actual[0].zoneIndexSet);
             }
@@ -1622,7 +1704,7 @@ namespace FancyZonesUnitTests
             TEST_METHOD (CustomZoneSetsReadTemp)
             {
                 //prepare device data
-                const std::wstring deviceId = L"default_device_id";
+                const auto deviceId = m_defaultDeviceId;
 
                 {
                     TDeviceInfoMap deviceInfoMap;
@@ -1678,7 +1760,7 @@ namespace FancyZonesUnitTests
             TEST_METHOD (CustomZoneSetsReadTempNonexistent)
             {
                 const std::wstring path = m_fzData.zonesSettingsFileName + L".test_tmp";
-                const std::wstring deviceId = L"default_device_id";
+                const auto uniqueId = m_defaultDeviceId;
 
                 m_fzData.ParseCustomZoneSetsFromTmpFile(path);
                 auto devices = m_fzData.GetDeviceInfoMap();
@@ -1689,7 +1771,7 @@ namespace FancyZonesUnitTests
             {
                 FancyZonesData data;
                 data.SetSettingsModulePath(m_moduleName);
-                const std::wstring uniqueId = m_defaultDeviceId;
+                const auto uniqueId = m_defaultDeviceId;
 
                 json::JsonArray devices;
                 devices.Append(m_defaultCustomDeviceValue);
@@ -1714,7 +1796,7 @@ namespace FancyZonesUnitTests
                 FancyZonesData data;
                 data.SetSettingsModulePath(m_moduleName);
                 const std::wstring expected = L"{39B25DD2-130D-4B5D-8851-4791D66B1539}";
-                const std::wstring uniqueId = m_defaultDeviceId;
+                const auto uniqueId = m_defaultDeviceId;
 
                 json::JsonArray devices;
                 devices.Append(m_defaultCustomDeviceValue);
@@ -1740,7 +1822,10 @@ namespace FancyZonesUnitTests
                 data.SetSettingsModulePath(m_moduleName);
 
                 const std::wstring expected = L"{33A2B101-06E0-437B-A61E-CDBECF502906}";
-                const std::wstring uniqueId = L"id-not-contained-by-device-info-map_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1539}";
+                const FancyZonesDataTypes::DeviceIdData uniqueId{ L"id-not-contained-by-device-info-map",
+                                                                  1920,
+                                                                  1200,
+                                                                  { 0X39B25DD2, (short)0X130D, (short)0X4B5D, { 0X88, 0X51, 0X47, 0X91, 0XD6, 0X6B, 0X15, 0X38 } } };
 
                 json::JsonArray devices;
                 devices.Append(m_defaultCustomDeviceValue);
@@ -1782,10 +1867,14 @@ namespace FancyZonesUnitTests
                     .cellChildMap = { { 0, 1, 2 } } }));
                 CustomZoneSetJSON zoneSets{ L"{33A2B101-06E0-437B-A61E-CDBECF502906}", CustomZoneSetData{ L"name", CustomLayoutType::Grid, grid } };
                 AppZoneHistoryData data{
-                    .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502906}", .deviceId = L"device-id", .zoneIndexSet = { 54321 }
+                    .zoneSetUuid = L"{33A2B101-06E0-437B-A61E-CDBECF502906}", .deviceId = FancyZonesDataTypes::DeviceIdData{}, .zoneIndexSet = { 54321 }
                 };
                 AppZoneHistoryJSON appZoneHistory{ L"app-path", std::vector<AppZoneHistoryData>{ data } };
-                DeviceInfoJSON deviceInfo{ L"{33A2B101-06E0-437B-A61E-CDBECF502906}", DeviceInfoData{ ZoneSetData{ L"uuid", ZoneSetLayoutType::Custom }, true, 16, 3 } };
+                const FancyZonesDataTypes::DeviceIdData uniqueId{ L"id-not-contained-by-device-info-map",
+                                                                  1920,
+                                                                  1200,
+                                                                  { 0X39B25DD2, (short)0X130D, (short)0X4B5D, { 0X88, 0X51, 0X47, 0X91, 0XD6, 0X6B, 0X15, 0X38 } } };
+                DeviceInfoJSON deviceInfo{ uniqueId, DeviceInfoData{ ZoneSetData{ L"uuid", ZoneSetLayoutType::Custom }, true, 16, 3 } };
                 json::JsonArray zoneSetsArray, appZonesArray, deviceInfoArray;
                 zoneSetsArray.Append(CustomZoneSetJSON::ToJson(zoneSets));
                 appZonesArray.Append(AppZoneHistoryJSON::ToJson(appZoneHistory));
@@ -1881,7 +1970,10 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (AppLastZoneIndex)
             {
-                const std::wstring deviceId = L"device-id";
+                const FancyZonesDataTypes::DeviceIdData deviceId{ L"AOC2460#4&fe3a015&0&UID65793",
+                                                                  1920,
+                                                                  1200,
+                                                                  { 0X39B25DD2, (short)0X130D, (short)0X4B5D, { 0X88, 0X51, 0X47, 0X91, 0XD6, 0X6B, 0X15, 0X38 } } };
                 const std::wstring zoneSetId = L"zoneset-uuid";
                 const auto window = Mocks::WindowCreate(m_hInst);
                 FancyZonesData data;
@@ -1897,7 +1989,10 @@ namespace FancyZonesUnitTests
             TEST_METHOD (AppLastZoneIndexZero)
             {
                 const std::wstring zoneSetId = L"zoneset-uuid";
-                const std::wstring deviceId = L"device-id";
+                const FancyZonesDataTypes::DeviceIdData deviceId{ L"AOC2460#4&fe3a015&0&UID65793",
+                                                                  1920,
+                                                                  1200,
+                                                                  { 0X39B25DD2, (short)0X130D, (short)0X4B5D, { 0X88, 0X51, 0X47, 0X91, 0XD6, 0X6B, 0X15, 0X38 } } };
                 const auto window = Mocks::WindowCreate(m_hInst);
                 FancyZonesData data;
                 data.SetSettingsModulePath(m_moduleName);
@@ -1910,7 +2005,10 @@ namespace FancyZonesUnitTests
             TEST_METHOD (AppLastZoneIndexNegative)
             {
                 const std::wstring zoneSetId = L"zoneset-uuid";
-                const std::wstring deviceId = L"device-id";
+                const FancyZonesDataTypes::DeviceIdData deviceId{ L"AOC2460#4&fe3a015&0&UID65793",
+                                                                  1920,
+                                                                  1200,
+                                                                  { 0X39B25DD2, (short)0X130D, (short)0X4B5D, { 0X88, 0X51, 0X47, 0X91, 0XD6, 0X6B, 0X15, 0X38 } } };
                 const auto window = Mocks::WindowCreate(m_hInst);
                 FancyZonesData data;
                 data.SetSettingsModulePath(m_moduleName);
@@ -1923,7 +2021,10 @@ namespace FancyZonesUnitTests
             TEST_METHOD (AppLastZoneIndexOverflow)
             {
                 const std::wstring zoneSetId = L"zoneset-uuid";
-                const std::wstring deviceId = L"device-id";
+                const FancyZonesDataTypes::DeviceIdData deviceId{ L"AOC2460#4&fe3a015&0&UID65793",
+                                                                  1920,
+                                                                  1200,
+                                                                  { 0X39B25DD2, (short)0X130D, (short)0X4B5D, { 0X88, 0X51, 0X47, 0X91, 0XD6, 0X6B, 0X15, 0X38 } } };
                 const auto window = Mocks::WindowCreate(m_hInst);
                 FancyZonesData data;
                 data.SetSettingsModulePath(m_moduleName);
@@ -1936,7 +2037,10 @@ namespace FancyZonesUnitTests
             TEST_METHOD (AppLastZoneIndexOverride)
             {
                 const std::wstring zoneSetId = L"zoneset-uuid";
-                const std::wstring deviceId = L"device-id";
+                const FancyZonesDataTypes::DeviceIdData deviceId{ L"AOC2460#4&fe3a015&0&UID65793",
+                                                                  1920,
+                                                                  1200,
+                                                                  { 0X39B25DD2, (short)0X130D, (short)0X4B5D, { 0X88, 0X51, 0X47, 0X91, 0XD6, 0X6B, 0X15, 0X38 } } };
                 const auto window = Mocks::WindowCreate(m_hInst);
                 FancyZonesData data;
                 data.SetSettingsModulePath(m_moduleName);
@@ -1951,7 +2055,10 @@ namespace FancyZonesUnitTests
             TEST_METHOD (AppLastZoneInvalidWindow)
             {
                 const std::wstring zoneSetId = L"zoneset-uuid";
-                const std::wstring deviceId = L"device-id";
+                const FancyZonesDataTypes::DeviceIdData deviceId{ L"AOC2460#4&fe3a015&0&UID65793",
+                                                                  1920,
+                                                                  1200,
+                                                                  { 0X39B25DD2, (short)0X130D, (short)0X4B5D, { 0X88, 0X51, 0X47, 0X91, 0XD6, 0X6B, 0X15, 0X38 } } };
                 const auto window = Mocks::Window();
                 FancyZonesData data;
                 data.SetSettingsModulePath(m_moduleName);
@@ -1970,14 +2077,20 @@ namespace FancyZonesUnitTests
                 data.SetSettingsModulePath(m_moduleName);
 
                 const int expectedZoneIndex = 1;
-                Assert::IsFalse(data.SetAppLastZones(window, L"device-id", zoneSetId, { expectedZoneIndex }));
+                Assert::IsFalse(data.SetAppLastZones(window, FancyZonesDataTypes::DeviceIdData{}, zoneSetId, { expectedZoneIndex }));
             }
 
             TEST_METHOD (AppLastdeviceIdTest)
             {
                 const std::wstring zoneSetId = L"zoneset-uuid";
-                const std::wstring deviceId1 = L"device-id-1";
-                const std::wstring deviceId2 = L"device-id-2";
+                const FancyZonesDataTypes::DeviceIdData deviceId1{ L"AOC2460#4&fe3a015&0&UID65793",
+                                                                  1920,
+                                                                  1200,
+                                                                   { 0X39B25DD2, (short)0X130D, (short)0X4B5D, { 0X88, 0X51, 0X47, 0X91, 0XD6, 0X6B, 0X15, 0X38 } } };
+                const FancyZonesDataTypes::DeviceIdData deviceId2{ L"AOC2460#4&fe3a015&0&UID65793",
+                                                                  1920,
+                                                                  1200,
+                                                                   { 0X39B25DD2, (short)0X130D, (short)0X4B5D, { 0X88, 0X51, 0X47, 0X91, 0XD6, 0X6B, 0X15, 0X39 } } };
                 const auto window = Mocks::WindowCreate(m_hInst);
                 FancyZonesData data;
                 data.SetSettingsModulePath(m_moduleName);
@@ -1992,7 +2105,10 @@ namespace FancyZonesUnitTests
             {
                 const std::wstring zoneSetId1 = L"zoneset-uuid-1";
                 const std::wstring zoneSetId2 = L"zoneset-uuid-2";
-                const std::wstring deviceId = L"device-id";
+                const FancyZonesDataTypes::DeviceIdData deviceId{ L"AOC2460#4&fe3a015&0&UID65793",
+                                                                  1920,
+                                                                  1200,
+                                                                  { 0X39B25DD2, (short)0X130D, (short)0X4B5D, { 0X88, 0X51, 0X47, 0X91, 0XD6, 0X6B, 0X15, 0X38 } } };
                 const auto window = Mocks::WindowCreate(m_hInst);
                 FancyZonesData data;
                 data.SetSettingsModulePath(m_moduleName);
@@ -2006,7 +2122,10 @@ namespace FancyZonesUnitTests
             TEST_METHOD (AppLastZoneRemoveWindow)
             {
                 const std::wstring zoneSetId = L"zoneset-uuid";
-                const std::wstring deviceId = L"device-id";
+                const FancyZonesDataTypes::DeviceIdData deviceId{ L"AOC2460#4&fe3a015&0&UID65793",
+                                                                  1920,
+                                                                  1200,
+                                                                  { 0X39B25DD2, (short)0X130D, (short)0X4B5D, { 0X88, 0X51, 0X47, 0X91, 0XD6, 0X6B, 0X15, 0X38 } } };
                 const auto window = Mocks::WindowCreate(m_hInst);
                 FancyZonesData data;
                 data.SetSettingsModulePath(m_moduleName);
@@ -2019,7 +2138,10 @@ namespace FancyZonesUnitTests
             TEST_METHOD (AppLastZoneRemoveUnknownWindow)
             {
                 const std::wstring zoneSetId = L"zoneset-uuid";
-                const std::wstring deviceId = L"device-id";
+                const FancyZonesDataTypes::DeviceIdData deviceId{ L"AOC2460#4&fe3a015&0&UID65793",
+                                                        1920,
+                                                        1200,
+                                                                  { 0X39B25DD2, (short)0X130D, (short)0X4B5D, { 0X88, 0X51, 0X47, 0X91, 0XD6, 0X6B, 0X15, 0X38 } } };
                 const auto window = Mocks::WindowCreate(m_hInst);
                 FancyZonesData data;
                 data.SetSettingsModulePath(m_moduleName);
@@ -2032,7 +2154,10 @@ namespace FancyZonesUnitTests
             {
                 const std::wstring zoneSetIdToInsert = L"zoneset-uuid-to-insert";
                 const std::wstring zoneSetIdToRemove = L"zoneset-uuid-to-remove";
-                const std::wstring deviceId = L"device-id";
+                const FancyZonesDataTypes::DeviceIdData deviceId{ L"AOC2460#4&fe3a015&0&UID65793",
+                                                                  1920,
+                                                                  1200,
+                                                                  { 0X39B25DD2, (short)0X130D, (short)0X4B5D, { 0X88, 0X51, 0X47, 0X91, 0XD6, 0X6B, 0X15, 0X38 } } };
                 const auto window = Mocks::WindowCreate(m_hInst);
                 FancyZonesData data;
                 data.SetSettingsModulePath(m_moduleName);
@@ -2045,8 +2170,14 @@ namespace FancyZonesUnitTests
             TEST_METHOD (AppLastZoneRemoveUnknownWindowId)
             {
                 const std::wstring zoneSetId = L"zoneset-uuid";
-                const std::wstring deviceIdToInsert = L"device-id-insert";
-                const std::wstring deviceIdToRemove = L"device-id-remove";
+                const FancyZonesDataTypes::DeviceIdData deviceIdToInsert{ L"AOC2460#4&fe3a015&0&UID65793",
+                                                                  1920,
+                                                                  1200,
+                                                                          { 0X39B25DD2, (short)0X130D, (short)0X4B5D, { 0X88, 0X51, 0X47, 0X91, 0XD6, 0X6B, 0X15, 0X38 } } };
+                const FancyZonesDataTypes::DeviceIdData deviceIdToRemove{ L"AOC2460#4&fe3a015&0&UID65794",
+                                                                  1920,
+                                                                  1200,
+                                                                          { 0X39B25DD2, (short)0X130D, (short)0X4B5D, { 0X88, 0X51, 0X47, 0X91, 0XD6, 0X6B, 0X15, 0X38 } } };
                 const auto window = Mocks::WindowCreate(m_hInst);
                 FancyZonesData data;
                 data.SetSettingsModulePath(m_moduleName);
@@ -2059,7 +2190,10 @@ namespace FancyZonesUnitTests
             TEST_METHOD (AppLastZoneRemoveNullWindow)
             {
                 const std::wstring zoneSetId = L"zoneset-uuid";
-                const std::wstring deviceId = L"device-id";
+                const FancyZonesDataTypes::DeviceIdData deviceId{ L"AOC2460#4&fe3a015&0&UID65793",
+                                                                  1920,
+                                                                  1200,
+                                                                  { 0X39B25DD2, (short)0X130D, (short)0X4B5D, { 0X88, 0X51, 0X47, 0X91, 0XD6, 0X6B, 0X15, 0X38 } } };
                 const auto window = Mocks::WindowCreate(m_hInst);
                 FancyZonesData data;
                 data.SetSettingsModulePath(m_moduleName);

--- a/src/modules/fancyzones/tests/UnitTests/JsonHelpers.Tests.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/JsonHelpers.Tests.cpp
@@ -88,61 +88,67 @@ namespace FancyZonesUnitTests
         TEST_METHOD (DeviceId)
         {
             const auto deviceId = L"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1539}";
-            Assert::IsFalse(FancyZonesDataTypes::DeviceIdData::Parse(deviceId).empty());
+            Assert::IsTrue(FancyZonesDataTypes::DeviceIdData::Parse(deviceId).has_value());
+        }
+
+        TEST_METHOD (DeviceId2)
+        {
+            const auto deviceId = L"AOC2460#4&fe3a015&0&UID65793_1920_1200_{00000000-0000-0000-0000-000000000000}";
+            Assert::IsTrue(FancyZonesDataTypes::DeviceIdData::Parse(deviceId).has_value());
         }
 
         TEST_METHOD (DeviceIdWithoutHashInName)
         {
-            const auto deviceId = L"LOCALDISPLAY_5120_1440_{00000000-0000-0000-0000-000000000000}";
-            Assert::IsFalse(FancyZonesDataTypes::DeviceIdData::Parse(deviceId).empty());
+            const auto deviceId = L"LOCALDISPLAY_5120_1440_{39B25DD2-130D-4B5D-8851-4791D66B1539}";
+            Assert::IsTrue(FancyZonesDataTypes::DeviceIdData::Parse(deviceId).has_value());
         }
 
         TEST_METHOD (DeviceIdWithoutHashInNameButWithUnderscores)
         {
-            const auto deviceId = L"LOCAL_DISPLAY_5120_1440_{00000000-0000-0000-0000-000000000000}";
-            Assert::IsTrue(FancyZonesDataTypes::DeviceIdData::Parse(deviceId).empty());
+            const auto deviceId = L"LOCAL_DISPLAY_5120_1440_{39B25DD2-130D-4B5D-8851-4791D66B1539}";
+            Assert::IsFalse(FancyZonesDataTypes::DeviceIdData::Parse(deviceId).has_value());
         }
 
         TEST_METHOD (DeviceIdWithUnderscoresInName)
         {
-            const auto deviceId = L"Default_Monitor#1&1f0c3c2f&0&UID256_5120_1440_{00000000-0000-0000-0000-000000000000}";
-            Assert::IsFalse(FancyZonesDataTypes::DeviceIdData::Parse(deviceId).empty());
+            const auto deviceId = L"Default_Monitor#1&1f0c3c2f&0&UID256_5120_1440_{39B25DD2-130D-4B5D-8851-4791D66B1539}";
+            Assert::IsTrue(FancyZonesDataTypes::DeviceIdData::Parse(deviceId).has_value());
         }
 
         TEST_METHOD (DeviceIdInvalidFormat)
         {
             const auto deviceId = L"_1920_1200_{39B25DD2-130D-4B5D-8851-4791D66B1539}";
-            Assert::IsTrue(FancyZonesDataTypes::DeviceIdData::Parse(deviceId).empty());
+            Assert::IsFalse(FancyZonesDataTypes::DeviceIdData::Parse(deviceId).has_value());
         }
 
         TEST_METHOD (DeviceIdInvalidFormat2)
         {
             const auto deviceId = L"AOC2460#4&fe3a015&0&UID65793_19201200_{39B25DD2-130D-4B5D-8851-4791D66B1539}";
-            Assert::IsTrue(FancyZonesDataTypes::DeviceIdData::Parse(deviceId).empty());
+            Assert::IsFalse(FancyZonesDataTypes::DeviceIdData::Parse(deviceId).has_value());
         }
 
         TEST_METHOD (DeviceIdInvalidDecimals)
         {
             const auto deviceId = L"AOC2460#4&fe3a015&0&UID65793_aaaa_1200_{39B25DD2-130D-4B5D-8851-4791D66B1539}";
-            Assert::IsTrue(FancyZonesDataTypes::DeviceIdData::Parse(deviceId).empty());
+            Assert::IsFalse(FancyZonesDataTypes::DeviceIdData::Parse(deviceId).has_value());
         }
 
         TEST_METHOD (DeviceIdInvalidDecimals2)
         {
             const auto deviceId = L"AOC2460#4&fe3a015&0&UID65793_19a0_1200_{39B25DD2-130D-4B5D-8851-4791D66B1539}";
-            Assert::IsTrue(FancyZonesDataTypes::DeviceIdData::Parse(deviceId).empty());
+            Assert::IsFalse(FancyZonesDataTypes::DeviceIdData::Parse(deviceId).has_value());
         }
 
         TEST_METHOD (DeviceIdInvalidDecimals3)
         {
             const auto deviceId = L"AOC2460#4&fe3a015&0&UID65793_1900_120000000000000_{39B25DD2-130D-4B5D-8851-4791D66B1539}";
-            Assert::IsTrue(FancyZonesDataTypes::DeviceIdData::Parse(deviceId).empty());
+            Assert::IsFalse(FancyZonesDataTypes::DeviceIdData::Parse(deviceId).has_value());
         }
 
         TEST_METHOD (DeviceIdInvalidGuid)
         {
             const auto deviceId = L"AOC2460#4&fe3a015&0&UID65793_1920_1200_{39B25DD2-4B5D-8851-4791D66B1539}";
-            Assert::IsTrue(FancyZonesDataTypes::DeviceIdData::Parse(deviceId).empty());
+            Assert::IsFalse(FancyZonesDataTypes::DeviceIdData::Parse(deviceId).has_value());
         }
     };
     TEST_CLASS (ZoneSetLayoutTypeUnitTest)
@@ -862,7 +868,8 @@ namespace FancyZonesUnitTests
             json::JsonObject expected = m_defaultJson;
 
             auto actual = DeviceInfoJSON::ToJson(deviceInfo);
-            compareJsonObjects(expected, actual);
+            Assert::IsTrue(actual.has_value());
+            compareJsonObjects(expected, *actual);
         }
 
         TEST_METHOD (FromJson)
@@ -870,8 +877,10 @@ namespace FancyZonesUnitTests
             DeviceInfoJSON expected = m_defaultDeviceInfo;
             expected.data.spacing = true;
 
-            json::JsonObject json = DeviceInfoJSON::ToJson(expected);
-            auto actual = DeviceInfoJSON::FromJson(json);
+            auto json = DeviceInfoJSON::ToJson(expected);
+            Assert::IsTrue(json.has_value());
+
+            auto actual = DeviceInfoJSON::FromJson(*json);
             Assert::IsTrue(actual.has_value());
 
             Assert::AreEqual(expected.deviceId, actual->deviceId, L"device id");
@@ -885,8 +894,10 @@ namespace FancyZonesUnitTests
             DeviceInfoJSON expected = m_defaultDeviceInfo;
             expected.data.spacing = true;
 
-            json::JsonObject json = DeviceInfoJSON::ToJson(expected);
-            auto actual = DeviceInfoJSON::FromJson(json);
+            auto json = DeviceInfoJSON::ToJson(expected);
+            Assert::IsTrue(json.has_value());
+
+            auto actual = DeviceInfoJSON::FromJson(*json);
             Assert::IsTrue(actual.has_value());
 
             Assert::AreEqual(expected.data.spacing, actual->data.spacing);
@@ -897,8 +908,10 @@ namespace FancyZonesUnitTests
             DeviceInfoJSON expected = m_defaultDeviceInfo;
             expected.data.activeZoneSet.type = ZoneSetLayoutType::Custom;
 
-            json::JsonObject json = DeviceInfoJSON::ToJson(expected);
-            auto actual = DeviceInfoJSON::FromJson(json);
+            auto json = DeviceInfoJSON::ToJson(expected);
+            Assert::IsTrue(json.has_value());
+
+            auto actual = DeviceInfoJSON::FromJson(*json);
             Assert::IsTrue(actual.has_value());
 
             Assert::AreEqual(expected.data.spacing, actual->data.spacing);
@@ -909,8 +922,10 @@ namespace FancyZonesUnitTests
             DeviceInfoJSON expected = m_defaultDeviceInfo;
             expected.data.activeZoneSet.type = ZoneSetLayoutType::PriorityGrid;
 
-            json::JsonObject json = DeviceInfoJSON::ToJson(expected);
-            auto actual = DeviceInfoJSON::FromJson(json);
+            auto json = DeviceInfoJSON::ToJson(expected);
+            Assert::IsTrue(json.has_value());
+
+            auto actual = DeviceInfoJSON::FromJson(*json);
             Assert::IsTrue(actual.has_value());
 
             Assert::AreEqual((int)expected.data.activeZoneSet.type, (int)actual->data.activeZoneSet.type, L"zone set type");
@@ -920,8 +935,9 @@ namespace FancyZonesUnitTests
         {
             DeviceInfoJSON deviceInfo{ m_defaultDeviceId, DeviceInfoData{ ZoneSetData{ L"{33A2B101-06E0-437B-A61E-CDBECF502906}", ZoneSetLayoutType::Custom }, true, 16, 3, DefaultValues::SensitivityRadius } };
             const auto json = DeviceInfoJSON::ToJson(deviceInfo);
+            Assert::IsTrue(json.has_value());
 
-            auto iter = json.First();
+            auto iter = json->First();
             while (iter.HasCurrent())
             {
                 //this setting has been added later and gets a default value, so missing key still result is valid Json
@@ -931,7 +947,7 @@ namespace FancyZonesUnitTests
                     continue;
                 }
 
-                json::JsonObject modifiedJson = json::JsonObject::Parse(json.Stringify());
+                json::JsonObject modifiedJson = json::JsonObject::Parse(json->Stringify());
                 modifiedJson.Remove(iter.Current().Key());
 
                 auto actual = DeviceInfoJSON::FromJson(modifiedJson);
@@ -1878,7 +1894,9 @@ namespace FancyZonesUnitTests
                 json::JsonArray zoneSetsArray, appZonesArray, deviceInfoArray;
                 zoneSetsArray.Append(CustomZoneSetJSON::ToJson(zoneSets));
                 appZonesArray.Append(AppZoneHistoryJSON::ToJson(appZoneHistory));
-                deviceInfoArray.Append(DeviceInfoJSON::ToJson(deviceInfo));
+                auto deviceInfoJson = DeviceInfoJSON::ToJson(deviceInfo);
+                Assert::IsTrue(deviceInfoJson.has_value());
+                deviceInfoArray.Append(*deviceInfoJson);
                 json::JsonObject fancyZones;
                 fancyZones.SetNamedValue(L"custom-zone-sets", zoneSetsArray);
                 fancyZones.SetNamedValue(L"app-zone-history", appZonesArray);

--- a/src/modules/fancyzones/tests/UnitTests/Util.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/Util.Spec.cpp
@@ -71,16 +71,16 @@ namespace FancyZonesUnitTests
             CLSIDFromString(expectedGuidStr, &guid);
             const FancyZonesDataTypes::DeviceIdData expected{ L"AOC0001#5&37ac4db&0&UID160002", 1536, 960, guid };
             
-            const auto actual = ParseDeviceId(input);
-            Assert::IsTrue(actual.has_value());
+            const auto actual = FancyZonesDataTypes::DeviceIdData::Parse(input);
+            Assert::IsFalse(actual.empty());
 
-            Assert::AreEqual(expected.deviceName, actual->deviceName);
-            Assert::AreEqual(expected.height, actual->height);
-            Assert::AreEqual(expected.width, actual->width);
-            Assert::AreEqual(expected.monitorId, actual->monitorId);
+            Assert::AreEqual(expected.deviceName, actual.deviceName);
+            Assert::AreEqual(expected.height, actual.height);
+            Assert::AreEqual(expected.width, actual.width);
+            Assert::AreEqual(expected.monitorId, actual.monitorId);
             
             wil::unique_cotaskmem_string actualGuidStr;
-            StringFromCLSID(actual->virtualDesktopId, &actualGuidStr);
+            StringFromCLSID(actual.virtualDesktopId, &actualGuidStr);
             Assert::AreEqual(expectedGuidStr, actualGuidStr.get());
         }
 
@@ -93,16 +93,16 @@ namespace FancyZonesUnitTests
             CLSIDFromString(expectedGuidStr, &guid);
             const FancyZonesDataTypes::DeviceIdData expected{ L"AOC0001#5&37ac4db&0&UID160002", 1536, 960, guid, L"monitorId" };
 
-            const auto actual = ParseDeviceId(input);
-            Assert::IsTrue(actual.has_value());
+            const auto actual = FancyZonesDataTypes::DeviceIdData::Parse(input);
+            Assert::IsFalse(actual.empty());
 
-            Assert::AreEqual(expected.deviceName, actual->deviceName);
-            Assert::AreEqual(expected.height, actual->height);
-            Assert::AreEqual(expected.width, actual->width);
-            Assert::AreEqual(expected.monitorId, actual->monitorId);
+            Assert::AreEqual(expected.deviceName, actual.deviceName);
+            Assert::AreEqual(expected.height, actual.height);
+            Assert::AreEqual(expected.width, actual.width);
+            Assert::AreEqual(expected.monitorId, actual.monitorId);
 
             wil::unique_cotaskmem_string actualGuidStr;
-            StringFromCLSID(actual->virtualDesktopId, &actualGuidStr);
+            StringFromCLSID(actual.virtualDesktopId, &actualGuidStr);
             Assert::AreEqual(expectedGuidStr, actualGuidStr.get());
         }
 
@@ -116,16 +116,16 @@ namespace FancyZonesUnitTests
             CLSIDFromString(expectedGuidStr, &guid);
             const FancyZonesDataTypes::DeviceIdData expected{ L"AOC00015&37ac4db&0&UID160002", 1536, 960, guid };
 
-            const auto actual = ParseDeviceId(input);
-            Assert::IsTrue(actual.has_value());
+            const auto actual = FancyZonesDataTypes::DeviceIdData::Parse(input);
+            Assert::IsFalse(actual.empty());
 
-            Assert::AreEqual(expected.deviceName, actual->deviceName);
-            Assert::AreEqual(expected.height, actual->height);
-            Assert::AreEqual(expected.width, actual->width);
-            Assert::AreEqual(expected.monitorId, actual->monitorId);
+            Assert::AreEqual(expected.deviceName, actual.deviceName);
+            Assert::AreEqual(expected.height, actual.height);
+            Assert::AreEqual(expected.width, actual.width);
+            Assert::AreEqual(expected.monitorId, actual.monitorId);
 
             wil::unique_cotaskmem_string actualGuidStr;
-            StringFromCLSID(actual->virtualDesktopId, &actualGuidStr);
+            StringFromCLSID(actual.virtualDesktopId, &actualGuidStr);
             Assert::AreEqual(expectedGuidStr, actualGuidStr.get());
         }
 
@@ -133,48 +133,48 @@ namespace FancyZonesUnitTests
         {
             // no width or height
             const std::wstring input = L"AOC00015&37ac4db&0&UID160002_1536960_{E0A2904E-889C-4532-95B1-28FE15C16F66}";
-            const auto actual = ParseDeviceId(input);
-            Assert::IsFalse(actual.has_value());
+            const auto actual = FancyZonesDataTypes::DeviceIdData::Parse(input);
+            Assert::IsTrue(actual.empty());
         }
 
         TEST_METHOD (TestParseDeviceIdInvalid02)
         {
             // no width and height
             const std::wstring input = L"AOC00015&37ac4db&0&UID160002_{E0A2904E-889C-4532-95B1-28FE15C16F66}_monitorId";
-            const auto actual = ParseDeviceId(input);
-            Assert::IsFalse(actual.has_value());
+            const auto actual = FancyZonesDataTypes::DeviceIdData::Parse(input);
+            Assert::IsTrue(actual.empty());
         }
 
         TEST_METHOD (TestParseDeviceIdInvalid03)
         {
             // no guid
             const std::wstring input = L"AOC00015&37ac4db&0&UID160002_1536960_";
-            const auto actual = ParseDeviceId(input);
-            Assert::IsFalse(actual.has_value());
+            const auto actual = FancyZonesDataTypes::DeviceIdData::Parse(input);
+            Assert::IsTrue(actual.empty());
         }
 
         TEST_METHOD (TestParseDeviceIdInvalid04)
         {
             // invalid guid
             const std::wstring input = L"AOC00015&37ac4db&0&UID160002_1536960_{asdf}";
-            const auto actual = ParseDeviceId(input);
-            Assert::IsFalse(actual.has_value());
+            const auto actual = FancyZonesDataTypes::DeviceIdData::Parse(input);
+            Assert::IsTrue(actual.empty());
         }
 
         TEST_METHOD (TestParseDeviceIdInvalid05)
         {
             // invalid width/height
             const std::wstring input = L"AOC00015&37ac4db&0&UID160002_15a6_960_{E0A2904E-889C-4532-95B1-28FE15C16F66}";
-            const auto actual = ParseDeviceId(input);
-            Assert::IsFalse(actual.has_value());
+            const auto actual = FancyZonesDataTypes::DeviceIdData::Parse(input);
+            Assert::IsTrue(actual.empty());
         }
 
         TEST_METHOD (TestParseDeviceIdInvalid06)
         {
             // changed order
             const std::wstring input = L"AOC00015&37ac4db&0&UID160002_15a6_960_monitorId_{E0A2904E-889C-4532-95B1-28FE15C16F66}";
-            const auto actual = ParseDeviceId(input);
-            Assert::IsFalse(actual.has_value());
+            const auto actual = FancyZonesDataTypes::DeviceIdData::Parse(input);
+            Assert::IsTrue(actual.empty());
         }
 
         TEST_METHOD(TestMonitorOrdering01)

--- a/src/modules/fancyzones/tests/UnitTests/Util.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/Util.Spec.cpp
@@ -72,15 +72,15 @@ namespace FancyZonesUnitTests
             const FancyZonesDataTypes::DeviceIdData expected{ L"AOC0001#5&37ac4db&0&UID160002", 1536, 960, guid };
             
             const auto actual = FancyZonesDataTypes::DeviceIdData::Parse(input);
-            Assert::IsFalse(actual.empty());
+            Assert::IsTrue(actual.has_value());
 
-            Assert::AreEqual(expected.deviceName, actual.deviceName);
-            Assert::AreEqual(expected.height, actual.height);
-            Assert::AreEqual(expected.width, actual.width);
-            Assert::AreEqual(expected.monitorId, actual.monitorId);
+            Assert::AreEqual(expected.deviceName, actual->deviceName);
+            Assert::AreEqual(expected.height, actual->height);
+            Assert::AreEqual(expected.width, actual->width);
+            Assert::AreEqual(expected.monitorId, actual->monitorId);
             
             wil::unique_cotaskmem_string actualGuidStr;
-            StringFromCLSID(actual.virtualDesktopId, &actualGuidStr);
+            StringFromCLSID(actual->virtualDesktopId, &actualGuidStr);
             Assert::AreEqual(expectedGuidStr, actualGuidStr.get());
         }
 
@@ -94,15 +94,15 @@ namespace FancyZonesUnitTests
             const FancyZonesDataTypes::DeviceIdData expected{ L"AOC0001#5&37ac4db&0&UID160002", 1536, 960, guid, L"monitorId" };
 
             const auto actual = FancyZonesDataTypes::DeviceIdData::Parse(input);
-            Assert::IsFalse(actual.empty());
+            Assert::IsTrue(actual.has_value());
 
-            Assert::AreEqual(expected.deviceName, actual.deviceName);
-            Assert::AreEqual(expected.height, actual.height);
-            Assert::AreEqual(expected.width, actual.width);
-            Assert::AreEqual(expected.monitorId, actual.monitorId);
+            Assert::AreEqual(expected.deviceName, actual->deviceName);
+            Assert::AreEqual(expected.height, actual->height);
+            Assert::AreEqual(expected.width, actual->width);
+            Assert::AreEqual(expected.monitorId, actual->monitorId);
 
             wil::unique_cotaskmem_string actualGuidStr;
-            StringFromCLSID(actual.virtualDesktopId, &actualGuidStr);
+            StringFromCLSID(actual->virtualDesktopId, &actualGuidStr);
             Assert::AreEqual(expectedGuidStr, actualGuidStr.get());
         }
 
@@ -117,15 +117,15 @@ namespace FancyZonesUnitTests
             const FancyZonesDataTypes::DeviceIdData expected{ L"AOC00015&37ac4db&0&UID160002", 1536, 960, guid };
 
             const auto actual = FancyZonesDataTypes::DeviceIdData::Parse(input);
-            Assert::IsFalse(actual.empty());
+            Assert::IsTrue(actual.has_value());
 
-            Assert::AreEqual(expected.deviceName, actual.deviceName);
-            Assert::AreEqual(expected.height, actual.height);
-            Assert::AreEqual(expected.width, actual.width);
-            Assert::AreEqual(expected.monitorId, actual.monitorId);
+            Assert::AreEqual(expected.deviceName, actual->deviceName);
+            Assert::AreEqual(expected.height, actual->height);
+            Assert::AreEqual(expected.width, actual->width);
+            Assert::AreEqual(expected.monitorId, actual->monitorId);
 
             wil::unique_cotaskmem_string actualGuidStr;
-            StringFromCLSID(actual.virtualDesktopId, &actualGuidStr);
+            StringFromCLSID(actual->virtualDesktopId, &actualGuidStr);
             Assert::AreEqual(expectedGuidStr, actualGuidStr.get());
         }
 
@@ -134,7 +134,7 @@ namespace FancyZonesUnitTests
             // no width or height
             const std::wstring input = L"AOC00015&37ac4db&0&UID160002_1536960_{E0A2904E-889C-4532-95B1-28FE15C16F66}";
             const auto actual = FancyZonesDataTypes::DeviceIdData::Parse(input);
-            Assert::IsTrue(actual.empty());
+            Assert::IsFalse(actual.has_value());
         }
 
         TEST_METHOD (TestParseDeviceIdInvalid02)
@@ -142,7 +142,7 @@ namespace FancyZonesUnitTests
             // no width and height
             const std::wstring input = L"AOC00015&37ac4db&0&UID160002_{E0A2904E-889C-4532-95B1-28FE15C16F66}_monitorId";
             const auto actual = FancyZonesDataTypes::DeviceIdData::Parse(input);
-            Assert::IsTrue(actual.empty());
+            Assert::IsFalse(actual.has_value());
         }
 
         TEST_METHOD (TestParseDeviceIdInvalid03)
@@ -150,7 +150,7 @@ namespace FancyZonesUnitTests
             // no guid
             const std::wstring input = L"AOC00015&37ac4db&0&UID160002_1536960_";
             const auto actual = FancyZonesDataTypes::DeviceIdData::Parse(input);
-            Assert::IsTrue(actual.empty());
+            Assert::IsFalse(actual.has_value());
         }
 
         TEST_METHOD (TestParseDeviceIdInvalid04)
@@ -158,7 +158,7 @@ namespace FancyZonesUnitTests
             // invalid guid
             const std::wstring input = L"AOC00015&37ac4db&0&UID160002_1536960_{asdf}";
             const auto actual = FancyZonesDataTypes::DeviceIdData::Parse(input);
-            Assert::IsTrue(actual.empty());
+            Assert::IsFalse(actual.has_value());
         }
 
         TEST_METHOD (TestParseDeviceIdInvalid05)
@@ -166,7 +166,7 @@ namespace FancyZonesUnitTests
             // invalid width/height
             const std::wstring input = L"AOC00015&37ac4db&0&UID160002_15a6_960_{E0A2904E-889C-4532-95B1-28FE15C16F66}";
             const auto actual = FancyZonesDataTypes::DeviceIdData::Parse(input);
-            Assert::IsTrue(actual.empty());
+            Assert::IsFalse(actual.has_value());
         }
 
         TEST_METHOD (TestParseDeviceIdInvalid06)
@@ -174,7 +174,7 @@ namespace FancyZonesUnitTests
             // changed order
             const std::wstring input = L"AOC00015&37ac4db&0&UID160002_15a6_960_monitorId_{E0A2904E-889C-4532-95B1-28FE15C16F66}";
             const auto actual = FancyZonesDataTypes::DeviceIdData::Parse(input);
-            Assert::IsTrue(actual.empty());
+            Assert::IsFalse(actual.has_value());
         }
 
         TEST_METHOD(TestMonitorOrdering01)

--- a/src/modules/fancyzones/tests/UnitTests/Util.h
+++ b/src/modules/fancyzones/tests/UnitTests/Util.h
@@ -75,3 +75,12 @@ std::wstring Microsoft::VisualStudio::CppUnitTestFramework::ToString(const std::
     str += L"}";
     return str;
 }
+
+namespace Microsoft::VisualStudio::CppUnitTestFramework
+{
+    template<>
+    inline std::wstring ToString<FancyZonesDataTypes::DeviceIdData>(const FancyZonesDataTypes::DeviceIdData& v)
+    {
+        return v.Serialize();
+    }
+}

--- a/src/modules/fancyzones/tests/UnitTests/Util.h
+++ b/src/modules/fancyzones/tests/UnitTests/Util.h
@@ -81,6 +81,6 @@ namespace Microsoft::VisualStudio::CppUnitTestFramework
     template<>
     inline std::wstring ToString<FancyZonesDataTypes::DeviceIdData>(const FancyZonesDataTypes::DeviceIdData& v)
     {
-        return v.Serialize();
+        return *v.Serialize();
     }
 }

--- a/src/modules/fancyzones/tests/UnitTests/ZoneSet.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/ZoneSet.Spec.cpp
@@ -1048,10 +1048,13 @@ namespace FancyZonesUnitTests
                 {
                     //prepare device data
                     {
-                        const std::wstring zoneUuid = L"default_device_id";
+                        DeviceIdData deviceId{ L"AOC2460#4&fe3a015&0&UID65793",
+                                                 1920,
+                                                 1200,
+                                               { 0X39B25DD2, (short)0X130D, (short)0X4B5D, { 0X88, 0X51, 0X47, 0X91, 0XD6, 0X6B, 0X15, 0X38 } } };
 
                         JSONHelpers::TDeviceInfoMap deviceInfoMap;
-                        deviceInfoMap.insert(std::make_pair(zoneUuid, DeviceInfoData{ ZoneSetData{ L"uuid", ZoneSetLayoutType::Custom }, true, 16, 3 }));
+                        deviceInfoMap.insert(std::make_pair(deviceId, DeviceInfoData{ ZoneSetData{ L"uuid", ZoneSetLayoutType::Custom }, true, 16, 3 }));
                         
                         GUID virtualDesktopId{};
                         Assert::IsTrue(VirtualDesktopUtils::GetCurrentVirtualDesktopId(&virtualDesktopId), L"Cannot create virtual desktop id");
@@ -1092,10 +1095,13 @@ namespace FancyZonesUnitTests
                 {
                     //prepare device data
                     {
-                        const std::wstring zoneUuid = L"default_device_id";
+                        DeviceIdData deviceId{ L"AOC2460#4&fe3a015&0&UID65793",
+                                               1920,
+                                               1200,
+                                               { 0X39B25DD2, (short)0X130D, (short)0X4B5D, { 0X88, 0X51, 0X47, 0X91, 0XD6, 0X6B, 0X15, 0X38 } } };
 
                         JSONHelpers::TDeviceInfoMap deviceInfoMap;
-                        deviceInfoMap.insert(std::make_pair(zoneUuid, DeviceInfoData{ ZoneSetData{ L"uuid", ZoneSetLayoutType::Custom }, true, 16, 3 }));
+                        deviceInfoMap.insert(std::make_pair(deviceId, DeviceInfoData{ ZoneSetData{ L"uuid", ZoneSetLayoutType::Custom }, true, 16, 3 }));
 
                         GUID virtualDesktopId{};
                         Assert::IsTrue(VirtualDesktopUtils::GetCurrentVirtualDesktopId(&virtualDesktopId), L"Cannot create virtual desktop id");

--- a/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
@@ -88,16 +88,21 @@ namespace FancyZonesUnitTests
             m_monitorInfo.cbSize = sizeof(m_monitorInfo);
             Assert::AreNotEqual(0, GetMonitorInfoW(m_monitor, &m_monitorInfo));
 
-            m_parentUniqueId = FancyZonesDataTypes::DeviceIdData::Parse(L"DELA026#5&10a58c63&0&UID16777488_" +
+            auto parentUniqueId = FancyZonesDataTypes::DeviceIdData::Parse(L"DELA026#5&10a58c63&0&UID16777488_" +
                                                                         std::to_wstring(m_monitorInfo.rcMonitor.right) +
                                                                         L"_" +
                                                                         std::to_wstring(m_monitorInfo.rcMonitor.bottom) +
                                                                         L"_{61FA9FC0-26A6-4B37-A834-491C148DFC57}");
-            m_uniqueId = FancyZonesDataTypes::DeviceIdData::Parse(L"DELA026#5&10a58c63&0&UID16777488_" +
+            Assert::IsTrue(parentUniqueId.has_value());
+            m_parentUniqueId = *parentUniqueId;
+
+            auto uniqueId = FancyZonesDataTypes::DeviceIdData::Parse(L"DELA026#5&10a58c63&0&UID16777488_" +
                                                                   std::to_wstring(m_monitorInfo.rcMonitor.right) +
                                                                   L"_" +
                                                                   std::to_wstring(m_monitorInfo.rcMonitor.bottom) +
                                                                   L"_{39B25DD2-130D-4B5D-8851-4791D66B1539}");
+            Assert::IsTrue(uniqueId.has_value());
+            m_uniqueId = *uniqueId;
 
             m_fancyZonesData.SetSettingsModulePath(L"FancyZonesUnitTests");
             m_fancyZonesData.clear_data();
@@ -109,7 +114,8 @@ namespace FancyZonesUnitTests
 
         TEST_METHOD(CreateZoneWindow)
         {
-            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, {});
+            FancyZonesDataTypes::DeviceIdData deviceIdData{};
+            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, deviceIdData);
             testZoneWindow(zoneWindow);
 
             auto* activeZoneSet{ zoneWindow->ActiveZoneSet() };
@@ -120,7 +126,8 @@ namespace FancyZonesUnitTests
 
         TEST_METHOD(CreateZoneWindowNoHinst)
         {
-            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), {}, m_monitor, m_uniqueId, {});
+            FancyZonesDataTypes::DeviceIdData deviceIdData{};
+            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), {}, m_monitor, m_uniqueId, deviceIdData);
             testZoneWindow(zoneWindow);
 
             auto* activeZoneSet{ zoneWindow->ActiveZoneSet() };
@@ -131,7 +138,8 @@ namespace FancyZonesUnitTests
 
         TEST_METHOD(CreateZoneWindowNoHinstFlashZones)
         {
-            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), {}, m_monitor, m_uniqueId, {});
+            FancyZonesDataTypes::DeviceIdData deviceIdData{};
+            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), {}, m_monitor, m_uniqueId, deviceIdData);
             testZoneWindow(zoneWindow);
 
             auto* activeZoneSet{ zoneWindow->ActiveZoneSet() };
@@ -142,7 +150,8 @@ namespace FancyZonesUnitTests
 
         TEST_METHOD(CreateZoneWindowNoMonitor)
         {
-            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, {}, m_uniqueId, {});
+            FancyZonesDataTypes::DeviceIdData deviceIdData{};
+            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, {}, m_uniqueId, deviceIdData);
             testZoneWindow(zoneWindow);
         }
 
@@ -150,7 +159,10 @@ namespace FancyZonesUnitTests
         {
             // Generate unique id without device id
             auto uniqueId = FancyZonesUtils::GenerateUniqueId(m_monitor, {}, m_virtualDesktopId);
-            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, uniqueId, {});
+            Assert::IsTrue(uniqueId.has_value());
+
+            FancyZonesDataTypes::DeviceIdData deviceIdData{};
+            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, *uniqueId, deviceIdData);
 
             const auto expectedUniqueId = FancyZonesDataTypes::DeviceIdData{ L"FallbackDevice",
                                                                                      m_monitorInfo.rcMonitor.right,
@@ -160,7 +172,7 @@ namespace FancyZonesUnitTests
             Assert::IsNotNull(zoneWindow.get());
             Assert::AreEqual(expectedUniqueId, zoneWindow->UniqueId());
 
-            auto* activeZoneSet{ zoneWindow->ActiveZoneSet() };
+            auto activeZoneSet{ zoneWindow->ActiveZoneSet() };
             Assert::IsNotNull(activeZoneSet);
             Assert::AreEqual(static_cast<int>(activeZoneSet->LayoutType()), static_cast<int>(FancyZonesDataTypes::ZoneSetLayoutType::PriorityGrid));
             Assert::AreEqual(activeZoneSet->GetZones().size(), static_cast<size_t>(3));
@@ -170,11 +182,14 @@ namespace FancyZonesUnitTests
         {
             // Generate unique id without virtual desktop id
             const auto uniqueId = FancyZonesUtils::GenerateUniqueId(m_monitor, m_deviceId, {});
-            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, uniqueId, {});
+            Assert::IsTrue(uniqueId.has_value());
+
+            FancyZonesDataTypes::DeviceIdData deviceIdData{};
+            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, *uniqueId, deviceIdData);
 
             Assert::IsNotNull(zoneWindow.get());
 
-            auto* activeZoneSet{ zoneWindow->ActiveZoneSet() };
+            auto activeZoneSet{ zoneWindow->ActiveZoneSet() };
             Assert::IsNotNull(activeZoneSet);
             Assert::AreEqual(static_cast<int>(activeZoneSet->LayoutType()), static_cast<int>(FancyZonesDataTypes::ZoneSetLayoutType::PriorityGrid));
             Assert::AreEqual(activeZoneSet->GetZones().size(), static_cast<size_t>(3));
@@ -189,15 +204,17 @@ namespace FancyZonesUnitTests
             for (int type = static_cast<int>(ZoneSetLayoutType::Focus); type < static_cast<int>(ZoneSetLayoutType::Custom); type++)
             {
                 const auto expectedZoneSet = ZoneSetData{ Helpers::CreateGuidString(), static_cast<ZoneSetLayoutType>(type) };
-                const auto data = DeviceInfoData{ expectedZoneSet, true, 16, 3 };
+                const auto data = DeviceInfoData{ expectedZoneSet, true, 16, 3, 20 };
                 const auto deviceInfo = JSONHelpers::DeviceInfoJSON{ m_uniqueId, data };
                 const auto json = JSONHelpers::DeviceInfoJSON::ToJson(deviceInfo);
-                json::to_file(activeZoneSetTempPath, json);
+                Assert::IsTrue(json.has_value());
+                json::to_file(activeZoneSetTempPath, *json);
 
                 m_fancyZonesData.ParseDeviceInfoFromTmpFile(activeZoneSetTempPath);
 
                 //temp file read on initialization
-                auto actual = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, {});
+                FancyZonesDataTypes::DeviceIdData deviceIdData{};
+                auto actual = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, deviceIdData);
 
                 testZoneWindow(actual);
 
@@ -213,7 +230,7 @@ namespace FancyZonesUnitTests
 
             const ZoneSetLayoutType type = ZoneSetLayoutType::Custom;
             const auto expectedZoneSet = ZoneSetData{ Helpers::CreateGuidString(), type };
-            const auto data = DeviceInfoData{ expectedZoneSet, true, 16, 3 };
+            const auto data = DeviceInfoData{ expectedZoneSet, true, 16, 3, 20 };
             JSONHelpers::TDeviceInfoMap deviceInfoMap;
             deviceInfoMap.insert(std::make_pair(m_uniqueId, data));
             JSONHelpers::SerializeDeviceInfoToTmpFile(deviceInfoMap, m_virtualDesktopGuid, activeZoneSetTempPath);
@@ -221,7 +238,8 @@ namespace FancyZonesUnitTests
             m_fancyZonesData.ParseDeviceInfoFromTmpFile(activeZoneSetTempPath);
 
             //temp file read on initialization
-            auto actual = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, {});
+            FancyZonesDataTypes::DeviceIdData deviceIdData{};
+            auto actual = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, deviceIdData);
 
             testZoneWindow(actual);
 
@@ -242,7 +260,7 @@ namespace FancyZonesUnitTests
             const ZoneSetLayoutType type = ZoneSetLayoutType::Custom;
             const auto customSetGuid = Helpers::CreateGuidString();
             const auto expectedZoneSet = ZoneSetData{ customSetGuid, type };
-            const auto data = DeviceInfoData{ expectedZoneSet, true, 16, 3 };
+            const auto data = DeviceInfoData{ expectedZoneSet, true, 16, 3, 20 };
             JSONHelpers::TDeviceInfoMap deviceInfoMap;
             deviceInfoMap.insert(std::make_pair(m_uniqueId, data));
             JSONHelpers::SerializeDeviceInfoToTmpFile(deviceInfoMap, m_virtualDesktopGuid, activeZoneSetTempPath);
@@ -259,7 +277,8 @@ namespace FancyZonesUnitTests
             m_fancyZonesData.ParseCustomZoneSetsFromTmpFile(appliedZoneSetTempPath);
 
             //temp file read on initialization
-            auto actual = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, {});
+            FancyZonesDataTypes::DeviceIdData deviceIdData{};
+            auto actual = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, deviceIdData);
 
             testZoneWindow(actual);
 
@@ -281,7 +300,7 @@ namespace FancyZonesUnitTests
             const ZoneSetLayoutType type = ZoneSetLayoutType::Custom;
             const auto customSetGuid = Helpers::CreateGuidString();
             const auto expectedZoneSet = ZoneSetData{ customSetGuid, type };
-            const auto data = DeviceInfoData{ expectedZoneSet, true, 16, 3 };
+            const auto data = DeviceInfoData{ expectedZoneSet, true, 16, 3, 20 };
             JSONHelpers::TDeviceInfoMap deviceInfoMap;
             deviceInfoMap.insert(std::make_pair(m_uniqueId, data));
             JSONHelpers::SerializeDeviceInfoToTmpFile(deviceInfoMap, m_virtualDesktopGuid, activeZoneSetTempPath);
@@ -308,7 +327,8 @@ namespace FancyZonesUnitTests
             m_fancyZonesData.ParseCustomZoneSetsFromTmpFile(appliedZoneSetTempPath);
 
             //temp file read on initialization
-            auto actual = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, {});
+            FancyZonesDataTypes::DeviceIdData deviceIdData{};
+            auto actual = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, deviceIdData);
 
             testZoneWindow(actual);
 
@@ -329,7 +349,7 @@ namespace FancyZonesUnitTests
             const ZoneSetLayoutType type = ZoneSetLayoutType::Custom;
             const auto customSetGuid = Helpers::CreateGuidString();
             const auto expectedZoneSet = ZoneSetData{ customSetGuid, type };
-            const auto data = DeviceInfoData{ expectedZoneSet, true, 16, 3 };
+            const auto data = DeviceInfoData{ expectedZoneSet, true, 16, 3, 20 };
             JSONHelpers::TDeviceInfoMap deviceInfoMap;
             deviceInfoMap.insert(std::make_pair(m_uniqueId, data));
             JSONHelpers::SerializeDeviceInfoToTmpFile(deviceInfoMap, m_virtualDesktopGuid, activeZoneSetTempPath);
@@ -357,7 +377,8 @@ namespace FancyZonesUnitTests
             m_fancyZonesData.ParseCustomZoneSetsFromTmpFile(appliedZoneSetTempPath);
 
             //temp file read on initialization
-            auto actual = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, {});
+            FancyZonesDataTypes::DeviceIdData deviceIdData{};
+            auto actual = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, deviceIdData);
 
             testZoneWindow(actual);
 
@@ -373,13 +394,15 @@ namespace FancyZonesUnitTests
             const ZoneSetLayoutType type = ZoneSetLayoutType::PriorityGrid;
             const int spacing = 10;
             const int zoneCount = 5;
+            const int sensitivityRadius = 20;
             const auto customSetGuid = Helpers::CreateGuidString();
             const auto parentZoneSet = ZoneSetData{ customSetGuid, type };
-            const auto parentDeviceInfo = DeviceInfoData{ parentZoneSet, true, spacing, zoneCount };
+            const auto parentDeviceInfo = DeviceInfoData{ parentZoneSet, true, spacing, zoneCount, sensitivityRadius };
             m_fancyZonesData.SetDeviceInfo(m_parentUniqueId, parentDeviceInfo);
 
             winrt::com_ptr<MockZoneWindowHost> zoneWindowHost = winrt::make_self<MockZoneWindowHost>();
-            auto parentZoneWindow = MakeZoneWindow(zoneWindowHost.get(), m_hInst, m_monitor, m_parentUniqueId, {});
+            FancyZonesDataTypes::DeviceIdData deviceIdData{};
+            auto parentZoneWindow = MakeZoneWindow(zoneWindowHost.get(), m_hInst, m_monitor, m_parentUniqueId, deviceIdData);
             zoneWindowHost->m_zoneWindow = parentZoneWindow.get();
 
             // newWorkArea = true - zoneWindow will be cloned from parent
@@ -393,6 +416,7 @@ namespace FancyZonesUnitTests
             auto currentDeviceInfo = m_fancyZonesData.GetDeviceInfoMap().at(m_uniqueId);
             Assert::AreEqual(zoneCount, currentDeviceInfo.zoneCount);
             Assert::AreEqual(spacing, currentDeviceInfo.spacing);
+            Assert::AreEqual(sensitivityRadius, currentDeviceInfo.sensitivityRadius);
             Assert::AreEqual(static_cast<int>(type), static_cast<int>(currentDeviceInfo.activeZoneSet.type));
         }
 
@@ -409,11 +433,12 @@ namespace FancyZonesUnitTests
             m_fancyZonesData.SetDeviceInfo(m_parentUniqueId, parentDeviceInfo);
 
             winrt::com_ptr<MockZoneWindowHost> zoneWindowHost = winrt::make_self<MockZoneWindowHost>();
-            auto parentZoneWindow = MakeZoneWindow(zoneWindowHost.get(), m_hInst, m_monitor, m_parentUniqueId, {});
+            FancyZonesDataTypes::DeviceIdData deviceIdData{};
+            auto parentZoneWindow = MakeZoneWindow(zoneWindowHost.get(), m_hInst, m_monitor, m_parentUniqueId, deviceIdData);
             zoneWindowHost->m_zoneWindow = parentZoneWindow.get();
 
             // newWorkArea = false - zoneWindow won't be cloned from parent
-            auto actualZoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, {});
+            auto actualZoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, deviceIdData);
 
             Assert::IsNotNull(actualZoneWindow->ActiveZoneSet());
 
@@ -445,11 +470,13 @@ namespace FancyZonesUnitTests
             m_monitorInfo.cbSize = sizeof(m_monitorInfo);
             Assert::AreNotEqual(0, GetMonitorInfoW(m_monitor, &m_monitorInfo));
 
-            m_uniqueId = FancyZonesDataTypes::DeviceIdData::Parse(L"DELA026#5&10a58c63&0&UID16777488_" +
+            auto uniqueId = FancyZonesDataTypes::DeviceIdData::Parse(L"DELA026#5&10a58c63&0&UID16777488_" +
                                                                   std::to_wstring(m_monitorInfo.rcMonitor.right) +
                                                                   L"_" +
                                                                   std::to_wstring(m_monitorInfo.rcMonitor.bottom) +
                                                                   L"_{39B25DD2-130D-4B5D-8851-4791D66B1539}");
+            Assert::IsTrue(uniqueId.has_value());
+            m_uniqueId = *uniqueId;
 
             m_fancyZonesData.SetSettingsModulePath(L"FancyZonesUnitTests");
             m_fancyZonesData.clear_data();
@@ -458,7 +485,8 @@ namespace FancyZonesUnitTests
     public:
         TEST_METHOD(MoveSizeEnter)
         {
-            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, {});
+            FancyZonesDataTypes::DeviceIdData deviceIdData{};
+            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, deviceIdData);
 
             const auto expected = S_OK;
             const auto actual = zoneWindow->MoveSizeEnter(Mocks::Window());
@@ -468,7 +496,8 @@ namespace FancyZonesUnitTests
 
         TEST_METHOD(MoveSizeEnterTwice)
         {
-            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, {});
+            FancyZonesDataTypes::DeviceIdData deviceIdData{};
+            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, deviceIdData);
 
             const auto expected = S_OK;
 
@@ -480,7 +509,8 @@ namespace FancyZonesUnitTests
 
         TEST_METHOD(MoveSizeUpdate)
         {
-            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, {});
+            FancyZonesDataTypes::DeviceIdData deviceIdData{};
+            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, deviceIdData);
 
             const auto expected = S_OK;
             const auto actual = zoneWindow->MoveSizeUpdate(POINT{ 0, 0 }, true, false);
@@ -490,7 +520,8 @@ namespace FancyZonesUnitTests
 
         TEST_METHOD(MoveSizeUpdatePointNegativeCoordinates)
         {
-            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, {});
+            FancyZonesDataTypes::DeviceIdData deviceIdData{};
+            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, deviceIdData);
 
             const auto expected = S_OK;
             const auto actual = zoneWindow->MoveSizeUpdate(POINT{ -10, -10 }, true, false);
@@ -500,7 +531,8 @@ namespace FancyZonesUnitTests
 
         TEST_METHOD(MoveSizeUpdatePointBigCoordinates)
         {
-            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, {});
+            FancyZonesDataTypes::DeviceIdData deviceIdData{};
+            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, deviceIdData);
 
             const auto expected = S_OK;
             const auto actual = zoneWindow->MoveSizeUpdate(POINT{ m_monitorInfo.rcMonitor.right + 1, m_monitorInfo.rcMonitor.bottom + 1 }, true, false);
@@ -510,7 +542,8 @@ namespace FancyZonesUnitTests
 
         TEST_METHOD(MoveSizeEnd)
         {
-            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, {});
+            FancyZonesDataTypes::DeviceIdData deviceIdData{};
+            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, deviceIdData);
 
             const auto window = Mocks::Window();
             zoneWindow->MoveSizeEnter(window);
@@ -527,7 +560,8 @@ namespace FancyZonesUnitTests
 
         TEST_METHOD(MoveSizeEndWindowNotAdded)
         {
-            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, {});
+            FancyZonesDataTypes::DeviceIdData deviceIdData{};
+            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, deviceIdData);
 
             const auto window = Mocks::Window();
             zoneWindow->MoveSizeEnter(window);
@@ -543,7 +577,8 @@ namespace FancyZonesUnitTests
 
         TEST_METHOD(MoveSizeEndDifferentWindows)
         {
-            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, {});
+            FancyZonesDataTypes::DeviceIdData deviceIdData{};
+            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, deviceIdData);
 
             const auto window = Mocks::Window();
             zoneWindow->MoveSizeEnter(window);
@@ -556,7 +591,8 @@ namespace FancyZonesUnitTests
 
         TEST_METHOD(MoveSizeEndWindowNotSet)
         {
-            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, {});
+            FancyZonesDataTypes::DeviceIdData deviceIdData{};
+            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, deviceIdData);
 
             const auto expected = E_INVALIDARG;
             const auto actual = zoneWindow->MoveSizeEnd(Mocks::Window(), POINT{ 0, 0 });
@@ -566,7 +602,8 @@ namespace FancyZonesUnitTests
 
         TEST_METHOD(MoveSizeEndInvalidPoint)
         {
-            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, {});
+            FancyZonesDataTypes::DeviceIdData deviceIdData{};
+            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, deviceIdData);
 
             const auto window = Mocks::Window();
             zoneWindow->MoveSizeEnter(window);
@@ -583,7 +620,8 @@ namespace FancyZonesUnitTests
 
         TEST_METHOD(MoveWindowIntoZoneByIndex)
         {
-            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, {});
+            FancyZonesDataTypes::DeviceIdData deviceIdData{};
+            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, deviceIdData);
             Assert::IsNotNull(zoneWindow->ActiveZoneSet());
 
             zoneWindow->MoveWindowIntoZoneByIndex(Mocks::Window(), 0);
@@ -593,7 +631,8 @@ namespace FancyZonesUnitTests
 
         TEST_METHOD(MoveWindowIntoZoneByDirectionAndIndex)
         {
-            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, {});
+            FancyZonesDataTypes::DeviceIdData deviceIdData{};
+            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, deviceIdData);
             Assert::IsNotNull(zoneWindow->ActiveZoneSet());
 
             const auto window = Mocks::WindowCreate(m_hInst);
@@ -608,7 +647,8 @@ namespace FancyZonesUnitTests
 
         TEST_METHOD(MoveWindowIntoZoneByDirectionManyTimes)
         {
-            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, {});
+            FancyZonesDataTypes::DeviceIdData deviceIdData{};
+            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, deviceIdData);
             Assert::IsNotNull(zoneWindow->ActiveZoneSet());
 
             const auto window = Mocks::WindowCreate(m_hInst);
@@ -625,7 +665,8 @@ namespace FancyZonesUnitTests
 
         TEST_METHOD(SaveWindowProcessToZoneIndexNullptrWindow)
         {
-            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, {});
+            FancyZonesDataTypes::DeviceIdData deviceIdData{};
+            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, deviceIdData);
             Assert::IsNotNull(zoneWindow->ActiveZoneSet());
 
             zoneWindow->SaveWindowProcessToZoneIndex(nullptr);
@@ -636,7 +677,8 @@ namespace FancyZonesUnitTests
 
         TEST_METHOD(SaveWindowProcessToZoneIndexNoWindowAdded)
         {
-            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, {});
+            FancyZonesDataTypes::DeviceIdData deviceIdData{};
+            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, deviceIdData);
             Assert::IsNotNull(zoneWindow->ActiveZoneSet());
 
             auto window = Mocks::WindowCreate(m_hInst);
@@ -651,7 +693,8 @@ namespace FancyZonesUnitTests
 
         TEST_METHOD(SaveWindowProcessToZoneIndexNoWindowAddedWithFilledAppZoneHistory)
         {
-            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, {});
+            FancyZonesDataTypes::DeviceIdData deviceIdData{};
+            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, deviceIdData);
             Assert::IsNotNull(zoneWindow->ActiveZoneSet());
 
             const auto window = Mocks::WindowCreate(m_hInst);
@@ -679,7 +722,8 @@ namespace FancyZonesUnitTests
 
         TEST_METHOD(SaveWindowProcessToZoneIndexWindowAdded)
         {
-            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, {});
+            FancyZonesDataTypes::DeviceIdData deviceIdData{};
+            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, deviceIdData);
             Assert::IsNotNull(zoneWindow->ActiveZoneSet());
 
             auto window = Mocks::WindowCreate(m_hInst);
@@ -709,7 +753,8 @@ namespace FancyZonesUnitTests
 
         TEST_METHOD(WhenWindowIsNotResizablePlacingItIntoTheZoneShouldNotResizeIt)
         {
-            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, {});
+            FancyZonesDataTypes::DeviceIdData deviceIdData{};
+            auto zoneWindow = MakeZoneWindow(winrt::make_self<MockZoneWindowHost>().get(), m_hInst, m_monitor, m_uniqueId, deviceIdData);
             Assert::IsNotNull(zoneWindow->ActiveZoneSet());
 
             auto window = Mocks::WindowCreate(m_hInst);


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_
Replace uniqueId string with uniqueId struct to avoid continuous string manipulation and introduce easier handling of devices

## PR Checklist
* [x] Applies to #3959
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Validation Steps Performed

_How does someone test & validate?_
Manually tested FZ, common usage. Also extensively tested virtual desktops logic and app zone history logic. 