### PR TITLE
[PT Run] Save raw command instead of resolved command in shell history

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Shell/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Shell/Main.cs
@@ -156,8 +156,8 @@ namespace Microsoft.Plugin.Shell
 
         private ProcessStartInfo PrepareProcessStartInfo(string command, bool runAsAdministrator = false)
         {
-            command = command.Trim();
-            command = Environment.ExpandEnvironmentVariables(command);
+            string trimmedCommand = command.Trim();
+            command = Environment.ExpandEnvironmentVariables(trimmedCommand);
             var workingDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
             var runAsAdministratorArg = !runAsAdministrator && !_settings.RunAsAdministrator ? string.Empty : "runas";
 
@@ -218,7 +218,7 @@ namespace Microsoft.Plugin.Shell
 
             info.UseShellExecute = true;
 
-            _settings.AddCmdHistory(command);
+            _settings.AddCmdHistory(trimmedCommand);
 
             return info;
         }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Shell history stores a resolved version of the command e.g the query `> %appdata%` is saved in the shell history as `C:\Users\someuser\AppData\Roaming`.

**What is include in the PR:** 
Modified `Microsoft.Plugin.Shell.Main.PrepareProcessStartInfo()` to remember the raw command (trimmed) instead of the resolved command.

**How does someone test / validate:** 

1. Open Run
1. Query `> %appdata%`, hit enter to execute the command
1. Open Run, type in `> %app`
1. `%appdata` should show up in the history
![image](https://user-images.githubusercontent.com/6239450/109739146-fe268d80-7b7d-11eb-9cf1-ff255620ac50.png)


## Quality Checklist

- [x] **Linked issue:** #3494
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
