### PR TITLE
[FancyZones] Update device info when setting custom zone sets from lib

### DIFF
--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -592,6 +592,7 @@ FancyZones::OnKeyDown(PKBDLLHOOKSTRUCT info) noexcept
             if (std::any_of(quickKeysMap.begin(), quickKeysMap.end(), [=](auto item) { return item.second == digitPressed; }))
             {
                 PostMessageW(m_window, WM_PRIV_QUICK_LAYOUT_KEY, 0, static_cast<LPARAM>(digitPressed));
+                Trace::FancyZones::QuickLayoutSwitched(changeLayoutWhileNotDragging);
                 return true;
             }
         }

--- a/src/modules/fancyzones/lib/FancyZonesData.cpp
+++ b/src/modules/fancyzones/lib/FancyZonesData.cpp
@@ -511,10 +511,33 @@ bool FancyZonesData::SetAppLastZones(HWND window, const std::wstring& deviceId, 
 void FancyZonesData::SetActiveZoneSet(const std::wstring& deviceId, const FancyZonesDataTypes::ZoneSetData& data)
 {
     std::scoped_lock lock{ dataLock };
-    auto it = deviceInfoMap.find(deviceId);
-    if (it != deviceInfoMap.end())
+
+    auto deviceIt = deviceInfoMap.find(deviceId);
+    if (deviceIt == deviceInfoMap.end())
     {
-        it->second.activeZoneSet = data;
+        return;
+    }
+
+    deviceIt->second.activeZoneSet = data;
+
+    // If the zone set is custom, we need to copy its properties to the device
+    auto zonesetIt = customZoneSetsMap.find(data.uuid);
+    if (zonesetIt != customZoneSetsMap.end())
+    {
+        if (zonesetIt->second.type == FancyZonesDataTypes::CustomLayoutType::Grid)
+        {
+            auto layoutInfo = std::get<FancyZonesDataTypes::GridLayoutInfo>(zonesetIt->second.info);
+            deviceIt->second.sensitivityRadius = layoutInfo.sensitivityRadius();
+            deviceIt->second.showSpacing = layoutInfo.showSpacing();
+            deviceIt->second.spacing = layoutInfo.spacing();
+            deviceIt->second.zoneCount = layoutInfo.zoneCount();
+        }
+        else if (zonesetIt->second.type == FancyZonesDataTypes::CustomLayoutType::Canvas)
+        {
+            auto layoutInfo = std::get<FancyZonesDataTypes::CanvasLayoutInfo>(zonesetIt->second.info);
+            deviceIt->second.sensitivityRadius = layoutInfo.sensitivityRadius;
+            deviceIt->second.zoneCount = (int)layoutInfo.zones.size();
+        }
     }
 }
 

--- a/src/modules/fancyzones/lib/FancyZonesDataTypes.cpp
+++ b/src/modules/fancyzones/lib/FancyZonesDataTypes.cpp
@@ -112,4 +112,18 @@ namespace FancyZonesDataTypes
             cellRow.resize(m_columns, 0);
         }
     }
+
+    int GridLayoutInfo::zoneCount() const
+    {
+        int high = 0;
+        for (const auto& row : m_cellChildMap)
+        {
+            for (int val : row)
+            {
+                high = max(high, val);
+            }
+        }
+
+        return high + 1;
+    }
 }

--- a/src/modules/fancyzones/lib/FancyZonesDataTypes.h
+++ b/src/modules/fancyzones/lib/FancyZonesDataTypes.h
@@ -86,6 +86,8 @@ namespace FancyZonesDataTypes
         inline int spacing() const { return m_spacing; }
         inline int sensitivityRadius() const { return m_sensitivityRadius; }
 
+        int zoneCount() const;
+
         int m_rows;
         int m_columns;
         std::vector<int> m_rowsPercents;


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Due to a less than ideal data schema in FancyZones, we need to update information stored in custom zone sets, such as `sensitivityRadius` and `spacing` to the target device when applying the layout. See issue #10390

**What is include in the PR:** 

**How does someone test / validate:** 

Check that the zone layout is applied correctly when switching layouts using the shortcut key.

## Quality Checklist

- [x] **Linked issue:** #10390
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
