### PR TITLE
[ColorPicker] Order colors with up/down buttons.

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ColorFormatModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ColorFormatModel.cs
@@ -12,6 +12,8 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         private string _name;
         private string _example;
         private bool _isShown;
+        private bool _canMoveUp = true;
+        private bool _canMoveDown = true;
 
         public ColorFormatModel(string name, string example, bool isShown)
         {
@@ -58,6 +60,34 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             set
             {
                 _isShown = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public bool CanMoveUp
+        {
+            get
+            {
+                return _canMoveUp;
+            }
+
+            set
+            {
+                _canMoveUp = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public bool CanMoveDown
+        {
+            get
+            {
+                return _canMoveDown;
+            }
+
+            set
+            {
+                _canMoveDown = value;
                 OnPropertyChanged();
             }
         }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/ColorPickerViewModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/ColorPickerViewModel.cs
@@ -247,11 +247,28 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
                 ColorFormats.Add(remainingColorFormat);
             }
 
+            // Reordering colors with buttons: disable first and last buttons
+            ColorFormats[0].CanMoveUp = false;
+            ColorFormats[ColorFormats.Count - 1].CanMoveDown = false;
+
             ColorFormats.CollectionChanged += ColorFormats_CollectionChanged;
         }
 
         private void ColorFormats_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
         {
+            // Reordering colors with buttons: update buttons availability depending on order
+            if (ColorFormats.Count > 0)
+            {
+                foreach (var color in ColorFormats)
+                {
+                    color.CanMoveUp = true;
+                    color.CanMoveDown = true;
+                }
+
+                ColorFormats[0].CanMoveUp = false;
+                ColorFormats[ColorFormats.Count - 1].CanMoveDown = false;
+            }
+
             UpdateColorFormats();
             ScheduleSavingOfSettings();
         }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -1170,4 +1170,10 @@ Win + Shift + O to toggle your video</value>
   <data name="Run_PluginsLoading.Text" xml:space="preserve">
     <value>Plugins are loading...</value>
   </data>
+  <data name="ColorPicker_ButtonDown.AutomationProperties.Name" xml:space="preserve">
+    <value>Move the color down</value>
+  </data>
+  <data name="ColorPicker_ButtonUp.AutomationProperties.Name" xml:space="preserve">
+    <value>Move the color up</value>
+  </data>
 </root>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -868,7 +868,7 @@
     <value>Open directly into the editor mode</value>
   </data>
   <data name="ColorPicker_ColorFormatsDescription.Text" xml:space="preserve">
-    <value>Editor color formats (Change the order by dragging)</value>
+    <value>Editor color formats</value>
   </data>
   <data name="ColorPicker_ShowColorName.Content" xml:space="preserve">
     <value>Show color name</value>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
@@ -196,7 +196,7 @@
                                        FontFamily="Segoe MDL2 Assets" /> -->
 
                             <Button x:Uid="ColorPicker_ButtonUp"
-                                    Content="&#xE971;"
+                                    Content="&#xE74A;"
                                     Grid.Row="0"
                                     HorizontalAlignment="Right"
                                     Margin="0,0,36,0"
@@ -204,7 +204,7 @@
                                     FontFamily="Segoe MDL2 Assets"
                                     Click="ReorderButtonUp_Click"/>
                             <Button x:Uid="ColorPicker_ButtonDown"
-                                    Content="&#xE972;"
+                                    Content="&#xE74B;"
                                     Grid.Row="1"
                                     HorizontalAlignment="Right"
                                     Margin="0,0,36,0"

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
@@ -197,6 +197,7 @@
 
                             <Button x:Uid="ColorPicker_ButtonUp"
                                     Content="&#xE74A;"
+                                    IsEnabled="{Binding CanMoveUp}"
                                     Grid.Row="0"
                                     HorizontalAlignment="Right"
                                     Margin="0,0,36,0"
@@ -205,6 +206,7 @@
                                     Click="ReorderButtonUp_Click"/>
                             <Button x:Uid="ColorPicker_ButtonDown"
                                     Content="&#xE74B;"
+                                    IsEnabled="{Binding CanMoveDown}"
                                     Grid.Row="1"
                                     HorizontalAlignment="Right"
                                     Margin="0,0,36,0"

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
@@ -194,7 +194,21 @@
                                        HorizontalAlignment="Right"
                                        Margin="0,0,36,0"
                                        FontFamily="Segoe MDL2 Assets" /> -->
-                                       FontFamily="Segoe MDL2 Assets" />
+
+                            <Button Content="&#xE971;"
+                                    Grid.Row="0"
+                                    HorizontalAlignment="Right"
+                                    Margin="0,0,36,0"
+                                    Background="Transparent"
+                                    FontFamily="Segoe MDL2 Assets"
+                                    Click="ReorderButtonUp_Click"/>
+                            <Button Content="&#xE972;"
+                                    Grid.Row="1"
+                                    HorizontalAlignment="Right"
+                                    Margin="0,0,36,0"
+                                    Background="Transparent"
+                                    FontFamily="Segoe MDL2 Assets"
+                                    Click="ReorderButtonDown_Click"/>
                         </Grid>
                     </DataTemplate>
                 </ListView.ItemTemplate>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
@@ -155,6 +155,9 @@
                       AutomationProperties.LabeledBy="{Binding ElementName=ColorFormatsListViewLabel}"
                       HorizontalAlignment="Left"
                       Margin="-12,6,0,0">
+                <ItemsControl.ItemContainerTransitions>
+                    <TransitionCollection/>
+                </ItemsControl.ItemContainerTransitions>
                 <ListView.ItemTemplate>
                     <DataTemplate>
                         <Grid Width="466" Background="Transparent">

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
@@ -195,14 +195,16 @@
                                        Margin="0,0,36,0"
                                        FontFamily="Segoe MDL2 Assets" /> -->
 
-                            <Button Content="&#xE971;"
+                            <Button x:Uid="ColorPicker_ButtonUp"
+                                    Content="&#xE971;"
                                     Grid.Row="0"
                                     HorizontalAlignment="Right"
                                     Margin="0,0,36,0"
                                     Background="Transparent"
                                     FontFamily="Segoe MDL2 Assets"
                                     Click="ReorderButtonUp_Click"/>
-                            <Button Content="&#xE972;"
+                            <Button x:Uid="ColorPicker_ButtonDown"
+                                    Content="&#xE972;"
                                     Grid.Row="1"
                                     HorizontalAlignment="Right"
                                     Margin="0,0,36,0"

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
@@ -184,8 +184,11 @@
                                        Grid.Row="1"
                                        Margin="0,0,0,8"/>
                             <ToggleSwitch IsOn="{Binding IsShown, Mode=TwoWay}"
+                                          OnContent=""
+                                          OffContent=""
                                           Grid.RowSpan="2"
-                                          HorizontalAlignment="Right" />
+                                          HorizontalAlignment="Right"
+                                          Margin="0,0,-36,0"/>
                             <!-- Disabled reordering by dragging
                             
                             <TextBlock Text="&#xE76F;"
@@ -203,7 +206,7 @@
                                     IsEnabled="{Binding CanMoveUp}"
                                     Grid.Row="0"
                                     HorizontalAlignment="Right"
-                                    Margin="0,0,36,0"
+                                    Margin="0,0,24,0"
                                     Background="Transparent"
                                     FontFamily="Segoe MDL2 Assets"
                                     Click="ReorderButtonUp_Click"/>
@@ -212,7 +215,7 @@
                                     IsEnabled="{Binding CanMoveDown}"
                                     Grid.Row="1"
                                     HorizontalAlignment="Right"
-                                    Margin="0,0,36,0"
+                                    Margin="0,0,24,0"
                                     Background="Transparent"
                                     FontFamily="Segoe MDL2 Assets"
                                     Click="ReorderButtonDown_Click"/>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
@@ -234,7 +234,14 @@
                                     Background="Transparent"
                                     Visibility="Collapsed"
                                     FontFamily="Segoe MDL2 Assets"
-                                    Click="ReorderButtonDown_Click"/>
+                                    Click="ReorderButtonDown_Click" >
+                                <Interactivity:Interaction.Behaviors>
+                                    <Core:EventTriggerBehavior EventName="Click">
+                                        <Core:ChangePropertyAction TargetObject="{Binding ElementName=ButtonUp}" PropertyName="Visibility" Value="Collapsed" />
+                                        <Core:ChangePropertyAction TargetObject="{Binding ElementName=ButtonDown}" PropertyName="Visibility" Value="Collapsed" />
+                                    </Core:EventTriggerBehavior>
+                                </Interactivity:Interaction.Behaviors>
+                            </Button>
                         </Grid>
                     </DataTemplate>
                 </ListView.ItemTemplate>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
@@ -171,6 +171,18 @@
                                     <Core:ChangePropertyAction TargetObject="{Binding ElementName=GripperIcon}" PropertyName="Visibility" Value="Collapsed" />
                                 </Core:EventTriggerBehavior>
                             </Interactivity:Interaction.Behaviors> -->
+
+                            <Interactivity:Interaction.Behaviors>
+                                <Core:EventTriggerBehavior EventName="PointerEntered">
+                                    <Core:ChangePropertyAction TargetObject="{Binding ElementName=ButtonUp}" PropertyName="Visibility" Value="Visible" />
+                                    <Core:ChangePropertyAction TargetObject="{Binding ElementName=ButtonDown}" PropertyName="Visibility" Value="Visible" />
+                                </Core:EventTriggerBehavior>
+                                <Core:EventTriggerBehavior EventName="PointerExited">
+                                    <Core:ChangePropertyAction TargetObject="{Binding ElementName=ButtonUp}" PropertyName="Visibility" Value="Collapsed" />
+                                    <Core:ChangePropertyAction TargetObject="{Binding ElementName=ButtonDown}" PropertyName="Visibility" Value="Collapsed" />
+                                </Core:EventTriggerBehavior>
+                            </Interactivity:Interaction.Behaviors>
+                            
                             <Grid.RowDefinitions>
                                 <RowDefinition/>
                                 <RowDefinition/>
@@ -202,21 +214,25 @@
                                        FontFamily="Segoe MDL2 Assets" /> -->
 
                             <Button x:Uid="ColorPicker_ButtonUp"
+                                    x:Name="ButtonUp"
                                     Content="&#xE74A;"
                                     IsEnabled="{Binding CanMoveUp}"
                                     Grid.Row="0"
                                     HorizontalAlignment="Right"
                                     Margin="0,0,24,0"
                                     Background="Transparent"
+                                    Visibility="Collapsed"
                                     FontFamily="Segoe MDL2 Assets"
                                     Click="ReorderButtonUp_Click"/>
                             <Button x:Uid="ColorPicker_ButtonDown"
+                                    x:Name="ButtonDown"
                                     Content="&#xE74B;"
                                     IsEnabled="{Binding CanMoveDown}"
                                     Grid.Row="1"
                                     HorizontalAlignment="Right"
                                     Margin="0,0,24,0"
                                     Background="Transparent"
+                                    Visibility="Collapsed"
                                     FontFamily="Segoe MDL2 Assets"
                                     Click="ReorderButtonDown_Click"/>
                         </Grid>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
@@ -1,4 +1,4 @@
-﻿<Page
+<Page
     x:Class="Microsoft.PowerToys.Settings.UI.Views.ColorPickerPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -147,17 +147,19 @@
                        Foreground="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToForegroundConverter}}"
                        Margin="{StaticResource SmallTopMargin}"/>
             
+            <!-- Disabled reordering -->
+            <!-- CanReorderItems="True" AllowDrop="True" -->
             <ListView ItemsSource="{Binding ColorFormats, Mode=TwoWay}"
-                      AllowDrop="True"
                       MaxWidth="466"
                       IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"
                       AutomationProperties.LabeledBy="{Binding ElementName=ColorFormatsListViewLabel}"
-                      CanReorderItems="True"
                       HorizontalAlignment="Left"
                       Margin="-12,6,0,0">
                 <ListView.ItemTemplate>
                     <DataTemplate>
                         <Grid Width="466" Background="Transparent">
+                            <!-- Disabled reordering
+                            
                             <Interactivity:Interaction.Behaviors>
                                 <Core:EventTriggerBehavior EventName="PointerEntered">
                                     <Core:ChangePropertyAction TargetObject="{Binding ElementName=GripperIcon}" PropertyName="Visibility" Value="Visible" />
@@ -165,7 +167,7 @@
                                 <Core:EventTriggerBehavior EventName="PointerExited">
                                     <Core:ChangePropertyAction TargetObject="{Binding ElementName=GripperIcon}" PropertyName="Visibility" Value="Collapsed" />
                                 </Core:EventTriggerBehavior>
-                            </Interactivity:Interaction.Behaviors>
+                            </Interactivity:Interaction.Behaviors> -->
                             <Grid.RowDefinitions>
                                 <RowDefinition/>
                                 <RowDefinition/>
@@ -181,6 +183,8 @@
                             <ToggleSwitch IsOn="{Binding IsShown, Mode=TwoWay}"
                                           Grid.RowSpan="2"
                                           HorizontalAlignment="Right" />
+                            <!-- Disabled reordering
+                            
                             <TextBlock Text="&#xE76F;"
                                        Visibility="Collapsed"
                                        x:Name="GripperIcon"
@@ -189,6 +193,7 @@
                                        FontSize="16"
                                        HorizontalAlignment="Right"
                                        Margin="0,0,36,0"
+                                       FontFamily="Segoe MDL2 Assets" /> -->
                                        FontFamily="Segoe MDL2 Assets" />
                         </Grid>
                     </DataTemplate>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
@@ -147,7 +147,7 @@
                        Foreground="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToForegroundConverter}}"
                        Margin="{StaticResource SmallTopMargin}"/>
             
-            <!-- Disabled reordering -->
+            <!-- Disabled reordering by dragging -->
             <!-- CanReorderItems="True" AllowDrop="True" -->
             <ListView ItemsSource="{Binding ColorFormats, Mode=TwoWay}"
                       MaxWidth="466"
@@ -158,7 +158,7 @@
                 <ListView.ItemTemplate>
                     <DataTemplate>
                         <Grid Width="466" Background="Transparent">
-                            <!-- Disabled reordering
+                            <!-- Disabled reordering by dragging
                             
                             <Interactivity:Interaction.Behaviors>
                                 <Core:EventTriggerBehavior EventName="PointerEntered">
@@ -183,7 +183,7 @@
                             <ToggleSwitch IsOn="{Binding IsShown, Mode=TwoWay}"
                                           Grid.RowSpan="2"
                                           HorizontalAlignment="Right" />
-                            <!-- Disabled reordering
+                            <!-- Disabled reordering by dragging
                             
                             <TextBlock Text="&#xE76F;"
                                        Visibility="Collapsed"

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
@@ -223,7 +223,14 @@
                                     Background="Transparent"
                                     Visibility="Collapsed"
                                     FontFamily="Segoe MDL2 Assets"
-                                    Click="ReorderButtonUp_Click"/>
+                                    Click="ReorderButtonUp_Click">
+                                <Interactivity:Interaction.Behaviors>
+                                    <Core:EventTriggerBehavior EventName="Click">
+                                    <Core:ChangePropertyAction TargetObject="{Binding ElementName=ButtonUp}" PropertyName="Visibility" Value="Collapsed" />
+                                    <Core:ChangePropertyAction TargetObject="{Binding ElementName=ButtonDown}" PropertyName="Visibility" Value="Collapsed" />
+                                </Core:EventTriggerBehavior>
+                                </Interactivity:Interaction.Behaviors>
+                            </Button>
                             <Button x:Uid="ColorPicker_ButtonDown"
                                     x:Name="ButtonDown"
                                     Content="&#xE74B;"

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml.cs
@@ -47,5 +47,35 @@ namespace Microsoft.PowerToys.Settings.UI.Views
 
             ColorPicker_ComboBox.SelectedIndex = index;
         }
+
+        private void ReorderButtonUp_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        {
+            ColorFormatModel color = ((Button)sender).DataContext as ColorFormatModel;
+            if (color == null)
+            {
+                return;
+            }
+
+            var index = ViewModel.ColorFormats.IndexOf(color);
+            if (index > 0)
+            {
+                ViewModel.ColorFormats.Move(index, index - 1);
+            }
+        }
+
+        private void ReorderButtonDown_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        {
+            ColorFormatModel color = ((Button)sender).DataContext as ColorFormatModel;
+            if (color == null)
+            {
+                return;
+            }
+
+            var index = ViewModel.ColorFormats.IndexOf(color);
+            if (index < ViewModel.ColorFormats.Count - 1)
+            {
+                ViewModel.ColorFormats.Move(index, index + 1);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Replaced dragging with up/down buttons for color ordering.

![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/8949536/112158099-e7151180-8bf8-11eb-9efa-7e8acff64069.gif)

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #8317  #8637
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
