### PR TITLE
[Settings] Plugin manager UX fixes

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -944,7 +944,7 @@
     <value>Direct activation phrase</value>
   </data>
   <data name="PowerLauncher_AuthoredBy.Text" xml:space="preserve">
-    <value>Author:</value>
+    <value>Authored by</value>
     <comment>example: Authored by Microsoft</comment>
   </data>
   <data name="PowerLauncher_IncludeInGlobalResult.Content" xml:space="preserve">

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -940,18 +940,15 @@
   <data name="PowerLauncher_Plugins.Text" xml:space="preserve">
     <value>Plug-ins</value>
   </data>
-  <data name="PowerLauncher_ActionKeywordTextBlock.Text" xml:space="preserve">
-    <value>Direct Activation phrase</value>
+  <data name="PowerLauncher_ActionKeyword.Text" xml:space="preserve">
+    <value>Direct activation phrase</value>
   </data>
   <data name="PowerLauncher_AuthoredBy.Text" xml:space="preserve">
-    <value>Authored by</value>
+    <value>Author:</value>
     <comment>example: Authored by Microsoft</comment>
   </data>
   <data name="PowerLauncher_IncludeInGlobalResult.Content" xml:space="preserve">
     <value>Include in global result</value>
-  </data>
-  <data name="PowerLauncher_ActionKeywordTextBox.AutomationProperties.Name" xml:space="preserve">
-    <value>Direct Activation phrase</value>
   </data>
   <data name="PowerLauncher_EnablePluginToggle.AutomationProperties.Name" xml:space="preserve">
     <value>Enable plugin</value>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
@@ -153,47 +153,77 @@
                        Style="{StaticResource SettingsGroupTitleStyle}"
                        Foreground="{x:Bind Mode=OneWay, Path=ViewModel.EnablePowerLauncher, Converter={StaticResource ModuleEnabledToForegroundConverter}}"/>
 
-            <ListView 
-                ItemsSource="{x:Bind Path=ViewModel.Plugins}"
-                SelectionMode="None"
-                IsItemClickEnabled="True"
-                IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.EnablePowerLauncher}"
-                ItemClick="ListView_ItemClick"
-                >
+            <ListView ItemsSource="{x:Bind Path=ViewModel.Plugins}"
+                      SelectionMode="None"
+                      IsItemClickEnabled="True"
+                      IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.EnablePowerLauncher}"
+                      ItemClick="ListView_ItemClick"
+                      Margin="-12,12,0,0">
 
                 <ListView.ItemContainerStyle>
                     <Style TargetType="ListViewItem">
-                        <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
-                        <Setter Property="VerticalContentAlignment" Value="Stretch" />
-                        <Setter Property="Padding" Value="0,0,0,0"/>
+                        <Setter Property="HorizontalContentAlignment"
+                                Value="Stretch" />
+                        <Setter Property="VerticalContentAlignment"
+                                Value="Stretch" />
+                        <Setter Property="Padding"
+                                Value="0,0,0,0" />
                     </Style>
                 </ListView.ItemContainerStyle>
                 <ListView.ItemTemplate>
                     <DataTemplate x:DataType="ViewModels:PowerLauncherPluginViewModel">
-                        <StackPanel Orientation="Vertical" Padding="20,10,20,10">
-                            <Grid ColumnSpacing="10">
+                        <StackPanel Orientation="Vertical"
+                                    Padding="0,12,0,12">
+                            <Grid ColumnSpacing="0">
                                 <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="40"/>
-                                    <ColumnDefinition Width="*"/>
-                                    <ColumnDefinition Width="40"/>
+                                    <ColumnDefinition Width="60" />
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="52" />
                                 </Grid.ColumnDefinitions>
 
-                                <Image Source="{x:Bind IconPath}"/>
+                                <Image Source="{x:Bind IconPath}"
+                                       Width="36"
+                                       HorizontalAlignment="Left"
+                                       VerticalAlignment="Top"
+                                       Margin="12,0,12,0"
+                                       Height="36" />
 
