### PR TITLE
disable plugin options when plugin is disabled

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/PowerLauncherPluginViewModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/PowerLauncherPluginViewModel.cs
@@ -55,6 +55,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
                     settings.Disabled = value;
                     NotifyPropertyChanged();
                     NotifyPropertyChanged(nameof(ShowNotAccessibleWarning));
+                    NotifyPropertyChanged(nameof(ShowNotAllowedKeywordWarning));
                     NotifyPropertyChanged(nameof(Enabled));
                     NotifyPropertyChanged(nameof(DisabledOpacity));
                 }
@@ -148,7 +149,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
 
         public bool ShowNotAllowedKeywordWarning
         {
-            get => NotAllowedKeywords.Contains(ActionKeyword);
+            get => !Disabled && NotAllowedKeywords.Contains(ActionKeyword);
         }
     }
 }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/PowerLauncherPluginViewModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/PowerLauncherPluginViewModel.cs
@@ -55,9 +55,15 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
                     settings.Disabled = value;
                     NotifyPropertyChanged();
                     NotifyPropertyChanged(nameof(ShowNotAccessibleWarning));
+                    NotifyPropertyChanged(nameof(Enabled));
+                    NotifyPropertyChanged(nameof(DisabledOpacity));
                 }
             }
         }
+
+        public bool Enabled => !Disabled;
+
+        public double DisabledOpacity => Disabled ? 0.5 : 1;
 
         public bool IsGlobal
         {

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/PowerLauncherViewModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/PowerLauncherViewModel.cs
@@ -97,7 +97,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
 
         private void OnPluginInfoChange(object sender, PropertyChangedEventArgs e)
         {
-            OnPropertyChanged(nameof(AllPluginsDisabled));
+            OnPropertyChanged(nameof(ShowAllPluginsDisabledWarning));
             UpdateSettings();
         }
 
@@ -128,6 +128,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
                 {
                     GeneralSettingsConfig.Enabled.PowerLauncher = value;
                     OnPropertyChanged(nameof(EnablePowerLauncher));
+                    OnPropertyChanged(nameof(ShowAllPluginsDisabledWarning));
                     OutGoingGeneralSettings outgoing = new OutGoingGeneralSettings(GeneralSettingsConfig);
                     SendConfigMSG(outgoing.ToString());
                 }
@@ -376,9 +377,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             }
         }
 
-        public bool AllPluginsDisabled
+        public bool ShowAllPluginsDisabledWarning
         {
-            get => Plugins.All(x => x.Disabled);
+            get => EnablePowerLauncher && Plugins.All(x => x.Disabled);
         }
     }
 }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
@@ -184,7 +184,7 @@
             <TextBlock x:Uid="Run_AllPluginsDisabled"
                        FontSize="12"
                        Foreground="{ThemeResource SystemControlErrorTextForegroundBrush}"
-                       Visibility="{x:Bind ViewModel.AllPluginsDisabled, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
+                       Visibility="{x:Bind ViewModel.ShowAllPluginsDisabledWarning, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
                        TextWrapping="Wrap"
                        Margin="{StaticResource SmallTopMargin}"/>
 

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
@@ -241,6 +241,7 @@
 
                                 <Image Source="{x:Bind IconPath}"
                                        Width="36"
+                                       Opacity="{x:Bind DisabledOpacity, Mode=OneWay}"
                                        HorizontalAlignment="Left"
                                        VerticalAlignment="Top"
                                        Margin="12,0,12,0"
@@ -249,11 +250,13 @@
                                 <StackPanel Orientation="Vertical"
                                             Grid.Column="1" Margin="0,0,12,0">
                                     <TextBlock FontSize="18"
-                                               Text="{x:Bind Path=Name}" />
+                                               Text="{x:Bind Path=Name}"
+                                               Opacity="{x:Bind DisabledOpacity}"/>
                                     <TextBlock FontSize="12"
+                                               Opacity="{x:Bind DisabledOpacity}"
                                                Foreground="{ThemeResource SystemBaseMediumColor}"
                                                Text="{x:Bind Description}"
-                                               TextWrapping="Wrap" />
+                                               TextWrapping="Wrap"/>
                                     <TextBlock 
                                         x:Uid="Run_NotAccessibleWarning"
                                         FontSize="12"
@@ -278,26 +281,31 @@
 
                             <StackPanel Margin="60,24,0,24" x:Name="AdditionalInfoPanel" Visibility="Collapsed">
                                 <CheckBox x:Uid="PowerLauncher_IncludeInGlobalResult"
-                                          IsChecked="{x:Bind Path=IsGlobal, Mode=TwoWay}" />
+                                          IsChecked="{x:Bind Path=IsGlobal, Mode=TwoWay}"
+                                          IsEnabled="{x:Bind Enabled, Mode=OneWay}"/>
 
                                 <TextBlock x:Uid="PowerLauncher_ActionKeyword"
                                            x:Name="ActionKeywordHeaderTextBlock"
-                                           Margin="{StaticResource SmallTopMargin}" />
+                                           Margin="{StaticResource SmallTopMargin}"
+                                           Opacity="{x:Bind DisabledOpacity}"/>
                                 <TextBox x:Uid="PowerLauncher_ActionKeyword"
                                          Text="{x:Bind Path=ActionKeyword, Mode=TwoWay}"
                                          Width="86"
                                          Margin="0,6,0,0"
                                          AutomationProperties.LabeledBy="{Binding ElementName=ActionKeywordHeaderTextBlock}"
-                                         HorizontalAlignment="Left" />
+                                         HorizontalAlignment="Left"
+                                         IsEnabled="{x:Bind Enabled, Mode=OneWay}"/>
 
                                 <TextBlock x:Name="AdditionalOptionsTextBlock"
                                            x:Uid="Run_AdditionalOptions"
                                            Margin="{StaticResource SmallTopMargin}"
                                            Visibility="{x:Bind ShowAdditionalOptions, Converter={StaticResource BoolToVisibilityConverter}}"
-                                           Style="{StaticResource SettingsGroupTitleStyle}"/>
+                                           Style="{StaticResource SettingsGroupTitleStyle}"
+                                           Opacity="{x:Bind DisabledOpacity}"/>
 
                                 <ListView ItemsSource="{x:Bind Path=AdditionalOptions}"
-                                          SelectionMode="None">
+                                          SelectionMode="None"
+                                          IsEnabled="{x:Bind Enabled, Mode=OneWay}">
                                     <ListView.ItemContainerStyle>
                                         <Style TargetType="ListViewItem">
                                             <Setter Property="HorizontalContentAlignment"
@@ -317,6 +325,7 @@
                                 </ListView>
 
                                 <TextBlock FontSize="12"
+                                           Opacity="{x:Bind DisabledOpacity}"
                                            Foreground="{ThemeResource SystemBaseMediumColor}"
                                            HorizontalAlignment="Right"
                                            Margin="0,0,12,0">


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Disable all controls when a plugin is disabled.

![image](https://user-images.githubusercontent.com/17161067/109018561-e738f480-76c0-11eb-9bb6-9c6386a2cab1.png)

**What is include in the PR:** 
- Added `IsEnabled` property to controls that have it
- Added `Opacity` property to controls that do not have `IsEnabled` property

**How does someone test / validate:** 
Check for different themes that plugin's controls are disabled for a disabled plugin.

## Quality Checklist

- [X] **Linked issue:** #9653
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [X] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
