### PR TITLE
[Run] hotkey initialization

### DIFF
--- a/src/modules/interface/powertoy_module_interface.h
+++ b/src/modules/interface/powertoy_module_interface.h
@@ -39,11 +39,11 @@ public:
     /* Describes a hotkey which can trigger an action in the PowerToy */
     struct Hotkey
     {
-        bool win = false;
-        bool ctrl = false;
-        bool shift = false;
-        bool alt = false;
-        unsigned char key = 0;
+        bool win;
+        bool ctrl;
+        bool shift;
+        bool alt;
+        unsigned char key;
 
         std::strong_ordering operator<=>(const Hotkey&) const = default;
     };

--- a/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
+++ b/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
@@ -73,7 +73,7 @@ private:
     static const int MAX_WAIT_MILLISEC = 10000;
 
     // Hotkey to invoke the module
-    Hotkey m_hotkey = { .key = {} };
+    Hotkey m_hotkey = {};
 
     // Helper function to extract the hotkey from the settings
     void parse_hotkey(PowerToysSettings::PowerToyValues& settings);

--- a/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
+++ b/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
@@ -73,7 +73,7 @@ private:
     static const int MAX_WAIT_MILLISEC = 10000;
 
     // Hotkey to invoke the module
-    Hotkey m_hotkey = { .key = 0 };
+    Hotkey m_hotkey = { .key = {} };
 
     // Helper function to extract the hotkey from the settings
     void parse_hotkey(PowerToysSettings::PowerToyValues& settings);


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
PT Run, randomly doesn't open when the hotkey is pressed.

**What is include in the PR:** 
Proper initialization of the `key` structure.

**How does someone test / validate:** 
Build the project and test the PT Run hotkey.
Change to hotkey to different values and test them.
Restart PowerToys multiple times (the bug hits intermittently) 

## Quality Checklist

- [x] **Linked issue:** https://github.com/microsoft/PowerToys/issues/8372
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [x] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
