### PR TITLE
[FZ Editor] Replace ItemsControls with GridViews

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/App.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/App.xaml
@@ -10,21 +10,9 @@
                 <ui:ThemeResources />
                 <ui:XamlControlsResources />
                 <ResourceDictionary Source="pack://application:,,,/Styles/ButtonStyles.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/Styles/GridViewStyles.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/Styles/LayoutPreviewStyles.xaml" />
             </ResourceDictionary.MergedDictionaries>
-
-            <Style x:Key="UWPFocusVisualStyle">
-                <Setter Property="Control.Template">
-                    <Setter.Value>
-                        <ControlTemplate>
-                            <Border Margin="-2"
-                                    CornerRadius="4"
-                                    BorderThickness="2"
-                                    BorderBrush="{DynamicResource PrimaryForegroundBrush}" />
-                        </ControlTemplate>
-                    </Setter.Value>
-                </Setter>
-            </Style>
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -80,6 +80,21 @@
             <Grid  Background="Transparent">
                 <Grid.ContextMenu>
                     <ContextMenu Visibility="{Binding Path=Type, Converter={StaticResource LayoutModelTypeBlankToVisibilityConverter}}">
+                        <MenuItem Header="{x:Static props:Resources.Edit}"
+                                  Click="EditLayout_Click">
+                            <MenuItem.Icon>
+                                <ui:FontIcon Glyph="&#xE104;" />
+                            </MenuItem.Icon>
+                        </MenuItem>
+                        <MenuItem Header="{x:Static props:Resources.Edit_zones}"
+                                  Visibility="{Binding Path=Type, Converter={StaticResource LayoutTypeCustomToVisibilityConverter}}"
+                                  Click="EditZones_Click">
+                            <MenuItem.Icon>
+                                <ui:FontIcon Glyph="&#xED35;" />
+                            </MenuItem.Icon>
+                        </MenuItem>
+
+                       
                         <MenuItem Header="{x:Static props:Resources.Duplicate}"
                                   Click="DuplicateLayout_Click"
                                   Visibility="{Binding Path=Type, Converter={StaticResource LayoutTypeCustomToVisibilityConverter}}">
@@ -95,7 +110,7 @@
                                 <ui:FontIcon Glyph="&#xE8C8;" />
                             </MenuItem.Icon>
                         </MenuItem>
-                        
+                        <Separator Visibility="{Binding Path=Type, Converter={StaticResource LayoutTypeCustomToVisibilityConverter}}" />
                         <MenuItem Header="{x:Static props:Resources.Delete}"
                                   Click="DeleteLayout_Click"
                                   Visibility="{Binding Path=Type, Converter={StaticResource LayoutTypeCustomToVisibilityConverter}}">
@@ -143,8 +158,8 @@
                         Background="Transparent"
                         Visibility="{Binding Path=Type, Converter={StaticResource LayoutModelTypeBlankToVisibilityConverter}}"
                         Foreground="{Binding (TextElement.Foreground), RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ContentPresenter}}}"
-                        ToolTip="{x:Static props:Resources.Edit_Layout}"
-                        AutomationProperties.Name="{x:Static props:Resources.Edit_Layout}"
+                        ToolTip="{x:Static props:Resources.Edit}"
+                        AutomationProperties.Name="{x:Static props:Resources.Edit}"
                         Style="{StaticResource AccentButtonStyle}"
                         ui:ControlHelper.CornerRadius="36" />
             </Grid>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -31,19 +31,13 @@
         <Converters:LayoutTypeTemplateToVisibilityConverter x:Key="LayoutTypeTemplateToVisibilityConverter" />
         <Converters:LayoutModelTypeBlankToVisibilityConverter x:Key="LayoutModelTypeBlankToVisibilityConverter" />
         <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
-        
-
 
         <DataTemplate x:Key="MonitorItemTemplate">
             <Border x:Name="MonitorItem"
                     Width="{Binding DisplayWidth}"
                     Height="{Binding DisplayHeight}"
                     AutomationProperties.Name="{x:Static props:Resources.Monitor}"
-                    AutomationProperties.HelpText="{Binding Index}"
-                    Margin="8,2,8,8"
-                    KeyDown="MonitorItem_KeyDown"
-                    MouseDown="MonitorItem_MouseDown"
-                   >
+                    AutomationProperties.HelpText="{Binding Index}">
                 <Border.ToolTip>
                     <ToolTip>
                         <StackPanel>
@@ -65,7 +59,7 @@
                                FontWeight="SemiBold"
                                HorizontalAlignment="Center"
                                VerticalAlignment="Center"
-                               Foreground="{DynamicResource PrimaryForegroundBrush}" />
+                               Foreground="{Binding (TextElement.Foreground), RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ContentPresenter}}}" />
                     <TextBlock Name="ResolutionText"
                                TextTrimming="CharacterEllipsis"
                                Text="{Binding Dimensions}"
@@ -75,224 +69,86 @@
                                FontWeight="SemiBold"
                                HorizontalAlignment="Center"
                                VerticalAlignment="Center"
-                               Foreground="{DynamicResource SecondaryForegroundBrush}" />
+                               Opacity="0.6"
+                               Foreground="{Binding (TextElement.Foreground), RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ContentPresenter}}}" />
                 </StackPanel>
             </Border>
-            <DataTemplate.Triggers>
-                <DataTrigger Binding="{Binding Selected}"
-                             Value="true">
-                    <Setter TargetName="IndexText"
-                            Property="Foreground"
-                            Value="{DynamicResource SystemControlBackgroundAccentBrush}" />
-                    <Setter TargetName="ResolutionText"
-                            Property="Foreground"
-                            Value="{DynamicResource SystemControlBackgroundAccentBrush}" />
-                    
-                    <Setter TargetName="MonitorItem"
-                            Property="BorderBrush"
-                            Value="{DynamicResource SystemControlBackgroundAccentBrush}" />
-                </DataTrigger>
-            </DataTemplate.Triggers>
+
         </DataTemplate>
 
-        <DataTemplate x:Key="SimpleItemTemplate">
-            <Grid Background="Red"
-                  AutomationProperties.Name="Woehoe">
-                <TextBlock Text="{Binding Name}"
-                           AutomationProperties.Name="Woehoe" />
-            </Grid>
-        </DataTemplate>
-        
         <DataTemplate x:Key="LayoutItemTemplate">
-            <Grid Background="Transparent"
-                  Width="216"
-                  AutomationProperties.Name="Woehoe"
-                  Height="172">
-                <Border x:Name="LayoutItem"
-                        Margin="16">
-                    <Grid>
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="24" />
-                            <RowDefinition Height="124" />
-                            <RowDefinition Height="0" />
-                        </Grid.RowDefinitions>
-                        <TextBlock Name="layoutName"
-                                   TextTrimming="CharacterEllipsis"
-                                   Text="{Binding Name}"
-                                   FontSize="15"
-                                   Grid.Row="0"
-                                   FontWeight="SemiBold"
-                                   HorizontalAlignment="Left"
-                                   VerticalAlignment="Top"
-                                   Margin="0,-4,24,0"
-                                   ToolTip="{Binding Name}"
-                                   Foreground="{DynamicResource PrimaryForegroundBrush}" />
-                        <local:LayoutPreview Grid.Row="1"
-                                             Margin="0,8,0,8" 
-                                             VerticalAlignment="Stretch"
-                                             HorizontalAlignment="Stretch" />
-                    </Grid>
-                </Border>
-                <Border x:Name="SelectionHighlight"
-                        CornerRadius="4"
-                        BorderThickness="3"
-                        Margin="0"
-                        Visibility="Collapsed"
-                        BorderBrush="{DynamicResource SystemControlBackgroundAccentBrush}" />
+            <Grid  Background="Transparent">
+                <Grid.ContextMenu>
+                    <ContextMenu Visibility="{Binding Path=Type, Converter={StaticResource LayoutModelTypeBlankToVisibilityConverter}}">
+                        <MenuItem Header="{x:Static props:Resources.Duplicate}"
+                                  Click="DuplicateLayout_Click"
+                                  Visibility="{Binding Path=Type, Converter={StaticResource LayoutTypeCustomToVisibilityConverter}}">
+                            <MenuItem.Icon>
+                                <ui:FontIcon Glyph="&#xE8C8;" />
+                            </MenuItem.Icon>
+                        </MenuItem>
 
