### PR TITLE
[PT Run] Fix Program Plugin launching issue in Turkish locale

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -964,6 +964,7 @@ ILogon
 IMAGEHLP
 imageresizer
 IMAGERESIZEREXT
+imagingdevices
 IMain
 IMarkdown
 ime

--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -964,7 +964,6 @@ ILogon
 IMAGEHLP
 imageresizer
 IMAGERESIZEREXT
-imagingdevices
 IMain
 IMarkdown
 ime

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program.UnitTests/Programs/Win32Tests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program.UnitTests/Programs/Win32Tests.cs
@@ -18,6 +18,15 @@ namespace Microsoft.Plugin.Program.UnitTests.Programs
     [TestFixture]
     public class Win32Tests
     {
+        private static readonly Win32Program _imagingDevices = new Win32Program
+        {
+            Name = "Imaging Devices",
+            ExecutableName = "imagingdevices.exe",
+            FullPath = "c:\\program files\\windows photo viewer\\imagingdevices.exe",
+            LnkResolvedPath = null,
+            AppType = Win32Program.ApplicationType.Win32Application,
+        };
+
         private static readonly Win32Program _notepadAppdata = new Win32Program
         {
             Name = "Notepad",
@@ -430,6 +439,12 @@ namespace Microsoft.Plugin.Program.UnitTests.Programs
 
             // the query matches the name (cmd) and is therefore not filtered (case-insensitive)
             Assert.IsTrue(_cmdRunCommand.QueryEqualsNameForRunCommands(query));
+        }
+
+        [TestCase("ımaging")]
+        public void Win32ApplicationsShouldNotHaveIncorrectPathWhenExecuting(string query)
+        {
+            Assert.IsFalse(_imagingDevices.FullPath.Contains(query, StringComparison.Ordinal));
         }
 
         [Test]

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32Program.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32Program.cs
@@ -344,6 +344,7 @@ namespace Microsoft.Plugin.Program.Programs
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Any error in CreateWin32Program should not prevent other programs from loading.")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1308:Normalize strings to uppercase", Justification = "User facing path needs to be shown in lowercase.")]
         private static Win32Program CreateWin32Program(string path)
         {
             try
@@ -354,8 +355,8 @@ namespace Microsoft.Plugin.Program.Programs
                     ExecutableName = Path.GetFileName(path),
                     IcoPath = path,
 
-                    // Using CurrentCulture since this is user facing
-                    FullPath = path.ToLower(CultureInfo.CurrentCulture),
+                    // Using InvariantCulture since this is user facing
+                    FullPath = path.ToLowerInvariant(),
                     UniqueIdentifier = path,
                     ParentDirectory = Directory.GetParent(path).FullName,
                     Description = string.Empty,
@@ -465,6 +466,7 @@ namespace Microsoft.Plugin.Program.Programs
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Unsure of what exceptions are caught here while enabling static analysis")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1308:Normalize strings to uppercase", Justification = "User facing path needs to be shown in lowercase.")]
         private static Win32Program LnkProgram(string path)
         {
             try
@@ -481,8 +483,8 @@ namespace Microsoft.Plugin.Program.Programs
                     {
                         program.LnkResolvedPath = program.FullPath;
 
-                        // Using CurrentCulture since this is user facing
-                        program.FullPath = Path.GetFullPath(target).ToLower(CultureInfo.CurrentCulture);
+                        // Using InvariantCulture since this is user facing
+                        program.FullPath = Path.GetFullPath(target).ToLowerInvariant();
                         program.AppType = GetAppTypeFromPath(target);
 
                         var description = ShellLinkHelper.Description;
@@ -693,10 +695,11 @@ namespace Microsoft.Plugin.Program.Programs
             return files;
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1308:Normalize strings to uppercase", Justification = "User facing path needs to be shown in lowercase.")]
         private static string Extension(string path)
         {
-            // Using CurrentCulture since this is user facing
-            var extension = Path.GetExtension(path)?.ToLower(CultureInfo.CurrentCulture);
+            // Using InvariantCulture since this is user facing
+            var extension = Path.GetExtension(path)?.ToLowerInvariant();
 
             if (!string.IsNullOrEmpty(extension))
             {


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
This PR tries to fix #9776

On environments with Turkish locale selected, you can't run programs with capitalized `I` because `I` becomes `ı` thus fails to open the specified program.

![step1e](https://user-images.githubusercontent.com/486818/116283035-1ee11d00-a794-11eb-8c25-bc198068b5e2.png)

![step 2 nt](https://user-images.githubusercontent.com/486818/116283744-ea219580-a794-11eb-8434-20b2a5fd39e5.png)

**What is include in the PR:**

I suppressed [CA1308](https://docs.microsoft.com/visualstudio/code-quality/ca1308) for user facing text and used InvariantCulture for the launch issue.

**How does someone test / validate:**

Here's the end result:

![step1-fe2e](https://user-images.githubusercontent.com/486818/116301562-da13b100-a7a8-11eb-921e-8796bd815f69.png)

One needs an environment with locale set to Turkish and try to run a program or a shortcut that has capitalized `I` in it.
Thankfully Windows has one in: `C:\Program Files\Windows Photo Viewer\ImagingDevices.exe`
I just needed to create a shortcut (LNK) for that and tested with it and it worked.

## Quality Checklist

- [x] **Linked issue:** #9776
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [x] **Tests:** Added/updated and all pass

## Contributor License Agreement (CLA)

I signed the CLA.