### PR TITLE
[Updating] Refactor autoupdate mechanism to use msgbox instead of toasts

### DIFF
--- a/src/common/updating/notifications.cpp
+++ b/src/common/updating/notifications.cpp
@@ -24,122 +24,42 @@ namespace updating
 
         void show_unavailable(const notifications::strings& strings, std::wstring reason)
         {
-            remove_toasts_by_tag(UPDATING_PROCESS_TOAST_TAG);
-
-            toast_params toast_params{ UPDATING_PROCESS_TOAST_TAG, false };
-            show_toast(std::move(reason), strings.TOAST_TITLE, std::move(toast_params));
-        }
-
-        void show_available(const updating::new_version_download_info& info, const notifications::strings& strings)
-        {
-            remove_toasts_by_tag(UPDATING_PROCESS_TOAST_TAG);
-
-            toast_params toast_params{ UPDATING_PROCESS_TOAST_TAG, false };
-            std::wstring contents = strings.GITHUB_NEW_VERSION_AVAILABLE;
-            contents += L'\n';
-            contents += current_version_to_next_version(info);
-
-            show_toast_with_activations(std::move(contents),
-                                        strings.TOAST_TITLE,
-                                        {},
-                                        { link_button{ strings.GITHUB_NEW_VERSION_UPDATE_NOW,
-                                                       L"powertoys://download_and_install_update/" },
-                                          link_button{ strings.GITHUB_NEW_VERSION_MORE_INFO,
-                                                       info.release_page_uri.ToString().c_str() } },
-                                        std::move(toast_params));
-        }
-
-        void show_download_start(const updating::new_version_download_info& info, const notifications::strings& strings)
-        {
-            remove_toasts_by_tag(UPDATING_PROCESS_TOAST_TAG);
-
-            progress_bar_params progress_bar_params;
-            std::wstring progress_title{ info.version.toWstring() };
-            progress_title += L' ';
-            progress_title += strings.DOWNLOAD_IN_PROGRESS;
-
-            progress_bar_params.progress_title = progress_title;
-            progress_bar_params.progress = .0f;
-            toast_params toast_params{ UPDATING_PROCESS_TOAST_TAG, false, std::move(progress_bar_params) };
-            show_toast_with_activations(strings.GITHUB_NEW_VERSION_DOWNLOAD_STARTED,
-                                        strings.TOAST_TITLE,
-                                        {},
-                                        {},
-                                        std::move(toast_params));
+            MessageBoxW(nullptr, reason.c_str(), strings.NOTIFICATION_TITLE.c_str(), MB_OK | MB_ICONWARNING);
         }
 
         void show_visit_github(const updating::new_version_download_info& info, const notifications::strings& strings)
         {
-            remove_toasts_by_tag(UPDATING_PROCESS_TOAST_TAG);
-
-            toast_params toast_params{ UPDATING_PROCESS_TOAST_TAG, false };
             std::wstring contents = strings.GITHUB_NEW_VERSION_AVAILABLE_OFFER_VISIT;
             contents += L'\n';
             contents += current_version_to_next_version(info);
-            show_toast_with_activations(std::move(contents),
-                                        strings.TOAST_TITLE,
-                                        {},
-                                        { link_button{ strings.GITHUB_NEW_VERSION_VISIT,
-                                                       info.release_page_uri.ToString().c_str() } },
-                                        std::move(toast_params));
+
+            const bool openURL = IDYES == MessageBoxW(nullptr, contents.c_str(), strings.NOTIFICATION_TITLE.c_str(), MB_ICONQUESTION | MB_YESNO);
+            if (openURL)
+            {
+                winrt::Windows::System::Launcher::LaunchUriAsync(info.release_page_uri).get();
+            }
         }
 
         void show_install_error(const updating::new_version_download_info& info, const notifications::strings& strings)
         {
-            remove_toasts_by_tag(UPDATING_PROCESS_TOAST_TAG);
-
-            toast_params toast_params{ UPDATING_PROCESS_TOAST_TAG, false };
             std::wstring contents = strings.GITHUB_NEW_VERSION_DOWNLOAD_INSTALL_ERROR;
             contents += L'\n';
             contents += current_version_to_next_version(info);
-            show_toast_with_activations(std::move(contents),
-                                        strings.TOAST_TITLE,
-                                        {},
-                                        { link_button{ strings.GITHUB_NEW_VERSION_VISIT, info.release_page_uri.ToString().c_str() } },
-                                        std::move(toast_params));
+            MessageBoxW(nullptr, contents.c_str(), strings.NOTIFICATION_TITLE.c_str(), MB_OK | MB_ICONERROR);
         }
 
