### PR TITLE
Color picker netcore 31

### DIFF
--- a/.pipelines/pipeline.user.windows.yml
+++ b/.pipelines/pipeline.user.windows.yml
@@ -64,7 +64,8 @@ build:
           include:
             - 'action_runner.exe'
             - 'modules\ColorPicker\ColorPicker.dll'
-            - 'modules\ColorPicker\ColorPicker.exe'
+            - 'modules\ColorPicker\ColorPickerUI.dll'
+            - 'modules\ColorPicker\ColorPickerUI.exe'
             - 'modules\ColorPicker\ManagedCommon.dll'
             - 'modules\ColorPicker\Microsoft.PowerToys.Settings.UI.Lib.dll'
             - 'modules\ColorPicker\PowerToysInterop.dll'

--- a/installer/PowerToysSetup/Product.wxs
+++ b/installer/PowerToysSetup/Product.wxs
@@ -577,7 +577,7 @@
 
     <DirectoryRef Id="ColorPickerInstallFolder" FileSource="$(var.BinX64Dir)modules\$(var.ColorPickerProjectName)">
       <Component Id="Module_ColorPicker" Guid="8A52A69E-37B2-4BEA-9D73-77763066052F" Win64="yes">
-        <?foreach File in ColorPicker.dll;System.IO.Abstractions.dll;ColorPicker.exe;ColorPicker.exe.config;Microsoft.Bcl.AsyncInterfaces.dll;Microsoft.Expression.Interactions.dll;Microsoft.PowerToys.Settings.UI.Lib.dll;PowerToysInterop.dll;System.Buffers.dll;System.Memory.dll;System.Numerics.Vectors.dll;System.Text.Encodings.Web.dll;System.Text.Json.dll;System.Threading.Tasks.Extensions.dll;System.ValueTuple.dll;System.Windows.Interactivity.dll;Telemetry.dll;ManagedCommon.dll;System.Runtime.CompilerServices.Unsafe.dll;ControlzEx.dll;Microsoft.Xaml.Behaviors.dll;ModernWpf.Controls.dll;ModernWpf.dll?>
+        <?foreach File in ColorPicker.dll;System.IO.Abstractions.dll;ColorPickerUI.exe;ColorPickerUI.dll;ColorPickerUI.deps.json;ColorPickerUI.runtimeconfig.json;Microsoft.PowerToys.Settings.UI.Lib.dll;PowerToysInterop.dll;System.Text.Json.dll;Telemetry.dll;ManagedCommon.dll;ControlzEx.dll;Microsoft.Xaml.Behaviors.dll;ModernWpf.Controls.dll;ModernWpf.dll;System.ComponentModel.Composition.dll?>
         <File Id="ColorPickerFile_$(var.File)" Source="$(var.BinX64Dir)modules\$(var.ColorPickerProjectName)\$(var.File)" />
         <?endforeach?>
       </Component>

--- a/src/modules/colorPicker/ColorPicker/dllmain.cpp
+++ b/src/modules/colorPicker/ColorPicker/dllmain.cpp
@@ -129,7 +129,7 @@ public:
 
             SHELLEXECUTEINFOW sei{ sizeof(sei) };
             sei.fMask = { SEE_MASK_NOCLOSEPROCESS | SEE_MASK_FLAG_NO_UI };
-            sei.lpFile = L"modules\\ColorPicker\\ColorPicker.exe";
+            sei.lpFile = L"modules\\ColorPicker\\ColorPickerUI.exe";
             sei.nShow = SW_SHOWNORMAL;
             sei.lpParameters = executable_args.data();
             ShellExecuteExW(&sei);

--- a/src/modules/colorPicker/ColorPickerUI/App.config
+++ b/src/modules/colorPicker/ColorPickerUI/App.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<configuration>
-    <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
-    </startup>
-</configuration>

--- a/src/modules/colorPicker/ColorPickerUI/App.xaml.cs
+++ b/src/modules/colorPicker/ColorPickerUI/App.xaml.cs
@@ -23,30 +23,10 @@ namespace ColorPickerUI
         private bool disposedValue;
         private ThemeManager _themeManager;
 
-        [STAThread]
-        public static void Main(string[] args)
-        {
-            _args = args;
-            AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
-            try
-            {
-                using (var application = new App())
-                {
-                    application.InitializeComponent();
-                    application.Run();
-                }
-            }
-#pragma warning disable CA1031 // Do not catch general exception types
-            catch (Exception ex)
-#pragma warning restore CA1031 // Do not catch general exception types
-            {
-                Logger.LogError("Unhandled exception", ex);
-                CursorManager.RestoreOriginalCursors();
-            }
-        }
-
         protected override void OnStartup(StartupEventArgs e)
         {
+            _args = e?.Args;
+
             // allow only one instance of color picker
             _instanceMutex = new Mutex(true, @"Global\ColorPicker", out bool createdNew);
             if (!createdNew)
@@ -56,7 +36,7 @@ namespace ColorPickerUI
                 return;
             }
 
