### PR TITLE
[FZ Editor] Layout hotkeys label should fit the dialog.

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -462,14 +462,14 @@
                                 </StackPanel>
                     <TextBox Text="{Binding Name}"
                              ui:ControlHelper.Header="{x:Static props:Resources.Name}"
-                             Margin="0,16,0,0"
+                             Margin="0,16,2,0"
                              Visibility="{Binding IsCustom, Converter={StaticResource BooleanToVisibilityConverter}}"
                              HorizontalAlignment="Stretch" />
                     
                     <CheckBox x:Name="spaceAroundSetting"
                               Content="{x:Static props:Resources.Show_Space_Zones}"
                               IsChecked="{Binding ShowSpacing}"
-                              Margin="0,16,0,0"
+                              Margin="0,16,12,0"
                               Visibility="{Binding Converter={StaticResource LayoutModelTypeToVisibilityConverter}}" />
 
                     <ui:NumberBox Margin="0,6,0,0"
@@ -485,7 +485,8 @@
 
                     <TextBlock Text="{x:Static props:Resources.Distance_adjacent_zones}"
                                IsEnabled="{Binding ShowSpacing}"
-                               Margin="0,16,0,0"
+                               Margin="0,16,12,0"
+                               TextWrapping="Wrap"
                                Foreground="{DynamicResource PrimaryForegroundBrush}"
                                x:Name="sensitivityRadiusValue" />
 
@@ -499,8 +500,9 @@
                                   AutomationProperties.LabeledBy="{Binding ElementName=sensitivityRadiusValue}" />
 
                     <TextBlock Text="{x:Static props:Resources.QuickKey_Select}"
-                               Margin="0,16,0,0"
+                               Margin="0,16,12,0"
                                Foreground="{DynamicResource PrimaryForegroundBrush}"
+                               TextWrapping="Wrap"
                                Visibility="{Binding Path=Type, Converter={StaticResource LayoutTypeCustomToVisibilityConverter}}"/>
                     <ComboBox x:Name="quickKeySelectionComboBox" 
                               Margin="0,6,0,0"


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Changed margins of elements in the dialog, added wrapping to text labels.

![image](https://user-images.githubusercontent.com/8949536/111637067-2236cf80-880a-11eb-8f12-ebea22e31ee1.png)

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #10306
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
