### PR TITLE
[FancyZones Editor] Editor window size overflow

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -46,6 +46,8 @@ namespace FancyZonesEditor
                 WrapPanelItemSize = SmallWrapPanelItemSize;
             }
 
+            MaxWidth = workArea.Width;
+            MaxHeight = workArea.Height;
             SizeToContent = SizeToContent.WidthAndHeight;
         }
 


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Set `MaxWidth` and `MaxHeight` for the main window.

![image](https://user-images.githubusercontent.com/8949536/106461901-74b06c80-64a6-11eb-84bc-4eb1427b6045.png)

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #9388 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
