### PR TITLE
Build of PowerToysSetup.sln fail on build farm

### DIFF
--- a/installer/PowerToysSetup/Product.wxs
+++ b/installer/PowerToysSetup/Product.wxs
@@ -245,7 +245,7 @@
                   <Directory Id="UriImagesFolder" Name="Images" />
                   <Directory Id="UriLanguagesFolder" Name="Languages" />
                 </Directory>
-                <Directory Id="VSCodeWorkspacePluginFolder" Name="VSCodeWorkspace">
+                <Directory Id="VSCodeWorkspacesPluginFolder" Name="VSCodeWorkspace">
                   <Directory Id="VSCodeWorkspaceImagesFolder" Name="Images" />
                   <Directory Id="VSCodeWorkspaceLanguagesFolder" Name="Languages" />
                 </Directory>
@@ -822,7 +822,7 @@
   <Fragment>
     <!-- Resource directories should be added only if the installer is built on the build farm -->
     <?ifdef env.IsPipeline?>
-        <?foreach ParentDirectory in LauncherInstallFolder;FancyZonesInstallFolder;ImageResizerInstallFolder;ColorPickerInstallFolder;FileExplorerPreviewInstallFolder;CalculatorPluginFolder;FolderPluginFolder;ProgramPluginFolder;ShellPluginFolder;IndexerPluginFolder;UriPluginFolder;WindowWalkerPluginFolder;RegistryPluginFolder;VSCodeWorkspacePluginFolder;ServicePluginFolder?>
+        <?foreach ParentDirectory in LauncherInstallFolder;FancyZonesInstallFolder;ImageResizerInstallFolder;ColorPickerInstallFolder;FileExplorerPreviewInstallFolder;CalculatorPluginFolder;FolderPluginFolder;ProgramPluginFolder;ShellPluginFolder;IndexerPluginFolder;UriPluginFolder;WindowWalkerPluginFolder;RegistryPluginFolder;VSCodeWorkspacesPluginFolder;ServicePluginFolder?>
             <DirectoryRef Id="$(var.ParentDirectory)">
                 <!-- Resource file directories -->
                 <?foreach Language in $(var.LocLanguageList)?>
@@ -1014,7 +1014,7 @@
       </Component>
 
       <!-- VSCodeWorkspaces Plugin -->
