### PR TITLE
[FZ Editor] Updated (preview) zone colors

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml
@@ -12,7 +12,7 @@
     <UserControl.Resources>
         <Style x:Key="CanvasZoneThumbStyle" TargetType="{x:Type Thumb}">
             <Setter Property="Stylus.IsPressAndHoldEnabled" Value="false"/>
-            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="Background" Value="Transparent" />
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="{x:Type Thumb}">
@@ -79,7 +79,7 @@
         </Style>
     </UserControl.Resources>
 
-    <Border BorderBrush="{DynamicResource SystemControlBackgroundAccentBrush}"
+    <Border BorderBrush="{DynamicResource LayoutPreviewZoneBorderBrush}"
             Background="{DynamicResource CanvasZoneBackgroundBrush}"
             CornerRadius="4"
             BorderThickness="1">
@@ -122,7 +122,7 @@
                     Foreground="{DynamicResource PrimaryForegroundBrush}" />
             </DockPanel>
 
-            <Thumb x:Name="Caption" Cursor="SizeAll" Background="Transparent" BorderThickness="3" Padding="4" Grid.Column="0" Grid.ColumnSpan="5" Grid.Row="0" Grid.RowSpan="5" DragDelta="UniversalDragDelta" DragStarted="Caption_DragStarted" Style="{DynamicResource CanvasZoneThumbStyle}"/>
+            <Thumb x:Name="Caption" Cursor="SizeAll" Background="Transparent" BorderThickness="3" Padding="4" Grid.Column="0" Grid.ColumnSpan="5" Margin="-1" Grid.Row="0" Grid.RowSpan="5" DragDelta="UniversalDragDelta" DragStarted="Caption_DragStarted" Style="{DynamicResource CanvasZoneThumbStyle}"/>
 
             <Thumb x:Name="NResize" Cursor="SizeNS" BorderThickness="0,3,0,0" Grid.ColumnSpan="5" DragDelta="UniversalDragDelta" DragStarted="NResize_DragStarted" Style="{DynamicResource CanvasZoneThumbStyle}"/>
             <Thumb x:Name="SResize" Cursor="SizeNS" BorderThickness="0,0,0,3" Grid.Row="4" Grid.ColumnSpan="5" DragDelta="UniversalDragDelta" DragStarted="SResize_DragStarted" Style="{DynamicResource CanvasZoneThumbStyle}"/>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml
@@ -82,6 +82,7 @@
     <Border BorderBrush="{DynamicResource LayoutPreviewZoneBorderBrush}"
             Background="{DynamicResource CanvasZoneBackgroundBrush}"
             CornerRadius="4"
+            Effect="{StaticResource ZoneDropShadow}"
             BorderThickness="1">
         <Grid x:Name="Frame">
             <Grid.RowDefinitions>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridZone.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridZone.xaml
@@ -9,7 +9,7 @@
     d:DesignHeight="450"
     d:DesignWidth="800"
     Background="{DynamicResource GridZoneBackgroundBrush}"
-    BorderBrush="{DynamicResource SystemControlBackgroundAccentBrush}"
+    BorderBrush="{DynamicResource LayoutPreviewZoneBorderBrush}"
     BorderThickness="1"
     Opacity="1"
     mc:Ignorable="d">

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridZone.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridZone.xaml
@@ -6,13 +6,17 @@
     xmlns:local="clr-namespace:FancyZonesEditor"
     xmlns:props="clr-namespace:FancyZonesEditor.Properties"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:ui="http://schemas.modernwpf.com/2019"
     d:DesignHeight="450"
     d:DesignWidth="800"
     Background="{DynamicResource GridZoneBackgroundBrush}"
     BorderBrush="{DynamicResource LayoutPreviewZoneBorderBrush}"
     BorderThickness="1"
     Opacity="1"
+    ui:ControlHelper.CornerRadius="4"
+    Effect="{StaticResource ZoneDropShadow}"
     mc:Ignorable="d">
+    
     <Grid x:Name="Frame">
         <Canvas x:Name="Body" />
         <DockPanel HorizontalAlignment="Center"

--- a/src/modules/fancyzones/editor/FancyZonesEditor/LayoutPreview.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/LayoutPreview.xaml.cs
@@ -189,7 +189,7 @@ namespace FancyZonesEditor
 
                         rect.Width = Math.Max(0, colInfo[maxCol].End - left);
                         rect.Height = Math.Max(0, rowInfo[maxRow].End - top);
-                        rect.Style = (Style)FindResource("GridLayoutPreviewActualSizeStyle");
+                        rect.Style = (Style)FindResource("GridLayoutActualScalePreviewStyle");
                         frame.Children.Add(rect);
                         _zones.Add(new Int32Rect(
                             (int)left, (int)top, (int)rect.Width, (int)rect.Height));
@@ -261,7 +261,7 @@ namespace FancyZonesEditor
 
                         Grid.SetColumnSpan(rect, span);
                         rect.Margin = margin;
-                        rect.Style = (Style)FindResource("GridLayoutPreviewStyle");
+                        rect.Style = (Style)FindResource("GridLayoutSmallScalePreviewStyle");
                         Body.Children.Add(rect);
                     }
                 }
