### PR TITLE
[OOBE] Bolded shortcuts / instructions

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/App.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/App.xaml
@@ -8,6 +8,7 @@
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <XamlControlsResources  xmlns="using:Microsoft.UI.Xaml.Controls" />
+                <ResourceDictionary Source="/Controls/KeyVisual/KeyVisual.xaml" />
                 <ResourceDictionary Source="/Styles/_Colors.xaml" />
                 <ResourceDictionary Source="/Styles/_FontSizes.xaml" />
                 <ResourceDictionary Source="/Styles/_Thickness.xaml" />

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/KeyVisual/KeyVisual.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/KeyVisual/KeyVisual.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace Microsoft.PowerToys.Settings.UI.Controls
+{
+    public sealed class KeyVisual : Control
+    {
+        public object Content
+        {
+            get => (string)GetValue(ContentProperty);
+            set => SetValue(ContentProperty, value);
+        }
+
+        public static readonly DependencyProperty ContentProperty = DependencyProperty.Register("Content", typeof(object), typeof(KeyVisual), new PropertyMetadata(default(string)));
+
+        public KeyVisual()
+        {
+            this.DefaultStyleKey = typeof(KeyVisual);
+        }
+
+        protected override void OnApplyTemplate()
+        {
+            base.OnApplyTemplate();
+        }
+    }
+}

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/KeyVisual/KeyVisual.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/KeyVisual/KeyVisual.xaml
@@ -1,0 +1,57 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:local="using:Microsoft.PowerToys.Settings.UI.Controls">
+
+    <!-- This can be removed once we adopt WinUI 2.6 or higher -->
+    <ResourceDictionary.ThemeDictionaries>
+        <ResourceDictionary x:Key="Default">
+            <Color x:Key="ControlStrokeColorDefault">#12FFFFFF</Color>
+            <Color x:Key="ControlStrokeColorSecondary">#18FFFFFF</Color>
+            <Color x:Key="ControlFillColorDefault">#0FFFFFFF</Color>
+            
+        </ResourceDictionary>
+        
+        <ResourceDictionary x:Key="Light">
+            <Color x:Key="ControlStrokeColorDefault">#0F000000</Color>
+            <Color x:Key="ControlStrokeColorSecondary">#29000000</Color>
+            <Color x:Key="ControlFillColorDefault">#B3FFFFFF</Color>
+            
+        </ResourceDictionary>
+        
+    </ResourceDictionary.ThemeDictionaries>
+    
+    <LinearGradientBrush x:Key="ControlElevationBorderBrush"
+                         MappingMode="Absolute"
+                         StartPoint="0,0"
+                         EndPoint="0,3">
+        <LinearGradientBrush.GradientStops>
+            <GradientStop Offset="0.33"
+                          Color="{ThemeResource ControlStrokeColorSecondary}" />
+            <GradientStop Offset="1.0"
+                          Color="{ThemeResource ControlStrokeColorDefault}" />
+        </LinearGradientBrush.GradientStops>
+    </LinearGradientBrush>
+    <!--- -->
+    
+    
+    <Style TargetType="local:KeyVisual">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="local:KeyVisual">
+                    <!-- Background="{ThemeResource ControlFillColorDefault}" -->
+                    <Border Background="LightGray"
+                            BorderThickness="1"
+                            BorderBrush="{ThemeResource ControlElevationBorderBrush}"
+                            CornerRadius="4"
+                            Padding="11,5,11,6"
+                            Height="32">
+                        <ContentPresenter Content="{TemplateBinding Content}"
+                                          FontWeight="SemiBold"
+                                          VerticalAlignment="Center" />
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+</ResourceDictionary>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/ShortcutTextControl.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/ShortcutTextControl.xaml
@@ -1,0 +1,11 @@
+﻿<UserControl x:Class="Microsoft.PowerToys.Settings.UI.Controls.ShortcutTextControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="using:Microsoft.PowerToys.Settings.UI.Controls"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DesignHeight="300"
+             d:DesignWidth="400">
+    <TextBlock x:Name="ContentText" TextWrapping="Wrap" />
+</UserControl>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/ShortcutTextControl.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/ShortcutTextControl.xaml.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using System.Text.RegularExpressions;
+using Windows.UI.Text;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Documents;
+
+namespace Microsoft.PowerToys.Settings.UI.Controls
+{
+    public sealed partial class ShortcutTextControl : UserControl
+    {
+        public string Text
+        {
+            get => (string)GetValue(TextProperty);
+            set => SetValue(TextProperty, value);
+        }
+
+        public ShortcutTextControl()
+        {
+            this.InitializeComponent();
+        }
+
+        public static readonly DependencyProperty TextProperty = DependencyProperty.Register("Text", typeof(string), typeof(ShortcutVisualControl), new PropertyMetadata(default(string), (s, e) =>
+        {
+            var self = (ShortcutTextControl)s;
+            var parts = Regex.Split(e.NewValue.ToString(), @"({[\s\S]+?})").Where(l => !string.IsNullOrEmpty(l)).ToArray();
+
+            foreach (var seg in parts)
+            {
+                if (!string.IsNullOrWhiteSpace(seg))
+                {
+                    if (seg.Contains("{", StringComparison.InvariantCulture))
+                    {
+                        Run key = new Run()
+                        {
+                            Text = Regex.Replace(seg, @"[{}]", string.Empty),
+                            FontWeight = FontWeights.SemiBold,
+                        };
+                        self.ContentText.Inlines.Add(key);
+                    }
+                    else
+                    {
+                        Run description = new Run()
+                        {
+                            Text = seg,
+                            FontWeight = FontWeights.Normal,
+                        };
+                        self.ContentText.Inlines.Add(description);
+                    }
+                }
+            }
+        }));
+    }
+}

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/ShortcutVisualControl.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/ShortcutVisualControl.xaml
@@ -1,0 +1,15 @@
+﻿<UserControl x:Class="Microsoft.PowerToys.Settings.UI.Controls.ShortcutVisualControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="using:Microsoft.PowerToys.Settings.UI.Controls"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls"
+             mc:Ignorable="d"
+             d:DesignHeight="300"
+             d:DesignWidth="400">
+
+    <controls:WrapPanel x:Name="contentPanel"
+                        Orientation="Horizontal"                      
+                        HorizontalSpacing="4" />
+</UserControl>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/ShortcutVisualControl.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/ShortcutVisualControl.xaml.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using System.Text.RegularExpressions;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace Microsoft.PowerToys.Settings.UI.Controls
+{
+    public sealed partial class ShortcutVisualControl : UserControl
+    {
+        public ShortcutVisualControl()
+        {
+            InitializeComponent();
+        }
+
+        public string Text
+        {
+            get => (string)GetValue(TextProperty);
+            set => SetValue(TextProperty, value);
+        }
+
+        public static readonly DependencyProperty TextProperty = DependencyProperty.Register("Text", typeof(string), typeof(ShortcutVisualControl), new PropertyMetadata(default(string), (s, e) =>
+        {
+            var self = (ShortcutVisualControl)s;
+            var parts = Regex.Split(e.NewValue.ToString(), @"({[\s\S]+?})").Where(l => !string.IsNullOrEmpty(l)).ToArray();
+
+            foreach (var seg in parts)
+            {
+                if (!string.IsNullOrWhiteSpace(seg))
+                {
+                    if (seg.Contains("{", StringComparison.InvariantCulture))
+                    {
+                        KeyVisual k = new KeyVisual
+                        {
+                            Content = Regex.Replace(seg, @"[{}]", string.Empty),
+                            VerticalAlignment = VerticalAlignment.Center,
+                        };
+
+                        self.contentPanel.Children.Add(k);
+                    }
+                    else
+                    {
+                        TextBlock t = new TextBlock
+                        {
+                            Text = seg,
+                            TextWrapping = TextWrapping.Wrap,
+                            VerticalAlignment = VerticalAlignment.Top,
+                            Margin = new Thickness(0, 6, 0, 0),
+                        };
+
+                        self.contentPanel.Children.Add(t);
+                    }
+                }
+            }
+        }));
+    }
+}

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Microsoft.PowerToys.Settings.UI.csproj
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Microsoft.PowerToys.Settings.UI.csproj
@@ -98,6 +98,10 @@
     <Compile Include="Controls\HotkeySettingsControl.xaml.cs">
       <DependentUpon>HotkeySettingsControl.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Controls\KeyVisual\KeyVisual.cs" />