+                        <MenuItem Header="{x:Static props:Resources.Create_Custom_From_Template}"
+                                  Click="DuplicateLayout_Click"
+                                  Visibility="{Binding Path=Type, Converter={StaticResource LayoutTypeTemplateToVisibilityConverter}}">
+                            <MenuItem.Icon>
+                                <ui:FontIcon Glyph="&#xE8C8;" />
+                            </MenuItem.Icon>
+                        </MenuItem>
+                        
+                        <MenuItem Header="{x:Static props:Resources.Delete}"
+                                  Click="DeleteLayout_Click"
+                                  Visibility="{Binding Path=Type, Converter={StaticResource LayoutTypeCustomToVisibilityConverter}}">
+                            <MenuItem.Icon>
+                                <ui:FontIcon Glyph="&#xE107;" />
+                            </MenuItem.Icon>
+                        </MenuItem>
+                    </ContextMenu>
+                </Grid.ContextMenu>
+                <Grid
+                      Width="180"
+                      Height="140"
+                      Margin="16">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="24" />
+                        <RowDefinition Height="124" />
+                        <RowDefinition Height="0" />
+                    </Grid.RowDefinitions>
+                    <TextBlock Name="layoutName"
+                               TextTrimming="CharacterEllipsis"
+                               Text="{Binding Name}"
+                               FontSize="15"
+                               FontWeight="SemiBold"
+                               Margin="0,-4,24,0"
+                               ToolTip="{Binding Name}"
+                               Foreground="{Binding (TextElement.Foreground), RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ContentPresenter}}}" />
+                    <local:LayoutPreview Grid.Row="1"
+                                         Margin="0,8,0,8"
+                                         VerticalAlignment="Stretch"
+                                         HorizontalAlignment="Stretch" />
+                </Grid>
                 <Button Content="&#xE104;"
                         x:Name="EditLayoutButton"
                         FontFamily="Segoe MDL2 Assets"
                         FontSize="14"
                         HorizontalAlignment="Right"
                         VerticalAlignment="Top"
-                        Margin="4           "
+                        Margin="4"
                         Height="36"
                         Width="36"
                         Padding="0"
+                        Grid.RowSpan="4"
                         BorderBrush="Transparent"
                         Click="EditLayout_Click"
                         Background="Transparent"
                         Visibility="{Binding Path=Type, Converter={StaticResource LayoutModelTypeBlankToVisibilityConverter}}"
-                        Foreground="{DynamicResource PrimaryForegroundBrush}"
+                        Foreground="{Binding (TextElement.Foreground), RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ContentPresenter}}}"
                         ToolTip="{x:Static props:Resources.Edit_Layout}"
                         AutomationProperties.Name="{x:Static props:Resources.Edit_Layout}"
                         Style="{StaticResource AccentButtonStyle}"
                         ui:ControlHelper.CornerRadius="36" />
             </Grid>
-            <DataTemplate.Triggers>
-                <DataTrigger Binding="{Binding IsApplied}"
-                             Value="true">
-                    <Setter TargetName="layoutName"
-                            Property="Foreground"
-                            Value="{DynamicResource SystemControlBackgroundAccentBrush}" />
-                    <Setter TargetName="SelectionHighlight"
-                            Property="Visibility"
-                            Value="Visible" />
-                </DataTrigger>
-                <DataTrigger Binding="{Binding IsSelected}"
-                             Value="true">
-                    <Setter TargetName="LayoutItem"
-                            Property="BorderBrush"
-                            Value="{DynamicResource LayoutItemBorderPointerOverBrush}" />
-
-                    <Setter TargetName="EditLayoutButton"
-                            Property="Foreground"
-                            Value="{DynamicResource SystemControlBackgroundAccentBrush}" />
-                </DataTrigger>
-            </DataTemplate.Triggers>
         </DataTemplate>
-
-        <Style x:Key="GridViewCardStyle" TargetType="ui:GridViewItem">
-            <Setter Property="Background"
-                    Value="Transparent" />
-            <Setter Property="Foreground"
-                    Value="{DynamicResource SystemControlForegroundBaseHighBrush}" />
-            <Setter Property="KeyboardNavigation.TabNavigation"
-                    Value="Local" />
-            <!--<Setter Property="IsHoldingEnabled" Value="True" />-->
-            <Setter Property="Margin"
-                    Value="8" />
-            <Setter Property="FocusVisualStyle"
-                    Value="{StaticResource UWPFocusVisualStyle}" />
-            <Setter Property="Template">
-                <Setter.Value>
-                    <ControlTemplate TargetType="ui:GridViewItem">
-                        <Border x:Name="ContentBorder"
-                                CornerRadius="4"
-                                Padding="0"
-                                AutomationProperties.Name="Woehoe"
-                                Background="{StaticResource LayoutItemBackgroundBrush}"
-                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
-                            <Border.Effect>
-                                <DropShadowEffect BlurRadius="6"
-                                                  Opacity="0.24"
-                                                  ShadowDepth="1" />
-                            </Border.Effect>
-                            <VisualStateManager.CustomVisualStateManager>
-                                <ui:SimpleVisualStateManager />
-                            </VisualStateManager.CustomVisualStateManager>
-                            <Grid>
-                                <ContentPresenter x:Name="ContentPresenter"
-                                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                                  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                  Margin="0"
-                                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
-                            </Grid>
-                        </Border>
-                        <ControlTemplate.Triggers>
-
-                            <!-- PointerOver -->
-                            <MultiTrigger>
-                                <MultiTrigger.Conditions>
-                                    <Condition Property="IsMouseOver"
-                                               Value="True" />
-                                    <Condition Property="IsSelected"
-                                               Value="False" />
-                                </MultiTrigger.Conditions>
-                                <Setter Property="Background"
-                                        TargetName="ContentBorder"
-                                        Value="{DynamicResource LayoutItemBackgroundPointerOverBrush}" />
-                                <Setter Property="BorderBrush"
-                                        TargetName="ContentBorder"
-                                        Value="{DynamicResource LayoutItemBackgroundPointerOverBrush}" />
-                 
-                            </MultiTrigger>
-                            <!-- Selected -->
-                            <MultiTrigger>
-                                <MultiTrigger.Conditions>
-                                    <Condition Property="IsMouseOver"
-                                               Value="False" />
-                                    <Condition Property="IsSelected"
-                                               Value="True" />
-                                </MultiTrigger.Conditions>
-
-                            </MultiTrigger>
-                            <!-- PointerOverSelected -->
-                            <MultiTrigger>
-                                <MultiTrigger.Conditions>
-                                    <Condition Property="IsMouseOver"
-                                               Value="True" />
-                                    <Condition Property="IsSelected"
-                                               Value="True" />
-                                </MultiTrigger.Conditions>
-                                <Setter Property="Background"
-                                        TargetName="ContentBorder"
-                                        Value="{DynamicResource LayoutItemBackgroundPointerOverBrush}" />
-                                <Setter Property="BorderBrush"
-                                        TargetName="ContentBorder"
-                                        Value="{DynamicResource LayoutItemBackgroundPointerOverBrush}" />
-                   
-
-                            </MultiTrigger>
-                            <!-- Disabled -->
-                            <Trigger Property="IsEnabled"
-                                     Value="False">
-                                <Setter TargetName="ContentBorder"
-                                        Property="Opacity"
-                                        Value="{DynamicResource ListViewItemDisabledThemeOpacity}" />
-                            </Trigger>
-                        </ControlTemplate.Triggers>
-                    </ControlTemplate>
-                </Setter.Value>
-            </Setter>
-        </Style>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     </Window.Resources>
 
     <Grid>
