### PR TITLE
[FZ Settings] Refactor "Override Windows Snap shortcut (Win + Arrow) to move windows between zones" settings

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/FancyZonesViewModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/FancyZonesViewModel.cs
@@ -26,6 +26,12 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
 
         private string settingsConfigFileFolder = string.Empty;
 
+        private enum MoveWindowBehaviour
+        {
+            MoveWindowBasedOnZoneIndex = 0,
+            MoveWindowBasedOnPosition,
+        }
+
         public FancyZonesViewModel(ISettingsRepository<GeneralSettings> settingsRepository, ISettingsRepository<FancyZonesSettings> moduleSettingsRepository, Func<string, int> ipcMSGCallBackFunc, string configFileSubfolder = "")
         {
             // To obtain the general settings configurations of PowerToys Settings.
@@ -51,7 +57,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             _mouseSwitch = Settings.Properties.FancyzonesMouseSwitch.Value;
             _overrideSnapHotkeys = Settings.Properties.FancyzonesOverrideSnapHotkeys.Value;
             _moveWindowsAcrossMonitors = Settings.Properties.FancyzonesMoveWindowsAcrossMonitors.Value;
-            _moveWindowsBasedOnPosition = Settings.Properties.FancyzonesMoveWindowsBasedOnPosition.Value;
+            _moveWindowBehaviour = Settings.Properties.FancyzonesMoveWindowsBasedOnPosition.Value ? MoveWindowBehaviour.MoveWindowBasedOnPosition : MoveWindowBehaviour.MoveWindowBasedOnZoneIndex;
             _displayChangemoveWindows = Settings.Properties.FancyzonesDisplayChangeMoveWindows.Value;
             _zoneSetChangeMoveWindows = Settings.Properties.FancyzonesZoneSetChangeMoveWindows.Value;
             _appLastZoneMoveWindows = Settings.Properties.FancyzonesAppLastZoneMoveWindows.Value;
@@ -85,7 +91,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
         private bool _mouseSwitch;
         private bool _overrideSnapHotkeys;
         private bool _moveWindowsAcrossMonitors;
-        private bool _moveWindowsBasedOnPosition;
+        private MoveWindowBehaviour _moveWindowBehaviour;
         private bool _displayChangemoveWindows;
         private bool _zoneSetChangeMoveWindows;
         private bool _appLastZoneMoveWindows;
@@ -217,15 +223,35 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
         {
             get
             {
-                return _moveWindowsBasedOnPosition;
+                return _moveWindowBehaviour == MoveWindowBehaviour.MoveWindowBasedOnPosition;
             }
 
             set
             {
-                if (value != _moveWindowsBasedOnPosition)
+                var settingsValue = Settings.Properties.FancyzonesMoveWindowsBasedOnPosition.Value;
+                if (value != settingsValue)
                 {
-                    _moveWindowsBasedOnPosition = value;
+                    _moveWindowBehaviour = value ? MoveWindowBehaviour.MoveWindowBasedOnPosition : MoveWindowBehaviour.MoveWindowBasedOnZoneIndex;
                     Settings.Properties.FancyzonesMoveWindowsBasedOnPosition.Value = value;
+                    NotifyPropertyChanged();
+                }
+            }
+        }
+
+        public bool MoveWindowsBasedOnZoneIndex
+        {
+            get
+            {
+                return _moveWindowBehaviour == MoveWindowBehaviour.MoveWindowBasedOnZoneIndex;
+            }
+
+            set
+            {
+                var settingsValue = Settings.Properties.FancyzonesMoveWindowsBasedOnPosition.Value;
+                if (value == settingsValue)
+                {
+                    _moveWindowBehaviour = value ? MoveWindowBehaviour.MoveWindowBasedOnZoneIndex : MoveWindowBehaviour.MoveWindowBasedOnPosition;
+                    Settings.Properties.FancyzonesMoveWindowsBasedOnPosition.Value = !value;
                     NotifyPropertyChanged();
                 }
             }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -928,6 +928,12 @@
     <value>https://aka.ms/PowerToysOverview_ShortcutGuide</value>
     <comment>URL. Do not loc</comment>
   </data>
+  <data name="FancyZones_MoveWindowBasedOnRelativePosition.Content" xml:space="preserve">
+    <value>Win + Up/Down/Left/Right to move windows based on relative position</value>
+  </data>
+  <data name="FancyZones_MoveWindowLeftRightBasedOnZoneIndex.Content" xml:space="preserve">
+    <value>Win + Left/Right to move windows based on zone index</value>
+  </data>
   <data name="ColorPicker_Editor.Text" xml:space="preserve">
     <value>Editor</value>
   </data>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -135,10 +135,17 @@
                       Margin="{StaticResource XSmallTopMargin}"
                       IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"/>
 
-            <CheckBox x:Uid="FancyZones_MoveWindowsBasedOnPositionCheckBoxControl"
-                      IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.MoveWindowsBasedOnPosition}"
-                      Margin="24,8,0,0"
-                      IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.SnapHotkeysCategoryEnabled}"/>
+            <RadioButton x:Uid="FancyZones_MoveWindowLeftRightBasedOnZoneIndex"
+                         GroupName="FancyZones_MoveWindowGroup"
+                         IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.MoveWindowsBasedOnZoneIndex}"
+                         Margin="24,8,0,0"
+                         IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.SnapHotkeysCategoryEnabled}"/>
+
+            <RadioButton x:Uid="FancyZones_MoveWindowBasedOnRelativePosition"
+                         GroupName="FancyZones_MoveWindowGroup"
+                         IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.MoveWindowsBasedOnPosition}"
+                         Margin="24,8,0,0"
+                         IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.SnapHotkeysCategoryEnabled}"/>
 
             <CheckBox x:Uid="FancyZones_MoveWindowsAcrossAllMonitorsCheckBoxControl"
                       IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.MoveWindowsAcrossMonitors}"


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Replaced `Move windows based on their position` checkbox with radio buttons.

![image](https://user-images.githubusercontent.com/8949536/106731934-25db1200-6621-11eb-99c3-e11a2f45ffbd.png)

**What is include in the PR:** 

**How does someone test / validate:** 

Check each option by snapping a window to a zone and using Win+Arrow.

## Quality Checklist

- [x] **Linked issue:** #7841 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
