### PR TITLE
[FZ Editor] Reset applied layout to "No layout" if it was deleted.

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/EditorWindow.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/EditorWindow.cs
@@ -26,7 +26,7 @@ namespace FancyZonesEditor
 
                 MainWindowSettingsModel settings = ((App)Application.Current).MainWindowSettings;
                 settings.SetAppliedModel(model);
-                App.Overlay.SaveCurrentLayoutSettings(model);
+                App.Overlay.SetLayoutSettings(App.Overlay.Monitors[App.Overlay.CurrentDesktop], model);
             }
 
             App.FancyZonesEditorIO.SerializeZoneSettings();

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -373,6 +373,22 @@ namespace FancyZonesEditor
             if (result == ContentDialogResult.Primary)
             {
                 LayoutModel model = element.DataContext as LayoutModel;
+
+                if (model == _settings.AppliedModel)
+                {
+                    _settings.SetAppliedModel(_settings.BlankModel);
+                    Select(_settings.BlankModel);
+                }
+
+                foreach (var monitor in App.Overlay.Monitors)
+                {
+                    if (monitor.Settings.ZonesetUuid == model.Uuid)
+                    {
+                        App.Overlay.SetLayoutSettings(monitor, _settings.BlankModel);
+                    }
+                }
+
+                App.FancyZonesEditorIO.SerializeZoneSettings();
                 model.Delete();
             }
         }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -203,7 +203,7 @@ namespace FancyZonesEditor
 
             model.Persist();
 
-            App.Overlay.SaveCurrentLayoutSettings(model);
+            App.Overlay.SetLayoutSettings(App.Overlay.Monitors[App.Overlay.CurrentDesktop], model);
             App.FancyZonesEditorIO.SerializeZoneSettings();
         }
 
@@ -213,7 +213,7 @@ namespace FancyZonesEditor
             if (mainEditor.CurrentDataContext is LayoutModel model)
             {
                 _settings.SetAppliedModel(model);
-                App.Overlay.SaveCurrentLayoutSettings(model);
+                App.Overlay.SetLayoutSettings(App.Overlay.Monitors[App.Overlay.CurrentDesktop], model);
                 App.FancyZonesEditorIO.SerializeZoneSettings();
             }
         }
@@ -350,7 +350,7 @@ namespace FancyZonesEditor
             // update current settings
             if (model == _settings.AppliedModel)
             {
-                App.Overlay.SaveCurrentLayoutSettings(model);
+                App.Overlay.SetLayoutSettings(App.Overlay.Monitors[App.Overlay.CurrentDesktop], model);
             }
 
             App.FancyZonesEditorIO.SerializeZoneSettings();

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/MainWindowSettingsModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/MainWindowSettingsModel.cs
@@ -31,14 +31,6 @@ namespace FancyZonesEditor
         private readonly GridLayoutModel _gridModel;
         private readonly GridLayoutModel _priorityGridModel;
 
-        public const ushort _focusModelId = 0xFFFF;
-        public const ushort _rowsModelId = 0xFFFE;
-        public const ushort _columnsModelId = 0xFFFD;
-        public const ushort _gridModelId = 0xFFFC;
-        public const ushort _priorityGridModelId = 0xFFFB;
-        public const ushort _blankCustomModelId = 0xFFFA;
-        public const ushort _lastDefinedId = _blankCustomModelId;
-
         // Non-localizable strings
         public static readonly string RegistryPath = "SOFTWARE\\SuperFancyZones";
         public static readonly string FullRegistryPath = "HKEY_CURRENT_USER\\" + RegistryPath;
@@ -62,9 +54,11 @@ namespace FancyZonesEditor
         public MainWindowSettingsModel()
         {
             // Initialize default layout models: Blank, Focus, Columns, Rows, Grid, and PriorityGrid
-            _blankModel = new CanvasLayoutModel(Properties.Resources.Template_Layout_Blank, LayoutType.Blank);
-            _blankModel.TemplateZoneCount = 0;
-            _blankModel.SensitivityRadius = 0;
+            _blankModel = new CanvasLayoutModel(Properties.Resources.Template_Layout_Blank, LayoutType.Blank)
+            {
+                TemplateZoneCount = 0,
+                SensitivityRadius = 0,
+            };
             DefaultModels.Add(_blankModel);
 
             _focusModel = new CanvasLayoutModel(Properties.Resources.Template_Layout_Focus, LayoutType.Focus);
@@ -135,6 +129,14 @@ namespace FancyZonesEditor
         }
 
         private bool _isCtrlKeyPressed;
+
+        public LayoutModel BlankModel
+        {
+            get
+            {
+                return _blankModel;
+            }
+        }
 
         public static IList<LayoutModel> DefaultModels { get; } = new List<LayoutModel>(6);
 
@@ -233,7 +235,7 @@ namespace FancyZonesEditor
 
             if (foundModel == null)
             {
-                foundModel = DefaultModels[5]; // PriorityGrid
+                foundModel = _priorityGridModel;
             }
 
             SetSelectedModel(foundModel);

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Overlay.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Overlay.cs
@@ -199,27 +199,27 @@ namespace FancyZonesEditor
             }
         }
 
-        public void SaveCurrentLayoutSettings(LayoutModel model)
+        public void SetLayoutSettings(Monitor monitor, LayoutModel model)
         {
             if (model == null)
             {
                 return;
             }
 
-            CurrentLayoutSettings.ZonesetUuid = model.Uuid;
-            CurrentLayoutSettings.Type = model.Type;
-            CurrentLayoutSettings.SensitivityRadius = model.SensitivityRadius;
-            CurrentLayoutSettings.ZoneCount = model.TemplateZoneCount;
+            monitor.Settings.ZonesetUuid = model.Uuid;
+            monitor.Settings.Type = model.Type;
+            monitor.Settings.SensitivityRadius = model.SensitivityRadius;
+            monitor.Settings.ZoneCount = model.TemplateZoneCount;
 
             if (model is GridLayoutModel grid)
             {
-                CurrentLayoutSettings.ShowSpacing = grid.ShowSpacing;
-                CurrentLayoutSettings.Spacing = grid.Spacing;
+                monitor.Settings.ShowSpacing = grid.ShowSpacing;
+                monitor.Settings.Spacing = grid.Spacing;
             }
             else
             {
-                CurrentLayoutSettings.ShowSpacing = false;
-                CurrentLayoutSettings.Spacing = 0;
+                monitor.Settings.ShowSpacing = false;
+                monitor.Settings.Spacing = 0;
             }
         }
 


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

If the user deletes the applied layout, "No layout" should be selected automatically.

**What is include in the PR:** 

**How does someone test / validate:** 

* Apply custom layout
* Delete applied layout
* Verify that on every monitor where that layout was applied it was reset to "No layout".

## Quality Checklist

- [x] **Linked issue:** #9162 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
