### PR TITLE
FZ: fix currently selected zone tracking

### DIFF
--- a/src/modules/fancyzones/dll/dllmain.cpp
+++ b/src/modules/fancyzones/dll/dllmain.cpp
@@ -210,11 +210,11 @@ private:
     //contains the non localized key of the powertoy
     std::wstring app_key;
 
-    static inline FancyZonesModule* s_instance;
-    static inline HHOOK s_llKeyboardHook;
+    static inline FancyZonesModule* s_instance = nullptr;
+    static inline HHOOK s_llKeyboardHook = nullptr;
 
     std::vector<HWINEVENTHOOK> m_staticWinEventHooks;
-    HWINEVENTHOOK m_objectLocationWinEventHook;
+    HWINEVENTHOOK m_objectLocationWinEventHook = nullptr;
 
     static LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam)
     {

--- a/src/modules/fancyzones/lib/GenericKeyHook.h
+++ b/src/modules/fancyzones/lib/GenericKeyHook.h
@@ -39,7 +39,7 @@ public:
     }
 
 private:
-    inline static HHOOK hHook;
+    inline static HHOOK hHook = nullptr;
     inline static std::function<void(bool)> callback;
 
     static LRESULT CALLBACK GenericKeyHookProc(int nCode, WPARAM wParam, LPARAM lParam)


### PR DESCRIPTION
## Summary of the Pull Request

`m_objectLocationWinEventHook` was uninitialized. also explicitly initialize some other fields, even though they're static and should be zero-initialized nevertheless, it just looks better 🙂

