### PR TITLE
[PT Run plugin] Immediately releases AppxManifest stream objects

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/UWP.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/UWP.cs
@@ -79,6 +79,11 @@ namespace Microsoft.Plugin.Program.Programs
 
                     return valid;
                 }).ToArray();
+
+                if (Marshal.ReleaseComObject(stream) > 0)
+                {
+                    Log.Error("AppxManifest.xml was leaked", MethodBase.GetCurrentMethod().DeclaringType);
+                }
             }
             else
             {


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
`stream` is a COM object, so GC should free it at some non-deterministic time, but it's also ref-counted, so the issue might be caused by GC delay. `Marshal.ReleaseComObject` will release it immediately instead. 
I've also added logging to discover if the objects are leaked.
**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #10315
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
