### PR TITLE
Add e to calculator

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Calculator.UnitTest/ExtendedCalculatorParserTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Calculator.UnitTest/ExtendedCalculatorParserTests.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Plugin.Calculator.UnitTests
         [TestCase("42")]
         [TestCase("test")]
         [TestCase("pi(2)")] // Incorrect input, constant is being treated as a function.
+        [TestCase("e(2)")]
         public void Interpret_NoResult_WhenCalled(string input)
         {
             // Arrange
@@ -62,6 +63,9 @@ namespace Microsoft.Plugin.Calculator.UnitTests
         [TestCase("8.43 + 4.43 - 12.86", 0D)]
         [TestCase("8.43 + 4.43 - 12.8", 0.06D)]
         [TestCase("exp(5)", 148.413159102577D)]
+        [TestCase("e^5", 148.413159102577D)]
+        [TestCase("e*2", 5.43656365691809D)]
+        [TestCase("log(e)", 1D)]
         [TestCase("cosh(0)", 1D)]
         public void Interpret_NoErrors_WhenCalledWithRounding(string input, decimal expectedResult)
         {

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Calculator/CalculateEngine.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Calculator/CalculateEngine.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using Mages.Core;
 
@@ -10,7 +11,13 @@ namespace Microsoft.Plugin.Calculator
 {
     public class CalculateEngine
     {
-        private readonly Engine _magesEngine = new Engine();
+        private readonly Engine _magesEngine = new Engine(new Configuration
+        {
+            Scope = new Dictionary<string, object>
+            {
+                { "e", Math.E } // e is not contained in the default mages engine
+            }
+        });
         public const int RoundingDigits = 10;
 
         public CalculateResult Interpret(string input)

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Calculator/CalculateEngine.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Calculator/CalculateEngine.cs
@@ -15,9 +15,10 @@ namespace Microsoft.Plugin.Calculator
         {
             Scope = new Dictionary<string, object>
             {
-                { "e", Math.E } // e is not contained in the default mages engine
-            }
+                { "e", Math.E }, // e is not contained in the default mages engine
+            },
         });
+
         public const int RoundingDigits = 10;
 
         public CalculateResult Interpret(string input)


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
This adds support for the euler number to the calculator.
**What is included in the PR:** 

**How does someone test / validate:** 
- Type equations that contain e in the launcher, e. g. `2*e`, `e^5`, `log(e)`
## Quality Checklist

- [X] **Linked issue:** #9123
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [X] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
