### PR TITLE
[FZ Editor] Move "Duplicate" and "Delete" buttons to the Edit dialog.

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -133,22 +133,7 @@
                   KeyDown="LayoutItem_KeyDown"
                   MouseDown="LayoutItem_Click"
                   Margin="0,0,0,12">
-                <Grid.ContextMenu>
-                    <ContextMenu>
-                        <MenuItem Header="{x:Static props:Resources.Duplicate}" Click="DuplicateLayout_Click">
-                            <MenuItem.Icon>
-                                <ui:FontIcon Glyph="&#xE8C8;" />
-                            </MenuItem.Icon>
-                        </MenuItem>
 
-                        <MenuItem Header="{x:Static props:Resources.Delete}" Click="DeleteLayout_Click">
-                            <MenuItem.Icon>
-                                <ui:FontIcon Glyph="&#xE107;" />
-                            </MenuItem.Icon>
-                        </MenuItem>
-                    </ContextMenu>
-                </Grid.ContextMenu>
-                
                 <Border x:Name="LayoutItem"
                         Style="{StaticResource CardStyle}"
                         Margin="8"
@@ -418,7 +403,7 @@
                         HorizontalAlignment="Stretch"
                         AutomationProperties.Name="{x:Static props:Resources.Edit_zones}"
                         Height="48"
-                        Margin="0,0,0,32"
+                        Margin="0,0,0,16"
                         Visibility="{Binding Path=Type, Converter={StaticResource LayoutTypeCustomToVisibilityConverter}}"
                         Style="{StaticResource AccentButtonStyle}">
                     <Button.Content>
@@ -435,6 +420,69 @@
                                           ShadowDepth="1" />
                     </Button.Effect>
                 </Button>