@@ -310,11 +310,11 @@ namespace FancyZonesEditor
 
                 if (IsActualSize)
                 {
-                   rect.Style = (Style)FindResource("CanvasLayoutPreviewActualSizeStyle");
+                   rect.Style = (Style)FindResource("CanvasLayoutActualScalePreviewStyle");
                 }
                 else
                 {
-                   rect.Style = (Style)FindResource("CanvasLayoutPreviewStyle");
+                   rect.Style = (Style)FindResource("CanvasLayoutSmallScalePreviewStyle");
                 }
 
                 frame.Children.Add(rect);

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Styles/LayoutPreviewStyles.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Styles/LayoutPreviewStyles.xaml
@@ -4,41 +4,30 @@
                     xmlns:local="clr-namespace:FancyZonesEditor.Styles">
 
     <Style x:Key="GridLayoutSmallScalePreviewStyle" TargetType="Border">
-        <Setter Property="Background"
-                Value="{DynamicResource LayoutPreviewSmallScaleZoneBackgroundBrush}" />
+        <Setter Property="Background" Value="{DynamicResource LayoutPreviewSmallScaleZoneBackgroundBrush}" />
         <Setter Property="BorderBrush" Value="{DynamicResource LayoutItemBackgroundBrush}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="CornerRadius" Value="4" />
     </Style>
 
-    <Style x:Key="GridLayoutActualScalePreviewStyle"
-           TargetType="Border">
-        <Setter Property="Background"
-                Value="{DynamicResource LayoutPreviewActualScaleZoneBackgroundBrush}" />
+    <Style x:Key="GridLayoutActualScalePreviewStyle" TargetType="Border">
+        <Setter Property="Background" Value="{DynamicResource LayoutPreviewActualScaleZoneBackgroundBrush}" />
         <Setter Property="BorderBrush" Value="{DynamicResource LayoutPreviewZoneBorderBrush}" />
-        <Setter Property="BorderThickness" Value="1" />
-        <Setter Property="CornerRadius"
-                Value="4" />
+        <Setter Property="BorderThickness" Value="2" />
+        <Setter Property="CornerRadius" Value="4" />
     </Style>
 
-    <Style x:Key="CanvasLayoutSmallScalePreviewStyle"
-           TargetType="Border">
-        <Setter Property="Background"
-                Value="{DynamicResource LayoutPreviewSmallScaleZoneBackgroundBrush}" />
+    <Style x:Key="CanvasLayoutSmallScalePreviewStyle" TargetType="Border">
+        <Setter Property="Background" Value="{DynamicResource LayoutPreviewSmallScaleZoneBackgroundBrush}" />
         <Setter Property="BorderBrush" Value="{DynamicResource LayoutItemBackgroundBrush}" />
         <Setter Property="BorderThickness" Value="10" />
         <Setter Property="CornerRadius" Value="4" />
     </Style>
 
-    <Style x:Key="CanvasLayoutActualScalePreviewStyle"
-           TargetType="Border">
-        <Setter Property="Background"
-                Value="{DynamicResource LayoutPreviewActualScaleZoneBackgroundBrush}" />
-        <Setter Property="BorderBrush"
-                Value="{DynamicResource LayoutPreviewZoneBorderBrush}" />
-        <Setter Property="BorderThickness"
-                Value="1" />
-        <Setter Property="CornerRadius"
-                Value="4" />
+    <Style x:Key="CanvasLayoutActualScalePreviewStyle" TargetType="Border">
+        <Setter Property="Background" Value="{DynamicResource LayoutPreviewActualScaleZoneBackgroundBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource LayoutPreviewZoneBorderBrush}" />
+        <Setter Property="BorderThickness" Value="2" />
+        <Setter Property="CornerRadius" Value="4" />
     </Style>
 </ResourceDictionary>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Styles/LayoutPreviewStyles.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Styles/LayoutPreviewStyles.xaml
@@ -3,39 +3,42 @@
                     xmlns:ui="http://schemas.modernwpf.com/2019"
                     xmlns:local="clr-namespace:FancyZonesEditor.Styles">
 
-    <Style x:Key="GridLayoutPreviewStyle" TargetType="Border">
-        <Setter Property="Background" Value="{DynamicResource LayoutPreviewZoneBackgroundBrush}" />
+    <Style x:Key="GridLayoutSmallScalePreviewStyle" TargetType="Border">
+        <Setter Property="Background"
+                Value="{DynamicResource LayoutPreviewSmallScaleZoneBackgroundBrush}" />
         <Setter Property="BorderBrush" Value="{DynamicResource LayoutItemBackgroundBrush}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="CornerRadius" Value="4" />
     </Style>
 
-    <Style x:Key="GridLayoutPreviewActualSizeStyle"
+    <Style x:Key="GridLayoutActualScalePreviewStyle"
            TargetType="Border">
