### PR TITLE
System.InvalidOperationException: Collection was modified

### DIFF
--- a/src/modules/launcher/PowerLauncher/Plugin/PluginManager.cs
+++ b/src/modules/launcher/PowerLauncher/Plugin/PluginManager.cs
@@ -24,6 +24,7 @@ namespace PowerLauncher.Plugin
     {
         private static readonly IFileSystem FileSystem = new FileSystem();
         private static readonly IDirectory Directory = FileSystem.Directory;
+        private static readonly object AllPluginsLock = new object();
 
         private static IEnumerable<PluginPair> _contextMenuPlugins = new List<PluginPair>();
 
@@ -44,7 +45,13 @@ namespace PowerLauncher.Plugin
             {
                 if (_allPlugins == null)
                 {
-                    _allPlugins = PluginsLoader.Plugins(PluginConfig.Parse(Directories));
+                    lock (AllPluginsLock)
+                    {
+                        if (_allPlugins == null)
+                        {
+                            _allPlugins = PluginsLoader.Plugins(PluginConfig.Parse(Directories));
+                        }
+                    }
                 }
 
                 return _allPlugins;

--- a/src/modules/launcher/PowerLauncher/Plugin/PluginsLoader.cs
+++ b/src/modules/launcher/PowerLauncher/Plugin/PluginsLoader.cs
@@ -27,7 +27,9 @@ namespace PowerLauncher.Plugin
         public static IEnumerable<PluginPair> CSharpPlugins(List<PluginMetadata> source)
         {
             var plugins = new List<PluginPair>();
-            var metadatas = source.Where(o => o.Language.ToUpperInvariant() == AllowedLanguage.CSharp);
+            var metadatas = source
+                .Where(o => o.Language.ToUpperInvariant() == AllowedLanguage.CSharp)
+                .ToList();
 
             foreach (var metadata in metadatas)
             {


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
We get `System.InvalidOperationException: Collection was modified` on startup of PT Run. It happens because `PluginConfig.PluginMetadatas` is modified while related `IEnumerable` is used in `foreach`. 

`PluginConfig.PluginMetadatas` should be initialized only once so that's why `AllPlugins` should be a threadsafe singleton.
Notice that `Lazy` is not used for singleton implementation because we need to initialize `AllPlugins` from tests. 

**What is include in the PR:** 
- Thread-safe singleton for PluginManager.AllPlugins
- Apply `ToList` before foreach

**How does someone test / validate:** 
There is no way to test it unless you experienced the issue before. We will ask the author of the issue to verify it.
 
## Quality Checklist

- [X] **Linked issue:** #10094
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
