### PR TITLE
Possibility to use the same action keyword for more than one plugin

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program.UnitTests/ProgramArgumentParser/ProgramArgumentParserTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program.UnitTests/ProgramArgumentParser/ProgramArgumentParserTests.cs
@@ -32,10 +32,7 @@ namespace Microsoft.Plugin.Program.UnitTests.ProgramArgumentParser
                 new NoArgumentsArgumentParser(),
            };
 
-            // basic version of the Quey parser which can be found at Wox.Core.Plugin.QueryBuilder but did not want to create a project reference
-            var splittedSearchString = inputQuery?.Split(Query.TermSeparator, System.StringSplitOptions.RemoveEmptyEntries);
-            var cleanQuery = string.Join(Query.TermSeparator, splittedSearchString);
-            var query = new Query(cleanQuery, cleanQuery, new ReadOnlyCollection<string>(splittedSearchString), string.Empty);
+            var query = new Query(inputQuery);
 
             // Act
             string program = null, programArguments = null;

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.System.UnitTests/ImageTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.System.UnitTests/ImageTests.cs
@@ -32,8 +32,7 @@ namespace Microsoft.PowerToys.Run.Plugin.System.UnitTests
             // Setup
             Mock<Main> main = new Mock<Main>();
             main.Object.IconTheme = "dark";
-            string[] terms = { typedString };
-            Query expectedQuery = new Query(typedString, typedString, new ReadOnlyCollection<string>(terms), string.Empty);
+            Query expectedQuery = new Query(typedString);
 
             // Act
             var result = main.Object.Query(expectedQuery).FirstOrDefault().IcoPath;
@@ -54,8 +53,7 @@ namespace Microsoft.PowerToys.Run.Plugin.System.UnitTests
             // Setup
             Mock<Main> main = new Mock<Main>();
             main.Object.IconTheme = "light";
-            string[] terms = { typedString };
-            Query expectedQuery = new Query(typedString, typedString, new ReadOnlyCollection<string>(terms), string.Empty);
+            Query expectedQuery = new Query(typedString);
 
             // Act
             var result = main.Object.Query(expectedQuery).FirstOrDefault().IcoPath;

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.System.UnitTests/QueryTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.System.UnitTests/QueryTests.cs
@@ -30,8 +30,7 @@ namespace Microsoft.PowerToys.Run.Plugin.System.UnitTests
         {
             // Setup
             Mock<Main> main = new Mock<Main>();
-            string[] terms = { typedString };
-            Query expectedQuery = new Query(typedString, typedString, new ReadOnlyCollection<string>(terms), string.Empty);
+            Query expectedQuery = new Query(typedString);
 
             // Act
             var result = main.Object.Query(expectedQuery).FirstOrDefault().SubTitle;

--- a/src/modules/launcher/PowerLauncher/Plugin/PluginManager.cs
+++ b/src/modules/launcher/PowerLauncher/Plugin/PluginManager.cs
@@ -61,15 +61,11 @@ namespace PowerLauncher.Plugin
             }
         }
 
-        public static Dictionary<string, PluginPair> NonGlobalPlugins
+        public static IEnumerable<PluginPair> NonGlobalPlugins
         {
             get
             {
-                return AllPlugins
-                    .Where(x => !string.IsNullOrWhiteSpace(x.Metadata.ActionKeyword))
-                    .GroupBy(x => x.Metadata.ActionKeyword)
-                    .Select(x => x.First())
-                    .ToDictionary(x => x.Metadata.ActionKeyword);
+                return AllPlugins.Where(x => !string.IsNullOrWhiteSpace(x.Metadata.ActionKeyword));
             }
         }
 

--- a/src/modules/launcher/PowerLauncher/Plugin/QueryBuilder.cs
+++ b/src/modules/launcher/PowerLauncher/Plugin/QueryBuilder.cs
@@ -36,34 +36,32 @@ namespace PowerLauncher.Plugin
 
             string possibleActionKeyword = terms[0];
 
