### PR TITLE
[FancyZones] Video memory leak fix, free render target

### DIFF
--- a/src/modules/fancyzones/lib/ZoneWindowDrawing.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindowDrawing.cpp
@@ -315,4 +315,9 @@ ZoneWindowDrawing::~ZoneWindowDrawing()
     }
     m_cv.notify_all();
     m_renderThread.join();
+
+    if (m_renderTarget)
+    {
+        m_renderTarget->Release();
+    }
 }


### PR DESCRIPTION
## Summary of the Pull Request

This should fix the Video memory leak issue some people are seeing. The reason why people saw their RAM used up is probably because their system doesn't have dedicated GPU memory.

## PR Checklist
* [x] Applies to #8378
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Validation Steps Performed

You can test this even you have dedicated GPU memory. Open Task Manager, run PT, do the following a couple of times:
* Create a few new virtual desktops
* Apply a zone layout on each (if you have a layout applied on the parent VD, this should happen automatically)
* Make sure you use FancyZones on each VD (it's enough to make the overlay appear)
* Delete all those VDs

You should see Video memory usage increase and not come down when VDs are deleted. With this PR however, it should come down to where it was.
