### PR TITLE
[FZ Editor] Spacing settings in layout flyouts

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/Converters/LayoutTypeToVisibilityConverter.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Converters/LayoutTypeToVisibilityConverter.cs
@@ -9,11 +9,11 @@ using FancyZonesEditor.Models;
 
 namespace FancyZonesEditor.Converters
 {
-    public class LayoutModelTypeToVisibilityConverter : IValueConverter
+    public class LayoutTypeToVisibilityConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            return value is CanvasLayoutModel ? Visibility.Collapsed : Visibility.Visible;
+            return (LayoutType)value == LayoutType.Custom ? Visibility.Visible : Visibility.Collapsed;
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
@@ -332,7 +332,7 @@ namespace FancyZonesEditor
                 }
             }
 
-            zone = new GridZone(model.ShowSpacing ? model.Spacing : 0);
+            zone = new GridZone(Model.ShowSpacing ? Model.Spacing : 0);
             zone.Split += OnSplit;
             zone.MergeDrag += OnMergeDrag;
             zone.MergeComplete += OnMergeComplete;

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
@@ -332,7 +332,7 @@ namespace FancyZonesEditor
                 }
             }
 
-            zone = new GridZone();
+            zone = new GridZone(model.ShowSpacing ? model.Spacing : 0);
             zone.Split += OnSplit;
             zone.MergeDrag += OnMergeDrag;
             zone.MergeComplete += OnMergeComplete;
@@ -383,9 +383,7 @@ namespace FancyZonesEditor
                 return;
             }
 
-            MainWindowSettingsModel settings = ((App)Application.Current).MainWindowSettings;
-
-            int spacing = settings.ShowSpacing ? settings.Spacing : 0;
+            int spacing = model.ShowSpacing ? model.Spacing : 0;
 
             _data.RecalculateZones(spacing, arrangeSize);
             _data.ArrangeZones(Preview.Children, spacing);
@@ -411,10 +409,10 @@ namespace FancyZonesEditor
                 if (_dragHandles.HasSnappedNonAdjacentResizers(resizer))
                 {
                     double spacing = 0;
-                    MainWindowSettingsModel settings = ((App)Application.Current).MainWindowSettings;
-                    if (settings.ShowSpacing)
+                    GridLayoutModel model = Model;
+                    if (model.ShowSpacing)
                     {
-                        spacing = settings.Spacing;
+                        spacing = model.Spacing;
                     }
 
                     _data.SplitOnDrag(resizer, delta, spacing);

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridZone.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridZone.xaml.cs
@@ -59,7 +59,7 @@ namespace FancyZonesEditor
             set { SetValue(IsSelectedProperty, value); }
         }
 
-        public GridZone()
+        public GridZone(int spacing)
         {
             InitializeComponent();
             OnSelectionChanged();
@@ -68,6 +68,9 @@ namespace FancyZonesEditor
                 Fill = SystemParameters.WindowGlassBrush,
             };
             Body.Children.Add(_splitter);
+
+            Spacing = spacing;
+            SplitterThickness = Math.Max(spacing, 1);
 
             ((App)Application.Current).MainWindowSettings.PropertyChanged += ZoneSettings_PropertyChanged;
         }
@@ -104,19 +107,9 @@ namespace FancyZonesEditor
             }
         }
 
-        private int SplitterThickness
-        {
-            get
-            {
-                MainWindowSettingsModel settings = ((App)Application.Current).MainWindowSettings;
-                if (!settings.ShowSpacing)
-                {
-                    return 1;
-                }
+        private int Spacing { get; set; }
 
-                return Math.Max(settings.Spacing, 1);
-            }
-        }
+        private int SplitterThickness { get; set; }
 
         private void UpdateSplitter()
         {
@@ -282,14 +275,7 @@ namespace FancyZonesEditor
 
         private void DoSplit(Orientation orientation, double offset)
         {
-            int spacing = 0;
-            MainWindowSettingsModel settings = ((App)Application.Current).MainWindowSettings;
-            if (settings.ShowSpacing)
-            {
-                spacing = settings.Spacing;
-            }
-
-            Split?.Invoke(this, new SplitEventArgs(orientation, offset, spacing));
+            Split?.Invoke(this, new SplitEventArgs(orientation, offset, Spacing));
         }
 
         private void FullSplit_Click(object sender, RoutedEventArgs e)

--- a/src/modules/fancyzones/editor/FancyZonesEditor/LayoutPreview.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/LayoutPreview.xaml.cs
@@ -115,9 +115,7 @@ namespace FancyZonesEditor
             RowColInfo[] colInfo = (from percent in grid.ColumnPercents
                                     select new RowColInfo(percent)).ToArray();
 
-            MainWindowSettingsModel settings = ((App)Application.Current).MainWindowSettings;
-
-            int spacing = settings.ShowSpacing ? settings.Spacing : 0;
+            int spacing = grid.ShowSpacing ? grid.Spacing : 0;
 
             var workArea = App.Overlay.WorkArea;
             double width = workArea.Width - (spacing * (cols + 1));
@@ -215,8 +213,7 @@ namespace FancyZonesEditor
                 Body.ColumnDefinitions.Add(def);
             }
 
-            MainWindowSettingsModel settings = ((App)Application.Current).MainWindowSettings;
-            Thickness margin = new Thickness(settings.ShowSpacing ? settings.Spacing / 20 : 0);
+            Thickness margin = new Thickness(grid.ShowSpacing ? grid.Spacing / 20 : 0);
 
             List<int> visited = new List<int>();
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -152,10 +152,35 @@
                         <ui:Flyout x:Name="EditFlyout"
                                    Placement="RightEdgeAlignedTop">
                             <StackPanel MinWidth="260">
