### PR TITLE
[FancyZones] Reduce VRAM use

### DIFF
--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -121,8 +121,7 @@ bool ZoneWindow::Init(IZoneWindowHost* host, HINSTANCE hinstance, HMONITOR monit
         {
             return false;
         }
-        const UINT dpi = GetDpiForMonitor(m_monitor);
-        workAreaRect = Rect(mi.rcWork, dpi);
+        workAreaRect = Rect(mi.rcWork);
     }
     else
     {


### PR DESCRIPTION
## Summary of the Pull Request

This PR should reduce use of VRAM by reducing the size of the window used to draw the overlay. We were multiplying the size by DPI, possibly because before we weren't DPI aware, but now it's completely unnecessary.

## PR Checklist
* [x] Applies to #8378
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Validation Steps Performed

Create a large number of virtual desktops and use FZ on each. Ideally at least one monitor should have a high resolution and the highest DPI scaling possible. You should see a lot less memory use with this PR than without it.

Also, of course, FZ should display correctly.
