### PR TITLE
WIP: Runner: Open Folders "in console" in Windows Terminal, if available

### DIFF
--- a/src/modules/launcher/Wox.Infrastructure/Helper.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Helper.cs
@@ -113,7 +113,7 @@ namespace Wox.Infrastructure
             {
                 WorkingDirectory = path,
                 FileName = "cmd.exe",
-                Arguments = $"/C wt.exe -d {path} 2> NUL >NUL || cmd.exe"
+                Arguments = $"/C wt.exe -d {path} 2> NUL >NUL || cmd.exe",
             };
 
             return Process.Start(processStartInfo);

--- a/src/modules/launcher/Wox.Infrastructure/Helper.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Helper.cs
@@ -113,6 +113,7 @@ namespace Wox.Infrastructure
             {
                 WorkingDirectory = path,
                 FileName = "cmd.exe",
+                Arguments = $"/C wt.exe -d {path} 2> NUL >NUL || cmd.exe"
             };
 
             return Process.Start(processStartInfo);


### PR DESCRIPTION
Open folders, which should be opened in a console, in windows terminal, if available.

**There are ongoing discussions (see below) about how to properly do this feature, but this is a simple change, that enables windows terminal, if available, without changing anything of the code structure/architecture.**

I personally love the launcher and found it inacceptable that it opened only cmd.

![Screenshot 2020-12-16 010019](https://user-images.githubusercontent.com/51182/102287607-1867ac80-3f3b-11eb-863b-d4102d2702d5.png)

Tries to open Windows Terminal in selected path. 
If not available, CMD will be opened.
(although I would prefer Powershell 😉, but which console a user wants, can be set in windows terminal)

## Summary of the Pull Request

_What is this about?_

When searching for a folder, one can open the folder in a console. This console should be Windows Terminal (`wt`), if available.
Currently it is set to `cmd`. 

## PR Checklist
* [ ] Applies to #xxx **?**
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed  **will try to find current tests and add to those**
* [ ] Requires documentation to be updated **no**
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

Includes a simply check, if `wt.exe` exists. If yes, it will be launched (with `-d PATH`), otherwise, old behavior is performed, i. e. launcing ye olde `cmd.exe`

## Validation Steps Performed

Tested the executed command on windows machines both with and without the Windows Terminal.

_How does someone test & validate?_

Run on a machine with and on one without Windows Terminal. With Windows Terminal, Windows Terminal should open. On a machine without WT, cmd (Command Prompt) should open.

## Specs / References
* Spec for Windows Terminal Process Model 2.0 #7240
* Spec for Windows Terminal Window Management #8135
* Default Terminal Spec #7414
* Scenario: Windows Terminal 2.0 Process Model Improvements #5000