### PR TITLE
[PT Settings] Crash on restart with OOBE window opened.

### DIFF
--- a/src/settings-ui/PowerToys.Settings/MainWindow.xaml.cs
+++ b/src/settings-ui/PowerToys.Settings/MainWindow.xaml.cs
@@ -73,6 +73,7 @@ namespace PowerToys.Settings
                 ShellPage.SetRestartAdminSndMessageCallback(msg =>
                 {
                     Program.GetTwoWayIPCManager().Send(msg);
+                    isOpen = false;
                     System.Windows.Application.Current.Shutdown(); // close application
                 });
 
@@ -117,7 +118,13 @@ namespace PowerToys.Settings
             // XAML Islands: If the window is open, explicitly force it to be shown to solve the blank dialog issue https://github.com/microsoft/PowerToys/issues/3384
             if (isOpen)
             {
-                Show();
+                try
+                {
+                    Show();
+                }
+                catch (InvalidOperationException)
+                {
+                }
             }
         }
 


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Restart PT with the OOBE window opened could cause a crash with an unhandled exception. Crash causes the `Show` method that's called after the `Shutdown` on restart. 
Since the OOBE window is opened, the `isOpen` flag doesn't being reset on the `Closing` event, so `Show` is called as like as the program didn't stop.

**What is include in the PR:** 

Added try-catch block to catch possible `InvalidOperationException` on `Show`.
Set `isOpen` flag to false before calling shutdown to prevent calling `Show`.

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #10004
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
