### PR TITLE
[CI build] exclude WebcamReportTool from build

### DIFF
--- a/.pipelines/build-tools.cmd
+++ b/.pipelines/build-tools.cmd
@@ -7,5 +7,3 @@ set SolutionDir=%cd%
 popd
 SET IsPipeline=1
 call msbuild ../tools/BugReportTool/BugReportTool.sln /p:Configuration=Release /p:Platform=x64 /p:CIBuild=true || exit /b 1
-call msbuild ../tools/WebcamReportTool/WebcamReportTool.sln /p:Configuration=Release /p:Platform=x64 /p:CIBuild=true || exit /b 1
-

--- a/.pipelines/pipeline.user.windows.yml
+++ b/.pipelines/pipeline.user.windows.yml
@@ -66,7 +66,6 @@ build:
           include:
             - 'action_runner.exe'
             - 'BugReportTool\BugReportTool.exe'
-            - 'WebcamReportTool\WebcamReportTool.exe'
             - 'modules\ColorPicker\ColorPicker.dll'
             - 'modules\ColorPicker\ColorPickerUI.dll'
             - 'modules\ColorPicker\ColorPickerUI.exe'
@@ -169,7 +168,6 @@ build:
           to: 'Build_Output'
           include:
             - 'BugReportTool\BugReportTool.exe'
-            - 'WebcamReportTool\WebcamReportTool.exe'
           signing_options:
             sign_inline: true  # This does signing a soon as this command completes
     - !!buildcommand


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
The internal CI fails to build the WebcamReportTool.

**What is include in the PR:** 
Remove the WebcamReportTool from the build.

**How does someone test / validate:** 

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