-        <Setter Property="Background" Value="{DynamicResource LayoutPreviewZoneBackgroundBrush}" />
+        <Setter Property="Background"
+                Value="{DynamicResource LayoutPreviewActualScaleZoneBackgroundBrush}" />
         <Setter Property="BorderBrush" Value="{DynamicResource LayoutPreviewZoneBorderBrush}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="CornerRadius"
                 Value="4" />
     </Style>
 
-    <Style x:Key="CanvasLayoutPreviewStyle"
+    <Style x:Key="CanvasLayoutSmallScalePreviewStyle"
            TargetType="Border">
-        <Setter Property="Background" Value="{DynamicResource LayoutPreviewZoneBackgroundBrush}" />
+        <Setter Property="Background"
+                Value="{DynamicResource LayoutPreviewSmallScaleZoneBackgroundBrush}" />
         <Setter Property="BorderBrush" Value="{DynamicResource LayoutItemBackgroundBrush}" />
         <Setter Property="BorderThickness" Value="10" />
         <Setter Property="CornerRadius" Value="4" />
     </Style>
 
-    <Style x:Key="CanvasLayoutPreviewActualSizeStyle"
+    <Style x:Key="CanvasLayoutActualScalePreviewStyle"
            TargetType="Border">
-        <Setter Property="Background" Value="{DynamicResource LayoutPreviewZoneBackgroundBrush}" />
-        <Setter Property="BorderBrush" Value="{DynamicResource LayoutPreviewZoneBorderBrush}" />
+        <Setter Property="Background"
+                Value="{DynamicResource LayoutPreviewActualScaleZoneBackgroundBrush}" />
+        <Setter Property="BorderBrush"
+                Value="{DynamicResource LayoutPreviewZoneBorderBrush}" />
         <Setter Property="BorderThickness"
                 Value="1" />
         <Setter Property="CornerRadius"
                 Value="4" />
-
     </Style>
-    
 </ResourceDictionary>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Styles/LayoutPreviewStyles.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Styles/LayoutPreviewStyles.xaml
@@ -3,6 +3,8 @@
                     xmlns:ui="http://schemas.modernwpf.com/2019"
                     xmlns:local="clr-namespace:FancyZonesEditor.Styles">
 
+    <DropShadowEffect x:Key="ZoneDropShadow" BlurRadius="16" Opacity="0.28" ShadowDepth="1" />
+
     <Style x:Key="GridLayoutSmallScalePreviewStyle" TargetType="Border">
         <Setter Property="Background" Value="{DynamicResource LayoutPreviewSmallScaleZoneBackgroundBrush}" />
         <Setter Property="BorderBrush" Value="{DynamicResource LayoutItemBackgroundBrush}" />
@@ -15,6 +17,7 @@
         <Setter Property="BorderBrush" Value="{DynamicResource LayoutPreviewZoneBorderBrush}" />
         <Setter Property="BorderThickness" Value="2" />
         <Setter Property="CornerRadius" Value="4" />
+        <Setter Property="Effect" Value="{StaticResource ZoneDropShadow}" />
     </Style>
 
     <Style x:Key="CanvasLayoutSmallScalePreviewStyle" TargetType="Border">
@@ -29,5 +32,6 @@
         <Setter Property="BorderBrush" Value="{DynamicResource LayoutPreviewZoneBorderBrush}" />
         <Setter Property="BorderThickness" Value="2" />
         <Setter Property="CornerRadius" Value="4" />
+        <Setter Property="Effect" Value="{StaticResource ZoneDropShadow}" />
     </Style>
 </ResourceDictionary>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Themes/Dark.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Themes/Dark.xaml
@@ -20,9 +20,10 @@
     <SolidColorBrush x:Key="LayoutItemBackgroundBrush" Color="#FF3A3A3A" />
     <SolidColorBrush x:Key="LayoutItemBackgroundPointerOverBrush" Color="#FF333333" />
     <SolidColorBrush x:Key="LayoutPreviewBackgroundBrush" Color="#331B1B1B" />
-    <SolidColorBrush x:Key="LayoutPreviewZoneBorderBrush" Color="#FF5a5a5a" />
+    <SolidColorBrush x:Key="LayoutPreviewZoneBorderBrush"
+                     Color="#FF555454" />
 
-    <SolidColorBrush x:Key="LayoutPreviewActualScaleZoneBackgroundBrush" Color="#CC202020" />
+    <SolidColorBrush x:Key="LayoutPreviewActualScaleZoneBackgroundBrush" Color="#E5202020" />
     <SolidColorBrush x:Key="LayoutPreviewSmallScaleZoneBackgroundBrush" Color="#FF202020" />
     <SolidColorBrush x:Key="CanvasZoneBackgroundBrush" Color="#E5202020" />
     <SolidColorBrush x:Key="GridZoneBackgroundBrush" Color="#E5202020" />

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Themes/Dark.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Themes/Dark.xaml
@@ -15,7 +15,7 @@
     <SolidColorBrush x:Key="TertiaryBackgroundBrush" Color="#FF202020" />
     <SolidColorBrush x:Key="PrimaryForegroundBrush" Color="#FFFFFFFF" />
     <SolidColorBrush x:Key="SecondaryForegroundBrush" Color="#FF9a9a9a" />
