### PR TITLE
[Color Picker] Fix for wrong style of right-click context menu

### DIFF
--- a/src/modules/colorPicker/ColorPickerUI/Controls/ColorFormatControl.xaml
+++ b/src/modules/colorPicker/ColorPickerUI/Controls/ColorFormatControl.xaml
@@ -6,7 +6,10 @@
              xmlns:p="clr-namespace:ColorPicker.Properties"
              xmlns:ui="http://schemas.modernwpf.com/2019"
              mc:Ignorable="d">
-
+    <UserControl.Resources>
+        <SolidColorBrush x:Key="TextControlBorderBrushFocused"
+                         Color="Transparent" />
+    </UserControl.Resources>
     <Border x:Name="MainBorder"
                     Margin="12,16,12,0"
                     Width="308"
@@ -37,9 +40,8 @@
                        Background="Transparent"
                        BorderThickness="0"
                        IsReadOnly="True"
-                       Margin="8"
                        VerticalAlignment="Center"
-                       Style="{DynamicResource TextBoxStyle}"
+                       Padding="8"
                        AutomationProperties.LabeledBy="{Binding FormatNameTextBlock}"
                      />
 


### PR DESCRIPTION
## Summary of the Pull Request

Due to a wrong reference to a non-existing style, the regular WPF right-click context menu showed. This PR fixes that by removing the reference entirely. To remove the selection border the selection brush color is overriden and made transparent.

Now, a context menu is shown that fits into the rest of the UI:

![image](https://user-images.githubusercontent.com/9866362/101647745-61020000-3a39-11eb-83ac-097b2b7c1601.png)


## PR Checklist
* [X] Applies to #8332
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx