### PR TITLE
FZ: do not activate zones window when it's shown

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -218,7 +218,6 @@ CDeclaration
 cdpx
 cdpxwin
 CENTERALIGN
-Cfg
 cfg
 changecursor
 Changemove
@@ -276,8 +275,8 @@ coclass
 codebase
 codecvt
 codeofconduct
-codereview
 codeql
+codereview
 COINIT
 Colorbrush
 colorconv
@@ -330,13 +329,11 @@ countslabelrenamingfmt
 countslabelselectedfmt
 cout
 CPlus
-cplusplus
 CPower
 cpp
 CPPARM
 cppblog
 cppm
-cpprestsdk
 cppruntime
 cppstd
 cppwinrt
@@ -651,14 +648,11 @@ ENU
 enum
 ENUMITEMS
 EOAC
-EOL
 eol
 epicgames
-eport
 ERASEBKGND
 EREOF
 EResize
-ERRORLEVEL
 errorlevel
 ERRORMESSAGE
 ERRORTITLE
@@ -1076,7 +1070,6 @@ ISavable
 isbi
 ISearch
 IService
-ISetting
 isetting
 isfinite
 IShell
@@ -1154,7 +1147,6 @@ keyremaps
 keystokes
 Keystool
 Keytool
-KEYUP
 keyup
 Kf
 KILLFOCUS
@@ -1224,7 +1216,6 @@ LOGPIXELSX
 LOn
 lookbehind
 lowlevel
-lowlevelkb
 LOWORD
 lparam
 LPBYTE
@@ -1300,7 +1291,6 @@ MBUTTON
 MBUTTONDBLCLK
 MBUTTONDOWN
 MBUTTONUP
-mday
 Mdb
 MDICHILD
 MDL
@@ -1343,8 +1333,8 @@ modulekey
 MONITORINFO
 MONITORINFOEX
 MONITORINFOEXW
-monitorinfof
 MONITORINFOF
+monitorinfof
 Monthand
 Moq
 MOUSEACTIVATE
@@ -1399,7 +1389,6 @@ multizone
 mutex
 mutexes
 muxc
-Mvvm
 mvvm
 MYICON
 myuri
@@ -1698,7 +1687,6 @@ propkey
 propvarutil
 Prt
 prui
-PRVPANE
 prvpane
 psapi
 PSECURITY
@@ -1747,7 +1735,6 @@ RAII
 RAlt
 randyrants
 RAWPATH
-rawtime
 rbegin
 Rbp
 RBUTTON
@@ -1793,7 +1780,6 @@ RENAMEONCOLLISION
 Renamer
 Reparse
 REPLACEWITH
-reportd
 Reportx
 requery
 requerying
@@ -1896,7 +1882,6 @@ serializer
 serizalization
 serverside
 SETCONTEXT
-SETCURSOR
 setcursor
 SETFOCUS
 SETFOREGROUND
@@ -1928,7 +1913,6 @@ SHELLDLL
 shellex
 SHELLEXECUTEINFO
 SHELLEXECUTEINFOW
-Shellscalingapi
 shellscalingapi
 Shelveset
 SHFILEINFO
@@ -1948,12 +1932,12 @@ SHORTCUTSTARTWITHMODIFIER
 Shortcuttool
 shortdate
 SHORTPATH
-should've
 showcolorname
 SHOWDEFAULT
 SHOWELEVATIONPROMPT
 SHOWMAXIMIZED
 SHOWMINIMIZED
+SHOWNA
 SHOWNORMAL
 showwindow
 shtypes
@@ -1980,7 +1964,6 @@ SIZENWSE
 sizeof
 SIZEWE
 sketchapp
-SKIPDOTNETINSTALL
 SKIPOWNPROCESS
 sku
 SKYBLUE
@@ -2047,7 +2030,6 @@ stdin
 stdlib
 STDMETHODCALLTYPE
 STDMETHODIMP
-Stdout
 stdout
 STEPIT
 stgm
@@ -2067,7 +2049,6 @@ stringtable
 stringval
 strsafe
 strutil
-STTNGS
 sttngs
 Stubless
 STYLECHANGED
@@ -2106,7 +2087,6 @@ SYSDEADCHAR
 SYSICONINDEX
 SYSKEY
 syskeydown
-SYSKEYUP
 syskeyup
 syslog
 SYSMENU
@@ -2164,7 +2144,6 @@ THISCOMPONENT
 thre
 tif
 TILEDWINDOW
-timeinfo
 Timeline
 timeunion
 timeutil
@@ -2182,8 +2161,8 @@ toggleright
 toggleswitch
 toolbar
 Toolchain
-toolset
 Toolset
+toolset
 tooltip
 toolwindow
 TOPDOWNDIB
@@ -2347,7 +2326,6 @@ VSTT
 VTABLE
 Vtbl
 Vx
-walkthrough
 watsonportal
 wav
 WBounds
@@ -2365,12 +2343,11 @@ wcslen
 wcsncmp
 wcsnicmp
 wdp
-WDS
 wds
 wdupenv
 weakme
 webapp
-webcam
+Webcam
 webclient
 webkit
 webp
@@ -2388,7 +2365,6 @@ wiki
 wikipedia
 wil
 wildcards
-WINAPI
 winapi
 winauto
 wincolor
@@ -2435,7 +2411,6 @@ wixtoolset
 WIXUI
 WKSG
 wmain
-wmi
 WMKEYDOWN
 WMKEYUP
 wmonk
@@ -2450,11 +2425,9 @@ WNDPROC
 woff
 wofstream
 wordpad
-wordpress
 workaround
 workflow
 wostream
-wostringstream
 wox
 wparam
 wpf
@@ -2511,7 +2484,6 @@ XStr
 XToolset
 xunit
 XY
-YAML
 yaml
 YAngle
 YDiff

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -702,9 +702,7 @@ void FancyZones::ToggleEditor() noexcept
     if (showDpiWarning)
     {
         // We must show the message box in a separate thread, since this code is called from a low-level
-        // keyboard hook callback, and launching messageboxes from it has unexpected side effects,
-        // like triggering EVENT_SYSTEM_MOVESIZEEND prematurely. 
-        // TODO: understand the root cause of this, until then it's commented out.
+        // keyboard hook callback, and launching messageboxes from it has unexpected side effects
         //std::thread{ [] {
         //    MessageBoxW(nullptr,
         //                GET_RESOURCE_STRING(IDS_SPAN_ACROSS_ZONES_WARNING).c_str(),

--- a/src/modules/fancyzones/lib/ZoneWindowDrawing.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindowDrawing.cpp
@@ -218,7 +218,7 @@ void ZoneWindowDrawing::Show(unsigned animationMillis)
 
     if (!m_animation)
     {
-        ShowWindow(m_window, SW_SHOWDEFAULT);
+        ShowWindow(m_window, SW_SHOWNA);
         if (animationMillis > 0)
         {
             m_animation.emplace(AnimationInfo{ std::chrono::steady_clock().now(), animationMillis });


### PR DESCRIPTION
## Summary of the Pull Request

This PR fixes instant window zoning which happens in various hard-to-repro circumstances. We've been activating zones window erroneously which foreground window switch, which in turn caused `EVENT_SYSTEM_MOVESIZEEND` to fire, and we zone window in response to it.

## PR Checklist
* [x] Applies to #8511

## Validation Steps Performed

shift-drag from the debugger and other scenarios
