### PR TITLE
[FZ Editor] Fixed "Save and apply" button behavior.

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/EditorWindow.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/EditorWindow.cs
@@ -26,6 +26,7 @@ namespace FancyZonesEditor
 
                 MainWindowSettingsModel settings = ((App)Application.Current).MainWindowSettings;
                 settings.SetAppliedModel(model);
+                App.Overlay.SaveCurrentLayoutSettings(model);
             }
 
             App.FancyZonesEditorIO.SerializeZoneSettings();


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Saving the new layout data correctly.

**What is include in the PR:** 

**How does someone test / validate:** 

* Create a new layout, click "Save and apply".
* Close and reopen the editor, verify that the new layout is applied.

## Quality Checklist

- [x] **Linked issue:** #9162 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
