### PR TITLE
"Clear the previous query on launch" has a flicker

### DIFF
--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml
@@ -22,7 +22,6 @@
         Closing="OnClosing"
         Background="Transparent"
         LocationChanged="OnLocationChanged"
-        Activated="OnActivated"
         Deactivated="OnDeactivated"
         IsVisibleChanged="OnVisibilityChanged"
         Visibility="{Binding MainWindowVisibility, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -161,20 +161,12 @@ namespace PowerLauncher
             _settings.WindowLeft = Left;
         }
 
-        private void OnActivated(object sender, EventArgs e)
-        {
-            if (_settings.ClearInputOnLaunch)
-            {
-                _viewModel.ClearQueryCommand.Execute(null);
-            }
-        }
-
         private void OnDeactivated(object sender, EventArgs e)
         {
             if (_settings.HideWhenDeactivated)
             {
                 // (this.FindResource("OutroStoryboard") as Storyboard).Begin();
-                Hide();
+                _viewModel.Hide();
             }
         }
 

--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Windows.Threading;
 using interop;
 using Microsoft.PowerLauncher.Telemetry;
 using Microsoft.PowerToys.Telemetry;
@@ -154,7 +155,7 @@ namespace PowerLauncher.ViewModel
                     // SelectedItem returns null if selection is empty.
                     if (result != null && result.Action != null)
                     {
-                        MainWindowVisibility = Visibility.Collapsed;
+                        Hide();
 
                         Application.Current.Dispatcher.Invoke(() =>
                         {
@@ -193,7 +194,7 @@ namespace PowerLauncher.ViewModel
                 }
                 else
                 {
-                    MainWindowVisibility = Visibility.Collapsed;
+                    Hide();
                 }
             });
 
@@ -805,7 +806,7 @@ namespace PowerLauncher.ViewModel
             });
         }
 
-        private void ToggleWox()
+        public void ToggleWox()
         {
             if (MainWindowVisibility != Visibility.Visible)
             {
@@ -813,7 +814,26 @@ namespace PowerLauncher.ViewModel
             }
             else
             {
-                MainWindowVisibility = Visibility.Collapsed;
+                if (_settings.ClearInputOnLaunch && Results.Visibility == Visibility.Visible)
+                {
+                    ClearQueryCommand.Execute(null);
+                    Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.ApplicationIdle, new Action(() =>
+                    {
+                        MainWindowVisibility = Visibility.Collapsed;
+                    }));
+                }
+                else
+                {
+                    MainWindowVisibility = Visibility.Collapsed;
+                }
+            }
+        }
+
+        public void Hide()
+        {
+            if (MainWindowVisibility != Visibility.Collapsed)
+            {
+                ToggleWox();
             }
         }
 

--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -817,10 +817,14 @@ namespace PowerLauncher.ViewModel
                 if (_settings.ClearInputOnLaunch && Results.Visibility == Visibility.Visible)
                 {
                     ClearQueryCommand.Execute(null);
-                    Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.ApplicationIdle, new Action(() =>
+                    Task.Run(() =>
                     {
-                        MainWindowVisibility = Visibility.Collapsed;
-                    }));
+                        Thread.Sleep(100);
+                        Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Normal, new Action(() =>
+                        {
+                            MainWindowVisibility = Visibility.Collapsed;
+                        }));
+                    });
                 }
                 else
                 {


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
A user experiences a flicker from previous results when "Clear the previous query on launch" option is selected. It happens even if we clear results before a window collapse. Apparently, UI changes that were not applied before a window collapse are then applied when the window is opened again.
 
**What is include in the PR:** 
- Move `ClearQueryCommand.Execute` to windows collapse from `OnActivated`
- Wait 100ms before collapsing the window so UI updates before collapsing and will not happen when the windows is opened again

**How does someone test / validate:** 
- Select `Clear the previous query on launch` in the settings
- Try to search for something in PT Run
- Relaunch PT Run and check that flicker is gone
- Try different collapsing scenarios: click on the side, ESC key, `Alt+Space` again, open result, use result's context menu

Let me know if you know how to wait or force UI updates so we do not have to wait 100ms.

## Quality Checklist

- [X] **Linked issue:** #5616
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [X] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
