### PR TITLE
[OOBE] UI bugfixes

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeColorPicker.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeColorPicker.xaml
@@ -17,7 +17,8 @@
         <Image Stretch="UniformToFill"
                Source="{x:Bind ViewModel.PreviewImageSource}" />
 
-        <ScrollViewer Grid.Row="1">
+        <ScrollViewer Grid.Row="1"
+                      VerticalScrollBarVisibility="Auto">
             <StackPanel Orientation="Vertical"
                         Margin="32,24,0,0"
                         VerticalAlignment="Top">

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeFancyZones.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeFancyZones.xaml
@@ -18,7 +18,8 @@
                Height="280"
                Source="{x:Bind ViewModel.PreviewImageSource}" />
 
-        <ScrollViewer Grid.Row="1">
+        <ScrollViewer Grid.Row="1"
+                      VerticalScrollBarVisibility="Auto">
             <StackPanel Orientation="Vertical"
                         Margin="32,24,32,24"
                         VerticalAlignment="Top">

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeFileExplorer.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeFileExplorer.xaml
@@ -20,7 +20,7 @@
 
         <ScrollViewer Grid.Row="1">
             <StackPanel Orientation="Vertical"
-                        Margin="32,24,0,0"
+                        Margin="32,24,32,24"
                         VerticalAlignment="Top">
 
                 <TextBlock Text="{x:Bind ViewModel.ModuleName}"

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeFileExplorer.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeFileExplorer.xaml
@@ -18,7 +18,8 @@
                Grid.Row="0"
                Source="{x:Bind ViewModel.PreviewImageSource}" />
 
-        <ScrollViewer Grid.Row="1">
+        <ScrollViewer Grid.Row="1"
+                      VerticalScrollBarVisibility="Auto">
             <StackPanel Orientation="Vertical"
                         Margin="32,24,32,24"
                         VerticalAlignment="Top">

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeImageResizer.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeImageResizer.xaml
@@ -19,7 +19,8 @@
                Grid.Row="0"
                Source="{x:Bind ViewModel.PreviewImageSource}" />
 
-        <ScrollViewer Grid.Row="1">
+        <ScrollViewer Grid.Row="1"
+                      VerticalScrollBarVisibility="Auto">
             <StackPanel Orientation="Vertical"
                         Margin="32,24,32,24"
                         VerticalAlignment="Top">

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeKBM.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeKBM.xaml
@@ -16,7 +16,8 @@
         <Image Stretch="UniformToFill"
                Source="{x:Bind ViewModel.PreviewImageSource}" />
 
-        <ScrollViewer Grid.Row="1">
+        <ScrollViewer Grid.Row="1"
+                      VerticalScrollBarVisibility="Auto">
             <StackPanel Orientation="Vertical"
                         Margin="32,24,32,24"
                         VerticalAlignment="Top">

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeOverview.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeOverview.xaml
@@ -17,7 +17,8 @@
                Height="320"
                Source="{x:Bind ViewModel.PreviewImageSource}" />
 
-        <ScrollViewer Grid.Row="1">
+        <ScrollViewer Grid.Row="1"
+                      VerticalScrollBarVisibility="Auto">
             <StackPanel Orientation="Vertical"
                         Margin="32,24,32,24"
                         VerticalAlignment="Top">

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobePowerRename.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobePowerRename.xaml
@@ -16,7 +16,8 @@
         <Image Stretch="UniformToFill"
                Source="{x:Bind ViewModel.PreviewImageSource}" />
 
-        <ScrollViewer Grid.Row="1">
+        <ScrollViewer Grid.Row="1"
+                      VerticalScrollBarVisibility="Auto">
             <StackPanel Orientation="Vertical"
                         Margin="32,24,32,24"
                         VerticalAlignment="Top">

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeRun.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeRun.xaml
@@ -17,7 +17,8 @@
         <Image Stretch="UniformToFill"
                Source="{x:Bind ViewModel.PreviewImageSource}" />
 
-        <ScrollViewer Grid.Row="1">
+        <ScrollViewer Grid.Row="1"
+                      VerticalScrollBarVisibility="Auto">
             <StackPanel Orientation="Vertical"
                         Margin="32,24,32,24"
                         VerticalAlignment="Top">

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeShellPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeShellPage.xaml
@@ -21,17 +21,40 @@
     </UserControl.Resources>
     
     <Grid>
