### PR TITLE
[PT Run] Black icons with light windows theme

### DIFF
--- a/src/common/Microsoft.PowerToys.Common.UI/ThemeManager.cs
+++ b/src/common/Microsoft.PowerToys.Common.UI/ThemeManager.cs
@@ -20,7 +20,8 @@ namespace Microsoft.PowerToys.Common.UI
         private const string HighContrastBlackTheme = "HighContrast.Accent4";
         private const string HighContrastWhiteTheme = "HighContrast.Accent5";
 
-        private Theme currentTheme;
+        private Theme _currentTheme;
+        private Theme _settingsTheme;
         private bool _disposed;
 
         public event ThemeChangedHandler ThemeChanged;
@@ -77,7 +78,7 @@ namespace Microsoft.PowerToys.Common.UI
 
         public Theme GetCurrentTheme()
         {
-            return currentTheme;
+            return _currentTheme;
         }
 
         private static Theme GetHighContrastBaseType()
@@ -103,64 +104,64 @@ namespace Microsoft.PowerToys.Common.UI
 
         private void ResetTheme()
         {
-            ChangeTheme(currentTheme, false);
+            ChangeTheme(_settingsTheme == Theme.System ? Theme.System : _currentTheme);
         }
 
-        public void ChangeTheme(Theme theme, bool forceSystem)
+        public void ChangeTheme(Theme theme, bool fromSettings = false)
         {
-            Theme oldTheme = currentTheme;
+            if (fromSettings)
+            {
+                _settingsTheme = theme;
+            }
+
+            Theme oldTheme = _currentTheme;
 
             if (theme == Theme.System)
             {
-                currentTheme = Theme.System;
+                _currentTheme = Theme.System;
                 if (ControlzEx.Theming.WindowsThemeHelper.IsHighContrastEnabled())
                 {
                     Theme highContrastBaseType = GetHighContrastBaseType();
-                    ChangeTheme(highContrastBaseType, true);
+                    ChangeTheme(highContrastBaseType, false);
                 }
                 else
                 {
                     string baseColor = ControlzEx.Theming.WindowsThemeHelper.GetWindowsBaseColor();
-                    ChangeTheme((Theme)Enum.Parse(typeof(Theme), baseColor), true);
+                    ChangeTheme((Theme)Enum.Parse(typeof(Theme), baseColor));
                 }
             }
             else if (theme == Theme.HighContrastOne)
             {
-                currentTheme = Theme.HighContrastOne;
+                _currentTheme = Theme.HighContrastOne;
                 ControlzEx.Theming.ThemeManager.Current.ChangeTheme(_app, HighContrastOneTheme, true);
             }
             else if (theme == Theme.HighContrastTwo)
             {
-                currentTheme = Theme.HighContrastTwo;
+                _currentTheme = Theme.HighContrastTwo;
                 ControlzEx.Theming.ThemeManager.Current.ChangeTheme(_app, HighContrastTwoTheme, true);
             }
             else if (theme == Theme.HighContrastWhite)
             {
-                currentTheme = Theme.HighContrastWhite;
+                _currentTheme = Theme.HighContrastWhite;
                 ControlzEx.Theming.ThemeManager.Current.ChangeTheme(_app, HighContrastWhiteTheme, true);
             }
             else if (theme == Theme.HighContrastBlack)
             {
-                currentTheme = Theme.HighContrastBlack;
+                _currentTheme = Theme.HighContrastBlack;
                 ControlzEx.Theming.ThemeManager.Current.ChangeTheme(_app, HighContrastBlackTheme, true);
             }
             else if (theme == Theme.Light)
             {
-                currentTheme = Theme.Light;
+                _currentTheme = Theme.Light;
                 ControlzEx.Theming.ThemeManager.Current.ChangeTheme(_app, LightTheme);
             }
             else if (theme == Theme.Dark)
             {
-                currentTheme = Theme.Dark;
+                _currentTheme = Theme.Dark;
                 ControlzEx.Theming.ThemeManager.Current.ChangeTheme(_app, DarkTheme);
             }
 
-            ThemeChanged?.Invoke(oldTheme, currentTheme);
-
-            if (forceSystem)
-            {
-                currentTheme = Theme.System;
-            }
+            ThemeChanged?.Invoke(oldTheme, _currentTheme);
         }
 
         private void Current_ThemeChanged(object sender, ControlzEx.Theming.ThemeChangedEventArgs e)

--- a/src/modules/launcher/PowerLauncher/SettingsWatcher.cs
+++ b/src/modules/launcher/PowerLauncher/SettingsWatcher.cs
@@ -7,7 +7,6 @@ using System.IO;
 using System.IO.Abstractions;
 using System.Threading;
 using System.Windows.Input;
-using ManagedCommon;
 using Microsoft.PowerToys.Common.UI;
 using Microsoft.PowerToys.Settings.UI.Library;
 using PowerLauncher.Helper;
@@ -45,7 +44,7 @@ namespace PowerLauncher
             OverloadSettings();
 
             // Apply theme at startup
-            _themeManager.ChangeTheme(_settings.Theme, _settings.Theme == Theme.System);
+            _themeManager.ChangeTheme(_settings.Theme, true);
         }
 
         public void CreateSettingsIfNotExists()
@@ -112,7 +111,7 @@ namespace PowerLauncher
                     if (_settings.Theme != overloadSettings.Properties.Theme)
                     {
                         _settings.Theme = overloadSettings.Properties.Theme;
-                        _themeManager.ChangeTheme(_settings.Theme, _settings.Theme == Theme.System);
+                        _themeManager.ChangeTheme(_settings.Theme, true);
                     }
 
                     retry = false;


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
With **Windows** color set to **Light** and **PT Run** color set to **Windows default** wrong icons are displayed in PT Run results list: white instead of black. 

**What is include in the PR:** 
Set black icons with Windows color to Light and PT Run color to Windows default.

**How does someone test / validate:** 
- Set PT Run color to Windows default
- Set Windows color to Light
- Search "shutdown"
- The launcher should be white and the icons should be black
- Set Windows color to Dark
- The launcher should be black and the icons should be white

## Quality Checklist

- [x] **Linked issue:** #9090
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [x] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
