### PR TITLE
Workspaces not showing in vscode plugin #10530

### DIFF
--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/WorkspacesHelper/VSCodeStorageFile.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/WorkspacesHelper/VSCodeStorageFile.cs
@@ -7,8 +7,16 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.WorkspacesHelper
         public openedPathsList openedPathsList { get; set; }
     }
 
+    public class VSCodeWorkspaceEntry
+    {
+        public string folderUri { get; set; }
+        public string label { get; set; }
+    }
+
     public class openedPathsList
     {
         public List<dynamic> workspaces3 { get; set; }
+
+        public List<VSCodeWorkspaceEntry> entries { get; set; }
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Unfortunately the latest vscode stable and insiders changed the format of the storage.json which made the plugin not work for some.

**What is include in the PR:** 

This fix makes the plugin work with previous versions and the more recently ones.

**How does someone test / validate:** 
- Activate vscode plugin
- Use the keyword {

## Quality Checklist

- [X] **Linked issue:** #10530
- [X] **Communication:** I've discussed this with core contributors in the issue. 
- [X] **Tests:** Added/updated and all pass
- [X] **Installer:** Added/updated and all pass
- [X] **Localization:** All end user facing strings can be localized
- [X] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
