### PR TITLE
[FZ Settings] Options for layout quick swap: on/off keyboard hook

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -736,6 +736,7 @@ finalizer
 findstr
 FIXEDFILEINFO
 FLASHZONES
+FLASHZONESONQUICKSWITCH
 Fle
 fluentui
 flyout

--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -1732,6 +1732,7 @@ QUERYENDSESSION
 queryfocus
 QUERYOPEN
 QUEUESYNC
+QUICKLAYOUTSWITCH
 qwertyuiopasdfghjklzxcvbnm
 qword
 qwrtyuiopsghjklzxvnm

--- a/src/modules/fancyzones/lib/Resources.resx
+++ b/src/modules/fancyzones/lib/Resources.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -249,5 +249,8 @@
   </data>
   <data name="Setting_Description_QuickLayoutSwitch" xml:space="preserve">
     <value>Enable quick layout switch</value>
+  </data>
+  <data name="Setting_Description_FlashZonesOnQuickSwitch" xml:space="preserve">
+    <value>Flash zones when switching layout</value>
   </data>
 </root>

--- a/src/modules/fancyzones/lib/Resources.resx
+++ b/src/modules/fancyzones/lib/Resources.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -246,5 +246,8 @@
   <data name="FancyZones_Settings_Save_Error" xml:space="preserve">
     <value>Failed to save the FancyZones settings. Please retry again later, if the problem persists report the bug to</value>
     <comment>"Report bug to" will have a URL after. FancyZone is a product name, keep as is.</comment>
+  </data>
+  <data name="Setting_Description_QuickLayoutSwitch" xml:space="preserve">
+    <value>Enable quick layout switch</value>
   </data>
 </root>

--- a/src/modules/fancyzones/lib/Settings.cpp
+++ b/src/modules/fancyzones/lib/Settings.cpp
@@ -22,6 +22,7 @@ namespace NonLocalizable
     const wchar_t OpenWindowOnActiveMonitorID[] = L"fancyzones_openWindowOnActiveMonitor";
     const wchar_t RestoreSizeID[] = L"fancyzones_restoreSize";
     const wchar_t QuickLayoutSwitch[] = L"fancyzones_quickLayoutSwitch";
+    const wchar_t FlashZonesOnQuickSwitch[] = L"fancyzones_flashZonesOnQuickSwitch";
     const wchar_t UseCursorPosEditorStartupScreenID[] = L"use_cursorpos_editor_startupscreen";
     const wchar_t ShowOnAllMonitorsID[] = L"fancyzones_show_on_all_monitors";
     const wchar_t SpanZonesAcrossMonitorsID[] = L"fancyzones_span_zones_across_monitors";
@@ -81,7 +82,7 @@ private:
         PCWSTR name;
         bool* value;
         int resourceId;
