### PR TITLE
[msi] enable telemetry on build farm

### DIFF
--- a/installer/PowerToysSetupCustomActions/PowerToysSetupCustomActions.vcxproj
+++ b/installer/PowerToysSetupCustomActions/PowerToysSetupCustomActions.vcxproj
@@ -48,6 +48,7 @@
     <LinkIncremental>false</LinkIncremental>
     <OutDir>$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)$(ProjectName)\$(Platform)\$(Configuration)\obj\</IntDir>
+    <IncludePath>..\..\src\common\Telemetry;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/installer/PowerToysSetupCustomActions/Telemetry/ProjectTelemetry.h
+++ b/installer/PowerToysSetupCustomActions/Telemetry/ProjectTelemetry.h
@@ -1,6 +1,0 @@
-#pragma once
-
-#include <TraceLoggingProvider.h>
-#include <TraceLoggingDefines.h>
-
-TRACELOGGING_DECLARE_PROVIDER(g_hProvider);

--- a/installer/PowerToysSetupCustomActions/Telemetry/TraceLoggingDefines.h
+++ b/installer/PowerToysSetupCustomActions/Telemetry/TraceLoggingDefines.h
@@ -1,6 +1,0 @@
-#pragma once
-
-#define TraceLoggingOptionProjectTelemetry() TraceLoggingOptionGroup(0x42749043, 0x438c, 0x46a2, 0x82, 0xbe, 0xc6, 0xcb, 0xeb, 0x19, 0x2f, 0xf2)
-#define ProjectTelemetryPrivacyDataTag(tag) TraceLoggingUInt64((tag), "Ignore")
-#define ProjectTelemetryTag_ProductAndServicePerformance 0x0u
-#define PROJECT_KEYWORD_MEASURE 0x0


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
MSI build on the build farm didn't have telemetry enabled (since 0.15)

**What is include in the PR:** 
Change the include path for the telemetry headers to use the headers from the common folder since those headers are corregly replaced with the ones that enable telemetry.

**How does someone test / validate:** 
Verify the that msi project builds correctly, after deleting the `installer\PowerToysSetupCustomActions\Telemtry\` folder.
To validate the MSI sends telemetry events, we will do a signed build and test it on an Windows Insider machine.

## Quality Checklist

- [x] **Linked issue:** #10304
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
