### PR TITLE
[FZ Editor] Move zones + and - buttons to the template layouts flyout

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/Converters/LayoutTypeCustomToVisibilityConverter.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Converters/LayoutTypeCustomToVisibilityConverter.cs
@@ -9,7 +9,7 @@ using FancyZonesEditor.Models;
 
 namespace FancyZonesEditor.Converters
 {
-    public class LayoutTypeToVisibilityConverter : IValueConverter
+    public class LayoutTypeCustomToVisibilityConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Converters/LayoutTypeTemplateToVisibilityConverter.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Converters/LayoutTypeTemplateToVisibilityConverter.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Windows;
+using System.Windows.Data;
+using FancyZonesEditor.Models;
+
+namespace FancyZonesEditor.Converters
+{
+    public class LayoutTypeTemplateToVisibilityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            var type = (LayoutType)value;
+            return type != LayoutType.Custom && type != LayoutType.Blank ? Visibility.Visible : Visibility.Collapsed;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            return null;
+        }
+    }
+}

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -27,7 +27,7 @@
         ResizeMode="CanResize">
     <Window.Resources>
 
-        <Converters:LayoutTypeToVisibilityConverter x:Key="LayoutTypeToVisibilityConverter" />
+        <Converters:LayoutTypeCustomToVisibilityConverter x:Key="LayoutTypeCustomToVisibilityConverter" />
 
         <DataTemplate x:Key="MonitorItemTemplate">
             <Border x:Name="MonitorItem"
@@ -156,7 +156,7 @@
                                         AutomationProperties.Name="{x:Static props:Resources.Edit_zones}"
                                         Height="48"
                                         Style="{StaticResource AccentButtonStyle}"
-                                        Visibility="{Binding Type, Converter={StaticResource LayoutTypeToVisibilityConverter}}">
+                                        Visibility="{Binding Type, Converter={StaticResource LayoutTypeCustomToVisibilityConverter}}">
                                     <Button.Content>
                                         <StackPanel Orientation="Horizontal">
                                             <TextBlock Text="&#xE104;"
@@ -170,11 +170,11 @@
                                            Text="{x:Static props:Resources.Name}"
                                            Margin="0,32,0,0"
                                            Foreground="{DynamicResource PrimaryForegroundBrush}"
-                                           Visibility="{Binding Type, Converter={StaticResource LayoutTypeToVisibilityConverter}}" />
+                                           Visibility="{Binding Type, Converter={StaticResource LayoutTypeCustomToVisibilityConverter}}" />
                                 <TextBox Text="{Binding Name}"
                                          Margin="0,6,0,16"
                                          AutomationProperties.LabeledBy="{Binding ElementName=nameHeader}"
-                                         Visibility="{Binding Type, Converter={StaticResource LayoutTypeToVisibilityConverter}}"/>
+                                         Visibility="{Binding Type, Converter={StaticResource LayoutTypeCustomToVisibilityConverter}}"/>
                                 
                                 <StackPanel Margin="0,0,0,0"
                                             Orientation="Vertical">
@@ -210,7 +210,7 @@
                                             AutomationProperties.Name="{x:Static props:Resources.Delete}"
                                             Click="DeleteLayout_Click"
                                             Background="Transparent"
-                                            Visibility="{Binding Type, Converter={StaticResource LayoutTypeToVisibilityConverter}}">
+                                            Visibility="{Binding Type, Converter={StaticResource LayoutTypeCustomToVisibilityConverter}}">
                                         <Button.Content>
                                             <StackPanel Orientation="Horizontal">
                                                 <TextBlock Text="&#xE107;"
@@ -322,7 +322,7 @@
                                         AutomationProperties.Name="{x:Static props:Resources.Edit_zones}"
                                         Height="48"
                                         Style="{StaticResource AccentButtonStyle}"
-                                        Visibility="{Binding Type, Converter={StaticResource LayoutTypeToVisibilityConverter}}">
+                                        Visibility="{Binding Type, Converter={StaticResource LayoutTypeCustomToVisibilityConverter}}">
                                     <Button.Content>
                                         <StackPanel Orientation="Horizontal">
                                             <TextBlock Text="&#xE104;"
