### PR TITLE
setup: don't set System.AppUserModel.ToastActivatorCLSID shortcut pro…

### DIFF
--- a/installer/PowerToysSetup/Product.wxs
+++ b/installer/PowerToysSetup/Product.wxs
@@ -292,7 +292,8 @@
                     IconIndex="0"
                     Advertise="yes">
             <ShortcutProperty Key="System.AppUserModel.ID" Value="Microsoft.PowerToysWin32"/>
-            <ShortcutProperty Key="System.AppUserModel.ToastActivatorCLSID" Value="{DD5CACDA-7C2E-4997-A62A-04A597B58F76}"/>
+            <!-- ToastActivatorCLSID is used only by toast background activation, which currently isn't used, but causes MSI warning 1946 to display for a small share of users -->
+            <!-- <ShortcutProperty Key="System.AppUserModel.ToastActivatorCLSID" Value="{DD5CACDA-7C2E-4997-A62A-04A597B58F76}"/> -->
           </Shortcut>
         </File>
 


### PR DESCRIPTION
…perty

## Summary of the Pull Request

see [comment](https://github.com/microsoft/PowerToys/issues/8535#issuecomment-748353681). 

## PR Checklist
* [x] Applies to #8535

## Validation Steps Performed

- setup PT on a clean VM and version set to 0.26. Update toast notification was shown and "Update now"/"at next launch" buttons worked without issues, meaning that url activation isn't broken by this change