+                                <Button Click="EditLayout_Click"
+                                        x:Name="editZoneLayoutButton"
+                                        HorizontalAlignment="Stretch"
+                                        AutomationProperties.Name="{x:Static props:Resources.Edit_zones}"
+                                        Height="48"
+                                        Style="{StaticResource AccentButtonStyle}"
+                                        Visibility="{Binding Type, Converter={StaticResource LayoutTypeToVisibilityConverter}}">
+                                    <Button.Content>
+                                        <StackPanel Orientation="Horizontal">
+                                            <TextBlock Text="&#xE104;"
+                                                       Margin="0,2,8,0"
+                                                       FontFamily="Segoe MDL2 Assets" />
+                                            <TextBlock Text="{x:Static props:Resources.Edit_zones}" />
+                                        </StackPanel>
+                                    </Button.Content>
+                                </Button>
+                                <TextBlock x:Name="nameHeader"
+                                           Text="{x:Static props:Resources.Name}"
+                                           Margin="0,32,0,0"
+                                           Foreground="{DynamicResource PrimaryForegroundBrush}"
+                                           Visibility="{Binding Type, Converter={StaticResource LayoutTypeToVisibilityConverter}}" />
+                                <TextBox Text="{Binding Name}"
+                                         Margin="0,6,0,16"
+                                         AutomationProperties.LabeledBy="{Binding ElementName=nameHeader}"
+                                         Visibility="{Binding Type, Converter={StaticResource LayoutTypeToVisibilityConverter}}"/>
+                                
                                 <StackPanel Margin="0,0,0,0"
                                             Orientation="Vertical">
                                     <TextBlock Text="{x:Static props:Resources.Distance_adjacent_zones}"
-                                               IsEnabled="{Binding ShowSpacing}"
                                                Margin="0,16,0,0"
                                                Foreground="{DynamicResource PrimaryForegroundBrush}"
                                                x:Name="sensitivityRadiusValue" />
@@ -179,6 +204,21 @@
                                                            Margin="0,3,8,0"
                                                            FontFamily="Segoe MDL2 Assets" />
                                                 <TextBlock Text="{x:Static props:Resources.Duplicate}" />
+                                            </StackPanel>
+                                        </Button.Content>
+                                    </Button>
+
+                                    <Button Foreground="#FFC50500"
+                                            AutomationProperties.Name="{x:Static props:Resources.Delete}"
+                                            Click="DeleteLayout_Click"
+                                            Background="Transparent"
+                                            Visibility="{Binding Type, Converter={StaticResource LayoutTypeToVisibilityConverter}}">
+                                        <Button.Content>
+                                            <StackPanel Orientation="Horizontal">
+                                                <TextBlock Text="&#xE107;"
+                                                           Margin="0,3,8,0"
+                                                           FontFamily="Segoe MDL2 Assets" />
+                                                <TextBlock Text="{x:Static props:Resources.Delete}" />
                                             </StackPanel>
                                         </Button.Content>
                                     </Button>
@@ -280,6 +320,32 @@
                         <ui:Flyout x:Name="EditFlyout"
                                    Placement="RightEdgeAlignedTop">
                             <StackPanel MinWidth="260">
+                                <Button Click="EditLayout_Click"
+                                        x:Name="editZoneLayoutButton"
+                                        HorizontalAlignment="Stretch"
+                                        AutomationProperties.Name="{x:Static props:Resources.Edit_zones}"
+                                        Height="48"
+                                        Style="{StaticResource AccentButtonStyle}"
+                                        Visibility="{Binding Type, Converter={StaticResource LayoutTypeToVisibilityConverter}}">
+                                    <Button.Content>
+                                        <StackPanel Orientation="Horizontal">
+                                            <TextBlock Text="&#xE104;"
+                                                       Margin="0,2,8,0"
+                                                       FontFamily="Segoe MDL2 Assets" />
+                                            <TextBlock Text="{x:Static props:Resources.Edit_zones}" />
+                                        </StackPanel>
+                                    </Button.Content>
+                                </Button>
+                                <TextBlock x:Name="nameHeader"
+                                           Text="{x:Static props:Resources.Name}"
+                                           Margin="0,32,0,0"
+                                           Foreground="{DynamicResource PrimaryForegroundBrush}"
+                                           Visibility="{Binding Type, Converter={StaticResource LayoutTypeToVisibilityConverter}}" />
+                                <TextBox Text="{Binding Name}"
+                                         Margin="0,6,0,16"
+                                         AutomationProperties.LabeledBy="{Binding ElementName=nameHeader}"
+                                         Visibility="{Binding Type, Converter={StaticResource LayoutTypeToVisibilityConverter}}"/>
+
                                 <StackPanel Margin="0,0,0,0"
                                             Orientation="Vertical">
                                     <ui:ToggleSwitch x:Name="spaceAroundSetting"
@@ -324,183 +390,12 @@
                                             </StackPanel>
                                         </Button.Content>
                                     </Button>
