### PR TITLE
[FZ Editor] Bind dialog properties

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
@@ -332,7 +332,7 @@ namespace FancyZonesEditor
                 }
             }
 
-            zone = new GridZone();
+            zone = new GridZone(Model.ShowSpacing ? Model.Spacing : 0);
             zone.Split += OnSplit;
             zone.MergeDrag += OnMergeDrag;
             zone.MergeComplete += OnMergeComplete;
@@ -383,9 +383,7 @@ namespace FancyZonesEditor
                 return;
             }
 
-            MainWindowSettingsModel settings = ((App)Application.Current).MainWindowSettings;
-
-            int spacing = settings.ShowSpacing ? settings.Spacing : 0;
+            int spacing = model.ShowSpacing ? model.Spacing : 0;
 
             _data.RecalculateZones(spacing, arrangeSize);
             _data.ArrangeZones(Preview.Children, spacing);
@@ -411,10 +409,10 @@ namespace FancyZonesEditor
                 if (_dragHandles.HasSnappedNonAdjacentResizers(resizer))
                 {
                     double spacing = 0;
-                    MainWindowSettingsModel settings = ((App)Application.Current).MainWindowSettings;
-                    if (settings.ShowSpacing)
+                    GridLayoutModel model = Model;
+                    if (model.ShowSpacing)
                     {
-                        spacing = settings.Spacing;
+                        spacing = model.Spacing;
                     }
 
                     _data.SplitOnDrag(resizer, delta, spacing);

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridZone.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridZone.xaml.cs
@@ -59,7 +59,7 @@ namespace FancyZonesEditor
             set { SetValue(IsSelectedProperty, value); }
         }
 
-        public GridZone()
+        public GridZone(int spacing)
         {
             InitializeComponent();
             OnSelectionChanged();
@@ -68,6 +68,9 @@ namespace FancyZonesEditor
                 Fill = SystemParameters.WindowGlassBrush,
             };
             Body.Children.Add(_splitter);
+
+            Spacing = spacing;
+            SplitterThickness = Math.Max(spacing, 1);
 
             ((App)Application.Current).MainWindowSettings.PropertyChanged += ZoneSettings_PropertyChanged;
         }
@@ -104,19 +107,9 @@ namespace FancyZonesEditor
             }
         }
 
-        private int SplitterThickness
-        {
-            get
-            {
-                MainWindowSettingsModel settings = ((App)Application.Current).MainWindowSettings;
-                if (!settings.ShowSpacing)
-                {
-                    return 1;
-                }
+        private int Spacing { get; set; }
 
-                return Math.Max(settings.Spacing, 1);
-            }
-        }
+        private int SplitterThickness { get; set; }
 
         private void UpdateSplitter()
         {
@@ -282,14 +275,7 @@ namespace FancyZonesEditor
 
         private void DoSplit(Orientation orientation, double offset)
         {
-            int spacing = 0;
-            MainWindowSettingsModel settings = ((App)Application.Current).MainWindowSettings;
-            if (settings.ShowSpacing)
-            {
-                spacing = settings.Spacing;
-            }
-
-            Split?.Invoke(this, new SplitEventArgs(orientation, offset, spacing));
+            Split?.Invoke(this, new SplitEventArgs(orientation, offset, Spacing));
         }
 
         private void FullSplit_Click(object sender, RoutedEventArgs e)

--- a/src/modules/fancyzones/editor/FancyZonesEditor/LayoutPreview.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/LayoutPreview.xaml.cs
@@ -115,9 +115,7 @@ namespace FancyZonesEditor
             RowColInfo[] colInfo = (from percent in grid.ColumnPercents
                                     select new RowColInfo(percent)).ToArray();
 
-            MainWindowSettingsModel settings = ((App)Application.Current).MainWindowSettings;
-
-            int spacing = settings.ShowSpacing ? settings.Spacing : 0;
+            int spacing = grid.ShowSpacing ? grid.Spacing : 0;
 
             var workArea = App.Overlay.WorkArea;
             double width = workArea.Width - (spacing * (cols + 1));
@@ -215,8 +213,7 @@ namespace FancyZonesEditor
                 Body.ColumnDefinitions.Add(def);
             }
 
-            MainWindowSettingsModel settings = ((App)Application.Current).MainWindowSettings;
-            Thickness margin = new Thickness(settings.ShowSpacing ? settings.Spacing / 20 : 0);
+            Thickness margin = new Thickness(grid.ShowSpacing ? grid.Spacing / 20 : 0);
 
             List<int> visited = new List<int>();
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/LayoutPreview.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/LayoutPreview.xaml.cs
@@ -50,7 +50,14 @@ namespace FancyZonesEditor
 
         private void LayoutPreview_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
         {
+            if (_model != null)
+            {
+                _model.PropertyChanged -= LayoutModel_PropertyChanged;
+            }
+
             _model = (LayoutModel)DataContext;
+            _model.PropertyChanged += LayoutModel_PropertyChanged;
+
             RenderPreview();
         }
 
@@ -67,6 +74,11 @@ namespace FancyZonesEditor
                     RenderPreview();
                 }
             }
+        }
+
+        private void LayoutModel_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            RenderPreview();
         }
 
         public Int32Rect[] GetZoneRects()

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -383,7 +383,8 @@
                           PrimaryButtonText="{x:Static props:Resources.Save}"
                           Title="{x:Static props:Resources.Edit_Layout}">
             <StackPanel Margin="0,16,0,0"
-                        MinWidth="420">
+                        MinWidth="420"
+                        DataContext="{Binding SelectedModel}">
                 <Button Click="EditZones_Click"
                         x:Name="editZoneLayoutButton"
                         HorizontalAlignment="Stretch"
@@ -418,7 +419,7 @@
                             Orientation="Vertical">
                     <ui:ToggleSwitch x:Name="spaceAroundSetting"
                                      Header="{x:Static props:Resources.Show_Space_Zones}"
-                                     IsOn="true"
+                                     IsOn="{Binding ShowSpacing}"
                                      Visibility="{Binding Converter={StaticResource LayoutModelTypeToVisibilityConverter}}" />
 
                     <TextBlock x:Name="paddingValue"
@@ -430,7 +431,7 @@
 
                     <TextBox Margin="0,6,0,0"
                              IsEnabled="{Binding ShowSpacing}"
-                             Text="32"
+                             Text="{Binding Spacing}"
                              Width="86"
                              HorizontalAlignment="Left"
                              AutomationProperties.LabeledBy="{Binding ElementName=paddingValue}"
@@ -443,7 +444,7 @@
                                x:Name="sensitivityRadiusValue" />
 
                     <TextBox Margin="0,6,0,0"
-                             Text="20"
+                             Text="{Binding SensitivityRadius}"
                              Width="86"
                              AutomationProperties.LabeledBy="{Binding ElementName=sensitivityRadiusValue}"
                              HorizontalAlignment="Left" />

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -381,6 +381,8 @@
                           PrimaryButtonStyle="{StaticResource AccentButtonStyle}"
                           SecondaryButtonText="{x:Static props:Resources.Cancel}"
                           PrimaryButtonText="{x:Static props:Resources.Save}"
+                          PrimaryButtonClick="EditLayoutDialog_PrimaryButtonClick"
+                          SecondaryButtonClick="EditLayoutDialog_SecondaryButtonClick"
                           Title="{x:Static props:Resources.Edit_Layout}">
             <StackPanel Margin="0,16,0,0"
                         MinWidth="420"

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -177,7 +177,8 @@ namespace FancyZonesEditor
 
             model.Persist();
 
-            App.Overlay.SaveLayoutSettings(model);
+            App.Overlay.SaveCurrentLayoutSettings(model);
+            App.FancyZonesEditorIO.SerializeZoneSettings();
         }
 
         private void Apply()
