### PR TITLE
[FZ Editor] Layout hotkeys: add the schema element to zones-settings.json

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -284,23 +284,6 @@
                    
                 </Grid>
             </ScrollViewer>
-
-            <Button x:Name="TEST"
-                    Click="TEST_Click"
-                    HorizontalAlignment="Center"
-                    VerticalAlignment="Bottom"
-                    Padding="0"
-                    Height="36"
-                    Margin="16"
-                    Style="{StaticResource AccentButtonStyle}"
-                    Grid.Row="3">
-                <TextBlock Text="test fast-access-layout-keys" Foreground="White" Margin="8" />
-                <Button.Effect>
-                    <DropShadowEffect BlurRadius="6"
-                                      Opacity="0.32"
-                                      ShadowDepth="1" />
-                </Button.Effect>
-            </Button>
             
             <Button x:Name="NewLayoutButton"
                     Click="NewLayoutButton_Click"

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -284,6 +284,24 @@
                    
                 </Grid>
             </ScrollViewer>
+
+            <Button x:Name="TEST"
+                    Click="TEST_Click"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Bottom"
+                    Padding="0"
+                    Height="36"
+                    Margin="16"
+                    Style="{StaticResource AccentButtonStyle}"
+                    Grid.Row="3">
+                <TextBlock Text="test fast-access-layout-keys" Foreground="White" Margin="8" />
+                <Button.Effect>
+                    <DropShadowEffect BlurRadius="6"
+                                      Opacity="0.32"
+                                      ShadowDepth="1" />
+                </Button.Effect>
+            </Button>
+            
             <Button x:Name="NewLayoutButton"
                     Click="NewLayoutButton_Click"
                     HorizontalAlignment="Right"

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -420,5 +420,12 @@ namespace FancyZonesEditor
         {
             _openedDialog = null;
         }
+
+        private void TEST_Click(object sender, RoutedEventArgs e)
+        {
+            FastAccessKeysModel.SelectKey(1, "{9AD7FC3A-0A6C-4373-B523-4958FC50C46C}");
+            FastAccessKeysModel.SelectKey(7, "{15052398-7250-404F-9AA6-9966704EEDE1}");
+            FastAccessKeysModel.FreeKey(2);
+        }
     }
 }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -420,12 +420,5 @@ namespace FancyZonesEditor
         {
             _openedDialog = null;
         }
-
-        private void TEST_Click(object sender, RoutedEventArgs e)
-        {
-            FastAccessKeysModel.SelectKey(1, "{9AD7FC3A-0A6C-4373-B523-4958FC50C46C}");
-            FastAccessKeysModel.SelectKey(7, "{15052398-7250-404F-9AA6-9966704EEDE1}");
-            FastAccessKeysModel.FreeKey(2);
-        }
     }
 }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/FastAccessKeysModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/FastAccessKeysModel.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace FancyZonesEditor.Models