@@ -300,8 +156,6 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-
-
 
         <Grid Grid.Row="1"
               Background="{DynamicResource PrimaryBackgroundBrush}">
@@ -322,29 +176,16 @@
 
                     <ui:GridView ItemsSource="{Binding DefaultModels}"
                                  Grid.Row="1"
-                                 ItemTemplate="{StaticResource SimpleItemTemplate}"
+                                 ItemTemplate="{StaticResource LayoutItemTemplate}"
                                  AutomationProperties.LabeledBy="{Binding ElementName=TemplatesHeaderBlock}"
-                                 TabIndex="4"
+                                 TabIndex="1"
                                  IsItemClickEnabled="True"
                                  SelectionMode="Single"
-                                 SelectedIndex="1"
-                            
-                                 ItemClick="DefaultModelsItemsControl_ItemClick"
-                                 x:Name="DefaultModelsItemsControl"
-                                 Margin="-8,8,-8,0"
-                                
-                                 
-                                 >
-                        <!--ItemContainerStyle="{StaticResource GridViewCardStyle}"-->
-                        <!--<ui:GridView.ItemContainerStyle>
-                            <Style TargetType="ui:GridViewItem">
-                                <Setter Property="Margin"
-                                        Value="0" />
-                             
-                                <Setter Property="FocusVisualStyle"
-                                        Value="{StaticResource UWPFocusVisualStyle}" />
-                            </Style>
-                        </ui:GridView.ItemContainerStyle>-->
+                                 IsSelectionEnabled="True"
+                                 ItemContainerStyle="{StaticResource LayoutItemContainerStyle}"
+                                 ItemClick="Layout_ItemClick"
+                                 Margin="-8,8,-8,0">
+                     
                     </ui:GridView>
 
                     <TextBlock Text="{x:Static props:Resources.Custom}"
@@ -382,17 +223,18 @@
                         <TextBlock Text="{x:Static props:Resources.No_Custom_Layouts_Message}" Margin="0,16,0,0" Foreground="{DynamicResource SecondaryForegroundBrush}" />
                     </StackPanel>
                     <ui:GridView ItemsSource="{Binding CustomModels}"
-                                  TabIndex="6"
-                                 IsItemClickEnabled="True"
+                                 TabIndex="2"
+                                 ItemTemplate="{StaticResource LayoutItemTemplate}"
+                                 IsSelectionEnabled="True"
                                  SelectionMode="Single"
-                                 ItemClick="DefaultModelsItemsControl_ItemClick"
+                                 IsItemClickEnabled="True"
+                                 ItemClick="Layout_ItemClick"
                                  AutomationProperties.LabeledBy="{Binding ElementName=CustomHeaderBlock}"
-                                  ItemTemplate="{StaticResource LayoutItemTemplate}"
-                                 ItemContainerStyle="{StaticResource GridViewCardStyle}"
-                                  Margin="-8,12,-8,0"
-                                  Grid.Row="4">
-                    </ui:GridView>
-                   
+                                 ItemContainerStyle="{StaticResource LayoutItemContainerStyle}"
+                                 Margin="-8,8,-8,0"
+                                 Grid.Row="4" />
+
+
                 </Grid>
             </ScrollViewer>
 
@@ -401,7 +243,7 @@
                     HorizontalAlignment="Right"
                     VerticalAlignment="Bottom"
                     AutomationProperties.Name="{x:Static props:Resources.Create_new_layout}"
-                    TabIndex="5"
+                    TabIndex="3"
                     Padding="0"
                     Height="36"
                     Margin="16"
@@ -440,19 +282,15 @@
                     <local1:MonitorViewModel x:Name="monitorViewModel" />
                 </ScrollViewer.DataContext>
                 <Grid>
-                    <ItemsControl x:Name="MainWindowItemControl"
-                                  TabIndex="0"
-                                  ItemTemplate="{StaticResource MonitorItemTemplate}"
-                                  ItemsSource="{Binding MonitorInfoForViewModel}">
-                        <ItemsControl.ItemsPanel>
-                            <ItemsPanelTemplate>
-                                <StackPanel Background="Transparent"
-                                            Orientation="Horizontal"
-                                            HorizontalAlignment="Center"
-                                            Margin="8, 0, 8, 16" />
-                            </ItemsPanelTemplate>
-                        </ItemsControl.ItemsPanel>
-                    </ItemsControl>
+                    <ui:GridView TabIndex="0"
+                                 HorizontalAlignment="Center"
+                                 IsSelectionEnabled="True"
+                                 SelectionMode="Single"
+                                 IsItemClickEnabled="True"
+                                 ItemClick="Monitor_ItemClick"
+                                 ItemContainerStyle="{StaticResource MonitorItemContainerStyle}"
+                                 ItemTemplate="{StaticResource MonitorItemTemplate}"
+                                 ItemsSource="{Binding MonitorInfoForViewModel}" />
                 </Grid>
             </ScrollViewer>
         </Grid>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -32,6 +32,47 @@
         <Converters:LayoutModelTypeBlankToVisibilityConverter x:Key="LayoutModelTypeBlankToVisibilityConverter" />
         <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
 
+        <ContextMenu x:Key="LayoutContextMenu" Visibility="{Binding Path=Type, Converter={StaticResource LayoutModelTypeBlankToVisibilityConverter}}">
+            <MenuItem Header="{x:Static props:Resources.Edit}"
+                      Click="EditLayout_Click">
+                <MenuItem.Icon>
+                    <ui:FontIcon Glyph="&#xE104;" />
+                </MenuItem.Icon>
+            </MenuItem>
+            <MenuItem Header="{x:Static props:Resources.Edit_zones}"
+                      Visibility="{Binding Path=Type, Converter={StaticResource LayoutTypeCustomToVisibilityConverter}}"
+                      Click="EditZones_Click">
+                <MenuItem.Icon>
+                    <ui:FontIcon Glyph="&#xED35;" />
+                </MenuItem.Icon>
+            </MenuItem>
+
+
+            <MenuItem Header="{x:Static props:Resources.Duplicate}"
+                      Click="DuplicateLayout_Click"
+                      Visibility="{Binding Path=Type, Converter={StaticResource LayoutTypeCustomToVisibilityConverter}}">
+                <MenuItem.Icon>
+                    <ui:FontIcon Glyph="&#xE8C8;" />
+                </MenuItem.Icon>
+            </MenuItem>
+
+            <MenuItem Header="{x:Static props:Resources.Create_Custom_From_Template}"
+                      Click="DuplicateLayout_Click"
+                      Visibility="{Binding Path=Type, Converter={StaticResource LayoutTypeTemplateToVisibilityConverter}}">
+                <MenuItem.Icon>
+                    <ui:FontIcon Glyph="&#xE8C8;" />
+                </MenuItem.Icon>
+            </MenuItem>
+            <Separator Visibility="{Binding Path=Type, Converter={StaticResource LayoutTypeCustomToVisibilityConverter}}" />
+            <MenuItem Header="{x:Static props:Resources.Delete}"
+                      Click="DeleteLayout_Click"
+                      Visibility="{Binding Path=Type, Converter={StaticResource LayoutTypeCustomToVisibilityConverter}}">
+                <MenuItem.Icon>
+                    <ui:FontIcon Glyph="&#xE107;" />
+                </MenuItem.Icon>
+            </MenuItem>
+        </ContextMenu>
+        
         <DataTemplate x:Key="MonitorItemTemplate">
             <Border x:Name="MonitorItem"
                     Width="{Binding DisplayWidth}"
