### PR TITLE
[FancyZones] Refactor/improve saving JSON files

### DIFF
--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -53,9 +53,7 @@ public:
             PostMessageW(m_window, WM_PRIV_LOCATIONCHANGE, NULL, NULL);
         }),
         m_fileWatcher(FancyZonesDataInstance().GetZonesSettingsFileName(), [this]() {
-            // This is commented out until we figure out why calling UpdateZoneSets() in response to this message
-            // causes Win+Arrow to break.
-            //PostMessageW(m_window, WM_PRIV_FILE_UPDATE, NULL, NULL);
+            PostMessageW(m_window, WM_PRIV_FILE_UPDATE, NULL, NULL);
         })
     {
         m_settings->SetCallback(this);

--- a/src/modules/fancyzones/lib/FancyZonesData.cpp
+++ b/src/modules/fancyzones/lib/FancyZonesData.cpp
@@ -553,11 +553,20 @@ void FancyZonesData::LoadFancyZonesData()
 void FancyZonesData::SaveFancyZonesData() const
 {
     std::scoped_lock lock{ dataLock };
-    JSONHelpers::SaveFancyZonesData(zonesSettingsFileName,
-                                    appZoneHistoryFileName,
-                                    deviceInfoMap,
-                                    customZoneSetsMap,
-                                    appZoneHistoryMap);
+    JSONHelpers::SaveZoneSettings(zonesSettingsFileName, deviceInfoMap, customZoneSetsMap);
+    JSONHelpers::SaveAppZoneHistory(appZoneHistoryFileName, appZoneHistoryMap);
+}
+
+void FancyZonesData::SaveZoneSettings() const
+{
+    std::scoped_lock lock{ dataLock };
+    JSONHelpers::SaveZoneSettings(zonesSettingsFileName, deviceInfoMap, customZoneSetsMap);
+}
+
+void FancyZonesData::SaveAppZoneHistory() const
+{
+    std::scoped_lock lock{ dataLock };
+    JSONHelpers::SaveAppZoneHistory(appZoneHistoryFileName, appZoneHistoryMap);
 }
 
 void FancyZonesData::RemoveDesktopAppZoneHistory(const std::wstring& desktopId)

--- a/src/modules/fancyzones/lib/FancyZonesData.cpp
+++ b/src/modules/fancyzones/lib/FancyZonesData.cpp
@@ -441,7 +441,7 @@ bool FancyZonesData::SetAppLastZones(HWND window, const std::wstring& deviceId, 
                 data.processIdToHandleMap[processId] = window;
                 data.zoneSetUuid = zoneSetId;
                 data.zoneIndexSet = zoneIndexSet;
-                SaveAppZoneHistory();
+                SaveFancyZonesData();
                 return true;
             }
         }
@@ -465,7 +465,7 @@ bool FancyZonesData::SetAppLastZones(HWND window, const std::wstring& deviceId, 
         appZoneHistoryMap[processPath] = std::vector<FancyZonesDataTypes::AppZoneHistoryData>{ data };
     }
 
-    SaveAppZoneHistory();
+    SaveFancyZonesData();
     return true;
 }
 

--- a/src/modules/fancyzones/lib/FancyZonesData.cpp
+++ b/src/modules/fancyzones/lib/FancyZonesData.cpp
@@ -441,7 +441,7 @@ bool FancyZonesData::SetAppLastZones(HWND window, const std::wstring& deviceId, 
                 data.processIdToHandleMap[processId] = window;
                 data.zoneSetUuid = zoneSetId;
                 data.zoneIndexSet = zoneIndexSet;
-                SaveFancyZonesData();
+                SaveAppZoneHistory();
                 return true;
             }
         }
@@ -465,7 +465,7 @@ bool FancyZonesData::SetAppLastZones(HWND window, const std::wstring& deviceId, 
         appZoneHistoryMap[processPath] = std::vector<FancyZonesDataTypes::AppZoneHistoryData>{ data };
     }
 