-            foreach (string pluginActionKeyword in PluginManager.NonGlobalPlugins.Keys)
+            foreach (var plugin in PluginManager.NonGlobalPlugins)
             {
-                // Using Ordinal since this is used internally
-                if (possibleActionKeyword.StartsWith(pluginActionKeyword, StringComparison.Ordinal))
+                var pluginActionKeyword = plugin.Metadata.ActionKeyword;
+                if (plugin.Metadata.Disabled || !possibleActionKeyword.StartsWith(pluginActionKeyword, StringComparison.Ordinal))
                 {
-                    if (PluginManager.NonGlobalPlugins.TryGetValue(pluginActionKeyword, out var pluginPair) && !pluginPair.Metadata.Disabled)
-                    {
-                        // The search string is the raw query excluding the action keyword
-                        string search = rawQuery.Substring(pluginActionKeyword.Length).Trim();
-
-                        // To set the terms of the query after removing the action keyword
-                        if (possibleActionKeyword.Length > pluginActionKeyword.Length)
-                        {
-                            // If the first term contains the action keyword, then set the remaining string to be the first term
-                            terms[0] = possibleActionKeyword.Substring(pluginActionKeyword.Length);
-                        }
-                        else
-                        {
-                            // If the first term is the action keyword, then skip it.
-                            terms = terms.Skip(1).ToArray();
-                        }
-
-                        // A new query is constructed for each plugin as they have different action keywords
-                        var query = new Query(rawQuery, search, new ReadOnlyCollection<string>(terms), pluginActionKeyword);
-
-                        pluginQueryPair.TryAdd(pluginPair, query);
-                    }
+                    continue;
                 }
+
+                string search = rawQuery.Substring(pluginActionKeyword.Length).Trim();
+
+                // To set the terms of the query after removing the action keyword
+                if (possibleActionKeyword.Length > pluginActionKeyword.Length)
+                {
+                    // If the first term contains the action keyword, then set the remaining string to be the first term
+                    terms[0] = possibleActionKeyword.Substring(pluginActionKeyword.Length);
+                }
+                else
+                {
+                    // If the first term is the action keyword, then skip it.
+                    terms = terms.Skip(1).ToArray();
+                }
+
+                // A new query is constructed for each plugin as they have different action keywords
+                var query = new Query(rawQuery, search, new ReadOnlyCollection<string>(terms), pluginActionKeyword);
+
+                pluginQueryPair.TryAdd(plugin, query);
             }
 
             // If the user has specified a matching action keyword, then do not