@@ -186,7 +187,8 @@ namespace FancyZonesEditor
             if (mainEditor.CurrentDataContext is LayoutModel model)
             {
                 _settings.SetAppliedModel(model);
-                App.Overlay.SaveLayoutSettings(model);
+                App.Overlay.SaveCurrentLayoutSettings(model);
+                App.FancyZonesEditorIO.SerializeZoneSettings();
             }
         }
 
@@ -356,11 +358,13 @@ namespace FancyZonesEditor
 
             _backup = null;
 
-            // update settings
-            if (model.Type == LayoutType.Custom || model == _settings.AppliedModel)
+            // update current settings
+            if (model == _settings.AppliedModel)
             {
-                App.Overlay.SaveLayoutSettings(model);
+                App.Overlay.SaveCurrentLayoutSettings(model);
             }
+
+            App.FancyZonesEditorIO.SerializeZoneSettings();
 
             // reset selected model
             Select(_settings.AppliedModel);

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -5,16 +5,11 @@
 using System;
 using System.Collections.Generic;
 using System.Windows;
-using System.Windows.Automation.Peers;
 using System.Windows.Controls;
 using System.Windows.Input;
-using System.Windows.Media;
 using FancyZonesEditor.Models;
 using FancyZonesEditor.Utils;
-using FancyZonesEditor.ViewModels;
 using ModernWpf.Controls;
-using ModernWpf.Controls.Primitives;
-using Windows.UI.Popups;
 
 namespace FancyZonesEditor
 {
@@ -23,8 +18,6 @@ namespace FancyZonesEditor
     /// </summary>
     public partial class MainWindow : Window
     {
-        // TODO: share the constants b/w C# Editor and FancyZoneLib
-        public const int MaxZones = 40;
         private const int DefaultWrapPanelItemSize = 164;
         private const int SmallWrapPanelItemSize = 164;
         private const int MinimalForDefaultWrapPanelsHeight = 900;
@@ -67,17 +60,29 @@ namespace FancyZonesEditor
 
         private void DecrementZones_Click(object sender, RoutedEventArgs e)
         {
-            if (_settings.ZoneCount > 1)
+            var mainEditor = App.Overlay;
+            if (!(mainEditor.CurrentDataContext is LayoutModel model))
             {
-                _settings.ZoneCount--;
+                return;
+            }
+
+            if (model.TemplateZoneCount > 1)
+            {
+                model.TemplateZoneCount--;
             }
         }
 
         private void IncrementZones_Click(object sender, RoutedEventArgs e)
         {
-            if (_settings.ZoneCount < MaxZones)
+            var mainEditor = App.Overlay;
+            if (!(mainEditor.CurrentDataContext is LayoutModel model))
             {
-                _settings.ZoneCount++;
+                return;
+            }
+
+            if (model.TemplateZoneCount < LayoutSettings.MaxZones)
+            {
+                model.TemplateZoneCount++;
             }
         }
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -187,11 +187,6 @@ namespace FancyZonesEditor
             {
                 model.Apply();
             }
-
-            if (!mainEditor.MultiMonitorMode)
-            {
-                Close();
-            }
         }
 
         private void OnClosing(object sender, EventArgs e)
@@ -267,11 +262,6 @@ namespace FancyZonesEditor
             overlay.CurrentDataContext = MainWindowSettingsModel.BlankModel;
 
             App.FancyZonesEditorIO.SerializeZoneSettings();
-
-            if (!overlay.MultiMonitorMode)
-            {
-                Close();
-            }
         }
 
         private void NewLayoutDialog_PrimaryButtonClick(ModernWpf.Controls.ContentDialog sender, ModernWpf.Controls.ContentDialogButtonClickEventArgs args)

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -345,7 +345,7 @@ namespace FancyZonesEditor
             Select(_settings.AppliedModel);
         }
 
-        // EditLayout: Apply changes
+        // EditLayout: Save changes
         private void EditLayoutDialog_PrimaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
         {
             var mainEditor = App.Overlay;
@@ -357,7 +357,7 @@ namespace FancyZonesEditor
             _backup = null;
 
             // update settings
-            if (model.Type == LayoutType.Custom)
+            if (model.Type == LayoutType.Custom || model == _settings.AppliedModel)
             {
                 App.Overlay.SaveLayoutSettings(model);
             }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -175,7 +175,8 @@ namespace FancyZonesEditor
             model.Name = name + " (" + (++maxCustomIndex) + ')';
 
             model.Persist();
-            App.FancyZonesEditorIO.SerializeZoneSettings();
+
+            App.Overlay.SaveLayoutSettings(model);
         }
 
         private void Apply()
@@ -183,8 +184,8 @@ namespace FancyZonesEditor
             var mainEditor = App.Overlay;
             if (mainEditor.CurrentDataContext is LayoutModel model)
             {
-                model.Apply();
                 _settings.SetAppliedModel(model);
+                App.Overlay.SaveLayoutSettings(model);
             }
         }
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -115,12 +115,7 @@ namespace FancyZonesEditor
 
         private void Select(LayoutModel newSelection)
         {
-            if (App.Overlay.CurrentDataContext is LayoutModel currentSelection)
-            {
-                currentSelection.IsSelected = false;
-            }
-
-            newSelection.IsSelected = true;
+            _settings.SetSelectedModel(newSelection);
             App.Overlay.CurrentDataContext = newSelection;
         }
 
@@ -185,12 +180,11 @@ namespace FancyZonesEditor
 
         private void Apply()
         {
-            ((App)Application.Current).MainWindowSettings.ResetAppliedModel();
-
             var mainEditor = App.Overlay;
             if (mainEditor.CurrentDataContext is LayoutModel model)
             {
                 model.Apply();
+                _settings.SetAppliedModel(model);
             }
         }
 
@@ -220,6 +214,8 @@ namespace FancyZonesEditor
 
         private async void EditLayout_Click(object sender, RoutedEventArgs e)
         {
+            var dataContext = ((FrameworkElement)sender).DataContext;
+            _settings.SetSelectedModel((LayoutModel)dataContext);
             await EditLayoutDialog.ShowAsync();
         }
 
@@ -231,9 +227,9 @@ namespace FancyZonesEditor
                 return;
             }
 
-            model.IsSelected = false;
-            Hide();
+            _settings.SetSelectedModel(model);
 
+            Hide();
             mainEditor.OpenEditor(model);
         }
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/CanvasLayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/CanvasLayoutModel.cs
@@ -70,6 +70,7 @@ namespace FancyZonesEditor.Models
                 layout.Zones.Add(zone);
             }
 
+            layout.SensitivityRadius = SensitivityRadius;
             return layout;
         }
 
@@ -80,6 +81,8 @@ namespace FancyZonesEditor.Models
             {
                 other.Zones.Add(zone);
             }
+
+            other.SensitivityRadius = SensitivityRadius;
         }
 
         // PersistData

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/CanvasLayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/CanvasLayoutModel.cs
@@ -34,6 +34,17 @@ namespace FancyZonesEditor.Models
         {
         }
 
+        public CanvasLayoutModel(CanvasLayoutModel other)
+            : base(other)
+        {
+            CanvasRect = new Rect(other.CanvasRect.X, other.CanvasRect.Y, other.CanvasRect.Width, other.CanvasRect.Height);
+
+            foreach (Int32Rect zone in other.Zones)
+            {
+                Zones.Add(zone);
+            }
+        }
+
         // Zones - the list of all zones in this layout, described as independent rectangles
         public IList<Int32Rect> Zones { get; private set; } = new List<Int32Rect>();
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/CanvasLayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/CanvasLayoutModel.cs
@@ -53,6 +53,28 @@ namespace FancyZonesEditor.Models
             UpdateLayout();
         }
 
