### PR TITLE
[FancyZones] Overlapping zones selection algorithm - settings

### DIFF
--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -175,6 +175,12 @@ public:
         return m_windowMoveHandler.InMoveSize();
     }
 
+    IFACEMETHODIMP_(Settings::OverlappingZonesAlgorithm)
+    GetOverlappingZonesAlgorithm() noexcept
+    {
+        return m_settings->GetSettings()->overlappingZonesAlgorithm;
+    }
+
     LRESULT WndProc(HWND, UINT, WPARAM, LPARAM) noexcept;
     void OnDisplayChange(DisplayChangeType changeType) noexcept;
     void AddZoneWindow(HMONITOR monitor, const std::wstring& deviceId) noexcept;

--- a/src/modules/fancyzones/lib/FancyZones.h
+++ b/src/modules/fancyzones/lib/FancyZones.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <common/hooks/WinHookEvent.h>
+#include "Settings.h"
 
 #include <functional>
 
@@ -101,6 +102,11 @@ interface __declspec(uuid("{5C8D99D6-34B2-4F4A-A8E5-7483F6869775}")) IZoneWindow
      * @returns Boolean indicating if move/size operation is currently active.
      */
     IFACEMETHOD_(bool, InMoveSize)
+    () = 0;
+    /**
+     * @returns Enumeration value indicating the algorithm used to choose one of multiple overlapped zones to highlight.
+     */
+    IFACEMETHOD_(Settings::OverlappingZonesAlgorithm, GetOverlappingZonesAlgorithm)
     () = 0;
 };
 

--- a/src/modules/fancyzones/lib/Settings.cpp
+++ b/src/modules/fancyzones/lib/Settings.cpp
@@ -15,6 +15,7 @@ namespace NonLocalizable
     const wchar_t OverrideSnapHotKeysID[] = L"fancyzones_overrideSnapHotkeys";
     const wchar_t MoveWindowAcrossMonitorsID[] = L"fancyzones_moveWindowAcrossMonitors";
     const wchar_t MoveWindowsBasedOnPositionID[] = L"fancyzones_moveWindowsBasedOnPosition";
+    const wchar_t OverlappingZonesAlgorithmID[] = L"fancyzones_overlappingZonesAlgorithm";
     const wchar_t DisplayChangeMoveWindowsID[] = L"fancyzones_displayChange_moveWindows";
     const wchar_t ZoneSetChangeMoveWindowsID[] = L"fancyzones_zoneSetChange_moveWindows";
     const wchar_t AppLastZoneMoveWindowsID[] = L"fancyzones_appLastZone_moveWindows";
@@ -79,16 +80,12 @@ private:
         PCWSTR name;
         bool* value;
         int resourceId;
-    } m_configBools[14 /* 15 */] = {
-        // "Turning FLASHING_ZONE option off"
+    } m_configBools[14] = {
         { NonLocalizable::ShiftDragID, &m_settings.shiftDrag, IDS_SETTING_DESCRIPTION_SHIFTDRAG },
         { NonLocalizable::MouseSwitchID, &m_settings.mouseSwitch, IDS_SETTING_DESCRIPTION_MOUSESWITCH },
         { NonLocalizable::OverrideSnapHotKeysID, &m_settings.overrideSnapHotkeys, IDS_SETTING_DESCRIPTION_OVERRIDE_SNAP_HOTKEYS },
         { NonLocalizable::MoveWindowAcrossMonitorsID, &m_settings.moveWindowAcrossMonitors, IDS_SETTING_DESCRIPTION_MOVE_WINDOW_ACROSS_MONITORS },
         { NonLocalizable::MoveWindowsBasedOnPositionID, &m_settings.moveWindowsBasedOnPosition, IDS_SETTING_DESCRIPTION_MOVE_WINDOWS_BASED_ON_POSITION },
-
-        // "Turning FLASHING_ZONE option off"
-        //{ L"fancyzones_zoneSetChange_flashZones", &m_settings.zoneSetChange_flashZones, IDS_SETTING_DESCRIPTION_ZONESETCHANGE_FLASHZONES },
         { NonLocalizable::DisplayChangeMoveWindowsID, &m_settings.displayChange_moveWindows, IDS_SETTING_DESCRIPTION_DISPLAYCHANGE_MOVEWINDOWS },
         { NonLocalizable::ZoneSetChangeMoveWindowsID, &m_settings.zoneSetChange_moveWindows, IDS_SETTING_DESCRIPTION_ZONESETCHANGE_MOVEWINDOWS },
         { NonLocalizable::AppLastZoneMoveWindowsID, &m_settings.appLastZone_moveWindows, IDS_SETTING_DESCRIPTION_APPLASTZONE_MOVEWINDOWS },
@@ -238,6 +235,11 @@ void FancyZonesSettings::LoadSettings(PCWSTR config, bool fromFile) noexcept
         {
             m_settings.zoneHighlightOpacity = *val;
         }
+
+        if (auto val = values.get_int_value(NonLocalizable::ZoneHighlightOpacityID))
+        {
+            m_settings.zoneHighlightOpacity = *val;
+        }
     }
     catch (...)
     {
@@ -264,6 +266,7 @@ void FancyZonesSettings::SaveSettings() noexcept
         values.add_property(NonLocalizable::ZoneBorderColorID, m_settings.zoneBorderColor);
         values.add_property(NonLocalizable::ZoneHighlightColorID, m_settings.zoneHighlightColor);
         values.add_property(NonLocalizable::ZoneHighlightOpacityID, m_settings.zoneHighlightOpacity);
+        values.add_property(NonLocalizable::OverlappingZonesAlgorithmID, (int)m_settings.overlappingZonesAlgorithm);
         values.add_property(NonLocalizable::EditorHotkeyID, m_settings.editorHotkey.get_json());
         values.add_property(NonLocalizable::ExcludedAppsID, m_settings.excludedApps);
 

--- a/src/modules/fancyzones/lib/Settings.cpp
+++ b/src/modules/fancyzones/lib/Settings.cpp
@@ -236,9 +236,13 @@ void FancyZonesSettings::LoadSettings(PCWSTR config, bool fromFile) noexcept
             m_settings.zoneHighlightOpacity = *val;
         }
 
