### PR TITLE
Add keyboard shortcuts for cycling windows in the same zone

### DIFF
--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -209,6 +209,7 @@ private:
 
     void UpdateZoneWindows() noexcept;
     void UpdateWindowsPositions() noexcept;
+    void CycleTabs(bool reverse) noexcept;
     void CycleActiveZoneSet(DWORD vkCode) noexcept;
     bool OnSnapHotkeyBasedOnZoneNumber(HWND window, DWORD vkCode) noexcept;
     bool OnSnapHotkeyBasedOnPosition(HWND window, DWORD vkCode) noexcept;
@@ -265,6 +266,14 @@ private:
         Exit,
         Terminate
     };
+
+    // IDs used to register hot keys (keyboard shortcuts).
+    enum class HotKeysIds : int
+    {
+        Editor = 1,
+        NextTab = 2,
+        PrevTab = 3,
+    };
 };
 
 std::function<void()> FancyZones::disableModuleCallback = {};
@@ -297,7 +306,9 @@ FancyZones::Run() noexcept
         return;
     }
 
-    RegisterHotKey(m_window, 1, m_settings->GetSettings()->editorHotkey.get_modifiers(), m_settings->GetSettings()->editorHotkey.get_code());
+    RegisterHotKey(m_window, static_cast<int>(HotKeysIds::Editor), m_settings->GetSettings()->editorHotkey.get_modifiers(), m_settings->GetSettings()->editorHotkey.get_code());
+    RegisterHotKey(m_window, static_cast<int>(HotKeysIds::NextTab), m_settings->GetSettings()->nextTabHotkey.get_modifiers(), m_settings->GetSettings()->nextTabHotkey.get_code());
+    RegisterHotKey(m_window, static_cast<int>(HotKeysIds::PrevTab), m_settings->GetSettings()->prevTabHotkey.get_modifiers(), m_settings->GetSettings()->prevTabHotkey.get_code());
 
     VirtualDesktopInitialize();
 
@@ -575,7 +586,6 @@ FancyZones::OnKeyDown(PKBDLLHOOKSTRUCT info) noexcept
     //    CycleActiveZoneSet(info->vkCode);
     //    return false;
     //}
-
     if (m_windowMoveHandler.IsDragEnabled() && shift)
     {
         return true;
@@ -750,8 +760,12 @@ void FancyZones::ToggleEditor() noexcept
 void FancyZones::SettingsChanged() noexcept
 {
     // Update the hotkey
-    UnregisterHotKey(m_window, 1);
-    RegisterHotKey(m_window, 1, m_settings->GetSettings()->editorHotkey.get_modifiers(), m_settings->GetSettings()->editorHotkey.get_code());
+    UnregisterHotKey(m_window, static_cast<int>(HotKeysIds::Editor));
+    UnregisterHotKey(m_window, static_cast<int>(HotKeysIds::NextTab));
+    UnregisterHotKey(m_window, static_cast<int>(HotKeysIds::PrevTab));
+    RegisterHotKey(m_window, static_cast<int>(HotKeysIds::Editor), m_settings->GetSettings()->editorHotkey.get_modifiers(), m_settings->GetSettings()->editorHotkey.get_code());
+    RegisterHotKey(m_window, static_cast<int>(HotKeysIds::NextTab), m_settings->GetSettings()->nextTabHotkey.get_modifiers(), m_settings->GetSettings()->nextTabHotkey.get_code());
+    RegisterHotKey(m_window, static_cast<int>(HotKeysIds::PrevTab), m_settings->GetSettings()->prevTabHotkey.get_modifiers(), m_settings->GetSettings()->prevTabHotkey.get_code());
 
     // Needed if we toggled spanZonesAcrossMonitors
     m_workAreaHandler.Clear();
@@ -774,9 +788,15 @@ LRESULT FancyZones::WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lpa
     {
     case WM_HOTKEY:
     {
-        if (wparam == 1)
+        auto hotKeyId = static_cast<HotKeysIds>(wparam);
+        if (hotKeyId == HotKeysIds::Editor)
         {
             ToggleEditor();
+        }
+        else if (hotKeyId == HotKeysIds::NextTab || hotKeyId == HotKeysIds::PrevTab)
+        {
+            bool reverese = hotKeyId == HotKeysIds::PrevTab;
+            CycleTabs(reverese);
         }
     }
     break;
@@ -1028,6 +1048,31 @@ void FancyZones::UpdateWindowsPositions() noexcept
         return TRUE;
     };
     EnumWindows(callback, reinterpret_cast<LPARAM>(this));
+}
+
+void FancyZones::CycleTabs(bool reverse) noexcept
+{
+    std::unique_lock writeLock(m_lock);
+
+    auto window = GetForegroundWindow();
+
+    HMONITOR current;
+    {
+        if (m_settings->GetSettings()->spanZonesAcrossMonitors)
+        {
+            current = NULL;
+        }
+        else
+        {
+            current = MonitorFromWindow(window, MONITOR_DEFAULTTONULL);
+        }
+    }
+
+    auto zoneWindow = m_workAreaHandler.GetWorkArea(m_currentDesktopId, current);
+    if (zoneWindow)
+    {
+        zoneWindow->CycleTabs(window, reverse);
+    }
 }
 
 void FancyZones::CycleActiveZoneSet(DWORD vkCode) noexcept

--- a/src/modules/fancyzones/lib/Resources.resx
+++ b/src/modules/fancyzones/lib/Resources.resx
@@ -196,6 +196,12 @@
   <data name="Setting_Launch_Editor_Hotkey_Label" xml:space="preserve">
     <value>Configure the zone editor hotkey</value>
   </data>
+  <data name="Setting_Launch_NextTab_Hotkey_Label" xml:space="preserve">
+    <value>Configure the hotkey to move to the next tab</value>
+  </data>
+  <data name="Setting_Launch_PrevTab_Hotkey_Label" xml:space="preserve">
+    <value>Configure the hotkey to move to the previous tab</value>
+  </data>
   <data name="Setting_Excluded_Apps_Description" xml:space="preserve">
     <value>To exclude an application from snapping to zones add its name here (one per line). Excluded apps will react to the Windows Snap regardless of all other settings.</value>
     <comment>Windows refers to the Operating system</comment>

--- a/src/modules/fancyzones/lib/Settings.cpp
+++ b/src/modules/fancyzones/lib/Settings.cpp
@@ -29,6 +29,8 @@ namespace NonLocalizable
     const wchar_t ZoneBorderColorID[] = L"fancyzones_zoneBorderColor";
     const wchar_t ZoneHighlightColorID[] = L"fancyzones_zoneHighlightColor";
     const wchar_t EditorHotkeyID[] = L"fancyzones_editor_hotkey";
+    const wchar_t NextTabHotkeyID[] = L"fancyzones_nextTab_hotkey";
+    const wchar_t PrevTabHotkeyID[] = L"fancyzones_prevTab_hotkey";
     const wchar_t ExcludedAppsID[] = L"fancyzones_excluded_apps";
     const wchar_t ZoneHighlightOpacityID[] = L"fancyzones_highlight_opacity";
 
@@ -120,6 +122,8 @@ FancyZonesSettings::GetConfig(_Out_ PWSTR buffer, _Out_ int* buffer_size) noexce
         IDS_SETTING_LAUNCH_EDITOR_BUTTON,
         IDS_SETTING_LAUNCH_EDITOR_DESCRIPTION);
     settings.add_hotkey(NonLocalizable::EditorHotkeyID, IDS_SETTING_LAUNCH_EDITOR_HOTKEY_LABEL, m_settings.editorHotkey);
