### PR TITLE
changed to match MSFT in appwiz.cpl

### DIFF
--- a/installer/PowerToysSetup/Product.wxs
+++ b/installer/PowerToysSetup/Product.wxs
@@ -16,7 +16,7 @@
        Name="PowerToys (Preview)"
        Language="1033"
        Version="$(var.Version)"
-       Manufacturer="Microsoft"
+       Manufacturer="Microsoft Corporation"
        UpgradeCode="42B84BF7-5FBF-473B-9C8B-049DC16F7708">
 
     <Package InstallerVersion="200" Compressed="yes" InstallScope="perMachine" InstallPrivileges="elevated" Platform="x64" />


### PR DESCRIPTION
## Summary of the Pull Request

in appwiz.cpl, msft uses "Microsoft Corporation" and PT has it only as "Microsoft"

![image](https://user-images.githubusercontent.com/1462282/102151955-e23a0800-3e28-11eb-8f6b-99f37bc66d49.png)

## PR Checklist
* [x] Applies to #8571
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

## Validation Steps Performed

_How does someone test & validate?_
