### PR TITLE
[FanzyZones] app history and zone settings granular saving

### DIFF
--- a/src/modules/fancyzones/dll/dllmain.cpp
+++ b/src/modules/fancyzones/dll/dllmain.cpp
@@ -162,6 +162,9 @@ public:
         m_settings = MakeFancyZonesSettings(reinterpret_cast<HINSTANCE>(&__ImageBase), FancyZonesModule::get_name(), FancyZonesModule::get_key());
         FancyZonesDataInstance().LoadFancyZonesData();
         s_instance = this;
+
+        // TODO: consider removing this call since the registry hasn't been used since 0.15
+        DeleteFancyZonesRegistryData();
     }
 
 private:

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -942,7 +942,7 @@ void FancyZones::AddZoneWindow(HMONITOR monitor, const std::wstring& deviceId) n
             if (workArea)
             {
                 m_workAreaHandler.AddWorkArea(m_currentDesktopId, monitor, workArea);
-                FancyZonesDataInstance().SaveFancyZonesData();
+                FancyZonesDataInstance().SaveZoneSettings();
             }
         }
     }

--- a/src/modules/fancyzones/lib/FancyZonesData.cpp
+++ b/src/modules/fancyzones/lib/FancyZonesData.cpp
@@ -16,6 +16,7 @@
 #include <sstream>
 #include <unordered_set>
 #include <common/utils/process_path.h>
+#include <common/logger/logger.h>
 
 // Non-localizable strings
 namespace NonLocalizable
@@ -523,14 +524,14 @@ void FancyZonesData::SaveAppZoneHistoryAndZoneSettings() const
 
 void FancyZonesData::SaveZoneSettings() const
 {
-    OutputDebugStringW(L"SaveZoneSettings\n");
+    Logger::trace("FancyZonesData::SaveZoneSettings()");
     std::scoped_lock lock{ dataLock };
     JSONHelpers::SaveZoneSettings(zonesSettingsFileName, deviceInfoMap, customZoneSetsMap);
 }
 
 void FancyZonesData::SaveAppZoneHistory() const
 {
-    OutputDebugStringW(L"SaveAppZoneHistory\n");
+    Logger::trace("FancyZonesData::SaveAppZoneHistory()");
     std::scoped_lock lock{ dataLock };
     JSONHelpers::SaveAppZoneHistory(appZoneHistoryFileName, appZoneHistoryMap);
 }

--- a/src/modules/fancyzones/lib/FancyZonesData.h
+++ b/src/modules/fancyzones/lib/FancyZonesData.h
@@ -81,7 +81,7 @@ public:
     json::JsonObject GetPersistFancyZonesJSON();
 
     void LoadFancyZonesData();
-    void SaveFancyZonesData() const;
+    void SaveAppZoneHistoryAndZoneSettings() const;
     void SaveZoneSettings() const;
     void SaveAppZoneHistory() const;
 

--- a/src/modules/fancyzones/tests/UnitTests/JsonHelpers.Tests.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/JsonHelpers.Tests.cpp
@@ -1727,7 +1727,7 @@ namespace FancyZonesUnitTests
                 data.SetSettingsModulePath(m_moduleName);
                 const auto& jsonPath = data.zonesSettingsFileName;
 
-                data.SaveFancyZonesData();
+                data.SaveAppZoneHistoryAndZoneSettings();
                 bool actual = std::filesystem::exists(jsonPath);
 
                 Assert::IsTrue(actual);
@@ -1751,7 +1751,7 @@ namespace FancyZonesUnitTests
                 // write json with templates to file
                 json::to_file(jsonPath, expectedJsonObj);
 
-                data.SaveFancyZonesData();
+                data.SaveAppZoneHistoryAndZoneSettings();
 
                 // verify that file was written successfully
                 Assert::IsTrue(std::filesystem::exists(jsonPath));


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Fix for a FZ regression in 0.31.1 that caused Win+arrow to stop working properly.
The `SaveFancyZonesData()` method was used to save the app zone history when a window is zoned.
Because  `SaveFancyZonesData()` also saves the `zones-settings.json` file, the  `zones-settings.json` was triggered to reload the fine and recreate some internal data structure, causing win+arrow to not work properly.

**What is include in the PR:** 
This PR replaces some calls to `SaveFancyZonesData()` with calls to `SaveAppZoneHistory()` to avoid triggering the file watcher for `zones-settings.json`

**How does someone test / validate:** 
Turn on these options:
![image](https://user-images.githubusercontent.com/3206696/106887081-f392e880-66e4-11eb-9645-8d9f9043d4a9.png)
Create a large grid layout (9 or more zones) and try zoning a window using win+arrows and win+ctrl+alt+arrows.
Also test that `app-zone-history.json` is correctly updated when removing virtual desktops.

## Quality Checklist

- [x] **Linked issue:** https://github.com/microsoft/PowerToys/issues/9453
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
