### PR TITLE
[PowerRename] don't show an error message for invalid regex syntax

### DIFF
--- a/src/modules/powerrename/lib/PowerRenameManager.cpp
+++ b/src/modules/powerrename/lib/PowerRenameManager.cpp
@@ -1060,7 +1060,9 @@ DWORD WINAPI CPowerRenameManager::s_regexWorkerThread(_In_ void* pv)
     }
     catch (...)
     {
-        MessageBox(NULL, L"RegexWorkerThread failed to execute.\nPlease report the bug to https://aka.ms/powerToysReportBug", L"PowerRename Error", MB_OK);
+        // TODO: an exception can happen while typing the expression and the syntax is not correct yet,
+        // we need to be more granular and raise an exception only when a real problem happened.
+        // MessageBox(NULL, L"RegexWorkerThread failed to execute.\nPlease report the bug to https://aka.ms/powerToysReportBug", L"PowerRename Error", MB_OK);
     }
 
     return 0;


### PR DESCRIPTION
## Summary of the Pull Request

Treat regex syntax errors as normal program flow

## PR Checklist
* [x] Applies to https://github.com/microsoft/PowerToys/issues/8787

## Info on Pull Request

Comment out the message box that shows the error message when a normal regex expression has been typed and not completed yet.
TODO: verify if there are cases when we should report an error.

## Validation Steps Performed

Select the Regular expression checkbox and start typing an expression
