### PR TITLE
Svg image preview is displayed unscaled and uncentered

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -2318,6 +2318,8 @@ vk
 VKey
 VKTAB
 vm
+vmax
+vmin
 Voicemail
 VOS
 VREDRAW
@@ -2331,6 +2333,7 @@ VSTS
 VSTT
 VTABLE
 Vtbl
+vw
 Vx
 watsonportal
 wav
@@ -2461,6 +2464,7 @@ xa
 xamarin
 xaml
 XAngle
+XAttribute
 xbf
 XBind
 XBUTTON

--- a/src/modules/previewpane/SvgPreviewHandler/SvgPreviewControl.cs
+++ b/src/modules/previewpane/SvgPreviewHandler/SvgPreviewControl.cs
@@ -55,6 +55,7 @@ namespace Microsoft.PowerToys.PreviewHandler.Svg
                     }
                 }
 
+                svgData = SvgPreviewHandlerHelper.ScaleSvg(svgData);
                 blocked = SvgPreviewHandlerHelper.CheckBlockedElements(svgData);
             }
 #pragma warning disable CA1031 // Do not catch general exception types

--- a/src/modules/previewpane/SvgPreviewHandler/SvgPreviewControl.cs
+++ b/src/modules/previewpane/SvgPreviewHandler/SvgPreviewControl.cs
@@ -73,6 +73,7 @@ namespace Microsoft.PowerToys.PreviewHandler.Svg
             catch (Exception ex)
 #pragma warning restore CA1031 // Do not catch general exception types
             {
+                _browser.ScrollBarsEnabled = true;
                 PowerToysTelemetry.Log.WriteEvent(new SvgFilePreviewError { Message = ex.Message });
             }
 
@@ -138,7 +139,7 @@ namespace Microsoft.PowerToys.PreviewHandler.Svg
             _browser.Dock = DockStyle.Fill;
             _browser.IsWebBrowserContextMenuEnabled = false;
             _browser.ScriptErrorsSuppressed = true;
-            _browser.ScrollBarsEnabled = true;
+            _browser.ScrollBarsEnabled = false;
             _browser.AllowNavigation = false;
             Controls.Add(_browser);
         }

--- a/src/modules/previewpane/SvgPreviewHandler/SvgPreviewControl.cs
+++ b/src/modules/previewpane/SvgPreviewHandler/SvgPreviewControl.cs
@@ -55,7 +55,6 @@ namespace Microsoft.PowerToys.PreviewHandler.Svg
                     }
                 }
 
-                svgData = SvgPreviewHandlerHelper.ScaleSvg(svgData);
                 blocked = SvgPreviewHandlerHelper.CheckBlockedElements(svgData);
             }
 #pragma warning disable CA1031 // Do not catch general exception types
@@ -64,6 +63,17 @@ namespace Microsoft.PowerToys.PreviewHandler.Svg
             {
                 PreviewError(ex, dataSource);
                 return;
+            }
+
+            try
+            {
+                svgData = SvgPreviewHandlerHelper.ScaleSvg(svgData);
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception ex)
+#pragma warning restore CA1031 // Do not catch general exception types
+            {
+                PowerToysTelemetry.Log.WriteEvent(new SvgFilePreviewError { Message = ex.Message });
             }
 
             InvokeOnControlThread(() =>

--- a/src/modules/previewpane/SvgPreviewHandler/SvgPreviewControl.cs
+++ b/src/modules/previewpane/SvgPreviewHandler/SvgPreviewControl.cs
@@ -67,7 +67,7 @@ namespace Microsoft.PowerToys.PreviewHandler.Svg
 
             try
             {
-                svgData = SvgPreviewHandlerHelper.ScaleSvg(svgData);
+                svgData = SvgPreviewHandlerHelper.AddStyleSVG(svgData);
             }
 #pragma warning disable CA1031 // Do not catch general exception types
             catch (Exception ex)

--- a/src/modules/previewpane/SvgPreviewHandler/Utilities/SvgPreviewHandlerHelper.cs
+++ b/src/modules/previewpane/SvgPreviewHandler/Utilities/SvgPreviewHandlerHelper.cs
@@ -68,5 +68,34 @@ namespace Microsoft.PowerToys.PreviewHandler.Svg.Utilities
 
             return foundBlockedElement;
         }