+        // InitTemplateZones
+        // Creates zones based on template zones count
+        public override void InitTemplateZones()
+        {
+            Zones.Clear();
+
+            var workingArea = App.Overlay.WorkArea;
+            int topLeftCoordinate = (int)App.Overlay.ScaleCoordinateWithCurrentMonitorDpi(100); // TODO: replace magic numbers
+            int width = (int)(workingArea.Width * 0.4);
+            int height = (int)(workingArea.Height * 0.4);
+            Int32Rect focusZoneRect = new Int32Rect(topLeftCoordinate, topLeftCoordinate, width, height);
+            int focusRectXIncrement = (TemplateZoneCount <= 1) ? 0 : (int)App.Overlay.ScaleCoordinateWithCurrentMonitorDpi(50); // TODO: replace magic numbers
+            int focusRectYIncrement = (TemplateZoneCount <= 1) ? 0 : (int)App.Overlay.ScaleCoordinateWithCurrentMonitorDpi(50); // TODO: replace magic numbers
+
+            for (int i = 0; i < TemplateZoneCount; i++)
+            {
+                Zones.Add(focusZoneRect);
+                focusZoneRect.X += focusRectXIncrement;
+                focusZoneRect.Y += focusRectYIncrement;
+            }
+        }
+
         private void UpdateLayout()
         {
             FirePropertyChanged();

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/GridLayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/GridLayoutModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation
+// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -96,10 +96,7 @@ namespace FancyZonesEditor.Models
                 if (value != _showSpacing)
                 {
                     _showSpacing = value;
-                    App.Overlay.Monitors[App.Overlay.CurrentDesktop].Settings.ShowSpacing = value;
-
                     FirePropertyChanged(nameof(ShowSpacing));
-                    App.FancyZonesEditorIO.SerializeZoneSettings();
                 }
             }
         }
@@ -119,10 +116,7 @@ namespace FancyZonesEditor.Models
                 if (value != _spacing)
                 {
                     _spacing = value;
-                    App.Overlay.Monitors[App.Overlay.CurrentDesktop].Settings.Spacing = value;
-
                     FirePropertyChanged(nameof(Spacing));
-                    App.FancyZonesEditorIO.SerializeZoneSettings();
                 }
             }
         }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/GridLayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/GridLayoutModel.cs
@@ -79,6 +79,8 @@ namespace FancyZonesEditor.Models
                 {
                     _showSpacing = value;
                     App.Overlay.Monitors[App.Overlay.CurrentDesktop].Settings.ShowSpacing = value;
+
+                    FirePropertyChanged(nameof(ShowSpacing));
                     App.FancyZonesEditorIO.SerializeZoneSettings();
                 }
             }
@@ -100,6 +102,8 @@ namespace FancyZonesEditor.Models
                 {
                     _spacing = value;
                     App.Overlay.Monitors[App.Overlay.CurrentDesktop].Settings.Spacing = value;
+
+                    FirePropertyChanged(nameof(Spacing));
                     App.FancyZonesEditorIO.SerializeZoneSettings();
                 }
             }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/GridLayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/GridLayoutModel.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation
+﻿// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -151,6 +151,36 @@ namespace FancyZonesEditor.Models
             RowPercents = rowPercents;
             ColumnPercents = colsPercents;
             CellChildMap = cellChildMap;
+        }
+
+        public GridLayoutModel(GridLayoutModel other)
+            : base(other)
+        {
+            _rows = other._rows;
+            _cols = other._cols;
+            _showSpacing = other._showSpacing;
+            _spacing = other._spacing;
+
+            CellChildMap = new int[_rows, _cols];
+            for (int row = 0; row < _rows; row++)
+            {
+                for (int col = 0; col < _cols; col++)
+                {
+                    CellChildMap[row, col] = other.CellChildMap[row, col];
+                }
+            }
+
+            RowPercents = new List<int>(_rows);
+            for (int row = 0; row < _rows; row++)
+            {
+                RowPercents.Add(other.RowPercents[row]);
+            }
+
+            ColumnPercents = new List<int>(_cols);
+            for (int col = 0; col < _cols; col++)
+            {
+                ColumnPercents.Add(other.ColumnPercents[col]);
+            }
         }
 
         public void Reload(byte[] data)

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/GridLayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/GridLayoutModel.cs
@@ -65,6 +65,48 @@ namespace FancyZonesEditor.Models
         // ColumnPercents - represents the %age width of each column in the grid
         public List<int> ColumnPercents { get; set; }
 
+        // ShowSpacing - flag if free space between cells should be presented
+        public bool ShowSpacing
+        {
+            get
+            {
+                return _showSpacing;
+            }
+
+            set
+            {
+                if (value != _showSpacing)
+                {
+                    _showSpacing = value;
+                    App.Overlay.Monitors[App.Overlay.CurrentDesktop].Settings.ShowSpacing = value;
+                    App.FancyZonesEditorIO.SerializeZoneSettings();
+                }
+            }
+        }
+
+        private bool _showSpacing = LayoutSettings.DefaultShowSpacing;
+
+        // Spacing - free space between cells
+        public int Spacing
+        {
+            get
+            {
+                return _spacing;
+            }
+
+            set
+            {
+                if (value != _spacing)
+                {
+                    _spacing = value;
+                    App.Overlay.Monitors[App.Overlay.CurrentDesktop].Settings.Spacing = value;
+                    App.FancyZonesEditorIO.SerializeZoneSettings();
+                }
+            }
+        }
+
+        private int _spacing = LayoutSettings.DefaultSpacing;
+
         // FreeZones (not persisted) - used to keep track of child indices that are no longer in use in the CellChildMap,
         //  making them candidates for re-use when it's needed to add another child
         //  TODO: do I need FreeZones on the data model?  - I think I do
@@ -169,6 +211,10 @@ namespace FancyZonesEditor.Models
             }
 
             layout.ColumnPercents = colPercents;
+
+            layout.ShowSpacing = ShowSpacing;
+            layout.Spacing = Spacing;
+            layout.SensitivityRadius = SensitivityRadius;
         }
 
         // PersistData

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
@@ -226,8 +226,7 @@ namespace FancyZonesEditor.Models
         public void Apply()
         {
             MainWindowSettingsModel settings = ((App)App.Current).MainWindowSettings;
-            settings.ResetAppliedModel();
-            IsApplied = true;
+            settings.SetAppliedModel(this);
 
             // update settings
             App.Overlay.CurrentLayoutSettings.ZonesetUuid = Uuid;

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
@@ -140,6 +140,32 @@ namespace FancyZonesEditor.Models
 
         private int _sensitivityRadius = LayoutSettings.DefaultSensitivityRadius;
 
+        // TemplateZoneCount - number of zones selected in the picker window for template layouts
+        public int TemplateZoneCount
+        {
+            get
+            {
+                return _zoneCount;
+            }
+
+            set
+            {
+                if (value != _zoneCount)
+                {
+                    _zoneCount = value;
+
+                    App.Overlay.Monitors[App.Overlay.CurrentDesktop].Settings.ZoneCount = value;
+                    App.FancyZonesEditorIO.SerializeZoneSettings();
+
+                    InitTemplateZones();
+
+                    FirePropertyChanged(nameof(TemplateZoneCount));
+                }
+            }
+        }
+
+        private int _zoneCount = LayoutSettings.DefaultZoneCount;
+
         // implementation of INotifyPropertyChanged
         public event PropertyChangedEventHandler PropertyChanged;
 
@@ -182,6 +208,10 @@ namespace FancyZonesEditor.Models
             App.FancyZonesEditorIO.SerializeZoneSettings();
         }
 