-                                </StackPanel>
-                            </StackPanel>
-                        </ui:Flyout>
-                    </ui:FlyoutService.Flyout>
-                </Button>
-            </Grid>
-            <DataTemplate.Triggers>
-                <DataTrigger Binding="{Binding IsApplied}"
-                             Value="true">
-                    <Setter TargetName="layoutName"
-                            Property="Foreground"
-                            Value="{DynamicResource SystemAccentColorLight1Brush}" />
-                    <Setter TargetName="EditLayoutButton"
-                            Property="Visibility"
-                            Value="Visible" />
-
-                    <Setter TargetName="SelectionHighlight"
-                            Property="Visibility"
-                            Value="Visible" />
-                </DataTrigger>
-                <DataTrigger Binding="{Binding IsSelected}"
-                             Value="true">
-                    <Setter TargetName="LayoutItem"
-                            Property="BorderBrush"
-                            Value="{DynamicResource LayoutItemBorderPointerOverBrush}" />
-                </DataTrigger>
-            </DataTemplate.Triggers>
-        </DataTemplate>
-
-        <DataTemplate x:Key="CustomLayoutItemTemplate">
-            <Grid Background="Transparent"
-                  KeyDown="LayoutItem_KeyDown"
-                  MouseEnter="LayoutItem_MouseEnter"
-                  MouseLeave="LayoutItem_MouseLeave"
-                  MouseDown="LayoutItem_Click"
-                  Margin="0,0,0,12">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="*" />
-                    <RowDefinition Height="24" />
-                </Grid.RowDefinitions>
-
-                <Border x:Name="LayoutItem"
-                        Background="{DynamicResource LayoutItemBackgroundBrush}"
-                        BorderBrush="{DynamicResource LayoutItemBackgroundBrush}"
-                        BorderThickness="1"
-                        Focusable="True"
-                        CornerRadius="4"
-                        Margin="8"
-                        FocusVisualStyle="{StaticResource UWPFocusVisualStyle}"
-                        FocusManager.GotFocus="LayoutItem_Focused">
-                    <Border.Effect>
-                        <DropShadowEffect BlurRadius="6"
-                                          Opacity="0.24"
-                                          ShadowDepth="1" />
-                    </Border.Effect>
-
-                    <local:LayoutPreview Margin="12"
-                                         VerticalAlignment="Stretch"
-                                         HorizontalAlignment="Stretch" />
-                </Border>
-                <Border x:Name="SelectionHighlight"
-                        CornerRadius="4"
-                        BorderThickness="3"
-                        Margin="6"
-                        Visibility="Collapsed"
-                        BorderBrush="{DynamicResource SystemControlBackgroundAccentBrush}" />
-                <TextBlock Name="layoutName"
-                           Padding="8,0,8,0"
-                           TextTrimming="CharacterEllipsis"
-                           Text="{Binding Name}"
-                           FontSize="14"
-                           Grid.Row="2"
-                           FontWeight="SemiBold"
-                           HorizontalAlignment="Center"
-                           VerticalAlignment="Center"
-                           Foreground="{DynamicResource PrimaryForegroundBrush}" />
-                <Button Content="&#xE104;"
-                        x:Name="EditLayoutButton"
-                        Visibility="Collapsed"
-                        FontFamily="Segoe MDL2 Assets"
-                        FontSize="14"
-                        HorizontalAlignment="Center"
-                        VerticalAlignment="Center"
-                        Width="36"
-                        Height="36"
-                        ToolTip="{x:Static props:Resources.Edit_Layout}"
-                        AutomationProperties.Name="{x:Static props:Resources.Edit_Layout}"
-                        Style="{StaticResource AccentButtonStyle}"
-                        ui:ControlHelper.CornerRadius="48">
-                    <Button.Effect>
-                        <DropShadowEffect BlurRadius="6"
-                                          Opacity="0.32"
-                                          ShadowDepth="1" />
-                    </Button.Effect>
-                    <ui:FlyoutService.Flyout>
-                        <ui:Flyout x:Name="EditFlyout"
-                                   Placement="RightEdgeAlignedTop">
-                            <StackPanel MinWidth="260">
-                                <Button Click="EditLayout_Click"
-                                        x:Name="editZoneLayoutButton"
-                                        HorizontalAlignment="Stretch"
-                                        AutomationProperties.Name="{x:Static props:Resources.Edit_zones}"
-                                        Height="48"
-                                        Style="{StaticResource AccentButtonStyle}">
-                                    <Button.Content>
-                                        <StackPanel Orientation="Horizontal">
-                                            <TextBlock Text="&#xE104;"
-                                                       Margin="0,2,8,0"
-                                                       FontFamily="Segoe MDL2 Assets" />
-                                            <TextBlock Text="{x:Static props:Resources.Edit_zones}" />
-                                        </StackPanel>
-                                    </Button.Content>
-                                </Button>
-
-
-                                <TextBlock x:Name="nameHeader"
-                                           Text="{x:Static props:Resources.Name}"
-                                           IsEnabled="{Binding ShowSpacing}"
-                                           Margin="0,32,0,0"
-                                           Foreground="{DynamicResource PrimaryForegroundBrush}" />
-                                <TextBox Text="{Binding Name}"
-                                         Margin="0,6,0,0"
-                                         AutomationProperties.LabeledBy="{Binding ElementName=nameHeader}" />
-                                <StackPanel Margin="0,16,0,0"
-                                            Orientation="Vertical">
-                                    <ui:ToggleSwitch x:Name="spaceAroundSetting"
-                                                     Header="{x:Static props:Resources.Show_Space_Zones}"
-                                                     IsOn="true" 
-                                                     Visibility="{Binding Converter={StaticResource LayoutModelTypeToVisibilityConverter}}"/>
-
-                                    <TextBlock x:Name="paddingValue"
-                                               Text="{x:Static props:Resources.Space_Around_Zones}"
-                                               Margin="0,8,0,0"
-                                               Foreground="{DynamicResource PrimaryForegroundBrush}" 
-                                               Visibility="{Binding Converter={StaticResource LayoutModelTypeToVisibilityConverter}}" />
-
-                                    <TextBox Margin="0,6,0,0"
-                                             Text="32"
-                                             Width="86"
-                                             HorizontalAlignment="Left"
-                                             AutomationProperties.LabeledBy="{Binding ElementName=paddingValue}" 
-                                             Visibility="{Binding Converter={StaticResource LayoutModelTypeToVisibilityConverter}}"/>
-
-                                    <TextBlock Text="{x:Static props:Resources.Distance_adjacent_zones}"
-                                               IsEnabled="{Binding ShowSpacing}"
-                                               Margin="0,16,0,0"
-                                               Foreground="{DynamicResource PrimaryForegroundBrush}"
-                                               x:Name="sensitivityRadiusValue" />
-
-                                    <TextBox Margin="0,6,0,0"
-                                             Text="20"
-                                             Width="86"
-                                             AutomationProperties.LabeledBy="{Binding ElementName=sensitivityRadiusValue}"
-                                             HorizontalAlignment="Left" />
-                                </StackPanel>
-
-                                <StackPanel Orientation="Horizontal"
-                                            VerticalAlignment="Bottom"
-                                            Margin="0,16,0,0"
-                                            HorizontalAlignment="Right">
-                                    <Button Click="DuplicateLayout_Click"
-                                            AutomationProperties.Name="{x:Static props:Resources.Duplicate}"
-                                            Background="Transparent">
-                                        <Button.Content>
-                                            <StackPanel Orientation="Horizontal">
-                                                <TextBlock Text="&#xE8C8;"
-                                                           Margin="0,3,8,0"
-                                                           FontFamily="Segoe MDL2 Assets" />
-                                                <TextBlock Text="{x:Static props:Resources.Duplicate}" />
-                                            </StackPanel>
-                                        </Button.Content>
-                                    </Button>
 
                                     <Button Foreground="#FFC50500"
                                             AutomationProperties.Name="{x:Static props:Resources.Delete}"
                                             Click="DeleteLayout_Click"
