### PR TITLE
[FZ editor] UX update for edit dialog

### DIFF
--- a/installer/PowerToysSetup/Product.wxs
+++ b/installer/PowerToysSetup/Product.wxs
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
-     xmlns:util="http://schemas.microsoft.com/wix/UtilExtension"
-     xmlns:netfx="http://schemas.microsoft.com/wix/NetFxExtension" >
+     xmlns:util="http://schemas.microsoft.com/wix/UtilExtension" >
 
   <?define FancyZonesProjectName="FancyZones"?>
   <?define ImageResizerProjectName="ImageResizer"?>
@@ -471,9 +470,7 @@
 
     <DirectoryRef Id="ImageResizerInstallFolder" FileSource="$(var.BinX64Dir)modules\$(var.ImageResizerProjectName)">
       <Component Id="Module_ImageResizer" Guid="96E63289-759C-4A73-A56B-EE7429932F72" Win64="yes">
-        <File Source="$(var.BinX64Dir)modules\$(var.ImageResizerProjectName)\ImageResizer.exe">
-          <netfx:NativeImage Id="ImageResizer.exe" Platform="all" Priority="0" />
-        </File>
+        <File Source="$(var.BinX64Dir)modules\$(var.ImageResizerProjectName)\ImageResizer.exe" />
         <File Source="$(var.BinX64Dir)modules\$(var.ImageResizerProjectName)\ImageResizerExt.dll" KeyPath="yes" />
         <File Source="$(var.BinX64Dir)modules\$(var.ImageResizerProjectName)\Newtonsoft.Json.dll" />
         <File Source="$(var.BinX64Dir)modules\$(var.ImageResizerProjectName)\ImageResizer.dll" />

--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml
@@ -112,14 +112,18 @@
                     FontWeight="SemiBold"
                     FontSize="64"
                     Foreground="{DynamicResource PrimaryForegroundBrush}" />
-                <Label
-                    Name="LabelSize"
-                    DockPanel.Dock="Bottom"
-                    HorizontalContentAlignment="Center"
-                    VerticalContentAlignment="Center"
-                    FontWeight="Thin"
-                    FontSize="32"
-                    Foreground="{DynamicResource PrimaryForegroundBrush}" />
+                <TextBlock FontSize="18"
+                           Foreground="{DynamicResource SecondaryForegroundBrush}"
+                           DockPanel.Dock="Bottom"
+                           FontWeight="SemiBold"
+                           HorizontalAlignment="Center"
+                           VerticalAlignment="Center">
+                     <Run x:Name="WidthLabel" />
+                     <Run Text="&#xE106;"
+                          FontSize="10"
+                          FontFamily="Segoe MDL2 Assets" />
+                    <Run x:Name="HeightLabel" />
+                </TextBlock>
             </DockPanel>
 
             <Thumb x:Name="Caption" Cursor="SizeAll" Background="Transparent" BorderThickness="3" Padding="4" Grid.Column="0" Grid.ColumnSpan="5" Grid.Row="0" Grid.RowSpan="5" DragDelta="UniversalDragDelta" DragStarted="Caption_DragStarted" Style="{DynamicResource CanvasZoneThumbStyle}"/>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml
@@ -112,7 +112,7 @@
                     FontWeight="SemiBold"
                     FontSize="64"
                     Foreground="{DynamicResource PrimaryForegroundBrush}" />
-                <TextBlock FontSize="18"
+                <TextBlock FontSize="16"
                            Foreground="{DynamicResource SecondaryForegroundBrush}"
                            DockPanel.Dock="Bottom"
                            FontWeight="SemiBold"

--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml.cs
@@ -27,7 +27,8 @@ namespace FancyZonesEditor
 
         private void CanvasZone_SizeChanged(object sender, SizeChangedEventArgs e)
         {
-            LabelSize.Content = "(" + Width.ToString() + "x" + Height.ToString() + ")";
+            WidthLabel.Text = Width.ToString();
+            HeightLabel.Text = Height.ToString();
         }
 
         private CanvasLayoutModel model;

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridZone.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridZone.xaml
@@ -26,14 +26,18 @@
                 FontWeight="SemiBold"
                 FontSize="64"
                 Foreground="{DynamicResource PrimaryForegroundBrush}" />
-            <Label
-                Name="LabelSize"
-                DockPanel.Dock="Bottom"
-                HorizontalContentAlignment="Center"
-                VerticalContentAlignment="Center"
-                FontWeight="Thin"
-                FontSize="32"
-                Foreground="{DynamicResource PrimaryForegroundBrush}" />
+            <TextBlock FontSize="18"
+                       Foreground="{DynamicResource SecondaryForegroundBrush}"
+                       DockPanel.Dock="Bottom"
+                       FontWeight="SemiBold"
+                       HorizontalAlignment="Center"
+                       VerticalAlignment="Center">
+                     <Run x:Name="WidthLabel" />
+                     <Run Text="&#xE106;"
+                          FontSize="10"
+                          FontFamily="Segoe MDL2 Assets" />
+                    <Run x:Name="HeightLabel" />
+            </TextBlock>
 
         </DockPanel>
         <!--<TextBlock Margin="2" Text="Shift Key switches direction&#13;Ctrl  Key repeats"/>-->

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridZone.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridZone.xaml
@@ -26,7 +26,7 @@
                 FontWeight="SemiBold"
                 FontSize="64"
                 Foreground="{DynamicResource PrimaryForegroundBrush}" />
