### PR TITLE
[PT Run] Service Notification Improvements

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Service/Helpers/ServiceHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Service/Helpers/ServiceHelper.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.ServiceProcess;
@@ -75,11 +74,11 @@ namespace Microsoft.PowerToys.Run.Plugin.Service.Helpers
 
                 if (exitCode == 0)
                 {
-                    contextAPI.ShowNotification(GetLocalizedMessage(serviceResult, action));
+                    contextAPI.ShowNotification(GetLocalizedMessage(action), serviceResult.DisplayName);
                 }
                 else
                 {
-                    contextAPI.ShowNotification("An error occurred");
+                    contextAPI.ShowNotification(GetLocalizedErrorMessage(action), serviceResult.DisplayName);
                     Log.Error($"The command returned {exitCode}", MethodBase.GetCurrentMethod().DeclaringType);
                 }
             }
@@ -192,19 +191,39 @@ namespace Microsoft.PowerToys.Run.Plugin.Service.Helpers
             }
         }
 
-        private static string GetLocalizedMessage(ServiceResult serviceResult, Action action)
+        private static string GetLocalizedMessage(Action action)
         {
             if (action == Action.Start)
             {
-                return string.Format(CultureInfo.CurrentCulture, Resources.wox_plugin_service_started_notification, serviceResult.DisplayName);
+                return Resources.wox_plugin_service_started_notification;
             }
             else if (action == Action.Stop)
             {
-                return string.Format(CultureInfo.CurrentCulture, Resources.wox_plugin_service_stopped_notification, serviceResult.DisplayName);
+                return Resources.wox_plugin_service_stopped_notification;
             }
             else if (action == Action.Restart)
             {
-                return string.Format(CultureInfo.CurrentCulture, Resources.wox_plugin_service_restarted_notification, serviceResult.DisplayName);
+                return Resources.wox_plugin_service_restarted_notification;
+            }
+            else
+            {
+                return string.Empty;
+            }
+        }
+
+        private static string GetLocalizedErrorMessage(Action action)
+        {
+            if (action == Action.Start)
+            {
+                return Resources.wox_plugin_service_start_error_notification;
+            }
+            else if (action == Action.Stop)
+            {
+                return Resources.wox_plugin_service_stop_error_notification;
+            }
+            else if (action == Action.Restart)
+            {
+                return Resources.wox_plugin_service_restart_error_notification;
             }
             else
             {

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Service/Properties/Resources.Designer.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Service/Properties/Resources.Designer.cs
@@ -124,7 +124,16 @@ namespace Microsoft.PowerToys.Run.Plugin.Service.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} has been restarted.
+        ///   Looks up a localized string similar to An error occurred while restarting the service.
+        /// </summary>
+        internal static string wox_plugin_service_restart_error_notification {
+            get {
+                return ResourceManager.GetString("wox_plugin_service_restart_error_notification", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The service has been restarted.
         /// </summary>
         internal static string wox_plugin_service_restarted_notification {
             get {
@@ -147,6 +156,15 @@ namespace Microsoft.PowerToys.Run.Plugin.Service.Properties {
         internal static string wox_plugin_service_start {
             get {
                 return ResourceManager.GetString("wox_plugin_service_start", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to An error occurred while starting the service.
+        /// </summary>
+        internal static string wox_plugin_service_start_error_notification {
+            get {
+                return ResourceManager.GetString("wox_plugin_service_start_error_notification", resourceCulture);
             }
         }
         
@@ -214,7 +232,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Service.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} has been started.
+        ///   Looks up a localized string similar to The service has been started.
         /// </summary>
         internal static string wox_plugin_service_started_notification {
             get {
@@ -250,6 +268,15 @@ namespace Microsoft.PowerToys.Run.Plugin.Service.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to An error occurred while stopping the service.
+        /// </summary>
+        internal static string wox_plugin_service_stop_error_notification {
+            get {
+                return ResourceManager.GetString("wox_plugin_service_stop_error_notification", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Stopping.
         /// </summary>
         internal static string wox_plugin_service_stop_pending {
@@ -268,7 +295,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Service.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} has been stopped.
+        ///   Looks up a localized string similar to The service has been stopped.
         /// </summary>
         internal static string wox_plugin_service_stopped_notification {
             get {

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Service/Properties/Resources.resx
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Service/Properties/Resources.resx
@@ -139,7 +139,10 @@
     <value>Restart (Ctrl+R)</value>
   </data>
   <data name="wox_plugin_service_restarted_notification" xml:space="preserve">
-    <value>{0} has been restarted</value>
+    <value>The service has been restarted</value>
+  </data>
+  <data name="wox_plugin_service_restart_error_notification" xml:space="preserve">
+    <value>An error occurred while restarting the service</value>
   </data>
   <data name="wox_plugin_service_running" xml:space="preserve">
     <value>Running</value>
@@ -151,10 +154,13 @@
     <value>Started</value>
   </data>
   <data name="wox_plugin_service_started_notification" xml:space="preserve">
-    <value>{0} has been started</value>
+    <value>The service has been started</value>
   </data>
   <data name="wox_plugin_service_startup" xml:space="preserve">
     <value>Startup</value>
+  </data>
+  <data name="wox_plugin_service_start_error_notification" xml:space="preserve">
+    <value>An error occurred while starting the service</value>
   </data>
   <data name="wox_plugin_service_start_mode_automatic" xml:space="preserve">
     <value>Automatic</value>
@@ -184,7 +190,10 @@
     <value>Stopped</value>
   </data>
   <data name="wox_plugin_service_stopped_notification" xml:space="preserve">
-    <value>{0} has been stopped</value>
+    <value>The service has been stopped</value>
+  </data>
+  <data name="wox_plugin_service_stop_error_notification" xml:space="preserve">
+    <value>An error occurred while stopping the service</value>
   </data>
   <data name="wox_plugin_service_stop_pending" xml:space="preserve">
     <value>Stopping</value>

--- a/src/modules/launcher/PowerLauncher/PublicAPIInstance.cs
+++ b/src/modules/launcher/PowerLauncher/PublicAPIInstance.cs
@@ -84,14 +84,18 @@ namespace Wox
             });
         }
 
-        public void ShowNotification(string text)
+        public void ShowNotification(string text, string secondaryText = null)
         {
+            var builder = new ToastContentBuilder().AddText(text);
+
+            if (!string.IsNullOrWhiteSpace(secondaryText))
+            {
+                builder.AddText(secondaryText);
+            }
+
             Application.Current.Dispatcher.Invoke(() =>
             {
-                ToastContent toastContent = new ToastContentBuilder()
-                    .AddText(text)
-                    .GetToastContent();
-                var toast = new ToastNotification(toastContent.GetXml());
+                var toast = new ToastNotification(builder.GetToastContent().GetXml());
                 DesktopNotificationManagerCompat.CreateToastNotifier().Show(toast);
             });
         }

--- a/src/modules/launcher/Wox.Plugin/IPublicAPI.cs
+++ b/src/modules/launcher/Wox.Plugin/IPublicAPI.cs
@@ -78,7 +78,8 @@ namespace Wox.Plugin
         /// <summary>
         /// Show toast notification
         /// </summary>
-        /// <param name="text">Notification text</param>
-        void ShowNotification(string text);
+        /// <param name="text">Notification main text</param>
+        /// <param name="secondaryText">Notification optional text</param>
+        void ShowNotification(string text, string secondaryText = null);
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Improvements for PT Run Service plugin notifications
Unfortunately error is just an exit. Not sure if we can translate in error message.

**What is include in the PR:** 

![OK](https://user-images.githubusercontent.com/25966642/108261098-6bd8bf80-7163-11eb-9c60-f7d5f41a833b.png) ![KO](https://user-images.githubusercontent.com/25966642/108261102-6d09ec80-7163-11eb-96bb-e3ed05d2e88d.png)

**How does someone test / validate:** 
Validate new notifications

## Quality Checklist

- [x] **Linked issue:** #9532 #9533
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