-    } m_configBools[15] = {
+    } m_configBools[16] = {
         { NonLocalizable::ShiftDragID, &m_settings.shiftDrag, IDS_SETTING_DESCRIPTION_SHIFTDRAG },
         { NonLocalizable::MouseSwitchID, &m_settings.mouseSwitch, IDS_SETTING_DESCRIPTION_MOUSESWITCH },
         { NonLocalizable::OverrideSnapHotKeysID, &m_settings.overrideSnapHotkeys, IDS_SETTING_DESCRIPTION_OVERRIDE_SNAP_HOTKEYS },
@@ -93,6 +94,7 @@ private:
         { NonLocalizable::OpenWindowOnActiveMonitorID, &m_settings.openWindowOnActiveMonitor, IDS_SETTING_DESCRIPTION_OPEN_WINDOW_ON_ACTIVE_MONITOR },
         { NonLocalizable::RestoreSizeID, &m_settings.restoreSize, IDS_SETTING_DESCRIPTION_RESTORESIZE },
         { NonLocalizable::QuickLayoutSwitch, &m_settings.quickLayoutSwitch, IDS_SETTING_DESCRIPTION_QUICKLAYOUTSWITCH },
+        { NonLocalizable::FlashZonesOnQuickSwitch, &m_settings.flashZonesOnQuickSwitch, IDS_SETTING_DESCRIPTION_FLASHZONESONQUICKSWITCH },
         { NonLocalizable::UseCursorPosEditorStartupScreenID, &m_settings.use_cursorpos_editor_startupscreen, IDS_SETTING_DESCRIPTION_USE_CURSORPOS_EDITOR_STARTUPSCREEN },
         { NonLocalizable::ShowOnAllMonitorsID, &m_settings.showZonesOnAllMonitors, IDS_SETTING_DESCRIPTION_SHOW_FANCY_ZONES_ON_ALL_MONITORS },
         { NonLocalizable::SpanZonesAcrossMonitorsID, &m_settings.spanZonesAcrossMonitors, IDS_SETTING_DESCRIPTION_SPAN_ZONES_ACROSS_MONITORS },

--- a/src/modules/fancyzones/lib/Settings.cpp
+++ b/src/modules/fancyzones/lib/Settings.cpp
@@ -21,6 +21,7 @@ namespace NonLocalizable
     const wchar_t AppLastZoneMoveWindowsID[] = L"fancyzones_appLastZone_moveWindows";
     const wchar_t OpenWindowOnActiveMonitorID[] = L"fancyzones_openWindowOnActiveMonitor";
     const wchar_t RestoreSizeID[] = L"fancyzones_restoreSize";
+    const wchar_t QuickLayoutSwitch[] = L"fancyzones_quickLayoutSwitch";
     const wchar_t UseCursorPosEditorStartupScreenID[] = L"use_cursorpos_editor_startupscreen";
     const wchar_t ShowOnAllMonitorsID[] = L"fancyzones_show_on_all_monitors";
     const wchar_t SpanZonesAcrossMonitorsID[] = L"fancyzones_span_zones_across_monitors";
@@ -80,7 +81,7 @@ private:
         PCWSTR name;
         bool* value;
         int resourceId;
-    } m_configBools[14] = {
+    } m_configBools[15] = {
         { NonLocalizable::ShiftDragID, &m_settings.shiftDrag, IDS_SETTING_DESCRIPTION_SHIFTDRAG },
         { NonLocalizable::MouseSwitchID, &m_settings.mouseSwitch, IDS_SETTING_DESCRIPTION_MOUSESWITCH },
         { NonLocalizable::OverrideSnapHotKeysID, &m_settings.overrideSnapHotkeys, IDS_SETTING_DESCRIPTION_OVERRIDE_SNAP_HOTKEYS },
@@ -91,6 +92,7 @@ private:
         { NonLocalizable::AppLastZoneMoveWindowsID, &m_settings.appLastZone_moveWindows, IDS_SETTING_DESCRIPTION_APPLASTZONE_MOVEWINDOWS },
         { NonLocalizable::OpenWindowOnActiveMonitorID, &m_settings.openWindowOnActiveMonitor, IDS_SETTING_DESCRIPTION_OPEN_WINDOW_ON_ACTIVE_MONITOR },
         { NonLocalizable::RestoreSizeID, &m_settings.restoreSize, IDS_SETTING_DESCRIPTION_RESTORESIZE },
+        { NonLocalizable::QuickLayoutSwitch, &m_settings.quickLayoutSwitch, IDS_SETTING_DESCRIPTION_QUICKLAYOUTSWITCH },
         { NonLocalizable::UseCursorPosEditorStartupScreenID, &m_settings.use_cursorpos_editor_startupscreen, IDS_SETTING_DESCRIPTION_USE_CURSORPOS_EDITOR_STARTUPSCREEN },
         { NonLocalizable::ShowOnAllMonitorsID, &m_settings.showZonesOnAllMonitors, IDS_SETTING_DESCRIPTION_SHOW_FANCY_ZONES_ON_ALL_MONITORS },
         { NonLocalizable::SpanZonesAcrossMonitorsID, &m_settings.spanZonesAcrossMonitors, IDS_SETTING_DESCRIPTION_SPAN_ZONES_ACROSS_MONITORS },

--- a/src/modules/fancyzones/lib/Settings.h
+++ b/src/modules/fancyzones/lib/Settings.h
@@ -34,8 +34,8 @@ struct Settings
     bool appLastZone_moveWindows = false;
     bool openWindowOnActiveMonitor = false;
     bool restoreSize = false;
-    bool quickLayoutSwitch = false;
-    bool flashZonesOnQuickSwitch = false;
+    bool quickLayoutSwitch = true;
+    bool flashZonesOnQuickSwitch = true;
     bool use_cursorpos_editor_startupscreen = true;
     bool showZonesOnAllMonitors = false;
     bool spanZonesAcrossMonitors = false;

--- a/src/modules/fancyzones/lib/Settings.h
+++ b/src/modules/fancyzones/lib/Settings.h
@@ -34,6 +34,7 @@ struct Settings
     bool appLastZone_moveWindows = false;
     bool openWindowOnActiveMonitor = false;
     bool restoreSize = false;
+    bool quickLayoutSwitch = false;
     bool use_cursorpos_editor_startupscreen = true;
     bool showZonesOnAllMonitors = false;
     bool spanZonesAcrossMonitors = false;

--- a/src/modules/fancyzones/lib/Settings.h
+++ b/src/modules/fancyzones/lib/Settings.h
@@ -35,6 +35,7 @@ struct Settings
     bool openWindowOnActiveMonitor = false;
     bool restoreSize = false;
     bool quickLayoutSwitch = false;
+    bool flashZonesOnQuickSwitch = false;
     bool use_cursorpos_editor_startupscreen = true;
     bool showZonesOnAllMonitors = false;
     bool spanZonesAcrossMonitors = false;

--- a/src/modules/fancyzones/tests/UnitTests/FancyZones.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/FancyZones.Spec.cpp
@@ -79,6 +79,7 @@ namespace FancyZonesUnitTests
             ptSettings.add_bool_toggle(L"fancyzones_appLastZone_moveWindows", IDS_SETTING_DESCRIPTION_APPLASTZONE_MOVEWINDOWS, settings.appLastZone_moveWindows);
             ptSettings.add_bool_toggle(L"fancyzones_restoreSize", IDS_SETTING_DESCRIPTION_RESTORESIZE, settings.restoreSize);
             ptSettings.add_bool_toggle(L"fancyzones_quickLayoutSwitch", IDS_SETTING_DESCRIPTION_QUICKLAYOUTSWITCH, settings.quickLayoutSwitch);
+            ptSettings.add_bool_toggle(L"fancyzones_flashZonesOnQuickSwitch", IDS_SETTING_DESCRIPTION_FLASHZONESONQUICKSWITCH, settings.flashZonesOnQuickSwitch);
             ptSettings.add_bool_toggle(L"use_cursorpos_editor_startupscreen", IDS_SETTING_DESCRIPTION_USE_CURSORPOS_EDITOR_STARTUPSCREEN, settings.use_cursorpos_editor_startupscreen);
             ptSettings.add_bool_toggle(L"fancyzones_show_on_all_monitors", IDS_SETTING_DESCRIPTION_SHOW_FANCY_ZONES_ON_ALL_MONITORS, settings.showZonesOnAllMonitors);
             ptSettings.add_bool_toggle(L"fancyzones_multi_monitor_mode", IDS_SETTING_DESCRIPTION_SPAN_ZONES_ACROSS_MONITORS, settings.spanZonesAcrossMonitors);
@@ -305,6 +306,7 @@ namespace FancyZonesUnitTests
             ptSettings.add_bool_toggle(L"fancyzones_appLastZone_moveWindows", IDS_SETTING_DESCRIPTION_APPLASTZONE_MOVEWINDOWS, settings.appLastZone_moveWindows);
             ptSettings.add_bool_toggle(L"fancyzones_restoreSize", IDS_SETTING_DESCRIPTION_RESTORESIZE, settings.restoreSize);
             ptSettings.add_bool_toggle(L"fancyzones_quickLayoutSwitch", IDS_SETTING_DESCRIPTION_QUICKLAYOUTSWITCH, settings.quickLayoutSwitch);
+            ptSettings.add_bool_toggle(L"fancyzones_flashZonesOnQuickSwitch", IDS_SETTING_DESCRIPTION_FLASHZONESONQUICKSWITCH, settings.flashZonesOnQuickSwitch);
             ptSettings.add_bool_toggle(L"use_cursorpos_editor_startupscreen", IDS_SETTING_DESCRIPTION_USE_CURSORPOS_EDITOR_STARTUPSCREEN, settings.use_cursorpos_editor_startupscreen);
             ptSettings.add_bool_toggle(L"fancyzones_show_on_all_monitors", IDS_SETTING_DESCRIPTION_SHOW_FANCY_ZONES_ON_ALL_MONITORS, settings.showZonesOnAllMonitors);
             ptSettings.add_bool_toggle(L"fancyzones_multi_monitor_mode", IDS_SETTING_DESCRIPTION_SPAN_ZONES_ACROSS_MONITORS, settings.spanZonesAcrossMonitors);

--- a/src/modules/fancyzones/tests/UnitTests/FancyZones.Spec.cpp
+++ b/src/modules/fancyzones/tests/UnitTests/FancyZones.Spec.cpp
@@ -78,6 +78,7 @@ namespace FancyZonesUnitTests
             ptSettings.add_bool_toggle(L"fancyzones_zoneSetChange_moveWindows", IDS_SETTING_DESCRIPTION_ZONESETCHANGE_MOVEWINDOWS, settings.zoneSetChange_moveWindows);
             ptSettings.add_bool_toggle(L"fancyzones_appLastZone_moveWindows", IDS_SETTING_DESCRIPTION_APPLASTZONE_MOVEWINDOWS, settings.appLastZone_moveWindows);
             ptSettings.add_bool_toggle(L"fancyzones_restoreSize", IDS_SETTING_DESCRIPTION_RESTORESIZE, settings.restoreSize);
+            ptSettings.add_bool_toggle(L"fancyzones_quickLayoutSwitch", IDS_SETTING_DESCRIPTION_QUICKLAYOUTSWITCH, settings.quickLayoutSwitch);
             ptSettings.add_bool_toggle(L"use_cursorpos_editor_startupscreen", IDS_SETTING_DESCRIPTION_USE_CURSORPOS_EDITOR_STARTUPSCREEN, settings.use_cursorpos_editor_startupscreen);
             ptSettings.add_bool_toggle(L"fancyzones_show_on_all_monitors", IDS_SETTING_DESCRIPTION_SHOW_FANCY_ZONES_ON_ALL_MONITORS, settings.showZonesOnAllMonitors);
             ptSettings.add_bool_toggle(L"fancyzones_multi_monitor_mode", IDS_SETTING_DESCRIPTION_SPAN_ZONES_ACROSS_MONITORS, settings.spanZonesAcrossMonitors);
@@ -303,6 +304,7 @@ namespace FancyZonesUnitTests
             ptSettings.add_bool_toggle(L"fancyzones_zoneSetChange_moveWindows", IDS_SETTING_DESCRIPTION_ZONESETCHANGE_MOVEWINDOWS, settings.zoneSetChange_moveWindows);
             ptSettings.add_bool_toggle(L"fancyzones_appLastZone_moveWindows", IDS_SETTING_DESCRIPTION_APPLASTZONE_MOVEWINDOWS, settings.appLastZone_moveWindows);
             ptSettings.add_bool_toggle(L"fancyzones_restoreSize", IDS_SETTING_DESCRIPTION_RESTORESIZE, settings.restoreSize);
+            ptSettings.add_bool_toggle(L"fancyzones_quickLayoutSwitch", IDS_SETTING_DESCRIPTION_QUICKLAYOUTSWITCH, settings.quickLayoutSwitch);
             ptSettings.add_bool_toggle(L"use_cursorpos_editor_startupscreen", IDS_SETTING_DESCRIPTION_USE_CURSORPOS_EDITOR_STARTUPSCREEN, settings.use_cursorpos_editor_startupscreen);
             ptSettings.add_bool_toggle(L"fancyzones_show_on_all_monitors", IDS_SETTING_DESCRIPTION_SHOW_FANCY_ZONES_ON_ALL_MONITORS, settings.showZonesOnAllMonitors);
             ptSettings.add_bool_toggle(L"fancyzones_multi_monitor_mode", IDS_SETTING_DESCRIPTION_SPAN_ZONES_ACROSS_MONITORS, settings.spanZonesAcrossMonitors);

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ConfigDefaults.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ConfigDefaults.cs
@@ -14,5 +14,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         // Fancy Zones Default Flags.
         public static readonly bool DefaultFancyzonesShiftDrag = true;
         public static readonly bool DefaultUseCursorposEditorStartupscreen = true;
+        public static readonly bool DefaultFancyzonesQuickLayoutSwitch = true;
+        public static readonly bool DefaultFancyzonesFlashZonesOnQuickSwitch = true;
     }
 }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/FZConfigProperties.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/FZConfigProperties.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation
+﻿// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -25,6 +25,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             FancyzonesOpenWindowOnActiveMonitor = new BoolProperty();
             FancyzonesRestoreSize = new BoolProperty();
             FancyzonesQuickLayoutSwitch = new BoolProperty();
+            FancyzonesFlashZonesOnQuickSwitch = new BoolProperty();
             UseCursorposEditorStartupscreen = new BoolProperty(ConfigDefaults.DefaultUseCursorposEditorStartupscreen);
             FancyzonesShowOnAllMonitors = new BoolProperty();
             FancyzonesSpanZonesAcrossMonitors = new BoolProperty();
@@ -72,6 +73,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library
 
         [JsonPropertyName("fancyzones_quickLayoutSwitch")]
         public BoolProperty FancyzonesQuickLayoutSwitch { get; set; }
+
+        [JsonPropertyName("fancyzones_flashZonesOnQuickSwitch")]
+        public BoolProperty FancyzonesFlashZonesOnQuickSwitch { get; set; }
 
         [JsonPropertyName("use_cursorpos_editor_startupscreen")]
         public BoolProperty UseCursorposEditorStartupscreen { get; set; }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/FZConfigProperties.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/FZConfigProperties.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation
+// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -24,6 +24,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             FancyzonesAppLastZoneMoveWindows = new BoolProperty();
             FancyzonesOpenWindowOnActiveMonitor = new BoolProperty();
             FancyzonesRestoreSize = new BoolProperty();