-        if (auto val = values.get_int_value(NonLocalizable::ZoneHighlightOpacityID))
+        if (auto val = values.get_int_value(NonLocalizable::OverlappingZonesAlgorithmID))
         {
-            m_settings.zoneHighlightOpacity = *val;
+            // Avoid undefined behavior
+            if (*val >= 0 || *val < (int)Settings::OverlappingZonesAlgorithm::EnumElements)
+            {
+                m_settings.overlappingZonesAlgorithm = (Settings::OverlappingZonesAlgorithm)*val;
+            }
         }
     }
     catch (...)

--- a/src/modules/fancyzones/lib/Settings.h
+++ b/src/modules/fancyzones/lib/Settings.h
@@ -14,6 +14,13 @@ namespace ZonedWindowProperties
 
 struct Settings
 {
+    enum struct OverlappingZonesAlgorithm
+    {
+        Smallest = 0,
+        Largest = 1,
+        Positional = 2,
+    };
+
     // The values specified here are the defaults.
     bool shiftDrag = true;
     bool mouseSwitch = false;
@@ -34,6 +41,7 @@ struct Settings
     std::wstring zoneBorderColor = L"#FFFFFF";
     std::wstring zoneHighlightColor = L"#008CFF";
     int zoneHighlightOpacity = 50;
+    OverlappingZonesAlgorithm overlappingZonesAlgorithm = OverlappingZonesAlgorithm::Smallest;
     PowerToysSettings::HotkeyObject editorHotkey = PowerToysSettings::HotkeyObject::from_settings(true, false, false, false, VK_OEM_3);
     std::wstring excludedApps = L"";
     std::vector<std::wstring> excludedAppsArray;

--- a/src/modules/fancyzones/lib/Settings.h
+++ b/src/modules/fancyzones/lib/Settings.h
@@ -14,11 +14,12 @@ namespace ZonedWindowProperties
 
 struct Settings
 {
-    enum struct OverlappingZonesAlgorithm
+    enum struct OverlappingZonesAlgorithm : int
     {
         Smallest = 0,
         Largest = 1,
         Positional = 2,
+        EnumElements = 3, // number of elements in the enum, not counting this
     };
 
     // The values specified here are the defaults.

--- a/src/modules/fancyzones/lib/ZoneSet.cpp
+++ b/src/modules/fancyzones/lib/ZoneSet.cpp
@@ -257,14 +257,16 @@ ZoneSet::ZonesFromPoint(POINT pt) const noexcept
 
         try
         {
+            using Algorithm = Settings::OverlappingZonesAlgorithm;
+
             switch (m_config.SelectionAlgorithm)
             {
-            case ZoneSelectionAlgorithm::SUBREGION:
-                return ZoneSelectSubregion(capturedZones, pt);
-            case ZoneSelectionAlgorithm::SMALLEST:
+            case Algorithm::Smallest:
                 return ZoneSelectPriority(capturedZones, [&](auto zone1, auto zone2) { return zoneArea(zone1) < zoneArea(zone2); });
-            case ZoneSelectionAlgorithm::LARGEST:
+            case Algorithm::Largest:
                 return ZoneSelectPriority(capturedZones, [&](auto zone1, auto zone2) { return zoneArea(zone1) > zoneArea(zone2); });
+            case Algorithm::Positional:
+                return ZoneSelectSubregion(capturedZones, pt);
             }
         }
         catch (std::out_of_range)

--- a/src/modules/fancyzones/lib/ZoneSet.h
+++ b/src/modules/fancyzones/lib/ZoneSet.h
@@ -152,24 +152,19 @@ interface __declspec(uuid("{E4839EB7-669D-49CF-84A9-71A2DFD851A3}")) IZoneSet : 
     IFACEMETHOD_(std::vector<size_t>, GetCombinedZoneRange)(const std::vector<size_t>& initialZones, const std::vector<size_t>& finalZones) const = 0;
 };
 
-enum struct ZoneSelectionAlgorithm
-{
-    SMALLEST = 0,
-    LARGEST = 1,
-    SUBREGION = 2,
-};
-
 struct ZoneSetConfig
 {
     ZoneSetConfig(
         GUID id,
         FancyZonesDataTypes::ZoneSetLayoutType layoutType,
         HMONITOR monitor,
-        int sensitivityRadius) noexcept :
+        int sensitivityRadius,
+        Settings::OverlappingZonesAlgorithm selectionAlgorithm = {}) noexcept :
             Id(id),
             LayoutType(layoutType),
             Monitor(monitor),
-            SensitivityRadius(sensitivityRadius)
+            SensitivityRadius(sensitivityRadius),
+            SelectionAlgorithm(selectionAlgorithm)
     {
     }
 
@@ -177,7 +172,7 @@ struct ZoneSetConfig
     FancyZonesDataTypes::ZoneSetLayoutType LayoutType{};
     HMONITOR Monitor{};
     int SensitivityRadius;
-    ZoneSelectionAlgorithm SelectionAlgorithm = ZoneSelectionAlgorithm::SMALLEST;
+    Settings::OverlappingZonesAlgorithm SelectionAlgorithm = Settings::OverlappingZonesAlgorithm::Smallest;
 };
 
 winrt::com_ptr<IZoneSet> MakeZoneSet(ZoneSetConfig const& config) noexcept;

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -406,7 +406,8 @@ void ZoneWindow::CalculateZoneSet() noexcept
             zoneSetId,
             activeZoneSet.type,
             m_monitor,