@@ -336,11 +336,11 @@
                                            Text="{x:Static props:Resources.Name}"
                                            Margin="0,32,0,0"
                                            Foreground="{DynamicResource PrimaryForegroundBrush}"
-                                           Visibility="{Binding Type, Converter={StaticResource LayoutTypeToVisibilityConverter}}" />
+                                           Visibility="{Binding Type, Converter={StaticResource LayoutTypeCustomToVisibilityConverter}}" />
                                 <TextBox Text="{Binding Name}"
                                          Margin="0,6,0,16"
                                          AutomationProperties.LabeledBy="{Binding ElementName=nameHeader}"
-                                         Visibility="{Binding Type, Converter={StaticResource LayoutTypeToVisibilityConverter}}"/>
+                                         Visibility="{Binding Type, Converter={StaticResource LayoutTypeCustomToVisibilityConverter}}"/>
 
                                 <StackPanel Margin="0,0,0,0"
                                             Orientation="Vertical">
@@ -391,7 +391,7 @@
                                             AutomationProperties.Name="{x:Static props:Resources.Delete}"
                                             Click="DeleteLayout_Click"
                                             Background="Transparent"
-                                            Visibility="{Binding Type, Converter={StaticResource LayoutTypeToVisibilityConverter}}">
+                                            Visibility="{Binding Type, Converter={StaticResource LayoutTypeCustomToVisibilityConverter}}">
                                         <Button.Content>
                                             <StackPanel Orientation="Horizontal">
                                                 <TextBlock Text="&#xE107;"

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -179,7 +179,7 @@
                                 
                                 <StackPanel Margin="0,0,0,0"
                                             Orientation="Vertical">
-                                    <StackPanel Margin="-8,-2,0,0"
+                                    <StackPanel Margin="0,0,0,8"
                                                 Orientation="Horizontal"
                                                 VerticalAlignment="Center"
                                                 HorizontalAlignment="Center"
@@ -391,7 +391,7 @@
 
                                 <StackPanel Margin="0,0,0,0"
                                             Orientation="Vertical">
-                                    <StackPanel Margin="-8,-2,0,0"
+                                    <StackPanel Margin="0,0,0,8"
                                                 Orientation="Horizontal"
                                                 VerticalAlignment="Center"
                                                 HorizontalAlignment="Center"

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -28,7 +28,8 @@
     <Window.Resources>
 
         <Converters:LayoutTypeCustomToVisibilityConverter x:Key="LayoutTypeCustomToVisibilityConverter" />
-
+        <Converters:LayoutTypeTemplateToVisibilityConverter x:Key="LayoutTypeTemplateToVisibilityConverter" />
+        
         <DataTemplate x:Key="MonitorItemTemplate">
             <Border x:Name="MonitorItem"
                     Width="{Binding DisplayWidth}"
@@ -178,6 +179,52 @@
                                 
                                 <StackPanel Margin="0,0,0,0"
                                             Orientation="Vertical">
+                                    <StackPanel Margin="-8,-2,0,0"
+                                                Orientation="Horizontal"
+                                                VerticalAlignment="Center"
+                                                HorizontalAlignment="Center"
+                                                Visibility="{Binding Type, Converter={StaticResource LayoutTypeTemplateToVisibilityConverter}}">
+
+                                        <Button x:Name="decrementZones"
+                                                Width="32"
+                                                Height="32"
+                                                Content="&#xE949;"
+                                                FontSize="14"
+                                                TabIndex="2"
+                                                HorizontalAlignment="Center"
+                                                Background="Transparent"
+                                                FontFamily="Segoe MDL2 Assets"
+                                                ToolTip="{x:Static props:Resources.Zone_Count_Decrement}"
+                                                AutomationProperties.Name="{x:Static props:Resources.Zone_Count_Decrement}"
+                                                Style="{StaticResource DefaultButtonStyle}"
+                                                Click="DecrementZones_Click" />
+
+                                        <TextBlock x:Name="zoneCount"
+                                                   Text="{Binding TemplateZoneCount}"
+                                                   TextAlignment="Center"
+                                                   FontSize="16"
+                                                   Width="32"
+                                                   Margin="8"
+                                                   Foreground="{DynamicResource SystemAccentColorLight1Brush}"
+                                                   FontWeight="SemiBold"
+                                                   HorizontalAlignment="Stretch"
+                                                   VerticalAlignment="Center" />
+
+                                        <Button x:Name="incrementZones"
+                                                Width="32"
+                                                Height="32"
+                                                FontSize="14"
+                                                TabIndex="3"
+                                                Background="Transparent"
+                                                Content="&#xE948;"
+                                                HorizontalAlignment="Center"
+                                                FontFamily="Segoe MDL2 Assets"
+                                                Style="{StaticResource DefaultButtonStyle}"
+                                                ToolTip="{x:Static props:Resources.Zone_Count_Increment}"
+                                                AutomationProperties.Name="{x:Static props:Resources.Zone_Count_Increment}"
+                                                Click="IncrementZones_Click" />
+                                    </StackPanel>
+                                    
                                     <TextBlock Text="{x:Static props:Resources.Distance_adjacent_zones}"
                                                Margin="0,16,0,0"
                                                Foreground="{DynamicResource PrimaryForegroundBrush}"