+        // InitTemplateZones
+        // Creates zones based on template zones count
+        public abstract void InitTemplateZones();
+
         // Callbacks that the base LayoutModel makes to derived types
         protected abstract void PersistData();
 
@@ -202,6 +232,14 @@ namespace FancyZonesEditor.Models
             // update settings
             App.Overlay.CurrentLayoutSettings.ZonesetUuid = Uuid;
             App.Overlay.CurrentLayoutSettings.Type = Type;
+            App.Overlay.CurrentLayoutSettings.SensitivityRadius = SensitivityRadius;
+            App.Overlay.CurrentLayoutSettings.ZoneCount = TemplateZoneCount;
+
+            if (this is GridLayoutModel)
+            {
+                App.Overlay.CurrentLayoutSettings.ShowSpacing = ((GridLayoutModel)this).ShowSpacing;
+                App.Overlay.CurrentLayoutSettings.Spacing = ((GridLayoutModel)this).Spacing;
+            }
 
             // update temp file
             App.FancyZonesEditorIO.SerializeZoneSettings();

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
@@ -132,8 +132,7 @@ namespace FancyZonesEditor.Models
                 if (value != _sensitivityRadius)
                 {
                     _sensitivityRadius = value;
-                    App.Overlay.Monitors[App.Overlay.CurrentDesktop].Settings.SensitivityRadius = value;
-                    App.FancyZonesEditorIO.SerializeZoneSettings();
+                    FirePropertyChanged(nameof(SensitivityRadius));
                 }
             }
         }
@@ -153,12 +152,7 @@ namespace FancyZonesEditor.Models
                 if (value != _zoneCount)
                 {
                     _zoneCount = value;
-
-                    App.Overlay.Monitors[App.Overlay.CurrentDesktop].Settings.ZoneCount = value;
-                    App.FancyZonesEditorIO.SerializeZoneSettings();
-
                     InitTemplateZones();
-
                     FirePropertyChanged(nameof(TemplateZoneCount));
                 }
             }
@@ -204,8 +198,6 @@ namespace FancyZonesEditor.Models
             {
                 customModels.Add(model);
             }
-
-            App.FancyZonesEditorIO.SerializeZoneSettings();
         }
 
         // InitTemplateZones
@@ -220,28 +212,6 @@ namespace FancyZonesEditor.Models
         public void Persist()
         {
             PersistData();
-            Apply();
-        }
-
-        public void Apply()
-        {
-            MainWindowSettingsModel settings = ((App)App.Current).MainWindowSettings;
-            settings.SetAppliedModel(this);
-
-            // update settings
-            App.Overlay.CurrentLayoutSettings.ZonesetUuid = Uuid;
-            App.Overlay.CurrentLayoutSettings.Type = Type;
-            App.Overlay.CurrentLayoutSettings.SensitivityRadius = SensitivityRadius;
-            App.Overlay.CurrentLayoutSettings.ZoneCount = TemplateZoneCount;
-
-            if (this is GridLayoutModel)
-            {
-                App.Overlay.CurrentLayoutSettings.ShowSpacing = ((GridLayoutModel)this).ShowSpacing;
-                App.Overlay.CurrentLayoutSettings.Spacing = ((GridLayoutModel)this).Spacing;
-            }
-
-            // update temp file
-            App.FancyZonesEditorIO.SerializeZoneSettings();
         }
     }
 }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
@@ -100,6 +100,7 @@ namespace FancyZonesEditor.Models
 
         private bool _isSelected;
 
+        // IsApplied (not-persisted) - tracks whether or not this LayoutModel is applied in the picker
         public bool IsApplied
         {
             get
@@ -118,6 +119,26 @@ namespace FancyZonesEditor.Models
         }
 
         private bool _isApplied;
+
+        public int SensitivityRadius
+        {
+            get
+            {
+                return _sensitivityRadius;
+            }
+
+            set
+            {
+                if (value != _sensitivityRadius)
+                {
+                    _sensitivityRadius = value;
+                    App.Overlay.Monitors[App.Overlay.CurrentDesktop].Settings.SensitivityRadius = value;
+                    App.FancyZonesEditorIO.SerializeZoneSettings();
+                }
+            }
+        }
+
+        private int _sensitivityRadius = LayoutSettings.DefaultSensitivityRadius;
 
         // implementation of INotifyPropertyChanged
         public event PropertyChangedEventHandler PropertyChanged;

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
@@ -39,6 +39,17 @@ namespace FancyZonesEditor.Models
             Type = type;
         }
 
+        protected LayoutModel(LayoutModel other)
+        {
+            _guid = other._guid;
+            _name = other._name;
+            Type = other.Type;
+            _isSelected = other._isSelected;
+            _isApplied = other._isApplied;
+            _sensitivityRadius = other._sensitivityRadius;
+            _zoneCount = other._zoneCount;
+        }
+
         // Name - the display name for this layout model - is also used as the key in the registry
         public string Name
         {
@@ -52,7 +63,7 @@ namespace FancyZonesEditor.Models
                 if (_name != value)
                 {
                     _name = value;
-                    FirePropertyChanged();
+                    FirePropertyChanged(nameof(Name));
                 }
             }
         }
@@ -93,7 +104,7 @@ namespace FancyZonesEditor.Models
                 if (_isSelected != value)
                 {
                     _isSelected = value;
-                    FirePropertyChanged();
+                    FirePropertyChanged(nameof(IsSelected));
                 }
             }
         }
@@ -113,7 +124,7 @@ namespace FancyZonesEditor.Models
                 if (_isApplied != value)
                 {
                     _isApplied = value;
-                    FirePropertyChanged();
+                    FirePropertyChanged(nameof(IsApplied));
                 }
             }
         }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutSettings.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutSettings.cs
