### PR TITLE
Fix indexer name

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Main.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Plugin.Indexer
 
         private string WarningIconPath { get; set; }
 
-        public string Name => Properties.Resources.Microsoft_plugin_indexer_name;
+        public string Name => Properties.Resources.Microsoft_plugin_indexer_plugin_name;
 
         public string Description => Properties.Resources.Microsoft_plugin_indexer_plugin_description;
 


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
![image](https://user-images.githubusercontent.com/17161067/108722132-77ddcc00-752b-11eb-8b36-8467374673a3.png)

**What is include in the PR:** 

**How does someone test / validate:** 
- Delete `PowerToys Run\settings.json`
- Check that indexer name is `Windows Indexer` not `Name`
## Quality Checklist

- [ ] **Linked issue:** #5273
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