-            sensitivityRadius));
+            sensitivityRadius,
+            m_host->GetOverlappingZonesAlgorithm()));
 
         RECT workArea;
         if (m_monitor)

--- a/src/modules/fancyzones/lib/trace.cpp
+++ b/src/modules/fancyzones/lib/trace.cpp
@@ -55,6 +55,7 @@
 #define NumberOfZonesKey "NumberOfZones"
 #define NumberOfWindowsKey "NumberOfWindows"
 #define InputModeKey "InputMode"
+#define OverlappingZonesAlgorithmKey "OverlappingZonesAlgorithm"
 
 TRACELOGGING_DEFINE_PROVIDER(
     g_hProvider,
@@ -260,6 +261,7 @@ void Trace::SettingsChanged(const Settings& settings) noexcept
         TraceLoggingWideString(settings.zoneBorderColor.c_str(), ZoneBorderColorKey),
         TraceLoggingWideString(settings.zoneHighlightColor.c_str(), ZoneHighlightColorKey),
         TraceLoggingInt32(settings.zoneHighlightOpacity, ZoneHighlightOpacityKey),
+        TraceLoggingInt32((int)settings.overlappingZonesAlgorithm, OverlappingZonesAlgorithmKey),
         TraceLoggingWideString(hotkeyStr.c_str(), HotkeyKey),
         TraceLoggingInt32(static_cast<int>(settings.excludedAppsArray.size()), ExcludedAppsCountKey));
 }

--- a/src/modules/fancyzones/tests/UnitTests/ZoneSet.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/ZoneSet.Spec.cpp
@@ -28,7 +28,7 @@ namespace FancyZonesUnitTests
                 auto hres = CoCreateGuid(&m_id);
                 Assert::AreEqual(S_OK, hres);
 
-                ZoneSetConfig m_config = ZoneSetConfig(m_id, m_layoutType, Mocks::Monitor(), DefaultValues::SensitivityRadius);
+                ZoneSetConfig m_config = ZoneSetConfig(m_id, m_layoutType, Mocks::Monitor(), DefaultValues::SensitivityRadius, Settings::OverlappingZonesAlgorithm::Smallest);
                 m_set = MakeZoneSet(m_config);
             }
 

--- a/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/ZoneWindow.Spec.cpp
@@ -56,6 +56,11 @@ namespace FancyZonesUnitTests
         {
             return false;
         }
+        IFACEMETHODIMP_(Settings::OverlappingZonesAlgorithm)
+        GetOverlappingZonesAlgorithm() noexcept
+        {
+            return Settings::OverlappingZonesAlgorithm::Smallest;
+        }
 
         IZoneWindow* m_zoneWindow;
     };

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/FZConfigProperties.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/FZConfigProperties.cs
@@ -18,9 +18,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             FancyzonesMouseSwitch = new BoolProperty();
             FancyzonesMoveWindowsAcrossMonitors = new BoolProperty();
             FancyzonesMoveWindowsBasedOnPosition = new BoolProperty();
-            FancyzonesOverlappingZonesSmallest = new BoolProperty();
-            FancyzonesOverlappingZonesLargest = new BoolProperty();
-            FancyzonesOverlappingZonesPositional = new BoolProperty();
+            FancyzonesOverlappingZonesAlgorithm = new IntProperty();
             FancyzonesDisplayChangeMoveWindows = new BoolProperty();
             FancyzonesZoneSetChangeMoveWindows = new BoolProperty();
             FancyzonesAppLastZoneMoveWindows = new BoolProperty();
@@ -53,14 +51,8 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         [JsonPropertyName("fancyzones_moveWindowsBasedOnPosition")]
         public BoolProperty FancyzonesMoveWindowsBasedOnPosition { get; set; }
 