+        <VisualStateManager.VisualStateGroups>
+            <VisualStateGroup x:Name="LayoutVisualStates">
+                <VisualState x:Name="WideLayout">
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger MinWindowWidth="{StaticResource WideLayoutMinWidth}" />
+                    </VisualState.StateTriggers>
+                </VisualState>
+                <VisualState x:Name="SmallLayout">
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger MinWindowWidth="{StaticResource SmallLayoutMinWidth}" />
+                        <AdaptiveTrigger MinWindowWidth="0" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="NavigationView.PaneDisplayMode"
+                                Value="LeftMinimal" />
+                        <Setter Target="NavigationView.IsPaneToggleButtonVisible"
+                                Value="True" />
+                    </VisualState.Setters>
+                </VisualState>
+            </VisualStateGroup>
+        </VisualStateManager.VisualStateGroups>
         <winui:NavigationView IsSettingsVisible="False"
-                        IsPaneToggleButtonVisible="False"
-                        IsPaneOpen="True"
-                        x:Name="NavigationView"
-                        OpenPaneLength="296"
-                        SelectionChanged="NavigationView_SelectionChanged"
-                        IsBackButtonVisible="Collapsed"
-                        MenuItemsSource="{x:Bind Modules, Mode=OneTime}"
-                        MenuItemTemplate="{StaticResource NavigationViewMenuItem}">
+                              IsPaneToggleButtonVisible="False"
+                              IsPaneOpen="True"
+                              x:Name="NavigationView"
+                              OpenPaneLength="296"
+                              PaneDisplayMode="Left"
+                              SelectionChanged="NavigationView_SelectionChanged"
+                              IsBackButtonVisible="Collapsed"
+                              MenuItemsSource="{x:Bind Modules, Mode=OneTime}"
+                              MenuItemTemplate="{StaticResource NavigationViewMenuItem}">
             <winui:NavigationView.PaneCustomContent>
                 <StackPanel Grid.Column="0" Margin="16"
+                            x:Name="HEaderContent"
                             Orientation="Vertical">
                     <TextBlock x:Uid="Oobe_GettingStarted"
                                TextWrapping="Wrap"

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeShellPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeShellPage.xaml
@@ -54,7 +54,6 @@
                               MenuItemTemplate="{StaticResource NavigationViewMenuItem}">
             <winui:NavigationView.PaneCustomContent>
                 <StackPanel Grid.Column="0" Margin="16"
-                            x:Name="HEaderContent"
                             Orientation="Vertical">
                     <TextBlock x:Uid="Oobe_GettingStarted"
                                TextWrapping="Wrap"

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeShortcutGuide.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeShortcutGuide.xaml
@@ -17,7 +17,8 @@
         <Image Stretch="UniformToFill"
                Source="{x:Bind ViewModel.PreviewImageSource}" />
 
-        <ScrollViewer Grid.Row="1">
+        <ScrollViewer Grid.Row="1"
+                      VerticalScrollBarVisibility="Auto">
             <StackPanel Orientation="Vertical"
                         Margin="32,24,32,24"
                         VerticalAlignment="Top">

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeVideoConference.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeVideoConference.xaml
@@ -17,7 +17,8 @@
         <Image Stretch="UniformToFill"
                Source="{x:Bind ViewModel.PreviewImageSource}" />
 
-        <ScrollViewer Grid.Row="1">
+        <ScrollViewer Grid.Row="1"
+                      VerticalScrollBarVisibility="Auto">
             <StackPanel Orientation="Vertical"
                         Margin="32,24,32,24"
                         VerticalAlignment="Top">

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ShellPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ShellPage.xaml
@@ -105,6 +105,7 @@
             </ic:EventTriggerBehavior>
         </i:Interaction.Behaviors>
         <ScrollViewer x:Name="scrollViewer"
+                      VerticalScrollBarVisibility="Auto"
                       Grid.Column="0">
                 <Grid Margin="{StaticResource MediumLeftRightBottomMargin}">
                     <Frame x:Name="shellFrame" />


### PR DESCRIPTION
## Summary of the Pull Request
- Solving the scrollbar issue: #9985
- Text spacing issue on File Explorer add-ons page: #9984
![image](https://user-images.githubusercontent.com/9866362/109673503-62ddea00-7b76-11eb-9401-dd6b580e1ba8.png)

In the (unique) case that the resolution of the screen is lower than 1100x700, the NavigationView will collapse and the pane button will be shown: #9986

![UI bug](https://user-images.githubusercontent.com/9866362/109673773-a2a4d180-7b76-11eb-9c24-367be9d39510.gif)


## Quality Checklist

- [X] **Linked issue:** #9984, #9986, #9985
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
