### PR TITLE
[KBM] Remappings not showing fix.

### DIFF
--- a/src/common/interop/interop.cpp
+++ b/src/common/interop/interop.cpp
@@ -160,9 +160,5 @@ public
         static String ^ ShowShortcutGuideSharedEvent() {
             return gcnew String(CommonSharedConstants::SHOW_SHORTCUT_GUIDE_SHARED_EVENT);
         }
-
-        static String ^ KeyboardManagerConfigFileMutexName() {
-            return gcnew String(CommonSharedConstants::KEYBOARD_MANAGER_CONFIG_FILE_MUTEX_NAME);
-        }
     };
 }

--- a/src/common/interop/shared_constants.h
+++ b/src/common/interop/shared_constants.h
@@ -27,7 +27,4 @@ namespace CommonSharedConstants
 
     // Max DWORD for key code to disable keys.
     const int VK_DISABLED = 0x100;
-
-    // Name of the mutex which controls access to the configuration file for Keyboard Manager
-    const wchar_t KEYBOARD_MANAGER_CONFIG_FILE_MUTEX_NAME[] = L"Local\\PowerToys_KeyboardManager_ConfigFileMutex";
 }

--- a/src/modules/keyboardmanager/KeyboardManagerEditor/KeyboardManagerEditor.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditor/KeyboardManagerEditor.cpp
@@ -114,7 +114,15 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
 KeyboardManagerEditor::KeyboardManagerEditor(HINSTANCE hInst) :
     hInstance(hInst)
 {
-    SettingsHelper::LoadSettings(keyboardManagerState);
+    bool loadedSuccessful = SettingsHelper::LoadSettings(keyboardManagerState);
+    if (!loadedSuccessful)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+        // retry once
+        SettingsHelper::LoadSettings(keyboardManagerState);
+    }
+
     StartLowLevelKeyboardHook();
 }
 

--- a/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardEventHandlers.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardEventHandlers.cpp
@@ -1,5 +1,8 @@
 #include "pch.h"
 #include "KeyboardEventHandlers.h"
+
+#include <common/interop/shared_constants.h>
+
 #include <keyboardmanager/common/KeyboardManagerState.h>
 #include <keyboardmanager/common/InputInterface.h>
 #include <keyboardmanager/common/Helpers.h>

--- a/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardManager.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardManager.cpp
@@ -56,7 +56,14 @@ KeyboardManager::KeyboardManager()
 
 void KeyboardManager::LoadSettings()
 {
-    SettingsHelper::LoadSettings(keyboardManagerState);
+    bool loadedSuccessful = SettingsHelper::LoadSettings(keyboardManagerState);
+    if (!loadedSuccessful)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+        // retry once
+        SettingsHelper::LoadSettings(keyboardManagerState);
+    }
 }
 
 LRESULT CALLBACK KeyboardManager::HookProc(int nCode, WPARAM wParam, LPARAM lParam)

--- a/src/modules/keyboardmanager/common/Helpers.cpp
+++ b/src/modules/keyboardmanager/common/Helpers.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 #include "Helpers.h"
 
+#include <common/interop/shared_constants.h>
 #include <common/utils/process_path.h>
 
 #include "ErrorTypes.h"

