### PR TITLE
[Settings] Fix UI glitch

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/PowerLauncherViewModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/PowerLauncherViewModel.cs
@@ -262,11 +262,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
                 if (value == true)
                 {
                     settings.Properties.Position = StartupPosition.Cursor;
+                    _isCursorPositionRadioButtonChecked = value;
+                    UpdateSettings();
                 }
-
-                _isCursorPositionRadioButtonChecked = value;
-
-                UpdateSettings();
             }
         }
 
@@ -282,11 +280,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
                 if (value == true)
                 {
                     settings.Properties.Position = StartupPosition.PrimaryMonitor;
+                    _isPrimaryMonitorPositionRadioButtonChecked = value;
+                    UpdateSettings();
                 }
-
-                _isPrimaryMonitorPositionRadioButtonChecked = value;
-
-                UpdateSettings();
             }
         }
 
@@ -302,11 +298,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
                 if (value == true)
                 {
                     settings.Properties.Position = StartupPosition.Focus;
+                    _isFocusPositionRadioButtonChecked = value;
+                    UpdateSettings();
                 }
-
-                _isFocusPositionRadioButtonChecked = value;
-
-                UpdateSettings();
             }
         }
 


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
![glitch](https://user-images.githubusercontent.com/9358361/112975664-3953b680-9154-11eb-8b6d-09a5642cbb39.gif)

We should not update settings three times when in reality only one property changes.

**What is include in the PR:** 

**How does someone test / validate:** 
Verify that glitch is gone.

## Quality Checklist

- [X] **Linked issue:** #10498
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [X] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
