### PR TITLE
[Oobe] Removed "Launch module" buttons for several modules.

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeFancyZones.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeFancyZones.xaml
@@ -30,12 +30,6 @@
             <StackPanel Orientation="Horizontal"
                         Margin="32,48,0,0"
                         Spacing="4">
-                <Button Style="{StaticResource AccentButtonStyle}">
-                    <TextBlock>
-                        <Run x:Uid="Oobe_Launch"/>
-                        <Run Text="{x:Bind ViewModel.ModuleName}"/>
-                    </TextBlock>
-                </Button>
                 <Button Foreground="{ThemeResource SystemControlBackgroundAccentBrush}"
                         VerticalAlignment="Bottom"
                         HorizontalAlignment="Left"

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeFileExplorer.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeFileExplorer.xaml
@@ -31,12 +31,6 @@
             <StackPanel Orientation="Horizontal"
                         Margin="32,48,0,0"
                         Spacing="4">
-                <Button Style="{StaticResource AccentButtonStyle}">
-                    <TextBlock>
-                        <Run x:Uid="Oobe_Launch"/>
-                        <Run Text="{x:Bind ViewModel.ModuleName}"/>
-                    </TextBlock>
-                </Button>
                 <Button Foreground="{ThemeResource SystemControlBackgroundAccentBrush}"
                         VerticalAlignment="Bottom"
                         HorizontalAlignment="Left"

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeImageResizer.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeImageResizer.xaml
@@ -31,12 +31,6 @@
             <StackPanel Orientation="Horizontal"
                         Margin="32,48,0,0"
                         Spacing="4">
-                <Button Style="{StaticResource AccentButtonStyle}">
-                    <TextBlock>
-                        <Run x:Uid="Oobe_Launch"/>
-                        <Run Text="{x:Bind ViewModel.ModuleName}"/>
-                    </TextBlock>
-                </Button>
                 <Button Foreground="{ThemeResource SystemControlBackgroundAccentBrush}"
                         VerticalAlignment="Bottom"
                         HorizontalAlignment="Left"

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeKBM.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeKBM.xaml
@@ -31,12 +31,6 @@
             <StackPanel Orientation="Horizontal"
                         Margin="32,48,0,0"
                         Spacing="4">
-                <Button Style="{StaticResource AccentButtonStyle}">
-                    <TextBlock>
-                        <Run x:Uid="Oobe_Launch"/>
-                        <Run Text="{x:Bind ViewModel.ModuleName}"/>
-                    </TextBlock>
-                </Button>
                 <Button Foreground="{ThemeResource SystemControlBackgroundAccentBrush}"
                         VerticalAlignment="Bottom"
                         HorizontalAlignment="Left"

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobePowerRename.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobePowerRename.xaml
@@ -31,12 +31,6 @@
             <StackPanel Orientation="Horizontal"
                         Margin="32,48,0,0"
                         Spacing="4">
-                <Button Style="{StaticResource AccentButtonStyle}">
-                    <TextBlock>
-                        <Run x:Uid="Oobe_Launch"/>
-                        <Run Text="{x:Bind ViewModel.ModuleName}"/>
-                    </TextBlock>
-                </Button>
                 <Button Foreground="{ThemeResource SystemControlBackgroundAccentBrush}"
                         VerticalAlignment="Bottom"
                         HorizontalAlignment="Left"

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeVideoConference.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeVideoConference.xaml
@@ -31,12 +31,6 @@
             <StackPanel Orientation="Horizontal"
                         Margin="32,48,0,0"
                         Spacing="4">
-                <Button Style="{StaticResource AccentButtonStyle}">
-                    <TextBlock>
-                        <Run x:Uid="Oobe_Launch"/>
-                        <Run Text="{x:Bind ViewModel.ModuleName}"/>
-                    </TextBlock>
-                </Button>
                 <Button Foreground="{ThemeResource SystemControlBackgroundAccentBrush}"
                         VerticalAlignment="Bottom"
                         HorizontalAlignment="Left"


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

For some modules "Launch _module_" button makes no sense since the module couldn't be launched without additional stuff such as a file to rename for PowerRename, etc.

Removed buttons for modules:
* FancyZones
* File explorer
* Image resizer
* Keyboard manager
* Power rename
* Video conference

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
