### PR TITLE
[Image Resizer] Visual updates + NumberBox

### DIFF
--- a/src/modules/imageresizer/ui/Views/InputPage.xaml
+++ b/src/modules/imageresizer/ui/Views/InputPage.xaml
@@ -127,15 +127,11 @@
                                           Style="{StaticResource DisabledWhenUnselectedTextBoxStyle}"
                                           AutomationProperties.Name="{x:Static p:Resources.Width}"
                                           Margin="8,0,0,0">
-                                <ui:NumberBox.Text>
-                                    <Binding Converter="{StaticResource AutoDoubleConverter}"
-                                             Path="Width"
+                                <ui:NumberBox.Value>
+                                    <Binding Path="Width"
                                              UpdateSourceTrigger="PropertyChanged">
-                                        <Binding.ValidationRules>
-                                            <local:AutoDoubleValidationRule />
-                                        </Binding.ValidationRules>
                                     </Binding>
-                                </ui:NumberBox.Text>
+                                </ui:NumberBox.Value>
                             </ui:NumberBox>
                             <TextBlock VerticalAlignment="Center"
                                    Text="&#xE711;"
@@ -152,15 +148,11 @@
                                           Width="102"
                                           AutomationProperties.Name="{x:Static p:Resources.Height}"
                                           Visibility="{Binding ShowHeight,Converter={StaticResource BoolValueConverter}}">
-                                <ui:NumberBox.Text>
-                                    <Binding Converter="{StaticResource AutoDoubleConverter}"
-                                             Path="Height"
+                                <ui:NumberBox.Value>
+                                    <Binding Path="Height"
                                              UpdateSourceTrigger="PropertyChanged">
-                                        <Binding.ValidationRules>
-                                            <local:AutoDoubleValidationRule />
-                                        </Binding.ValidationRules>
                                     </Binding>
-                                </ui:NumberBox.Text>
+                                </ui:NumberBox.Value>
                             </ui:NumberBox>
                             <ComboBox Margin="8,0,0,0"
                                   ItemsSource="{Binding Source={StaticResource ResizeUnitValues}}"

--- a/src/modules/imageresizer/ui/Views/InputPage.xaml
+++ b/src/modules/imageresizer/ui/Views/InputPage.xaml
@@ -123,7 +123,7 @@
                             </ComboBox.ItemTemplate>
                         </ComboBox>
                             <ui:NumberBox SpinButtonPlacementMode="Compact"
-                            Minimum="1"
+                                          Minimum="1"
                                           Width="102"
                                           Style="{StaticResource DisabledWhenUnselectedTextBoxStyle}"
                                           AutomationProperties.Name="{x:Static p:Resources.Width}"

--- a/src/modules/imageresizer/ui/Views/InputPage.xaml
+++ b/src/modules/imageresizer/ui/Views/InputPage.xaml
@@ -17,7 +17,9 @@
                 </DataTrigger>
             </Style.Triggers>
         </Style>
-        <Style x:Key="DisabledWhenUnselectedTextBoxStyle" TargetType="TextBox" BasedOn="{StaticResource DefaultTextBoxStyle}">
+        <Style x:Key="DisabledWhenUnselectedTextBoxStyle"
+               TargetType="ui:NumberBox"
+               >
             <Style.Triggers>
                 <DataTrigger Binding="{Binding IsSelected, RelativeSource={RelativeSource AncestorType=ListBoxItem}}" Value="True">
                     <Setter Property="IsEnabled" Value="True"/>
@@ -80,12 +82,20 @@
                 </DataTemplate>
                 
                 <DataTemplate DataType="{x:Type m:CustomSize}">
-                    <StackPanel Orientation="Horizontal" Margin="0,-8,0,0">
-                        <TextBlock VerticalAlignment="Center"
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="36" />
+                            <RowDefinition Height="*" />
+                            
+                        </Grid.RowDefinitions>
+                        <TextBlock VerticalAlignment="Top"
                                    Text="{Binding Name}"
                                    Foreground="{DynamicResource PrimaryForegroundBrush}"
-                                   FontWeight="SemiBold"/>
-                        <ComboBox Margin="8,0,0,0"
+                                   FontWeight="SemiBold" />
+                  
+                    <StackPanel Orientation="Horizontal" Grid.Row="1" Margin="0,-8,0,0">
+                  
+                        <ComboBox Margin="0,0,0,0"
                                   ItemsSource="{Binding Source={StaticResource ResizeFitValues}}"
                                   Style="{StaticResource DisabledWhenUnselectedComboBoxStyle}"
                                   AutomationProperties.Name="{x:Static p:Resources.Resize_Type}"
@@ -96,22 +106,22 @@
                                 </DataTemplate>
                             </ComboBox.ItemTemplate>
                         </ComboBox>