--- a/src/modules/launcher/PowerLauncher/Plugin/QueryBuilder.cs
+++ b/src/modules/launcher/PowerLauncher/Plugin/QueryBuilder.cs
@@ -12,55 +12,27 @@ namespace PowerLauncher.Plugin
 {
     public static class QueryBuilder
     {
-        public static Dictionary<PluginPair, Query> Build(ref string text)
+        public static Dictionary<PluginPair, Query> Build(string text)
         {
             if (text == null)
             {
                 throw new ArgumentNullException(nameof(text));
             }
 
-            // replace multiple white spaces with one white space
-            var terms = text.Split(new[] { Query.TermSeparator }, StringSplitOptions.RemoveEmptyEntries);
-            if (terms.Length == 0)
-            { // nothing was typed
-                return null;
-            }
+            text = text.Trim();
 
             // This Dictionary contains the corresponding query for each plugin
             Dictionary<PluginPair, Query> pluginQueryPair = new Dictionary<PluginPair, Query>();
-
-            var rawQuery = string.Join(Query.TermSeparator, terms);
-
-            // This is the query on removing extra spaces which would be executed by global Plugins
-            text = rawQuery;
-
-            string possibleActionKeyword = terms[0];
-
             foreach (var plugin in PluginManager.NonGlobalPlugins)
             {
                 var pluginActionKeyword = plugin.Metadata.ActionKeyword;
-                if (plugin.Metadata.Disabled || !possibleActionKeyword.StartsWith(pluginActionKeyword, StringComparison.Ordinal))
+                if (plugin.Metadata.Disabled || !text.StartsWith(pluginActionKeyword, StringComparison.Ordinal))
                 {
                     continue;
                 }
 
-                string search = rawQuery.Substring(pluginActionKeyword.Length).Trim();
-
-                // To set the terms of the query after removing the action keyword
-                if (possibleActionKeyword.Length > pluginActionKeyword.Length)
-                {
-                    // If the first term contains the action keyword, then set the remaining string to be the first term
-                    terms[0] = possibleActionKeyword.Substring(pluginActionKeyword.Length);
-                }
-                else
-                {
-                    // If the first term is the action keyword, then skip it.
-                    terms = terms.Skip(1).ToArray();
-                }
-
                 // A new query is constructed for each plugin as they have different action keywords
-                var query = new Query(rawQuery, search, new ReadOnlyCollection<string>(terms), pluginActionKeyword);
-
+                var query = new Query(text, pluginActionKeyword);
                 pluginQueryPair.TryAdd(plugin, query);
             }
 
@@ -72,7 +44,7 @@ namespace PowerLauncher.Plugin
                 {
                     if (!pluginQueryPair.ContainsKey(globalPlugin))
                     {
-                        var query = new Query(rawQuery, rawQuery, new ReadOnlyCollection<string>(terms), string.Empty);
+                        var query = new Query(text);
                         pluginQueryPair.Add(globalPlugin, query);
                     }
                 }

--- a/src/modules/launcher/PowerLauncher/Plugin/QueryBuilder.cs
+++ b/src/modules/launcher/PowerLauncher/Plugin/QueryBuilder.cs
@@ -4,8 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using Mono.Collections.Generic;
 using Wox.Plugin;
 
 namespace PowerLauncher.Plugin
@@ -31,7 +29,7 @@ namespace PowerLauncher.Plugin
                     continue;
                 }
 
-                // A new query is constructed for each plugin as they have different action keywords
+                // A new query is constructed for each plugin
                 var query = new Query(text, pluginActionKeyword);
                 pluginQueryPair.TryAdd(plugin, query);
             }
@@ -42,7 +40,7 @@ namespace PowerLauncher.Plugin
             {
                 foreach (PluginPair globalPlugin in PluginManager.GlobalPlugins)
                 {
-                    if (!pluginQueryPair.ContainsKey(globalPlugin))
+                    if (!globalPlugin.Metadata.Disabled && !pluginQueryPair.ContainsKey(globalPlugin))
                     {
                         var query = new Query(text);
                         pluginQueryPair.Add(globalPlugin, query);

--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -501,7 +501,7 @@ namespace PowerLauncher.ViewModel
                     Title = string.Format(CultureInfo.InvariantCulture, title, h.Query),
                     SubTitle = string.Format(CultureInfo.InvariantCulture, time, h.ExecutedDateTime),
                     IcoPath = "Images\\history.png",
-                    OriginQuery = new Query { RawQuery = h.Query },
+                    OriginQuery = new Query(h.Query),
                     Action = _ =>
                     {
                         SelectedResults = Results;
@@ -539,9 +539,10 @@ namespace PowerLauncher.ViewModel
                 _updateToken = currentCancellationToken;
                 var queryText = QueryText.Trim();
 
-                var pluginQueryPairs = QueryBuilder.Build(ref queryText);
+                var pluginQueryPairs = QueryBuilder.Build(queryText);
                 if (pluginQueryPairs != null && pluginQueryPairs.Count > 0)
                 {
+                    queryText = pluginQueryPairs.Values.First().ActionKeyword;
                     _currentQuery = queryText;
                     Task.Run(
                         () =>
@@ -885,7 +886,7 @@ namespace PowerLauncher.ViewModel
 
             // Fix Cold start for plugins
             string s = "m";
-            var pluginQueryPairs = QueryBuilder.Build(ref s);
+            var pluginQueryPairs = QueryBuilder.Build(s);
 
             // To execute a query corresponding to each plugin
             foreach (KeyValuePair<PluginPair, Query> pluginQueryItem in pluginQueryPairs)

--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -877,9 +877,8 @@ namespace PowerLauncher.ViewModel
             Results.Clear();
             MainWindowVisibility = System.Windows.Visibility.Collapsed;
 
-            // Fix Cold start for plugins
-            string s = "m";
-            var pluginQueryPairs = QueryBuilder.Build(s);
+            // Fix Cold start for plugins, "m" is just a random string needed to query results
+            var pluginQueryPairs = QueryBuilder.Build("m");
 
             // To execute a query corresponding to each plugin
             foreach (KeyValuePair<PluginPair, Query> pluginQueryItem in pluginQueryPairs)

--- a/src/modules/launcher/Wox.Plugin/Query.cs
+++ b/src/modules/launcher/Wox.Plugin/Query.cs
@@ -19,19 +19,32 @@ namespace Wox.Plugin
         /// Initializes a new instance of the <see cref="Query"/> class.
         /// to allow unit tests for plug ins
         /// </summary>
-        public Query(string rawQuery, string search, ReadOnlyCollection<string> terms, string actionKeyword = "")
+        public Query(string query, string actionKeyword = "")
         {
-            Search = search;
-            RawQuery = rawQuery;
-            Terms = terms;
+            _query = query;
             ActionKeyword = actionKeyword;
         }
+
+        private string _rawQuery;
 
         /// <summary>
         /// Gets raw query, this includes action keyword if it has
         /// We didn't recommend use this property directly. You should always use Search property.
         /// </summary>
-        public string RawQuery { get; internal set; }
+        public string RawQuery
+        {
+            get
+            {
+                if (_rawQuery == null)
+                {
+                    _rawQuery = string.Join(Query.TermSeparator, _query.Split(new[] { TermSeparator }, StringSplitOptions.RemoveEmptyEntries));
+                }
+
+                return _rawQuery;
+            }
+        }
+
+        private string _search;
 
         /// <summary>
         /// Gets search part of a query.
@@ -39,12 +52,41 @@ namespace Wox.Plugin
         /// Since we allow user to switch a exclusive plugin to generic plugin,
         /// so this property will always give you the "real" query part of the query
         /// </summary>
-        public string Search { get; internal set; }
+        public string Search
+        {
+            get
+            {
+                if (_search == null)
+                {
+                    _search = RawQuery.Substring(ActionKeyword.Length).Trim();
+                }
+
+                return _search;
+            }
+        }
+
+        private ReadOnlyCollection<string> _terms;
 
         /// <summary>
         /// Gets the raw query splited into a string array.
         /// </summary>
-        public ReadOnlyCollection<string> Terms { get; private set; }
+        public ReadOnlyCollection<string> Terms
+        {
+            get
+            {
+                if (_terms == null)
+                {
+                    var terms = _query
+                        .Trim()
+                        .Substring(ActionKeyword.Length)
+                        .Split(new[] { TermSeparator }, StringSplitOptions.RemoveEmptyEntries);
+
+                    _terms = new ReadOnlyCollection<string>(terms);
+                }
+
+                return _terms;
+            }
+        }
 
         /// <summary>
         /// Query can be splited into multiple terms by whitespace
@@ -101,6 +143,8 @@ namespace Wox.Plugin
                 return string.Empty;
             }
         }
+
+        private string _query;
 
         public override string ToString() => RawQuery;
 

--- a/src/modules/launcher/Wox.Test/QueryBuilderTest.cs
+++ b/src/modules/launcher/Wox.Test/QueryBuilderTest.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Mono.Collections.Generic;
 using NUnit.Framework;
 using PowerLauncher.Plugin;
@@ -36,25 +37,8 @@ namespace Wox.Test
             string searchQuery = ">   file.txt    file2 file3";
 
             // Act
-            var pluginQueryPairs = QueryBuilder.Build(ref searchQuery);
-
-            // Assert
-            Assert.AreEqual("> file.txt file2 file3", searchQuery);
-        }
-
-        [Test]
-        public void QueryBuilderShouldRemoveExtraSpacesForDisabledNonGlobalPlugin()
-        {
-            // Arrange
-            PluginManager.SetAllPlugins(new List<PluginPair>()
-            {
-                new PluginPair { Metadata = new PluginMetadata() { Disabled = true, ActionKeyword = ">" } },
-            });
-
-            string searchQuery = ">   file.txt    file2 file3";
-
-            // Act
-            var pluginQueryPairs = QueryBuilder.Build(ref searchQuery);
+            var pluginQueryPairs = QueryBuilder.Build(searchQuery);
+            searchQuery = pluginQueryPairs.Values.First().RawQuery;
 
             // Assert
             Assert.AreEqual("> file.txt file2 file3", searchQuery);
@@ -65,9 +49,14 @@ namespace Wox.Test
         {
             // Arrange
             string searchQuery = "file.txt  file2  file3";
+            PluginManager.SetAllPlugins(new List<PluginPair>()
+            {
+                new PluginPair { Metadata = new PluginMetadata() { Disabled = true, IsGlobal = true } },
+            });
 
             // Act
-            var pluginQueryPairs = QueryBuilder.Build(ref searchQuery);
+            var pluginQueryPairs = QueryBuilder.Build(searchQuery);
+            searchQuery = pluginQueryPairs.Values.First().RawQuery;
 
             // Assert
             Assert.AreEqual("file.txt file2 file3", searchQuery);
@@ -87,10 +76,10 @@ namespace Wox.Test
             var secondQueryText = "a search";
 
             // Act
-            var firstPluginQueryPair = QueryBuilder.Build(ref firstQueryText);
+            var firstPluginQueryPair = QueryBuilder.Build(firstQueryText);
             var firstQuery = firstPluginQueryPair.GetValueOrDefault(plugin);
 
-            var secondPluginQueryPairs = QueryBuilder.Build(ref secondQueryText);
+            var secondPluginQueryPairs = QueryBuilder.Build(secondQueryText);
             var secondQuery = secondPluginQueryPairs.GetValueOrDefault(plugin);
 
             // Assert
@@ -113,14 +102,14 @@ namespace Wox.Test
             });
 
             // Act
-            var pluginQueryPairs = QueryBuilder.Build(ref searchQuery);
+            var pluginQueryPairs = QueryBuilder.Build(searchQuery);
 
             var firstQuery = pluginQueryPairs.GetValueOrDefault(firstPlugin);
             var secondQuery = pluginQueryPairs.GetValueOrDefault(secondPlugin);
 
             // Assert
-            Assert.IsTrue(AreEqual(firstQuery, new Query { RawQuery = searchQuery, Search = searchQuery.Substring(firstPlugin.Metadata.ActionKeyword.Length), ActionKeyword = firstPlugin.Metadata.ActionKeyword } ));
-            Assert.IsTrue(AreEqual(secondQuery, new Query { RawQuery = searchQuery, Search = searchQuery.Substring(secondPlugin.Metadata.ActionKeyword.Length), ActionKeyword = secondPlugin.Metadata.ActionKeyword }));
+            Assert.IsTrue(AreEqual(firstQuery, new Query(searchQuery, firstPlugin.Metadata.ActionKeyword)));
+            Assert.IsTrue(AreEqual(secondQuery, new Query(searchQuery, secondPlugin.Metadata.ActionKeyword)));
         }
 
         [Test]
@@ -137,7 +126,7 @@ namespace Wox.Test
             });
 
             // Act
-            var pluginQueryPairs = QueryBuilder.Build(ref searchQuery);
+            var pluginQueryPairs = QueryBuilder.Build(searchQuery);
 
             var firstQuery = pluginQueryPairs.GetValueOrDefault(firstPlugin);
             var secondQuery = pluginQueryPairs.GetValueOrDefault(secondPlugin);
@@ -146,6 +135,26 @@ namespace Wox.Test
             // Using Ordinal since this is used internally
             Assert.IsTrue(firstQuery.Terms[0].Equals("cd", StringComparison.Ordinal) && firstQuery.Terms[1].Equals("efgh", StringComparison.Ordinal) && firstQuery.Terms.Count == 2);
             Assert.IsTrue(secondQuery.Terms[0].Equals("efgh", StringComparison.Ordinal) && secondQuery.Terms.Count == 1);
+        }
+
+        [Test]
+        public void QueryBuilderShouldReturnAllPluginsWithTheActionWord()
+        {
+            // Arrange
+            string searchQuery = "!efgh";
+            var firstPlugin = new PluginPair { Metadata = new PluginMetadata { ActionKeyword = "!", ID = "plugin1" } };
+            var secondPlugin = new PluginPair { Metadata = new PluginMetadata { ActionKeyword = "!", ID = "plugin2" } };
+            PluginManager.SetAllPlugins(new List<PluginPair>()
+            {
+                firstPlugin,
+                secondPlugin,
+            });
+
+            // Act
+            var pluginQueryPairs = QueryBuilder.Build(searchQuery);
+
+            // Assert
+            Assert.AreEqual(2, pluginQueryPairs.Count);
         }
     }
 }

