### PR TITLE
[FancyZones] Trace various function calls

### DIFF
--- a/src/modules/fancyzones/lib/CallTracer.cpp
+++ b/src/modules/fancyzones/lib/CallTracer.cpp
@@ -1,0 +1,20 @@
+#include "pch.h"
+#include "CallTracer.h"
+
+namespace
+{
+    // Non-localizable
+    const std::string entering = "Entering: ";
+    const std::string exiting = "Exiting: ";
+}
+
+CallTracer::CallTracer(const char* functionName) :
+    functionName(functionName)
+{
+    Logger::trace((entering + functionName).c_str());
+}
+
+CallTracer::~CallTracer()
+{
+    Logger::trace((exiting + functionName).c_str());
+}

--- a/src/modules/fancyzones/lib/CallTracer.cpp
+++ b/src/modules/fancyzones/lib/CallTracer.cpp
@@ -16,7 +16,7 @@ namespace
         std::unique_lock lock(indentLevelMutex);
         int level = indentLevel[std::this_thread::get_id()];
 
-        if (level == 0)
+        if (level <= 0)
         {
             return {};
         }
@@ -25,15 +25,29 @@ namespace
             return std::string(2 * min(level, 64) - 1, ' ') + " - ";
         }
     }
+
+    void Indent()
+    {
+        std::unique_lock lock(indentLevelMutex);
+        indentLevel[std::this_thread::get_id()]++;
+    }
+
+    void Unindent()
+    {
+        std::unique_lock lock(indentLevelMutex);
+        indentLevel[std::this_thread::get_id()]--;
+    }
 }
 
 CallTracer::CallTracer(const char* functionName) :
     functionName(functionName)
