### PR TITLE
runner: fix possible crash when dispatching json 

### DIFF
--- a/src/runner/settings_window.cpp
+++ b/src/runner/settings_window.cpp
@@ -151,34 +151,30 @@ void dispatch_received_json(const std::wstring& json_to_parse)
     const json::JsonObject j = json::JsonObject::Parse(json_to_parse);
     for (const auto& base_element : j)
     {
+        if (!current_settings_ipc)
+        {
+            continue;
+        }
+
         const auto name = base_element.Key();
         const auto value = base_element.Value();
 
         if (name == L"general")
         {
             apply_general_settings(value.GetObjectW());
-            if (current_settings_ipc != nullptr)
-            {
-                const std::wstring settings_string{ get_all_settings().Stringify().c_str() };
-                current_settings_ipc->send(settings_string);
-            }
+            const std::wstring settings_string{ get_all_settings().Stringify().c_str() };
+            current_settings_ipc->send(settings_string);
         }
         else if (name == L"powertoys")
         {
             dispatch_json_config_to_modules(value.GetObjectW());
-            if (current_settings_ipc != nullptr)
-            {
-                const std::wstring settings_string{ get_all_settings().Stringify().c_str() };
-                current_settings_ipc->send(settings_string);
-            }
+            const std::wstring settings_string{ get_all_settings().Stringify().c_str() };
+            current_settings_ipc->send(settings_string);
         }
         else if (name == L"refresh")
         {
-            if (current_settings_ipc != nullptr)
-            {
-                const std::wstring settings_string{ get_all_settings().Stringify().c_str() };
-                current_settings_ipc->send(settings_string);
-            }
+            const std::wstring settings_string{ get_all_settings().Stringify().c_str() };
+            current_settings_ipc->send(settings_string);
         }
         else if (name == L"action")
         {


### PR DESCRIPTION
## Summary of the Pull Request

settings window could request "Last checked date" from the runner before the pipe is created, because we have a race condition between creating the pipe and starting the settings process. The issue was there probably a very long time, but we didn't discover it, because no other settings action was requesting something from the runner as part of XAML rendering

## Validation Steps Performed

open settings page, restart as elevated