-                                            Background="Transparent">
+                                            Background="Transparent"
+                                            Visibility="{Binding Type, Converter={StaticResource LayoutTypeToVisibilityConverter}}">
                                         <Button.Content>
                                             <StackPanel Orientation="Horizontal">
                                                 <TextBlock Text="&#xE107;"
@@ -682,7 +577,6 @@
                     <ItemsControl ItemsSource="{Binding CustomModels}"
                                   TabIndex="6"
                                   AutomationProperties.LabeledBy="{Binding ElementName=CustomHeaderBlock}"
-                                  ItemTemplate="{StaticResource CustomLayoutItemTemplate}"
                                   Margin="-8,4,-8,0"
                                   Grid.Row="4">
                         <ItemsControl.ItemsPanel>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -186,7 +186,7 @@
                                                x:Name="sensitivityRadiusValue" />
 
                                     <TextBox Margin="0,6,0,0"
-                                             Text="20"
+                                             Text="{Binding SensitivityRadius}"
                                              Width="86"
                                              AutomationProperties.LabeledBy="{Binding ElementName=sensitivityRadiusValue}"
                                              HorizontalAlignment="Left" />

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -9,6 +9,7 @@
         xmlns:Converters="clr-namespace:FancyZonesEditor.Converters"
         xmlns:props="clr-namespace:FancyZonesEditor.Properties"
         xmlns:local1="clr-namespace:FancyZonesEditor.ViewModels"
+        xmlns:models="clr-namespace:FancyZonesEditor.Models"
         xmlns:ui="http://schemas.modernwpf.com/2019"
         xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
         xmlns:controls="clr-namespace:ModernWpf.Controls;assembly=ModernWpf"
@@ -81,8 +82,136 @@
                 </DataTrigger>
             </DataTemplate.Triggers>
         </DataTemplate>
-        
-        <DataTemplate x:Key="DefaultLayoutItemTemplate">
+
+        <DataTemplate DataType="{x:Type models:CanvasLayoutModel}">
+            <Grid Background="Transparent"
+                  KeyDown="LayoutItem_KeyDown"
+                  MouseEnter="LayoutItem_MouseEnter"
+                  MouseLeave="LayoutItem_MouseLeave"
+                  MouseDown="LayoutItem_Click"
+                  Margin="0,0,0,12">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="24" />
+                </Grid.RowDefinitions>
+
+                <Border x:Name="LayoutItem"
+                        Background="{DynamicResource LayoutItemBackgroundBrush}"
+                        BorderBrush="{DynamicResource LayoutItemBackgroundBrush}"
+                        BorderThickness="1"
+                        Focusable="True"
+                        CornerRadius="4"
+                        Margin="8"
+                        FocusVisualStyle="{StaticResource UWPFocusVisualStyle}"
+                        FocusManager.GotFocus="LayoutItem_Focused">
+                    <Border.Effect>
+                        <DropShadowEffect BlurRadius="6"
+                                          Opacity="0.24"
+                                          ShadowDepth="1" />
+                    </Border.Effect>
+
+                    <local:LayoutPreview Margin="12"
+                                         VerticalAlignment="Stretch"
+                                         HorizontalAlignment="Stretch" />
+                </Border>
+                <Border x:Name="SelectionHighlight"
+                        CornerRadius="4"
+                        BorderThickness="3"
+                        Margin="6"
+                        Visibility="Collapsed"
+                        BorderBrush="{DynamicResource SystemControlBackgroundAccentBrush}" />
+                <TextBlock Name="layoutName"
+                           Padding="8,0,8,0"
+                           TextTrimming="CharacterEllipsis"
+                           Text="{Binding Name}"
+                           FontSize="14"
+                           Grid.Row="2"
+                           FontWeight="SemiBold"
+                           HorizontalAlignment="Center"
+                           VerticalAlignment="Center"
+                           Foreground="{DynamicResource PrimaryForegroundBrush}" />
+                <Button Content="&#xE104;"
+                        x:Name="EditLayoutButton"
+                        Visibility="Collapsed"
+                        FontFamily="Segoe MDL2 Assets"
+                        FontSize="14"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        Width="36"
+                        Height="36"
+                        ToolTip="{x:Static props:Resources.Edit_Layout}"
+                        AutomationProperties.Name="{x:Static props:Resources.Edit_Layout}"
+                        Style="{StaticResource AccentButtonStyle}"
+                        ui:ControlHelper.CornerRadius="48">
+                    <Button.Effect>
+                        <DropShadowEffect BlurRadius="6"
+                                          Opacity="0.32"
+                                          ShadowDepth="1" />
+                    </Button.Effect>
+                    <ui:FlyoutService.Flyout>
+                        <ui:Flyout x:Name="EditFlyout"
+                                   Placement="RightEdgeAlignedTop">
+                            <StackPanel MinWidth="260">
+                                <StackPanel Margin="0,0,0,0"
+                                            Orientation="Vertical">
+                                    <TextBlock Text="{x:Static props:Resources.Distance_adjacent_zones}"
+                                               IsEnabled="{Binding ShowSpacing}"
+                                               Margin="0,16,0,0"
+                                               Foreground="{DynamicResource PrimaryForegroundBrush}"
+                                               x:Name="sensitivityRadiusValue" />
+
+                                    <TextBox Margin="0,6,0,0"
+                                             Text="20"
+                                             Width="86"
+                                             AutomationProperties.LabeledBy="{Binding ElementName=sensitivityRadiusValue}"
+                                             HorizontalAlignment="Left" />
+                                </StackPanel>
+                                <StackPanel Orientation="Horizontal"
+                                            VerticalAlignment="Bottom"
+                                            Margin="0,16,0,0"
+                                            HorizontalAlignment="Right">
+                                    <Button Click="DuplicateLayout_Click"
+                                            AutomationProperties.Name="{x:Static props:Resources.Duplicate}"
+                                            Background="Transparent">
+                                        <Button.Content>
+                                            <StackPanel Orientation="Horizontal">
+                                                <TextBlock Text="&#xE8C8;"
+                                                           Margin="0,3,8,0"
+                                                           FontFamily="Segoe MDL2 Assets" />
+                                                <TextBlock Text="{x:Static props:Resources.Duplicate}" />
+                                            </StackPanel>
+                                        </Button.Content>
+                                    </Button>
+                                </StackPanel>
+                            </StackPanel>
+                        </ui:Flyout>
+                    </ui:FlyoutService.Flyout>
+                </Button>
+            </Grid>
+            <DataTemplate.Triggers>
+                <DataTrigger Binding="{Binding IsApplied}"
+                             Value="true">
+                    <Setter TargetName="layoutName"
+                            Property="Foreground"
+                            Value="{DynamicResource SystemAccentColorLight1Brush}" />
+                    <Setter TargetName="EditLayoutButton"
+                            Property="Visibility"
+                            Value="Visible" />
+                    
+                    <Setter TargetName="SelectionHighlight"
+                            Property="Visibility"
+                            Value="Visible" />
+                </DataTrigger>
+                <DataTrigger Binding="{Binding IsSelected}"
+                             Value="true">
+                    <Setter TargetName="LayoutItem"
+                            Property="BorderBrush"
+                            Value="{DynamicResource LayoutItemBorderPointerOverBrush}" />
+                </DataTrigger>
+            </DataTemplate.Triggers>
+        </DataTemplate>
+
+        <DataTemplate DataType="{x:Type models:GridLayoutModel}">
             <Grid Background="Transparent"
                   KeyDown="LayoutItem_KeyDown"
                   MouseEnter="LayoutItem_MouseEnter"
