### PR TITLE
[FancyZones Editor] Create new custom layout with one zone by default.

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -304,10 +304,9 @@ namespace FancyZonesEditor
             }
             else
             {
-                selectedLayoutModel = new CanvasLayoutModel(LayoutNameText.Text, LayoutType.Custom)
-                {
-                    TemplateZoneCount = 0,
-                };
+                CanvasLayoutModel canvasModel = new CanvasLayoutModel(LayoutNameText.Text, LayoutType.Custom);
+                canvasModel.AddZone();
+                selectedLayoutModel = canvasModel;
             }
 
             selectedLayoutModel.InitTemplateZones();


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

When creating a new canvas layout, the zones editor is opening with one zone by default.

![image](https://user-images.githubusercontent.com/8949536/106740762-e108a880-662b-11eb-9c50-cf9e94cd2fdc.png)


**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #9365 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
