### PR TITLE
Run Settings on same elevation as PowerToys.exe

### DIFF
--- a/src/runner/settings_window.cpp
+++ b/src/runner/settings_window.cpp
@@ -390,9 +390,7 @@ void run_settings_window()
     // Due to a bug in .NET, running the Settings process as non-elevated
     // from an elevated process sometimes results in a crash.
     // TODO: Revisit this after switching to .NET 5
-    const bool force_same_elevation = true;
-
-    if (is_process_elevated() && !force_same_elevation)
+    if (is_process_elevated() && !UseNewSettings())
     {
         process_created = run_settings_non_elevated(executable_path.c_str(), executable_args.data(), &process_info);
     }

--- a/src/runner/settings_window.cpp
+++ b/src/runner/settings_window.cpp
@@ -386,7 +386,13 @@ void run_settings_window()
     executable_args.append(settings_isUserAnAdmin);
 
     BOOL process_created = false;
-    if (is_process_elevated())
+
+    // Due to a bug in .NET, running the Settings process as non-elevated
+    // from an elevated process sometimes results in a crash.
+    // TODO: Revisit this after switching to .NET 5
+    const bool force_same_elevation = true;
+
+    if (is_process_elevated() && !force_same_elevation)
     {
         process_created = run_settings_non_elevated(executable_path.c_str(), executable_args.data(), &process_info);
     }


### PR DESCRIPTION
## Summary of the Pull Request

Running the Settings process as non-elevated from elevated PowerToys.exe sometimes results in a crash.

**What is this about:**

After fixing wrong calls to CreateProcessW in #9063, we discovered that Settings was running elevated all along.
And sometimes, when running Settings non-elevated, we get a crash that can only be linked to a bug in .NET.
This has happened before: https://github.com/dotnet/runtime/issues/37129

**What is include in the PR:** 

For now, we disable running Settings from `run_settings_non_elevated` until we move to .NET 5 or figure out exactly what's going on.

**How does someone test / validate:** 

The bug discussed in  #9063 is easiest to reproduce by building the installer, installing, running PowerToys, opening the settings, by clicking the tray icon, restarting as Admin, and clicking the tray icon again. The crash should be gone now.

## Quality Checklist

- [x] **Linked issue:** #9042
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
