### PR TITLE
updating: add support for prereleases

### DIFF
--- a/src/action_runner/action_runner.vcxproj
+++ b/src/action_runner/action_runner.vcxproj
@@ -31,6 +31,7 @@
     <ProjectName>action_runner</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="..\..\deps\expected.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>

--- a/src/common/common.cpp
+++ b/src/common/common.cpp
@@ -49,7 +49,7 @@ bool is_system_window(HWND hwnd, const char* class_name)
 
 int run_message_loop(const bool until_idle, const std::optional<uint32_t> timeout_seconds)
 {
-    MSG msg;
+    MSG msg{};
     bool stop = false;
     UINT_PTR timerId = 0;
     if (timeout_seconds.has_value())

--- a/src/common/updating/notifications.cpp
+++ b/src/common/updating/notifications.cpp
@@ -18,7 +18,7 @@ namespace updating
         {
             auto current_version_to_next_version = VersionHelper{ VERSION_MAJOR, VERSION_MINOR, VERSION_REVISION }.toWstring();
             current_version_to_next_version += L" -> ";
-            current_version_to_next_version += info.version_string;
+            current_version_to_next_version += info.version.toWstring();
             return current_version_to_next_version;
         }
 
@@ -54,7 +54,7 @@ namespace updating
             remove_toasts(UPDATING_PROCESS_TOAST_TAG);
 
             progress_bar_params progress_bar_params;
-            std::wstring progress_title{ info.version_string };
+            std::wstring progress_title{ info.version.toWstring() };
             progress_title += L' ';
             progress_title += strings.DOWNLOAD_IN_PROGRESS;
 
@@ -134,7 +134,7 @@ namespace updating
         {
             progress_bar_params progress_bar_params;
 
-            std::wstring progress_title{ info.version_string };
+            std::wstring progress_title{ info.version.toWstring() };
             progress_title += L' ';
             progress_title += progress < 1 ? strings.DOWNLOAD_IN_PROGRESS : strings.DOWNLOAD_COMPLETE;
             progress_bar_params.progress_title = progress_title;

--- a/src/common/updating/updating.cpp
+++ b/src/common/updating/updating.cpp
@@ -22,13 +22,54 @@
 namespace // Strings in this namespace should not be localized
 {
     const wchar_t LATEST_RELEASE_ENDPOINT[] = L"https://api.github.com/repos/microsoft/PowerToys/releases/latest";
+    const wchar_t ALL_RELEASES_ENDPOINT[] = L"https://api.github.com/repos/microsoft/PowerToys/releases";
 
     const size_t MAX_DOWNLOAD_ATTEMPTS = 3;
 }
 
 namespace updating
 {
-    std::future<nonstd::expected<new_version_download_info, std::wstring>> get_new_github_version_info_async(const notifications::strings& strings)
+    std::optional<VersionHelper> extract_version_from_release_object(const json::JsonObject& release_object)
+    {
+        try
+        {
+            return VersionHelper{ winrt::to_string(release_object.GetNamedString(L"tag_name")) };
+        }
+        catch (...)
+        {
+        }
+        return std::nullopt;
+    }
+
+    std::pair<Uri, std::wstring> extract_installer_asset_download_info(const json::JsonObject& release_object)
+    {
+        const std::wstring_view required_architecture = get_architecture_string(get_current_architecture());
+        constexpr const std::wstring_view required_filename_pattern = updating::INSTALLER_FILENAME_PATTERN;
+        // Desc-sorted by its priority
+        const std::array<std::wstring_view, 2> asset_extensions = { L".exe", L".msi" };
+        for (const auto asset_extension : asset_extensions)
+        {
+            for (auto asset_elem : release_object.GetNamedArray(L"assets"))
+            {
+                auto asset{ asset_elem.GetObjectW() };
+                std::wstring filename_lower = asset.GetNamedString(L"name", {}).c_str();
+                std::transform(begin(filename_lower), end(filename_lower), begin(filename_lower), ::towlower);
+
+                const bool extension_matched = filename_lower.ends_with(asset_extension);
+                const bool architecture_matched = filename_lower.find(required_architecture) != std::wstring::npos;
+                const bool filename_matched = filename_lower.find(required_filename_pattern) != std::wstring::npos;
+                const bool asset_matched = extension_matched && architecture_matched && filename_matched;
+                if (extension_matched && architecture_matched && filename_matched)
+                {
+                    return std::make_pair(Uri{ asset.GetNamedString(L"browser_download_url") }, std::move(filename_lower));
+                }
+            }
+        }
+
+        throw std::runtime_error("Release object doesn't have the required asset");
+    }
+
+    std::future<nonstd::expected<new_version_download_info, std::wstring>> get_new_github_version_info_async(const notifications::strings& strings, const bool prerelease)
     {
         // If the current version starts with 0.0.*, it means we're on a local build from a farm and shouldn't check for updates.
         if (VERSION_MAJOR == 0 && VERSION_MINOR == 0)
@@ -38,46 +79,53 @@ namespace updating
         try
         {
             http::HttpClient client;
-            const auto body = co_await client.request(winrt::Windows::Foundation::Uri{ LATEST_RELEASE_ENDPOINT });
-            auto json_body = json::JsonValue::Parse(body).GetObjectW();
-            auto new_version = json_body.GetNamedString(L"tag_name");
-            winrt::Windows::Foundation::Uri release_page_uri{ json_body.GetNamedString(L"html_url") };
-
-            VersionHelper github_version(winrt::to_string(new_version));
-            VersionHelper current_version(VERSION_MAJOR, VERSION_MINOR, VERSION_REVISION);
+            json::JsonObject release_object;
+            const VersionHelper current_version(VERSION_MAJOR, VERSION_MINOR, VERSION_REVISION);
+            VersionHelper github_version = current_version;
+            if (prerelease)
+            {
+                const auto body = co_await client.request(Uri{ ALL_RELEASES_ENDPOINT });
+                for (const auto& json : json::JsonValue::Parse(body).GetArray())
+                {
+                    auto potential_release_object = json.GetObjectW();
+                    const bool is_prerelease = potential_release_object.GetNamedBoolean(L"prerelease", false);
+                    auto extracted_version = extract_version_from_release_object(potential_release_object);
+                    if (!is_prerelease || !extracted_version || *extracted_version <= github_version)
+                    {
+                        continue;
+                    }
+                    // Do not break, since https://developer.github.com/v3/repos/releases/#list-releases
+                    // doesn't specify the order in which release object appear
+                    github_version = std::move(*extracted_version);
+                    release_object = std::move(potential_release_object);
+                }
+            }
+            else
+            {
+                const auto body = co_await client.request(Uri{ LATEST_RELEASE_ENDPOINT });
+                release_object = json::JsonValue::Parse(body).GetObjectW();
+                if (auto extracted_version = extract_version_from_release_object(release_object))
+                {
+                    github_version = *extracted_version;
+                }
+            }
 
             if (github_version <= current_version)
             {
                 co_return nonstd::make_unexpected(strings.GITHUB_NEW_VERSION_UP_TO_DATE);
             }
 
-            const std::wstring_view required_architecture = get_architecture_string(get_current_architecture());
-            constexpr const std::wstring_view required_filename_pattern = updating::INSTALLER_FILENAME_PATTERN;
-            // Desc-sorted by its priority
-            const std::array<std::wstring_view, 2> asset_extensions = { L".exe", L".msi" };
-            for (const auto asset_extension : asset_extensions)
-            {
-                for (auto asset_elem : json_body.GetNamedArray(L"assets"))
-                {
-                    auto asset{ asset_elem.GetObjectW() };
-                    std::wstring filename_lower = asset.GetNamedString(L"name", {}).c_str();
-                    std::transform(begin(filename_lower), end(filename_lower), begin(filename_lower), ::towlower);
-
-                    const bool extension_matched = filename_lower.ends_with(asset_extension);
-                    const bool architecture_matched = filename_lower.find(required_architecture) != std::wstring::npos;
-                    const bool filename_matched = filename_lower.find(required_filename_pattern) != std::wstring::npos;
-                    if (extension_matched && architecture_matched && filename_matched)
-                    {
-                        winrt::Windows::Foundation::Uri msi_download_url{ asset.GetNamedString(L"browser_download_url") };
-                        co_return new_version_download_info{ std::move(release_page_uri), new_version.c_str(), std::move(msi_download_url), std::move(filename_lower) };
-                    }
-                }
-            }
+            Uri release_page_url{ release_object.GetNamedString(L"html_url") };
+            auto installer_download_url = extract_installer_asset_download_info(release_object);
+            co_return new_version_download_info{ std::move(release_page_url),
+                                                 std::move(github_version),
+                                                 std::move(installer_download_url.first),
+                                                 std::move(installer_download_url.second) };
         }
         catch (...)
         {
-            co_return nonstd::make_unexpected(strings.GITHUB_NEW_VERSION_CHECK_ERROR);
         }
+        co_return nonstd::make_unexpected(strings.GITHUB_NEW_VERSION_CHECK_ERROR);
     }
 
     bool could_be_costly_connection()
@@ -140,19 +188,6 @@ namespace updating
         {
             updating::notifications::show_visit_github(new_version.value(), strings);
         }
-    }
-
-    std::future<std::wstring> check_new_version_available(const notifications::strings& strings)
-    {
-        auto new_version = co_await get_new_github_version_info_async(strings);
-        if (!new_version)
-        {
-            updating::notifications::show_unavailable(strings, std::move(new_version.error()));
-            co_return VersionHelper{ VERSION_MAJOR, VERSION_MINOR, VERSION_REVISION }.toWstring();
-        }
-
-        updating::notifications::show_available(new_version.value(), strings);
-        co_return new_version->version_string;
     }
 
     std::future<std::wstring> download_update(const notifications::strings& strings)

--- a/src/common/updating/updating.h
+++ b/src/common/updating/updating.h
@@ -5,25 +5,26 @@
 #include <future>
 #include <filesystem>
 #include <winrt/Windows.Foundation.h>
+#include <expected.hpp>
 
 #include "notifications.h"
 #include "../VersionHelper.h"
 
 namespace updating
 {
+    using winrt::Windows::Foundation::Uri;
     struct new_version_download_info
     {
-        winrt::Windows::Foundation::Uri release_page_uri = nullptr;
-        std::wstring version_string;
-        winrt::Windows::Foundation::Uri installer_download_url = nullptr;
+        Uri release_page_uri = nullptr;
+        VersionHelper version{ 0, 0, 0 };
+        Uri installer_download_url = nullptr;
         std::wstring installer_filename;
     };
 
     std::future<void> try_autoupdate(const bool download_updates_automatically, const notifications::strings&);
     std::filesystem::path get_pending_updates_path();
-
-    std::future<std::wstring> check_new_version_available(const notifications::strings&);
     std::future<std::wstring> download_update(const notifications::strings&);
+    std::future<nonstd::expected<new_version_download_info, std::wstring>> get_new_github_version_info_async(const notifications::strings& strings, const bool prerelease = false);
 
     // non-localized
     constexpr inline std::wstring_view INSTALLER_FILENAME_PATTERN = L"powertoyssetup";

--- a/src/runner/runner.vcxproj
+++ b/src/runner/runner.vcxproj
@@ -22,6 +22,7 @@
     <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="..\..\deps\expected.props" />
   <ImportGroup Label="Shared" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>

--- a/src/runner/settings_window.cpp
+++ b/src/runner/settings_window.cpp
@@ -81,13 +81,14 @@ std::optional<std::wstring> dispatch_json_action_to_module(const json::JsonObjec
                 }
                 else if (action == L"check_for_updates")
                 {
-                    std::wstring latestVersion = check_for_updates();
-                    VersionHelper current_version(VERSION_MAJOR, VERSION_MINOR, VERSION_REVISION);
-                    bool isRunningLatest = latestVersion.compare(current_version.toWstring()) == 0;
+                    auto new_version_info = check_for_updates();
+                    const VersionHelper latestVersion =
+                        new_version_info ? new_version_info->version :
+                                           VersionHelper{ VERSION_MAJOR, VERSION_MINOR, VERSION_REVISION };
 
                     json::JsonObject json;
-                    json.SetNamedValue(L"version", json::JsonValue::CreateStringValue(latestVersion));
-                    json.SetNamedValue(L"isVersionLatest", json::JsonValue::CreateBooleanValue(isRunningLatest));
+                    json.SetNamedValue(L"version", json::JsonValue::CreateStringValue(latestVersion.toWstring()));
+                    json.SetNamedValue(L"isVersionLatest", json::JsonValue::CreateBooleanValue(!new_version_info));
 
                     result.emplace(json.Stringify());
                 }

--- a/src/runner/update_utils.h
+++ b/src/runner/update_utils.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <common/updating/updating.h>
+
 bool start_msi_uninstallation_sequence();
 void github_update_worker();
-std::wstring check_for_updates();
+std::optional<updating::new_version_download_info> check_for_updates();
 bool launch_pending_update();


### PR DESCRIPTION
## Summary of the Pull Request

We need a different method of updating when using Github's prerelease API. 

## PR Checklist
* [x] Applies to #8291

## Validation Steps Performed

- update from a local build with the 0.0-version-check commented out