-        void show_version_ready(const updating::new_version_download_info& info, const notifications::strings& strings)
+        bool show_confirm_update(const updating::new_version_download_info& info, const notifications::strings& strings)
         {
-            remove_toasts_by_tag(UPDATING_PROCESS_TOAST_TAG);
-
-            toast_params toast_params{ UPDATING_PROCESS_TOAST_TAG, false };
             std::wstring new_version_ready{ strings.GITHUB_NEW_VERSION_READY_TO_INSTALL };
             new_version_ready += L'\n';
             new_version_ready += current_version_to_next_version(info);
 
-            show_toast_with_activations(std::move(new_version_ready),
-                                        strings.TOAST_TITLE,
-                                        {},
-                                        { link_button{ strings.GITHUB_NEW_VERSION_UPDATE_NOW,
-                                                       L"powertoys://update_now/" + info.installer_filename },
-                                          link_button{ strings.GITHUB_NEW_VERSION_UPDATE_AFTER_RESTART,
-                                                       L"powertoys://schedule_update/" + info.installer_filename },
-                                          snooze_button{
-                                              strings.GITHUB_NEW_VERSION_SNOOZE_TITLE,
-                                              { { strings.GITHUB_NEW_VERSION_UPDATE_SNOOZE_1D, 24 * 60 },
-                                                { strings.GITHUB_NEW_VERSION_UPDATE_SNOOZE_5D, 120 * 60 } },
-                                              strings.SNOOZE_BUTTON } },
-                                        std::move(toast_params));
+            return IDYES == MessageBoxW(nullptr, new_version_ready.c_str(), strings.NOTIFICATION_TITLE.c_str(), MB_ICONQUESTION | MB_YESNO);
         }
 
         void show_uninstallation_error(const notifications::strings& strings)
         {
-            remove_toasts_by_tag(UPDATING_PROCESS_TOAST_TAG);
-
-            show_toast(strings.UNINSTALLATION_UNKNOWN_ERROR, strings.TOAST_TITLE);
-        }
-
-        void update_download_progress(const updating::new_version_download_info& info, float progress, const notifications::strings& strings)
-        {
-            progress_bar_params progress_bar_params;
-
-            std::wstring progress_title{ info.version.toWstring() };
-            progress_title += L' ';
-            progress_title += progress < 1 ? strings.DOWNLOAD_IN_PROGRESS : strings.DOWNLOAD_COMPLETE;
-            progress_bar_params.progress_title = progress_title;
-            progress_bar_params.progress = progress;
-            update_toast_progress_bar(UPDATING_PROCESS_TOAST_TAG, progress_bar_params);
+            MessageBoxW(nullptr, strings.UNINSTALLATION_UNKNOWN_ERROR.c_str(), strings.NOTIFICATION_TITLE.c_str(), MB_OK | MB_ICONERROR);
         }
     }
 }

--- a/src/common/updating/notifications.h
+++ b/src/common/updating/notifications.h
@@ -34,20 +34,16 @@ namespace updating
             std::wstring OFFER_UNINSTALL_MSI_TITLE;
 
             std::wstring SNOOZE_BUTTON;
-            std::wstring TOAST_TITLE;
+            std::wstring NOTIFICATION_TITLE;
 
             std::wstring UNINSTALLATION_UNKNOWN_ERROR;
         };
 
         void show_unavailable(const notifications::strings& strings, std::wstring reason);
