### PR TITLE
Fix installer pipeline

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -408,6 +408,7 @@ Datavalue
 DATAW
 davidegiacometti
 Dayof
+dbdfc
 Dbg
 DBLCLKS
 DBLEPSILON
@@ -568,6 +569,7 @@ ECDE
 ECDF
 ECEB
 ECEE
+ecef
 ECFE
 ECFF
 ecount
@@ -620,6 +622,7 @@ EED
 EEED
 EEEF
 EEF
+efa
 EFB
 EFBA
 EFC

--- a/.pipelines/pipeline.user.windows.yml
+++ b/.pipelines/pipeline.user.windows.yml
@@ -5,7 +5,7 @@ environment:
     version: '2019'
   runtime:
     provider: 'appcontainer'
-    image: 'cdpxwin1809.azurecr.io/global/vse2019:latest'
+    image: 'cdpxwin1809.azurecr.io/global/vse2019:16.8.2'
     source_mode: 'map'
 
 version:

--- a/.pipelines/pipeline.user.windows.yml
+++ b/.pipelines/pipeline.user.windows.yml
@@ -5,7 +5,8 @@ environment:
     version: '2019'
   runtime:
     provider: 'appcontainer'
-    image: 'cdpxwin1809.azurecr.io/global/vse2019:16.5.0'
+    # we will want to shift this to latest in the near future but this unblocks us
+    image: 'cdpxwin1809.azurecr.io/global/vse2019@sha256:44a8af0de5efa68829dbdfc3ecef3864d9770f1fc426b897fc37888032c9f60c'
     source_mode: 'map'
 
 version:

--- a/.pipelines/pipeline.user.windows.yml
+++ b/.pipelines/pipeline.user.windows.yml
@@ -5,7 +5,7 @@ environment:
     version: '2019'
   runtime:
     provider: 'appcontainer'
-    image: 'cdpxwin1809.azurecr.io/global/vse2019:16.6.2'
+    image: 'cdpxwin1809.azurecr.io/global/vse2019:16.5.0'
     source_mode: 'map'
 
 version:

--- a/.pipelines/pipeline.user.windows.yml
+++ b/.pipelines/pipeline.user.windows.yml
@@ -5,7 +5,7 @@ environment:
     version: '2019'
   runtime:
     provider: 'appcontainer'
-    image: 'cdpxwin1809.azurecr.io/global/vse2019:16.8.2'
+    image: 'cdpxwin1809.azurecr.io/global/vse2019:16.7.2'
     source_mode: 'map'
 
 version:

--- a/.pipelines/pipeline.user.windows.yml
+++ b/.pipelines/pipeline.user.windows.yml
@@ -5,7 +5,7 @@ environment:
     version: '2019'
   runtime:
     provider: 'appcontainer'
-    image: 'cdpxwin1809.azurecr.io/global/vse2019:16.7.2'
+    image: 'cdpxwin1809.azurecr.io/global/vse2019:16.6.2'
     source_mode: 'map'
 
 version:


### PR DESCRIPTION
Fix for CDPX pipeline.  points to their old image that use to be latest
https://github-private.visualstudio.com/microsoft/_build/results?buildId=19276&view=logs&j=fd490c07-0b22-5182-fac9-6d67fe1e939b&t=dcf93f35-c1ba-5dce-0078-8d628250da3a