-      <Component Id="VSCodeWorkspacesComponent" Directory="VSCodeWorkspacePluginFolder" Guid="78363DBD-7E38-4D5F-8987-9963DF609B94">
+      <Component Id="VSCodeWorkspacesComponent" Directory="VSCodeWorkspacesPluginFolder" Guid="78363DBD-7E38-4D5F-8987-9963DF609B94">
         <File Id="VSCodeWorkspaceFolder_deps" Source="$(var.BinX64Dir)modules\launcher\Plugins\VSCodeWorkspaces\Community.PowerToys.Run.Plugin.VSCodeWorkspaces.deps.json" />
         <?foreach File in plugin.json;Community.PowerToys.Run.Plugin.VSCodeWorkspaces.dll?>
           <File Id="VSCodeWorkspaces_$(var.File)" Source="$(var.BinX64Dir)modules\launcher\Plugins\VSCodeWorkspaces\$(var.File)" />


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
```
2021-03-08T00:44:23.1596961Z [INFO] [61] S:\installer\PowerToysSetup\Product.wxs(901): error LGHT0094: Unresolved reference to symbol 'Directory:ResourcecsVSCodeWorkspacesPluginFolder' in section 'Fragment:'. [S:\installer\PowerToysSetup\PowerToysSetup.wixproj]
2021-03-08T00:44:23.1598278Z [INFO] [62] S:\installer\PowerToysSetup\Product.wxs(901): error LGHT0094: Unresolved reference to symbol 'Directory:ResourcedeVSCodeWorkspacesPluginFolder' in section 'Fragment:'. [S:\installer\PowerToysSetup\PowerToysSetup.wixproj]
2021-03-08T00:44:23.1599515Z [INFO] [63] S:\installer\PowerToysSetup\Product.wxs(901): error LGHT0094: Unresolved reference to symbol 'Directory:ResourceesVSCodeWorkspacesPluginFolder' in section 'Fragment:'. [S:\installer\PowerToysSetup\PowerToysSetup.wixproj]
2021-03-08T00:44:23.1601011Z [INFO] [64] S:\installer\PowerToysSetup\Product.wxs(901): error LGHT0094: Unresolved reference to symbol 'Directory:ResourcefrVSCodeWorkspacesPluginFolder' in section 'Fragment:'. [S:\installer\PowerToysSetup\PowerToysSetup.wixproj]
2021-03-08T00:44:23.1602217Z [INFO] [65] S:\installer\PowerToysSetup\Product.wxs(901): error LGHT0094: Unresolved reference to symbol 'Directory:ResourcehuVSCodeWorkspacesPluginFolder' in section 'Fragment:'. [S:\installer\PowerToysSetup\PowerToysSetup.wixproj]
2021-03-08T00:44:23.1603421Z [INFO] [66] S:\installer\PowerToysSetup\Product.wxs(901): error LGHT0094: Unresolved reference to symbol 'Directory:ResourceitVSCodeWorkspacesPluginFolder' in section 'Fragment:'. [S:\installer\PowerToysSetup\PowerToysSetup.wixproj]
2021-03-08T00:44:23.1604607Z [INFO] [67] S:\installer\PowerToysSetup\Product.wxs(901): error LGHT0094: Unresolved reference to symbol 'Directory:ResourcejaVSCodeWorkspacesPluginFolder' in section 'Fragment:'. [S:\installer\PowerToysSetup\PowerToysSetup.wixproj]
2021-03-08T00:44:23.1605785Z [INFO] [68] S:\installer\PowerToysSetup\Product.wxs(901): error LGHT0094: Unresolved reference to symbol 'Directory:ResourcekoVSCodeWorkspacesPluginFolder' in section 'Fragment:'. [S:\installer\PowerToysSetup\PowerToysSetup.wixproj]
2021-03-08T00:44:23.1606952Z [INFO] [69] S:\installer\PowerToysSetup\Product.wxs(901): error LGHT0094: Unresolved reference to symbol 'Directory:ResourcenlVSCodeWorkspacesPluginFolder' in section 'Fragment:'. [S:\installer\PowerToysSetup\PowerToysSetup.wixproj]
2021-03-08T00:44:23.1608121Z [INFO] [70] S:\installer\PowerToysSetup\Product.wxs(901): error LGHT0094: Unresolved reference to symbol 'Directory:ResourceplVSCodeWorkspacesPluginFolder' in section 'Fragment:'. [S:\installer\PowerToysSetup\PowerToysSetup.wixproj]
2021-03-08T00:44:23.1609509Z [INFO] [71] S:\installer\PowerToysSetup\Product.wxs(901): error LGHT0094: Unresolved reference to symbol 'Directory:Resourcept_BRVSCodeWorkspacesPluginFolder' in section 'Fragment:'. [S:\installer\PowerToysSetup\PowerToysSetup.wixproj]
2021-03-08T00:44:23.1611185Z [INFO] [72] S:\installer\PowerToysSetup\Product.wxs(901): error LGHT0094: Unresolved reference to symbol 'Directory:Resourcept_PTVSCodeWorkspacesPluginFolder' in section 'Fragment:'. [S:\installer\PowerToysSetup\PowerToysSetup.wixproj]
2021-03-08T00:44:23.1612863Z [INFO] [73] S:\installer\PowerToysSetup\Product.wxs(901): error LGHT0094: Unresolved reference to symbol 'Directory:ResourceruVSCodeWorkspacesPluginFolder' in section 'Fragment:'. [S:\installer\PowerToysSetup\PowerToysSetup.wixproj]
2021-03-08T00:44:23.1613933Z [INFO] [74] S:\installer\PowerToysSetup\Product.wxs(901): error LGHT0094: Unresolved reference to symbol 'Directory:ResourcesvVSCodeWorkspacesPluginFolder' in section 'Fragment:'. [S:\installer\PowerToysSetup\PowerToysSetup.wixproj]
2021-03-08T00:44:23.1615149Z [INFO] [75] S:\installer\PowerToysSetup\Product.wxs(901): error LGHT0094: Unresolved reference to symbol 'Directory:ResourcetrVSCodeWorkspacesPluginFolder' in section 'Fragment:'. [S:\installer\PowerToysSetup\PowerToysSetup.wixproj]
2021-03-08T00:44:23.1616239Z [INFO] [76] S:\installer\PowerToysSetup\Product.wxs(901): error LGHT0094: Unresolved reference to symbol 'Directory:Resourcezh_HansVSCodeWorkspacesPluginFolder' in section 'Fragment:'. [S:\installer\PowerToysSetup\PowerToysSetup.wixproj]
2021-03-08T00:44:23.1617483Z [INFO] [77] S:\installer\PowerToysSetup\Product.wxs(901): error LGHT0094: Unresolved reference to symbol 'Directory:Resourcezh_HantVSCodeWorkspacesPluginFolder' in section 'Fragment:'. [S:\installer\PowerToysSetup\PowerToysSetup.wixproj]
2021-03-08T00:44:23.1667885Z [INFO] [78] Done Building Project "S:\installer\PowerToysSetup\PowerToysSetup.wixproj" (default targets) -- FAILED.
2021-03-08T00:44:23.1683482Z [INFO] [79] Done Building Project "S:\installer\PowerToysSetup.sln" (default targets) -- FAILED.
2021-03-08T00:44:23.1745839Z [INFO] [80] Build FAILED.
```
**What is include in the PR:** 

**How does someone test / validate:** 
Check if the build fails on the build farm.

## Quality Checklist

- [x] **Linked issue:** follow up to https://github.com/microsoft/PowerToys/issues/10033
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