+    <Compile Include="Controls\ShortcutVisualControl.xaml.cs">
+      <DependentUpon>ShortcutVisualControl.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Converters\ModuleEnabledToForegroundConverter.cs" />
     <Compile Include="Generated Files\AssemblyInfo.cs">
       <SubType>Code</SubType>
@@ -241,6 +245,9 @@
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI">
       <Version>6.1.1</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Controls">
+      <Version>6.1.1</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Win32.UI.XamlApplication">
       <Version>6.1.2</Version>
     </PackageReference>
@@ -271,6 +278,14 @@
     <Page Include="Controls\HotkeySettingsControl.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Controls\KeyVisual\KeyVisual.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Controls\ShortcutVisualControl.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="OOBE\Views\OobeColorPicker.xaml">
       <SubType>Designer</SubType>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Microsoft.PowerToys.Settings.UI.csproj
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Microsoft.PowerToys.Settings.UI.csproj
@@ -99,6 +99,9 @@
       <DependentUpon>HotkeySettingsControl.xaml</DependentUpon>
     </Compile>
     <Compile Include="Controls\KeyVisual\KeyVisual.cs" />
+    <Compile Include="Controls\ShortcutTextControl.xaml.cs">
+      <DependentUpon>ShortcutTextControl.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Controls\ShortcutVisualControl.xaml.cs">
       <DependentUpon>ShortcutVisualControl.xaml</DependentUpon>
     </Compile>