-            <TextBlock FontSize="18"
+            <TextBlock FontSize="16"
                        Foreground="{DynamicResource SecondaryForegroundBrush}"
                        DockPanel.Dock="Bottom"
                        FontWeight="SemiBold"

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridZone.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridZone.xaml.cs
@@ -78,7 +78,8 @@ namespace FancyZonesEditor
 
         private void GridZone_SizeChanged(object sender, SizeChangedEventArgs e)
         {
-            LabelSize.Content = "(" + Math.Round(ActualWidth).ToString() + "x" + Math.Round(ActualHeight).ToString() + ")";
+            WidthLabel.Text = Math.Round(ActualWidth).ToString();
+            HeightLabel.Text = Math.Round(ActualHeight).ToString();
         }
 
         private void ZoneSettings_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -30,11 +30,12 @@
         <Converters:LayoutTypeCustomToVisibilityConverter x:Key="LayoutTypeCustomToVisibilityConverter" />
         <Converters:LayoutTypeTemplateToVisibilityConverter x:Key="LayoutTypeTemplateToVisibilityConverter" />
         <Converters:LayoutModelTypeBlankToVisibilityConverter x:Key="LayoutModelTypeBlankToVisibilityConverter" />
-
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+        
         <DropShadowEffect x:Key="CardShadow" BlurRadius="6"
                           Opacity="0.24"
                           ShadowDepth="1" />
-        
+
         <Style x:Key="CardStyle"
                TargetType="Border">
             <Setter Property="Background"
@@ -60,44 +61,6 @@
                             Value="{DynamicResource LayoutItemBackgroundPointerOverBrush}" />
                 </Trigger>
             </Style.Triggers>
-        </Style>
-
-        <Style x:Key="SpinnerButton" TargetType="Button">
-            <Setter Property="FontFamily" Value="Segoe UI" />
-            <Setter Property="FontWeight" Value="SemiBold" />
-            <Setter Property="Foreground" Value="{DynamicResource PrimaryForegroundBrush}"/>
-            <Setter Property="FontSize" Value="18"/>
-            <Setter Property="Padding" Value="0,0,0,5"/>
-            <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="Background" Value="{DynamicResource SecondaryBackgroundBrush}"/>
-            <Setter Property="Margin" Value="0,0,0,0" />
-
-            <Setter Property="Template">
-                <Setter.Value>
-                    <ControlTemplate TargetType="{x:Type Button}">
-                        <Border Background="{TemplateBinding Background}" BorderBrush="{DynamicResource SecondaryBackgroundBrush}" BorderThickness="0">
-                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                        </Border>
-                    </ControlTemplate>
-                </Setter.Value>
-            </Setter>
-            
-            <Style.Triggers>
-                <Trigger Property="Border.IsMouseOver" Value="True">
-                    <Setter Property="Background"
-                            Value="{DynamicResource LayoutItemBackgroundPointerOverBrush}" />
-                </Trigger>
-            </Style.Triggers>
-        </Style>
-
-        <Style x:Key="ZoneCount" TargetType="TextBlock">
-            <Setter Property="FontFamily" Value="Segoe UI" />
-            <Setter Property="FontWeight" Value="Regular" />
-            <Setter Property="FontSize" Value="18"/>
-            <Setter Property="LineHeight" Value="24" />
-            <Setter Property="Margin" Value="20,0,20,0" />
-            <Setter Property="HorizontalAlignment" Value="Center"/>
-            <Setter Property="VerticalAlignment" Value="Center"/>
         </Style>
 
         <DataTemplate x:Key="MonitorItemTemplate">
@@ -393,151 +356,121 @@
                           Title="{x:Static props:Resources.Edit_Layout}"
                           Opened="Dialog_Opened"
                           Closed="Dialog_Closed">
-            <StackPanel Margin="0,16,0,0"
-                        MinWidth="420"
-                        DataContext="{Binding SelectedModel}">
-                <Button Click="EditZones_Click"
-                        x:Name="editZoneLayoutButton"
-                        HorizontalAlignment="Stretch"
-                        AutomationProperties.Name="{x:Static props:Resources.Edit_zones}"
-                        Height="48"
-                        Margin="0,0,0,16"
-                        Visibility="{Binding Path=Type, Converter={StaticResource LayoutTypeCustomToVisibilityConverter}}"
-                        Style="{StaticResource AccentButtonStyle}">
-                    <Button.Content>
-                        <StackPanel Orientation="Horizontal">
-                            <TextBlock Text="&#xE104;"
-                                       Margin="0,2,8,0"
-                                       FontFamily="Segoe MDL2 Assets" />
-                            <TextBlock Text="{x:Static props:Resources.Edit_zones}" />
-                        </StackPanel>
-                    </Button.Content>
-                    <Button.Effect>
-                        <DropShadowEffect BlurRadius="6"
-                                          Opacity="0.32"
-                                          ShadowDepth="1" />
-                    </Button.Effect>
-                </Button>
+            <Grid DataContext="{Binding SelectedModel}"
+                  MinWidth="320" Margin="0,0,0,32">
 
