### PR TITLE
[PT Settings] PowerToys Settings and OOBE title hardcoded for localization

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -1145,4 +1145,10 @@ Win + Shift + O to toggle your video</value>
   <data name="Oobe_Button.Text" xml:space="preserve">
     <value>Welcome to PowerToys</value>
   </data>
+  <data name="OobeWindow_Title" xml:space="preserve">
+    <value>Welcome to PowerToys</value>
+  </data>
+  <data name="SettingsWindow_Title" xml:space="preserve">
+    <value>PowerToys Settings</value>
+  </data>
 </root>

--- a/src/settings-ui/PowerToys.Settings/MainWindow.xaml
+++ b/src/settings-ui/PowerToys.Settings/MainWindow.xaml
@@ -7,7 +7,6 @@
         xmlns:Controls="clr-namespace:Microsoft.Toolkit.Wpf.UI.Controls;assembly=Microsoft.Toolkit.Wpf.UI.Controls"
         xmlns:xaml="clr-namespace:Microsoft.Toolkit.Wpf.UI.XamlHost;assembly=Microsoft.Toolkit.Wpf.UI.XamlHost"
         mc:Ignorable="d"
-        Title="PowerToys Settings"
         Height="860"
         MinHeight="400"
         Width="1180"

--- a/src/settings-ui/PowerToys.Settings/MainWindow.xaml.cs
+++ b/src/settings-ui/PowerToys.Settings/MainWindow.xaml.cs
@@ -9,6 +9,7 @@ using Microsoft.PowerToys.Settings.UI.Library.Utilities;
 using Microsoft.PowerToys.Settings.UI.Views;
 using Microsoft.PowerToys.Telemetry;
 using Microsoft.Toolkit.Wpf.UI.XamlHost;
+using Windows.ApplicationModel.Resources;
 using Windows.Data.Json;
 
 namespace PowerToys.Settings
@@ -28,6 +29,9 @@ namespace PowerToys.Settings
             this.InitializeComponent();
 
             Utils.FitToScreen(this);
+
+            ResourceLoader loader = ResourceLoader.GetForViewIndependentUse();
+            Title = loader.GetString("SettingsWindow_Title");
 
             bootTime.Stop();
 

--- a/src/settings-ui/PowerToys.Settings/OobeWindow.xaml
+++ b/src/settings-ui/PowerToys.Settings/OobeWindow.xaml
@@ -7,7 +7,6 @@
         xmlns:Controls="clr-namespace:Microsoft.Toolkit.Wpf.UI.Controls;assembly=Microsoft.Toolkit.Wpf.UI.Controls"
         xmlns:xaml="clr-namespace:Microsoft.Toolkit.Wpf.UI.XamlHost;assembly=Microsoft.Toolkit.Wpf.UI.XamlHost"
         mc:Ignorable="d"
-        Title="Welcome to PowerToys"
         MinWidth="480" Height="700" Width="1100"
         ResizeMode="NoResize"
         WindowStartupLocation="CenterScreen"

--- a/src/settings-ui/PowerToys.Settings/OobeWindow.xaml.cs
+++ b/src/settings-ui/PowerToys.Settings/OobeWindow.xaml.cs
@@ -8,6 +8,7 @@ using interop;
 using Microsoft.PowerToys.Settings.UI.Helpers;
 using Microsoft.PowerToys.Settings.UI.OOBE.Views;
 using Microsoft.Toolkit.Wpf.UI.XamlHost;
+using Windows.ApplicationModel.Resources;
 
 namespace PowerToys.Settings
 {
@@ -31,6 +32,9 @@ namespace PowerToys.Settings
         {
             InitializeComponent();
             Utils.FitToScreen(this);
+
+            ResourceLoader loader = ResourceLoader.GetForViewIndependentUse();
+            Title = loader.GetString("OobeWindow_Title");
         }
 
         private void Window_Closed(object sender, EventArgs e)


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Use localized resources for the PT Settings and OOBE window titles.

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #9416 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
