### PR TITLE
[OOBE] Delegate foreground window ability to PowerToys.exe on SCG launch

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Helpers/NativeMethods.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Helpers/NativeMethods.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.PowerToys.Settings.UI.Helpers
 {
-    internal static class NativeMethods
+    public static class NativeMethods
     {
         [DllImport("user32.dll")]
         internal static extern uint SendInput(uint nInputs, NativeKeyboardHelper.INPUT[] pInputs, int cbSize);
@@ -14,7 +14,12 @@ namespace Microsoft.PowerToys.Settings.UI.Helpers
         [DllImport("user32.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.StdCall, SetLastError = true)]
         internal static extern short GetAsyncKeyState(int vKey);
 
+#pragma warning disable CA1401 // P/Invokes should not be visible
         [DllImport("user32.dll")]
         public static extern bool ShowWindow(System.IntPtr hWnd, int nCmdShow);
+
+        [DllImport("user32.dll")]
+        public static extern bool AllowSetForegroundWindow(int dwProcessId);
+#pragma warning restore CA1401 // P/Invokes should not be visible
     }
 }

--- a/src/settings-ui/PowerToys.Settings/MainWindow.xaml.cs
+++ b/src/settings-ui/PowerToys.Settings/MainWindow.xaml.cs
@@ -6,6 +6,7 @@ using System;
 using System.Windows;
 using interop;
 using Microsoft.PowerLauncher.Telemetry;
+using Microsoft.PowerToys.Settings.UI.Helpers;
 using Microsoft.PowerToys.Settings.UI.Library.Utilities;
 using Microsoft.PowerToys.Settings.UI.OOBE.Views;
 using Microsoft.PowerToys.Settings.UI.Views;
@@ -87,6 +88,7 @@ namespace PowerToys.Settings
 
                 OobeShellPage.SetShortcutGuideSharedEvent(() =>
                 {
+                    NativeMethods.AllowSetForegroundWindow(PowerToys.Settings.Program.PowerToysPID);
                     return Constants.ShowShortcutGuideSharedEvent();
                 });
 


### PR DESCRIPTION
## Summary of the Pull Request

SetForegroundWindow could fail due to permission issues described in https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setforegroundwindow

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
