### PR TITLE
[chore] cleanup 'using' statements

### DIFF
--- a/src/modules/colorPicker/ColorPickerUI/Keyboard/KeyboardMonitor.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Keyboard/KeyboardMonitor.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Diagnostics;
 using System.Windows.Input;
 using ColorPicker.Helpers;
 using ColorPicker.Settings;

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/Main.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/Main.cs
@@ -3,12 +3,10 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
-using System.Windows.Controls;
 using Community.PowerToys.Run.Plugin.VSCodeWorkspaces.Properties;
 using Community.PowerToys.Run.Plugin.VSCodeWorkspaces.RemoteMachinesHelper;
 using Community.PowerToys.Run.Plugin.VSCodeWorkspaces.VSCodeHelper;
 using Community.PowerToys.Run.Plugin.VSCodeWorkspaces.WorkspacesHelper;
-using Microsoft.PowerToys.Settings.UI.Library;
 using Wox.Plugin;
 
 namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Main.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Windows.Controls;
 using ManagedCommon;
 using Microsoft.Plugin.Folder.Sources;
-using Microsoft.PowerToys.Settings.UI.Library;
 using Wox.Infrastructure.Storage;
 using Wox.Plugin;
 

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Shell/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Shell/Main.cs
@@ -13,7 +13,6 @@ using System.Linq;
 using System.Reflection;
 using System.Windows.Input;
 using ManagedCommon;
-using Microsoft.PowerToys.Settings.UI.Library;
 using Wox.Infrastructure.Storage;
 using Wox.Plugin;
 using Wox.Plugin.Logger;

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/SettingsUtils.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/SettingsUtils.cs
@@ -54,7 +54,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
                 throw new FileNotFoundException();
             }
 
-            // Given the file already exists, to deserialize the file and read it's content.
+            // Given the file already exists, to deserialize the file and read its content.
             T deserializedSettings = GetFile<T>(powertoy, fileName);
 
             // If the file needs to be modified, to save the new configurations accordingly.

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Converters/ModuleEnabledToForegroundConverter.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Converters/ModuleEnabledToForegroundConverter.cs
@@ -3,8 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Globalization;
-using Microsoft.PowerToys.Settings.UI.Library;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Media;

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml.cs
@@ -2,7 +2,6 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.IO.Abstractions;
 using Microsoft.PowerToys.Settings.UI.Library;
 using Microsoft.PowerToys.Settings.UI.Library.ViewModels;
 using Windows.UI.Xaml.Controls;


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Remove unused 'using' statements.
I ran into these 'using' statements when researching why some modules have a dependency on `Microsoft.PowerToys.Settings.UI.Library`

**What is include in the PR:** 
It also includes fixing a type in a comment.

**How does someone test / validate:** 
Verify the solution builds without errors.

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
