### PR TITLE
[Settings] Settings window arguments revision

### DIFF
--- a/src/settings-ui/PowerToys.Settings/Program.cs
+++ b/src/settings-ui/PowerToys.Settings/Program.cs
@@ -3,20 +3,27 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
-using System.Threading.Tasks;
 using System.Windows;
 using interop;
 using ManagedCommon;
-using Windows.UI.Popups;
 
 namespace PowerToys.Settings
 {
     public static class Program
     {
+        private enum Arguments
+        {
+            ExecutablePath = 0,
+            PTPipeName,
+            SettingsPipeName, // used in the old settings
+            PTPid,
+            Theme, // used in the old settings
+            ElevatedStatus,
+            IsUserAdmin,
+        }
+
         // Quantity of arguments
-        private const int ArgumentsQty = 5;
+        private const int ArgumentsQty = 6;
 
         // Create an instance of the  IPC wrapper.
         private static TwoWayPipeMessageIPCManaged ipcmanager;
@@ -39,10 +46,10 @@ namespace PowerToys.Settings
 
                 if (args != null && args.Length >= ArgumentsQty)
                 {
-                    _ = int.TryParse(args[2], out int powerToysPID);
+                    _ = int.TryParse(args[(int)Arguments.PTPid], out int powerToysPID);
                     PowerToysPID = powerToysPID;
 
-                    if (args[4] == "true")
+                    if (args[(int)Arguments.ElevatedStatus] == "true")
                     {
                         IsElevated = true;
                     }
@@ -51,7 +58,7 @@ namespace PowerToys.Settings
                         IsElevated = false;
                     }
 
-                    if (args[5] == "true")
+                    if (args[(int)Arguments.IsUserAdmin] == "true")
                     {
                         IsUserAnAdmin = true;
                     }
@@ -65,7 +72,7 @@ namespace PowerToys.Settings
                         Environment.Exit(0);
                     });
 
-                    ipcmanager = new TwoWayPipeMessageIPCManaged(args[1], args[0], (string message) =>
+                    ipcmanager = new TwoWayPipeMessageIPCManaged(args[(int)Arguments.PTPipeName], args[(int)Arguments.ExecutablePath], (string message) =>
                     {
                         if (IPCMessageReceivedCallback != null && message.Length > 0)
                         {

--- a/src/settings-ui/PowerToys.Settings/Program.cs
+++ b/src/settings-ui/PowerToys.Settings/Program.cs
@@ -13,9 +13,8 @@ namespace PowerToys.Settings
     {
         private enum Arguments
         {
-            ExecutablePath = 0,
-            PTPipeName,
-            SettingsPipeName, // used in the old settings
+            PTPipeName = 0,
+            SettingsPipeName,
             PTPid,
             Theme, // used in the old settings
             ElevatedStatus,
@@ -49,30 +48,15 @@ namespace PowerToys.Settings
                     _ = int.TryParse(args[(int)Arguments.PTPid], out int powerToysPID);
                     PowerToysPID = powerToysPID;
 
-                    if (args[(int)Arguments.ElevatedStatus] == "true")
-                    {
-                        IsElevated = true;
-                    }
-                    else
-                    {
-                        IsElevated = false;
-                    }
-
-                    if (args[(int)Arguments.IsUserAdmin] == "true")
-                    {
-                        IsUserAnAdmin = true;
-                    }
-                    else
-                    {
-                        IsUserAnAdmin = false;
-                    }
+                    IsElevated = args[(int)Arguments.ElevatedStatus] == "true";
+                    IsUserAnAdmin = args[(int)Arguments.IsUserAdmin] == "true";
 
                     RunnerHelper.WaitForPowerToysRunner(PowerToysPID, () =>
                     {
                         Environment.Exit(0);
                     });
 
-                    ipcmanager = new TwoWayPipeMessageIPCManaged(args[(int)Arguments.PTPipeName], args[(int)Arguments.ExecutablePath], (string message) =>
+                    ipcmanager = new TwoWayPipeMessageIPCManaged(args[(int)Arguments.SettingsPipeName], args[(int)Arguments.PTPipeName], (string message) =>
                     {
                         if (IPCMessageReceivedCallback != null && message.Length > 0)
                         {


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Fixes arguments parsing in the new settings app. 

**What is include in the PR:** 

**How does someone test / validate:** 

Check that settings app is working as expected.

## Quality Checklist

- [x] **Linked issue:** #9758 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
