### PR TITLE
[FZ Editor] Save template layouts in the settings.

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -2378,6 +2378,7 @@ Whichdoes
 whitespaces
 WIC
 Wifi
+wifstream
 wih
 wiki
 wikipedia

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/MainWindowSettingsModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/MainWindowSettingsModel.cs
@@ -61,11 +61,10 @@ namespace FancyZonesEditor
 
         public MainWindowSettingsModel()
         {
-            // Initialize the five default layout models: Blank, Focus, Columns, Rows, Grid, and PriorityGrid
-            DefaultModels = new List<LayoutModel>(6);
-
+            // Initialize default layout models: Blank, Focus, Columns, Rows, Grid, and PriorityGrid
             _blankModel = new CanvasLayoutModel(Properties.Resources.Template_Layout_Blank, LayoutType.Blank);
             _blankModel.TemplateZoneCount = 0;
+            _blankModel.SensitivityRadius = 0;
             DefaultModels.Add(_blankModel);
 
             _focusModel = new CanvasLayoutModel(Properties.Resources.Template_Layout_Focus, LayoutType.Focus);

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/MainWindowSettingsModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/MainWindowSettingsModel.cs
@@ -136,7 +136,7 @@ namespace FancyZonesEditor
 
         private bool _isCtrlKeyPressed;
 
-        public IList<LayoutModel> DefaultModels { get; }
+        public static IList<LayoutModel> DefaultModels { get; } = new List<LayoutModel>(6);
 
         public static ObservableCollection<LayoutModel> CustomModels
         {

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
@@ -707,6 +707,11 @@ namespace FancyZonesEditor.Utils
 
         private bool SetDevices(List<DeviceWrapper> devices)
         {
+            if (devices == null)
+            {
+                return false;
+            }
+
             bool result = true;
             var monitors = App.Overlay.Monitors;
             foreach (var device in devices)
@@ -749,6 +754,11 @@ namespace FancyZonesEditor.Utils
 
         private bool SetCustomLayouts(List<CustomLayoutWrapper> customLayouts)
         {
+            if (customLayouts == null)
+            {
+                return false;
+            }
+
             MainWindowSettingsModel.CustomModels.Clear();
             bool result = true;
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
@@ -527,6 +527,7 @@ namespace FancyZonesEditor.Utils
                 {
                     bool devicesParsingResult = SetDevices(zoneSettings.Devices);
                     bool customZonesParsingResult = SetCustomLayouts(zoneSettings.CustomZoneSets);
+                    bool templatesParsingResult = SetTemplateLayouts(zoneSettings.Templates);
 
                     if (!devicesParsingResult || !customZonesParsingResult)
                     {
@@ -801,6 +802,38 @@ namespace FancyZonesEditor.Utils
             }
 
             return result;
+        }
+
+        private bool SetTemplateLayouts(List<TemplateLayoutWrapper> templateLayouts)
+        {
+            if (templateLayouts == null)
+            {
+                return false;
+            }
+
+            foreach (var wrapper in templateLayouts)
+            {
+                var type = JsonTagToLayoutType(wrapper.Type);
+
+                foreach (var layout in MainWindowSettingsModel.DefaultModels)
+                {
+                    if (layout.Type == type)
+                    {
+                        layout.SensitivityRadius = wrapper.SensitivityRadius;
+                        layout.TemplateZoneCount = wrapper.ZoneCount;
+
+                        if (layout is GridLayoutModel grid)
+                        {
+                            grid.ShowSpacing = wrapper.ShowSpacing;
+                            grid.Spacing = wrapper.Spacing;
+                        }
+
+                        layout.InitTemplateZones();
+                    }
+                }
+            }
+
+            return true;
         }
 
         private LayoutType JsonTagToLayoutType(string tag)

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
@@ -161,11 +161,26 @@ namespace FancyZonesEditor.Utils
             public JsonElement Info { get; set; } // CanvasInfoWrapper or GridInfoWrapper
         }
 
+        private struct TemplateLayoutWrapper
+        {
+            public string Type { get; set; }
+
+            public bool ShowSpacing { get; set; }
+
+            public int Spacing { get; set; }
+
+            public int ZoneCount { get; set; }
+
+            public int SensitivityRadius { get; set; }
+        }
+
         private struct ZoneSettingsWrapper
         {
             public List<DeviceWrapper> Devices { get; set; }
 
             public List<CustomLayoutWrapper> CustomZoneSets { get; set; }
+
+            public List<TemplateLayoutWrapper> Templates { get; set; }
         }
 
         private struct EditorParams
@@ -532,6 +547,7 @@ namespace FancyZonesEditor.Utils
             ZoneSettingsWrapper zoneSettings = new ZoneSettingsWrapper { };
             zoneSettings.Devices = new List<DeviceWrapper>();
             zoneSettings.CustomZoneSets = new List<CustomLayoutWrapper>();
+            zoneSettings.Templates = new List<TemplateLayoutWrapper>();
 
             // Serialize used devices
             foreach (var monitor in App.Overlay.Monitors)
@@ -647,6 +663,25 @@ namespace FancyZonesEditor.Utils
                 };
 
                 zoneSettings.CustomZoneSets.Add(customLayout);
+            }
+
+            // Serialize template layouts
+            foreach (LayoutModel layout in MainWindowSettingsModel.DefaultModels)
+            {
+                TemplateLayoutWrapper wrapper = new TemplateLayoutWrapper
+                {
+                    Type = LayoutTypeToJsonTag(layout.Type),
+                    SensitivityRadius = layout.SensitivityRadius,
+                    ZoneCount = layout.TemplateZoneCount,
+                };
+
+                if (layout is GridLayoutModel grid)
+                {
+                    wrapper.ShowSpacing = grid.ShowSpacing;
+                    wrapper.Spacing = grid.Spacing;
+                }
+
+                zoneSettings.Templates.Add(wrapper);
             }
 
             try

--- a/src/modules/fancyzones/lib/JsonHelpers.cpp
+++ b/src/modules/fancyzones/lib/JsonHelpers.cpp
@@ -42,6 +42,7 @@ namespace NonLocalizable
     const wchar_t SensitivityRadius[] = L"sensitivity-radius";
     const wchar_t ShowSpacing[] = L"show-spacing";
     const wchar_t Spacing[] = L"spacing";
+    const wchar_t Templates[] = L"templates";
     const wchar_t TypeStr[] = L"type";
     const wchar_t UuidStr[] = L"uuid";
     const wchar_t WidthStr[] = L"width";
@@ -533,14 +534,29 @@ namespace JSONHelpers
                             const TAppZoneHistoryMap& appZoneHistoryMap)
 
     {
+        auto before = json::from_file(zonesSettingsFileName);
+
         json::JsonObject root{};
         json::JsonObject appZoneHistoryRoot{};
+        json::JsonArray templates{};
 
+        try
+        {
+            if (before.has_value() && before->HasKey(NonLocalizable::Templates))
+            {
+                templates = before->GetNamedArray(NonLocalizable::Templates);
+            }
+        }
+        catch (const winrt::hresult_error&)
+        {
+        
+        }
+               
         appZoneHistoryRoot.SetNamedValue(NonLocalizable::AppZoneHistoryStr, JSONHelpers::SerializeAppZoneHistory(appZoneHistoryMap));
         root.SetNamedValue(NonLocalizable::DevicesStr, JSONHelpers::SerializeDeviceInfos(deviceInfoMap));
         root.SetNamedValue(NonLocalizable::CustomZoneSetsStr, JSONHelpers::SerializeCustomZoneSets(customZoneSetsMap));
-
-        auto before = json::from_file(zonesSettingsFileName);
+        root.SetNamedValue(NonLocalizable::Templates, templates);
+        
         if (!before.has_value() || before.value().Stringify() != root.Stringify())
         {
             Trace::FancyZones::DataChanged();

--- a/src/modules/fancyzones/tests/UnitTests/JsonHelpers.Tests.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/JsonHelpers.Tests.cpp
@@ -1733,6 +1733,36 @@ namespace FancyZonesUnitTests
                 Assert::IsTrue(actual);
             }
 
+            TEST_METHOD (SaveFancyZonesDataWithTemplates)
+            {
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
+                const auto& jsonPath = data.zonesSettingsFileName;
+
+                // json with templates
+                json::JsonObject expectedJsonObj;
+                json::JsonObject templateObj = json::JsonObject::Parse(L"{\"type\": \"focus\", \"show-spacing\": false, \"spacing\": 15, \"zone-count\": 7, \"sensitivity-radius\": 25}");
+                json::JsonArray templatesArray{};
+                templatesArray.Append(templateObj);
+                expectedJsonObj.SetNamedValue(L"devices", json::JsonArray{});
+                expectedJsonObj.SetNamedValue(L"custom-zone-sets", json::JsonArray{});
+                expectedJsonObj.SetNamedValue(L"templates", templatesArray);
+
+                // write json with templates to file
+                json::to_file(jsonPath, expectedJsonObj);
+
+                data.SaveFancyZonesData();
+
+                // verify that file was written sucessfully
+                Assert::IsTrue(std::filesystem::exists(jsonPath));
+
+                // verify that templates were not changed after calling SaveFancyZonesData()
+                std::wstring str;
+                std::wifstream { jsonPath, std::ios::binary } >> str;
+                json::JsonObject actualJson = json::JsonObject::Parse(str);
+                compareJsonObjects(expectedJsonObj, actualJson);
+            }
+
             TEST_METHOD (AppLastZoneIndex)
             {
                 const std::wstring deviceId = L"device-id";

--- a/src/modules/fancyzones/tests/UnitTests/JsonHelpers.Tests.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/JsonHelpers.Tests.cpp
@@ -1753,7 +1753,7 @@ namespace FancyZonesUnitTests
 
                 data.SaveFancyZonesData();
 
-                // verify that file was written sucessfully
+                // verify that file was written successfully
                 Assert::IsTrue(std::filesystem::exists(jsonPath));
 
                 // verify that templates were not changed after calling SaveFancyZonesData()


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Template layout settings are saved along with the custom layouts and restored on the editor opening.

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #9162 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
