### PR TITLE
[FancyZones] Place log files in subfolders with the version number.

### DIFF
--- a/PowerToys.sln
+++ b/PowerToys.sln
@@ -284,6 +284,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "utils", "utils", "{B39DC643
 		src\common\utils\elevation.h = src\common\utils\elevation.h
 		src\common\utils\exec.h = src\common\utils\exec.h
 		src\common\utils\json.h = src\common\utils\json.h
+		src\common\utils\logger_helper.h = src\common\utils\logger_helper.h
 		src\common\utils\os-detect.h = src\common\utils\os-detect.h
 		src\common\utils\process_path.h = src\common\utils\process_path.h
 		src\common\utils\resources.h = src\common\utils\resources.h

--- a/src/common/logger/logger_settings.h
+++ b/src/common/logger/logger_settings.h
@@ -15,6 +15,7 @@ struct LogSettings
     inline const static std::wstring launcherLogPath = L"LogsModuleInterface\\launcher-log.txt";
     inline const static std::string fancyZonesLoggerName = "fancyzones";
     inline const static std::wstring fancyZonesLogPath = L"fancyzones-log.txt";
+    inline const static std::wstring fancyZonesOldLogPath = L"FancyZonesLogs\\"; // needed to clean up old logs
     inline const static std::string shortcutGuideLoggerName = "shortcut-guide";
     inline const static std::wstring shortcutGuideLogPath = L"ShortcutGuideLogs\\shortcut-guide-log.txt";
     inline const static std::string keyboardManagerLoggerName = "keyboard-manager";

--- a/src/common/logger/logger_settings.h
+++ b/src/common/logger/logger_settings.h
@@ -7,13 +7,14 @@ struct LogSettings
     inline const static std::wstring defaultLogLevel = L"trace";
     inline const static std::wstring logLevelOption = L"logLevel";
     inline const static std::string runnerLoggerName = "runner";
+    inline const static std::wstring logPath = L"Logs\\";
     inline const static std::wstring runnerLogPath = L"RunnerLogs\\runner-log.txt";
     inline const static std::string actionRunnerLoggerName = "action-runner";
     inline const static std::wstring actionRunnerLogPath = L"RunnerLogs\\action-runner-log.txt";
     inline const static std::string launcherLoggerName = "launcher";
     inline const static std::wstring launcherLogPath = L"LogsModuleInterface\\launcher-log.txt";
     inline const static std::string fancyZonesLoggerName = "fancyzones";
-    inline const static std::wstring fancyZonesLogPath = L"FancyZonesLogs\\fancyzones-log.txt";
+    inline const static std::wstring fancyZonesLogPath = L"fancyzones-log.txt";
     inline const static std::string shortcutGuideLoggerName = "shortcut-guide";
     inline const static std::wstring shortcutGuideLogPath = L"ShortcutGuideLogs\\shortcut-guide-log.txt";
     inline const static std::string keyboardManagerLoggerName = "keyboard-manager";

--- a/src/common/utils/logger_helper.h
+++ b/src/common/utils/logger_helper.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <filesystem>
+#include <common/version/version.h>
+
+namespace LoggerHelpers
+{
+    std::filesystem::path get_log_folder_path(std::wstring_view appPath)
+    {
+        std::filesystem::path logFolderPath(appPath);
+        logFolderPath.append(LogSettings::logPath);
+        logFolderPath.append(get_product_version());
+        return logFolderPath;
+    }
+
+    inline bool delete_old_log_folder(const std::filesystem::path& logFolderPath)
+    {
+        try
+        {
+            std::filesystem::remove_all(logFolderPath);
+            return true;
+        }
+        catch (std::filesystem::filesystem_error& e)
+        {
+            Logger::error("Failed to delete old log folder: {}", e.what());
+        }
+
+        return false;
+    }
+
+    inline bool delete_other_versions_log_folders(std::wstring_view appPath, const std::filesystem::path& currentVersionLogFolder)
+    {
+        try
+        {
+            std::filesystem::path logFolderPath(appPath);
+            logFolderPath.append(LogSettings::logPath);
+
+            for (const auto& dir : std::filesystem::directory_iterator(logFolderPath))
+            {
+                if (dir != currentVersionLogFolder)
+                {
+                    std::filesystem::remove_all(dir);
+                }
+            }
+
+            return true;
+        }
+        catch (std::filesystem::filesystem_error& e)
+        {
+            Logger::error("Failed to delete previous version log folder: {}", e.what());
+        }
+
+        return false;
+    }
+}

