### PR TITLE
Upgrade System.IO.Abstractions.TestingHelpers from 12.2.3 to 13.2.1 in Settings Unittests

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/Microsoft.PowerToys.Settings.UI.UnitTests.csproj
+++ b/src/core/Microsoft.PowerToys.Settings.UI.UnitTests/Microsoft.PowerToys.Settings.UI.UnitTests.csproj
@@ -41,7 +41,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="12.2.3" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="13.2.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

## PR Checklist
* [x] Applies to None
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

Upgrades System.IO.Abstractions.TestingHelpers from 12.2.3 to 13.2.1 in Settings Unittests

## Validation Steps Performed

_How does someone test & validate?_