-    <SolidColorBrush x:Key="BackdropBrush" Color="#88000000" />
+    <SolidColorBrush x:Key="BackdropBrush" Color="#E55B5B5B" />
     <SolidColorBrush x:Key="TitleBarSecondaryForegroundBrush" Color="#FF9a9a9a" />
     <SolidColorBrush x:Key="LayoutItemBackgroundBrush" Color="#FF3A3A3A" />
     <SolidColorBrush x:Key="LayoutItemBackgroundPointerOverBrush" Color="#FF333333" />

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Themes/Dark.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Themes/Dark.xaml
@@ -20,8 +20,7 @@
     <SolidColorBrush x:Key="LayoutItemBackgroundBrush" Color="#FF3A3A3A" />
     <SolidColorBrush x:Key="LayoutItemBackgroundPointerOverBrush" Color="#FF333333" />
     <SolidColorBrush x:Key="LayoutPreviewBackgroundBrush" Color="#331B1B1B" />
-    <SolidColorBrush x:Key="LayoutPreviewZoneBorderBrush"
-                     Color="#FF555454" />
+    <SolidColorBrush x:Key="LayoutPreviewZoneBorderBrush" Color="#FF555454" />
 
     <SolidColorBrush x:Key="LayoutPreviewActualScaleZoneBackgroundBrush" Color="#E5202020" />
     <SolidColorBrush x:Key="LayoutPreviewSmallScaleZoneBackgroundBrush" Color="#FF202020" />

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Themes/Dark.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Themes/Dark.xaml
@@ -19,9 +19,11 @@
     <SolidColorBrush x:Key="TitleBarSecondaryForegroundBrush" Color="#FF9a9a9a" />
     <SolidColorBrush x:Key="LayoutItemBackgroundBrush" Color="#FF3A3A3A" />
     <SolidColorBrush x:Key="LayoutItemBackgroundPointerOverBrush" Color="#FF333333" />
-    <SolidColorBrush x:Key="LayoutPreviewZoneBackgroundBrush" Color="#BF1b1b1b" />
     <SolidColorBrush x:Key="LayoutPreviewBackgroundBrush" Color="#331B1B1B" />
     <SolidColorBrush x:Key="LayoutPreviewZoneBorderBrush" Color="#FF5a5a5a" />
-    <SolidColorBrush x:Key="CanvasZoneBackgroundBrush" Color="#BF1b1b1b"/>
-    <SolidColorBrush x:Key="GridZoneBackgroundBrush" Color="#E51b1b1b" />
+
+    <SolidColorBrush x:Key="LayoutPreviewActualScaleZoneBackgroundBrush" Color="#CC202020" />
+    <SolidColorBrush x:Key="LayoutPreviewSmallScaleZoneBackgroundBrush" Color="#FF202020" />
+    <SolidColorBrush x:Key="CanvasZoneBackgroundBrush" Color="#E5202020" />
+    <SolidColorBrush x:Key="GridZoneBackgroundBrush" Color="#E5202020" />
 </ResourceDictionary>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Themes/HighContrast1.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Themes/HighContrast1.xaml
@@ -20,9 +20,9 @@
     <SolidColorBrush x:Key="LayoutItemBackgroundBrush" Color="#FF2b2b2b" />
     <SolidColorBrush x:Key="LayoutItemBackgroundPointerOverBrush" Color="#FF333333" />
     <SolidColorBrush x:Key="LayoutPreviewBackgroundBrush" Color="#331B1B1B" />
-    <SolidColorBrush x:Key="LayoutPreviewZoneBorderBrush" Color="#FF1b1b1b" />
+    <SolidColorBrush x:Key="LayoutPreviewZoneBorderBrush" Color="#FF1C1C1C" />
 
-    <SolidColorBrush x:Key="LayoutPreviewActualScaleZoneBackgroundBrush" Color="#CC202020" />
+    <SolidColorBrush x:Key="LayoutPreviewActualScaleZoneBackgroundBrush" Color="#E5202020" />
     <SolidColorBrush x:Key="LayoutPreviewSmallScaleZoneBackgroundBrush" Color="#FF202020" />
     <SolidColorBrush x:Key="CanvasZoneBackgroundBrush" Color="#E5202020" />
     <SolidColorBrush x:Key="GridZoneBackgroundBrush" Color="#E5202020" />

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Themes/HighContrast1.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Themes/HighContrast1.xaml
@@ -15,7 +15,7 @@
     <SolidColorBrush x:Key="TertiaryBackgroundBrush" Color="#FF202020" />
     <SolidColorBrush x:Key="PrimaryForegroundBrush" Color="#FFffff00" />
     <SolidColorBrush x:Key="SecondaryForegroundBrush" Color="#FF00ff00" />