-                <Grid Margin="0,0,0,32"
-                      Height="Auto"
-                      HorizontalAlignment="Stretch">
-                    
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*"/>
-                        <ColumnDefinition Width="*"/>
-                    </Grid.ColumnDefinitions>
-                    
+                <StackPanel Margin="0,-32,0,0"
+                            HorizontalAlignment="Right"
+                            VerticalAlignment="Top"
+                            Orientation="Horizontal">
                     <Button Click="DuplicateLayout_Click"
                             x:Name="duplicateLayoutButton"
-                            HorizontalAlignment="Stretch"
                             AutomationProperties.Name="{x:Static props:Resources.Duplicate}"
-                            Height="48"
-                            Margin="0,0,4,0"
-                            Grid.Column="0"
-                            Visibility="{Binding Path=Type, Converter={StaticResource LayoutTypeCustomToVisibilityConverter}}">
-                        <Button.Content>
-                            <StackPanel Orientation="Horizontal">
-                                <TextBlock Text="&#xE8C8;"
-                                       Margin="0,2,8,0"
-                                       FontFamily="Segoe MDL2 Assets" />
-                                <TextBlock Text="{x:Static props:Resources.Duplicate}" />
-                            </StackPanel>
-                        </Button.Content>
-                    </Button>
-                    <Button Click="DeleteLayout_Click"
-                            x:Name="deleteLayoutButton"
-                            HorizontalAlignment="Stretch"
-                            AutomationProperties.Name="{x:Static props:Resources.Delete}"
-                            Height="48"
-                            Margin="4,0,0,0"
-                            Grid.Column="1"
-                            Visibility="{Binding Path=Type, Converter={StaticResource LayoutTypeCustomToVisibilityConverter}}">
-                        <Button.Content>
-                            <StackPanel Orientation="Horizontal">
-                                <TextBlock Text="&#xE107;"
-                                       Margin="0,2,8,0"
-                                       FontFamily="Segoe MDL2 Assets" />
-                                <TextBlock Text="{x:Static props:Resources.Delete}" />
-                            </StackPanel>
-                        </Button.Content>
-                    </Button>
+                            ToolTip="{x:Static props:Resources.Duplicate}"
+                            Content="&#xE8C8;"
+                            Background="Transparent"
+                            FontFamily="Segoe MDL2 Assets"
+                            Visibility="{Binding Path=Type, Converter={StaticResource LayoutTypeCustomToVisibilityConverter}}" />
 
                     <Button Click="DuplicateLayout_Click"
                             x:Name="createFromTemplateLayoutButton"
-                            HorizontalAlignment="Stretch"
                             AutomationProperties.Name="{x:Static props:Resources.Create_Custom_From_Template}"
-                            Height="48"
-                            Margin="0,0,4,0"
-                            Grid.Column="0"
-                            Visibility="{Binding Path=Type, Converter={StaticResource LayoutTypeTemplateToVisibilityConverter}}">
-                        <Button.Content>
-                            <StackPanel Orientation="Horizontal">
-                                <TextBlock Text="&#xE8C8;"
-                                       Margin="0,2,8,0"
-                                       FontFamily="Segoe MDL2 Assets" />
-                                <TextBlock Text="{x:Static props:Resources.Create_Custom_From_Template}" />
-                            </StackPanel>
-                        </Button.Content>
-                    </Button>
-                </Grid>
+                            ToolTip="{x:Static props:Resources.Create_Custom_From_Template}"
+                            Content="&#xE8C8;"
+                            Background="Transparent"
+                            FontFamily="Segoe MDL2 Assets"
+                            Visibility="{Binding Path=Type, Converter={StaticResource LayoutTypeTemplateToVisibilityConverter}}" />
 
-                <TextBlock x:Name="nameHeader"
-                           Text="{x:Static props:Resources.Name}"
-                           IsEnabled="{Binding ShowSpacing}"
-                           Margin="0,0,0,0"
-                           Foreground="{DynamicResource PrimaryForegroundBrush}" />
-                <TextBox Text="{Binding Name}"
-                         Margin="0,6,0,0"
-                         IsEnabled="{Binding IsCustom}"
-                         AutomationProperties.LabeledBy="{Binding ElementName=nameHeader}" />
-
-                <TextBlock x:Name="numberOfZonesHeader"
-                           Text="{x:Static props:Resources.NumberOfZones}"
-                           Margin="0,16,0,0"
-                           Foreground="{DynamicResource PrimaryForegroundBrush}" 
-                           Visibility="{Binding Path=Type, Converter={StaticResource LayoutTypeTemplateToVisibilityConverter}}" />
-                <StackPanel Margin="0,6,0,0" 
-                            Orientation="Horizontal" 
-                            Visibility="{Binding Path=Type, Converter={StaticResource LayoutTypeTemplateToVisibilityConverter}}">
-                    <Button x:Name="decrementZones" 
-                            Width="40" 
-                            Height="40" 
-                            AutomationProperties.Name="{x:Static props:Resources.Zone_Count_Decrement}" 
-                            Content="-" 
-                            Style="{StaticResource SpinnerButton}"
-                            Click="DecrementZones_Click"/>
-                    <TextBlock x:Name="zoneCount" Text="{Binding TemplateZoneCount}" Style="{StaticResource ZoneCount}"/>
-                    <Button x:Name="incrementZones" 
-                            Width="40" 
-                            Height="40" 
-                            AutomationProperties.Name="{x:Static props:Resources.Zone_Count_Increment}" 
-                            Content="+" 
-                            Style="{StaticResource SpinnerButton}" 
-                            Click="IncrementZones_Click"/>
+                    <Button Click="DeleteLayout_Click"
+                            x:Name="deleteLayoutButton"
+                            AutomationProperties.Name="{x:Static props:Resources.Delete}"
+                            ToolTip="{x:Static props:Resources.Delete}"
+                            Background="Transparent"
+                            Content="&#xE107;"
+                            FontFamily="Segoe MDL2 Assets"
+                            Foreground="Red"
+                            Visibility="{Binding Path=Type, Converter={StaticResource LayoutTypeCustomToVisibilityConverter}}" />
                 </StackPanel>
