### PR TITLE
[Oobe] Show OOBE window at the first launch.

### DIFF
--- a/src/common/SettingsAPI/settings_helpers.cpp
+++ b/src/common/SettingsAPI/settings_helpers.cpp
@@ -5,6 +5,7 @@ namespace PTSettingsHelper
 {
     constexpr inline const wchar_t* settings_filename = L"\\settings.json";
     constexpr inline const wchar_t* log_settings_filename = L"log_settings.json";
+    constexpr inline const wchar_t* oobe_filename = L"oobe_settings.json";
 
     std::wstring get_root_save_folder_location()
     {
@@ -76,5 +77,35 @@ namespace PTSettingsHelper
         std::filesystem::path result(PTSettingsHelper::get_root_save_folder_location());
         result = result.append(log_settings_filename);
         return result.wstring();
+    }
+
+    bool get_oobe_opened_state()
+    {
+        std::filesystem::path oobePath(PTSettingsHelper::get_root_save_folder_location());
+        oobePath = oobePath.append(oobe_filename);
+        if (std::filesystem::exists(oobePath))
+        {
+            auto saved_settings = json::from_file(oobePath.c_str());
+            if (!saved_settings.has_value())
+            {
+                return false;
+            }
+
+            bool opened = saved_settings->GetNamedBoolean(L"openedAtFirstLaunch", false);
+            return opened;
+        }
+
+        return false;
+    }
+
+    void save_oobe_opened_state()
+    {
+        std::filesystem::path oobePath(PTSettingsHelper::get_root_save_folder_location());
+        oobePath = oobePath.append(oobe_filename);
+
+        json::JsonObject obj;
+        obj.SetNamedValue(L"openedAtFirstLaunch", json::value(true));
+
+        json::to_file(oobePath.c_str(), obj);
     }
 }

--- a/src/common/SettingsAPI/settings_helpers.cpp
+++ b/src/common/SettingsAPI/settings_helpers.cpp
@@ -79,45 +79,33 @@ namespace PTSettingsHelper
         return result.wstring();
     }
 
-    bool get_oobe_opened_state() noexcept
+    bool get_oobe_opened_state()
     {
-        try
+        std::filesystem::path oobePath(PTSettingsHelper::get_root_save_folder_location());
+        oobePath = oobePath.append(oobe_filename);
+        if (std::filesystem::exists(oobePath))
         {
-            std::filesystem::path oobePath(PTSettingsHelper::get_root_save_folder_location());
-            oobePath = oobePath.append(oobe_filename);
-            if (std::filesystem::exists(oobePath))
+            auto saved_settings = json::from_file(oobePath.c_str());
+            if (!saved_settings.has_value())
             {
-                auto saved_settings = json::from_file(oobePath.c_str());
-                if (!saved_settings.has_value())
-                {
-                    return false;
-                }
-
-                bool opened = saved_settings->GetNamedBoolean(L"openedAtFirstLaunch", false);
-                return opened;
+                return false;
             }
-        }
-        catch (const std::exception&)
-        {
+
+            bool opened = saved_settings->GetNamedBoolean(L"openedAtFirstLaunch", false);
+            return opened;
         }
         
         return false;
     }
 
-    void save_oobe_opened_state() noexcept
+    void save_oobe_opened_state()
     {
-        try
-        {
-            std::filesystem::path oobePath(PTSettingsHelper::get_root_save_folder_location());
-            oobePath = oobePath.append(oobe_filename);
+        std::filesystem::path oobePath(PTSettingsHelper::get_root_save_folder_location());
+        oobePath = oobePath.append(oobe_filename);
 
-            json::JsonObject obj;
-            obj.SetNamedValue(L"openedAtFirstLaunch", json::value(true));
+        json::JsonObject obj;
+        obj.SetNamedValue(L"openedAtFirstLaunch", json::value(true));
 
-            json::to_file(oobePath.c_str(), obj);
-        }
-        catch (const std::exception&)
-        {
-        }        
+        json::to_file(oobePath.c_str(), obj);      
     }
 }

--- a/src/common/SettingsAPI/settings_helpers.cpp
+++ b/src/common/SettingsAPI/settings_helpers.cpp
@@ -79,33 +79,45 @@ namespace PTSettingsHelper
         return result.wstring();
     }
 