@@ -9,13 +9,13 @@ namespace FancyZonesEditor
 {
     public class LayoutSettings
     {
-        public static bool DefaultShowSpacing => true;
+        public const bool DefaultShowSpacing = true;
 
-        public static int DefaultSpacing => 16;
+        public const int DefaultSpacing = 16;
 
-        public static int DefaultZoneCount => 3;
+        public const int DefaultZoneCount = 3;
 
-        public static int DefaultSensitivityRadius => 20;
+        public const int DefaultSensitivityRadius = 20;
 
         public string ZonesetUuid { get; set; } = string.Empty;
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutSettings.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutSettings.cs
@@ -9,6 +9,7 @@ namespace FancyZonesEditor
 {
     public class LayoutSettings
     {
+        // TODO: share the constants b/w C# Editor and FancyZoneLib
         public const bool DefaultShowSpacing = true;
 
         public const int DefaultSpacing = 16;
@@ -16,6 +17,8 @@ namespace FancyZonesEditor
         public const int DefaultZoneCount = 3;
 
         public const int DefaultSensitivityRadius = 20;
+
+        public const int MaxZones = 40;
 
         public string ZonesetUuid { get; set; } = string.Empty;
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/MainWindowSettingsModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/MainWindowSettingsModel.cs
@@ -155,6 +155,44 @@ namespace FancyZonesEditor
 
         private static CanvasLayoutModel _blankModel = new CanvasLayoutModel(string.Empty, LayoutType.Blank);
 
+        public LayoutModel SelectedModel
+        {
+            get
+            {
+                return _selectedModel;
+            }
+
+            private set
+            {
+                if (_selectedModel != value)
+                {
+                    _selectedModel = value;
+                    FirePropertyChanged(nameof(SelectedModel));
+                }
+            }
+        }
+
+        private LayoutModel _selectedModel = null;
+
+        public LayoutModel AppliedModel
+        {
+            get
+            {
+                return _appliedModel;
+            }
+
+            private set
+            {
+                if (_appliedModel != value)
+                {
+                    _appliedModel = value;
+                    FirePropertyChanged(nameof(AppliedModel));
+                }
+            }
+        }
+
+        private LayoutModel _appliedModel = null;
+
         public static bool IsPredefinedLayout(LayoutModel model)
         {
             return model.Type != LayoutType.Custom;
@@ -162,9 +200,6 @@ namespace FancyZonesEditor
 
         public LayoutModel UpdateSelectedLayoutModel()
         {
-            ResetAppliedModel();
-            ResetSelectedModel();
-
             LayoutModel foundModel = null;
             LayoutSettings currentApplied = App.Overlay.CurrentLayoutSettings;
 
@@ -195,10 +230,10 @@ namespace FancyZonesEditor
                         foundModel = model;
                         foundModel.TemplateZoneCount = currentApplied.ZoneCount;
                         foundModel.SensitivityRadius = currentApplied.SensitivityRadius;
-                        if (foundModel is GridLayoutModel)
+                        if (foundModel is GridLayoutModel grid)
                         {
-                            ((GridLayoutModel)foundModel).ShowSpacing = currentApplied.ShowSpacing;
-                            ((GridLayoutModel)foundModel).Spacing = currentApplied.Spacing;
+                            grid.ShowSpacing = currentApplied.ShowSpacing;
+                            grid.Spacing = currentApplied.Spacing;
                         }
 
                         foundModel.InitTemplateZones();
@@ -212,53 +247,40 @@ namespace FancyZonesEditor
                 foundModel = DefaultModels[4]; // PriorityGrid
             }
 
-            foundModel.IsSelected = true;
-            foundModel.IsApplied = true;
-
+            SetSelectedModel(foundModel);
+            SetAppliedModel(foundModel);
             FirePropertyChanged(nameof(IsCustomLayoutActive));
             return foundModel;
         }
 
-        public void ResetSelectedModel()
+        public void SetSelectedModel(LayoutModel model)
         {
-            foreach (LayoutModel model in CustomModels)
+            if (_selectedModel != null)
             {
-                if (model.IsSelected)
-                {
-                    model.IsSelected = false;
-                    break;
-                }
+                _selectedModel.IsSelected = false;
             }
 
-            foreach (LayoutModel model in DefaultModels)
+            if (model != null)
             {
-                if (model.IsSelected)
-                {
-                    model.IsSelected = false;
-                    break;
-                }
+                model.IsSelected = true;
             }
+
+            SelectedModel = model;
         }
 
-        public void ResetAppliedModel()
+        public void SetAppliedModel(LayoutModel model)
         {
-            foreach (LayoutModel model in CustomModels)
+            if (_appliedModel != null)
             {
-                if (model.IsApplied)
-                {
-                    model.IsApplied = false;
-                    break;
-                }
+                _appliedModel.IsApplied = false;
             }
 
-            foreach (LayoutModel model in DefaultModels)
+            if (model != null)
             {
-                if (model.IsApplied)
-                {
-                    model.IsApplied = false;
-                    break;
-                }
+                model.IsApplied = true;
             }
+
+            AppliedModel = model;
         }
 
         public void UpdateDefaultModels()

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/MainWindowSettingsModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/MainWindowSettingsModel.cs
@@ -126,65 +126,6 @@ namespace FancyZonesEditor
             }
         }
 
-        // Spacing - how much space in between zones of the grid do you want
-        public int Spacing
-        {
-            get
-            {
-                return App.Overlay.CurrentLayoutSettings.Spacing;
-            }
-
-            set
-            {
-                value = Math.Max(0, value);
-                if (App.Overlay.CurrentLayoutSettings.Spacing != value)
-                {
-                    App.Overlay.CurrentLayoutSettings.Spacing = value;
-                    UpdateTemplateLayoutModels();
-                    FirePropertyChanged(nameof(Spacing));
-                }
-            }
-        }
-
-        // ShowSpacing - is the Spacing value used or ignored?
-        public bool ShowSpacing
-        {
-            get
-            {
-                return App.Overlay.CurrentLayoutSettings.ShowSpacing;
-            }
-
-            set
-            {
-                if (App.Overlay.CurrentLayoutSettings.ShowSpacing != value)
-                {
-                    App.Overlay.CurrentLayoutSettings.ShowSpacing = value;
-                    UpdateTemplateLayoutModels();
-                    FirePropertyChanged(nameof(ShowSpacing));
-                }
-            }
-        }
-
-        // SensitivityRadius - how much space inside the zone to highlight the adjacent zone too
-        public int SensitivityRadius
-        {
-            get
-            {
-                return App.Overlay.CurrentLayoutSettings.SensitivityRadius;
-            }
-
-            set
-            {
-                value = Math.Max(0, value);
-                if (App.Overlay.CurrentLayoutSettings.SensitivityRadius != value)
-                {
-                    App.Overlay.CurrentLayoutSettings.SensitivityRadius = value;
-                    UpdateTemplateLayoutModels();
-                    FirePropertyChanged(nameof(SensitivityRadius));
-                }
-            }
-        }
-
         // IsShiftKeyPressed - is the shift key currently being held down
         public bool IsShiftKeyPressed
         {
@@ -465,21 +406,6 @@ namespace FancyZonesEditor
             if (prevSettings.ZoneCount != ZoneCount)
             {
                 FirePropertyChanged(nameof(ZoneCount));
-            }
-
-            if (prevSettings.Spacing != Spacing)
-            {
-                FirePropertyChanged(nameof(Spacing));
-            }
-
-            if (prevSettings.ShowSpacing != ShowSpacing)
-            {
-                FirePropertyChanged(nameof(ShowSpacing));
-            }
-
-            if (prevSettings.SensitivityRadius != SensitivityRadius)
-            {
-                FirePropertyChanged(nameof(SensitivityRadius));
             }
         }
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/MainWindowSettingsModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/MainWindowSettingsModel.cs
@@ -253,6 +253,26 @@ namespace FancyZonesEditor
             return foundModel;
         }
 
+        public void RestoreSelectedModel(LayoutModel model)
+        {
+            if (SelectedModel == null || model == null)
+            {
+                return;
+            }
+
+            SelectedModel.SensitivityRadius = model.SensitivityRadius;
+            SelectedModel.TemplateZoneCount = model.TemplateZoneCount;
+            SelectedModel.IsSelected = model.IsSelected;
+            SelectedModel.IsApplied = model.IsApplied;
+            SelectedModel.Name = model.Name;
+
+            if (model is GridLayoutModel grid)
+            {
+                ((GridLayoutModel)SelectedModel).Spacing = grid.Spacing;
+                ((GridLayoutModel)SelectedModel).ShowSpacing = grid.ShowSpacing;
+            }
+        }
+
         public void SetSelectedModel(LayoutModel model)
         {
             if (_selectedModel != null)

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/MainWindowSettingsModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/MainWindowSettingsModel.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
-using System.Windows;
 using FancyZonesEditor.Models;
 
 namespace FancyZonesEditor
@@ -43,22 +42,6 @@ namespace FancyZonesEditor
         public static readonly string RegistryPath = "SOFTWARE\\SuperFancyZones";
         public static readonly string FullRegistryPath = "HKEY_CURRENT_USER\\" + RegistryPath;
 
-        // hard coded data for all the "Priority Grid" configurations that are unique to "Grid"
-        private static readonly byte[][] _priorityData = new byte[][]
-        {
-            new byte[] { 0, 0, 0, 0, 0, 1, 1, 39, 16, 39, 16, 0 },
-            new byte[] { 0, 0, 0, 0, 0, 1, 2, 39, 16, 26, 11, 13, 5, 0, 1 },
-            new byte[] { 0, 0, 0, 0, 0, 1, 3, 39, 16, 9, 196, 19, 136, 9, 196, 0, 1, 2 },
-            new byte[] { 0, 0, 0, 0, 0, 2, 3, 19, 136, 19, 136, 9, 196, 19, 136, 9, 196, 0, 1, 2, 0, 1, 3 },
-            new byte[] { 0, 0, 0, 0, 0, 2, 3, 19, 136, 19, 136, 9, 196, 19, 136, 9, 196, 0, 1, 2, 3, 1, 4 },
-            new byte[] { 0, 0, 0, 0, 0, 3, 3, 13, 5, 13, 6, 13, 5, 9, 196, 19, 136, 9, 196, 0, 1, 2, 0, 1, 3, 4, 1, 5 },
-            new byte[] { 0, 0, 0, 0, 0, 3, 3, 13, 5, 13, 6, 13, 5, 9, 196, 19, 136, 9, 196, 0, 1, 2, 3, 1, 4, 5, 1, 6 },
-            new byte[] { 0, 0, 0, 0, 0, 3, 4, 13, 5, 13, 6, 13, 5, 9, 196, 9, 196, 9, 196, 9, 196, 0, 1, 2, 3, 4, 1, 2, 5, 6, 1, 2, 7 },
-            new byte[] { 0, 0, 0, 0, 0, 3, 4, 13, 5, 13, 6, 13, 5, 9, 196, 9, 196, 9, 196, 9, 196, 0, 1, 2, 3, 4, 1, 2, 5, 6, 1, 7, 8 },
-            new byte[] { 0, 0, 0, 0, 0, 3, 4, 13, 5, 13, 6, 13, 5, 9, 196, 9, 196, 9, 196, 9, 196, 0, 1, 2, 3, 4, 1, 5, 6, 7, 1, 8, 9 },
-            new byte[] { 0, 0, 0, 0, 0, 3, 4, 13, 5, 13, 6, 13, 5, 9, 196, 9, 196, 9, 196, 9, 196, 0, 1, 2, 3, 4, 1, 5, 6, 7, 8, 9, 10 },
-        };
-
         private const int _multiplier = 10000;
 
         public bool IsCustomLayoutActive
@@ -82,6 +65,7 @@ namespace FancyZonesEditor
             // Initialize the five default layout models: Focus, Columns, Rows, Grid, and PriorityGrid
             DefaultModels = new List<LayoutModel>(5);
             _focusModel = new CanvasLayoutModel(Properties.Resources.Template_Layout_Focus, LayoutType.Focus);
+            _focusModel.InitTemplateZones();
             DefaultModels.Add(_focusModel);
 
             _columnsModel = new GridLayoutModel(Properties.Resources.Template_Layout_Columns, LayoutType.Columns)
@@ -89,6 +73,7 @@ namespace FancyZonesEditor
                 Rows = 1,
                 RowPercents = new List<int>(1) { _multiplier },
             };
+            _columnsModel.InitTemplateZones();
             DefaultModels.Add(_columnsModel);
 
             _rowsModel = new GridLayoutModel(Properties.Resources.Template_Layout_Rows, LayoutType.Rows)
@@ -96,34 +81,16 @@ namespace FancyZonesEditor
                 Columns = 1,
                 ColumnPercents = new List<int>(1) { _multiplier },
             };