@@ -280,6 +283,10 @@
       <SubType>Designer</SubType>
     </Page>
     <Page Include="Controls\KeyVisual\KeyVisual.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Controls\ShortcutTextControl.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeColorPicker.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeColorPicker.xaml
@@ -41,18 +41,12 @@
                 <TextBlock x:Uid="Oobe_HowToUse"
                            Style="{StaticResource OobeSubtitleStyle}" />
 
-                <StackPanel Orientation="Horizontal" Spacing="4">
-                    <controls:KeyVisual Content="Win" />
-                    <controls:KeyVisual Content="Shift" />
-                    <controls:KeyVisual Content="C" />
-                    <TextBlock Text="Super long string that is super long and long and long and long and long. ANd even longer, it;s so long you wont even believe it it's, so long oh yeah it's awesome." TextWrapping="Wrap" Margin="12,0,0,0" />
-                </StackPanel>
-
+                <controls:ShortcutTextControl x:Uid="Oobe_ColorPicker_HowToUse" />
+              
                 <TextBlock x:Uid="Oobe_TipsAndTricks"
                        Style="{StaticResource OobeSubtitleStyle}"/>
-                
-            <TextBlock x:Uid="Oobe_ColorPicker_TipsAndTricks"
-                       TextWrapping="Wrap" />
+
+                <controls:ShortcutTextControl x:Uid="Oobe_ColorPicker_TipsAndTricks" />
             
             <StackPanel Orientation="Horizontal"
                         Spacing="4"

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeColorPicker.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeColorPicker.xaml
@@ -38,11 +38,44 @@
                 </HyperlinkButton>
 
                 <TextBlock x:Uid="Oobe_HowToUse"
-                           Style="{StaticResource OobeSubtitleStyle}"/>
+                           Style="{StaticResource OobeSubtitleStyle}" />
                 
-            <TextBlock x:Uid="Oobe_ColorPicker_HowToUse"
-                       TextWrapping="Wrap"/>
-            
+                <StackPanel Orientation="Horizontal" Spacing="2" Margin="0,6,0,0">
+
+                    <Border BorderBrush="#CFCFCF"
+                            BorderThickness="1"
+                            Height="32"
+                            CornerRadius="2">
+                        <Viewbox Width="16"
+                                 Height="16"
+                                 Margin="8,0,8,0"
+                                 HorizontalAlignment="Center"
+                                 VerticalAlignment="Center">
+                            <PathIcon Data="M0,4.248,12.26,2.583l.005,11.789-12.254.07ZM12.254,15.731l.01,11.8L.01,25.851v-10.2ZM13.74,2.365,30,0V14.222l-16.256.129ZM30,15.842,30,30,13.74,27.713l-.023-11.9Z" />
+                        </Viewbox>
+                    </Border>
+                    
+                    <Border BorderBrush="#CFCFCF"
+                            BorderThickness="1"
+                            Height="32"
+                            Padding="12,0,12,0"
+                            CornerRadius="2">
+                        <TextBlock Text="Shift"
+                                   VerticalAlignment="Center" />
+                    </Border>
+                    <Border BorderBrush="#CFCFCF"
+                            BorderThickness="1"
+                            Height="32"
+                            Padding="12,0,12,0"
+                            CornerRadius="2">
+                        <TextBlock Text="C"
+                                   VerticalAlignment="Center" />
+                    </Border>
+                    
+                    <TextBlock Text="Open Color Picker" VerticalAlignment="Center"
+                               TextWrapping="Wrap" Margin="12,0,0,0" />
+                </StackPanel>
+                
             <TextBlock x:Uid="Oobe_TipsAndTricks"
                        Style="{StaticResource OobeSubtitleStyle}"/>
                 

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeColorPicker.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeColorPicker.xaml
@@ -6,7 +6,8 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
-    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+      xmlns:controls="using:Microsoft.PowerToys.Settings.UI.Controls"
+      Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
     <Grid>
         <Grid.RowDefinitions>
@@ -39,44 +40,15 @@
 
                 <TextBlock x:Uid="Oobe_HowToUse"
                            Style="{StaticResource OobeSubtitleStyle}" />
-                
-                <StackPanel Orientation="Horizontal" Spacing="2" Margin="0,6,0,0">
 