-        [JsonPropertyName("fancyzones_overlappingZonesSmallest")]
-        public BoolProperty FancyzonesOverlappingZonesSmallest { get; set; }
-
-        [JsonPropertyName("fancyzones_overlappingZonesLargest")]
-        public BoolProperty FancyzonesOverlappingZonesLargest { get; set; }
-
-        [JsonPropertyName("fancyzones_overlappingZonesPositional")]
-        public BoolProperty FancyzonesOverlappingZonesPositional { get; set; }
+        [JsonPropertyName("fancyzones_overlappingZonesAlgorithm")]
+        public IntProperty FancyzonesOverlappingZonesAlgorithm { get; set; }
 
         [JsonPropertyName("fancyzones_displayChange_moveWindows")]
         public BoolProperty FancyzonesDisplayChangeMoveWindows { get; set; }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/FZConfigProperties.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/FZConfigProperties.cs
@@ -18,6 +18,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             FancyzonesMouseSwitch = new BoolProperty();
             FancyzonesMoveWindowsAcrossMonitors = new BoolProperty();
             FancyzonesMoveWindowsBasedOnPosition = new BoolProperty();
+            FancyzonesOverlappingZonesSmallest = new BoolProperty();
+            FancyzonesOverlappingZonesLargest = new BoolProperty();
+            FancyzonesOverlappingZonesPositional = new BoolProperty();
             FancyzonesDisplayChangeMoveWindows = new BoolProperty();
             FancyzonesZoneSetChangeMoveWindows = new BoolProperty();
             FancyzonesAppLastZoneMoveWindows = new BoolProperty();
@@ -49,6 +52,15 @@ namespace Microsoft.PowerToys.Settings.UI.Library
 
         [JsonPropertyName("fancyzones_moveWindowsBasedOnPosition")]
         public BoolProperty FancyzonesMoveWindowsBasedOnPosition { get; set; }
+
+        [JsonPropertyName("fancyzones_overlappingZonesSmallest")]
+        public BoolProperty FancyzonesOverlappingZonesSmallest { get; set; }
+
+        [JsonPropertyName("fancyzones_overlappingZonesLargest")]
+        public BoolProperty FancyzonesOverlappingZonesLargest { get; set; }
+
+        [JsonPropertyName("fancyzones_overlappingZonesPositional")]
+        public BoolProperty FancyzonesOverlappingZonesPositional { get; set; }
 
         [JsonPropertyName("fancyzones_displayChange_moveWindows")]
         public BoolProperty FancyzonesDisplayChangeMoveWindows { get; set; }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/FancyZonesViewModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/FancyZonesViewModel.cs
@@ -266,55 +266,19 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             }
         }
 
-        public bool OverlappingZonesSmallest
+        public int OverlappingZonesAlgorithmIndex
         {
             get
             {
-                return _overlappingZonesAlgorithm == OverlappingZonesAlgorithm.Smallest;
+                return (int)_overlappingZonesAlgorithm;
             }
 
             set
             {
-                if (value && _overlappingZonesAlgorithm != OverlappingZonesAlgorithm.Smallest)
+                if (value != (int)_overlappingZonesAlgorithm)
                 {
-                    _overlappingZonesAlgorithm = OverlappingZonesAlgorithm.Smallest;
-                    Settings.Properties.FancyzonesOverlappingZonesAlgorithm.Value = (int)OverlappingZonesAlgorithm.Smallest;
-                    NotifyPropertyChanged();
-                }
-            }
-        }
-
-        public bool OverlappingZonesLargest
-        {
-            get
-            {
-                return _overlappingZonesAlgorithm == OverlappingZonesAlgorithm.Largest;
-            }
-
-            set
-            {
-                if (value && _overlappingZonesAlgorithm != OverlappingZonesAlgorithm.Largest)
-                {
-                    _overlappingZonesAlgorithm = OverlappingZonesAlgorithm.Largest;
-                    Settings.Properties.FancyzonesOverlappingZonesAlgorithm.Value = (int)OverlappingZonesAlgorithm.Largest;
-                    NotifyPropertyChanged();
-                }
-            }
-        }
-
-        public bool OverlappingZonesPositional
-        {
-            get
-            {
-                return _overlappingZonesAlgorithm == OverlappingZonesAlgorithm.Positional;
-            }
-
-            set
-            {
-                if (value && _overlappingZonesAlgorithm != OverlappingZonesAlgorithm.Positional)
-                {
-                    _overlappingZonesAlgorithm = OverlappingZonesAlgorithm.Positional;
-                    Settings.Properties.FancyzonesOverlappingZonesAlgorithm.Value = (int)OverlappingZonesAlgorithm.Positional;
+                    _overlappingZonesAlgorithm = (OverlappingZonesAlgorithm)value;
+                    Settings.Properties.FancyzonesOverlappingZonesAlgorithm.Value = value;
                     NotifyPropertyChanged();
                 }
             }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/FancyZonesViewModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/FancyZonesViewModel.cs
@@ -32,7 +32,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             MoveWindowBasedOnPosition,
         }
 
