### PR TITLE
[Run] Fix context menu

### DIFF
--- a/src/modules/launcher/PowerLauncher/LauncherControl.xaml
+++ b/src/modules/launcher/PowerLauncher/LauncherControl.xaml
@@ -6,6 +6,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
     xmlns:p="clr-namespace:PowerLauncher.Properties"
     xmlns:local="clr-namespace:PowerLauncher"
+    xmlns:ui="http://schemas.modernwpf.com/2019"
     mc:Ignorable="d" 
     d:DesignHeight="300"
     d:DesignWidth="720">
@@ -20,6 +21,7 @@
             <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
             <Setter Property="AllowDrop" Value="true"/>
             <Setter Property="ContextMenu" Value="{DynamicResource TextControlContextMenu}" />
+            <Setter Property="ui:TextContextMenu.UsingTextContextMenu" Value="True" />
             <Setter Property="ScrollViewer.PanningMode" Value="VerticalFirst"/>
             <Setter Property="Stylus.IsFlicksEnabled" Value="False"/>
             <Setter Property="Padding" Value="12,0,0,0" />

--- a/src/modules/launcher/PowerLauncher/LauncherControl.xaml
+++ b/src/modules/launcher/PowerLauncher/LauncherControl.xaml
@@ -19,6 +19,7 @@
             <Setter Property="HorizontalContentAlignment" Value="Left"/>
             <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
             <Setter Property="AllowDrop" Value="true"/>
+            <Setter Property="ContextMenu" Value="{DynamicResource TextControlContextMenu}" />
             <Setter Property="ScrollViewer.PanningMode" Value="VerticalFirst"/>
             <Setter Property="Stylus.IsFlicksEnabled" Value="False"/>
             <Setter Property="Padding" Value="12,0,0,0" />


### PR DESCRIPTION
## Summary of the Pull Request
Right-clicking the search box would bring up a context menu with an outdated look and feel (#9607):

![image](https://user-images.githubusercontent.com/9866362/107879310-6c115a80-6ed8-11eb-8d17-93f0c44e9601.png)


This PR adds the correct visual style:
![image](https://user-images.githubusercontent.com/9866362/107879341-9400be00-6ed8-11eb-8516-5454cbb7b74d.png)



## Quality Checklist

- [X] **Linked issue:** #9607
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