+            FancyzonesQuickLayoutSwitch = new BoolProperty();
             UseCursorposEditorStartupscreen = new BoolProperty(ConfigDefaults.DefaultUseCursorposEditorStartupscreen);
             FancyzonesShowOnAllMonitors = new BoolProperty();
             FancyzonesSpanZonesAcrossMonitors = new BoolProperty();
@@ -68,6 +69,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library
 
         [JsonPropertyName("fancyzones_restoreSize")]
         public BoolProperty FancyzonesRestoreSize { get; set; }
+
+        [JsonPropertyName("fancyzones_quickLayoutSwitch")]
+        public BoolProperty FancyzonesQuickLayoutSwitch { get; set; }
 
         [JsonPropertyName("use_cursorpos_editor_startupscreen")]
         public BoolProperty UseCursorposEditorStartupscreen { get; set; }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/FZConfigProperties.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/FZConfigProperties.cs
@@ -24,8 +24,8 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             FancyzonesAppLastZoneMoveWindows = new BoolProperty();
             FancyzonesOpenWindowOnActiveMonitor = new BoolProperty();
             FancyzonesRestoreSize = new BoolProperty();
-            FancyzonesQuickLayoutSwitch = new BoolProperty();
-            FancyzonesFlashZonesOnQuickSwitch = new BoolProperty();
+            FancyzonesQuickLayoutSwitch = new BoolProperty(ConfigDefaults.DefaultFancyzonesQuickLayoutSwitch);
+            FancyzonesFlashZonesOnQuickSwitch = new BoolProperty(ConfigDefaults.DefaultFancyzonesFlashZonesOnQuickSwitch);
             UseCursorposEditorStartupscreen = new BoolProperty(ConfigDefaults.DefaultUseCursorposEditorStartupscreen);
             FancyzonesShowOnAllMonitors = new BoolProperty();
             FancyzonesSpanZonesAcrossMonitors = new BoolProperty();

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/FancyZonesViewModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/FancyZonesViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation
+// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -71,6 +71,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             _appLastZoneMoveWindows = Settings.Properties.FancyzonesAppLastZoneMoveWindows.Value;
             _openWindowOnActiveMonitor = Settings.Properties.FancyzonesOpenWindowOnActiveMonitor.Value;
             _restoreSize = Settings.Properties.FancyzonesRestoreSize.Value;
