### PR TITLE
[PT Run] Helper for Execute Shells Process Calls

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/ContextMenuLoader.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/ContextMenuLoader.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO.Abstractions;
 using System.Reflection;
 using System.Windows;
@@ -112,16 +111,10 @@ namespace Microsoft.Plugin.Folder
                 AcceleratorModifiers = ModifierKeys.Control | ModifierKeys.Shift,
                 Action = _ =>
                 {
-                    try
-                    {
-                        Process.Start("explorer.exe", $" /select,\"{record.FullPath}\"");
-                    }
-                    catch (Exception e)
+                    if (!Helper.OpenInShell("explorer.exe", $"/select,\"{record.FullPath}\""))
                     {
                         var message = $"{Properties.Resources.Microsoft_plugin_folder_file_open_failed} {record.FullPath}";
-                        Log.Exception(message, e, GetType());
                         _context.API.ShowMsg(message);
-
                         return false;
                     }
 

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/ShellAction.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/ShellAction.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Reflection;
 using System.Text.RegularExpressions;
+using Wox.Infrastructure;
 using Wox.Plugin;
 using Wox.Plugin.Logger;
 
@@ -48,23 +49,12 @@ namespace Microsoft.Plugin.Folder.Sources
             return sanitizedPath.Insert(0, "\\");
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "We want to keep the process alive and instead inform the user of the error")]
         private static bool OpenFileOrFolder(string path, IPublicAPI contextApi)
         {
-            try
+            if (!Helper.OpenInShell(path))
             {
-                using (var process = new Process())
-                {
-                    process.StartInfo.FileName = path;
-                    process.StartInfo.UseShellExecute = true;
-                    process.Start();
-                }
-            }
-            catch (Exception e)
-            {
-                string messageBoxTitle = string.Format(CultureInfo.InvariantCulture, "{0} {1}", Properties.Resources.wox_plugin_folder_select_folder_OpenFileOrFolder_error_message, path);
-                Log.Exception($"Failed to open {path}, {e.Message}", e, MethodBase.GetCurrentMethod().DeclaringType);
-                contextApi.ShowMsg(messageBoxTitle, e.Message);
+                var message = string.Format(CultureInfo.InvariantCulture, "{0}: {1}", Properties.Resources.wox_plugin_folder_select_folder_OpenFileOrFolder_error_message, path);
+                contextApi.ShowMsg(message);
             }
 
             return true;

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/ContextMenuLoader.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/ContextMenuLoader.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO.Abstractions;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -175,15 +174,9 @@ namespace Microsoft.Plugin.Indexer
                 AcceleratorModifiers = ModifierKeys.Control | ModifierKeys.Shift,
                 Action = _ =>
                 {
-                    try
-                    {
-                        Process.Start("explorer.exe", $" /select,\"{record.Path}\"");
-                    }
-                    catch (Exception e)
+                    if (!Helper.OpenInShell("explorer.exe", $"/select,\"{record.Path}\""))
                     {
                         var message = $"{Properties.Resources.Microsoft_plugin_indexer_folder_open_failed} {record.Path}";
-                        Log.Exception(message, e, GetType());
-
                         _context.API.ShowMsg(message);
                         return false;
                     }

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Main.cs
@@ -4,8 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Diagnostics;
 using System.Globalization;
 using System.IO.Abstractions;
 using System.Linq;
@@ -16,6 +14,7 @@ using Microsoft.Plugin.Indexer.DriveDetection;
 using Microsoft.Plugin.Indexer.SearchHelper;
 using Microsoft.PowerToys.Settings.UI.Library;
 using Microsoft.Search.Interop;
+using Wox.Infrastructure;
 using Wox.Infrastructure.Storage;
 using Wox.Plugin;
 using Wox.Plugin.Logger;
@@ -85,15 +84,7 @@ namespace Microsoft.Plugin.Indexer
                                 IcoPath = WarningIconPath,
                                 Action = e =>
                                 {
-                                    try
-                                    {
-                                        Process.Start(GetWindowsSearchSettingsProcessInfo());
-                                    }
-                                    catch (Exception ex)
-                                    {
-                                        Log.Exception($"Unable to launch Windows Search Settings: {ex.Message}", ex, GetType());
-                                    }
-
+                                    Helper.OpenInShell("ms-settings:cortana-windowssearch");
                                     return true;
                                 },
                             });
