### PR TITLE
[Image Resizer] Handling percentage unit

### DIFF
--- a/src/modules/imageresizer/ui/Models/ResizeSize.cs
+++ b/src/modules/imageresizer/ui/Models/ResizeSize.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Brice Lambson
+// Copyright (c) Brice Lambson
 // The Brice Lambson licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.  Code forked from Brice Lambson's https://github.com/bricelam/ImageResizer/
 
@@ -52,14 +52,7 @@ namespace ImageResizer.Models
         public ResizeFit Fit
         {
             get => _fit;
-            set
-            {
-                Set(ref _fit, value);
-                if (!Equals(_fit, value))
-                {
-                    UpdateShowHeight();
-                }
-            }
+            set => Set(ref _fit, value);
         }
 
         [JsonProperty(PropertyName = "width")]
@@ -77,7 +70,10 @@ namespace ImageResizer.Models
         }
 
         public bool ShowHeight
-            => _showHeight;
+        {
+            get => _showHeight;
+            set => Set(ref _showHeight, value);
+        }
 
         public bool HasAuto
             => Width == 0 || Height == 0;
@@ -88,8 +84,9 @@ namespace ImageResizer.Models
             get => _unit;
             set
             {
+                var previousUnit = _unit;
                 Set(ref _unit, value);
-                if (!Equals(_unit, value))
+                if (!Equals(previousUnit, value))
                 {
                     UpdateShowHeight();
                 }
@@ -114,9 +111,9 @@ namespace ImageResizer.Models
                 : text;
 
         private void UpdateShowHeight()
-            => Set(
-                ref _showHeight,
-                Fit == ResizeFit.Stretch || Unit != ResizeUnit.Percent);
+        {
+            ShowHeight = Unit != ResizeUnit.Percent;
+        }
 
         private double ConvertToPixels(double value, ResizeUnit unit, int originalValue, double dpi)
         {

--- a/src/modules/imageresizer/ui/Views/MainWindow.xaml
+++ b/src/modules/imageresizer/ui/Views/MainWindow.xaml
@@ -11,6 +11,7 @@
         Name="_this"
         ResizeMode="NoResize"
         SizeToContent="WidthAndHeight"
+        MinWidth="485"
         Title="{x:Static p:Resources.ImageResizer}"
         WindowStartupLocation="CenterScreen"
         ui:WindowHelper.UseModernWindowStyle="True"


### PR DESCRIPTION
## Summary of the Pull Request

Aligned the behaviour of Image Resizer UI to PowerToys settings when using percentage as resize unit.
I have also set a minimum width for the window of 485px becouse the window automatically resizing selecting percentage looked so bad.

![image](https://user-images.githubusercontent.com/25966642/101992515-3b345f80-3cb4-11eb-93f5-2b06c5941d8f.png)


## PR Checklist
* [x] Applies to #8005
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

Aligned the behaviour of Image Resizer UI to PowerToys settings when using percentage as resize unit.

## Validation Steps Performed

- Open Image Resizer
- Select Custom
- Select Percentage as resize unit
- The height textbox is set as not visible