### PR TITLE
[Settings, OOBE] set location to center screen

### DIFF
--- a/src/settings-ui/PowerToys.Settings/App.xaml.cs
+++ b/src/settings-ui/PowerToys.Settings/App.xaml.cs
@@ -33,20 +33,8 @@ namespace PowerToys.Settings
         {
             settingsWindow = new MainWindow();
 
-            // To avoid visual flickering, show the window with a size of 0,0
-            // and don't show it in the taskbar
-            var originalHight = settingsWindow.Height;
-            var originalWidth = settingsWindow.Width;
-            settingsWindow.Height = 0;
-            settingsWindow.Width = 0;
-            settingsWindow.ShowInTaskbar = false;
-
-            settingsWindow.Show();
-            settingsWindow.Hide();
-
-            settingsWindow.Height = originalHight;
-            settingsWindow.Width = originalWidth;
-            settingsWindow.ShowInTaskbar = true;
+            Utils.ShowHide(settingsWindow);
+            Utils.CenterToScreen(settingsWindow);
         }
 
         private void Application_Startup(object sender, StartupEventArgs e)

--- a/src/settings-ui/PowerToys.Settings/MainWindow.xaml
+++ b/src/settings-ui/PowerToys.Settings/MainWindow.xaml
@@ -7,7 +7,15 @@
         xmlns:Controls="clr-namespace:Microsoft.Toolkit.Wpf.UI.Controls;assembly=Microsoft.Toolkit.Wpf.UI.Controls"
         xmlns:xaml="clr-namespace:Microsoft.Toolkit.Wpf.UI.XamlHost;assembly=Microsoft.Toolkit.Wpf.UI.XamlHost"
         mc:Ignorable="d"
-        Title="PowerToys Settings" MinWidth="480" Height="800" Width="1100" Closing="MainWindow_Closing" Loaded="MainWindow_Loaded" Activated="MainWindow_Activated">
+        Title="PowerToys Settings"
+        Height="860"
+        MinHeight="400"
+        Width="1180"
+        MinWidth="480"
+        WindowStartupLocation="CenterScreen"
+        Closing="MainWindow_Closing"
+        Loaded="MainWindow_Loaded"
+        Activated="MainWindow_Activated">
     <Grid>
         <xaml:WindowsXamlHost InitialTypeName="Microsoft.PowerToys.Settings.UI.Views.ShellPage" ChildChanged="WindowsXamlHost_ChildChanged" />
     </Grid>

--- a/src/settings-ui/PowerToys.Settings/MainWindow.xaml.cs
+++ b/src/settings-ui/PowerToys.Settings/MainWindow.xaml.cs
@@ -26,6 +26,9 @@ namespace PowerToys.Settings
             bootTime.Start();
 
             this.InitializeComponent();
+
+            Utils.FitToScreen(this);
+
             bootTime.Stop();
 
             PowerToysTelemetry.Log.WriteEvent(new SettingsBootEvent() { BootTimeMs = bootTime.ElapsedMilliseconds });

--- a/src/settings-ui/PowerToys.Settings/OobeWindow.xaml.cs
+++ b/src/settings-ui/PowerToys.Settings/OobeWindow.xaml.cs
@@ -30,6 +30,7 @@ namespace PowerToys.Settings
         public OobeWindow()
         {
             InitializeComponent();
+            Utils.FitToScreen(this);
         }
 
         private void Window_Closed(object sender, EventArgs e)

--- a/src/settings-ui/PowerToys.Settings/Utils.cs
+++ b/src/settings-ui/PowerToys.Settings/Utils.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Windows;
+
+namespace PowerToys.Settings
+{
+    internal class Utils
+    {
+        public static void FitToScreen(Window window)
+        {
+            if (SystemParameters.WorkArea.Width < window.Width)
+            {
+                window.Width = SystemParameters.WorkArea.Width;
+            }
+
+            if (SystemParameters.WorkArea.Height < window.Height)
+            {
+                window.Height = SystemParameters.WorkArea.Height;
+            }
+        }
+
+        public static void CenterToScreen(Window window)
+        {
+            if (SystemParameters.WorkArea.Height <= window.Height)
+            {
+                window.Top = 0;
+            }
+            else
+            {
+                window.Top = (SystemParameters.WorkArea.Height - window.Height) / 2;
+            }
+
+            if (SystemParameters.WorkArea.Width <= window.Width)
+            {
+                window.Left = 0;
+            }
+            else
+            {
+                window.Left = (SystemParameters.WorkArea.Width - window.Width) / 2;
+            }
+        }
+
+        public static void ShowHide(Window window)
+        {
+            // To limit the visual flickering, show the window with a size of 0,0
+            // and don't show it in the taskbar
+            var originalHeight = window.Height;
+            var originalWidth = window.Width;
+            var originalMinHeight = window.MinHeight;
+            var originalMinWidth = window.MinWidth;
+
+            window.MinHeight = 0;
+            window.MinWidth = 0;
+            window.Height = 0;
+            window.Width = 0;
+            window.ShowInTaskbar = false;
+
+            window.Show();
+            window.Hide();
+
+            window.Height = originalHeight;
+            window.Width = originalWidth;
+            window.MinHeight = originalMinHeight;
+            window.MinWidth = originalMinWidth;
+            window.ShowInTaskbar = true;
+        }
+    }
+}


### PR DESCRIPTION
and ensure the window is inside the screen work area

## Summary of the Pull Request

**What is this about:**
This is a pre-requisite for #3685, it sets a default location for the Settings that is the screen center and also guarantees the window is fully inside the screen work area. That is done for both the Settings and OOBE.

**What is include in the PR:** 
Added some helpers to center and resize windows.
The Settings window didn't have a min height set.

**How does someone test / validate:** 
Run PT on large and small screen and verify that the Settings window is centered and it's all contained in the screen work area.
Open OOBE and verify it's centered and it's all contained in the screen work area.

## Quality Checklist

- [x] **Linked issue:** #3685
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