-                    <Border BorderBrush="#CFCFCF"
-                            BorderThickness="1"
-                            Height="32"
-                            CornerRadius="2">
-                        <Viewbox Width="16"
-                                 Height="16"
-                                 Margin="8,0,8,0"
-                                 HorizontalAlignment="Center"
-                                 VerticalAlignment="Center">
-                            <PathIcon Data="M0,4.248,12.26,2.583l.005,11.789-12.254.07ZM12.254,15.731l.01,11.8L.01,25.851v-10.2ZM13.74,2.365,30,0V14.222l-16.256.129ZM30,15.842,30,30,13.74,27.713l-.023-11.9Z" />
-                        </Viewbox>
-                    </Border>
-                    
-                    <Border BorderBrush="#CFCFCF"
-                            BorderThickness="1"
-                            Height="32"
-                            Padding="12,0,12,0"
-                            CornerRadius="2">
-                        <TextBlock Text="Shift"
-                                   VerticalAlignment="Center" />
-                    </Border>
-                    <Border BorderBrush="#CFCFCF"
-                            BorderThickness="1"
-                            Height="32"
-                            Padding="12,0,12,0"
-                            CornerRadius="2">
-                        <TextBlock Text="C"
-                                   VerticalAlignment="Center" />
-                    </Border>
-                    
-                    <TextBlock Text="Open Color Picker" VerticalAlignment="Center"
-                               TextWrapping="Wrap" Margin="12,0,0,0" />
+                <StackPanel Orientation="Horizontal" Spacing="4">
+                    <controls:KeyVisual Content="Win" />
+                    <controls:KeyVisual Content="Shift" />
+                    <controls:KeyVisual Content="C" />
+                    <TextBlock Text="Super long string that is super long and long and long and long and long. ANd even longer, it;s so long you wont even believe it it's, so long oh yeah it's awesome." TextWrapping="Wrap" Margin="12,0,0,0" />
                 </StackPanel>
-                
-            <TextBlock x:Uid="Oobe_TipsAndTricks"
+
+                <TextBlock x:Uid="Oobe_TipsAndTricks"
                        Style="{StaticResource OobeSubtitleStyle}"/>
                 
             <TextBlock x:Uid="Oobe_ColorPicker_TipsAndTricks"

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeFancyZones.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeFancyZones.xaml
@@ -5,7 +5,8 @@
     xmlns:local="using:Microsoft.PowerToys.Settings.UI.OOBE.Views"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d"
+      xmlns:controls="using:Microsoft.PowerToys.Settings.UI.Controls"
+      mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
     <Grid>
@@ -38,14 +39,14 @@
                 
                 <TextBlock x:Uid="Oobe_HowToUse"
                            Style="{StaticResource OobeSubtitleStyle}" />
-                <TextBlock x:Uid="Oobe_FancyZones_HowToUse"
-                           TextWrapping="Wrap" />
 
+                <controls:ShortcutVisualControl x:Uid="Oobe_FancyZones_HowToUse" />
+                
                 <TextBlock x:Uid="Oobe_TipsAndTricks"
                            Style="{StaticResource OobeSubtitleStyle}" />
-                <TextBlock x:Uid="Oobe_FancyZones_TipsAndTricks"
-                           TextWrapping="Wrap" />
 
+                <controls:ShortcutVisualControl x:Uid="Oobe_FancyZones_TipsAndTricks" />
+                
                 <StackPanel Orientation="Horizontal"
                             Spacing="4"
                             Margin="0,32,0,0">

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeFancyZones.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeFancyZones.xaml
@@ -40,13 +40,14 @@
                 <TextBlock x:Uid="Oobe_HowToUse"
                            Style="{StaticResource OobeSubtitleStyle}" />
 
-                <controls:ShortcutVisualControl x:Uid="Oobe_FancyZones_HowToUse" />
-                
+
+                <controls:ShortcutTextControl x:Uid="Oobe_FancyZones_HowToUse" />
+
                 <TextBlock x:Uid="Oobe_TipsAndTricks"
                            Style="{StaticResource OobeSubtitleStyle}" />
 
-                <controls:ShortcutVisualControl x:Uid="Oobe_FancyZones_TipsAndTricks" />
-                
+                <controls:ShortcutTextControl x:Uid="Oobe_FancyZones_TipsAndTricks" />
+
                 <StackPanel Orientation="Horizontal"
                             Spacing="4"
                             Margin="0,32,0,0">

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeFileExplorer.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeFileExplorer.xaml
@@ -4,6 +4,7 @@
       xmlns:local="using:Microsoft.PowerToys.Settings.UI.OOBE.Views"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:controls="using:Microsoft.PowerToys.Settings.UI.Controls"
       mc:Ignorable="d"
       Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
