### PR TITLE
[FZ Editor] Disable templates key assignment

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -500,12 +500,14 @@
 
                     <TextBlock Text="{x:Static props:Resources.QuickKey_Select}"
                                Margin="0,16,0,0"
-                               Foreground="{DynamicResource PrimaryForegroundBrush}" />
+                               Foreground="{DynamicResource PrimaryForegroundBrush}"
+                               Visibility="{Binding Path=Type, Converter={StaticResource LayoutTypeCustomToVisibilityConverter}}"/>
                     <ComboBox x:Name="quickKeySelectionComboBox" 
                               Margin="0,6,0,0"
                               ItemsSource="{Binding QuickKeysAvailable}"
                               SelectedItem="{Binding QuickKey}"
-                              Width="106" />
+                              Width="106"
+                              Visibility="{Binding Path=Type, Converter={StaticResource LayoutTypeCustomToVisibilityConverter}}"/>
                 </StackPanel>
             </Grid>
         </ui:ContentDialog>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
@@ -18,7 +18,7 @@ namespace FancyZonesEditor.Models
             _guid = Guid.NewGuid();
             Type = LayoutType.Custom;
 
-            MainWindowSettingsModel.QuickKeys.PropertyChanged += FastAccessKeys_PropertyChanged;
+            MainWindowSettingsModel.QuickKeys.PropertyChanged += QuickSwitchKeys_PropertyChanged;
         }
 
         protected LayoutModel(string name)
@@ -53,7 +53,7 @@ namespace FancyZonesEditor.Models
             _zoneCount = other._zoneCount;
             _quickKey = other._quickKey;
 
-            MainWindowSettingsModel.QuickKeys.PropertyChanged += FastAccessKeys_PropertyChanged;
+            MainWindowSettingsModel.QuickKeys.PropertyChanged += QuickSwitchKeys_PropertyChanged;
         }
 
         // Name - the display name for this layout model - is also used as the key in the registry
@@ -313,7 +313,7 @@ namespace FancyZonesEditor.Models
             PersistData();
         }
 
