### PR TITLE
[PT Run] String with accented characters search

### DIFF
--- a/src/modules/launcher/Wox.Infrastructure/StringMatcher.cs
+++ b/src/modules/launcher/Wox.Infrastructure/StringMatcher.cs
@@ -96,7 +96,18 @@ namespace Wox.Infrastructure
                     spaceIndices.Add(compareStringIndex);
                 }
 
-                bool compareResult = opt.IgnoreCase ? string.Compare(fullStringToCompareWithoutCase[compareStringIndex].ToString(), currentQuerySubstring[currentQuerySubstringCharacterIndex].ToString(), CultureInfo.CurrentCulture, CompareOptions.IgnoreCase | CompareOptions.IgnoreNonSpace) != 0 : fullStringToCompareWithoutCase[compareStringIndex] != currentQuerySubstring[currentQuerySubstringCharacterIndex];
+                bool compareResult;
+                if (opt.IgnoreCase)
+                {
+                    var fullStringToCompare = fullStringToCompareWithoutCase[compareStringIndex].ToString();
+                    var querySubstring = currentQuerySubstring[currentQuerySubstringCharacterIndex].ToString();
+                    compareResult = string.Compare(fullStringToCompare, querySubstring, CultureInfo.CurrentCulture, CompareOptions.IgnoreCase | CompareOptions.IgnoreNonSpace) != 0;
+                }
+                else
+                {
+                    compareResult = fullStringToCompareWithoutCase[compareStringIndex] != currentQuerySubstring[currentQuerySubstringCharacterIndex];
+                }
+
                 if (compareResult)
                 {
                     matchFoundInPreviousLoop = false;

--- a/src/modules/launcher/Wox.Infrastructure/StringMatcher.cs
+++ b/src/modules/launcher/Wox.Infrastructure/StringMatcher.cs
@@ -96,7 +96,8 @@ namespace Wox.Infrastructure
                     spaceIndices.Add(compareStringIndex);
                 }
 
-                if (fullStringToCompareWithoutCase[compareStringIndex] != currentQuerySubstring[currentQuerySubstringCharacterIndex])
+                bool compareResult = opt.IgnoreCase ? string.Compare(fullStringToCompareWithoutCase[compareStringIndex].ToString(), currentQuerySubstring[currentQuerySubstringCharacterIndex].ToString(), CultureInfo.CurrentCulture, CompareOptions.IgnoreCase | CompareOptions.IgnoreNonSpace) != 0 : fullStringToCompareWithoutCase[compareStringIndex] != currentQuerySubstring[currentQuerySubstringCharacterIndex];
+                if (compareResult)
                 {
                     matchFoundInPreviousLoop = false;
                     continue;


### PR DESCRIPTION
## Summary of the Pull Request

Compare strings using `CultureInfo.CurrentCulture, CompareOptions.IgnoreCase | CompareOptions.IgnoreNonSpace`.

## PR Checklist
* [x] Applies to #4147
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

![Image 2020-12-18 at 7 04 09 PM](https://user-images.githubusercontent.com/8949536/102635323-349a6200-4164-11eb-81a0-590837d2767b.png)
![Image 2020-12-18 at 7 06 11 PM](https://user-images.githubusercontent.com/8949536/102635355-3ebc6080-4164-11eb-9164-48b6b30c2576.png)

## Validation Steps Performed

Search any app or file containing an accented character in the name without using accented characters.
