### PR TITLE
[FancyZones] Implement quick access keys, flashing

### DIFF
--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -568,7 +568,7 @@ FancyZones::OnKeyDown(PKBDLLHOOKSTRUCT info) noexcept
         }
     }
 
-    if (!shift && win && ctrl && alt)
+    if (!shift && win && ctrl && alt && m_settings->GetSettings()->quickLayoutSwitch)
     {
         if ('0' <= info->vkCode && info->vkCode <= '9')
         {

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -573,6 +573,8 @@ FancyZones::OnKeyDown(PKBDLLHOOKSTRUCT info) noexcept
         if ('0' <= info->vkCode && info->vkCode <= '9')
         {
             PostMessageW(m_window, WM_PRIV_QUICK_LAYOUT_KEY, 0, static_cast<LPARAM>(info->vkCode));
+            // Do not swallow the key press
+            return false;
         }
     }
 

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -582,7 +582,7 @@ FancyZones::OnKeyDown(PKBDLLHOOKSTRUCT info) noexcept
             digitPressed = info->vkCode - VK_NUMPAD0;
         }
 
-        bool dragging = m_windowMoveHandler.IsDragEnabled();
+        bool dragging = m_windowMoveHandler.InMoveSize();
         bool changeLayoutWhileNotDragging = !dragging && !shift && win && ctrl && alt && digitPressed != -1;
         bool changeLayoutWhileDragging = dragging && digitPressed != -1;
 

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -1372,16 +1372,12 @@ void FancyZones::ApplyQuickLayout(int key) noexcept
     FancyZonesDataInstance().SetActiveZoneSet(workArea->UniqueId(), data);
     FancyZonesDataInstance().SaveZoneSettings();
     UpdateZoneSets(writeLock);
-
-    if (!m_windowMoveHandler.IsDragEnabled())
-    {
-        FlashZones(writeLock);
-    }
+    FlashZones(writeLock);
 }
 
 void FancyZones::FlashZones(require_write_lock) noexcept
 {
-    if (m_settings->GetSettings()->flashZonesOnQuickSwitch)
+    if (m_settings->GetSettings()->flashZonesOnQuickSwitch && !m_windowMoveHandler.IsDragEnabled())
     {
         for (auto [monitor, workArea] : m_workAreaHandler.GetWorkAreasByDesktopId(m_currentDesktopId))
         {

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -217,7 +217,6 @@ private:
 
     void UpdateZoneWindows() noexcept;
     void UpdateWindowsPositions() noexcept;
-    void CycleActiveZoneSet(DWORD vkCode) noexcept;
     bool OnSnapHotkeyBasedOnZoneNumber(HWND window, DWORD vkCode) noexcept;
     bool OnSnapHotkeyBasedOnPosition(HWND window, DWORD vkCode) noexcept;
     bool OnSnapHotkey(DWORD vkCode) noexcept;
@@ -1039,26 +1038,6 @@ void FancyZones::UpdateWindowsPositions() noexcept
         return TRUE;
     };
     EnumWindows(callback, reinterpret_cast<LPARAM>(this));
-}
-
-void FancyZones::CycleActiveZoneSet(DWORD vkCode) noexcept
-{
-    _TRACER_;
-    auto window = GetForegroundWindow();
-    if (FancyZonesUtils::IsCandidateForZoning(window, m_settings->GetSettings()->excludedAppsArray))
-    {
-        const HMONITOR monitor = MonitorFromWindow(window, MONITOR_DEFAULTTONULL);
-        if (monitor)
-        {
-            std::shared_lock readLock(m_lock);
-
-            auto zoneWindow = m_workAreaHandler.GetWorkArea(m_currentDesktopId, monitor);
-            if (zoneWindow)
-            {
-                zoneWindow->CycleActiveZoneSet(vkCode);
-            }
-        }
-    }
 }
 
 bool FancyZones::OnSnapHotkeyBasedOnZoneNumber(HWND window, DWORD vkCode) noexcept

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -241,7 +241,6 @@ private:
     std::vector<std::pair<HMONITOR, RECT>> GetRawMonitorData() noexcept;
     std::vector<HMONITOR> GetMonitorsSorted() noexcept;
     HMONITOR WorkAreaKeyFromWindow(HWND window) noexcept;
-    HMONITOR WorkAreaKeyFromCursor() noexcept;
 
     const HINSTANCE m_hinstance{};
 
@@ -1347,8 +1346,6 @@ void FancyZones::ApplyQuickLayout(int key) noexcept
 {
     std::unique_lock writeLock(m_lock);
 
-    HMONITOR monitor = WorkAreaKeyFromCursor();
-
     std::wstring uuid;
     for (auto [zoneUuid, hotkey] : FancyZonesDataInstance().GetLayoutQuickKeys())
     {
@@ -1358,7 +1355,7 @@ void FancyZones::ApplyQuickLayout(int key) noexcept
         }
     }
 
-    auto workArea = m_workAreaHandler.GetWorkArea(m_currentDesktopId, monitor);
+    auto workArea = m_workAreaHandler.GetWorkAreaFromCursor(m_currentDesktopId);
 
     // Find a custom zone set with this uuid and apply it
     auto customZoneSets = FancyZonesDataInstance().GetCustomZoneSetsMap();
@@ -1426,24 +1423,6 @@ HMONITOR FancyZones::WorkAreaKeyFromWindow(HWND window) noexcept
     else
     {
         return MonitorFromWindow(window, MONITOR_DEFAULTTONULL);
-    }
-}
-
-HMONITOR FancyZones::WorkAreaKeyFromCursor() noexcept
-{
-    if (m_settings->GetSettings()->spanZonesAcrossMonitors)
-    {
-        return NULL;
-    }
-    else
-    {
-        POINT cursorPoint;
-        if (!GetCursorPos(&cursorPoint))
-        {
-            return NULL;
-        }
-
-        return MonitorFromPoint(cursorPoint, MONITOR_DEFAULTTONULL);
     }
 }
 

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -568,13 +568,17 @@ FancyZones::OnKeyDown(PKBDLLHOOKSTRUCT info) noexcept
         }
     }
 
