### PR TITLE
Fix "Converting null literal or possible null value to non-nullable type" warning

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Registry/Helper/RegistryHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Registry/Helper/RegistryHelper.cs
@@ -95,7 +95,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Registry.Helper
 
             var subKeysNames = subKeyPath.Split('\\');
             var index = 0;
-            var subKey = baseKey;
+            RegistryKey? subKey = baseKey;
 
             ICollection<RegistryEntry> result;
 


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Change the variable type to nullable, to prevent the warning.

**How does someone test / validate:** 

Build the solution and verify the warning/error is not generated.

## Quality Checklist

- [x] **Linked issue:** https://github.com/microsoft/PowerToys/issues/9204
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
