### PR TITLE
[Run] [Plugin manager] UI fixes

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/PowerLauncherPluginViewModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/PowerLauncherPluginViewModel.cs
@@ -54,7 +54,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
                 {
                     settings.Disabled = value;
                     NotifyPropertyChanged();
-                    NotifyPropertyChanged(nameof(ShowWarning));
+                    NotifyPropertyChanged(nameof(ShowNotAccessibleWarning));
                 }
             }
         }
@@ -72,7 +72,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
                 {
                     settings.IsGlobal = value;
                     NotifyPropertyChanged();
-                    NotifyPropertyChanged(nameof(ShowWarning));
+                    NotifyPropertyChanged(nameof(ShowNotAccessibleWarning));
                 }
             }
         }
@@ -90,7 +90,8 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
                 {
                     settings.ActionKeyword = value;
                     NotifyPropertyChanged();
-                    NotifyPropertyChanged(nameof(ShowWarning));
+                    NotifyPropertyChanged(nameof(ShowNotAccessibleWarning));
+                    NotifyPropertyChanged(nameof(ShowNotAllowedKeywordWarning));
                 }
             }
         }
@@ -129,9 +130,19 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
 
-        public bool ShowWarning
+        public bool ShowNotAccessibleWarning
         {
             get => !Disabled && !IsGlobal && string.IsNullOrWhiteSpace(ActionKeyword);
+        }
+
+        private static readonly List<string> NotAllowedKeywords = new List<string>()
+        {
+            "~", @"\", @"\\",
+        };
+
+        public bool ShowNotAllowedKeywordWarning
+        {
+            get => NotAllowedKeywords.Contains(ActionKeyword);
         }
     }
 }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/PowerLauncherViewModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/PowerLauncherViewModel.cs
@@ -97,6 +97,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
 
         private void OnPluginInfoChange(object sender, PropertyChangedEventArgs e)
         {
+            OnPropertyChanged(nameof(AllPluginsDisabled));
             UpdateSettings();
         }
 
@@ -373,6 +374,11 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
 
                 return _plugins;
             }
+        }
+
+        public bool AllPluginsDisabled
+        {
+            get => Plugins.All(x => x.Disabled);
         }
     }
 }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -957,7 +957,7 @@
     <value>Please define an activation phrase or allow this plugin for the global results to use it</value>
   </data>
   <data name="Run_AllPluginsDisabled.Text" xml:space="preserve">
-    <value>PowerToys Run is not usable. Enable at least one plugin to use it.</value>
+    <value>PowerToys Run can't provide any results without plugins. Please enable at least one plugin.</value>
   </data>
   <data name="Run_NotAllowedActionKeyword.Text" xml:space="preserve">
     <value>The action keyword is not allowed</value>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -960,6 +960,6 @@
     <value>PowerToys Run can't provide any results without plugins. Please enable at least one plugin.</value>
   </data>
   <data name="Run_NotAllowedActionKeyword.Text" xml:space="preserve">
-    <value>The action keyword is not allowed</value>
+    <value>This activation phrase overrides the behavior of other plugins. Please change it to something else.</value>
   </data>
 </root>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -956,6 +956,9 @@
   <data name="Run_NotAccessibleWarning.Text" xml:space="preserve">
     <value>Please define an activation phrase or allow this plugin for the global results to use it</value>
   </data>
+  <data name="Run_AllPluginsDisabled.Text" xml:space="preserve">
+    <value>PowerToys Run is not usable. Enable at least one plugin to use it.</value>
+  </data>
   <data name="Run_NotAllowedActionKeyword.Text" xml:space="preserve">
     <value>The action keyword is not allowed</value>
   </data>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -956,4 +956,7 @@
   <data name="Run_NotAccessibleWarning.Text" xml:space="preserve">
     <value>Please define an activation phrase or allow this plugin for the global results to use it</value>
   </data>
+  <data name="Run_NotAllowedActionKeyword.Text" xml:space="preserve">
+    <value>The action keyword is not allowed</value>
+  </data>
 </root>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
@@ -154,6 +154,13 @@
                        Style="{StaticResource SettingsGroupTitleStyle}"
                        Foreground="{x:Bind Mode=OneWay, Path=ViewModel.EnablePowerLauncher, Converter={StaticResource ModuleEnabledToForegroundConverter}}"/>
 
