### PR TITLE
[KBM] scale editor window size based on DPI

### DIFF
--- a/src/common/Display/dpi_aware.cpp
+++ b/src/common/Display/dpi_aware.cpp
@@ -51,6 +51,19 @@ namespace DPIAware
         }
     }
 
+    void ConvertByCursorPosition(int& width, int& height)
+    {
+        HMONITOR targetMonitor = nullptr;
+        POINT currentCursorPos{};
+
+        if (GetCursorPos(&currentCursorPos))
+        {
+            targetMonitor = MonitorFromPoint(currentCursorPos, MONITOR_DEFAULTTOPRIMARY);
+        }
+        
+        Convert(targetMonitor, width, height);
+    }
+
     void InverseConvert(HMONITOR monitor_handle, int& width, int& height)
     {
         if (monitor_handle == NULL)

--- a/src/common/Display/dpi_aware.h
+++ b/src/common/Display/dpi_aware.h
@@ -10,6 +10,7 @@ namespace DPIAware
     HRESULT GetScreenDPIForWindow(HWND hwnd, UINT& dpi_x, UINT& dpi_y);
     HRESULT GetScreenDPIForPoint(POINT p, UINT& dpi_x, UINT& dpi_y);
     void Convert(HMONITOR monitor_handle, int& width, int& height);
+    void ConvertByCursorPosition(int& width, int& height);
     void InverseConvert(HMONITOR monitor_handle, int& width, int& height);
     void EnableDPIAwarenessForThisProcess();
 

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/EditKeyboardWindow.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/EditKeyboardWindow.cpp
@@ -142,7 +142,8 @@ inline void CreateEditKeyboardWindowImpl(HINSTANCE hInst, KeyboardManagerState& 
     // Calculate DPI dependent window size
     int windowWidth = KeyboardManagerConstants::DefaultEditKeyboardWindowWidth;
     int windowHeight = KeyboardManagerConstants::DefaultEditKeyboardWindowHeight;
-    DPIAware::Convert(nullptr, windowWidth, windowHeight);
+
+    DPIAware::ConvertByCursorPosition(windowWidth, windowHeight);
     
     // Window Creation
     HWND _hWndEditKeyboardWindow = CreateWindow(
@@ -422,7 +423,7 @@ LRESULT CALLBACK EditKeyboardWindowProc(HWND hWnd, UINT messageCode, WPARAM wPar
         LPMINMAXINFO lpMMI = (LPMINMAXINFO)lParam;
         int minWidth = KeyboardManagerConstants::MinimumEditKeyboardWindowWidth;
         int minHeight = KeyboardManagerConstants::MinimumEditKeyboardWindowHeight;
-        DPIAware::Convert(nullptr, minWidth, minHeight);
+        DPIAware::Convert(MonitorFromWindow(hWnd, MONITOR_DEFAULTTONULL), minWidth, minHeight);
         lpMMI->ptMinTrackSize.x = minWidth;
         lpMMI->ptMinTrackSize.y = minHeight;
     }

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/EditShortcutsWindow.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/EditShortcutsWindow.cpp
@@ -95,7 +95,7 @@ inline void CreateEditShortcutsWindowImpl(HINSTANCE hInst, KeyboardManagerState&
     // Calculate DPI dependent window size
     int windowWidth = KeyboardManagerConstants::DefaultEditShortcutsWindowWidth;
     int windowHeight = KeyboardManagerConstants::DefaultEditShortcutsWindowHeight;
-    DPIAware::Convert(nullptr, windowWidth, windowHeight);
+    DPIAware::ConvertByCursorPosition(windowWidth, windowHeight);
 
     // Window Creation
     HWND _hWndEditShortcutsWindow = CreateWindow(
@@ -377,7 +377,7 @@ LRESULT CALLBACK EditShortcutsWindowProc(HWND hWnd, UINT messageCode, WPARAM wPa
         LPMINMAXINFO lpMMI = (LPMINMAXINFO)lParam;
         int minWidth = KeyboardManagerConstants::MinimumEditShortcutsWindowWidth;
         int minHeight = KeyboardManagerConstants::MinimumEditShortcutsWindowHeight;
-        DPIAware::Convert(nullptr, minWidth, minHeight);
+        DPIAware::Convert(MonitorFromWindow(hWnd, MONITOR_DEFAULTTONULL), minWidth, minHeight);
         lpMMI->ptMinTrackSize.x = minWidth;
         lpMMI->ptMinTrackSize.y = minHeight;
     }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Since the editor is DPI aware, it needs to scale it's startup size accordingly.

**What is include in the PR:** 
Added a helper function to scale dimensions based on current cursor position.

**How does someone test / validate:** 
Open the Settings page on a monitor with high DPI scaling and verify the editor windows are sized as expected.

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