@@ -77,49 +118,7 @@
         </DataTemplate>
 
         <DataTemplate x:Key="LayoutItemTemplate">
-            <Grid  Background="Transparent">
-                <Grid.ContextMenu>
-                    <ContextMenu Visibility="{Binding Path=Type, Converter={StaticResource LayoutModelTypeBlankToVisibilityConverter}}">
-                        <MenuItem Header="{x:Static props:Resources.Edit}"
-                                  Click="EditLayout_Click">
-                            <MenuItem.Icon>
-                                <ui:FontIcon Glyph="&#xE104;" />
-                            </MenuItem.Icon>
-                        </MenuItem>
-                        <MenuItem Header="{x:Static props:Resources.Edit_zones}"
-                                  Visibility="{Binding Path=Type, Converter={StaticResource LayoutTypeCustomToVisibilityConverter}}"
-                                  Click="EditZones_Click">
-                            <MenuItem.Icon>
-                                <ui:FontIcon Glyph="&#xED35;" />
-                            </MenuItem.Icon>
-                        </MenuItem>
-
-                       
-                        <MenuItem Header="{x:Static props:Resources.Duplicate}"
-                                  Click="DuplicateLayout_Click"
-                                  Visibility="{Binding Path=Type, Converter={StaticResource LayoutTypeCustomToVisibilityConverter}}">
-                            <MenuItem.Icon>
-                                <ui:FontIcon Glyph="&#xE8C8;" />
-                            </MenuItem.Icon>
-                        </MenuItem>
-
-                        <MenuItem Header="{x:Static props:Resources.Create_Custom_From_Template}"
-                                  Click="DuplicateLayout_Click"
-                                  Visibility="{Binding Path=Type, Converter={StaticResource LayoutTypeTemplateToVisibilityConverter}}">
-                            <MenuItem.Icon>
-                                <ui:FontIcon Glyph="&#xE8C8;" />
-                            </MenuItem.Icon>
-                        </MenuItem>
-                        <Separator Visibility="{Binding Path=Type, Converter={StaticResource LayoutTypeCustomToVisibilityConverter}}" />
-                        <MenuItem Header="{x:Static props:Resources.Delete}"
-                                  Click="DeleteLayout_Click"
-                                  Visibility="{Binding Path=Type, Converter={StaticResource LayoutTypeCustomToVisibilityConverter}}">
-                            <MenuItem.Icon>
-                                <ui:FontIcon Glyph="&#xE107;" />
-                            </MenuItem.Icon>
-                        </MenuItem>
-                    </ContextMenu>
-                </Grid.ContextMenu>
+            <Grid Background="Transparent">
                 <Grid
                       Width="180"
                       Height="140"
@@ -197,10 +196,16 @@
                                  IsItemClickEnabled="True"
                                  SelectionMode="Single"
                                  IsSelectionEnabled="True"
-                                 ItemContainerStyle="{StaticResource LayoutItemContainerStyle}"
                                  ItemClick="Layout_ItemClick"
                                  Margin="-8,8,-8,0">
-                     
+                        <ui:GridView.ItemContainerStyle>
+                            <Style BasedOn="{StaticResource LayoutItemContainerStyle}"
+                                   TargetType="ui:GridViewItem">
+                                <Setter Property="ContextMenu"
+                                        Value="{StaticResource LayoutContextMenu}">
+                                </Setter>
+                            </Style>
+                        </ui:GridView.ItemContainerStyle>
                     </ui:GridView>
 
                     <TextBlock Text="{x:Static props:Resources.Custom}"
@@ -245,9 +250,17 @@
                                  IsItemClickEnabled="True"
                                  ItemClick="Layout_ItemClick"
                                  AutomationProperties.LabeledBy="{Binding ElementName=CustomHeaderBlock}"
-                                 ItemContainerStyle="{StaticResource LayoutItemContainerStyle}"
                                  Margin="-8,8,-8,0"
-                                 Grid.Row="4" />
+                                 Grid.Row="4">
+                        <ui:GridView.ItemContainerStyle>
+                            <Style BasedOn="{StaticResource LayoutItemContainerStyle}"
+                                   TargetType="ui:GridViewItem">
+                                <Setter Property="ContextMenu"
+                                        Value="{StaticResource LayoutContextMenu}">
+                                </Setter>
+                            </Style>
+                        </ui:GridView.ItemContainerStyle>
+                    </ui:GridView>
 
 
                 </Grid>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -32,36 +32,7 @@
         <Converters:LayoutModelTypeBlankToVisibilityConverter x:Key="LayoutModelTypeBlankToVisibilityConverter" />
         <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
         
-        <DropShadowEffect x:Key="CardShadow" BlurRadius="6"
-                          Opacity="0.24"
-                          ShadowDepth="1" />
 
-        <Style x:Key="CardStyle"
-               TargetType="Border">
-            <Setter Property="Background"
-                    Value="{DynamicResource LayoutItemBackgroundBrush}" />
-            <Setter Property="BorderBrush"
-                    Value="{DynamicResource LayoutItemBackgroundBrush}" />
-            <Setter Property="BorderThickness"
-                    Value="2" />
-            <Setter Property="CornerRadius"
-                    Value="4" />
-            <Setter Property="Focusable"
-                    Value="True" />
-            <Setter Property="FocusVisualStyle"
-                    Value="{StaticResource UWPFocusVisualStyle}" />
-            <Setter Property="Border.Effect"
-                    Value="{StaticResource CardShadow}" />
-            <Style.Triggers>
-                <Trigger Property="Border.IsMouseOver"
-                         Value="True">
-                    <Setter Property="Border.Background"
-                            Value="{DynamicResource LayoutItemBackgroundPointerOverBrush}" />
-                    <Setter Property="Border.BorderBrush"
-                            Value="{DynamicResource LayoutItemBackgroundPointerOverBrush}" />
-                </Trigger>
-            </Style.Triggers>
-        </Style>
 
         <DataTemplate x:Key="MonitorItemTemplate">
             <Border x:Name="MonitorItem"
@@ -72,7 +43,7 @@
                     Margin="8,2,8,8"
                     KeyDown="MonitorItem_KeyDown"
                     MouseDown="MonitorItem_MouseDown"
-                    Style="{StaticResource CardStyle}">
+                   >
                 <Border.ToolTip>
                     <ToolTip>
                         <StackPanel>
@@ -124,22 +95,22 @@
             </DataTemplate.Triggers>
         </DataTemplate>
 