-        void show_available(const updating::new_version_download_info& info, const strings&);
-        void show_download_start(const updating::new_version_download_info& info, const strings&);
         void show_visit_github(const updating::new_version_download_info& info, const strings&);
         void show_install_error(const updating::new_version_download_info& info, const strings&);
-        void show_version_ready(const updating::new_version_download_info& info, const strings&);
+        bool show_confirm_update(const updating::new_version_download_info& info, const strings&);
         void show_uninstallation_error(const notifications::strings& strings);
-
-        void update_download_progress(const updating::new_version_download_info& info, float progress, const notifications::strings& strings);
     }
 }
 
@@ -75,6 +71,6 @@ namespace updating
         .OFFER_UNINSTALL_MSI = GET_RESOURCE_STRING(IDS_OFFER_UNINSTALL_MSI),                                               \
         .OFFER_UNINSTALL_MSI_TITLE = GET_RESOURCE_STRING(IDS_OFFER_UNINSTALL_MSI_TITLE),                                   \
         .SNOOZE_BUTTON = GET_RESOURCE_STRING(IDS_SNOOZE_BUTTON),                                                           \
-        .TOAST_TITLE = GET_RESOURCE_STRING(IDS_TOAST_TITLE),                                                               \
+        .NOTIFICATION_TITLE = GET_RESOURCE_STRING(IDS_TOAST_TITLE),                                                        \
         .UNINSTALLATION_UNKNOWN_ERROR = GET_RESOURCE_STRING(IDS_UNINSTALLATION_UNKNOWN_ERROR)                              \
     }

--- a/src/common/updating/pch.h
+++ b/src/common/updating/pch.h
@@ -27,9 +27,9 @@
 
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Foundation.Collections.h>
-#include <winrt/Windows.Networking.Connectivity.h>
 #include <winrt/Windows.ApplicationModel.h>
 #include <winrt/Windows.Management.Deployment.h>
+#include <winrt/Windows.System.h>
 
 #endif //PCH_H
 

