### PR TITLE
[KBM] move interop methods to dedicated class

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/Utilities/NativeMethods.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/Utilities/NativeMethods.cs
@@ -13,5 +13,16 @@ namespace Microsoft.PowerToys.Settings.UI.Library.Utilities
     {
         [DllImport("user32.dll")]
         public static extern bool AllowSetForegroundWindow(int dwProcessId);
+
+        public const int SWRESTORE = 9;
+
+        [System.Runtime.InteropServices.DllImport("User32.dll")]
+        public static extern bool SetForegroundWindow(IntPtr handle);
+
+        [System.Runtime.InteropServices.DllImport("User32.dll")]
+        public static extern bool ShowWindow(IntPtr handle, int nCmdShow);
+
+        [System.Runtime.InteropServices.DllImport("User32.dll")]
+        public static extern bool IsIconic(IntPtr handle);
     }
 }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/KeyboardManagerViewModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/KeyboardManagerViewModel.cs
@@ -192,26 +192,13 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             }
 
             IntPtr handle = process.MainWindowHandle;
-            if (IsIconic(handle))
+            if (NativeMethods.IsIconic(handle))
             {
-                ShowWindow(handle, SWRESTORE);
+                NativeMethods.ShowWindow(handle, NativeMethods.SWRESTORE);
             }
 
-            SetForegroundWindow(handle);
+            NativeMethods.SetForegroundWindow(handle);
         }
-
-        private const int SWRESTORE = 9;
-
-        [System.Runtime.InteropServices.DllImport("User32.dll")]
-        private static extern bool SetForegroundWindow(IntPtr handle);
-
-        [System.Runtime.InteropServices.DllImport("User32.dll")]
-
-        private static extern bool ShowWindow(IntPtr handle, int nCmdShow);
-
-        [System.Runtime.InteropServices.DllImport("User32.dll")]
-
-        private static extern bool IsIconic(IntPtr handle);
 
         [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Exceptions here (especially mutex errors) should not halt app execution, but they will be logged.")]
         private void OpenEditor(int type)


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Native methods causing https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1060

**What is include in the PR:** 
Move the native methods to the dedicated class.

**How does someone test / validate:** 
Run the internal CI to build the solution.

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
