### PR TITLE
[KBM Engine] Remove global usings

### DIFF
--- a/src/modules/keyboardmanager/KeyboardManagerEngine/main.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngine/main.cpp
@@ -8,14 +8,11 @@
 #include <keyboardmanager/KeyboardManagerEngineLibrary/trace.h>
 #include <common/utils/UnhandledExceptionHandler_x64.h>
 
-using namespace winrt;
-using namespace Windows::Foundation;
-
 const std::wstring instanceMutexName = L"Local\\PowerToys_KBMEngine_InstanceMutex";
 
 int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR lpCmdLine, int nCmdShow)
 {
-    init_apartment();
+    winrt::init_apartment();
     LoggerHelpers::init_logger(KeyboardManagerConstants::ModuleName, L"Engine", LogSettings::keyboardManagerLoggerName);
     
     InitUnhandledExceptionHandler_x64();

--- a/src/modules/keyboardmanager/KeyboardManagerEngine/main.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngine/main.cpp
@@ -10,7 +10,7 @@
 
 const std::wstring instanceMutexName = L"Local\\PowerToys_KBMEngine_InstanceMutex";
 
-int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR lpCmdLine, int nCmdShow)
+int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _In_ PWSTR lpCmdLine, _In_ int nCmdShow)
 {
     winrt::init_apartment();
     LoggerHelpers::init_logger(KeyboardManagerConstants::ModuleName, L"Engine", LogSettings::keyboardManagerLoggerName);


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
The internal pipeline was still failing to build with `error C2872` 

**What is include in the PR:** 
Don't use global namespace to prevent `error C2872`
Also fix a build warning for winMain missing the SAL annotation.

**How does someone test / validate:** 
Run a internal pipeline build.

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
