### PR TITLE
[FanzyZones] app history and zone settings granular saving (#9489)

### DIFF
--- a/src/modules/fancyzones/dll/dllmain.cpp
+++ b/src/modules/fancyzones/dll/dllmain.cpp
@@ -162,6 +162,9 @@ public:
         m_settings = MakeFancyZonesSettings(reinterpret_cast<HINSTANCE>(&__ImageBase), FancyZonesModule::get_name(), FancyZonesModule::get_key());
         FancyZonesDataInstance().LoadFancyZonesData();
         s_instance = this;
+
+        // TODO: consider removing this call since the registry hasn't been used since 0.15
+        DeleteFancyZonesRegistryData();
     }
 
 private:

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -942,7 +942,7 @@ void FancyZones::AddZoneWindow(HMONITOR monitor, const std::wstring& deviceId) n
             if (workArea)
             {
                 m_workAreaHandler.AddWorkArea(m_currentDesktopId, monitor, workArea);
-                FancyZonesDataInstance().SaveFancyZonesData();
+                FancyZonesDataInstance().SaveZoneSettings();
             }
         }
     }

--- a/src/modules/fancyzones/lib/FancyZonesData.cpp
+++ b/src/modules/fancyzones/lib/FancyZonesData.cpp
@@ -16,6 +16,7 @@
 #include <sstream>
 #include <unordered_set>
 #include <common/utils/process_path.h>
+#include <common/logger/logger.h>
 
 // Non-localizable strings
 namespace NonLocalizable
@@ -222,7 +223,10 @@ void FancyZonesData::UpdatePrimaryDesktopData(const std::wstring& desktopId)
     auto replaceDesktopId = [&desktopId](const std::wstring& deviceId) {
         return deviceId.substr(0, deviceId.rfind('_') + 1) + desktopId;
     };
+
     std::scoped_lock lock{ dataLock };
+    bool dirtyFlag = false;
+
     for (auto& [path, perDesktopData] : appZoneHistoryMap)
     {
         for (auto& data : perDesktopData)
@@ -230,30 +234,42 @@ void FancyZonesData::UpdatePrimaryDesktopData(const std::wstring& desktopId)
             if (ExtractVirtualDesktopId(data.deviceId) == NonLocalizable::DefaultGuid)
             {
                 data.deviceId = replaceDesktopId(data.deviceId);
+                dirtyFlag = true;
             }
         }
     }
+    
     std::vector<std::wstring> toReplace{};
+    
     for (const auto& [id, data] : deviceInfoMap)
     {
         if (ExtractVirtualDesktopId(id) == NonLocalizable::DefaultGuid)
         {
             toReplace.push_back(id);
+            dirtyFlag = true;
         }
     }
+    
     for (const auto& id : toReplace)
     {
         auto mapEntry = deviceInfoMap.extract(id);
         mapEntry.key() = replaceDesktopId(id);
         deviceInfoMap.insert(std::move(mapEntry));
     }
-    SaveFancyZonesData();
+    
+    // TODO: when updating the primary desktop GUID, the app zone history also needs to be updated 
+    if (dirtyFlag)
+    {
+        SaveZoneSettings();
+    }
 }
 
 void FancyZonesData::RemoveDeletedDesktops(const std::vector<std::wstring>& activeDesktops)
 {
     std::unordered_set<std::wstring> active(std::begin(activeDesktops), std::end(activeDesktops));
     std::scoped_lock lock{ dataLock };
+    bool dirtyFlag = false;
+
     for (auto it = std::begin(deviceInfoMap); it != std::end(deviceInfoMap);)
     {
         std::wstring desktopId = ExtractVirtualDesktopId(it->first);
@@ -264,12 +280,17 @@ void FancyZonesData::RemoveDeletedDesktops(const std::vector<std::wstring>& acti
             {
                 RemoveDesktopAppZoneHistory(desktopId);
                 it = deviceInfoMap.erase(it);
+                dirtyFlag = true;
                 continue;
             }
         }
         ++it;
     }
-    SaveFancyZonesData();
+
+    if (dirtyFlag)
+    {
+        SaveAppZoneHistoryAndZoneSettings();
+    }
 }
 
 bool FancyZonesData::IsAnotherWindowOfApplicationInstanceZoned(HWND window, const std::wstring_view& deviceId) const
@@ -392,7 +413,7 @@ bool FancyZonesData::RemoveAppLastZone(HWND window, const std::wstring_view& dev
                     {
                         appZoneHistoryMap.erase(processPath);
                     }
-                    SaveFancyZonesData();
+                    SaveAppZoneHistory();
                     return true;
                 }
                 else
