### PR TITLE
[Image Resizer] Handling percentage unit fix

### DIFF
--- a/src/modules/imageresizer/tests/Models/ResizeSizeTests.cs
+++ b/src/modules/imageresizer/tests/Models/ResizeSizeTests.cs
@@ -7,7 +7,6 @@ using System.ComponentModel;
 using ImageResizer.Properties;
 using ImageResizer.Test;
 using Xunit;
-using Xunit.Extensions;
 
 namespace ImageResizer.Models
 {
@@ -268,6 +267,42 @@ namespace ImageResizer.Models
             var result = size.GetPixelWidth(100, 96);
 
             Assert.Equal(50, result);
+        }
+
+        [Theory]
+        [InlineData(ResizeFit.Fill, ResizeUnit.Centimeter)]
+        [InlineData(ResizeFit.Fill, ResizeUnit.Inch)]
+        [InlineData(ResizeFit.Fill, ResizeUnit.Pixel)]
+        [InlineData(ResizeFit.Fit, ResizeUnit.Centimeter)]
+        [InlineData(ResizeFit.Fit, ResizeUnit.Inch)]
+        [InlineData(ResizeFit.Fit, ResizeUnit.Pixel)]
+        [InlineData(ResizeFit.Stretch, ResizeUnit.Centimeter)]
+        [InlineData(ResizeFit.Stretch, ResizeUnit.Inch)]
+        [InlineData(ResizeFit.Stretch, ResizeUnit.Percent)]
+        [InlineData(ResizeFit.Stretch, ResizeUnit.Pixel)]
+        public void HeightVisible(ResizeFit fit, ResizeUnit unit)
+        {
+            var size = new ResizeSize
+            {
+                Fit = fit,
+                Unit = unit,
+            };
+
+            Assert.True(size.ShowHeight);
+        }
+
+        [Theory]
+        [InlineData(ResizeFit.Fill, ResizeUnit.Percent)]
+        [InlineData(ResizeFit.Fit, ResizeUnit.Percent)]
+        public void HeightNotVisible(ResizeFit fit, ResizeUnit unit)
+        {
+            var size = new ResizeSize
+            {
+                Fit = fit,
+                Unit = unit,
+            };
+
+            Assert.False(size.ShowHeight);
         }
     }
 }

--- a/src/modules/imageresizer/ui/Models/ResizeSize.cs
+++ b/src/modules/imageresizer/ui/Models/ResizeSize.cs
@@ -52,7 +52,15 @@ namespace ImageResizer.Models
         public ResizeFit Fit
         {
             get => _fit;
-            set => Set(ref _fit, value);
+            set
+            {
+                var previousFit = _fit;
+                Set(ref _fit, value);
+                if (!Equals(previousFit, value))
+                {
+                    UpdateShowHeight();
+                }
+            }
         }
 
         [JsonProperty(PropertyName = "width")]
@@ -112,7 +120,7 @@ namespace ImageResizer.Models
 
         private void UpdateShowHeight()
         {
-            ShowHeight = Unit != ResizeUnit.Percent;
+            ShowHeight = Fit == ResizeFit.Stretch || Unit != ResizeUnit.Percent;
         }
 
         private double ConvertToPixels(double value, ResizeUnit unit, int originalValue, double dpi)

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ImageSize.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ImageSize.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation
+// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -70,7 +70,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         {
             get
             {
-                if (Unit == 2)
+                if (Unit == 2 && Fit != 2)
                 {
                     return 0;
                 }
@@ -85,7 +85,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         {
             get
             {
-                if (Unit == 2)
+                if (Unit == 2 && Fit != 2)
                 {
                     return false;
                 }
@@ -128,6 +128,8 @@ namespace Microsoft.PowerToys.Settings.UI.Library
                 {
                     _fit = value;
                     OnPropertyChanged();
+                    OnPropertyChanged(nameof(ExtraBoxOpacity));
+                    OnPropertyChanged(nameof(EnableEtraBoxes));
                 }
             }
         }


### PR DESCRIPTION
## Summary of the Pull Request

This fix the previous PR https://github.com/microsoft/PowerToys/pull/8567
Aligned the behaviour of Image Resizer and PowerToys Settings when using percentage as resize unit.

## PR Checklist
* [x] Applies to #8005
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

When percentage unit is selected height is displayed only if mode is stretch.

## Validation Steps Performed

Validate height visibility when percetange unit is selected in Image Resizer and PowerToys Settings.