-    bool get_oobe_opened_state()
+    bool get_oobe_opened_state() noexcept
     {
-        std::filesystem::path oobePath(PTSettingsHelper::get_root_save_folder_location());
-        oobePath = oobePath.append(oobe_filename);
-        if (std::filesystem::exists(oobePath))
+        try
         {
-            auto saved_settings = json::from_file(oobePath.c_str());
-            if (!saved_settings.has_value())
+            std::filesystem::path oobePath(PTSettingsHelper::get_root_save_folder_location());
+            oobePath = oobePath.append(oobe_filename);
+            if (std::filesystem::exists(oobePath))
             {
-                return false;
+                auto saved_settings = json::from_file(oobePath.c_str());
+                if (!saved_settings.has_value())
+                {
+                    return false;
+                }
+
+                bool opened = saved_settings->GetNamedBoolean(L"openedAtFirstLaunch", false);
+                return opened;
             }
-
-            bool opened = saved_settings->GetNamedBoolean(L"openedAtFirstLaunch", false);
-            return opened;
         }
-
+        catch (const std::exception&)
+        {
+        }
+        
         return false;
     }
 
-    void save_oobe_opened_state()
+    void save_oobe_opened_state() noexcept
     {
-        std::filesystem::path oobePath(PTSettingsHelper::get_root_save_folder_location());
-        oobePath = oobePath.append(oobe_filename);
+        try
+        {
+            std::filesystem::path oobePath(PTSettingsHelper::get_root_save_folder_location());
+            oobePath = oobePath.append(oobe_filename);
 
-        json::JsonObject obj;
-        obj.SetNamedValue(L"openedAtFirstLaunch", json::value(true));
+            json::JsonObject obj;
+            obj.SetNamedValue(L"openedAtFirstLaunch", json::value(true));
 
-        json::to_file(oobePath.c_str(), obj);
+            json::to_file(oobePath.c_str(), obj);
+        }
+        catch (const std::exception&)
+        {
+        }        
     }
 }

--- a/src/common/SettingsAPI/settings_helpers.h
+++ b/src/common/SettingsAPI/settings_helpers.h
@@ -14,4 +14,7 @@ namespace PTSettingsHelper
     void save_general_settings(const json::JsonObject& settings);
     json::JsonObject load_general_settings();
     std::wstring get_log_settings_file_location();
+
+    bool get_oobe_opened_state();
+    void save_oobe_opened_state();
 }

--- a/src/common/SettingsAPI/settings_helpers.h
+++ b/src/common/SettingsAPI/settings_helpers.h
@@ -15,6 +15,6 @@ namespace PTSettingsHelper
     json::JsonObject load_general_settings();
     std::wstring get_log_settings_file_location();
 
-    bool get_oobe_opened_state() noexcept;
-    void save_oobe_opened_state() noexcept;
+    bool get_oobe_opened_state();
+    void save_oobe_opened_state();
 }

--- a/src/common/SettingsAPI/settings_helpers.h
+++ b/src/common/SettingsAPI/settings_helpers.h
@@ -15,6 +15,6 @@ namespace PTSettingsHelper
     json::JsonObject load_general_settings();
     std::wstring get_log_settings_file_location();
 
-    bool get_oobe_opened_state();
-    void save_oobe_opened_state();
+    bool get_oobe_opened_state() noexcept;
+    void save_oobe_opened_state() noexcept;
 }

--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -80,10 +80,6 @@ void open_menu_from_another_instance()
 
 int runner(bool isProcessElevated, bool openSettings, bool openOobe)
 {
-    std::filesystem::path logFilePath(PTSettingsHelper::get_root_save_folder_location());
-    logFilePath.append(LogSettings::runnerLogPath);
-    Logger::init(LogSettings::runnerLoggerName, logFilePath.wstring(), PTSettingsHelper::get_log_settings_file_location());
-
     Logger::info("Runner is starting. Elevated={}", isProcessElevated);
     DPIAware::EnableDPIAwarenessForThisProcess();
 
@@ -341,6 +337,10 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         // continue as usual
         break;
     }
+
+    std::filesystem::path logFilePath(PTSettingsHelper::get_root_save_folder_location());
+    logFilePath.append(LogSettings::runnerLogPath);
+    Logger::init(LogSettings::runnerLoggerName, logFilePath.wstring(), PTSettingsHelper::get_log_settings_file_location());
 
     wil::unique_mutex_nothrow msi_mutex;
     wil::unique_mutex_nothrow msix_mutex;

--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -407,6 +407,20 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         }
     }
 
