### PR TITLE
[Shortcut Guide] Excluded Apps

### DIFF
--- a/src/modules/shortcut_guide/shortcut_guide.h
+++ b/src/modules/shortcut_guide/shortcut_guide.h
@@ -37,6 +37,10 @@ public:
 
     bool overlay_visible() const;
 
+    bool is_disabled_app(wchar_t* exePath);
+
+    void get_exe_path(HWND window, wchar_t* exePath);
+
 private:
     std::wstring app_name;
     //contains the non localized key of the powertoy
@@ -46,9 +50,11 @@ private:
     bool _enabled = false;
     HHOOK hook_handle;
     std::unique_ptr<NativeEventWaiter> event_waiter;
+    std::vector<std::wstring> disabled_apps_array;
 
     void init_settings();
     void disable(bool trace_event);
+    void update_disabled_apps();
 
     struct PressTime
     {
@@ -75,4 +81,10 @@ private:
             { L"dark", IDS_SETTING_DESCRIPTION_THEME_DARK }
         };
     } theme;
+
+    struct DisabledApps
+    {
+        PCWSTR name = L"disabled_apps";
+        std::wstring value = L"";
+    } disabledApps;
 };

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ShortcutGuideProperties.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ShortcutGuideProperties.cs
@@ -13,6 +13,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             OverlayOpacity = new IntProperty(90);
             PressTime = new IntProperty(900);
             Theme = new StringProperty("system");
+            DisabledApps = new StringProperty();
         }
 
         [JsonPropertyName("overlay_opacity")]
@@ -23,5 +24,8 @@ namespace Microsoft.PowerToys.Settings.UI.Library
 
         [JsonPropertyName("theme")]
         public StringProperty Theme { get; set; }
+
+        [JsonPropertyName("disabled_apps")]
+        public StringProperty DisabledApps { get; set; }
     }
 }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/ShortcutGuideViewModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/ShortcutGuideViewModel.cs
@@ -20,6 +20,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
         private Func<string, int> SendConfigMSG { get; }
 
         private string _settingsConfigFileFolder = string.Empty;
+        private string _disabledApps;
 
         public ShortcutGuideViewModel(ISettingsRepository<GeneralSettings> settingsRepository, ISettingsRepository<ShortcutGuideSettings> moduleSettingsRepository, Func<string, int> ipcMSGCallBackFunc, string configFileSubfolder = "")
         {
@@ -49,6 +50,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             _isEnabled = GeneralSettingsConfig.Enabled.ShortcutGuide;
             _pressTime = Settings.Properties.PressTime.Value;
             _opacity = Settings.Properties.OverlayOpacity.Value;
+            _disabledApps = Settings.Properties.DisabledApps.Value;
 
             string theme = Settings.Properties.Theme.Value;
 
@@ -165,6 +167,24 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
                 {
                     _opacity = value;
                     Settings.Properties.OverlayOpacity.Value = value;
+                    NotifyPropertyChanged();
+                }
+            }
+        }
+
+        public string DisabledApps
+        {
+            get
+            {
+                return _disabledApps;
+            }
+
+            set
+            {
+                if (value != _disabledApps)
+                {
+                    _disabledApps = value;
+                    Settings.Properties.DisabledApps.Value = value;
                     NotifyPropertyChanged();
                 }
             }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -491,6 +491,16 @@
   <data name="ShortcutGuide_OverlayOpacity.Header" xml:space="preserve">
     <value>Opacity of background</value>
   </data>
+  <data name="ShortcutGuide_DisabledApps.Text" xml:space="preserve">
+    <value>Disable for apps</value>
+  </data>
+  <data name="ShortcutGuide_DisabledApps_TextBoxControl.Header" xml:space="preserve">
+    <value>Turn off Shortcut Guide when these applications have focus. Add one application name per line.</value>
+  </data>
+  <data name="ShortcutGuide_DisabledApps_TextBoxControl.PlaceholderText" xml:space="preserve">
+    <value>Example: outlook.exe</value>
+    <comment>Don't translate outlook.exe</comment>
+  </data>
   <data name="ImageResizer_CustomSizes.Text" xml:space="preserve">
     <value>Image sizes</value>
   </data>
@@ -793,6 +803,7 @@
   </data>
   <data name="FancyZones_ExcludeApps_TextBoxControl.PlaceholderText" xml:space="preserve">
     <value>Example: outlook.exe</value>
+    <comment>Don't translate outlook.exe</comment>
   </data>
   <data name="ImageResizer_FilenameFormatPlaceholder.PlaceholderText" xml:space="preserve">
     <value>Example: %1 (%2)</value>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ShortcutGuidePage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ShortcutGuidePage.xaml
@@ -111,6 +111,23 @@
                              IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}">
                 <TextBlock x:Uid="Windows_Color_Settings" />
             </HyperlinkButton>
+            
+            <TextBlock x:Uid="ShortcutGuide_DisabledApps"
+                       Style="{StaticResource SettingsGroupTitleStyle}"
+                       Foreground="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToForegroundConverter}}"/>
+            
+            <TextBox x:Uid="ShortcutGuide_DisabledApps_TextBoxControl"
+                     Margin="{StaticResource SmallTopMargin}"
+                     Text="{x:Bind Mode=TwoWay, Path=ViewModel.DisabledApps}"
+                     IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"
+                     ScrollViewer.VerticalScrollBarVisibility ="Visible"
+                     ScrollViewer.VerticalScrollMode="Enabled"
+                     ScrollViewer.IsVerticalRailEnabled="True"
+                     TextWrapping="Wrap"
+                     AcceptsReturn="True"
+                     HorizontalAlignment="Left"
+                     MinWidth="240"
+                     MinHeight="160" />
         </StackPanel>
 
         <RelativePanel x:Name="SidePanel" 


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Excluded apps for Shortcut Guide

**What is include in the PR:** 
Option for exclude programs from Shortcut Guide similar to FanzyZones

**How does someone test / validate:** 
- Build
- Add one or more apps in Settings > Shortcut Guide > Excluded apps
- Open an excluded app
- Long press win key
- Shortcut Guide shouldn't be showed
- Release win key
- Start menu should be opened

Wondering if original poster issue is fixed by this.
Any chance to test it against a program that is using win key without remapping it?

## Quality Checklist

- [x] **Linked issue:** #1241
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