@@ -40,9 +41,8 @@
                 <TextBlock x:Uid="Oobe_HowToEnable"
                            Style="{StaticResource OobeSubtitleStyle}" />
 
-                <TextBlock x:Uid="Oobe_FileExplorer_HowToEnable"
-                           TextWrapping="Wrap" />
-
+                <controls:ShortcutTextControl x:Uid="Oobe_FileExplorer_HowToEnable" />
+                
                 <StackPanel Orientation="Horizontal"
                             Spacing="4"
                             Margin="0,32,0,0">

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeImageResizer.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeImageResizer.xaml
@@ -5,7 +5,8 @@
     xmlns:local="using:Microsoft.PowerToys.Settings.UI.OOBE.Views"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d"
+      xmlns:controls="using:Microsoft.PowerToys.Settings.UI.Controls"
+      mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
     <Grid>
@@ -41,14 +42,12 @@
                 <TextBlock x:Uid="Oobe_HowToLaunch"
                            Style="{StaticResource OobeSubtitleStyle}" />
 
-                <TextBlock x:Uid="Oobe_ImageResizer_HowToLaunch"
-                           TextWrapping="Wrap" />
+                <controls:ShortcutTextControl x:Uid="Oobe_ImageResizer_HowToLaunch" />
 
                 <TextBlock x:Uid="Oobe_TipsAndTricks"
                            Style="{StaticResource OobeSubtitleStyle}" />
 
-                <TextBlock x:Uid="Oobe_ImageResizer_TipsAndTricks"
-                           TextWrapping="Wrap" />
+                <controls:ShortcutTextControl x:Uid="Oobe_ImageResizer_TipsAndTricks" />
 
                 <StackPanel Orientation="Horizontal"
                             Spacing="4"

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeKBM.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeKBM.xaml
@@ -4,6 +4,7 @@
       xmlns:local="using:Microsoft.PowerToys.Settings.UI.OOBE.Views"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:controls="using:Microsoft.PowerToys.Settings.UI.Controls"
       mc:Ignorable="d"
       Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
@@ -40,14 +41,12 @@
                 <TextBlock x:Uid="Oobe_HowToCreateMappings"
                            Style="{StaticResource OobeSubtitleStyle}" />
 
-                <TextBlock x:Uid="Oobe_KBM_HowToCreateMappings"
-                           TextWrapping="Wrap" />
+                <controls:ShortcutTextControl x:Uid="Oobe_KBM_HowToCreateMappings" />
 
                 <TextBlock x:Uid="Oobe_TipsAndTricks"
                            Style="{StaticResource OobeSubtitleStyle}" />
 
-                <TextBlock x:Uid="Oobe_KBM_TipsAndTricks"
-                           TextWrapping="Wrap" />
+                <controls:ShortcutTextControl x:Uid="Oobe_KBM_TipsAndTricks" />
 
                 <StackPanel Orientation="Horizontal"
                             Spacing="4"

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobePowerRename.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobePowerRename.xaml
@@ -4,6 +4,7 @@
       xmlns:local="using:Microsoft.PowerToys.Settings.UI.OOBE.Views"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:controls="using:Microsoft.PowerToys.Settings.UI.Controls"
       mc:Ignorable="d"
       Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
@@ -41,8 +42,7 @@
                 <TextBlock x:Uid="Oobe_HowToUse"
                            Style="{StaticResource OobeSubtitleStyle}" />
 
-                <TextBlock x:Uid="Oobe_PowerRename_HowToUse"
-                           TextWrapping="Wrap" />
+                <controls:ShortcutTextControl x:Uid="Oobe_PowerRename_HowToUse" />
 
                 <TextBlock x:Uid="Oobe_TipsAndTricks"
                            Style="{StaticResource OobeSubtitleStyle}" />

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeRun.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeRun.xaml
@@ -5,7 +5,8 @@
     xmlns:local="using:Microsoft.PowerToys.Settings.UI.OOBE.Views"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d"
+      xmlns:controls="using:Microsoft.PowerToys.Settings.UI.Controls"
+      mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
     <Grid>
@@ -42,8 +43,8 @@
                 <TextBlock x:Uid="Oobe_HowToLaunch"
                            Style="{StaticResource OobeSubtitleStyle}" />
 
-                <TextBlock x:Uid="Oobe_Run_HowToLaunch" />
-
+                <controls:ShortcutVisualControl x:Uid="Oobe_Run_HowToLaunch" />
+                
                 <TextBlock x:Uid="Oobe_TipsAndTricks"
                            Style="{StaticResource OobeSubtitleStyle}" />
 

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeRun.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeRun.xaml
@@ -43,13 +43,12 @@
                 <TextBlock x:Uid="Oobe_HowToLaunch"
                            Style="{StaticResource OobeSubtitleStyle}" />
 
