### PR TITLE
[msi] remove old settings from installer

### DIFF
--- a/installer/PowerToysSetup/Product.wxs
+++ b/installer/PowerToysSetup/Product.wxs
@@ -281,9 +281,6 @@
               <Directory Id="SettingsV2XamlAssetsInstallFolder" Name="Assets" />
             </Directory>
           </Directory>
-          <Directory Id="SettingsHtmlInstallFolder" Name="settings-html">
-            <Directory Id="SettingsHtmlDistInstallFolder" Name="dist"/>
-          </Directory>
         </Directory>
       </Directory>
       <Directory Id="ProgramMenuFolder">
@@ -314,9 +311,6 @@
             <RegistryValue Type="string" Value="&quot;[INSTALLFOLDER]PowerToys.exe&quot; &quot;%1&quot;" />
           </RegistryKey>
         </RegistryKey>
-      </Component>
-      <Component Id="settings_exe" Guid="A5A461A9-7097-4CBA-9D39-3DBBB6B7B80C" Win64="yes">
-        <File Id="PowerToysSettings.exe" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="BackgroundActivator_dll" Guid="23B25EE4-BCA2-45DF-BBCD-82FBDF01C5AB" Win64="yes">
         <File Id="BackgroundActivatorDLL.dll" KeyPath="yes" Checksum="yes" />
@@ -743,23 +737,6 @@
       </Component>
     </DirectoryRef>
 
-    <DirectoryRef Id="SettingsHtmlInstallFolder" FileSource="$(var.RepoDir)\settings\settings-html\">
-      <Component Id="settings_html" Guid="87881A99-E917-4B0D-B1D8-5C6EB9709F96" Win64="yes">
-        <File Source="$(var.RepoDir)\src\settings\settings-html\index.html" KeyPath="yes" />
-      </Component>
-      <Component Id="settings_dark_html" Guid="855866C7-2F13-4B08-B5C1-B507354C2760" Win64="yes">
-        <File Source="$(var.RepoDir)\src\settings\settings-html\index-dark.html" KeyPath="yes" />
-      </Component>
-    </DirectoryRef>
-    <DirectoryRef Id="SettingsHtmlDistInstallFolder" FileSource="$(var.RepoDir)\settings\settings-html\dist\">
-      <Component Id="settings_js_bundle" Guid="9EF539C1-2F50-421E-B074-C58ED3A9785C" Win64="yes">
-        <File Source="$(var.RepoDir)\src\settings\settings-html\dist\bundle.js" KeyPath="yes" />
-      </Component>
-      <Component Id="settings_css" Guid="9B8EBF56-A7A7-4D83-B53C-75A692E2F95A" Win64="yes">
-        <File Source="$(var.RepoDir)\src\settings\settings-html\dist\layout.css" KeyPath="yes" />
-      </Component>
-    </DirectoryRef>
-
     <DirectoryRef Id="DesktopFolder">
       <Component Id="DesktopShortcut" Guid="87321F2B-CC48-4326-881E-9C62CC260DC8">
         <Condition>INSTALLDESKTOPSHORTCUT</Condition>
@@ -814,11 +791,6 @@
       <ComponentRef Id="SettingsV2Styles" />
       <ComponentRef Id="SettingsV2Views" />
       <ComponentRef Id="SettingsV2XamlAssets" />
-      <ComponentRef Id="settings_exe" />
-      <ComponentRef Id="settings_html" />
-      <ComponentRef Id="settings_dark_html" />
-      <ComponentRef Id="settings_js_bundle" />
-      <ComponentRef Id="settings_css" />
     </ComponentGroup>
     <ComponentGroup Id="ToolComponents" Directory="ToolsFolder">
       <ComponentRef Id="BugReportTool_exe" />


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Starting with 0.37, the old settings are deprecated.

**What is include in the PR:** 
Remove the old settings binaries and resources from the .msi installer.
The old settings will be removed from the main solution and from the repo in another PR.

**How does someone test / validate:** 
Build the .msi, install PT and verify:
 - the old settings files are not installed
 - the new Settings are not affected by this change

![image](https://user-images.githubusercontent.com/3206696/113423977-b2127700-93cf-11eb-8e89-26bb111c3837.png)

## Quality Checklist

- [x] **Linked issue:** #9417
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
