### PR TITLE
[ColorPicker] Disable forwarding the scroll event

### DIFF
--- a/src/modules/colorPicker/ColorPickerUI/Mouse/MouseHook.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Mouse/MouseHook.cs
@@ -114,6 +114,7 @@ namespace ColorPicker.Mouse
                     {
                         MouseDevice mouseDev = InputManager.Current.PrimaryMouseDevice;
                         MouseWheel.Invoke(null, new MouseWheelEventArgs(mouseDev, Environment.TickCount, (int)mouseHookStruct.mouseData >> 16));
+                        return new IntPtr(-1);
                     }
                 }
             }


### PR DESCRIPTION
## Summary of the Pull Request

ColorPicker captures the mouse scroll event while active. The event should not be forwarded to other apps. In the future we will consider adding an option to only capture scroll events while Ctrl is pressed.

**What is this about:**

**What is include in the PR:** 

Returning -1 from the hook when scrolling achieves the effect.

**How does someone test / validate:** 

Use ColorPicker above a browser or any other app which responds to scroll events. Also try moving the mouse away from the zoomed-in preview panel and scroll.

## Quality Checklist

- [x] **Linked issue:** #5746 
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
