### PR TITLE
[runner, color picker, run] remove os dection

### DIFF
--- a/src/modules/colorPicker/ColorPicker/dllmain.cpp
+++ b/src/modules/colorPicker/ColorPicker/dllmain.cpp
@@ -6,7 +6,6 @@
 #include "Generated Files/resource.h"
 #include <common/logger/logger.h>
 #include <common/SettingsAPI/settings_objects.h>
-#include <common/utils/os-detect.h>
 #include <common/utils/resources.h>
 
 #include <colorPicker/ColorPicker/ColorPickerConstants.h>
@@ -227,12 +226,8 @@ public:
     {
         ResetEvent(send_telemetry_event);
         ResetEvent(m_hInvokeEvent);
-        // use only with new settings?
-        if (UseNewSettings())
-        {
-            launch_process();
-            m_enabled = true;
-        }
+        launch_process();
+        m_enabled = true;
     };
 
     virtual void disable()

--- a/src/runner/settings_window.cpp
+++ b/src/runner/settings_window.cpp
@@ -20,7 +20,6 @@
 #include <common/version/helper.h>
 #include <common/logger/logger.h>
 #include <common/utils/elevation.h>
-#include <common/utils/os-detect.h>
 #include <common/utils/process_path.h>
 #include <common/utils/timeutil.h>
 #include <common/utils/winapi_error.h>
@@ -367,12 +366,12 @@ void run_settings_window(bool showOobeWindow)
     
     BOOL process_created = false;
 
-    // Due to a bug in .NET, running the Settings process as non-elevated
-    // from an elevated process sometimes results in a crash.
-    // TODO: Revisit this after switching to .NET 5
-    if (is_process_elevated() && !UseNewSettings())
+    if (is_process_elevated())
     {
-        process_created = run_settings_non_elevated(executable_path.c_str(), executable_args.data(), &process_info);
+        // TODO: Revisit this after switching to .NET 5
+        // Due to a bug in .NET, running the Settings process as non-elevated
+        // from an elevated process sometimes results in a crash.  
+        // process_created = run_settings_non_elevated(executable_path.c_str(), executable_args.data(), &process_info);
     }
 
     if (FALSE == process_created)


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Starting with 0.37, old settings are not supported anymore, and PowerToys only installs on 1903 and newer.
The `UseNewSettings()` is not needed anymore.

**What is include in the PR:** 
Remove `UseNewSettings()` from Color Picker, PT Run and Runner.

**How does someone test / validate:** 
Verify Color Picker and PT Run open when the hotkey is pressed.
Verify the Settings app opens when PowerToys  is running as a user or as an admin.

## Quality Checklist

- [x] **Linked issue:** #9417
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