-                
-                <StackPanel Margin="0,16,0,0"
-                            Orientation="Vertical">
-                    <ui:ToggleSwitch x:Name="spaceAroundSetting"
-                                     Header="{x:Static props:Resources.Show_Space_Zones}"
-                                     IsOn="{Binding ShowSpacing}"
-                                     Visibility="{Binding Converter={StaticResource LayoutModelTypeToVisibilityConverter}}" />
 
-                    <TextBlock x:Name="paddingValue"
-                               Text="{x:Static props:Resources.Space_Around_Zones}"
-                               IsEnabled="{Binding ShowSpacing}"
-                               Margin="0,8,0,0"
-                               Foreground="{DynamicResource PrimaryForegroundBrush}"
-                               Visibility="{Binding Converter={StaticResource LayoutModelTypeToVisibilityConverter}}" />
+                <StackPanel>
+                    <local:LayoutPreview Width="216"
+                                         Height="132"
+                                         Margin="0,16,0,16" />
+                    <ui:HyperlinkButton Click="EditZones_Click"
+                                        x:Name="editZoneLayoutButton"
+                                        HorizontalAlignment="Stretch"
+                                        AutomationProperties.Name="{x:Static props:Resources.Edit_zones}"
+                                        HorizontalContentAlignment="Center"
+                                        Visibility="{Binding Path=Type, Converter={StaticResource LayoutTypeCustomToVisibilityConverter}}">
+                        <ui:HyperlinkButton.Content>
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="&#xE104;"
+                                           Margin="0,2,8,0"
+                                           FontFamily="Segoe MDL2 Assets" />
+                                <TextBlock Text="{x:Static props:Resources.Edit_zones}" />
+                            </StackPanel>
+                        </ui:HyperlinkButton.Content>
+                    </ui:HyperlinkButton>
+
+                    <StackPanel Orientation="Horizontal"
+                                HorizontalAlignment="Center"
+                                Visibility="{Binding Path=Type, Converter={StaticResource LayoutTypeTemplateToVisibilityConverter}}">
+                        <ui:HyperlinkButton x:Name="incrementZones"
+                                            Width="40"
+                                            Height="40"
+                                            AutomationProperties.Name="{x:Static props:Resources.Zone_Count_Increment}"
+                                            ToolTip="{x:Static props:Resources.Zone_Count_Increment}"
+                                            Click="IncrementZones_Click">
+                            <ui:HyperlinkButton.Content>
+                                <TextBlock Text="&#xE109;"
+                                           FontFamily="Segoe MDL2 Assets" />
+                            </ui:HyperlinkButton.Content>
+                        </ui:HyperlinkButton>
+                        <TextBlock x:Name="zoneCount"
+                                   Text="{Binding TemplateZoneCount}"
+                                   FontWeight="SemiBold"
+                                   FontSize="18"
+                                   Width="32"
+                                   HorizontalAlignment="Center"
+                                   TextAlignment="Center"
+                                   Margin="0,-4,0,0"
+                                   ToolTip="Number of zones"
+                                   VerticalAlignment="Center" />
+
+                        <ui:HyperlinkButton x:Name="decrementZones"
+                                            Width="40"
+                                            Height="40"
+                                            AutomationProperties.Name="{x:Static props:Resources.Zone_Count_Decrement}"
+                                            ToolTip="{x:Static props:Resources.Zone_Count_Decrement}"
+                                            Click="DecrementZones_Click">
+                            <ui:HyperlinkButton.Content>
+                                <TextBlock Text="&#xE108;"
+                                           FontFamily="Segoe MDL2 Assets" />
+                            </ui:HyperlinkButton.Content>
+                        </ui:HyperlinkButton>
+                    </StackPanel>
+                    <TextBox Text="{Binding Name}"
+                             ui:ControlHelper.Header="{x:Static props:Resources.Name}"
+                             Margin="0,16,0,0"
+                             Visibility="{Binding IsCustom, Converter={StaticResource BooleanToVisibilityConverter}}"
+                             HorizontalAlignment="Stretch" />
+                    
+                    <CheckBox x:Name="spaceAroundSetting"
+                              Content="{x:Static props:Resources.Show_Space_Zones}"
+                              IsChecked="{Binding ShowSpacing}"
+                              Margin="0,16,0,0"
+                              Visibility="{Binding Converter={StaticResource LayoutModelTypeToVisibilityConverter}}" />
 
                     <ui:NumberBox Margin="0,6,0,0"