+    settings.add_hotkey(NonLocalizable::NextTabHotkeyID, IDS_SETTING_LAUNCH_NEXTTAB_HOTKEY_LABEL, m_settings.nextTabHotkey);
+    settings.add_hotkey(NonLocalizable::PrevTabHotkeyID, IDS_SETTING_LAUNCH_PREVTAB_HOTKEY_LABEL, m_settings.prevTabHotkey);
 
     for (auto const& setting : m_configBools)
     {
@@ -211,6 +215,16 @@ void FancyZonesSettings::LoadSettings(PCWSTR config, bool fromFile) noexcept
             m_settings.editorHotkey = PowerToysSettings::HotkeyObject::from_json(*val);
         }
 
+        if (const auto val = values.get_json(NonLocalizable::NextTabHotkeyID))
+        {
+            m_settings.nextTabHotkey = PowerToysSettings::HotkeyObject::from_json(*val);
+        }
+
+        if (const auto val = values.get_json(NonLocalizable::PrevTabHotkeyID))
+        {
+            m_settings.prevTabHotkey = PowerToysSettings::HotkeyObject::from_json(*val);
+        }
+
         if (auto val = values.get_string_value(NonLocalizable::ExcludedAppsID))
         {
             m_settings.excludedApps = std::move(*val);
@@ -265,6 +279,8 @@ void FancyZonesSettings::SaveSettings() noexcept
         values.add_property(NonLocalizable::ZoneHighlightColorID, m_settings.zoneHighlightColor);
         values.add_property(NonLocalizable::ZoneHighlightOpacityID, m_settings.zoneHighlightOpacity);
         values.add_property(NonLocalizable::EditorHotkeyID, m_settings.editorHotkey.get_json());
+        values.add_property(NonLocalizable::NextTabHotkeyID, m_settings.nextTabHotkey.get_json());
+        values.add_property(NonLocalizable::PrevTabHotkeyID, m_settings.prevTabHotkey.get_json());
         values.add_property(NonLocalizable::ExcludedAppsID, m_settings.excludedApps);
 
         values.save_to_settings_file();

--- a/src/modules/fancyzones/lib/Settings.h
+++ b/src/modules/fancyzones/lib/Settings.h
@@ -35,6 +35,8 @@ struct Settings
     std::wstring zoneHighlightColor = L"#008CFF";
     int zoneHighlightOpacity = 50;
     PowerToysSettings::HotkeyObject editorHotkey = PowerToysSettings::HotkeyObject::from_settings(true, false, false, false, VK_OEM_3);
+    PowerToysSettings::HotkeyObject nextTabHotkey = PowerToysSettings::HotkeyObject::from_settings(true, false, false, false, VK_NEXT);
+    PowerToysSettings::HotkeyObject prevTabHotkey = PowerToysSettings::HotkeyObject::from_settings(true, false, false, false, VK_PRIOR);
     std::wstring excludedApps = L"";
     std::vector<std::wstring> excludedAppsArray;
 };

