### PR TITLE
[FancyZones] Improve zone selection

### DIFF
--- a/src/modules/fancyzones/lib/ZoneSet.cpp
+++ b/src/modules/fancyzones/lib/ZoneSet.cpp
@@ -8,6 +8,7 @@
 #include "Zone.h"
 #include "util.h"
 
+#include <common/logger/logger.h>
 #include <common/display/dpi_aware.h>
 
 #include <limits>
@@ -290,7 +291,8 @@ ZoneSet::ZonesFromPoint(POINT pt) const noexcept
         }
         catch (std::out_of_range)
         {
-            return {};
+            Logger::error("Exception out_of_range was thrown in ZoneSet::ZonesFromPoint");
+            return { capturedZones[0] };
         }
     }
 

--- a/src/modules/fancyzones/lib/ZoneSet.cpp
+++ b/src/modules/fancyzones/lib/ZoneSet.cpp
@@ -268,7 +268,7 @@ ZoneSet::ZonesFromPoint(POINT pt) const noexcept
                 overlap.right = min(overlap.right, current.right);
             }
 
-            // Avoid divison by zero
+            // Avoid division by zero
             int width = max(overlap.right - overlap.left, 1);
             int height = max(overlap.bottom - overlap.top, 1);
 

--- a/src/modules/fancyzones/lib/ZoneSet.h
+++ b/src/modules/fancyzones/lib/ZoneSet.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Zone.h"
+#include "Settings.h"
 
 namespace FancyZonesDataTypes
 {
@@ -151,6 +152,13 @@ interface __declspec(uuid("{E4839EB7-669D-49CF-84A9-71A2DFD851A3}")) IZoneSet : 
     IFACEMETHOD_(std::vector<size_t>, GetCombinedZoneRange)(const std::vector<size_t>& initialZones, const std::vector<size_t>& finalZones) const = 0;
 };
 
+enum struct ZoneSelectionAlgorithm
+{
+    SMALLEST = 0,
+    LARGEST = 1,
+    SUBREGION = 2,
+};
+
 struct ZoneSetConfig
 {
     ZoneSetConfig(
@@ -169,6 +177,7 @@ struct ZoneSetConfig
     FancyZonesDataTypes::ZoneSetLayoutType LayoutType{};
     HMONITOR Monitor{};
     int SensitivityRadius;
+    ZoneSelectionAlgorithm SelectionAlgorithm = ZoneSelectionAlgorithm::SMALLEST;
 };
 
 winrt::com_ptr<IZoneSet> MakeZoneSet(ZoneSetConfig const& config) noexcept;

--- a/src/modules/fancyzones/tests/UnitTests/ZoneSet.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/ZoneSet.Spec.cpp
@@ -483,7 +483,9 @@ namespace FancyZonesUnitTests
 
                 m_set->MoveWindowIntoZoneByPoint(window, Mocks::Window(), POINT{ 50, 50 });
 
-                Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window));
+                // Move into the middle zone, since we're in the middle of the overlapped area.
+                // See the implementation of ZonesFromPoint.
+                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window));
             }
     };
 

--- a/src/modules/fancyzones/tests/UnitTests/ZoneSet.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/ZoneSet.Spec.cpp
@@ -483,9 +483,7 @@ namespace FancyZonesUnitTests
 
                 m_set->MoveWindowIntoZoneByPoint(window, Mocks::Window(), POINT{ 50, 50 });
 
-                // Move into the middle zone, since we're in the middle of the overlapped area.
-                // See the implementation of ZonesFromPoint.
-                Assert::IsTrue(std::vector<size_t>{ 1 } == m_set->GetZoneIndexSetFromWindow(window));
+                Assert::IsTrue(std::vector<size_t>{ 2 } == m_set->GetZoneIndexSetFromWindow(window));
             }
     };
 


### PR DESCRIPTION
## Summary of the Pull Request

Some users like to have their zones overlap, sometimes, it was impossible to drop a window into a zone if it's covered by other, smaller zones. This PR should hopefully fulfill these users' needs. For the discussion, see issue #1167 

**What is include in the PR:** 

A modification of a single function. With this change, if there are multiple overlapping zones covering the point above which the user is hovering, one of the zones will be selected based on the position inside the overlapped area, allowing the user to drop the window into the desired zone.

**How does someone test / validate:** 

Check the discussion in #1167. Also, make sure there are no changes in behavior if zones don't overlap, e.g. we can still select multiple non-overlapping zones by hovering between them.

One unit test is failing but I will add a commit to this PR to fix it.

## Quality Checklist

- [x] **Linked issue:** #1167
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] ~~**Tests:** Added/updated and all pass~~ **(see above)**
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
