### PR TITLE
[Settings] ComboBox fix on FZ page

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -943,7 +943,7 @@
   <data name="FancyZones_OverlappingZonesSmallest.Content" xml:space="preserve">
     <value>Activate the smallest zone by area</value>
   </data>
-  <data name="FancyZones_OverlappingZonesLabel.Text" xml:space="preserve">
+  <data name="FancyZones_OverlappingZones.Header" xml:space="preserve">
     <value>When multiple zones overlap:</value>
   </data>
   <data name="PowerLauncher_Plugins.Text" xml:space="preserve">

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -123,15 +123,11 @@
             <CheckBox x:Uid="FancyZones_SpanZonesAcrossMonitorsCheckBoxControl"
                       IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.SpanZonesAcrossMonitors}"
                       Margin="{StaticResource XSmallTopMargin}"
-                      IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"/>
+                      IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}" />
 
-            <TextBlock x:Uid="FancyZones_OverlappingZonesLabel"
-                       Margin="{StaticResource SmallTopMargin}"
-                       Foreground="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToForegroundConverter}}"/>
-
-            <ComboBox Name="FancyZones_OverlappingZonesComboBox"
-                      x:Uid="FancyZones_OverlappingZonesComboBox"
+            <ComboBox x:Uid="FancyZones_OverlappingZones"
                       SelectedIndex="{x:Bind Path=ViewModel.OverlappingZonesAlgorithmIndex, Mode=TwoWay}"
+                      IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"
                       VerticalAlignment="Center"
                       Width="{StaticResource MaxComboBoxWidth}"
                       Margin="{StaticResource SmallTopMargin}">


### PR DESCRIPTION
## Summary of the Pull Request
- Removed the TextBlock that was acting as a Header and used the Header property of the ComboBox to fix inconsistent spacing.
- Set the IsEnabled property to resolve: #10089

![image](https://user-images.githubusercontent.com/9866362/110240071-73ada780-7f4a-11eb-9566-0615ffa820b9.png)

## Quality Checklist

- [X] **Linked issue:** #10089
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
