### PR TITLE
[Settings] UI fixes

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -711,7 +711,7 @@
     <value>Administrator mode</value>
   </data>
   <data name="General_RunAsAdminRequired.Text" xml:space="preserve">
-    <value>You need to run as administrator to use this setting</value>
+    <value>You need to run as administrator to use this setting.</value>
   </data>
   <data name="ShortcutWarningLabel.Text" xml:space="preserve">
     <value>Only shortcuts with the following hotkeys are valid:</value>
@@ -783,7 +783,7 @@
     <value>Preview Pane</value>
   </data>
   <data name="FileExplorerPreview_RunAsAdminRequired.Text" xml:space="preserve">
-    <value>You need to run as administrator to modify these settings</value>
+    <value>You need to run as administrator to modify these settings.</value>
   </data>
   <data name="FileExplorerPreview_AffectsAllUsers.Text" xml:space="preserve">
     <value>The settings on this page affect all users on the system</value>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
@@ -181,7 +181,8 @@
                        Foreground="{x:Bind Mode=OneWay, Path=ViewModel.EnablePowerLauncher, Converter={StaticResource ModuleEnabledToForegroundConverter}}"/>
 
             <TextBlock x:Uid="Run_PluginUseDescription"
-                       Margin="{StaticResource SmallTopMargin}" 
+                       Margin="{StaticResource SmallTopMargin}"
+                       Foreground="{x:Bind Mode=OneWay, Path=ViewModel.EnablePowerLauncher, Converter={StaticResource ModuleEnabledToForegroundConverter}}"
                        TextWrapping="Wrap"/>
             
             <TextBlock x:Uid="Run_AllPluginsDisabled"

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
@@ -170,7 +170,8 @@
                 <RadioButton x:Uid="Radio_Theme_Default"
                              IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.EnablePowerLauncher}"
                              IsChecked="{Binding Mode=TwoWay, Path=IsSystemThemeRadioButtonChecked}" />
-                <HyperlinkButton Click="OpenColorsSettings_Click">
+                <HyperlinkButton Click="OpenColorsSettings_Click"
+                                 IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.EnablePowerLauncher}">
                     <TextBlock x:Uid="Windows_Color_Settings" />
                 </HyperlinkButton>
             </StackPanel>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
@@ -239,21 +239,21 @@
                                     <TextBlock FontSize="18"
                                                Text="{x:Bind Path=Name}"
                                                Opacity="{x:Bind DisabledOpacity}"/>
-                                    <TextBlock FontSize="12"
+                                    <TextBlock 
                                                Opacity="{x:Bind DisabledOpacity}"
                                                Foreground="{ThemeResource SystemBaseMediumColor}"
                                                Text="{x:Bind Description}"
                                                TextWrapping="Wrap"/>
                                     <TextBlock 
                                         x:Uid="Run_NotAccessibleWarning"
-                                        FontSize="12"
+                                        
                                         Foreground="{ThemeResource SystemControlErrorTextForegroundBrush}"
                                         Visibility="{x:Bind ShowNotAccessibleWarning, Converter={StaticResource BoolToVisibilityConverter}}"
                                         TextWrapping="Wrap" />
 
                                     <TextBlock 
                                         x:Uid="Run_NotAllowedActionKeyword"
-                                        FontSize="12"
+                                      
                                         Foreground="{ThemeResource SystemControlErrorTextForegroundBrush}"
                                         Visibility="{x:Bind ShowNotAllowedKeywordWarning, Converter={StaticResource BoolToVisibilityConverter}}"
                                         TextWrapping="Wrap" />

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
@@ -180,12 +180,10 @@
                        Foreground="{x:Bind Mode=OneWay, Path=ViewModel.EnablePowerLauncher, Converter={StaticResource ModuleEnabledToForegroundConverter}}"/>
 
             <TextBlock x:Uid="Run_PluginUseDescription"
-                       FontSize="12"
-                       Foreground="{ThemeResource SystemBaseMediumColor}"
+                       Margin="{StaticResource SmallTopMargin}" 
                        TextWrapping="Wrap"/>
             
             <TextBlock x:Uid="Run_AllPluginsDisabled"
-                       FontSize="12"
                        Foreground="{ThemeResource SystemControlErrorTextForegroundBrush}"
                        Visibility="{x:Bind ViewModel.ShowAllPluginsDisabledWarning, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
                        TextWrapping="Wrap"
@@ -218,7 +216,7 @@
                 <ListView.ItemTemplate>
                     <DataTemplate x:DataType="ViewModels:PowerLauncherPluginViewModel" x:DefaultBindMode="OneWay">
                         <StackPanel Orientation="Vertical" Background="Transparent"
-                                    Padding="0,12,0,12">
+                                    Padding="0,12,12,12">
                             <Grid ColumnSpacing="0">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="60" />
@@ -235,7 +233,7 @@
                                        Height="36" />
 
                                 <StackPanel Orientation="Vertical"
-                                            Grid.Column="1" Margin="0,0,12,0">
+                                            Grid.Column="1" Margin="0,0,16,0">
                                     <TextBlock FontSize="18"
                                                Text="{x:Bind Path=Name}"
                                                Opacity="{x:Bind DisabledOpacity}"/>
@@ -246,14 +244,12 @@
                                                TextWrapping="Wrap"/>
                                     <TextBlock 
                                         x:Uid="Run_NotAccessibleWarning"