-    if (win && alt && !shift && !ctrl)
+    if (shift && alt && !win && !ctrl)
     {
         if ('0' <= info->vkCode && info->vkCode <= '9')
         {
-            PostMessageW(m_window, WM_PRIV_QUICK_LAYOUT_KEY, 0, static_cast<LPARAM>(info->vkCode));
-            // Do not swallow the key press
-            return false;
+            auto quickKeysMap = FancyZonesDataInstance().GetLayoutQuickKeys();
+            if (std::any_of(quickKeysMap.begin(), quickKeysMap.end(), [=](auto item) {
+                return item.second == info->vkCode - '0'; }))
+            {
+                PostMessageW(m_window, WM_PRIV_QUICK_LAYOUT_KEY, 0, static_cast<LPARAM>(info->vkCode));
+                return true;
+            }
         }
     }
 

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -236,6 +236,7 @@ private:
     void UpdateZoneSets() noexcept;
     bool ShouldProcessSnapHotkey(DWORD vkCode) noexcept;
     void ApplyQuickLayout(int key) noexcept;
+    void FlashZones() noexcept;
 
     std::vector<std::pair<HMONITOR, RECT>> GetRawMonitorData() noexcept;
     std::vector<HMONITOR> GetMonitorsSorted() noexcept;
@@ -1412,6 +1413,14 @@ void FancyZones::ApplyQuickLayout(int vKey) noexcept
     FancyZonesDataInstance().SetActiveZoneSet(workArea->UniqueId(), data);
     FancyZonesDataInstance().SaveZoneSettings();
     UpdateZoneSets();
+
+    if (m_settings->GetSettings()->flashZonesOnQuickSwitch)
+    {
+        for (auto [monitor, workArea] : m_workAreaHandler.GetWorkAreasByDesktopId(m_currentDesktopId))
+        {
+            workArea->FlashZones();
+        }
+    }
 }
 
 std::vector<HMONITOR> FancyZones::GetMonitorsSorted() noexcept

