### PR TITLE
[FZ Editor] Serialize/deserialize settings fix

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
@@ -548,7 +548,7 @@ namespace FancyZonesEditor.Utils
                 });
             }
 
-            // Seriaslize unused devices
+            // Serialize unused devices
             foreach (var device in _unusedDevices)
             {
                 zoneSettings.Devices.Add(device);

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -650,6 +650,11 @@ void FancyZones::ToggleEditor() noexcept
     std::vector<std::pair<HMONITOR, MONITORINFOEX>> allMonitors;
     allMonitors = FancyZonesUtils::GetAllMonitorInfo<&MONITORINFOEX::rcWork>();
 
+    if (spanZonesAcrossMonitors)
+    {
+        params += FancyZonesUtils::GenerateUniqueIdAllMonitorsArea(virtualDesktopId.get()) + divider; /* Monitor id where the Editor should be opened */
+    }
+   
     // device id map
     std::unordered_map<std::wstring, DWORD> displayDeviceIdxMap;
 
@@ -664,7 +669,7 @@ void FancyZones::ToggleEditor() noexcept
         std::wstring deviceId = FancyZonesUtils::GetDisplayDeviceId(monitorInfo.szDevice, displayDeviceIdxMap);
         std::wstring monitorId = FancyZonesUtils::GenerateUniqueId(monitor, deviceId, virtualDesktopId.get());
 
-        if (monitor == targetMonitor)
+        if (monitor == targetMonitor && !spanZonesAcrossMonitors)
         {
             params += monitorId + divider; /* Monitor id where the Editor should be opened */
         }

--- a/src/modules/fancyzones/lib/FancyZonesData.cpp
+++ b/src/modules/fancyzones/lib/FancyZonesData.cpp
@@ -513,41 +513,59 @@ void FancyZonesData::SaveFancyZonesEditorParameters(bool spanZonesAcrossMonitors
     argsJson.processId = GetCurrentProcessId(); /* Process id */
     argsJson.spanZonesAcrossMonitors = spanZonesAcrossMonitors; /* Span zones */
 
-    std::vector<std::pair<HMONITOR, MONITORINFOEX>> allMonitors;
-    allMonitors = FancyZonesUtils::GetAllMonitorInfo<&MONITORINFOEX::rcWork>();
-
-    // device id map for correct device ids
-    std::unordered_map<std::wstring, DWORD> displayDeviceIdxMap;
-
-    for (auto& monitorData : allMonitors)
+    if (spanZonesAcrossMonitors)
     {
-        HMONITOR monitor = monitorData.first;
-        auto monitorInfo = monitorData.second;
+        auto monitorRect = FancyZonesUtils::GetAllMonitorsCombinedRect<&MONITORINFOEX::rcWork>();
+        std::wstring monitorId = FancyZonesUtils::GenerateUniqueIdAllMonitorsArea(virtualDesktopId);
 
         JSONHelpers::MonitorInfo monitorJson;
-
-        std::wstring deviceId = FancyZonesUtils::GetDisplayDeviceId(monitorInfo.szDevice, displayDeviceIdxMap);
-        std::wstring monitorId = FancyZonesUtils::GenerateUniqueId(monitor, deviceId, virtualDesktopId);
-        
-        if (monitor == targetMonitor)
-        {
-            monitorJson.isSelected = true; /* Is monitor selected for the main editor window opening */
-        }
-
-        monitorJson.id = monitorId; /* Monitor id */
-
-        UINT dpiX = 0;
-        UINT dpiY = 0;
-        if (GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &dpiX, &dpiY) == S_OK)
-        {
-            monitorJson.dpi = dpiX; /* DPI */
-        }
-
-        monitorJson.top = monitorInfo.rcMonitor.top; /* Top coordinate */
-        monitorJson.left = monitorInfo.rcMonitor.left; /* Left coordinate */
+        monitorJson.id = monitorId;
+        monitorJson.top = monitorRect.top;
+        monitorJson.left = monitorRect.left;
+        monitorJson.isSelected = true;
+        monitorJson.dpi = 0; // unused
 
         argsJson.monitors.emplace_back(std::move(monitorJson)); /* add monitor data */
     }
+    else
+    {
+        std::vector<std::pair<HMONITOR, MONITORINFOEX>> allMonitors;
+        allMonitors = FancyZonesUtils::GetAllMonitorInfo<&MONITORINFOEX::rcWork>();
+
+        // device id map for correct device ids
+        std::unordered_map<std::wstring, DWORD> displayDeviceIdxMap;
+
+        for (auto& monitorData : allMonitors)
+        {
+            HMONITOR monitor = monitorData.first;
+            auto monitorInfo = monitorData.second;
+
+            JSONHelpers::MonitorInfo monitorJson;
+
+            std::wstring deviceId = FancyZonesUtils::GetDisplayDeviceId(monitorInfo.szDevice, displayDeviceIdxMap);
+            std::wstring monitorId = FancyZonesUtils::GenerateUniqueId(monitor, deviceId, virtualDesktopId);
+
+            if (monitor == targetMonitor)
+            {
+                monitorJson.isSelected = true; /* Is monitor selected for the main editor window opening */
+            }
+
+            monitorJson.id = monitorId; /* Monitor id */
+
+            UINT dpiX = 0;
+            UINT dpiY = 0;
+            if (GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &dpiX, &dpiY) == S_OK)
+            {
+                monitorJson.dpi = dpiX; /* DPI */
+            }
+
+            monitorJson.top = monitorInfo.rcMonitor.top; /* Top coordinate */
+            monitorJson.left = monitorInfo.rcMonitor.left; /* Left coordinate */
+
+            argsJson.monitors.emplace_back(std::move(monitorJson)); /* add monitor data */
+        }
+    }
+    
 
     json::to_file(editorParametersFileName, JSONHelpers::EditorArgs::ToJson(argsJson));
 }


### PR DESCRIPTION
## Summary of the Pull Request

Fix data resetting after switching `Allow zones to span across monitors` option.

## PR Checklist
* [x] Applies to #8614
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Info on Pull Request

_What does this include?_

## Validation Steps Performed

* Apply layouts with the option `Allow zones to span across monitors` on and off
* Verify that layouts were saved and applied correctly after switching the option