-        private void FastAccessKeys_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        private void QuickSwitchKeys_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
             foreach (var pair in MainWindowSettingsModel.QuickKeys.SelectedKeys)
             {

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
@@ -30,7 +30,7 @@ namespace FancyZonesEditor.Models
         protected LayoutModel(string uuid, string name, LayoutType type)
             : this()
         {
-            Uuid = uuid;
+            _guid = Guid.Parse(uuid);
             Name = name;
             Type = type;
         }
@@ -93,17 +93,6 @@ namespace FancyZonesEditor.Models
             get
             {
                 return "{" + Guid.ToString().ToUpperInvariant() + "}";
-            }
-
-            set
-            {
-                try
-                {
-                    _guid = Guid.Parse(value);
-                }
-                catch (Exception)
-                {
-                }
             }
         }
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
@@ -169,8 +169,6 @@ namespace FancyZonesEditor.Utils
         // zones-settings: templates
         private struct TemplateLayoutWrapper
         {
-            public string Uuid { get; set; }
-
             public string Type { get; set; }
 
             public bool ShowSpacing { get; set; }
@@ -692,7 +690,6 @@ namespace FancyZonesEditor.Utils
             {
                 TemplateLayoutWrapper wrapper = new TemplateLayoutWrapper
                 {
-                    Uuid = layout.Uuid,
                     Type = LayoutTypeToJsonTag(layout.Type),
                     SensitivityRadius = layout.SensitivityRadius,
                     ZoneCount = layout.TemplateZoneCount,
@@ -885,7 +882,6 @@ namespace FancyZonesEditor.Utils
                 LayoutType type = JsonTagToLayoutType(wrapper.Type);
                 LayoutModel layout = MainWindowSettingsModel.DefaultModels[(int)type];
 
-                layout.Uuid = wrapper.Uuid;
                 layout.SensitivityRadius = wrapper.SensitivityRadius;
                 layout.TemplateZoneCount = wrapper.ZoneCount;
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
@@ -547,7 +547,7 @@ namespace FancyZonesEditor.Utils
                     bool devicesParsingResult = SetDevices(zoneSettings.Devices);
                     bool customZonesParsingResult = SetCustomLayouts(zoneSettings.CustomZoneSets);
                     bool templatesParsingResult = SetTemplateLayouts(zoneSettings.Templates);
-                    bool fastAccessKeysParsingResult = SetFastAccessKeys(zoneSettings.QuickLayoutKeys);
+                    bool quickLayoutSwitchKeysParsingResult = SetQuickLayoutSwitchKeys(zoneSettings.QuickLayoutKeys);
 
                     if (!devicesParsingResult || !customZonesParsingResult)
                     {
@@ -707,7 +707,7 @@ namespace FancyZonesEditor.Utils
                 zoneSettings.Templates.Add(wrapper);
             }
 
-            // Serialize fast access layout keys
+            // Serialize quick layout switch keys
             foreach (var pair in MainWindowSettingsModel.QuickKeys.SelectedKeys)
             {
                 if (pair.Value != string.Empty)
@@ -885,15 +885,15 @@ namespace FancyZonesEditor.Utils
             return true;
         }
 
-        private bool SetFastAccessKeys(List<QuickLayoutKeysWrapper> fastAccessKeys)
+        private bool SetQuickLayoutSwitchKeys(List<QuickLayoutKeysWrapper> quickSwitchKeys)
         {
-            if (fastAccessKeys == null)
+            if (quickSwitchKeys == null)
             {
                 return false;
             }
 
             MainWindowSettingsModel.QuickKeys.CleanUp();
-            foreach (var wrapper in fastAccessKeys)
+            foreach (var wrapper in quickSwitchKeys)
             {
                 MainWindowSettingsModel.QuickKeys.SelectKey(wrapper.Key.ToString(), wrapper.Uuid);
             }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
@@ -824,7 +824,15 @@ namespace FancyZonesEditor.Utils
                         zones.Add(new Int32Rect { X = (int)zone.X, Y = (int)zone.Y, Width = (int)zone.Width, Height = (int)zone.Height });
                     }
 
-                    layout = new CanvasLayoutModel(zoneSet.Uuid, zoneSet.Name, LayoutType.Custom, zones, info.RefWidth, info.RefHeight);
+                    try
+                    {
+                        layout = new CanvasLayoutModel(zoneSet.Uuid, zoneSet.Name, LayoutType.Custom, zones, info.RefWidth, info.RefHeight);
+                    }
+                    catch (Exception)
+                    {
+                        continue;
+                    }
+
                     layout.SensitivityRadius = info.SensitivityRadius;
                 }
                 else if (zoneSet.Type == GridLayoutModel.ModelTypeID)
@@ -840,7 +848,15 @@ namespace FancyZonesEditor.Utils
                         }
                     }
 
-                    layout = new GridLayoutModel(zoneSet.Uuid, zoneSet.Name, LayoutType.Custom, info.Rows, info.Columns, info.RowsPercentage, info.ColumnsPercentage, cells);
+                    try
+                    {
+                        layout = new GridLayoutModel(zoneSet.Uuid, zoneSet.Name, LayoutType.Custom, info.Rows, info.Columns, info.RowsPercentage, info.ColumnsPercentage, cells);
+                    }
+                    catch (Exception)
+                    {
+                        continue;
+                    }
+
                     layout.SensitivityRadius = info.SensitivityRadius;
                     (layout as GridLayoutModel).ShowSpacing = info.ShowSpacing;
                     (layout as GridLayoutModel).Spacing = info.Spacing;


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

* Disabled layout hotkeys assignment for templates.
* Reverted saving UUID in the `zones-settings.json` for template layouts.

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #10296
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
