### PR TITLE
Make delete_other_versions_log_folders more reliable

### DIFF
--- a/src/common/utils/logger_helper.h
+++ b/src/common/utils/logger_helper.h
@@ -49,7 +49,7 @@ namespace LoggerHelpers
 
         if (!dir_exists(logFolderPath))
         {
-            Logger::warn("Directory {} does not exist", logFolderPath.string());
+            Logger::trace("Directory {} does not exist", logFolderPath.string());
             return true;
         }
 

--- a/src/common/utils/logger_helper.h
+++ b/src/common/utils/logger_helper.h
@@ -28,11 +28,40 @@ namespace LoggerHelpers
         return false;
     }
 
+    inline bool create_dir_if_does_not_exist(std::filesystem::path dir)
+    {
+        std::error_code err;
+        auto entry = std::filesystem::directory_entry(dir, err);
+        if (err.value())
+        {
+            Logger::error("Failed to create directory entry. {}", err.message());
+            return false;
+        }
+
+        if (!entry.exists())
+        {
+            Logger::warn("Directory {} does not exist", dir.string());
+            std::error_code err;
+            if (!std::filesystem::create_directory(dir, err))
+            {
+                Logger::error("Failed to create directory {}. {}", dir.string(), err.message());
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     inline bool delete_other_versions_log_folders(std::wstring_view appPath, const std::filesystem::path& currentVersionLogFolder)
     {
         bool result = true;
         std::filesystem::path logFolderPath(appPath);
         logFolderPath.append(LogSettings::logPath);
+
+        if (!create_dir_if_does_not_exist(logFolderPath))
+        {
+            return false;
+        }
 
         std::error_code err;
         auto folders = std::filesystem::directory_iterator(logFolderPath, err);

--- a/src/common/utils/logger_helper.h
+++ b/src/common/utils/logger_helper.h
@@ -34,7 +34,15 @@ namespace LoggerHelpers
         std::filesystem::path logFolderPath(appPath);
         logFolderPath.append(LogSettings::logPath);
 
-        for (const auto& dir : std::filesystem::directory_iterator(logFolderPath))
+        std::error_code err;
+        auto folders = std::filesystem::directory_iterator(logFolderPath, err);
+        if (err.value())
+        {
+            Logger::error("Failed to create directory iterator for {}. {}", logFolderPath.string(), err.message());
+            return false;
+        }
+
+        for (const auto& dir : folders)
         {
             if (dir != currentVersionLogFolder)
             {

--- a/src/common/utils/logger_helper.h
+++ b/src/common/utils/logger_helper.h
@@ -28,7 +28,7 @@ namespace LoggerHelpers
         return false;
     }
 
-    inline bool create_dir_if_does_not_exist(std::filesystem::path dir)
+    inline bool dir_exists(std::filesystem::path dir)
     {
         std::error_code err;
         auto entry = std::filesystem::directory_entry(dir, err);
@@ -38,18 +38,7 @@ namespace LoggerHelpers
             return false;
         }
 
-        if (!entry.exists())
-        {
-            Logger::warn("Directory {} does not exist", dir.string());
-            std::error_code err;
-            if (!std::filesystem::create_directory(dir, err))
-            {
-                Logger::error("Failed to create directory {}. {}", dir.string(), err.message());
-                return false;
-            }
-        }
-
-        return true;
+        return entry.exists();
     }
 
     inline bool delete_other_versions_log_folders(std::wstring_view appPath, const std::filesystem::path& currentVersionLogFolder)
@@ -58,9 +47,10 @@ namespace LoggerHelpers
         std::filesystem::path logFolderPath(appPath);
         logFolderPath.append(LogSettings::logPath);
 
-        if (!create_dir_if_does_not_exist(logFolderPath))
+        if (!dir_exists(logFolderPath))
         {
-            return false;
+            Logger::warn("Directory {} does not exist", logFolderPath.string());
+            return true;
         }
 
         std::error_code err;


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
As was pointed out by @enricogior `delete_other_versions_log_folders` is not reliable. It can throw if `std::filesystem::directory_iterator` fails and we do not catch it.

**What is include in the PR:** 

**How does someone test / validate:** 
One can artificially test it. For example, the folder does not exist or the process does not have rights to access the folder.

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
