### PR TITLE
adding vsconfig to main solution

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -7,6 +7,7 @@
     "Microsoft.VisualStudio.Workload.ManagedDesktop",
     "Microsoft.VisualStudio.Workload.Universal",
     "Microsoft.VisualStudio.Component.Windows10SDK.17134",
+    "Microsoft.VisualStudio.Component.Windows10SDK.18362",
     "Microsoft.VisualStudio.ComponentGroup.UWP.VC",
     "Microsoft.VisualStudio.Component.VC.Runtimes.x86.x64.Spectre", 
     "Microsoft.VisualStudio.Component.VC.ATL.Spectre"

--- a/.vsconfig
+++ b/.vsconfig
@@ -1,0 +1,14 @@
+{
+  "version": "1.0",
+  "components": [  
+    "Microsoft.VisualStudio.Component.CoreEditor",
+    "Microsoft.VisualStudio.Workload.CoreEditor",
+    "Microsoft.VisualStudio.Workload.NativeDesktop",
+    "Microsoft.VisualStudio.Workload.ManagedDesktop",
+    "Microsoft.VisualStudio.Workload.Universal",
+    "Microsoft.VisualStudio.Component.Windows10SDK.17134",
+    "Microsoft.VisualStudio.ComponentGroup.UWP.VC",
+    "Microsoft.VisualStudio.Component.VC.Runtimes.x86.x64.Spectre", 
+    "Microsoft.VisualStudio.Component.VC.ATL.Spectre"
+  ]
+} 

--- a/doc/devdocs/readme.md
+++ b/doc/devdocs/readme.md
@@ -82,8 +82,8 @@ The installer can only be compiled in `Release` mode, step 1 and 2 must be done 
 
 1. Compile `PowerToys.sln`. Instructions are listed above.
 2. Compile `BugReportTool.sln` tool. Path from root: `tools\BugReportTool\BugReportTool.sln` (details listed below)
-3. Compile PowerToysSetup.sln Path from root: `installer\PowerToysSetup.sln` (details listed below)
-4. Compile PowerToysBootstrapper.sln Path from root: `installer\PowerToysBootstrapper\PowerToysBootstrapper.sln` (details listed below)
+3. Compile `PowerToysSetup.sln` Path from root: `installer\PowerToysSetup.sln` (details listed below)
+4. Compile `PowerToysBootstrapper.sln` Path from root: `installer\PowerToysBootstrapper\PowerToysBootstrapper.sln` (details listed below)
 
 ### Prerequisites for building the MSI installer
 
@@ -92,17 +92,25 @@ The installer can only be compiled in `Release` mode, step 1 and 2 must be done 
 
 ### Locally compiling the Bug reporting tool
 
-Build `tools\BugReportTool\BugReportTool.sln`: in Visual Studio, in the `Solutions Configuration` drop-down menu select `Release`, from the `Build` menu choose `Build Solution`.
+1. Open `tools\BugReportTool\BugReportTool.sln`
+1. In Visual Studio, in the `Solutions Configuration` drop-down menu select `Release`
+2. From the `Build` menu, choose `Build Solution`.
 
 ### Locally compiling the .MSI installer
 
