### PR TITLE
updating: require dotnet >=3.1.10

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -38,7 +38,6 @@ AGGREGATABLE
 AHybrid
 Aissue
 akamaihd
-alannt
 ALarger
 alekhyareddy
 alertsolid
@@ -117,8 +116,8 @@ atlfile
 atlstr
 attr
 Attribs
-aumid
 AUMID
+aumid
 AUTHN
 AUTOAPPEND
 autocomplete
@@ -222,6 +221,7 @@ CENTERALIGN
 cfg
 changecursor
 Changemove
+charconv
 charset
 chdir
 checkbox
@@ -279,7 +279,6 @@ codeofconduct
 codeql
 codereview
 COINIT
-Colorbrush
 colorconv
 colorhistory
 colorhistorylimit
@@ -467,8 +466,8 @@ DISPIDAMBIENTDLCONTROL
 DISPINFO
 Displayandhidethedesktop
 DISPLAYCHANGE
-displayname
 DISPLAYNAME
+displayname
 divyan
 DLACTIVEXCTLS
 DLCONTROL
@@ -655,7 +654,7 @@ ERASEBKGND
 EREOF
 EResize
 eriawan
-ERRORLEVEL
+errc
 errorlevel
 ERRORMESSAGE
 ERRORTITLE
@@ -797,7 +796,6 @@ globalplugins
 globals
 gmx
 google
-gordonwatts
 GPTR
 grayscale
 GText
@@ -857,8 +855,8 @@ HLSL
 hmenu
 hmodule
 hmon
-hmonitor
 HMONITOR
+hmonitor
 HOLDENTER
 HOLDESC
 homljgmgpmcbpjbnjpfijnhipfkiclkd
@@ -1338,7 +1336,6 @@ modulekey
 MONITORINFO
 MONITORINFOEX
 MONITORINFOEXW
-MONITORINFOF
 monitorinfof
 Monthand
 Moq
@@ -1803,6 +1800,7 @@ resw
 resx
 returnvalue
 retval
+rexit
 rfind
 rgb
 RGBQUAD
@@ -2003,6 +2001,7 @@ sql
 src
 SRCCOPY
 sre
+sregex
 SResize
 srme
 srre
@@ -2077,7 +2076,6 @@ SVGIn
 svgpreviewhandler
 svgr
 SVGSVG
-SWAPBUTTON
 Switchbetweenvirtualdesktops
 SWP
 swprintf
@@ -2167,7 +2165,6 @@ toggleright
 toggleswitch
 toolbar
 Toolchain
-Toolset
 toolset
 tooltip
 toolwindow

--- a/src/common/updating/pch.h
+++ b/src/common/updating/pch.h
@@ -7,6 +7,7 @@
 #include <winrt/base.h>
 #pragma warning(default : 5205)
 #define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
 #include <Windows.h>
 #include <MsiQuery.h>
 #include <Shlwapi.h>
@@ -19,6 +20,8 @@
 #include <PathCch.h>
 
 #include <optional>
+#include <regex>
+#include <charconv>
 
 #include <expected.hpp>
 


### PR DESCRIPTION
## Summary of the Pull Request

use regex iterator to find out the latest 3.1.x dotnet version installed.

**What is include in the PR:** 

**How does someone test / validate:** 

call `dotnet_is_installed` from runner's main.cpp / install on a machine which doesn't have 3.1.10+ dotnet core

## Quality Checklist

- [x] **Linked issue:** #8875
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