+
+        /// <summary>
+        /// Edit metadata of svgData so it preview scaled properly
+        /// </summary>
+        /// <param name="svgData">Input Svg.</param>
+        /// <returns>Returns modifed filed with scaled parameters</returns>
+        public static string ScaleSvg(string svgData)
+        {
+            XElement contacts = XElement.Parse(svgData);
+            var atr = contacts.Attributes();
+            int length = contacts.Attributes().Count();
+            for (int i = 0; i < length; i++)
+            {
+                if (atr.ElementAt(i).Name == "height")
+                {
+                    atr.ElementAt(i).Value = "100%";
+                }
+
+                if (atr.ElementAt(i).Name == "width")
+                {
+                    atr.ElementAt(i).Value = "100%";
+                }
+            }
+
+            XAttribute pos = new XAttribute("position", "absolute");
+            atr = atr.Append(pos);
+            contacts.ReplaceAttributes(atr);
+            return contacts.ToString();
+        }
     }
 }

--- a/src/modules/previewpane/SvgPreviewHandler/Utilities/SvgPreviewHandlerHelper.cs
+++ b/src/modules/previewpane/SvgPreviewHandler/Utilities/SvgPreviewHandlerHelper.cs
@@ -73,7 +73,7 @@ namespace Microsoft.PowerToys.PreviewHandler.Svg.Utilities
         /// Edit metadata of svgData so that preview scales properly
         /// </summary>
         /// <param name="svgData">Input Svg</param>
-        /// <returns>Returns modifed filed with changed metadata</returns>
+        /// <returns>Returns modified filed with changed metadata</returns>
         public static string ScaleSvg(string svgData)
         {
             XElement contacts = XElement.Parse(svgData);

--- a/src/modules/previewpane/SvgPreviewHandler/Utilities/SvgPreviewHandlerHelper.cs
+++ b/src/modules/previewpane/SvgPreviewHandler/Utilities/SvgPreviewHandlerHelper.cs
@@ -70,31 +70,24 @@ namespace Microsoft.PowerToys.PreviewHandler.Svg.Utilities
         }
 
         /// <summary>
-        /// Edit metadata of svgData so it preview scaled properly
+        /// Edit metadata of svgData so that preview scales properly
         /// </summary>
-        /// <param name="svgData">Input Svg.</param>
-        /// <returns>Returns modifed filed with scaled parameters</returns>
+        /// <param name="svgData">Input Svg</param>
+        /// <returns>Returns modifed filed with changed metadata</returns>
         public static string ScaleSvg(string svgData)
         {
             XElement contacts = XElement.Parse(svgData);
-            var atr = contacts.Attributes();
-            int length = contacts.Attributes().Count();
-            for (int i = 0; i < length; i++)
+            var attributes = contacts.Attributes();
+            for (int i = 0; i < attributes.Count(); i++)
             {
-                if (atr.ElementAt(i).Name == "height")
+                if (attributes.ElementAt(i).Name == "height" || attributes.ElementAt(i).Name == "width")
                 {
-                    atr.ElementAt(i).Value = "100%";
-                }
-
-                if (atr.ElementAt(i).Name == "width")
-                {
-                    atr.ElementAt(i).Value = "100%";
+                    attributes.ElementAt(i).Value = "100%";
                 }
             }
 
-            XAttribute pos = new XAttribute("position", "absolute");
-            atr = atr.Append(pos);
-            contacts.ReplaceAttributes(atr);
+            attributes = attributes.Append(new XAttribute("position", "absolute"));
+            contacts.ReplaceAttributes(attributes);
             return contacts.ToString();
         }
     }

--- a/src/modules/previewpane/SvgPreviewHandler/Utilities/SvgPreviewHandlerHelper.cs
+++ b/src/modules/previewpane/SvgPreviewHandler/Utilities/SvgPreviewHandlerHelper.cs
@@ -70,23 +70,40 @@ namespace Microsoft.PowerToys.PreviewHandler.Svg.Utilities
         }
 
         /// <summary>
-        /// Edit metadata of svgData so that preview scales properly
+        /// Add attribute style to SVG element in svgData so that it displays properly
         /// </summary>
         /// <param name="svgData">Input Svg</param>
