### PR TITLE
Disable forwarding the Escape event

### DIFF
--- a/src/modules/colorPicker/ColorPickerUI/Helpers/AppStateHandler.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/AppStateHandler.cs
@@ -54,7 +54,7 @@ namespace ColorPicker.Helpers
             }
         }
 
-        public void EndUserSession()
+        public bool EndUserSession()
         {
             lock (_colorPickerVisibilityLock)
             {
@@ -70,7 +70,11 @@ namespace ColorPicker.Helpers
                     }
 
                     SessionEventHelper.End();
+
+                    return true;
                 }
+
+                return false;
             }
         }
 

--- a/src/modules/colorPicker/ColorPickerUI/Keyboard/KeyboardMonitor.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Keyboard/KeyboardMonitor.cs
@@ -72,7 +72,7 @@ namespace ColorPicker.Keyboard
             // ESC pressed
             if (virtualCode == KeyInterop.VirtualKeyFromKey(Key.Escape))
             {
-                _appStateHandler.EndUserSession();
+                e.Handled = _appStateHandler.EndUserSession();
                 return;
             }
 


### PR DESCRIPTION
## Summary of the Pull Request
**What is this about:**

Color Picker captures the Escape key event while active. The event should not be forwarded to other applications.

**What is included in the PR:** 

Return whether Color Picker was successfully closed, as a `bool`, from `EndUserSession`, then set `e.Handled` to the returned value in `Hook_KeyboardPressed`.

**How does someone test / validate:** 

Open an app that responds to Escape being pressed, use Color Picker, then press escape to close Color Picker.

## Quality Checklist

- [x] **Linked issue:** #10693
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
