### PR TITLE
[KBM] Move resources from the Common project to the Editor.

### DIFF
--- a/src/modules/keyboardmanager/KeyboardManagerEditor/BufferValidationHelpers.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditor/BufferValidationHelpers.cpp
@@ -3,7 +3,7 @@
 
 #include <common/interop/shared_constants.h>
 
-#include <Constants.h>
+#include <KeyboardManagerEditorStrings.h>
 #include <KeyboardManagerConstants.h>
 #include <KeyDropDownControl.h>
 
@@ -220,7 +220,7 @@ namespace BufferValidationHelpers
 
             // Convert app name to lower case
             std::transform(appName.begin(), appName.end(), appName.begin(), towlower);
-            std::wstring lowercaseDefAppName = KeyboardManagerConstants::DefaultAppName;
+            std::wstring lowercaseDefAppName = KeyboardManagerEditorStrings::DefaultAppName;
             std::transform(lowercaseDefAppName.begin(), lowercaseDefAppName.end(), lowercaseDefAppName.begin(), towlower);
             if (appName == lowercaseDefAppName)
             {

--- a/src/modules/keyboardmanager/KeyboardManagerEditor/EditKeyboardWindow.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditor/EditKeyboardWindow.cpp
@@ -14,6 +14,7 @@
 #include <dll/Generated Files/resource.h>
 
 #include "EditKeyboardWindow.h"
+#include "ErrorTypes.h"
 #include "SingleKeyRemapControl.h"
 #include "KeyDropDownControl.h"
 #include "XamlBridge.h"

--- a/src/modules/keyboardmanager/KeyboardManagerEditor/EditKeyboardWindow.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditor/EditKeyboardWindow.cpp
@@ -11,8 +11,6 @@
 #include <KeyboardManagerConstants.h>
 #include <KeyboardManagerState.h>
 
-#include <dll/Generated Files/resource.h>
-
 #include "EditKeyboardWindow.h"
 #include "ErrorTypes.h"
 #include "SingleKeyRemapControl.h"

--- a/src/modules/keyboardmanager/KeyboardManagerEditor/EditShortcutsWindow.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditor/EditShortcutsWindow.cpp
@@ -7,6 +7,7 @@
 #include <KeyboardManagerState.h>
 
 #include <Dialog.h>
+#include <ErrorTypes.h>
 #include <KeyDropDownControl.h>
 #include <LoadingAndSavingRemappingHelper.h>
 #include <ShortcutControl.h>

--- a/src/modules/keyboardmanager/KeyboardManagerEditor/KeyDropDownControl.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditor/KeyDropDownControl.cpp
@@ -5,7 +5,7 @@
 #include <KeyboardManagerState.h>
 
 #include <BufferValidationHelpers.h>
-#include <Constants.h>
+#include <KeyboardManagerEditorStrings.h>
 #include <ErrorTypes.h>
 
 // Initialized to null
@@ -119,7 +119,7 @@ void KeyDropDownControl::SetSelectionHandler(StackPanel& table, StackPanel row, 
         // If there is an error set the warning flyout
         if (errorType != KeyboardManagerHelper::ErrorType::NoError)
         {
-            SetDropDownError(currentDropDown, KeyboardManagerHelper::GetErrorMessage(errorType));
+            SetDropDownError(currentDropDown, KeyboardManagerEditorStrings::GetErrorMessage(errorType));
         }
     };
 
@@ -186,7 +186,7 @@ std::pair<KeyboardManagerHelper::ErrorType, int> KeyDropDownControl::ValidateSho
         // If the remapping is invalid display an error message
         if (validationResult.first != KeyboardManagerHelper::ErrorType::NoError)
         {
-            SetDropDownError(currentDropDown, KeyboardManagerHelper::GetErrorMessage(validationResult.first));
+            SetDropDownError(currentDropDown, KeyboardManagerEditorStrings::GetErrorMessage(validationResult.first));
         }
 
         // Handle None case if there are no other errors
@@ -255,7 +255,7 @@ void KeyDropDownControl::SetSelectionHandler(StackPanel& table, StackPanel row, 
             if (targetApp != nullptr)
             {
                 std::wstring newText = targetApp.Text().c_str();
-                std::wstring lowercaseDefAppName = KeyboardManagerConstants::DefaultAppName;
+                std::wstring lowercaseDefAppName = KeyboardManagerEditorStrings::DefaultAppName;
                 std::transform(newText.begin(), newText.end(), newText.begin(), towlower);
                 std::transform(lowercaseDefAppName.begin(), lowercaseDefAppName.end(), lowercaseDefAppName.begin(), towlower);
                 if (newText == lowercaseDefAppName)

--- a/src/modules/keyboardmanager/KeyboardManagerEditor/KeyDropDownControl.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditor/KeyDropDownControl.cpp
@@ -6,6 +6,7 @@
 
 #include <BufferValidationHelpers.h>
 #include <Constants.h>
+#include <ErrorTypes.h>
 
 // Initialized to null
 KeyboardManagerState* KeyDropDownControl::keyboardManagerState = nullptr;

--- a/src/modules/keyboardmanager/KeyboardManagerEditor/KeyboardManagerEditor.vcxproj
+++ b/src/modules/keyboardmanager/KeyboardManagerEditor/KeyboardManagerEditor.vcxproj
@@ -129,7 +129,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="BufferValidationHelpers.h" />
-    <ClInclude Include="Constants.h" />
+    <ClInclude Include="KeyboardManagerEditorStrings.h" />
     <ClInclude Include="Dialog.h" />
     <ClInclude Include="EditKeyboardWindow.h" />
     <ClInclude Include="EditShortcutsWindow.h" />

--- a/src/modules/keyboardmanager/KeyboardManagerEditor/KeyboardManagerEditor.vcxproj
+++ b/src/modules/keyboardmanager/KeyboardManagerEditor/KeyboardManagerEditor.vcxproj
@@ -149,6 +149,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="BufferValidationHelpers.cpp" />
+    <ClCompile Include="KeyboardManagerEditorStrings.cpp" />
     <ClCompile Include="Dialog.cpp" />
     <ClCompile Include="EditKeyboardWindow.cpp" />
     <ClCompile Include="EditShortcutsWindow.cpp" />

--- a/src/modules/keyboardmanager/KeyboardManagerEditor/KeyboardManagerEditor.vcxproj.filters
+++ b/src/modules/keyboardmanager/KeyboardManagerEditor/KeyboardManagerEditor.vcxproj.filters
@@ -66,7 +66,7 @@
     <ClInclude Include="resource.base.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="Constants.h">
+    <ClInclude Include="KeyboardManagerEditorStrings.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Generated Files\resource.h">

--- a/src/modules/keyboardmanager/KeyboardManagerEditor/KeyboardManagerEditor.vcxproj.filters
+++ b/src/modules/keyboardmanager/KeyboardManagerEditor/KeyboardManagerEditor.vcxproj.filters
@@ -113,6 +113,9 @@
     <ClCompile Include="XamlBridge.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="KeyboardManagerEditorStrings.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="KeyboardManagerEditor.base.rc">

--- a/src/modules/keyboardmanager/KeyboardManagerEditor/KeyboardManagerEditorStrings.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditor/KeyboardManagerEditorStrings.cpp
@@ -1,0 +1,50 @@
+#include "pch.h"
+#include "KeyboardManagerEditorStrings.h"
+
+// Function to return the error message
+winrt::hstring KeyboardManagerEditorStrings::GetErrorMessage(KeyboardManagerHelper::ErrorType errorType)
+{
+    using namespace KeyboardManagerHelper;
+
+    switch (errorType)
+    {
+    case ErrorType::NoError:
+        return GET_RESOURCE_STRING(IDS_ERRORMESSAGE_REMAPSUCCESSFUL).c_str();
+    case ErrorType::SameKeyPreviouslyMapped:
+        return GET_RESOURCE_STRING(IDS_ERRORMESSAGE_SAMEKEYPREVIOUSLYMAPPED).c_str();
+    case ErrorType::MapToSameKey:
+        return GET_RESOURCE_STRING(IDS_ERRORMESSAGE_MAPPEDTOSAMEKEY).c_str();
+    case ErrorType::ConflictingModifierKey:
+        return GET_RESOURCE_STRING(IDS_ERRORMESSAGE_CONFLICTINGMODIFIERKEY).c_str();
+    case ErrorType::SameShortcutPreviouslyMapped:
+        return GET_RESOURCE_STRING(IDS_ERRORMESSAGE_SAMESHORTCUTPREVIOUSLYMAPPED).c_str();
+    case ErrorType::MapToSameShortcut:
+        return GET_RESOURCE_STRING(IDS_ERRORMESSAGE_MAPTOSAMESHORTCUT).c_str();
+    case ErrorType::ConflictingModifierShortcut:
+        return GET_RESOURCE_STRING(IDS_ERRORMESSAGE_CONFLICTINGMODIFIERSHORTCUT).c_str();
+    case ErrorType::WinL:
+        return GET_RESOURCE_STRING(IDS_ERRORMESSAGE_WINL).c_str();
+    case ErrorType::CtrlAltDel:
+        return GET_RESOURCE_STRING(IDS_ERRORMESSAGE_CTRLALTDEL).c_str();
+    case ErrorType::RemapUnsuccessful:
+        return GET_RESOURCE_STRING(IDS_ERRORMESSAGE_REMAPUNSUCCESSFUL).c_str();
+    case ErrorType::SaveFailed:
+        return GET_RESOURCE_STRING(IDS_ERRORMESSAGE_SAVEFAILED).c_str();
+    case ErrorType::ShortcutStartWithModifier:
+        return GET_RESOURCE_STRING(IDS_ERRORMESSAGE_SHORTCUTSTARTWITHMODIFIER).c_str();
+    case ErrorType::ShortcutCannotHaveRepeatedModifier:
+        return GET_RESOURCE_STRING(IDS_ERRORMESSAGE_SHORTCUTNOREPEATEDMODIFIER).c_str();
+    case ErrorType::ShortcutAtleast2Keys:
+        return GET_RESOURCE_STRING(IDS_ERRORMESSAGE_SHORTCUTATLEAST2KEYS).c_str();
+    case ErrorType::ShortcutOneActionKey:
+        return GET_RESOURCE_STRING(IDS_ERRORMESSAGE_SHORTCUTONEACTIONKEY).c_str();
+    case ErrorType::ShortcutNotMoreThanOneActionKey:
+        return GET_RESOURCE_STRING(IDS_ERRORMESSAGE_SHORTCUTMAXONEACTIONKEY).c_str();
+    case ErrorType::ShortcutMaxShortcutSizeOneActionKey:
+        return GET_RESOURCE_STRING(IDS_ERRORMESSAGE_MAXSHORTCUTSIZE).c_str();
+    case ErrorType::ShortcutDisableAsActionKey:
+        return GET_RESOURCE_STRING(IDS_ERRORMESSAGE_DISABLEASACTIONKEY).c_str();
+    default:
+        return GET_RESOURCE_STRING(IDS_ERRORMESSAGE_DEFAULT).c_str();
+    }
+}

--- a/src/modules/keyboardmanager/KeyboardManagerEditor/KeyboardManagerEditorStrings.h
+++ b/src/modules/keyboardmanager/KeyboardManagerEditor/KeyboardManagerEditorStrings.h
@@ -2,8 +2,13 @@
 
 #include "pch.h"
 
+#include <ErrorTypes.h>
+
 namespace KeyboardManagerEditorStrings
 {
     // String constant for the default app name in Remap shortcuts
     inline const std::wstring DefaultAppName = GET_RESOURCE_STRING(IDS_EDITSHORTCUTS_ALLAPPS);
+        
+    // Function to return the error message
+    winrt::hstring GetErrorMessage(KeyboardManagerHelper::ErrorType errorType);
 }

--- a/src/modules/keyboardmanager/KeyboardManagerEditor/KeyboardManagerEditorStrings.h
+++ b/src/modules/keyboardmanager/KeyboardManagerEditor/KeyboardManagerEditorStrings.h
@@ -2,7 +2,7 @@
 
 #include "pch.h"
 
-namespace KeyboardManagerConstants
+namespace KeyboardManagerEditorStrings
 {
     // String constant for the default app name in Remap shortcuts
     inline const std::wstring DefaultAppName = GET_RESOURCE_STRING(IDS_EDITSHORTCUTS_ALLAPPS);

--- a/src/modules/keyboardmanager/KeyboardManagerEditor/LoadingAndSavingRemappingHelper.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditor/LoadingAndSavingRemappingHelper.cpp
@@ -5,6 +5,7 @@
 
 #include <common/interop/shared_constants.h>
 #include <trace.h>
+#include <ErrorTypes.h>
 #include <KeyboardManagerState.h>
 
 namespace LoadingAndSavingRemappingHelper

--- a/src/modules/keyboardmanager/KeyboardManagerEditor/Resources.resx
+++ b/src/modules/keyboardmanager/KeyboardManagerEditor/Resources.resx
@@ -188,6 +188,69 @@
   <data name="EditShortcuts_InfoExample" xml:space="preserve">
     <value>For example, if you want to press "Ctrl+C" and get "Alt" only on Microsoft Edge, "Ctrl+C" would be your "Shortcut" column, the key "Alt" would be your "Mapped To" column, and "MSEdge" would be your "Target App" column. If no target app is entered, it will apply globally. The name must be the process name and not the app name.</value>
   </data>
+  <data name="ErrorMessage_RemapSuccessful" xml:space="preserve">
+    <value>Remapping successful</value>
+  </data>
+  <data name="ErrorMessage_RemapUnsuccessful" xml:space="preserve">
+    <value>Some remappings were not applied</value>
+  </data>
+  <data name="ErrorMessage_SameKeyPreviouslyMapped" xml:space="preserve">
+    <value>Cannot remap a key more than once</value>
+    <comment>Key on a keyboard</comment>
+  </data>
+  <data name="ErrorMessage_MappedToSameKey" xml:space="preserve">
+    <value>Cannot remap a key to itself</value>
+    <comment>Key on a keyboard</comment>
+  </data>
+  <data name="ErrorMessage_ConflictingModifierKey" xml:space="preserve">
+    <value>Cannot remap this key as it conflicts with another remapped key</value>
+    <comment>Key on a keyboard</comment>
+  </data>
+  <data name="ErrorMessage_SameShortcutPreviouslyMapped" xml:space="preserve">
+    <value>Cannot remap a shortcut more than once for the same target app</value>
+  </data>
+  <data name="ErrorMessage_MapToSameShortcut" xml:space="preserve">
+    <value>Cannot remap a shortcut to itself</value>
+  </data>
+  <data name="ErrorMessage_ConflictingModifierShortcut" xml:space="preserve">
+    <value>Cannot remap this shortcut as it conflicts with another remapped shortcut</value>
+  </data>
+  <data name="ErrorMessage_WinL" xml:space="preserve">
+    <value>Cannot remap from/to Win L</value>
+    <comment>Win refers to Windows as in the OS</comment>
+  </data>
+  <data name="ErrorMessage_CtrlAltDel" xml:space="preserve">
+    <value>Cannot remap from/to Ctrl Alt Del</value>
+  </data>
+  <data name="ErrorMessage_SaveFailed" xml:space="preserve">
+    <value>Failed to save the remappings</value>
+  </data>
+  <data name="ErrorMessage_ShortcutStartWithModifier" xml:space="preserve">
+    <value>Shortcut must start with a modifier key</value>
+    <comment>Key on a keyboard</comment>
+  </data>
+  <data name="ErrorMessage_ShortcutNoRepeatedModifier" xml:space="preserve">
+    <value>Shortcut cannot contain a repeated modifier</value>
+  </data>
+  <data name="ErrorMessage_ShortcutAtleast2Keys" xml:space="preserve">
+    <value>Shortcut must have atleast 2 keys</value>
+    <comment>Key on a keyboard</comment>
+  </data>
+  <data name="ErrorMessage_ShortcutOneActionKey" xml:space="preserve">
+    <value>Shortcut must contain an action key</value>
+    <comment>Key on a keyboard</comment>
+  </data>
+  <data name="ErrorMessage_ShortcutMaxOneActionKey" xml:space="preserve">
+    <value>Shortcut cannot have more than one action key</value>
+    <comment>Key on a keyboard</comment>
+  </data>
+  <data name="ErrorMessage_MaxShortcutSize" xml:space="preserve">
+    <value>Shortcuts can only have up to 2 modifier keys</value>
+    <comment>Key on a keyboard</comment>
+  </data>
+  <data name="ErrorMessage_Default" xml:space="preserve">
+    <value>Unexpected error</value>
+  </data>
   <data name="Type_Button" xml:space="preserve">
     <value>Type</value>
     <comment>As in type a key</comment>

--- a/src/modules/keyboardmanager/KeyboardManagerEditor/ShortcutControl.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditor/ShortcutControl.cpp
@@ -6,7 +6,7 @@
 #include <KeyboardManagerState.h>
 #include <Helpers.h>
 
-#include <Constants.h>
+#include <KeyboardManagerEditorStrings.h>
 #include <KeyDropDownControl.h>
 
 //Both static members are initialized to null
@@ -108,7 +108,7 @@ void ShortcutControl::AddNewShortcutControlRow(StackPanel& parent, std::vector<s
     row.Children().Append(target);
 
     targetAppTextBox.Width(KeyboardManagerConstants::ShortcutTableDropDownWidth);
-    targetAppTextBox.PlaceholderText(KeyboardManagerConstants::DefaultAppName);
+    targetAppTextBox.PlaceholderText(KeyboardManagerEditorStrings::DefaultAppName);
     targetAppTextBox.Text(targetAppName);
 
     // GotFocus handler will be called whenever the user tabs into or clicks on the textbox
@@ -155,7 +155,7 @@ void ShortcutControl::AddNewShortcutControlRow(StackPanel& parent, std::vector<s
             shortcutRemapBuffer[rowIndex].first[1] = tempShortcut;
         }
         std::wstring newText = targetAppTextBox.Text().c_str();
-        std::wstring lowercaseDefAppName = KeyboardManagerConstants::DefaultAppName;
+        std::wstring lowercaseDefAppName = KeyboardManagerEditorStrings::DefaultAppName;
         std::transform(newText.begin(), newText.end(), newText.begin(), towlower);
         std::transform(lowercaseDefAppName.begin(), lowercaseDefAppName.end(), lowercaseDefAppName.begin(), towlower);
         if (newText == lowercaseDefAppName)

--- a/src/modules/keyboardmanager/KeyboardManagerEngineTest/HelperTests.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineTest/HelperTests.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include "CppUnitTest.h"
+#include <keyboardmanager/common/ErrorTypes.h>
 #include <keyboardmanager/common/Helpers.h>
 #include "TestHelpers.h"
 #include <common/interop/keyboard_layout.h>

--- a/src/modules/keyboardmanager/KeyboardManagerEngineTest/ShortcutTests.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineTest/ShortcutTests.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include "CppUnitTest.h"
+#include <keyboardmanager/common/ErrorTypes.h>
 #include <keyboardmanager/common/Shortcut.h>
 #include <keyboardmanager/common/Helpers.h>
 #include "TestHelpers.h"

--- a/src/modules/keyboardmanager/common/ErrorTypes.h
+++ b/src/modules/keyboardmanager/common/ErrorTypes.h
@@ -1,0 +1,27 @@
+#pragma once
+
+namespace KeyboardManagerHelper
+{
+    // Type to store codes for different errors
+    enum class ErrorType
+    {
+        NoError,
+        SameKeyPreviouslyMapped,
+        MapToSameKey,
+        ConflictingModifierKey,
+        SameShortcutPreviouslyMapped,
+        MapToSameShortcut,
+        ConflictingModifierShortcut,
+        WinL,
+        CtrlAltDel,
+        RemapUnsuccessful,
+        SaveFailed,
+        ShortcutStartWithModifier,
+        ShortcutCannotHaveRepeatedModifier,
+        ShortcutAtleast2Keys,
+        ShortcutOneActionKey,
+        ShortcutNotMoreThanOneActionKey,
+        ShortcutMaxShortcutSizeOneActionKey,
+        ShortcutDisableAsActionKey
+    };
+}

--- a/src/modules/keyboardmanager/common/Helpers.cpp
+++ b/src/modules/keyboardmanager/common/Helpers.cpp
@@ -8,7 +8,6 @@
 #include <common/utils/resources.h>
 
 #include <shlwapi.h>
-#include "keyboardmanager/dll/Generated Files/resource.h"
 #include <common/interop/keyboard_layout.h>
 #include "ErrorTypes.h"
 #include "KeyboardManagerConstants.h"
@@ -139,52 +138,6 @@ namespace KeyboardManagerHelper
         else
         {
             return ErrorType::NoError;
-        }
-    }
-
-    // Function to return the error message
-    winrt::hstring GetErrorMessage(ErrorType errorType)
-    {
-        switch (errorType)
-        {
-        case ErrorType::NoError:
-            return GET_RESOURCE_STRING(IDS_ERRORMESSAGE_REMAPSUCCESSFUL).c_str();
-        case ErrorType::SameKeyPreviouslyMapped:
-            return GET_RESOURCE_STRING(IDS_ERRORMESSAGE_SAMEKEYPREVIOUSLYMAPPED).c_str();
-        case ErrorType::MapToSameKey:
-            return GET_RESOURCE_STRING(IDS_ERRORMESSAGE_MAPPEDTOSAMEKEY).c_str();
-        case ErrorType::ConflictingModifierKey:
-            return GET_RESOURCE_STRING(IDS_ERRORMESSAGE_CONFLICTINGMODIFIERKEY).c_str();
-        case ErrorType::SameShortcutPreviouslyMapped:
-            return GET_RESOURCE_STRING(IDS_ERRORMESSAGE_SAMESHORTCUTPREVIOUSLYMAPPED).c_str();
-        case ErrorType::MapToSameShortcut:
-            return GET_RESOURCE_STRING(IDS_ERRORMESSAGE_MAPTOSAMESHORTCUT).c_str();
-        case ErrorType::ConflictingModifierShortcut:
-            return GET_RESOURCE_STRING(IDS_ERRORMESSAGE_CONFLICTINGMODIFIERSHORTCUT).c_str();
-        case ErrorType::WinL:
-            return GET_RESOURCE_STRING(IDS_ERRORMESSAGE_WINL).c_str();
-        case ErrorType::CtrlAltDel:
-            return GET_RESOURCE_STRING(IDS_ERRORMESSAGE_CTRLALTDEL).c_str();
-        case ErrorType::RemapUnsuccessful:
-            return GET_RESOURCE_STRING(IDS_ERRORMESSAGE_REMAPUNSUCCESSFUL).c_str();
-        case ErrorType::SaveFailed:
-            return GET_RESOURCE_STRING(IDS_ERRORMESSAGE_SAVEFAILED).c_str();
-        case ErrorType::ShortcutStartWithModifier:
-            return GET_RESOURCE_STRING(IDS_ERRORMESSAGE_SHORTCUTSTARTWITHMODIFIER).c_str();
-        case ErrorType::ShortcutCannotHaveRepeatedModifier:
-            return GET_RESOURCE_STRING(IDS_ERRORMESSAGE_SHORTCUTNOREPEATEDMODIFIER).c_str();
-        case ErrorType::ShortcutAtleast2Keys:
-            return GET_RESOURCE_STRING(IDS_ERRORMESSAGE_SHORTCUTATLEAST2KEYS).c_str();
-        case ErrorType::ShortcutOneActionKey:
-            return GET_RESOURCE_STRING(IDS_ERRORMESSAGE_SHORTCUTONEACTIONKEY).c_str();
-        case ErrorType::ShortcutNotMoreThanOneActionKey:
-            return GET_RESOURCE_STRING(IDS_ERRORMESSAGE_SHORTCUTMAXONEACTIONKEY).c_str();
-        case ErrorType::ShortcutMaxShortcutSizeOneActionKey:
-            return GET_RESOURCE_STRING(IDS_ERRORMESSAGE_MAXSHORTCUTSIZE).c_str();
-        case ErrorType::ShortcutDisableAsActionKey:
-            return GET_RESOURCE_STRING(IDS_ERRORMESSAGE_DISABLEASACTIONKEY).c_str();
-        default:
-            return GET_RESOURCE_STRING(IDS_ERRORMESSAGE_DEFAULT).c_str();
         }
     }
 

--- a/src/modules/keyboardmanager/common/Helpers.cpp
+++ b/src/modules/keyboardmanager/common/Helpers.cpp
@@ -10,6 +10,7 @@
 #include <shlwapi.h>
 #include "keyboardmanager/dll/Generated Files/resource.h"
 #include <common/interop/keyboard_layout.h>
+#include "ErrorTypes.h"
 #include "KeyboardManagerConstants.h"
 
 using namespace winrt::Windows::Foundation;

--- a/src/modules/keyboardmanager/common/Helpers.h
+++ b/src/modules/keyboardmanager/common/Helpers.h
@@ -55,9 +55,6 @@ namespace KeyboardManagerHelper
     // Function to check if two keys are equal or cover the same set of keys. Return value depends on type of overlap
     ErrorType DoKeysOverlap(DWORD first, DWORD second);
 
-    // Function to return the error message
-    winrt::hstring GetErrorMessage(ErrorType errorType);
-
     // Function to return the list of key name in the order for the drop down based on the key codes
     winrt::Windows::Foundation::Collections::IVector<winrt::Windows::Foundation::IInspectable> ToBoxValue(const std::vector<std::pair<DWORD,std::wstring>>& list);
 

--- a/src/modules/keyboardmanager/common/Helpers.h
+++ b/src/modules/keyboardmanager/common/Helpers.h
@@ -29,29 +29,6 @@ namespace KeyboardManagerHelper
         Action
     };
 
-    // Type to store codes for different errors
-    enum class ErrorType
-    {
-        NoError,
-        SameKeyPreviouslyMapped,
-        MapToSameKey,
-        ConflictingModifierKey,
-        SameShortcutPreviouslyMapped,
-        MapToSameShortcut,
-        ConflictingModifierShortcut,
-        WinL,
-        CtrlAltDel,
-        RemapUnsuccessful,
-        SaveFailed,
-        ShortcutStartWithModifier,
-        ShortcutCannotHaveRepeatedModifier,
-        ShortcutAtleast2Keys,
-        ShortcutOneActionKey,
-        ShortcutNotMoreThanOneActionKey,
-        ShortcutMaxShortcutSizeOneActionKey,
-        ShortcutDisableAsActionKey
-    };
-
     // Enum type to store possible decision for input in the low level hook
     enum class KeyboardHookDecision
     {

--- a/src/modules/keyboardmanager/common/KeyboardManagerCommon.vcxproj
+++ b/src/modules/keyboardmanager/common/KeyboardManagerCommon.vcxproj
@@ -57,6 +57,7 @@
     <ClCompile Include="trace.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="ErrorTypes.h" />
     <ClInclude Include="Input.h" />
     <ClInclude Include="KeyboardEventHandlers.h" />
     <ClInclude Include="ModifierKey.h" />

--- a/src/modules/keyboardmanager/common/KeyboardManagerCommon.vcxproj.filters
+++ b/src/modules/keyboardmanager/common/KeyboardManagerCommon.vcxproj.filters
@@ -86,6 +86,9 @@
     <ClInclude Include="Input.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="ErrorTypes.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/modules/keyboardmanager/common/Shortcut.cpp
+++ b/src/modules/keyboardmanager/common/Shortcut.cpp
@@ -2,6 +2,7 @@
 #include "Shortcut.h"
 #include <common/interop/keyboard_layout.h>
 #include <common/interop/shared_constants.h>
+#include "ErrorTypes.h"
 #include "Helpers.h"
 #include "InputInterface.h"
 


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

* Moved error messages related only to the editor from the `KeyboardManagerCommon` to the `KeyboardManagerEditor` project. 
* Error types moved to a separate file in the `KeyboardManagerCommon`. 

**What is include in the PR:** 

**How does someone test / validate:** 

Build projects in the `keyboardmanager` folder, verify no build errors.
Verify that error message strings are shown correctly.

## Quality Checklist

- [x] **Linked issue:** #10127 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