-        private enum OverlappingZonesBehaviour
+        private enum OverlappingZonesAlgorithm
         {
             OverlappingZonesSmallest = 0,
             OverlappingZonesLargest,
@@ -65,20 +65,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             _overrideSnapHotkeys = Settings.Properties.FancyzonesOverrideSnapHotkeys.Value;
             _moveWindowsAcrossMonitors = Settings.Properties.FancyzonesMoveWindowsAcrossMonitors.Value;
             _moveWindowBehaviour = Settings.Properties.FancyzonesMoveWindowsBasedOnPosition.Value ? MoveWindowBehaviour.MoveWindowBasedOnPosition : MoveWindowBehaviour.MoveWindowBasedOnZoneIndex;
-
-            if (Settings.Properties.FancyzonesOverlappingZonesSmallest.Value)
-            {
-                _overlappingZonesBehaviour = OverlappingZonesBehaviour.OverlappingZonesSmallest;
-            }
-            else if (Settings.Properties.FancyzonesOverlappingZonesLargest.Value)
-            {
-                _overlappingZonesBehaviour = OverlappingZonesBehaviour.OverlappingZonesLargest;
-            }
-            else
-            {
-                _overlappingZonesBehaviour = OverlappingZonesBehaviour.OverlappingZonesPositional;
-            }
-
+            _overlappingZonesAlgorithm = (OverlappingZonesAlgorithm)Settings.Properties.FancyzonesOverlappingZonesAlgorithm.Value;
             _displayChangemoveWindows = Settings.Properties.FancyzonesDisplayChangeMoveWindows.Value;
             _zoneSetChangeMoveWindows = Settings.Properties.FancyzonesZoneSetChangeMoveWindows.Value;
             _appLastZoneMoveWindows = Settings.Properties.FancyzonesAppLastZoneMoveWindows.Value;
@@ -113,7 +100,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
         private bool _overrideSnapHotkeys;
         private bool _moveWindowsAcrossMonitors;
         private MoveWindowBehaviour _moveWindowBehaviour;
-        private OverlappingZonesBehaviour _overlappingZonesBehaviour;
+        private OverlappingZonesAlgorithm _overlappingZonesAlgorithm;
         private bool _displayChangemoveWindows;
         private bool _zoneSetChangeMoveWindows;
         private bool _appLastZoneMoveWindows;
@@ -283,14 +270,14 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
         {
             get
             {
-                return _overlappingZonesBehaviour == OverlappingZonesBehaviour.OverlappingZonesSmallest;
+                return _overlappingZonesAlgorithm == OverlappingZonesAlgorithm.OverlappingZonesSmallest;
             }
 
             set
             {
-                if (value && _overlappingZonesBehaviour != OverlappingZonesBehaviour.OverlappingZonesSmallest)
+                if (value && _overlappingZonesAlgorithm != OverlappingZonesAlgorithm.OverlappingZonesSmallest)
                 {
-                    _overlappingZonesBehaviour = OverlappingZonesBehaviour.OverlappingZonesSmallest;
+                    _overlappingZonesAlgorithm = OverlappingZonesAlgorithm.OverlappingZonesSmallest;
                     NotifyPropertyChanged();
                 }
             }
@@ -300,14 +287,14 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
         {
             get
             {
-                return _overlappingZonesBehaviour == OverlappingZonesBehaviour.OverlappingZonesLargest;
+                return _overlappingZonesAlgorithm == OverlappingZonesAlgorithm.OverlappingZonesLargest;
             }
 
             set
             {
-                if (value && _overlappingZonesBehaviour != OverlappingZonesBehaviour.OverlappingZonesLargest)
+                if (value && _overlappingZonesAlgorithm != OverlappingZonesAlgorithm.OverlappingZonesLargest)
                 {
-                    _overlappingZonesBehaviour = OverlappingZonesBehaviour.OverlappingZonesLargest;
+                    _overlappingZonesAlgorithm = OverlappingZonesAlgorithm.OverlappingZonesLargest;
                     NotifyPropertyChanged();
                 }
             }
@@ -317,14 +304,14 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
         {
             get
             {
-                return _overlappingZonesBehaviour == OverlappingZonesBehaviour.OverlappingZonesPositional;
+                return _overlappingZonesAlgorithm == OverlappingZonesAlgorithm.OverlappingZonesPositional;
             }
 
             set
             {
-                if (value && _overlappingZonesBehaviour != OverlappingZonesBehaviour.OverlappingZonesPositional)
+                if (value && _overlappingZonesAlgorithm != OverlappingZonesAlgorithm.OverlappingZonesPositional)
                 {
-                    _overlappingZonesBehaviour = OverlappingZonesBehaviour.OverlappingZonesPositional;
+                    _overlappingZonesAlgorithm = OverlappingZonesAlgorithm.OverlappingZonesPositional;
                     NotifyPropertyChanged();
                 }
             }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/FancyZonesViewModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/FancyZonesViewModel.cs
@@ -32,6 +32,13 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             MoveWindowBasedOnPosition,
         }
 
+        private enum OverlappingZonesBehaviour
+        {
+            OverlappingZonesSmallest = 0,
+            OverlappingZonesLargest,
+            OverlappingZonesPositional,
+        }
+
         public FancyZonesViewModel(ISettingsRepository<GeneralSettings> settingsRepository, ISettingsRepository<FancyZonesSettings> moduleSettingsRepository, Func<string, int> ipcMSGCallBackFunc, string configFileSubfolder = "")
         {
             // To obtain the general settings configurations of PowerToys Settings.
@@ -58,6 +65,20 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             _overrideSnapHotkeys = Settings.Properties.FancyzonesOverrideSnapHotkeys.Value;
             _moveWindowsAcrossMonitors = Settings.Properties.FancyzonesMoveWindowsAcrossMonitors.Value;
             _moveWindowBehaviour = Settings.Properties.FancyzonesMoveWindowsBasedOnPosition.Value ? MoveWindowBehaviour.MoveWindowBasedOnPosition : MoveWindowBehaviour.MoveWindowBasedOnZoneIndex;
+
+            if (Settings.Properties.FancyzonesOverlappingZonesSmallest.Value)
+            {
+                _overlappingZonesBehaviour = OverlappingZonesBehaviour.OverlappingZonesSmallest;
+            }
+            else if (Settings.Properties.FancyzonesOverlappingZonesLargest.Value)
+            {
+                _overlappingZonesBehaviour = OverlappingZonesBehaviour.OverlappingZonesLargest;
+            }
+            else
+            {
+                _overlappingZonesBehaviour = OverlappingZonesBehaviour.OverlappingZonesPositional;
+            }
+
             _displayChangemoveWindows = Settings.Properties.FancyzonesDisplayChangeMoveWindows.Value;
             _zoneSetChangeMoveWindows = Settings.Properties.FancyzonesZoneSetChangeMoveWindows.Value;
             _appLastZoneMoveWindows = Settings.Properties.FancyzonesAppLastZoneMoveWindows.Value;
@@ -92,6 +113,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
         private bool _overrideSnapHotkeys;
         private bool _moveWindowsAcrossMonitors;
         private MoveWindowBehaviour _moveWindowBehaviour;
+        private OverlappingZonesBehaviour _overlappingZonesBehaviour;
         private bool _displayChangemoveWindows;
         private bool _zoneSetChangeMoveWindows;
         private bool _appLastZoneMoveWindows;
@@ -252,6 +274,57 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
                 {
                     _moveWindowBehaviour = value ? MoveWindowBehaviour.MoveWindowBasedOnZoneIndex : MoveWindowBehaviour.MoveWindowBasedOnPosition;
                     Settings.Properties.FancyzonesMoveWindowsBasedOnPosition.Value = !value;
+                    NotifyPropertyChanged();
+                }
+            }
+        }
+
+        public bool OverlappingZonesSmallest
+        {
+            get
+            {
+                return _overlappingZonesBehaviour == OverlappingZonesBehaviour.OverlappingZonesSmallest;
+            }
+
+            set
+            {
+                if (value && _overlappingZonesBehaviour != OverlappingZonesBehaviour.OverlappingZonesSmallest)
+                {
+                    _overlappingZonesBehaviour = OverlappingZonesBehaviour.OverlappingZonesSmallest;
+                    NotifyPropertyChanged();
+                }
+            }
+        }
+
+        public bool OverlappingZonesLargest
+        {
+            get
+            {
+                return _overlappingZonesBehaviour == OverlappingZonesBehaviour.OverlappingZonesLargest;
+            }
+
+            set
+            {
+                if (value && _overlappingZonesBehaviour != OverlappingZonesBehaviour.OverlappingZonesLargest)
+                {
+                    _overlappingZonesBehaviour = OverlappingZonesBehaviour.OverlappingZonesLargest;
+                    NotifyPropertyChanged();
+                }
+            }
+        }
+
+        public bool OverlappingZonesPositional
+        {
+            get
+            {
+                return _overlappingZonesBehaviour == OverlappingZonesBehaviour.OverlappingZonesPositional;
+            }
+
+            set
+            {
+                if (value && _overlappingZonesBehaviour != OverlappingZonesBehaviour.OverlappingZonesPositional)
+                {
+                    _overlappingZonesBehaviour = OverlappingZonesBehaviour.OverlappingZonesPositional;
                     NotifyPropertyChanged();
                 }
             }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/FancyZonesViewModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/FancyZonesViewModel.cs
@@ -278,6 +278,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
                 if (value && _overlappingZonesAlgorithm != OverlappingZonesAlgorithm.Smallest)
                 {
                     _overlappingZonesAlgorithm = OverlappingZonesAlgorithm.Smallest;
+                    Settings.Properties.FancyzonesOverlappingZonesAlgorithm.Value = (int)OverlappingZonesAlgorithm.Smallest;
                     NotifyPropertyChanged();
                 }
             }
@@ -295,6 +296,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
                 if (value && _overlappingZonesAlgorithm != OverlappingZonesAlgorithm.Largest)
                 {
                     _overlappingZonesAlgorithm = OverlappingZonesAlgorithm.Largest;
+                    Settings.Properties.FancyzonesOverlappingZonesAlgorithm.Value = (int)OverlappingZonesAlgorithm.Largest;
                     NotifyPropertyChanged();
                 }
             }
@@ -312,6 +314,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
                 if (value && _overlappingZonesAlgorithm != OverlappingZonesAlgorithm.Positional)
                 {
                     _overlappingZonesAlgorithm = OverlappingZonesAlgorithm.Positional;
+                    Settings.Properties.FancyzonesOverlappingZonesAlgorithm.Value = (int)OverlappingZonesAlgorithm.Positional;
                     NotifyPropertyChanged();
                 }
             }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/FancyZonesViewModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/FancyZonesViewModel.cs
