### PR TITLE
[FancyZones editor] Fix CanvasRect not being initialized

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/LayoutPreview.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/LayoutPreview.xaml.cs
@@ -261,7 +261,7 @@ namespace FancyZonesEditor
         private void RenderCanvasPreview(CanvasLayoutModel canvas)
         {
             var workArea = canvas.CanvasRect;
-            if (workArea.Width == 0 || workArea.Height == 0 || App.Overlay.SpanZonesAcrossMonitors)
+            if (workArea.Width == 0 || workArea.Height == 0)
             {
                 workArea = App.Overlay.WorkArea;
             }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -304,7 +304,8 @@ namespace FancyZonesEditor
             }
             else
             {
-                CanvasLayoutModel canvasModel = new CanvasLayoutModel(LayoutNameText.Text, LayoutType.Custom);
+                var area = App.Overlay.WorkArea;
+                CanvasLayoutModel canvasModel = new CanvasLayoutModel(LayoutNameText.Text, LayoutType.Custom, (int)area.Width, (int)area.Height);
                 canvasModel.AddZone();
                 selectedLayoutModel = canvasModel;
             }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/CanvasLayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/CanvasLayoutModel.cs
@@ -36,6 +36,12 @@ namespace FancyZonesEditor.Models
             CanvasRect = new Rect(new Size(width, height));
         }
 
+        public CanvasLayoutModel(string name, LayoutType type, int width, int height)
+        : base(name, type)
+        {
+            CanvasRect = new Rect(new Size(width, height));
+        }
+
         public CanvasLayoutModel(string name, LayoutType type)
         : base(name, type)
         {
@@ -148,6 +154,7 @@ namespace FancyZonesEditor.Models
             }
 
             layout.SensitivityRadius = SensitivityRadius;
+            layout.CanvasRect = CanvasRect;
             return layout;
         }
 
@@ -161,6 +168,7 @@ namespace FancyZonesEditor.Models
 
             other._topLeft = _topLeft;
             other.SensitivityRadius = SensitivityRadius;
+            other.CanvasRect = CanvasRect;
             other.UpdateLayout();
         }
 


### PR DESCRIPTION
## Summary of the Pull Request

One member of CanvasLayoutModel was not initialized when a new layout is created, leading to some bugs like #9330. This PR should fix that.

**What is include in the PR:** 

A new CanvasLayoutModel constructor which is called when a new layout is created. It sets the reference width/height for the layout.

**How does someone test / validate:** 

Create new layouts, use old layouts, try switching between monitors, especially if they have different resolutions or DPIs. This PR also fixes an issue when the option to span zones across monitors is used.

## Quality Checklist

- [x] **Linked issue:** #9330
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
