### PR TITLE
updating: do not update update_check date when we couldn't do it

### DIFF
--- a/src/common/updating/updating.h
+++ b/src/common/updating/updating.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <future>
 #include <filesystem>
+#include <variant>
 #include <winrt/Windows.Foundation.h>
 #include <expected.hpp>
 
@@ -13,6 +14,9 @@
 namespace updating
 {
     using winrt::Windows::Foundation::Uri;
+    struct version_up_to_date {};
+    using github_version_info = std::variant<new_version_download_info, version_up_to_date>;
+
     struct new_version_download_info
     {
         Uri release_page_uri = nullptr;
@@ -21,10 +25,11 @@ namespace updating
         std::wstring installer_filename;
     };
 
-    std::future<void> try_autoupdate(const bool download_updates_automatically, const notifications::strings&);
+    // Returns whether the update check has succeeded
+    std::future<bool> try_autoupdate(const bool download_updates_automatically, const notifications::strings&);
     std::filesystem::path get_pending_updates_path();
     std::future<std::wstring> download_update(const notifications::strings&);
-    std::future<nonstd::expected<new_version_download_info, std::wstring>> get_new_github_version_info_async(const notifications::strings& strings, const bool prerelease = false);
+    std::future<nonstd::expected<github_version_info, std::wstring>> get_github_version_info_async(const notifications::strings& strings, const bool prerelease = false);
 
     // non-localized
     constexpr inline std::wstring_view INSTALLER_FILENAME_PATTERN = L"powertoyssetup";

--- a/src/runner/update_utils.h
+++ b/src/runner/update_utils.h
@@ -4,5 +4,5 @@
 
 bool start_msi_uninstallation_sequence();
 void github_update_worker();
-std::optional<updating::new_version_download_info> check_for_updates();
+std::optional<updating::github_version_info> check_for_updates();
 bool launch_pending_update();

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/GeneralViewModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/GeneralViewModel.cs
@@ -237,6 +237,14 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             }
         }
 
+        public static bool AutoUpdatesEnabled
+        {
+            get
+            {
+                return Helper.GetProductVersion() != "v0.0.1";
+            }
+        }
+
         [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "This may throw if the XAML page is not initialized in tests (https://github.com/microsoft/PowerToys/pull/2676)")]
         public bool IsDarkThemeRadioButtonChecked
         {

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/GeneralViewModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/GeneralViewModel.cs
@@ -388,10 +388,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             GeneralSettingsCustomAction customaction = new GeneralSettingsCustomAction(outsettings);
 
             SendCheckForUpdatesConfigMSG(customaction.ToString());
-            RequestUpdateCheckedDate();
         }
 
-        private void RequestUpdateCheckedDate()
+        public void RequestUpdateCheckedDate()
         {
             GeneralSettingsConfig.CustomActionName = "request_update_state_date";
 

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -705,7 +705,7 @@
     <value>Version:</value>
   </data>
   <data name="General_VersionLastChecked.Text" xml:space="preserve">
-    <value>Last checked: </value>
+    <value>Last successfully checked: </value>
   </data>
   <data name="General_Version.AutomationProperties.Name" xml:space="preserve">
     <value>Version</value>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml
@@ -133,7 +133,9 @@
 
             <StackPanel Orientation="Horizontal" 
                         Margin="{StaticResource SmallBottomMargin}"
-                        AutomationProperties.LabeledBy="{Binding ElementName=General_VersionLastChecked}">
+                        AutomationProperties.LabeledBy="{Binding ElementName=General_VersionLastChecked}"
+                        Visibility="{Binding AutoUpdatesEnabled,
+                                             Converter={StaticResource VisibleIfTrueConverter}}">
                  <TextBlock x:Name="General_VersionLastChecked" x:Uid="General_VersionLastChecked" />
                  <TextBlock Text="{x:Bind ViewModel.UpdateCheckedDate, Mode=OneWay}"
                             Foreground="{ThemeResource ListViewItemForegroundPointerOver}"
@@ -144,12 +146,14 @@
                     Style="{StaticResource AccentButtonStyle}"
                     Foreground="White"
                     Command="{Binding CheckForUpdatesEventHandler}"
+                    IsEnabled="{Binding AutoUpdatesEnabled}"
                     />
 
             <ToggleSwitch x:Uid="GeneralPage_ToggleSwitch_AutoDownloadUpdates" 
                           Margin="{StaticResource MediumTopMargin}"
                           Visibility="{Binding Mode=TwoWay, Path=IsAdmin, Converter={StaticResource VisibleIfTrueConverter}}"
-                          IsOn="{Binding Mode=TwoWay, Path=AutoDownloadUpdates}"/>
+                          IsOn="{Binding Mode=TwoWay, Path=AutoDownloadUpdates}"
+                          IsEnabled="{Binding AutoUpdatesEnabled}" />
 
         </StackPanel>
 

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml.cs
@@ -56,6 +56,11 @@ namespace Microsoft.PowerToys.Settings.UI.Views
                     string version = json.GetNamedString("version", string.Empty);
                     bool isLatest = json.GetNamedBoolean("isVersionLatest", false);
 
+                    if (json.ContainsKey("version"))
+                    {
+                        ViewModel.RequestUpdateCheckedDate();
+                    }
+
                     var str = string.Empty;
                     if (isLatest)
                     {


### PR DESCRIPTION
## Summary of the Pull Request
- improve general settings page "Last Checked" feature

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #8741
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.

## Tests

- try autoupdate from local build: observe that the Last checked time is unchanged, since trying to update a dev build is error
- recompile with hardcorded version v0.45 -> date is changed, even though it's up to date.
- check manuallly with no internet connection -> date is not changed etc.
- recompile with hardcorded version v0.25, remove the update_state.json and launch it. -> we get the update notification on start. autoupdate process works as expected