@@ -344,7 +391,53 @@
 
                                 <StackPanel Margin="0,0,0,0"
                                             Orientation="Vertical">
-                                    <ui:ToggleSwitch x:Name="spaceAroundSetting"
+                                    <StackPanel Margin="-8,-2,0,0"
+                                                Orientation="Horizontal"
+                                                VerticalAlignment="Center"
+                                                HorizontalAlignment="Center"
+                                                Visibility="{Binding Type, Converter={StaticResource LayoutTypeTemplateToVisibilityConverter}}">
+
+                                        <Button x:Name="decrementZones"
+                                            Width="32"
+                                            Height="32"
+                                            Content="&#xE949;"
+                                            FontSize="14"
+                                            TabIndex="2"
+                                            HorizontalAlignment="Center"
+                                            Background="Transparent"
+                                            FontFamily="Segoe MDL2 Assets"
+                                            ToolTip="{x:Static props:Resources.Zone_Count_Decrement}"
+                                            AutomationProperties.Name="{x:Static props:Resources.Zone_Count_Decrement}"
+                                            Style="{StaticResource DefaultButtonStyle}"
+                                            Click="DecrementZones_Click" />
+
+                                        <TextBlock x:Name="zoneCount"
+                                                Text="{Binding TemplateZoneCount}"
+                                                TextAlignment="Center"
+                                                FontSize="16"
+                                                Width="32"
+                                                Margin="8"
+                                                Foreground="{DynamicResource SystemAccentColorLight1Brush}"
+                                                FontWeight="SemiBold"
+                                                HorizontalAlignment="Stretch"
+                                                VerticalAlignment="Center" />
+
+                                        <Button x:Name="incrementZones"
+                                            Width="32"
+                                            Height="32"
+                                            FontSize="14"
+                                            TabIndex="3"
+                                            Background="Transparent"
+                                            Content="&#xE948;"
+                                            HorizontalAlignment="Center"
+                                            FontFamily="Segoe MDL2 Assets"
+                                            Style="{StaticResource DefaultButtonStyle}"
+                                            ToolTip="{x:Static props:Resources.Zone_Count_Increment}"
+                                            AutomationProperties.Name="{x:Static props:Resources.Zone_Count_Increment}"
+                                            Click="IncrementZones_Click" />
+                                        </StackPanel>
+                                        
+                                        <ui:ToggleSwitch x:Name="spaceAroundSetting"
                                                      Header="{x:Static props:Resources.Show_Space_Zones}"
                                                      IsOn="{Binding ShowSpacing}" />
 
@@ -454,51 +547,6 @@
                                x:Name="TemplatesHeaderBlock"
                                FontWeight="SemiBold"
                                FontSize="24" />
