### PR TITLE
[Runner] Open settings when restarted as admin

### DIFF
--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -418,7 +418,8 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         if ((elevated ||
              general_settings.GetNamedBoolean(L"run_elevated", false) == false ||
              std::string(lpCmdLine).find("--dont-elevate") != std::string::npos))
-        {   
+        {
+
             result = runner(elevated, openSettings);
         }
         else

--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -409,7 +409,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         modules();
 
         auto general_settings = load_general_settings();
-        bool openSettings = std::string(lpCmdLine).find("--open-settings") != std::string::npos;
+        const bool openSettings = std::string(lpCmdLine).find("--open-settings") != std::string::npos;
 
         // Apply the general settings but don't save it as the modules() variable has not been loaded yet
         apply_general_settings(general_settings, false);

--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -77,7 +77,7 @@ void open_menu_from_another_instance()
     PostMessageW(hwnd_main, WM_COMMAND, ID_SETTINGS_MENU_COMMAND, 0);
 }
 
-int runner(bool isProcessElevated)
+int runner(bool isProcessElevated, bool openSettings)
 {
     std::filesystem::path logFilePath(PTSettingsHelper::get_root_save_folder_location());
     logFilePath.append(LogSettings::runnerLogPath);
@@ -155,6 +155,11 @@ int runner(bool isProcessElevated)
         start_initial_powertoys();
 
         Trace::EventLaunch(get_product_version(), isProcessElevated);
+
+        if (openSettings)
+        {
+            open_settings_window();
+        }
 
         result = run_message_loop();
     }
@@ -404,6 +409,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         modules();
 
         auto general_settings = load_general_settings();
+        bool openSettings = std::string(lpCmdLine).find("--open-settings") != std::string::npos;
 
         // Apply the general settings but don't save it as the modules() variable has not been loaded yet
         apply_general_settings(general_settings, false);
@@ -411,13 +417,13 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         const bool elevated = is_process_elevated();
         if ((elevated ||
              general_settings.GetNamedBoolean(L"run_elevated", false) == false ||
-             strcmp(lpCmdLine, "--dont-elevate") == 0))
-        {
-            result = runner(elevated);
+             std::string(lpCmdLine).find("--dont-elevate") != std::string::npos))
+        {   
+            result = runner(elevated, openSettings);
         }
         else
         {
-            schedule_restart_as_elevated();
+            schedule_restart_as_elevated(openSettings);
             result = 0;
         }
     }

--- a/src/runner/restart_elevated.cpp
+++ b/src/runner/restart_elevated.cpp
@@ -7,14 +7,16 @@ enum State
 {
     None,
     RestartAsElevated,
+    RestartAsElevatedOpenSettings,
     RestartAsNonElevated
 };
 static State state = None;
 
-void schedule_restart_as_elevated()
+void schedule_restart_as_elevated(bool openSettings)
 {
-    state = RestartAsElevated;
+    state = openSettings ? RestartAsElevatedOpenSettings : RestartAsElevated;
 }
+
 
 void schedule_restart_as_non_elevated()
 {
@@ -36,6 +38,8 @@ bool restart_if_scheduled()
     {
     case RestartAsElevated:
         return run_elevated(exe_path.get(), {});
+    case RestartAsElevatedOpenSettings:
+        return run_elevated(exe_path.get(), L"--open-settings");
     case RestartAsNonElevated:
         return run_non_elevated(exe_path.get(), L"--dont-elevate", NULL);
     default:

--- a/src/runner/restart_elevated.h
+++ b/src/runner/restart_elevated.h
@@ -1,5 +1,5 @@
 #pragma once
-void schedule_restart_as_elevated();
+void schedule_restart_as_elevated(bool openSettings);
 void schedule_restart_as_non_elevated();
 bool is_restart_scheduled();
 bool restart_if_scheduled();

--- a/src/runner/settings_window.cpp
+++ b/src/runner/settings_window.cpp
@@ -79,7 +79,7 @@ std::optional<std::wstring> dispatch_json_action_to_module(const json::JsonObjec
                     }
                     else
                     {
-                        schedule_restart_as_elevated();
+                        schedule_restart_as_elevated(true);
                         PostQuitMessage(0);
                     }
                 }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
`--open-settings` parameter added to `PowerToys.exe` used when user restart the PowerToys as admin

**What is include in the PR:** 
When the user press **Restart as administrator** button from settings UI PowerToys is restarted and settings UI is opened

**How does someone test / validate:** 
- Start PowerToys as user
- Open Settings
- Press **Restart as administrator** button
- PowerToys should be restarted and settings UI should be opened

## Quality Checklist

- [x] **Linked issue:** #3201
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
