### PR TITLE
[bootstrapper] change newer version detected action

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -371,6 +371,7 @@ CSY
 CTAB
 CTest
 ctime
+CTLCOLORSTATIC
 ctor
 CTRLALTDEL
 Ctx
@@ -2232,6 +2233,7 @@ uint
 uintptr
 UIPI
 UIs
+UITo
 ul
 ULARGE
 ULLONG

--- a/installer/PowerToysBootstrapper/bootstrapper/Resources.resx
+++ b/installer/PowerToysBootstrapper/bootstrapper/Resources.resx
@@ -128,19 +128,19 @@
     <value>PowerToys: uninstall previous version?</value>
   </data>
   <data name="INSTALLER_EXTRACT_ERROR" xml:space="preserve">
-    <value>Couldn't extract MSI installer!</value>
+    <value>Couldn't extract MSI installer.</value>
   </data>
   <data name="EXTRACTING_INSTALLER" xml:space="preserve">
     <value>Extracting PowerToys MSI...</value>
   </data>
   <data name="UNINSTALL_PREVIOUS_VERSION_ERROR" xml:space="preserve">
-    <value>Couldn't uninstall previous PowerToys version!</value>
+    <value>Couldn't uninstall previous PowerToys version.</value>
   </data>
   <data name="DOWNLOADING_DOTNET" xml:space="preserve">
-    <value>Downloading .NET Core Runtime...</value>
+    <value>Downloading .NET Core...</value>
   </data>
   <data name="DOTNET_INSTALL_ERROR" xml:space="preserve">
-    <value>Couldn't install dotnet!</value>
+    <value>Couldn't install .NET Core.</value>
   </data>
   <data name="NEW_VERSION_INSTALLATION_ERROR" xml:space="preserve">
     <value>Couldn't install new PowerToys version.</value>
@@ -154,5 +154,8 @@
   </data>
   <data name="GITHUB_NEW_VERSION_CHECK_ERROR" xml:space="preserve">
     <value>Failed to connect to the server. Check your network connection or retry later.</value>
+  </data>
+   <data name="NEWER_VERSION_ERROR" xml:space="preserve">
+    <value>A newer version is already installed.</value>
   </data>
 </root>


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
When a newer version is detected, don't run the new version's MSI, instead show an error dialog and exit.

![image](https://user-images.githubusercontent.com/3206696/107751511-c6b28700-6d1d-11eb-99e9-183398eb91c6.png)

**What is include in the PR:** 
Improve the error dialog logic. Add more logging.

**How does someone test / validate:** 
- Build the bootstrapper
- Run the bootstrapper when there is no newer version installed -> the bootstrapper should proceed to install PowerToys
- Run the bootstrapper when a newer version is installed -> the bootstrapper should show the error dialog and exit

## Quality Checklist

- [x] **Linked issue:** #9678
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
