### PR TITLE
[FancyZones] fix for secondary mouse button

### DIFF
--- a/src/modules/fancyzones/lib/SecondaryMouseButtonsHook.cpp
+++ b/src/modules/fancyzones/lib/SecondaryMouseButtonsHook.cpp
@@ -43,7 +43,7 @@ LRESULT CALLBACK SecondaryMouseButtonsHook::SecondaryMouseButtonsProc(int nCode,
 {
     if (nCode == HC_ACTION)
     {
-        if (wParam == (GetSystemMetrics(SM_SWAPBUTTON) ? WM_LBUTTONDOWN : WM_RBUTTONDOWN) || wParam == WM_MBUTTONDOWN || wParam == WM_XBUTTONDOWN)
+        if (wParam == WM_RBUTTONDOWN || wParam == WM_MBUTTONDOWN || wParam == WM_XBUTTONDOWN)
         {
             callback();
         }


### PR DESCRIPTION
## Summary of the Pull Request

Primary mouse button switch is transparent to the application, the system still returns the same values as for the default case

**What is include in the PR:** 

**How does someone test / validate:** 

- Turn on 
![image](https://user-images.githubusercontent.com/3206696/103477837-c213be00-4dc2-11eb-8c14-d4cf263fdf2c.png)
- drag a window and verify that clicking on the right button toggles the zone activation
- open the Windows 10 Settings, go to the mouse settings and change the primary button to `Right`
![image](https://user-images.githubusercontent.com/3206696/103477861-fe471e80-4dc2-11eb-9c49-9e61890e084c.png)
- drag a window and verify that clicking on the left button toggles the zone activation

## Quality Checklist

- [x] **Linked issue:** https://github.com/microsoft/PowerToys/issues/8565
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
