### PR TITLE
[FZ Editor] "Number of zones" buttons colors.

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -65,12 +65,29 @@
         <Style x:Key="SpinnerButton" TargetType="Button">
             <Setter Property="FontFamily" Value="Segoe UI" />
             <Setter Property="FontWeight" Value="SemiBold" />
-            <Setter Property="Foreground" Value="Black"/>
+            <Setter Property="Foreground" Value="{DynamicResource PrimaryForegroundBrush}"/>
             <Setter Property="FontSize" Value="18"/>
             <Setter Property="Padding" Value="0,0,0,5"/>
             <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="Background" Value="#F2F2F2"/>
+            <Setter Property="Background" Value="{DynamicResource SecondaryBackgroundBrush}"/>
             <Setter Property="Margin" Value="0,0,0,0" />
+
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="{x:Type Button}">
+                        <Border Background="{TemplateBinding Background}" BorderBrush="{DynamicResource SecondaryBackgroundBrush}" BorderThickness="0">
+                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+            
+            <Style.Triggers>
+                <Trigger Property="Border.IsMouseOver" Value="True">
+                    <Setter Property="Background"
+                            Value="{DynamicResource LayoutItemBackgroundPointerOverBrush}" />
+                </Trigger>
+            </Style.Triggers>
         </Style>
 
         <Style x:Key="ZoneCount" TargetType="TextBlock">
@@ -504,9 +521,21 @@
                 <StackPanel Margin="0,6,0,0" 
                             Orientation="Horizontal" 
                             Visibility="{Binding Path=Type, Converter={StaticResource LayoutTypeTemplateToVisibilityConverter}}">
-                    <Button x:Name="decrementZones" Width="40" Height="40" AutomationProperties.Name="{x:Static props:Resources.Zone_Count_Decrement}" Content="-" Style="{StaticResource SpinnerButton}" Click="DecrementZones_Click"/>
+                    <Button x:Name="decrementZones" 
+                            Width="40" 
+                            Height="40" 
+                            AutomationProperties.Name="{x:Static props:Resources.Zone_Count_Decrement}" 
+                            Content="-" 
+                            Style="{StaticResource SpinnerButton}"
+                            Click="DecrementZones_Click"/>
                     <TextBlock x:Name="zoneCount" Text="{Binding TemplateZoneCount}" Style="{StaticResource ZoneCount}"/>
-                    <Button x:Name="incrementZones" Width="40" Height="40" AutomationProperties.Name="{x:Static props:Resources.Zone_Count_Increment}" Content="+" Style="{StaticResource SpinnerButton}" Click="IncrementZones_Click"/>
+                    <Button x:Name="incrementZones" 
+                            Width="40" 
+                            Height="40" 
+                            AutomationProperties.Name="{x:Static props:Resources.Zone_Count_Increment}" 
+                            Content="+" 
+                            Style="{StaticResource SpinnerButton}" 
+                            Click="IncrementZones_Click"/>
                 </StackPanel>
                 
                 <StackPanel Margin="0,16,0,0"


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Fixed colors of the "+", "-" buttons in the "Edit layout" dialog.

![image](https://user-images.githubusercontent.com/8949536/105987491-68e03700-60af-11eb-878b-3f7d6515c2f8.png)

![image](https://user-images.githubusercontent.com/8949536/105987505-6c73be00-60af-11eb-9560-bf1f7f2ca8fc.png)

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #9162 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