+            <TextBlock x:Uid="Run_AllPluginsDisabled"
+                       FontSize="12"
+                       Foreground="{ThemeResource SystemControlErrorTextForegroundBrush}"
+                       Visibility="{x:Bind ViewModel.AllPluginsDisabled, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
+                       TextWrapping="Wrap"
+                       Margin="{StaticResource SmallTopMargin}"/>
+
             <ListView ItemsSource="{x:Bind Path=ViewModel.Plugins, Mode=OneWay}"                
                       IsItemClickEnabled="True"
                       x:Name="PluginsListView"

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
@@ -17,7 +17,7 @@
         <converters:BoolToObjectConverter x:Key="BoolToVisibilityConverter" TrueValue="Visible" FalseValue="Collapsed"/>
         <converters:BoolNegationConverter x:Key="BoolNegationConverter"/>
     </Page.Resources>
-    
+
     <Grid RowSpacing="{StaticResource DefaultRowSpacing}" >
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup x:Name="LayoutVisualStates">
@@ -220,16 +220,18 @@
                                                Foreground="{ThemeResource SystemBaseMediumColor}"
                                                Text="{x:Bind Description}"
                                                TextWrapping="Wrap" />
-                                    <TextBlock FontSize="12"
-                                               Foreground="{ThemeResource SystemBaseMediumColor}">
-                                           <Run x:Uid="PowerLauncher_AuthoredBy" />
-                                           <Run FontWeight="SemiBold" Text="{x:Bind Author}" />
-                                    </TextBlock>
                                     <TextBlock 
                                         x:Uid="Run_NotAccessibleWarning"
                                         FontSize="12"
                                         Foreground="{ThemeResource SystemControlErrorTextForegroundBrush}"
-                                        Visibility="{x:Bind ShowWarning, Converter={StaticResource BoolToVisibilityConverter}}"
+                                        Visibility="{x:Bind ShowNotAccessibleWarning, Converter={StaticResource BoolToVisibilityConverter}}"
+                                        TextWrapping="Wrap" />
+
+                                    <TextBlock 
+                                        x:Uid="Run_NotAllowedActionKeyword"
+                                        FontSize="12"
+                                        Foreground="{ThemeResource SystemControlErrorTextForegroundBrush}"
+                                        Visibility="{x:Bind ShowNotAllowedKeywordWarning, Converter={StaticResource BoolToVisibilityConverter}}"
                                         TextWrapping="Wrap" />
                                 </StackPanel>
 
@@ -240,8 +242,7 @@
                                               Grid.Column="2" />
                             </Grid>
 
-                            <StackPanel  Margin="60,24,0,24" x:Name="AdditionalInfoPanel" Visibility="Collapsed">
-
+                            <StackPanel Margin="60,24,0,24" x:Name="AdditionalInfoPanel" Visibility="Collapsed">
                                 <CheckBox x:Uid="PowerLauncher_IncludeInGlobalResult"
                                           IsChecked="{x:Bind Path=IsGlobal, Mode=TwoWay}" />
 
@@ -280,6 +281,14 @@
                                         </DataTemplate>
                                     </ListView.ItemTemplate>
                                 </ListView>
+
+                                <TextBlock FontSize="12"
+                                           Foreground="{ThemeResource SystemBaseMediumColor}"
+                                           HorizontalAlignment="Right"
+                                           Margin="0,0,12,0">
+                                           <Run x:Uid="PowerLauncher_AuthoredBy" />
+                                           <Run FontWeight="SemiBold" Text="{x:Bind Author}" />
+                                </TextBlock>
                             </StackPanel>
                         </StackPanel>
                     </DataTemplate>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
@@ -150,6 +150,33 @@
                       IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.EnablePowerLauncher}"
             />
 
