### PR TITLE
[telemetry][ColorPicker] add event name support

### DIFF
--- a/src/common/ManagedTelemetry/Telemetry/Events/EventBase.cs
+++ b/src/common/ManagedTelemetry/Telemetry/Events/EventBase.cs
@@ -16,6 +16,8 @@ namespace Microsoft.PowerToys.Telemetry.Events
     {
         public bool UTCReplace_AppSessionGuid => true;
 
+        public string EventName { get; set; }
+
         private string _version;
 
         public string Version

--- a/src/common/ManagedTelemetry/Telemetry/PowerToysTelemetry.cs
+++ b/src/common/ManagedTelemetry/Telemetry/PowerToysTelemetry.cs
@@ -37,7 +37,7 @@ namespace Microsoft.PowerToys.Telemetry
             where T : EventBase, IEvent
         {
             this.Write<T>(
-                null,
+                telemetryEvent.EventName,
                 new EventSourceOptions()
                 {
                     Keywords = ProjectKeywordMeasure,

--- a/src/modules/colorPicker/ColorPickerUI/Telemetry/ColorPickerSession.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Telemetry/ColorPickerSession.cs
@@ -12,6 +12,11 @@ namespace ColorPicker.Telemetry
     [EventData]
     public class ColorPickerSession : EventBase, IEvent
     {
+        public ColorPickerSession()
+        {
+            EventName = "ColorPicker_Session";
+        }
+
         public string StartedAs { get; set; }
 
         public bool ZoomUsed { get; set; }

--- a/src/modules/colorPicker/ColorPickerUI/Telemetry/ColorPickerSettings.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Telemetry/ColorPickerSettings.cs
@@ -15,6 +15,7 @@ namespace ColorPicker.Telemetry
         public ColorPickerSettings(IDictionary<string, bool> editorFormats)
         {
             EditorFormats = editorFormats;
+            EventName = "ColorPicker_Settings";
         }
 
         public string ActivationShortcut { get; set; }


### PR DESCRIPTION
## Summary of the Pull Request
Add the ability to set the telemetry event name in C# projects (C++ projects already have this by default).
Start using the new functionality for ColorPicker.

**What is this about:**
Until now, in C# projects, all telemetry events were using the event class name as event name.
This PR adds the `EventName` property that will still allow the event to use the class name if it's not set.
We will force every event to explicitly set the event name after all projects will be updated to use the new `EventName` property.

**What is include in the PR:** 
Change to the telemetry event base class.

**How does someone test / validate:** 
Build the installer with telemetry enabled and check the events generated:

![image](https://user-images.githubusercontent.com/3206696/112810071-f96cd080-907a-11eb-86b9-b83b5649e5c8.png)


## Quality Checklist

- [x] **Linked issue:** #9343
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
