### PR TITLE
[FancyZones] Fix deadlocks in ZoneWindowDrawing

### DIFF
--- a/src/modules/fancyzones/lib/FancyZones.cpp
+++ b/src/modules/fancyzones/lib/FancyZones.cpp
@@ -647,7 +647,7 @@ void FancyZones::ToggleEditor() noexcept
     wil::unique_cotaskmem_string virtualDesktopId;
     if (!SUCCEEDED(StringFromCLSID(m_currentDesktopId, &virtualDesktopId)))
     {
-        return;   
+        return;
     }
 
     /*
@@ -677,7 +677,7 @@ void FancyZones::ToggleEditor() noexcept
     {
         params += FancyZonesUtils::GenerateUniqueIdAllMonitorsArea(virtualDesktopId.get()) + divider; /* Monitor id where the Editor should be opened */
     }
-   
+
     // device id map
     std::unordered_map<std::wstring, DWORD> displayDeviceIdxMap;
 

--- a/src/modules/fancyzones/lib/ZoneWindow.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindow.cpp
@@ -163,8 +163,6 @@ private:
     std::vector<size_t> m_highlightZone;
     WPARAM m_keyLast{};
     size_t m_keyCycle{};
-    static const UINT m_showAnimationDuration = 200; // ms
-    static const UINT m_flashDuration = 1000; // ms
     std::unique_ptr<ZoneWindowDrawing> m_zoneWindowDrawing;
 };
 
@@ -384,7 +382,7 @@ ZoneWindow::ShowZoneWindow() noexcept
     {
         SetAsTopmostWindow();
         m_zoneWindowDrawing->DrawActiveZoneSet(m_activeZoneSet->GetZones(), m_highlightZone, m_host);
-        m_zoneWindowDrawing->Show(m_showAnimationDuration);
+        m_zoneWindowDrawing->Show();
     }
 }
 
@@ -427,7 +425,7 @@ ZoneWindow::FlashZones() noexcept
     {
         SetAsTopmostWindow();
         m_zoneWindowDrawing->DrawActiveZoneSet(m_activeZoneSet->GetZones(), {}, m_host);
-        m_zoneWindowDrawing->Flash(m_flashDuration);
+        m_zoneWindowDrawing->Flash();
     }
 }
 

