### PR TITLE
start run, color picker, shortcut guide from oobe

### DIFF
--- a/src/common/interop/interop.cpp
+++ b/src/common/interop/interop.cpp
@@ -141,6 +141,10 @@ public
 
         static String ^ ShowColorPickerSharedEvent() {
             return gcnew String(CommonSharedConstants::SHOW_COLOR_PICKER_SHARED_EVENT);
+        } 
+        
+        static String ^ ShowShortcutGuideSharedEvent() {
+            return gcnew String(CommonSharedConstants::SHOW_SHORTCUT_GUIDE_SHARED_EVENT);
         }
     };
 }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeColorPicker.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeColorPicker.xaml
@@ -46,8 +46,9 @@
             <StackPanel Orientation="Horizontal"
                         Margin="32,48,0,0"
                         Spacing="4">
-                <Button Style="{StaticResource AccentButtonStyle}"
-                        Click="LaunchModuleButton_Click">
+                <Button x:Name="Start_ColorPicker"
+                        Style="{StaticResource AccentButtonStyle}"
+                        Click="Start_ColorPicker_Click">
                     <TextBlock>
                         <Run x:Uid="Oobe_Launch"/>
                         <Run Text="{x:Bind ViewModel.ModuleName}"/>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeColorPicker.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeColorPicker.xaml.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading;
 using Microsoft.PowerToys.Settings.UI.OOBE.Enums;
 using Microsoft.PowerToys.Settings.UI.OOBE.ViewModel;
 using Windows.UI.Xaml.Controls;
@@ -22,14 +23,19 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
             DataContext = ViewModel;
         }
 
+        private void Start_ColorPicker_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        {
+            using (var eventHandle = new EventWaitHandle(false, EventResetMode.AutoReset, OobeShellPage.ColorPickerSharedEventCallback()))
+            {
+                eventHandle.Set();
+            }
+
+            ViewModel.LogRunningModuleEvent();
+        }
+
         private void SettingsLaunchButton_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
             ViewModel.LogOpeningSettingsEvent();
-        }
-
-        private void LaunchModuleButton_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
-        {
-            ViewModel.LogRunningModuleEvent();
         }
     }
 }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeRun.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeRun.xaml
@@ -45,8 +45,9 @@
             <StackPanel Orientation="Horizontal"
                         Margin="32,48,0,0"
                         Spacing="4">
-                <Button Style="{StaticResource AccentButtonStyle}"
-                        Click="LaunchModuleButton_Click">
+                <Button x:Name="Start_Run"
+                        Style="{StaticResource AccentButtonStyle}"
+                        Click="Start_Run_Click">
                     <TextBlock>
                         <Run x:Uid="Oobe_Launch"/>
                         <Run Text="{x:Bind ViewModel.ModuleName}"/>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeRun.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeRun.xaml.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading;
 using Microsoft.PowerToys.Settings.UI.OOBE.Enums;
 using Microsoft.PowerToys.Settings.UI.OOBE.ViewModel;
 using Windows.UI.Xaml.Controls;
@@ -22,14 +23,19 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
             DataContext = ViewModel;
         }
 
+        private void Start_Run_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        {
+            using (var eventHandle = new EventWaitHandle(false, EventResetMode.AutoReset, OobeShellPage.RunSharedEventCallback()))
+            {
+                eventHandle.Set();
+            }
+
+            ViewModel.LogRunningModuleEvent();
+        }
+
         private void SettingsLaunchButton_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
             ViewModel.LogOpeningSettingsEvent();
-        }
-
-        private void LaunchModuleButton_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
-        {
-            ViewModel.LogRunningModuleEvent();
         }
     }
 }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeShellPage.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeShellPage.xaml.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.PowerToys.Settings.UI.Library.Telemetry.Events;
