### PR TITLE
[Settings] ColorPicker spacing issue

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -837,7 +837,7 @@
     <value>Activation behavior</value>
   </data>
   <data name="ColorFormats.Text" xml:space="preserve">
-    <value>Color formats</value>
+    <value>Picker behavior</value>
   </data>
   <data name="KBM_KeysCannotBeRemapped.Text" xml:space="preserve">
     <value>Learn more about remapping limitations</value>
@@ -927,5 +927,8 @@
   <data name="ShortcutGuide_ImageHyperlinkToDocs.NavigateUri" xml:space="preserve">
     <value>https://aka.ms/PowerToysOverview_ShortcutGuide</value>
     <comment>URL. Do not loc</comment>
+  </data>
+  <data name="ColorPicker_Editor.Text" xml:space="preserve">
+    <value>Editor</value>
   </data>
 </root>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
@@ -154,7 +154,7 @@
                       AutomationProperties.LabeledBy="{Binding ElementName=ColorFormatsListViewLabel}"
                       CanReorderItems="True"
                       HorizontalAlignment="Left"
-                      Margin="-12,12,0,0">
+                      Margin="-12,6,0,0">
                 <ListView.ItemTemplate>
                     <DataTemplate>
                         <Grid Width="466" Background="Transparent">

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
@@ -144,7 +144,8 @@
             <TextBlock x:Name="ColorFormatsListViewLabel"
                        TextWrapping="WrapWholeWords"
                        x:Uid="ColorPicker_ColorFormatsDescription"
-                       Foreground="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToForegroundConverter}}"/>
+                       Foreground="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToForegroundConverter}}"
+                       Margin="{StaticResource SmallTopMargin}"/>
             
             <ListView ItemsSource="{Binding ColorFormats, Mode=TwoWay}"
                       AllowDrop="True"

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
@@ -133,15 +133,19 @@
                       SelectedValuePath="Key" />
             
             <CheckBox x:Uid="ColorPicker_ShowColorName"
-                          IsChecked="{Binding ShowColorName, Mode=TwoWay}"
-                          Margin="{StaticResource SmallTopMargin}"
-                          IsEnabled="{Binding IsEnabled}"/>
+                      IsChecked="{Binding ShowColorName, Mode=TwoWay}"
+                      Margin="{StaticResource SmallTopMargin}"
+                      IsEnabled="{Binding IsEnabled}"/>
+
+            <TextBlock x:Uid="ColorPicker_Editor"
+                       Style="{StaticResource SettingsGroupTitleStyle}"
+                       Foreground="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToForegroundConverter}}" />
             
-            <TextBlock Margin="{StaticResource MediumTopMargin}"
-                       x:Name="ColorFormatsListViewLabel"
+            <TextBlock x:Name="ColorFormatsListViewLabel"
                        TextWrapping="WrapWholeWords"
                        x:Uid="ColorPicker_ColorFormatsDescription"
                        Foreground="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToForegroundConverter}}"/>
+            
             <ListView ItemsSource="{Binding ColorFormats, Mode=TwoWay}"
                       AllowDrop="True"
                       MaxWidth="466"
@@ -149,7 +153,7 @@
                       AutomationProperties.LabeledBy="{Binding ElementName=ColorFormatsListViewLabel}"
                       CanReorderItems="True"
                       HorizontalAlignment="Left"
-                      Margin="-12,6,0,0">
+                      Margin="-12,12,0,0">
                 <ListView.ItemTemplate>
                     <DataTemplate>
                         <Grid Width="466" Background="Transparent">


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Added a "Picker behavior" and "Editor" header in the ColorPicker settings, resolving: #8951

![image](https://user-images.githubusercontent.com/9866362/105365704-d6e3b480-5bfe-11eb-953f-11b37f1c89ba.png)


## Quality Checklist

- [X] **Linked issue:** #8951
- [X] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
