### PR TITLE
[FancyZones] initialize zone container window state

### DIFF
--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -140,6 +140,10 @@ bool ZoneWindow::Init(IZoneWindowHost* host, HINSTANCE hinstance, HMONITOR monit
     }
 
     MakeWindowTransparent(m_window.get());
+    // Call ShowWindow(m_window.get(), SW_SHOWNORMAL) here so we can call ShowWindow(m_window.get(), SW_SHOWNA) later
+    // without causing the unexpected behaviour reported in https://github.com/microsoft/PowerToys/issues/8808
+    ShowWindow(m_window.get(), SW_SHOWNORMAL);
+    ShowWindow(m_window.get(), SW_HIDE);
 
     m_zoneWindowDrawing = std::make_unique<ZoneWindowDrawing>(m_window.get());
 


### PR DESCRIPTION
## Summary of the Pull Request

Make sure the zone container is properly initialized before using it when showing the zones.

## PR Checklist
* [x] Applies to https://github.com/microsoft/PowerToys/issues/8808

## Info on Pull Request

After we fixed a [different bug]( https://github.com/microsoft/PowerToys/pull/8795/commits/feff9af242a5d7816bf7f9c2e91e66c564c91be1) this bug showed up since the zone container is never shown with the `SW_SHOWNORMAL` argument.
Since we cannot use `SW_SHOWNORMAL` when showing the zone while a window is dragged, we call it once when the window is created.

## Validation Steps Performed

Restart PowerToys.exe multiple time and each time verify that all zones are displayed on all monitors when shift-dragging a window.