--- a/src/modules/fancyzones/lib/ZoneWindowDrawing.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindowDrawing.cpp
@@ -218,7 +218,7 @@ void ZoneWindowDrawing::RenderLoop()
 void ZoneWindowDrawing::Hide()
 {
     _TRACER_;
-    bool shouldHideWindow;
+    bool shouldHideWindow{};
     {
         std::unique_lock lock(m_mutex);
         m_animation.reset();
@@ -235,7 +235,7 @@ void ZoneWindowDrawing::Hide()
 void ZoneWindowDrawing::Show(unsigned animationMillis)
 {
     _TRACER_;
-    bool shouldShowWindow;
+    bool shouldShowWindow{};
     {
         std::unique_lock lock(m_mutex);
         shouldShowWindow = !m_shouldRender;
@@ -260,7 +260,7 @@ void ZoneWindowDrawing::Show(unsigned animationMillis)
 void ZoneWindowDrawing::Flash(unsigned animationMillis)
 {
     _TRACER_;
-    bool shouldShowWindow;
+    bool shouldShowWindow{};
     {
         std::unique_lock lock(m_mutex);
         shouldShowWindow = !m_shouldRender;

--- a/src/modules/fancyzones/lib/ZoneWindowDrawing.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindowDrawing.cpp
@@ -205,7 +205,7 @@ void ZoneWindowDrawing::RenderLoop()
 
         auto result = Render();
 
-        if (result == RenderResult::AnimationEnded)
+        if (result == RenderResult::AnimationEnded || result == RenderResult::Failed)
         {
             Hide();
         }

--- a/src/modules/fancyzones/lib/ZoneWindowDrawing.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindowDrawing.cpp
@@ -22,7 +22,6 @@ namespace NonLocalizable
 
 float ZoneWindowDrawing::GetAnimationAlpha()
 {
-    _TRACER_;
     std::unique_lock lock(m_mutex);
 
     if (!m_animation)
@@ -213,7 +212,7 @@ void ZoneWindowDrawing::RenderLoop()
 void ZoneWindowDrawing::Hide()
 {
     _TRACER_;
-    bool shouldHideWindow{};
+    bool shouldHideWindow = true;
     {
         std::unique_lock lock(m_mutex);
         m_animation.reset();
@@ -230,7 +229,7 @@ void ZoneWindowDrawing::Hide()
 void ZoneWindowDrawing::Show()
 {
     _TRACER_;
-    bool shouldShowWindow{};
+    bool shouldShowWindow = true;
     {
         std::unique_lock lock(m_mutex);
         shouldShowWindow = !m_shouldRender;
@@ -238,7 +237,7 @@ void ZoneWindowDrawing::Show()
 
         if (!m_animation)
         {
-            m_animation.emplace(AnimationInfo{ std::chrono::steady_clock().now(), false });
+            m_animation.emplace(AnimationInfo{ .tStart = std::chrono::steady_clock().now(), .autoHide = false });
         }
         else if (m_animation->autoHide)
         {
@@ -258,13 +257,13 @@ void ZoneWindowDrawing::Show()
 void ZoneWindowDrawing::Flash()
 {
     _TRACER_;
-    bool shouldShowWindow{};
+    bool shouldShowWindow = true;
     {
         std::unique_lock lock(m_mutex);
         shouldShowWindow = !m_shouldRender;
         m_shouldRender = true;
     
-        m_animation.emplace(AnimationInfo{ std::chrono::steady_clock().now(), true });
+        m_animation.emplace(AnimationInfo{ .tStart = std::chrono::steady_clock().now(), .autoHide = true });
     }
 
     if (shouldShowWindow)

--- a/src/modules/fancyzones/lib/ZoneWindowDrawing.cpp
+++ b/src/modules/fancyzones/lib/ZoneWindowDrawing.cpp
@@ -95,7 +95,7 @@ ZoneWindowDrawing::ZoneWindowDrawing(HWND window)
         D2D1::PixelFormat(DXGI_FORMAT_UNKNOWN, D2D1_ALPHA_MODE_PREMULTIPLIED),
         96.f,
         96.f);
-    
+
     auto renderTargetSize = D2D1::SizeU(m_clientRect.right - m_clientRect.left, m_clientRect.bottom - m_clientRect.top);
     auto hwndRenderTargetProperties = D2D1::HwndRenderTargetProperties(window, renderTargetSize);
 
@@ -125,7 +125,7 @@ ZoneWindowDrawing::RenderResult ZoneWindowDrawing::Render()
     {
         return RenderResult::AnimationEnded;
     }
-    
+
     m_renderTarget->BeginDraw();
 
     // Draw backdrop
@@ -265,7 +265,7 @@ void ZoneWindowDrawing::Flash()
         std::unique_lock lock(m_mutex);
         shouldShowWindow = !m_shouldRender;
         m_shouldRender = true;
-    
+
         m_animation.emplace(AnimationInfo{ .tStart = std::chrono::steady_clock().now(), .autoHide = true });
     }
 
@@ -278,8 +278,8 @@ void ZoneWindowDrawing::Flash()
 }
 
 void ZoneWindowDrawing::DrawActiveZoneSet(const IZoneSet::ZonesMap& zones,
-                       const std::vector<size_t>& highlightZones,
-                       winrt::com_ptr<IZoneWindowHost> host)
+                                          const std::vector<size_t>& highlightZones,
+                                          winrt::com_ptr<IZoneWindowHost> host)
 {
     _TRACER_;
     std::unique_lock lock(m_mutex);

--- a/src/modules/fancyzones/lib/ZoneWindowDrawing.h
+++ b/src/modules/fancyzones/lib/ZoneWindowDrawing.h
@@ -25,8 +25,7 @@ class ZoneWindowDrawing
     struct AnimationInfo
     {
         std::chrono::steady_clock::time_point tStart;
-        unsigned duration;
-        bool fadeIn;
+        bool autoHide;
     };
 
     HWND m_window = nullptr;
@@ -42,7 +41,7 @@ class ZoneWindowDrawing
     static IDWriteFactory* GetWriteFactory();
     static D2D1_COLOR_F ConvertColor(COLORREF color);
     static D2D1_RECT_F ConvertRect(RECT rect);
-    void Render();
+    void Render(float animationAlpha);
     void RenderLoop();
 
     std::atomic<bool> m_shouldRender = false;
@@ -55,8 +54,8 @@ public:
     ~ZoneWindowDrawing();
     ZoneWindowDrawing(HWND window);
     void Hide();
-    void Show(unsigned animationMillis);
-    void Flash(unsigned animationMillis);
+    void Show();
+    void Flash();
     void DrawActiveZoneSet(const IZoneSet::ZonesMap& zones,
                            const std::vector<size_t>& highlightZones,
                            winrt::com_ptr<IZoneWindowHost> host);

--- a/src/modules/fancyzones/lib/ZoneWindowDrawing.h
+++ b/src/modules/fancyzones/lib/ZoneWindowDrawing.h
@@ -28,6 +28,13 @@ class ZoneWindowDrawing
         bool autoHide;
     };
 
+    enum struct RenderResult
+    {
+        Ok,
+        AnimationEnded,
+        Failed,
+    };
+
     HWND m_window = nullptr;
     RECT m_clientRect{};
     ID2D1HwndRenderTarget* m_renderTarget = nullptr;
@@ -41,7 +48,7 @@ class ZoneWindowDrawing
     static IDWriteFactory* GetWriteFactory();
     static D2D1_COLOR_F ConvertColor(COLORREF color);
     static D2D1_RECT_F ConvertRect(RECT rect);
-    void Render(float animationAlpha);
+    RenderResult Render();
     void RenderLoop();
 
     std::atomic<bool> m_shouldRender = false;


### PR DESCRIPTION
## Summary of the Pull Request

See #10459.

**What is this about:**

ShowWindow waits until the message to hide the window is processed. This causes problems if there are other messages in the queue. In that case, WndProc (main thread) sometimes tries to take the lock (for example, if it ends up in `DrawActiveZoneSet` and waits on it while it's still held by `ZoneWindowDrawing::Hide`, so we end up with a deadlock.

**What is include in the PR:** 

Moved all possibly reentrant or blocking calls to ShowWindow out of critical sections.

⚠ With code in this PR, the deadlock might get replaced by zones not being flashed after pressing the shortcut (when you press after exactly 1 second), but all data remains intact and FZ proceeds working normally. From my testing this happens much less often than the deadlock. This will hardly be noticed by users.

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #10459 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