--- a/src/common/utils/logger_helper.h
+++ b/src/common/utils/logger_helper.h
@@ -5,7 +5,7 @@
 
 namespace LoggerHelpers
 {
-    std::filesystem::path get_log_folder_path(std::wstring_view appPath)
+    inline std::filesystem::path get_log_folder_path(std::wstring_view appPath)
     {
         std::filesystem::path logFolderPath(appPath);
         logFolderPath.append(LogSettings::logPath);

--- a/src/common/utils/logger_helper.h
+++ b/src/common/utils/logger_helper.h
@@ -30,26 +30,26 @@ namespace LoggerHelpers
 
     inline bool delete_other_versions_log_folders(std::wstring_view appPath, const std::filesystem::path& currentVersionLogFolder)
     {
-        try
-        {
-            std::filesystem::path logFolderPath(appPath);
-            logFolderPath.append(LogSettings::logPath);
+        bool result = true;
+        std::filesystem::path logFolderPath(appPath);
+        logFolderPath.append(LogSettings::logPath);
 
-            for (const auto& dir : std::filesystem::directory_iterator(logFolderPath))
+        for (const auto& dir : std::filesystem::directory_iterator(logFolderPath))
+        {
+            if (dir != currentVersionLogFolder)
             {
-                if (dir != currentVersionLogFolder)
+                try
                 {
                     std::filesystem::remove_all(dir);
                 }
+                catch (std::filesystem::filesystem_error& e)
+                {
+                    Logger::error("Failed to delete previous version log folder: {}", e.what());
+                    result = false;
+                }                
             }
-
-            return true;
-        }
-        catch (std::filesystem::filesystem_error& e)
-        {
-            Logger::error("Failed to delete previous version log folder: {}", e.what());
         }
 
-        return false;
+        return result;
     }
 }

--- a/src/modules/fancyzones/dll/dllmain.cpp
+++ b/src/modules/fancyzones/dll/dllmain.cpp
@@ -17,6 +17,7 @@
 #include <common/utils/resources.h>
 #include <common/utils/winapi_error.h>
 #include <common/utils/window.h>
+#include <common/version/version.h>
 
 BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
 {
@@ -157,6 +158,8 @@ public:
         app_name = GET_RESOURCE_STRING(IDS_FANCYZONES);
         app_key = NonLocalizable::FancyZonesStr;
         std::filesystem::path logFilePath(PTSettingsHelper::get_module_save_folder_location(app_key));
+        logFilePath.append(LogSettings::logPath);
+        logFilePath.append(get_product_version());
         logFilePath.append(LogSettings::fancyZonesLogPath);
         Logger::init(LogSettings::fancyZonesLoggerName, logFilePath.wstring(), PTSettingsHelper::get_log_settings_file_location());
         m_settings = MakeFancyZonesSettings(reinterpret_cast<HINSTANCE>(&__ImageBase), FancyZonesModule::get_name(), FancyZonesModule::get_key());

--- a/src/modules/fancyzones/dll/dllmain.cpp
+++ b/src/modules/fancyzones/dll/dllmain.cpp
@@ -18,7 +18,6 @@
 #include <common/utils/resources.h>
 #include <common/utils/winapi_error.h>
 #include <common/utils/window.h>
-#include <common/version/version.h>
 
 BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
 {

--- a/src/modules/fancyzones/dll/dllmain.cpp
+++ b/src/modules/fancyzones/dll/dllmain.cpp
@@ -14,6 +14,7 @@
 #include <lib/FancyZonesWinHookEventIDs.h>
 #include <lib/FancyZonesData.cpp>
 #include <common/logger/logger.h>
+#include <common/utils/logger_helper.h>
 #include <common/utils/resources.h>
 #include <common/utils/winapi_error.h>
 #include <common/utils/window.h>
@@ -157,11 +158,19 @@ public:
     {
         app_name = GET_RESOURCE_STRING(IDS_FANCYZONES);
         app_key = NonLocalizable::FancyZonesStr;
-        std::filesystem::path logFilePath(PTSettingsHelper::get_module_save_folder_location(app_key));
-        logFilePath.append(LogSettings::logPath);
-        logFilePath.append(get_product_version());
+        const auto appFolder = PTSettingsHelper::get_module_save_folder_location(app_key);
+        const std::filesystem::path logFolder = LoggerHelpers::get_log_folder_path(appFolder);
+        
+        std::filesystem::path logFilePath(logFolder);
         logFilePath.append(LogSettings::fancyZonesLogPath);
         Logger::init(LogSettings::fancyZonesLoggerName, logFilePath.wstring(), PTSettingsHelper::get_log_settings_file_location());
+        
+        std::filesystem::path oldLogFolder(appFolder);
+        oldLogFolder.append(LogSettings::fancyZonesOldLogPath);
+        LoggerHelpers::delete_old_log_folder(oldLogFolder);
+
+        LoggerHelpers::delete_other_versions_log_folders(appFolder, logFolder);
+
         m_settings = MakeFancyZonesSettings(reinterpret_cast<HINSTANCE>(&__ImageBase), FancyZonesModule::get_name(), FancyZonesModule::get_key());
         FancyZonesDataInstance().LoadFancyZonesData();
         s_instance = this;


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Create a subfolder with the version number for logs, e.g. `PowerToys\FancyZones\Logs\v0.35.0`.
Delete old logs in `PowerToys\FancyZones\FancyZonesLogs` and logs in subfolders with different versions.

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #10540 #8419
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
