### PR TITLE
Added telemetry to run plugins

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/Telemetry/Events/PluginSettingsCompleteEvent.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/Telemetry/Events/PluginSettingsCompleteEvent.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics.Tracing;
+using Microsoft.PowerToys.Telemetry;
+using Microsoft.PowerToys.Telemetry.Events;
+
+namespace Microsoft.PowerToys.Settings.UI.Library.Telemetry.Events
+{
+    [EventData]
+    public class PluginSettingsCompleteEvent : EventBase, IEvent
+    {
+        public string Name { get; set; }
+
+        public bool Disabled { get; set; }
+
+        public bool IsGlobal { get; set; }
+
+        public string ActionKeyword { get; set; }
+
+        public PartA_PrivTags PartA_PrivTags => PartA_PrivTags.ProductAndServiceUsage;
+    }
+}

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/App.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/App.xaml.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Globalization;
 using Microsoft.PowerToys.Settings.UI.Helpers;
 using Microsoft.PowerToys.Settings.UI.Library;
@@ -19,6 +20,13 @@ namespace Microsoft.PowerToys.Settings.UI
             var coreWindow = Windows.UI.Core.CoreWindow.GetForCurrentThread();
             var coreWindowInterop = Interop.GetInterop(coreWindow);
             NativeMethods.ShowWindow(coreWindowInterop.WindowHandle, Interop.SW_HIDE);
+        }
+
+        public event Action OnHostAppExit;
+
+        public void HostAppExit()
+        {
+            OnHostAppExit?.Invoke();
         }
 
         public static bool IsDarkTheme()

--- a/src/settings-ui/PowerToys.Settings/Program.cs
+++ b/src/settings-ui/PowerToys.Settings/Program.cs
@@ -38,7 +38,7 @@ namespace PowerToys.Settings
         [STAThread]
         public static void Main(string[] args)
         {
-            using (new Microsoft.PowerToys.Settings.UI.App())
+            using (var xamlApp = new Microsoft.PowerToys.Settings.UI.App())
             {
                 App app = new App();
                 app.InitializeComponent();
@@ -67,6 +67,12 @@ namespace PowerToys.Settings
                         }
                     });
                     ipcmanager.Start();
+
+                    app.Exit += (object sender, ExitEventArgs e) =>
+                    {
+                        xamlApp.HostAppExit();
+                    };
+
                     app.Run();
                 }
                 else


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Information that we want to validate:
- Validate if a plugin should be off by default based on population
- Validate if we should shift the Action word
- Validate if we should shift the `Include in global result` default value

**What is include in the PR:** 
- Added `PluginSettingsCompleteEvent` to send flat data for a plugin
- Introduced `OnHostAppExit` event for xaml app. It does not have appropriate events to subscribe to windows close. One possible event is `Suspending` but it does not seem to work.
- `WritePluginsTelemetry` iteself

**How does someone test / validate:** 
Check if `PowerLauncherPage.WritePluginsTelemetry` is called on settings window close.

## Quality Checklist

- [X] **Linked issue:** #9660
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [X] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
