### PR TITLE
CI: disable win-app-driver project

### DIFF
--- a/PowerToys.sln
+++ b/PowerToys.sln
@@ -234,7 +234,7 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "interop", "src\common\inter
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "common-md-flag", "src\common\common-md-flag\common-md-flag.vcxproj", "{985B3F2F-CEED-4C0A-A249-69257E719145}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Interop.Tests", "src\common\interop-tests\Microsoft.Interop.Tests.csproj", "{437AD818-3F1F-4CA5-A79B-25233A157026}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Interop.Tests", "src\common\interop-tests\Microsoft.Interop.Tests.csproj", "{437AD818-3F1F-4CA5-A79B-25233A157026}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Plugin.Folder", "src\modules\launcher\Plugins\Microsoft.Plugin.Folder\Microsoft.Plugin.Folder.csproj", "{787B8AA6-CA93-4C84-96FE-DF31110AD1C4}"
 EndProject
@@ -254,7 +254,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SvgThumbnailProvider", "src
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ColorPicker", "src\modules\colorPicker\ColorPicker\ColorPicker.vcxproj", "{655C9AF2-18D3-4DA6-80E4-85504A7722BA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ColorPickerUI", "src\modules\colorPicker\ColorPickerUI\ColorPickerUI.csproj", "{BA58206B-1493-4C75-BFEA-A85768A1E156}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ColorPickerUI", "src\modules\colorPicker\ColorPickerUI\ColorPickerUI.csproj", "{BA58206B-1493-4C75-BFEA-A85768A1E156}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "colorpicker", "colorpicker", "{1D78B84B-CA39-406C-98F4-71F7EC266CC0}"
 EndProject
@@ -567,9 +567,7 @@ Global
 		{D9B8FC84-322A-4F9F-BBB9-20915C47DDFD}.Release|x64.ActiveCfg = Release|x64
 		{D9B8FC84-322A-4F9F-BBB9-20915C47DDFD}.Release|x64.Build.0 = Release|x64
 		{F9E7CD57-0E86-4734-B56A-1B87179BC23C}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{F9E7CD57-0E86-4734-B56A-1B87179BC23C}.Debug|x64.Build.0 = Debug|Any CPU
 		{F9E7CD57-0E86-4734-B56A-1B87179BC23C}.Release|x64.ActiveCfg = Release|Any CPU
-		{F9E7CD57-0E86-4734-B56A-1B87179BC23C}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Fixes the issue [mentioned here](https://github.com/microsoft/PowerToys/pull/8412#issuecomment-742416712).
We'll re-enable it later as part of [this task](https://github.com/microsoft/PowerToys/issues/8542).