@@ -155,37 +284,30 @@
                                             Orientation="Vertical">
                                     <ui:ToggleSwitch x:Name="spaceAroundSetting"
                                                      Header="{x:Static props:Resources.Show_Space_Zones}"
-                                                     IsOn="true" 
-                                                     Visibility="{Binding Converter={StaticResource LayoutModelTypeToVisibilityConverter}}"/>
+                                                     IsOn="{Binding ShowSpacing}" />
 
                                     <TextBlock x:Name="paddingValue"
                                                Text="{x:Static props:Resources.Space_Around_Zones}"
-                                               IsEnabled="{Binding ShowSpacing}"
                                                Margin="0,8,0,0"
-                                               Foreground="{DynamicResource PrimaryForegroundBrush}" 
-                                               Visibility="{Binding Converter={StaticResource LayoutModelTypeToVisibilityConverter}}"/>
+                                               Foreground="{DynamicResource PrimaryForegroundBrush}" />
 
                                     <TextBox Margin="0,6,0,0"
-                                             IsEnabled="{Binding ShowSpacing}"
-                                             Text="32"
+                                             Text="{Binding Spacing}"
                                              Width="86"
                                              HorizontalAlignment="Left"
-                                             AutomationProperties.LabeledBy="{Binding ElementName=paddingValue}" 
-                                             Visibility="{Binding Converter={StaticResource LayoutModelTypeToVisibilityConverter}}"/>
+                                             AutomationProperties.LabeledBy="{Binding ElementName=paddingValue}" />
 
                                     <TextBlock Text="{x:Static props:Resources.Distance_adjacent_zones}"
-                                               IsEnabled="{Binding ShowSpacing}"
                                                Margin="0,16,0,0"
                                                Foreground="{DynamicResource PrimaryForegroundBrush}"
                                                x:Name="sensitivityRadiusValue" />
 
                                     <TextBox Margin="0,6,0,0"
-                                             Text="20"
+                                             Text="{Binding SensitivityRadius}"
                                              Width="86"
                                              AutomationProperties.LabeledBy="{Binding ElementName=sensitivityRadiusValue}"
                                              HorizontalAlignment="Left" />
                                 </StackPanel>
-
                                 <StackPanel Orientation="Horizontal"
                                             VerticalAlignment="Bottom"
                                             Margin="0,16,0,0"
@@ -217,7 +339,7 @@
                     <Setter TargetName="EditLayoutButton"
                             Property="Visibility"
                             Value="Visible" />
-                    
+
                     <Setter TargetName="SelectionHighlight"
                             Property="Visibility"
                             Value="Visible" />
@@ -230,6 +352,7 @@
                 </DataTrigger>
             </DataTemplate.Triggers>
         </DataTemplate>
+
         <DataTemplate x:Key="CustomLayoutItemTemplate">
             <Grid Background="Transparent"
                   KeyDown="LayoutItem_KeyDown"
@@ -333,13 +456,11 @@
 
                                     <TextBlock x:Name="paddingValue"
                                                Text="{x:Static props:Resources.Space_Around_Zones}"
-                                               IsEnabled="{Binding ShowSpacing}"
                                                Margin="0,8,0,0"
                                                Foreground="{DynamicResource PrimaryForegroundBrush}" 
                                                Visibility="{Binding Converter={StaticResource LayoutModelTypeToVisibilityConverter}}" />
 
                                     <TextBox Margin="0,6,0,0"
-                                             IsEnabled="{Binding ShowSpacing}"
                                              Text="32"
                                              Width="86"
                                              HorizontalAlignment="Left"
@@ -490,7 +611,6 @@
 
                     <ItemsControl ItemsSource="{Binding DefaultModels}"
                                   Grid.Row="1"
-                                  ItemTemplate="{StaticResource DefaultLayoutItemTemplate}"
                                   AutomationProperties.LabeledBy="{Binding ElementName=TemplatesHeaderBlock}"
                                   TabIndex="4"
                                   x:Name="DefaultModelsItemsControl"

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -27,7 +27,7 @@
         ResizeMode="CanResize">
     <Window.Resources>
 
-        <Converters:LayoutModelTypeToVisibilityConverter x:Key="LayoutModelTypeToVisibilityConverter" />
+        <Converters:LayoutTypeToVisibilityConverter x:Key="LayoutTypeToVisibilityConverter" />
 
         <DataTemplate x:Key="MonitorItemTemplate">
             <Border x:Name="MonitorItem"

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/CanvasLayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/CanvasLayoutModel.cs
@@ -70,6 +70,7 @@ namespace FancyZonesEditor.Models
                 layout.Zones.Add(zone);
             }
 
