### PR TITLE
[ColorPicker] Prevent creation of duplicate colors in history

### DIFF
--- a/src/modules/colorPicker/ColorPickerUI/ViewModels/MainViewModel.cs
+++ b/src/modules/colorPicker/ColorPickerUI/ViewModels/MainViewModel.cs
@@ -133,7 +133,17 @@ namespace ColorPicker.ViewModels
         {
             ClipboardHelper.CopyToClipboard(ColorText);
 
-            _userSettings.ColorHistory.Insert(0, GetColorString());
+            var color = GetColorString();
+
+            var oldIndex = _userSettings.ColorHistory.IndexOf(color);
+            if (oldIndex != -1)
+            {
+                _userSettings.ColorHistory.Move(oldIndex, 0);
+            }
+            else
+            {
+                _userSettings.ColorHistory.Insert(0, color);
+            }
 
             if (_userSettings.ColorHistory.Count > _userSettings.ColorHistoryLimit.Value)
             {


### PR DESCRIPTION
If color already exists in history, move it to position 0.
This prevents new duplicate colors, but ignores existing duplicates.

## Summary of the Pull Request

**What is this about:**

Currently, chosen colors are always added to the top of history, regardless of existing history. This can lead to many duplicates existing simultaneously. In most cases, this is undesirable behavior.

**What is included in the PR:** 

Before adding a new color, check if the color already exists in history, then move it to the top.

**How does someone test / validate:** 

Use the color picker to choose a color already in history. Instead of creating a new color, it will move the existing color to the top.
If the existing color is already at the top, it essentially does nothing.

## Quality Checklist

- [x] **Linked issue:** #9728
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
