### PR TITLE
[FZ Editor] Updated accent color

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridZone.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridZone.xaml.cs
@@ -21,6 +21,7 @@ namespace FancyZonesEditor
         private const string ObjectDependencyID = "IsSelected";
         private const string GridZoneBackgroundBrushID = "GridZoneBackgroundBrush";
         private const string SecondaryForegroundBrushID = "SecondaryForegroundBrush";
+        private const string AccentColorBrushID = "SystemControlBackgroundAccentBrush";
 
         public static readonly DependencyProperty IsSelectedProperty = DependencyProperty.Register(ObjectDependencyID, typeof(bool), typeof(GridZone), new PropertyMetadata(false, OnSelectionChanged));
 
@@ -50,7 +51,7 @@ namespace FancyZonesEditor
 
         private void OnSelectionChanged()
         {
-            Background = IsSelected ? SystemParameters.WindowGlassBrush : App.Current.Resources[GridZoneBackgroundBrushID] as SolidColorBrush;
+            Background = IsSelected ? Application.Current.Resources[AccentColorBrushID] as SolidColorBrush : Application.Current.Resources[GridZoneBackgroundBrushID] as SolidColorBrush;
         }
 
         public bool IsSelected
@@ -65,7 +66,7 @@ namespace FancyZonesEditor
             OnSelectionChanged();
             _splitter = new Rectangle
             {
-                Fill = SystemParameters.WindowGlassBrush,
+                Fill = Application.Current.Resources[AccentColorBrushID] as SolidColorBrush,
             };
             Body.Children.Add(_splitter);
 
@@ -139,8 +140,8 @@ namespace FancyZonesEditor
                 enabled = _canSplit(Orientation.Horizontal, _snappedPositionY);
             }
 
-            Brush disabledBrush = App.Current.Resources[SecondaryForegroundBrushID] as SolidColorBrush;
-            Brush enabledBrush = SystemParameters.WindowGlassBrush; // Active Accent color
+            Brush disabledBrush = Application.Current.Resources[SecondaryForegroundBrushID] as SolidColorBrush;
+            Brush enabledBrush = Application.Current.Resources[AccentColorBrushID] as SolidColorBrush;
             _splitter.Fill = enabled ? enabledBrush : disabledBrush;
         }
 
@@ -148,7 +149,7 @@ namespace FancyZonesEditor
         {
             _hovering = true;
             UpdateSplitter();
-            _splitter.Fill = SystemParameters.WindowGlassBrush;
+            _splitter.Fill = Application.Current.Resources[AccentColorBrushID] as SolidColorBrush;
         }
 
         protected override void OnMouseLeave(MouseEventArgs e)


### PR DESCRIPTION
## Summary of the Pull Request

- Replaced the WindowGlassBrush (that takes the color that is used as a 1px border around a window) with a true AccentColorBrush (ModernWPF).

@enricogior I wasn't able to reproduce the bug you described. Either way, we shouldn't use the SystemParameters.WindowGlassBrush.

## Quality Checklist

- [X] **Linked issue:** #10253
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
