### PR TITLE
[KBM] fix build error C2079

### DIFF
--- a/src/common/utils/UnhandledExceptionHandler_x64.h
+++ b/src/common/utils/UnhandledExceptionHandler_x64.h
@@ -1,6 +1,7 @@
 #include <Windows.h>
 #include <DbgHelp.h>
 #include <signal.h>
+#include <sstream>
 #include <stdio.h>
 #include "../logger/logger.h"
 

--- a/src/modules/keyboardmanager/common/Helpers.cpp
+++ b/src/modules/keyboardmanager/common/Helpers.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include "Helpers.h"
+#include <sstream>
 
 #include <common/interop/shared_constants.h>
 #include <common/utils/process_path.h>


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Internal CI reports build error:
```
\src\modules\keyboardmanager\common\Helpers.cpp(17,36): error C2079: 'ss' uses undefined class 'std::basic_stringstream<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t>>'
```

**What is include in the PR:** 
Add `#include <sstream>`

**How does someone test / validate:** 
Run internal CI build.

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
