### PR TITLE
[OOBE] FZ Editor hotkey change

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -1051,7 +1051,7 @@ Take a moment to preview the various utilities listed or view our comprehensive 
     <value>To select a color with more precision, {scroll the mouse wheel} to zoom in.</value>
   </data>
   <data name="Oobe_FancyZones_HowToUse.Text" xml:space="preserve">
-    <value>{Shift} + {dragging the window} to snap a window to a zone, and release the window in the desired zone. {Win} + {`} to open the FancyZones editor.</value>
+    <value>{Shift} + {dragging the window} to snap a window to a zone, and release the window in the desired zone. {Win} + {Shift} + {`} to open the FancyZones editor.</value>
   </data>
   <data name="Oobe_FancyZones_TipsAndTricks.Text" xml:space="preserve">
     <value>Snap a window to multiple zones by holding the {Ctrl} key (while also holding {Shift}) when dragging a window.</value>


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
FZ Editor default hotkey has been changed.

**What is include in the PR:** 
https://github.com/microsoft/PowerToys/pull/10751 didn't include the change for OOBE

**How does someone test / validate:** 
Open OOBE and verify the new hotkey is displayed:

![image](https://user-images.githubusercontent.com/3206696/116377445-7bcee880-a811-11eb-8dbf-d40ebc04f91b.png)

We should consider putting the second sentence to a new line since the current formatting isn't ideal

## Quality Checklist

- [x] **Linked issue:** https://github.com/microsoft/PowerToys/issues/10749
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
