### PR TITLE
[Run] Fix exception

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program.UnitTests/Storage/Win32ProgramRepositoryTest.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program.UnitTests/Storage/Win32ProgramRepositoryTest.cs
@@ -349,7 +349,7 @@ namespace Microsoft.Plugin.Program.UnitTests.Storage
             Win32Program olditem = new Win32Program
             {
                 Name = "oldpath",
-                ExecutableName = path,
+                ExecutableName = oldpath,
                 FullPath = fullPath,
             };
 

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Storage/Win32ProgramRepository.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Storage/Win32ProgramRepository.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Plugin.Program.Storage
 
             string extension = Path.GetExtension(newPath);
             Win32Program.ApplicationType appType = Win32Program.GetAppTypeFromPath(newPath);
-            Programs.Win32Program newApp = Programs.Win32Program.GetAppFromPath(newPath);
+            Programs.Win32Program newApp = Win32Program.GetAppFromPath(newPath);
             Programs.Win32Program oldApp = null;
 
             // Once the shortcut application is renamed, the old app does not exist and therefore when we try to get the FullPath we get the lnk path instead of the exe path
@@ -111,7 +111,7 @@ namespace Microsoft.Plugin.Program.Storage
             {
                 if (appType == Win32Program.ApplicationType.ShortcutApplication)
                 {
-                    oldApp = new Win32Program() { Name = Path.GetFileNameWithoutExtension(e.OldName), ExecutableName = newApp.ExecutableName, FullPath = newApp.FullPath };
+                    oldApp = new Win32Program() { Name = Path.GetFileNameWithoutExtension(e.OldName), ExecutableName = Path.GetFileName(e.OldName), FullPath = newApp.FullPath };
                 }
                 else if (appType == Win32Program.ApplicationType.InternetShortcutApplication)
                 {
@@ -124,13 +124,20 @@ namespace Microsoft.Plugin.Program.Storage
             }
             catch (Exception ex)
             {
-                Log.Exception($"OnAppRenamed-{extension}Program|{oldPath}|Unable to create program from {oldPath}", ex, GetType());
+                Log.Exception($"OnAppRenamed-{extension} Program|{e.OldName}|Unable to create program from {oldPath}", ex, GetType());
             }
 
             // To remove the old app which has been renamed and to add the new application.
             if (oldApp != null)
             {
-                Remove(oldApp);
+                if (string.IsNullOrWhiteSpace(oldApp.Name) || string.IsNullOrWhiteSpace(oldApp.ExecutableName) || string.IsNullOrWhiteSpace(oldApp.FullPath))
+                {
+                    Log.Error($"Old app was not initialized properly. OldFullPath: {e.OldFullPath}; OldName: {e.OldName}; FullPath: {e.FullPath}", GetType());
+                }
+                else
+                {
+                    Remove(oldApp);
+                }
             }
 
             if (newApp != null)


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Null reference exception on program rename. 

**What is include in the PR:** 
- Fix `oldApp` initialization for a shortcut. Before when a shortcut was renamed an old entry was not deleted from `ListRepository`.
- Fix unhandled null reference exception and added logs so it is easier to identify the root cause. The reason for the exception was `oldApp` was not initialized properly.
 
**How does someone test / validate:** 
One can check that on a shortcut rename one item is deleted from `ListRepository` and one is added.

## Quality Checklist

- [X] **Linked issue:** #8544
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [X] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [X] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