-
-       
-
+        <DataTemplate x:Key="SimpleItemTemplate">
+            <Grid Background="Red"
+                  AutomationProperties.Name="Woehoe">
+                <TextBlock Text="{Binding Name}"
+                           AutomationProperties.Name="Woehoe" />
+            </Grid>
+        </DataTemplate>
+        
         <DataTemplate x:Key="LayoutItemTemplate">
             <Grid Background="Transparent"
                   Width="216"
-                  KeyDown="LayoutItem_KeyDown"
-                  MouseDown="LayoutItem_Click"
-                  Margin="0,0,0,12">
-
+                  AutomationProperties.Name="Woehoe"
+                  Height="172">
                 <Border x:Name="LayoutItem"
-                        Style="{StaticResource CardStyle}"
-                        Margin="8"
-                        FocusManager.GotFocus="LayoutItem_Focused">
-
-                    <Grid Margin="16">
+                        Margin="16">
+                    <Grid>
                         <Grid.RowDefinitions>
                             <RowDefinition Height="24" />
                             <RowDefinition Height="124" />
@@ -156,30 +127,8 @@
                                    Margin="0,-4,24,0"
                                    ToolTip="{Binding Name}"
                                    Foreground="{DynamicResource PrimaryForegroundBrush}" />
-
-                        <Button Content="&#xE104;"
-                                x:Name="EditLayoutButton"
-                                FontFamily="Segoe MDL2 Assets"
-                                FontSize="14"
-                                HorizontalAlignment="Right"
-                                VerticalAlignment="Bottom"
-                                Margin="-8,-16,-8,0"
-                                Height="36"
-                                Width="36"
-                                Padding="0"
-                                BorderBrush="Transparent"
-                                Click="EditLayout_Click"
-                                Background="Transparent"
-                                Visibility="{Binding Path=Type, Converter={StaticResource LayoutModelTypeBlankToVisibilityConverter}}"
-                                Foreground="{DynamicResource PrimaryForegroundBrush}"
-                                ToolTip="{x:Static props:Resources.Edit_Layout}"
-                                AutomationProperties.Name="{x:Static props:Resources.Edit_Layout}"
-                                Style="{StaticResource AccentButtonStyle}"
-                                ui:ControlHelper.CornerRadius="36">
-                        </Button>
-
                         <local:LayoutPreview Grid.Row="1"
-                                             Margin="0,8,0,8"
+                                             Margin="0,8,0,8" 
                                              VerticalAlignment="Stretch"
                                              HorizontalAlignment="Stretch" />
                     </Grid>
@@ -187,9 +136,29 @@
                 <Border x:Name="SelectionHighlight"
                         CornerRadius="4"
                         BorderThickness="3"
-                        Margin="6"
+                        Margin="0"
                         Visibility="Collapsed"
                         BorderBrush="{DynamicResource SystemControlBackgroundAccentBrush}" />
+
+                <Button Content="&#xE104;"
+                        x:Name="EditLayoutButton"
+                        FontFamily="Segoe MDL2 Assets"
+                        FontSize="14"
+                        HorizontalAlignment="Right"
+                        VerticalAlignment="Top"
+                        Margin="4           "
+                        Height="36"
+                        Width="36"
+                        Padding="0"
+                        BorderBrush="Transparent"
+                        Click="EditLayout_Click"
+                        Background="Transparent"
+                        Visibility="{Binding Path=Type, Converter={StaticResource LayoutModelTypeBlankToVisibilityConverter}}"
+                        Foreground="{DynamicResource PrimaryForegroundBrush}"
+                        ToolTip="{x:Static props:Resources.Edit_Layout}"
+                        AutomationProperties.Name="{x:Static props:Resources.Edit_Layout}"
+                        Style="{StaticResource AccentButtonStyle}"
+                        ui:ControlHelper.CornerRadius="36" />
             </Grid>
             <DataTemplate.Triggers>
                 <DataTrigger Binding="{Binding IsApplied}"
@@ -213,6 +182,117 @@
                 </DataTrigger>
             </DataTemplate.Triggers>
         </DataTemplate>
+
+        <Style x:Key="GridViewCardStyle" TargetType="ui:GridViewItem">
+            <Setter Property="Background"
+                    Value="Transparent" />
+            <Setter Property="Foreground"
+                    Value="{DynamicResource SystemControlForegroundBaseHighBrush}" />
+            <Setter Property="KeyboardNavigation.TabNavigation"
+                    Value="Local" />
+            <!--<Setter Property="IsHoldingEnabled" Value="True" />-->
+            <Setter Property="Margin"
+                    Value="8" />
+            <Setter Property="FocusVisualStyle"
+                    Value="{StaticResource UWPFocusVisualStyle}" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="ui:GridViewItem">
+                        <Border x:Name="ContentBorder"
+                                CornerRadius="4"
+                                Padding="0"
+                                AutomationProperties.Name="Woehoe"
+                                Background="{StaticResource LayoutItemBackgroundBrush}"
+                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                            <Border.Effect>
+                                <DropShadowEffect BlurRadius="6"
+                                                  Opacity="0.24"
+                                                  ShadowDepth="1" />
+                            </Border.Effect>
+                            <VisualStateManager.CustomVisualStateManager>
+                                <ui:SimpleVisualStateManager />
+                            </VisualStateManager.CustomVisualStateManager>
+                            <Grid>
+                                <ContentPresenter x:Name="ContentPresenter"
+                                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                  Margin="0"
+                                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                            </Grid>
+                        </Border>
+                        <ControlTemplate.Triggers>
+
+                            <!-- PointerOver -->
+                            <MultiTrigger>
+                                <MultiTrigger.Conditions>
+                                    <Condition Property="IsMouseOver"
+                                               Value="True" />
+                                    <Condition Property="IsSelected"
+                                               Value="False" />
+                                </MultiTrigger.Conditions>
+                                <Setter Property="Background"
+                                        TargetName="ContentBorder"
+                                        Value="{DynamicResource LayoutItemBackgroundPointerOverBrush}" />
+                                <Setter Property="BorderBrush"
+                                        TargetName="ContentBorder"
+                                        Value="{DynamicResource LayoutItemBackgroundPointerOverBrush}" />
+                 
+                            </MultiTrigger>
+                            <!-- Selected -->
+                            <MultiTrigger>
+                                <MultiTrigger.Conditions>
+                                    <Condition Property="IsMouseOver"
+                                               Value="False" />
+                                    <Condition Property="IsSelected"
+                                               Value="True" />
+                                </MultiTrigger.Conditions>
+
+                            </MultiTrigger>
+                            <!-- PointerOverSelected -->
+                            <MultiTrigger>
+                                <MultiTrigger.Conditions>
+                                    <Condition Property="IsMouseOver"
+                                               Value="True" />
+                                    <Condition Property="IsSelected"
+                                               Value="True" />
+                                </MultiTrigger.Conditions>
+                                <Setter Property="Background"
+                                        TargetName="ContentBorder"
+                                        Value="{DynamicResource LayoutItemBackgroundPointerOverBrush}" />
+                                <Setter Property="BorderBrush"
+                                        TargetName="ContentBorder"
+                                        Value="{DynamicResource LayoutItemBackgroundPointerOverBrush}" />
+                   
+
+                            </MultiTrigger>
+                            <!-- Disabled -->
+                            <Trigger Property="IsEnabled"
+                                     Value="False">
+                                <Setter TargetName="ContentBorder"
+                                        Property="Opacity"
+                                        Value="{DynamicResource ListViewItemDisabledThemeOpacity}" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     </Window.Resources>
 
     <Grid>
@@ -240,20 +320,32 @@
                                FontWeight="SemiBold"
                                FontSize="24" />
 
