### PR TITLE
[OOBE] Fix opening PT modules and settings at the first launch 

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeColorPicker.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeColorPicker.xaml.cs
@@ -27,9 +27,12 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
 
         private void Start_ColorPicker_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
-            using (var eventHandle = new EventWaitHandle(false, EventResetMode.AutoReset, OobeShellPage.ColorPickerSharedEventCallback()))
+            if (OobeShellPage.ColorPickerSharedEventCallback != null)
             {
-                eventHandle.Set();
+                using (var eventHandle = new EventWaitHandle(false, EventResetMode.AutoReset, OobeShellPage.ColorPickerSharedEventCallback()))
+                {
+                    eventHandle.Set();
+                }
             }
 
             ViewModel.LogRunningModuleEvent();

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeColorPicker.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeColorPicker.xaml.cs
@@ -37,7 +37,11 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
 
         private void SettingsLaunchButton_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
-            OobeShellPage.OpenMainWindowCallback(typeof(ColorPickerPage));
+            if (OobeShellPage.OpenMainWindowCallback != null)
+            {
+                OobeShellPage.OpenMainWindowCallback(typeof(ColorPickerPage));
+            }
+
             ViewModel.LogOpeningSettingsEvent();
         }
 

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeFancyZones.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeFancyZones.xaml.cs
@@ -26,7 +26,11 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
 
         private void SettingsLaunchButton_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
-            OobeShellPage.OpenMainWindowCallback(typeof(FancyZonesPage));
+            if (OobeShellPage.OpenMainWindowCallback != null)
+            {
+                OobeShellPage.OpenMainWindowCallback(typeof(FancyZonesPage));
+            }
+
             ViewModel.LogOpeningSettingsEvent();
         }
 

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeFileExplorer.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeFileExplorer.xaml.cs
@@ -26,7 +26,11 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
 
         private void SettingsLaunchButton_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
-            OobeShellPage.OpenMainWindowCallback(typeof(PowerPreviewPage));
+            if (OobeShellPage.OpenMainWindowCallback != null)
+            {
+                OobeShellPage.OpenMainWindowCallback(typeof(PowerPreviewPage));
+            }
+
             ViewModel.LogOpeningSettingsEvent();
         }
 

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeImageResizer.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeImageResizer.xaml.cs
@@ -26,7 +26,11 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
 
         private void SettingsLaunchButton_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
-            OobeShellPage.OpenMainWindowCallback(typeof(ImageResizerPage));
+            if (OobeShellPage.OpenMainWindowCallback != null)
+            {
+                OobeShellPage.OpenMainWindowCallback(typeof(ImageResizerPage));
+            }
+
             ViewModel.LogOpeningSettingsEvent();
         }
 

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeKBM.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeKBM.xaml.cs
@@ -26,7 +26,11 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
 
         private void SettingsLaunchButton_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
-            OobeShellPage.OpenMainWindowCallback(typeof(KeyboardManagerPage));
+            if (OobeShellPage.OpenMainWindowCallback != null)
+            {
+                OobeShellPage.OpenMainWindowCallback(typeof(KeyboardManagerPage));
+            }
+
             ViewModel.LogOpeningSettingsEvent();
         }
 

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeOverview.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeOverview.xaml.cs
@@ -23,7 +23,11 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
 
         private void SettingsLaunchButton_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
-            OobeShellPage.OpenMainWindowCallback(typeof(GeneralPage));
+            if (OobeShellPage.OpenMainWindowCallback != null)
+            {
+                OobeShellPage.OpenMainWindowCallback(typeof(GeneralPage));
+            }
+
             ViewModel.LogOpeningSettingsEvent();
         }
 

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobePowerRename.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobePowerRename.xaml.cs
@@ -26,7 +26,11 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
 
         private void SettingsLaunchButton_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
-            OobeShellPage.OpenMainWindowCallback(typeof(PowerRenamePage));
+            if (OobeShellPage.OpenMainWindowCallback != null)
+            {
+                OobeShellPage.OpenMainWindowCallback(typeof(PowerRenamePage));
+            }
+
             ViewModel.LogOpeningSettingsEvent();
         }
 

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeRun.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeRun.xaml.cs
@@ -37,7 +37,11 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
 
         private void SettingsLaunchButton_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