@@ -34,9 +34,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
 
         private enum OverlappingZonesAlgorithm
         {
-            OverlappingZonesSmallest = 0,
-            OverlappingZonesLargest,
-            OverlappingZonesPositional,
+            Smallest = 0,
+            Largest = 1,
+            Positional = 2,
         }
 
         public FancyZonesViewModel(ISettingsRepository<GeneralSettings> settingsRepository, ISettingsRepository<FancyZonesSettings> moduleSettingsRepository, Func<string, int> ipcMSGCallBackFunc, string configFileSubfolder = "")
@@ -270,14 +270,14 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
         {
             get
             {
-                return _overlappingZonesAlgorithm == OverlappingZonesAlgorithm.OverlappingZonesSmallest;
+                return _overlappingZonesAlgorithm == OverlappingZonesAlgorithm.Smallest;
             }
 
             set
             {
-                if (value && _overlappingZonesAlgorithm != OverlappingZonesAlgorithm.OverlappingZonesSmallest)
+                if (value && _overlappingZonesAlgorithm != OverlappingZonesAlgorithm.Smallest)
                 {
-                    _overlappingZonesAlgorithm = OverlappingZonesAlgorithm.OverlappingZonesSmallest;
+                    _overlappingZonesAlgorithm = OverlappingZonesAlgorithm.Smallest;
                     NotifyPropertyChanged();
                 }
             }
@@ -287,14 +287,14 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
         {
             get
             {
-                return _overlappingZonesAlgorithm == OverlappingZonesAlgorithm.OverlappingZonesLargest;
+                return _overlappingZonesAlgorithm == OverlappingZonesAlgorithm.Largest;
             }
 
             set
             {
-                if (value && _overlappingZonesAlgorithm != OverlappingZonesAlgorithm.OverlappingZonesLargest)
+                if (value && _overlappingZonesAlgorithm != OverlappingZonesAlgorithm.Largest)
                 {
-                    _overlappingZonesAlgorithm = OverlappingZonesAlgorithm.OverlappingZonesLargest;
+                    _overlappingZonesAlgorithm = OverlappingZonesAlgorithm.Largest;
                     NotifyPropertyChanged();
                 }
             }
@@ -304,14 +304,14 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
         {
             get
             {
-                return _overlappingZonesAlgorithm == OverlappingZonesAlgorithm.OverlappingZonesPositional;
+                return _overlappingZonesAlgorithm == OverlappingZonesAlgorithm.Positional;
             }
 
             set
             {
-                if (value && _overlappingZonesAlgorithm != OverlappingZonesAlgorithm.OverlappingZonesPositional)
+                if (value && _overlappingZonesAlgorithm != OverlappingZonesAlgorithm.Positional)
                 {
-                    _overlappingZonesAlgorithm = OverlappingZonesAlgorithm.OverlappingZonesPositional;
+                    _overlappingZonesAlgorithm = OverlappingZonesAlgorithm.Positional;
                     NotifyPropertyChanged();
                 }
             }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -937,13 +937,16 @@
   <data name="ColorPicker_Editor.Text" xml:space="preserve">
     <value>Editor</value>
   </data>
-  <data name="FancyZones_OverlappingZonesLargest" xml:space="preserve">
+  <data name="FancyZones_OverlappingZonesLargest.Content" xml:space="preserve">
     <value>Largest zone by area</value>
   </data>
-  <data name="FancyZones_OverlappingZonesPositional" xml:space="preserve">
+  <data name="FancyZones_OverlappingZonesPositional.Content" xml:space="preserve">
     <value>Select a zone based on position inside overlap</value>
   </data>
-  <data name="FancyZones_OverlappingZonesSmallest" xml:space="preserve">
+  <data name="FancyZones_OverlappingZonesSmallest.Content" xml:space="preserve">
     <value>Smallest zone by area</value>
+  </data>
+  <data name="FancyZones_OverlappingZonesLabel.Content" xml:space="preserve">
+    <value>When multiple zones overlap, choose which zone gets highlighted:</value>
   </data>
 </root>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -946,7 +946,7 @@
   <data name="FancyZones_OverlappingZonesSmallest.Content" xml:space="preserve">
     <value>Smallest zone by area</value>
   </data>
-  <data name="FancyZones_OverlappingZonesLabel.Content" xml:space="preserve">
+  <data name="FancyZones_OverlappingZonesLabel.Text" xml:space="preserve">
     <value>When multiple zones overlap, choose which zone gets highlighted:</value>
   </data>
 </root>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -937,4 +937,13 @@
   <data name="ColorPicker_Editor.Text" xml:space="preserve">
     <value>Editor</value>
   </data>
+  <data name="FancyZones_OverlappingZonesLargest" xml:space="preserve">
+    <value>Largest zone by area</value>
+  </data>
+  <data name="FancyZones_OverlappingZonesPositional" xml:space="preserve">
+    <value>Select a zone based on position inside overlap</value>
+  </data>
+  <data name="FancyZones_OverlappingZonesSmallest" xml:space="preserve">
+    <value>Smallest zone by area</value>
+  </data>
 </root>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -938,15 +938,15 @@
     <value>Editor</value>
   </data>
   <data name="FancyZones_OverlappingZonesLargest.Content" xml:space="preserve">
-    <value>Largest zone by area</value>
+    <value>Activate the largest zone by area</value>
   </data>
   <data name="FancyZones_OverlappingZonesPositional.Content" xml:space="preserve">
-    <value>Select a zone based on position inside overlap</value>
+    <value>Split the overlapped area into multiple activation targets</value>
   </data>
   <data name="FancyZones_OverlappingZonesSmallest.Content" xml:space="preserve">
-    <value>Smallest zone by area</value>
+    <value>Activate the smallest zone by area</value>
   </data>
   <data name="FancyZones_OverlappingZonesLabel.Text" xml:space="preserve">
-    <value>When multiple zones overlap, choose which zone gets highlighted:</value>
+    <value>When multiple zones overlap:</value>
   </data>
 </root>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Styles/_Sizes.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Styles/_Sizes.xaml
@@ -19,4 +19,7 @@
 
     <!-- MaxWidth of the content panel, similar to W10 Settings -->
     <x:Double x:Key="MaxContentWidth">460</x:Double>
+
+    <!-- Maximum Width of a combo box inside the content panel -->
+    <x:Double x:Key="MaxComboBoxWidth">444</x:Double>
 </ResourceDictionary>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -126,6 +126,7 @@
                       IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"/>
 
             <TextBlock x:Uid="FancyZones_OverlappingZonesLabel"
+                       Margin="{StaticResource SmallTopMargin}"
                        Foreground="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToForegroundConverter}}"/>
 
             <RadioButton x:Uid="FancyZones_OverlappingZonesSmallest"

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -125,6 +125,9 @@
                       Margin="{StaticResource XSmallTopMargin}"
                       IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"/>
 
+            <TextBlock x:Uid="FancyZones_OverlappingZonesLabel"
+                       Foreground="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToForegroundConverter}}"/>
+
             <RadioButton x:Uid="FancyZones_OverlappingZonesSmallest"
                          GroupName="FancyZones_OverlappingZonesGroup"
                          IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.OverlappingZonesSmallest}"

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -129,23 +129,16 @@
                        Margin="{StaticResource SmallTopMargin}"
                        Foreground="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToForegroundConverter}}"/>
 
-            <RadioButton x:Uid="FancyZones_OverlappingZonesSmallest"
-                         GroupName="FancyZones_OverlappingZonesGroup"
-                         IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.OverlappingZonesSmallest}"
-                         Margin="24,8,0,0"
-                         IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"/>
-
-            <RadioButton x:Uid="FancyZones_OverlappingZonesLargest"
-                         GroupName="FancyZones_OverlappingZonesGroup"
-                         IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.OverlappingZonesLargest}"
-                         Margin="24,8,0,0"
-                         IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"/>
-
-            <RadioButton x:Uid="FancyZones_OverlappingZonesPositional"
-                         GroupName="FancyZones_OverlappingZonesGroup"
-                         IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.OverlappingZonesPositional}"
-                         Margin="24,8,0,0"
-                         IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"/>
+            <ComboBox Name="FancyZones_OverlappingZonesComboBox"
+                      x:Uid="FancyZones_OverlappingZonesComboBox"
+                      SelectedIndex="{x:Bind Path=ViewModel.OverlappingZonesAlgorithmIndex, Mode=TwoWay}"
+                      VerticalAlignment="Center"
+                      Width="{StaticResource MaxComboBoxWidth}"
+                      Margin="{StaticResource SmallTopMargin}">
+                <ComboBoxItem x:Uid="FancyZones_OverlappingZonesSmallest" />
+                <ComboBoxItem x:Uid="FancyZones_OverlappingZonesLargest" />
+                <ComboBoxItem x:Uid="FancyZones_OverlappingZonesPositional" />
+            </ComboBox>
 
             <TextBlock x:Uid="FancyZones_WindowBehavior_GroupSettings"
                        Style="{StaticResource SettingsGroupTitleStyle}"

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -125,6 +125,23 @@
                       Margin="{StaticResource XSmallTopMargin}"
                       IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"/>
 
