### PR TITLE
[FZ Editor] hide tool windows from alt-tab

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/LayoutOverlayWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/LayoutOverlayWindow.xaml
@@ -12,4 +12,5 @@
         ResizeMode="NoResize"
         WindowStyle="None"
         AllowsTransparency="True"
+        Loaded="Window_Loaded"
         Background="{DynamicResource BackdropBrush}"/>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/LayoutOverlayWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/LayoutOverlayWindow.xaml.cs
@@ -2,9 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Windows;
-using System.Windows.Media;
 
 namespace FancyZonesEditor
 {
@@ -16,6 +14,11 @@ namespace FancyZonesEditor
         public LayoutOverlayWindow()
         {
             InitializeComponent();
+        }
+
+        private void Window_Loaded(object sender, RoutedEventArgs e)
+        {
+            Utils.NativeMethods.SetWindowStyleToolWindow(this);
         }
     }
 }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Utils/NativeMethods.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Utils/NativeMethods.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Windows;
+using System.Windows.Interop;
+
+namespace FancyZonesEditor.Utils
+{
+    internal class NativeMethods
+    {
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern int GetWindowLong(IntPtr hWnd, int nIndex);
+
+        [DllImport("user32.dll")]
+        private static extern int SetWindowLong(IntPtr hWnd, int nIndex, int dwNewLong);
+
+#pragma warning disable SA1310 // Field names should not contain underscore
+        private const int GWL_EX_STYLE = -20;
+        private const int WS_EX_APPWINDOW = 0x00040000;
+        private const int WS_EX_TOOLWINDOW = 0x00000080;
+#pragma warning restore SA1310 // Field names should not contain underscore
+
+        public static void SetWindowStyleToolWindow(Window hwnd)
+        {
+            var helper = new WindowInteropHelper(hwnd).Handle;
+            SetWindowLong(helper, GWL_EX_STYLE, (GetWindowLong(helper, GWL_EX_STYLE) | WS_EX_TOOLWINDOW) & ~WS_EX_APPWINDOW);
+        }
+    }
+}


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
FZ Editor had two windows that were shown as targets when alt-tabbing.

**What is include in the PR:** 
Add a helper class to invoke `SetWindowLong` to set the window style to `WS_EX_TOOLWINDOW` so it's not shown as a alt-tab target.

**How does someone test / validate:** 
Open the FZ Editor and then press alt-tab.

![image](https://user-images.githubusercontent.com/3206696/109829106-8750c980-7c3d-11eb-9e82-90fa03f72c4b.png)


## Quality Checklist

- [x] **Linked issue:** #1380
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
