### PR TITLE
[FancyZones] Fix an issue with zone sizes

### DIFF
--- a/src/modules/fancyzones/lib/ZoneSet.cpp
+++ b/src/modules/fancyzones/lib/ZoneSet.cpp
@@ -882,9 +882,9 @@ bool ZoneSet::CalculateGridZones(Rect workArea, FancyZonesDataTypes::GridLayoutI
                 long bottom = rowInfo[maxRow].End;
 
                 top += row == 0 ? spacing : spacing / 2;
-                bottom -= row == gridLayoutInfo.rows() - 1 ? spacing : spacing / 2;
+                bottom -= maxRow == gridLayoutInfo.rows() - 1 ? spacing : spacing / 2;
                 left += col == 0 ? spacing : spacing / 2;
-                right -= col == gridLayoutInfo.columns() - 1 ? spacing : spacing / 2;
+                right -= maxCol == gridLayoutInfo.columns() - 1 ? spacing : spacing / 2;
 
                 auto zone = MakeZone(RECT{ left, top, right, bottom }, i);
                 if (zone)


### PR DESCRIPTION
## Summary of the Pull Request

There was an error in calculating the zones for grid layouts, see #10594.
This PR fixes that.

**How does someone test / validate:** 

Verify that the layout described in the issue gets drawn correctly. Don't forget to set spacing to see the difference. Also verify its transpose, as it also had this issue. By transpose i mean:
12
33

## Quality Checklist

- [x] **Linked issue:** #10594 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
