### PR TITLE
init launcher start shortcut with default if it does not exsist in th…

### DIFF
--- a/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
+++ b/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
@@ -387,7 +387,7 @@ void Microsoft_Launcher::parse_hotkey(PowerToysSettings::PowerToyValues& setting
     }
     catch (...)
     {
-        Logger::error("Failed to initialize PT Launcher start shortcut");
+        Logger::error("Failed to initialize PT Run start shortcut");
         m_hotkey.key = 0;
     }
 }

--- a/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
+++ b/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
@@ -372,7 +372,7 @@ void Microsoft_Launcher::parse_hotkey(PowerToysSettings::PowerToyValues& setting
             m_hotkey.alt = jsonHotkeyObject.GetNamedBoolean(JSON_KEY_ALT);
             m_hotkey.shift = jsonHotkeyObject.GetNamedBoolean(JSON_KEY_SHIFT);
             m_hotkey.ctrl = jsonHotkeyObject.GetNamedBoolean(JSON_KEY_CTRL);
-            m_hotkey.key = static_cast<unsigned char>(jsonHotkeyObject.GetNamedNumber(JSON_KEY_CODE));        
+            m_hotkey.key = static_cast<unsigned char>(jsonHotkeyObject.GetNamedNumber(JSON_KEY_CODE));
         }
         catch(...)
         {

--- a/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
+++ b/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
@@ -382,7 +382,7 @@ void Microsoft_Launcher::parse_hotkey(PowerToysSettings::PowerToyValues& setting
             m_hotkey.alt = true;
             m_hotkey.shift = false;
             m_hotkey.ctrl = false;
-            m_hotkey.key = 32;
+            m_hotkey.key = VK_SPACE;
         }
     }
     catch (...)

