### PR TITLE
[FZ Editor] Pressing Esc closes dialogues.

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -394,7 +394,9 @@
                           PrimaryButtonText="{x:Static props:Resources.Save}"
                           PrimaryButtonClick="EditLayoutDialog_PrimaryButtonClick"
                           SecondaryButtonClick="EditLayoutDialog_SecondaryButtonClick"
-                          Title="{x:Static props:Resources.Edit_Layout}">
+                          Title="{x:Static props:Resources.Edit_Layout}"
+                          Opened="Dialog_Opened"
+                          Closed="Dialog_Closed">
             <StackPanel Margin="0,16,0,0"
                         MinWidth="420"
                         DataContext="{Binding SelectedModel}">
@@ -551,7 +553,9 @@
                           PrimaryButtonText="{x:Static props:Resources.Create}"
                           PrimaryButtonClick="NewLayoutDialog_PrimaryButtonClick"
                           IsPrimaryButtonEnabled="{Binding ElementName=LayoutNameText, Path=Text.Length}"
-                          Title="{x:Static props:Resources.Choose_layout_type}">
+                          Title="{x:Static props:Resources.Choose_layout_type}"
+                          Opened="Dialog_Opened"
+                          Closed="Dialog_Closed">
             <StackPanel Margin="0,16,0,0">
                 <TextBlock x:Name="NameHeaderText"
                            Text="{x:Static props:Resources.Name}" />

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -25,6 +25,8 @@ namespace FancyZonesEditor
         private readonly MainWindowSettingsModel _settings = ((App)Application.Current).MainWindowSettings;
         private LayoutModel _backup = null;
 
+        private ContentDialog _openedDialog = null;
+
         public int WrapPanelItemSize { get; set; } = DefaultWrapPanelItemSize;
 
         public MainWindow(bool spanZonesAcrossMonitors, Rect workArea)
@@ -56,7 +58,14 @@ namespace FancyZonesEditor
         {
             if (e.Key == Key.Escape)
             {
-                OnClosing(sender, null);
+                if (_openedDialog != null)
+                {
+                    _openedDialog.Hide();
+                }
+                else
+                {
+                    OnClosing(sender, null);
+                }
             }
         }
 
@@ -374,6 +383,16 @@ namespace FancyZonesEditor
                 LayoutModel model = element.DataContext as LayoutModel;
                 model.Delete();
             }
+        }
+
+        private void Dialog_Opened(ContentDialog sender, ContentDialogOpenedEventArgs args)
+        {
+            _openedDialog = sender;
+        }
+
+        private void Dialog_Closed(ContentDialog sender, ContentDialogClosedEventArgs args)
+        {
+            _openedDialog = null;
         }
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

If any dialog window is opened, Esc should close a dialog and shouldn't close the app.

**What is include in the PR:** 

**How does someone test / validate:** 

* Open "Create new layout" dialog, press Esc. The dialog should be closed, the main window should remain open.
* Open "Edit layout" dialog, press Esc. The dialog should be closed, the main window should remain open.
* Press Esc without dialogs. Main window should be closed.

## Quality Checklist

- [x] **Linked issue:** #9162 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
