### PR TITLE
Use local mutexes

### DIFF
--- a/src/common/interop/PowerToysInterop.vcxproj
+++ b/src/common/interop/PowerToysInterop.vcxproj
@@ -87,6 +87,7 @@
     <ClInclude Include="KeyboardHook.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="resource.h" />
+    <ClInclude Include="shared_constants.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Generated Files\AssemblyInfo.cpp" />

--- a/src/common/interop/PowerToysInterop.vcxproj.filters
+++ b/src/common/interop/PowerToysInterop.vcxproj.filters
@@ -27,6 +27,9 @@
     <ClInclude Include="resource.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="shared_constants.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="interop.cpp">

--- a/src/common/interop/interop.cpp
+++ b/src/common/interop/interop.cpp
@@ -160,5 +160,9 @@ public
         static String ^ ShowShortcutGuideSharedEvent() {
             return gcnew String(CommonSharedConstants::SHOW_SHORTCUT_GUIDE_SHARED_EVENT);
         }
+
+        static String ^ KeyboardManagerConfigFileMutexName() {
+            return gcnew String(CommonSharedConstants::KEYBOARD_MANAGER_CONFIG_FILE_MUTEX_NAME);
+        }
     };
 }

--- a/src/common/interop/shared_constants.h
+++ b/src/common/interop/shared_constants.h
@@ -27,4 +27,7 @@ namespace CommonSharedConstants
 
     // Max DWORD for key code to disable keys.
     const int VK_DISABLED = 0x100;
+
+    // Name of the mutex which controls access to the configuration file for Keyboard Manager
+    const wchar_t KEYBOARD_MANAGER_CONFIG_FILE_MUTEX_NAME[] = L"Local\\PowerToys_KeyboardManager_ConfigFileMutex";
 }

--- a/src/common/utils/appMutex.h
+++ b/src/common/utils/appMutex.h
@@ -12,6 +12,7 @@ namespace
 {
     constexpr inline wchar_t POWERTOYS_MSI_MUTEX_NAME[] = L"Local\\PowerToys_Runner_MSI_InstanceMutex";
     constexpr inline wchar_t POWERTOYS_MSIX_MUTEX_NAME[] = L"Local\\PowerToys_Runner_MSIX_InstanceMutex";
+    constexpr inline wchar_t POWERTOYS_BOOTSTRAPPER_MUTEX_NAME[] = L"Local\\PowerToys_Bootstrapper_InstanceMutex";
 }
 
 inline wil::unique_mutex_nothrow createAppMutex(const std::wstring& mutexName)

--- a/src/common/utils/appMutex.h
+++ b/src/common/utils/appMutex.h
@@ -10,17 +10,12 @@
 
 namespace
 {
-    constexpr inline wchar_t POWERTOYS_MSI_MUTEX_NAME[] = L"Local\\PowerToyRunMutex";
-    constexpr inline wchar_t POWERTOYS_MSIX_MUTEX_NAME[] = L"Local\\PowerToyMSIXRunMutex";
-    constexpr inline wchar_t POWERTOYS_BOOTSTRAPPER_MUTEX_NAME[] = L"PowerToysBootstrapperMutex";
+    constexpr inline wchar_t POWERTOYS_MSI_MUTEX_NAME[] = L"Local\\PowerToys_Runner_MSI_InstanceMutex";
+    constexpr inline wchar_t POWERTOYS_MSIX_MUTEX_NAME[] = L"Local\\PowerToys_Runner_MSIX_InstanceMutex";
 }
 
