### PR TITLE
ColorPicker: don't show context menu when color history is empty

### DIFF
--- a/src/modules/colorPicker/ColorPickerUI/ViewModels/ColorEditorViewModel.cs
+++ b/src/modules/colorPicker/ColorPickerUI/ViewModels/ColorEditorViewModel.cs
@@ -130,6 +130,12 @@ namespace ColorPicker.ViewModels
 
         private void DeleteSelectedColor()
         {
+            if (ColorsHistory.Count == 0)
+            {
+                // nothing to do
+                return;
+            }
+
             // select new color on the same index if possible, otherwise the last one
             var indexToSelect = SelectedColorIndex == ColorsHistory.Count - 1 ? ColorsHistory.Count - 2 : SelectedColorIndex;
             ColorsHistory.RemoveAt(SelectedColorIndex);

--- a/src/modules/colorPicker/ColorPickerUI/Views/ColorEditorView.xaml
+++ b/src/modules/colorPicker/ColorPickerUI/Views/ColorEditorView.xaml
@@ -27,9 +27,11 @@
                          ItemsSource="{Binding ColorsHistory}"
                          SelectedIndex="{Binding SelectedColorIndex}"
                          ItemContainerStyle="{DynamicResource ColorHistoryListViewStyle}">
-                <ui:ListView.ContextMenu>
-                    <ContextMenu>
-                        <MenuItem Header="{x:Static p:Resources.Remove}"
+        <ui:ListView.ContextMenu>
+          <ContextMenu 
+              Visibility="{Binding ColorsHistory.Count, Converter={StaticResource numberToVisibilityConverter}}">
+                        <MenuItem
+                                  Header="{x:Static p:Resources.Remove}"
                                   Command="{Binding RemoveColorCommand}">
                             <MenuItem.Icon>
                                 <ui:FontIcon Glyph="&#xE107;" />


### PR DESCRIPTION
## Summary of the Pull Request

also check index in relay command as an additional precaution

## PR Checklist
* [x] Applies to #8322

## Validation Steps Performed

play with color history 