+            <TextBlock x:Uid="Appearance_GroupSettings"
+                       Style="{StaticResource SettingsGroupTitleStyle}"
+                       Foreground="{x:Bind Mode=OneWay, Path=ViewModel.EnablePowerLauncher, Converter={StaticResource ModuleEnabledToForegroundConverter}}" />
+            <!-- We cannot navigate to all the radio buttons using the arrow keys because of an XYNavigation issue in the RadioButtons control.
+            The screen reader does not read the heading when we tab into a radio button, even though the LabeledBy automation property is set.
+            Link to the issue in the winui repository - https://github.com/microsoft/microsoft-ui-xaml/issues/3156 -->
+            <TextBlock x:Uid="ColorModeHeader"
+                       x:Name="RadioButtons_Name_Theme" 
+                       Margin="{StaticResource SmallTopMargin}"
+                       Foreground="{x:Bind Mode=OneWay, Path=ViewModel.EnablePowerLauncher, Converter={StaticResource ModuleEnabledToForegroundConverter}}" />
+            <StackPanel AutomationProperties.LabeledBy="{Binding ElementName=RadioButtons_Name_Theme}">
+                <RadioButton x:Uid="Radio_Theme_Dark"
+                             IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.EnablePowerLauncher}"
+                             IsChecked="{Binding Mode=TwoWay, Path=IsDarkThemeRadioButtonChecked}" />
+
+                <RadioButton x:Uid="Radio_Theme_Light"
+                             IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.EnablePowerLauncher}"
+                             IsChecked="{Binding Mode=TwoWay, Path=IsLightThemeRadioButtonChecked}" />
+
+                <RadioButton x:Uid="Radio_Theme_Default"
+                             IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.EnablePowerLauncher}"
+                             IsChecked="{Binding Mode=TwoWay, Path=IsSystemThemeRadioButtonChecked}" />
+                <HyperlinkButton Click="OpenColorsSettings_Click">
+                    <TextBlock x:Uid="Windows_Color_Settings" />
+                </HyperlinkButton>
+            </StackPanel>
+
             <TextBlock x:Uid="PowerLauncher_Plugins"
                        Style="{StaticResource SettingsGroupTitleStyle}"
                        Foreground="{x:Bind Mode=OneWay, Path=ViewModel.EnablePowerLauncher, Converter={StaticResource ModuleEnabledToForegroundConverter}}"/>
@@ -301,34 +328,6 @@
                     </DataTemplate>
                 </ListView.ItemTemplate>
             </ListView>
-
-            <TextBlock x:Uid="Appearance_GroupSettings"
-                       Style="{StaticResource SettingsGroupTitleStyle}"
-                       Foreground="{x:Bind Mode=OneWay, Path=ViewModel.EnablePowerLauncher, Converter={StaticResource ModuleEnabledToForegroundConverter}}" />
-
-            <!-- We cannot navigate to all the radio buttons using the arrow keys because of an XYNavigation issue in the RadioButtons control.
-            The screen reader does not read the heading when we tab into a radio button, even though the LabeledBy automation property is set.
-            Link to the issue in the winui repository - https://github.com/microsoft/microsoft-ui-xaml/issues/3156 -->
-            <TextBlock x:Uid="ColorModeHeader"
-                       x:Name="RadioButtons_Name_Theme" 
-                       Margin="{StaticResource SmallTopMargin}"
-                       Foreground="{x:Bind Mode=OneWay, Path=ViewModel.EnablePowerLauncher, Converter={StaticResource ModuleEnabledToForegroundConverter}}" />
-            <StackPanel AutomationProperties.LabeledBy="{Binding ElementName=RadioButtons_Name_Theme}">
-                <RadioButton x:Uid="Radio_Theme_Dark"
-                             IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.EnablePowerLauncher}"
-                             IsChecked="{Binding Mode=TwoWay, Path=IsDarkThemeRadioButtonChecked}" />
-
-                <RadioButton x:Uid="Radio_Theme_Light"
-                             IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.EnablePowerLauncher}"
-                             IsChecked="{Binding Mode=TwoWay, Path=IsLightThemeRadioButtonChecked}" />
-
-                <RadioButton x:Uid="Radio_Theme_Default"
-                             IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.EnablePowerLauncher}"
-                             IsChecked="{Binding Mode=TwoWay, Path=IsSystemThemeRadioButtonChecked}" />
-                <HyperlinkButton Click="OpenColorsSettings_Click">
-                    <TextBlock x:Uid="Windows_Color_Settings" />
-                </HyperlinkButton>
-            </StackPanel>
         </StackPanel>
 
         <RelativePanel x:Name="SidePanel" 


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
- Consider showing a warning when all plugins are disabled
![image](https://user-images.githubusercontent.com/17161067/108744006-1d039f00-7542-11eb-97d2-b691812f5031.png)

- Consider validating Action keyword for * and ~
- Reconsider author placement #9650 (comment)
![image](https://user-images.githubusercontent.com/17161067/108744163-4ae8e380-7542-11eb-8a69-a4234ea4095f.png)

- Reorder Plugins and Appearance sections
![image](https://user-images.githubusercontent.com/17161067/108746872-8b962c00-7545-11eb-9a31-a04c4de1f7d2.png)

Not allowed action keywords are: "~", "\\", "\\\\". All of them rewrite the behavior of the folder plugin. Take into account that we show a warning but a user still can use not allowed action keywords.

**How does someone test / validate:** 
Check if warnings are shown.

## Quality Checklist

- [X] **Linked issue:** #9653
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [X] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