-inline wil::unique_mutex_nothrow createAppMutex(std::wstring mutexName)
+inline wil::unique_mutex_nothrow createAppMutex(const std::wstring& mutexName)
 {
-    wchar_t username[UNLEN + 1];
-    DWORD username_length = UNLEN + 1;
-    GetUserNameW(username, &username_length);
-    mutexName += username;
     wil::unique_mutex_nothrow result{ CreateMutexW(nullptr, TRUE, mutexName.c_str()) };
 
     return GetLastError() == ERROR_ALREADY_EXISTS ? wil::unique_mutex_nothrow{} : std::move(result);

--- a/src/modules/keyboardmanager/common/KeyboardManagerConstants.h
+++ b/src/modules/keyboardmanager/common/KeyboardManagerConstants.h
@@ -3,6 +3,7 @@
 #include <winrt/base.h>
 #include <common/utils/resources.h>
 #include "keyboardmanager/dll/Generated Files/resource.h"
+#include "common/interop/shared_constants.h"
 
 namespace KeyboardManagerConstants
 {
@@ -40,7 +41,7 @@ namespace KeyboardManagerConstants
     inline const std::wstring DefaultConfiguration = L"default";
 
     // Name of the named mutex used for configuration file.
-    inline const std::wstring ConfigFileMutexName = L"PowerToys.KeyboardManager.ConfigMutex";
+    inline const std::wstring ConfigFileMutexName = CommonSharedConstants::KEYBOARD_MANAGER_CONFIG_FILE_MUTEX_NAME;
 
     // Name of the dummy update file.
     inline const std::wstring DummyUpdateFileName = L"settings-updated.json";

--- a/src/modules/launcher/PowerLauncher/App.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/App.xaml.cs
@@ -29,7 +29,7 @@ namespace PowerLauncher
     {
         public static PublicAPIInstance API { get; private set; }
 
-        private const string Unique = "PowerToys_PowerLauncher_InstanceMutex";
+        private const string Unique = "PowerToys_PowerToysRun_InstanceMutex";
         private static bool _disposed;
         private PowerToysRunSettings _settings;
         private MainViewModel _mainVM;

--- a/src/modules/launcher/PowerLauncher/App.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/App.xaml.cs
@@ -29,7 +29,7 @@ namespace PowerLauncher
     {
         public static PublicAPIInstance API { get; private set; }
 
-        private const string Unique = "PowerLauncher_Unique_Application_Mutex";
+        private const string Unique = "PowerToys_PowerLauncher_InstanceMutex";
         private static bool _disposed;
         private PowerToysRunSettings _settings;
         private MainViewModel _mainVM;

--- a/src/modules/launcher/PowerLauncher/Helper/SingleInstance`1.cs
+++ b/src/modules/launcher/PowerLauncher/Helper/SingleInstance`1.cs
@@ -45,6 +45,11 @@ namespace PowerLauncher.Helper
         private const string ChannelNameSuffix = "SingeInstanceIPCChannel";
 
         /// <summary>
+        /// Prefix to the names of mutexes which ensures they are unique in a Windows session.
+        /// </summary>
+        private const string LocalMutexPrefix = @"Local\";
+
+        /// <summary>
         /// Gets or sets application mutex.
         /// </summary>
         internal static Mutex SingleInstanceMutex { get; set; }
@@ -62,7 +67,8 @@ namespace PowerLauncher.Helper
             string channelName = string.Concat(applicationIdentifier, Delimiter, ChannelNameSuffix);
 
             // Create mutex based on unique application Id to check if this is the first instance of the application.
-            SingleInstanceMutex = new Mutex(true, applicationIdentifier, out bool firstInstance);
+            string mutexName = string.Concat(LocalMutexPrefix, uniqueName);
+            SingleInstanceMutex = new Mutex(true, mutexName, out bool firstInstance);
             if (firstInstance)
             {
                 _ = CreateRemoteService(channelName);

--- a/src/runner/update_state.cpp
+++ b/src/runner/update_state.cpp
@@ -8,7 +8,7 @@
 namespace
 {
     const wchar_t PERSISTENT_STATE_FILENAME[] = L"\\update_state.json";
-    const wchar_t UPDATE_STATE_MUTEX[] = L"PTUpdateStateMutex";
+    const wchar_t UPDATE_STATE_MUTEX[] = L"Local\\PowerToys_Runner_UpdateStateMutex";
 }
 
 UpdateState deserialize(const json::JsonObject& json)

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/KeyboardManagerViewModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/KeyboardManagerViewModel.cs
@@ -29,8 +29,10 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
         private const string EditShortcutActionName = "EditShortcut";
         private const string EditShortcutActionValue = "Open Edit Shortcut Window";
         private const string JsonFileType = ".json";
-        private const string ProfileFileMutexName = "PowerToys.KeyboardManager.ConfigMutex";
-        private const int ProfileFileMutexWaitTimeoutMilliseconds = 1000;
+
+        private static string ConfigFileMutexName => interop.Constants.KeyboardManagerConfigFileMutexName();
+
+        private const int ConfigFileMutexWaitTimeoutMilliseconds = 1000;
 
         public KeyboardManagerSettings Settings { get; set; }
 
@@ -203,9 +205,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
 
             try
             {
-                using (var profileFileMutex = Mutex.OpenExisting(ProfileFileMutexName))
+                using (var profileFileMutex = Mutex.OpenExisting(ConfigFileMutexName))
                 {
-                    if (profileFileMutex.WaitOne(ProfileFileMutexWaitTimeoutMilliseconds))
+                    if (profileFileMutex.WaitOne(ConfigFileMutexWaitTimeoutMilliseconds))
                     {
                         // update the UI element here.
                         try


### PR DESCRIPTION
## Summary of the Pull Request

See #10541.

### General remarks

https://docs.microsoft.com/en-us/dotnet/api/system.threading.mutex
When the Local namespace is specified, which is also the default when no namespace is specified, the synchronization object may be shared with processes in the same session.

Changing the names of mutexes between versions will allow different program versions to run at the same time. However, this shouldn't be an issue for users.

In this PR, a Mutex is assumed to be a synchronization object managed by the OS, used to coordinate different processes running on the same machine. It's not `std::mutex` or similar, these are used to synchronize threads within a process. A Mutex is created and used through Win32 APIs, or by using System.Threading.Mutex in C# while also giving it a name.

The names of Mutexes should henceforth follow this pattern: Local\PowerToys_ModuleName_MutexPurpose

### What is included in this PR

_src\common\utils\appMutex.h_
Removed unused mutex name to avoid confusion. Changed name according to the pattern. Removed Windows username from the mutex name as it's not needed.

_src\modules\keyboardmanager\common\KeyboardManagerConstants.h_
src\settings-ui\Microsoft.PowerToys.Settings.UI.Library\ViewModels\KeyboardManagerViewModel.cs
Renamed the mutex, moved the definition of its name to the common interop class, as it's needed across these two projects. Also renamed some variables.

_src\modules\launcher\PowerLauncher\App.xaml.cs_
_src\modules\launcher\PowerLauncher\Helper\SingleInstance`1.cs_
Explicitly marked the Mutex as Local, removed Windows username from the mutex name as it's not needed. Updated the name to follow the pattern.

_src\runner\update_state.cpp_
Explicitly marked the Mutex as Local, updated the name to follow the pattern.

**How does someone test / validate:** 

Check whether the mutexes work by trying to run running multiple instances of affected executables.

## Quality Checklist

- [x] **Linked issue:** #10541
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
