### PR TITLE
[FZ Editor] Hide unsupported settings in custom layouts flyouts

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/Converters/LayoutModelTypeToVisibilityConverter.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Converters/LayoutModelTypeToVisibilityConverter.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Windows;
+using System.Windows.Data;
+using FancyZonesEditor.Models;
+
+namespace FancyZonesEditor.Converters
+{
+    public class LayoutModelTypeToVisibilityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            return value is CanvasLayoutModel ? Visibility.Collapsed : Visibility.Visible;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            return null;
+        }
+    }
+}

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -26,6 +26,8 @@
         ResizeMode="CanResize">
     <Window.Resources>
 
+        <Converters:LayoutModelTypeToVisibilityConverter x:Key="LayoutModelTypeToVisibilityConverter" />
+
         <DataTemplate x:Key="MonitorItemTemplate">
             <Border x:Name="MonitorItem"
                     Width="{Binding DisplayWidth}"
@@ -153,20 +155,23 @@
                                             Orientation="Vertical">
                                     <ui:ToggleSwitch x:Name="spaceAroundSetting"
                                                      Header="{x:Static props:Resources.Show_Space_Zones}"
-                                                     IsOn="true" />
+                                                     IsOn="true" 
+                                                     Visibility="{Binding Converter={StaticResource LayoutModelTypeToVisibilityConverter}}"/>
 
                                     <TextBlock x:Name="paddingValue"
                                                Text="{x:Static props:Resources.Space_Around_Zones}"
                                                IsEnabled="{Binding ShowSpacing}"
                                                Margin="0,8,0,0"
-                                               Foreground="{DynamicResource PrimaryForegroundBrush}" />
+                                               Foreground="{DynamicResource PrimaryForegroundBrush}" 
+                                               Visibility="{Binding Converter={StaticResource LayoutModelTypeToVisibilityConverter}}"/>
 
                                     <TextBox Margin="0,6,0,0"
                                              IsEnabled="{Binding ShowSpacing}"
                                              Text="32"
                                              Width="86"
                                              HorizontalAlignment="Left"
-                                             AutomationProperties.LabeledBy="{Binding ElementName=paddingValue}" />
+                                             AutomationProperties.LabeledBy="{Binding ElementName=paddingValue}" 
+                                             Visibility="{Binding Converter={StaticResource LayoutModelTypeToVisibilityConverter}}"/>
 
                                     <TextBlock Text="{x:Static props:Resources.Distance_adjacent_zones}"
                                                IsEnabled="{Binding ShowSpacing}"
@@ -323,20 +328,23 @@
                                             Orientation="Vertical">
                                     <ui:ToggleSwitch x:Name="spaceAroundSetting"
                                                      Header="{x:Static props:Resources.Show_Space_Zones}"
-                                                     IsOn="true" />
+                                                     IsOn="true" 
+                                                     Visibility="{Binding Converter={StaticResource LayoutModelTypeToVisibilityConverter}}"/>
 
                                     <TextBlock x:Name="paddingValue"
                                                Text="{x:Static props:Resources.Space_Around_Zones}"
                                                IsEnabled="{Binding ShowSpacing}"
                                                Margin="0,8,0,0"
-                                               Foreground="{DynamicResource PrimaryForegroundBrush}" />
+                                               Foreground="{DynamicResource PrimaryForegroundBrush}" 
+                                               Visibility="{Binding Converter={StaticResource LayoutModelTypeToVisibilityConverter}}" />
 
                                     <TextBox Margin="0,6,0,0"
                                              IsEnabled="{Binding ShowSpacing}"
                                              Text="32"
                                              Width="86"
                                              HorizontalAlignment="Left"
-                                             AutomationProperties.LabeledBy="{Binding ElementName=paddingValue}" />
+                                             AutomationProperties.LabeledBy="{Binding ElementName=paddingValue}" 
+                                             Visibility="{Binding Converter={StaticResource LayoutModelTypeToVisibilityConverter}}"/>
 
                                     <TextBlock Text="{x:Static props:Resources.Distance_adjacent_zones}"
                                                IsEnabled="{Binding ShowSpacing}"


### PR DESCRIPTION
## Summary of the Pull Request

Hide in the custom layouts flyouts spacing settings for canvas-based layouts.

![Image 2020-12-23 at 11 27 16 AM (Small)](https://user-images.githubusercontent.com/8949536/102976322-6ae43280-4512-11eb-8eb4-3c062a2a7af2.png)
![Image 2020-12-23 at 11 27 53 AM (Small)](https://user-images.githubusercontent.com/8949536/102976393-89e2c480-4512-11eb-8805-48667133cefa.png)



## PR Checklist
* [x] Applies to #8715
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Validation Steps Performed

Click on an `Edit Layout` button and verify that `Show space around zones` and `Space around zones` settings presented for grid layouts and not presented for canvas layouts, both custom and template.