@@ -436,7 +457,7 @@ bool FancyZonesData::SetAppLastZones(HWND window, const std::wstring& deviceId, 
                 data.processIdToHandleMap[processId] = window;
                 data.zoneSetUuid = zoneSetId;
                 data.zoneIndexSet = zoneIndexSet;
-                SaveFancyZonesData();
+                SaveAppZoneHistory();
                 return true;
             }
         }
@@ -460,7 +481,7 @@ bool FancyZonesData::SetAppLastZones(HWND window, const std::wstring& deviceId, 
         appZoneHistoryMap[processPath] = std::vector<FancyZonesDataTypes::AppZoneHistoryData>{ data };
     }
 
-    SaveFancyZonesData();
+    SaveAppZoneHistory();
     return true;
 }
 
@@ -483,7 +504,7 @@ void FancyZonesData::LoadFancyZonesData()
 {
     if (!std::filesystem::exists(zonesSettingsFileName))
     {
-        SaveFancyZonesData();
+        SaveAppZoneHistoryAndZoneSettings();
     }
     else
     {
@@ -493,25 +514,24 @@ void FancyZonesData::LoadFancyZonesData()
         deviceInfoMap = JSONHelpers::ParseDeviceInfos(fancyZonesDataJSON);
         customZoneSetsMap = JSONHelpers::ParseCustomZoneSets(fancyZonesDataJSON);
     }
-
-    DeleteFancyZonesRegistryData();
 }
 
-void FancyZonesData::SaveFancyZonesData() const
+void FancyZonesData::SaveAppZoneHistoryAndZoneSettings() const
 {
-    std::scoped_lock lock{ dataLock };
-    JSONHelpers::SaveZoneSettings(zonesSettingsFileName, deviceInfoMap, customZoneSetsMap);
-    JSONHelpers::SaveAppZoneHistory(appZoneHistoryFileName, appZoneHistoryMap);
+    SaveZoneSettings();
+    SaveAppZoneHistory();
 }
 
 void FancyZonesData::SaveZoneSettings() const
 {
+    Logger::trace("FancyZonesData::SaveZoneSettings()");
     std::scoped_lock lock{ dataLock };
     JSONHelpers::SaveZoneSettings(zonesSettingsFileName, deviceInfoMap, customZoneSetsMap);
 }
 
 void FancyZonesData::SaveAppZoneHistory() const
 {
+    Logger::trace("FancyZonesData::SaveAppZoneHistory()");
     std::scoped_lock lock{ dataLock };
     JSONHelpers::SaveAppZoneHistory(appZoneHistoryFileName, appZoneHistoryMap);
 }

--- a/src/modules/fancyzones/lib/FancyZonesData.h
+++ b/src/modules/fancyzones/lib/FancyZonesData.h
@@ -81,7 +81,7 @@ public:
     json::JsonObject GetPersistFancyZonesJSON();
 
     void LoadFancyZonesData();
-    void SaveFancyZonesData() const;
+    void SaveAppZoneHistoryAndZoneSettings() const;
     void SaveZoneSettings() const;
     void SaveAppZoneHistory() const;
 

--- a/src/modules/fancyzones/tests/UnitTests/JsonHelpers.Tests.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/JsonHelpers.Tests.cpp
@@ -1727,7 +1727,7 @@ namespace FancyZonesUnitTests
                 data.SetSettingsModulePath(m_moduleName);
                 const auto& jsonPath = data.zonesSettingsFileName;
 
-                data.SaveFancyZonesData();
+                data.SaveAppZoneHistoryAndZoneSettings();
                 bool actual = std::filesystem::exists(jsonPath);
 
                 Assert::IsTrue(actual);
@@ -1751,7 +1751,7 @@ namespace FancyZonesUnitTests
                 // write json with templates to file
                 json::to_file(jsonPath, expectedJsonObj);
 
-                data.SaveFancyZonesData();
+                data.SaveAppZoneHistoryAndZoneSettings();
 
                 // verify that file was written successfully
                 Assert::IsTrue(std::filesystem::exists(jsonPath));


### PR DESCRIPTION
move DeleteFancyZonesRegistryData to proper place
add logging

## Summary of the Pull Request

**What is this about:**
Cherry-pick hot fix from stable see https://github.com/microsoft/PowerToys/pull/9489

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** https://github.com/microsoft/PowerToys/issues/9453
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
