### PR TITLE
[Color Picker] Use escape key to exit colour editor UI

### DIFF
--- a/src/modules/colorPicker/ColorPickerUI/Helpers/AppStateHandler.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/AppStateHandler.cs
@@ -71,6 +71,27 @@ namespace ColorPicker.Helpers
             _colorEditorWindow.Show();
         }
 
+        public void HideColorPickerEditor()
+        {
+            if (_colorEditorWindow != null)
+            {
+                _colorEditorWindow.Hide();
+            }
+        }
+
+        public bool IsColorPickerEditorVisible()
+        {
+            if (_colorEditorWindow == null)
+            {
+                return false;
+            }
+            else
+            {
+                // Check if we are visible and on top. Using focus producing unreliable results the first time the picker is opened.
+                return _colorEditorWindow.Topmost && _colorEditorWindow.IsVisible;
+            }
+        }
+
         public static void SetTopMost()
         {
             Application.Current.MainWindow.Topmost = false;

--- a/src/modules/colorPicker/ColorPickerUI/Helpers/AppStateHandler.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/AppStateHandler.cs
@@ -81,15 +81,13 @@ namespace ColorPicker.Helpers
 
         public bool IsColorPickerEditorVisible()
         {
-            if (_colorEditorWindow == null)
-            {
-                return false;
-            }
-            else
+            if (_colorEditorWindow != null)
             {
                 // Check if we are visible and on top. Using focus producing unreliable results the first time the picker is opened.
                 return _colorEditorWindow.Topmost && _colorEditorWindow.IsVisible;
             }
+
+            return false;
         }
 
         public static void SetTopMost()

--- a/src/modules/colorPicker/ColorPickerUI/Keyboard/KeyboardMonitor.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Keyboard/KeyboardMonitor.cs
@@ -72,8 +72,16 @@ namespace ColorPicker.Keyboard
             // ESC pressed
             if (virtualCode == KeyInterop.VirtualKeyFromKey(Key.Escape))
             {
-                _appStateHandler.HideColorPicker();
-                PowerToysTelemetry.Log.WriteEvent(new ColorPickerCancelledEvent());
+                if (_appStateHandler.IsColorPickerEditorVisible())
+                {
+                    _appStateHandler.HideColorPickerEditor();
+                }
+                else
+                {
+                    _appStateHandler.HideColorPicker();
+                    PowerToysTelemetry.Log.WriteEvent(new ColorPickerCancelledEvent());
+                }
+
                 return;
             }
 


### PR DESCRIPTION
## Summary of the Pull Request

Use the escape key to exit the colour editor UI. I wasn't sure if this was the right way to do this but using other methods didn't produce a reliable result especially when opening the UI from the picker and not interacting with it, escape wouldn't actually work.

**What is this about:**

Use the escape key to exit the colour editor UI.

**What is include in the PR:** 

Add additional methods to detect and close the UI.

**How does someone test / validate:** 

Manual testing.

## Quality Checklist

- [x] **Linked issue:** #9696
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
