### PR TITLE
[KBM editor] Run only one instance, exit when parent process exits

### DIFF
--- a/src/modules/keyboardmanager/KeyboardManagerEditor/KeyboardManagerEditor.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditor/KeyboardManagerEditor.cpp
@@ -72,7 +72,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
                     Logger::error(L"Failed to wait for parent process exit. {}", get_last_error_or_default(err));
                 }
 
-                Logger::info(L"Parrent process exited. Exiting KeyboardManager editor");
+                Logger::info(L"Parent process exited. Exiting KeyboardManager editor");
                 PostThreadMessage(mainThreadId, WM_QUIT, 0, 0);
             });
         }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/KeyboardManagerViewModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/KeyboardManagerViewModel.cs
@@ -200,7 +200,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
                 string path = Path.Combine(Environment.CurrentDirectory, KeyboardManagerEditorPath);
 
                 // InvariantCulture: type represents the KeyboardManagerEditorType enum value
-                editor = Process.Start(path, type.ToString(CultureInfo.InvariantCulture));
+                editor = Process.Start(path, $"{type.ToString(CultureInfo.InvariantCulture)} {Process.GetCurrentProcess().Id}");
             }
             catch (Exception e)
             {


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

**What is include in the PR:** 
- Exit editor when parent process exited
- Do not run more than one editor instance
 
**How does someone test / validate:** 
- Open an editor's window and exit PowerToys
- Verify that the editor's window exit as well(It's not enough to just close settings window because we hide it and the settings process is still alive)
- Try to start few single instances of the editor. Notice that the editor has mandatory cmd arguments
- Verify that only the first one starts and there is warnings in the logs

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
