### PR TITLE
[FZ Editor] Added default custom layout name

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -129,7 +129,24 @@ namespace FancyZonesEditor
 
         private async void NewLayoutButton_Click(object sender, RoutedEventArgs e)
         {
-            LayoutNameText.Text = string.Empty;
+            string defaultNamePrefix = FancyZonesEditor.Properties.Resources.Default_Custom_Layout_Name;
+            int maxCustomIndex = 0;
+            foreach (LayoutModel customModel in MainWindowSettingsModel.CustomModels)
+            {
+                string name = customModel.Name;
+                if (name.StartsWith(defaultNamePrefix))
+                {
+                    if (int.TryParse(name.Substring(defaultNamePrefix.Length), out int i))
+                    {
+                        if (maxCustomIndex < i)
+                        {
+                            maxCustomIndex = i;
+                        }
+                    }
+                }
+            }
+
+            LayoutNameText.Text = defaultNamePrefix + " " + (++maxCustomIndex);
             GridLayoutRadioButton.IsChecked = true;
             GridLayoutRadioButton.Focus();
             await NewLayoutDialog.ShowAsync();

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
@@ -223,6 +223,15 @@ namespace FancyZonesEditor.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Custom layout.
+        /// </summary>
+        public static string Default_Custom_Layout_Name {
+            get {
+                return ResourceManager.GetString("Default_Custom_Layout_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Delete.
         /// </summary>
         public static string Delete {

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
@@ -331,4 +331,7 @@ To merge zones, select the zones and click "merge".</value>
   <data name="Create_Custom_From_Template" xml:space="preserve">
     <value>Create custom layout</value>
   </data>
+  <data name="Default_Custom_Layout_Name" xml:space="preserve">
+    <value>Custom layout</value>
+  </data>
 </root>


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Added default layout name in the "Create new layout" dialog.

![image](https://user-images.githubusercontent.com/8949536/105807497-2dfad800-5fb7-11eb-9a6a-fbb449fc562b.png)

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #9162 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
