### PR TITLE
[FZ Editor] Limit zones number for custom layouts.

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditorWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditorWindow.xaml
@@ -46,6 +46,8 @@
                     Content="&#xE109;"
                     FontSize="24"
                     ToolTip="{x:Static props:Resources.Add_zone}"
+                    DataContext="{Binding Path=Model, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Window}}"
+                    IsEnabled="{Binding IsZoneAddingAllowed}"
                     Click="OnAddZone" />
 
             <Grid Margin="0,24,0,0">

--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditorWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditorWindow.xaml.cs
@@ -10,18 +10,6 @@ namespace FancyZonesEditor
 {
     public partial class CanvasEditorWindow : EditorWindow
     {
-        // Default distance from the top and left borders to the zone.
-        private const int DefaultOffset = 100;
-
-        // Next created zone will be by OffsetShift value below and to the right of the previous.
-        private const int OffsetShift = 50;
-
-        // Zone size depends on the work area size multiplied by ZoneSizeMultiplier value.
-        private const double ZoneSizeMultiplier = 0.4;
-
-        // Distance from the top and left borders to the zone.
-        private int _offset = DefaultOffset;
-
         private CanvasLayoutModel _model;
         private CanvasLayoutModel _stashedModel;
 
@@ -45,22 +33,7 @@ namespace FancyZonesEditor
 
         private void OnAddZone(object sender, RoutedEventArgs e)
         {
-            Rect workingArea = App.Overlay.WorkArea;
-            int offset = (int)App.Overlay.ScaleCoordinateWithCurrentMonitorDpi(_offset);
-
-            if (offset + (int)(workingArea.Width * ZoneSizeMultiplier) < (int)workingArea.Width
-                && offset + (int)(workingArea.Height * ZoneSizeMultiplier) < (int)workingArea.Height)
-            {
-                _model.AddZone(new Int32Rect(offset, offset, (int)(workingArea.Width * ZoneSizeMultiplier), (int)(workingArea.Height * ZoneSizeMultiplier)));
-            }
-            else
-            {
-                _offset = DefaultOffset;
-                offset = (int)App.Overlay.ScaleCoordinateWithCurrentMonitorDpi(_offset);
-                _model.AddZone(new Int32Rect(offset, offset, (int)(workingArea.Width * ZoneSizeMultiplier), (int)(workingArea.Height * ZoneSizeMultiplier)));
-            }
-
-            _offset += OffsetShift;
+            _model.AddZone();
         }
 
         protected new void OnCancel(object sender, RoutedEventArgs e)

--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditorWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditorWindow.xaml.cs
@@ -35,6 +35,14 @@ namespace FancyZonesEditor
             _stashedModel = (CanvasLayoutModel)_model.Clone();
         }
 
+        public LayoutModel Model
+        {
+            get
+            {
+                return _model;
+            }
+        }
+
         private void OnAddZone(object sender, RoutedEventArgs e)
         {
             Rect workingArea = App.Overlay.WorkArea;

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -91,7 +91,7 @@ namespace FancyZonesEditor
                 return;
             }
 
-            if (model.TemplateZoneCount < LayoutSettings.MaxZones)
+            if (model.IsZoneAddingAllowed)
             {
                 model.TemplateZoneCount++;
             }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/CanvasLayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/CanvasLayoutModel.cs
@@ -20,6 +20,7 @@ namespace FancyZonesEditor.Models
             : base(uuid, name, type)
         {
             Zones = zones;
+            TemplateZoneCount = Zones.Count;
             CanvasRect = new Rect(new Size(width, height));
         }
 
@@ -52,6 +53,7 @@ namespace FancyZonesEditor.Models
         public void RemoveZoneAt(int index)
         {
             Zones.RemoveAt(index);
+            TemplateZoneCount = Zones.Count;
             UpdateLayout();
         }
 
@@ -60,6 +62,7 @@ namespace FancyZonesEditor.Models
         public void AddZone(Int32Rect zone)
         {
             Zones.Add(zone);
+            TemplateZoneCount = Zones.Count;
             UpdateLayout();
         }
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/CanvasLayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/CanvasLayoutModel.cs
@@ -14,6 +14,18 @@ namespace FancyZonesEditor.Models
         // Non-localizable strings
         public const string ModelTypeID = "canvas";
 
+        // Default distance from the top and left borders to the zone.
+        private const int DefaultOffset = 100;
+
+        // Next created zone will be by OffsetShift value below and to the right of the previous.
+        private const int OffsetShift = 50;
+
+        // Zone size depends on the work area size multiplied by ZoneSizeMultiplier value.
+        private const double ZoneSizeMultiplier = 0.4;
+
+        // Distance from the top and left borders to the zone.
+        private int _topLeft = DefaultOffset;
+
         public Rect CanvasRect { get; private set; }
 
         public CanvasLayoutModel(string uuid, string name, LayoutType type, IList<Int32Rect> zones, int width, int height)
@@ -66,26 +78,52 @@ namespace FancyZonesEditor.Models
             UpdateLayout();
         }
 
