### PR TITLE
[Oobe] Keep oobe window working after closing settings window

### DIFF
--- a/src/settings-ui/PowerToys.Settings/MainWindow.xaml
+++ b/src/settings-ui/PowerToys.Settings/MainWindow.xaml
@@ -7,7 +7,7 @@
         xmlns:Controls="clr-namespace:Microsoft.Toolkit.Wpf.UI.Controls;assembly=Microsoft.Toolkit.Wpf.UI.Controls"
         xmlns:xaml="clr-namespace:Microsoft.Toolkit.Wpf.UI.XamlHost;assembly=Microsoft.Toolkit.Wpf.UI.XamlHost"
         mc:Ignorable="d"
-        Title="PowerToys Settings" MinWidth="480" Height="800" Width="1100" Closing="MainWindow_Closing">
+        Title="PowerToys Settings" MinWidth="480" Height="800" Width="1100" Closing="MainWindow_Closing" Loaded="MainWindow_Loaded">
     <Grid>
         <xaml:WindowsXamlHost InitialTypeName="Microsoft.PowerToys.Settings.UI.Views.ShellPage" ChildChanged="WindowsXamlHost_ChildChanged" />
     </Grid>

--- a/src/settings-ui/PowerToys.Settings/MainWindow.xaml
+++ b/src/settings-ui/PowerToys.Settings/MainWindow.xaml
@@ -7,7 +7,7 @@
         xmlns:Controls="clr-namespace:Microsoft.Toolkit.Wpf.UI.Controls;assembly=Microsoft.Toolkit.Wpf.UI.Controls"
         xmlns:xaml="clr-namespace:Microsoft.Toolkit.Wpf.UI.XamlHost;assembly=Microsoft.Toolkit.Wpf.UI.XamlHost"
         mc:Ignorable="d"
-        Title="PowerToys Settings" MinWidth="480" Height="800" Width="1100" Closing="MainWindow_Closing" Loaded="MainWindow_Loaded">
+        Title="PowerToys Settings" MinWidth="480" Height="800" Width="1100" Closing="MainWindow_Closing" Loaded="MainWindow_Loaded" Activated="MainWindow_Activated">
     <Grid>
         <xaml:WindowsXamlHost InitialTypeName="Microsoft.PowerToys.Settings.UI.Views.ShellPage" ChildChanged="WindowsXamlHost_ChildChanged" />
     </Grid>

--- a/src/settings-ui/PowerToys.Settings/MainWindow.xaml.cs
+++ b/src/settings-ui/PowerToys.Settings/MainWindow.xaml.cs
@@ -136,5 +136,13 @@ namespace PowerToys.Settings
         {
             inst = (Window)sender;
         }
+
+        private void MainWindow_Activated(object sender, EventArgs e)
+        {
+            if (((Window)sender).Visibility == Visibility.Hidden)
+            {
+                ((Window)sender).Visibility = Visibility.Visible;
+            }
+        }
     }
 }

--- a/src/settings-ui/PowerToys.Settings/OobeWindow.xaml.cs
+++ b/src/settings-ui/PowerToys.Settings/OobeWindow.xaml.cs
@@ -14,6 +14,14 @@ namespace PowerToys.Settings
     {
         private static Window inst;
 
+        public static bool IsOpened
+        {
+            get
+            {
+                return inst != null;
+            }
+        }
+
         public OobeWindow()
         {
             InitializeComponent();
@@ -22,6 +30,7 @@ namespace PowerToys.Settings
         private void Window_Closed(object sender, EventArgs e)
         {
             inst = null;
+            MainWindow.CloseHiddenWindow();
         }
 
         private void Window_Loaded(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Cancel closing event from MainWindow if the Oobe window is opened.

**What is include in the PR:** 

**How does someone test / validate:** 

* open Settings 
* open OOBE
* close Settings -> check if oobe window works.
* reopen Settings -> check if Settings window works
* reopen OOBE
* close OOBE
* close Settings

Check that both windows could be opened and closed, and responding as expected.

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