+    bool openOobe = false;
+    try
+    {
+        openOobe = !PTSettingsHelper::get_oobe_opened_state();
+        if (openOobe)
+        {
+            PTSettingsHelper::save_oobe_opened_state();
+        }
+    }
+    catch (const std::exception& e)
+    {
+        Logger::error("Failed to get or save OOBE state with an exception: {}", e.what());
+    }
+
     int result = 0;
     try
     {
@@ -415,14 +429,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         modules();
 
         auto general_settings = load_general_settings();
-        const bool openSettings = std::string(lpCmdLine).find("--open-settings") != std::string::npos;
-
-        // Open OOBE window at the first launch
-        const bool openOobe = !PTSettingsHelper::get_oobe_opened_state();
-        if (openOobe)
-        {
-            PTSettingsHelper::save_oobe_opened_state();
-        }
+        const bool openSettings = std::string(lpCmdLine).find("--open-settings") != std::string::npos;       
 
         // Apply the general settings but don't save it as the modules() variable has not been loaded yet
         apply_general_settings(general_settings, false);

--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -429,7 +429,8 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         modules();
 
         auto general_settings = load_general_settings();
-        const bool openSettings = std::string(lpCmdLine).find("--open-settings") != std::string::npos;       
+        const bool openSettings = std::string(lpCmdLine).find("--open-settings") != std::string::npos;
+
 
         // Apply the general settings but don't save it as the modules() variable has not been loaded yet
         apply_general_settings(general_settings, false);

--- a/src/runner/settings_window.cpp
+++ b/src/runner/settings_window.cpp
@@ -303,7 +303,7 @@ void run_settings_window(bool showOobeWindow)
         executable_path.append(L"\\PowerToysSettings.exe");
     }
 
-    // Arg 2: pipe server. Generate unique names for the pipes, if getting a UUID is possible.
+    // Args 2,3: pipe server. Generate unique names for the pipes, if getting a UUID is possible.
     std::wstring powertoys_pipe_name(L"\\\\.\\pipe\\powertoys_runner_");
     std::wstring settings_pipe_name(L"\\\\.\\pipe\\powertoys_settings_");
     UUID temp_uuid;
@@ -327,10 +327,10 @@ void run_settings_window(bool showOobeWindow)
         uuid_chars = nullptr;
     }
 
-    // Arg 3: process pid.
+    // Arg 4: process pid.
     DWORD powertoys_pid = GetCurrentProcessId();
 
-    // Arg 4: settings theme.
+    // Arg 5: settings theme.
     const std::wstring settings_theme_setting{ get_general_settings().theme };
     std::wstring settings_theme = L"system";
     if (settings_theme_setting == L"dark" || (settings_theme_setting == L"system" && WindowsColors::is_dark_mode()))
@@ -338,43 +338,18 @@ void run_settings_window(bool showOobeWindow)
         settings_theme = L"dark";
     }
 
-    // Arg 4: settings theme.
     GeneralSettings save_settings = get_general_settings();
 
+    // Arg 6: elevated status
     bool isElevated{ get_general_settings().isElevated };
-    std::wstring settings_elevatedStatus;
-    settings_elevatedStatus = isElevated;
-
-    if (isElevated)
-    {
-        settings_elevatedStatus = L"true";
-    }
-    else
-    {
-        settings_elevatedStatus = L"false";
-    }
-
+    std::wstring settings_elevatedStatus = isElevated ? L"true" : L"false";
+    
+    // Arg 7: is user an admin
     bool isAdmin{ get_general_settings().isAdmin };
-    std::wstring settings_isUserAnAdmin;
+    std::wstring settings_isUserAnAdmin = isAdmin ? L"true" : L"false";
 
-    if (isAdmin)
-    {
-        settings_isUserAnAdmin = L"true";
-    }
-    else
-    {
-        settings_isUserAnAdmin = L"false";
-    }
-
-    std::wstring settings_showOobe;
-    if (showOobeWindow)
-    {
-        settings_showOobe = L"true";
-    }
-    else
-    {
-        settings_showOobe = L"false";
-    }
+    // Arg 8: should oobe window be shown
+    std::wstring settings_showOobe = showOobeWindow ? L"true" : L"false";
 
     // create general settings file to initialize the settings file with installation configurations like :
     // 1. Run on start up.

--- a/src/runner/settings_window.cpp
+++ b/src/runner/settings_window.cpp
@@ -277,7 +277,7 @@ BOOL run_settings_non_elevated(LPCWSTR executable_path, LPWSTR executable_args, 
 
 DWORD g_settings_process_id = 0;
 
-void run_settings_window()
+void run_settings_window(bool showOobeWindow)
 {
     g_isLaunchInProgress = true;
 
@@ -366,6 +366,16 @@ void run_settings_window()
         settings_isUserAnAdmin = L"false";
     }
 
+    std::wstring settings_showOobe;
+    if (showOobeWindow)
+    {
+        settings_showOobe = L"true";
+    }
+    else
+    {
+        settings_showOobe = L"false";
+    }
+
     // create general settings file to initialize the settings file with installation configurations like :
     // 1. Run on start up.
     PTSettingsHelper::save_general_settings(save_settings.to_json());
@@ -384,7 +394,9 @@ void run_settings_window()
     executable_args.append(settings_elevatedStatus);
     executable_args.append(L" ");
     executable_args.append(settings_isUserAnAdmin);
-
+    executable_args.append(L" ");
+    executable_args.append(settings_showOobe);
+    
     BOOL process_created = false;
 
     // Due to a bug in .NET, running the Settings process as non-elevated
@@ -510,7 +522,9 @@ void open_settings_window()
     {
         if (!g_isLaunchInProgress)
         {
-            std::thread(run_settings_window).detach();
+            std::thread([]() {
+                run_settings_window(false);
+            }).detach();
         }
     }
 }
