### PR TITLE
Add error handling for all possible failing of winrt::check_hresult

### DIFF
--- a/src/modules/shortcut_guide/shortcut_guide.cpp
+++ b/src/modules/shortcut_guide/shortcut_guide.cpp
@@ -233,7 +233,16 @@ void OverlayWindow::enable()
         winkey_popup->apply_overlay_opacity(((float)overlayOpacity.value) / 100.0f);
         winkey_popup->set_theme(theme.value);
         target_state = std::make_unique<TargetState>(pressTime.value);
-        winkey_popup->initialize();
+        try
+        {
+            winkey_popup->initialize();
+        }
+        catch (...)
+        {
+            Logger::critical("Winkey popup failed to initialize");
+            return;
+        }
+        
 #if defined(DISABLE_LOWLEVEL_HOOKS_WHEN_DEBUGGED)
         const bool hook_disabled = IsDebuggerPresent();
 #else

--- a/src/modules/shortcut_guide/target_state.cpp
+++ b/src/modules/shortcut_guide/target_state.cpp
@@ -3,6 +3,7 @@
 #include "common/start_visible.h"
 #include "keyboard_state.h"
 #include "common/shared_constants.h"
+#include <common\logger\logger.h>
 
 TargetState::TargetState(int ms_delay) :
     // TODO: All this processing should be done w/o a separate thread etc. in pre_wnd_proc of winkey_popup to avoid
@@ -143,13 +144,36 @@ void TargetState::thread_proc()
             handle_hidden();
             break;
         case Timeout:
-            handle_timeout();
+            try
+            {
+                handle_timeout();
+            }
+            catch (...)
+            {
+                Logger::critical("Timeout, handle_timeout failed.");
+            }
             break;
         case Shown:
-            handle_shown(false);
+            try
+            {
+                handle_shown(false);
+            }
+            catch (...)
+            {
+                Logger::critical("Shown, handle_shown failed.");
+            }
+            
             break;
         case ForceShown:
-            handle_shown(true);
+            try
+            {
+                handle_shown(true);
+            }
+            catch (...)
+            {
+                Logger::critical("ForceShown, handle_shown failed.");
+            }
+            
             break;
         case Exiting:
         default:


### PR DESCRIPTION
## Summary of the Pull Request

_What is this about?_

If `winrt::check_hresult` throws an exception in Shortcut Guide it can crash the entire PowerToys process. 
This pull request should catch all possible exceptions thrown by `winrt::check_hresult`.

## PR Checklist
* [X] Applies to #6192
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_
- Add exception handling to the `enable` method as the runner does not catch anything
- Add exception handling to `thread_proc`. This function is responsible for showing SG window
- Low-level keyboard hook does not fail because of `winrt::check_result`
- Maybe we should add a popup window to inform a user

## Validation Steps Performed

_How does someone test & validate?_

One possible way is to imitate `winrt::check_result` function. For example one can do something like
```
#define check_hresult test47
namespace winrt
{
    void test47()
    {
        throw -1;
    }
}
```