### PR TITLE
[FZ Editor] Empty layout template.

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/Converters/LayoutModelTypeBlankToVisibilityConverter.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Converters/LayoutModelTypeBlankToVisibilityConverter.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+using FancyZonesEditor.Models;
+
+namespace FancyZonesEditor.Converters
+{
+    public class LayoutModelTypeBlankToVisibilityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return (LayoutType)value == LayoutType.Blank ? Visibility.Collapsed : Visibility.Visible;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return null;
+        }
+    }
+}

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -29,6 +29,7 @@
         <Converters:LayoutModelTypeToVisibilityConverter x:Key="LayoutModelTypeToVisibilityConverter" />
         <Converters:LayoutTypeCustomToVisibilityConverter x:Key="LayoutTypeCustomToVisibilityConverter" />
         <Converters:LayoutTypeTemplateToVisibilityConverter x:Key="LayoutTypeTemplateToVisibilityConverter" />
+        <Converters:LayoutModelTypeBlankToVisibilityConverter x:Key="LayoutModelTypeBlankToVisibilityConverter" />
 
         <DropShadowEffect x:Key="CardShadow" BlurRadius="6"
                           Opacity="0.24"
@@ -183,6 +184,7 @@
                                 BorderBrush="Transparent"
                                 Click="EditLayout_Click"
                                 Background="Transparent"
+                                Visibility="{Binding Path=Type, Converter={StaticResource LayoutModelTypeBlankToVisibilityConverter}}"
                                 Foreground="{DynamicResource PrimaryForegroundBrush}"
                                 ToolTip="{x:Static props:Resources.Edit_Layout}"
                                 AutomationProperties.Name="{x:Static props:Resources.Edit_Layout}"

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -263,23 +263,6 @@ namespace FancyZonesEditor
             e.Handled = true;
         }
 
-        private void Reset_Click(object sender, RoutedEventArgs e)
-        {
-            var overlay = App.Overlay;
-
-            if (overlay.CurrentDataContext is LayoutModel model)
-            {
-                model.IsSelected = false;
-                model.IsApplied = false;
-            }
-
-            overlay.CurrentLayoutSettings.ZonesetUuid = MainWindowSettingsModel.BlankModel.Uuid;
-            overlay.CurrentLayoutSettings.Type = LayoutType.Blank;
-            overlay.CurrentDataContext = MainWindowSettingsModel.BlankModel;
-
-            App.FancyZonesEditorIO.SerializeZoneSettings();
-        }
-
         private void NewLayoutDialog_PrimaryButtonClick(ModernWpf.Controls.ContentDialog sender, ModernWpf.Controls.ContentDialogButtonClickEventArgs args)
         {
             LayoutModel selectedLayoutModel;

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -269,32 +269,22 @@ namespace FancyZonesEditor
 
             if (GridLayoutRadioButton.IsChecked == true)
             {
-                // 1:1 Copy from MainWindowSettingsModel, so probably needs to be refactored / combined.
-                int multiplier = 10000;
-                int zoneCount = 3;
-
-                GridLayoutModel columnsModel = new GridLayoutModel(LayoutNameText.Text, LayoutType.Columns)
+                GridLayoutModel gridModel = new GridLayoutModel(LayoutNameText.Text, LayoutType.Columns)
                 {
                     Rows = 1,
-                    RowPercents = new List<int>(1) { multiplier },
+                    RowPercents = new List<int>(1) { GridLayoutModel.GridMultiplier },
                 };
-
-                columnsModel.CellChildMap = new int[1, zoneCount];
-                columnsModel.Columns = zoneCount;
-                columnsModel.ColumnPercents = new List<int>(zoneCount);
-
-                for (int i = 0; i < 3; i++)
-                {
-                    columnsModel.CellChildMap[0, i] = i;
-                    columnsModel.ColumnPercents.Add(((multiplier * (i + 1)) / zoneCount) - ((multiplier * i) / zoneCount));
-                }
-
-                selectedLayoutModel = columnsModel;
+                selectedLayoutModel = gridModel;
             }
             else
             {
-                selectedLayoutModel = new CanvasLayoutModel(LayoutNameText.Text, LayoutType.Blank);
+                selectedLayoutModel = new CanvasLayoutModel(LayoutNameText.Text, LayoutType.Custom)
+                {
+                    TemplateZoneCount = 0,
+                };
             }
+
+            selectedLayoutModel.InitTemplateZones();
 
             App.Overlay.CurrentDataContext = selectedLayoutModel;
             var mainEditor = App.Overlay;

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/GridLayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/GridLayoutModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation
+// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -14,7 +14,7 @@ namespace FancyZonesEditor.Models
         // Non-localizable strings
         public const string ModelTypeID = "grid";
 
-        private const int _multiplier = 10000;
+        public const int GridMultiplier = 10000;
 
         // hard coded data for all the "Priority Grid" configurations that are unique to "Grid"
         private static readonly byte[][] _priorityData = new byte[][]
@@ -78,10 +78,10 @@ namespace FancyZonesEditor.Models
         public int[,] CellChildMap { get; set; }
 
         // RowPercents - represents the %age height of each row in the grid
-        public List<int> RowPercents { get; set; }
+        public List<int> RowPercents { get; set; } = new List<int>();
 
         // ColumnPercents - represents the %age width of each column in the grid
-        public List<int> ColumnPercents { get; set; }
+        public List<int> ColumnPercents { get; set; } = new List<int>();
 
         // ShowSpacing - flag if free space between cells should be presented
         public bool ShowSpacing
@@ -170,13 +170,11 @@ namespace FancyZonesEditor.Models
                 }
             }
 