-                                        
                                         Foreground="{ThemeResource SystemControlErrorTextForegroundBrush}"
                                         Visibility="{x:Bind ShowNotAccessibleWarning, Converter={StaticResource BoolToVisibilityConverter}}"
                                         TextWrapping="Wrap" />
 
                                     <TextBlock 
                                         x:Uid="Run_NotAllowedActionKeyword"
-                                      
                                         Foreground="{ThemeResource SystemControlErrorTextForegroundBrush}"
                                         Visibility="{x:Bind ShowNotAllowedKeywordWarning, Converter={StaticResource BoolToVisibilityConverter}}"
                                         TextWrapping="Wrap" />
@@ -266,24 +262,28 @@
                                               Grid.Column="2" />
                             </Grid>
 
-                            <StackPanel Margin="60,24,0,24" 
+                            <StackPanel Margin="60,0,0,0" 
                                         x:Name="AdditionalInfoPanel" 
                                         Visibility="{x:Bind ShowAdditionalInfoPanel, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
-                                <CheckBox x:Uid="PowerLauncher_IncludeInGlobalResult"
-                                          IsChecked="{x:Bind Path=IsGlobal, Mode=TwoWay}"
-                                          IsEnabled="{x:Bind Enabled, Mode=OneWay}"/>
-
                                 <TextBlock x:Uid="PowerLauncher_ActionKeyword"
                                            x:Name="ActionKeywordHeaderTextBlock"
                                            Margin="{StaticResource SmallTopMargin}"
-                                           Opacity="{x:Bind DisabledOpacity}"/>
+                                           Opacity="{x:Bind DisabledOpacity}" />
+
                                 <TextBox x:Uid="PowerLauncher_ActionKeyword"
                                          Text="{x:Bind Path=ActionKeyword, Mode=TwoWay}"
                                          Width="86"
                                          Margin="0,6,0,0"
                                          AutomationProperties.LabeledBy="{Binding ElementName=ActionKeywordHeaderTextBlock}"
                                          HorizontalAlignment="Left"
-                                         IsEnabled="{x:Bind Enabled, Mode=OneWay}"/>
+                                         IsEnabled="{x:Bind Enabled, Mode=OneWay}" />
+                                
+                                <CheckBox x:Uid="PowerLauncher_IncludeInGlobalResult"
+                                          IsChecked="{x:Bind Path=IsGlobal, Mode=TwoWay}"
+                                          IsEnabled="{x:Bind Enabled, Mode=OneWay}"
+                                          Margin="{StaticResource SmallTopMargin}"/>
+
+
 
                                 <TextBlock x:Name="AdditionalOptionsTextBlock"
                                            x:Uid="Run_AdditionalOptions"
@@ -313,8 +313,7 @@
                                     </ListView.ItemTemplate>
                                 </ListView>
 
-                                <TextBlock FontSize="12"
-                                           Opacity="{x:Bind DisabledOpacity}"
+                                <TextBlock Opacity="{x:Bind DisabledOpacity}"
                                            Foreground="{ThemeResource SystemBaseMediumColor}"
                                            HorizontalAlignment="Right"
                                            Margin="0,0,12,0">

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerPreviewPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerPreviewPage.xaml
@@ -62,7 +62,6 @@
             <TextBlock x:Uid="FileExplorerPreview_AffectsAllUsers"
                        Foreground="{x:Bind Mode=OneWay, Path=ViewModel.IsElevated, Converter={StaticResource ModuleEnabledToForegroundConverter}}"
                        Margin="{StaticResource SmallBottomMargin}"
-                       FontWeight="SemiBold"
                        TextWrapping="Wrap"/>
 
             <TextBlock x:Uid="FileExplorerPreview_PreviewPane_GroupSettings"
@@ -86,11 +85,9 @@
             <TextBlock x:Uid="FileExplorerPreview_RebootRequired"
                        Foreground="{x:Bind Mode=OneWay, Path=ViewModel.IsElevated, Converter={StaticResource ModuleEnabledToForegroundConverter}}"
                        Margin="{StaticResource SmallTopBottomMargin}"
-                       FontWeight="SemiBold"
                        TextWrapping="Wrap"/>
 
             <ToggleSwitch x:Uid="FileExplorerPreview_ToggleSwitch_SVG_Thumbnail"
-                          Margin="{StaticResource SmallTopMargin}"
                           IsOn="{Binding Mode=TwoWay, Path=SVGThumbnailIsEnabled}"
                           IsEnabled="{Binding Mode=OneWay, Path=IsElevated}"/>
         </StackPanel>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ShortcutGuidePage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ShortcutGuidePage.xaml
@@ -107,7 +107,8 @@
                 <RadioButton x:Uid="Radio_Theme_Light" />
                 <RadioButton x:Uid="Radio_Theme_Default"/>
             </muxc:RadioButtons>
-            <HyperlinkButton Click="OpenColorsSettings_Click">
+            <HyperlinkButton Click="OpenColorsSettings_Click"
+                             IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}">
                 <TextBlock x:Uid="Windows_Color_Settings" />
             </HyperlinkButton>
         </StackPanel>


### PR DESCRIPTION
## Summary of the Pull Request
- Windows color settings hyperlink buttons are now disabled if the module is disabled (#9877).
- Spacing fixes on the File Explorer add-ons page.
- Spacing fixes on Plug-in manager item template. (#9918)
- Increased the Plug-in manager to OS default: 14px for better readability.
- Adding periods after warnings (#9881).

![image](https://user-images.githubusercontent.com/9866362/109390188-62dcb080-7910-11eb-9411-7ab422fad242.png)

## Quality Checklist

- [X] **Linked issue:** #9918, #9881, #9877
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
