### PR TITLE
Default add triage to issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: 🐛 Bug report
 about: Report errors or unexpected behavior
 title: ''
-labels: Issue-Bug
+labels: Issue-Bug,Triage-Needed
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/documentation-issue.md
+++ b/.github/ISSUE_TEMPLATE/documentation-issue.md
@@ -2,7 +2,7 @@
 name: "\U0001F4DA Documentation Issue"
 about: Report issues in our documentation
 title: ''
-labels: Issue-Docs
+labels: Issue-Docs,Triage-Needed
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: "⭐ Feature request"
 about: Propose something new.
 title: ''
-labels: ''
+labels: Triage-Needed
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/translation_issue.md
+++ b/.github/ISSUE_TEMPLATE/translation_issue.md
@@ -2,7 +2,7 @@
 name: 📖 Localization/Translation issue
 about: Report incorrect translations.
 title: ''
-labels: Issue-Bug,Area-Localization,Issue-Translation 
+labels: Issue-Bug,Area-Localization,Issue-Translation,Triage-Needed 
 assignees: ''
 
 ---


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

adding in Triage Needed by default

**What is include in the PR:** 

the templates with the tag

**How does someone test / validate:** 

We merge in and check.  Does not touch any source

## Quality Checklist

- [x] **Linked issue:** #9136
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