@@ -129,23 +120,13 @@ namespace Microsoft.Plugin.Indexer
                             r.ToolTipData = new ToolTipData(toolTipTitle, toolTipText);
                             r.Action = c =>
                             {
-                                bool hide;
-                                try
+                                bool hide = true;
+                                if (!Helper.OpenInShell(path, null, workingDir))
                                 {
-                                    Process.Start(new ProcessStartInfo
-                                    {
-                                        FileName = path,
-                                        UseShellExecute = true,
-                                        WorkingDirectory = workingDir,
-                                    });
-                                    hide = true;
-                                }
-                                catch (Win32Exception)
-                                {
+                                    hide = false;
                                     var name = $"Plugin: {_context.CurrentPluginMetadata.Name}";
                                     var msg = Properties.Resources.Microsoft_plugin_indexer_file_open_failed;
                                     _context.API.ShowMsg(name, msg, string.Empty);
-                                    hide = false;
                                 }
 
                                 return hide;
@@ -237,18 +218,6 @@ namespace Microsoft.Plugin.Indexer
         public Control CreateSettingPanel()
         {
             throw new NotImplementedException();
-        }
-
-        // Returns the Process Start Information for the new Windows Search Settings
-        public static ProcessStartInfo GetWindowsSearchSettingsProcessInfo()
-        {
-            var ps = new ProcessStartInfo("ms-settings:cortana-windowssearch")
-            {
-                UseShellExecute = true,
-                Verb = "open",
-            };
-
-            return ps;
         }
 
         protected virtual void Dispose(bool disposing)

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program.UnitTests/Storage/Win32ProgramRepositoryTest.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program.UnitTests/Storage/Win32ProgramRepositoryTest.cs
@@ -240,7 +240,7 @@ namespace Microsoft.Plugin.Program.UnitTests.Storage
             // ShellLinkHelper must be mocked for lnk applications
             var mockShellLink = new Mock<IShellLinkHelper>();
             mockShellLink.Setup(m => m.RetrieveTargetPath(It.IsAny<string>())).Returns(string.Empty);
-            Win32Program.Helper = mockShellLink.Object;
+            Win32Program.ShellLinkHelper = mockShellLink.Object;
 
             // Act
             _fileSystemMocks[0].Raise(m => m.Changed += null, e);
@@ -310,7 +310,7 @@ namespace Microsoft.Plugin.Program.UnitTests.Storage
             // ShellLinkHelper must be mocked for lnk applications
             var mockShellLink = new Mock<IShellLinkHelper>();
             mockShellLink.Setup(m => m.RetrieveTargetPath(It.IsAny<string>())).Returns(string.Empty);
-            Win32Program.Helper = mockShellLink.Object;
+            Win32Program.ShellLinkHelper = mockShellLink.Object;
 
             string fullPath = directory + "\\" + path;
             Win32Program item = new Win32Program
@@ -343,7 +343,7 @@ namespace Microsoft.Plugin.Program.UnitTests.Storage
             // ShellLinkHelper must be mocked for lnk applications
             var mockShellLink = new Mock<IShellLinkHelper>();
             mockShellLink.Setup(m => m.RetrieveTargetPath(It.IsAny<string>())).Returns(string.Empty);
-            Win32Program.Helper = mockShellLink.Object;
+            Win32Program.ShellLinkHelper = mockShellLink.Object;
 
             // old item and new item are the actual items when they are in existence
             Win32Program olditem = new Win32Program

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/UWPApplication.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/UWPApplication.cs
@@ -170,7 +170,7 @@ namespace Microsoft.Plugin.Program.Programs
                     AcceleratorModifiers = ModifierKeys.Control | ModifierKeys.Shift,
                     Action = _ =>
                     {
-                        Main.StartProcess(Process.Start, new ProcessStartInfo("explorer", Package.Location));
+                        Helper.OpenInShell(Package.Location);
 
                         return true;
                     },

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32Program.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32Program.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Plugin.Program.Programs
 
         public static IFile FileWrapper { get; set; } = new FileSystem().File;
 
-        public static IShellLinkHelper Helper { get; set; } = new ShellLinkHelper();
+        public static IShellLinkHelper ShellLinkHelper { get; set; } = new ShellLinkHelper();
 
         public static IDirectoryWrapper DirectoryWrapper { get; set; } = new DirectoryWrapper();
 
@@ -294,7 +294,7 @@ namespace Microsoft.Plugin.Program.Programs
                     AcceleratorModifiers = ModifierKeys.Control | ModifierKeys.Shift,
                     Action = _ =>
                     {
-                        Main.StartProcess(Process.Start, new ProcessStartInfo("explorer", ParentDirectory));
+                        Helper.OpenInShell(ParentDirectory);
                         return true;
                     },
                 });
@@ -473,7 +473,7 @@ namespace Microsoft.Plugin.Program.Programs
                 const int MAX_PATH = 260;
                 StringBuilder buffer = new StringBuilder(MAX_PATH);
 
