### PR TITLE
[build] add configuration to localize new plugins

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Registry/LocProject.json
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Registry/LocProject.json
@@ -1,0 +1,14 @@
+{
+    "Projects": [
+        {
+            "LanguageSet": "Azure_Languages",
+            "LocItems": [
+              {
+                "SourceFile": "src\\modules\\launcher\\Plugins\\Microsoft.PowerToys.Run.Plugin.Registry\\Properties\\Resources.resx",
+                "CopyOption": "LangIDOnName",
+                "OutputPath": "src\\modules\\launcher\\Plugins\\Microsoft.PowerToys.Run.Plugin.Registry\\Properties"
+              }
+            ]
+        }
+    ]
+}

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Service/LocProject.json
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Service/LocProject.json
@@ -1,0 +1,14 @@
+{
+    "Projects": [
+        {
+            "LanguageSet": "Azure_Languages",
+            "LocItems": [
+              {
+                "SourceFile": "src\\modules\\launcher\\Plugins\\Microsoft.PowerToys.Run.Plugin.Service\\Properties\\Resources.resx",
+                "CopyOption": "LangIDOnName",
+                "OutputPath": "src\\modules\\launcher\\Plugins\\Microsoft.PowerToys.Run.Plugin.Service\\Properties"
+              }
+            ]
+        }
+    ]
+}

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.System/LocProject.json
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.System/LocProject.json
@@ -1,0 +1,14 @@
+{
+    "Projects": [
+        {
+            "LanguageSet": "Azure_Languages",
+            "LocItems": [
+              {
+                "SourceFile": "src\\modules\\launcher\\Plugins\\Microsoft.PowerToys.Run.Plugin.System\\Properties\\Resources.resx",
+                "CopyOption": "LangIDOnName",
+                "OutputPath": "src\\modules\\launcher\\Plugins\\Microsoft.PowerToys.Run.Plugin.System\\Properties"
+              }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
New PT Run plugins need a config file to enable localization in the build farm.

**What is include in the PR:** 
Added the required files.

**How does someone test / validate:** 
It has been already tested in the build farm, it cannot be tested localy.

## Quality Checklist

- [x] **Linked issue:** https://github.com/microsoft/PowerToys/issues/9294
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
