### PR TITLE
[KBM] Clean up keyboard hook handles

### DIFF
--- a/src/modules/keyboardmanager/KeyboardManagerEditor/KeyboardManagerEditor.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditor/KeyboardManagerEditor.cpp
@@ -96,12 +96,6 @@ void KeyboardManagerEditor::openEditorWindow(KeyboardManagerEditorType type)
 
 intptr_t KeyboardManagerEditor::HandleKeyboardHookEvent(LowlevelKeyboardEvent* data) noexcept
 {
-    // If key has suppress flag, then suppress it
-    if (data->lParam->dwExtraInfo == KeyboardManagerConstants::KEYBOARDMANAGER_SUPPRESS_FLAG)
-    {
-        return 1;
-    }
-
     // If the Detect Key Window is currently activated, then suppress the keyboard event
     KeyboardManagerHelper::KeyboardHookDecision singleKeyRemapUIDetected = keyboardManagerState.DetectSingleRemapKeyUIBackend(data);
     if (singleKeyRemapUIDetected == KeyboardManagerHelper::KeyboardHookDecision::Suppress)
@@ -124,15 +118,6 @@ intptr_t KeyboardManagerEditor::HandleKeyboardHookEvent(LowlevelKeyboardEvent* d
         return 0;
     }
 
-    // Remap a key
-    intptr_t SingleKeyRemapResult = KeyboardEventHandlers::HandleSingleKeyRemapEvent(editor->getInputHandler(), data, keyboardManagerState);
-
-    // Single key remaps have priority. If a key is remapped, only the remapped version should be visible to the shortcuts and hence the event should be suppressed here.
-    if (SingleKeyRemapResult == 1)
-    {
-        return 1;
-    }
-
     // If the Detect Shortcut Window is currently activated, then suppress the keyboard event
     KeyboardManagerHelper::KeyboardHookDecision shortcutUIDetected = keyboardManagerState.DetectShortcutUIBackend(data, false);
     if (shortcutUIDetected == KeyboardManagerHelper::KeyboardHookDecision::Suppress)
@@ -144,23 +129,7 @@ intptr_t KeyboardManagerEditor::HandleKeyboardHookEvent(LowlevelKeyboardEvent* d
         return 0;
     }
 
-    /* This feature has not been enabled (code from proof of concept stage)
-        * 
-        //// Remap a key to behave like a modifier instead of a toggle
-        //intptr_t SingleKeyToggleToModResult = KeyboardEventHandlers::HandleSingleKeyToggleToModEvent(inputHandler, data, keyboardManagerState);
-        */
-
-    // Handle an app-specific shortcut remapping
-    intptr_t AppSpecificShortcutRemapResult = KeyboardEventHandlers::HandleAppSpecificShortcutRemapEvent(editor->getInputHandler(), data, keyboardManagerState);
-
-    // If an app-specific shortcut is remapped then the os-level shortcut remapping should be suppressed.
-    if (AppSpecificShortcutRemapResult == 1)
-    {
-        return 1;
-    }
-
-    // Handle an os-level shortcut remapping
-    return KeyboardEventHandlers::HandleOSLevelShortcutRemapEvent(editor->getInputHandler(), data, keyboardManagerState);
+    return 0;
 }
 
 // Hook procedure definition


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Clean up keyboard hook handler. Removed unnecessary remap events handling from the editor. 
These are handlers that are used in the KBM engine, the editor shouldn't handle any remappings. 

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #10127
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