-    SaveFancyZonesData();
+    SaveAppZoneHistory();
     return true;
 }
 

--- a/src/modules/fancyzones/lib/FancyZonesData.h
+++ b/src/modules/fancyzones/lib/FancyZonesData.h
@@ -85,6 +85,8 @@ public:
 
     void LoadFancyZonesData();
     void SaveFancyZonesData() const;
+    void SaveZoneSettings() const;
+    void SaveAppZoneHistory() const;
 
 private:
 #if defined(UNIT_TESTS)

--- a/src/modules/fancyzones/lib/JsonHelpers.cpp
+++ b/src/modules/fancyzones/lib/JsonHelpers.cpp
@@ -539,10 +539,14 @@ namespace JSONHelpers
                             const TAppZoneHistoryMap& appZoneHistoryMap)
 
     {
-        json::JsonObject root{};
-        json::JsonObject appZoneHistoryRoot{};
+        SaveZoneSettings(zonesSettingsFileName, deviceInfoMap, customZoneSetsMap);
+        SaveAppZoneHistory(appZoneHistoryFileName, appZoneHistoryMap);
+    }
 
-        appZoneHistoryRoot.SetNamedValue(NonLocalizable::AppZoneHistoryStr, JSONHelpers::SerializeAppZoneHistory(appZoneHistoryMap));
+    void SaveZoneSettings(const std::wstring& zonesSettingsFileName, const TDeviceInfoMap& deviceInfoMap, const TCustomZoneSetsMap& customZoneSetsMap)
+    {
+        json::JsonObject root{};
+
         root.SetNamedValue(NonLocalizable::DevicesStr, JSONHelpers::SerializeDeviceInfos(deviceInfoMap));
         root.SetNamedValue(NonLocalizable::CustomZoneSetsStr, JSONHelpers::SerializeCustomZoneSets(customZoneSetsMap));
 
@@ -553,7 +557,14 @@ namespace JSONHelpers
         }
 
         json::to_file(zonesSettingsFileName, root);
-        json::to_file(appZoneHistoryFileName, appZoneHistoryRoot);
+    }
+
+    void SaveAppZoneHistory(const std::wstring& appZoneHistoryFileName, const TAppZoneHistoryMap& appZoneHistoryMap)
+    {
+        json::JsonObject root{};
+
+        root.SetNamedValue(NonLocalizable::AppZoneHistoryStr, JSONHelpers::SerializeAppZoneHistory(appZoneHistoryMap));
+        json::to_file(appZoneHistoryFileName, root);
     }
 
     TAppZoneHistoryMap ParseAppZoneHistory(const json::JsonObject& fancyZonesDataJSON)

--- a/src/modules/fancyzones/lib/JsonHelpers.cpp
+++ b/src/modules/fancyzones/lib/JsonHelpers.cpp
@@ -543,9 +543,8 @@ namespace JSONHelpers
         if (!before.has_value() || before.value().Stringify() != root.Stringify())
         {
             Trace::FancyZones::DataChanged();
+            json::to_file(zonesSettingsFileName, root);
         }
-
-        json::to_file(zonesSettingsFileName, root);
     }
 
     void SaveAppZoneHistory(const std::wstring& appZoneHistoryFileName, const TAppZoneHistoryMap& appZoneHistoryMap)
@@ -553,7 +552,12 @@ namespace JSONHelpers
         json::JsonObject root{};
 
         root.SetNamedValue(NonLocalizable::AppZoneHistoryStr, JSONHelpers::SerializeAppZoneHistory(appZoneHistoryMap));
-        json::to_file(appZoneHistoryFileName, root);
+
+        auto before = json::from_file(appZoneHistoryFileName);
+        if (!before.has_value() || before.value().Stringify() != root.Stringify())
+        {
+            json::to_file(appZoneHistoryFileName, root);
+        }
     }
 
     TAppZoneHistoryMap ParseAppZoneHistory(const json::JsonObject& fancyZonesDataJSON)