-    <SolidColorBrush x:Key="BackdropBrush" Color="#88000000" />
+    <SolidColorBrush x:Key="BackdropBrush" Color="#E55B5B5B" />
     <SolidColorBrush x:Key="TitleBarSecondaryForegroundBrush" Color="#FF9a9a9a" />
     <SolidColorBrush x:Key="LayoutItemBackgroundBrush" Color="#FF2b2b2b" />
     <SolidColorBrush x:Key="LayoutItemBackgroundPointerOverBrush" Color="#FF333333" />

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Themes/HighContrast1.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Themes/HighContrast1.xaml
@@ -20,7 +20,7 @@
     <SolidColorBrush x:Key="LayoutItemBackgroundBrush" Color="#FF2b2b2b" />
     <SolidColorBrush x:Key="LayoutItemBackgroundPointerOverBrush" Color="#FF333333" />
     <SolidColorBrush x:Key="LayoutPreviewBackgroundBrush" Color="#331B1B1B" />
-    <SolidColorBrush x:Key="LayoutPreviewZoneBorderBrush" Color="#FF1C1C1C" />
+    <SolidColorBrush x:Key="LayoutPreviewZoneBorderBrush" Color="#FF555454" />
 
     <SolidColorBrush x:Key="LayoutPreviewActualScaleZoneBackgroundBrush" Color="#E5202020" />
     <SolidColorBrush x:Key="LayoutPreviewSmallScaleZoneBackgroundBrush" Color="#FF202020" />

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Themes/HighContrast1.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Themes/HighContrast1.xaml
@@ -19,9 +19,11 @@
     <SolidColorBrush x:Key="TitleBarSecondaryForegroundBrush" Color="#FF9a9a9a" />
     <SolidColorBrush x:Key="LayoutItemBackgroundBrush" Color="#FF2b2b2b" />
     <SolidColorBrush x:Key="LayoutItemBackgroundPointerOverBrush" Color="#FF333333" />
-    <SolidColorBrush x:Key="LayoutPreviewZoneBackgroundBrush" Color="#BF1b1b1b" />
     <SolidColorBrush x:Key="LayoutPreviewBackgroundBrush" Color="#331B1B1B" />
     <SolidColorBrush x:Key="LayoutPreviewZoneBorderBrush" Color="#FF1b1b1b" />
-    <SolidColorBrush x:Key="CanvasZoneBackgroundBrush" Color="#BF1b1b1b" />
-    <SolidColorBrush x:Key="GridZoneBackgroundBrush" Color="#E51b1b1b" />
+
+    <SolidColorBrush x:Key="LayoutPreviewActualScaleZoneBackgroundBrush" Color="#CC202020" />
+    <SolidColorBrush x:Key="LayoutPreviewSmallScaleZoneBackgroundBrush" Color="#FF202020" />
+    <SolidColorBrush x:Key="CanvasZoneBackgroundBrush" Color="#E5202020" />
+    <SolidColorBrush x:Key="GridZoneBackgroundBrush" Color="#E5202020" />
 </ResourceDictionary>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Themes/HighContrast2.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Themes/HighContrast2.xaml
@@ -20,9 +20,9 @@
     <SolidColorBrush x:Key="LayoutItemBackgroundBrush" Color="#FF2b2b2b" />
     <SolidColorBrush x:Key="LayoutItemBackgroundPointerOverBrush" Color="#FF333333" />
     <SolidColorBrush x:Key="LayoutPreviewBackgroundBrush" Color="#331B1B1B" />
-    <SolidColorBrush x:Key="LayoutPreviewZoneBorderBrush" Color="#FF1b1b1b" />
+    <SolidColorBrush x:Key="LayoutPreviewZoneBorderBrush" Color="#FF1C1C1C" />
 
-    <SolidColorBrush x:Key="LayoutPreviewActualScaleZoneBackgroundBrush" Color="#CC202020" />
+    <SolidColorBrush x:Key="LayoutPreviewActualScaleZoneBackgroundBrush" Color="#E5202020" />
     <SolidColorBrush x:Key="LayoutPreviewSmallScaleZoneBackgroundBrush" Color="#FF202020" />
     <SolidColorBrush x:Key="CanvasZoneBackgroundBrush" Color="#E5202020" />
     <SolidColorBrush x:Key="GridZoneBackgroundBrush" Color="#E5202020" />

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Themes/HighContrast2.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Themes/HighContrast2.xaml
@@ -15,7 +15,7 @@
     <SolidColorBrush x:Key="TertiaryBackgroundBrush" Color="#FF202020" />
     <SolidColorBrush x:Key="PrimaryForegroundBrush" Color="#FFffff00" />
     <SolidColorBrush x:Key="SecondaryForegroundBrush" Color="#FFc0c0c0" />
-    <SolidColorBrush x:Key="BackdropBrush" Color="#88000000" />
+    <SolidColorBrush x:Key="BackdropBrush" Color="#E55B5B5B" />
     <SolidColorBrush x:Key="TitleBarSecondaryForegroundBrush" Color="#FF9a9a9a" />
     <SolidColorBrush x:Key="LayoutItemBackgroundBrush" Color="#FF2b2b2b" />
     <SolidColorBrush x:Key="LayoutItemBackgroundPointerOverBrush" Color="#FF333333" />

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Themes/HighContrast2.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Themes/HighContrast2.xaml
@@ -20,7 +20,7 @@
     <SolidColorBrush x:Key="LayoutItemBackgroundBrush" Color="#FF2b2b2b" />
     <SolidColorBrush x:Key="LayoutItemBackgroundPointerOverBrush" Color="#FF333333" />
     <SolidColorBrush x:Key="LayoutPreviewBackgroundBrush" Color="#331B1B1B" />