-                <controls:ShortcutVisualControl x:Uid="Oobe_Run_HowToLaunch" />
+                <controls:ShortcutTextControl x:Uid="Oobe_Run_HowToLaunch" />
                 
                 <TextBlock x:Uid="Oobe_TipsAndTricks"
                            Style="{StaticResource OobeSubtitleStyle}" />
 
-                <TextBlock x:Uid="Oobe_Run_TipsAndTricks"
-                           TextWrapping="Wrap" />
+                <controls:ShortcutTextControl x:Uid="Oobe_Run_TipsAndTricks" />
 
                 <StackPanel Orientation="Horizontal"
                             Margin="0,32,0,0"

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeShortcutGuide.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeShortcutGuide.xaml
@@ -5,7 +5,8 @@
     xmlns:local="using:Microsoft.PowerToys.Settings.UI.OOBE.Views"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d"
+      xmlns:controls="using:Microsoft.PowerToys.Settings.UI.Controls"
+      mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
     <Grid>
@@ -42,9 +43,8 @@
                 <TextBlock x:Uid="Oobe_HowToLaunch"
                            Style="{StaticResource OobeSubtitleStyle}" />
 
-                <TextBlock x:Uid="Oobe_ShortcutGuide_HowToLaunch"
-                           TextWrapping="Wrap" />
-
+                <controls:ShortcutVisualControl x:Uid="Oobe_ShortcutGuide_HowToLaunch" />
+                
                 <StackPanel Orientation="Horizontal"
                             Margin="0,32,0,0"
                             Spacing="8">

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeShortcutGuide.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeShortcutGuide.xaml
@@ -43,7 +43,7 @@
                 <TextBlock x:Uid="Oobe_HowToLaunch"
                            Style="{StaticResource OobeSubtitleStyle}" />
 
-                <controls:ShortcutVisualControl x:Uid="Oobe_ShortcutGuide_HowToLaunch" />
+                <controls:ShortcutTextControl x:Uid="Oobe_ShortcutGuide_HowToLaunch" />
                 
                 <StackPanel Orientation="Horizontal"
                             Margin="0,32,0,0"

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeVideoConference.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeVideoConference.xaml
@@ -5,7 +5,8 @@
     xmlns:local="using:Microsoft.PowerToys.Settings.UI.OOBE.Views"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d"
+      xmlns:controls="using:Microsoft.PowerToys.Settings.UI.Controls"
+      mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
     <Grid>
@@ -41,8 +42,7 @@
                 <TextBlock x:Uid="Oobe_HowToLaunch"
                            Style="{StaticResource OobeSubtitleStyle}" />
 
-                <TextBlock x:Uid="Oobe_VideoConference_HowToLaunch"
-                           TextWrapping="Wrap" />
+                <controls:ShortcutTextControl x:Uid="Oobe_VideoConference_HowToLaunch" />
 
                 <StackPanel Orientation="Horizontal"
                             Margin="0,32,0,0"

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -1033,19 +1033,19 @@ Take a moment to preview the various utilities listed or view our comprehensive 
     <value>PowerToys in our release notes.</value>
   </data>
   <data name="Oobe_ColorPicker_HowToUse.Text" xml:space="preserve">
-    <value>Open Color Picker.</value>
+    <value>{Win} + {Ctrl} + {C} to open Color Picker.</value>
   </data>
   <data name="Oobe_ColorPicker_TipsAndTricks.Text" xml:space="preserve">
-    <value>To select a color with more precision, scroll the mouse wheel to zoom in.</value>
+    <value>To select a color with more precision, {scroll the mouse wheel} to zoom in.</value>
   </data>
   <data name="Oobe_FancyZones_HowToUse.Text" xml:space="preserve">
-    <value>{Shift} + drag while dragging the window to snap a window to a zone, and release the window in the desired zone. {Win} + ` to open the FancyZones editor.</value>
+    <value>{Shift} + {dragging the window} to snap a window to a zone, and release the window in the desired zone. {Win} + {`} to open the FancyZones editor.</value>
   </data>
   <data name="Oobe_FancyZones_TipsAndTricks.Text" xml:space="preserve">
     <value>Snap a window to multiple zones by holding the {Ctrl} key (while also holding {Shift}) when dragging a window.</value>
   </data>
   <data name="Oobe_FileExplorer_HowToEnable.Text" xml:space="preserve">
-    <value>Open Windows File Explorer, select the View tab in the File Explorer ribbon, then select Preview Pane. 
+    <value>Open File Explorer, {select the View tab} in the File Explorer ribbon, then {select Preview Pane}. 
 From there, simply click on a Markdown file or SVG icon in the File Explorer and observe the content on the preview pane!</value>
   </data>
   <data name="Oobe_HowToCreateMappings.Text" xml:space="preserve">
