### PR TITLE
[Oobe] Telemetry: When specific OOBE sections are entered/exited

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/Telemetry/Events/OobeSectionEvent.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/Telemetry/Events/OobeSectionEvent.cs
@@ -11,7 +11,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library.Telemetry.Events
     [EventData]
     public class OobeSectionEvent : EventBase, IEvent
     {
-        public string SectionEntered { get; set; }
+        public string Section { get; set; }
+
+        public double TimeOpenedMs { get; set; }
 
         public PartA_PrivTags PartA_PrivTags => PartA_PrivTags.ProductAndServiceUsage;
     }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/ViewModel/OobePowerToysModule.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/ViewModel/OobePowerToysModule.cs
@@ -9,6 +9,8 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.ViewModel
 {
     public class OobePowerToysModule
     {
+        private System.Diagnostics.Stopwatch timeOpened = new System.Diagnostics.Stopwatch();
+
         public string ModuleName { get; set; }
 
         public string Tag { get; set; }
@@ -60,6 +62,17 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.ViewModel
         public void LogRunningModuleEvent()
         {
             PowerToysTelemetry.Log.WriteEvent(new OobeModuleRunEvent() { ModuleName = this.ModuleName });
+        }
+
+        public void LogOpeningModuleEvent()
+        {
+            timeOpened.Start();
+        }
+
+        public void LogClosingModuleEvent()
+        {
+            timeOpened.Stop();
+            PowerToysTelemetry.Log.WriteEvent(new OobeSectionEvent() { Section = this.ModuleName, TimeOpenedMs = timeOpened.ElapsedMilliseconds });
         }
     }
 }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/ViewModel/OobePowerToysModule.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/ViewModel/OobePowerToysModule.cs
@@ -52,6 +52,7 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.ViewModel
             Description = other.Description;
             Link = other.Link;
             DescriptionLink = other.DescriptionLink;
+            timeOpened = other.timeOpened;
         }
 
         public void LogOpeningSettingsEvent()

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeColorPicker.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeColorPicker.xaml.cs
@@ -7,6 +7,7 @@ using Microsoft.PowerToys.Settings.UI.OOBE.Enums;
 using Microsoft.PowerToys.Settings.UI.OOBE.ViewModel;
 using Microsoft.PowerToys.Settings.UI.Views;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Navigation;
 
 namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
 {
@@ -38,6 +39,16 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
         {
             OobeShellPage.OpenMainWindowCallback(typeof(ColorPickerPage));
             ViewModel.LogOpeningSettingsEvent();
+        }
+
+        protected override void OnNavigatedTo(NavigationEventArgs e)
+        {
+            ViewModel.LogOpeningModuleEvent();
+        }
+
+        protected override void OnNavigatedFrom(NavigationEventArgs e)
+        {
+            ViewModel.LogClosingModuleEvent();
         }
     }
 }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeFancyZones.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeFancyZones.xaml.cs
@@ -6,6 +6,7 @@ using Microsoft.PowerToys.Settings.UI.OOBE.Enums;
 using Microsoft.PowerToys.Settings.UI.OOBE.ViewModel;
 using Microsoft.PowerToys.Settings.UI.Views;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Navigation;
 
 namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
 {
@@ -27,6 +28,16 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
         {
             OobeShellPage.OpenMainWindowCallback(typeof(FancyZonesPage));
             ViewModel.LogOpeningSettingsEvent();
+        }
+
+        protected override void OnNavigatedTo(NavigationEventArgs e)
+        {
+            ViewModel.LogOpeningModuleEvent();
+        }
+
+        protected override void OnNavigatedFrom(NavigationEventArgs e)
+        {
+            ViewModel.LogClosingModuleEvent();
         }
     }
 }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeFileExplorer.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeFileExplorer.xaml.cs
@@ -6,6 +6,7 @@ using Microsoft.PowerToys.Settings.UI.OOBE.Enums;
 using Microsoft.PowerToys.Settings.UI.OOBE.ViewModel;
 using Microsoft.PowerToys.Settings.UI.Views;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Navigation;
 
 namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
 {
@@ -27,6 +28,16 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
         {
             OobeShellPage.OpenMainWindowCallback(typeof(PowerPreviewPage));
             ViewModel.LogOpeningSettingsEvent();
+        }
+
+        protected override void OnNavigatedTo(NavigationEventArgs e)
+        {
+            ViewModel.LogOpeningModuleEvent();
+        }
+
+        protected override void OnNavigatedFrom(NavigationEventArgs e)
+        {
+            ViewModel.LogClosingModuleEvent();
         }
     }
 }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeImageResizer.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeImageResizer.xaml.cs