+            layout.SensitivityRadius = SensitivityRadius;
             return layout;
         }
 
@@ -80,6 +81,8 @@ namespace FancyZonesEditor.Models
             {
                 other.Zones.Add(zone);
             }
+
+            other.SensitivityRadius = SensitivityRadius;
         }
 
         // PersistData

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/GridLayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/GridLayoutModel.cs
@@ -65,6 +65,12 @@ namespace FancyZonesEditor.Models
         // ColumnPercents - represents the %age width of each column in the grid
         public List<int> ColumnPercents { get; set; }
 
+        // ShowSpacing - flag if free space between cells should be presented
+        public bool ShowSpacing { get; set; } = true;
+
+        // Spacing - free space between cells
+        public int Spacing { get; set; } = 16;
+
         // FreeZones (not persisted) - used to keep track of child indices that are no longer in use in the CellChildMap,
         //  making them candidates for re-use when it's needed to add another child
         //  TODO: do I need FreeZones on the data model?  - I think I do

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/GridLayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/GridLayoutModel.cs
@@ -78,6 +78,7 @@ namespace FancyZonesEditor.Models
                 if (value != _showSpacing)
                 {
                     _showSpacing = value;
+                    App.Overlay.Monitors[App.Overlay.CurrentDesktop].Settings.ShowSpacing = value;
                     App.FancyZonesEditorIO.SerializeZoneSettings();
                 }
             }
@@ -98,6 +99,7 @@ namespace FancyZonesEditor.Models
                 if (value != _spacing)
                 {
                     _spacing = value;
+                    App.Overlay.Monitors[App.Overlay.CurrentDesktop].Settings.Spacing = value;
                     App.FancyZonesEditorIO.SerializeZoneSettings();
                 }
             }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/GridLayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/GridLayoutModel.cs
@@ -66,10 +66,44 @@ namespace FancyZonesEditor.Models
         public List<int> ColumnPercents { get; set; }
 
         // ShowSpacing - flag if free space between cells should be presented
-        public bool ShowSpacing { get; set; } = true;
+        public bool ShowSpacing
+        {
+            get
+            {
+                return _showSpacing;
+            }
+
+            set
+            {
+                if (value != _showSpacing)
+                {
+                    _showSpacing = value;
+                    App.FancyZonesEditorIO.SerializeZoneSettings();
+                }
+            }
+        }
+
+        private bool _showSpacing = true;
 
         // Spacing - free space between cells
-        public int Spacing { get; set; } = 16;
+        public int Spacing
+        {
+            get
+            {
+                return _spacing;
+            }
+
+            set
+            {
+                if (value != _spacing)
+                {
+                    _spacing = value;
+                    App.FancyZonesEditorIO.SerializeZoneSettings();
+                }
+            }
+        }
+
+        private int _spacing = 16;
 
         // FreeZones (not persisted) - used to keep track of child indices that are no longer in use in the CellChildMap,
         //  making them candidates for re-use when it's needed to add another child

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/GridLayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/GridLayoutModel.cs
@@ -175,6 +175,10 @@ namespace FancyZonesEditor.Models
             }
 
             layout.ColumnPercents = colPercents;
+
+            layout.ShowSpacing = ShowSpacing;
+            layout.Spacing = Spacing;
+            layout.SensitivityRadius = SensitivityRadius;
         }
 
         // PersistData

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/GridLayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/GridLayoutModel.cs
@@ -83,7 +83,7 @@ namespace FancyZonesEditor.Models
             }
         }
 
-        private bool _showSpacing = true;
+        private bool _showSpacing = LayoutSettings.DefaultShowSpacing;
 
         // Spacing - free space between cells
         public int Spacing
@@ -103,7 +103,7 @@ namespace FancyZonesEditor.Models
             }
         }
 
-        private int _spacing = 16;
+        private int _spacing = LayoutSettings.DefaultSpacing;
 
         // FreeZones (not persisted) - used to keep track of child indices that are no longer in use in the CellChildMap,
         //  making them candidates for re-use when it's needed to add another child

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
@@ -132,6 +132,7 @@ namespace FancyZonesEditor.Models
                 if (value != _sensitivityRadius)
                 {
                     _sensitivityRadius = value;
+                    App.Overlay.Monitors[App.Overlay.CurrentDesktop].Settings.SensitivityRadius = value;
                     App.FancyZonesEditorIO.SerializeZoneSettings();
                 }
             }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
@@ -137,7 +137,7 @@ namespace FancyZonesEditor.Models
             }
         }
 
-        private int _sensitivityRadius = 20;
+        private int _sensitivityRadius = LayoutSettings.DefaultSensitivityRadius;
 
         // implementation of INotifyPropertyChanged
         public event PropertyChangedEventHandler PropertyChanged;

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
@@ -100,6 +100,7 @@ namespace FancyZonesEditor.Models
 
         private bool _isSelected;
 
+        // IsApplied (not-persisted) - tracks whether or not this LayoutModel is applied in the picker
         public bool IsApplied
         {
             get
@@ -118,6 +119,8 @@ namespace FancyZonesEditor.Models
         }
 
         private bool _isApplied;
+
+        public int SensitivityRadius { get; set; } = 20;
 
         // implementation of INotifyPropertyChanged
         public event PropertyChangedEventHandler PropertyChanged;

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
@@ -120,7 +120,24 @@ namespace FancyZonesEditor.Models
 
         private bool _isApplied;
 
-        public int SensitivityRadius { get; set; } = 20;
+        public int SensitivityRadius
+        {
+            get
+            {
+                return _sensitivityRadius;
+            }
+
+            set
+            {
+                if (value != _sensitivityRadius)
+                {
+                    _sensitivityRadius = value;
+                    App.FancyZonesEditorIO.SerializeZoneSettings();
+                }
+            }
+        }
+
+        private int _sensitivityRadius = 20;
 
         // implementation of INotifyPropertyChanged
         public event PropertyChangedEventHandler PropertyChanged;

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutSettings.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutSettings.cs
@@ -9,13 +9,13 @@ namespace FancyZonesEditor
 {
     public class LayoutSettings
     {
-        public static bool DefaultShowSpacing => true;
+        public const bool DefaultShowSpacing = true;
 
-        public static int DefaultSpacing => 16;
+        public const int DefaultSpacing = 16;
 
-        public static int DefaultZoneCount => 3;
+        public const int DefaultZoneCount = 3;
 
-        public static int DefaultSensitivityRadius => 20;
+        public const int DefaultSensitivityRadius = 20;
 
         public string ZonesetUuid { get; set; } = string.Empty;
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/MainWindowSettingsModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/MainWindowSettingsModel.cs
@@ -126,65 +126,6 @@ namespace FancyZonesEditor
             }
         }
 
