### PR TITLE
[Color Picker] Fix null reference exception

### DIFF
--- a/src/modules/colorPicker/ColorPickerUI/Keyboard/KeyboardMonitor.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Keyboard/KeyboardMonitor.cs
@@ -21,7 +21,7 @@ namespace ColorPicker.Keyboard
     {
         private readonly AppStateHandler _appStateHandler;
         private readonly IUserSettings _userSettings;
-        private List<string> _previouslyPressedKeys;
+        private List<string> _previouslyPressedKeys = new List<string>();
 
         private List<string> _activationKeys = new List<string>();
         private GlobalKeyboardHook _keyboardHook;


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
According to https://github.com/microsoft/PowerToys/issues/9573#issuecomment-795812278, we get null reference exception  in https://github.com/microsoft/PowerToys/blob/77d67f35999bdf5cbaf96092c87e718afab91409/src/modules/colorPicker/ColorPickerUI/Keyboard/KeyboardMonitor.cs#L103

Note, that the variable `currentlyPressedKeys` is initialized at the beginning of the method.

**What is include in the PR:** 

**How does someone test / validate:** 
We do not have steps to reproduce. Thioreticly, it is possible to get that exception if the first keyboard event captured by ColorPicker is keyup. Furthermore, from https://github.com/microsoft/PowerToys/issues/9573#issuecomment-795812278 we can see that it is possible.
## Quality Checklist

- [X] **Linked issue:** #9573
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [X] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