--- a/src/modules/fancyzones/lib/ZoneSet.h
+++ b/src/modules/fancyzones/lib/ZoneSet.h
@@ -123,6 +123,14 @@ interface __declspec(uuid("{E4839EB7-669D-49CF-84A9-71A2DFD851A3}")) IZoneSet : 
     IFACEMETHOD_(void, MoveWindowIntoZoneByPoint)
     (HWND window, HWND workAreaWindow, POINT ptClient) = 0;
     /**
+     * Cycle through tabs in the zone that the window is in.
+     *
+     * @param   window Handle of the current window who is cycled to its next.
+     * @param   reverse Whether we should move to in reverse order (to the previous tab) or move to the next tab.
+     */
+    IFACEMETHOD_(void, CycleTabs)
+    (HWND window, bool reverse) = 0;
+    /**
      * Calculate zone coordinates within zone layout based on number of zones and spacing.
      *
      * @param   workAreaRect The rectangular area on the screen on which the zone layout is applied.

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -48,6 +48,8 @@ public:
     ExtendWindowByDirectionAndPosition(HWND window, DWORD vkCode) noexcept;
     IFACEMETHODIMP_(void)
     CycleActiveZoneSet(DWORD vkCode) noexcept;
+    IFACEMETHODIMP_(void)
+    CycleTabs(HWND window, bool reverse) noexcept;
     IFACEMETHODIMP_(std::wstring)
     UniqueId() noexcept { return { m_uniqueId }; }
     IFACEMETHODIMP_(void)
@@ -292,6 +294,15 @@ ZoneWindow::CycleActiveZoneSet(DWORD wparam) noexcept
     if (m_windowMoveSize)
     {
         InvalidateRect(m_window.get(), nullptr, true);
+    }
+}
+
+IFACEMETHODIMP_(void)
+ZoneWindow::CycleTabs(HWND window, bool reverese) noexcept
+{
+    if (m_activeZoneSet)
+    {
+        m_activeZoneSet->CycleTabs(window, reverese);
     }
 }
 

--- a/src/modules/fancyzones/lib/ZoneWindow.h
+++ b/src/modules/fancyzones/lib/ZoneWindow.h
@@ -92,7 +92,13 @@ interface __declspec(uuid("{7F017528-8110-4FB3-BE41-F472969C2560}")) IZoneWindow
      * @param   vkCode Pressed key representing layout index.
      */
     IFACEMETHOD_(void, CycleActiveZoneSet)(DWORD vkCode) = 0;