-                        <TextBox Width="56"
-                                 TextWrapping="Wrap"
-                                 Style="{StaticResource DisabledWhenUnselectedTextBoxStyle}"
-                                 AutomationProperties.Name="{x:Static p:Resources.Width}"
-                                 Margin="8,0,0,0">
-                            <TextBox.Text>
-                                <Binding Converter="{StaticResource AutoDoubleConverter}"
-                                         Path="Width"
-                                         UpdateSourceTrigger="PropertyChanged">
-                                    <Binding.ValidationRules>
-                                        <local:AutoDoubleValidationRule/>
-                                    </Binding.ValidationRules>
-                                </Binding>
-                            </TextBox.Text>
-                        </TextBox>
-                        <TextBlock VerticalAlignment="Center"
+                            <ui:NumberBox SpinButtonPlacementMode="Compact"
+                                          Width="102"
+                                          Style="{StaticResource DisabledWhenUnselectedTextBoxStyle}"
+                                          AutomationProperties.Name="{x:Static p:Resources.Width}"
+                                          Margin="8,0,0,0">
+                                <ui:NumberBox.Text>
+                                    <Binding Converter="{StaticResource AutoDoubleConverter}"
+                                             Path="Width"
+                                             UpdateSourceTrigger="PropertyChanged">
+                                        <Binding.ValidationRules>
+                                            <local:AutoDoubleValidationRule />
+                                        </Binding.ValidationRules>
+                                    </Binding>
+                                </ui:NumberBox.Text>
+                            </ui:NumberBox>
+                            <TextBlock VerticalAlignment="Center"
                                    Text="&#xE711;"
                                    FontFamily="Segoe MDL2 Assets"
                                    Width="25"
@@ -121,22 +131,22 @@
                                    TextAlignment="Center"
                                    Visibility="{Binding ShowHeight,Converter={StaticResource BoolValueConverter}}"/>
 
-                        <TextBox Width="56"
-                                 Style="{StaticResource DisabledWhenUnselectedTextBoxStyle}"
-                                 TextWrapping="Wrap"
-                                 AutomationProperties.Name="{x:Static p:Resources.Height}"
-                                 Visibility="{Binding ShowHeight,Converter={StaticResource BoolValueConverter}}">
-                            <TextBox.Text>
-                                <Binding Converter="{StaticResource AutoDoubleConverter}"
-                                         Path="Height"
-                                         UpdateSourceTrigger="PropertyChanged">
-                                    <Binding.ValidationRules>
-                                        <local:AutoDoubleValidationRule/>
-                                    </Binding.ValidationRules>
-                                </Binding>
-                            </TextBox.Text>
-                        </TextBox>
-                        <ComboBox Margin="8,0,0,0"
+                            <ui:NumberBox Style="{StaticResource DisabledWhenUnselectedTextBoxStyle}"
+                                          SpinButtonPlacementMode="Compact"
+                                          Width="102"
+                                          AutomationProperties.Name="{x:Static p:Resources.Height}"
+                                          Visibility="{Binding ShowHeight,Converter={StaticResource BoolValueConverter}}">
+                                <ui:NumberBox.Text>
+                                    <Binding Converter="{StaticResource AutoDoubleConverter}"
+                                             Path="Height"
+                                             UpdateSourceTrigger="PropertyChanged">
+                                        <Binding.ValidationRules>
+                                            <local:AutoDoubleValidationRule />
+                                        </Binding.ValidationRules>
+                                    </Binding>
+                                </ui:NumberBox.Text>
+                            </ui:NumberBox>
+                            <ComboBox Margin="8,0,0,0"
                                   ItemsSource="{Binding Source={StaticResource ResizeUnitValues}}"
                                   Style="{StaticResource DisabledWhenUnselectedComboBoxStyle}"
                                   AutomationProperties.Name="{x:Static p:Resources.Unit}"
@@ -148,6 +158,7 @@
                             </ComboBox.ItemTemplate>
                         </ComboBox>
                     </StackPanel>
+                    </Grid>
                 </DataTemplate>
             </ListBox.Resources>
         </ListBox>

--- a/src/modules/imageresizer/ui/Views/InputPage.xaml
+++ b/src/modules/imageresizer/ui/Views/InputPage.xaml
@@ -145,6 +145,7 @@
 
                             <ui:NumberBox Style="{StaticResource DisabledWhenUnselectedTextBoxStyle}"
                                           SpinButtonPlacementMode="Compact"
+                                          Minimum="1"
                                           Width="102"
                                           AutomationProperties.Name="{x:Static p:Resources.Height}"
                                           Visibility="{Binding ShowHeight,Converter={StaticResource BoolValueConverter}}">

