### PR TITLE
[FZ Editor] Create new layout: editor opening crash fix

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridData.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridData.cs
@@ -474,6 +474,11 @@ namespace FancyZonesEditor
 
         public void ArrangeZones(UIElementCollection zones, int spacing)
         {
+            if (zones.Count == 0)
+            {
+                return;
+            }
+
             int rows = _model.Rows;
             int cols = _model.Columns;
             int[,] cells = _model.CellChildMap;

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditor.xaml.cs
@@ -40,27 +40,27 @@ namespace FancyZonesEditor
         private void GridEditor_Loaded(object sender, RoutedEventArgs e)
         {
             GridLayoutModel model = (GridLayoutModel)DataContext;
-            if (model != null)
+            if (model == null)
             {
-                _data = new GridData(model);
-                _dragHandles = new GridDragHandles(AdornerLayer.Children, Resizer_DragDelta, Resizer_DragCompleted);
-
-                int zoneCount = _data.ZoneCount;
-                for (int i = 0; i <= zoneCount; i++)
-                {
-                    AddZone();
-                }
+                return;
             }
+
+            _data = new GridData(model);
+            _dragHandles = new GridDragHandles(AdornerLayer.Children, Resizer_DragDelta, Resizer_DragCompleted);
+            _dragHandles.InitDragHandles(model);
 
             Model = model;
-            if (Model == null)
+            Model.PropertyChanged += OnGridDimensionsChanged;
+
+            int zoneCount = _data.ZoneCount;
+            for (int i = 0; i <= zoneCount; i++)
             {
-                Model = new GridLayoutModel();
-                DataContext = Model;
+                AddZone();
             }
 
-            Model.PropertyChanged += OnGridDimensionsChanged;
-            _dragHandles.InitDragHandles(model);
+            Rect workingArea = App.Overlay.WorkArea;
+            Size actualSize = new Size(workingArea.Width, workingArea.Height);
+            ArrangeGridRects(actualSize);
         }
 
         private void GridEditor_Unloaded(object sender, RoutedEventArgs e)
@@ -330,15 +330,17 @@ namespace FancyZonesEditor
                     zone.Visibility = Visibility.Visible;
                     return freeIndex;
                 }
+
+                zone = new GridZone(Model.ShowSpacing ? Model.Spacing : 0);
+                zone.Split += OnSplit;
+                zone.MergeDrag += OnMergeDrag;
+                zone.MergeComplete += OnMergeComplete;
+                zone.FullSplit += OnFullSplit;
+                Preview.Children.Add(zone);
+                return Preview.Children.Count - 1;
             }
 
-            zone = new GridZone(Model.ShowSpacing ? Model.Spacing : 0);
-            zone.Split += OnSplit;
-            zone.MergeDrag += OnMergeDrag;
-            zone.MergeComplete += OnMergeComplete;
-            zone.FullSplit += OnFullSplit;
-            Preview.Children.Add(zone);
-            return Preview.Children.Count - 1;
+            return 0;
         }
 
         private void OnGridDimensionsChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
@@ -372,7 +374,7 @@ namespace FancyZonesEditor
             Preview.Height = workArea.Height;
 
             GridLayoutModel model = Model;
-            if (model == null)
+            if (model == null || _data == null)
             {
                 return;
             }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/LayoutPreview.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/LayoutPreview.xaml.cs
@@ -56,9 +56,11 @@ namespace FancyZonesEditor
             }
 
             _model = (LayoutModel)DataContext;
-            _model.PropertyChanged += LayoutModel_PropertyChanged;
-
-            RenderPreview();
+            if (_model != null)
+            {
+                _model.PropertyChanged += LayoutModel_PropertyChanged;
+                RenderPreview();
+            }
         }
 
         private void ZoneSettings_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Fixed editor crash after new layout creation. 

**What is include in the PR:** 

**How does someone test / validate:** 

Click `Create new layout`, try to create `Canvas` and `Grid` layouts (name could be empty). Validate that the editor is not crashing.

## Quality Checklist

- [x] **Linked issue:** #9162 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