-                string target = Helper.RetrieveTargetPath(path);
+                string target = ShellLinkHelper.RetrieveTargetPath(path);
 
                 if (!string.IsNullOrEmpty(target))
                 {
@@ -485,7 +485,7 @@ namespace Microsoft.Plugin.Program.Programs
                         program.FullPath = Path.GetFullPath(target).ToLower(CultureInfo.CurrentCulture);
                         program.AppType = GetAppTypeFromPath(target);
 
-                        var description = Helper.Description;
+                        var description = ShellLinkHelper.Description;
                         if (!string.IsNullOrEmpty(description))
                         {
                             program.Description = description;

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Uri/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Uri/Main.cs
@@ -4,11 +4,11 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO.Abstractions;
 using System.Text;
 using ManagedCommon;
 using Microsoft.Plugin.Uri.UriHelper;
+using Wox.Infrastructure;
 using Wox.Infrastructure.Storage;
 using Wox.Plugin;
 using Wox.Plugin.Logger;
@@ -67,10 +67,14 @@ namespace Microsoft.Plugin.Uri
                         : DefaultIconPath,
                     Action = action =>
                     {
-                        Process.Start(new ProcessStartInfo(uriResultString)
+                        if (!Helper.OpenInShell(uriResultString))
                         {
-                            UseShellExecute = true,
-                        });
+                            var title = $"Plugin: {Properties.Resources.Microsoft_plugin_uri_plugin_name}";
+                            var message = $"{Properties.Resources.Microsoft_plugin_uri_open_failed}: {uriResultString}";
+                            Context.API.ShowMsg(title, message);
+                            return false;
+                        }
+
                         return true;
                     },
                 });

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Uri/Properties/Resources.Designer.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Uri/Properties/Resources.Designer.cs
@@ -61,6 +61,15 @@ namespace Microsoft.Plugin.Uri.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to open URL.
+        /// </summary>
+        public static string Microsoft_plugin_uri_open_failed {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_uri_open_failed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Handles urls.
         /// </summary>
         public static string Microsoft_plugin_uri_plugin_description {

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Uri/Properties/Resources.resx
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Uri/Properties/Resources.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="Microsoft_plugin_uri_open_failed" xml:space="preserve">
+    <value>Failed to open URL</value>
+  </data>
   <data name="Microsoft_plugin_uri_plugin_description" xml:space="preserve">
     <value>Handles urls</value>
   </data>

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Registry/Helper/RegistryHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Registry/Helper/RegistryHelper.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Diagnostics;
 using System.Linq;
 using Microsoft.PowerToys.Run.Plugin.Registry.Classes;
 using Microsoft.PowerToys.Run.Plugin.Registry.Constants;
@@ -144,21 +143,8 @@ namespace Microsoft.PowerToys.Run.Plugin.Registry.Helper
             // it's impossible to directly open a key via command-line option, so we must override the last remember key
             Win32.Registry.SetValue(@"HKEY_Current_User\Software\Microsoft\Windows\CurrentVersion\Applets\Regedit", "LastKey", fullKey);
 
-            var processStartInfo = new ProcessStartInfo
-            {
-                // -m => allow multi-instance (hidden start option)
-                Arguments = "-m",
-
-                FileName = "regedit.exe",
-
-                // Start as administrator
-                Verb = "runas",
-
-                // Start as administrator will not work without this
-                UseShellExecute = true,
-            };
-
-            Process.Start(processStartInfo);
+            // -m => allow multi-instance (hidden start option)
+            Wox.Infrastructure.Helper.OpenInShell("regedit.exe", "-m", null, true);
         }
 
         /// <summary>

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Service/Helpers/ServiceHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Service/Helpers/ServiceHelper.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Reflection;
 using System.ServiceProcess;
 using Microsoft.PowerToys.Run.Plugin.Service.Properties;
+using Wox.Infrastructure;
 using Wox.Plugin;
 using Wox.Plugin.Logger;
 
@@ -91,20 +92,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Service.Helpers
 
         public static void OpenServices()
         {
-            try
-            {
-                var info = new ProcessStartInfo
-                {
-                    FileName = "services.msc",
-                    UseShellExecute = true,
-                };
-
-                Process.Start(info);
-            }
-            catch (Win32Exception ex)
-            {
-                Log.Error(ex.Message, MethodBase.GetCurrentMethod().DeclaringType);
-            }
+            Helper.OpenInShell("services.msc");
         }
 
         private static string GetResultTitle(ServiceController serviceController)

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Service/Microsoft.PowerToys.Run.Plugin.Service.csproj
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Service/Microsoft.PowerToys.Run.Plugin.Service.csproj
@@ -71,6 +71,7 @@
   
   <ItemGroup>
     <ProjectReference Include="..\..\Wox.Plugin\Wox.Plugin.csproj" />
+    <ProjectReference Include="..\..\Wox.Infrastructure\Wox.Infrastructure.csproj" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.System/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.System/Main.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Windows;
 using System.Windows.Interop;
 using ManagedCommon;
@@ -70,7 +69,7 @@ namespace Microsoft.PowerToys.Run.Plugin.System
                     IcoPath = $"Images\\shutdown.{IconTheme}.png",
                     Action = c =>
                     {
-                        Process.Start("shutdown", "/s /t 0");
+                        Helper.OpenInShell("shutdown", "/s /t 0");
                         return true;
                     },
                 },
