### PR TITLE
[Run] Revert ClearType regression

### DIFF
--- a/src/modules/launcher/PowerLauncher/LauncherControl.xaml
+++ b/src/modules/launcher/PowerLauncher/LauncherControl.xaml
@@ -55,9 +55,7 @@
                                     <ScrollViewer.ContentTemplate>
                                         <DataTemplate>
                                             <Grid
-                                                Background="{Binding Background, ElementName=PART_ContentHost}"
-                                                RenderOptions.ClearTypeHint="Enabled"
-                                                TextOptions.TextFormattingMode="Display">
+                                                Background="{Binding Background, ElementName=PART_ContentHost}">
                                                 <ContentPresenter Content="{Binding Path=Content, ElementName=PART_ContentHost}"/>
                                             </Grid>
                                         </DataTemplate>
@@ -113,7 +111,6 @@
             FontSize="24"
             Style="{StaticResource QueryTextBoxStyle}"
             Tag="{x:Static p:Resources.startTyping}"
-            RenderOptions.ClearTypeHint="Enabled"
             />
         <TextBlock
             x:Name="AutoCompleteTextBlock"
@@ -125,7 +122,6 @@
             FontSize="24"
             Foreground="{DynamicResource TextControlPlaceholderForeground}"
             Background="{DynamicResource SystemChromeLow}"
-            RenderOptions.ClearTypeHint="Enabled"
          />
         <TextBlock
             AutomationProperties.Name="{x:Static p:Resources.SearchIcon}"
@@ -136,8 +132,6 @@
             HorizontalAlignment="Center" 
             VerticalAlignment="Center"
             Foreground="{DynamicResource TextControlPlaceholderForeground}" 
-            RenderOptions.ClearTypeHint="Enabled"
-            TextOptions.TextRenderingMode="Auto"
             SnapsToDevicePixels="True"/>
     </Grid>
 </UserControl>

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml
@@ -10,8 +10,6 @@
         Topmost="True"
         SizeToContent="Height"
         ResizeMode="NoResize"
-        TextOptions.TextRenderingMode="ClearType"
-        RenderOptions.ClearTypeHint="Enabled"
         WindowStyle="None"
         WindowStartupLocation="Manual"
         AllowDrop="True"

--- a/src/modules/launcher/PowerLauncher/ResultList.xaml
+++ b/src/modules/launcher/PowerLauncher/ResultList.xaml
@@ -209,13 +209,11 @@
                                         Style="{DynamicResource CollapsableTextblock}"
                                         FontWeight="Bold"
                                         Text="{Binding Result.ToolTipData.Title}"
-                                        TextWrapping="Wrap" 
-                                        RenderOptions.ClearTypeHint="Enabled" />
+                                        TextWrapping="Wrap" />
                                     <TextBlock 
                                         Style="{DynamicResource CollapsableTextblock}"
                                         Text="{Binding Result.ToolTipData.Text}"                               
-                                        TextWrapping="Wrap" 
-                                        RenderOptions.ClearTypeHint="Enabled" />
+                                        TextWrapping="Wrap" />
                                 </StackPanel>
                             </ToolTip>
                         </Grid.ToolTip>
@@ -235,8 +233,7 @@
                             FontWeight="SemiBold"
                             FontSize="20"
                             Margin="0,0,0,-2"
-                            VerticalAlignment="Bottom"
-                            RenderOptions.ClearTypeHint="Enabled"/>
+                            VerticalAlignment="Bottom"/>
                         <TextBlock
                             AutomationProperties.Name="{x:Static p:Resources.Subtitle}"
                             x:Name="Path"
@@ -245,8 +242,7 @@
                             Grid.Row="1"
                             Foreground="{DynamicResource SecondaryTextForeground}"
                             Margin="0,2,0,0"
-                            VerticalAlignment="Top"
-                            RenderOptions.ClearTypeHint="Enabled"/>
+                            VerticalAlignment="Top"/>
                         <ListView      
                             AutomationProperties.Name="{x:Static p:Resources.ContextMenuItemsCollection}"
                             HorizontalAlignment="Right" 
@@ -284,8 +280,7 @@
                                             <ToolTip >
                                                 <TextBlock
                                                     AutomationProperties.Name="{x:Static p:Resources.ContextMenuItemAdditionalInformation}"
-                                                    Text="{Binding Title}"
-                                                    RenderOptions.ClearTypeHint="Enabled"/>
+                                                    Text="{Binding Title}"/>
                                             </ToolTip>
                                         </ToolTipService.ToolTip>
                                         <Button.Content>
@@ -293,8 +288,7 @@
                                                 AutomationProperties.Name="{x:Static p:Resources.ContextMenuIcon}"
                                                 FontFamily="{Binding FontFamily}"
                                                 FontSize="16"
-                                                Text="{Binding Glyph}"
-                                                RenderOptions.ClearTypeHint="Enabled"/>
+                                                Text="{Binding Glyph}"/>
                                         </Button.Content>
                                     </Button>
                                 </DataTemplate>


### PR DESCRIPTION
## Summary of the Pull Request

Removed manual ClearType setting since it causes on higher resolution screens (as discussed with @crutkas here: #6462). It now renders smoother.

Before:
![RunCT](https://user-images.githubusercontent.com/9866362/113488271-3858b700-94bd-11eb-833f-cc7329cf35b4.PNG)

After:
![RunwithoutCT](https://user-images.githubusercontent.com/9866362/113488273-3c84d480-94bd-11eb-8346-a4000fdeaae6.PNG)



## Quality Checklist

- [X] **Linked issue:** #6462
- [X] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
