### PR TITLE
Show progress dialog during startup 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -342,3 +342,5 @@ src/common/Telemetry/*.etl
 !**/MergeModules/Release/
 !**/MergeModules/Debug/
 /src/modules/previewpane/SvgThumbnailProvider/$(SolutionDir)$(Platform)/$(Configuration)/modules/FileExplorerPreview/SvgThumbnailProvider.xml
+/src/modules/powerrename/ui/RCa24464
+/src/modules/powerrename/ui/RCb24464

--- a/src/modules/powerrename/lib/Helpers.cpp
+++ b/src/modules/powerrename/lib/Helpers.cpp
@@ -482,3 +482,30 @@ bool DataObjectContainsRenamableItem(_In_ IUnknown* dataSource)
     }
     return hasRenamable;
 }
+
+HWND CreateMsgWindow(_In_ HINSTANCE hInst, _In_ WNDPROC pfnWndProc, _In_ void* p)
+{
+    WNDCLASS wc = { 0 };
+    PCWSTR wndClassName = L"MsgWindow";
+
+    wc.lpfnWndProc = DefWindowProc;
+    wc.cbWndExtra = sizeof(void*);
+    wc.hInstance = hInst;
+    wc.hbrBackground = (HBRUSH)(COLOR_BTNFACE + 1);
+    wc.lpszClassName = wndClassName;
+
+    RegisterClass(&wc);
+
+    HWND hwnd = CreateWindowEx(
+        0, wndClassName, nullptr, 0, 0, 0, 0, 0, HWND_MESSAGE, 0, hInst, nullptr);
+    if (hwnd)
+    {
+        SetWindowLongPtr(hwnd, 0, (LONG_PTR)p);
+        if (pfnWndProc)
+        {
+            SetWindowLongPtr(hwnd, GWLP_WNDPROC, (LONG_PTR)pfnWndProc);
+        }
+    }
+
+    return hwnd;
+}

--- a/src/modules/powerrename/lib/Helpers.cpp
+++ b/src/modules/powerrename/lib/Helpers.cpp
@@ -275,7 +275,7 @@ HRESULT GetDatedFileName(_Out_ PWSTR result, UINT cchMax, _In_ PCWSTR source, SY
     return hr;
 }
 