+            _rowsModel.InitTemplateZones();
             DefaultModels.Add(_rowsModel);
 
             _gridModel = new GridLayoutModel(Properties.Resources.Template_Layout_Grid, LayoutType.Grid);
+            _gridModel.InitTemplateZones();
             DefaultModels.Add(_gridModel);
 
             _priorityGridModel = new GridLayoutModel(Properties.Resources.Template_Layout_Priority_Grid, LayoutType.PriorityGrid);
+            _priorityGridModel.InitTemplateZones();
             DefaultModels.Add(_priorityGridModel);
-
-            UpdateTemplateLayoutModels();
-        }
-
-        // ZoneCount - number of zones selected in the picker window
-        public int ZoneCount
-        {
-            get
-            {
-                return App.Overlay.CurrentLayoutSettings.ZoneCount;
-            }
-
-            set
-            {
-                if (App.Overlay.CurrentLayoutSettings.ZoneCount != value)
-                {
-                    App.Overlay.CurrentLayoutSettings.ZoneCount = value;
-                    UpdateTemplateLayoutModels();
-                    FirePropertyChanged(nameof(ZoneCount));
-                }
-            }
         }
 
         // IsShiftKeyPressed - is the shift key currently being held down
@@ -166,119 +133,6 @@ namespace FancyZonesEditor
 
         private bool _isCtrlKeyPressed;
 
-        // UpdateLayoutModels
-        // Update the five default layouts based on the new ZoneCount
-        private void UpdateTemplateLayoutModels()
-        {
-            // Update the "Focus" Default Layout
-            _focusModel.Zones.Clear();
-
-            // Sanity check for imported settings that may have invalid data
-            if (ZoneCount < 1)
-            {
-                ZoneCount = 3;
-            }
-
-            // If changing focus layout zones size and/or increment,
-            // same change should be applied in ZoneSet.cpp (ZoneSet::CalculateFocusLayout)
-            var workingArea = App.Overlay.WorkArea;
-            int topLeftCoordinate = (int)App.Overlay.ScaleCoordinateWithCurrentMonitorDpi(100); // TODO: replace magic numbers
-            int width = (int)(workingArea.Width * 0.4);
-            int height = (int)(workingArea.Height * 0.4);
-            Int32Rect focusZoneRect = new Int32Rect(topLeftCoordinate, topLeftCoordinate, width, height);
-            int focusRectXIncrement = (ZoneCount <= 1) ? 0 : (int)App.Overlay.ScaleCoordinateWithCurrentMonitorDpi(50);
-            int focusRectYIncrement = (ZoneCount <= 1) ? 0 : (int)App.Overlay.ScaleCoordinateWithCurrentMonitorDpi(50);
-
-            for (int i = 0; i < ZoneCount; i++)
-            {
-                _focusModel.Zones.Add(focusZoneRect);
-                focusZoneRect.X += focusRectXIncrement;
-                focusZoneRect.Y += focusRectYIncrement;
-            }
-
-            // Update the "Rows" and "Columns" Default Layouts
-            // They can share their model, just transposed
-            _rowsModel.CellChildMap = new int[ZoneCount, 1];
-            _columnsModel.CellChildMap = new int[1, ZoneCount];
-            _rowsModel.Rows = _columnsModel.Columns = ZoneCount;
-            _rowsModel.RowPercents = _columnsModel.ColumnPercents = new List<int>(ZoneCount);
-
-            for (int i = 0; i < ZoneCount; i++)
-            {
-                _rowsModel.CellChildMap[i, 0] = i;
-                _columnsModel.CellChildMap[0, i] = i;
-
-                // Note: This is NOT equal to _multiplier / ZoneCount and is done like this to make
-                // the sum of all RowPercents exactly (_multiplier).
-                // _columnsModel is sharing the same array
-                _rowsModel.RowPercents.Add(((_multiplier * (i + 1)) / ZoneCount) - ((_multiplier * i) / ZoneCount));
-            }
-
-            // Update the "Grid" Default Layout
-            int rows = 1;
-            while (ZoneCount / rows >= rows)
-            {
-                rows++;
-            }
-
-            rows--;
-            int cols = ZoneCount / rows;
-            if (ZoneCount % rows == 0)
-            {
-                // even grid
-            }
-            else
-            {
-                cols++;
-            }
-
-            _gridModel.Rows = rows;
-            _gridModel.Columns = cols;
-            _gridModel.RowPercents = new List<int>(rows);
-            _gridModel.ColumnPercents = new List<int>(cols);
-            _gridModel.CellChildMap = new int[rows, cols];
-
-            // Note: The following are NOT equal to _multiplier divided by rows or columns and is
-            // done like this to make the sum of all RowPercents exactly (_multiplier).
-            for (int row = 0; row < rows; row++)
-            {
-                _gridModel.RowPercents.Add(((_multiplier * (row + 1)) / rows) - ((_multiplier * row) / rows));
-            }
-
-            for (int col = 0; col < cols; col++)
-            {
-                _gridModel.ColumnPercents.Add(((_multiplier * (col + 1)) / cols) - ((_multiplier * col) / cols));
-            }
-
-            int index = 0;
-            for (int row = 0; row < rows; row++)
-            {
-                for (int col = 0; col < cols; col++)
-                {
-                    _gridModel.CellChildMap[row, col] = index++;
-                    if (index == ZoneCount)
-                    {
-                        index--;
-                    }
-                }
-            }
-
-            // Update the "Priority Grid" Default Layout
-            if (ZoneCount <= _priorityData.Length)
-            {
-                _priorityGridModel.Reload(_priorityData[ZoneCount - 1]);
-            }
-            else
-            {
-                // same as grid;
-                _priorityGridModel.Rows = _gridModel.Rows;
-                _priorityGridModel.Columns = _gridModel.Columns;
-                _priorityGridModel.RowPercents = _gridModel.RowPercents;
-                _priorityGridModel.ColumnPercents = _gridModel.ColumnPercents;
-                _priorityGridModel.CellChildMap = _gridModel.CellChildMap;
-            }
-        }
-
         public IList<LayoutModel> DefaultModels { get; }
 
         public static ObservableCollection<LayoutModel> CustomModels
