### PR TITLE
[Shortcut guide] Activate from OOBE

### DIFF
--- a/src/modules/shortcut_guide/d2d_window.cpp
+++ b/src/modules/shortcut_guide/d2d_window.cpp
@@ -41,6 +41,7 @@ void D2DWindow::show(UINT x, UINT y, UINT width, UINT height)
     on_show();
     SetWindowPos(hwnd, HWND_TOPMOST, x, y, width, height, 0);
     ShowWindow(hwnd, SW_SHOWNORMAL);
+    SetForegroundWindow(hwnd);
     UpdateWindow(hwnd);
 }
 

--- a/src/modules/shortcut_guide/shortcut_guide.cpp
+++ b/src/modules/shortcut_guide/shortcut_guide.cpp
@@ -95,6 +95,8 @@ namespace
                            ((style & WS_THICKFRAME) == WS_THICKFRAME);
         return result;
     }
+
+    const LPARAM eventActivateWindow = 1;
 }
 
 OverlayWindow::OverlayWindow()
@@ -213,6 +215,13 @@ void OverlayWindow::enable()
             instance->target_state->toggle_force_shown();
             return 0;
         }
+
+        if (msg == WM_APP && lparam == eventActivateWindow)
+        {
+            instance->target_state->toggle_force_shown();
+            return 0;
+        }
+
         if (msg != WM_HOTKEY)
         {
             return 0;
@@ -263,7 +272,7 @@ void OverlayWindow::enable()
         RegisterHotKey(winkey_popup->get_window_handle(), alternative_switch_hotkey_id, alternative_switch_modifier_mask, alternative_switch_vk_code);
 
         auto show_action = [&]() {
-            target_state->toggle_force_shown();
+            SendMessageW(winkey_popup->get_window_handle(), WM_APP, 0, eventActivateWindow);
         };
 
         event_waiter = std::make_unique<NativeEventWaiter>(CommonSharedConstants::SHOW_SHORTCUT_GUIDE_SHARED_EVENT, show_action);

--- a/src/modules/shortcut_guide/shortcut_guide.cpp
+++ b/src/modules/shortcut_guide/shortcut_guide.cpp
@@ -272,7 +272,7 @@ void OverlayWindow::enable()
         RegisterHotKey(winkey_popup->get_window_handle(), alternative_switch_hotkey_id, alternative_switch_modifier_mask, alternative_switch_vk_code);
 
         auto show_action = [&]() {
-            SendMessageW(winkey_popup->get_window_handle(), WM_APP, 0, eventActivateWindow);
+            PostMessageW(winkey_popup->get_window_handle(), WM_APP, 0, eventActivateWindow);
         };
 
         event_waiter = std::make_unique<NativeEventWaiter>(CommonSharedConstants::SHOW_SHORTCUT_GUIDE_SHARED_EVENT, show_action);
@@ -292,11 +292,11 @@ void OverlayWindow::disable(bool trace_event)
             Trace::EnableShortcutGuide(false);
         }
         UnregisterHotKey(winkey_popup->get_window_handle(), alternative_switch_hotkey_id);
+        event_waiter.reset();
         winkey_popup->hide();
         target_state->exit();
         target_state.reset();
         winkey_popup.reset();
-        event_waiter.reset();
         if (hook_handle)
         {
             bool success = UnhookWindowsHookEx(hook_handle);


### PR DESCRIPTION
## Summary of the Pull Request

This PR fixes the way the Shortcut Guide window is activated from the OOBE window. With this PR, the window is also activated i.e. brought to focus, so it can be exited by clicking Esc without having to click the window first.

**How does someone test / validate:** 

Check that you can quit the Shortcut Guide window using the Esc key after lauching it from OOBE.

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
