### PR TITLE
Settings telemetry for PT Run

### DIFF
--- a/src/common/interop/interop.cpp
+++ b/src/common/interop/interop.cpp
@@ -139,8 +139,8 @@ public
             return gcnew String(CommonSharedConstants::POWER_LAUNCHER_SHARED_EVENT);
         }
 
-        static String ^ SendRunSettingsTelemetryEvent() {
-            return gcnew String(CommonSharedConstants::SEND_RUN_SETTINGS_TELEMETRY_EVENT);
+        static String ^ RunSendSettingsTelemetryEvent() {
+            return gcnew String(CommonSharedConstants::RUN_SEND_SETTINGS_TELEMETRY_EVENT);
         }
 
         static String ^ ShowColorPickerSharedEvent() {

--- a/src/common/interop/interop.cpp
+++ b/src/common/interop/interop.cpp
@@ -139,6 +139,10 @@ public
             return gcnew String(CommonSharedConstants::POWER_LAUNCHER_SHARED_EVENT);
         }
 
+        static String ^ SendRunSettingsTelemetryEvent() {
+            return gcnew String(CommonSharedConstants::SEND_RUN_SETTINGS_TELEMETRY_EVENT);
+        }
+
         static String ^ ShowColorPickerSharedEvent() {
             return gcnew String(CommonSharedConstants::SHOW_COLOR_PICKER_SHARED_EVENT);
         } 

--- a/src/common/interop/shared_constants.h
+++ b/src/common/interop/shared_constants.h
@@ -13,7 +13,7 @@ namespace CommonSharedConstants
     // Path to the event used by PowerLauncher
     const wchar_t POWER_LAUNCHER_SHARED_EVENT[] = L"Local\\PowerToysRunInvokeEvent-30f26ad7-d36d-4c0e-ab02-68bb5ff3c4ab";
 
-    const wchar_t SEND_RUN_SETTINGS_TELEMETRY_EVENT[] = L"Local\\PowerToysRunInvokeEvent-638ec522-0018-4b96-837d-6bd88e06f0d6";
+    const wchar_t RUN_SEND_SETTINGS_TELEMETRY_EVENT[] = L"Local\\PowerToysRunInvokeEvent-638ec522-0018-4b96-837d-6bd88e06f0d6";
 
     // Path to the event used to show Color Picker
     const wchar_t SHOW_COLOR_PICKER_SHARED_EVENT[] = L"Local\\ShowColorPickerEvent-8c46be2a-3e05-4186-b56b-4ae986ef2525";

--- a/src/common/interop/shared_constants.h
+++ b/src/common/interop/shared_constants.h
@@ -13,6 +13,8 @@ namespace CommonSharedConstants
     // Path to the event used by PowerLauncher
     const wchar_t POWER_LAUNCHER_SHARED_EVENT[] = L"Local\\PowerToysRunInvokeEvent-30f26ad7-d36d-4c0e-ab02-68bb5ff3c4ab";
 
+    const wchar_t SEND_RUN_SETTINGS_TELEMETRY_EVENT[] = L"Local\\PowerToysRunInvokeEvent-638ec522-0018-4b96-837d-6bd88e06f0d6";
+
     // Path to the event used to show Color Picker
     const wchar_t SHOW_COLOR_PICKER_SHARED_EVENT[] = L"Local\\ShowColorPickerEvent-8c46be2a-3e05-4186-b56b-4ae986ef2525";
 

--- a/src/modules/interface/powertoy_module_interface.h
+++ b/src/modules/interface/powertoy_module_interface.h
@@ -82,6 +82,10 @@ public:
      * if the key press is to be swallowed.
      */
     virtual bool on_hotkey(size_t hotkeyId) { return false; }
+
+    virtual void send_settings_telemetry()
+    {
+    }
 };
 
 /*

--- a/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
+++ b/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
@@ -107,7 +107,7 @@ public:
         auto sa1 = getDefaultSecurityAttribute();
         m_hEvent = CreateEventW(&sa1, FALSE, FALSE, CommonSharedConstants::POWER_LAUNCHER_SHARED_EVENT);
         auto sa2 = getDefaultSecurityAttribute();
-        send_telemetry_event = CreateEventW(&sa2, FALSE, FALSE, CommonSharedConstants::SEND_RUN_SETTINGS_TELEMETRY_EVENT);
+        send_telemetry_event = CreateEventW(&sa2, FALSE, FALSE, CommonSharedConstants::RUN_SEND_SETTINGS_TELEMETRY_EVENT);
     };
 
     ~Microsoft_Launcher()

--- a/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
+++ b/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
@@ -81,6 +81,7 @@ private:
     // Handle to event used to invoke the Runner
     HANDLE m_hEvent;
 
+    HANDLE send_telemetry_event;
 public:
     // Constructor
     Microsoft_Launcher()
@@ -98,6 +99,7 @@ public:
         sa.bInheritHandle = false;
         sa.lpSecurityDescriptor = NULL;
         m_hEvent = CreateEventW(&sa, FALSE, FALSE, CommonSharedConstants::POWER_LAUNCHER_SHARED_EVENT);
+        send_telemetry_event = CreateEventW(&sa, FALSE, FALSE, CommonSharedConstants::SEND_RUN_SETTINGS_TELEMETRY_EVENT);
     };
 
     ~Microsoft_Launcher()
@@ -185,6 +187,7 @@ public:
     {
         Logger::info("Launcher is enabling");
         ResetEvent(m_hEvent);
+        ResetEvent(send_telemetry_event);
         // Start PowerLauncher.exe only if the OS is 19H1 or higher
         if (UseNewSettings())
         {
@@ -265,6 +268,7 @@ public:
         if (m_enabled)
         {
             ResetEvent(m_hEvent);
+            ResetEvent(send_telemetry_event);
             terminateProcess();
         }
 
@@ -346,6 +350,12 @@ public:
             TerminateProcess(m_hProcess, 1);
         }
         */