-            if (_args.Length > 0)
+            if (_args?.Length > 0)
             {
                 _ = int.TryParse(_args[0], out _powerToysPid);
             }
@@ -79,12 +59,6 @@ namespace ColorPickerUI
 
             CursorManager.RestoreOriginalCursors();
             base.OnExit(e);
-        }
-
-        private static void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
-        {
-            Logger.LogError("Unhandled exception", (e.ExceptionObject is Exception) ? (e.ExceptionObject as Exception) : new Exception());
-            CursorManager.RestoreOriginalCursors();
         }
 
         protected virtual void Dispose(bool disposing)

--- a/src/modules/colorPicker/ColorPickerUI/Behaviors/AppearAnimationBehavior.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Behaviors/AppearAnimationBehavior.cs
@@ -4,8 +4,8 @@
 
 using System;
 using System.Windows;
-using System.Windows.Interactivity;
 using System.Windows.Media.Animation;
+using Microsoft.Xaml.Behaviors;
 
 namespace ColorPicker.Behaviors
 {

--- a/src/modules/colorPicker/ColorPickerUI/Behaviors/ChangeWindowPositionBehavior.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Behaviors/ChangeWindowPositionBehavior.cs
@@ -3,9 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Windows;
-using System.Windows.Interactivity;
 using ColorPicker.Helpers;
 using ColorPicker.Mouse;
+using Microsoft.Xaml.Behaviors;
 
 namespace ColorPicker.Behaviors
 {

--- a/src/modules/colorPicker/ColorPickerUI/Behaviors/CloseZoomWindowBehavior.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Behaviors/CloseZoomWindowBehavior.cs
@@ -3,8 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Windows;
-using System.Windows.Interactivity;
 using ColorPicker.Helpers;
+using Microsoft.Xaml.Behaviors;
 
 namespace ColorPicker.Behaviors
 {

--- a/src/modules/colorPicker/ColorPickerUI/Behaviors/DragAndDropReorderBehavior.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Behaviors/DragAndDropReorderBehavior.cs
@@ -9,8 +9,8 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
-using System.Windows.Interactivity;
 using ColorPicker.Models;
+using Microsoft.Xaml.Behaviors;
 
 namespace ColorPicker.Behaviors
 {

--- a/src/modules/colorPicker/ColorPickerUI/Behaviors/DragWindowBehavior.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Behaviors/DragWindowBehavior.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Windows;
-using System.Windows.Interactivity;
+using Microsoft.Xaml.Behaviors;
 
 namespace ColorPicker.Behaviors
 {

--- a/src/modules/colorPicker/ColorPickerUI/Behaviors/GridEffectBehavior.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Behaviors/GridEffectBehavior.cs
@@ -3,8 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Windows;
-using System.Windows.Interactivity;
 using ColorPicker.Shaders;
+using Microsoft.Xaml.Behaviors;
 
 namespace ColorPicker.Behaviors
 {

--- a/src/modules/colorPicker/ColorPickerUI/Behaviors/MoveWindowBehavior.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Behaviors/MoveWindowBehavior.cs
@@ -4,8 +4,8 @@
 
 using System;
 using System.Windows;
-using System.Windows.Interactivity;
 using System.Windows.Media.Animation;
+using Microsoft.Xaml.Behaviors;
 
 namespace ColorPicker.Behaviors
 {

--- a/src/modules/colorPicker/ColorPickerUI/Behaviors/ResizeBehavior.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Behaviors/ResizeBehavior.cs
@@ -4,8 +4,8 @@
 
 using System;
 using System.Windows;
-using System.Windows.Interactivity;
 using System.Windows.Media.Animation;
+using Microsoft.Xaml.Behaviors;
 
 namespace ColorPicker.Behaviors
 {

--- a/src/modules/colorPicker/ColorPickerUI/ColorEditorWindow.xaml
+++ b/src/modules/colorPicker/ColorPickerUI/ColorEditorWindow.xaml
@@ -7,7 +7,7 @@
         xmlns:p="clr-namespace:ColorPicker.Properties"
         mc:Ignorable="d"
         AutomationProperties.Name="{x:Static p:Resources.cp_editor}"
-        xmlns:e="http://schemas.microsoft.com/expression/2010/interactivity"
+        xmlns:e="http://schemas.microsoft.com/xaml/behaviors"
         xmlns:behaviors="clr-namespace:ColorPicker.Behaviors"
         ui:TitleBar.ExtendViewIntoTitleBar="True"
         ui:TitleBar.ButtonStyle="{DynamicResource AppTitleBarButtonStyle}"

--- a/src/modules/colorPicker/ColorPickerUI/ColorPickerUI.csproj
+++ b/src/modules/colorPicker/ColorPickerUI/ColorPickerUI.csproj
@@ -7,6 +7,7 @@
     <AssemblyCopyright>Copyright (C) 2020 Microsoft Corporation</AssemblyCopyright>
     <AssemblyProduct>PowerToys</AssemblyProduct>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\modules\ColorPicker</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <UseWPF>true</UseWPF>
@@ -25,7 +26,6 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>..\..\..\..\x64\Debug\modules\ColorPicker\</OutputPath>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DebugType>full</DebugType>

--- a/src/modules/colorPicker/ColorPickerUI/ColorPickerUI.csproj
+++ b/src/modules/colorPicker/ColorPickerUI/ColorPickerUI.csproj
@@ -11,6 +11,7 @@
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <UseWPF>true</UseWPF>
     <Platforms>x64</Platforms>
+    <StartupObject>ColorPicker.Program</StartupObject>
   </PropertyGroup>
   <PropertyGroup>
     <Platform Condition=" '$(Platform)' == '' ">x64</Platform>

--- a/src/modules/colorPicker/ColorPickerUI/ColorPickerUI.csproj
+++ b/src/modules/colorPicker/ColorPickerUI/ColorPickerUI.csproj
@@ -1,84 +1,65 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+    <Import Project="..\..\..\Version.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyTitle>ColorPicker</AssemblyTitle>
     <AssemblyDescription>PowerToys ColorPicker</AssemblyDescription>
     <AssemblyCompany>Microsoft Corp.</AssemblyCompany>
     <AssemblyCopyright>Copyright (C) 2020 Microsoft Corporation</AssemblyCopyright>
     <AssemblyProduct>PowerToys</AssemblyProduct>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <CodeAnalysisRuleSet>..\..\..\codeAnalysis\Rules.ruleset</CodeAnalysisRuleSet>
+    <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\modules\ColorPicker</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <UseWPF>true</UseWPF>
+    <Platforms>x64</Platforms>
   </PropertyGroup>
-  <ItemGroup>
-    <AssemblyVersionFiles Include="Generated Files\AssemblyInfo.cs" />
-  </ItemGroup>
-  <Import Project="..\..\..\Version.props" />
-  <Target Name="GenerateAssemblyInfo" BeforeTargets="PrepareForBuild">
-    <ItemGroup>
-      <HeaderLines Include="// Copyright (c) Microsoft Corporation" />
-      <HeaderLines Include="// The Microsoft Corporation licenses this file to you under the MIT license." />
-      <HeaderLines Include="// See the LICENSE file in the project root for more information." />
-      <HeaderLines Include="#pragma warning disable SA1516" />
-      <HeaderLines Include="using System.Reflection%3b" />
-      <HeaderLines Include="using System.Resources%3b" />
-      <HeaderLines Include="using System.Runtime.InteropServices%3b" />
-      <HeaderLines Include="using System.Windows%3b" />
-      <HeaderLines Include="[assembly: AssemblyTitle(&quot;$(AssemblyTitle)&quot;)]" />
-      <HeaderLines Include="[assembly: AssemblyDescription(&quot;$(AssemblyDescription)&quot;)]" />
-      <HeaderLines Include="[assembly: AssemblyConfiguration(&quot;&quot;)]" />
-      <HeaderLines Include="[assembly: AssemblyCompany(&quot;$(AssemblyCompany)&quot;)]" />
-      <HeaderLines Include="[assembly: AssemblyCopyright(&quot;$(AssemblyCopyright)&quot;)]" />
-      <HeaderLines Include="[assembly: AssemblyProduct(&quot;$(AssemblyProduct)&quot;)]" />
-      <HeaderLines Include="[assembly: AssemblyTrademark(&quot;&quot;)]" />
-      <HeaderLines Include="[assembly: AssemblyCulture(&quot;&quot;)]" />
-      <HeaderLines Include="[assembly: ComVisible(false)]" />
-      <HeaderLines Include="[assembly: NeutralResourcesLanguage(&quot;en-US&quot;)]" />
-      <HeaderLines Include="[assembly: ThemeInfo(ResourceDictionaryLocation.None, ResourceDictionaryLocation.SourceAssembly)]" />
-      <HeaderLines Include="[assembly: AssemblyVersion(&quot;$(Version).0&quot;)]" />
-      <HeaderLines Include="[assembly: AssemblyFileVersion(&quot;$(Version).0&quot;)]" />
-    </ItemGroup>
-    <WriteLinesToFile File="Generated Files\AssemblyInfo.cs" Lines="@(HeaderLines)" Overwrite="true" Encoding="Unicode" WriteOnlyWhenDifferent="true" />
-  </Target>
   <PropertyGroup>
+    <Platform Condition=" '$(Platform)' == '' ">x64</Platform>
+    <ProjectGuid>{BA58206B-1493-4C75-BFEA-A85768A1E156}</ProjectGuid>
     <OutputType>WinExe</OutputType>
     <RootNamespace>ColorPicker</RootNamespace>
     <AssemblyName>ColorPicker</AssemblyName>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <IntermediateOutputPath>$(SolutionDir)$(Platform)\$(Configuration)\obj\$(AssemblyName)\</IntermediateOutputPath>
   </PropertyGroup>
-  <PropertyGroup>
-    <ApplicationManifest>App.manifest</ApplicationManifest>
-  </PropertyGroup>
+  <PropertyGroup />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
-    <OutputPath>..\..\..\..\x64\Debug\modules\ColorPicker\</OutputPath>
-    <LangVersion>8.0</LangVersion>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Optimize>false</Optimize>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
-    <OutputPath>..\..\..\..\x64\Release\modules\ColorPicker\</OutputPath>
-    <LangVersion>8.0</LangVersion>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Optimize>true</Optimize>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>Resources\icon.ico</ApplicationIcon>
+    <NeutralLanguage>en-US</NeutralLanguage>
   </PropertyGroup>
   <ItemGroup>
     <Resource Include="Shaders\GridShader.cso" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ControlzEx" Version="4.4.0"/>
+    <PackageReference Include="ControlzEx" Version="4.4.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="ModernWpfUI" Version="0.9.2"/>
+    <PackageReference Include="ModernWpfUI" Version="0.9.2" />
     <PackageReference Include="System.ComponentModel.Composition" Version="5.0.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
-    <PackageReference Include="System.IO.Abstractions" Version="12.2.5"/>
+    <PackageReference Include="System.IO.Abstractions" Version="12.2.5" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.19" />
+    <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
   </ItemGroup>
   <ItemGroup>
+    <None Update="Properties\Settings.settings">
+      <Generator>SettingsSingleFileGenerator</Generator>
+      <LastGenOutput>Settings.Designer.cs</LastGenOutput>
+    </None>
     <None Update="Resources\colorPicker.cur">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
@@ -92,12 +73,15 @@
     <ProjectReference Include="..\..\..\core\Microsoft.PowerToys.Settings.UI.Library\Microsoft.PowerToys.Settings.UI.Library.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\..\..\codeAnalysis\GlobalSuppressions.cs">
-      <Link>GlobalSuppressions.cs</Link>
-    </Compile>
-    <AdditionalFiles Include="..\..\..\codeAnalysis\StyleCop.json">
-      <Link>StyleCop.json</Link>
-    </AdditionalFiles>
+    <Compile Include="..\..\..\codeAnalysis\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />
+    <AdditionalFiles Include="..\..\..\codeAnalysis\StyleCop.json" Link="StyleCop.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Update="Properties\Resources.resx">
+      <Generator>PublicResXFileCodeGenerator</Generator>
+      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
@@ -107,5 +91,17 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="Shaders\GridShader.fx" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Update="Properties\Resources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Resources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="Properties\Settings.Designer.cs">
+      <DesignTimeSharedInput>True</DesignTimeSharedInput>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Settings.settings</DependentUpon>
+    </Compile>
   </ItemGroup>
 </Project>

--- a/src/modules/colorPicker/ColorPickerUI/ColorPickerUI.csproj
+++ b/src/modules/colorPicker/ColorPickerUI/ColorPickerUI.csproj
@@ -6,8 +6,7 @@
     <AssemblyCompany>Microsoft Corp.</AssemblyCompany>
     <AssemblyCopyright>Copyright (C) 2020 Microsoft Corporation</AssemblyCopyright>
     <AssemblyProduct>PowerToys</AssemblyProduct>
-    <CodeAnalysisRuleSet>..\..\..\codeAnalysis\Rules.ruleset</CodeAnalysisRuleSet>
-    <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\modules\ColorPicker</OutputPath>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <UseWPF>true</UseWPF>
@@ -20,16 +19,22 @@
     <RootNamespace>ColorPicker</RootNamespace>
     <AssemblyName>ColorPicker</AssemblyName>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <LangVersion>8.0</LangVersion>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <IntermediateOutputPath>$(SolutionDir)$(Platform)\$(Configuration)\obj\$(AssemblyName)\</IntermediateOutputPath>
   </PropertyGroup>
-  <PropertyGroup />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>..\..\..\..\x64\Debug\modules\ColorPicker\</OutputPath>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <DefineConstants>TRACE</DefineConstants>
+    <DebugType>pdbonly</DebugType>
+    <ErrorReport>prompt</ErrorReport>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Optimize>true</Optimize>
     <PlatformTarget>x64</PlatformTarget>
@@ -37,6 +42,7 @@
   <PropertyGroup>
     <ApplicationIcon>Resources\icon.ico</ApplicationIcon>
     <NeutralLanguage>en-US</NeutralLanguage>
+    <ApplicationManifest>App.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
     <Resource Include="Shaders\GridShader.cso" />
@@ -97,11 +103,6 @@
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
       <DependentUpon>Resources.resx</DependentUpon>
-    </Compile>
-    <Compile Update="Properties\Settings.Designer.cs">
-      <DesignTimeSharedInput>True</DesignTimeSharedInput>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Settings.settings</DependentUpon>
     </Compile>
   </ItemGroup>
 </Project>

--- a/src/modules/colorPicker/ColorPickerUI/ColorPickerUI.csproj
+++ b/src/modules/colorPicker/ColorPickerUI/ColorPickerUI.csproj
@@ -66,26 +66,17 @@
     <Resource Include="Shaders\GridShader.cso" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ControlzEx">
-      <Version>4.4.0</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers">
-      <Version>3.3.0</Version>
+    <PackageReference Include="ControlzEx" Version="4.4.0"/>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="ModernWpfUI">
-      <Version>0.9.2</Version>
-    </PackageReference>
+    <PackageReference Include="ModernWpfUI" Version="0.9.2"/>
     <PackageReference Include="System.ComponentModel.Composition" Version="5.0.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
-    <PackageReference Include="System.IO.Abstractions">
-      <Version>12.2.5</Version>
-    </PackageReference>
-    <PackageReference Include="System.Windows.Interactivity.WPF">
-      <Version>2.0.20525</Version>
-    </PackageReference>
+    <PackageReference Include="System.IO.Abstractions" Version="12.2.5"/>
+    <PackageReference Include="System.Windows.Interactivity.WPF" Version="2.0.20525"/>
   </ItemGroup>
   <ItemGroup>
     <None Update="Resources\colorPicker.cur">
@@ -109,8 +100,7 @@
     </AdditionalFiles>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="StyleCop.Analyzers">
-      <Version>1.1.118</Version>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/modules/colorPicker/ColorPickerUI/ColorPickerUI.csproj
+++ b/src/modules/colorPicker/ColorPickerUI/ColorPickerUI.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
     <Import Project="..\..\..\Version.props" />
   <PropertyGroup>
-    <AssemblyTitle>ColorPicker</AssemblyTitle>
+    <AssemblyTitle>ColorPickerUI</AssemblyTitle>
     <AssemblyDescription>PowerToys ColorPicker</AssemblyDescription>
     <AssemblyCompany>Microsoft Corp.</AssemblyCompany>
     <AssemblyCopyright>Copyright (C) 2020 Microsoft Corporation</AssemblyCopyright>
@@ -18,7 +18,7 @@
     <ProjectGuid>{BA58206B-1493-4C75-BFEA-A85768A1E156}</ProjectGuid>
     <OutputType>WinExe</OutputType>
     <RootNamespace>ColorPicker</RootNamespace>
-    <AssemblyName>ColorPicker</AssemblyName>
+    <AssemblyName>ColorPickerUI</AssemblyName>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/src/modules/colorPicker/ColorPickerUI/ColorPickerUI.csproj
+++ b/src/modules/colorPicker/ColorPickerUI/ColorPickerUI.csproj
@@ -76,7 +76,7 @@
     <PackageReference Include="System.ComponentModel.Composition" Version="5.0.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="System.IO.Abstractions" Version="12.2.5"/>
-    <PackageReference Include="System.Windows.Interactivity.WPF" Version="2.0.20525"/>
+    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.19" />
   </ItemGroup>
   <ItemGroup>
     <None Update="Resources\colorPicker.cur">

--- a/src/modules/colorPicker/ColorPickerUI/ColorPickerUI.csproj
+++ b/src/modules/colorPicker/ColorPickerUI/ColorPickerUI.csproj
@@ -1,18 +1,18 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <Import Project="..\..\..\Version.props" />
-  <!-- We don't have GenerateAssemblyInfo task until we use .net core, so we generate it with WriteLinesToFile -->
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyTitle>ColorPicker</AssemblyTitle>
     <AssemblyDescription>PowerToys ColorPicker</AssemblyDescription>
     <AssemblyCompany>Microsoft Corp.</AssemblyCompany>
     <AssemblyCopyright>Copyright (C) 2020 Microsoft Corporation</AssemblyCopyright>
     <AssemblyProduct>PowerToys</AssemblyProduct>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <UseWPF>true</UseWPF>
   </PropertyGroup>
   <ItemGroup>
     <AssemblyVersionFiles Include="Generated Files\AssemblyInfo.cs" />
   </ItemGroup>
+  <Import Project="..\..\..\Version.props" />
   <Target Name="GenerateAssemblyInfo" BeforeTargets="PrepareForBuild">
     <ItemGroup>
       <HeaderLines Include="// Copyright (c) Microsoft Corporation" />
@@ -40,249 +40,30 @@
     <WriteLinesToFile File="Generated Files\AssemblyInfo.cs" Lines="@(HeaderLines)" Overwrite="true" Encoding="Unicode" WriteOnlyWhenDifferent="true" />
   </Target>
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{BA58206B-1493-4C75-BFEA-A85768A1E156}</ProjectGuid>
     <OutputType>WinExe</OutputType>
     <RootNamespace>ColorPicker</RootNamespace>
     <AssemblyName>ColorPicker</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <WarningLevel>4</WarningLevel>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <Deterministic>true</Deterministic>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationManifest>App.manifest</ApplicationManifest>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
-    <DebugSymbols>true</DebugSymbols>
     <OutputPath>..\..\..\..\x64\Debug\modules\ColorPicker\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <DebugType>full</DebugType>
-    <PlatformTarget>x64</PlatformTarget>
     <LangVersion>8.0</LangVersion>
-    <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <Prefer32Bit>true</Prefer32Bit>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>..\..\..\..\x64\Release\modules\ColorPicker\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <Optimize>true</Optimize>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>x64</PlatformTarget>
     <LangVersion>8.0</LangVersion>
-    <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <Prefer32Bit>true</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>Resources\icon.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.ComponentModel.Composition" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Xml" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xaml">
-      <RequiredTargetFramework>4.0</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="WindowsBase" />
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Behaviors\DragAndDropReorderBehavior.cs" />
-    <Compile Include="Behaviors\DragWindowBehavior.cs" />
-    <Compile Include="ColorEditorWindow.xaml.cs">
-      <DependentUpon>ColorEditorWindow.xaml</DependentUpon>
-    </Compile>
-    <Compile Include="Common\RangeObservableCollection.cs" />
-    <Compile Include="Controls\ColorFormatControl.xaml.cs">
-      <DependentUpon>ColorFormatControl.xaml</DependentUpon>
-    </Compile>
-    <Compile Include="Controls\ColorPickerControl.xaml.cs">
-      <DependentUpon>ColorPickerControl.xaml</DependentUpon>
-    </Compile>
-    <Compile Include="Controls\HSVColor.cs" />
-    <Compile Include="Converters\ColorToBrushConverter.cs" />
-    <Compile Include="Converters\ColorToStringConverter.cs" />
-    <Compile Include="Converters\NumberToInvertedVisibilityConverter.cs" />
-    <Compile Include="Converters\NumberToVisibilityConverter.cs" />
-    <Compile Include="Helpers\ClipboardHelper.cs" />
-    <Compile Include="Behaviors\GridEffectBehavior.cs" />
-    <Compile Include="Helpers\ColorHelper.cs" />
-    <Compile Include="Helpers\ColorRepresentationHelper.cs" />
-    <Compile Include="Helpers\CustomLibraryThemeProvider.cs" />
-    <Compile Include="Helpers\IThrottledActionInvoker.cs" />
-    <Compile Include="Helpers\ThrottledActionInvoker.cs" />
-    <Compile Include="Models\ColorFormatModel.cs" />
-    <Compile Include="NativeMethods.cs" />
-    <Compile Include="Settings\IUserSettings.cs" />
-    <Compile Include="Settings\SettingItem`1.cs" />
-    <Compile Include="Settings\UserSettings.cs" />
-    <Compile Include="Shaders\Global.cs" />
-    <Compile Include="Shaders\GridShaderEffect.cs" />
-    <Compile Include="Telemetry\ColorPickerCancelledEvent.cs" />
-    <Compile Include="Telemetry\ColorPickerShowEvent.cs" />
-    <Compile Include="Telemetry\ColorPickerZoomOpenedEvent.cs" />
-    <Compile Include="ThemeManager.cs" />
-    <Compile Include="ViewModelContracts\IColorEditorViewModel.cs" />
-    <Compile Include="ViewModels\ColorEditorViewModel.cs" />
-    <Compile Include="Views\ColorEditorView.xaml.cs">
-      <DependentUpon>ColorEditorView.xaml</DependentUpon>
-    </Compile>
-    <Compile Include="ZoomWindow.xaml.cs">
-      <DependentUpon>ZoomWindow.xaml</DependentUpon>
-    </Compile>
-    <Page Include="App.xaml">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-    </Page>
-    <Compile Include="Bootstrapper.cs" />
-    <Compile Include="ViewModelContracts\IMainViewModel.cs" />
-    <Compile Include="ViewModelContracts\IZoomViewModel.cs" />
-    <Compile Include="ViewModels\MainViewModel.cs" />
-    <Compile Include="ViewModels\ZoomViewModel.cs" />
-    <Compile Include="Views\MainView.xaml.cs">
-      <DependentUpon>MainView.xaml</DependentUpon>
-    </Compile>
-    <Compile Include="Views\ZoomView.xaml.cs">
-      <DependentUpon>ZoomView.xaml</DependentUpon>
-    </Compile>
-    <Page Include="ColorEditorWindow.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Page Include="Controls\ColorFormatControl.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Page Include="Controls\ColorPickerControl.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Page Include="MainWindow.xaml">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-    </Page>
-    <Compile Include="App.xaml.cs">
-      <DependentUpon>App.xaml</DependentUpon>
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Behaviors\AppearAnimationBehavior.cs" />
-    <Compile Include="Behaviors\ChangeWindowPositionBehavior.cs" />
-    <Compile Include="Behaviors\CloseZoomWindowBehavior.cs" />
-    <Compile Include="Behaviors\MoveWindowBehavior.cs" />
-    <Compile Include="Behaviors\ResizeBehavior.cs" />
-    <Compile Include="Common\RelayCommand.cs" />
-    <Compile Include="Common\ViewModelBase.cs" />
-    <Compile Include="Helpers\AppStateHandler.cs" />
-    <Compile Include="Helpers\Logger.cs" />
-    <Compile Include="Helpers\MonitorResolutionHelper.cs" />
-    <Compile Include="Helpers\ZoomWindowHelper.cs" />
-    <Compile Include="Keyboard\GlobalKeyboardHook.cs" />
-    <Compile Include="Keyboard\GlobalKeyboardHookEventArgs.cs" />
-    <Compile Include="Keyboard\KeyboardMonitor.cs" />
-    <Compile Include="MainWindow.xaml.cs">
-      <DependentUpon>MainWindow.xaml</DependentUpon>
-      <SubType>Code</SubType>
-    </Compile>
-    <Page Include="Resources\Styles.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Page Include="Resources\ViewModelViewMappings.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Page Include="Themes\Dark.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Page Include="Themes\HighContrast1.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Page Include="Themes\HighContrast2.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Page Include="Themes\HighContrastBlack.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Page Include="Themes\HighContrastWhite.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Page Include="Themes\Light.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Page Include="Views\ColorEditorView.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Page Include="Views\MainView.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Page Include="Views\ZoomView.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Page Include="ZoomWindow.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Generated Files\AssemblyInfo.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Mouse\CursorManager.cs" />
-    <Compile Include="Mouse\IMouseInfoProvider.cs" />
-    <Compile Include="Mouse\MouseHook.cs" />
-    <Compile Include="Mouse\MouseInfoProvider.cs" />
-    <Compile Include="Properties\Resources.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>Resources.resx</DependentUpon>
-    </Compile>
-    <Compile Include="Properties\Settings.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Settings.settings</DependentUpon>
-      <DesignTimeSharedInput>True</DesignTimeSharedInput>
-    </Compile>
-    <EmbeddedResource Include="Properties\Resources.resx">
-      <Generator>PublicResXFileCodeGenerator</Generator>
-      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Properties\Resources.*.resx" />
-    <None Include="App.manifest" />
-    <None Include="Properties\Settings.settings">
-      <Generator>SettingsSingleFileGenerator</Generator>
-      <LastGenOutput>Settings.Designer.cs</LastGenOutput>
-    </None>
     <Resource Include="Shaders\GridShader.cso" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="App.config" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ControlzEx">
@@ -293,9 +74,12 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="ModernWpfUI">
       <Version>0.9.2</Version>
     </PackageReference>
+    <PackageReference Include="System.ComponentModel.Composition" Version="5.0.0" />
+    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="System.IO.Abstractions">
       <Version>12.2.5</Version>
     </PackageReference>
@@ -304,26 +88,17 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="Resources\colorPicker.cur">
+    <None Update="Resources\colorPicker.cur">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Include="Resources\icon.ico">
+    <None Update="Resources\icon.ico">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\common\ManagedCommon\ManagedCommon.csproj">
-      <Project>{4AED67B6-55FD-486F-B917-E543DEE2CB3C}</Project>
-      <Name>ManagedCommon</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\..\common\ManagedTelemetry\Telemetry\Telemetry.csproj">
-      <Project>{5d00d290-4016-4cfe-9e41-1e7c724509ba}</Project>
-      <Name>Telemetry</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\..\core\Microsoft.PowerToys.Settings.UI.Library\Microsoft.PowerToys.Settings.UI.Library.csproj">
-      <Project>{b1bcc8c6-46b5-4bfa-8f22-20f32d99ec6a}</Project>
-      <Name>Microsoft.PowerToys.Settings.UI.Library</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\..\..\common\ManagedCommon\ManagedCommon.csproj" />
+    <ProjectReference Include="..\..\..\common\ManagedTelemetry\Telemetry\Telemetry.csproj" />
+    <ProjectReference Include="..\..\..\core\Microsoft.PowerToys.Settings.UI.Library\Microsoft.PowerToys.Settings.UI.Library.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\..\codeAnalysis\GlobalSuppressions.cs">
@@ -343,5 +118,4 @@
   <ItemGroup>
     <Content Include="Shaders\GridShader.fx" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml.cs
@@ -393,7 +393,7 @@ namespace ColorPicker.Controls
 
         private static string ColorToHex(Color color)
         {
-            return "#" + BitConverter.ToString(new byte[] { color.R, color.G, color.B }).Replace("-", string.Empty);
+            return "#" + BitConverter.ToString(new byte[] { color.R, color.G, color.B }).Replace("-", string.Empty, StringComparison.CurrentCulture);
         }
     }
 }

--- a/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml.cs
@@ -393,7 +393,7 @@ namespace ColorPicker.Controls
 
         private static string ColorToHex(Color color)
         {
-            return "#" + BitConverter.ToString(new byte[] { color.R, color.G, color.B }).Replace("-", string.Empty, StringComparison.CurrentCulture);
+            return "#" + BitConverter.ToString(new byte[] { color.R, color.G, color.B }).Replace("-", string.Empty, StringComparison.InvariantCulture);
         }
     }
 }

--- a/src/modules/colorPicker/ColorPickerUI/MainWindow.xaml
+++ b/src/modules/colorPicker/ColorPickerUI/MainWindow.xaml
@@ -4,7 +4,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d"
-        xmlns:e="http://schemas.microsoft.com/expression/2010/interactivity"
+        xmlns:e="http://schemas.microsoft.com/xaml/behaviors"
         xmlns:behaviors="clr-namespace:ColorPicker.Behaviors"
         Height="64"
         WindowStyle="None"

--- a/src/modules/colorPicker/ColorPickerUI/Program.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Program.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+using ColorPicker.Helpers;
+using ColorPicker.Mouse;
+
+using ColorPickerUI;
+
+namespace ColorPicker
+{
+    public static class Program
+    {
+        private static string[] _args;
+
+        [STAThread]
+        public static void Main(string[] args)
+        {
+            _args = args;
+            AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
+            try
+            {
+                using (var application = new App())
+                {
+                    application.InitializeComponent();
+                    application.Run();
+                }
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception ex)
+#pragma warning restore CA1031 // Do not catch general exception types
+            {
+                Logger.LogError("Unhandled exception", ex);
+                CursorManager.RestoreOriginalCursors();
+            }
+        }
+
+        private static void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
+        {
+            Logger.LogError("Unhandled exception", (e.ExceptionObject is Exception) ? (e.ExceptionObject as Exception) : new Exception());
+            CursorManager.RestoreOriginalCursors();
+        }
+    }
+}

--- a/src/modules/colorPicker/ColorPickerUI/Views/ColorEditorView.xaml
+++ b/src/modules/colorPicker/ColorPickerUI/Views/ColorEditorView.xaml
@@ -7,7 +7,7 @@
              mc:Ignorable="d"
 
              xmlns:ui="http://schemas.modernwpf.com/2019"
-             xmlns:e="http://schemas.microsoft.com/expression/2010/interactivity"
+             xmlns:e="http://schemas.microsoft.com/xaml/behaviors"
              xmlns:controls="clr-namespace:ColorPicker.Controls"
              xmlns:behaviors="clr-namespace:ColorPicker.Behaviors"
              WindowChrome.IsHitTestVisibleInChrome="True"           

--- a/src/modules/colorPicker/ColorPickerUI/Views/ZoomView.xaml
+++ b/src/modules/colorPicker/ColorPickerUI/Views/ZoomView.xaml
@@ -5,7 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              mc:Ignorable="d" 
              xmlns:shaders="clr-namespace:ColorPicker.Shaders"
-             xmlns:e="http://schemas.microsoft.com/expression/2010/interactivity"
+             xmlns:e="http://schemas.microsoft.com/xaml/behaviors"
              xmlns:behaviors="clr-namespace:ColorPicker.Behaviors"
              Background="Transparent"
              Focusable="False">

--- a/src/modules/colorPicker/ColorPickerUI/ZoomWindow.xaml
+++ b/src/modules/colorPicker/ColorPickerUI/ZoomWindow.xaml
@@ -3,7 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:e="http://schemas.microsoft.com/expression/2010/interactivity"
+        xmlns:e="http://schemas.microsoft.com/xaml/behaviors"
         xmlns:behaviors="clr-namespace:ColorPicker.Behaviors"
         mc:Ignorable="d"
         Title="Zoom window"


### PR DESCRIPTION
## Summary of the Pull Request

Conversion of the Color Picker module from .NET Framework to .NET Core 3.1.

## PR Checklist
* [X] Applies to #776
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [X] Tests added/passed
* [ ] Requires documentation to be updated
* [X] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

## Validation Steps Performed

The Unit Tests for the Color Picker run successfully, the module itself can be run properly in both a standalone instance and within the runner. Colors are properly detected and selected. The key combination works properly.