-                             IsEnabled="{Binding ShowSpacing}"
-                             Text="{Binding Spacing}"
-                             Width="86"
-                             HorizontalAlignment="Left"
-                             AutomationProperties.LabeledBy="{Binding ElementName=paddingValue}"
-                             Visibility="{Binding Converter={StaticResource LayoutModelTypeToVisibilityConverter}}" />
+                                  IsEnabled="{Binding ShowSpacing}"
+                                  Text="{Binding Spacing}"
+                                  Width="106"
+                                  Minimum="-20"
+                                  Maximum="1000"
+                                  SpinButtonPlacementMode="Compact"
+                                  HorizontalAlignment="Left"
+                                  AutomationProperties.LabeledBy="{Binding ElementName=spaceAroundSetting}"
+                                  Visibility="{Binding Converter={StaticResource LayoutModelTypeToVisibilityConverter}}" />
 
                     <TextBlock Text="{x:Static props:Resources.Distance_adjacent_zones}"
                                IsEnabled="{Binding ShowSpacing}"
@@ -546,12 +479,15 @@
                                x:Name="sensitivityRadiusValue" />
 
                     <ui:NumberBox Margin="0,6,0,0"
-                             Text="{Binding SensitivityRadius}"
-                             Width="86"
-                             AutomationProperties.LabeledBy="{Binding ElementName=sensitivityRadiusValue}"
-                             HorizontalAlignment="Left" />
+                                  Text="{Binding SensitivityRadius}"
+                                  Width="106"
+                                  Minimum="0"
+                                  Maximum="1000"
+                                  SpinButtonPlacementMode="Compact"
+                                  HorizontalAlignment="Left"
+                                  AutomationProperties.LabeledBy="{Binding ElementName=sensitivityRadiusValue}" />
                 </StackPanel>
-            </StackPanel>
+            </Grid>
         </ui:ContentDialog>
         
         <ui:ContentDialog x:Name="NewLayoutDialog"

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -170,7 +170,7 @@
                                    FontWeight="SemiBold"
                                    HorizontalAlignment="Left"
                                    VerticalAlignment="Top"
-                                   Margin="0,-4,0,0"
+                                   Margin="0,-4,24,0"
                                    Foreground="{DynamicResource PrimaryForegroundBrush}" />
 
                         <Button Content="&#xE104;"
@@ -196,26 +196,8 @@
 
                         <local:LayoutPreview Grid.Row="1"
                                              Margin="0,8,0,8"
-                                             VerticalAlignment="Stretch"                                
+                                             VerticalAlignment="Stretch"
                                              HorizontalAlignment="Stretch" />
-                        <Grid Grid.Row="2"
-                              Visibility="Collapsed"
-                              HorizontalAlignment="Stretch"
-                              Margin="2,0,0,0">
-                            <StackPanel Orientation="Vertical"
-                                        HorizontalAlignment="Center"
-                                        VerticalAlignment="Center">
-                                <TextBlock ToolTip="{x:Static props:Resources.Space_Around_Zones}"
-                                           x:Name="SpacingTextBlock"
-                                           Foreground="{DynamicResource SecondaryForegroundBrush}">
-                                    <Run FontSize="10"
-                                         Text="&#xE1D9;"
-                                         FontFamily="Segoe MDL2 Assets" />
-                                    <Run Text=" " />
-                                    <Run Text="20" />
-                                </TextBlock>
-                            </StackPanel>
-                        </Grid>
                     </Grid>
                 </Border>
                 <Border x:Name="SelectionHighlight"
@@ -229,9 +211,6 @@
                 <DataTrigger Binding="{Binding IsApplied}"
                              Value="true">
                     <Setter TargetName="layoutName"
-                            Property="Foreground"
-                            Value="{DynamicResource SystemControlBackgroundAccentBrush}" />
-                    <Setter TargetName="SpacingTextBlock"
                             Property="Foreground"
                             Value="{DynamicResource SystemControlBackgroundAccentBrush}" />
                     <Setter TargetName="SelectionHighlight"
@@ -552,7 +531,7 @@
                                Foreground="{DynamicResource PrimaryForegroundBrush}"
                                Visibility="{Binding Converter={StaticResource LayoutModelTypeToVisibilityConverter}}" />
 
-                    <TextBox Margin="0,6,0,0"
+                    <ui:NumberBox Margin="0,6,0,0"
                              IsEnabled="{Binding ShowSpacing}"
                              Text="{Binding Spacing}"
                              Width="86"
@@ -566,7 +545,7 @@
                                Foreground="{DynamicResource PrimaryForegroundBrush}"
                                x:Name="sensitivityRadiusValue" />
 
-                    <TextBox Margin="0,6,0,0"
+                    <ui:NumberBox Margin="0,6,0,0"
                              Text="{Binding SensitivityRadius}"
                              Width="86"
                              AutomationProperties.LabeledBy="{Binding ElementName=sensitivityRadiusValue}"

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -134,6 +134,7 @@
                                    HorizontalAlignment="Left"
                                    VerticalAlignment="Top"
                                    Margin="0,-4,24,0"
+                                   ToolTip="{Binding Name}"
                                    Foreground="{DynamicResource PrimaryForegroundBrush}" />
 
                         <Button Content="&#xE104;"

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -418,19 +418,21 @@
                     <StackPanel Orientation="Horizontal"
                                 HorizontalAlignment="Center"
                                 Visibility="{Binding Path=Type, Converter={StaticResource LayoutTypeTemplateToVisibilityConverter}}">
