### PR TITLE
FZ: fix incorrect snapping zoning behavior caused by calling MessageBox from LLKBHook cb

### DIFF
--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -634,7 +634,7 @@ void FancyZones::ToggleEditor() noexcept
 
     const bool spanZonesAcrossMonitors = m_settings->GetSettings()->spanZonesAcrossMonitors;
     params += std::to_wstring(spanZonesAcrossMonitors) + divider; /* Span zones */
-        
+
     std::vector<std::pair<HMONITOR, MONITORINFOEX>> allMonitors;
     allMonitors = FancyZonesUtils::GetAllMonitorInfo<&MONITORINFOEX::rcWork>();
     
@@ -691,10 +691,16 @@ void FancyZones::ToggleEditor() noexcept
 
     if (showDpiWarning)
     {
-        MessageBoxW(NULL,
-                    GET_RESOURCE_STRING(IDS_SPAN_ACROSS_ZONES_WARNING).c_str(),
-                    GET_RESOURCE_STRING(IDS_POWERTOYS_FANCYZONES).c_str(),
-                    MB_OK | MB_ICONWARNING);
+        // We must show the message box in a separate thread, since this code is called from a low-level
+        // keyboard hook callback, and launching messageboxes from it has unexpected side effects,
+        // like triggering EVENT_SYSTEM_MOVESIZEEND prematurely. 
+        // TODO: understand the root cause of this, until then it's commented out.
+        //std::thread{ [] {
+        //    MessageBoxW(nullptr,
+        //                GET_RESOURCE_STRING(IDS_SPAN_ACROSS_ZONES_WARNING).c_str(),
+        //                GET_RESOURCE_STRING(IDS_POWERTOYS_FANCYZONES).c_str(),
+        //                MB_OK | MB_ICONWARNING);
+        //} }.detach();
     }
 
     const auto& fancyZonesData = FancyZonesDataInstance();
@@ -1288,7 +1294,6 @@ bool FancyZones::IsSplashScreen(HWND window)
 
 void FancyZones::OnEditorExitEvent() noexcept
 {
-    Logger::trace("OnEditorExitEvent");
     // Collect information about changes in zone layout after editor exited.
     FancyZonesDataInstance().ParseDataFromTmpFiles();
 

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -2,7 +2,6 @@
 
 #include <common/common.h>
 #include <common/dpi_aware.h>
-#include <common/logger/logger.h>
 #include <common/on_thread_executor.h>
 #include <common/window_helpers.h>
 
@@ -535,9 +534,6 @@ FancyZones::OnKeyDown(PKBDLLHOOKSTRUCT info) noexcept
     bool const win = GetAsyncKeyState(VK_LWIN) & 0x8000 || GetAsyncKeyState(VK_RWIN) & 0x8000;
     bool const alt = GetAsyncKeyState(VK_MENU) & 0x8000;
     bool const ctrl = GetAsyncKeyState(VK_CONTROL) & 0x8000;
-
-    Logger::trace("OnKeyDown: shift {}", shift);
-
     if ((win && !shift && !ctrl) || (win && ctrl && alt))
     {
         // Temporarily disable Win+Ctrl+Number functionality
@@ -574,10 +570,8 @@ FancyZones::OnKeyDown(PKBDLLHOOKSTRUCT info) noexcept
 
     if (m_windowMoveHandler.IsDragEnabled() && shift)
     {
-        Logger::trace("OnKeyDown: drag enabled -> return true");
         return true;
     }
-    Logger::trace("OnKeyDown: return false");
     return false;
 }
 

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -1,7 +1,6 @@
 #include "pch.h"
 
 #include <common/common.h>
-#include <common/logger/logger.h>
 #include <common/on_thread_executor.h>
 
 #include "FancyZonesData.h"
@@ -319,11 +318,9 @@ ZoneWindow::SaveWindowProcessToZoneIndex(HWND window) noexcept
 IFACEMETHODIMP_(void)
 ZoneWindow::ShowZoneWindow() noexcept
 {
-    Logger::trace("ShowZoneWindow: Enter");
     auto window = m_window.get();
     if (!window)
     {
-        Logger::trace("ShowZoneWindow: no window");
         return;
     }
 
@@ -345,15 +342,10 @@ ZoneWindow::HideZoneWindow() noexcept
 {
     if (m_window)
     {
-        Logger::trace("HideZoneWindow: hiding");
         m_zoneWindowDrawing->Hide();
         m_keyLast = 0;
         m_windowMoveSize = nullptr;
         m_highlightZone = {};
-    }
-    else
-    {
-        Logger::trace("HideZoneWindow: no window");
     }
 }
 


### PR DESCRIPTION
## Summary of the Pull Request

The issue is caused by displaying a messagebox warning during editor toggle. you can repro the issue reliably if you set a second monitor to a different DPI, enable "Allow zones to span across monitors" option and toggle the editor.
The erroneous behavior could only be caused by invoking MoveSizeEnd prematurely. The only place we call it is when reacting to system's WM_PRIV_MOVESIZEEND, which is an event generated by Windows (see HandleWinHookEvent).

For now:
- removed the logging from FZ (it was too verbose)
- commented out msgbox logic and added a comment

## PR Checklist
* [x] Applies to #8330

## Validation Steps Performed

- played with FZ, couldn't repro anymore