### PR TITLE
rename windows indexer to window search

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Properties/Resources.Designer.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Properties/Resources.Designer.cs
@@ -169,7 +169,7 @@ namespace Microsoft.Plugin.Indexer.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Windows Indexer.
+        ///   Looks up a localized string similar to Windows Search.
         /// </summary>
         public static string Microsoft_plugin_indexer_plugin_name {
             get {

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Properties/Resources.resx
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Properties/Resources.resx
@@ -154,7 +154,7 @@
     <value>Returns files and folders</value>
   </data>
   <data name="Microsoft_plugin_indexer_plugin_name" xml:space="preserve">
-    <value>Windows Indexer</value>
+    <value>Windows Search</value>
   </data>
   <data name="Microsoft_plugin_indexer_subtitle_header" xml:space="preserve">
     <value>Search</value>


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
![image](https://user-images.githubusercontent.com/17161067/108834760-3efb3100-75d7-11eb-8409-d4ea310a7640.png)

**What is include in the PR:** 

**How does someone test / validate:** 
- Delete `PowerToys Run\settings.json` file
- Check that new name is available
## Quality Checklist

- [X] **Linked issue:** #5273
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [X] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