+{
+    public class FastAccessKeysModel
+    {
+        public static List<int> FreeKeys { get; } = new List<int>() { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+
+        public static SortedDictionary<int, string> SelectedKeys { get; } = new SortedDictionary<int, string>();
+
+        public FastAccessKeysModel()
+        {
+        }
+
+        public static void FreeKey(int key)
+        {
+            SelectedKeys.Remove(key);
+            FreeKeys.Add(key);
+        }
+
+        public static bool SelectKey(int key, string uuid)
+        {
+            if (SelectedKeys.ContainsKey(key))
+            {
+                return false;
+            }
+
+            FreeKeys.Remove(key);
+            SelectedKeys.Add(key, uuid);
+            return true;
+        }
+    }
+}

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/FastAccessKeysModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/FastAccessKeysModel.cs
@@ -8,9 +8,19 @@ namespace FancyZonesEditor.Models
 {
     public class FastAccessKeysModel
     {
-        public static List<int> FreeKeys { get; } = new List<int>() { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
-
-        public static SortedDictionary<int, string> SelectedKeys { get; } = new SortedDictionary<int, string>();
+        public static SortedDictionary<int, string> SelectedKeys { get; } = new SortedDictionary<int, string>()
+        {
+            { 0, string.Empty },
+            { 1, string.Empty },
+            { 2, string.Empty },
+            { 3, string.Empty },
+            { 4, string.Empty },
+            { 5, string.Empty },
+            { 6, string.Empty },
+            { 7, string.Empty },
+            { 8, string.Empty },
+            { 9, string.Empty },
+        };
 
         public FastAccessKeysModel()
         {
@@ -18,19 +28,20 @@ namespace FancyZonesEditor.Models
 
         public static void FreeKey(int key)
         {
-            SelectedKeys.Remove(key);
-            FreeKeys.Add(key);
+            if (SelectedKeys.ContainsKey(key))
+            {
+                SelectedKeys[key] = string.Empty;
+            }
         }
 
         public static bool SelectKey(int key, string uuid)
         {
-            if (SelectedKeys.ContainsKey(key))
+            if (!SelectedKeys.ContainsKey(key))
             {
                 return false;
             }
 
-            FreeKeys.Remove(key);
-            SelectedKeys.Add(key, uuid);
+            SelectedKeys[key] = uuid;
             return true;
         }
     }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/FastAccessKeysModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/FastAccessKeysModel.cs
@@ -1,8 +1,9 @@
-﻿// Copyright (c) Microsoft Corporation
+// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Linq;
 
 namespace FancyZonesEditor.Models
 {
@@ -43,6 +44,15 @@ namespace FancyZonesEditor.Models
 
             SelectedKeys[key] = uuid;
             return true;
+        }
+
+        public static void CleanUp()
+        {
+            var keys = SelectedKeys.Keys.ToList();
+            foreach (var key in keys)
+            {
+                SelectedKeys[key] = string.Empty;
+            }
         }
     }
 }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
@@ -707,13 +707,16 @@ namespace FancyZonesEditor.Utils
             // Serialize fast access layout keys
             foreach (var pair in FastAccessKeysModel.SelectedKeys)
             {
-                FastAccessLayoutKeysWrapper wrapper = new FastAccessLayoutKeysWrapper
+                if (pair.Value != string.Empty)
                 {
-                    Key = pair.Key,
-                    Uuid = pair.Value,
-                };
+                    FastAccessLayoutKeysWrapper wrapper = new FastAccessLayoutKeysWrapper
+                    {
+                        Key = pair.Key,
+                        Uuid = pair.Value,
+                    };
 
-                zoneSettings.FastAccessLayoutKeys.Add(wrapper);
+                    zoneSettings.FastAccessLayoutKeys.Add(wrapper);
+                }
             }
 
             try

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
@@ -57,6 +57,7 @@ namespace FancyZonesEditor.Utils
             MonitorTop,
         }
 
+        // parsing cmd args
         private struct NativeMonitorData
         {
             public string MonitorId { get; set; }
@@ -87,6 +88,7 @@ namespace FancyZonesEditor.Utils
             }
         }
 
+        // zones-settings: devices
         private struct DeviceWrapper
         {
             public struct ActiveZoneSetWrapper
@@ -109,6 +111,7 @@ namespace FancyZonesEditor.Utils
             public int EditorSensitivityRadius { get; set; }
         }
 
+        // zones-settings: custom-zone-sets
         private class CanvasInfoWrapper
         {
             public struct CanvasZoneWrapper
@@ -131,6 +134,7 @@ namespace FancyZonesEditor.Utils
             public int SensitivityRadius { get; set; } = LayoutSettings.DefaultSensitivityRadius;
         }
 
+        // zones-settings: custom-zone-sets
         private class GridInfoWrapper
         {
             public int Rows { get; set; }
@@ -150,6 +154,7 @@ namespace FancyZonesEditor.Utils
             public int SensitivityRadius { get; set; } = LayoutSettings.DefaultSensitivityRadius;
         }
 
+        // zones-settings: custom-zone-sets
         private struct CustomLayoutWrapper
         {
             public string Uuid { get; set; }
@@ -161,6 +166,7 @@ namespace FancyZonesEditor.Utils
             public JsonElement Info { get; set; } // CanvasInfoWrapper or GridInfoWrapper
         }
 
