### PR TITLE
Centralized keyboard hook logs

### DIFF
--- a/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
+++ b/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
@@ -345,6 +345,12 @@ public:
     void terminateProcess()
     {
         Logger::trace(L"Terminating PowerToys Run process. Handle {}.", m_hProcess);
+        if (WaitForSingleObject(m_hProcess, 0) == WAIT_OBJECT_0)
+        {
+            Logger::warn("PowerToys Run has exited unexpectedly, so there is no need to terminate it.");
+            return;
+        }
+
         DWORD processID = GetProcessId(m_hProcess);
         if (TerminateProcess(m_hProcess, 1) == 0)
         {

--- a/src/runner/centralized_kb_hook.cpp
+++ b/src/runner/centralized_kb_hook.cpp
@@ -2,6 +2,7 @@
 #include "centralized_kb_hook.h"
 #include <common/debug_control.h>
 #include <common/utils/winapi_error.h>
+#include <common/logger/logger.h>
 
 namespace CentralizedKeyboardHook
 {
@@ -79,12 +80,14 @@ namespace CentralizedKeyboardHook
 
     void SetHotkeyAction(const std::wstring& moduleName, const Hotkey& hotkey, std::function<bool()>&& action) noexcept
     {
+        Logger::trace(L"Register hotkey action for {}", moduleName);
         std::unique_lock lock{ mutex };
         hotkeyDescriptors.insert({ .hotkey = hotkey, .moduleName = moduleName, .action = std::move(action) });
     }
 
     void ClearModuleHotkeys(const std::wstring& moduleName) noexcept
     {
+        Logger::trace(L"UnRegister hotkey action for {}", moduleName);
         std::unique_lock lock{ mutex };
         auto it = hotkeyDescriptors.begin();
         while (it != hotkeyDescriptors.end())

--- a/src/runner/powertoy_module.cpp
+++ b/src/runner/powertoy_module.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 #include "powertoy_module.h"
 #include "centralized_kb_hook.h"
+#include <common/logger/logger.h>
 
 std::map<std::wstring, PowertoyModule>& modules()
 {
@@ -60,6 +61,7 @@ void PowertoyModule::update_hotkeys()
     for (size_t i = 0; i < hotkeyCount; i++)
     {
         CentralizedKeyboardHook::SetHotkeyAction(pt_module->get_key(), hotkeys[i], [modulePtr, i] {
+            Logger::trace(L"{} hotkey is invoked from Centralized keyboard hook", modulePtr->get_key());
             return modulePtr->on_hotkey(i);
         });
     }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

**What is include in the PR:** 
- Logs for centralized keyboard hook
- Do not terminate the PowerToys Run process if it was already terminated. We get a lot `Launcher process was not terminated. 
Access is denied`. I think it happens because the process is already terminated and is not an issue with the PowerToys Run interface.

**How does someone test / validate:** 

## Quality Checklist

- [X] **Linked issue:** #https://github.com/microsoft/PowerToys/issues/10463
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [X] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