-                                <StackPanel Orientation="Vertical" Grid.Column="1">
-                                    <TextBlock FontSize="18" Text="{x:Bind Path=Name}"/>
-                                    <TextBlock FontSize="12" TextWrapping="Wrap">
-                                        <Run Text="{x:Bind Description}" />. <Run x:Uid="PowerLauncher_AuthoredBy" /> <Run Text="{x:Bind Author}" /><Run Text="." />
+                                <StackPanel Orientation="Vertical"
+                                            Grid.Column="1" Margin="0,0,12,0">
+                                    <TextBlock FontSize="18"
+                                               Text="{x:Bind Path=Name}" />
+                                    <TextBlock FontSize="12"
+                                               Foreground="{ThemeResource SystemBaseMediumColor}"
+                                               Text="{x:Bind Description}"
+                                               TextWrapping="Wrap" />
+                                    <TextBlock FontSize="12"
+                                               Foreground="{ThemeResource SystemBaseMediumColor}">
+                                           <Run x:Uid="PowerLauncher_AuthoredBy" />
+                                           <Run FontWeight="SemiBold" Text="{x:Bind Author}" />
                                     </TextBlock>
                                 </StackPanel>
 
-                                <ToggleSwitch x:Uid="PowerLauncher_EnablePluginToggle" x:Name="ToggleSwitch" IsOn="{x:Bind Path=Disabled, Converter={StaticResource BooleanInvertConverter}, Mode=TwoWay}" Grid.Column="2"/>
+                                <ToggleSwitch x:Uid="PowerLauncher_EnablePluginToggle"
+                                              x:Name="ToggleSwitch"
+                                              HorizontalAlignment="Center"
+                                              IsOn="{x:Bind Path=Disabled, Converter={StaticResource BooleanInvertConverter}, Mode=TwoWay}"
+                                              Grid.Column="2" />
                             </Grid>
 
-                            <StackPanel  Padding="10,10,10,0" Visibility="{x:Bind Path=ShowAdditionalInfo, Mode=TwoWay, Converter={StaticResource BooleanToVisibilityConverter}}">
-                                <CheckBox x:Uid="PowerLauncher_IncludeInGlobalResult" IsChecked="{x:Bind Path=IsGlobal, Mode=TwoWay}" />
-                                <TextBlock x:Uid="PowerLauncher_ActionKeywordTextBlock" Margin="0,5,0,0" />
-                                <TextBox x:Uid="PowerLauncher_ActionKeywordTextBox" Text="{x:Bind Path=ActionKeyword, Mode=TwoWay}" Width="150px" HorizontalAlignment="Left"></TextBox>
+                            <StackPanel  Margin="60,24,0,0"
+                                         Visibility="{x:Bind Path=ShowAdditionalInfo, Mode=TwoWay, Converter={StaticResource BooleanToVisibilityConverter}}">
+
+                                <CheckBox x:Uid="PowerLauncher_IncludeInGlobalResult"
+                                          IsChecked="{x:Bind Path=IsGlobal, Mode=TwoWay}" />
+                                <TextBlock x:Uid="PowerLauncher_ActionKeyword"
+                                           x:Name="ActionKeywordHeaderTextBlock"
+                                           Margin="{StaticResource SmallTopMargin}" />
+                                <TextBox x:Uid="PowerLauncher_ActionKeyword"
+                                         Text="{x:Bind Path=ActionKeyword, Mode=TwoWay}"
+                                         Width="86"
+                                         Margin="0,6,0,0"
+                                         AutomationProperties.LabeledBy="{Binding ElementName=ActionKeywordHeaderTextBlock}"
+                                         HorizontalAlignment="Left" />
                             </StackPanel>
                         </StackPanel>
                     </DataTemplate>


### PR DESCRIPTION
## Summary of the Pull Request

I made some minor changes (XAML only) to the plug-in manager UX so it's inline with W10 Settings and adhering to the correct margins/paddings across PT settings.

![Settingsv2](https://user-images.githubusercontent.com/9866362/107885805-9aa12c80-6efc-11eb-9be8-598a7bc5c6dc.gif)


@enricogior @mykhailopylyp I know this branch / feature is still work in progress, so if it's blocking anything at the moment let me know.

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