+    }
+
+    virtual void send_settings_telemetry() override
+    {
+        Logger::info("Send settings telemetry");
+        SetEvent(send_telemetry_event);
     }
 };
 

--- a/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
+++ b/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
@@ -82,6 +82,16 @@ private:
     HANDLE m_hEvent;
 
     HANDLE send_telemetry_event;
+
+    SECURITY_ATTRIBUTES getDefaultSecurityAttribute() 
+    {
+        SECURITY_ATTRIBUTES sa;
+        sa.nLength = sizeof(sa);
+        sa.bInheritHandle = false;
+        sa.lpSecurityDescriptor = NULL;
+        return sa;
+    }
+
 public:
     // Constructor
     Microsoft_Launcher()
@@ -94,12 +104,10 @@ public:
         Logger::info("Launcher object is constructing");
         init_settings();
 
-        SECURITY_ATTRIBUTES sa;
-        sa.nLength = sizeof(sa);
-        sa.bInheritHandle = false;
-        sa.lpSecurityDescriptor = NULL;
-        m_hEvent = CreateEventW(&sa, FALSE, FALSE, CommonSharedConstants::POWER_LAUNCHER_SHARED_EVENT);
-        send_telemetry_event = CreateEventW(&sa, FALSE, FALSE, CommonSharedConstants::SEND_RUN_SETTINGS_TELEMETRY_EVENT);
+        auto sa1 = getDefaultSecurityAttribute();
+        m_hEvent = CreateEventW(&sa1, FALSE, FALSE, CommonSharedConstants::POWER_LAUNCHER_SHARED_EVENT);
+        auto sa2 = getDefaultSecurityAttribute();
+        send_telemetry_event = CreateEventW(&sa2, FALSE, FALSE, CommonSharedConstants::SEND_RUN_SETTINGS_TELEMETRY_EVENT);
     };
 
     ~Microsoft_Launcher()

