### PR TITLE
[FancyZones] Use a window pool for zone windows

### DIFF
--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -60,6 +60,7 @@ namespace
             if (IsEmpty())
             {
                 HWND window = CreateWindowExW(WS_EX_TOOLWINDOW, NonLocalizable::ToolWindowClassName, L"", WS_POPUP, position.left(), position.top(), position.width(), position.height(), nullptr, nullptr, hinstance, owner);
+                Logger::info("Creating new zone window, hWnd = {}", (void*)window);
                 MakeWindowTransparent(window);
 
                 // According to ShowWindow docs, we must call it with SW_SHOWNORMAL the first time
@@ -70,6 +71,7 @@ namespace
             else
             {
                 HWND window = ExtractWindow();
+                Logger::info("Reusing zone window from pool, hWnd = {}", (void*)window);
                 SetWindowLongPtrW(window, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(owner));
                 MoveWindow(window, position.left(), position.top(), position.width(), position.height(), TRUE);
                 return window;
@@ -78,6 +80,7 @@ namespace
 
         void FreeZoneWindow(HWND window)
         {
+            Logger::info("Freeing zone window, hWnd = {}", (void*)window);
             SetWindowLongPtrW(window, GWLP_USERDATA, 0);
             ShowWindow(window, SW_HIDE);
 


### PR DESCRIPTION
## Summary of the Pull Request

This PR implements a new class which manages created HWNDs used for zone windows, in order to fix (but not close) #8976.

**What is this about:**

The reason for using this class is the need to call `ShowWindow(window, SW_SHOWNORMAL);` on each newly created window for it to be displayed properly. The call sometimes has side effects when a fullscreen app is running, and happens when the resolution change event is triggered (e.g. when running some games).

This class will serve as a pool of windows for which this call was already done.

**What is include in the PR:** 

**How does someone test / validate:** 

Check that FancyZones works and everything is displayed properly after changing resolution and connecting/disconnecting displays. Make sure that games are not minimized as in issue #8976. All relevant unit tests pass. As of now, some unit tests are broken, but that's another issue.

## Quality Checklist

- [x] **Linked issue:** #8976
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