-                        <Button x:Name="incrementZones"
-                                            Width="40"
-                                            Height="40"
-                                            AutomationProperties.Name="{x:Static props:Resources.Zone_Count_Increment}"
-                                            ToolTip="{x:Static props:Resources.Zone_Count_Increment}"
-                                            Foreground="{DynamicResource SystemControlBackgroundAccentBrush}"
-                                            Style="{StaticResource IconOnlyButtonStyle}"
-                                            Click="IncrementZones_Click">
+
+                        <Button x:Name="decrementZones"
+                                Width="40"
+                                Height="40"
+                                AutomationProperties.Name="{x:Static props:Resources.Zone_Count_Decrement}"
+                                ToolTip="{x:Static props:Resources.Zone_Count_Decrement}"
+                                Foreground="{DynamicResource SystemControlBackgroundAccentBrush}"
+                                Style="{StaticResource IconOnlyButtonStyle}"
+                                Click="DecrementZones_Click">
                             <Button.Content>
-                                <TextBlock Text="&#xE109;"
+                                <TextBlock Text="&#xE108;"
                                            FontFamily="Segoe MDL2 Assets" />
                             </Button.Content>
                         </Button>
+                     
                         <TextBlock x:Name="zoneCount"
                                    Text="{Binding TemplateZoneCount}"
                                    FontWeight="SemiBold"
@@ -442,16 +444,16 @@
                                    ToolTip="Number of zones"
                                    VerticalAlignment="Center" />
 
-                        <Button x:Name="decrementZones"
-                                            Width="40"
-                                            Height="40"
-                                            AutomationProperties.Name="{x:Static props:Resources.Zone_Count_Decrement}"
-                                            ToolTip="{x:Static props:Resources.Zone_Count_Decrement}"
-                                            Foreground="{DynamicResource SystemControlBackgroundAccentBrush}"
-                                            Style="{StaticResource IconOnlyButtonStyle}"
-                                            Click="DecrementZones_Click">
+                        <Button x:Name="incrementZones"
+                                Width="40"
+                                Height="40"
+                                AutomationProperties.Name="{x:Static props:Resources.Zone_Count_Increment}"
+                                ToolTip="{x:Static props:Resources.Zone_Count_Increment}"
+                                Foreground="{DynamicResource SystemControlBackgroundAccentBrush}"
+                                Style="{StaticResource IconOnlyButtonStyle}"
+                                Click="IncrementZones_Click">
                             <Button.Content>
-                                <TextBlock Text="&#xE108;"
+                                <TextBlock Text="&#xE109;"
                                            FontFamily="Segoe MDL2 Assets" />
                             </Button.Content>
                         </Button>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -369,8 +369,8 @@
                             AutomationProperties.Name="{x:Static props:Resources.Duplicate}"
                             ToolTip="{x:Static props:Resources.Duplicate}"
                             Content="&#xE8C8;"
-                            Background="Transparent"
                             FontFamily="Segoe MDL2 Assets"
+                            Style="{StaticResource IconOnlyButtonStyle}"
                             Visibility="{Binding Path=Type, Converter={StaticResource LayoutTypeCustomToVisibilityConverter}}" />
 
                     <Button Click="DuplicateLayout_Click"
@@ -378,18 +378,18 @@
                             AutomationProperties.Name="{x:Static props:Resources.Create_Custom_From_Template}"
                             ToolTip="{x:Static props:Resources.Create_Custom_From_Template}"
                             Content="&#xE8C8;"
-                            Background="Transparent"
                             FontFamily="Segoe MDL2 Assets"
+                            Style="{StaticResource IconOnlyButtonStyle}"
                             Visibility="{Binding Path=Type, Converter={StaticResource LayoutTypeTemplateToVisibilityConverter}}" />
 
                     <Button Click="DeleteLayout_Click"
                             x:Name="deleteLayoutButton"
                             AutomationProperties.Name="{x:Static props:Resources.Delete}"
                             ToolTip="{x:Static props:Resources.Delete}"
-                            Background="Transparent"
                             Content="&#xE107;"
                             FontFamily="Segoe MDL2 Assets"
-                            Foreground="Red"
+                            Foreground="#c50500"
+                            Style="{StaticResource IconOnlyButtonStyle}"
                             Visibility="{Binding Path=Type, Converter={StaticResource LayoutTypeCustomToVisibilityConverter}}" />
                 </StackPanel>
 
@@ -397,36 +397,40 @@
                     <local:LayoutPreview Width="216"
                                          Height="132"
                                          Margin="0,16,0,16" />
-                    <ui:HyperlinkButton Click="EditZones_Click"
+                    <Button Click="EditZones_Click"
                                         x:Name="editZoneLayoutButton"
                                         HorizontalAlignment="Stretch"
                                         AutomationProperties.Name="{x:Static props:Resources.Edit_zones}"
                                         HorizontalContentAlignment="Center"
+                                        Foreground="{DynamicResource SystemControlBackgroundAccentBrush}"
+                                        Style="{StaticResource IconOnlyButtonStyle}"
                                         Visibility="{Binding Path=Type, Converter={StaticResource LayoutTypeCustomToVisibilityConverter}}">