-    <SolidColorBrush x:Key="LayoutPreviewZoneBorderBrush" Color="#FF1C1C1C" />
+    <SolidColorBrush x:Key="LayoutPreviewZoneBorderBrush" Color="#FF555454" />
 
     <SolidColorBrush x:Key="LayoutPreviewActualScaleZoneBackgroundBrush" Color="#E5202020" />
     <SolidColorBrush x:Key="LayoutPreviewSmallScaleZoneBackgroundBrush" Color="#FF202020" />

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Themes/HighContrast2.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Themes/HighContrast2.xaml
@@ -19,9 +19,11 @@
     <SolidColorBrush x:Key="TitleBarSecondaryForegroundBrush" Color="#FF9a9a9a" />
     <SolidColorBrush x:Key="LayoutItemBackgroundBrush" Color="#FF2b2b2b" />
     <SolidColorBrush x:Key="LayoutItemBackgroundPointerOverBrush" Color="#FF333333" />
-    <SolidColorBrush x:Key="LayoutPreviewZoneBackgroundBrush" Color="#BF1b1b1b" />
     <SolidColorBrush x:Key="LayoutPreviewBackgroundBrush" Color="#331B1B1B" />
     <SolidColorBrush x:Key="LayoutPreviewZoneBorderBrush" Color="#FF1b1b1b" />
-    <SolidColorBrush x:Key="CanvasZoneBackgroundBrush" Color="#BF1b1b1b" />
-    <SolidColorBrush x:Key="GridZoneBackgroundBrush" Color="#E51b1b1b" />
+
+    <SolidColorBrush x:Key="LayoutPreviewActualScaleZoneBackgroundBrush" Color="#CC202020" />
+    <SolidColorBrush x:Key="LayoutPreviewSmallScaleZoneBackgroundBrush" Color="#FF202020" />
+    <SolidColorBrush x:Key="CanvasZoneBackgroundBrush" Color="#E5202020" />
+    <SolidColorBrush x:Key="GridZoneBackgroundBrush" Color="#E5202020" />
 </ResourceDictionary>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Themes/HighContrastBlack.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Themes/HighContrastBlack.xaml
@@ -20,9 +20,9 @@
     <SolidColorBrush x:Key="LayoutItemBackgroundBrush" Color="#FF3A3A3A" />
     <SolidColorBrush x:Key="LayoutItemBackgroundPointerOverBrush" Color="#FF333333" />
     <SolidColorBrush x:Key="LayoutPreviewBackgroundBrush" Color="#331B1B1B" />
-    <SolidColorBrush x:Key="LayoutPreviewZoneBorderBrush" Color="#FF5a5a5a" />
+    <SolidColorBrush x:Key="LayoutPreviewZoneBorderBrush" Color="#FF555454" />
 
-    <SolidColorBrush x:Key="LayoutPreviewActualScaleZoneBackgroundBrush" Color="#CC202020" />
+    <SolidColorBrush x:Key="LayoutPreviewActualScaleZoneBackgroundBrush" Color="#E5202020" />
     <SolidColorBrush x:Key="LayoutPreviewSmallScaleZoneBackgroundBrush" Color="#FF202020" />
     <SolidColorBrush x:Key="CanvasZoneBackgroundBrush" Color="#E5202020" />
     <SolidColorBrush x:Key="GridZoneBackgroundBrush" Color="#E5202020" />

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Themes/HighContrastBlack.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Themes/HighContrastBlack.xaml
@@ -15,7 +15,7 @@
     <SolidColorBrush x:Key="TertiaryBackgroundBrush" Color="#FF202020" />
     <SolidColorBrush x:Key="PrimaryForegroundBrush" Color="#FFffffff" />
     <SolidColorBrush x:Key="SecondaryForegroundBrush" Color="#FF1aebff" />
-    <SolidColorBrush x:Key="BackdropBrush" Color="#88000000" />
+    <SolidColorBrush x:Key="BackdropBrush" Color="#E55B5B5B" />
     <SolidColorBrush x:Key="TitleBarSecondaryForegroundBrush" Color="#FF9a9a9a" />
     <SolidColorBrush x:Key="LayoutItemBackgroundBrush" Color="#FF3A3A3A" />
     <SolidColorBrush x:Key="LayoutItemBackgroundPointerOverBrush" Color="#FF333333" />

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Themes/HighContrastBlack.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Themes/HighContrastBlack.xaml
@@ -19,9 +19,11 @@
     <SolidColorBrush x:Key="TitleBarSecondaryForegroundBrush" Color="#FF9a9a9a" />
     <SolidColorBrush x:Key="LayoutItemBackgroundBrush" Color="#FF3A3A3A" />
     <SolidColorBrush x:Key="LayoutItemBackgroundPointerOverBrush" Color="#FF333333" />