+
+                <Grid Margin="0,0,0,32"
+                      Height="Auto"
+                      HorizontalAlignment="Stretch">
+                    
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    
+                    <Button Click="DuplicateLayout_Click"
+                            x:Name="duplicateLayoutButton"
+                            HorizontalAlignment="Stretch"
+                            AutomationProperties.Name="{x:Static props:Resources.Duplicate}"
+                            Height="48"
+                            Margin="0,0,4,0"
+                            Grid.Column="0"
+                            Visibility="{Binding Path=Type, Converter={StaticResource LayoutTypeCustomToVisibilityConverter}}">
+                        <Button.Content>
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="&#xE8C8;"
+                                       Margin="0,2,8,0"
+                                       FontFamily="Segoe MDL2 Assets" />
+                                <TextBlock Text="{x:Static props:Resources.Duplicate}" />
+                            </StackPanel>
+                        </Button.Content>
+                    </Button>
+                    <Button Click="DeleteLayout_Click"
+                            x:Name="deleteLayoutButton"
+                            HorizontalAlignment="Stretch"
+                            AutomationProperties.Name="{x:Static props:Resources.Delete}"
+                            Height="48"
+                            Margin="4,0,0,0"
+                            Grid.Column="1"
+                            Visibility="{Binding Path=Type, Converter={StaticResource LayoutTypeCustomToVisibilityConverter}}">
+                        <Button.Content>
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="&#xE107;"
+                                       Margin="0,2,8,0"
+                                       FontFamily="Segoe MDL2 Assets" />
+                                <TextBlock Text="{x:Static props:Resources.Delete}" />
+                            </StackPanel>
+                        </Button.Content>
+                    </Button>
+
+                    <Button Click="DuplicateLayout_Click"
+                            x:Name="createFromTemplateLayoutButton"
+                            HorizontalAlignment="Stretch"
+                            AutomationProperties.Name="{x:Static props:Resources.Create_Custom_From_Template}"
+                            Height="48"
+                            Margin="0,0,4,0"
+                            Grid.Column="0"
+                            Visibility="{Binding Path=Type, Converter={StaticResource LayoutTypeTemplateToVisibilityConverter}}">
+                        <Button.Content>
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="&#xE8C8;"
+                                       Margin="0,2,8,0"
+                                       FontFamily="Segoe MDL2 Assets" />
+                                <TextBlock Text="{x:Static props:Resources.Create_Custom_From_Template}" />
+                            </StackPanel>
+                        </Button.Content>
+                    </Button>
+                </Grid>
 
                 <TextBlock x:Name="nameHeader"
                            Text="{x:Static props:Resources.Name}"

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -269,7 +269,7 @@ namespace FancyZonesEditor
 
             if (GridLayoutRadioButton.IsChecked == true)
             {
-                GridLayoutModel gridModel = new GridLayoutModel(LayoutNameText.Text, LayoutType.Columns)
+                GridLayoutModel gridModel = new GridLayoutModel(LayoutNameText.Text, LayoutType.Custom)
                 {
                     Rows = 1,
                     RowPercents = new List<int>(1) { GridLayoutModel.GridMultiplier },

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -131,6 +131,8 @@ namespace FancyZonesEditor
 
         private void DuplicateLayout_Click(object sender, RoutedEventArgs e)
         {
+            EditLayoutDialog.Hide();
+
             var mainEditor = App.Overlay;
             if (!(mainEditor.CurrentDataContext is LayoutModel model))
             {
@@ -200,21 +202,10 @@ namespace FancyZonesEditor
             App.Current.Shutdown();
         }
 
-        private async void DeleteLayout_Click(object sender, RoutedEventArgs e)
+        private void DeleteLayout_Click(object sender, RoutedEventArgs e)
         {
-            var dialog = new ModernWpf.Controls.ContentDialog()
-            {
-                Title = FancyZonesEditor.Properties.Resources.Are_You_Sure,
-                Content = FancyZonesEditor.Properties.Resources.Are_You_Sure_Description,
-                PrimaryButtonText = FancyZonesEditor.Properties.Resources.Delete,
-                SecondaryButtonText = FancyZonesEditor.Properties.Resources.Cancel,
-            };
-            var result = await dialog.ShowAsync();
-            if (result == ContentDialogResult.Primary)
-            {
-                LayoutModel model = ((FrameworkElement)sender).DataContext as LayoutModel;
-                model.Delete();
-            }
+            EditLayoutDialog.Hide();
+            DeleteLayout((FrameworkElement)sender);
         }
 
         private async void EditLayout_Click(object sender, RoutedEventArgs e)
@@ -342,6 +333,24 @@ namespace FancyZonesEditor
 
             // reset selected model
             Select(_settings.AppliedModel);
+        }
+
+        private async void DeleteLayout(FrameworkElement element)
+        {
+            var dialog = new ModernWpf.Controls.ContentDialog()
+            {
+                Title = FancyZonesEditor.Properties.Resources.Are_You_Sure,
+                Content = FancyZonesEditor.Properties.Resources.Are_You_Sure_Description,
+                PrimaryButtonText = FancyZonesEditor.Properties.Resources.Delete,
+                SecondaryButtonText = FancyZonesEditor.Properties.Resources.Cancel,
+            };
+
+            var result = await dialog.ShowAsync();
+            if (result == ContentDialogResult.Primary)
+            {
+                LayoutModel model = element.DataContext as LayoutModel;
+                model.Delete();
+            }
         }
     }
 }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/GridLayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/GridLayoutModel.cs
@@ -281,6 +281,9 @@ namespace FancyZonesEditor.Models
                 case LayoutType.PriorityGrid:
                     InitPriorityGrid();
                     break;
+                case LayoutType.Custom:
+                    InitColumns(); // Custom is initialized with columns
+                    break;
             }
 
             FirePropertyChanged();

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
@@ -178,6 +178,15 @@ namespace FancyZonesEditor.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Create custom layout.
+        /// </summary>
+        public static string Create_Custom_From_Template {
+            get {
+                return ResourceManager.GetString("Create_Custom_From_Template", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Create new layout.
         /// </summary>
         public static string Create_new_layout {

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
@@ -328,4 +328,7 @@ To merge zones, select the zones and click "merge".</value>
   <data name="Template_Layout_Blank" xml:space="preserve">
     <value>No layout</value>
   </data>
+  <data name="Create_Custom_From_Template" xml:space="preserve">
+    <value>Create custom layout</value>
+  </data>
 </root>


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

* Removed context menu 
* Added "Duplicate" ("Create custom layout" for templates) and "Delete" buttons to the Edit dialog.

![image](https://user-images.githubusercontent.com/8949536/105694407-fe45c480-5f11-11eb-96cc-ca91fe3f21af.png)

![image](https://user-images.githubusercontent.com/8949536/105694445-07cf2c80-5f12-11eb-8b29-21b0626d768a.png)

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #9162 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