@@ -15,6 +16,27 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
 {
     public sealed partial class OobeShellPage : UserControl
     {
+        public static Func<string> RunSharedEventCallback { get; set; }
+
+        public static void SetRunSharedEventCallback(Func<string> implementation)
+        {
+            RunSharedEventCallback = implementation;
+        }
+
+        public static Func<string> ColorPickerSharedEventCallback { get; set; }
+
+        public static void SetColorPickerSharedEventCallback(Func<string> implementation)
+        {
+            ColorPickerSharedEventCallback = implementation;
+        }
+
+        public static Func<string> ShortcutGuideSharedEvent { get; set; }
+
+        public static void SetShortcutGuideSharedEvent(Func<string> implementation)
+        {
+            ShortcutGuideSharedEvent = implementation;
+        }
+
         /// <summary>
         /// Gets view model.
         /// </summary>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeShortcutGuide.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeShortcutGuide.xaml
@@ -39,8 +39,9 @@
             <StackPanel Orientation="Horizontal"
                         Margin="32,48,0,0"
                         Spacing="4">
-                <Button Style="{StaticResource AccentButtonStyle}"
-                        Click="LaunchModuleButton_Click">
+                <Button x:Name="Start_ShortcutGuide"
+                        Style="{StaticResource AccentButtonStyle}"
+                        Click="Start_ShortcutGuide_Click">
                     <TextBlock>
                         <Run x:Uid="Oobe_Launch"/>
                         <Run Text="{x:Bind ViewModel.ModuleName}"/>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeShortcutGuide.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeShortcutGuide.xaml.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading;
 using Microsoft.PowerToys.Settings.UI.OOBE.Enums;
 using Microsoft.PowerToys.Settings.UI.OOBE.ViewModel;
 using Windows.UI.Xaml.Controls;
@@ -22,14 +23,19 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
             DataContext = ViewModel;
         }
 
+        private void Start_ShortcutGuide_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        {
+            using (var eventHandle = new EventWaitHandle(false, EventResetMode.AutoReset, OobeShellPage.ShortcutGuideSharedEvent()))
+            {
+                eventHandle.Set();
+            }
+
+            ViewModel.LogRunningModuleEvent();
+        }
+
         private void SettingsLaunchButton_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
             ViewModel.LogOpeningSettingsEvent();
-        }
-
-        private void LaunchModuleButton_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
-        {
-            ViewModel.LogRunningModuleEvent();
         }
     }
 }

--- a/src/settings-ui/PowerToys.Settings/MainWindow.xaml.cs
+++ b/src/settings-ui/PowerToys.Settings/MainWindow.xaml.cs
@@ -4,8 +4,10 @@
 
 using System;
 using System.Windows;
+using interop;
 using Microsoft.PowerLauncher.Telemetry;
 using Microsoft.PowerToys.Settings.UI.Library.Utilities;
+using Microsoft.PowerToys.Settings.UI.OOBE.Views;
 using Microsoft.PowerToys.Settings.UI.Views;
 using Microsoft.PowerToys.Telemetry;
 using Microsoft.Toolkit.Wpf.UI.XamlHost;
@@ -71,6 +73,21 @@ namespace PowerToys.Settings
                 ShellPage.SetCheckForUpdatesMessageCallback(msg =>
                 {
                     Program.GetTwoWayIPCManager().Send(msg);
+                });
+
+                OobeShellPage.SetRunSharedEventCallback(() =>
+                {
+                    return Constants.PowerLauncherSharedEvent();
+                });
+
+                OobeShellPage.SetColorPickerSharedEventCallback(() =>
+                {
+                    return Constants.ShowColorPickerSharedEvent();
+                });
+
+                OobeShellPage.SetShortcutGuideSharedEvent(() =>
+                {
+                    return Constants.ShowShortcutGuideSharedEvent();
                 });
 
                 // open oobe


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

**What is include in the PR:** 

**How does someone test / validate:** 
Open Run, ColorPicker, Shortcut guide from OOBE, and check that default shortcuts still works.
To cancel the Shotcut guide one has to click on it and then press ESC. 

## Quality Checklist

- [] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