-    <SolidColorBrush x:Key="LayoutPreviewZoneBackgroundBrush" Color="#BF1b1b1b" />
     <SolidColorBrush x:Key="LayoutPreviewBackgroundBrush" Color="#331B1B1B" />
     <SolidColorBrush x:Key="LayoutPreviewZoneBorderBrush" Color="#FF5a5a5a" />
-    <SolidColorBrush x:Key="CanvasZoneBackgroundBrush" Color="#BF1b1b1b" />
-    <SolidColorBrush x:Key="GridZoneBackgroundBrush" Color="#E51b1b1b" />
+
+    <SolidColorBrush x:Key="LayoutPreviewActualScaleZoneBackgroundBrush" Color="#CC202020" />
+    <SolidColorBrush x:Key="LayoutPreviewSmallScaleZoneBackgroundBrush" Color="#FF202020" />
+    <SolidColorBrush x:Key="CanvasZoneBackgroundBrush" Color="#E5202020" />
+    <SolidColorBrush x:Key="GridZoneBackgroundBrush" Color="#E5202020" />
 </ResourceDictionary>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Themes/HighContrastWhite.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Themes/HighContrastWhite.xaml
@@ -15,7 +15,7 @@
     <SolidColorBrush x:Key="TertiaryBackgroundBrush" Color="#FFF3F3F3" />
     <SolidColorBrush x:Key="PrimaryForegroundBrush" Color="#FF000000" />
     <SolidColorBrush x:Key="SecondaryForegroundBrush" Color="#FF37006e" />
-    <SolidColorBrush x:Key="BackdropBrush" Color="#88FFFFFF" />
+    <SolidColorBrush x:Key="BackdropBrush" Color="#E5949494" />
     <SolidColorBrush x:Key="TitleBarSecondaryForegroundBrush" Color="#FF949494" />
     <SolidColorBrush x:Key="LayoutItemBackgroundBrush" Color="#FFffffff" />
     <SolidColorBrush x:Key="LayoutItemBackgroundPointerOverBrush" Color="#FFf2f2f2" />

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Themes/HighContrastWhite.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Themes/HighContrastWhite.xaml
@@ -22,7 +22,7 @@
     <SolidColorBrush x:Key="LayoutPreviewBackgroundBrush" Color="#19949494" />
     <SolidColorBrush x:Key="LayoutPreviewZoneBorderBrush" Color="#9c9c9c" />
     
-    <SolidColorBrush x:Key="LayoutPreviewActualScaleZoneBackgroundBrush" Color="#E5F3F3F3" />
+    <SolidColorBrush x:Key="LayoutPreviewActualScaleZoneBackgroundBrush" Color="#EFF3F3F3" />
     <SolidColorBrush x:Key="LayoutPreviewSmallScaleZoneBackgroundBrush" Color="#FFDCDCDC" />
     <SolidColorBrush x:Key="CanvasZoneBackgroundBrush" Color="#E5F3F3F3" />
     <SolidColorBrush x:Key="GridZoneBackgroundBrush" Color="#E5F3F3F3" />

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Themes/HighContrastWhite.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Themes/HighContrastWhite.xaml
@@ -19,9 +19,11 @@
     <SolidColorBrush x:Key="TitleBarSecondaryForegroundBrush" Color="#FF949494" />
     <SolidColorBrush x:Key="LayoutItemBackgroundBrush" Color="#FFffffff" />
     <SolidColorBrush x:Key="LayoutItemBackgroundPointerOverBrush" Color="#FFf2f2f2" />
-    <SolidColorBrush x:Key="LayoutPreviewZoneBackgroundBrush" Color="#88cccccc" />
     <SolidColorBrush x:Key="LayoutPreviewBackgroundBrush" Color="#19949494" />
     <SolidColorBrush x:Key="LayoutPreviewZoneBorderBrush" Color="#9c9c9c" />
-    <SolidColorBrush x:Key="CanvasZoneBackgroundBrush" Color="#BFffffff" />
-    <SolidColorBrush x:Key="GridZoneBackgroundBrush" Color="#E5ffffff" />
+    
+    <SolidColorBrush x:Key="LayoutPreviewActualScaleZoneBackgroundBrush" Color="#E5F3F3F3" />
+    <SolidColorBrush x:Key="LayoutPreviewSmallScaleZoneBackgroundBrush" Color="#FFDCDCDC" />
+    <SolidColorBrush x:Key="CanvasZoneBackgroundBrush" Color="#E5F3F3F3" />
+    <SolidColorBrush x:Key="GridZoneBackgroundBrush" Color="#E5F3F3F3" />
 </ResourceDictionary>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Themes/Light.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Themes/Light.xaml
@@ -19,9 +19,11 @@
     <SolidColorBrush x:Key="TitleBarSecondaryForegroundBrush" Color="#FF949494" />
     <SolidColorBrush x:Key="LayoutItemBackgroundBrush" Color="#FFffffff"/>
     <SolidColorBrush x:Key="LayoutItemBackgroundPointerOverBrush" Color="#FFf2f2f2" />
-    <SolidColorBrush x:Key="LayoutPreviewZoneBackgroundBrush" Color="#88cccccc"/>
     <SolidColorBrush x:Key="LayoutPreviewBackgroundBrush" Color="#19949494" />
     <SolidColorBrush x:Key="LayoutPreviewZoneBorderBrush" Color="#9c9c9c" />
