### PR TITLE
Navigation from additional panel

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/PowerLauncherPluginViewModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/PowerLauncherPluginViewModel.cs
@@ -123,6 +123,21 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
 
         public string IconPath { get => isDark() ? settings.IconPathDark : settings.IconPathLight; }
 
+        private bool _showAdditionalInfoPanel;
+
+        public bool ShowAdditionalInfoPanel
+        {
+            get => _showAdditionalInfoPanel;
+            set
+            {
+                if (value != _showAdditionalInfoPanel)
+                {
+                    _showAdditionalInfoPanel = value;
+                    NotifyPropertyChanged();
+                }
+            }
+        }
+
         public event PropertyChangedEventHandler PropertyChanged;
 
         private void NotifyPropertyChanged([CallerMemberName] string propertyName = "")

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
@@ -7,8 +7,6 @@
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     x:Class="Microsoft.PowerToys.Settings.UI.Views.PowerLauncherPage"
     xmlns:CustomControls="using:Microsoft.PowerToys.Settings.UI.Controls"
-    xmlns:Interactivity="using:Microsoft.Xaml.Interactivity"
-    xmlns:Core="using:Microsoft.Xaml.Interactions.Core"
     xmlns:converters="using:Microsoft.Toolkit.Uwp.UI.Converters"
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
@@ -190,6 +188,7 @@
 
             <ListView ItemsSource="{x:Bind Path=ViewModel.Plugins, Mode=OneWay}"                
                       IsItemClickEnabled="True"
+                      SelectionChanged="PluginsListView_SelectionChanged"
                       x:Name="PluginsListView"
                       IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.EnablePowerLauncher}"
                       Margin="-12,12,0,0">
@@ -215,23 +214,6 @@
                     <DataTemplate x:DataType="ViewModels:PowerLauncherPluginViewModel" x:DefaultBindMode="OneWay">
                         <StackPanel Orientation="Vertical" Background="Transparent"
                                     Padding="0,12,0,12">
-                            <Interactivity:Interaction.Behaviors>
-
-                                <Core:DataTriggerBehavior Binding="{Binding ElementName=PluginsListView, Path=SelectedItem.Id, Mode=OneWay}"
-                                                          Value="{Binding Id}"
-                                                          ComparisonCondition="Equal">
-                                    <Core:ChangePropertyAction TargetObject="{Binding ElementName=AdditionalInfoPanel}"
-                                                               PropertyName="Visibility"
-                                                               Value="Visible" />
-                                </Core:DataTriggerBehavior>
-                                <Core:DataTriggerBehavior Binding="{Binding ElementName=PluginsListView, Path=SelectedItem.Id, Mode=OneWay}"
-                                                          Value="{Binding Id}"
-                                                          ComparisonCondition="NotEqual">
-                                    <Core:ChangePropertyAction TargetObject="{Binding ElementName=AdditionalInfoPanel}"
-                                                               PropertyName="Visibility"
-                                                               Value="Collapsed" />
-                                </Core:DataTriggerBehavior>
-                            </Interactivity:Interaction.Behaviors>
                             <Grid ColumnSpacing="0">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="60" />
@@ -276,7 +258,9 @@
                                               Grid.Column="2" />
                             </Grid>
 
-                            <StackPanel Margin="60,24,0,24" x:Name="AdditionalInfoPanel" Visibility="Collapsed">
+                            <StackPanel Margin="60,24,0,24" 
+                                        x:Name="AdditionalInfoPanel" 
+                                        Visibility="{x:Bind ShowAdditionalInfoPanel, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
                                 <CheckBox x:Uid="PowerLauncher_IncludeInGlobalResult"
                                           IsChecked="{x:Bind Path=IsGlobal, Mode=TwoWay}" />
 

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml.cs
@@ -45,6 +45,15 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             Helpers.StartProcessHelper.Start(Helpers.StartProcessHelper.ColorsSettings);
         }
 
+        private void PluginsListView_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            var selectedPlugin = (sender as ListView)?.SelectedItem;
+            foreach (var plugin in ViewModel.Plugins)
+            {
+                plugin.ShowAdditionalInfoPanel = plugin == selectedPlugin;
+            }
+        }
+
         /*
         public Tuple<string, string> SelectedSearchResultPreference
         {


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Navigation from the Additional info panel to the next and previous list item.

**What is include in the PR:** 
- Replace `Microsoft.Xaml.Interactivity` with code behind visibility handling for Additional info panel 

**How does someone test / validate:** 
Navigate to controls in additional info panel with tab and try to move up/down with arrow up/down

## Quality Checklist

- [X] **Linked issue:** #9653
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [X] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