-            OobeShellPage.OpenMainWindowCallback(typeof(PowerLauncherPage));
+            if (OobeShellPage.OpenMainWindowCallback != null)
+            {
+                OobeShellPage.OpenMainWindowCallback(typeof(PowerLauncherPage));
+            }
+
             ViewModel.LogOpeningSettingsEvent();
         }
 

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeRun.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeRun.xaml.cs
@@ -27,9 +27,12 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
 
         private void Start_Run_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
-            using (var eventHandle = new EventWaitHandle(false, EventResetMode.AutoReset, OobeShellPage.RunSharedEventCallback()))
+            if (OobeShellPage.RunSharedEventCallback != null)
             {
-                eventHandle.Set();
+                using (var eventHandle = new EventWaitHandle(false, EventResetMode.AutoReset, OobeShellPage.RunSharedEventCallback()))
+                {
+                    eventHandle.Set();
+                }
             }
 
             ViewModel.LogRunningModuleEvent();

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeShellPage.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeShellPage.xaml.cs
@@ -28,11 +28,11 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
             ColorPickerSharedEventCallback = implementation;
         }
 
-        public static Func<string> ShortcutGuideSharedEvent { get; set; }
+        public static Func<string> ShortcutGuideSharedEventCallback { get; set; }
 
         public static void SetShortcutGuideSharedEvent(Func<string> implementation)
         {
-            ShortcutGuideSharedEvent = implementation;
+            ShortcutGuideSharedEventCallback = implementation;
         }
 
         public static Action<Type> OpenMainWindowCallback { get; set; }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeShellPage.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeShellPage.xaml.cs
@@ -30,7 +30,7 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
 
         public static Func<string> ShortcutGuideSharedEventCallback { get; set; }
 
-        public static void SetShortcutGuideSharedEvent(Func<string> implementation)
+        public static void SetShortcutGuideSharedEventCallback(Func<string> implementation)
         {
             ShortcutGuideSharedEventCallback = implementation;
         }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeShortcutGuide.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeShortcutGuide.xaml.cs
@@ -27,9 +27,12 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
 
         private void Start_ShortcutGuide_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
-            using (var eventHandle = new EventWaitHandle(false, EventResetMode.AutoReset, OobeShellPage.ShortcutGuideSharedEvent()))
+            if (OobeShellPage.ShortcutGuideSharedEventCallback != null)
             {
-                eventHandle.Set();
+                using (var eventHandle = new EventWaitHandle(false, EventResetMode.AutoReset, OobeShellPage.ShortcutGuideSharedEventCallback()))
+                {
+                    eventHandle.Set();
+                }
             }
 
             ViewModel.LogRunningModuleEvent();

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeShortcutGuide.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeShortcutGuide.xaml.cs
@@ -37,7 +37,11 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
 
         private void SettingsLaunchButton_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
-            OobeShellPage.OpenMainWindowCallback(typeof(ShortcutGuidePage));
+            if (OobeShellPage.OpenMainWindowCallback != null)
+            {
+                OobeShellPage.OpenMainWindowCallback(typeof(ShortcutGuidePage));
+            }
+
             ViewModel.LogOpeningSettingsEvent();
         }
 