-    <SolidColorBrush x:Key="CanvasZoneBackgroundBrush" Color="#BFffffff"/>
-    <SolidColorBrush x:Key="GridZoneBackgroundBrush" Color="#E5ffffff" />
+
+    <SolidColorBrush x:Key="LayoutPreviewActualScaleZoneBackgroundBrush" Color="#E5F3F3F3" />
+    <SolidColorBrush x:Key="LayoutPreviewSmallScaleZoneBackgroundBrush" Color="#FFDCDCDC" />
+    <SolidColorBrush x:Key="CanvasZoneBackgroundBrush" Color="#E5F3F3F3" />
+    <SolidColorBrush x:Key="GridZoneBackgroundBrush" Color="#E5F3F3F3" />
 </ResourceDictionary>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Themes/Light.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Themes/Light.xaml
@@ -15,16 +15,14 @@
     <SolidColorBrush x:Key="TertiaryBackgroundBrush" Color="#FFF3F3F3" />
     <SolidColorBrush x:Key="PrimaryForegroundBrush" Color="#FF000000" />
     <SolidColorBrush x:Key="SecondaryForegroundBrush" Color="#FF949494" />
-    <SolidColorBrush x:Key="BackdropBrush" Color="#88FFFFFF" />
+    <SolidColorBrush x:Key="BackdropBrush" Color="#E5949494" />
     <SolidColorBrush x:Key="TitleBarSecondaryForegroundBrush" Color="#FF949494" />
     <SolidColorBrush x:Key="LayoutItemBackgroundBrush" Color="#FFffffff"/>
     <SolidColorBrush x:Key="LayoutItemBackgroundPointerOverBrush" Color="#FFf2f2f2" />
     <SolidColorBrush x:Key="LayoutPreviewBackgroundBrush" Color="#19949494" />
-    <SolidColorBrush x:Key="LayoutPreviewZoneBorderBrush"
-                     Color="#FFC3BEBE" />
+    <SolidColorBrush x:Key="LayoutPreviewZoneBorderBrush" Color="#FFC3BEBE" />
 
-    <SolidColorBrush x:Key="LayoutPreviewActualScaleZoneBackgroundBrush"
-                     Color="#E5F3F3F3" />
+    <SolidColorBrush x:Key="LayoutPreviewActualScaleZoneBackgroundBrush" Color="#E5F3F3F3" />
     <SolidColorBrush x:Key="LayoutPreviewSmallScaleZoneBackgroundBrush" Color="#FFDCDCDC" />
     <SolidColorBrush x:Key="CanvasZoneBackgroundBrush" Color="#E5F3F3F3" />
     <SolidColorBrush x:Key="GridZoneBackgroundBrush" Color="#E5F3F3F3" />

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Themes/Light.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Themes/Light.xaml
@@ -20,9 +20,11 @@
     <SolidColorBrush x:Key="LayoutItemBackgroundBrush" Color="#FFffffff"/>
     <SolidColorBrush x:Key="LayoutItemBackgroundPointerOverBrush" Color="#FFf2f2f2" />
     <SolidColorBrush x:Key="LayoutPreviewBackgroundBrush" Color="#19949494" />
-    <SolidColorBrush x:Key="LayoutPreviewZoneBorderBrush" Color="#9c9c9c" />
+    <SolidColorBrush x:Key="LayoutPreviewZoneBorderBrush"
+                     Color="#FFC3BEBE" />
 
-    <SolidColorBrush x:Key="LayoutPreviewActualScaleZoneBackgroundBrush" Color="#E5F3F3F3" />
+    <SolidColorBrush x:Key="LayoutPreviewActualScaleZoneBackgroundBrush"
+                     Color="#E5F3F3F3" />
     <SolidColorBrush x:Key="LayoutPreviewSmallScaleZoneBackgroundBrush" Color="#FFDCDCDC" />
     <SolidColorBrush x:Key="CanvasZoneBackgroundBrush" Color="#E5F3F3F3" />
     <SolidColorBrush x:Key="GridZoneBackgroundBrush" Color="#E5F3F3F3" />


### PR DESCRIPTION
## Summary of the Pull Request
This PR splits out the colors for the LayoutPreview. ActualScale is used for the background preview, SmallScale is used for the thumbnail preview.

It also aligns the colors with what WinUI defines in their upcoming design token refresh.


Dark
![image](https://user-images.githubusercontent.com/9866362/108515853-dace2980-72c5-11eb-9522-80cfcfb6c02c.png)
![image](https://user-images.githubusercontent.com/9866362/108517731-12d66c00-72c8-11eb-80ec-c008e43259b4.png)

Light
![image](https://user-images.githubusercontent.com/9866362/108517849-34cfee80-72c8-11eb-8b6a-321ac66c0239.png)
![image](https://user-images.githubusercontent.com/9866362/108517893-41ecdd80-72c8-11eb-81ce-fca7b97db053.png)


## Quality Checklist

- [X] **Linked issue:** #9348
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