-                    <ItemsControl ItemsSource="{Binding DefaultModels}"
-                                  Grid.Row="1"
-                                  ItemTemplate="{StaticResource LayoutItemTemplate}"
-                                  AutomationProperties.LabeledBy="{Binding ElementName=TemplatesHeaderBlock}"
-                                  TabIndex="4"
-                                  x:Name="DefaultModelsItemsControl"
-                                  Margin="-8,8,-8,0">
-                        <ItemsControl.ItemsPanel>
-                            <ItemsPanelTemplate>
-                                <WrapPanel Orientation="Horizontal"
-                                           x:Name="DefaultModelsWrapPanel" />
-                            </ItemsPanelTemplate>
-                        </ItemsControl.ItemsPanel>
-                    </ItemsControl>
+                    <ui:GridView ItemsSource="{Binding DefaultModels}"
+                                 Grid.Row="1"
+                                 ItemTemplate="{StaticResource SimpleItemTemplate}"
+                                 AutomationProperties.LabeledBy="{Binding ElementName=TemplatesHeaderBlock}"
+                                 TabIndex="4"
+                                 IsItemClickEnabled="True"
+                                 SelectionMode="Single"
+                                 SelectedIndex="1"
+                            
+                                 ItemClick="DefaultModelsItemsControl_ItemClick"
+                                 x:Name="DefaultModelsItemsControl"
+                                 Margin="-8,8,-8,0"
+                                
+                                 
+                                 >
+                        <!--ItemContainerStyle="{StaticResource GridViewCardStyle}"-->
+                        <!--<ui:GridView.ItemContainerStyle>
+                            <Style TargetType="ui:GridViewItem">
+                                <Setter Property="Margin"
+                                        Value="0" />
+                             
+                                <Setter Property="FocusVisualStyle"
+                                        Value="{StaticResource UWPFocusVisualStyle}" />
+                            </Style>
+                        </ui:GridView.ItemContainerStyle>-->
+                    </ui:GridView>
 
                     <TextBlock Text="{x:Static props:Resources.Custom}"
                                x:Name="CustomHeaderBlock"
@@ -289,19 +381,17 @@
                             Data="M45,48H25.5V45H45V25.5H25.5v-3H45V3H25.5V0H48V48ZM22.5,48H3V45H22.5V3H3V0H25.5V48ZM0,48V0H3V48Z" />
                         <TextBlock Text="{x:Static props:Resources.No_Custom_Layouts_Message}" Margin="0,16,0,0" Foreground="{DynamicResource SecondaryForegroundBrush}" />
                     </StackPanel>
-                    <ItemsControl ItemsSource="{Binding CustomModels}"
+                    <ui:GridView ItemsSource="{Binding CustomModels}"
                                   TabIndex="6"
-                                  AutomationProperties.LabeledBy="{Binding ElementName=CustomHeaderBlock}"
+                                 IsItemClickEnabled="True"
+                                 SelectionMode="Single"
+                                 ItemClick="DefaultModelsItemsControl_ItemClick"
+                                 AutomationProperties.LabeledBy="{Binding ElementName=CustomHeaderBlock}"
                                   ItemTemplate="{StaticResource LayoutItemTemplate}"
+                                 ItemContainerStyle="{StaticResource GridViewCardStyle}"
                                   Margin="-8,12,-8,0"
                                   Grid.Row="4">
-                        <ItemsControl.ItemsPanel>
-                            <ItemsPanelTemplate>
-                                <WrapPanel Orientation="Horizontal"
-                                           x:Name="CustomModelsWrapPanel" />
-                            </ItemsPanelTemplate>
-                        </ItemsControl.ItemsPanel>
-                    </ItemsControl>
+                    </ui:GridView>
                    
                 </Grid>
             </ScrollViewer>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -254,6 +254,8 @@ namespace FancyZonesEditor
 
         private void EditZones_Click(object sender, RoutedEventArgs e)
         {
+            var dataContext = ((FrameworkElement)sender).DataContext;
+            Select((LayoutModel)dataContext);
             EditLayoutDialog.Hide();
             var mainEditor = App.Overlay;
             if (!(mainEditor.CurrentDataContext is LayoutModel model))

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -325,19 +325,6 @@ namespace FancyZonesEditor
             InvalidateVisual();
         }
 
-        private void MonitorItem_KeyDown(object sender, KeyEventArgs e)
-        {
-            if (e.Key == Key.Return || e.Key == Key.Space)
-            {
-                monitorViewModel.SelectCommand.Execute((MonitorInfoModel)(sender as Border).DataContext);
-            }
-        }
-
-        private void MonitorItem_MouseDown(object sender, MouseButtonEventArgs e)
-        {
-            monitorViewModel.SelectCommand.Execute((MonitorInfoModel)(sender as Border).DataContext);
-        }
-
         // EditLayout: Cancel changes
         private void EditLayoutDialog_SecondaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
         {
@@ -373,12 +360,12 @@ namespace FancyZonesEditor
 
         private async void DeleteLayout(FrameworkElement element)
         {
-            var dialog = new ModernWpf.Controls.ContentDialog()
+            var dialog = new ContentDialog()
             {
-                Title = FancyZonesEditor.Properties.Resources.Are_You_Sure,
-                Content = FancyZonesEditor.Properties.Resources.Are_You_Sure_Description,
-                PrimaryButtonText = FancyZonesEditor.Properties.Resources.Delete,
-                SecondaryButtonText = FancyZonesEditor.Properties.Resources.Cancel,
+                Title = Properties.Resources.Are_You_Sure,
+                Content = Properties.Resources.Are_You_Sure_Description,
+                PrimaryButtonText = Properties.Resources.Delete,
+                SecondaryButtonText = Properties.Resources.Cancel,
             };
 
             var result = await dialog.ShowAsync();
@@ -424,11 +411,15 @@ namespace FancyZonesEditor
             }
         }
 
-        private void DefaultModelsItemsControl_ItemClick(object sender, ItemClickEventArgs e)
+        private void Layout_ItemClick(object sender, ItemClickEventArgs e)
         {
-            LayoutModel selectedLayoutModel = e.ClickedItem as LayoutModel;
-            Select(selectedLayoutModel);
+            Select(e.ClickedItem as LayoutModel);
             Apply();
+        }
+
+        private void Monitor_ItemClick(object sender, ItemClickEventArgs e)
+        {
+            monitorViewModel.SelectCommand.Execute(e.ClickedItem as MonitorInfoModel);
         }
     }
 }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -104,13 +104,6 @@ namespace FancyZonesEditor
             // Select(((Grid)sender).DataContext as LayoutModel);
         }
 
-        private void LayoutItem_Click(object sender, MouseButtonEventArgs e)
-        {
-            LayoutModel selectedLayoutModel = ((Grid)sender).DataContext as LayoutModel;
-            Select(selectedLayoutModel);
-            Apply();
-        }
-
         private void LayoutItem_Focused(object sender, RoutedEventArgs e)
         {
             // Ignore focus on Edit button click
@@ -429,6 +422,13 @@ namespace FancyZonesEditor
             {
                 e.Handled = true;
             }
+        }
+
+        private void DefaultModelsItemsControl_ItemClick(object sender, ItemClickEventArgs e)
+        {
+            LayoutModel selectedLayoutModel = e.ClickedItem as LayoutModel;
+            Select(selectedLayoutModel);
+            Apply();
         }
     }
 }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