+        // zones-settings: templates
         private struct TemplateLayoutWrapper
         {
             public string Type { get; set; }
@@ -174,6 +180,15 @@ namespace FancyZonesEditor.Utils
             public int SensitivityRadius { get; set; }
         }
 
+        // zones-settings: fast-access-layout-keys-wrapper
+        private struct FastAccessLayoutKeysWrapper
+        {
+            public int Key { get; set; }
+
+            public string Uuid { get; set; }
+        }
+
+        // zones-settings
         private struct ZoneSettingsWrapper
         {
             public List<DeviceWrapper> Devices { get; set; }
@@ -181,6 +196,8 @@ namespace FancyZonesEditor.Utils
             public List<CustomLayoutWrapper> CustomZoneSets { get; set; }
 
             public List<TemplateLayoutWrapper> Templates { get; set; }
+
+            public List<FastAccessLayoutKeysWrapper> FastAccessLayoutKeys { get; set; }
         }
 
         private struct EditorParams
@@ -528,6 +545,7 @@ namespace FancyZonesEditor.Utils
                     bool devicesParsingResult = SetDevices(zoneSettings.Devices);
                     bool customZonesParsingResult = SetCustomLayouts(zoneSettings.CustomZoneSets);
                     bool templatesParsingResult = SetTemplateLayouts(zoneSettings.Templates);
+                    bool fastAccessKeysParsingResult = SetFastAccessKeys(zoneSettings.FastAccessLayoutKeys);
 
                     if (!devicesParsingResult || !customZonesParsingResult)
                     {
@@ -549,6 +567,7 @@ namespace FancyZonesEditor.Utils
             zoneSettings.Devices = new List<DeviceWrapper>();
             zoneSettings.CustomZoneSets = new List<CustomLayoutWrapper>();
             zoneSettings.Templates = new List<TemplateLayoutWrapper>();
+            zoneSettings.FastAccessLayoutKeys = new List<FastAccessLayoutKeysWrapper>();
 
             // Serialize used devices
             foreach (var monitor in App.Overlay.Monitors)
@@ -683,6 +702,18 @@ namespace FancyZonesEditor.Utils
                 }
 
                 zoneSettings.Templates.Add(wrapper);
+            }
+
+            // Serialize fast access layout keys
+            foreach (var pair in FastAccessKeysModel.SelectedKeys)
+            {
+                FastAccessLayoutKeysWrapper wrapper = new FastAccessLayoutKeysWrapper
+                {
+                    Key = pair.Key,
+                    Uuid = pair.Value,
+                };
+
+                zoneSettings.FastAccessLayoutKeys.Add(wrapper);
             }
 
             try
@@ -841,6 +872,21 @@ namespace FancyZonesEditor.Utils
                         layout.InitTemplateZones();
                     }
                 }
+            }
+
+            return true;
+        }
+
+        private bool SetFastAccessKeys(List<FastAccessLayoutKeysWrapper> fastAccessKeys)
+        {
+            if (fastAccessKeys == null)
+            {
+                return false;
+            }
+
+            foreach (var wrapper in fastAccessKeys)
+            {
+                FastAccessKeysModel.SelectKey(wrapper.Key, wrapper.Uuid);
             }
 
             return true;

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
@@ -887,6 +887,7 @@ namespace FancyZonesEditor.Utils
                 return false;
             }
 
