### PR TITLE
[Updating] Install dotnet 3.1.13 and bump min required version

### DIFF
--- a/src/common/updating/dotnet_installation.cpp
+++ b/src/common/updating/dotnet_installation.cpp
@@ -10,7 +10,7 @@ namespace fs = std::filesystem;
 
 namespace updating
 {
-    constexpr size_t REQUIRED_MINIMAL_PATCH = 11;
+    constexpr size_t REQUIRED_MINIMAL_PATCH = 13;
 
     bool dotnet_is_installed()
     {
@@ -46,7 +46,7 @@ namespace updating
 
     std::optional<fs::path> download_dotnet()
     {
-        const wchar_t DOTNET_DESKTOP_DOWNLOAD_LINK[] = L"https://download.visualstudio.microsoft.com/download/pr/3f1cc4f7-0c1a-48ca-9551-a8447fa55892/ed9809822448f55b649858920afb35cb/windowsdesktop-runtime-3.1.11-win-x64.exe";
+        const wchar_t DOTNET_DESKTOP_DOWNLOAD_LINK[] = L"https://download.visualstudio.microsoft.com/download/pr/aa717f57-3ae5-48fa-a3ab-0018338d0726/fb37276b1575772461701339110e7a54/windowsdesktop-runtime-3.1.13-win-x64.exe";
         const wchar_t DOTNET_DESKTOP_FILENAME[] = L"windowsdesktop-runtime.exe";
 
         auto dotnet_download_path = fs::temp_directory_path() / DOTNET_DESKTOP_FILENAME;


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [ ] **Linked issue:** #10122
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
