### PR TITLE
[Run] [Plugin manager] Updated plugins listview selection logic

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/PowerLauncherPluginViewModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/PowerLauncherPluginViewModel.cs
@@ -85,21 +85,6 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
 
         public string IconPath { get => isDark() ? settings.IconPathDark : settings.IconPathLight; }
 
-        private bool _showAdditionalInfo;
-
-        public bool ShowAdditionalInfo
-        {
-            get => _showAdditionalInfo;
-            set
-            {
-                if (value != _showAdditionalInfo)
-                {
-                    _showAdditionalInfo = value;
-                    NotifyPropertyChanged();
-                }
-            }
-        }
-
         public event PropertyChangedEventHandler PropertyChanged;
 
         private void NotifyPropertyChanged([CallerMemberName] string propertyName = "")

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
@@ -7,9 +7,9 @@
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     x:Class="Microsoft.PowerToys.Settings.UI.Views.PowerLauncherPage"
     xmlns:CustomControls="using:Microsoft.PowerToys.Settings.UI.Controls"
-      xmlns:Interactivity="using:Microsoft.Xaml.Interactivity"
-      xmlns:Core="using:Microsoft.Xaml.Interactions.Core"
-      mc:Ignorable="d"
+    xmlns:Interactivity="using:Microsoft.Xaml.Interactivity"
+    xmlns:Core="using:Microsoft.Xaml.Interactions.Core"
+    mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     AutomationProperties.LandmarkType="Main">
     

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
@@ -7,7 +7,9 @@
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     x:Class="Microsoft.PowerToys.Settings.UI.Views.PowerLauncherPage"
     xmlns:CustomControls="using:Microsoft.PowerToys.Settings.UI.Controls"
-    mc:Ignorable="d"
+      xmlns:Interactivity="using:Microsoft.Xaml.Interactivity"
+      xmlns:Core="using:Microsoft.Xaml.Interactions.Core"
+      mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     AutomationProperties.LandmarkType="Main">
     
@@ -153,13 +155,19 @@
                        Style="{StaticResource SettingsGroupTitleStyle}"
                        Foreground="{x:Bind Mode=OneWay, Path=ViewModel.EnablePowerLauncher, Converter={StaticResource ModuleEnabledToForegroundConverter}}"/>
 
-            <ListView ItemsSource="{x:Bind Path=ViewModel.Plugins}"
-                      SelectionMode="None"
+            <ListView ItemsSource="{x:Bind Path=ViewModel.Plugins}"                
                       IsItemClickEnabled="True"
+                      x:Name="PluginsListView"
                       IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.EnablePowerLauncher}"
-                      ItemClick="ListView_ItemClick"
                       Margin="-12,12,0,0">
-
+                <ListView.Resources>
+                    <SolidColorBrush x:Key="ListViewItemBackgroundSelected"
+                                     Color="{ThemeResource SystemChromeLowColor}" />
+                    <SolidColorBrush x:Key="ListViewItemBackgroundSelectedPointerOver"
+                                     Color="{ThemeResource SystemChromeLowColor}" />
+                    <SolidColorBrush x:Key="ListViewItemBackgroundSelectedPressed"
+                                     Color="{ThemeResource SystemChromeLowColor}" />
+                </ListView.Resources>
                 <ListView.ItemContainerStyle>
                     <Style TargetType="ListViewItem">
                         <Setter Property="HorizontalContentAlignment"
@@ -172,8 +180,25 @@
                 </ListView.ItemContainerStyle>
                 <ListView.ItemTemplate>
                     <DataTemplate x:DataType="ViewModels:PowerLauncherPluginViewModel">
-                        <StackPanel Orientation="Vertical"
+                        <StackPanel Orientation="Vertical" Background="Transparent"
                                     Padding="0,12,0,12">
+                            <Interactivity:Interaction.Behaviors>
+
+                                <Core:DataTriggerBehavior Binding="{Binding ElementName=PluginsListView, Path=SelectedItem.Id, Mode=OneWay}"
+                                                          Value="{Binding Id}"
+                                                          ComparisonCondition="Equal">
+                                    <Core:ChangePropertyAction TargetObject="{Binding ElementName=AdditionalInfoPanel}"
+                                                               PropertyName="Visibility"
+                                                               Value="Visible" />
+                                </Core:DataTriggerBehavior>
+                                <Core:DataTriggerBehavior Binding="{Binding ElementName=PluginsListView, Path=SelectedItem.Id, Mode=OneWay}"
+                                                          Value="{Binding Id}"
+                                                          ComparisonCondition="NotEqual">
+                                    <Core:ChangePropertyAction TargetObject="{Binding ElementName=AdditionalInfoPanel}"
+                                                               PropertyName="Visibility"
+                                                               Value="Collapsed" />
+                                </Core:DataTriggerBehavior>
+                            </Interactivity:Interaction.Behaviors>
                             <Grid ColumnSpacing="0">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="60" />
@@ -210,8 +235,7 @@
                                               Grid.Column="2" />
                             </Grid>
 
-                            <StackPanel  Margin="60,24,0,0"
-                                         Visibility="{x:Bind Path=ShowAdditionalInfo, Mode=TwoWay, Converter={StaticResource BooleanToVisibilityConverter}}">
+                            <StackPanel  Margin="60,24,0,24" x:Name="AdditionalInfoPanel" Visibility="Collapsed">
 
                                 <CheckBox x:Uid="PowerLauncher_IncludeInGlobalResult"
                                           IsChecked="{x:Bind Path=IsGlobal, Mode=TwoWay}" />

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml.cs
@@ -40,17 +40,6 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             searchTypePreferencesOptions.Add(Tuple.Create(loader.GetString("PowerLauncher_SearchTypePreference_ExecutableName"), "executable_name"));
         }
 
-        private void ListView_ItemClick(object sender, ItemClickEventArgs e)
-        {
-            var plugin = e.ClickedItem as PowerLauncherPluginViewModel;
-            if (plugin == null)
-            {
-                return;
-            }
-
-            plugin.ShowAdditionalInfo = plugin.ShowAdditionalInfo != true;
-        }
-
         private void OpenColorsSettings_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
             Helpers.StartProcessHelper.Start(Helpers.StartProcessHelper.ColorsSettings);


### PR DESCRIPTION
## Summary of the Pull Request
This PR moves the selection logic (= show additional logic) to XAML only (and not the ViewModel) to enable the correct behavior:

- Only 1 plug-in can be expanded at a time.
- The expanded plug-in has the correct highlight brush.

Comparison: plugin manager vs. W10 Settings

![PLuginselection](https://user-images.githubusercontent.com/9866362/108045392-b4995700-7043-11eb-81e2-bbf3b1fd6024.gif)

## Quality Checklist

- [X] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