@@ -81,7 +80,7 @@ namespace Microsoft.PowerToys.Run.Plugin.System
                     IcoPath = $"Images\\restart.{IconTheme}.png",
                     Action = c =>
                     {
-                        Process.Start("shutdown", "/r /t 0");
+                        Helper.OpenInShell("shutdown", "/r /t 0");
                         return true;
                     },
                 },

--- a/src/modules/launcher/PowerLauncher/ReportWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/ReportWindow.xaml.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.IO.Abstractions;
@@ -12,9 +11,7 @@ using System.Text;
 using System.Windows;
 using System.Windows.Documents;
 using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
 using PowerLauncher.Helper;
-using Wox.Infrastructure;
 using Wox.Infrastructure.Image;
 using Wox.Plugin.Logger;
 
@@ -83,12 +80,8 @@ namespace PowerLauncher
 
         private void RepositoryHyperlink_Click(object sender, RoutedEventArgs e)
         {
-            var ps = new ProcessStartInfo((sender as Hyperlink).NavigateUri.ToString())
-            {
-                UseShellExecute = true,
-                Verb = "open",
-            };
-            Process.Start(ps);
+            var uri = (sender as Hyperlink).NavigateUri.ToString();
+            Wox.Infrastructure.Helper.OpenInShell(uri);
         }
     }
 }

--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
@@ -240,11 +239,6 @@ namespace PowerLauncher.ViewModel
 
             SelectFirstResultCommand = new RelayCommand(_ => SelectedResults.SelectFirstResult());
 
-            StartHelpCommand = new RelayCommand(_ =>
-            {
-                Process.Start("https://aka.ms/PowerToys/");
-            });
-
             OpenResultWithKeyboardCommand = new RelayCommand(index =>
             {
                 OpenResultsEvent(index, false);
@@ -458,8 +452,6 @@ namespace PowerLauncher.ViewModel
         public ICommand SelectPrevPageCommand { get; set; }
 
         public ICommand SelectFirstResultCommand { get; set; }
-
-        public ICommand StartHelpCommand { get; set; }
 
         public ICommand LoadContextMenuCommand { get; set; }
 

--- a/src/modules/launcher/Wox.Infrastructure/Helper.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Helper.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO.Abstractions;
 using System.Reflection;
@@ -116,6 +117,34 @@ namespace Wox.Infrastructure
             };
 
             return Process.Start(processStartInfo);
+        }
+
+        public static bool OpenInShell(string path, string arguments = null, string workingDir = null, bool runAsAdmin = false)
+        {
+            using (var process = new Process())
+            {
+                process.StartInfo.FileName = path;
+                process.StartInfo.WorkingDirectory = string.IsNullOrWhiteSpace(workingDir) ? string.Empty : workingDir;
+                process.StartInfo.Arguments = string.IsNullOrWhiteSpace(arguments) ? string.Empty : arguments;
+
+                if (runAsAdmin)
+                {
+                    process.StartInfo.Verb = "RunAs";
+                }
+
+                process.StartInfo.UseShellExecute = true;
+
+                try
+                {
+                    process.Start();
+                    return true;
+                }
+                catch (Win32Exception ex)
+                {
+                    Log.Exception($"Unable to open {path}: {ex.Message}", ex, MethodBase.GetCurrentMethod().DeclaringType);
+                    return false;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Common helper for execute shell across PT Run plugins.

**What is include in the PR:** 
Removed most of the `Process.Start` used for invoking shell across PT Run plugins.
Still have 2 hardcorded `explorer.exe` in folder and indexer plugin used to focus the file when explorer is opened https://github.com/microsoft/PowerToys/issues/7339#issuecomment-774528261
 
**How does someone test / validate:** 
- Folder plugin
  - Open file
  - Open folder
  - Open containing folder
- Indexer plugin
  - Open containing folder
  - Click on index warning
  - Open file
- Program plugin
  - Open containing folder UWP app
  - Open containing folder Win32 app
- URI plugin
  - Open an URI
- Registry plugin
  - Open registry
- Service plugin
  - Open services.msc
- System plugin
  - Shutdown
  - Reboot
- Report Window
  - Open GitHub URL

## Quality Checklist

- [x] **Linked issue:** #4622 #7339
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