-- Open `installer\PowerToysSetup.sln`: in Visual Studio, in the `Solutions Configuration` drop-down menu select `Release`, from the `Build` menu choose `Build Solution`.
-- The resulting `PowerToysSetup.msi` installer will be available in the `installer\PowerToysSetup\x64\Release\` folder.
+1. Open `installer\PowerToysSetup.sln`
+2. In Visual Studio, in the `Solutions Configuration` drop-down menu select `Release`
+3. From the `Build` menu choose `Build Solution`.
+
+The resulting `PowerToysSetup.msi` installer will be available in the `installer\PowerToysSetup\x64\Release\` folder.
 
 ### Locally compiling the .EXE Bootstrapper installer
 
-- Open `installer\PowerToysBootstrapper\PowerToysBootstrapper.sln`: in Visual Studio, in the `Solutions Configuration` drop-down menu select `Release`, from the `Build` menu choose `Build Solution`.
-- The `PowerToysSetup-0.0.1-x64.exe` binary is created in the `installer\PowerToysBootstrapper\x64\Release\` folder.
+1. Open `installer\PowerToysBootstrapper\PowerToysBootstrapper.sln` 
+2. In Visual Studio, in the `Solutions Configuration` drop-down menu select `Release`
+3. From the `Build` menu choose `Build Solution`.
+
+The `PowerToysSetup-0.0.1-x64.exe` binary is created in the `installer\PowerToysBootstrapper\x64\Release\` folder.
 
 #### Supported arguments for the .EXE Bootstrapper installer
 

--- a/doc/devdocs/readme.md
+++ b/doc/devdocs/readme.md
@@ -64,28 +64,7 @@ Various tools used by PowerToys. Includes the Visual Studio 2019 project templat
 
 1. Windows 10 April 2018 Update (version 1803) or newer
 2. Visual Studio Community/Professional/Enterprise 2019
-3. Run the command below in cmd/terminal to install all the workloads and components for VS.
-
-```shell
-cd "%ProgramFiles(x86)%\Microsoft Visual Studio\2019"
-SET targetFolder="\"
-IF EXIST Preview\NUL (SET targetFolder=Preview)
-IF EXIST Enterprise\NUL (SET targetFolder=Enterprise)
-IF EXIST Professional\NUL (SET targetFolder=Professional)
-IF EXIST Community\NUL (SET targetFolder=Community)
-
-ECHO %targetFolder%
-
-"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vs_installer.exe" ^
-modify --installpath "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\%targetFolder%" ^
---add Microsoft.VisualStudio.Workload.NativeDesktop ^
---add Microsoft.VisualStudio.Workload.ManagedDesktop ^
---add Microsoft.VisualStudio.Workload.Universal ^
---add Microsoft.VisualStudio.Component.Windows10SDK.17134 ^
---add Microsoft.VisualStudio.ComponentGroup.UWP.VC ^
---add Microsoft.VisualStudio.Component.VC.Runtimes.x86.x64.Spectre ^
---add Microsoft.VisualStudio.Component.VC.ATL.Spectre
-```
+3. Once you've cloned and started the `PowerToys.sln`, in the solution explorer, if you see a dialog that says `install extra components`, click `install`
 
 ### Compile source code
 
@@ -101,15 +80,19 @@ Our installer is two parts, an EXE and an MSI.  The EXE (Bootstrapper) contains 
 
 The installer can only be compiled in `Release` mode, step 1 and 2 must be done before the MSI will be able to be compiled.
 
-1. Compile PowerToys.sln. Instructions are listed above.
-2. Compile Bug reporting tool. Path from root: `tools\BugReportTool\BugReportTool.sln` (details listed below)
+1. Compile `PowerToys.sln`. Instructions are listed above.
+2. Compile `BugReportTool.sln` tool. Path from root: `tools\BugReportTool\BugReportTool.sln` (details listed below)
 3. Compile PowerToysSetup.sln Path from root: `installer\PowerToysSetup.sln` (details listed below)
+4. Compile PowerToysBootstrapper.sln Path from root: `installer\PowerToysBootstrapper\PowerToysBootstrapper.sln` (details listed below)
 
 ### Prerequisites for building the MSI installer
 
-1. Build `tools\BugReportTool\BugReportTool.sln`: in Visual Studio, in the `Solutions Configuration` drop-down menu select `Release`, from the `Build` menu choose `Build Solution`.
-2. Install the [WiX Toolset Visual Studio 2019 Extension](https://marketplace.visualstudio.com/items?itemName=RobMensching.WiXToolset).
-3. Install the [WiX Toolset build tools](https://wixtoolset.org/releases/).
+1. Install the [WiX Toolset Visual Studio 2019 Extension](https://marketplace.visualstudio.com/items?itemName=RobMensching.WiXToolset).
+2. Install the [WiX Toolset build tools](https://wixtoolset.org/releases/).
+
+### Locally compiling the Bug reporting tool
+
+Build `tools\BugReportTool\BugReportTool.sln`: in Visual Studio, in the `Solutions Configuration` drop-down menu select `Release`, from the `Build` menu choose `Build Solution`.
 
 ### Locally compiling the .MSI installer
 


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Onboarding is important.  This will replace the need for the install script from here:
https://github.com/microsoft/PowerToys/tree/master/doc/devdocs#prerequisites-for-compiling-powertoys

We'll still need an install script for Wix and what not but this gets the main SLN however in a 'shovel ready' state for work.

**What is include in the PR:** 

VS Config was added to replace setup script

**How does someone test / validate:** 

setup new VM, install VS as just a pure "core", clone and "install"
![image](https://user-images.githubusercontent.com/1462282/110676362-b8268680-8188-11eb-97e6-8d70a1d6827a.png)

After everything is installed, this will install remaining dependencies needed.

## Quality Checklist

- [x] **Linked issue:** #https://github.com/microsoft/PowerToys/issues/9806
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [x] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