@@ -6,6 +6,7 @@ using Microsoft.PowerToys.Settings.UI.OOBE.Enums;
 using Microsoft.PowerToys.Settings.UI.OOBE.ViewModel;
 using Microsoft.PowerToys.Settings.UI.Views;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Navigation;
 
 namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
 {
@@ -27,6 +28,16 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
         {
             OobeShellPage.OpenMainWindowCallback(typeof(ImageResizerPage));
             ViewModel.LogOpeningSettingsEvent();
+        }
+
+        protected override void OnNavigatedTo(NavigationEventArgs e)
+        {
+            ViewModel.LogOpeningModuleEvent();
+        }
+
+        protected override void OnNavigatedFrom(NavigationEventArgs e)
+        {
+            ViewModel.LogClosingModuleEvent();
         }
     }
 }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeKBM.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeKBM.xaml.cs
@@ -6,6 +6,7 @@ using Microsoft.PowerToys.Settings.UI.OOBE.Enums;
 using Microsoft.PowerToys.Settings.UI.OOBE.ViewModel;
 using Microsoft.PowerToys.Settings.UI.Views;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Navigation;
 
 namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
 {
@@ -27,6 +28,16 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
         {
             OobeShellPage.OpenMainWindowCallback(typeof(KeyboardManagerPage));
             ViewModel.LogOpeningSettingsEvent();
+        }
+
+        protected override void OnNavigatedTo(NavigationEventArgs e)
+        {
+            ViewModel.LogOpeningModuleEvent();
+        }
+
+        protected override void OnNavigatedFrom(NavigationEventArgs e)
+        {
+            ViewModel.LogClosingModuleEvent();
         }
     }
 }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeOverview.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeOverview.xaml.cs
@@ -5,6 +5,7 @@
 using Microsoft.PowerToys.Settings.UI.OOBE.Enums;
 using Microsoft.PowerToys.Settings.UI.OOBE.ViewModel;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Navigation;
 
 namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
 {
@@ -17,6 +18,16 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
             this.InitializeComponent();
             ViewModel = new OobePowerToysModule(OobeShellPage.OobeShellHandler.Modules[(int)PowerToysModulesEnum.Overview]);
             DataContext = ViewModel;
+        }
+
+        protected override void OnNavigatedTo(NavigationEventArgs e)
+        {
+            ViewModel.LogOpeningModuleEvent();
+        }
+
+        protected override void OnNavigatedFrom(NavigationEventArgs e)
+        {
+            ViewModel.LogClosingModuleEvent();
         }
     }
 }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobePowerRename.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobePowerRename.xaml.cs
@@ -6,6 +6,7 @@ using Microsoft.PowerToys.Settings.UI.OOBE.Enums;
 using Microsoft.PowerToys.Settings.UI.OOBE.ViewModel;
 using Microsoft.PowerToys.Settings.UI.Views;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Navigation;
 
 namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
 {
@@ -27,6 +28,16 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
         {
             OobeShellPage.OpenMainWindowCallback(typeof(PowerRenamePage));
             ViewModel.LogOpeningSettingsEvent();
+        }
+
+        protected override void OnNavigatedTo(NavigationEventArgs e)
+        {
+            ViewModel.LogOpeningModuleEvent();
+        }
+
+        protected override void OnNavigatedFrom(NavigationEventArgs e)
+        {
+            ViewModel.LogClosingModuleEvent();
         }
     }
 }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeRun.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeRun.xaml.cs
@@ -7,6 +7,7 @@ using Microsoft.PowerToys.Settings.UI.OOBE.Enums;
 using Microsoft.PowerToys.Settings.UI.OOBE.ViewModel;
 using Microsoft.PowerToys.Settings.UI.Views;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Navigation;
 
 namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
 {
@@ -38,6 +39,16 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
         {
             OobeShellPage.OpenMainWindowCallback(typeof(PowerLauncherPage));
             ViewModel.LogOpeningSettingsEvent();
+        }
+
+        protected override void OnNavigatedTo(NavigationEventArgs e)
+        {
+            ViewModel.LogOpeningModuleEvent();
+        }
+
+        protected override void OnNavigatedFrom(NavigationEventArgs e)
+        {
+            ViewModel.LogClosingModuleEvent();
         }
     }
 }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeShellPage.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeShellPage.xaml.cs
@@ -5,10 +5,8 @@
 using System;
 using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
-using Microsoft.PowerToys.Settings.UI.Library.Telemetry.Events;
 using Microsoft.PowerToys.Settings.UI.OOBE.Enums;
 using Microsoft.PowerToys.Settings.UI.OOBE.ViewModel;
-using Microsoft.PowerToys.Telemetry;
 using Windows.ApplicationModel.Resources;
 using Windows.UI.Xaml.Controls;
 
