### PR TITLE
[FancyZones Editor] hold-shift for rotating splitter fix.

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/App.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/App.xaml.cs
@@ -91,6 +91,22 @@ namespace FancyZonesEditor
             Overlay.Show();
         }
 
+        public void App_KeyUp(object sender, System.Windows.Input.KeyEventArgs e)
+        {
+            if (e.Key == System.Windows.Input.Key.LeftShift || e.Key == System.Windows.Input.Key.RightShift)
+            {
+                MainWindowSettings.IsShiftKeyPressed = false;
+            }
+        }
+
+        public void App_KeyDown(object sender, System.Windows.Input.KeyEventArgs e)
+        {
+            if (e.Key == System.Windows.Input.Key.LeftShift || e.Key == System.Windows.Input.Key.RightShift)
+            {
+                MainWindowSettings.IsShiftKeyPressed = true;
+            }
+        }
+
         public static void ShowExceptionMessageBox(string message, Exception exception = null)
         {
             string fullMessage = FancyZonesEditor.Properties.Resources.Error_Report + PowerToysIssuesURL + " \n" + message;

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditorWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditorWindow.xaml.cs
@@ -19,6 +19,7 @@ namespace FancyZonesEditor
             InitializeComponent();
 
             KeyUp += GridEditorWindow_KeyUp;
+            KeyDown += ((App)Application.Current).App_KeyDown;
 
             _stashedModel = (GridLayoutModel)(App.Overlay.CurrentDataContext as GridLayoutModel).Clone();
         }
@@ -36,6 +37,8 @@ namespace FancyZonesEditor
             {
                 OnCancel(sender, null);
             }
+
+            ((App)Application.Current).App_KeyUp(sender, e);
         }
 
         private GridLayoutModel _stashedModel;

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/Monitor.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/Monitor.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Reflection;
 using System.Windows;
+using System.Windows.Input;
 using System.Windows.Media;
 using FancyZonesEditor.Utils;
 
@@ -31,6 +32,9 @@ namespace FancyZonesEditor.Models
                 Window.Opacity = 0.5;
                 Window.Background = (Brush)properties[milliseconds % properties.Length].GetValue(null, null);
             }
+
+            Window.KeyUp += ((App)Application.Current).App_KeyUp;
+            Window.KeyDown += ((App)Application.Current).App_KeyDown;
 
             Window.Left = workArea.X;
             Window.Top = workArea.Y;


### PR DESCRIPTION
## Summary of the Pull Request

Fix unexpected behavior on pressing `shift`.

## PR Checklist
* [x] Applies to #7636, #750
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed

## Info on Pull Request

Added key event handlers in `GridEditorWindow` and layout windows.
After opening the editor the `GridEditorWindow` is activated and catches key events. When a user starts to edit the layout, a layout window becomes activated. Without any of these handlers behavior would be broken. 

## Validation Steps Performed

Edit any layout of the _grid_ type (`Columns`, `Rows`, `Grid`, `Priority Grid`), hold `shift`, and verify that the splitter has changed orientation. Split layouts and verify that `shift` behavior still works as expected.
