### PR TITLE
[FZ Editor] Crash with malformed layout data fix.

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
@@ -837,7 +837,7 @@ namespace FancyZonesEditor.Utils
                 {
                     var info = JsonSerializer.Deserialize<GridInfoWrapper>(zoneSet.Info.GetRawText(), _options);
 
-                    // Check if rows and cols are valid
+                    // Check if rows and columns are valid
                     if (info.Rows <= 0 || info.Columns <= 0)
                     {
                         result = false;
@@ -853,7 +853,7 @@ namespace FancyZonesEditor.Utils
                         }
                     }
 
-                    // Check if percentage is valid. Overwise Editor could crash on render.
+                    // Check if percentage is valid. Otherwise, Editor could crash on layout rendering.
                     foreach (int percent in info.RowsPercentage)
                     {
                         if (percent < 0)


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

FZ Editor could crash on layout rendering if the layout has negative width/height or row/column percentage. 
Values are checked on the layout parsing from `zones-settings.json` and the user gets notified that some layout is malformed.

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #10499
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
