### PR TITLE
[Runner/common] Fixed two potential issues with CreateProcess

### DIFF
--- a/src/common/utils/elevation.h
+++ b/src/common/utils/elevation.h
@@ -169,7 +169,7 @@ inline bool run_same_elevation(const std::wstring& file, const std::wstring& par
         executable_args += L" " + params;
     }
 
-    STARTUPINFO si = { 0 };
+    STARTUPINFO si = { sizeof(STARTUPINFO) };
     PROCESS_INFORMATION pi = { 0 };
     auto succeeded = CreateProcessW(file.c_str(),
                                     const_cast<LPWSTR>(executable_args.c_str()),

--- a/src/runner/settings_window.cpp
+++ b/src/runner/settings_window.cpp
@@ -248,7 +248,6 @@ BOOL run_settings_non_elevated(LPCWSTR executable_path, LPWSTR executable_args, 
     siex.lpAttributeList = pptal;
     siex.StartupInfo.cb = sizeof(siex);
 
-    // here (flag)
     BOOL process_created = CreateProcessW(executable_path,
                                           executable_args,
                                           nullptr,

--- a/src/runner/settings_window.cpp
+++ b/src/runner/settings_window.cpp
@@ -248,12 +248,13 @@ BOOL run_settings_non_elevated(LPCWSTR executable_path, LPWSTR executable_args, 
     siex.lpAttributeList = pptal;
     siex.StartupInfo.cb = sizeof(siex);
 
+    // here (flag)
     BOOL process_created = CreateProcessW(executable_path,
                                           executable_args,
                                           nullptr,
                                           nullptr,
                                           FALSE,
-                                          0,
+                                          EXTENDED_STARTUPINFO_PRESENT,
                                           nullptr,
                                           nullptr,
                                           &siex.StartupInfo,


### PR DESCRIPTION
## Summary of the Pull Request

Fix improper calls to CreateProcessW.

**What is this about:**

After carefully reading the docs regarding the CreateProcessW function, I identified two potential issues.
One is a missing flag and the other is uninitialized size member.

**What is include in the PR:** 

Fixed those issues.

**How does someone test / validate:** 

No specific validation, just ensure that PT generally works both as user and as admin.

## Quality Checklist

- [x] **Linked issue:** #9042
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
