### PR TITLE
[FZ Editor] Preview the applied layout after editing another layout.

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -102,6 +102,12 @@ namespace FancyZonesEditor
 
         private void LayoutItem_Focused(object sender, RoutedEventArgs e)
         {
+            // Ignore focus on Edit button click
+            if (e.Source is Button)
+            {
+                return;
+            }
+
             Select(((Border)sender).DataContext as LayoutModel);
         }
 
@@ -211,7 +217,7 @@ namespace FancyZonesEditor
         private async void EditLayout_Click(object sender, RoutedEventArgs e)
         {
             var dataContext = ((FrameworkElement)sender).DataContext;
-            _settings.SetSelectedModel((LayoutModel)dataContext);
+            Select((LayoutModel)dataContext);
 
             if (_settings.SelectedModel is GridLayoutModel grid)
             {


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

* Preview editing layout.
* Preview applied layout after editing was finished.

![image](https://user-images.githubusercontent.com/8949536/105707885-abc1d380-5f24-11eb-95d1-b914245d20fa.png)

![image](https://user-images.githubusercontent.com/8949536/105708023-e0ce2600-5f24-11eb-951f-f15fd0e4d9b2.png)

**What is include in the PR:** 

**How does someone test / validate:** 

* Apply any layout.
* Edit another layout, verify that editing layout is previewed.
* Save/Cancel editing, verify that applied layout is previewed. 
* (Additional) Verify that preview in layout cards is updated while editing.

## Quality Checklist

- [x] **Linked issue:** #9162 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