-        // Spacing - how much space in between zones of the grid do you want
-        public int Spacing
-        {
-            get
-            {
-                return App.Overlay.CurrentLayoutSettings.Spacing;
-            }
-
-            set
-            {
-                value = Math.Max(0, value);
-                if (App.Overlay.CurrentLayoutSettings.Spacing != value)
-                {
-                    App.Overlay.CurrentLayoutSettings.Spacing = value;
-                    UpdateTemplateLayoutModels();
-                    FirePropertyChanged(nameof(Spacing));
-                }
-            }
-        }
-
-        // ShowSpacing - is the Spacing value used or ignored?
-        public bool ShowSpacing
-        {
-            get
-            {
-                return App.Overlay.CurrentLayoutSettings.ShowSpacing;
-            }
-
-            set
-            {
-                if (App.Overlay.CurrentLayoutSettings.ShowSpacing != value)
-                {
-                    App.Overlay.CurrentLayoutSettings.ShowSpacing = value;
-                    UpdateTemplateLayoutModels();
-                    FirePropertyChanged(nameof(ShowSpacing));
-                }
-            }
-        }
-
-        // SensitivityRadius - how much space inside the zone to highlight the adjacent zone too
-        public int SensitivityRadius
-        {
-            get
-            {
-                return App.Overlay.CurrentLayoutSettings.SensitivityRadius;
-            }
-
-            set
-            {
-                value = Math.Max(0, value);
-                if (App.Overlay.CurrentLayoutSettings.SensitivityRadius != value)
-                {
-                    App.Overlay.CurrentLayoutSettings.SensitivityRadius = value;
-                    UpdateTemplateLayoutModels();
-                    FirePropertyChanged(nameof(SensitivityRadius));
-                }
-            }
-        }
-
         // IsShiftKeyPressed - is the shift key currently being held down
         public bool IsShiftKeyPressed
         {
@@ -465,21 +406,6 @@ namespace FancyZonesEditor
             if (prevSettings.ZoneCount != ZoneCount)
             {
                 FirePropertyChanged(nameof(ZoneCount));
-            }
-
-            if (prevSettings.Spacing != Spacing)
-            {
-                FirePropertyChanged(nameof(Spacing));
-            }
-
-            if (prevSettings.ShowSpacing != ShowSpacing)
-            {
-                FirePropertyChanged(nameof(ShowSpacing));
-            }
-
-            if (prevSettings.SensitivityRadius != SensitivityRadius)
-            {
-                FirePropertyChanged(nameof(SensitivityRadius));
             }
         }
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
@@ -108,7 +108,7 @@ namespace FancyZonesEditor.Utils
             public int EditorSensitivityRadius { get; set; }
         }
 
-        private struct CanvasInfoWrapper
+        private class CanvasInfoWrapper
         {
             public struct CanvasZoneWrapper
             {
@@ -127,10 +127,10 @@ namespace FancyZonesEditor.Utils
 
             public List<CanvasZoneWrapper> Zones { get; set; }
 
-            public int SensitivityRadius { get; set; }
+            public int SensitivityRadius { get; set; } = LayoutSettings.DefaultSensitivityRadius;
         }
 
-        private struct GridInfoWrapper
+        private class GridInfoWrapper
         {
             public int Rows { get; set; }
 
@@ -142,11 +142,11 @@ namespace FancyZonesEditor.Utils
 
             public int[][] CellChildMap { get; set; }
 
-            public bool ShowSpacing { get; set; }
+            public bool ShowSpacing { get; set; } = LayoutSettings.DefaultShowSpacing;
 
-            public int Spacing { get; set; }
+            public int Spacing { get; set; } = LayoutSettings.DefaultSpacing;
 
-            public int SensitivityRadius { get; set; }
+            public int SensitivityRadius { get; set; } = LayoutSettings.DefaultSensitivityRadius;
         }
 
         private struct CustomLayoutWrapper

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
@@ -126,6 +126,8 @@ namespace FancyZonesEditor.Utils
             public int RefHeight { get; set; }
 
             public List<CanvasZoneWrapper> Zones { get; set; }
+
+            public int SensitivityRadius { get; set; }
         }
 
         private struct GridInfoWrapper
@@ -139,6 +141,12 @@ namespace FancyZonesEditor.Utils
             public List<int> ColumnsPercentage { get; set; }
 
             public int[][] CellChildMap { get; set; }
+
+            public bool ShowSpacing { get; set; }
+
+            public int Spacing { get; set; }
+
+            public int SensitivityRadius { get; set; }
         }
 
         private struct CustomLayoutWrapper
@@ -581,6 +589,7 @@ namespace FancyZonesEditor.Utils
                         RefWidth = (int)canvasRect.Width,
                         RefHeight = (int)canvasRect.Height,
                         Zones = new List<CanvasInfoWrapper.CanvasZoneWrapper>(),
+                        SensitivityRadius = canvasLayout.SensitivityRadius,
                     };
 
                     foreach (var zone in canvasLayout.Zones)
@@ -619,6 +628,9 @@ namespace FancyZonesEditor.Utils
                         RowsPercentage = gridLayout.RowPercents,
                         ColumnsPercentage = gridLayout.ColumnPercents,
                         CellChildMap = cells,
+                        ShowSpacing = gridLayout.ShowSpacing,
+                        Spacing = gridLayout.Spacing,
+                        SensitivityRadius = gridLayout.SensitivityRadius,
                     };
 
                     string json = JsonSerializer.Serialize(wrapper, _options);
