### PR TITLE
spell-check: ignore drafts

### DIFF
--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -1,12 +1,15 @@
 name: Spell checking
 on:
   pull_request_target:
-  push:
+    branches:
+      - "**"
+    types: ['opened', 'reopened', 'synchronize', 'ready_for_review']
 
 jobs:
   build:
     name: Spell checking
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     steps:
     - name: checkout-merge
       if: "contains(github.event_name, 'pull_request')"


### PR DESCRIPTION
## Summary of the Pull Request

Reduces chatter from the spell check tool until PRs are ready for review

**What is this about:**
#10584

https://github.community/t/dont-run-actions-on-draft-pull-requests/16817/18

**What is include in the PR:** 

1. Turns off spell checking on push
2. Turns off spell checking for PRs in draft
3. Turns on spell checking when a PR switches from draft to ready for review

The pictures here are for a different project (I'm not really awake, so I drafted the work in the wrong place), but the flow is the same (hurray for reusable code):
#### draft -> ignore spell checking
![draft ignored](https://user-images.githubusercontent.com/2119212/113559426-54e51400-95cf-11eb-94de-03bf61918e8a.png)

#### ready for review -> trigger first spell check
![ready for review check triggered](https://user-images.githubusercontent.com/2119212/113559786-fd937380-95cf-11eb-9f60-5cd85011b6b4.png)

**How does someone test / validate:** 

1. Create a local branch / fork
2. Push a typo to it (note that the bot ignores you)
3. Create a draft PR of the typo branch to the local branch w/ this change (note that the bot ignores you)
4. Convert the draft PR to a normal PR (note that the bot immediately performs a run and complains)

## Quality Checklist

- [x] **Linked issue:** #10584
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