-
-                    <StackPanel Margin="-8,-2,0,0"
-                                Orientation="Horizontal"
-                                VerticalAlignment="Center"
-                                HorizontalAlignment="Center">
-
-                        <Button x:Name="decrementZones"
-                                Width="32"
-                                Height="32"
-                                Content="&#xE949;"
-                                FontSize="14"
-                                TabIndex="2"
-                                HorizontalAlignment="Center"
-                                Background="Transparent"
-                                FontFamily="Segoe MDL2 Assets"
-                                ToolTip="{x:Static props:Resources.Zone_Count_Decrement}"
-                                AutomationProperties.Name="{x:Static props:Resources.Zone_Count_Decrement}"
-                                Style="{StaticResource DefaultButtonStyle}"
-                                Click="DecrementZones_Click" />
-
-                        <TextBlock x:Name="zoneCount"
-                                   Text="{Binding ZoneCount}"
-                                   TextAlignment="Center"
-                                   FontSize="16"
-                                   Width="32"
-                                   Margin="8"
-                                   Foreground="{DynamicResource SystemAccentColorLight1Brush}"
-                                   FontWeight="SemiBold"
-                                   HorizontalAlignment="Stretch"
-                                   VerticalAlignment="Center" />
-
-                        <Button x:Name="incrementZones"
-                                Width="32"
-                                Height="32"
-                                FontSize="14"
-                                TabIndex="3"
-                                Background="Transparent"
-                                Content="&#xE948;"
-                                HorizontalAlignment="Center"
-                                FontFamily="Segoe MDL2 Assets"
-                                Style="{StaticResource DefaultButtonStyle}"
-                                ToolTip="{x:Static props:Resources.Zone_Count_Increment}"
-                                AutomationProperties.Name="{x:Static props:Resources.Zone_Count_Increment}"
-                                Click="IncrementZones_Click" />
-                    </StackPanel>
 
                     <ItemsControl ItemsSource="{Binding DefaultModels}"
                                   Grid.Row="1"

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -23,8 +23,6 @@ namespace FancyZonesEditor
     /// </summary>
     public partial class MainWindow : Window
     {
-        // TODO: share the constants b/w C# Editor and FancyZoneLib
-        public const int MaxZones = 40;
         private const int DefaultWrapPanelItemSize = 164;
         private const int SmallWrapPanelItemSize = 164;
         private const int MinimalForDefaultWrapPanelsHeight = 900;

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -5,16 +5,11 @@
 using System;
 using System.Collections.Generic;
 using System.Windows;
-using System.Windows.Automation.Peers;
 using System.Windows.Controls;
 using System.Windows.Input;
-using System.Windows.Media;
 using FancyZonesEditor.Models;
 using FancyZonesEditor.Utils;
-using FancyZonesEditor.ViewModels;
 using ModernWpf.Controls;
-using ModernWpf.Controls.Primitives;
-using Windows.UI.Popups;
 
 namespace FancyZonesEditor
 {
@@ -65,17 +60,29 @@ namespace FancyZonesEditor
 
         private void DecrementZones_Click(object sender, RoutedEventArgs e)
         {
-            if (_settings.ZoneCount > 1)
+            var mainEditor = App.Overlay;
+            if (!(mainEditor.CurrentDataContext is LayoutModel model))
             {
-                _settings.ZoneCount--;
+                return;
+            }
+
+            if (model.TemplateZoneCount > 1)
+            {
+                model.TemplateZoneCount--;
             }
         }
 
         private void IncrementZones_Click(object sender, RoutedEventArgs e)
         {
-            if (_settings.ZoneCount < MaxZones)
+            var mainEditor = App.Overlay;
+            if (!(mainEditor.CurrentDataContext is LayoutModel model))
             {
-                _settings.ZoneCount++;
+                return;
+            }
+
+            if (model.TemplateZoneCount < LayoutSettings.MaxZones)
+            {
+                model.TemplateZoneCount++;
             }
         }
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/CanvasLayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/CanvasLayoutModel.cs
@@ -53,6 +53,28 @@ namespace FancyZonesEditor.Models
             UpdateLayout();
         }
 
+        // InitTemplateZones
+        // Creates zones based on template zones count
+        public override void InitTemplateZones()
+        {
+            Zones.Clear();
+
+            var workingArea = App.Overlay.WorkArea;
+            int topLeftCoordinate = (int)App.Overlay.ScaleCoordinateWithCurrentMonitorDpi(100); // TODO: replace magic numbers
+            int width = (int)(workingArea.Width * 0.4);
+            int height = (int)(workingArea.Height * 0.4);
+            Int32Rect focusZoneRect = new Int32Rect(topLeftCoordinate, topLeftCoordinate, width, height);
+            int focusRectXIncrement = (TemplateZoneCount <= 1) ? 0 : (int)App.Overlay.ScaleCoordinateWithCurrentMonitorDpi(50); // TODO: replace magic numbers
+            int focusRectYIncrement = (TemplateZoneCount <= 1) ? 0 : (int)App.Overlay.ScaleCoordinateWithCurrentMonitorDpi(50); // TODO: replace magic numbers
+
+            for (int i = 0; i < TemplateZoneCount; i++)
+            {
+                Zones.Add(focusZoneRect);
+                focusZoneRect.X += focusRectXIncrement;
+                focusZoneRect.Y += focusRectYIncrement;
+            }
+        }
+
         private void UpdateLayout()
         {
             FirePropertyChanged();

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
@@ -232,6 +232,14 @@ namespace FancyZonesEditor.Models
             // update settings
             App.Overlay.CurrentLayoutSettings.ZonesetUuid = Uuid;
             App.Overlay.CurrentLayoutSettings.Type = Type;
+            App.Overlay.CurrentLayoutSettings.SensitivityRadius = SensitivityRadius;
+            App.Overlay.CurrentLayoutSettings.ZoneCount = TemplateZoneCount;
+
+            if (this is GridLayoutModel)
+            {
+                App.Overlay.CurrentLayoutSettings.ShowSpacing = ((GridLayoutModel)this).ShowSpacing;
+                App.Overlay.CurrentLayoutSettings.Spacing = ((GridLayoutModel)this).Spacing;
+            }
 
             // update temp file
             App.FancyZonesEditorIO.SerializeZoneSettings();

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
@@ -140,6 +140,32 @@ namespace FancyZonesEditor.Models
 
         private int _sensitivityRadius = LayoutSettings.DefaultSensitivityRadius;
 
+        // TemplateZoneCount - number of zones selected in the picker window for template layouts
+        public int TemplateZoneCount
+        {
+            get
+            {
+                return _zoneCount;
+            }
+
+            set
+            {
+                if (value != _zoneCount)
+                {
+                    _zoneCount = value;
+
+                    App.Overlay.Monitors[App.Overlay.CurrentDesktop].Settings.ZoneCount = value;
+                    App.FancyZonesEditorIO.SerializeZoneSettings();
+
+                    InitTemplateZones();
+
+                    FirePropertyChanged(nameof(TemplateZoneCount));
+                }
+            }
+        }
+
+        private int _zoneCount = LayoutSettings.DefaultZoneCount;
+
         // implementation of INotifyPropertyChanged
         public event PropertyChangedEventHandler PropertyChanged;
 
@@ -181,6 +207,10 @@ namespace FancyZonesEditor.Models
 
             App.FancyZonesEditorIO.SerializeZoneSettings();
         }
+
+        // InitTemplateZones
+        // Creates zones based on template zones count
+        public abstract void InitTemplateZones();
 
         // Callbacks that the base LayoutModel makes to derived types
         protected abstract void PersistData();

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutSettings.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutSettings.cs
@@ -9,6 +9,7 @@ namespace FancyZonesEditor
 {
     public class LayoutSettings
     {
+        // TODO: share the constants b/w C# Editor and FancyZoneLib
         public const bool DefaultShowSpacing = true;
 
         public const int DefaultSpacing = 16;
@@ -16,6 +17,8 @@ namespace FancyZonesEditor
         public const int DefaultZoneCount = 3;
 
         public const int DefaultSensitivityRadius = 20;
+
+        public const int MaxZones = 40;
 
         public string ZonesetUuid { get; set; } = string.Empty;
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/MainWindowSettingsModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/MainWindowSettingsModel.cs
@@ -175,7 +175,7 @@ namespace FancyZonesEditor
             }
             else if (currentApplied.Type == LayoutType.Custom)
             {
-                foreach (LayoutModel model in MainWindowSettingsModel.CustomModels)
+                foreach (LayoutModel model in CustomModels)
                 {
                     if ("{" + model.Guid.ToString().ToUpperInvariant() + "}" == currentApplied.ZonesetUuid.ToUpperInvariant())
                     {
@@ -193,6 +193,15 @@ namespace FancyZonesEditor
                     {
                         // found match
                         foundModel = model;
+                        foundModel.TemplateZoneCount = currentApplied.ZoneCount;
+                        foundModel.SensitivityRadius = currentApplied.SensitivityRadius;
+                        if (foundModel is GridLayoutModel)
+                        {
+                            ((GridLayoutModel)foundModel).ShowSpacing = currentApplied.ShowSpacing;
+                            ((GridLayoutModel)foundModel).Spacing = currentApplied.Spacing;
+                        }
+
+                        foundModel.InitTemplateZones();
                         break;
                     }
                 }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/MainWindowSettingsModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/MainWindowSettingsModel.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
-using System.Windows;
 using FancyZonesEditor.Models;
 
 namespace FancyZonesEditor
@@ -43,22 +42,6 @@ namespace FancyZonesEditor
         public static readonly string RegistryPath = "SOFTWARE\\SuperFancyZones";
         public static readonly string FullRegistryPath = "HKEY_CURRENT_USER\\" + RegistryPath;
 
-        // hard coded data for all the "Priority Grid" configurations that are unique to "Grid"
-        private static readonly byte[][] _priorityData = new byte[][]
-        {
-            new byte[] { 0, 0, 0, 0, 0, 1, 1, 39, 16, 39, 16, 0 },
-            new byte[] { 0, 0, 0, 0, 0, 1, 2, 39, 16, 26, 11, 13, 5, 0, 1 },
-            new byte[] { 0, 0, 0, 0, 0, 1, 3, 39, 16, 9, 196, 19, 136, 9, 196, 0, 1, 2 },
-            new byte[] { 0, 0, 0, 0, 0, 2, 3, 19, 136, 19, 136, 9, 196, 19, 136, 9, 196, 0, 1, 2, 0, 1, 3 },
-            new byte[] { 0, 0, 0, 0, 0, 2, 3, 19, 136, 19, 136, 9, 196, 19, 136, 9, 196, 0, 1, 2, 3, 1, 4 },
-            new byte[] { 0, 0, 0, 0, 0, 3, 3, 13, 5, 13, 6, 13, 5, 9, 196, 19, 136, 9, 196, 0, 1, 2, 0, 1, 3, 4, 1, 5 },
-            new byte[] { 0, 0, 0, 0, 0, 3, 3, 13, 5, 13, 6, 13, 5, 9, 196, 19, 136, 9, 196, 0, 1, 2, 3, 1, 4, 5, 1, 6 },
-            new byte[] { 0, 0, 0, 0, 0, 3, 4, 13, 5, 13, 6, 13, 5, 9, 196, 9, 196, 9, 196, 9, 196, 0, 1, 2, 3, 4, 1, 2, 5, 6, 1, 2, 7 },
-            new byte[] { 0, 0, 0, 0, 0, 3, 4, 13, 5, 13, 6, 13, 5, 9, 196, 9, 196, 9, 196, 9, 196, 0, 1, 2, 3, 4, 1, 2, 5, 6, 1, 7, 8 },
-            new byte[] { 0, 0, 0, 0, 0, 3, 4, 13, 5, 13, 6, 13, 5, 9, 196, 9, 196, 9, 196, 9, 196, 0, 1, 2, 3, 4, 1, 5, 6, 7, 1, 8, 9 },
-            new byte[] { 0, 0, 0, 0, 0, 3, 4, 13, 5, 13, 6, 13, 5, 9, 196, 9, 196, 9, 196, 9, 196, 0, 1, 2, 3, 4, 1, 5, 6, 7, 8, 9, 10 },
-        };
-
         private const int _multiplier = 10000;
 
         public bool IsCustomLayoutActive
@@ -82,6 +65,7 @@ namespace FancyZonesEditor
             // Initialize the five default layout models: Focus, Columns, Rows, Grid, and PriorityGrid
             DefaultModels = new List<LayoutModel>(5);
             _focusModel = new CanvasLayoutModel(Properties.Resources.Template_Layout_Focus, LayoutType.Focus);
+            _focusModel.InitTemplateZones();
             DefaultModels.Add(_focusModel);
 
             _columnsModel = new GridLayoutModel(Properties.Resources.Template_Layout_Columns, LayoutType.Columns)
@@ -89,6 +73,7 @@ namespace FancyZonesEditor
                 Rows = 1,
                 RowPercents = new List<int>(1) { _multiplier },
             };
+            _columnsModel.InitTemplateZones();
             DefaultModels.Add(_columnsModel);
 
             _rowsModel = new GridLayoutModel(Properties.Resources.Template_Layout_Rows, LayoutType.Rows)
@@ -96,34 +81,16 @@ namespace FancyZonesEditor
                 Columns = 1,
                 ColumnPercents = new List<int>(1) { _multiplier },
             };
+            _rowsModel.InitTemplateZones();
             DefaultModels.Add(_rowsModel);
 
             _gridModel = new GridLayoutModel(Properties.Resources.Template_Layout_Grid, LayoutType.Grid);
+            _gridModel.InitTemplateZones();
             DefaultModels.Add(_gridModel);
 
             _priorityGridModel = new GridLayoutModel(Properties.Resources.Template_Layout_Priority_Grid, LayoutType.PriorityGrid);
+            _priorityGridModel.InitTemplateZones();
             DefaultModels.Add(_priorityGridModel);
-
-            UpdateTemplateLayoutModels();
-        }
-
-        // ZoneCount - number of zones selected in the picker window
-        public int ZoneCount
-        {
-            get
-            {
-                return App.Overlay.CurrentLayoutSettings.ZoneCount;
-            }
-
-            set
-            {
-                if (App.Overlay.CurrentLayoutSettings.ZoneCount != value)
-                {
-                    App.Overlay.CurrentLayoutSettings.ZoneCount = value;
-                    UpdateTemplateLayoutModels();
-                    FirePropertyChanged(nameof(ZoneCount));
-                }
-            }
         }
 
         // IsShiftKeyPressed - is the shift key currently being held down
@@ -166,119 +133,6 @@ namespace FancyZonesEditor
 
         private bool _isCtrlKeyPressed;
 
-        // UpdateLayoutModels
-        // Update the five default layouts based on the new ZoneCount
-        private void UpdateTemplateLayoutModels()
-        {
-            // Update the "Focus" Default Layout
-            _focusModel.Zones.Clear();
-
-            // Sanity check for imported settings that may have invalid data
-            if (ZoneCount < 1)
-            {
-                ZoneCount = 3;
-            }
-
-            // If changing focus layout zones size and/or increment,
-            // same change should be applied in ZoneSet.cpp (ZoneSet::CalculateFocusLayout)
-            var workingArea = App.Overlay.WorkArea;
-            int topLeftCoordinate = (int)App.Overlay.ScaleCoordinateWithCurrentMonitorDpi(100); // TODO: replace magic numbers
-            int width = (int)(workingArea.Width * 0.4);
-            int height = (int)(workingArea.Height * 0.4);
-            Int32Rect focusZoneRect = new Int32Rect(topLeftCoordinate, topLeftCoordinate, width, height);
-            int focusRectXIncrement = (ZoneCount <= 1) ? 0 : (int)App.Overlay.ScaleCoordinateWithCurrentMonitorDpi(50);
-            int focusRectYIncrement = (ZoneCount <= 1) ? 0 : (int)App.Overlay.ScaleCoordinateWithCurrentMonitorDpi(50);
-
-            for (int i = 0; i < ZoneCount; i++)
-            {
-                _focusModel.Zones.Add(focusZoneRect);
-                focusZoneRect.X += focusRectXIncrement;
-                focusZoneRect.Y += focusRectYIncrement;
-            }
-
-            // Update the "Rows" and "Columns" Default Layouts
-            // They can share their model, just transposed
-            _rowsModel.CellChildMap = new int[ZoneCount, 1];
-            _columnsModel.CellChildMap = new int[1, ZoneCount];
-            _rowsModel.Rows = _columnsModel.Columns = ZoneCount;
-            _rowsModel.RowPercents = _columnsModel.ColumnPercents = new List<int>(ZoneCount);
-
-            for (int i = 0; i < ZoneCount; i++)
-            {
-                _rowsModel.CellChildMap[i, 0] = i;
-                _columnsModel.CellChildMap[0, i] = i;
-
-                // Note: This is NOT equal to _multiplier / ZoneCount and is done like this to make
-                // the sum of all RowPercents exactly (_multiplier).
-                // _columnsModel is sharing the same array
-                _rowsModel.RowPercents.Add(((_multiplier * (i + 1)) / ZoneCount) - ((_multiplier * i) / ZoneCount));
-            }
-
-            // Update the "Grid" Default Layout
-            int rows = 1;
-            while (ZoneCount / rows >= rows)
-            {
-                rows++;
-            }
-
-            rows--;
-            int cols = ZoneCount / rows;
-            if (ZoneCount % rows == 0)
-            {
-                // even grid
-            }
-            else
-            {
-                cols++;
-            }
-
-            _gridModel.Rows = rows;
-            _gridModel.Columns = cols;
-            _gridModel.RowPercents = new List<int>(rows);
-            _gridModel.ColumnPercents = new List<int>(cols);
-            _gridModel.CellChildMap = new int[rows, cols];
-
-            // Note: The following are NOT equal to _multiplier divided by rows or columns and is
-            // done like this to make the sum of all RowPercents exactly (_multiplier).
-            for (int row = 0; row < rows; row++)
-            {
-                _gridModel.RowPercents.Add(((_multiplier * (row + 1)) / rows) - ((_multiplier * row) / rows));
-            }
-
-            for (int col = 0; col < cols; col++)
-            {
-                _gridModel.ColumnPercents.Add(((_multiplier * (col + 1)) / cols) - ((_multiplier * col) / cols));
-            }
-
-            int index = 0;
-            for (int row = 0; row < rows; row++)
-            {
-                for (int col = 0; col < cols; col++)
-                {
-                    _gridModel.CellChildMap[row, col] = index++;
-                    if (index == ZoneCount)
-                    {
-                        index--;
-                    }
-                }
-            }
-
-            // Update the "Priority Grid" Default Layout
-            if (ZoneCount <= _priorityData.Length)
-            {
-                _priorityGridModel.Reload(_priorityData[ZoneCount - 1]);
-            }
-            else
-            {
-                // same as grid;
-                _priorityGridModel.Rows = _gridModel.Rows;
-                _priorityGridModel.Columns = _gridModel.Columns;
-                _priorityGridModel.RowPercents = _gridModel.RowPercents;
-                _priorityGridModel.ColumnPercents = _gridModel.ColumnPercents;
-                _priorityGridModel.CellChildMap = _gridModel.CellChildMap;
-            }
-        }
-
         public IList<LayoutModel> DefaultModels { get; }
 
         public static ObservableCollection<LayoutModel> CustomModels
@@ -308,7 +162,6 @@ namespace FancyZonesEditor
 
         public LayoutModel UpdateSelectedLayoutModel()
         {
-            UpdateTemplateLayoutModels();
             ResetAppliedModel();
             ResetSelectedModel();
 
@@ -399,13 +252,15 @@ namespace FancyZonesEditor
             }
         }
 