+            _quickLayoutSwitch = Settings.Properties.FancyzonesQuickLayoutSwitch.Value;
             _useCursorPosEditorStartupScreen = Settings.Properties.UseCursorposEditorStartupscreen.Value;
             _showOnAllMonitors = Settings.Properties.FancyzonesShowOnAllMonitors.Value;
             _spanZonesAcrossMonitors = Settings.Properties.FancyzonesSpanZonesAcrossMonitors.Value;
@@ -107,6 +108,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
         private bool _openWindowOnActiveMonitor;
         private bool _spanZonesAcrossMonitors;
         private bool _restoreSize;
+        private bool _quickLayoutSwitch;
         private bool _useCursorPosEditorStartupScreen;
         private bool _showOnAllMonitors;
         private bool _makeDraggedWindowTransparent;
@@ -369,6 +371,24 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
                 {
                     _restoreSize = value;
                     Settings.Properties.FancyzonesRestoreSize.Value = value;
+                    NotifyPropertyChanged();
+                }
+            }
+        }
+
+        public bool QuickLayoutSwitch
+        {
+            get
+            {
+                return _quickLayoutSwitch;
+            }
+
+            set
+            {
+                if (value != _quickLayoutSwitch)
+                {
+                    _quickLayoutSwitch = value;
+                    Settings.Properties.FancyzonesQuickLayoutSwitch.Value = value;
                     NotifyPropertyChanged();
                 }
             }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/FancyZonesViewModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/FancyZonesViewModel.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation
+﻿// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -72,6 +72,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             _openWindowOnActiveMonitor = Settings.Properties.FancyzonesOpenWindowOnActiveMonitor.Value;
             _restoreSize = Settings.Properties.FancyzonesRestoreSize.Value;
             _quickLayoutSwitch = Settings.Properties.FancyzonesQuickLayoutSwitch.Value;
+            _flashZones = Settings.Properties.FancyzonesFlashZonesOnQuickSwitch.Value;
             _useCursorPosEditorStartupScreen = Settings.Properties.UseCursorposEditorStartupscreen.Value;
             _showOnAllMonitors = Settings.Properties.FancyzonesShowOnAllMonitors.Value;
             _spanZonesAcrossMonitors = Settings.Properties.FancyzonesSpanZonesAcrossMonitors.Value;
@@ -109,6 +110,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
         private bool _spanZonesAcrossMonitors;
         private bool _restoreSize;
         private bool _quickLayoutSwitch;
+        private bool _flashZones;
         private bool _useCursorPosEditorStartupScreen;
         private bool _showOnAllMonitors;
         private bool _makeDraggedWindowTransparent;
@@ -140,6 +142,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
                     SendConfigMSG(snd.ToString());
                     OnPropertyChanged(nameof(IsEnabled));
                     OnPropertyChanged(nameof(SnapHotkeysCategoryEnabled));
+                    OnPropertyChanged(nameof(QuickSwitchEnabled));
                 }
             }
         }
