### PR TITLE
notifications: use message/title directly instead of binding to it, b…

### DIFF
--- a/src/common/notifications/notifications.h
+++ b/src/common/notifications/notifications.h
@@ -62,6 +62,5 @@ namespace notifications
     void show_toast(std::wstring plaintext_message, std::wstring title, toast_params params = {});
     void show_toast_with_activations(std::wstring plaintext_message, std::wstring title, std::wstring_view background_handler_id, std::vector<action_t> actions, toast_params params = {});
     void update_toast_progress_bar(std::wstring_view tag, progress_bar_params params);
-    void update_toast_contents(std::wstring_view tag, std::wstring plaintext_message, std::wstring title);
     void remove_toasts(std::wstring_view tag);
 }


### PR DESCRIPTION
## Summary of the Pull Request
…ecause it breaks snoozed notifications

We must set toast's title and contents immediately, because some of the toasts we send could be snoozed. Windows instantiates the snoozed toast from scratch before showing it again, so all bindings that were set with `NotificationData` would be empty.

## PR Checklist
* [x] Applies to #8550

## Validation Steps Performed

- remove update_state.json
- manually set snooze time to 1 minute in `show_version_ready`
- build PT and install
- receive and snooze notification
- observe that it has non-corrupted content