-        public void UpdateDesktopDependantProperties(LayoutSettings prevSettings)
+        public void UpdateDefaultModels()
         {
-            UpdateTemplateLayoutModels();
-
-            if (prevSettings.ZoneCount != ZoneCount)
+            foreach (LayoutModel model in DefaultModels)
             {
-                FirePropertyChanged(nameof(ZoneCount));
+                if (App.Overlay.CurrentLayoutSettings.Type == model.Type && App.Overlay.CurrentLayoutSettings.ZoneCount != model.TemplateZoneCount)
+                {
+                    model.TemplateZoneCount = App.Overlay.CurrentLayoutSettings.ZoneCount;
+                    model.InitTemplateZones();
+                }
             }
         }
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Overlay.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Overlay.cs
@@ -101,14 +101,13 @@ namespace FancyZonesEditor
                         return;
                     }
 
-                    var prevSettings = CurrentLayoutSettings;
                     _currentDesktop = value;
 
                     MainWindowSettingsModel settings = ((App)Application.Current).MainWindowSettings;
                     if (settings != null)
                     {
                         settings.ResetAppliedModel();
-                        settings.UpdateDesktopDependantProperties(prevSettings);
+                        settings.UpdateDefaultModels();
                     }
 
                     Update();


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

* Moved `+` and `-` buttons to the template layouts flyout.
* Possibility to change zone count individually for each template layout.

![Untitled](https://user-images.githubusercontent.com/8949536/104332276-0f013e00-5501-11eb-9c04-cd9fdb7bf538.png)

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #8715 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
