### PR TITLE
[PT Run] Files not processed by URI plugin

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Uri.UnitTests/UriHelper/ExtendedUriParserTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Uri.UnitTests/UriHelper/ExtendedUriParserTests.cs
@@ -40,6 +40,9 @@ namespace Microsoft.Plugin.Uri.UnitTests.UriHelper
         [TestCase("[::]", true, "http://[::]/")]
         [TestCase("[2001:0DB8::1]", true, "http://[2001:db8::1]/")]
         [TestCase("[2001:0DB8::1]:80", true, "http://[2001:db8::1]/")]
+        [TestCase("\\\\localhost", false, null)]
+        [TestCase("C:\\Temp", false, null)]
+        [TestCase("file://", false, null)]
         public void TryParseCanParseHostName(string query, bool expectedSuccess, string expectedResult)
         {
             // Arrange

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Uri/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Uri/Main.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO.Abstractions;
 using System.Text;
@@ -67,10 +68,22 @@ namespace Microsoft.Plugin.Uri
                         : DefaultIconPath,
                     Action = action =>
                     {
-                        Process.Start(new ProcessStartInfo(uriResultString)
+                        try
                         {
-                            UseShellExecute = true,
-                        });
+                            Process.Start(new ProcessStartInfo(uriResultString)
+                            {
+                                UseShellExecute = true,
+                            });
+                        }
+                        catch (Win32Exception ex)
+                        {
+                            var title = $"Plugin: {Properties.Resources.Microsoft_plugin_uri_plugin_name}";
+                            var message = $"{Properties.Resources.Microsoft_plugin_uri_open_failed}: {ex.Message}";
+                            Log.Warn(message, GetType());
+                            Context.API.ShowMsg(title, message);
+                            return false;
+                        }
+
                         return true;
                     },
                 });

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Uri/Properties/Resources.Designer.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Uri/Properties/Resources.Designer.cs
@@ -61,6 +61,15 @@ namespace Microsoft.Plugin.Uri.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to open URL.
+        /// </summary>
+        public static string Microsoft_plugin_uri_open_failed {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_uri_open_failed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Handles urls.
         /// </summary>
         public static string Microsoft_plugin_uri_plugin_description {

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Uri/Properties/Resources.resx
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Uri/Properties/Resources.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="Microsoft_plugin_uri_open_failed" xml:space="preserve">
+    <value>Failed to open URL</value>
+  </data>
   <data name="Microsoft_plugin_uri_plugin_description" xml:space="preserve">
     <value>Handles urls</value>
   </data>

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Uri/UriHelper/ExtendedUriParser.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Uri/UriHelper/ExtendedUriParser.cs
@@ -32,6 +32,14 @@ namespace Microsoft.Plugin.Uri.UriHelper
                 var urlBuilder = new UriBuilder(input);
 
                 result = urlBuilder.Uri;
+
+                // Files should be processed by Folder plugin
+                if (result.IsFile)
+                {
+                    result = default;
+                    return false;
+                }
+
                 return true;
             }
             catch (System.UriFormatException)


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
PT Run crash if you try to open `\\invalid-network-path` or `file://invalid-network-path`

**What is include in the PR:**
Change URI plugin to not process a file URI.
A file URI should be processed only by Folder plugin.
No need to make URI plugin processing `file://` since is a job for Folder plugin.

**How does someone test / validate:** 
- ALT + SPACE
- Insert a valid network path
- Only results from Folder plugin should be displayed
- Insert an invalid network path
- No result should be displayed

## Quality Checklist

- [x] **Linked issue:** #8364 #8891 #9013
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [x] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
