### PR TITLE
Fix localization of  VSCode workspace plugin

### DIFF
--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/LocProject.json
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/LocProject.json
@@ -4,9 +4,9 @@
             "LanguageSet": "Azure_Languages",
             "LocItems": [
               {
-                "SourceFile": "src\\modules\\launcher\\Plugins\\VSCodeWorkspaces\\Properties\\Resources.resx",
+                "SourceFile": "src\\modules\\launcher\\Plugins\\Community.PowerToys.Run.Plugin.VSCodeWorkspaces\\Properties\\Resources.resx",
                 "CopyOption": "LangIDOnName",
-                "OutputPath": "src\\modules\\launcher\\Plugins\\VSCodeWorkspaces\\Properties"
+                "OutputPath": "src\\modules\\launcher\\Plugins\\Community.PowerToys.Run.Plugin.VSCodeWorkspaces\\Properties"
               }
             ]
         }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

**What is include in the PR:** 

**How does someone test / validate:** 
- Run the build to see if localize process succeeds 

## Quality Checklist

- [X] **Linked issue:** #10033
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [X] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
