### PR TITLE
[Run Settings] Don't update view if settings were not changed

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/BasePTModuleSettings.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/BasePTModuleSettings.cs
@@ -23,5 +23,16 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             // By default JsonSerializer will only serialize the properties in the base class. This can be avoided by passing the object type (more details at https://stackoverflow.com/a/62498888)
             return JsonSerializer.Serialize(this, GetType());
         }
+
+        public override int GetHashCode()
+        {
+            return ToJsonString().GetHashCode();
+        }
+
+        public override bool Equals(object obj)
+        {
+            var settings = obj as BasePTModuleSettings;
+            return settings?.ToJsonString() == ToJsonString();
+        }
     }
 }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/PowerLauncherViewModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/PowerLauncherViewModel.cs
@@ -453,5 +453,10 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
         {
             get => EnablePowerLauncher && !Plugins.Any();
         }
+
+        public bool IsUpToDate(PowerLauncherSettings settings)
+        {
+            return this.settings.Equals(settings);
+        }
     }
 }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml.cs
@@ -28,24 +28,24 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             DataContext = ViewModel;
             _ = Helper.GetFileWatcher(PowerLauncherSettings.ModuleName, "settings.json", () =>
             {
-                _ = Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () =>
+                PowerLauncherSettings powerLauncherSettings = null;
+                try
                 {
-                    PowerLauncherSettings powerLauncherSettings = null;
-                    try
-                    {
-                        powerLauncherSettings = settingsUtils.GetSettingsOrDefault<PowerLauncherSettings>(PowerLauncherSettings.ModuleName);
-                    }
-                    catch (IOException ex)
-                    {
-                        Logger.LogInfo(ex.Message);
-                    }
+                    powerLauncherSettings = settingsUtils.GetSettingsOrDefault<PowerLauncherSettings>(PowerLauncherSettings.ModuleName);
+                }
+                catch (IOException ex)
+                {
+                    Logger.LogInfo(ex.Message);
+                }
 
-                    if (powerLauncherSettings != null)
+                if (powerLauncherSettings != null && !ViewModel.IsUpToDate(powerLauncherSettings))
+                {
+                    _ = Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () =>
                     {
                         DataContext = ViewModel = new PowerLauncherViewModel(powerLauncherSettings, SettingsRepository<GeneralSettings>.GetInstance(settingsUtils), ShellPage.SendDefaultIPCMessage, App.IsDarkTheme);
                         this.Bindings.Update();
-                    }
-                });
+                    });
+                }
             });
 
             var loader = Windows.ApplicationModel.Resources.ResourceLoader.GetForCurrentView();


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
We get a lot of glitches while updating plugins in the Plugin Manager. It happens because the view is completly rerendered on every change

**What is include in the PR:** 
- Ovverided equal facilities for `BasePTModuleSettings`
- Move reading settings and comparing  out of UI thread
- Do not update the view if it is up to date.

**How does someone test / validate:** 
- Check that glitches are gone
- Check that the view is updated on settings change

## Quality Checklist

- [X] **Linked issue:** #10404
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [X] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
