### PR TITLE
[PT Run] Tilde as user home

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/Path/FolderHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/Path/FolderHelper.cs
@@ -84,10 +84,16 @@ namespace Microsoft.Plugin.Folder.Sources
                 throw new ArgumentNullException(nameof(search));
             }
 
-            // Absolute path of system drive: \Windows\System32
             if (search[0] == '\\' && (search.Length == 1 || search[1] != '\\'))
             {
+                // Absolute path of system drive: \Windows\System32
                 search = Path.Combine(Path.GetPathRoot(Environment.SystemDirectory), search.Substring(1));
+            }
+            else if (search[0] == '~')
+            {
+                // User home
+                var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+                search = search.Length > 1 ? Path.Combine(home, search.Substring(2)) : home;
             }
 
             return Environment.ExpandEnvironmentVariables(search);


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

![image](https://user-images.githubusercontent.com/25966642/107279110-e7958680-6a56-11eb-8637-5c3533949e8a.png)

**What is include in the PR:** 
Tilde recognized as user home directory as PowerShell does.

**How does someone test / validate:** 
- Open PT Run
- Type `~`
- Should be recognized as user home directory `%USERPROFILE%`

## Quality Checklist

- [x] **Linked issue:** #9578
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