-                        <ui:HyperlinkButton.Content>
+                        <Button.Content>
                             <StackPanel Orientation="Horizontal">
                                 <TextBlock Text="&#xE104;"
                                            Margin="0,2,8,0"
                                            FontFamily="Segoe MDL2 Assets" />
                                 <TextBlock Text="{x:Static props:Resources.Edit_zones}" />
                             </StackPanel>
-                        </ui:HyperlinkButton.Content>
-                    </ui:HyperlinkButton>
+                        </Button.Content>
+                    </Button>
 
                     <StackPanel Orientation="Horizontal"
                                 HorizontalAlignment="Center"
                                 Visibility="{Binding Path=Type, Converter={StaticResource LayoutTypeTemplateToVisibilityConverter}}">
-                        <ui:HyperlinkButton x:Name="incrementZones"
+                        <Button x:Name="incrementZones"
                                             Width="40"
                                             Height="40"
                                             AutomationProperties.Name="{x:Static props:Resources.Zone_Count_Increment}"
                                             ToolTip="{x:Static props:Resources.Zone_Count_Increment}"
+                                            Foreground="{DynamicResource SystemControlBackgroundAccentBrush}"
+                                            Style="{StaticResource IconOnlyButtonStyle}"
                                             Click="IncrementZones_Click">
-                            <ui:HyperlinkButton.Content>
+                            <Button.Content>
                                 <TextBlock Text="&#xE109;"
                                            FontFamily="Segoe MDL2 Assets" />
-                            </ui:HyperlinkButton.Content>
-                        </ui:HyperlinkButton>
+                            </Button.Content>
+                        </Button>
                         <TextBlock x:Name="zoneCount"
                                    Text="{Binding TemplateZoneCount}"
                                    FontWeight="SemiBold"
@@ -438,17 +442,19 @@
                                    ToolTip="Number of zones"
                                    VerticalAlignment="Center" />
 
-                        <ui:HyperlinkButton x:Name="decrementZones"
+                        <Button x:Name="decrementZones"
                                             Width="40"
                                             Height="40"
                                             AutomationProperties.Name="{x:Static props:Resources.Zone_Count_Decrement}"
                                             ToolTip="{x:Static props:Resources.Zone_Count_Decrement}"
+                                            Foreground="{DynamicResource SystemControlBackgroundAccentBrush}"
+                                            Style="{StaticResource IconOnlyButtonStyle}"
                                             Click="DecrementZones_Click">
-                            <ui:HyperlinkButton.Content>
+                            <Button.Content>
                                 <TextBlock Text="&#xE108;"
                                            FontFamily="Segoe MDL2 Assets" />
-                            </ui:HyperlinkButton.Content>
-                        </ui:HyperlinkButton>
+                            </Button.Content>
+                        </Button>
                     </StackPanel>
                     <TextBox Text="{Binding Name}"
                              ui:ControlHelper.Header="{x:Static props:Resources.Name}"

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -360,7 +360,7 @@
             <Grid DataContext="{Binding SelectedModel}"
                   MinWidth="320" Margin="0,0,0,32">
 