-        /// <returns>Returns modified filed with changed metadata</returns>
+        /// <returns>Returns modified svgData with added style</returns>
         public static string ScaleSvg(string svgData)
         {
             XElement contacts = XElement.Parse(svgData);
             var attributes = contacts.Attributes();
+            string width = string.Empty;
+            string height = string.Empty;
+
+            // Get width and height of element and remove it afterwards because it will be added inside style attribute
             for (int i = 0; i < attributes.Count(); i++)
             {
-                if (attributes.ElementAt(i).Name == "height" || attributes.ElementAt(i).Name == "width")
+                if (attributes.ElementAt(i).Name == "height")
                 {
-                    attributes.ElementAt(i).Value = "100%";
+                    height = attributes.ElementAt(i).Value;
+                    attributes.ElementAt(i).Remove();
+                }
+
+                if (attributes.ElementAt(i).Name == "width")
+                {
+                    width = attributes.ElementAt(i).Value;
+                    attributes.ElementAt(i).Remove();
                 }
             }
 
-            attributes = attributes.Append(new XAttribute("position", "absolute"));
+            // Set style that will center SVG
+            string centering = "position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);";
+
+            // Set style that will downscale SVG if the preview window is smaller than default SVG size
+            string scaling = $"width: min(100%,{width}px); height: min(100%,{height}px);";
+            string style = scaling + centering;
+            attributes = attributes.Append(new XAttribute("style", style));
             contacts.ReplaceAttributes(attributes);
             return contacts.ToString();
         }

--- a/src/modules/previewpane/SvgPreviewHandler/Utilities/SvgPreviewHandlerHelper.cs
+++ b/src/modules/previewpane/SvgPreviewHandler/Utilities/SvgPreviewHandlerHelper.cs
@@ -128,40 +128,40 @@ namespace Microsoft.PowerToys.PreviewHandler.Svg.Utilities
         /// <summary>
         /// If there is a CSS unit at the end return the same string, else return the string with a px unit at the end
         /// </summary>
-        /// <param name="lenght">CSS length</param>
+        /// <param name="length">CSS length</param>
         /// <returns>Returns modified length</returns>
-        private static string CheckUnit(string lenght)
+        private static string CheckUnit(string length)
         {
             string[] cssUnits = { "cm", "mm", "in", "px", "pt", "pc", "em", "ex", "ch", "rem", "vw", "vh", "vmin", "vmax", "%" };
             foreach (var unit in cssUnits)
             {
-                if (lenght.EndsWith(unit, System.StringComparison.CurrentCultureIgnoreCase))
+                if (length.EndsWith(unit, System.StringComparison.CurrentCultureIgnoreCase))
                 {
-                    return lenght;
+                    return length;
                 }
             }
 
-            return lenght + "px";
+            return length + "px";
         }
 
         /// <summary>
         /// Remove a CSS unit from the end of the string
         /// </summary>
-        /// <param name="lenght">CSS length</param>
+        /// <param name="length">CSS length</param>
         /// <returns>Returns modified length</returns>
-        private static string RemoveUnit(string lenght)
+        private static string RemoveUnit(string length)
         {
             string[] cssUnits = { "cm", "mm", "in", "px", "pt", "pc", "em", "ex", "ch", "rem", "vw", "vh", "vmin", "vmax", "%" };
             foreach (var unit in cssUnits)
             {
-                if (lenght.EndsWith(unit, System.StringComparison.CurrentCultureIgnoreCase))
+                if (length.EndsWith(unit, System.StringComparison.CurrentCultureIgnoreCase))
                 {
-                    lenght = lenght.Remove(lenght.Length - unit.Length);
-                    return lenght;
+                    length = length.Remove(length.Length - unit.Length);
+                    return length;
                 }
             }
 
-            return lenght;
+            return length;
         }
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request
SVG preview needs to be centered and scaled.

**What is this about:**
Fixed issue with centering and scaling preview SVG.

**What is included in the PR:** 
Just fix for this.

**How does someone test / validate:** 
Need PowerToys to be built and installed.

## Quality Checklist

- [X] **Linked issue:** #2417 
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [X] **Binaries:** Any new files are added to WXS / YML
   - [X] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries
- [ ] **Installer:** Added/updated and all pass

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