--- a/src/settings-ui/PowerToys.Settings/App.xaml.cs
+++ b/src/settings-ui/PowerToys.Settings/App.xaml.cs
@@ -14,26 +14,26 @@ namespace PowerToys.Settings
     /// </summary>
     public partial class App : Application
     {
-        private MainWindow mainWindow;
+        private MainWindow settingsWindow;
 
         public bool ShowOobe { get; set; }
 
-        public void OpenMainWindow(Type type)
+        public void OpenSettingsWindow(Type type)
         {
-            if (mainWindow == null)
+            if (settingsWindow == null)
             {
-                mainWindow = new MainWindow();
+                settingsWindow = new MainWindow();
             }
 
-            mainWindow.OpenMainWindow(type);
+            settingsWindow.Open(type);
         }
 
         private void Application_Startup(object sender, StartupEventArgs e)
         {
             if (!ShowOobe)
             {
-                mainWindow = new MainWindow();
-                mainWindow.Show();
+                settingsWindow = new MainWindow();
+                settingsWindow.Show();
             }
             else
             {

--- a/src/settings-ui/PowerToys.Settings/App.xaml.cs
+++ b/src/settings-ui/PowerToys.Settings/App.xaml.cs
@@ -33,7 +33,7 @@ namespace PowerToys.Settings
         {
             settingsWindow = new MainWindow();
 
-            // To avoid visual flikering, show the window with a size of 0,0
+            // To avoid visual flickering, show the window with a size of 0,0
             // and don't show it in the taskbar
             var originalHight = settingsWindow.Height;
             var originalWidth = settingsWindow.Width;

--- a/src/settings-ui/PowerToys.Settings/App.xaml.cs
+++ b/src/settings-ui/PowerToys.Settings/App.xaml.cs
@@ -25,7 +25,8 @@ namespace PowerToys.Settings
                 settingsWindow = new MainWindow();
             }
 
-            settingsWindow.Open(type);
+            settingsWindow.Show();
+            settingsWindow.NavigateToSection(type);
         }
 
         private void Application_Startup(object sender, StartupEventArgs e)

--- a/src/settings-ui/PowerToys.Settings/App.xaml.cs
+++ b/src/settings-ui/PowerToys.Settings/App.xaml.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Windows;
 using Microsoft.PowerToys.Settings.UI.Library.Telemetry.Events;
 using Microsoft.PowerToys.Telemetry;
@@ -13,13 +14,25 @@ namespace PowerToys.Settings
     /// </summary>
     public partial class App : Application
     {
+        private MainWindow mainWindow;
+
         public bool ShowOobe { get; set; }
+
+        public void OpenMainWindow(Type type)
+        {
+            if (mainWindow == null)
+            {
+                mainWindow = new MainWindow();
+            }
+
+            mainWindow.OpenMainWindow(type);
+        }
 
         private void Application_Startup(object sender, StartupEventArgs e)
         {
             if (!ShowOobe)
             {
-                MainWindow mainWindow = new MainWindow();
+                mainWindow = new MainWindow();
                 mainWindow.Show();
             }
             else

--- a/src/settings-ui/PowerToys.Settings/MainWindow.xaml.cs
+++ b/src/settings-ui/PowerToys.Settings/MainWindow.xaml.cs
@@ -39,18 +39,13 @@ namespace PowerToys.Settings
             }
         }
 
-        public void Open(Type type)
+        public void NavigateToSection(Type type)
         {
             if (inst != null)
             {
-                this.Activate();
+                Activate();
+                ShellPage.Navigate(type);
             }
-            else
-            {
-                this.Show();
-            }
-
-            ShellPage.Navigate(type);
         }
 
         private void WindowsXamlHost_ChildChanged(object sender, EventArgs e)

--- a/src/settings-ui/PowerToys.Settings/MainWindow.xaml.cs
+++ b/src/settings-ui/PowerToys.Settings/MainWindow.xaml.cs
@@ -47,8 +47,7 @@ namespace PowerToys.Settings
             }
             else
             {
-                var newWindow = new MainWindow();
-                newWindow.Show();
+                this.Show();
             }
 
             ShellPage.Navigate(type);

--- a/src/settings-ui/PowerToys.Settings/MainWindow.xaml.cs
+++ b/src/settings-ui/PowerToys.Settings/MainWindow.xaml.cs
@@ -39,7 +39,7 @@ namespace PowerToys.Settings
             }
         }
 