--- a/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
+++ b/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
@@ -377,7 +377,7 @@ void Microsoft_Launcher::parse_hotkey(PowerToysSettings::PowerToyValues& setting
         }
         else
         {
-            Logger::info("PT Launcher start shortcut is not present in settings. Use default shortcut instead.");
+            Logger::info("PT Run start shortcut is not present in settings. Use default shortcut instead.");
             m_hotkey.win = false;
             m_hotkey.alt = true;
             m_hotkey.shift = false;

--- a/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
+++ b/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
@@ -362,33 +362,36 @@ void Microsoft_Launcher::init_settings()
 
 void Microsoft_Launcher::parse_hotkey(PowerToysSettings::PowerToyValues& settings)
 {
-    try
+    auto settingsObject = settings.get_raw_json();
+    if (settingsObject.GetView().Size())
     {
-        auto settingsObject = settings.get_raw_json();
-
-        if (settingsObject.HasKey(JSON_KEY_PROPERTIES))
+        try
         {
             auto jsonHotkeyObject = settingsObject.GetNamedObject(JSON_KEY_PROPERTIES).GetNamedObject(JSON_KEY_OPEN_POWERLAUNCHER);
             m_hotkey.win = jsonHotkeyObject.GetNamedBoolean(JSON_KEY_WIN);
             m_hotkey.alt = jsonHotkeyObject.GetNamedBoolean(JSON_KEY_ALT);
             m_hotkey.shift = jsonHotkeyObject.GetNamedBoolean(JSON_KEY_SHIFT);
             m_hotkey.ctrl = jsonHotkeyObject.GetNamedBoolean(JSON_KEY_CTRL);
-            m_hotkey.key = static_cast<unsigned char>(jsonHotkeyObject.GetNamedNumber(JSON_KEY_CODE));
+            m_hotkey.key = static_cast<unsigned char>(jsonHotkeyObject.GetNamedNumber(JSON_KEY_CODE));        
         }
-        else
+        catch(...)
         {
-            Logger::info("PT Run start shortcut is not present in settings. Use default shortcut instead.");
-            m_hotkey.win = false;
-            m_hotkey.alt = true;
-            m_hotkey.shift = false;
-            m_hotkey.ctrl = false;
-            m_hotkey.key = VK_SPACE;
+            Logger::error("Failed to initialize PT Run start shortcut");
         }
     }
-    catch (...)
+    else
     {
-        Logger::error("Failed to initialize PT Run start shortcut");
-        m_hotkey.key = 0;
+        Logger::info("PT Run settings are empty");
+    }
+
+    if (!m_hotkey.key)
+    {
+        Logger::info("PT Run is going to use default shortcut");
+        m_hotkey.win = false;
+        m_hotkey.alt = true;
+        m_hotkey.shift = false;
+        m_hotkey.ctrl = false;
+        m_hotkey.key = VK_SPACE;
     }
 }
 

--- a/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
+++ b/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
@@ -364,15 +364,29 @@ void Microsoft_Launcher::parse_hotkey(PowerToysSettings::PowerToyValues& setting
 {
     try
     {
-        auto jsonHotkeyObject = settings.get_raw_json().GetNamedObject(JSON_KEY_PROPERTIES).GetNamedObject(JSON_KEY_OPEN_POWERLAUNCHER);
-        m_hotkey.win = jsonHotkeyObject.GetNamedBoolean(JSON_KEY_WIN);
-        m_hotkey.alt = jsonHotkeyObject.GetNamedBoolean(JSON_KEY_ALT);
-        m_hotkey.shift = jsonHotkeyObject.GetNamedBoolean(JSON_KEY_SHIFT);
-        m_hotkey.ctrl = jsonHotkeyObject.GetNamedBoolean(JSON_KEY_CTRL);
-        m_hotkey.key = static_cast<unsigned char>(jsonHotkeyObject.GetNamedNumber(JSON_KEY_CODE));
+        auto settingsObject = settings.get_raw_json();
+
+        if (settingsObject.HasKey(JSON_KEY_PROPERTIES))
+        {
+            auto jsonHotkeyObject = settingsObject.GetNamedObject(JSON_KEY_PROPERTIES).GetNamedObject(JSON_KEY_OPEN_POWERLAUNCHER);
+            m_hotkey.win = jsonHotkeyObject.GetNamedBoolean(JSON_KEY_WIN);
+            m_hotkey.alt = jsonHotkeyObject.GetNamedBoolean(JSON_KEY_ALT);
+            m_hotkey.shift = jsonHotkeyObject.GetNamedBoolean(JSON_KEY_SHIFT);
+            m_hotkey.ctrl = jsonHotkeyObject.GetNamedBoolean(JSON_KEY_CTRL);
+            m_hotkey.key = static_cast<unsigned char>(jsonHotkeyObject.GetNamedNumber(JSON_KEY_CODE));
+        }else
+        {
+            Logger::info("PT Launcher start shortcut is not present in settings. Use default shortcut instead.");
+            m_hotkey.win = false;
+            m_hotkey.alt = true;
+            m_hotkey.shift = false;
+            m_hotkey.ctrl = false;
+            m_hotkey.key = 32;
+        }
     }
     catch (...)
     {
+        Logger::error("Failed to initialize PT Launcher start shortcut");
         m_hotkey.key = 0;
     }
 }

--- a/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
+++ b/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
@@ -374,7 +374,8 @@ void Microsoft_Launcher::parse_hotkey(PowerToysSettings::PowerToyValues& setting
             m_hotkey.shift = jsonHotkeyObject.GetNamedBoolean(JSON_KEY_SHIFT);
             m_hotkey.ctrl = jsonHotkeyObject.GetNamedBoolean(JSON_KEY_CTRL);
             m_hotkey.key = static_cast<unsigned char>(jsonHotkeyObject.GetNamedNumber(JSON_KEY_CODE));
-        }else
+        }
+        else
         {
             Logger::info("PT Launcher start shortcut is not present in settings. Use default shortcut instead.");
             m_hotkey.win = false;


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
If the PT Run settings do not exist at the start of PT most probably PT Run will not open on `Alt+Space`. It is a fix for it. 

**What is include in the PR:** 
- Check if the settings contain the shortcut info and if not initialize `m_hotkey` with default one.
- Additional logs

**How does someone test / validate:** 
- Delete 'PowerToys Run\settings.json'
- Start PT run
- Check that PT run starts on `Alt+Space`

## Quality Checklist

- [X] **Linked issue:** #7847 #9018
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [X] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
