### PR TITLE
Bring Back Transparency to FancyZones Editor

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/LayoutOverlayWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/LayoutOverlayWindow.xaml
@@ -13,4 +13,10 @@
         WindowStyle="None"
         AllowsTransparency="True"
         Loaded="Window_Loaded"
-        Background="{DynamicResource BackdropBrush}"/>
+        Background="{DynamicResource BackdropBrush}" 
+	Opacity="0.75" 
+	AllowsTransparency="True">
+        <Window.Effect>
+                <BlurEffect/>
+        </Window.Effect>
+</Window>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/LayoutOverlayWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/LayoutOverlayWindow.xaml
@@ -11,7 +11,6 @@
         ShowInTaskbar="False"
         ResizeMode="NoResize"
         WindowStyle="None"
-        AllowsTransparency="True"
         Loaded="Window_Loaded"
         Background="{DynamicResource BackdropBrush}" 
 	Opacity="0.75" 


### PR DESCRIPTION
add 75% opacity to layout overlay preview

## Summary of the Pull Request

**What is this about:**

bringing back less opacity to layout preview overlay

**What is include in the PR:** 
```
        Background="{DynamicResource BackdropBrush}" 
	Opacity="0.75" 
	AllowsTransparency="True">
        <Window.Effect>
              <BlurEffect/>
        </Window.Effect>
</Window>
```
**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #10066
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [x] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
