### PR TITLE
Fixing issues when color picker freezes

### DIFF
--- a/src/modules/colorPicker/ColorPickerUI/Helpers/AppStateHandler.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/AppStateHandler.cs
@@ -14,6 +14,8 @@ namespace ColorPicker.Helpers
     {
         private readonly IColorEditorViewModel _colorEditorViewModel;
         private ColorEditorWindow _colorEditorWindow;
+        private bool _colorPickerShown;
+        private object _colorPickerVisibilityLock = new object();
 
         [ImportingConstructor]
         public AppStateHandler(IColorEditorViewModel colorEditorViewModel)
@@ -30,16 +32,30 @@ namespace ColorPicker.Helpers
 
         public void ShowColorPicker()
         {
-            AppShown?.Invoke(this, EventArgs.Empty);
-            Application.Current.MainWindow.Opacity = 0;
-            Application.Current.MainWindow.Visibility = Visibility.Visible;
+            lock (_colorPickerVisibilityLock)
+            {
+                if (!_colorPickerShown)
+                {
+                    AppShown?.Invoke(this, EventArgs.Empty);
+                    Application.Current.MainWindow.Opacity = 0;
+                    Application.Current.MainWindow.Visibility = Visibility.Visible;
+                    _colorPickerShown = true;
+                }
+            }
         }
 
         public void HideColorPicker()
         {
-            Application.Current.MainWindow.Opacity = 0;
-            Application.Current.MainWindow.Visibility = Visibility.Collapsed;
-            AppHidden?.Invoke(this, EventArgs.Empty);
+            lock (_colorPickerVisibilityLock)
+            {
+                if (_colorPickerShown)
+                {
+                    Application.Current.MainWindow.Opacity = 0;
+                    Application.Current.MainWindow.Visibility = Visibility.Collapsed;
+                    AppHidden?.Invoke(this, EventArgs.Empty);
+                    _colorPickerShown = false;
+                }
+            }
         }
 
         public void ShowColorPickerEditor()

--- a/src/modules/colorPicker/ColorPickerUI/Helpers/ClipboardHelper.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/ClipboardHelper.cs
@@ -23,7 +23,7 @@ namespace ColorPicker.Helpers
                 {
                     try
                     {
-                        Clipboard.SetText(colorRepresentationToCopy);
+                        Clipboard.SetDataObject(colorRepresentationToCopy);
                         break;
                     }
                     catch (COMException ex)

--- a/src/modules/colorPicker/ColorPickerUI/Helpers/ClipboardHelper.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/ClipboardHelper.cs
@@ -3,7 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Windows;
+using static ColorPicker.NativeMethods;
 
 namespace ColorPicker.Helpers
 {
@@ -28,9 +30,18 @@ namespace ColorPicker.Helpers
                     }
                     catch (COMException ex)
                     {
+                        var hwnd = GetOpenClipboardWindow();
+                        var sb = new StringBuilder(501);
+                        _ = GetWindowText(hwnd.ToInt32(), sb, 500);
+                        var applicationUsingClipboard = sb.ToString();
+
                         if ((uint)ex.ErrorCode != ErrorCodeClipboardCantOpen)
                         {
                             Logger.LogError("Failed to set text into clipboard", ex);
+                        }
+                        else
+                        {
+                            Logger.LogError("Failed to set text into clipboard, application that is locking clipboard - " + applicationUsingClipboard, ex);
                         }
                     }
 

--- a/src/modules/colorPicker/ColorPickerUI/Keyboard/KeyboardMonitor.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Keyboard/KeyboardMonitor.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using System.Diagnostics;
 using System.Windows.Input;
 using ColorPicker.Helpers;
 using ColorPicker.Settings;
@@ -21,10 +22,12 @@ namespace ColorPicker.Keyboard
     {
         private readonly AppStateHandler _appStateHandler;
         private readonly IUserSettings _userSettings;
+        private List<string> _previouslyPressedKeys;
 
         private List<string> _activationKeys = new List<string>();
         private GlobalKeyboardHook _keyboardHook;
         private bool disposedValue;
+        private bool _activationShortcutPressed;
 
         [ImportingConstructor]
         public KeyboardMonitor(AppStateHandler appStateHandler, IUserSettings userSettings)
@@ -80,26 +83,38 @@ namespace ColorPicker.Keyboard
             // If the last key pressed is a modifier key, then currentlyPressedKeys cannot possibly match with _activationKeys
             // because _activationKeys contains exactly 1 non-modifier key. Hence, there's no need to check if `name` is a
             // modifier key or to do any additional processing on it.
-
-            // Check pressed modifier keys.
-            AddModifierKeys(currentlyPressedKeys);
-
             if (e.KeyboardState == GlobalKeyboardHook.KeyboardState.KeyDown || e.KeyboardState == GlobalKeyboardHook.KeyboardState.SysKeyDown)
             {
+                // Check pressed modifier keys.
+                AddModifierKeys(currentlyPressedKeys);
+
                 currentlyPressedKeys.Add(name);
             }
 
             currentlyPressedKeys.Sort();
 
+            if (currentlyPressedKeys.Count == 0 && _previouslyPressedKeys.Count != 0)
+            {
+                // no keys pressed, we can enable activation shortcut again
+                _activationShortcutPressed = false;
+            }
+
+            _previouslyPressedKeys = currentlyPressedKeys;
+
             if (ArraysAreSame(currentlyPressedKeys, _activationKeys))
             {
-                if (_userSettings.ActivationAction.Value == ColorPickerActivationAction.OpenEditor)
+                // avoid triggering this action multiple times as this will be called nonstop while keys are pressed
+                if (!_activationShortcutPressed)
                 {
-                    _appStateHandler.ShowColorPickerEditor();
-                }
-                else
-                {
-                    _appStateHandler.ShowColorPicker();
+                    _activationShortcutPressed = true;
+                    if (_userSettings.ActivationAction.Value == ColorPickerActivationAction.OpenEditor)
+                    {
+                        _appStateHandler.ShowColorPickerEditor();
+                    }
+                    else
+                    {
+                        _appStateHandler.ShowColorPicker();
+                    }
                 }
             }
         }

--- a/src/modules/colorPicker/ColorPickerUI/NativeMethods.cs
+++ b/src/modules/colorPicker/ColorPickerUI/NativeMethods.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
+using System.Text;
 
 namespace ColorPicker
 {
@@ -161,5 +162,11 @@ namespace ColorPicker
             /// </summary>
             public IntPtr AdditionalInformation;
         }
+
+        [DllImport("user32.dll")]
+        internal static extern IntPtr GetOpenClipboardWindow();
+
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+        internal static extern int GetWindowText(int hwnd, StringBuilder text, int count);
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request

Color picker can freeze when you pick a color because we are trying to access clipboard using `Clipboard.SetText` - but this method might as some other applications can hold clipboard.
Switching to use `Clipboard.SetDataObject` I couldn't reproduce this issue anymore

This also fixes another issue when user holds activations keys while picking - this was causing that show picker was called many times and in the end it resulted in a nasty bug where we called copy into clipboard and into the editor nonstop.  Can be seen here - https://youtu.be/6mzs90-KlMg?t=195
Described also here #6594

## PR Checklist
* [x] Applies to #6594
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request


## Validation Steps Performed
Unless you use some special tools for clipboard, it is hard to reproduce as it can happen randomly, but to get a stable reproduction, install [Clipjump](http://clipjump.sourceforge.net/) tool with this running this issue is reproducible all the time and it basically simulate the same issue that can happen randomly with some other application. With the fix, this issue does not appear anymore. 

The other issue can be easily reproduced by holding activation keys while picking a color.