-
+    /**
+     * Cycle through tabs in the zone that the window is in.
+     *
+     * @param   window Handle of the current window who is cycled to its next.
+     * @param   reverse Whether we should move to in reverse order (to the previous tab) or move to the next tab.
+     */
+    IFACEMETHOD_(void, CycleTabs)(HWND window, bool reverse) = 0;
     /**
      * Save information about zone in which window was assigned, when closing the window.
      * Used once we open same window again to assign it to its previous zone.

--- a/src/modules/fancyzones/lib/trace.cpp
+++ b/src/modules/fancyzones/lib/trace.cpp
@@ -48,7 +48,9 @@
 #define ZoneBorderColorKey "ZoneBorderColor"
 #define ZoneHighlightColorKey "ZoneHighlightColor"
 #define ZoneHighlightOpacityKey "ZoneHighlightOpacity"
-#define HotkeyKey "Hotkey"
+#define EditorHotkeyKey "EditorHotkey"
+#define NextTabHotkey "NextTabHotkey"
+#define PrevTabHotkey "PrevTabHotkey"
 #define ExcludedAppsCountKey "ExcludedAppsCount"
 #define KeyboardValueKey "KeyboardValue"
 #define ActiveSetKey "ActiveSet"
@@ -226,15 +228,21 @@ void Trace::FancyZones::Error(const DWORD errorCode, std::wstring errorMessage, 
         TraceLoggingValue(errorMessage.c_str(), "ErrorMessage"));
 }
 
-void Trace::SettingsChanged(const Settings& settings) noexcept
+static std::wstring HotKeyToString(const PowerToysSettings::HotkeyObject& editorHotkey)
 {
-    const auto& editorHotkey = settings.editorHotkey;
-    std::wstring hotkeyStr = L"alt:" + std::to_wstring(editorHotkey.alt_pressed())
+    return L"alt:" + std::to_wstring(editorHotkey.alt_pressed())
         + L", ctrl:" + std::to_wstring(editorHotkey.ctrl_pressed())
         + L", shift:" + std::to_wstring(editorHotkey.shift_pressed())
         + L", win:" + std::to_wstring(editorHotkey.win_pressed())
         + L", code:" + std::to_wstring(editorHotkey.get_code())
         + L", keyFromCode:" + editorHotkey.get_key();
+}
+
+void Trace::SettingsChanged(const Settings& settings) noexcept
+{
+    auto editorHotkeyStr = HotKeyToString(settings.editorHotkey);
+    auto nextTabHotkeyStr = HotKeyToString(settings.nextTabHotkey);
+    auto prevTabHotkeyStr = HotKeyToString(settings.prevTabHotkey);
 
     TraceLoggingWrite(
         g_hProvider,
@@ -260,7 +268,9 @@ void Trace::SettingsChanged(const Settings& settings) noexcept
         TraceLoggingWideString(settings.zoneBorderColor.c_str(), ZoneBorderColorKey),
         TraceLoggingWideString(settings.zoneHighlightColor.c_str(), ZoneHighlightColorKey),
         TraceLoggingInt32(settings.zoneHighlightOpacity, ZoneHighlightOpacityKey),
-        TraceLoggingWideString(hotkeyStr.c_str(), HotkeyKey),
+        TraceLoggingWideString(editorHotkeyStr.c_str(), EditorHotkeyKey),
+        TraceLoggingWideString(nextTabHotkeyStr.c_str(), NextTabHotkey),
+        TraceLoggingWideString(prevTabHotkeyStr.c_str(), PrevTabHotkey),
         TraceLoggingInt32(static_cast<int>(settings.excludedAppsArray.size()), ExcludedAppsCountKey));
 }
 

--- a/src/modules/fancyzones/tests/UnitTests/FancyZones.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/FancyZones.Spec.cpp
@@ -68,6 +68,8 @@ namespace FancyZonesUnitTests
             PowerToysSettings::Settings ptSettings(HINSTANCE{}, L"FancyZonesUnitTests");
 
             ptSettings.add_hotkey(L"fancyzones_editor_hotkey", IDS_SETTING_LAUNCH_EDITOR_HOTKEY_LABEL, settings.editorHotkey);
+            ptSettings.add_hotkey(L"fancyzones_nextTab_hotkey", IDS_SETTING_LAUNCH_NEXTTAB_HOTKEY_LABEL, settings.nextTabHotkey);
+            ptSettings.add_hotkey(L"fancyzones_prevTab_hotkey", IDS_SETTING_LAUNCH_PREVTAB_HOTKEY_LABEL, settings.prevTabHotkey);
             ptSettings.add_bool_toggle(L"fancyzones_shiftDrag", IDS_SETTING_DESCRIPTION_SHIFTDRAG, settings.shiftDrag);
             ptSettings.add_bool_toggle(L"fancyzones_mouseSwitch", IDS_SETTING_DESCRIPTION_MOUSESWITCH, settings.mouseSwitch);
             ptSettings.add_bool_toggle(L"fancyzones_overrideSnapHotkeys", IDS_SETTING_DESCRIPTION_OVERRIDE_SNAP_HOTKEYS, settings.overrideSnapHotkeys);
@@ -133,6 +135,8 @@ namespace FancyZonesUnitTests
                         .zoneHighlightColor = L"#FAFAFA",
                         .zoneHighlightOpacity = 45,
                         .editorHotkey = PowerToysSettings::HotkeyObject::from_settings(false, false, false, false, VK_OEM_3),
+                        .nextTabHotkey = PowerToysSettings::HotkeyObject::from_settings(false, false, false, false, VK_NEXT),
+                        .prevTabHotkey = PowerToysSettings::HotkeyObject::from_settings(false, false, false, false, VK_PRIOR),
                         .excludedApps = L"app\r\napp2",
                         .excludedAppsArray = { L"APP", L"APP2" },
                     };
@@ -165,6 +169,8 @@ namespace FancyZonesUnitTests
                         .zoneHighlightColor = L"#FAFAFA",
                         .zoneHighlightOpacity = 45,
                         .editorHotkey = PowerToysSettings::HotkeyObject::from_settings(false, false, false, false, VK_OEM_3),
+                        .nextTabHotkey = PowerToysSettings::HotkeyObject::from_settings(false, false, false, false, VK_NEXT),
+                        .prevTabHotkey = PowerToysSettings::HotkeyObject::from_settings(false, false, false, false, VK_PRIOR),
                         .excludedApps = L"app\r\napp2",
                         .excludedAppsArray = { L"APP", L"APP2" },
                     };
@@ -199,6 +205,8 @@ namespace FancyZonesUnitTests
                         .zoneHighlightColor = L"#abafee",
                         .zoneHighlightOpacity = 45,
                         .editorHotkey = PowerToysSettings::HotkeyObject::from_settings(false, false, false, false, VK_OEM_3),
+                        .nextTabHotkey = PowerToysSettings::HotkeyObject::from_settings(false, false, false, false, VK_NEXT),
+                        .prevTabHotkey = PowerToysSettings::HotkeyObject::from_settings(false, false, false, false, VK_PRIOR),
                         .excludedApps = L"app\r\napp2",
                         .excludedAppsArray = { L"APP", L"APP2" },
                     };
@@ -233,6 +241,8 @@ namespace FancyZonesUnitTests
                         .zoneHighlightColor = L"#abafee",
                         .zoneHighlightOpacity = expected,
                         .editorHotkey = PowerToysSettings::HotkeyObject::from_settings(false, false, false, false, VK_OEM_3),
+                        .nextTabHotkey = PowerToysSettings::HotkeyObject::from_settings(false, false, false, false, VK_NEXT),
+                        .prevTabHotkey = PowerToysSettings::HotkeyObject::from_settings(false, false, false, false, VK_PRIOR),
                         .excludedApps = L"app\r\napp2",
                         .excludedAppsArray = { L"APP", L"APP2" },
                     };
@@ -267,6 +277,8 @@ namespace FancyZonesUnitTests
                         .zoneHighlightColor = L"#abafee",
                         .zoneHighlightOpacity = expected,
                         .editorHotkey = PowerToysSettings::HotkeyObject::from_settings(false, false, false, false, VK_OEM_3),
+                        .nextTabHotkey = PowerToysSettings::HotkeyObject::from_settings(false, false, false, false, VK_NEXT),
+                        .prevTabHotkey = PowerToysSettings::HotkeyObject::from_settings(false, false, false, false, VK_PRIOR),
                         .excludedApps = L"app\r\napp2",
                         .excludedAppsArray = { L"APP", L"APP2" },
                     };
@@ -293,6 +305,8 @@ namespace FancyZonesUnitTests
             PowerToysSettings::Settings ptSettings(HINSTANCE{}, L"FancyZonesUnitTests");
 
             ptSettings.add_hotkey(L"fancyzones_editor_hotkey", IDS_SETTING_LAUNCH_EDITOR_HOTKEY_LABEL, settings.editorHotkey);
+            ptSettings.add_hotkey(L"fancyzones_nextTab_hotkey", IDS_SETTING_LAUNCH_NEXTTAB_HOTKEY_LABEL, settings.nextTabHotkey);
+            ptSettings.add_hotkey(L"fancyzones_prevTab_hotkey", IDS_SETTING_LAUNCH_PREVTAB_HOTKEY_LABEL, settings.prevTabHotkey);
             ptSettings.add_bool_toggle(L"fancyzones_shiftDrag", IDS_SETTING_DESCRIPTION_SHIFTDRAG, settings.shiftDrag);
             ptSettings.add_bool_toggle(L"fancyzones_mouseSwitch", IDS_SETTING_DESCRIPTION_MOUSESWITCH, settings.mouseSwitch);
             ptSettings.add_bool_toggle(L"fancyzones_overrideSnapHotkeys", IDS_SETTING_DESCRIPTION_OVERRIDE_SNAP_HOTKEYS, settings.overrideSnapHotkeys);

--- a/src/modules/fancyzones/tests/UnitTests/FancyZonesSettings.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/FancyZonesSettings.Spec.cpp
@@ -53,6 +53,8 @@ namespace FancyZonesUnitTests
         }
 
         compareHotkeyObjects(expected.editorHotkey, actual.editorHotkey);
+        compareHotkeyObjects(expected.nextTabHotkey, actual.nextTabHotkey);
+        compareHotkeyObjects(expected.prevTabHotkey, actual.prevTabHotkey);
     }
 
     TEST_CLASS (FancyZonesSettingsCreationUnitTest)
@@ -128,6 +130,8 @@ namespace FancyZonesUnitTests
                     values.add_property(L"fancyzones_zoneHighlightColor", expected.zoneHighlightColor);
                     values.add_property(L"fancyzones_highlight_opacity", expected.zoneHighlightOpacity);
                     values.add_property(L"fancyzones_editor_hotkey", expected.editorHotkey.get_json());
+                    values.add_property(L"fancyzones_nextTab_hotkey", expected.nextTabHotkey.get_json());
+                    values.add_property(L"fancyzones_prevTab_hotkey", expected.prevTabHotkey.get_json());
                     values.add_property(L"fancyzones_excluded_apps", expected.excludedApps);
 
                     values.save_to_settings_file();
@@ -168,6 +172,8 @@ namespace FancyZonesUnitTests
                     values.add_property(L"fancyzones_zoneHighlightColor", expected.zoneHighlightColor);
                     values.add_property(L"fancyzones_highlight_opacity", expected.zoneHighlightOpacity);
                     values.add_property(L"fancyzones_editor_hotkey", expected.editorHotkey.get_json());
+                    values.add_property(L"fancyzones_nextTab_hotkey", expected.nextTabHotkey.get_json());
+                    values.add_property(L"fancyzones_prevTab_hotkey", expected.prevTabHotkey.get_json());
                     values.add_property(L"fancyzones_excluded_apps", expected.excludedApps);
 
                     values.save_to_settings_file();
@@ -202,6 +208,8 @@ namespace FancyZonesUnitTests
                         .zoneHighlightColor = L"#00FFD7",
                         .zoneHighlightOpacity = 45,
                         .editorHotkey = PowerToysSettings::HotkeyObject::from_settings(false, true, true, false, VK_OEM_3),
+                        .nextTabHotkey = PowerToysSettings::HotkeyObject::from_settings(false, true, true, false, VK_NEXT),
+                        .prevTabHotkey = PowerToysSettings::HotkeyObject::from_settings(false, true, true, false, VK_PRIOR),
                         .excludedApps = L"app",
                         .excludedAppsArray = { L"APP" },
                     };
@@ -212,6 +220,8 @@ namespace FancyZonesUnitTests
                     values.add_property(L"fancyzones_zoneHighlightColor", expected.zoneHighlightColor);
                     values.add_property(L"fancyzones_highlight_opacity", expected.zoneHighlightOpacity);
                     values.add_property(L"fancyzones_editor_hotkey", expected.editorHotkey.get_json());
+                    values.add_property(L"fancyzones_nextTab_hotkey", expected.nextTabHotkey.get_json());
+                    values.add_property(L"fancyzones_prevTab_hotkey", expected.prevTabHotkey.get_json());
                     values.add_property(L"fancyzones_excluded_apps", expected.excludedApps);
 
                     values.save_to_settings_file();
@@ -246,6 +256,8 @@ namespace FancyZonesUnitTests
                     values.add_property(L"fancyzones_makeDraggedWindowTransparent", expected.makeDraggedWindowTransparent);
                     values.add_property(L"fancyzones_highlight_opacity", expected.zoneHighlightOpacity);
                     values.add_property(L"fancyzones_editor_hotkey", expected.editorHotkey.get_json());
+                    values.add_property(L"fancyzones_nextTab_hotkey", expected.nextTabHotkey.get_json());
+                    values.add_property(L"fancyzones_prevTab_hotkey", expected.prevTabHotkey.get_json());
                     values.add_property(L"fancyzones_excluded_apps", expected.excludedApps);
 
                     values.save_to_settings_file();
@@ -281,6 +293,8 @@ namespace FancyZonesUnitTests
                     values.add_property(L"fancyzones_zoneColor", expected.zoneColor);
                     values.add_property(L"fancyzones_zoneHighlightColor", expected.zoneHighlightColor);
                     values.add_property(L"fancyzones_editor_hotkey", expected.editorHotkey.get_json());
+                    values.add_property(L"fancyzones_nextTab_hotkey", expected.nextTabHotkey.get_json());
+                    values.add_property(L"fancyzones_prevTab_hotkey", expected.prevTabHotkey.get_json());
                     values.add_property(L"fancyzones_excluded_apps", expected.excludedApps);
 
                     values.save_to_settings_file();
@@ -354,6 +368,8 @@ namespace FancyZonesUnitTests
                     values.add_property(L"fancyzones_zoneHighlightColor", expected.zoneHighlightColor);
                     values.add_property(L"fancyzones_highlight_opacity", expected.zoneHighlightOpacity);
                     values.add_property(L"fancyzones_editor_hotkey", expected.editorHotkey.get_json());
+                    values.add_property(L"fancyzones_nextTab_hotkey", expected.nextTabHotkey.get_json());
+                    values.add_property(L"fancyzones_prevTab_hotkey", expected.prevTabHotkey.get_json());
 
                     values.save_to_settings_file();
 
@@ -472,6 +488,8 @@ namespace FancyZonesUnitTests
                     .zoneHighlightColor = L"#00FFD7",
                     .zoneHighlightOpacity = 45,
                     .editorHotkey = PowerToysSettings::HotkeyObject::from_settings(false, true, true, false, VK_OEM_3),
+                    .nextTabHotkey = PowerToysSettings::HotkeyObject::from_settings(false, true, true, false, VK_NEXT),
+                    .prevTabHotkey = PowerToysSettings::HotkeyObject::from_settings(false, true, true, false, VK_PRIOR),
                     .excludedApps = L"app",
                     .excludedAppsArray = { L"APP" },
                 };
@@ -497,6 +515,8 @@ namespace FancyZonesUnitTests
                 values.add_property(L"fancyzones_zoneHighlightColor", expected.zoneHighlightColor);
                 values.add_property(L"fancyzones_highlight_opacity", expected.zoneHighlightOpacity);
                 values.add_property(L"fancyzones_editor_hotkey", expected.editorHotkey.get_json());
+                values.add_property(L"fancyzones_nextTab_hotkey", expected.nextTabHotkey.get_json());
+                values.add_property(L"fancyzones_prevTab_hotkey", expected.prevTabHotkey.get_json());
                 values.add_property(L"fancyzones_excluded_apps", expected.excludedApps);
 
                 values.save_to_settings_file();
@@ -598,6 +618,8 @@ namespace FancyZonesUnitTests
                 IDS_SETTING_LAUNCH_EDITOR_BUTTON,
                 IDS_SETTING_LAUNCH_EDITOR_DESCRIPTION);
             ptSettings.add_hotkey(L"fancyzones_editor_hotkey", IDS_SETTING_LAUNCH_EDITOR_HOTKEY_LABEL, settings.editorHotkey);
+            ptSettings.add_hotkey(L"fancyzones_nextTab_hotkey", IDS_SETTING_LAUNCH_NEXTTAB_HOTKEY_LABEL, settings.nextTabHotkey);
+            ptSettings.add_hotkey(L"fancyzones_prevTab_hotkey", IDS_SETTING_LAUNCH_PREVTAB_HOTKEY_LABEL, settings.prevTabHotkey);
             ptSettings.add_bool_toggle(L"fancyzones_shiftDrag", IDS_SETTING_DESCRIPTION_SHIFTDRAG, settings.shiftDrag);
             ptSettings.add_bool_toggle(L"fancyzones_mouseSwitch", IDS_SETTING_DESCRIPTION_MOUSESWITCH, settings.mouseSwitch);
             ptSettings.add_bool_toggle(L"fancyzones_overrideSnapHotkeys", IDS_SETTING_DESCRIPTION_OVERRIDE_SNAP_HOTKEYS, settings.overrideSnapHotkeys);
@@ -699,6 +721,8 @@ namespace FancyZonesUnitTests
                         .zoneHighlightColor = L"#00AABB",
                         .zoneHighlightOpacity = 45,
                         .editorHotkey = PowerToysSettings::HotkeyObject::from_settings(false, false, false, false, VK_OEM_3),
+                        .nextTabHotkey = PowerToysSettings::HotkeyObject::from_settings(false, false, false, false, VK_NEXT),
+                        .prevTabHotkey = PowerToysSettings::HotkeyObject::from_settings(false, false, false, false, VK_PRIOR),
                         .excludedApps = L"app\r\napp2",
                         .excludedAppsArray = { L"APP", L"APP2" },
                     };

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/FZConfigProperties.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/FZConfigProperties.cs
@@ -9,7 +9,13 @@ namespace Microsoft.PowerToys.Settings.UI.Library
 {
     public class FZConfigProperties
     {
-        public static readonly HotkeySettings DefaultHotkeyValue = new HotkeySettings(true, false, false, false, 0xc0);
+        public const int VkOem3 = 0xc0;
+        public const int VkNext = 0x22;
+        public const int VkPrior = 0x21;
+
+        public static readonly HotkeySettings DefaultEditorHotkeyValue = new HotkeySettings(true, false, false, false, VkOem3);
+        public static readonly HotkeySettings DefaultNextTabHotkeyValue = new HotkeySettings(true, false, false, false, VkNext);
+        public static readonly HotkeySettings DefaultPrevTabHotkeyValue = new HotkeySettings(true, false, false, false, VkPrior);
 
         public FZConfigProperties()
         {
@@ -28,7 +34,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             FancyzonesSpanZonesAcrossMonitors = new BoolProperty();
             FancyzonesZoneHighlightColor = new StringProperty(ConfigDefaults.DefaultFancyZonesZoneHighlightColor);
             FancyzonesHighlightOpacity = new IntProperty(50);
-            FancyzonesEditorHotkey = new KeyboardKeysProperty(DefaultHotkeyValue);
+            FancyzonesEditorHotkey = new KeyboardKeysProperty(DefaultEditorHotkeyValue);
+            FancyzonesNextTabHotkey = new KeyboardKeysProperty(DefaultNextTabHotkeyValue);
+            FancyzonesPrevTabHotkey = new KeyboardKeysProperty(DefaultPrevTabHotkeyValue);
             FancyzonesMakeDraggedWindowTransparent = new BoolProperty();
             FancyzonesExcludedApps = new StringProperty();
             FancyzonesInActiveColor = new StringProperty(ConfigDefaults.DefaultFancyZonesInActiveColor);
@@ -85,6 +93,12 @@ namespace Microsoft.PowerToys.Settings.UI.Library
 
         [JsonPropertyName("fancyzones_editor_hotkey")]
         public KeyboardKeysProperty FancyzonesEditorHotkey { get; set; }
+
+        [JsonPropertyName("fancyzones_nextTab_hotkey")]
+        public KeyboardKeysProperty FancyzonesNextTabHotkey { get; set; }
+
+        [JsonPropertyName("fancyzones_prevTab_hotkey")]
+        public KeyboardKeysProperty FancyzonesPrevTabHotkey { get; set; }
 
         [JsonPropertyName("fancyzones_excluded_apps")]
         public StringProperty FancyzonesExcludedApps { get; set; }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/FancyZonesViewModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/FancyZonesViewModel.cs
@@ -64,6 +64,8 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             _highlightOpacity = Settings.Properties.FancyzonesHighlightOpacity.Value;
             _excludedApps = Settings.Properties.FancyzonesExcludedApps.Value;
             EditorHotkey = Settings.Properties.FancyzonesEditorHotkey.Value;
+            NextTabHotkey = Settings.Properties.FancyzonesNextTabHotkey.Value;
+            PrevTabHotkey = Settings.Properties.FancyzonesPrevTabHotkey.Value;
 
             // set the callback functions value to hangle outgoing IPC message.
             SendConfigMSG = ipcMSGCallBackFunc;
@@ -99,6 +101,8 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
         private int _highlightOpacity;
         private string _excludedApps;
         private HotkeySettings _editorHotkey;
+        private HotkeySettings _nextTabHotkey;
+        private HotkeySettings _prevTabHotkey;
         private string _zoneInActiveColor;
         private string _zoneBorderColor;
         private string _zoneHighlightColor;
@@ -492,7 +496,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
                 {
                     if (value == null || value.IsEmpty())
                     {
-                        _editorHotkey = FZConfigProperties.DefaultHotkeyValue;
+                        _editorHotkey = FZConfigProperties.DefaultEditorHotkeyValue;
                     }
                     else
                     {
@@ -500,6 +504,58 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
                     }
 
                     Settings.Properties.FancyzonesEditorHotkey.Value = _editorHotkey;
+                    NotifyPropertyChanged();
+                }
+            }
+        }
+
+        public HotkeySettings NextTabHotkey
+        {
+            get
+            {
+                return _nextTabHotkey;
+            }
+
+            set
+            {
+                if (value != _nextTabHotkey)
+                {
+                    if (value == null || value.IsEmpty())
+                    {
+                        _nextTabHotkey = FZConfigProperties.DefaultNextTabHotkeyValue;
+                    }
+                    else
+                    {
+                        _nextTabHotkey = value;
+                    }
+
+                    Settings.Properties.FancyzonesNextTabHotkey.Value = _nextTabHotkey;
+                    NotifyPropertyChanged();
+                }
+            }
+        }
+
+        public HotkeySettings PrevTabHotkey
+        {
+            get
+            {
+                return _prevTabHotkey;
+            }
+
+            set
+            {
+                if (value != _prevTabHotkey)
+                {
+                    if (value == null || value.IsEmpty())
+                    {
+                        _prevTabHotkey = FZConfigProperties.DefaultPrevTabHotkeyValue;
+                    }
+                    else
+                    {
+                        _prevTabHotkey = value;
+                    }
+
+                    Settings.Properties.FancyzonesNextTabHotkey.Value = _prevTabHotkey;
                     NotifyPropertyChanged();
                 }
             }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.UnitTests/ViewModelTests/FancyZones.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.UnitTests/ViewModelTests/FancyZones.cs
@@ -51,6 +51,8 @@ namespace ViewModelTests
             Assert.AreEqual(originalSettings.Properties.FancyzonesBorderColor.Value, viewModel.ZoneBorderColor);
             Assert.AreEqual(originalSettings.Properties.FancyzonesDisplayChangeMoveWindows.Value, viewModel.DisplayChangeMoveWindows);
             Assert.AreEqual(originalSettings.Properties.FancyzonesEditorHotkey.Value.ToString(), viewModel.EditorHotkey.ToString());
+            Assert.AreEqual(originalSettings.Properties.FancyzonesNextTabHotkey.Value.ToString(), viewModel.NextTabHotkey.ToString());
+            Assert.AreEqual(originalSettings.Properties.FancyzonesPrevTabHotkey.Value.ToString(), viewModel.PrevTabHotkey.ToString());
             Assert.AreEqual(originalSettings.Properties.FancyzonesExcludedApps.Value, viewModel.ExcludedApps);
             Assert.AreEqual(originalSettings.Properties.FancyzonesHighlightOpacity.Value, viewModel.HighlightOpacity);
             Assert.AreEqual(originalSettings.Properties.FancyzonesInActiveColor.Value, viewModel.ZoneInActiveColor);

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -336,6 +336,14 @@
     <value>Open layout editor</value>
     <comment>Shortcut to launch the FancyZones layout editor application</comment>
   </data>
+  <data name="FancyZones_HotkeyNextTabControl.Header" xml:space="preserve">
+    <value>Move to next tab</value>
+    <comment>Shortcut to move to the next application (tab) in the current zone.</comment>
+  </data>
+  <data name="FancyZones_HotkeyPrevTabControl.Header" xml:space="preserve">
+    <value>Move to previous tab</value>
+    <comment>Shortcut to move to the previous application (tab) in the current zone.</comment>
+  </data>
   <data name="SettingsPage_SetShortcut.AutomationProperties.Name" xml:space="preserve">
     <value>Shortcut setting</value>
   </data>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -87,7 +87,25 @@
                 MinWidth="240"
                 />
 
+            <CustomControls:HotkeySettingsControl
+                x:Uid="FancyZones_HotkeyNextTabControl"
+                Margin="{StaticResource SmallTopMargin}"
+                HotkeySettings="{x:Bind Path=ViewModel.NextTabHotkey, Mode=TwoWay}"
+                Keys="Win, Ctrl, Alt, Shift"
+                Enabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"
+                HorizontalAlignment="Left"
+                MinWidth="240"
+                />
 
+            <CustomControls:HotkeySettingsControl
+                x:Uid="FancyZones_HotkeyPrevTabControl"
+                Margin="{StaticResource SmallTopMargin}"
+                HotkeySettings="{x:Bind Path=ViewModel.PrevTabHotkey, Mode=TwoWay}"
+                Keys="Win, Ctrl, Alt, Shift"
+                Enabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"
+                HorizontalAlignment="Left"
+                MinWidth="240"
+                />
 
             <CheckBox x:Uid="FancyZones_UseCursorPosEditorStartupScreen"
                       IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.UseCursorPosEditorStartupScreen}"


### PR DESCRIPTION
Add keyboard shortcuts (without GUI) for cycling windows in the same zone (tabs).

## Summary of the Pull Request

Add keyboard shortcuts for cycling windows snapped to the same zone. These windows are named tabs.

## PR Checklist
* [ ] Applies (very partially) to #10 and implements #175.
* [ ] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests modified to work
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan.

## Info on Pull Request

_What does this include?_

## Validation Steps Performed

Snap multiple windows to the same zone. Once snapped, use chosen shortcuts (Widows key + Page Down / Widows key + Page Up) to cycle forward / backward.