--- a/src/modules/fancyzones/lib/JsonHelpers.cpp
+++ b/src/modules/fancyzones/lib/JsonHelpers.cpp
@@ -532,17 +532,6 @@ namespace JSONHelpers
         }
     }
 
-    void SaveFancyZonesData(const std::wstring& zonesSettingsFileName,
-                            const std::wstring& appZoneHistoryFileName,
-                            const TDeviceInfoMap& deviceInfoMap,
-                            const TCustomZoneSetsMap& customZoneSetsMap,
-                            const TAppZoneHistoryMap& appZoneHistoryMap)
-
-    {
-        SaveZoneSettings(zonesSettingsFileName, deviceInfoMap, customZoneSetsMap);
-        SaveAppZoneHistory(appZoneHistoryFileName, appZoneHistoryMap);
-    }
-
     void SaveZoneSettings(const std::wstring& zonesSettingsFileName, const TDeviceInfoMap& deviceInfoMap, const TCustomZoneSetsMap& customZoneSetsMap)
     {
         json::JsonObject root{};

--- a/src/modules/fancyzones/lib/JsonHelpers.h
+++ b/src/modules/fancyzones/lib/JsonHelpers.h
@@ -67,11 +67,6 @@ namespace JSONHelpers
     };
 
     json::JsonObject GetPersistFancyZonesJSON(const std::wstring& zonesSettingsFileName, const std::wstring& appZoneHistoryFileName);
-    void SaveFancyZonesData(const std::wstring& zonesSettingsFileName,
-                            const std::wstring& appZoneHistoryFileName,
-                            const TDeviceInfoMap& deviceInfoMap,
-                            const TCustomZoneSetsMap& customZoneSetsMap,
-                            const TAppZoneHistoryMap& appZoneHistoryMap);
 
     void SaveZoneSettings(const std::wstring& zonesSettingsFileName, const TDeviceInfoMap& deviceInfoMap, const TCustomZoneSetsMap& customZoneSetsMap);
     void SaveAppZoneHistory(const std::wstring& appZoneHistoryFileName, const TAppZoneHistoryMap& appZoneHistoryMap);

--- a/src/modules/fancyzones/lib/JsonHelpers.h
+++ b/src/modules/fancyzones/lib/JsonHelpers.h
@@ -73,6 +73,9 @@ namespace JSONHelpers
                             const TCustomZoneSetsMap& customZoneSetsMap,
                             const TAppZoneHistoryMap& appZoneHistoryMap);
 
+    void SaveZoneSettings(const std::wstring& zonesSettingsFileName, const TDeviceInfoMap& deviceInfoMap, const TCustomZoneSetsMap& customZoneSetsMap);
+    void SaveAppZoneHistory(const std::wstring& appZoneHistoryFileName, const TAppZoneHistoryMap& appZoneHistoryMap);
+
     TAppZoneHistoryMap ParseAppZoneHistory(const json::JsonObject& fancyZonesDataJSON);
     json::JsonArray SerializeAppZoneHistory(const TAppZoneHistoryMap& appZoneHistoryMap);
 


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

This adds functions to save the two JSON files separately. Also it adds a check to ensure that
these files aren't saved if the contents won't change. This also allows us to restore the functionality of FileWatcher.
Linked issue: #8779 

**What is included in the PR:** 

**How does someone test / validate:** 

Check that FileWatcher can be used again. Use these repro steps:
* Create a grid layout with 6 zones
* Enable overriding Win+Arrows and disable moving zones based on position
* Slowly press Win+Right

On current master with `PostMessageW(m_window, WM_PRIV_FILE_UPDATE, NULL, NULL);` uncommented, the above
repro steps will result in the window not moving. With this PR however, it should work.
**One unit test in FZ is failing but it's also failing in master.**

## Quality Checklist

- [x] **Linked issue:** #8779
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [x] **Tests: See above!**
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
