### PR TITLE
[Run plugin] add tooltips to vscode workspaces plugin

### DIFF
--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/Main.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/Main.cs
@@ -49,11 +49,14 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces
                         title += $" - {(a.ExtraInfo != null ? $"{a.ExtraInfo} ({typeWorkspace})" : typeWorkspace)}";
                     }
 
+                    var tooltip = new ToolTipData(title, $"{Resources.Workspace}{(a.TypeWorkspace != TypeWorkspace.Local ? $" {Resources.In} {typeWorkspace}" : "")}: {SystemPath.RealPath(a.RelativePath)}");
+
                     results.Add(new Result
                     {
                         Title = title,
                         SubTitle = $"{Resources.Workspace}{(a.TypeWorkspace != TypeWorkspace.Local ? $" {Resources.In} {typeWorkspace}" : "")}: {SystemPath.RealPath(a.RelativePath)}",
                         Icon = a.VSCodeInstance.WorkspaceIcon,
+                        ToolTipData = tooltip,
                         Action = c =>
                         {
                             bool hide;
@@ -83,6 +86,7 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces
                     });
                 });
 
+
                 // Search opened remote machines
                 _machinesApi.Machines.ForEach(a =>
                 {
@@ -93,11 +97,14 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces
                         title += $" [{a.User}@{a.HostName}]";
                     }
 
+                    var tooltip = new ToolTipData(title, Resources.SSHRemoteMachine);
+
                     results.Add(new Result
                     {
                         Title = title,
                         SubTitle = Resources.SSHRemoteMachine,
                         Icon = a.VSCodeInstance.RemoteIcon,
+                        ToolTipData = tooltip,
                         Action = c =>
                         {
                             bool hide;


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Add tooltip to vscode workspaces plugin for powertoys run

**What is include in the PR:** 
Tooltips

**How does someone test / validate:**
Move the mouse over a result of vscode workspaces 

## Quality Checklist

- [x] **Linked issue:** #3547
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [x] **Tests:** Added/updated and all pass
- [x] **Installer:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [x] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
