### PR TITLE
[File Explorer Add-ons] remove old settings support

### DIFF
--- a/src/common/utils/os-detect.h
+++ b/src/common/utils/os-detect.h
@@ -22,10 +22,3 @@ inline bool Is19H1OrHigher()
 {
   return IsAPIContractV8Available();
 }
-
-// This function returns true if the build is 19h1 or higher, so that we deploy the new settings.
-// It returns false otherwise.
-inline bool UseNewSettings()
-{
-  return Is19H1OrHigher();
-}

--- a/src/modules/previewpane/powerpreview/powerpreview.cpp
+++ b/src/modules/previewpane/powerpreview/powerpreview.cpp
@@ -44,11 +44,9 @@ PowerPreviewModule::PowerPreviewModule() :
         std::make_unique<RegistryWrapper>(),
         L".svg\\shellex\\{E357FCCD-A995-4576-B01F-234630154E96}"));
 
-    // If the user is on the new settings interface, File Explorer might be disabled if they updated from old to new settings, so initialize the registry state in the constructor as PowerPreviewModule::enable/disable will not be called on startup
-    if (UseNewSettings())
-    {
-        update_registry_to_match_toggles();
-    }
+    // File Explorer might be disabled if user updated from old to new settings.
+    // Initialize the registry state in the constructor as PowerPreviewModule::enable/disable will not be called on startup
+    update_registry_to_match_toggles();
 }
 
 // Destroy the powertoy and free memory.
@@ -111,8 +109,8 @@ void PowerPreviewModule::set_config(const wchar_t* config)
         bool isElevated = is_process_elevated(false);
         for (auto& fileExplorerModule : m_fileExplorerModules)
         {
-            // If the user is using the new settings interface, as it does not have a toggle to modify enabled consider File Explorer to always be enabled
-            updateSuccess = updateSuccess && fileExplorerModule->UpdateState(settings, this->m_enabled || UseNewSettings(), isElevated);
+            // The new settings interface does not have a toggle to modify enabled, consider File Explorer to always be enabled
+            updateSuccess = updateSuccess && fileExplorerModule->UpdateState(settings, true, isElevated);
         }
 
         if (!updateSuccess)
@@ -131,12 +129,6 @@ void PowerPreviewModule::set_config(const wchar_t* config)
 // Enable preview handlers.
 void PowerPreviewModule::enable()
 {
-    // Should only be done for old settings as it is already done for new settings in the constructor.
-    if (!UseNewSettings())
-    {
-        update_registry_to_match_toggles();
-    }
-
     if (!this->m_enabled)
     {
         Trace::EnabledPowerPreview(true);


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
0.37 will only run on 1903 and newer, therefore we can remove support for old settings.

**What is include in the PR:** 
Remove the conditional checks for File Explorer Add-ons.

**How does someone test / validate:** 

- Build the MSI
- Install PowerToys
- Restart it as administrator
- Open the File Explorer Add-ons settings
- Turn the options on and off and verify they work as expected (be aware of https://github.com/microsoft/PowerToys/issues/10867 to turn off the SVG Preview you also have to turn off the SVG thumbnails). I used `src/runner/svgs` to test it.

## Quality Checklist

- [x] **Linked issue:** https://github.com/microsoft/PowerToys/issues/9417
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
