### PR TITLE
Update PowerToys Run page on settings.json change

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/PowerLauncherViewModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/PowerLauncherViewModel.cs
@@ -135,7 +135,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
                     GeneralSettingsConfig.Enabled.PowerLauncher = value;
                     OnPropertyChanged(nameof(EnablePowerLauncher));
                     OnPropertyChanged(nameof(ShowAllPluginsDisabledWarning));
-                    OnPropertyChanged(nameof(ShowPluginsLoadingWarning));
+                    OnPropertyChanged(nameof(ShowPluginsLoadingMessage));
                     OutGoingGeneralSettings outgoing = new OutGoingGeneralSettings(GeneralSettingsConfig);
                     SendConfigMSG(outgoing.ToString());
                 }
@@ -449,7 +449,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             get => EnablePowerLauncher && Plugins.Any() && Plugins.All(x => x.Disabled);
         }
 
-        public bool ShowPluginsLoadingWarning
+        public bool ShowPluginsLoadingMessage
         {
             get => EnablePowerLauncher && !Plugins.Any();
         }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/PowerLauncherViewModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/PowerLauncherViewModel.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Globalization;
@@ -28,8 +27,6 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
 
         private GeneralSettings GeneralSettingsConfig { get; set; }
 
-        private readonly ISettingsUtils _settingsUtils;
-
         private PowerLauncherSettings settings;
 
         public delegate void SendCallback(PowerLauncherSettings settings);
@@ -40,9 +37,14 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
 
         private Func<string, int> SendConfigMSG { get; }
 
-        public PowerLauncherViewModel(ISettingsUtils settingsUtils, ISettingsRepository<GeneralSettings> settingsRepository, Func<string, int> ipcMSGCallBackFunc, int defaultKeyCode, Func<bool> isDark)
+        public PowerLauncherViewModel(PowerLauncherSettings settings, ISettingsRepository<GeneralSettings> settingsRepository, Func<string, int> ipcMSGCallBackFunc, Func<bool> isDark)
         {
-            _settingsUtils = settingsUtils ?? throw new ArgumentNullException(nameof(settingsUtils));
+            if (settings == null)
+            {
+                throw new ArgumentException("settings argument can not be null");
+            }
+
+            this.settings = settings;
             this.isDark = isDark;
 
             // To obtain the general Settings configurations of PowerToys
@@ -55,7 +57,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
 
             // set the callback functions value to hangle outgoing IPC message.
             SendConfigMSG = ipcMSGCallBackFunc;
-            callback = (PowerLauncherSettings settings) =>
+            callback = (PowerLauncherSettings s) =>
             {
                 // Propagate changes to Power Launcher through IPC
                 // Using InvariantCulture as this is an IPC message
@@ -64,21 +66,8 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
                         CultureInfo.InvariantCulture,
                         "{{ \"powertoys\": {{ \"{0}\": {1} }} }}",
                         PowerLauncherSettings.ModuleName,
-                        JsonSerializer.Serialize(settings)));
+                        JsonSerializer.Serialize(s)));
             };
-
-            if (_settingsUtils.SettingsExists(PowerLauncherSettings.ModuleName))
-            {
-                settings = _settingsUtils.GetSettingsOrDefault<PowerLauncherSettings>(PowerLauncherSettings.ModuleName);
-            }
-            else
-            {
-                settings = new PowerLauncherSettings();
-                settings.Properties.OpenPowerLauncher.Alt = true;
-                settings.Properties.OpenPowerLauncher.Code = defaultKeyCode;
-                settings.Properties.MaximumNumberOfResults = 4;
-                callback(settings);
-            }
 
             switch (settings.Properties.Theme)
             {
@@ -146,6 +135,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
                     GeneralSettingsConfig.Enabled.PowerLauncher = value;
                     OnPropertyChanged(nameof(EnablePowerLauncher));
                     OnPropertyChanged(nameof(ShowAllPluginsDisabledWarning));
+                    OnPropertyChanged(nameof(ShowPluginsLoadingWarning));
                     OutGoingGeneralSettings outgoing = new OutGoingGeneralSettings(GeneralSettingsConfig);
                     SendConfigMSG(outgoing.ToString());
                 }
@@ -456,7 +446,12 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
 
         public bool ShowAllPluginsDisabledWarning
         {
-            get => EnablePowerLauncher && Plugins.All(x => x.Disabled);
+            get => EnablePowerLauncher && Plugins.Any() && Plugins.All(x => x.Disabled);
+        }
+
+        public bool ShowPluginsLoadingWarning
+        {
+            get => EnablePowerLauncher && !Plugins.Any();
         }
     }
 }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.UnitTests/ViewModelTests/PowerLauncherViewModelTest.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.UnitTests/ViewModelTests/PowerLauncherViewModelTest.cs
@@ -66,7 +66,7 @@ namespace ViewModelTests
 
             // Initialise View Model with test Config files
             Func<string, int> sendMockIPCConfigMSG = msg => { return 0; };
-            PowerLauncherViewModel viewModel = new PowerLauncherViewModel(mockSettingsUtils, generalSettingsRepository, sendMockIPCConfigMSG, 32, () => true);
+            PowerLauncherViewModel viewModel = new PowerLauncherViewModel(originalSettings, generalSettingsRepository, sendMockIPCConfigMSG, () => true);
 
             // Verify that the old settings persisted
             Assert.AreEqual(originalGeneralSettings.Enabled.PowerLauncher, viewModel.EnablePowerLauncher);
