### PR TITLE
[FZ Editor] Hack to workaround crash

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -310,10 +310,18 @@ namespace FancyZonesEditor
 
             selectedLayoutModel.InitTemplateZones();
 
+            try
+            {
+                Hide();
+            }
+            catch
+            {
+                // See https://github.com/microsoft/PowerToys/issues/9396
+                Hide();
+            }
+
             App.Overlay.CurrentDataContext = selectedLayoutModel;
-            var mainEditor = App.Overlay;
-            Hide();
-            mainEditor.OpenEditor(selectedLayoutModel);
+            App.Overlay.OpenEditor(selectedLayoutModel);
         }
 
         // This is required to fix a WPF rendering bug when using custom chrome


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Workaround for a crashing bug in FZ Editor.

**What is include in the PR:** 
The workaround is a hack for an obscure crash when hiding the FZ main window before opening the layout editor.

**How does someone test / validate:** 
The bug is very difficult to replicate, see https://github.com/microsoft/PowerToys/issues/9396 for details.

## Quality Checklist

- [x] **Linked issue:** https://github.com/microsoft/PowerToys/issues/9396
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
