### PR TITLE
[OOBE] Add event listeners to Shortcut guide and Color picker

### DIFF
--- a/src/common/interop/interop.cpp
+++ b/src/common/interop/interop.cpp
@@ -138,5 +138,9 @@ public
         static String ^ PowerLauncherSharedEvent() {
             return gcnew String(CommonSharedConstants::POWER_LAUNCHER_SHARED_EVENT);
         }
+
+        static String ^ ShowColorPickerSharedEvent() {
+            return gcnew String(CommonSharedConstants::SHOW_COLOR_PICKER_SHARED_EVENT);
+        }
     };
 }

--- a/src/common/interop/shared_constants.h
+++ b/src/common/interop/shared_constants.h
@@ -13,6 +13,9 @@ namespace CommonSharedConstants
     // Path to the event used by PowerLauncher
     const wchar_t POWER_LAUNCHER_SHARED_EVENT[] = L"Local\\PowerToysRunInvokeEvent-30f26ad7-d36d-4c0e-ab02-68bb5ff3c4ab";
 
+    // Path to the event used to show Color Picker
+    const wchar_t SHOW_COLOR_PICKER_SHARED_EVENT[] = L"Local\\ShowColorPickerEvent-8c46be2a-3e05-4186-b56b-4ae986ef2525";
+
     // Max DWORD for key code to disable keys.
     const int VK_DISABLED = 0x100;
 }

--- a/src/common/interop/shared_constants.h
+++ b/src/common/interop/shared_constants.h
@@ -16,6 +16,9 @@ namespace CommonSharedConstants
     // Path to the event used to show Color Picker
     const wchar_t SHOW_COLOR_PICKER_SHARED_EVENT[] = L"Local\\ShowColorPickerEvent-8c46be2a-3e05-4186-b56b-4ae986ef2525";
 
+    // Path to the event used to show Shortcut Guide
+    const wchar_t SHOW_SHORTCUT_GUIDE_SHARED_EVENT[] = L"Local\\ShowShortcutGuideEvent-6982d682-7462-404f-95af-86ae3f089c4f";
+
     // Max DWORD for key code to disable keys.
     const int VK_DISABLED = 0x100;
 }

--- a/src/modules/colorPicker/ColorPickerUI/Helpers/NativeEventWaiter.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/NativeEventWaiter.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Threading;
+using System.Windows;
+using interop;
+
+namespace ColorPicker.Helpers
+{
+    [Export(typeof(NativeEventWaiter))]
+    public class NativeEventWaiter
+    {
+        private AppStateHandler _appStateHandler;
+
+        [ImportingConstructor]
+        public NativeEventWaiter(AppStateHandler appStateHandler)
+        {
+            _appStateHandler = appStateHandler;
+            WaitForEventLoop(Constants.ShowColorPickerSharedEvent(), _appStateHandler.ShowColorPicker);
+        }
+
+        public static void WaitForEventLoop(string eventName, Action callback)
+        {
+            new Thread(() =>
+            {
+                var eventHandle = new EventWaitHandle(false, EventResetMode.AutoReset, eventName);
+                while (true)
+                {
+                    if (eventHandle.WaitOne())
+                    {
+                        Logger.LogInfo("Successfully waited for SHOW_COLOR_PICKER_EVENT");
+                        Application.Current.Dispatcher.Invoke(callback);
+                    }
+                }
+            }).Start();
+        }
+    }
+}

--- a/src/modules/colorPicker/ColorPickerUI/ViewModels/MainViewModel.cs
+++ b/src/modules/colorPicker/ColorPickerUI/ViewModels/MainViewModel.cs
@@ -26,6 +26,7 @@ namespace ColorPicker.ViewModels
         private readonly ZoomWindowHelper _zoomWindowHelper;
         private readonly AppStateHandler _appStateHandler;
         private readonly IUserSettings _userSettings;
+        private readonly NativeEventWaiter _nativeEventWaiter;
 
         /// <summary>
         /// Backing field for <see cref="OtherColor"/>
@@ -48,11 +49,13 @@ namespace ColorPicker.ViewModels
             ZoomWindowHelper zoomWindowHelper,
             AppStateHandler appStateHandler,
             KeyboardMonitor keyboardMonitor,