-{ 
+{
+    Indent();
     Logger::trace((GetIndentation() + functionName + entering).c_str());
 }
 
 CallTracer::~CallTracer()
 {
     Logger::trace((GetIndentation() + functionName + exiting).c_str());
+    Unindent();
 }

--- a/src/modules/fancyzones/lib/CallTracer.cpp
+++ b/src/modules/fancyzones/lib/CallTracer.cpp
@@ -4,17 +4,17 @@
 namespace
 {
     // Non-localizable
-    const std::string entering = "Entering: ";
-    const std::string exiting = "Exiting: ";
+    const std::string entering = " Enter";
+    const std::string exiting = " Exit";
 }
 
 CallTracer::CallTracer(const char* functionName) :
     functionName(functionName)
 {
-    Logger::trace((entering + functionName).c_str());
+    Logger::trace((functionName + entering).c_str());
 }
 
 CallTracer::~CallTracer()
 {
-    Logger::trace((exiting + functionName).c_str());
+    Logger::trace((functionName + exiting).c_str());
 }

--- a/src/modules/fancyzones/lib/CallTracer.cpp
+++ b/src/modules/fancyzones/lib/CallTracer.cpp
@@ -29,7 +29,7 @@ namespace
 
 CallTracer::CallTracer(const char* functionName) :
     functionName(functionName)
-{  
+{ 
     Logger::trace((GetIndentation() + functionName + entering).c_str());
 }
 

--- a/src/modules/fancyzones/lib/CallTracer.cpp
+++ b/src/modules/fancyzones/lib/CallTracer.cpp
@@ -42,12 +42,12 @@ namespace
 CallTracer::CallTracer(const char* functionName) :
     functionName(functionName)
 {
-    Indent();
     Logger::trace((GetIndentation() + functionName + entering).c_str());
+    Indent();
 }
 
 CallTracer::~CallTracer()
 {
-    Logger::trace((GetIndentation() + functionName + exiting).c_str());
     Unindent();
+    Logger::trace((GetIndentation() + functionName + exiting).c_str());
 }

--- a/src/modules/fancyzones/lib/CallTracer.cpp
+++ b/src/modules/fancyzones/lib/CallTracer.cpp
@@ -1,20 +1,39 @@
 #include "pch.h"
 #include "CallTracer.h"
+#include <thread>
 
 namespace
 {
     // Non-localizable
     const std::string entering = " Enter";
     const std::string exiting = " Exit";
+
+    std::mutex indentLevelMutex;
+    std::map<std::thread::id, int> indentLevel;
+
+    std::string GetIndentation()
+    {
+        std::unique_lock lock(indentLevelMutex);
+        int level = indentLevel[std::this_thread::get_id()];
+
+        if (level == 0)
+        {
+            return {};
+        }
+        else
+        {
+            return std::string(2 * min(level, 64) - 1, ' ') + " - ";
+        }
+    }
 }
 
 CallTracer::CallTracer(const char* functionName) :
     functionName(functionName)
-{
-    Logger::trace((functionName + entering).c_str());
+{  
+    Logger::trace((GetIndentation() + functionName + entering).c_str());
 }
 
 CallTracer::~CallTracer()
 {
-    Logger::trace((functionName + exiting).c_str());
+    Logger::trace((GetIndentation() + functionName + exiting).c_str());
 }

--- a/src/modules/fancyzones/lib/CallTracer.h
+++ b/src/modules/fancyzones/lib/CallTracer.h
@@ -2,7 +2,7 @@
 
 #include "common/logger/logger.h"
 
-#define _TRACER_ CallTracer callTracer(__FUNCTION__);
+#define _TRACER_ CallTracer callTracer(__FUNCTION__)
 
 class CallTracer
 {

--- a/src/modules/fancyzones/lib/CallTracer.h
+++ b/src/modules/fancyzones/lib/CallTracer.h
@@ -2,6 +2,8 @@
 
 #include "common/logger/logger.h"
 
+#define _TRACER_ CallTracer callTracer(__FUNCTION__);
+
 class CallTracer
 {
     std::string functionName;

--- a/src/modules/fancyzones/lib/CallTracer.h
+++ b/src/modules/fancyzones/lib/CallTracer.h
@@ -1,4 +1,5 @@
 #pragma once
+
 #include "common/logger/logger.h"
 
 class CallTracer

--- a/src/modules/fancyzones/lib/CallTracer.h
+++ b/src/modules/fancyzones/lib/CallTracer.h
@@ -1,0 +1,10 @@
+#pragma once
+#include "common/logger/logger.h"
+
+class CallTracer
+{
+    std::string functionName;
+public:
+    CallTracer(const char* functionName);
+    ~CallTracer();
+};

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -70,6 +70,7 @@ public:
 
     void MoveSizeStart(HWND window, HMONITOR monitor, POINT const& ptScreen) noexcept
     {
+        CallTracer callTracer(__FUNCTION__);
         std::unique_lock writeLock(m_lock);
         if (m_settings->GetSettings()->spanZonesAcrossMonitors)
         {
@@ -80,6 +81,7 @@ public:
 
     void MoveSizeUpdate(HMONITOR monitor, POINT const& ptScreen) noexcept
     {
+        CallTracer callTracer(__FUNCTION__);
         std::unique_lock writeLock(m_lock);
         if (m_settings->GetSettings()->spanZonesAcrossMonitors)
         {
@@ -90,6 +92,7 @@ public:
 
     void MoveSizeEnd(HWND window, POINT const& ptScreen) noexcept
     {
+        CallTracer callTracer(__FUNCTION__);
         std::unique_lock writeLock(m_lock);
         m_windowMoveHandler.MoveSizeEnd(window, ptScreen, m_workAreaHandler.GetWorkAreasByDesktopId(m_currentDesktopId));
     }
@@ -97,6 +100,7 @@ public:
     IFACEMETHODIMP_(void)
     HandleWinHookEvent(const WinHookEvent* data) noexcept
     {
+        CallTracer callTracer(__FUNCTION__);
         const auto wparam = reinterpret_cast<WPARAM>(data->hwnd);
         const LONG lparam = 0;
         std::shared_lock readLock(m_lock);
@@ -172,6 +176,7 @@ public:
     IFACEMETHODIMP_(bool)
     InMoveSize() noexcept
     {
+        CallTracer callTracer(__FUNCTION__);
         std::shared_lock readLock(m_lock);
         return m_windowMoveHandler.InMoveSize();
     }
@@ -287,6 +292,7 @@ UINT FancyZones::WM_PRIV_SNAP_HOTKEY = RegisterWindowMessage(L"{763c03a3-03d9-4c
 IFACEMETHODIMP_(void)
 FancyZones::Run() noexcept
 {
+    CallTracer callTracer(__FUNCTION__);
     std::unique_lock writeLock(m_lock);
 
     WNDCLASSEXW wcex{};
@@ -322,6 +328,7 @@ FancyZones::Run() noexcept
 IFACEMETHODIMP_(void)
 FancyZones::Destroy() noexcept
 {
+    CallTracer callTracer(__FUNCTION__);
     std::unique_lock writeLock(m_lock);
     m_workAreaHandler.Clear();
     BufferedPaintUnInit();
@@ -501,6 +508,7 @@ void OpenWindowOnActiveMonitor(HWND window, HMONITOR monitor) noexcept
 IFACEMETHODIMP_(void)
 FancyZones::WindowCreated(HWND window) noexcept
 {
+    CallTracer callTracer(__FUNCTION__);
     std::shared_lock readLock(m_lock);
     GUID desktopId{};
     if (VirtualDesktopUtils::GetWindowDesktopId(window, &desktopId) && desktopId != m_currentDesktopId)
@@ -593,6 +601,7 @@ FancyZones::OnKeyDown(PKBDLLHOOKSTRUCT info) noexcept
 // IFancyZonesCallback
 void FancyZones::ToggleEditor() noexcept
 {
+    CallTracer callTracer(__FUNCTION__);
     {
         std::shared_lock readLock(m_lock);
         if (m_terminateEditorEvent)
@@ -773,6 +782,7 @@ FancyZones::MoveWindowsOnActiveZoneSetChange() noexcept
 
 LRESULT FancyZones::WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lparam) noexcept
 {
+    CallTracer callTracer(__FUNCTION__);
     switch (message)
     {
     case WM_HOTKEY:
@@ -884,6 +894,7 @@ LRESULT FancyZones::WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lpa
 
 void FancyZones::OnDisplayChange(DisplayChangeType changeType) noexcept
 {
+    CallTracer callTracer(__FUNCTION__);
     if (changeType == DisplayChangeType::VirtualDesktop ||
         changeType == DisplayChangeType::Initialization)
     {
@@ -921,6 +932,7 @@ void FancyZones::OnDisplayChange(DisplayChangeType changeType) noexcept
 
 void FancyZones::AddZoneWindow(HMONITOR monitor, const std::wstring& deviceId) noexcept
 {
+    CallTracer callTracer(__FUNCTION__);
     std::unique_lock writeLock(m_lock);
 
     if (m_workAreaHandler.IsNewWorkArea(m_currentDesktopId, monitor))
@@ -1006,7 +1018,9 @@ void FancyZones::UpdateZoneWindows() noexcept
 
 void FancyZones::UpdateWindowsPositions() noexcept
 {
+    CallTracer callTracer(__FUNCTION__);
     auto callback = [](HWND window, LPARAM data) -> BOOL {
+        CallTracer callTracer(__FUNCTION__);
         size_t bitmask = reinterpret_cast<size_t>(::GetProp(window, ZonedWindowProperties::PropertyMultipleZoneID));
 
         if (bitmask != 0)
@@ -1035,6 +1049,7 @@ void FancyZones::UpdateWindowsPositions() noexcept
 
 void FancyZones::CycleActiveZoneSet(DWORD vkCode) noexcept
 {
+    CallTracer callTracer(__FUNCTION__);
     auto window = GetForegroundWindow();
     if (FancyZonesUtils::IsCandidateForZoning(window, m_settings->GetSettings()->excludedAppsArray))
     {
@@ -1054,6 +1069,7 @@ void FancyZones::CycleActiveZoneSet(DWORD vkCode) noexcept
 
 bool FancyZones::OnSnapHotkeyBasedOnZoneNumber(HWND window, DWORD vkCode) noexcept
 {
+    CallTracer callTracer(__FUNCTION__);
     HMONITOR current;
 
     if (m_settings->GetSettings()->spanZonesAcrossMonitors)
@@ -1284,6 +1300,7 @@ bool FancyZones::ProcessDirectedSnapHotkey(HWND window, DWORD vkCode, bool cycle
 
 void FancyZones::RegisterVirtualDesktopUpdates(std::vector<GUID>& ids) noexcept
 {
+    CallTracer callTracer(__FUNCTION__);
     std::unique_lock writeLock(m_lock);
 
     m_workAreaHandler.RegisterUpdates(ids);
@@ -1358,6 +1375,7 @@ bool FancyZones::ShouldProcessSnapHotkey(DWORD vkCode) noexcept
 
 std::vector<HMONITOR> FancyZones::GetMonitorsSorted() noexcept
 {
+    CallTracer callTracer(__FUNCTION__);
     std::shared_lock readLock(m_lock);
 
     auto monitorInfo = GetRawMonitorData();
@@ -1369,6 +1387,7 @@ std::vector<HMONITOR> FancyZones::GetMonitorsSorted() noexcept
 
 std::vector<std::pair<HMONITOR, RECT>> FancyZones::GetRawMonitorData() noexcept
 {
+    CallTracer callTracer(__FUNCTION__);
     std::shared_lock readLock(m_lock);
 
     std::vector<std::pair<HMONITOR, RECT>> monitorInfo;

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -70,7 +70,6 @@ public:
 
     void MoveSizeStart(HWND window, HMONITOR monitor, POINT const& ptScreen) noexcept
     {
-        CallTracer callTracer(__FUNCTION__);
         std::unique_lock writeLock(m_lock);
         if (m_settings->GetSettings()->spanZonesAcrossMonitors)
         {
@@ -81,7 +80,6 @@ public:
 
     void MoveSizeUpdate(HMONITOR monitor, POINT const& ptScreen) noexcept
     {
-        CallTracer callTracer(__FUNCTION__);
         std::unique_lock writeLock(m_lock);
         if (m_settings->GetSettings()->spanZonesAcrossMonitors)
         {
@@ -92,7 +90,7 @@ public:
 
     void MoveSizeEnd(HWND window, POINT const& ptScreen) noexcept
     {
-        CallTracer callTracer(__FUNCTION__);
+        _TRACER_
         std::unique_lock writeLock(m_lock);
         m_windowMoveHandler.MoveSizeEnd(window, ptScreen, m_workAreaHandler.GetWorkAreasByDesktopId(m_currentDesktopId));
     }
@@ -100,7 +98,6 @@ public:
     IFACEMETHODIMP_(void)
     HandleWinHookEvent(const WinHookEvent* data) noexcept
     {
-        CallTracer callTracer(__FUNCTION__);
         const auto wparam = reinterpret_cast<WPARAM>(data->hwnd);
         const LONG lparam = 0;
         std::shared_lock readLock(m_lock);
@@ -176,7 +173,6 @@ public:
     IFACEMETHODIMP_(bool)
     InMoveSize() noexcept
     {
-        CallTracer callTracer(__FUNCTION__);
         std::shared_lock readLock(m_lock);
         return m_windowMoveHandler.InMoveSize();
     }
@@ -292,7 +288,6 @@ UINT FancyZones::WM_PRIV_SNAP_HOTKEY = RegisterWindowMessage(L"{763c03a3-03d9-4c
 IFACEMETHODIMP_(void)
 FancyZones::Run() noexcept
 {
-    CallTracer callTracer(__FUNCTION__);
     std::unique_lock writeLock(m_lock);
 
     WNDCLASSEXW wcex{};
@@ -328,7 +323,6 @@ FancyZones::Run() noexcept
 IFACEMETHODIMP_(void)
 FancyZones::Destroy() noexcept
 {
-    CallTracer callTracer(__FUNCTION__);
     std::unique_lock writeLock(m_lock);
     m_workAreaHandler.Clear();
     BufferedPaintUnInit();
@@ -429,6 +423,7 @@ std::pair<winrt::com_ptr<IZoneWindow>, std::vector<size_t>> FancyZones::GetAppZo
 
 void FancyZones::MoveWindowIntoZone(HWND window, winrt::com_ptr<IZoneWindow> zoneWindow, const std::vector<size_t>& zoneIndexSet) noexcept
 {
+    _TRACER_
     auto& fancyZonesData = FancyZonesDataInstance();
     if (!fancyZonesData.IsAnotherWindowOfApplicationInstanceZoned(window, zoneWindow->UniqueId()))
     {
@@ -508,7 +503,6 @@ void OpenWindowOnActiveMonitor(HWND window, HMONITOR monitor) noexcept
 IFACEMETHODIMP_(void)
 FancyZones::WindowCreated(HWND window) noexcept
 {
-    CallTracer callTracer(__FUNCTION__);
     std::shared_lock readLock(m_lock);
     GUID desktopId{};
     if (VirtualDesktopUtils::GetWindowDesktopId(window, &desktopId) && desktopId != m_currentDesktopId)
@@ -601,7 +595,7 @@ FancyZones::OnKeyDown(PKBDLLHOOKSTRUCT info) noexcept
 // IFancyZonesCallback
 void FancyZones::ToggleEditor() noexcept
 {
-    CallTracer callTracer(__FUNCTION__);
+    _TRACER_
     {
         std::shared_lock readLock(m_lock);
         if (m_terminateEditorEvent)
@@ -782,7 +776,6 @@ FancyZones::MoveWindowsOnActiveZoneSetChange() noexcept
 
 LRESULT FancyZones::WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lparam) noexcept
 {
-    CallTracer callTracer(__FUNCTION__);
     switch (message)
     {
     case WM_HOTKEY:
@@ -894,7 +887,7 @@ LRESULT FancyZones::WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lpa
 
 void FancyZones::OnDisplayChange(DisplayChangeType changeType) noexcept
 {
-    CallTracer callTracer(__FUNCTION__);
+    _TRACER_
     if (changeType == DisplayChangeType::VirtualDesktop ||
         changeType == DisplayChangeType::Initialization)
     {
@@ -932,7 +925,7 @@ void FancyZones::OnDisplayChange(DisplayChangeType changeType) noexcept
 
 void FancyZones::AddZoneWindow(HMONITOR monitor, const std::wstring& deviceId) noexcept
 {
-    CallTracer callTracer(__FUNCTION__);
+    _TRACER_
     std::unique_lock writeLock(m_lock);
 
     if (m_workAreaHandler.IsNewWorkArea(m_currentDesktopId, monitor))
@@ -1018,9 +1011,9 @@ void FancyZones::UpdateZoneWindows() noexcept
 
 void FancyZones::UpdateWindowsPositions() noexcept
 {
-    CallTracer callTracer(__FUNCTION__);
+    _TRACER_
     auto callback = [](HWND window, LPARAM data) -> BOOL {
-        CallTracer callTracer(__FUNCTION__);
+        _TRACER_
         size_t bitmask = reinterpret_cast<size_t>(::GetProp(window, ZonedWindowProperties::PropertyMultipleZoneID));
 
         if (bitmask != 0)
@@ -1049,7 +1042,7 @@ void FancyZones::UpdateWindowsPositions() noexcept
 
 void FancyZones::CycleActiveZoneSet(DWORD vkCode) noexcept
 {
-    CallTracer callTracer(__FUNCTION__);
+    _TRACER_
     auto window = GetForegroundWindow();
     if (FancyZonesUtils::IsCandidateForZoning(window, m_settings->GetSettings()->excludedAppsArray))
     {
@@ -1069,7 +1062,7 @@ void FancyZones::CycleActiveZoneSet(DWORD vkCode) noexcept
 
 bool FancyZones::OnSnapHotkeyBasedOnZoneNumber(HWND window, DWORD vkCode) noexcept
 {
-    CallTracer callTracer(__FUNCTION__);
+    _TRACER_
     HMONITOR current;
 
     if (m_settings->GetSettings()->spanZonesAcrossMonitors)
@@ -1300,7 +1293,7 @@ bool FancyZones::ProcessDirectedSnapHotkey(HWND window, DWORD vkCode, bool cycle
 
 void FancyZones::RegisterVirtualDesktopUpdates(std::vector<GUID>& ids) noexcept
 {
-    CallTracer callTracer(__FUNCTION__);
+    _TRACER_
     std::unique_lock writeLock(m_lock);
 
     m_workAreaHandler.RegisterUpdates(ids);
@@ -1375,7 +1368,6 @@ bool FancyZones::ShouldProcessSnapHotkey(DWORD vkCode) noexcept
 
 std::vector<HMONITOR> FancyZones::GetMonitorsSorted() noexcept
 {
-    CallTracer callTracer(__FUNCTION__);
     std::shared_lock readLock(m_lock);
 
     auto monitorInfo = GetRawMonitorData();
@@ -1387,7 +1379,7 @@ std::vector<HMONITOR> FancyZones::GetMonitorsSorted() noexcept
 
 std::vector<std::pair<HMONITOR, RECT>> FancyZones::GetRawMonitorData() noexcept
 {
-    CallTracer callTracer(__FUNCTION__);
+    _TRACER_
     std::shared_lock readLock(m_lock);
 
     std::vector<std::pair<HMONITOR, RECT>> monitorInfo;

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -19,6 +19,7 @@
 #include "VirtualDesktopUtils.h"
 #include "MonitorWorkAreaHandler.h"
 #include "util.h"
+#include "CallTracer.h"
 
 #include <lib/SecondaryMouseButtonsHook.h>
 

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -90,7 +90,7 @@ public:
 
     void MoveSizeEnd(HWND window, POINT const& ptScreen) noexcept
     {
-        _TRACER_
+        _TRACER_;
         std::unique_lock writeLock(m_lock);
         m_windowMoveHandler.MoveSizeEnd(window, ptScreen, m_workAreaHandler.GetWorkAreasByDesktopId(m_currentDesktopId));
     }
@@ -423,7 +423,7 @@ std::pair<winrt::com_ptr<IZoneWindow>, std::vector<size_t>> FancyZones::GetAppZo
 
 void FancyZones::MoveWindowIntoZone(HWND window, winrt::com_ptr<IZoneWindow> zoneWindow, const std::vector<size_t>& zoneIndexSet) noexcept
 {
-    _TRACER_
+    _TRACER_;
     auto& fancyZonesData = FancyZonesDataInstance();
     if (!fancyZonesData.IsAnotherWindowOfApplicationInstanceZoned(window, zoneWindow->UniqueId()))
     {
@@ -595,7 +595,7 @@ FancyZones::OnKeyDown(PKBDLLHOOKSTRUCT info) noexcept
 // IFancyZonesCallback
 void FancyZones::ToggleEditor() noexcept
 {
-    _TRACER_
+    _TRACER_;
     {
         std::shared_lock readLock(m_lock);
         if (m_terminateEditorEvent)
@@ -887,7 +887,7 @@ LRESULT FancyZones::WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lpa
 
 void FancyZones::OnDisplayChange(DisplayChangeType changeType) noexcept
 {
-    _TRACER_
+    _TRACER_;
     if (changeType == DisplayChangeType::VirtualDesktop ||
         changeType == DisplayChangeType::Initialization)
     {
@@ -925,7 +925,7 @@ void FancyZones::OnDisplayChange(DisplayChangeType changeType) noexcept
 
 void FancyZones::AddZoneWindow(HMONITOR monitor, const std::wstring& deviceId) noexcept
 {
-    _TRACER_
+    _TRACER_;
     std::unique_lock writeLock(m_lock);
 
     if (m_workAreaHandler.IsNewWorkArea(m_currentDesktopId, monitor))
@@ -1011,9 +1011,9 @@ void FancyZones::UpdateZoneWindows() noexcept
 
 void FancyZones::UpdateWindowsPositions() noexcept
 {
-    _TRACER_
+    _TRACER_;
     auto callback = [](HWND window, LPARAM data) -> BOOL {
-        _TRACER_
+        _TRACER_;
         size_t bitmask = reinterpret_cast<size_t>(::GetProp(window, ZonedWindowProperties::PropertyMultipleZoneID));
 
         if (bitmask != 0)
@@ -1042,7 +1042,7 @@ void FancyZones::UpdateWindowsPositions() noexcept
 
 void FancyZones::CycleActiveZoneSet(DWORD vkCode) noexcept
 {
-    _TRACER_
+    _TRACER_;
     auto window = GetForegroundWindow();
     if (FancyZonesUtils::IsCandidateForZoning(window, m_settings->GetSettings()->excludedAppsArray))
     {
@@ -1062,7 +1062,7 @@ void FancyZones::CycleActiveZoneSet(DWORD vkCode) noexcept
 
 bool FancyZones::OnSnapHotkeyBasedOnZoneNumber(HWND window, DWORD vkCode) noexcept
 {
-    _TRACER_
+    _TRACER_;
     HMONITOR current;
 
     if (m_settings->GetSettings()->spanZonesAcrossMonitors)
@@ -1293,7 +1293,7 @@ bool FancyZones::ProcessDirectedSnapHotkey(HWND window, DWORD vkCode, bool cycle
 
 void FancyZones::RegisterVirtualDesktopUpdates(std::vector<GUID>& ids) noexcept
 {
-    _TRACER_
+    _TRACER_;
     std::unique_lock writeLock(m_lock);
 
     m_workAreaHandler.RegisterUpdates(ids);
@@ -1379,7 +1379,7 @@ std::vector<HMONITOR> FancyZones::GetMonitorsSorted() noexcept
 
 std::vector<std::pair<HMONITOR, RECT>> FancyZones::GetRawMonitorData() noexcept
 {
-    _TRACER_
+    _TRACER_;
     std::shared_lock readLock(m_lock);
 
     std::vector<std::pair<HMONITOR, RECT>> monitorInfo;

--- a/src/modules/fancyzones/lib/FancyZonesData.cpp
+++ b/src/modules/fancyzones/lib/FancyZonesData.cpp
@@ -4,6 +4,7 @@
 #include "JsonHelpers.h"
 #include "ZoneSet.h"
 #include "Settings.h"
+#include "CallTracer.h"
 
 #include <common/utils/json.h>
 #include <fancyzones/lib/util.h>
@@ -155,6 +156,7 @@ FancyZonesData::FancyZonesData()
 
 std::optional<FancyZonesDataTypes::DeviceInfoData> FancyZonesData::FindDeviceInfo(const std::wstring& zoneWindowId) const
 {
+    CallTracer callTracer(__FUNCTION__);
     std::scoped_lock lock{ dataLock };
     auto it = deviceInfoMap.find(zoneWindowId);
     return it != end(deviceInfoMap) ? std::optional{ it->second } : std::nullopt;
@@ -162,6 +164,7 @@ std::optional<FancyZonesDataTypes::DeviceInfoData> FancyZonesData::FindDeviceInf
 
 std::optional<FancyZonesDataTypes::CustomZoneSetData> FancyZonesData::FindCustomZoneSet(const std::wstring& guid) const
 {
+    CallTracer callTracer(__FUNCTION__);
     std::scoped_lock lock{ dataLock };
     auto it = customZoneSetsMap.find(guid);
     return it != end(customZoneSetsMap) ? std::optional{ it->second } : std::nullopt;
@@ -169,6 +172,7 @@ std::optional<FancyZonesDataTypes::CustomZoneSetData> FancyZonesData::FindCustom
 
 bool FancyZonesData::AddDevice(const std::wstring& deviceId)
 {
+    CallTracer callTracer(__FUNCTION__);
     using namespace FancyZonesDataTypes;
 
     std::scoped_lock lock{ dataLock };
@@ -197,6 +201,7 @@ bool FancyZonesData::AddDevice(const std::wstring& deviceId)
 
 void FancyZonesData::CloneDeviceInfo(const std::wstring& source, const std::wstring& destination)
 {
+    CallTracer callTracer(__FUNCTION__);
     if (source == destination)
     {
         return;
@@ -214,6 +219,7 @@ void FancyZonesData::CloneDeviceInfo(const std::wstring& source, const std::wstr
 
 void FancyZonesData::UpdatePrimaryDesktopData(const std::wstring& desktopId)
 {
+    CallTracer callTracer(__FUNCTION__);
     // Explorer persists current virtual desktop identifier to registry on a per session basis,
     // but only after first virtual desktop switch happens. If the user hasn't switched virtual
     // desktops in this session value in registry will be empty and we will use default GUID in
@@ -266,6 +272,7 @@ void FancyZonesData::UpdatePrimaryDesktopData(const std::wstring& desktopId)
 
 void FancyZonesData::RemoveDeletedDesktops(const std::vector<std::wstring>& activeDesktops)
 {
+    CallTracer callTracer(__FUNCTION__);
     std::unordered_set<std::wstring> active(std::begin(activeDesktops), std::end(activeDesktops));
     std::scoped_lock lock{ dataLock };
     bool dirtyFlag = false;
@@ -295,6 +302,7 @@ void FancyZonesData::RemoveDeletedDesktops(const std::vector<std::wstring>& acti
 
 bool FancyZonesData::IsAnotherWindowOfApplicationInstanceZoned(HWND window, const std::wstring_view& deviceId) const
 {
+    CallTracer callTracer(__FUNCTION__);
     std::scoped_lock lock{ dataLock };
     auto processPath = get_process_path(window);
     if (!processPath.empty())
@@ -330,6 +338,7 @@ bool FancyZonesData::IsAnotherWindowOfApplicationInstanceZoned(HWND window, cons
 
 void FancyZonesData::UpdateProcessIdToHandleMap(HWND window, const std::wstring_view& deviceId)
 {
+    CallTracer callTracer(__FUNCTION__);
     std::scoped_lock lock{ dataLock };
     auto processPath = get_process_path(window);
     if (!processPath.empty())
@@ -354,6 +363,7 @@ void FancyZonesData::UpdateProcessIdToHandleMap(HWND window, const std::wstring_
 
 std::vector<size_t> FancyZonesData::GetAppLastZoneIndexSet(HWND window, const std::wstring_view& deviceId, const std::wstring_view& zoneSetId) const
 {
+    CallTracer callTracer(__FUNCTION__);
     std::scoped_lock lock{ dataLock };
     auto processPath = get_process_path(window);
     if (!processPath.empty())
@@ -377,6 +387,7 @@ std::vector<size_t> FancyZonesData::GetAppLastZoneIndexSet(HWND window, const st
 
 bool FancyZonesData::RemoveAppLastZone(HWND window, const std::wstring_view& deviceId, const std::wstring_view& zoneSetId)
 {
+    CallTracer callTracer(__FUNCTION__);
     std::scoped_lock lock{ dataLock };
     auto processPath = get_process_path(window);
     if (!processPath.empty())
@@ -429,6 +440,7 @@ bool FancyZonesData::RemoveAppLastZone(HWND window, const std::wstring_view& dev
 
 bool FancyZonesData::SetAppLastZones(HWND window, const std::wstring& deviceId, const std::wstring& zoneSetId, const std::vector<size_t>& zoneIndexSet)
 {
+    CallTracer callTracer(__FUNCTION__);
     std::scoped_lock lock{ dataLock };
 
     if (IsAnotherWindowOfApplicationInstanceZoned(window, deviceId))
@@ -487,6 +499,7 @@ bool FancyZonesData::SetAppLastZones(HWND window, const std::wstring& deviceId, 
 
 void FancyZonesData::SetActiveZoneSet(const std::wstring& deviceId, const FancyZonesDataTypes::ZoneSetData& data)
 {
+    CallTracer callTracer(__FUNCTION__);
     std::scoped_lock lock{ dataLock };
     auto it = deviceInfoMap.find(deviceId);
     if (it != deviceInfoMap.end())
@@ -524,14 +537,14 @@ void FancyZonesData::SaveAppZoneHistoryAndZoneSettings() const
 
 void FancyZonesData::SaveZoneSettings() const
 {
-    Logger::trace("FancyZonesData::SaveZoneSettings()");
+    CallTracer callTracer(__FUNCTION__);
     std::scoped_lock lock{ dataLock };
     JSONHelpers::SaveZoneSettings(zonesSettingsFileName, deviceInfoMap, customZoneSetsMap);
 }
 
 void FancyZonesData::SaveAppZoneHistory() const
 {
-    Logger::trace("FancyZonesData::SaveAppZoneHistory()");
+    CallTracer callTracer(__FUNCTION__);
     std::scoped_lock lock{ dataLock };
     JSONHelpers::SaveAppZoneHistory(appZoneHistoryFileName, appZoneHistoryMap);
 }

--- a/src/modules/fancyzones/lib/FancyZonesData.cpp
+++ b/src/modules/fancyzones/lib/FancyZonesData.cpp
@@ -154,6 +154,27 @@ FancyZonesData::FancyZonesData()
     editorParametersFileName = saveFolderPath + L"\\" + std::wstring(NonLocalizable::FancyZonesEditorParametersFile);
 }
 
+const JSONHelpers::TDeviceInfoMap& FancyZonesData::GetDeviceInfoMap() const
+{
+    CallTracer callTracer(__FUNCTION__);
+    std::scoped_lock lock{ dataLock };
+    return deviceInfoMap;
+}
+
+const JSONHelpers::TCustomZoneSetsMap& FancyZonesData::GetCustomZoneSetsMap() const
+{
+    CallTracer callTracer(__FUNCTION__);
+    std::scoped_lock lock{ dataLock };
+    return customZoneSetsMap;
+}
+
+const std::unordered_map<std::wstring, std::vector<FancyZonesDataTypes::AppZoneHistoryData>>& FancyZonesData::GetAppZoneHistoryMap() const
+{
+    CallTracer callTracer(__FUNCTION__);
+    std::scoped_lock lock{ dataLock };
+    return appZoneHistoryMap;
+}
+
 std::optional<FancyZonesDataTypes::DeviceInfoData> FancyZonesData::FindDeviceInfo(const std::wstring& zoneWindowId) const
 {
     CallTracer callTracer(__FUNCTION__);

--- a/src/modules/fancyzones/lib/FancyZonesData.cpp
+++ b/src/modules/fancyzones/lib/FancyZonesData.cpp
@@ -188,7 +188,7 @@ std::optional<FancyZonesDataTypes::CustomZoneSetData> FancyZonesData::FindCustom
 
 bool FancyZonesData::AddDevice(const std::wstring& deviceId)
 {
-    _TRACER_
+    _TRACER_;
     using namespace FancyZonesDataTypes;
 
     std::scoped_lock lock{ dataLock };
@@ -234,7 +234,7 @@ void FancyZonesData::CloneDeviceInfo(const std::wstring& source, const std::wstr
 
 void FancyZonesData::UpdatePrimaryDesktopData(const std::wstring& desktopId)
 {
-    _TRACER_
+    _TRACER_;
     // Explorer persists current virtual desktop identifier to registry on a per session basis,
     // but only after first virtual desktop switch happens. If the user hasn't switched virtual
     // desktops in this session value in registry will be empty and we will use default GUID in
@@ -398,7 +398,7 @@ std::vector<size_t> FancyZonesData::GetAppLastZoneIndexSet(HWND window, const st
 
 bool FancyZonesData::RemoveAppLastZone(HWND window, const std::wstring_view& deviceId, const std::wstring_view& zoneSetId)
 {
-    _TRACER_
+    _TRACER_;
     std::scoped_lock lock{ dataLock };
     auto processPath = get_process_path(window);
     if (!processPath.empty())
@@ -451,7 +451,7 @@ bool FancyZonesData::RemoveAppLastZone(HWND window, const std::wstring_view& dev
 
 bool FancyZonesData::SetAppLastZones(HWND window, const std::wstring& deviceId, const std::wstring& zoneSetId, const std::vector<size_t>& zoneIndexSet)
 {
-    _TRACER_
+    _TRACER_;
     std::scoped_lock lock{ dataLock };
 
     if (IsAnotherWindowOfApplicationInstanceZoned(window, deviceId))
@@ -547,14 +547,14 @@ void FancyZonesData::SaveAppZoneHistoryAndZoneSettings() const
 
 void FancyZonesData::SaveZoneSettings() const
 {
-    _TRACER_
+    _TRACER_;
     std::scoped_lock lock{ dataLock };
     JSONHelpers::SaveZoneSettings(zonesSettingsFileName, deviceInfoMap, customZoneSetsMap);
 }
 
 void FancyZonesData::SaveAppZoneHistory() const
 {
-    _TRACER_
+    _TRACER_;
     std::scoped_lock lock{ dataLock };
     JSONHelpers::SaveAppZoneHistory(appZoneHistoryFileName, appZoneHistoryMap);
 }

--- a/src/modules/fancyzones/lib/FancyZonesData.cpp
+++ b/src/modules/fancyzones/lib/FancyZonesData.cpp
@@ -156,28 +156,24 @@ FancyZonesData::FancyZonesData()
 
 const JSONHelpers::TDeviceInfoMap& FancyZonesData::GetDeviceInfoMap() const
 {
-    CallTracer callTracer(__FUNCTION__);
     std::scoped_lock lock{ dataLock };
     return deviceInfoMap;
 }
 
 const JSONHelpers::TCustomZoneSetsMap& FancyZonesData::GetCustomZoneSetsMap() const
 {
-    CallTracer callTracer(__FUNCTION__);
     std::scoped_lock lock{ dataLock };
     return customZoneSetsMap;
 }
 
 const std::unordered_map<std::wstring, std::vector<FancyZonesDataTypes::AppZoneHistoryData>>& FancyZonesData::GetAppZoneHistoryMap() const
 {
-    CallTracer callTracer(__FUNCTION__);
     std::scoped_lock lock{ dataLock };
     return appZoneHistoryMap;
 }
 
 std::optional<FancyZonesDataTypes::DeviceInfoData> FancyZonesData::FindDeviceInfo(const std::wstring& zoneWindowId) const
 {
-    CallTracer callTracer(__FUNCTION__);
     std::scoped_lock lock{ dataLock };
     auto it = deviceInfoMap.find(zoneWindowId);
     return it != end(deviceInfoMap) ? std::optional{ it->second } : std::nullopt;
@@ -185,7 +181,6 @@ std::optional<FancyZonesDataTypes::DeviceInfoData> FancyZonesData::FindDeviceInf
 
 std::optional<FancyZonesDataTypes::CustomZoneSetData> FancyZonesData::FindCustomZoneSet(const std::wstring& guid) const
 {
-    CallTracer callTracer(__FUNCTION__);
     std::scoped_lock lock{ dataLock };
     auto it = customZoneSetsMap.find(guid);
     return it != end(customZoneSetsMap) ? std::optional{ it->second } : std::nullopt;
@@ -193,7 +188,7 @@ std::optional<FancyZonesDataTypes::CustomZoneSetData> FancyZonesData::FindCustom
 
 bool FancyZonesData::AddDevice(const std::wstring& deviceId)
 {
-    CallTracer callTracer(__FUNCTION__);
+    _TRACER_
     using namespace FancyZonesDataTypes;
 
     std::scoped_lock lock{ dataLock };
@@ -222,7 +217,6 @@ bool FancyZonesData::AddDevice(const std::wstring& deviceId)
 
 void FancyZonesData::CloneDeviceInfo(const std::wstring& source, const std::wstring& destination)
 {
-    CallTracer callTracer(__FUNCTION__);
     if (source == destination)
     {
         return;
@@ -240,7 +234,7 @@ void FancyZonesData::CloneDeviceInfo(const std::wstring& source, const std::wstr
 
 void FancyZonesData::UpdatePrimaryDesktopData(const std::wstring& desktopId)
 {
-    CallTracer callTracer(__FUNCTION__);
+    _TRACER_
     // Explorer persists current virtual desktop identifier to registry on a per session basis,
     // but only after first virtual desktop switch happens. If the user hasn't switched virtual
     // desktops in this session value in registry will be empty and we will use default GUID in
@@ -293,7 +287,6 @@ void FancyZonesData::UpdatePrimaryDesktopData(const std::wstring& desktopId)
 
 void FancyZonesData::RemoveDeletedDesktops(const std::vector<std::wstring>& activeDesktops)
 {
-    CallTracer callTracer(__FUNCTION__);
     std::unordered_set<std::wstring> active(std::begin(activeDesktops), std::end(activeDesktops));
     std::scoped_lock lock{ dataLock };
     bool dirtyFlag = false;
@@ -323,7 +316,6 @@ void FancyZonesData::RemoveDeletedDesktops(const std::vector<std::wstring>& acti
 
 bool FancyZonesData::IsAnotherWindowOfApplicationInstanceZoned(HWND window, const std::wstring_view& deviceId) const
 {
-    CallTracer callTracer(__FUNCTION__);
     std::scoped_lock lock{ dataLock };
     auto processPath = get_process_path(window);
     if (!processPath.empty())
@@ -359,7 +351,6 @@ bool FancyZonesData::IsAnotherWindowOfApplicationInstanceZoned(HWND window, cons
 
 void FancyZonesData::UpdateProcessIdToHandleMap(HWND window, const std::wstring_view& deviceId)
 {
-    CallTracer callTracer(__FUNCTION__);
     std::scoped_lock lock{ dataLock };
     auto processPath = get_process_path(window);
     if (!processPath.empty())
@@ -384,7 +375,6 @@ void FancyZonesData::UpdateProcessIdToHandleMap(HWND window, const std::wstring_
 
 std::vector<size_t> FancyZonesData::GetAppLastZoneIndexSet(HWND window, const std::wstring_view& deviceId, const std::wstring_view& zoneSetId) const
 {
-    CallTracer callTracer(__FUNCTION__);
     std::scoped_lock lock{ dataLock };
     auto processPath = get_process_path(window);
     if (!processPath.empty())
@@ -408,7 +398,7 @@ std::vector<size_t> FancyZonesData::GetAppLastZoneIndexSet(HWND window, const st
 
 bool FancyZonesData::RemoveAppLastZone(HWND window, const std::wstring_view& deviceId, const std::wstring_view& zoneSetId)
 {
-    CallTracer callTracer(__FUNCTION__);
+    _TRACER_
     std::scoped_lock lock{ dataLock };
     auto processPath = get_process_path(window);
     if (!processPath.empty())
@@ -461,7 +451,7 @@ bool FancyZonesData::RemoveAppLastZone(HWND window, const std::wstring_view& dev
 
 bool FancyZonesData::SetAppLastZones(HWND window, const std::wstring& deviceId, const std::wstring& zoneSetId, const std::vector<size_t>& zoneIndexSet)
 {
-    CallTracer callTracer(__FUNCTION__);
+    _TRACER_
     std::scoped_lock lock{ dataLock };
 
     if (IsAnotherWindowOfApplicationInstanceZoned(window, deviceId))
@@ -520,7 +510,6 @@ bool FancyZonesData::SetAppLastZones(HWND window, const std::wstring& deviceId, 
 
 void FancyZonesData::SetActiveZoneSet(const std::wstring& deviceId, const FancyZonesDataTypes::ZoneSetData& data)
 {
-    CallTracer callTracer(__FUNCTION__);
     std::scoped_lock lock{ dataLock };
     auto it = deviceInfoMap.find(deviceId);
     if (it != deviceInfoMap.end())
@@ -558,14 +547,14 @@ void FancyZonesData::SaveAppZoneHistoryAndZoneSettings() const
 
 void FancyZonesData::SaveZoneSettings() const
 {
-    CallTracer callTracer(__FUNCTION__);
+    _TRACER_
     std::scoped_lock lock{ dataLock };
     JSONHelpers::SaveZoneSettings(zonesSettingsFileName, deviceInfoMap, customZoneSetsMap);
 }
 
 void FancyZonesData::SaveAppZoneHistory() const
 {
-    CallTracer callTracer(__FUNCTION__);
+    _TRACER_
     std::scoped_lock lock{ dataLock };
     JSONHelpers::SaveAppZoneHistory(appZoneHistoryFileName, appZoneHistoryMap);
 }

--- a/src/modules/fancyzones/lib/FancyZonesData.h
+++ b/src/modules/fancyzones/lib/FancyZonesData.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "JsonHelpers.h"
+#include "CallTracer.h"
 
 #include <common/SettingsAPI/settings_helpers.h>
 #include <common/utils/json.h>
@@ -44,18 +45,21 @@ public:
 
     inline const JSONHelpers::TDeviceInfoMap & GetDeviceInfoMap() const
     {
+        CallTracer callTracer(__FUNCTION__);
         std::scoped_lock lock{ dataLock };
         return deviceInfoMap;
     }
 
     inline const JSONHelpers::TCustomZoneSetsMap & GetCustomZoneSetsMap() const
     {
+        CallTracer callTracer(__FUNCTION__);
         std::scoped_lock lock{ dataLock };
         return customZoneSetsMap;
     }
 
     inline const std::unordered_map<std::wstring, std::vector<FancyZonesDataTypes::AppZoneHistoryData>>& GetAppZoneHistoryMap() const
     {
+        CallTracer callTracer(__FUNCTION__);
         std::scoped_lock lock{ dataLock };
         return appZoneHistoryMap;
     }

--- a/src/modules/fancyzones/lib/FancyZonesData.h
+++ b/src/modules/fancyzones/lib/FancyZonesData.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "JsonHelpers.h"
-#include "CallTracer.h"
 
 #include <common/SettingsAPI/settings_helpers.h>
 #include <common/utils/json.h>
@@ -43,26 +42,11 @@ public:
 
     std::optional<FancyZonesDataTypes::CustomZoneSetData> FindCustomZoneSet(const std::wstring& guid) const;
 
-    inline const JSONHelpers::TDeviceInfoMap & GetDeviceInfoMap() const
-    {
-        CallTracer callTracer(__FUNCTION__);
-        std::scoped_lock lock{ dataLock };
-        return deviceInfoMap;
-    }
+    const JSONHelpers::TDeviceInfoMap& GetDeviceInfoMap() const;
 
-    inline const JSONHelpers::TCustomZoneSetsMap & GetCustomZoneSetsMap() const
-    {
-        CallTracer callTracer(__FUNCTION__);
-        std::scoped_lock lock{ dataLock };
-        return customZoneSetsMap;
-    }
+    const JSONHelpers::TCustomZoneSetsMap& GetCustomZoneSetsMap() const;
 
-    inline const std::unordered_map<std::wstring, std::vector<FancyZonesDataTypes::AppZoneHistoryData>>& GetAppZoneHistoryMap() const
-    {
-        CallTracer callTracer(__FUNCTION__);
-        std::scoped_lock lock{ dataLock };
-        return appZoneHistoryMap;
-    }
+    const std::unordered_map<std::wstring, std::vector<FancyZonesDataTypes::AppZoneHistoryData>>& GetAppZoneHistoryMap() const;
 
     inline const std::wstring& GetZonesSettingsFileName() const 
     {

--- a/src/modules/fancyzones/lib/FancyZonesLib.vcxproj
+++ b/src/modules/fancyzones/lib/FancyZonesLib.vcxproj
@@ -37,6 +37,7 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="CallTracer.h" />
     <ClInclude Include="FancyZones.h" />
     <ClInclude Include="FancyZonesDataTypes.h" />
     <ClInclude Include="FancyZonesWinHookEventIDs.h" />
@@ -61,6 +62,7 @@
     <ClInclude Include="ZoneWindowDrawing.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="CallTracer.cpp" />
     <ClCompile Include="FancyZones.cpp" />
     <ClCompile Include="FancyZonesDataTypes.cpp" />
     <ClCompile Include="FancyZonesWinHookEventIDs.cpp" />

--- a/src/modules/fancyzones/lib/FancyZonesLib.vcxproj.filters
+++ b/src/modules/fancyzones/lib/FancyZonesLib.vcxproj.filters
@@ -81,6 +81,9 @@
     <ClInclude Include="FileWatcher.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="CallTracer.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp">
@@ -138,6 +141,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="FileWatcher.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="CallTracer.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/modules/fancyzones/lib/OnThreadExecutor.cpp
+++ b/src/modules/fancyzones/lib/OnThreadExecutor.cpp
@@ -10,7 +10,6 @@ OnThreadExecutor::OnThreadExecutor() :
 
 std::future<void> OnThreadExecutor::submit(task_t task)
 {
-    CallTracer callTracer(__FUNCTION__);
     auto future = task.get_future();
     std::lock_guard lock{ _task_mutex };
     _task_queue.emplace(std::move(task));
@@ -20,7 +19,6 @@ std::future<void> OnThreadExecutor::submit(task_t task)
 
 void OnThreadExecutor::cancel()
 {
-    CallTracer callTracer(__FUNCTION__);
     std::lock_guard lock{ _task_mutex };
     _task_queue = {};
     _task_cv.notify_one();

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -42,7 +42,7 @@ namespace
 
         HWND ExtractWindow()
         {
-            _TRACER_
+            _TRACER_;
             std::unique_lock lock(m_mutex);
 
             if (m_pool.empty())
@@ -82,7 +82,7 @@ namespace
 
         void FreeZoneWindow(HWND window)
         {
-            _TRACER_
+            _TRACER_;
             Logger::info("Freeing zone window, hWnd = {}", (void*)window);
             SetWindowLongPtrW(window, GWLP_USERDATA, 0);
             ShowWindow(window, SW_HIDE);

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -42,7 +42,7 @@ namespace
 
         HWND ExtractWindow()
         {
-            CallTracer callTracer(__FUNCTION__);
+            _TRACER_
             std::unique_lock lock(m_mutex);
 
             if (m_pool.empty())
@@ -82,7 +82,7 @@ namespace
 
         void FreeZoneWindow(HWND window)
         {
-            CallTracer callTracer(__FUNCTION__);
+            _TRACER_
             Logger::info("Freeing zone window, hWnd = {}", (void*)window);
             SetWindowLongPtrW(window, GWLP_USERDATA, 0);
             ShowWindow(window, SW_HIDE);

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -10,6 +10,7 @@
 #include "util.h"
 #include "on_thread_executor.h"
 #include "Settings.h"
+#include "CallTracer.h"
 
 #include <ShellScalingApi.h>
 #include <mutex>
@@ -41,6 +42,7 @@ namespace
 
         HWND ExtractWindow()
         {
+            CallTracer callTracer(__FUNCTION__);
             std::unique_lock lock(m_mutex);
 
             if (m_pool.empty())
@@ -80,6 +82,7 @@ namespace
 
         void FreeZoneWindow(HWND window)
         {
+            CallTracer callTracer(__FUNCTION__);
             Logger::info("Freeing zone window, hWnd = {}", (void*)window);
             SetWindowLongPtrW(window, GWLP_USERDATA, 0);
             ShowWindow(window, SW_HIDE);

--- a/src/modules/fancyzones/lib/ZoneWindowDrawing.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindowDrawing.cpp
@@ -103,7 +103,6 @@ ZoneWindowDrawing::ZoneWindowDrawing(HWND window)
     m_renderThread = std::thread([this]() {
         while (!m_abortThread)
         {
-            CallTracer callTracer(__FUNCTION__ "(renderLoop)");
             // Force repeated rendering while in the animation loop.
             // Yield if low latency locking was requested
             if (!m_lowLatencyLock)
@@ -127,7 +126,6 @@ ZoneWindowDrawing::ZoneWindowDrawing(HWND window)
 
 void ZoneWindowDrawing::Render()
 {
-    CallTracer callTracer(__FUNCTION__);
     std::unique_lock lock(m_mutex);
 
     if (!m_renderTarget)
@@ -205,7 +203,7 @@ void ZoneWindowDrawing::Render()
 
 void ZoneWindowDrawing::Hide()
 {
-    CallTracer callTracer(__FUNCTION__);
+    _TRACER_
     m_lowLatencyLock = true;
     std::unique_lock lock(m_mutex);
     m_lowLatencyLock = false;
@@ -219,7 +217,7 @@ void ZoneWindowDrawing::Hide()
 
 void ZoneWindowDrawing::Show(unsigned animationMillis)
 {
-    CallTracer callTracer(__FUNCTION__);
+    _TRACER_
     m_lowLatencyLock = true;
     std::unique_lock lock(m_mutex);
     m_lowLatencyLock = false;
@@ -240,7 +238,7 @@ void ZoneWindowDrawing::DrawActiveZoneSet(const IZoneSet::ZonesMap& zones,
                        const std::vector<size_t>& highlightZones,
                        winrt::com_ptr<IZoneWindowHost> host)
 {
-    CallTracer callTracer(__FUNCTION__);
+    _TRACER_
     m_lowLatencyLock = true;
     std::unique_lock lock(m_mutex);
     m_lowLatencyLock = false;
@@ -308,7 +306,6 @@ void ZoneWindowDrawing::DrawActiveZoneSet(const IZoneSet::ZonesMap& zones,
 
 void ZoneWindowDrawing::ForceRender()
 {
-    CallTracer callTracer(__FUNCTION__);
     m_lowLatencyLock = true;
     std::unique_lock lock(m_mutex);
     m_lowLatencyLock = false;
@@ -318,7 +315,6 @@ void ZoneWindowDrawing::ForceRender()
 
 ZoneWindowDrawing::~ZoneWindowDrawing()
 {
-    CallTracer callTracer(__FUNCTION__);
     {
         std::unique_lock lock(m_mutex);
         m_abortThread = true;

--- a/src/modules/fancyzones/lib/ZoneWindowDrawing.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindowDrawing.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include "ZoneWindowDrawing.h"
+#include "CallTracer.h"
 
 #include <algorithm>
 #include <map>
@@ -102,6 +103,7 @@ ZoneWindowDrawing::ZoneWindowDrawing(HWND window)
     m_renderThread = std::thread([this]() {
         while (!m_abortThread)
         {
+            CallTracer callTracer(__FUNCTION__ "(renderLoop)");
             // Force repeated rendering while in the animation loop.
             // Yield if low latency locking was requested
             if (!m_lowLatencyLock)
@@ -125,6 +127,7 @@ ZoneWindowDrawing::ZoneWindowDrawing(HWND window)
 
 void ZoneWindowDrawing::Render()
 {
+    CallTracer callTracer(__FUNCTION__);
     std::unique_lock lock(m_mutex);
 
     if (!m_renderTarget)
@@ -202,6 +205,7 @@ void ZoneWindowDrawing::Render()
 
 void ZoneWindowDrawing::Hide()
 {
+    CallTracer callTracer(__FUNCTION__);
     m_lowLatencyLock = true;
     std::unique_lock lock(m_mutex);
     m_lowLatencyLock = false;
@@ -215,6 +219,7 @@ void ZoneWindowDrawing::Hide()
 
 void ZoneWindowDrawing::Show(unsigned animationMillis)
 {
+    CallTracer callTracer(__FUNCTION__);
     m_lowLatencyLock = true;
     std::unique_lock lock(m_mutex);
     m_lowLatencyLock = false;
@@ -235,6 +240,7 @@ void ZoneWindowDrawing::DrawActiveZoneSet(const IZoneSet::ZonesMap& zones,
                        const std::vector<size_t>& highlightZones,
                        winrt::com_ptr<IZoneWindowHost> host)
 {
+    CallTracer callTracer(__FUNCTION__);
     m_lowLatencyLock = true;
     std::unique_lock lock(m_mutex);
     m_lowLatencyLock = false;
@@ -302,6 +308,7 @@ void ZoneWindowDrawing::DrawActiveZoneSet(const IZoneSet::ZonesMap& zones,
 
 void ZoneWindowDrawing::ForceRender()
 {
+    CallTracer callTracer(__FUNCTION__);
     m_lowLatencyLock = true;
     std::unique_lock lock(m_mutex);
     m_lowLatencyLock = false;
@@ -311,6 +318,7 @@ void ZoneWindowDrawing::ForceRender()
 
 ZoneWindowDrawing::~ZoneWindowDrawing()
 {
+    CallTracer callTracer(__FUNCTION__);
     {
         std::unique_lock lock(m_mutex);
         m_abortThread = true;

--- a/src/modules/fancyzones/lib/ZoneWindowDrawing.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindowDrawing.cpp
@@ -203,7 +203,7 @@ void ZoneWindowDrawing::Render()
 
 void ZoneWindowDrawing::Hide()
 {
-    _TRACER_
+    _TRACER_;
     m_lowLatencyLock = true;
     std::unique_lock lock(m_mutex);
     m_lowLatencyLock = false;
@@ -217,7 +217,7 @@ void ZoneWindowDrawing::Hide()
 
 void ZoneWindowDrawing::Show(unsigned animationMillis)
 {
-    _TRACER_
+    _TRACER_;
     m_lowLatencyLock = true;
     std::unique_lock lock(m_mutex);
     m_lowLatencyLock = false;
@@ -238,7 +238,7 @@ void ZoneWindowDrawing::DrawActiveZoneSet(const IZoneSet::ZonesMap& zones,
                        const std::vector<size_t>& highlightZones,
                        winrt::com_ptr<IZoneWindowHost> host)
 {
-    _TRACER_
+    _TRACER_;
     m_lowLatencyLock = true;
     std::unique_lock lock(m_mutex);
     m_lowLatencyLock = false;


### PR DESCRIPTION
## Summary of the Pull Request

Due to a bug, FancyZones sometimes hangs. We think this is because of a deadlock, so this PR adds trace logging to function calls which use synchronization.

**What is include in the PR:** 

A new class CallTracer which logs construction and destruction of its instances. Objects of this class are then placed into various functions, allowing us to see which function calls are happening.

Perhaps we should also log the thread ID?

**How does someone test / validate:** 

Run PowerToys with logging level set to Trace, and look at the logs.

## Quality Checklist

- [x] **Linked issue:** #9853 
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
