### PR TITLE
[Runner] Fix stealing shortcuts on older Win10 builds

### DIFF
--- a/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
+++ b/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
@@ -202,9 +202,16 @@ public:
                 sei.lpFile = L"modules\\launcher\\PowerLauncher.exe";
                 sei.nShow = SW_SHOWNORMAL;
                 sei.lpParameters = executable_args.data();
-                ShellExecuteExW(&sei);
-
-                m_hProcess = sei.hProcess;
+                
+                if (ShellExecuteExW(&sei))
+                {
+                    m_enabled = true;
+                    m_hProcess = sei.hProcess;
+                }
+                else
+                {
+                    Logger::error("Launcher failed to start");
+                }
             }
             else
             {
@@ -231,6 +238,7 @@ public:
 
                         if (run_non_elevated(action_runner_path, params, pidBuffer))
                         {
+                            m_enabled = true;
                             const int maxRetries = 80;
                             for (int retry = 0; retry < maxRetries; ++retry)
                             {
@@ -248,8 +256,6 @@ public:
                 }
             }
         }
-
-        m_enabled = true;
     }
 
     // Disable the powertoy


### PR DESCRIPTION
## Summary of the Pull Request

In issue #9519, a user has an older Windows 10 build, and one code path thinks that PT Run is enabled and should accept its keyboard shortcut (Alt+Space by default), so the user cannot use this shortcut even though PT Run isn't running. This PR fixes the issue.

**What is this about:**

The issue is not with the centralized keyboard hook as initially suspected, but with the member `m_enabled` being set to `true` even when PT Run isn't actually enabled, thus causing the hook to accept the shortuct.

**What is include in the PR:** 

Set `m_enabled = true` only when PT Run is actually started.

**How does someone test / validate:** 

First, make sure that PT Run is enabled in the settings and the shortcut is set to some value e.g. Alt+Space. Replace the implementation of `inline bool UseNewSettings()` in `os-detect.h` to `return false;` to simulate behavior on older Win10 builds. Test the behavior with and without the change in this PR. 

## Quality Checklist

- [x] **Linked issue:** #9519 
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
