### PR TITLE
updating: remove all scheduled toast notifications from previous vers…

### DIFF
--- a/src/common/notifications/notifications.h
+++ b/src/common/notifications/notifications.h
@@ -62,5 +62,6 @@ namespace notifications
     void show_toast(std::wstring plaintext_message, std::wstring title, toast_params params = {});
     void show_toast_with_activations(std::wstring plaintext_message, std::wstring title, std::wstring_view background_handler_id, std::vector<action_t> actions, toast_params params = {});
     void update_toast_progress_bar(std::wstring_view tag, progress_bar_params params);
-    void remove_toasts(std::wstring_view tag);
+    void remove_toasts_by_tag(std::wstring_view tag);
+    void remove_all_scheduled_toasts();
 }

--- a/src/common/updating/notifications.cpp
+++ b/src/common/updating/notifications.cpp
@@ -24,7 +24,7 @@ namespace updating
 
         void show_unavailable(const notifications::strings& strings, std::wstring reason)
         {
-            remove_toasts(UPDATING_PROCESS_TOAST_TAG);
+            remove_toasts_by_tag(UPDATING_PROCESS_TOAST_TAG);
 
             toast_params toast_params{ UPDATING_PROCESS_TOAST_TAG, false };
             show_toast(std::move(reason), strings.TOAST_TITLE, std::move(toast_params));
@@ -32,7 +32,7 @@ namespace updating
 
         void show_available(const updating::new_version_download_info& info, const notifications::strings& strings)
         {
-            remove_toasts(UPDATING_PROCESS_TOAST_TAG);
+            remove_toasts_by_tag(UPDATING_PROCESS_TOAST_TAG);
 
             toast_params toast_params{ UPDATING_PROCESS_TOAST_TAG, false };
             std::wstring contents = strings.GITHUB_NEW_VERSION_AVAILABLE;
@@ -51,7 +51,7 @@ namespace updating
 
         void show_download_start(const updating::new_version_download_info& info, const notifications::strings& strings)
         {
-            remove_toasts(UPDATING_PROCESS_TOAST_TAG);
+            remove_toasts_by_tag(UPDATING_PROCESS_TOAST_TAG);
 
             progress_bar_params progress_bar_params;
             std::wstring progress_title{ info.version.toWstring() };
@@ -70,7 +70,7 @@ namespace updating
 
         void show_visit_github(const updating::new_version_download_info& info, const notifications::strings& strings)
         {
-            remove_toasts(UPDATING_PROCESS_TOAST_TAG);
+            remove_toasts_by_tag(UPDATING_PROCESS_TOAST_TAG);
 
             toast_params toast_params{ UPDATING_PROCESS_TOAST_TAG, false };
             std::wstring contents = strings.GITHUB_NEW_VERSION_AVAILABLE_OFFER_VISIT;
@@ -86,7 +86,7 @@ namespace updating
 
         void show_install_error(const updating::new_version_download_info& info, const notifications::strings& strings)
         {
-            remove_toasts(UPDATING_PROCESS_TOAST_TAG);
+            remove_toasts_by_tag(UPDATING_PROCESS_TOAST_TAG);
 
             toast_params toast_params{ UPDATING_PROCESS_TOAST_TAG, false };
             std::wstring contents = strings.GITHUB_NEW_VERSION_DOWNLOAD_INSTALL_ERROR;
@@ -101,7 +101,7 @@ namespace updating
 
         void show_version_ready(const updating::new_version_download_info& info, const notifications::strings& strings)
         {
-            remove_toasts(UPDATING_PROCESS_TOAST_TAG);
+            remove_toasts_by_tag(UPDATING_PROCESS_TOAST_TAG);
 
             toast_params toast_params{ UPDATING_PROCESS_TOAST_TAG, false };
             std::wstring new_version_ready{ strings.GITHUB_NEW_VERSION_READY_TO_INSTALL };
@@ -125,7 +125,7 @@ namespace updating
 
         void show_uninstallation_error(const notifications::strings& strings)
         {
-            remove_toasts(UPDATING_PROCESS_TOAST_TAG);
+            remove_toasts_by_tag(UPDATING_PROCESS_TOAST_TAG);
 
             show_toast(strings.UNINSTALLATION_UNKNOWN_ERROR, strings.TOAST_TITLE);
         }

--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -318,7 +318,8 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         }
     case SpecialMode::ReportSuccessfulUpdate:
     {
-        notifications::remove_toasts(notifications::UPDATING_PROCESS_TOAST_TAG);
+        notifications::remove_toasts_by_tag(notifications::UPDATING_PROCESS_TOAST_TAG);
+        notifications::remove_all_scheduled_toasts();
         notifications::show_toast(GET_RESOURCE_STRING(IDS_PT_UPDATE_MESSAGE_BOX_TEXT),
                                   L"PowerToys",
                                   notifications::toast_params{ notifications::UPDATING_PROCESS_TOAST_TAG });


### PR DESCRIPTION
## Summary of the Pull Request

This is not an exhaustive fix for #7753, since scheduled (snoozed) toast notifications do not save their original attached properties like tag and group, so we cannot determine reliably<sup>[1]</sup> which of the scheduled notifications to remove. That's why we remove all scheduled notifications upon successful update, assuming they are no longer of any interest.


[1] - in theory, we could inspect raw XML content of the scheduled toasts, while leaving some identification info inside it as XML comments beforehand. we could explore that approach if we continue to get these kind of issue reports.

## PR Checklist
* [x] Applies to #7753

## Validation Steps Performed

- test that a scheduled notification is removed using the new API