### PR TITLE
[runner] rename 'module' variables

### DIFF
--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -138,8 +138,8 @@ int runner(bool isProcessElevated)
         {
             try
             {
-                auto module = load_powertoy(moduleSubdir);
-                modules().emplace(module->get_key(), std::move(module));
+                auto pt_module = load_powertoy(moduleSubdir);
+                modules().emplace(pt_module->get_key(), std::move(pt_module));
             }
             catch (...)
             {

--- a/src/runner/powertoy_module.cpp
+++ b/src/runner/powertoy_module.cpp
@@ -17,29 +17,29 @@ PowertoyModule load_powertoy(const std::wstring_view filename)
         FreeLibrary(handle);
         winrt::throw_last_error();
     }
-    auto module = create();
-    if (!module)
+    auto pt_module = create();
+    if (!pt_module)
     {
         FreeLibrary(handle);
         winrt::throw_hresult(winrt::hresult(E_POINTER));
     }
-    return PowertoyModule(module, handle);
+    return PowertoyModule(pt_module, handle);
 }
 
 json::JsonObject PowertoyModule::json_config() const
 {
     int size = 0;
-    module->get_config(nullptr, &size);
+    pt_module->get_config(nullptr, &size);
     std::wstring result;
     result.resize(size - 1);
-    module->get_config(result.data(), &size);
+    pt_module->get_config(result.data(), &size);
     return json::JsonObject::Parse(result);
 }
 
-PowertoyModule::PowertoyModule(PowertoyModuleIface* module, HMODULE handle) :
-    handle(handle), module(module)
+PowertoyModule::PowertoyModule(PowertoyModuleIface* pt_module, HMODULE handle) :
+    handle(handle), pt_module(pt_module)
 {
-    if (!module)
+    if (!pt_module)
     {
         throw std::runtime_error("Module not initialized");
     }
@@ -49,17 +49,17 @@ PowertoyModule::PowertoyModule(PowertoyModuleIface* module, HMODULE handle) :
 
 void PowertoyModule::update_hotkeys()
 {
-    CentralizedKeyboardHook::ClearModuleHotkeys(module->get_key());
+    CentralizedKeyboardHook::ClearModuleHotkeys(pt_module->get_key());
 
-    size_t hotkeyCount = module->get_hotkeys(nullptr, 0);
+    size_t hotkeyCount = pt_module->get_hotkeys(nullptr, 0);
     std::vector<PowertoyModuleIface::Hotkey> hotkeys(hotkeyCount);
-    module->get_hotkeys(hotkeys.data(), hotkeyCount);
+    pt_module->get_hotkeys(hotkeys.data(), hotkeyCount);
 
-    auto modulePtr = module.get();
+    auto modulePtr = pt_module.get();
 
     for (size_t i = 0; i < hotkeyCount; i++)
     {
-        CentralizedKeyboardHook::SetHotkeyAction(module->get_key(), hotkeys[i], [modulePtr, i] {
+        CentralizedKeyboardHook::SetHotkeyAction(pt_module->get_key(), hotkeys[i], [modulePtr, i] {
             return modulePtr->on_hotkey(i);
         });
     }

--- a/src/runner/powertoy_module.h
+++ b/src/runner/powertoy_module.h
@@ -10,11 +10,11 @@
 
 struct PowertoyModuleDeleter
 {
-    void operator()(PowertoyModuleIface* module) const
+    void operator()(PowertoyModuleIface* pt_module) const
     {
-        if (module)
+        if (pt_module)
         {
-            module->destroy();
+            pt_module->destroy();
         }
     }
 };
@@ -31,11 +31,11 @@ struct PowertoyModuleDLLDeleter
 class PowertoyModule
 {
 public:
-    PowertoyModule(PowertoyModuleIface* module, HMODULE handle);
+    PowertoyModule(PowertoyModuleIface* pt_module, HMODULE handle);
 
     inline PowertoyModuleIface* operator->()
     {
-        return module.get();
+        return pt_module.get();
     }
 
     json::JsonObject json_config() const;
@@ -44,7 +44,7 @@ public:
 
 private:
     std::unique_ptr<HMODULE, PowertoyModuleDLLDeleter> handle;
-    std::unique_ptr<PowertoyModuleIface, PowertoyModuleDeleter> module;
+    std::unique_ptr<PowertoyModuleIface, PowertoyModuleDeleter> pt_module;
 };
 
 PowertoyModule load_powertoy(const std::wstring_view filename);


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Rename all occurrences of 'module' to 'pt_module' to prevent intellisense error.

**What is include in the PR:** 
`module` is a reserved keyword in C++20 and it should not be used as a variable name.

**How does someone test / validate:** 
Build the PowerToys solution and verify PowerToys runs as expected and the modules are loaded and active.
In particular verify that PT Run works as expected.

## Quality Checklist

- [x] **Linked issue:** https://github.com/microsoft/PowerToys/issues/8998
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [x] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