-        public void OpenMainWindow(Type type)
+        public void Open(Type type)
         {
             if (inst != null)
             {

--- a/src/settings-ui/PowerToys.Settings/MainWindow.xaml.cs
+++ b/src/settings-ui/PowerToys.Settings/MainWindow.xaml.cs
@@ -4,11 +4,8 @@
 
 using System;
 using System.Windows;
-using interop;
 using Microsoft.PowerLauncher.Telemetry;
-using Microsoft.PowerToys.Settings.UI.Helpers;
 using Microsoft.PowerToys.Settings.UI.Library.Utilities;
-using Microsoft.PowerToys.Settings.UI.OOBE.Views;
 using Microsoft.PowerToys.Settings.UI.Views;
 using Microsoft.PowerToys.Telemetry;
 using Microsoft.Toolkit.Wpf.UI.XamlHost;
@@ -40,6 +37,21 @@ namespace PowerToys.Settings
             {
                 inst.Close();
             }
+        }
+
+        public void OpenMainWindow(Type type)
+        {
+            if (inst != null)
+            {
+                this.Activate();
+            }
+            else
+            {
+                var newWindow = new MainWindow();
+                newWindow.Show();
+            }
+
+            ShellPage.Navigate(type);
         }
 
         private void WindowsXamlHost_ChildChanged(object sender, EventArgs e)
@@ -76,42 +88,11 @@ namespace PowerToys.Settings
                     Program.GetTwoWayIPCManager().Send(msg);
                 });
 
-                OobeShellPage.SetRunSharedEventCallback(() =>
-                {
-                    return Constants.PowerLauncherSharedEvent();
-                });
-
-                OobeShellPage.SetColorPickerSharedEventCallback(() =>
-                {
-                    return Constants.ShowColorPickerSharedEvent();
-                });
-
-                OobeShellPage.SetShortcutGuideSharedEvent(() =>
-                {
-                    NativeMethods.AllowSetForegroundWindow(PowerToys.Settings.Program.PowerToysPID);
-                    return Constants.ShowShortcutGuideSharedEvent();
-                });
-
                 // open oobe
                 ShellPage.SetOpenOobeCallback(() =>
                 {
                     var oobe = new OobeWindow();
                     oobe.Show();
-                });
-
-                OobeShellPage.SetOpenMainWindowCallback((Type type) =>
-                {
-                    if (isOpen)
-                    {
-                        this.Activate();
-                    }
-                    else
-                    {
-                        var newWindow = new MainWindow();
-                        newWindow.Show();
-                    }
-
-                    ShellPage.Navigate(type);
                 });
 
                 // receive IPC Message

--- a/src/settings-ui/PowerToys.Settings/OobeWindow.xaml.cs
+++ b/src/settings-ui/PowerToys.Settings/OobeWindow.xaml.cs
@@ -4,6 +4,8 @@
 
 using System;
 using System.Windows;
+using interop;
+using Microsoft.PowerToys.Settings.UI.Helpers;
 using Microsoft.PowerToys.Settings.UI.OOBE.Views;
 using Microsoft.Toolkit.Wpf.UI.XamlHost;
 
@@ -60,6 +62,27 @@ namespace PowerToys.Settings
 
             WindowsXamlHost windowsXamlHost = sender as WindowsXamlHost;
             shellPage = windowsXamlHost.GetUwpInternalObject() as OobeShellPage;
+
+            OobeShellPage.SetRunSharedEventCallback(() =>
+            {
+                return Constants.PowerLauncherSharedEvent();
+            });
+
+            OobeShellPage.SetColorPickerSharedEventCallback(() =>
+            {
+                return Constants.ShowColorPickerSharedEvent();
+            });
+
+            OobeShellPage.SetShortcutGuideSharedEventCallback(() =>
+            {
+                NativeMethods.AllowSetForegroundWindow(PowerToys.Settings.Program.PowerToysPID);
+                return Constants.ShowShortcutGuideSharedEvent();
+            });
+
+            OobeShellPage.SetOpenMainWindowCallback((Type type) =>
+            {
+                ((App)Application.Current).OpenMainWindow(type);
+            });
         }
     }
 }

--- a/src/settings-ui/PowerToys.Settings/OobeWindow.xaml.cs
+++ b/src/settings-ui/PowerToys.Settings/OobeWindow.xaml.cs
@@ -81,7 +81,7 @@ namespace PowerToys.Settings
 
             OobeShellPage.SetOpenMainWindowCallback((Type type) =>
             {
-                ((App)Application.Current).OpenMainWindow(type);
+                ((App)Application.Current).OpenSettingsWindow(type);
             });
         }
     }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Moved the callbacks setting from the main window to the oobe window. 

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
