### PR TITLE
[OOBE] Changed modules order

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Enums/PowerToysModulesEnum.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Enums/PowerToysModulesEnum.cs
@@ -9,11 +9,11 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.Enums
         Overview = 0,
         ColorPicker,
         FancyZones,
+        FileExplorer,
         ImageResizer,
         KBM,
         Run,
         PowerRename,
-        FileExplorer,
         ShortcutGuide,
         VideoConference,
     }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeShellPage.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeShellPage.xaml.cs
@@ -100,6 +100,18 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
                 Description = loader.GetString("Oobe_FancyZones_Description"),
                 Link = "https://aka.ms/PowerToysOverview_FancyZones",
             });
+            Modules.Insert((int)PowerToysModulesEnum.FileExplorer, new OobePowerToysModule()
+            {
+                ModuleName = loader.GetString("Oobe_FileExplorer"),
+                Tag = "FileExplorer",
+                IsNew = false,
+                Icon = "\uEC50",
+                FluentIcon = "ms-appx:///Assets/FluentIcons/FluentIconsFileExplorerPreview.png",
+                Image = "ms-appx:///Assets/Modules/PowerPreview.png",
+                Description = loader.GetString("Oobe_FileExplorer_Description"),
+                PreviewImageSource = "ms-appx:///Assets/Modules/OOBE/FileExplorer.png",
+                Link = "https://aka.ms/PowerToysOverview_FileExplorerAddOns",
+            });
             Modules.Insert((int)PowerToysModulesEnum.ImageResizer, new OobePowerToysModule()
             {
                 ModuleName = loader.GetString("Oobe_ImageResizer"),
@@ -147,18 +159,6 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
                 Description = loader.GetString("Oobe_PowerRename_Description"),
                 PreviewImageSource = "ms-appx:///Assets/Modules/OOBE/PowerRename.gif",
                 Link = "https://aka.ms/PowerToysOverview_PowerRename",
-            });
-            Modules.Insert((int)PowerToysModulesEnum.FileExplorer, new OobePowerToysModule()
-            {
-                ModuleName = loader.GetString("Oobe_FileExplorer"),
-                Tag = "FileExplorer",
-                IsNew = false,
-                Icon = "\uEC50",
-                FluentIcon = "ms-appx:///Assets/FluentIcons/FluentIconsFileExplorerPreview.png",
-                Image = "ms-appx:///Assets/Modules/PowerPreview.png",
-                Description = loader.GetString("Oobe_FileExplorer_Description"),
-                PreviewImageSource = "ms-appx:///Assets/Modules/OOBE/FileExplorer.png",
-                Link = "https://aka.ms/PowerToysOverview_FileExplorerAddOns",
             });
             Modules.Insert((int)PowerToysModulesEnum.ShortcutGuide, new OobePowerToysModule()
             {


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Changed position on the "File Explorer add-ons" in the navigation view.

![image](https://user-images.githubusercontent.com/8949536/109961191-b5e0aa00-7cfa-11eb-864e-2ff95af5681d.png)

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #9983
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
