### PR TITLE
[KBM] Force kill editor process to avoid XAML crash

### DIFF
--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/EditKeyboardWindow.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/EditKeyboardWindow.cpp
@@ -93,7 +93,7 @@ static IAsyncAction OnClickAccept(KeyboardManagerState& keyboardManagerState, Xa
 }
 
 // Function to create the Edit Keyboard Window
-void createEditKeyboardWindow(HINSTANCE hInst, KeyboardManagerState& keyboardManagerState)
+inline void createEditKeyboardWindowImpl(HINSTANCE hInst, KeyboardManagerState& keyboardManagerState)
 {
     event_locker locker(KeyboardManagerConstants::EditorWindowEventName.c_str());
     Logger::trace("Creating Remap keys window");
@@ -351,6 +351,12 @@ void createEditKeyboardWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMan
 
     // Cannot be done in WM_DESTROY because that causes crashes due to fatal app exit
     xamlBridge.ClearXamlIslands();
+}
+
+void createEditKeyboardWindow(HINSTANCE hInst, KeyboardManagerState& keyboardManagerState)
+{
+    // Move implementation into the separate method so resources get destroyed correctly
+    createEditKeyboardWindowImpl(hInst, keyboardManagerState);
 
     // Calling ClearXamlIslands() outside of the message loop is not enough to prevent
     // Microsoft.UI.XAML.dll from crashing during deinitialization, see https://github.com/microsoft/PowerToys/issues/10906

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/EditKeyboardWindow.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/EditKeyboardWindow.cpp
@@ -337,11 +337,9 @@ void createEditKeyboardWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMan
         ShowWindow(_hWndEditKeyboardWindow, SW_SHOW);
         UpdateWindow(_hWndEditKeyboardWindow);
     }
-
-    Logger::trace("Start EditKeyboardWindow message loop");
+    
     // Message loop:
     xamlBridge.MessageLoop();
-    Logger::trace("Stopped EditKeyboardWindow message loop");
 
     // Reset pointers to nullptr
     xamlBridgePtr = nullptr;
@@ -353,6 +351,10 @@ void createEditKeyboardWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMan
 
     // Cannot be done in WM_DESTROY because that causes crashes due to fatal app exit
     xamlBridge.ClearXamlIslands();
+
+    // Calling ClearXamlIslands() outside of the message loop is not enough to prevent
+    // Microsoft.UI.XAML.dll from crashing during deinitialization, see https://github.com/microsoft/PowerToys/issues/10906
+    TerminateProcess(GetCurrentProcess(), 0);
 }
 
 inline std::wstring getMessage(UINT messageCode)

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/EditShortcutsWindow.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/EditShortcutsWindow.cpp
@@ -47,7 +47,7 @@ static IAsyncAction OnClickAccept(
 }
 
 // Function to create the Edit Shortcuts Window
-void createEditShortcutsWindow(HINSTANCE hInst, KeyboardManagerState& keyboardManagerState)
+inline void createEditShortcutsWindowImpl(HINSTANCE hInst, KeyboardManagerState& keyboardManagerState)
 {
     event_locker locker(KeyboardManagerConstants::EditorWindowEventName.c_str());
     Logger::trace("Creating Remap shortcuts window");
@@ -327,6 +327,12 @@ void createEditShortcutsWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMa
 
     // Cannot be done in WM_DESTROY because that causes crashes due to fatal app exit
     xamlBridge.ClearXamlIslands();
+}
+
+void createEditShortcutsWindow(HINSTANCE hInst, KeyboardManagerState& keyboardManagerState)
+{
+    // Move implementation into the separate method so resources get destroyed correctly
+    createEditShortcutsWindowImpl(hInst, keyboardManagerState);
 
     // Calling ClearXamlIslands() outside of the message loop is not enough to prevent
     // Microsoft.UI.XAML.dll from crashing during deinitialization, see https://github.com/microsoft/PowerToys/issues/10906

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/EditShortcutsWindow.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/EditShortcutsWindow.cpp
@@ -327,6 +327,10 @@ void createEditShortcutsWindow(HINSTANCE hInst, KeyboardManagerState& keyboardMa
 
     // Cannot be done in WM_DESTROY because that causes crashes due to fatal app exit
     xamlBridge.ClearXamlIslands();
+
+    // Calling ClearXamlIslands() outside of the message loop is not enough to prevent
+    // Microsoft.UI.XAML.dll from crashing during deinitialization, see https://github.com/microsoft/PowerToys/issues/10906
+    TerminateProcess(GetCurrentProcess(), 0);
 }
 
 LRESULT CALLBACK EditShortcutsWindowProc(HWND hWnd, UINT messageCode, WPARAM wParam, LPARAM lParam)


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
See the issue

**What is include in the PR:** 
Killing the Editor process when exiting.
Removed logging before and after `xamlBridge.MessageLoop()` since `xamlBridge.MessageLoop()` already logs the start and stop.

**How does someone test / validate:** 
Open and close multiple times the key and shortcut editor and verify no crash is reported in the Event viewer.

## Quality Checklist

- [x] **Linked issue:** https://github.com/microsoft/PowerToys/issues/10906
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