-                <StackPanel Margin="0,-32,0,0"
+                <StackPanel Margin="0,-37,0,0"
                             HorizontalAlignment="Right"
                             VerticalAlignment="Top"
                             Orientation="Horizontal">

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
@@ -529,8 +529,8 @@ namespace FancyZonesEditor.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Hold down Shift key to change orientation of splitter.
-        ///To merge zones, select the zones and click &quot;merge&quot;..
+        ///   Looks up a localized string similar to To change the orientation of the splitter, hold down the Shift key.
+        ///To merge zones, click and drag over the zones you wish to merge..
         /// </summary>
         public static string Note_Custom_Table {
             get {

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
@@ -286,7 +286,7 @@ namespace FancyZonesEditor.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Edit zones.
+        ///   Looks up a localized string similar to Edit zone layout.
         /// </summary>
         public static string Edit_zones {
             get {
@@ -665,7 +665,7 @@ namespace FancyZonesEditor.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Decrement number of zones in template layout.
+        ///   Looks up a localized string similar to Decrement number of zones.
         /// </summary>
         public static string Zone_Count_Decrement {
             get {
@@ -674,7 +674,7 @@ namespace FancyZonesEditor.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Increment number of zones in template layout.
+        ///   Looks up a localized string similar to Increment number of zones.
         /// </summary>
         public static string Zone_Count_Increment {
             get {

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
@@ -529,8 +529,8 @@ namespace FancyZonesEditor.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to To change the orientation of the splitter, hold down the Shift key.
-        ///To merge zones, click and drag over the zones you wish to merge..
+        ///   Looks up a localized string similar to Hold down Shift key to change orientation of splitter.
+        ///To merge zones, select the zones and click &quot;merge&quot;..
         /// </summary>
         public static string Note_Custom_Table {
             get {

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
@@ -176,10 +176,10 @@ To merge zones, select the zones and click "merge".</value>
     <value>Templates</value>
   </data>
   <data name="Zone_Count_Decrement" xml:space="preserve">
-    <value>Decrement number of zones in template layout</value>
+    <value>Decrement number of zones</value>
   </data>
   <data name="Zone_Count_Increment" xml:space="preserve">
-    <value>Increment number of zones in template layout</value>
+    <value>Increment number of zones</value>
   </data>
   <data name="Error_Invalid_Arguments" xml:space="preserve">
     <value>FancyZones Editor arguments are invalid.</value>
@@ -298,7 +298,7 @@ To merge zones, select the zones and click "merge".</value>
     <value>Are you sure you want to delete this layout?</value>
   </data>
   <data name="Edit_zones" xml:space="preserve">
-    <value>Edit zones</value>
+    <value>Edit zone layout</value>
   </data>
   <data name="No_Custom_Layouts_Message" xml:space="preserve">
     <value>Create or duplicate a layout to get started</value>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
@@ -160,8 +160,8 @@
     <value>Name</value>
   </data>
   <data name="Note_Custom_Table" xml:space="preserve">
-    <value>Hold down Shift key to change orientation of splitter.
-To merge zones, select the zones and click "merge".</value>
+    <value>To change the orientation of the splitter, hold down the Shift key.
+To merge zones, click and drag over the zones you wish to merge.</value>
   </data>
   <data name="Save_Apply" xml:space="preserve">
     <value>Save &amp; apply</value>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
@@ -160,8 +160,8 @@
     <value>Name</value>
   </data>
   <data name="Note_Custom_Table" xml:space="preserve">
-    <value>To change the orientation of the splitter, hold down the Shift key.
-To merge zones, click and drag over the zones you wish to merge.</value>
+    <value>Hold down Shift key to change orientation of splitter.
+To merge zones, select the zones and click "merge".</value>
   </data>
   <data name="Save_Apply" xml:space="preserve">
     <value>Save &amp; apply</value>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Styles/ButtonStyles.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Styles/ButtonStyles.xaml
@@ -1,6 +1,7 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:ui="http://schemas.modernwpf.com/2019"
+                    xmlns:primitives="clr-namespace:ModernWpf.Controls.Primitives"
                     xmlns:local="clr-namespace:FancyZonesEditor.Styles">
     
     <Style x:Key="LayoutTypeRadioButtonStyle" TargetType="RadioButton">
@@ -84,6 +85,70 @@
                             <Setter TargetName="ContentPresenter" Property="Foreground" Value="{DynamicResource RadioButtonForegroundDisabled}" />
                             <Setter TargetName="RootGrid" Property="Background" Value="{DynamicResource RadioButtonBackgroundDisabled}" />
                             <Setter TargetName="RootGrid" Property="BorderBrush" Value="{DynamicResource RadioButtonBorderBrushDisabled}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="IconOnlyButtonStyle"
+           BasedOn="{StaticResource DefaultButtonStyle}"
+           TargetType="Button">
+        <Setter Property="Background"
+                Value="Transparent" />
+        <Setter Property="Foreground"
+                Value="{DynamicResource ButtonForeground}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="Background"
+                            Background="Transparent"
+                            CornerRadius="{TemplateBinding ui:ControlHelper.CornerRadius}"
+                            SnapsToDevicePixels="True">
+                        <Border x:Name="Border"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                Padding="{TemplateBinding Padding}"
+                                CornerRadius="{TemplateBinding ui:ControlHelper.CornerRadius}">
+                            <ContentPresenter x:Name="ContentPresenter"
+                                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                              Focusable="False"
+                                              RecognizesAccessKey="True"
+                                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                        </Border>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver"
+                                 Value="True">
+                            <Setter TargetName="Background"
+                                    Property="Background"
+                                    Value="{DynamicResource ButtonBackgroundPointerOver}" />
+                            <Setter TargetName="Border"
+                                    Property="BorderBrush"
+                                    Value="{DynamicResource ButtonBorderBrushPointerOver}" />
+                        </Trigger>
+                        <Trigger Property="IsPressed"
+                                 Value="True">
+                            <Setter TargetName="Background"
+                                    Property="Background"
+                                    Value="{DynamicResource ButtonBackgroundPressed}" />
+                            <Setter TargetName="Border"
+                                    Property="BorderBrush"
+                                    Value="{DynamicResource ButtonBorderBrushPressed}" />
+                        </Trigger>
+                        <Trigger Property="IsEnabled"
+                                 Value="False">
+                            <Setter TargetName="Background"
+                                    Property="Background"
+                                    Value="{DynamicResource ButtonBackgroundDisabled}" />
+                            <Setter TargetName="Border"
+                                    Property="BorderBrush"
+                                    Value="{DynamicResource ButtonBorderBrushDisabled}" />
+                            <Setter TargetName="ContentPresenter"
+                                    Property="TextElement.Foreground"
+                                    Value="{DynamicResource ButtonForegroundDisabled}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>


### PR DESCRIPTION
## Summary of the Pull Request

This PR introduces some minor UX changes:

- Smaller font-size and use of secondary brush for the zone resolution labels.
- Layout title no longer runs through the edit button (#9610)
- Added tooltips to the increment/decrement buttons. (#7075)

- Redesign edit dialog (partly #9335):
- NumberBoxes instead of TextBoxes for numeric values
- LayoutPreview is now also visible within the dialog.
- Improved visual hierarchy, aligned with inbox applications (like the new Alarms & Clock applications).


![EditorDialgoV2](https://user-images.githubusercontent.com/9866362/107878779-1ab39c00-6ed5-11eb-8b53-014455b7d57b.gif)


## Quality Checklist

- [X] **Linked issue:** #9610, #7075, #9335
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
