### PR TITLE
[Log] Change log level to trace part 1

### DIFF
--- a/src/common/SettingsAPI/settings_helpers.cpp
+++ b/src/common/SettingsAPI/settings_helpers.cpp
@@ -4,7 +4,6 @@
 namespace PTSettingsHelper
 {
     constexpr inline const wchar_t* settings_filename = L"\\settings.json";
-    constexpr inline const wchar_t* log_settings_filename = L"log_settings.json";
     constexpr inline const wchar_t* oobe_filename = L"oobe_settings.json";
 
     std::wstring get_root_save_folder_location()

--- a/src/common/SettingsAPI/settings_helpers.h
+++ b/src/common/SettingsAPI/settings_helpers.h
@@ -6,6 +6,8 @@
 
 namespace PTSettingsHelper
 {
+    constexpr inline const wchar_t* log_settings_filename = L"log_settings.json";
+
     std::wstring get_module_save_folder_location(std::wstring_view powertoy_name);
     std::wstring get_root_save_folder_location();
 

--- a/src/common/logger/logger_settings.h
+++ b/src/common/logger/logger_settings.h
@@ -4,7 +4,7 @@
 struct LogSettings
 {
     // The following strings are not localizable
-    inline const static std::wstring defaultLogLevel = L"warn";
+    inline const static std::wstring defaultLogLevel = L"trace";
     inline const static std::wstring logLevelOption = L"logLevel";
     inline const static std::string runnerLoggerName = "runner";
     inline const static std::wstring runnerLogPath = L"RunnerLogs\\runner-log.txt";


### PR DESCRIPTION
## Summary of the Pull Request

Remove log_settings.json during installation and change default level to trace

**What is this about:**

**What is include in the PR:** 

**How does someone test / validate:** 
- build PT/Bootstrapper, install it
- launch PT and verify that `%localappdata%\microsoft\PowerToys\log_settings.json` contains `trace` severity level

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