@@ -149,6 +152,14 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             get
             {
                 return _isEnabled && _overrideSnapHotkeys;
+            }
+        }
+
+        public bool QuickSwitchEnabled
+        {
+            get
+            {
+                return _isEnabled && _quickLayoutSwitch;
             }
         }
 
@@ -389,6 +400,25 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
                 {
                     _quickLayoutSwitch = value;
                     Settings.Properties.FancyzonesQuickLayoutSwitch.Value = value;
+                    NotifyPropertyChanged();
+                    OnPropertyChanged(nameof(QuickSwitchEnabled));
+                }
+            }
+        }
+
+        public bool FlashZones
+        {
+            get
+            {
+                return _flashZones;
+            }
+
+            set
+            {
+                if (value != _flashZones)
+                {
+                    _flashZones = value;
+                    Settings.Properties.FancyzonesFlashZonesOnQuickSwitch.Value = value;
                     NotifyPropertyChanged();
                 }
             }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/FancyZonesViewModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/FancyZonesViewModel.cs
@@ -72,7 +72,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             _openWindowOnActiveMonitor = Settings.Properties.FancyzonesOpenWindowOnActiveMonitor.Value;
             _restoreSize = Settings.Properties.FancyzonesRestoreSize.Value;
             _quickLayoutSwitch = Settings.Properties.FancyzonesQuickLayoutSwitch.Value;
-            _flashZones = Settings.Properties.FancyzonesFlashZonesOnQuickSwitch.Value;
+            _flashZonesOnQuickLayoutSwitch = Settings.Properties.FancyzonesFlashZonesOnQuickSwitch.Value;
             _useCursorPosEditorStartupScreen = Settings.Properties.UseCursorposEditorStartupscreen.Value;
             _showOnAllMonitors = Settings.Properties.FancyzonesShowOnAllMonitors.Value;
             _spanZonesAcrossMonitors = Settings.Properties.FancyzonesSpanZonesAcrossMonitors.Value;
@@ -110,7 +110,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
         private bool _spanZonesAcrossMonitors;
         private bool _restoreSize;
         private bool _quickLayoutSwitch;
-        private bool _flashZones;
+        private bool _flashZonesOnQuickLayoutSwitch;
         private bool _useCursorPosEditorStartupScreen;
         private bool _showOnAllMonitors;
         private bool _makeDraggedWindowTransparent;
@@ -406,18 +406,18 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             }
         }
 
