### PR TITLE
Divide load and initialize of plugins into two stages

### DIFF
--- a/src/modules/launcher/PowerLauncher/Plugin/PluginManager.cs
+++ b/src/modules/launcher/PowerLauncher/Plugin/PluginManager.cs
@@ -128,9 +128,9 @@ namespace PowerLauncher.Plugin
                     return;
                 }
 
-                pair.LoadPlugin(API);
+                pair.InitializePlugin(API);
 
-                if (!pair.IsPluginLoaded)
+                if (!pair.IsPluginInitialized)
                 {
                     failedPlugins.Enqueue(pair);
                 }
@@ -159,7 +159,7 @@ namespace PowerLauncher.Plugin
                 throw new ArgumentNullException(nameof(pair));
             }
 
-            if (!pair.IsPluginLoaded)
+            if (!pair.IsPluginInitialized)
             {
                 return new List<Result>();
             }

--- a/src/modules/launcher/PowerLauncher/SettingsReader.cs
+++ b/src/modules/launcher/PowerLauncher/SettingsReader.cs
@@ -187,8 +187,8 @@ namespace PowerLauncher
             return PluginManager.AllPlugins.Select(x => new PowerLauncherPluginSettings()
             {
                 Id = x.Metadata.ID,
-                Name = x.Plugin.Name,
-                Description = x.Plugin.Description,
+                Name = x.Plugin == null ? x.Metadata.Name : x.Plugin.Name,
+                Description = x.Plugin?.Description,
                 Author = x.Metadata.Author,
                 Disabled = x.Metadata.Disabled,
                 IsGlobal = x.Metadata.IsGlobal,

--- a/src/modules/launcher/Wox.Test/PluginManagerTest.cs
+++ b/src/modules/launcher/Wox.Test/PluginManagerTest.cs
@@ -48,7 +48,7 @@ namespace Wox.Test
             var pluginPair = new PluginPair(metadata)
             {
                 Plugin = pluginMock.Object,
-                IsPluginLoaded = true,
+                IsPluginInitialized = true,
             };
 
             // Act


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
A plugin has to be always loaded as plugin instance provide settings(Name, Description, AdditionalSettings) to be stored in `settings.json` file.

**What is include in the PR:** 
Divide load and initializing of plugins

**How does someone test / validate:** 
- Test empty configuration(delete AppData)
- Try to disable and enable plugins
- Start PowerToys when there are few plugins disabled. Try to enable them and test if they work

## Quality Checklist

- [X] **Linked issue:** #10649
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [X] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
