### PR TITLE
improve sorting vscodeworkspaces plugin

### DIFF
--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/Main.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/Main.cs
@@ -135,6 +135,11 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces
                 });
             }
 
+            if (query.ActionKeyword == String.Empty || (query.ActionKeyword != String.Empty && query.Search != String.Empty))
+            {
+                results = results.Where(a => a.Title.ToLower().Contains(query.Search.ToLower())).ToList();
+            }
+
             results.ForEach(x =>
             {
                 if (x.Score == 0)
@@ -142,22 +147,22 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces
                     x.Score = 100;
                 }
 
+                //intersect the title with the query
+                var intersection = Convert.ToInt32(x.Title.ToLower().Intersect(query.Search.ToLower()).Count() * query.Search.Count());
+                var differenceWithQuery = Convert.ToInt32((x.Title.Count() - intersection) * query.Search.Count() * 0.7);
+                x.Score = x.Score - differenceWithQuery + intersection;
+
                 //if is a remote machine give it 12 extra points
                 if (x.ContextData is VSCodeRemoteMachine)
                 {
-                    x.Score = x.Score + (query.Search.Count() * 5);
+                    x.Score = Convert.ToInt32(x.Score + intersection * 2);
                 }
-
-                //intersect the title with the query
-                var intersection = x.Title.ToLower().Intersect(query.Search.ToLower()).Count();
-                x.Score = x.Score - (Convert.ToInt32(((x.Title.Count() - intersection) *2.5)));
             });
 
-            results = results.OrderBy(x => x.Title).ToList();
-
-            if (query.ActionKeyword == String.Empty || (query.ActionKeyword != String.Empty && query.Search != String.Empty))
+            results = results.OrderByDescending(x => x.Score).ToList();
+            if (query.Search == String.Empty || query.Search.Replace(" ", "") == String.Empty)
             {
-                results = results.Where(a => a.Title.ToLower().Contains(query.Search.ToLower())).ToList();
+                results = results.OrderBy(x => x.Title).ToList();
             }
 
             return results;

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/Main.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/Main.cs
@@ -92,7 +92,7 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces
                 {
                     var title = $"{a.Host}";
 
-                    if (a.User != null && a.User != String.Empty && a.HostName != null && a.HostName != String.Empty)
+                    if (a.User != null && a.User != string.Empty && a.HostName != null && a.HostName != string.Empty)
                     {
                         title += $" [{a.User}@{a.HostName}]";
                     }
@@ -148,7 +148,7 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces
                 }
 
                 //intersect the title with the query
-                var intersection = Convert.ToInt32(x.Title.ToLowerInvariant().Intersect(query.Search.ToLower()).Count() * query.Search.Count());
+                var intersection = Convert.ToInt32(x.Title.ToLowerInvariant().Intersect(query.Search.ToLowerInvariant()).Count() * query.Search.Count());
                 var differenceWithQuery = Convert.ToInt32((x.Title.Count() - intersection) * query.Search.Count() * 0.7);
                 x.Score = x.Score - differenceWithQuery + intersection;
 
@@ -160,7 +160,7 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces
             });
 
             results = results.OrderByDescending(x => x.Score).ToList();
-            if (query.Search == String.Empty || query.Search.Replace(" ", "") == String.Empty)
+            if (query.Search == string.Empty || query.Search.Replace(" ", "") == string.Empty)
             {
                 results = results.OrderBy(x => x.Title).ToList();
             }

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/Main.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/Main.cs
@@ -135,9 +135,9 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces
                 });
             }
 
-            if (query.ActionKeyword == String.Empty || (query.ActionKeyword != String.Empty && query.Search != String.Empty))
+            if (query.ActionKeyword == string.Empty || (query.ActionKeyword != string.Empty && query.Search != string.Empty))
             {
-                results = results.Where(a => a.Title.ToLower().Contains(query.Search.ToLower())).ToList();
+                results = results.Where(a => a.Title.ToLowerInvariant().Contains(query.Search.ToLowerInvariant())).ToList();
             }
 
             results.ForEach(x =>
@@ -148,7 +148,7 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces
                 }
 
                 //intersect the title with the query
-                var intersection = Convert.ToInt32(x.Title.ToLower().Intersect(query.Search.ToLower()).Count() * query.Search.Count());
+                var intersection = Convert.ToInt32(x.Title.ToLowerInvariant().Intersect(query.Search.ToLower()).Count() * query.Search.Count());
                 var differenceWithQuery = Convert.ToInt32((x.Title.Count() - intersection) * query.Search.Count() * 0.7);
                 x.Score = x.Score - differenceWithQuery + intersection;
 


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:** 
Improve workspaces order in vscode workspace plugin for powertoys run.

**What is include in the PR:** 
A new way of sorting workspaces.

**How does someone test / validate:** 
Enable vscode plugin on powertoys run setting and then use { to query for available workspaces.

## Quality Checklist

- [x] **Linked issue:** #10957
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [x] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