+            <RadioButton x:Uid="FancyZones_OverlappingZonesSmallest"
+                         GroupName="FancyZones_OverlappingZonesGroup"
+                         IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.OverlappingZonesSmallest}"
+                         Margin="24,8,0,0"
+                         IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"/>
+
+            <RadioButton x:Uid="FancyZones_OverlappingZonesLargest"
+                         GroupName="FancyZones_OverlappingZonesGroup"
+                         IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.OverlappingZonesLargest}"
+                         Margin="24,8,0,0"
+                         IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"/>
+
+            <RadioButton x:Uid="FancyZones_OverlappingZonesPositional"
+                         GroupName="FancyZones_OverlappingZonesGroup"
+                         IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.OverlappingZonesPositional}"
+                         Margin="24,8,0,0"
+                         IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"/>
 
             <TextBlock x:Uid="FancyZones_WindowBehavior_GroupSettings"
                        Style="{StaticResource SettingsGroupTitleStyle}"


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

In a previous PR #9447, we added support for different algorithms which should determine which zone gets selected when a user drags a window over a point contained inside several zones. The default is "smallest zone wins", and this is also respected in this PR. This PR exposes the option in PowerToys settings (only the new settings, for now).

**How does someone test / validate:** 

In order to test this, create a canvas zone layout with overlapping zones. For examples of such layouts, see #1167.
Change the setting and check whether the highlighted zone is the expected one.
## Quality Checklist

- [x] **Linked issue:** #1167
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [x] **Tests: See below**
- [ ] **Installer:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

Some unit tests fail because the logger isn't initialized.

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