--- a/src/modules/launcher/Wox.Test/QueryBuilderTest.cs
+++ b/src/modules/launcher/Wox.Test/QueryBuilderTest.cs
@@ -51,7 +51,7 @@ namespace Wox.Test
             string searchQuery = "file.txt  file2  file3";
             PluginManager.SetAllPlugins(new List<PluginPair>()
             {
-                new PluginPair { Metadata = new PluginMetadata() { Disabled = true, IsGlobal = true } },
+                new PluginPair { Metadata = new PluginMetadata() { Disabled = false, IsGlobal = true } },
             });
 
             // Act


### PR DESCRIPTION
## Summary of the Pull Request

**What is include in the PR:** 
- Use list instead of Dictionary for `PluginManager.NonGlobalPlugins`. It allows showing results from more than one plugin for the action keyword
- Removed `search` and `terms` arguments From `Query` as they can be calculated from the other two
- Removed ref form `QueryBuilder.Build`
- `QueryBuilderShouldRemoveExtraSpacesForDisabledNonGlobalPlugin` test is redundant as there is not consumers of `QueryBuilder.Build` that expect `queryText` to be normalized when there is no plugins
- Added `QueryBuilderShouldReturnAllPluginsWithTheActionWord` test for new functionality

**How does someone test / validate:** 
- Try to assign the same action keys for few plugins
- Test for regressions

## Quality Checklist

- [X] **Linked issue:** #9657
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [X] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