-            RowPercents = new List<int>(_rows);
             for (int row = 0; row < _rows; row++)
             {
                 RowPercents.Add(other.RowPercents[row]);
             }
 
-            ColumnPercents = new List<int>(_cols);
             for (int col = 0; col < _cols; col++)
             {
                 ColumnPercents.Add(other.ColumnPercents[col]);
@@ -306,7 +304,7 @@ namespace FancyZonesEditor.Models
 
                 // Note: This is NOT equal to _multiplier / ZoneCount and is done like this to make
                 // the sum of all RowPercents exactly (_multiplier).
-                RowPercents.Add(((_multiplier * (i + 1)) / TemplateZoneCount) - ((_multiplier * i) / TemplateZoneCount));
+                RowPercents.Add(((GridMultiplier * (i + 1)) / TemplateZoneCount) - ((GridMultiplier * i) / TemplateZoneCount));
             }
 
             _rows = TemplateZoneCount;
@@ -323,7 +321,7 @@ namespace FancyZonesEditor.Models
 
                 // Note: This is NOT equal to _multiplier / ZoneCount and is done like this to make
                 // the sum of all RowPercents exactly (_multiplier).
-                ColumnPercents.Add(((_multiplier * (i + 1)) / TemplateZoneCount) - ((_multiplier * i) / TemplateZoneCount));
+                ColumnPercents.Add(((GridMultiplier * (i + 1)) / TemplateZoneCount) - ((GridMultiplier * i) / TemplateZoneCount));
             }
 
             _cols = TemplateZoneCount;
@@ -356,12 +354,12 @@ namespace FancyZonesEditor.Models
             // done like this to make the sum of all RowPercents exactly (_multiplier).
             for (int row = 0; row < rows; row++)
             {
-                RowPercents.Add(((_multiplier * (row + 1)) / rows) - ((_multiplier * row) / rows));
+                RowPercents.Add(((GridMultiplier * (row + 1)) / rows) - ((GridMultiplier * row) / rows));
             }
 
             for (int col = 0; col < cols; col++)
             {
-                ColumnPercents.Add(((_multiplier * (col + 1)) / cols) - ((_multiplier * col) / cols));
+                ColumnPercents.Add(((GridMultiplier * (col + 1)) / cols) - ((GridMultiplier * col) / cols));
             }
 
             int index = 0;

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/MainWindowSettingsModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/MainWindowSettingsModel.cs
@@ -24,6 +24,7 @@ namespace FancyZonesEditor
             VirtualDesktopId,
         }
 
+        private readonly CanvasLayoutModel _blankModel;
         private readonly CanvasLayoutModel _focusModel;
         private readonly GridLayoutModel _rowsModel;
         private readonly GridLayoutModel _columnsModel;