+            FastAccessKeysModel.CleanUp();
             foreach (var wrapper in fastAccessKeys)
             {
                 FastAccessKeysModel.SelectKey(wrapper.Key, wrapper.Uuid);

--- a/src/modules/fancyzones/lib/JsonHelpers.cpp
+++ b/src/modules/fancyzones/lib/JsonHelpers.cpp
@@ -30,6 +30,7 @@ namespace NonLocalizable
     const wchar_t EditorSpacingStr[] = L"editor-spacing";
     const wchar_t EditorZoneCountStr[] = L"editor-zone-count";
     const wchar_t EditorSensitivityRadiusStr[] = L"editor-sensitivity-radius";
+    const wchar_t FastAccessLayoutKeys[] = L"fast-access-layout-keys";
     const wchar_t GridStr[] = L"grid";
     const wchar_t HeightStr[] = L"height";
     const wchar_t HistoryStr[] = L"history";
@@ -533,12 +534,18 @@ namespace JSONHelpers
 
         json::JsonObject root{};
         json::JsonArray templates{};
+        json::JsonArray fastAccessLayoutKeys{};
 
         try
         {
             if (before.has_value() && before->HasKey(NonLocalizable::Templates))
             {
                 templates = before->GetNamedArray(NonLocalizable::Templates);
+            }
+
+            if (before.has_value() && before->HasKey(NonLocalizable::FastAccessLayoutKeys))
+            {
+                fastAccessLayoutKeys = before->GetNamedArray(NonLocalizable::FastAccessLayoutKeys);
             }
         }
         catch (const winrt::hresult_error&)
@@ -549,6 +556,7 @@ namespace JSONHelpers
         root.SetNamedValue(NonLocalizable::DevicesStr, JSONHelpers::SerializeDeviceInfos(deviceInfoMap));
         root.SetNamedValue(NonLocalizable::CustomZoneSetsStr, JSONHelpers::SerializeCustomZoneSets(customZoneSetsMap));
         root.SetNamedValue(NonLocalizable::Templates, templates);
+        root.SetNamedValue(NonLocalizable::FastAccessLayoutKeys, fastAccessLayoutKeys);
         
         if (!before.has_value() || before.value().Stringify() != root.Stringify())
         {

--- a/src/modules/fancyzones/tests/UnitTests/JsonHelpers.Tests.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/JsonHelpers.Tests.cpp
@@ -1763,6 +1763,36 @@ namespace FancyZonesUnitTests
                 compareJsonObjects(expectedJsonObj, actualJson);
             }
 
+            TEST_METHOD (SaveFancyZonesDataWithFastAccessLayoutKeys)
+            {
+                FancyZonesData data;
+                data.SetSettingsModulePath(m_moduleName);
+                const auto& jsonPath = data.zonesSettingsFileName;
+
+                // json with fast-access-layout-keys
+                json::JsonObject expectedJsonObj;
+                json::JsonObject fastAccessKeyObj = json::JsonObject::Parse(L"{\"key\": 1, \"uuid\": \"{9AD7FC3A-0A6C-4373-B523-4958FC50C46C}\"}");
+                json::JsonArray fastAccessKeysArray{};
+                fastAccessKeysArray.Append(fastAccessKeyObj);
+                expectedJsonObj.SetNamedValue(L"devices", json::JsonArray{});
+                expectedJsonObj.SetNamedValue(L"custom-zone-sets", json::JsonArray{});
+                expectedJsonObj.SetNamedValue(L"fast-access-layout-keys", fastAccessKeysArray);
+
+                // write json with fast-access-layout-keys to file
+                json::to_file(jsonPath, expectedJsonObj);
+
+                data.SaveAppZoneHistoryAndZoneSettings();
+
+                // verify that file was written successfully
+                Assert::IsTrue(std::filesystem::exists(jsonPath));
+
+                // verify that fast-access-layout-keys were not changed after calling SaveFancyZonesData()
+                std::wstring str;
+                std::wifstream{ jsonPath, std::ios::binary } >> str;
+                json::JsonObject actualJson = json::JsonObject::Parse(str);
+                compareJsonObjects(expectedJsonObj, actualJson);
+            }
+
             TEST_METHOD (AppLastZoneIndex)
             {
                 const std::wstring deviceId = L"device-id";


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Added `fast-access-layout-keys` to the zones-settings.json.
Currently the schema is:

```
{
  "devices": [],
  "custom-zone-sets": [],
  "templates": [],
  "fast-access-layout-keys": [
    {
      "key": 1,
      "uuid": "{xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}"
    }
  ]
}
```

**What is include in the PR:** 

**How does someone test / validate:** 

For testings purposes, I added the temporary button at the bottom of the Editor that calls adding and freeing fast access keys. 
After clicking you can verify in the JSON file that some values were added (and weren't duplicated) and they're not erased after reading and rewriting settings by the FancyZonesLib.
The temporary button will be removed in the next PR or in this PR after reviewing.

By default, the `fast-access-layout-keys` array is empty.

## Quality Checklist

- [x] **Linked issue:** #10025
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