-        public bool FlashZones
+        public bool FlashZonesOnQuickSwitch
         {
             get
             {
-                return _flashZones;
+                return _flashZonesOnQuickLayoutSwitch;
             }
 
             set
             {
-                if (value != _flashZones)
+                if (value != _flashZonesOnQuickLayoutSwitch)
                 {
-                    _flashZones = value;
+                    _flashZonesOnQuickLayoutSwitch = value;
                     Settings.Properties.FancyzonesFlashZonesOnQuickSwitch.Value = value;
                     NotifyPropertyChanged();
                 }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -1167,4 +1167,10 @@ Win + Shift + O to toggle your video</value>
   <data name="Run_Radio_Position_Primary_Monitor.Content" xml:space="preserve">
     <value>Primary monitor</value>
   </data>
+  <data name="FancyZones_QuickLayoutSwitch.Content" xml:space="preserve">
+    <value>Enable quick layout switch</value>
+  </data>
+  <data name="FancyZones_QuickLayoutSwitch_GroupSettings.Text" xml:space="preserve">
+    <value>Quick layout switch</value>
+  </data>
 </root>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -1167,7 +1167,7 @@ Win + Shift + O to toggle your video</value>
   <data name="Run_Radio_Position_Primary_Monitor.Content" xml:space="preserve">
     <value>Primary monitor</value>
   </data>
-  <data name="FancyZones_FlashZones.Content" xml:space="preserve">
+  <data name="FancyZones_FlashZonesOnQuickSwitch.Content" xml:space="preserve">
     <value>Flash zones when switching layout</value>
   </data>
   <data name="FancyZones_QuickLayoutSwitch.Content" xml:space="preserve">

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -1167,6 +1167,9 @@ Win + Shift + O to toggle your video</value>
   <data name="Run_Radio_Position_Primary_Monitor.Content" xml:space="preserve">
     <value>Primary monitor</value>
   </data>
+  <data name="FancyZones_FlashZones.Content" xml:space="preserve">
+    <value>Flash zones when switching layout</value>
+  </data>
   <data name="FancyZones_QuickLayoutSwitch.Content" xml:space="preserve">
     <value>Enable quick layout switch</value>
   </data>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -1,4 +1,4 @@
-<Page
+﻿<Page
     x:Class="Microsoft.PowerToys.Settings.UI.Views.FancyZonesPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -197,6 +197,11 @@
                       IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.QuickLayoutSwitch}"
                       Margin="{StaticResource XSmallTopMargin}"
                       IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"/>
+
+            <CheckBox x:Uid="FancyZones_FlashZones"
+                      IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.FlashZones}"
+                      Margin="24,8,0,0"
+                      IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.QuickSwitchEnabled}"/>
 
             <TextBlock x:Uid="Appearance_GroupSettings"
                        Style="{StaticResource SettingsGroupTitleStyle}"

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -1,4 +1,4 @@
-﻿<Page
+<Page
     x:Class="Microsoft.PowerToys.Settings.UI.Views.FancyZonesPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -188,6 +188,15 @@
                       Margin="{StaticResource XSmallTopMargin}"
                       IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"/>
 
