### PR TITLE
[FZ Editor] Do not close the editor after applying a layout in the single-monitor mode

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -191,11 +191,6 @@ namespace FancyZonesEditor
             {
                 model.Apply();
             }
-
-            if (!mainEditor.MultiMonitorMode)
-            {
-                Close();
-            }
         }
 
         private void OnClosing(object sender, EventArgs e)
@@ -266,11 +261,6 @@ namespace FancyZonesEditor
             overlay.CurrentDataContext = MainWindowSettingsModel.BlankModel;
 
             App.FancyZonesEditorIO.SerializeZoneSettings();
-
-            if (!overlay.MultiMonitorMode)
-            {
-                Close();
-            }
         }
 
         private void NewLayoutDialog_PrimaryButtonClick(ModernWpf.Controls.ContentDialog sender, ModernWpf.Controls.ContentDialogButtonClickEventArgs args)


### PR DESCRIPTION
## Summary of the Pull Request

Do not close the editor after applying a layout in the single-monitor mode

## PR Checklist
* [x] Applies to #8715
* [x] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [x] Tests added/passed
* [ ] Requires documentation to be updated
* [ ] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #xxx

## Validation Steps Performed

* Apply layout
* Reset layout
