### PR TITLE
[FZ Editor] Closing context menu after Duplicate or Delete button clicked

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Automation.Peers;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Input;
 using System.Windows.Media;
 using FancyZonesEditor.Models;
@@ -123,6 +124,8 @@ namespace FancyZonesEditor
 
         private void DuplicateLayout_Click(object sender, RoutedEventArgs e)
         {
+            CloseFlyout((DependencyObject)sender);
+
             var mainEditor = App.Overlay;
             if (!(mainEditor.CurrentDataContext is LayoutModel model))
             {
@@ -197,6 +200,8 @@ namespace FancyZonesEditor
 
         private async void DeleteLayout_Click(object sender, RoutedEventArgs e)
         {
+            CloseFlyout((DependencyObject)sender);
+
             var dialog = new ModernWpf.Controls.ContentDialog()
             {
                 Title = FancyZonesEditor.Properties.Resources.Are_You_Sure,
@@ -314,6 +319,30 @@ namespace FancyZonesEditor
         private void MonitorItem_MouseDown(object sender, MouseButtonEventArgs e)
         {
             monitorViewModel.SelectCommand.Execute((MonitorInfoModel)(sender as Border).DataContext);
+        }
+
+        private void CloseFlyout(DependencyObject closingButton)
+        {
+            try
+            {
+                var flyoutPresenter = VisualTreeHelper.GetParent(closingButton);
+                while (flyoutPresenter != null && !(flyoutPresenter is FlyoutPresenter))
+                {
+                    flyoutPresenter = VisualTreeHelper.GetParent(flyoutPresenter);
+                }
+
+                if (flyoutPresenter != null)
+                {
+                    var popup = ((FrameworkElement)flyoutPresenter).Parent as Popup;
+                    if (popup != null)
+                    {
+                        popup.IsOpen = false;
+                    }
+                }
+            }
+            catch (Exception)
+            {
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

After clicking the `Duplicate` or `Delete` button in the editing context menu of the layout the menu will be closed automatically.

![Screen Recording 2021-01-13 at 07 43 56 47 PM](https://user-images.githubusercontent.com/8949536/104482730-527aab80-55d8-11eb-949e-b56189613a5d.gif)

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #8715
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