@@ -728,6 +740,7 @@ namespace FancyZonesEditor.Utils
                     }
 
                     layout = new CanvasLayoutModel(zoneSet.Uuid, zoneSet.Name, LayoutType.Custom, zones, info.RefWidth, info.RefHeight);
+                    layout.SensitivityRadius = info.SensitivityRadius;
                 }
                 else if (zoneSet.Type == GridLayoutModel.ModelTypeID)
                 {
@@ -743,6 +756,9 @@ namespace FancyZonesEditor.Utils
                     }
 
                     layout = new GridLayoutModel(zoneSet.Uuid, zoneSet.Name, LayoutType.Custom, info.Rows, info.Columns, info.RowsPercentage, info.ColumnsPercentage, cells);
+                    layout.SensitivityRadius = info.SensitivityRadius;
+                    (layout as GridLayoutModel).ShowSpacing = info.ShowSpacing;
+                    (layout as GridLayoutModel).Spacing = info.Spacing;
                 }
                 else
                 {

--- a/src/modules/fancyzones/lib/FancyZonesDataTypes.h
+++ b/src/modules/fancyzones/lib/FancyZonesDataTypes.h
@@ -45,6 +45,7 @@ namespace FancyZonesDataTypes
             int height;
         };
         std::vector<CanvasLayoutInfo::Rect> zones;
+        int sensitivityRadius;
     };
 
     struct GridLayoutInfo
@@ -62,6 +63,9 @@ namespace FancyZonesDataTypes
             const std::vector<int>& rowsPercents;
             const std::vector<int>& columnsPercents;
             const std::vector<std::vector<int>>& cellChildMap;
+            bool showSpacing;
+            int spacing;
+            int sensitivityRadius;
         };
 
         GridLayoutInfo(const Minimal& info);
@@ -74,16 +78,23 @@ namespace FancyZonesDataTypes
 
         inline int rows() const { return m_rows; }
         inline int columns() const { return m_columns; }
-
+        
         inline const std::vector<int>& rowsPercents() const { return m_rowsPercents; };
         inline const std::vector<int>& columnsPercents() const { return m_columnsPercents; };
         inline const std::vector<std::vector<int>>& cellChildMap() const { return m_cellChildMap; };
+
+        inline bool showSpacing() const { return m_showSpacing; }
+        inline int spacing() const { return m_spacing; }
+        inline int sensitivityRadius() const { return m_sensitivityRadius; }
 
         int m_rows;
         int m_columns;
         std::vector<int> m_rowsPercents;
         std::vector<int> m_columnsPercents;
         std::vector<std::vector<int>> m_cellChildMap;
+        bool m_showSpacing;
+        int m_spacing;
+        int m_sensitivityRadius;
     };
 
     struct CustomZoneSetData

--- a/src/modules/fancyzones/lib/JsonHelpers.cpp
+++ b/src/modules/fancyzones/lib/JsonHelpers.cpp
@@ -39,6 +39,9 @@ namespace NonLocalizable
     const wchar_t RefWidthStr[] = L"ref-width";
     const wchar_t RowsPercentageStr[] = L"rows-percentage";
     const wchar_t RowsStr[] = L"rows";
+    const wchar_t SensitivityRadius[] = L"sensitivity-radius";
+    const wchar_t ShowSpacing[] = L"show-spacing";
+    const wchar_t Spacing[] = L"spacing";
     const wchar_t TypeStr[] = L"type";
     const wchar_t UuidStr[] = L"uuid";
     const wchar_t WidthStr[] = L"width";
@@ -137,6 +140,7 @@ namespace JSONHelpers
             zonesJson.Append(zoneJson);
         }
         infoJson.SetNamedValue(NonLocalizable::ZonesStr, zonesJson);
+        infoJson.SetNamedValue(NonLocalizable::SensitivityRadius, json::value(canvasInfo.sensitivityRadius));
         return infoJson;
     }
 
@@ -161,6 +165,8 @@ namespace JSONHelpers
                 FancyZonesDataTypes::CanvasLayoutInfo::Rect zone{ x, y, width, height };
                 info.zones.push_back(zone);
             }
+
+            info.sensitivityRadius = infoJson.GetNamedNumber(NonLocalizable::SensitivityRadius, DefaultValues::SensitivityRadius);
             return info;
         }
         catch (const winrt::hresult_error&)
@@ -183,6 +189,10 @@ namespace JSONHelpers
             cellChildMapJson.Append(NumVecToJsonArray(gridInfo.m_cellChildMap[i]));
         }
         infoJson.SetNamedValue(NonLocalizable::CellChildMapStr, cellChildMapJson);
+        
+        infoJson.SetNamedValue(NonLocalizable::SensitivityRadius, json::value(gridInfo.m_sensitivityRadius));
+        infoJson.SetNamedValue(NonLocalizable::ShowSpacing, json::value(gridInfo.m_showSpacing));
+        infoJson.SetNamedValue(NonLocalizable::Spacing, json::value(gridInfo.m_spacing));
 
         return infoJson;
     }
@@ -216,6 +226,10 @@ namespace JSONHelpers
                 }
                 info.cellChildMap().push_back(JsonArrayToNumVec(cellsArray));
             }
+
+            info.m_showSpacing = infoJson.GetNamedBoolean(NonLocalizable::ShowSpacing, DefaultValues::ShowSpacing);
+            info.m_spacing = infoJson.GetNamedNumber(NonLocalizable::Spacing, DefaultValues::Spacing);
+            info.m_sensitivityRadius = infoJson.GetNamedNumber(NonLocalizable::SensitivityRadius, DefaultValues::SensitivityRadius);
 
             return info;
         }


### PR DESCRIPTION
## Summary of the Pull Request

Added spacing and sensitivity radius properties to layout models. 
Added info into `zones-settings.json` to keep different settings per custom layout.

```
{
    "type": "grid",
    "info": {
        ...
        "show-spacing": true,
        "spacing": 16,
        "sensitivity-radius": 20
    }
}
```
```
{
    "type": "canvas",
    "info": {
        ...
        "sensitivity-radius": 20
    }
}
```
## PR Checklist
* [x] Applies to #8715
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Validation Steps Performed

Set different spacing and sensitivity radius settings to layouts and verify that they were saved and applied properly.