@@ -1061,39 +1061,39 @@ From there, simply click on a Markdown file or SVG icon in the File Explorer and
     <value>How to use</value>
   </data>
   <data name="Oobe_ImageResizer_HowToLaunch.Text" xml:space="preserve">
-    <value>In File Explorer, right-clicking one or more image files and clicking on Resize pictures from the context menu.</value>
+    <value>In File Explorer, {right-clicking one or more image files} and {clicking on Resize pictures} from the context menu.</value>
   </data>
   <data name="Oobe_ImageResizer_TipsAndTricks.Text" xml:space="preserve">
     <value>Want a custom size? You can add them in the PowerToys Settings!</value>
   </data>
   <data name="Oobe_KBM_HowToCreateMappings.Text" xml:space="preserve">
-    <value>Launch PowerToys settings, navigate to the Keyboard Manager menu, and select either Remap a key or Remap a shortcut.</value>
+    <value>Launch {PowerToys settings}, navigate to the Keyboard Manager menu, and select either {Remap a key} or {Remap a shortcut}.</value>
   </data>
   <data name="Oobe_KBM_TipsAndTricks.Text" xml:space="preserve">
     <value>Want to only have a shortcut work for a single application? Use the Target App field when creating the shortcut remapping.</value>
   </data>
   <data name="Oobe_PowerRename_HowToUse.Text" xml:space="preserve">
-    <value>In File Explorer, right-clicking one or more selected files and clicking on PowerRename from the context menu.</value>
+    <value>In File Explorer, {right-clicking one or more selected files} and {clicking on PowerRename} from the context menu.</value>
   </data>
   <data name="Oobe_PowerRename_TipsAndTricks.Text" xml:space="preserve">
     <value>PowerRename supports searching for files using regular expressions to enable more advanced renaming functionalities.</value>
   </data>
   <data name="Oobe_Run_HowToLaunch.Text" xml:space="preserve">
-    <value>{Alt} {Space} to open Run and just start typing.</value>
+    <value>{Alt} + {Space} to open Run and just start typing.</value>
   </data>
   <data name="Oobe_Run_TipsAndTricks.Text" xml:space="preserve">
-    <value>PowerToys runs supports various action keys to funnel search queries for a specific subset of results. Typing &lt; searches for running processes only, ? will search only for file, or . for installed applications! See PowerToys documentation for the complete set of 'Action Keys' available.</value>
+    <value>PowerToys Run supports various action keys to funnel search queries for a specific subset of results. Typing {&lt;} searches for running processes only, {?} will search only for file, or {.} for installed applications! See PowerToys documentation for the complete set of 'Action Keys' available.</value>
   </data>
   <data name="Oobe_ShortcutGuide_HowToLaunch.Text" xml:space="preserve">
-    <value>{Win} {?} to open Shortcut Guide, press it again to close or press {Esc}. You can also launch it by holding the {Win} key for one second!</value>
+    <value>{Win} + {?} to open Shortcut Guide, press it again to close or press {Esc}. You can also launch it by holding the {Win} key for one second!</value>
   </data>
   <data name="Oobe_TipsAndTricks.Text" xml:space="preserve">
     <value>Tips &amp; tricks</value>
   </data>
   <data name="Oobe_VideoConference_HowToLaunch.Text" xml:space="preserve">
-    <value>{Win} {N} to toggle both your microphone and video
-{Win} {Shift} {A} to toggle your microphone 
-{Win} {Shift} {O} to toggle your video</value>
+    <value>{Win} + {N} to toggle both your microphone and video
+{Win} + {Shift} + {A} to toggle your microphone 
+{Win} + {Shift} + {O} to toggle your video</value>
   </data>
   <data name="Oobe_ColorPicker" xml:space="preserve">
     <value>Color Picker</value>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -1033,17 +1033,16 @@ Take a moment to preview the various utilities listed or view our comprehensive 
     <value>PowerToys in our release notes.</value>
   </data>
   <data name="Oobe_ColorPicker_HowToUse.Text" xml:space="preserve">
-    <value>Win + Shift + C to open Color Picker.</value>
+    <value>Open Color Picker.</value>
   </data>
   <data name="Oobe_ColorPicker_TipsAndTricks.Text" xml:space="preserve">
     <value>To select a color with more precision, scroll the mouse wheel to zoom in.</value>
   </data>
   <data name="Oobe_FancyZones_HowToUse.Text" xml:space="preserve">
-    <value>Shift + drag while dragging the window to snap a window to a zone, and release the window in the desired zone.
-Win + ` to open the FancyZones editor.</value>
+    <value>{Shift} + drag while dragging the window to snap a window to a zone, and release the window in the desired zone. {Win} + ` to open the FancyZones editor.</value>
   </data>
   <data name="Oobe_FancyZones_TipsAndTricks.Text" xml:space="preserve">