-HRESULT _GetShellItemArrayFromDataOject(_In_ IUnknown* dataSource, _COM_Outptr_ IShellItemArray** items)
+HRESULT GetShellItemArrayFromDataObject(_In_ IUnknown* dataSource, _COM_Outptr_ IShellItemArray** items)
 {
     *items = nullptr;
     CComPtr<IDataObject> dataObj;
@@ -287,90 +287,6 @@ HRESULT _GetShellItemArrayFromDataOject(_In_ IUnknown* dataSource, _COM_Outptr_ 
     else
     {
         hr = dataSource->QueryInterface(IID_PPV_ARGS(items));
-    }
-
-    return hr;
-}
-
-HRESULT _ParseEnumItems(_In_ IEnumShellItems* pesi, _In_ IPowerRenameManager* psrm, _In_opt_ IProgressDialog* ppd, _In_ int depth = 0)
-{
-    HRESULT hr = E_INVALIDARG;
-
-    // We shouldn't get this deep since we only enum the contents of
-    // regular folders but adding just in case
-    if ((pesi) && (depth < (MAX_PATH / 2)))
-    {
-        hr = S_OK;
-
-        ULONG celtFetched;
-        CComPtr<IShellItem> spsi;
-        while ((S_OK == pesi->Next(1, &spsi, &celtFetched)) && (SUCCEEDED(hr)))
-        {
-            if (ppd && ppd->HasUserCancelled())
-            {
-                // Cancelled by user
-                hr = E_ABORT;
-                break;
-            }
-
-            CComPtr<IPowerRenameItemFactory> spsrif;
-            hr = psrm->GetRenameItemFactory(&spsrif);
-            if (SUCCEEDED(hr))
-            {
-                CComPtr<IPowerRenameItem> spNewItem;
-                hr = spsrif->Create(spsi, &spNewItem);
-                if (SUCCEEDED(hr))
-                {
-                    spNewItem->PutDepth(depth);
-                    hr = psrm->AddItem(spNewItem);
-                    if (SUCCEEDED(hr) && ppd)
-                    {
-                        // Update the progress dialog
-                        PWSTR pathDisplay = nullptr;
-                        if (SUCCEEDED(spNewItem->GetPath(&pathDisplay)))
-                        {
-                            ppd->SetLine(2, pathDisplay, TRUE, nullptr);
-                            CoTaskMemFree(pathDisplay);
-                        }
-                    }
-                }
-
-                if (SUCCEEDED(hr))
-                {
-                    bool isFolder = false;
-                    if (SUCCEEDED(spNewItem->GetIsFolder(&isFolder)) && isFolder)
-                    {
-                        // Bind to the IShellItem for the IEnumShellItems interface
-                        CComPtr<IEnumShellItems> spesiNext;
-                        hr = spsi->BindToHandler(nullptr, BHID_EnumItems, IID_PPV_ARGS(&spesiNext));
-                        if (SUCCEEDED(hr))
-                        {
-                            // Parse the folder contents recursively
-                            hr = _ParseEnumItems(spesiNext, psrm, ppd, depth + 1);
-                        }
-                    }
-                }
-            }
-
-            spsi = nullptr;
-        }
-    }
-
-    return hr;
-}
-
-// Iterate through the data source and add paths to the rotation manager
-HRESULT EnumerateDataObject(_In_ IUnknown* pdo, _In_ IPowerRenameManager* psrm, _In_opt_ IProgressDialog* ppd)
-{
-    CComPtr<IShellItemArray> spsia;
-    HRESULT hr = E_FAIL;
-    if (SUCCEEDED(_GetShellItemArrayFromDataOject(pdo, &spsia)))
-    {
-        CComPtr<IEnumShellItems> spesi;
-        if (SUCCEEDED(spsia->EnumItems(&spesi)))
-        {
-            hr = _ParseEnumItems(spesi, psrm, ppd);
-        }
     }
 
     return hr;
@@ -545,7 +461,7 @@ bool DataObjectContainsRenamableItem(_In_ IUnknown* dataSource)
 {
     bool hasRenamable = false;
     CComPtr<IShellItemArray> spsia;
-    if (SUCCEEDED(_GetShellItemArrayFromDataOject(dataSource, &spsia)))
+    if (SUCCEEDED(GetShellItemArrayFromDataObject(dataSource, &spsia)))
     {
         CComPtr<IEnumShellItems> spesi;
         if (SUCCEEDED(spsia->EnumItems(&spesi)))

--- a/src/modules/powerrename/lib/Helpers.h
+++ b/src/modules/powerrename/lib/Helpers.h
@@ -15,3 +15,4 @@ BOOL GetEnumeratedFileName(
     __in_opt PCWSTR pszDir,
     unsigned long ulMinLong,
     __inout unsigned long* pulNumUsed);
+HWND CreateMsgWindow(_In_ HINSTANCE hInst, _In_ WNDPROC pfnWndProc, _In_ void* p);

--- a/src/modules/powerrename/lib/Helpers.h
+++ b/src/modules/powerrename/lib/Helpers.h
@@ -7,7 +7,7 @@ HRESULT GetTransformedFileName(_Out_ PWSTR result, UINT cchMax, _In_ PCWSTR sour
 HRESULT GetDatedFileName(_Out_ PWSTR result, UINT cchMax, _In_ PCWSTR source, SYSTEMTIME fileTime);
 bool isFileTimeUsed(_In_ PCWSTR source);
 bool DataObjectContainsRenamableItem(_In_ IUnknown* dataSource);
-HRESULT EnumerateDataObject(_In_ IUnknown* pdo, _In_ IPowerRenameManager* psrm);
+HRESULT EnumerateDataObject(_In_ IUnknown* pdo, _In_ IPowerRenameManager* psrm, _In_opt_ IProgressDialog* ppd);
 BOOL GetEnumeratedFileName(
     __out_ecount(cchMax) PWSTR pszUniqueName,
     UINT cchMax,

--- a/src/modules/powerrename/lib/Helpers.h
+++ b/src/modules/powerrename/lib/Helpers.h
@@ -7,7 +7,7 @@ HRESULT GetTransformedFileName(_Out_ PWSTR result, UINT cchMax, _In_ PCWSTR sour
 HRESULT GetDatedFileName(_Out_ PWSTR result, UINT cchMax, _In_ PCWSTR source, SYSTEMTIME fileTime);
 bool isFileTimeUsed(_In_ PCWSTR source);
 bool DataObjectContainsRenamableItem(_In_ IUnknown* dataSource);
-HRESULT EnumerateDataObject(_In_ IUnknown* pdo, _In_ IPowerRenameManager* psrm, _In_opt_ IProgressDialog* ppd);
+HRESULT GetShellItemArrayFromDataObject(_In_ IUnknown* dataSource, _COM_Outptr_ IShellItemArray** items);
 BOOL GetEnumeratedFileName(
     __out_ecount(cchMax) PWSTR pszUniqueName,
     UINT cchMax,

--- a/src/modules/powerrename/lib/PowerRenameEnum.cpp
+++ b/src/modules/powerrename/lib/PowerRenameEnum.cpp
@@ -1,0 +1,224 @@
+#include "pch.h"
+#include "PowerRenameEnum.h"
+#include <ShlGuid.h>
+#include <helpers.h>
+
+IFACEMETHODIMP_(ULONG) CPowerRenameEnum::AddRef()
+{
+    return InterlockedIncrement(&m_refCount);
+}
+
+IFACEMETHODIMP_(ULONG) CPowerRenameEnum::Release()
+{
+    long refCount = InterlockedDecrement(&m_refCount);
+
+    if (refCount == 0)
+    {
+        delete this;
+    }
+    return refCount;
+}
+
+IFACEMETHODIMP CPowerRenameEnum::QueryInterface(_In_ REFIID riid, _Outptr_ void** ppv)
+{
+    static const QITAB qit[] = {
+        QITABENT(CPowerRenameEnum, IPowerRenameEnum),
+        { 0 }
+    };
+    return QISearch(this, qit, riid, ppv);
+}
+
+IFACEMETHODIMP CPowerRenameEnum::Advise(_In_ IPowerRenameEnumEvents* pRenameEnumEvents, _Out_ DWORD* cookie)
+{
+    CSRWExclusiveAutoLock lock(&m_lockEvents);
+    m_cookie++;
+    RENAME_ENUM_EVENT srme;
+    srme.cookie = m_cookie;
+    srme.pEvents = pRenameEnumEvents;
+    pRenameEnumEvents->AddRef();
+    m_renameEnumEvents.push_back(srme);
+
+    *cookie = m_cookie;
+
+    return S_OK;
+}
+
+IFACEMETHODIMP CPowerRenameEnum::UnAdvise(_In_ DWORD cookie)
+{
+    HRESULT hr = E_FAIL;
+    CSRWExclusiveAutoLock lock(&m_lockEvents);
+
+    for (std::vector<RENAME_ENUM_EVENT>::iterator it = m_renameEnumEvents.begin(); it != m_renameEnumEvents.end(); ++it)
+    {
+        if (it->cookie == cookie)
+        {
+            hr = S_OK;
+            it->cookie = 0;
+            if (it->pEvents)
+            {
+                it->pEvents->Release();
+                it->pEvents = nullptr;
+            }
+            break;
+        }
+    }
+
+    return hr;
+}
+
+IFACEMETHODIMP CPowerRenameEnum::Start()
+{
+    _OnStarted();
+    m_canceled = false;
+    CComPtr<IShellItemArray> spsia;
+    HRESULT hr = GetShellItemArrayFromDataObject(m_spdo, &spsia);
+    if (SUCCEEDED(hr))
+    {
+        CComPtr<IEnumShellItems> spesi;
+        hr = spsia->EnumItems(&spesi);
+        if (SUCCEEDED(hr))
+        {
+            hr = _ParseEnumItems(spesi);
+        }
+    }
+
+    _OnCompleted();
+    return hr;
+}
+
+IFACEMETHODIMP CPowerRenameEnum::Cancel()
+{
+    m_canceled = true;
+    return S_OK;
+}
+
+HRESULT CPowerRenameEnum::s_CreateInstance(_In_ IUnknown* pdo, _In_ IPowerRenameManager* pManager, _In_ REFIID iid, _Outptr_ void** resultInterface)
+{
+    *resultInterface = nullptr;
+
+    CPowerRenameEnum* newRenameEnum = new CPowerRenameEnum();
+    HRESULT hr = newRenameEnum ? S_OK : E_OUTOFMEMORY;
+    if (SUCCEEDED(hr))
+    {
+        hr = newRenameEnum->_Init(pdo, pManager);
+        if (SUCCEEDED(hr))
+        {
+            hr = newRenameEnum->QueryInterface(iid, resultInterface);
+        }
+
+        newRenameEnum->Release();
+    }
+    return hr;
+}
+
+CPowerRenameEnum::CPowerRenameEnum() :
+    m_refCount(1)
+{
+}
+
+CPowerRenameEnum::~CPowerRenameEnum()
+{
+}
+
+void CPowerRenameEnum::_OnStarted()
+{
+    CSRWSharedAutoLock lock(&m_lockEvents);
+
+    for (std::vector<RENAME_ENUM_EVENT>::iterator it = m_renameEnumEvents.begin(); it != m_renameEnumEvents.end(); ++it)
+    {
+        if (it->pEvents)
+        {
+            it->pEvents->OnStarted();
+        }
+    }
+}
+
+void CPowerRenameEnum::_OnCompleted()
+{
+    CSRWSharedAutoLock lock(&m_lockEvents);
+
+    for (std::vector<RENAME_ENUM_EVENT>::iterator it = m_renameEnumEvents.begin(); it != m_renameEnumEvents.end(); ++it)
+    {
+        if (it->pEvents)
+        {
+            it->pEvents->OnCompleted(m_canceled);
+        }
+    }
+}
+
+void CPowerRenameEnum::_OnFoundItem(_In_ IPowerRenameItem* pItem)
+{
+    CSRWSharedAutoLock lock(&m_lockEvents);
+
+    for (std::vector<RENAME_ENUM_EVENT>::iterator it = m_renameEnumEvents.begin(); it != m_renameEnumEvents.end(); ++it)
+    {
+        if (it->pEvents)
+        {
+            it->pEvents->OnFoundItem(pItem);
+        }
+    }
+}
+
+HRESULT CPowerRenameEnum::_Init(_In_ IUnknown* pdo, _In_ IPowerRenameManager* pManager)
+{
+    m_spdo = pdo;
+    m_spsrm = pManager;
+    return S_OK;
+}
+
+HRESULT CPowerRenameEnum::_ParseEnumItems(_In_ IEnumShellItems* pesi, _In_ int depth)
+{
+    HRESULT hr = E_INVALIDARG;
+
+    // We shouldn't get this deep since we only enum the contents of
+    // regular folders but adding just in case
+    if ((pesi) && (depth < (MAX_PATH / 2)))
+    {
+        hr = S_OK;
+
+        ULONG celtFetched;
+        CComPtr<IShellItem> spsi;
+        while ((S_OK == pesi->Next(1, &spsi, &celtFetched)) && (SUCCEEDED(hr)))
+        {
+            if (m_canceled)
+            {
+                return E_ABORT;
+            }
+
+            CComPtr<IPowerRenameItemFactory> spFactory;
+            hr = m_spsrm->GetRenameItemFactory(&spFactory);
+            if (SUCCEEDED(hr))
+            {
+                CComPtr<IPowerRenameItem> spNewItem;
+                // Failure may be valid if we come across a shell item that does
+                // not support a file system path.  In that case we simply ignore
+                // the item.
+                if (SUCCEEDED(spFactory->Create(spsi, &spNewItem)))
+                {
+                    spNewItem->PutDepth(depth);
+                    _OnFoundItem(spNewItem);
+                    hr = m_spsrm->AddItem(spNewItem);
+                    if (SUCCEEDED(hr))
+                    {
+                        bool isFolder = false;
+                        if (SUCCEEDED(spNewItem->GetIsFolder(&isFolder)) && isFolder)
+                        {
+                            // Bind to the IShellItem for the IEnumShellItems interface
+                            CComPtr<IEnumShellItems> spesiNext;
+                            hr = spsi->BindToHandler(nullptr, BHID_EnumItems, IID_PPV_ARGS(&spesiNext));
+                            if (SUCCEEDED(hr))
+                            {
+                                // Parse the folder contents recursively
+                                hr = _ParseEnumItems(spesiNext, depth + 1);
+                            }
+                        }
+                    }
+                }
+            }
+
+            spsi = nullptr;
+        }
+    }
+
+    return hr;
+}

--- a/src/modules/powerrename/lib/PowerRenameEnum.h
+++ b/src/modules/powerrename/lib/PowerRenameEnum.h
@@ -14,8 +14,6 @@ public:
     IFACEMETHODIMP_(ULONG) Release();
 
     // ISmartRenameEnum
-    IFACEMETHODIMP Advise(_In_ IPowerRenameEnumEvents* renameEnumEvents, _Out_ DWORD* cookie);
-    IFACEMETHODIMP UnAdvise(_In_ DWORD cookie);
     IFACEMETHODIMP Start();
     IFACEMETHODIMP Cancel();
 
@@ -28,21 +26,6 @@ protected:
 
     HRESULT _Init(_In_ IUnknown* pdo, _In_ IPowerRenameManager* pManager);
     HRESULT _ParseEnumItems(_In_ IEnumShellItems* pesi, _In_ int depth = 0);
-
-    void _OnStarted();
-    void _OnCompleted();
-    void _OnFoundItem(_In_ IPowerRenameItem* pItem);
-
-    struct RENAME_ENUM_EVENT
-    {
-        IPowerRenameEnumEvents* pEvents;
-        DWORD cookie;
-    };
-
-    DWORD m_cookie = 0;
-
-    CSRWLock m_lockEvents;
-    _Guarded_by_(m_lockEvents) std::vector<RENAME_ENUM_EVENT> m_renameEnumEvents;
 
     CComPtr<IPowerRenameManager> m_spsrm;
     CComPtr<IUnknown> m_spdo;

--- a/src/modules/powerrename/lib/PowerRenameEnum.h
+++ b/src/modules/powerrename/lib/PowerRenameEnum.h
@@ -1,0 +1,51 @@
+#pragma once
+#include "pch.h"
+#include "PowerRenameInterfaces.h"
+#include <vector>
+#include "srwlock.h"
+
+class CPowerRenameEnum :
+    public IPowerRenameEnum
+{
+public:
+    // IUnknown
+    IFACEMETHODIMP QueryInterface(_In_ REFIID iid, _Outptr_ void** resultInterface);
+    IFACEMETHODIMP_(ULONG) AddRef();
+    IFACEMETHODIMP_(ULONG) Release();
+
+    // ISmartRenameEnum
+    IFACEMETHODIMP Advise(_In_ IPowerRenameEnumEvents* renameEnumEvents, _Out_ DWORD* cookie);
+    IFACEMETHODIMP UnAdvise(_In_ DWORD cookie);
+    IFACEMETHODIMP Start();
+    IFACEMETHODIMP Cancel();
+
+public:
+    static HRESULT s_CreateInstance(_In_ IUnknown* pdo, _In_ IPowerRenameManager* pManager, _In_ REFIID iid, _Outptr_ void** resultInterface);
+
+protected:
+    CPowerRenameEnum();
+    virtual ~CPowerRenameEnum();
+
+    HRESULT _Init(_In_ IUnknown* pdo, _In_ IPowerRenameManager* pManager);
+    HRESULT _ParseEnumItems(_In_ IEnumShellItems* pesi, _In_ int depth = 0);
+
+    void _OnStarted();
+    void _OnCompleted();
+    void _OnFoundItem(_In_ IPowerRenameItem* pItem);
+
+    struct RENAME_ENUM_EVENT
+    {
+        IPowerRenameEnumEvents* pEvents;
+        DWORD cookie;
+    };
+
+    DWORD m_cookie = 0;
+
+    CSRWLock m_lockEvents;
+    _Guarded_by_(m_lockEvents) std::vector<RENAME_ENUM_EVENT> m_renameEnumEvents;
+
+    CComPtr<IPowerRenameManager> m_spsrm;
+    CComPtr<IUnknown> m_spdo;
+    bool m_canceled = false;
+    long m_refCount = 0;
+};

--- a/src/modules/powerrename/lib/PowerRenameInterfaces.h
+++ b/src/modules/powerrename/lib/PowerRenameInterfaces.h
@@ -134,19 +134,9 @@ public:
     IFACEMETHOD(AddMRUString)(_In_ PCWSTR entry) = 0;
 };
 
-interface __declspec(uuid("010CE791-731A-4409-9118-E2F0DB0104D3")) IPowerRenameEnumEvents : public IUnknown
-{
-public:
-    IFACEMETHOD(OnStarted)() = 0;
-    IFACEMETHOD(OnCompleted)(_In_ bool canceled) = 0;
-    IFACEMETHOD(OnFoundItem)(_In_ IPowerRenameItem* pItem) = 0;
-};
-
 interface __declspec(uuid("CE8C8616-C1A8-457A-9601-10570F5B9F1F")) IPowerRenameEnum : public IUnknown
 {
 public:
-    IFACEMETHOD(Advise)(_In_ IPowerRenameEnumEvents* renameEnumEvents, _Out_ DWORD* cookie) = 0;
-    IFACEMETHOD(UnAdvise)(_In_ DWORD cookie) = 0;
     IFACEMETHOD(Start)() = 0;
     IFACEMETHOD(Cancel)() = 0;
 };

--- a/src/modules/powerrename/lib/PowerRenameInterfaces.h
+++ b/src/modules/powerrename/lib/PowerRenameInterfaces.h
@@ -134,3 +134,19 @@ public:
     IFACEMETHOD(AddMRUString)(_In_ PCWSTR entry) = 0;
 };
 
+interface __declspec(uuid("010CE791-731A-4409-9118-E2F0DB0104D3")) IPowerRenameEnumEvents : public IUnknown
+{
+public:
+    IFACEMETHOD(OnStarted)() = 0;
+    IFACEMETHOD(OnCompleted)(_In_ bool canceled) = 0;
+    IFACEMETHOD(OnFoundItem)(_In_ IPowerRenameItem* pItem) = 0;
+};
+
+interface __declspec(uuid("CE8C8616-C1A8-457A-9601-10570F5B9F1F")) IPowerRenameEnum : public IUnknown
+{
+public:
+    IFACEMETHOD(Advise)(_In_ IPowerRenameEnumEvents* renameEnumEvents, _Out_ DWORD* cookie) = 0;
+    IFACEMETHOD(UnAdvise)(_In_ DWORD cookie) = 0;
+    IFACEMETHOD(Start)() = 0;
+    IFACEMETHOD(Cancel)() = 0;
+};

--- a/src/modules/powerrename/lib/PowerRenameLib.vcxproj
+++ b/src/modules/powerrename/lib/PowerRenameLib.vcxproj
@@ -40,6 +40,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="Helpers.h" />
+    <ClInclude Include="PowerRenameEnum.h" />
     <ClInclude Include="PowerRenameItem.h" />
     <ClInclude Include="PowerRenameInterfaces.h" />
     <ClInclude Include="PowerRenameManager.h" />
@@ -52,6 +53,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Helpers.cpp" />
+    <ClCompile Include="PowerRenameEnum.cpp" />
     <ClCompile Include="PowerRenameItem.cpp" />
     <ClCompile Include="PowerRenameManager.cpp" />
     <ClCompile Include="PowerRenameRegEx.cpp" />

--- a/src/modules/powerrename/lib/PowerRenameManager.cpp
+++ b/src/modules/powerrename/lib/PowerRenameManager.cpp
@@ -13,34 +13,6 @@ namespace fs = std::filesystem;
 
 extern HINSTANCE g_hInst;
 
-HWND CreateMsgWindow(_In_ HINSTANCE hInst, _In_ WNDPROC pfnWndProc, _In_ void* p)
-{
-    WNDCLASS wc = { 0 };
-
-    PCWSTR wndClassName = L"MsgWindow";
-
-    wc.lpfnWndProc = DefWindowProc;
-    wc.cbWndExtra = sizeof(void*);
-    wc.hInstance = hInst;
-    wc.hbrBackground = (HBRUSH)(COLOR_BTNFACE + 1);
-    wc.lpszClassName = wndClassName;
-
-    RegisterClass(&wc);
-
-    HWND hwnd = CreateWindowEx(
-        0, wndClassName, nullptr, 0, 0, 0, 0, 0, HWND_MESSAGE, 0, hInst, nullptr);
-    if (hwnd)
-    {
-        SetWindowLongPtr(hwnd, 0, (LONG_PTR)p);
-        if (pfnWndProc)
-        {
-            SetWindowLongPtr(hwnd, GWLP_WNDPROC, (LONG_PTR)pfnWndProc);
-        }
-    }
-
-    return hwnd;
-}
-
 // The default FOF flags to use in the rename operations
 #define FOF_DEFAULTFLAGS (FOF_ALLOWUNDO | FOFX_ADDUNDORECORD | FOFX_SHOWELEVATIONPROMPT | FOF_RENAMEONCOLLISION)
 

--- a/src/modules/powerrename/lib/pch.h
+++ b/src/modules/powerrename/lib/pch.h
@@ -17,6 +17,7 @@
 #include <shobjidl.h>
 #include <shellapi.h>
 #include <shlwapi.h>
+#include <ShlObj_core.h>
 
 #include <ProjectTelemetry.h>
 

--- a/src/modules/powerrename/ui/PowerRenameUI.cpp
+++ b/src/modules/powerrename/ui/PowerRenameUI.cpp
@@ -265,6 +265,8 @@ IFACEMETHODIMP CPowerRenameUI::OnFoundItem(_In_ IPowerRenameItem* pItem)
             wchar_t buff[100] = { 0 };
             LoadString(g_hInst, IDS_LOADING, buff, ARRAYSIZE(buff));
             m_sppd->SetLine(1, buff, FALSE, NULL);
+            LoadString(g_hInst, IDS_LOADING_MSG, buff, ARRAYSIZE(buff));
+            m_sppd->SetLine(2, buff, FALSE, NULL);
             LoadString(g_hInst, IDS_APP_TITLE, buff, ARRAYSIZE(buff));
             m_sppd->SetTitle(buff);
             m_sppd->StartProgressDialog(m_hwnd, NULL, PROGDLG_MARQUEEPROGRESS, NULL);
@@ -277,16 +279,6 @@ IFACEMETHODIMP CPowerRenameUI::OnFoundItem(_In_ IPowerRenameItem* pItem)
         {
             // Cancel the enumeration
             m_sppre->Cancel();
-        }
-        else
-        {
-            // Update the progress dialog
-            PWSTR pathDisplay = nullptr;
-            if (SUCCEEDED(pItem->GetPath(&pathDisplay)))
-            {
-                m_sppd->SetLine(2, pathDisplay, TRUE, nullptr);
-                CoTaskMemFree(pathDisplay);
-            }
         }
     }
     return S_OK;

--- a/src/modules/powerrename/ui/PowerRenameUI.h
+++ b/src/modules/powerrename/ui/PowerRenameUI.h
@@ -141,7 +141,7 @@ private:
     void _SetCheckboxesFromFlags(_In_ DWORD flags);
     void _ValidateFlagCheckbox(_In_ DWORD checkBoxId);
 
-    void _EnumerateItems(_In_ IUnknown* pdtobj);
+    HRESULT _EnumerateItems(_In_ IUnknown* pdtobj);
     void _UpdateCounts();
 
     void _CollectItemPosition(_In_ DWORD id);

--- a/src/modules/powerrename/ui/PowerRenameUI.h
+++ b/src/modules/powerrename/ui/PowerRenameUI.h
@@ -171,7 +171,7 @@ private:
     int m_lastWidth = 0;
     int m_lastHeight = 0;
     ULONGLONG m_enumStartTick = 0;
-    const ULONGLONG m_progressDlgDelayMS = 3000;
+    const ULONGLONG m_progressDlgDelayMS = 1500;
     CComPtr<IPowerRenameManager> m_spsrm;
     CComPtr<IUnknown> m_dataSource;
     CComPtr<IPowerRenameEnum> m_sppre;

--- a/src/modules/powerrename/ui/PowerRenameUI.h
+++ b/src/modules/powerrename/ui/PowerRenameUI.h
@@ -38,7 +38,8 @@ private:
 class CPowerRenameUI :
     public IDropTarget,
     public IPowerRenameUI,
-    public IPowerRenameManagerEvents
+    public IPowerRenameManagerEvents,
+    public IPowerRenameEnumEvents
 {
 public:
     CPowerRenameUI();
@@ -66,6 +67,11 @@ public:
     IFACEMETHODIMP OnRegExCompleted(_In_ DWORD threadId);
     IFACEMETHODIMP OnRenameStarted();
     IFACEMETHODIMP OnRenameCompleted();
+
+    // IPowerRenameEnumEvents
+    IFACEMETHODIMP OnStarted();
+    IFACEMETHODIMP OnCompleted(_In_ bool canceled);
+    IFACEMETHODIMP OnFoundItem(_In_ IPowerRenameItem* pItem);
 
     // IDropTarget
     IFACEMETHODIMP DragEnter(_In_ IDataObject* pdtobj, DWORD grfKeyState, POINTL pt, _Inout_ DWORD* pdwEffect);
@@ -164,12 +170,16 @@ private:
     int m_initialHeight = 0;
     int m_lastWidth = 0;
     int m_lastHeight = 0;
+    ULONGLONG m_enumStartTick = 0;
+    const ULONGLONG m_progressDlgDelayMS = 3000;
     CComPtr<IPowerRenameManager> m_spsrm;
     CComPtr<IUnknown> m_dataSource;
+    CComPtr<IPowerRenameEnum> m_sppre;
     CComPtr<IDropTargetHelper> m_spdth;
     CComPtr<IAutoComplete2> m_spSearchAC;
     CComPtr<IUnknown> m_spSearchACL;
     CComPtr<IAutoComplete2> m_spReplaceAC;
     CComPtr<IUnknown> m_spReplaceACL;
+    CComPtr<IProgressDialog> m_sppd;
     CPowerRenameListView m_listview;
 };

--- a/src/modules/powerrename/ui/PowerRenameUI.h
+++ b/src/modules/powerrename/ui/PowerRenameUI.h
@@ -171,7 +171,7 @@ private:
     int m_lastWidth = 0;
     int m_lastHeight = 0;
     ULONGLONG m_enumStartTick = 0;
-    const ULONGLONG m_progressDlgDelayMS = 1500;
+    const ULONGLONG m_progressDlgDelayMS = 2500;
     CComPtr<IPowerRenameManager> m_spsrm;
     CComPtr<IUnknown> m_dataSource;
     CComPtr<IPowerRenameEnum> m_sppre;

--- a/src/modules/powerrename/ui/Resources.resx
+++ b/src/modules/powerrename/ui/Resources.resx
@@ -208,4 +208,7 @@ Please select from the options above to show items.</value>
   <data name="Loading" xml:space="preserve">
     <value>Loading...</value>
   </data>
+  <data name="Loading_Msg" xml:space="preserve">
+    <value>Please wait while the selected items are enumerated.</value>
+  </data>
 </root>

--- a/src/modules/powerrename/ui/Resources.resx
+++ b/src/modules/powerrename/ui/Resources.resx
@@ -205,4 +205,7 @@ Please select from the options above to show items.</value>
   <data name="Rename_Criteria" xml:space="preserve">
     <value>Enter the criteria below to rename the items</value>
   </data>
+  <data name="Loading" xml:space="preserve">
+    <value>Loading...</value>
+  </data>
 </root>


### PR DESCRIPTION
This change adds a standard shell progress dialog during startup to give feedback to the user that we are gathering all the items that were selected (including items in subfolders).  This allows the user to know we are still doing work as well as provide a means to cancel the operation.

![image](https://user-images.githubusercontent.com/6734176/105622807-6a68e100-5dc9-11eb-9480-2bd74ff9ae99.png)

Applies to #9254 