### PR TITLE
Initialize logger to default

### DIFF
--- a/src/common/logger/logger.cpp
+++ b/src/common/logger/logger.cpp
@@ -38,7 +38,7 @@ level_enum getLogLevel(std::wstring_view logSettingsPath)
     return result;
 }
 
-std::shared_ptr<spdlog::logger> Logger::logger;
+std::shared_ptr<spdlog::logger> Logger::logger = spdlog::null_logger_mt("null");
 
 bool Logger::wasLogFailedShown()
 {


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Tests fail if the logger is not initialized. Initialize it to `null_logger_mt`.
 
**What is include in the PR:** 

**How does someone test / validate:** 
Run Fancy zones tests.

## Quality Checklist

- [X] **Linked issue:** #9684 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [X] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