+
+            <TextBlock x:Uid="FancyZones_QuickLayoutSwitch_GroupSettings"
+                       Style="{StaticResource SettingsGroupTitleStyle}"
+                       Foreground="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToForegroundConverter}}"/>
+
+            <CheckBox x:Uid="FancyZones_QuickLayoutSwitch"
+                      IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.QuickLayoutSwitch}"
+                      Margin="{StaticResource XSmallTopMargin}"
+                      IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"/>
 
             <TextBlock x:Uid="Appearance_GroupSettings"
                        Style="{StaticResource SettingsGroupTitleStyle}"

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -198,8 +198,8 @@
                       Margin="{StaticResource XSmallTopMargin}"
                       IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"/>
 
-            <CheckBox x:Uid="FancyZones_FlashZones"
-                      IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.FlashZones}"
+            <CheckBox x:Uid="FancyZones_FlashZonesOnQuickSwitch"
+                      IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.FlashZonesOnQuickSwitch}"
                       Margin="24,8,0,0"
                       IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.QuickSwitchEnabled}"/>
 


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Added `Quick layout switch` section in the FancyZones settings with `Enable quick layout switch` and `Flash zones when switching layout` CheckBoxes.
The options are saved in settings as `fancyzones_quickLayoutSwitch` and `fancyzones_flashZonesOnQuickSwitch`.

![image](https://user-images.githubusercontent.com/8949536/111351362-293bd180-8694-11eb-9494-89547807083c.png)

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #10027 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
