### PR TITLE
[File Explorer] OneDrive SVG fix

### DIFF
--- a/src/modules/previewpane/SvgPreviewHandler/SvgPreviewControl.cs
+++ b/src/modules/previewpane/SvgPreviewHandler/SvgPreviewControl.cs
@@ -43,6 +43,7 @@ namespace Microsoft.PowerToys.PreviewHandler.Svg
         public override void DoPreview<T>(T dataSource)
         {
             string svgData = null;
+            bool blocked = false;
 
             try
             {
@@ -53,6 +54,8 @@ namespace Microsoft.PowerToys.PreviewHandler.Svg
                         svgData = reader.ReadToEnd();
                     }
                 }
+
+                blocked = SvgPreviewHandlerHelper.CheckBlockedElements(svgData);
             }
 #pragma warning disable CA1031 // Do not catch general exception types
             catch (Exception ex)
@@ -69,7 +72,7 @@ namespace Microsoft.PowerToys.PreviewHandler.Svg
                     _infoBarAdded = false;
 
                     // Add a info bar on top of the Preview if any blocked element is present.
-                    if (SvgPreviewHandlerHelper.CheckBlockedElements(svgData))
+                    if (blocked)
                     {
                         _infoBarAdded = true;
                         AddTextBoxControl(Resource.BlockedElementInfoText);


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

When disk access is really slow, or more commonly, when .svg files are being accessed using e.g. OneDrive, the reading and processing of the file was being done on the Explorer UI thread, which caused the window to be unresponsive. This PR fixes that issue. See #8152 

**What is include in the PR:** 

This PR moves the code which reads the file and checks if it is valid outside the UI loop, ensuring the UI stays responsive.

**How does someone test / validate:** 

* Put a large .svg file in your OneDrive folder, for example, this one: https://upload.wikimedia.org/wikipedia/commons/6/63/A_large_blank_world_map_with_oceans_marked_in_blue.svg
* In OneDrive settings, set download speed limit to 400 KB/s

Before this PR, the UI will be unresponsive for about 10 seconds (the time it takes to download the file).
With this PR, the image will appear after 10 seconds but in the meantime, the UI will be responsive.

Remember that you must test this PR by building the installer. Also I recommend manually terminating explorer.exe to ensure the proper version of PT File Explorer is being tested.

## Quality Checklist

- [x] **Linked issue:** #8152 
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