@@ -286,7 +286,7 @@ namespace FancyZonesEditor.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Edit zones layout.
+        ///   Looks up a localized string similar to Edit zones.
         /// </summary>
         public static string Edit_zones {
             get {

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
@@ -286,7 +286,7 @@ namespace FancyZonesEditor.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Edit zone layout.
+        ///   Looks up a localized string similar to Edit zones layout.
         /// </summary>
         public static string Edit_zones {
             get {

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
@@ -292,7 +292,7 @@
     <value>Are you sure you want to delete this layout?</value>
   </data>
   <data name="Edit_zones" xml:space="preserve">
-    <value>Edit zones layout</value>
+    <value>Edit zones</value>
   </data>
   <data name="No_Custom_Layouts_Message" xml:space="preserve">
     <value>Create or duplicate a layout to get started</value>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
@@ -148,9 +148,6 @@
     <value>Highlight distance</value>
     <comment>Distance of when an adjacent zone should light up when the window is close to it</comment>
   </data>
-  <data name="Edit_Layout" xml:space="preserve">
-    <value>Edit layout</value>
-  </data>
   <data name="Fancy_Zones_Editor_App_Title" xml:space="preserve">
     <value>FancyZones Editor</value>
   </data>
@@ -295,7 +292,7 @@
     <value>Are you sure you want to delete this layout?</value>
   </data>
   <data name="Edit_zones" xml:space="preserve">
-    <value>Edit zone layout</value>
+    <value>Edit zones layout</value>
   </data>
   <data name="No_Custom_Layouts_Message" xml:space="preserve">
     <value>Create or duplicate a layout to get started</value>
@@ -359,5 +356,8 @@
   </data>
   <data name="QuickKey_Title" xml:space="preserve">
     <value>Layout shortcut</value>
+  </data>
+  <data name="Edit_Layout" xml:space="preserve">
+    <value>Edit layout</value>
   </data>
 </root>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Styles/GridViewStyles.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Styles/GridViewStyles.xaml
@@ -1,0 +1,337 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:ui="http://schemas.modernwpf.com/2019">
+
+    <Style x:Key="UWPFocusVisualStyle">
+        <Setter Property="Control.Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <Border Margin="-2"
+                            CornerRadius="4"
+                            BorderThickness="2"
+                            BorderBrush="{DynamicResource PrimaryForegroundBrush}" />
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+    
+    <DropShadowEffect x:Key="CardDropShadow"
+                      BlurRadius="6"
+                      Opacity="0.24"
+                      ShadowDepth="1" />
+
+    <Style x:Key="MonitorItemContainerStyle"
+           TargetType="ui:GridViewItem">
+        <Setter Property="Background"
+                Value="{DynamicResource LayoutItemBackgroundBrush}" />
+        <Setter Property="IsSelected"
+                Value="{Binding Selected, Mode=OneWay}" />
+        <Setter Property="AutomationProperties.Name"
+                Value="{Binding Index}" />
+        <Setter Property="KeyboardNavigation.TabNavigation"
+                Value="Local" />
+        <Setter Property="MinWidth"
+                Value="0" />
+        <Setter Property="MinHeight"
+                Value="0" />
+        <!--<Setter Property="IsHoldingEnabled" Value="True" />-->
+        <Setter Property="CornerRadius"
+                Value="4" />
+        <Setter Property="Margin"
+                Value="8" />
+        <Setter Property="UseSystemFocusVisuals"
+                Value="{DynamicResource UseSystemFocusVisuals}" />
+        <Setter Property="FocusVisualMargin"
+                Value="-2" />
+        <Setter Property="FocusVisualStyle"
+                Value="{DynamicResource UWPFocusVisualStyle}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ui:GridViewItem">
+                    <Border x:Name="ContentBorder"
+                            Height="{Binding DisplayHeight}"
+                            Width="{Binding DisplayWidth}"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{TemplateBinding CornerRadius}"
+                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                            Effect="{StaticResource CardDropShadow}">
+                        <VisualStateManager.CustomVisualStateManager>
+                            <ui:SimpleVisualStateManager />
+                        </VisualStateManager.CustomVisualStateManager>
+
+                        <Grid>
+                            <ContentPresenter x:Name="ContentPresenter"
+                                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                              Margin="{TemplateBinding Padding}"
+                                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                            <Border x:Name="BorderRectangle"
+                                    IsHitTestVisible="False"
+                                    BorderBrush="{DynamicResource SystemControlHighlightListAccentLowBrush}"
+                                    BorderThickness="2"
+                                    CornerRadius="4"
+                                    Opacity="0" />
+                        </Grid>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <!-- Focused -->
+                        <Trigger Property="ui:FocusVisualHelper.ShowFocusVisual"
+                                 Value="True">
+                            <Setter TargetName="BorderRectangle"
+                                    Property="Visibility"
+                                    Value="Collapsed" />
+                        </Trigger>
+
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Selected}"
+                                           Value="True" />
+
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="ContentPresenter"
+                                    Property="TextElement.Foreground"
+                                    Value="{DynamicResource SystemControlHighlightAccentBrush}" />
+                            <Setter TargetName="BorderRectangle"
+                                    Property="Opacity"
+                                    Value="1" />
+                            <Setter TargetName="BorderRectangle"
+                                    Property="BorderBrush"
+                                    Value="{DynamicResource SystemControlHighlightAccentBrush}" />
+                        </MultiDataTrigger>
+
+                        <!-- PointerOver -->
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsMouseOver"
+                                           Value="True" />
+                                <Condition Property="IsSelected"
+                                           Value="False" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="BorderRectangle"
+                                    Property="Opacity"
+                                    Value="1" />
+                            <Setter TargetName="BorderRectangle"
+                                    Property="BorderBrush"
+                                    Value="{DynamicResource SystemControlHighlightListLowBrush}" />
+                            <Setter TargetName="ContentPresenter"
+                                    Property="TextElement.Foreground"
+                                    Value="{DynamicResource SystemControlForegroundBaseHighBrush}" />
+                            <Setter Property="ui:FocusVisualHelper.FocusVisualSecondaryBrush"
+                                    Value="{DynamicResource SystemControlHighlightListLowBrush}" />
+                            <Setter Property="ui:FocusVisualHelper.FocusVisualSecondaryThickness"
+                                    Value="2" />
+                        </MultiTrigger>
+                        <!-- Selected -->
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsMouseOver"
+                                           Value="False" />
+                                <Condition Property="IsSelected"
+                                           Value="True" />
+                            </MultiTrigger.Conditions>
+
+                            <!--<Setter TargetName="BorderRectangle"
+                                        Property="Opacity"
+                                        Value="1" />
+                                <Setter TargetName="BorderRectangle"
+                                        Property="Stroke"
+                                        Value="{DynamicResource SystemControlHighlightAccentBrush}" />
+                                <Setter TargetName="ContentPresenter"
+                                        Property="TextElement.Foreground"
+                                        Value="{DynamicResource SystemControlHighlightAccentBrush}" />
+                                <Setter Property="ui:FocusVisualHelper.FocusVisualSecondaryBrush"
+                                        Value="{DynamicResource SystemControlHighlightAccentBrush}" />
+                                <Setter Property="ui:FocusVisualHelper.FocusVisualSecondaryThickness"
+                                        Value="2" />-->
+
+                        </MultiTrigger>
+                        <!-- PointerOverSelected -->
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsMouseOver"
+                                           Value="True" />
+                                <Condition Property="IsSelected"
+                                           Value="True" />
+                            </MultiTrigger.Conditions>
+
+                            <Setter TargetName="BorderRectangle"
+                                    Property="Opacity"
+                                    Value="1" />
+                            <Setter TargetName="BorderRectangle"
+                                    Property="BorderBrush"
+                                    Value="{DynamicResource SystemControlHighlightListAccentMediumBrush}" />
+                            <Setter Property="ui:FocusVisualHelper.FocusVisualSecondaryBrush"
+                                    Value="{DynamicResource SystemControlHighlightListAccentMediumBrush}" />
+                            <Setter Property="ui:FocusVisualHelper.FocusVisualSecondaryThickness"
+                                    Value="2" />
+
+                        </MultiTrigger>
+                        <!-- Disabled -->
+                        <Trigger Property="IsEnabled"
+                                 Value="False">
+                            <Setter TargetName="ContentBorder"
+                                    Property="Opacity"
+                                    Value="{DynamicResource ListViewItemDisabledThemeOpacity}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+    <Style x:Key="LayoutItemContainerStyle"
+           TargetType="ui:GridViewItem">
+        <Setter Property="Background"
+                Value="{DynamicResource LayoutItemBackgroundBrush}" />
+        <Setter Property="IsSelected"
+                Value="{Binding IsApplied, Mode=OneWay}" />
+        <Setter Property="AutomationProperties.Name"
+                Value="{Binding Name}" />
+        <Setter Property="KeyboardNavigation.TabNavigation"
+                Value="Local" />
+        <!--<Setter Property="IsHoldingEnabled" Value="True" />-->
+        <Setter Property="CornerRadius"
+                Value="4" />
+        <Setter Property="Margin"
+                Value="8" />
+        <Setter Property="UseSystemFocusVisuals"
+                Value="{DynamicResource UseSystemFocusVisuals}" />
+        <Setter Property="FocusVisualMargin"
+                Value="-2" />
+        <Setter Property="FocusVisualStyle"
+                Value="{DynamicResource UWPFocusVisualStyle}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ui:GridViewItem">
+                    <Border x:Name="ContentBorder"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{TemplateBinding CornerRadius}"
+                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                            Effect="{StaticResource CardDropShadow}">
+                        <VisualStateManager.CustomVisualStateManager>
+                            <ui:SimpleVisualStateManager />
+                        </VisualStateManager.CustomVisualStateManager>
+
+                        <Grid>
+                            <ContentPresenter x:Name="ContentPresenter"
+                                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                              Margin="{TemplateBinding Padding}"
+                                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                            <Border x:Name="BorderRectangle"
+                                    IsHitTestVisible="False"
+                                    BorderBrush="{DynamicResource SystemControlHighlightListAccentLowBrush}"
+                                    BorderThickness="2"
+                                    CornerRadius="4"
+                                    Opacity="0" />
+                        </Grid>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <!-- Focused -->
+                        <Trigger Property="ui:FocusVisualHelper.ShowFocusVisual"
+                                 Value="True">
+                            <Setter TargetName="BorderRectangle"
+                                    Property="Visibility"
+                                    Value="Collapsed" />
+                        </Trigger>
+
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsApplied}"
+                                           Value="True" />
+
+                            </MultiDataTrigger.Conditions>
+                            <Setter TargetName="ContentPresenter"
+                                    Property="TextElement.Foreground"
+                                    Value="{DynamicResource SystemControlHighlightAccentBrush}" />
+                            <Setter TargetName="BorderRectangle"
+                                    Property="Opacity"
+                                    Value="1" />
+                            <Setter TargetName="BorderRectangle"
+                                    Property="BorderBrush"
+                                    Value="{DynamicResource SystemControlHighlightAccentBrush}" />
+                        </MultiDataTrigger>
+
+                        <!-- PointerOver -->
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsMouseOver"
+                                           Value="True" />
+                                <Condition Property="IsSelected"
+                                           Value="False" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="BorderRectangle"
+                                    Property="Opacity"
+                                    Value="1" />
+                            <Setter TargetName="BorderRectangle"
+                                    Property="BorderBrush"
+                                    Value="{DynamicResource SystemControlHighlightListLowBrush}" />
+                            <Setter TargetName="ContentPresenter"
+                                    Property="TextElement.Foreground"
+                                    Value="{DynamicResource SystemControlForegroundBaseHighBrush}" />
+                            <Setter Property="ui:FocusVisualHelper.FocusVisualSecondaryBrush"
+                                    Value="{DynamicResource SystemControlHighlightListLowBrush}" />
+                            <Setter Property="ui:FocusVisualHelper.FocusVisualSecondaryThickness"
+                                    Value="2" />
+                        </MultiTrigger>
+                        <!-- Selected -->
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsMouseOver"
+                                           Value="False" />
+                                <Condition Property="IsSelected"
+                                           Value="True" />
+                            </MultiTrigger.Conditions>
+
+                            <!--<Setter TargetName="BorderRectangle"
+                                        Property="Opacity"
+                                        Value="1" />
+                                <Setter TargetName="BorderRectangle"
+                                        Property="Stroke"
+                                        Value="{DynamicResource SystemControlHighlightAccentBrush}" />
+                                <Setter TargetName="ContentPresenter"
+                                        Property="TextElement.Foreground"
+                                        Value="{DynamicResource SystemControlHighlightAccentBrush}" />
+                                <Setter Property="ui:FocusVisualHelper.FocusVisualSecondaryBrush"
+                                        Value="{DynamicResource SystemControlHighlightAccentBrush}" />
+                                <Setter Property="ui:FocusVisualHelper.FocusVisualSecondaryThickness"
+                                        Value="2" />-->
+
+                        </MultiTrigger>
+                        <!-- PointerOverSelected -->
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsMouseOver"
+                                           Value="True" />
+                                <Condition Property="IsSelected"
+                                           Value="True" />
+                            </MultiTrigger.Conditions>
+
+                            <Setter TargetName="BorderRectangle"
+                                    Property="Opacity"
+                                    Value="1" />
+                            <Setter TargetName="BorderRectangle"
+                                    Property="BorderBrush"
+                                    Value="{DynamicResource SystemControlHighlightListAccentMediumBrush}" />
+                            <Setter Property="ui:FocusVisualHelper.FocusVisualSecondaryBrush"
+                                    Value="{DynamicResource SystemControlHighlightListAccentMediumBrush}" />
+                            <Setter Property="ui:FocusVisualHelper.FocusVisualSecondaryThickness"
+                                    Value="2" />
+
+                        </MultiTrigger>
+                        <!-- Disabled -->
+                        <Trigger Property="IsEnabled"
+                                 Value="False">
+                            <Setter TargetName="ContentBorder"
+                                    Property="Opacity"
+                                    Value="{DynamicResource ListViewItemDisabledThemeOpacity}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+</ResourceDictionary>


### PR DESCRIPTION
## Summary of the Pull Request

**THIS PR SHOULD BE MERGED IN BEFORE: #11047**


This PR replaces the ItemsControls (showing the monitors and layouts) with a ModernWPF GridView. This comes with the following advantages:

- Keyboard navigation is way better now and inline with Windows standards (Tab for moving between GridViews, arrow to move around between layouts)
- Solving a bunch of narrator issues.
- Mouse-over visual now inline with WinUI.
- Right-mouse context menu added (since we no longer have the MouseDown event to trigger the layout)

Final result:
![AccesibilityFZeditor](https://user-images.githubusercontent.com/9866362/116825327-14a59100-ab8f-11eb-92dd-b9107020f1ef.gif)


## Quality Checklist

- [X] **Linked issue:** #10842, #10841, #10784
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