@@ -200,7 +198,6 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
         private void NavigationView_SelectionChanged(Microsoft.UI.Xaml.Controls.NavigationView sender, Microsoft.UI.Xaml.Controls.NavigationViewSelectionChangedEventArgs args)
         {
             OobePowerToysModule selectedItem = args.SelectedItem as OobePowerToysModule;
-            PowerToysTelemetry.Log.WriteEvent(new OobeSectionEvent() { SectionEntered = selectedItem.ModuleName });
 
             switch (selectedItem.Tag)
             {

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeShellPage.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeShellPage.xaml.cs
@@ -198,7 +198,7 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
         {
             if (Modules.Count > 0)
             {
-                NavigationView.SelectedItem = Modules[0];
+                NavigationView.SelectedItem = Modules[(int)PowerToysModulesEnum.Overview];
             }
         }
 

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeShellPage.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeShellPage.xaml.cs
@@ -186,6 +186,14 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
             }); */
         }
 
+        public void OnClosing()
+        {
+            if (NavigationView.SelectedItem != null)
+            {
+                ((OobePowerToysModule)NavigationView.SelectedItem).LogClosingModuleEvent();
+            }
+        }
+
         private void UserControl_Loaded(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
             if (Modules.Count > 0)

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeShortcutGuide.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeShortcutGuide.xaml.cs
@@ -7,6 +7,7 @@ using Microsoft.PowerToys.Settings.UI.OOBE.Enums;
 using Microsoft.PowerToys.Settings.UI.OOBE.ViewModel;
 using Microsoft.PowerToys.Settings.UI.Views;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Navigation;
 
 namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
 {
@@ -38,6 +39,16 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
         {
             OobeShellPage.OpenMainWindowCallback(typeof(ShortcutGuidePage));
             ViewModel.LogOpeningSettingsEvent();
+        }
+
+        protected override void OnNavigatedTo(NavigationEventArgs e)
+        {
+            ViewModel.LogOpeningModuleEvent();
+        }
+
+        protected override void OnNavigatedFrom(NavigationEventArgs e)
+        {
+            ViewModel.LogClosingModuleEvent();
         }
     }
 }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeVideoConference.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeVideoConference.xaml.cs
@@ -5,6 +5,7 @@
 using Microsoft.PowerToys.Settings.UI.OOBE.Enums;
 using Microsoft.PowerToys.Settings.UI.OOBE.ViewModel;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Navigation;
 
 namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
 {
@@ -25,6 +26,16 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
         private void SettingsLaunchButton_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
             ViewModel.LogOpeningSettingsEvent();
+        }
+
+        protected override void OnNavigatedTo(NavigationEventArgs e)
+        {
+            ViewModel.LogOpeningModuleEvent();
+        }
+
+        protected override void OnNavigatedFrom(NavigationEventArgs e)
+        {
+            ViewModel.LogClosingModuleEvent();
         }
     }
 }

--- a/src/settings-ui/PowerToys.Settings/OobeWindow.xaml
+++ b/src/settings-ui/PowerToys.Settings/OobeWindow.xaml
@@ -14,6 +14,6 @@
         Loaded="Window_Loaded"
         Closed="Window_Closed">
     <Grid>
-        <xaml:WindowsXamlHost InitialTypeName="Microsoft.PowerToys.Settings.UI.OOBE.Views.OobeShellPage" />
+        <xaml:WindowsXamlHost InitialTypeName="Microsoft.PowerToys.Settings.UI.OOBE.Views.OobeShellPage" ChildChanged="WindowsXamlHost_ChildChanged" />
     </Grid>
 </Window>

--- a/src/settings-ui/PowerToys.Settings/OobeWindow.xaml.cs
+++ b/src/settings-ui/PowerToys.Settings/OobeWindow.xaml.cs
@@ -4,6 +4,8 @@
 
 using System;
 using System.Windows;
+using Microsoft.PowerToys.Settings.UI.OOBE.Views;
+using Microsoft.Toolkit.Wpf.UI.XamlHost;
 
 namespace PowerToys.Settings
 {
@@ -13,6 +15,7 @@ namespace PowerToys.Settings
     public partial class OobeWindow : Window
     {
         private static Window inst;
+        private OobeShellPage shellPage;
 
         public static bool IsOpened
         {
@@ -29,6 +32,11 @@ namespace PowerToys.Settings
 
         private void Window_Closed(object sender, EventArgs e)
         {
+            if (shellPage != null)
+            {
+                shellPage.OnClosing();
+            }
+
             inst = null;
             MainWindow.CloseHiddenWindow();
         }
@@ -41,6 +49,17 @@ namespace PowerToys.Settings
             }
 
             inst = this;
+        }
+
+        private void WindowsXamlHost_ChildChanged(object sender, EventArgs e)
+        {
+            if (sender == null)
+            {
+                return;
+            }
+
+            WindowsXamlHost windowsXamlHost = sender as WindowsXamlHost;
+            shellPage = windowsXamlHost.GetUwpInternalObject() as OobeShellPage;
         }
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Added to log for how long section was opened.
Logs are being sent on the `OnNavigatedFrom` event and on OOBE window closing.

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
