### PR TITLE
Update plugins settings with changes

### DIFF
--- a/src/modules/launcher/PowerLauncher/SettingsWatcher.cs
+++ b/src/modules/launcher/PowerLauncher/SettingsWatcher.cs
@@ -75,10 +75,10 @@ namespace PowerLauncher
 
                     var overloadSettings = _settingsUtils.GetSettingsOrDefault<PowerLauncherSettings>(PowerLauncherSettings.ModuleName);
 
-                    if (overloadSettings.Plugins == null || !overloadSettings.Plugins.Any())
+                    if (overloadSettings.Plugins == null || overloadSettings.Plugins.Count() != PluginManager.AllPlugins.Count)
                     {
                         // Needed to be consistent with old settings
-                        overloadSettings.Plugins = GetDefaultPluginsSettings();
+                        overloadSettings.Plugins = CombineWithDefaultSettings(overloadSettings.Plugins);
                         _settingsUtils.SaveSettings(overloadSettings.ToJsonString(), PowerLauncherSettings.ModuleName);
                     }
                     else
@@ -171,6 +171,20 @@ namespace PowerLauncher
             Key key = KeyInterop.KeyFromVirtualKey(hotkey.Code);
             HotkeyModel model = new HotkeyModel(hotkey.Alt, hotkey.Shift, hotkey.Win, hotkey.Ctrl, key);
             return model.ToString();
+        }
+
+        private static List<PowerLauncherPluginSettings> CombineWithDefaultSettings(IEnumerable<PowerLauncherPluginSettings> plugins)
+        {
+            var results = GetDefaultPluginsSettings().ToDictionary(x => x.Id);
+            foreach (var plugin in plugins)
+            {
+                if (results.ContainsKey(plugin.Id))
+                {
+                    results[plugin.Id] = plugin;
+                }
+            }
+
+            return results.Values.ToList();
         }
 
         private static IEnumerable<PowerLauncherPluginSettings> GetDefaultPluginsSettings()


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
When a new plugin is added or deleted from the plugins folder the plugin manager section should be updated accordingly. 

![image](https://user-images.githubusercontent.com/17161067/110116446-30bfc880-7dc0-11eb-85ae-dd7732817be4.png)

**What is include in the PR:** 
- Update `PowerToys\settings.json` if the number of plugins changed(a plugin was deleted or added)

**How does someone test / validate:** 
Check that added plugins are added to the plugin manager section:
- Install 0.33.1 and run PT Run
- Make specific changes to plugins
- Run local build and check that VSCode WorkSpaces plugin was added to the plugin manager section and plugins settings are preserved.

Check that deleted plugins are not shown in the plugin manager section:
- Delete a plugin from plugins from the plugins folder
- Check that it is not shown in the plugin manager section
## Quality Checklist

- [ ] **Linked issue:** #10060
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