@@ -308,7 +162,6 @@ namespace FancyZonesEditor
 
         public LayoutModel UpdateSelectedLayoutModel()
         {
-            UpdateTemplateLayoutModels();
             ResetAppliedModel();
             ResetSelectedModel();
 
@@ -322,7 +175,7 @@ namespace FancyZonesEditor
             }
             else if (currentApplied.Type == LayoutType.Custom)
             {
-                foreach (LayoutModel model in MainWindowSettingsModel.CustomModels)
+                foreach (LayoutModel model in CustomModels)
                 {
                     if ("{" + model.Guid.ToString().ToUpperInvariant() + "}" == currentApplied.ZonesetUuid.ToUpperInvariant())
                     {
@@ -340,6 +193,15 @@ namespace FancyZonesEditor
                     {
                         // found match
                         foundModel = model;
+                        foundModel.TemplateZoneCount = currentApplied.ZoneCount;
+                        foundModel.SensitivityRadius = currentApplied.SensitivityRadius;
+                        if (foundModel is GridLayoutModel)
+                        {
+                            ((GridLayoutModel)foundModel).ShowSpacing = currentApplied.ShowSpacing;
+                            ((GridLayoutModel)foundModel).Spacing = currentApplied.Spacing;
+                        }
+
+                        foundModel.InitTemplateZones();
                         break;
                     }
                 }
@@ -399,13 +261,15 @@ namespace FancyZonesEditor
             }
         }
 
-        public void UpdateDesktopDependantProperties(LayoutSettings prevSettings)
+        public void UpdateDefaultModels()
         {
-            UpdateTemplateLayoutModels();
-
-            if (prevSettings.ZoneCount != ZoneCount)
+            foreach (LayoutModel model in DefaultModels)
             {
-                FirePropertyChanged(nameof(ZoneCount));
+                if (App.Overlay.CurrentLayoutSettings.Type == model.Type && App.Overlay.CurrentLayoutSettings.ZoneCount != model.TemplateZoneCount)
+                {
+                    model.TemplateZoneCount = App.Overlay.CurrentLayoutSettings.ZoneCount;
+                    model.InitTemplateZones();
+                }
             }
         }
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Overlay.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Overlay.cs
@@ -101,14 +101,13 @@ namespace FancyZonesEditor
                         return;
                     }
 
-                    var prevSettings = CurrentLayoutSettings;
                     _currentDesktop = value;
 
                     MainWindowSettingsModel settings = ((App)Application.Current).MainWindowSettings;
                     if (settings != null)
                     {
                         settings.ResetAppliedModel();
-                        settings.UpdateDesktopDependantProperties(prevSettings);
+                        settings.UpdateDefaultModels();
                     }
 
                     Update();

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Overlay.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Overlay.cs
@@ -106,7 +106,7 @@ namespace FancyZonesEditor
                     MainWindowSettingsModel settings = ((App)Application.Current).MainWindowSettings;
                     if (settings != null)
                     {
-                        settings.ResetAppliedModel();
+                        settings.SetAppliedModel(null);
                         settings.UpdateDefaultModels();
                     }
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Overlay.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Overlay.cs
@@ -6,9 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Media;
 using FancyZonesEditor.Models;
-using Windows.UI.Xaml.Media;
 
 namespace FancyZonesEditor
 {
@@ -199,6 +197,32 @@ namespace FancyZonesEditor
             {
                 Monitors[i].Window.Show();
             }
+        }
+
+        public void SaveLayoutSettings(LayoutModel model)
+        {
+            if (model == null)
+            {
+                return;
+            }
+
+            CurrentLayoutSettings.ZonesetUuid = model.Uuid;
+            CurrentLayoutSettings.Type = model.Type;
+            CurrentLayoutSettings.SensitivityRadius = model.SensitivityRadius;
+            CurrentLayoutSettings.ZoneCount = model.TemplateZoneCount;
+
+            if (model is GridLayoutModel grid)
+            {
+                CurrentLayoutSettings.ShowSpacing = grid.ShowSpacing;
+                CurrentLayoutSettings.Spacing = grid.Spacing;
+            }
+            else
+            {
+                CurrentLayoutSettings.ShowSpacing = false;
+                CurrentLayoutSettings.Spacing = 0;
+            }
+
+            App.FancyZonesEditorIO.SerializeZoneSettings();
         }
 
         public void OpenEditor(LayoutModel model)

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Overlay.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Overlay.cs
@@ -199,7 +199,7 @@ namespace FancyZonesEditor
             }
         }
 
-        public void SaveLayoutSettings(LayoutModel model)
+        public void SaveCurrentLayoutSettings(LayoutModel model)
         {
             if (model == null)
             {
@@ -221,8 +221,6 @@ namespace FancyZonesEditor
                 CurrentLayoutSettings.ShowSpacing = false;
                 CurrentLayoutSettings.Spacing = 0;
             }
-
-            App.FancyZonesEditorIO.SerializeZoneSettings();
         }
 
         public void OpenEditor(LayoutModel model)

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
@@ -108,7 +108,7 @@ namespace FancyZonesEditor.Utils
             public int EditorSensitivityRadius { get; set; }
         }
 
-        private struct CanvasInfoWrapper
+        private class CanvasInfoWrapper
         {
             public struct CanvasZoneWrapper
             {
@@ -126,9 +126,11 @@ namespace FancyZonesEditor.Utils
             public int RefHeight { get; set; }
 
             public List<CanvasZoneWrapper> Zones { get; set; }
+
+            public int SensitivityRadius { get; set; } = LayoutSettings.DefaultSensitivityRadius;
         }
 
-        private struct GridInfoWrapper
+        private class GridInfoWrapper
         {
             public int Rows { get; set; }
 
@@ -139,6 +141,12 @@ namespace FancyZonesEditor.Utils
             public List<int> ColumnsPercentage { get; set; }
 
             public int[][] CellChildMap { get; set; }
+
+            public bool ShowSpacing { get; set; } = LayoutSettings.DefaultShowSpacing;
+
+            public int Spacing { get; set; } = LayoutSettings.DefaultSpacing;
+
+            public int SensitivityRadius { get; set; } = LayoutSettings.DefaultSensitivityRadius;
         }
 
         private struct CustomLayoutWrapper
@@ -581,6 +589,7 @@ namespace FancyZonesEditor.Utils
                         RefWidth = (int)canvasRect.Width,
                         RefHeight = (int)canvasRect.Height,
                         Zones = new List<CanvasInfoWrapper.CanvasZoneWrapper>(),
+                        SensitivityRadius = canvasLayout.SensitivityRadius,
                     };
 
                     foreach (var zone in canvasLayout.Zones)
