### PR TITLE
Color picker logs path

### DIFF
--- a/src/common/interop/interop.cpp
+++ b/src/common/interop/interop.cpp
@@ -135,6 +135,10 @@ public
     public:
         literal int VK_WIN_BOTH = CommonSharedConstants::VK_WIN_BOTH;
 
+        static String ^ AppDataPath() {
+            return gcnew String(CommonSharedConstants::APPDATA_PATH);
+        }
+
         static String ^ PowerLauncherSharedEvent() {
             return gcnew String(CommonSharedConstants::POWER_LAUNCHER_SHARED_EVENT);
         }

--- a/src/common/interop/interop.cpp
+++ b/src/common/interop/interop.cpp
@@ -136,7 +136,9 @@ public
         literal int VK_WIN_BOTH = CommonSharedConstants::VK_WIN_BOTH;
 
         static String ^ AppDataPath() {
-            return gcnew String(CommonSharedConstants::APPDATA_PATH);
+            auto localPath = Environment::GetFolderPath(Environment::SpecialFolder::LocalApplicationData);
+            auto powerToysPath = gcnew String(CommonSharedConstants::APPDATA_PATH);
+            return System::IO::Path::Combine(localPath, powerToysPath);
         }
 
         static String ^ PowerLauncherSharedEvent() {

--- a/src/common/interop/shared_constants.h
+++ b/src/common/interop/shared_constants.h
@@ -10,6 +10,8 @@ namespace CommonSharedConstants
     // Fake key code to represent VK_WIN.
     inline const int VK_WIN_BOTH = 0x104;
 
+    const wchar_t APPDATA_PATH[] = L"Microsoft\\PowerToys";
+
     // Path to the event used by PowerLauncher
     const wchar_t POWER_LAUNCHER_SHARED_EVENT[] = L"Local\\PowerToysRunInvokeEvent-30f26ad7-d36d-4c0e-ab02-68bb5ff3c4ab";
 

--- a/src/modules/colorPicker/ColorPickerUI/Helpers/Logger.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/Logger.cs
@@ -7,14 +7,14 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.IO.Abstractions;
+using interop;
 
 namespace ColorPicker.Helpers
 {
     public static class Logger
     {
         private static readonly IFileSystem _fileSystem = new FileSystem();
-        private const string ModuleLocation = "Microsoft\\PowerToys\\ColorPicker";
-        private static readonly string ApplicationLogPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), ModuleLocation, "Logs");
+        private static readonly string ApplicationLogPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), Constants.AppDataPath(), "ColorPicker\\Logs");
 
         static Logger()
         {

--- a/src/modules/colorPicker/ColorPickerUI/Helpers/Logger.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/Logger.cs
@@ -14,7 +14,7 @@ namespace ColorPicker.Helpers
     public static class Logger
     {
         private static readonly IFileSystem _fileSystem = new FileSystem();
-        private static readonly string ApplicationLogPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), Constants.AppDataPath(), "ColorPicker\\Logs");
+        private static readonly string ApplicationLogPath = Path.Combine(Constants.AppDataPath(), "ColorPicker\\Logs");
 
         static Logger()
         {

--- a/src/modules/colorPicker/ColorPickerUI/Helpers/Logger.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/Logger.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Diagnostics;
 using System.Globalization;
+using System.IO;
 using System.IO.Abstractions;
 
 namespace ColorPicker.Helpers
@@ -12,7 +13,8 @@ namespace ColorPicker.Helpers
     public static class Logger
     {
         private static readonly IFileSystem _fileSystem = new FileSystem();
-        private static readonly string ApplicationLogPath = _fileSystem.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "ColorPicker");
+        private const string ModuleLocation = "Microsoft\\PowerToys\\ColorPicker";
+        private static readonly string ApplicationLogPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), ModuleLocation, "Logs");
 
         static Logger()
         {


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Change ColorPicker's logs path to `Microsoft\PowerToys\ColorPicker\Logs`.

**What is include in the PR:** 

**How does someone test / validate:** 
Check that logs are written to the new location.

## Quality Checklist

- [X] **Linked issue:** #10359
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [X] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
