### PR TITLE
[Image Resizer] UI fixes

### DIFF
--- a/src/modules/imageresizer/ui/Properties/Resources.Designer.cs
+++ b/src/modules/imageresizer/ui/Properties/Resources.Designer.cs
@@ -376,7 +376,7 @@ namespace ImageResizer.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to _Resize.
+        ///   Looks up a localized string similar to Resize.
         /// </summary>
         public static string Input_Resize {
             get {

--- a/src/modules/imageresizer/ui/Properties/Resources.resx
+++ b/src/modules/imageresizer/ui/Properties/Resources.resx
@@ -227,7 +227,7 @@
     <value>R_esize the original pictures (don't create copies)</value>
   </data>
   <data name="Input_Resize" xml:space="preserve">
-    <value>_Resize</value>
+    <value>Resize</value>
   </data>
   <data name="Input_ShowAdvanced" xml:space="preserve">
     <value>Settings</value>

--- a/src/modules/imageresizer/ui/Themes/HighContrastWhite.xaml
+++ b/src/modules/imageresizer/ui/Themes/HighContrastWhite.xaml
@@ -10,8 +10,8 @@
     <system:String x:Key="Theme.ColorScheme">Accent5</system:String>
     <Color x:Key="Theme.PrimaryAccentColor">White</Color>
 
-    <SolidColorBrush x:Key="SecondaryBackgroundBrush" Color="#FFe5e5e5" />
-    <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FFf5f5f5" />
+    <SolidColorBrush x:Key="SecondaryBackgroundBrush" Color="#FFf3f3f3" />
+    <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FFffffff" />
     <SolidColorBrush x:Key="PrimaryForegroundBrush" Color="#FF000000" />
     <SolidColorBrush x:Key="SecondaryForegroundBrush" Color="#FF676666" />
     <SolidColorBrush x:Key="PrimaryBorderBrush" Color="Black"/>

--- a/src/modules/imageresizer/ui/Themes/Light.xaml
+++ b/src/modules/imageresizer/ui/Themes/Light.xaml
@@ -10,8 +10,8 @@
     <system:String x:Key="Theme.ColorScheme">Accent1</system:String>
     <Color x:Key="Theme.PrimaryAccentColor">White</Color>
 
-    <SolidColorBrush x:Key="SecondaryBackgroundBrush" Color="#FFe5e5e5" />
-    <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FFf5f5f5" />
+    <SolidColorBrush x:Key="SecondaryBackgroundBrush" Color="#FFf3f3f3" />
+    <SolidColorBrush x:Key="PrimaryBackgroundBrush" Color="#FFffffff" />
     <SolidColorBrush x:Key="PrimaryForegroundBrush" Color="#FF000000" />
     <SolidColorBrush x:Key="SecondaryForegroundBrush" Color="#FF676666" />
     <SolidColorBrush x:Key="PrimaryBorderBrush" Color="Transparent"/>

--- a/src/modules/imageresizer/ui/Views/InputPage.xaml
+++ b/src/modules/imageresizer/ui/Views/InputPage.xaml
@@ -186,8 +186,7 @@
                         ToolTip="{x:Static p:Resources.Input_ShowAdvanced}"
                         Background="Transparent"
                         Command="{Binding ShowAdvancedCommand}"
-                       
-                        />
+                        Visibility="{Binding ShowAdvancedSettings, Converter={StaticResource BoolValueConverter}}"/>
 
                 <Button Grid.Column="1"
                         Style="{StaticResource AccentButtonStyle}"

--- a/src/modules/imageresizer/ui/Views/InputPage.xaml
+++ b/src/modules/imageresizer/ui/Views/InputPage.xaml
@@ -186,7 +186,7 @@
                         ToolTip="{x:Static p:Resources.Input_ShowAdvanced}"
                         Background="Transparent"
                         Command="{Binding ShowAdvancedCommand}"
-                        Visibility="{Binding ShowAdvancedSettings, Converter={StaticResource BoolValueConverter}}"
+                       
                         />
 
                 <Button Grid.Column="1"


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
- Updated brushes for light theme so it's inline with default WinUI theming. (#8592)
- Added accessibility name for the Resize button.

**What is include in the PR:** 
- Updated brushes for Primary and Secondary background.
- Added accessible name in the Resources file.

**How does someone test / validate:** 
- Run the app in light mode to see the theming updates.
- Run Accessibility Insights and see the name of the resize button.

![image](https://user-images.githubusercontent.com/9866362/104022676-e73c6e00-51c0-11eb-9bb2-3f24adc41e95.png)


## Quality Checklist

- [X] **Linked issue:** #8592, #7062
- [X] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [X] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [X] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