@@ -619,6 +628,9 @@ namespace FancyZonesEditor.Utils
                         RowsPercentage = gridLayout.RowPercents,
                         ColumnsPercentage = gridLayout.ColumnPercents,
                         CellChildMap = cells,
+                        ShowSpacing = gridLayout.ShowSpacing,
+                        Spacing = gridLayout.Spacing,
+                        SensitivityRadius = gridLayout.SensitivityRadius,
                     };
 
                     string json = JsonSerializer.Serialize(wrapper, _options);
@@ -728,6 +740,7 @@ namespace FancyZonesEditor.Utils
                     }
 
                     layout = new CanvasLayoutModel(zoneSet.Uuid, zoneSet.Name, LayoutType.Custom, zones, info.RefWidth, info.RefHeight);
+                    layout.SensitivityRadius = info.SensitivityRadius;
                 }
                 else if (zoneSet.Type == GridLayoutModel.ModelTypeID)
                 {
@@ -743,6 +756,9 @@ namespace FancyZonesEditor.Utils
                     }
 
                     layout = new GridLayoutModel(zoneSet.Uuid, zoneSet.Name, LayoutType.Custom, info.Rows, info.Columns, info.RowsPercentage, info.ColumnsPercentage, cells);
+                    layout.SensitivityRadius = info.SensitivityRadius;
+                    (layout as GridLayoutModel).ShowSpacing = info.ShowSpacing;
+                    (layout as GridLayoutModel).Spacing = info.Spacing;
                 }
                 else
                 {

--- a/src/modules/fancyzones/lib/FancyZonesDataTypes.h
+++ b/src/modules/fancyzones/lib/FancyZonesDataTypes.h
@@ -78,7 +78,6 @@ namespace FancyZonesDataTypes
 
         inline int rows() const { return m_rows; }
         inline int columns() const { return m_columns; }
-        
         inline const std::vector<int>& rowsPercents() const { return m_rowsPercents; };
         inline const std::vector<int>& columnsPercents() const { return m_columnsPercents; };
         inline const std::vector<std::vector<int>>& cellChildMap() const { return m_cellChildMap; };

--- a/src/modules/fancyzones/lib/FancyZonesDataTypes.h
+++ b/src/modules/fancyzones/lib/FancyZonesDataTypes.h
@@ -45,6 +45,7 @@ namespace FancyZonesDataTypes
             int height;
         };
         std::vector<CanvasLayoutInfo::Rect> zones;
+        int sensitivityRadius;
     };
 
     struct GridLayoutInfo
@@ -62,6 +63,9 @@ namespace FancyZonesDataTypes
             const std::vector<int>& rowsPercents;
             const std::vector<int>& columnsPercents;
             const std::vector<std::vector<int>>& cellChildMap;
+            bool showSpacing;
+            int spacing;
+            int sensitivityRadius;
         };
 
         GridLayoutInfo(const Minimal& info);
@@ -74,16 +78,23 @@ namespace FancyZonesDataTypes
 
         inline int rows() const { return m_rows; }
         inline int columns() const { return m_columns; }
-
+        
         inline const std::vector<int>& rowsPercents() const { return m_rowsPercents; };
         inline const std::vector<int>& columnsPercents() const { return m_columnsPercents; };
         inline const std::vector<std::vector<int>>& cellChildMap() const { return m_cellChildMap; };
+
+        inline bool showSpacing() const { return m_showSpacing; }
+        inline int spacing() const { return m_spacing; }
+        inline int sensitivityRadius() const { return m_sensitivityRadius; }
 
         int m_rows;
         int m_columns;
         std::vector<int> m_rowsPercents;
         std::vector<int> m_columnsPercents;
         std::vector<std::vector<int>> m_cellChildMap;
+        bool m_showSpacing;
+        int m_spacing;
+        int m_sensitivityRadius;
     };
 
     struct CustomZoneSetData

--- a/src/modules/fancyzones/lib/JsonHelpers.cpp
+++ b/src/modules/fancyzones/lib/JsonHelpers.cpp
@@ -39,6 +39,9 @@ namespace NonLocalizable
     const wchar_t RefWidthStr[] = L"ref-width";
     const wchar_t RowsPercentageStr[] = L"rows-percentage";
     const wchar_t RowsStr[] = L"rows";
+    const wchar_t SensitivityRadius[] = L"sensitivity-radius";
+    const wchar_t ShowSpacing[] = L"show-spacing";
+    const wchar_t Spacing[] = L"spacing";
     const wchar_t TypeStr[] = L"type";
     const wchar_t UuidStr[] = L"uuid";
     const wchar_t WidthStr[] = L"width";
@@ -137,6 +140,7 @@ namespace JSONHelpers
             zonesJson.Append(zoneJson);
         }
         infoJson.SetNamedValue(NonLocalizable::ZonesStr, zonesJson);
+        infoJson.SetNamedValue(NonLocalizable::SensitivityRadius, json::value(canvasInfo.sensitivityRadius));
         return infoJson;
     }
 
@@ -161,6 +165,8 @@ namespace JSONHelpers
                 FancyZonesDataTypes::CanvasLayoutInfo::Rect zone{ x, y, width, height };
                 info.zones.push_back(zone);
             }
+
+            info.sensitivityRadius = infoJson.GetNamedNumber(NonLocalizable::SensitivityRadius, DefaultValues::SensitivityRadius);
             return info;
         }
         catch (const winrt::hresult_error&)
@@ -183,6 +189,10 @@ namespace JSONHelpers
             cellChildMapJson.Append(NumVecToJsonArray(gridInfo.m_cellChildMap[i]));
         }
         infoJson.SetNamedValue(NonLocalizable::CellChildMapStr, cellChildMapJson);
+        
+        infoJson.SetNamedValue(NonLocalizable::SensitivityRadius, json::value(gridInfo.m_sensitivityRadius));
+        infoJson.SetNamedValue(NonLocalizable::ShowSpacing, json::value(gridInfo.m_showSpacing));
+        infoJson.SetNamedValue(NonLocalizable::Spacing, json::value(gridInfo.m_spacing));
 
         return infoJson;
     }
@@ -216,6 +226,10 @@ namespace JSONHelpers
                 }
                 info.cellChildMap().push_back(JsonArrayToNumVec(cellsArray));
             }
+
+            info.m_showSpacing = infoJson.GetNamedBoolean(NonLocalizable::ShowSpacing, DefaultValues::ShowSpacing);
+            info.m_spacing = infoJson.GetNamedNumber(NonLocalizable::Spacing, DefaultValues::Spacing);
+            info.m_sensitivityRadius = infoJson.GetNamedNumber(NonLocalizable::SensitivityRadius, DefaultValues::SensitivityRadius);
 
             return info;
         }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Bind a dialog to layout properties.  Properties would be saved to the settings file after the `Save` button clicked and restored after `Cancel`.
If the user changes template layout properties they would be saved only if the layout was applied. Non-applied templates would be with default properties after editor restart.

![image](https://user-images.githubusercontent.com/8949536/105314845-7db05c80-5bcf-11eb-952f-8f261c25e6e6.png)

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #9162
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