+            NativeEventWaiter nativeEventWaiter,
             IUserSettings userSettings)
         {
             _zoomWindowHelper = zoomWindowHelper;
             _appStateHandler = appStateHandler;
             _userSettings = userSettings;
+            _nativeEventWaiter = nativeEventWaiter;
 
             if (mouseInfoProvider != null)
             {

--- a/src/modules/shortcut_guide/native_event_waiter.cpp
+++ b/src/modules/shortcut_guide/native_event_waiter.cpp
@@ -1,0 +1,29 @@
+#include "pch.h"
+#include "native_event_waiter.h"
+
+void NativeEventWaiter::run()
+{
+    while (!aborting)
+    {
+        auto result = WaitForSingleObject(event_handle, timeout);
+        if (!aborting && result == WAIT_OBJECT_0)
+        {
+            action();
+        }
+    }
+}
+
+NativeEventWaiter::NativeEventWaiter(const std::wstring& event_name, std::function<void()> action)
+{
+    event_handle = CreateEventW(NULL, FALSE, FALSE, event_name.c_str());
+    this->action = action;
+    running_thread = std::thread([&]() { run(); });
+}
+
+NativeEventWaiter::~NativeEventWaiter()
+{
+    aborting = true;
+    SetEvent(event_handle);
+    running_thread.join();
+    CloseHandle(event_handle);
+}

--- a/src/modules/shortcut_guide/native_event_waiter.h
+++ b/src/modules/shortcut_guide/native_event_waiter.h
@@ -1,0 +1,20 @@
+#pragma once
+#include "pch.h"
+#include "common/interop/shared_constants.h"
+
+class NativeEventWaiter
+{
+    static const int timeout = 1000;
+
+    HANDLE event_handle;
+    std::function<void()> action;
+    std::atomic<bool> aborting;
+
+    void run();
+    std::thread running_thread;
+
+public:
+
+    NativeEventWaiter(const std::wstring& event_name, std::function<void()> action);
+    ~NativeEventWaiter();
+};

--- a/src/modules/shortcut_guide/shortcut_guide.cpp
+++ b/src/modules/shortcut_guide/shortcut_guide.cpp
@@ -5,6 +5,7 @@
 
 #include <common/SettingsAPI/settings_objects.h>
 #include <common/debug_control.h>
+#include <common/interop/shared_constants.h>
 #include <sstream>
 #include <modules/shortcut_guide/ShortcutGuideConstants.h>
 
@@ -260,6 +261,12 @@ void OverlayWindow::enable()
             }
         }
         RegisterHotKey(winkey_popup->get_window_handle(), alternative_switch_hotkey_id, alternative_switch_modifier_mask, alternative_switch_vk_code);
+
+        auto show_action = [&]() {
+            target_state->toggle_force_shown();
+        };
+
+        event_waiter = std::make_unique<NativeEventWaiter>(CommonSharedConstants::SHOW_SHORTCUT_GUIDE_SHARED_EVENT, show_action);
     }
     _enabled = true;
 }
@@ -280,6 +287,7 @@ void OverlayWindow::disable(bool trace_event)
         target_state->exit();
         target_state.reset();
         winkey_popup.reset();
+        event_waiter.reset();
         if (hook_handle)
         {
             bool success = UnhookWindowsHookEx(hook_handle);

--- a/src/modules/shortcut_guide/shortcut_guide.h
+++ b/src/modules/shortcut_guide/shortcut_guide.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <interface/powertoy_module_interface.h>
 #include "overlay_window.h"
+#include "native_event_waiter.h"
 
 #include "Generated Files/resource.h"
 
@@ -44,6 +45,7 @@ private:
     std::unique_ptr<D2DOverlayWindow> winkey_popup;
     bool _enabled = false;
     HHOOK hook_handle;
+    std::unique_ptr<NativeEventWaiter> event_waiter;
 
     void init_settings();
     void disable(bool trace_event);

--- a/src/modules/shortcut_guide/shortcut_guide.vcxproj
+++ b/src/modules/shortcut_guide/shortcut_guide.vcxproj
@@ -67,6 +67,7 @@
     <ClInclude Include="d2d_svg.h" />
     <ClInclude Include="d2d_text.h" />
     <ClInclude Include="d2d_window.h" />
+    <ClInclude Include="native_event_waiter.h" />
     <ClInclude Include="overlay_window.h" />
     <ClInclude Include="keyboard_state.h" />
     <ClInclude Include="Generated Files/resource.h" />
@@ -83,6 +84,7 @@
     <ClCompile Include="d2d_svg.cpp" />
     <ClCompile Include="d2d_text.cpp" />
     <ClCompile Include="d2d_window.cpp" />
+    <ClCompile Include="native_event_waiter.cpp" />
     <ClCompile Include="overlay_window.cpp" />
     <ClCompile Include="dllmain.cpp" />
     <ClCompile Include="keyboard_state.cpp" />

--- a/src/modules/shortcut_guide/shortcut_guide.vcxproj.filters
+++ b/src/modules/shortcut_guide/shortcut_guide.vcxproj.filters
@@ -36,6 +36,9 @@
     <ClCompile Include="tasklist_positions.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="native_event_waiter.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
@@ -71,6 +74,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="start_visible.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="native_event_waiter.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
## Summary of the Pull Request

In order to implement functionality required in the OOBE project. we need to add event listeners to modules so they can be invoked programatically. This PR adds support for Shortcut guide and Color picker.

**What is include in the PR:** 

Event handlers which pick up signaled events.

**How does someone test / validate:** 

You can run this code to trigger the events. Replace the string contents with

`Local\\ShowColorPickerEvent-8c46be2a-3e05-4186-b56b-4ae986ef2525`

to try out Color picker.

```
#include <Windows.h>
int main()
{
	HANDLE h = CreateEventW(NULL, FALSE, FALSE, L"Local\\ShowShortcutGuideEvent-6982d682-7462-404f-95af-86ae3f089c4f");
	SetEvent(h);
}
```

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
