### PR TITLE
[PT Settings] Opening windows color settings from inside PT

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Helpers/StartProcessHelper.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Helpers/StartProcessHelper.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+
+namespace Microsoft.PowerToys.Settings.UI.Helpers
+{
+    public static class StartProcessHelper
+    {
+        public const string ColorsSettings = "ms-settings:colors";
+
+        public static void Start(string process)
+        {
+            Process.Start(new ProcessStartInfo(process) { UseShellExecute = true });
+        }
+    }
+}

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Microsoft.PowerToys.Settings.UI.csproj
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Microsoft.PowerToys.Settings.UI.csproj
@@ -108,6 +108,7 @@
     <Compile Include="Helpers\Observable.cs" />
     <Compile Include="Helpers\RelayCommand.cs" />
     <Compile Include="Helpers\ResourceExtensions.cs" />
+    <Compile Include="Helpers\StartProcessHelper.cs" />
     <Compile Include="ICoreWindowInterop.cs" />
     <Compile Include="Interop.cs" />
     <Compile Include="Services\ActivationService.cs" />

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml
@@ -106,7 +106,7 @@
 
                 <RadioButton x:Uid="Radio_Theme_Default"
                              IsChecked="{ Binding Mode=TwoWay, Path=IsSystemThemeRadioButtonChecked}"/>
-                <HyperlinkButton NavigateUri="ms-settings:colors">
+                <HyperlinkButton Click="OpenColorsSettings_Click">
                     <TextBlock x:Uid="Windows_Color_Settings" />
                 </HyperlinkButton>
             </StackPanel>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml.cs
@@ -117,5 +117,10 @@ namespace Microsoft.PowerToys.Settings.UI.Views
 
             return 0;
         }
+
+        private void OpenColorsSettings_Click(object sender, RoutedEventArgs e)
+        {
+            Helpers.StartProcessHelper.Start(Helpers.StartProcessHelper.ColorsSettings);
+        }
     }
 }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
@@ -172,7 +172,7 @@
                 <RadioButton x:Uid="Radio_Theme_Default"
                              IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.EnablePowerLauncher}"
                              IsChecked="{Binding Mode=TwoWay, Path=IsSystemThemeRadioButtonChecked}" />
-                <HyperlinkButton NavigateUri="ms-settings:colors">
+                <HyperlinkButton Click="OpenColorsSettings_Click">
                     <TextBlock x:Uid="Windows_Color_Settings" />
                 </HyperlinkButton>
             </StackPanel>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml.cs
@@ -38,6 +38,11 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             searchTypePreferencesOptions.Add(Tuple.Create(loader.GetString("PowerLauncher_SearchTypePreference_ExecutableName"), "executable_name"));
         }
 
+        private void OpenColorsSettings_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        {
+            Helpers.StartProcessHelper.Start(Helpers.StartProcessHelper.ColorsSettings);
+        }
+
         /*
         public Tuple<string, string> SelectedSearchResultPreference
         {

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ShortcutGuidePage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ShortcutGuidePage.xaml
@@ -107,7 +107,7 @@
                 <RadioButton x:Uid="Radio_Theme_Light" />
                 <RadioButton x:Uid="Radio_Theme_Default"/>
             </muxc:RadioButtons>
-            <HyperlinkButton NavigateUri="ms-settings:colors">
+            <HyperlinkButton Click="OpenColorsSettings_Click">
                 <TextBlock x:Uid="Windows_Color_Settings" />
             </HyperlinkButton>
         </StackPanel>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ShortcutGuidePage.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ShortcutGuidePage.xaml.cs
@@ -21,5 +21,10 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             ViewModel = new ShortcutGuideViewModel(SettingsRepository<GeneralSettings>.GetInstance(settingsUtils), SettingsRepository<ShortcutGuideSettings>.GetInstance(settingsUtils), ShellPage.SendDefaultIPCMessage);
             DataContext = ViewModel;
         }
+
+        private void OpenColorsSettings_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        {
+            Helpers.StartProcessHelper.Start(Helpers.StartProcessHelper.ColorsSettings);
+        }
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Replaced `NavigateUri` with a handler calling `Process.Start` to open Windows Colors settings.

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #9580 #7651 #7652
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