-    <value>Snap a window to multiple zones by holding the Ctrl key (while also holding Shift) when dragging a window.</value>
+    <value>Snap a window to multiple zones by holding the {Ctrl} key (while also holding {Shift}) when dragging a window.</value>
   </data>
   <data name="Oobe_FileExplorer_HowToEnable.Text" xml:space="preserve">
     <value>Open Windows File Explorer, select the View tab in the File Explorer ribbon, then select Preview Pane. 
@@ -1080,21 +1079,21 @@ From there, simply click on a Markdown file or SVG icon in the File Explorer and
     <value>PowerRename supports searching for files using regular expressions to enable more advanced renaming functionalities.</value>
   </data>
   <data name="Oobe_Run_HowToLaunch.Text" xml:space="preserve">
-    <value>Alt + Space to open PowerToys and just start typing.</value>
+    <value>{Alt} {Space} to open Run and just start typing.</value>
   </data>
   <data name="Oobe_Run_TipsAndTricks.Text" xml:space="preserve">
     <value>PowerToys runs supports various action keys to funnel search queries for a specific subset of results. Typing &lt; searches for running processes only, ? will search only for file, or . for installed applications! See PowerToys documentation for the complete set of 'Action Keys' available.</value>
   </data>
   <data name="Oobe_ShortcutGuide_HowToLaunch.Text" xml:space="preserve">
-    <value>Win + ? to open Shortcut Guide, press it again to close or press Esc. You can also launch it by holding the Win key for one second!</value>
+    <value>{Win} {?} to open Shortcut Guide, press it again to close or press {Esc}. You can also launch it by holding the {Win} key for one second!</value>
   </data>
   <data name="Oobe_TipsAndTricks.Text" xml:space="preserve">
     <value>Tips &amp; tricks</value>
   </data>
   <data name="Oobe_VideoConference_HowToLaunch.Text" xml:space="preserve">
-    <value>Win + N to toggle both your microphone and video 
-Win + Shift + A to toggle your microphone 
-Win + Shift + O to toggle your video</value>
+    <value>{Win} {N} to toggle both your microphone and video
+{Win} {Shift} {A} to toggle your microphone 
+{Win} {Shift} {O} to toggle your video</value>
   </data>
   <data name="Oobe_ColorPicker" xml:space="preserve">
     <value>Color Picker</value>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Styles/TextBlock.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Styles/TextBlock.xaml
@@ -31,6 +31,7 @@
 
     <Style x:Key="OobeSubtitleStyle" TargetType="TextBlock">
         <Setter Property="FontWeight" Value="SemiBold"/>
+        <Setter Property="FontSize" Value="16" />
         <Setter Property="Margin" Value="0,16,0,0" />
     </Style>
 </ResourceDictionary>

--- a/src/settings-ui/PowerToys.Settings/MainWindow.xaml.cs
+++ b/src/settings-ui/PowerToys.Settings/MainWindow.xaml.cs
@@ -87,7 +87,7 @@ namespace PowerToys.Settings
                 // send IPC Message
                 ShellPage.SetCheckForUpdatesMessageCallback(msg =>
                 {
-                    Program.GetTwoWayIPCManager().Send(msg);
+                    // Program.GetTwoWayIPCManager().Send(msg);
                 });
 
                 // open oobe

--- a/src/settings-ui/PowerToys.Settings/MainWindow.xaml.cs
+++ b/src/settings-ui/PowerToys.Settings/MainWindow.xaml.cs
@@ -87,7 +87,7 @@ namespace PowerToys.Settings
                 // send IPC Message
                 ShellPage.SetCheckForUpdatesMessageCallback(msg =>
                 {
-                    // Program.GetTwoWayIPCManager().Send(msg);
+                    Program.GetTwoWayIPCManager().Send(msg);
                 });
 
                 // open oobe


### PR DESCRIPTION
## Summary of the Pull Request

This PR introduces a new TextBlock-based control that can be used to highlight/bold e.g. shortcuts or important instructions, inline with Windows Tips.

Parts of strings can be bolded by using the { and } tags.

E.g.:

Press {Ctrl} to open this module => Press **Ctrl** to open this module


![OOBE](https://user-images.githubusercontent.com/9866362/113509684-48bd7000-9557-11eb-8a01-d7e7c90f9dbf.gif)


@crutkas @enricogior I went for the text-highlighting option, putting in a shortcut visual was a bit complex when having shortcuts within the text string itself. I kept that control (ShortcutVisualControl) in if we want to use it later on.

## Quality Checklist

- [X] **Linked issue:** #10356
- [X] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