+        public void AddZone()
+        {
+            AddNewZone();
+            TemplateZoneCount = Zones.Count;
+            UpdateLayout();
+        }
+
+        private void AddNewZone()
+        {
+            if (Zones.Count == 0)
+            {
+                _topLeft = DefaultOffset;
+            }
+
+            Rect workingArea = App.Overlay.WorkArea;
+            int topLeft = (int)App.Overlay.ScaleCoordinateWithCurrentMonitorDpi(_topLeft);
+            int width = (int)(workingArea.Width * ZoneSizeMultiplier);
+            int height = (int)(workingArea.Height * ZoneSizeMultiplier);
+
+            if (topLeft + width >= (int)workingArea.Width || topLeft + height >= (int)workingArea.Height)
+            {
+                _topLeft = DefaultOffset;
+                topLeft = (int)App.Overlay.ScaleCoordinateWithCurrentMonitorDpi(_topLeft);
+            }
+
+            Zones.Add(new Int32Rect(topLeft, topLeft, width, height));
+            _topLeft += OffsetShift;
+        }
+
         // InitTemplateZones
         // Creates zones based on template zones count
         public override void InitTemplateZones()
         {
+            if (Type == LayoutType.Custom || Type == LayoutType.Blank)
+            {
+                return;
+            }
+
             Zones.Clear();
-
-            var workingArea = App.Overlay.WorkArea;
-            int topLeftCoordinate = (int)App.Overlay.ScaleCoordinateWithCurrentMonitorDpi(100); // TODO: replace magic numbers
-            int width = (int)(workingArea.Width * 0.4);
-            int height = (int)(workingArea.Height * 0.4);
-            Int32Rect focusZoneRect = new Int32Rect(topLeftCoordinate, topLeftCoordinate, width, height);
-            int focusRectXIncrement = (TemplateZoneCount <= 1) ? 0 : (int)App.Overlay.ScaleCoordinateWithCurrentMonitorDpi(50); // TODO: replace magic numbers
-            int focusRectYIncrement = (TemplateZoneCount <= 1) ? 0 : (int)App.Overlay.ScaleCoordinateWithCurrentMonitorDpi(50); // TODO: replace magic numbers
-
             for (int i = 0; i < TemplateZoneCount; i++)
             {
-                Zones.Add(focusZoneRect);
-                focusZoneRect.X += focusRectXIncrement;
-                focusZoneRect.Y += focusRectYIncrement;
+                AddNewZone();
             }
+
+            TemplateZoneCount = Zones.Count;
+            UpdateLayout();
         }
 
         private void UpdateLayout()

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
@@ -173,11 +173,20 @@ namespace FancyZonesEditor.Models
                     _zoneCount = value;
                     InitTemplateZones();
                     FirePropertyChanged(nameof(TemplateZoneCount));
+                    FirePropertyChanged(nameof(IsZoneAddingAllowed));
                 }
             }
         }
 
         private int _zoneCount = LayoutSettings.DefaultZoneCount;
+
+        public bool IsZoneAddingAllowed
+        {
+            get
+            {
+                return TemplateZoneCount < LayoutSettings.MaxZones;
+            }
+        }
 
         // implementation of INotifyPropertyChanged
         public event PropertyChangedEventHandler PropertyChanged;


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

The custom layout zone number is limited with 40 zones as like as a template.

![ezgif com-gif-maker](https://user-images.githubusercontent.com/8949536/106263274-36f8dd00-6235-11eb-8860-2bd862c9f9f2.gif)

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #9352 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
