### PR TITLE
[PT Run][Service] Improved Shortcuts

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Service/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Service/Main.cs
@@ -62,7 +62,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Service
                     Glyph = "\xE72C",
                     FontFamily = "Segoe MDL2 Assets",
                     AcceleratorKey = Key.R,
-                    AcceleratorModifiers = ModifierKeys.Control | ModifierKeys.Shift,
+                    AcceleratorModifiers = ModifierKeys.Control,
                     Action = _ =>
                     {
                         Task.Run(() => ServiceHelper.ChangeStatus(serviceResult, Action.Restart, _context.API));
@@ -96,7 +96,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Service
                 Glyph = "\xE8A7",
                 FontFamily = "Segoe MDL2 Assets",
                 AcceleratorKey = Key.O,
-                AcceleratorModifiers = ModifierKeys.Control | ModifierKeys.Shift,
+                AcceleratorModifiers = ModifierKeys.Control,
                 Action = _ =>
                 {
                     Task.Run(() => ServiceHelper.OpenServices());

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Service/Properties/Resources.Designer.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Service/Properties/Resources.Designer.cs
@@ -8,8 +8,10 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace Microsoft.PowerToys.Run.Plugin.Service.Properties
-{
+namespace Microsoft.PowerToys.Run.Plugin.Service.Properties {
+    using System;
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -68,7 +70,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Service.Properties
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Open services (Ctrl+Shift+O).
+        ///   Looks up a localized string similar to Open services (Ctrl+O).
         /// </summary>
         internal static string wox_plugin_service_open_services {
             get {
@@ -113,7 +115,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Service.Properties
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Restart (Ctrl+Shift+R).
+        ///   Looks up a localized string similar to Restart (Ctrl+R).
         /// </summary>
         internal static string wox_plugin_service_restart {
             get {

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Service/Properties/Resources.resx
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Service/Properties/Resources.resx
@@ -121,7 +121,7 @@
     <value>Continue</value>
   </data>
   <data name="wox_plugin_service_open_services" xml:space="preserve">
-    <value>Open services (Ctrl+Shift+O)</value>
+    <value>Open services (Ctrl+O)</value>
   </data>
   <data name="wox_plugin_service_paused" xml:space="preserve">
     <value>Paused</value>
@@ -136,7 +136,7 @@
     <value>Service</value>
   </data>
   <data name="wox_plugin_service_restart" xml:space="preserve">
-    <value>Restart (Ctrl+Shift+R)</value>
+    <value>Restart (Ctrl+R)</value>
   </data>
   <data name="wox_plugin_service_restarted_notification" xml:space="preserve">
     <value>{0} has been restarted</value>


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Improved shortcuts for PT Run Service plugin

**What is include in the PR:** 

- CTRL+R restart service
- CTRL+S open services

**How does someone test / validate:** 
Validate new shortcuts and tooltip text on context menu buttons.

## Quality Checklist

- [x] **Linked issue:** #9046
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