@@ -82,7 +82,6 @@ namespace ViewModelTests
 
             // Verify that the stub file was used
             var expectedCallCount = 2;  // once via the view model, and once by the test (GetSettings<T>)
-            BackCompatTestProperties.VerifyModuleIOProviderWasRead(mockIOProvider, PowerLauncherSettings.ModuleName, expectedCallCount);
             BackCompatTestProperties.VerifyGeneralSettingsIOProviderWasRead(mockGeneralIOProvider, expectedCallCount);
         }
 

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -1167,4 +1167,7 @@ Win + Shift + O to toggle your video</value>
   <data name="Run_Radio_Position_Primary_Monitor.Content" xml:space="preserve">
     <value>Primary monitor</value>
   </data>
+  <data name="Run_PluginsLoading.Text" xml:space="preserve">
+    <value>Plugins are loading...</value>
+  </data>
 </root>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
@@ -212,6 +212,12 @@
                        TextWrapping="Wrap"
                        Margin="{StaticResource SmallTopMargin}"/>
 
+            <TextBlock x:Uid="Run_PluginsLoading"
+                       Foreground="{ThemeResource SystemControlErrorTextForegroundBrush}"
+                       Visibility="{x:Bind ViewModel.ShowPluginsLoadingWarning, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
+                       TextWrapping="Wrap"
+                       Margin="{StaticResource SmallTopMargin}"/>
+
             <ListView ItemsSource="{x:Bind Path=ViewModel.Plugins, Mode=OneWay}"                
                       IsItemClickEnabled="True"
                       SelectionChanged="PluginsListView_SelectionChanged"

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
@@ -213,8 +213,7 @@
                        Margin="{StaticResource SmallTopMargin}"/>
 
             <TextBlock x:Uid="Run_PluginsLoading"
-                       Foreground="{ThemeResource SystemControlErrorTextForegroundBrush}"
-                       Visibility="{x:Bind ViewModel.ShowPluginsLoadingWarning, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
+                       Visibility="{x:Bind ViewModel.ShowPluginsLoadingMessage, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
                        TextWrapping="Wrap"
                        Margin="{StaticResource SmallTopMargin}"/>
 

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml.cs
@@ -4,11 +4,10 @@
 
 using System;
 using System.Collections.ObjectModel;
-using System.Globalization;
+using System.IO;
 using Microsoft.PowerToys.Settings.UI.Library;
 using Microsoft.PowerToys.Settings.UI.Library.Utilities;
 using Microsoft.PowerToys.Settings.UI.Library.ViewModels;
-using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
 namespace Microsoft.PowerToys.Settings.UI.Views
@@ -24,8 +23,30 @@ namespace Microsoft.PowerToys.Settings.UI.Views
         {
             InitializeComponent();
             var settingsUtils = new SettingsUtils();
-            ViewModel = new PowerLauncherViewModel(settingsUtils, SettingsRepository<GeneralSettings>.GetInstance(settingsUtils), ShellPage.SendDefaultIPCMessage, (int)Windows.System.VirtualKey.Space, App.IsDarkTheme);
+            PowerLauncherSettings settings = settingsUtils.GetSettingsOrDefault<PowerLauncherSettings>(PowerLauncherSettings.ModuleName);
+            ViewModel = new PowerLauncherViewModel(settings, SettingsRepository<GeneralSettings>.GetInstance(settingsUtils), ShellPage.SendDefaultIPCMessage, App.IsDarkTheme);
             DataContext = ViewModel;
+            _ = Helper.GetFileWatcher(PowerLauncherSettings.ModuleName, "settings.json", () =>
+            {
+                _ = Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () =>
+                {
+                    PowerLauncherSettings powerLauncherSettings = null;
+                    try
+                    {
+                        powerLauncherSettings = settingsUtils.GetSettingsOrDefault<PowerLauncherSettings>(PowerLauncherSettings.ModuleName);
+                    }
+                    catch (IOException ex)
+                    {
+                        Logger.LogInfo(ex.Message);
+                    }
+
+                    if (powerLauncherSettings != null)
+                    {
+                        DataContext = ViewModel = new PowerLauncherViewModel(powerLauncherSettings, SettingsRepository<GeneralSettings>.GetInstance(settingsUtils), ShellPage.SendDefaultIPCMessage, App.IsDarkTheme);
+                        this.Bindings.Update();
+                    }
+                });
+            });
 
             var loader = Windows.ApplicationModel.Resources.ResourceLoader.GetForCurrentView();
 


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Sometimes plugins list is not shown in the settings because plugins were not loaded yet. We show a warning message and update settings when they are loaded.

**What is include in the PR:** 
- Show warning 'Plugins are loading...' when list of plugins are empty
- File watcher for settings.json file

**How does someone test / validate:** 
- Disable PowerToys Run
- Exit PowerToys
- Delete `PowerToys Run\settings.json`
- Start PowerToys
- Go to PowerToys Run page
- Enable PowerToys Run
- Verify that 'Plugins are loading...' warning is shown and the page eventually get updated with plugins

Extra testing:
- Open PowerToys on PowerToys Run page
- Chage settings in `PowerToys Run\settings.json` file
- Verify that changes are propagated to the page

## Quality Checklist

- [X] **Linked issue:** #9916
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [X] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