--- a/src/common/updating/updating.h
+++ b/src/common/updating/updating.h
@@ -14,9 +14,9 @@
 namespace updating
 {
     using winrt::Windows::Foundation::Uri;
-    struct version_up_to_date {};
-    using github_version_info = std::variant<new_version_download_info, version_up_to_date>;
-
+    struct version_up_to_date
+    {
+    };
     struct new_version_download_info
     {
         Uri release_page_uri = nullptr;
@@ -24,11 +24,9 @@ namespace updating
         Uri installer_download_url = nullptr;
         std::wstring installer_filename;
     };
+    using github_version_info = std::variant<new_version_download_info, version_up_to_date>;
 
-    // Returns whether the update check has succeeded
-    std::future<bool> try_autoupdate(const bool download_updates_automatically, const notifications::strings&);
     std::filesystem::path get_pending_updates_path();
-    std::future<std::wstring> download_update(const notifications::strings&);
     std::future<nonstd::expected<github_version_info, std::wstring>> get_github_version_info_async(const notifications::strings& strings, const bool prerelease = false);
 
     // non-localized

--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -251,56 +251,11 @@ toast_notification_handler_result toast_notification_handler(const std::wstring_
 {
     const std::wstring_view cant_drag_elevated_disable = L"cant_drag_elevated_disable/";
     const std::wstring_view couldnt_toggle_powerpreview_modules_disable = L"couldnt_toggle_powerpreview_modules_disable/";
-    const std::wstring_view download_and_install_update = L"download_and_install_update/";
     const std::wstring_view open_settings = L"open_settings/";
-    const std::wstring_view schedule_update = L"schedule_update/";
-    const std::wstring_view update_now = L"update_now/";
 
     if (param == cant_drag_elevated_disable)
     {
         return notifications::disable_toast(notifications::CantDragElevatedDontShowAgainRegistryPath) ? toast_notification_handler_result::exit_success : toast_notification_handler_result::exit_error;
-    }
-    else if (param.starts_with(update_now))
-    {
-        std::wstring args{ UPDATE_NOW_LAUNCH_STAGE1_CMDARG };
-        const auto installerFilename = param.data() + size(update_now);
-        args += L' ';
-        args += installerFilename;
-        launch_action_runner(args.c_str());
-        return toast_notification_handler_result::exit_success;
-    }
-    else if (param.starts_with(schedule_update))
-    {
-        const auto installerFilename = param.data() + size(schedule_update);
-        UpdateState::store([=](UpdateState& state) {
-            state.pending_update = true;
-            state.pending_installer_filename = installerFilename;
-        });
-
-        return toast_notification_handler_result::exit_success;
-    }
-    else if (param.starts_with(download_and_install_update))
-    {
-        try
-        {
-            std::wstring installer_filename = updating::download_update(Strings).get();
-
-            std::wstring args{ UPDATE_NOW_LAUNCH_STAGE1_CMDARG };
-            args += L' ';
-            args += installer_filename;
-            launch_action_runner(args.c_str());
-
-            return toast_notification_handler_result::exit_success;
-        }
-        catch (...)
-        {
-            MessageBoxW(nullptr,
-                        GET_RESOURCE_STRING(IDS_DOWNLOAD_UPDATE_ERROR).c_str(),
-                        L"PowerToys",
-                        MB_ICONWARNING | MB_OK);
-
-            return toast_notification_handler_result::exit_error;
-        }
     }
     else if (param == couldnt_toggle_powerpreview_modules_disable)
     {
@@ -333,6 +288,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         L"(ML;;NX;;;LW)"; // Integrity label on No execute up for Low mandatory level
     initializeCOMSecurity(securityDescriptor);
 
+    // TODO: this is deprecated and should be removed
     if (launch_pending_update())
     {
         return 0;

--- a/src/runner/pch.h
+++ b/src/runner/pch.h
@@ -28,6 +28,7 @@
 #include <ProjectTelemetry.h>
 
 #include <winrt/Windows.ApplicationModel.h>
+#include <winrt/Windows.Networking.Connectivity.h>
 #include <winrt/Windows.Storage.h>
 
 #include <wil/resource.h>

--- a/src/runner/settings_window.cpp
+++ b/src/runner/settings_window.cpp
@@ -92,6 +92,8 @@ std::optional<std::wstring> dispatch_json_action_to_module(const json::JsonObjec
                         {
                             latestVersion = new_version->version;
                             isVersionLatest = false;
+
+                            proceed_with_update(*new_version, true);
                         }
                         json::JsonObject json;
                         json.SetNamedValue(L"version", json::value(latestVersion.toWstring()));

--- a/src/runner/update_utils.h
+++ b/src/runner/update_utils.h
@@ -5,4 +5,5 @@
 bool start_msi_uninstallation_sequence();
 void github_update_worker();
 std::optional<updating::github_version_info> check_for_updates();
+void proceed_with_update(const updating::new_version_download_info& download_info, const bool download_update);
 bool launch_pending_update();


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

- toasts notifications complicate update logic, since a user could click them while PT isn't running
- they also caused issues for some users where the notification isn't visible for some reason

Therefore, we've decided to move to simple messagebox notifications for now.

**What is include in the PR:** 
- do not use toast notifications for autoupdate
- unifies the logic for periodic update check and "Check for updates" button
- we only download the release from github after the user has confirmed update intent by pressing "Yes" on the confirmation dialog

I haven't removed some of the "update at next launch" functionality, since we haven't decided if we want to keep it. The relevant code is marked with TODO deprecation.

**How does someone test / validate:** 
- modify `Version.props` to some lower version
- test "Check for updates" button
- remove `%localappdata%\Microsoft\PowerToys\update_state.json` to reset periodic check cooldown and restart PT

## Quality Checklist

- [x] **Linked issue:** #10589
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