@@ -525,4 +539,11 @@ void close_settings_window()
             TerminateProcess(proc, 0);
         }
     }
+}
+
+void open_oobe_window()
+{
+    std::thread([]() {
+        run_settings_window(true);
+    }).detach();
 }

--- a/src/runner/settings_window.h
+++ b/src/runner/settings_window.h
@@ -1,3 +1,5 @@
 #pragma once
 void open_settings_window();
 void close_settings_window();
+
+void open_oobe_window();

--- a/src/settings-ui/PowerToys.Settings/App.xaml
+++ b/src/settings-ui/PowerToys.Settings/App.xaml
@@ -1,7 +1,7 @@
 ﻿<Application x:Class="PowerToys.Settings.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             StartupUri="MainWindow.xaml">
+             Startup="Application_Startup">
     <Application.Resources>
          
     </Application.Resources>

--- a/src/settings-ui/PowerToys.Settings/App.xaml.cs
+++ b/src/settings-ui/PowerToys.Settings/App.xaml.cs
@@ -11,5 +11,20 @@ namespace PowerToys.Settings
     /// </summary>
     public partial class App : Application
     {
+        public bool ShowOobe { get; set; }
+
+        private void Application_Startup(object sender, StartupEventArgs e)
+        {
+            if (!ShowOobe)
+            {
+                MainWindow mainWindow = new MainWindow();
+                mainWindow.Show();
+            }
+            else
+            {
+                OobeWindow otherWindow = new OobeWindow();
+                otherWindow.Show();
+            }
+        }
     }
 }

--- a/src/settings-ui/PowerToys.Settings/Program.cs
+++ b/src/settings-ui/PowerToys.Settings/Program.cs
@@ -19,6 +19,7 @@ namespace PowerToys.Settings
             Theme, // used in the old settings
             ElevatedStatus,
             IsUserAdmin,
+            ShowOobeWindow,
         }
 
         // Quantity of arguments
@@ -50,6 +51,12 @@ namespace PowerToys.Settings
 
                     IsElevated = args[(int)Arguments.ElevatedStatus] == "true";
                     IsUserAnAdmin = args[(int)Arguments.IsUserAdmin] == "true";
+
+                    if (args.Length > ArgumentsQty)
+                    {
+                        // open oobe window
+                        app.ShowOobe = args[(int)Arguments.ShowOobeWindow] == "true";
+                    }
 
                     RunnerHelper.WaitForPowerToysRunner(PowerToysPID, () =>
                     {

--- a/src/settings-ui/PowerToys.Settings/Program.cs
+++ b/src/settings-ui/PowerToys.Settings/Program.cs
@@ -23,7 +23,8 @@ namespace PowerToys.Settings
         }
 
         // Quantity of arguments
-        private const int ArgumentsQty = 6;
+        private const int RequiredArgumentsQty = 6;
+        private const int RequiredAndOptionalArgumentsQty = 7;
 
         // Create an instance of the  IPC wrapper.
         private static TwoWayPipeMessageIPCManaged ipcmanager;
@@ -44,7 +45,7 @@ namespace PowerToys.Settings
                 App app = new App();
                 app.InitializeComponent();
 
-                if (args != null && args.Length >= ArgumentsQty)
+                if (args != null && args.Length >= RequiredArgumentsQty)
                 {
                     _ = int.TryParse(args[(int)Arguments.PTPid], out int powerToysPID);
                     PowerToysPID = powerToysPID;
@@ -52,7 +53,7 @@ namespace PowerToys.Settings
                     IsElevated = args[(int)Arguments.ElevatedStatus] == "true";
                     IsUserAnAdmin = args[(int)Arguments.IsUserAdmin] == "true";
 
-                    if (args.Length > ArgumentsQty)
+                    if (args.Length == RequiredAndOptionalArgumentsQty)
                     {
                         // open oobe window
                         app.ShowOobe = args[(int)Arguments.ShowOobeWindow] == "true";


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

At the first PT launch, the OOBE window will be opened automatically without opening the settings window. 
`oobe_settings.json` in the root settings folder marks oobe state to avoid opening the window later.

**What is include in the PR:** 

**How does someone test / validate:** 

* Launch PT without `oobe_settings.json`, verify that OOBE window was opened and the settings file was created.
* Launch PT with `oobe_settings.json`, verify that OOBE window wasn't opened, file was not changed.

## Quality Checklist

- [x] **Linked issue:** #9741
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