@@ -62,8 +63,13 @@ namespace FancyZonesEditor
 
         public MainWindowSettingsModel()
         {
-            // Initialize the five default layout models: Focus, Columns, Rows, Grid, and PriorityGrid
-            DefaultModels = new List<LayoutModel>(5);
+            // Initialize the five default layout models: Blank, Focus, Columns, Rows, Grid, and PriorityGrid
+            DefaultModels = new List<LayoutModel>(6);
+
+            _blankModel = new CanvasLayoutModel(Properties.Resources.Template_Layout_Blank, LayoutType.Blank);
+            _blankModel.TemplateZoneCount = 0;
+            DefaultModels.Add(_blankModel);
+
             _focusModel = new CanvasLayoutModel(Properties.Resources.Template_Layout_Focus, LayoutType.Focus);
             _focusModel.InitTemplateZones();
             DefaultModels.Add(_focusModel);
@@ -145,16 +151,6 @@ namespace FancyZonesEditor
 
         private static ObservableCollection<LayoutModel> _customModels = new ObservableCollection<LayoutModel>();
 
-        public static CanvasLayoutModel BlankModel
-        {
-            get
-            {
-                return _blankModel;
-            }
-        }
-
-        private static CanvasLayoutModel _blankModel = new CanvasLayoutModel(string.Empty, LayoutType.Blank);
-
         public LayoutModel SelectedModel
         {
             get
@@ -204,11 +200,7 @@ namespace FancyZonesEditor
             LayoutSettings currentApplied = App.Overlay.CurrentLayoutSettings;
 
             // set new layout
-            if (currentApplied.Type == LayoutType.Blank)
-            {
-                foundModel = BlankModel;
-            }
-            else if (currentApplied.Type == LayoutType.Custom)
+            if (currentApplied.Type == LayoutType.Custom)
             {
                 foreach (LayoutModel model in CustomModels)
                 {
@@ -244,7 +236,7 @@ namespace FancyZonesEditor
 
             if (foundModel == null)
             {
-                foundModel = DefaultModels[4]; // PriorityGrid
+                foundModel = DefaultModels[5]; // PriorityGrid
             }
 
             SetSelectedModel(foundModel);

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/MainWindowSettingsModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/MainWindowSettingsModel.cs
@@ -43,8 +43,6 @@ namespace FancyZonesEditor
         public static readonly string RegistryPath = "SOFTWARE\\SuperFancyZones";
         public static readonly string FullRegistryPath = "HKEY_CURRENT_USER\\" + RegistryPath;
 
-        private const int _multiplier = 10000;
-
         public bool IsCustomLayoutActive
         {
             get
@@ -77,7 +75,7 @@ namespace FancyZonesEditor
             _columnsModel = new GridLayoutModel(Properties.Resources.Template_Layout_Columns, LayoutType.Columns)
             {
                 Rows = 1,
-                RowPercents = new List<int>(1) { _multiplier },
+                RowPercents = new List<int>(1) { GridLayoutModel.GridMultiplier },
             };
             _columnsModel.InitTemplateZones();
             DefaultModels.Add(_columnsModel);
@@ -85,7 +83,7 @@ namespace FancyZonesEditor
             _rowsModel = new GridLayoutModel(Properties.Resources.Template_Layout_Rows, LayoutType.Rows)
             {
                 Columns = 1,
-                ColumnPercents = new List<int>(1) { _multiplier },
+                ColumnPercents = new List<int>(1) { GridLayoutModel.GridMultiplier },
             };
             _rowsModel.InitTemplateZones();
             DefaultModels.Add(_rowsModel);

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
@@ -584,6 +584,15 @@ namespace FancyZonesEditor.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No layout.
+        /// </summary>
+        public static string Template_Layout_Blank {
+            get {
+                return ResourceManager.GetString("Template_Layout_Blank", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Columns.
         /// </summary>
         public static string Template_Layout_Columns {

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
@@ -325,4 +325,7 @@ To merge zones, select the zones and click "merge".</value>
   <data name="NumberOfZones" xml:space="preserve">
     <value>Number of zones</value>
   </data>
+  <data name="Template_Layout_Blank" xml:space="preserve">
+    <value>No layout</value>
+  </data>
 </root>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
@@ -36,6 +36,7 @@ namespace FancyZonesEditor.Utils
         private readonly JsonSerializerOptions _options = new JsonSerializerOptions
         {
             PropertyNamingPolicy = new DashCaseNamingPolicy(),
+            WriteIndented = true,
         };
 
         private List<DeviceWrapper> _unusedDevices = new List<DeviceWrapper>();
@@ -565,11 +566,6 @@ namespace FancyZonesEditor.Utils
             // Serialize custom zonesets
             foreach (LayoutModel layout in MainWindowSettingsModel.CustomModels)
             {
-                if (layout.Type == LayoutType.Blank)
-                {
-                    continue;
-                }
-
                 JsonElement info;
                 string type;
 
@@ -774,36 +770,33 @@ namespace FancyZonesEditor.Utils
 
         private LayoutType JsonTagToLayoutType(string tag)
         {
-            LayoutType type = LayoutType.Blank;
             switch (tag)
             {
+                case BlankJsonTag:
+                    return LayoutType.Blank;
                 case FocusJsonTag:
-                    type = LayoutType.Focus;
-                    break;
+                    return LayoutType.Focus;
                 case ColumnsJsonTag:
-                    type = LayoutType.Columns;
-                    break;
+                    return LayoutType.Columns;
                 case RowsJsonTag:
-                    type = LayoutType.Rows;
-                    break;
+                    return LayoutType.Rows;
                 case GridJsonTag:
-                    type = LayoutType.Grid;
-                    break;
+                    return LayoutType.Grid;
                 case PriorityGridJsonTag:
-                    type = LayoutType.PriorityGrid;
-                    break;
+                    return LayoutType.PriorityGrid;
                 case CustomJsonTag:
-                    type = LayoutType.Custom;
-                    break;
+                    return LayoutType.Custom;
             }
 
-            return type;
+            return LayoutType.Blank;
         }
 
         private string LayoutTypeToJsonTag(LayoutType type)
         {
             switch (type)
             {
+                case LayoutType.Blank:
+                    return BlankJsonTag;
                 case LayoutType.Focus:
                     return FocusJsonTag;
                 case LayoutType.Columns:


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

A "No layout" card added in templates to replace the "Reset layout" button.

![image](https://user-images.githubusercontent.com/8949536/105511692-3b774000-5ce1-11eb-98d3-f02196faf614.png)

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #9162 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