--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -236,7 +236,6 @@ private:
     void UpdateZoneSets() noexcept;
     bool ShouldProcessSnapHotkey(DWORD vkCode) noexcept;
     void ApplyQuickLayout(int key) noexcept;
-    void FlashZones() noexcept;
 
     std::vector<std::pair<HMONITOR, RECT>> GetRawMonitorData() noexcept;
     std::vector<HMONITOR> GetMonitorsSorted() noexcept;

--- a/src/modules/fancyzones/lib/MonitorWorkAreaHandler.cpp
+++ b/src/modules/fancyzones/lib/MonitorWorkAreaHandler.cpp
@@ -17,6 +17,27 @@ winrt::com_ptr<IZoneWindow> MonitorWorkAreaHandler::GetWorkArea(const GUID& desk
     return nullptr;
 }
 
+winrt::com_ptr<IZoneWindow> MonitorWorkAreaHandler::GetWorkAreaFromCursor(const GUID& desktopId)
+{
+    auto allMonitorsWorkArea = GetWorkArea(desktopId, NULL);
+    if (allMonitorsWorkArea)
+    {
+        // First, check if there's a work area spanning all monitors (signalled by the NULL monitor handle)
+        return allMonitorsWorkArea;
+    }
+    else
+    {
+        // Otherwise, look for the work area based on cursor position
+        POINT cursorPoint;
+        if (!GetCursorPos(&cursorPoint))
+        {
+            return nullptr;
+        }
+
+        return GetWorkArea(desktopId, MonitorFromPoint(cursorPoint, MONITOR_DEFAULTTONULL));
+    }
+}
+
 winrt::com_ptr<IZoneWindow> MonitorWorkAreaHandler::GetWorkArea(HWND window)
 {
     GUID desktopId{};

--- a/src/modules/fancyzones/lib/MonitorWorkAreaHandler.h
+++ b/src/modules/fancyzones/lib/MonitorWorkAreaHandler.h
@@ -30,6 +30,16 @@ public:
     winrt::com_ptr<IZoneWindow> GetWorkArea(const GUID& desktopId, HMONITOR monitor);
 
     /**
+     * Get work area based on virtual desktop id and the current cursor position.
+     *
+     * @param[in]  desktopId Virtual desktop identifier.
+     *
+     * @returns    Object representing single work area, interface to all actions available on work area
+     *             (e.g. moving windows through zone layout specified for that work area).
+     */
+    winrt::com_ptr<IZoneWindow> GetWorkAreaFromCursor(const GUID& desktopId);
+
+    /**
      * Get work area on which specified window is located.
      *
      * @param[in]  window Window handle.

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -404,6 +404,10 @@ IFACEMETHODIMP_(void)
 ZoneWindow::UpdateActiveZoneSet() noexcept
 {
     CalculateZoneSet();
+    if (m_window)
+    {
+        m_zoneWindowDrawing->DrawActiveZoneSet(m_activeZoneSet->GetZones(), m_highlightZone, m_host);
+    }
 }
 
 IFACEMETHODIMP_(void)

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -167,7 +167,7 @@ private:
     WPARAM m_keyLast{};
     size_t m_keyCycle{};
     static const UINT m_showAnimationDuration = 200; // ms
-    static const UINT m_flashDuration = 700; // ms
+    static const UINT m_flashDuration = 1000; // ms
     std::unique_ptr<ZoneWindowDrawing> m_zoneWindowDrawing;
 };
 
@@ -444,8 +444,11 @@ ZoneWindow::ClearSelectedZones() noexcept
 IFACEMETHODIMP_(void)
 ZoneWindow::FlashZones() noexcept
 {
-    m_zoneWindowDrawing->Flash(m_flashDuration);
-    m_zoneWindowDrawing->DrawActiveZoneSet(m_activeZoneSet->GetZones(), {}, m_host);
+    if (m_window)
+    {
+        m_zoneWindowDrawing->DrawActiveZoneSet(m_activeZoneSet->GetZones(), {}, m_host);
+        m_zoneWindowDrawing->Flash(m_flashDuration);
+    }
 }
 
 #pragma region private

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -140,6 +140,8 @@ public:
     UpdateActiveZoneSet() noexcept;
     IFACEMETHODIMP_(void)
     ClearSelectedZones() noexcept;
+    IFACEMETHODIMP_(void)
+    FlashZones() noexcept;
 
 protected:
     static LRESULT CALLBACK s_WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lparam) noexcept;
@@ -437,6 +439,13 @@ ZoneWindow::ClearSelectedZones() noexcept
         m_highlightZone.clear();
         m_zoneWindowDrawing->DrawActiveZoneSet(m_activeZoneSet->GetZones(), m_highlightZone, m_host);
     }
+}
+
+IFACEMETHODIMP_(void)
+ZoneWindow::FlashZones() noexcept
+{
+    m_zoneWindowDrawing->Flash(m_flashDuration);
+    m_zoneWindowDrawing->DrawActiveZoneSet(m_activeZoneSet->GetZones(), {}, m_host);
 }
 
 #pragma region private

--- a/src/modules/fancyzones/lib/ZoneWindow.h
+++ b/src/modules/fancyzones/lib/ZoneWindow.h
@@ -87,13 +87,6 @@ interface __declspec(uuid("{7F017528-8110-4FB3-BE41-F472969C2560}")) IZoneWindow
      */
     IFACEMETHOD_(bool, ExtendWindowByDirectionAndPosition)(HWND window, DWORD vkCode) = 0;
     /**
-     * Cycle through active zone layouts (giving hints about each layout).
-     *
-     * @param   vkCode Pressed key representing layout index.
-     */
-    IFACEMETHOD_(void, CycleActiveZoneSet)(DWORD vkCode) = 0;
-
-    /**
      * Save information about zone in which window was assigned, when closing the window.
      * Used once we open same window again to assign it to its previous zone.
      *

--- a/src/modules/fancyzones/lib/ZoneWindow.h
+++ b/src/modules/fancyzones/lib/ZoneWindow.h
@@ -118,6 +118,10 @@ interface __declspec(uuid("{7F017528-8110-4FB3-BE41-F472969C2560}")) IZoneWindow
      * Clear the selected zones when this ZoneWindow loses focus.
      */
     IFACEMETHOD_(void, ClearSelectedZones)() = 0;
+    /*
+     * Display the layout on the screen and then hide it.
+     */
+    IFACEMETHOD_(void, FlashZones)() = 0;
 };
 
 winrt::com_ptr<IZoneWindow> MakeZoneWindow(IZoneWindowHost* host, HINSTANCE hinstance, HMONITOR monitor,

--- a/src/modules/fancyzones/lib/ZoneWindowDrawing.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindowDrawing.cpp
@@ -247,6 +247,7 @@ void ZoneWindowDrawing::Show(unsigned animationMillis)
 
 void ZoneWindowDrawing::Flash(unsigned animationMillis)
 {
+    _TRACER_;
     m_lowLatencyLock = true;
     std::unique_lock lock(m_mutex);
     m_lowLatencyLock = false;

--- a/src/modules/fancyzones/lib/ZoneWindowDrawing.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindowDrawing.cpp
@@ -182,7 +182,7 @@ void ZoneWindowDrawing::Render()
         textBrush->Release();
     }
 
-    // The lock must be released here, as EndDraw() will wait for Vsync
+    // The lock must be released here, as EndDraw() will wait for vertical sync
     lock.unlock();
 
     m_renderTarget->EndDraw();

--- a/src/modules/fancyzones/lib/ZoneWindowDrawing.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindowDrawing.cpp
@@ -114,16 +114,16 @@ ZoneWindowDrawing::ZoneWindowDrawing(HWND window)
 
             // Force repeated rendering while in the animation loop.
             // Yield if low latency locking was requested
-            if (animationAlpha > 0.f)
+            if (!m_lowLatencyLock)
             {
-                if (!m_lowLatencyLock)
+                if (animationAlpha > 0.f)
                 {
                     m_shouldRender = true;
                 }
-            }
-            else
-            {
-                Hide();
+                else
+                {
+                    Hide();
+                }
             }
 
             Render();
@@ -231,7 +231,7 @@ void ZoneWindowDrawing::Show(unsigned animationMillis)
 
     if (!m_animation)
     {
-        ShowWindowAsync(m_window, SW_SHOWNA);
+        ShowWindow(m_window, SW_SHOWNA);
     }
 
     animationMillis = max(animationMillis, 1);
@@ -254,11 +254,15 @@ void ZoneWindowDrawing::Flash(unsigned animationMillis)
 
     if (!m_animation)
     {
-        ShowWindowAsync(m_window, SW_SHOWNA);
+        ShowWindow(m_window, SW_SHOWNA);
     }
 
     animationMillis = max(animationMillis, 1);
-    m_animation.emplace(AnimationInfo{ std::chrono::steady_clock().now(), animationMillis, false });
+
+    if (!m_animation || m_animation->fadeIn)
+    {
+        m_animation.emplace(AnimationInfo{ std::chrono::steady_clock().now(), animationMillis, false });
+    }
 
     m_shouldRender = true;
     m_cv.notify_all();

--- a/src/modules/fancyzones/lib/ZoneWindowDrawing.h
+++ b/src/modules/fancyzones/lib/ZoneWindowDrawing.h
@@ -26,6 +26,7 @@ class ZoneWindowDrawing
     {
         std::chrono::steady_clock::time_point tStart;
         unsigned duration;
+        bool fadeIn;
     };
 
     HWND m_window = nullptr;
@@ -55,6 +56,7 @@ public:
     ZoneWindowDrawing(HWND window);
     void Hide();
     void Show(unsigned animationMillis);
+    void Flash(unsigned animationMillis);
     void ForceRender();
     void DrawActiveZoneSet(const IZoneSet::ZonesMap& zones,
                            const std::vector<size_t>& highlightZones,

--- a/src/modules/fancyzones/lib/ZoneWindowDrawing.h
+++ b/src/modules/fancyzones/lib/ZoneWindowDrawing.h
@@ -43,10 +43,10 @@ class ZoneWindowDrawing
     static D2D1_COLOR_F ConvertColor(COLORREF color);
     static D2D1_RECT_F ConvertRect(RECT rect);
     void Render();
+    void RenderLoop();
 
     std::atomic<bool> m_shouldRender = false;
     std::atomic<bool> m_abortThread = false;
-    std::atomic<bool> m_lowLatencyLock = false;
     std::condition_variable m_cv;
     std::thread m_renderThread;
 
@@ -57,7 +57,6 @@ public:
     void Hide();
     void Show(unsigned animationMillis);
     void Flash(unsigned animationMillis);
-    void ForceRender();
     void DrawActiveZoneSet(const IZoneSet::ZonesMap& zones,
                            const std::vector<size_t>& highlightZones,
                            winrt::com_ptr<IZoneWindowHost> host);


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

See issue #10026 
This PR currently does not add any extra telemetry or do anything if there is no layout with the desired key.
I'll add telemetry once we agree what should be included.

**What is included in the PR:** 

* Press Ctrl+Win+Alt+number to quickly switch layouts. Other shortcuts didn't work or are already in use by Windows.  This modifier combo might need to be updated.
* The monitor is picked based on cursor position.
* The layout will flash if the corresponding option is turned on. All layouts on the current VD will flash. If this is not desired, this can also be easily modified.

**How does someone test / validate:** 

Try switching layouts while dragging and quickly switching layouts and activating zones to stress test the concurrency code controlling visuals.

## Quality Checklist

- [x] **Linked issue:** #10026
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
