### PR TITLE
Additional Options in indexer had null value exception

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Main.cs
@@ -227,8 +227,16 @@ namespace Microsoft.Plugin.Indexer
 
         public void UpdateSettings(PowerLauncherPluginSettings settings)
         {
-            var option = settings.AdditionalOptions.FirstOrDefault(x => x.Key == DisableDriveDetectionWarning);
-            _driveDetection.IsDriveDetectionWarningCheckBoxSelected = option == null ? false : option.Value;
+            var driveDetection = false;
+
+            if (settings.AdditionalOptions != null)
+            {
+                var option = settings.AdditionalOptions.FirstOrDefault(x => x.Key == DisableDriveDetectionWarning);
+
+                driveDetection = option == null ? false : option.Value;
+            }
+
+            _driveDetection.IsDriveDetectionWarningCheckBoxSelected = driveDetection;
         }
 
         public Control CreateSettingPanel()


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

I hit this null reference when going between the OOBE and main branch.  

settings.AdditionalOptions was null so wrapped the detection.  On only master, i couldn't repro but going between the two, my settings got into a state where this was a valid permutation.

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #https://github.com/microsoft/PowerToys/issues/9977
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