--- a/src/modules/keyboardmanager/common/KeyboardManagerConstants.h
+++ b/src/modules/keyboardmanager/common/KeyboardManagerConstants.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <common/interop/shared_constants.h>
-
 namespace KeyboardManagerConstants
 {
     // Event name for signaling settings changes
@@ -41,9 +39,6 @@ namespace KeyboardManagerConstants
 
     // Name of the default configuration.
     inline const std::wstring DefaultConfiguration = L"default";
-
-    // Name of the named mutex used for configuration file.
-    inline const std::wstring ConfigFileMutexName = CommonSharedConstants::KEYBOARD_MANAGER_CONFIG_FILE_MUTEX_NAME;
 
     // Name of the dummy update file.
     inline const std::wstring DummyUpdateFileName = L"settings-updated.json";

--- a/src/modules/keyboardmanager/common/KeyboardManagerState.cpp
+++ b/src/modules/keyboardmanager/common/KeyboardManagerState.cpp
@@ -579,6 +579,7 @@ bool KeyboardManagerState::SaveConfigToFile()
     catch (...)
     {
         result = false;
+        Logger::error(L"Failed to save the settings");
     }
 
     if (result)

--- a/src/modules/keyboardmanager/common/KeyboardManagerState.cpp
+++ b/src/modules/keyboardmanager/common/KeyboardManagerState.cpp
@@ -11,19 +11,11 @@
 KeyboardManagerState::KeyboardManagerState() :
     uiState(KeyboardManagerUIState::Deactivated), currentUIWindow(nullptr), currentShortcutUI1(nullptr), currentShortcutUI2(nullptr), currentSingleKeyUI(nullptr), detectedRemapKey(NULL), remappingsEnabled(true)
 {
-    configFile_mutex = CreateMutex(
-        NULL, // default security descriptor
-        FALSE, // mutex not owned
-        KeyboardManagerConstants::ConfigFileMutexName.c_str());
 }
 
 // Destructor
 KeyboardManagerState::~KeyboardManagerState()
 {
-    if (configFile_mutex)
-    {
-        CloseHandle(configFile_mutex);
-    }
 }
 
 // Function to check the if the UI state matches the argument state. For states with detect windows it also checks if the window is in focus.
@@ -580,26 +572,11 @@ bool KeyboardManagerState::SaveConfigToFile()
     configJson.SetNamedValue(KeyboardManagerConstants::RemapKeysSettingName, remapKeys);
     configJson.SetNamedValue(KeyboardManagerConstants::RemapShortcutsSettingName, remapShortcuts);
 
-    // Set timeout of 1sec to wait for file to get free.
-    DWORD timeout = 1000;
-    auto dwWaitResult = WaitForSingleObject(
-        configFile_mutex,
-        timeout);
-    if (dwWaitResult == WAIT_OBJECT_0)
+    try
     {
-        try
-        {
-            json::to_file((PTSettingsHelper::get_module_save_folder_location(KeyboardManagerConstants::ModuleName) + L"\\" + GetCurrentConfigName() + L".json"), configJson);
-        }
-        catch (...)
-        {
-            result = false;
-        }
-
-        // Make sure to release the Mutex.
-        ReleaseMutex(configFile_mutex);
+        json::to_file((PTSettingsHelper::get_module_save_folder_location(KeyboardManagerConstants::ModuleName) + L"\\" + GetCurrentConfigName() + L".json"), configJson);
     }
-    else
+    catch (...)
     {
         result = false;
     }

--- a/src/modules/keyboardmanager/common/KeyboardManagerState.h
+++ b/src/modules/keyboardmanager/common/KeyboardManagerState.h
@@ -78,9 +78,6 @@ private:
     std::wstring currentConfig = KeyboardManagerConstants::DefaultConfiguration;
     std::mutex currentConfig_mutex;
 
-    // Handle of named mutex used for configuration file.
-    HANDLE configFile_mutex;
-
     // Registered KeyDelay objects, used to notify delayed key events.
     std::map<DWORD, std::unique_ptr<KeyDelay>> keyDelays;
     std::mutex keyDelays_mutex;


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

After reopening the KBM settings page remappings possibly could not be shown in the settings.
This caused by the mutex which controls access for the KBM config file.

```
[Method]: LoadProfile [Class]: KeyboardManagerViewModel
    Exception encountered when loading Keyboard Manager profile
No handle of the given name exists.
Inner exception: 
Stack trace: 
   at System.Threading.Mutex.OpenExisting(String name)
```

![image](https://user-images.githubusercontent.com/8949536/116103884-e6fcab80-a6a7-11eb-82c2-5e1e85c13b62.png)

**What is include in the PR:** 

Removed a mutex that is actually no longer needed.

**How does someone test / validate:** 

Remap keys or shortcuts, open KBM settings, verify that everything is shown correctly.

## Quality Checklist

- [x] **Linked issue:** #10127 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
