### PR TITLE
Log a warning if a plugin search takes more than 50 milliseconds

### DIFF
--- a/src/modules/launcher/PowerLauncher/Plugin/PluginManager.cs
+++ b/src/modules/launcher/PowerLauncher/Plugin/PluginManager.cs
@@ -186,6 +186,11 @@ namespace PowerLauncher.Plugin
                     }
                 });
 
+                if (milliseconds > 50)
+                {
+                    Log.Warn($"PluginManager.QueryForPlugin {metadata.Name}. Query cost - {milliseconds} milliseconds", typeof(PluginManager));
+                }
+
                 metadata.QueryCount += 1;
                 metadata.AvgQueryTime = metadata.QueryCount == 1 ? milliseconds : (metadata.AvgQueryTime + milliseconds) / 2;
 


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Some users report that typing in PowerToys Run is slow. It can be caused by plugins taking a lot of time to search. We want to verify it. For example, in https://github.com/microsoft/PowerToys/issues/10714 PT Run froze. But if a user disables Windows search everything works smoothly.

**What is include in the PR:** 
Log a warning if a plugin takes more than 50 milliseconds. It's a bad idea to log all queries cost as it generates a lot of logs(using PT Run for one minute generates more than 1MB of logs).
 
**How does someone test / validate:** 
We may consider deleting other version logs as we do for c++ projects

## Quality Checklist

- [X] **Linked issue:** #10714
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
