### PR TITLE
Deleted unused resources

### DIFF
--- a/src/modules/launcher/PowerLauncher/Properties/Resources.Designer.cs
+++ b/src/modules/launcher/PowerLauncher/Properties/Resources.Designer.cs
@@ -61,15 +61,6 @@ namespace PowerLauncher.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You have activated Wox {0} times.
-        /// </summary>
-        public static string about_activate_times {
-            get {
-                return ResourceManager.GetString("about_activate_times", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Application Icon.
         /// </summary>
         public static string AppIcon {

--- a/src/modules/launcher/PowerLauncher/Properties/Resources.resx
+++ b/src/modules/launcher/PowerLauncher/Properties/Resources.resx
@@ -129,9 +129,6 @@
   <data name="lastExecuteTime" xml:space="preserve">
     <value>Last execution time: {0}</value>
   </data>
-  <data name="about_activate_times" xml:space="preserve">
-    <value>You have activated Wox {0} times</value>
-  </data>
   <data name="reportWindow_header" xml:space="preserve">
     <value>Something went wrong.</value>
   </data>

--- a/src/modules/launcher/PowerLauncher/ViewModel/SettingWindowViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/SettingWindowViewModel.cs
@@ -17,13 +17,6 @@ namespace PowerLauncher.ViewModel
         {
             _storage = new WoxJsonStorage<PowerToysRunSettings>();
             Settings = _storage.Load();
-            Settings.PropertyChanged += (s, e) =>
-            {
-                if (e.PropertyName == nameof(Settings.ActivateTimes))
-                {
-                    OnPropertyChanged(nameof(ActivatedTimes));
-                }
-            };
         }
 
         public PowerToysRunSettings Settings { get; set; }
@@ -32,7 +25,5 @@ namespace PowerLauncher.ViewModel
         {
             _storage.Save();
         }
-
-        public string ActivatedTimes => string.Format(CultureInfo.InvariantCulture, Properties.Resources.about_activate_times, Settings.ActivateTimes);
     }
 }

--- a/src/modules/launcher/Wox.Plugin/Properties/Resources.Designer.cs
+++ b/src/modules/launcher/Wox.Plugin/Properties/Resources.Designer.cs
@@ -59,32 +59,5 @@ namespace Wox.Plugin.Properties {
                 resourceCulture = value;
             }
         }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Copying path {0} has failed, it will now be deleted for consistency.
-        /// </summary>
-        public static string filesfolder_copy_failed {
-            get {
-                return ResourceManager.GetString("filesfolder_copy_failed", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Not able to delete folder {0}, please go to the location and manually delete it.
-        /// </summary>
-        public static string filesfolder_removefolder_failed {
-            get {
-                return ResourceManager.GetString("filesfolder_removefolder_failed", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Unable to verify folders and files between {0} and {1}.
-        /// </summary>
-        public static string filesfolder_verifybothfolderfilesequal_failed {
-            get {
-                return ResourceManager.GetString("filesfolder_verifybothfolderfilesequal_failed", resourceCulture);
-            }
-        }
     }
 }

--- a/src/modules/launcher/Wox.Plugin/Properties/Resources.resx
+++ b/src/modules/launcher/Wox.Plugin/Properties/Resources.resx
@@ -117,16 +117,4 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="filesfolder_copy_failed" xml:space="preserve">
-    <value>Copying path {0} has failed, it will now be deleted for consistency</value>
-    <comment>parameter: targetPath</comment>
-  </data>
-  <data name="filesfolder_removefolder_failed" xml:space="preserve">
-    <value>Not able to delete folder {0}, please go to the location and manually delete it</value>
-    <comment>parameter: path</comment>
-  </data>
-  <data name="filesfolder_verifybothfolderfilesequal_failed" xml:space="preserve">
-    <value>Unable to verify folders and files between {0} and {1}</value>
-    <comment>parameters: fromPath, toPath</comment>
-  </data>
 </root>


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
There are few labels in resource files that are not used anywhere.

**What is include in the PR:** 
- Delete unused label resources

**How does someone test / validate:** 
Start PT Run and try all plugins. 

## Quality Checklist

- [X] **Linked issue:** #8213
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [X] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
