### PR TITLE
[FZ Editor] Update layout preview after editing

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/LayoutPreview.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/LayoutPreview.xaml.cs
@@ -50,7 +50,14 @@ namespace FancyZonesEditor
 
         private void LayoutPreview_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
         {
+            if (_model != null)
+            {
+                _model.PropertyChanged -= LayoutModel_PropertyChanged;
+            }
+
             _model = (LayoutModel)DataContext;
+            _model.PropertyChanged += LayoutModel_PropertyChanged;
+
             RenderPreview();
         }
 
@@ -67,6 +74,11 @@ namespace FancyZonesEditor
                     RenderPreview();
                 }
             }
+        }
+
+        private void LayoutModel_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            RenderPreview();
         }
 
         public Int32Rect[] GetZoneRects()

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -358,7 +358,7 @@
                                                Foreground="{DynamicResource PrimaryForegroundBrush}" />
 
                                     <TextBox Margin="0,6,0,0"
-                                             Text="{Binding Spacing}"
+                                             Text="{Binding Spacing, UpdateSourceTrigger=PropertyChanged}"
                                              Width="86"
                                              HorizontalAlignment="Left"
                                              AutomationProperties.LabeledBy="{Binding ElementName=paddingValue}" />

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/GridLayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/GridLayoutModel.cs
@@ -79,6 +79,8 @@ namespace FancyZonesEditor.Models
                 {
                     _showSpacing = value;
                     App.Overlay.Monitors[App.Overlay.CurrentDesktop].Settings.ShowSpacing = value;
+
+                    FirePropertyChanged(nameof(ShowSpacing));
                     App.FancyZonesEditorIO.SerializeZoneSettings();
                 }
             }
@@ -100,6 +102,8 @@ namespace FancyZonesEditor.Models
                 {
                     _spacing = value;
                     App.Overlay.Monitors[App.Overlay.CurrentDesktop].Settings.Spacing = value;
+
+                    FirePropertyChanged(nameof(Spacing));
                     App.FancyZonesEditorIO.SerializeZoneSettings();
                 }
             }


### PR DESCRIPTION
## Summary of the Pull Request

A preview is updated right after changing settings.

## PR Checklist
* [x] Applies to #8715
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Validation Steps Performed

Update layout spacing settings and verify that they are previewed immediately.