--- a/src/modules/imageresizer/ui/Views/InputPage.xaml
+++ b/src/modules/imageresizer/ui/Views/InputPage.xaml
@@ -123,6 +123,7 @@
                             </ComboBox.ItemTemplate>
                         </ComboBox>
                             <ui:NumberBox SpinButtonPlacementMode="Compact"
+                            Minimum="1"
                                           Width="102"
                                           Style="{StaticResource DisabledWhenUnselectedTextBoxStyle}"
                                           AutomationProperties.Name="{x:Static p:Resources.Width}"

--- a/src/modules/imageresizer/ui/Views/InputPage.xaml
+++ b/src/modules/imageresizer/ui/Views/InputPage.xaml
@@ -69,27 +69,43 @@
             
             <ListBox.Resources>
                 <DataTemplate DataType="{x:Type m:ResizeSize}">
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock Text="{Binding Name}" FontWeight="SemiBold" Foreground="{DynamicResource PrimaryForegroundBrush}"/>
-                        <TextBlock Text="(" Margin="4,0,0,0" Foreground="{DynamicResource SecondaryForegroundBrush}"/>
-                        <TextBlock Text="{Binding Fit,Converter={StaticResource EnumValueConverter},ConverterParameter=ThirdPersonSingular}" Foreground="{DynamicResource SecondaryForegroundBrush}"/>
+                    <Grid Margin="0,0,0,4">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="20" />
+                            <RowDefinition Height="24" />
+
+                        </Grid.RowDefinitions>
+                        <TextBlock Text="{Binding Name}"
+                                   FontWeight="SemiBold"
+                                   FontSize="16"
+                                   Margin="0,-2,0,0"
+                                   VerticalAlignment="Top"
+                                   Foreground="{DynamicResource PrimaryForegroundBrush}" />
+                        <StackPanel Orientation="Horizontal"
+                                    Grid.Row="1"
+                                    VerticalAlignment="Top">
+                            <TextBlock Text="{Binding Fit,Converter={StaticResource EnumValueConverter},ConverterParameter=ThirdPersonSingular}" Foreground="{DynamicResource SecondaryForegroundBrush}"/>
                         <TextBlock Text="{Binding Width,Converter={StaticResource AutoDoubleConverter},ConverterParameter=Auto}" Margin="4,0,0,0" Foreground="{DynamicResource SecondaryForegroundBrush}"/>
                         <TextBlock Text="&#xE711;" FontSize="11" FontFamily="Segoe MDL2 Assets" Visibility="{Binding ShowHeight,Converter={StaticResource BoolValueConverter}}" Margin="4,5,0,0" Foreground="{DynamicResource SecondaryForegroundBrush}"/>
                         <TextBlock Text="{Binding Height,Converter={StaticResource AutoDoubleConverter},ConverterParameter=Auto}" Visibility="{Binding ShowHeight,Converter={StaticResource BoolValueConverter}}" Margin="4,0,0,0" Foreground="{DynamicResource SecondaryForegroundBrush}"/>
-                        <TextBlock Text="{Binding Unit,Converter={StaticResource EnumValueConverter},ConverterParameter=ToLower}" Margin="4,0,0,0" Foreground="{DynamicResource SecondaryForegroundBrush}"/>
-                        <TextBlock Text=")" Foreground="{DynamicResource SecondaryForegroundBrush}"/>
-                    </StackPanel>
+                            <TextBlock Text="{Binding Unit,Converter={StaticResource EnumValueConverter},ConverterParameter=ToLower}"
+                                       Margin="4,0,0,0"
+                                       Foreground="{DynamicResource SecondaryForegroundBrush}" />
+                        </StackPanel>
+                    </Grid>
                 </DataTemplate>
                 
                 <DataTemplate DataType="{x:Type m:CustomSize}">
                     <Grid>
                         <Grid.RowDefinitions>
-                            <RowDefinition Height="36" />
+                            <RowDefinition Height="32" />
                             <RowDefinition Height="*" />
                             
                         </Grid.RowDefinitions>
                         <TextBlock VerticalAlignment="Top"
                                    Text="{Binding Name}"
+                                   FontSize="16"
+                                   Margin="0,-2,0,0"
                                    Foreground="{DynamicResource PrimaryForegroundBrush}"
                                    FontWeight="SemiBold" />
                   


### PR DESCRIPTION
## Summary of the Pull Request
- Swapped out the custom input TextBox with NumberBox so they will have immediate keyboard focus (#10363)
- NumberBoxes need more width to display all UI chrome, therefore the inputfields are moved under the title to save space (especially for languages that have long titles). Did the same with the predefined sizes. 

Result:

![ImageResizerNUmberBOx](https://user-images.githubusercontent.com/9866362/113590646-3153b500-9633-11eb-8180-d9fa57d3802c.gif)



## Quality Checklist

- [X] **Linked issue:** #10363
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