--- a/src/modules/launcher/PowerLauncher.Telemetry/Events/PluginModel.cs
+++ b/src/modules/launcher/PowerLauncher.Telemetry/Events/PluginModel.cs
@@ -9,8 +9,6 @@ namespace PowerLauncher.Telemetry.Events
     [EventData]
     public class PluginModel
     {
-        public string Name { get; set; }
-
         public bool Disabled { get; set; }
 
         public bool IsGlobal { get; set; }

--- a/src/modules/launcher/PowerLauncher.Telemetry/Events/PluginModel.cs
+++ b/src/modules/launcher/PowerLauncher.Telemetry/Events/PluginModel.cs
@@ -2,8 +2,11 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.Tracing;
+
 namespace PowerLauncher.Telemetry.Events
 {
+    [EventData]
     public class PluginModel
     {
         public string Name { get; set; }

--- a/src/modules/launcher/PowerLauncher.Telemetry/Events/PluginModel.cs
+++ b/src/modules/launcher/PowerLauncher.Telemetry/Events/PluginModel.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace PowerLauncher.Telemetry.Events
+{
+    public class PluginModel
+    {
+        public string Name { get; set; }
+
+        public bool Disabled { get; set; }
+
+        public bool IsGlobal { get; set; }
+
+        public string ActionKeyword { get; set; }
+    }
+}

--- a/src/modules/launcher/PowerLauncher.Telemetry/Events/RunPluginsSettingsEvent.cs
+++ b/src/modules/launcher/PowerLauncher.Telemetry/Events/RunPluginsSettingsEvent.cs
@@ -3,16 +3,21 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Diagnostics.Tracing;
 using Microsoft.PowerToys.Telemetry;
 using Microsoft.PowerToys.Telemetry.Events;
 
 namespace PowerLauncher.Telemetry.Events
 {
-    public class RunSettingsEvent : EventBase, IEvent
+    [EventData]
+    public class RunPluginsSettingsEvent : EventBase, IEvent
     {
-#pragma warning disable CA2227 // Collection properties should be read only
-        public IDictionary<string, PluginModel> PluginManager { get; set; }
-#pragma warning restore CA2227 // Collection properties should be read only
+        public RunPluginsSettingsEvent(IDictionary<string, PluginModel> pluginManager)
+        {
+            PluginManager = pluginManager;
+        }
+
+        public IDictionary<string, PluginModel> PluginManager { get; private set; }
 
         public PartA_PrivTags PartA_PrivTags => PartA_PrivTags.ProductAndServiceUsage;
     }

--- a/src/modules/launcher/PowerLauncher.Telemetry/Events/RunSettingsEvent.cs
+++ b/src/modules/launcher/PowerLauncher.Telemetry/Events/RunSettingsEvent.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Microsoft.PowerToys.Telemetry;
+using Microsoft.PowerToys.Telemetry.Events;
+
+namespace PowerLauncher.Telemetry.Events
+{
+    public class RunSettingsEvent : EventBase, IEvent
+    {
+#pragma warning disable CA2227 // Collection properties should be read only
+        public IDictionary<string, PluginModel> PluginManager { get; set; }
+#pragma warning restore CA2227 // Collection properties should be read only
+
+        public PartA_PrivTags PartA_PrivTags => PartA_PrivTags.ProductAndServiceUsage;
+    }
+}

--- a/src/modules/launcher/PowerLauncher/Helper/NativeEventWaiter.cs
+++ b/src/modules/launcher/PowerLauncher/Helper/NativeEventWaiter.cs
@@ -21,7 +21,7 @@ namespace PowerLauncher.Helper
                 {
                     if (eventHandle.WaitOne())
                     {
-                        Log.Info("Successfully waited for POWER_LAUNCHER_SHARED_EVENT", MethodBase.GetCurrentMethod().DeclaringType);
+                        Log.Info($"Successfully waited for {eventName}", MethodBase.GetCurrentMethod().DeclaringType);
                         Application.Current.Dispatcher.Invoke(callback);
                     }
                 }

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -44,7 +44,7 @@ namespace PowerLauncher
 
             _firstDeleteTimer.Elapsed += CheckForFirstDelete;
             _firstDeleteTimer.Interval = 1000;
-            NativeEventWaiter.WaitForEventLoop(Constants.SendRunSettingsTelemetryEvent(), SendSettingsTelemetry);
+            NativeEventWaiter.WaitForEventLoop(Constants.RunSendSettingsTelemetryEvent(), SendSettingsTelemetry);
         }
 
         private void SendSettingsTelemetry()

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -52,7 +52,6 @@ namespace PowerLauncher
             Log.Info("Send Run settings telemetry", this.GetType());
             var plugins = PluginManager.AllPlugins.ToDictionary(x => x.Metadata.Name, x => new PluginModel()
             {
-                Name = x.Metadata.Name,
                 Disabled = x.Metadata.Disabled,
                 ActionKeyword = x.Metadata.ActionKeyword,
                 IsGlobal = x.Metadata.IsGlobal,

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -50,17 +50,15 @@ namespace PowerLauncher
         private void SendSettingsTelemetry()
         {
             Log.Info("Send Run settings telemetry", this.GetType());
-            var telemetryEvent = new RunSettingsEvent()
+            var plugins = PluginManager.AllPlugins.ToDictionary(x => x.Metadata.Name, x => new PluginModel()
             {
-                PluginManager = PluginManager.AllPlugins.ToDictionary(x => x.Metadata.Name, x => new PluginModel()
-                {
-                    Name = x.Metadata.Name,
-                    Disabled = x.Metadata.Disabled,
-                    ActionKeyword = x.Metadata.ActionKeyword,
-                    IsGlobal = x.Metadata.IsGlobal,
-                }),
-            };
+                Name = x.Metadata.Name,
+                Disabled = x.Metadata.Disabled,
+                ActionKeyword = x.Metadata.ActionKeyword,
+                IsGlobal = x.Metadata.IsGlobal,
+            });
 
+            var telemetryEvent = new RunPluginsSettingsEvent(plugins);
             PowerToysTelemetry.Log.WriteEvent(telemetryEvent);
         }
 

--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -9,6 +9,7 @@
 #include "restart_elevated.h"
 #include "RestartManagement.h"
 #include "Generated files/resource.h"
+#include "settings_telemetry.h"
 
 #include <common/comUtils/comUtils.h>
 #include <common/display/dpi_aware.h>
@@ -163,6 +164,7 @@ int runner(bool isProcessElevated, bool openSettings, bool openOobe)
             open_oobe_window(); 
         }
 
+        settings_telemetry::init();
         result = run_message_loop();
     }
     catch (std::runtime_error& err)

--- a/src/runner/runner.vcxproj
+++ b/src/runner/runner.vcxproj
@@ -56,6 +56,7 @@
     <ClCompile Include="main.cpp" />
     <ClCompile Include="restart_elevated.cpp" />
     <ClCompile Include="centralized_kb_hook.cpp" />
+    <ClCompile Include="settings_telemetry.cpp" />
     <ClCompile Include="settings_window.cpp" />
     <ClCompile Include="trace.cpp" />
     <ClCompile Include="tray_icon.cpp" />
@@ -69,6 +70,7 @@
     <ClInclude Include="general_settings.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="centralized_kb_hook.h" />
+    <ClInclude Include="settings_telemetry.h" />
     <ClInclude Include="update_utils.h" />
     <ClInclude Include="update_state.h" />
     <ClInclude Include="powertoy_module.h" />

--- a/src/runner/runner.vcxproj.filters
+++ b/src/runner/runner.vcxproj.filters
@@ -42,6 +42,9 @@
     <ClCompile Include="..\common\interop\two_way_pipe_message_ipc.cpp">
       <Filter>Utils</Filter>
     </ClCompile>
+    <ClCompile Include="settings_telemetry.cpp">
+      <Filter>Utils</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
@@ -82,6 +85,9 @@
       <Filter>Utils</Filter>
     </ClInclude>
     <ClInclude Include="centralized_kb_hook.h">
+      <Filter>Utils</Filter>
+    </ClInclude>
+    <ClInclude Include="settings_telemetry.h">
       <Filter>Utils</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/runner/settings_telemetry.cpp
+++ b/src/runner/settings_telemetry.cpp
@@ -1,0 +1,93 @@
+#pragma once
+#include "pch.h"
+#include "settings_telemetry.h"
+#include <Windows.h>
+#include <thread>
+#include <common/logger/logger.h>
+#include <common/utils/timeutil.h>
+#include <common/SettingsAPI/settings_helpers.h>
+#include <filesystem>
+#include "powertoy_module.h"
+
+using JsonObject = winrt::Windows::Data::Json::JsonObject;
+using JsonValue = winrt::Windows::Data::Json::JsonValue;
+
+std::wstring get_info_file_path()
+{
+    std::filesystem::path settingsFilePath(PTSettingsHelper::get_root_save_folder_location());
+    settingsFilePath = settingsFilePath.append(settings_telemetry::send_info_file);
+    return settingsFilePath.wstring();
+}
+
+std::optional<time_t> get_last_send_time()
+{
+    auto settings = json::from_file(get_info_file_path());
+    if (!settings.has_value() || !settings.value().HasKey(settings_telemetry::last_send_option))
+    {
+        return std::nullopt;
+    }
+
+    auto stringTime = (std::wstring)settings.value().GetNamedString(settings_telemetry::last_send_option);
+    return timeutil::from_string(stringTime);
+}
+
+void update_last_send_time(time_t time)
+{
+    auto settings = JsonObject();
+    settings.SetNamedValue(settings_telemetry::last_send_option, JsonValue::CreateStringValue(timeutil::to_string(time)));
+    json::to_file(get_info_file_path(), settings);
+}
+
+void send()
+{
+    for (auto& [name, powertoy] : modules())
+    {
+        if (powertoy->is_enabled())
+        {
+            try
+            {
+                powertoy->send_settings_telemetry();
+            }
+            catch(...)
+            {
+                Logger::error(L"Failed to send telemetry for {} module", name);
+            }
+        }
+    }
+}
+
+void run_interval()
+{
+    auto time = get_last_send_time();
+    long long wait_time = 24*3600;
+    long long left_to_wait = 0;
+    if (time.has_value())
+    {
+        left_to_wait = max(0, wait_time - timeutil::diff::in_seconds(timeutil::now(), time.value()));
+    }
+
+    Sleep((DWORD)left_to_wait * 1000);
+    send();
+    update_last_send_time(timeutil::now());
+
+    while (true)
+    {
+        Sleep((DWORD)wait_time * 1000);
+        send();
+        update_last_send_time(timeutil::now());
+    }
+}
+
+void settings_telemetry::init()
+{
+    std::thread([]() {
+        try
+        {
+            run_interval();
+        }
+        catch (...)
+        {
+            Logger::error("Failed to send settings telemetry");    
+        }
+    }).detach();
+}

--- a/src/runner/settings_telemetry.h
+++ b/src/runner/settings_telemetry.h
@@ -1,0 +1,7 @@
+#pragma once
+namespace settings_telemetry
+{
+    static std::wstring send_info_file = L"settings-telemetry.json";
+    static std::wstring last_send_option = L"last_send_time";
+    void init();
+}


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
We decided to send settings telemetry every day. The runner is responsible for sending coordination. We save last sent time to a file in order to avoid sending more than once a day.

**What is include in the PR:** 
- Run sending of telemetry in a separate thread
- Store last send time in `telemetry-settings.json`
- Add `send_settings_telemetry` method in `PowertoyModuleIface`
- Use the auto-reset event to signal the `PowerLauncher.exe` process to send telemetry. At first glance, it can look that it is better to send PT Run telemetry from inside of the runner process. But because the PT Run module interface is unaware of PT Run settings it is better to keep it this way.

**How does someone test / validate:** 
It is going to be tested in a Windows 10 Insider machine

## Quality Checklist

- [X] **Linked issue:** #9660
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [X] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
