### PR TITLE
[FZ Editor] Double-click layout to close editor

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -197,6 +197,7 @@
                                  SelectionMode="Single"
                                  IsSelectionEnabled="True"
                                  ItemClick="Layout_ItemClick"
+                                 MouseDoubleClick="LayoutItem_MouseDoubleClick"
                                  Margin="-8,8,-8,0">
                         <ui:GridView.ItemContainerStyle>
                             <Style BasedOn="{StaticResource LayoutItemContainerStyle}"
@@ -249,6 +250,7 @@
                                  SelectionMode="Single"
                                  IsItemClickEnabled="True"
                                  ItemClick="Layout_ItemClick"
+                                 MouseDoubleClick="LayoutItem_MouseDoubleClick"
                                  AutomationProperties.LabeledBy="{Binding ElementName=CustomHeaderBlock}"
                                  Margin="-8,8,-8,0"
                                  Grid.Row="4">

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -60,14 +60,24 @@ namespace FancyZonesEditor
         {
             if (e.Key == Key.Escape)
             {
-                if (_openedDialog != null)
-                {
-                    _openedDialog.Hide();
-                }
-                else
-                {
-                    OnClosing(sender, null);
-                }
+                CloseDialog(sender);
+            }
+        }
+
+        private void LayoutItem_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            CloseDialog(sender);
+        }
+
+        private void CloseDialog(object sender)
+        {
+            if (_openedDialog != null)
+            {
+                _openedDialog.Hide();
+            }
+            else
+            {
+                OnClosing(sender, null);
             }
         }
 


### PR DESCRIPTION
## Summary of the Pull Request
By moving to a GridView, adding a double mouse click event is easy. This allows (power)users to quickly select a layout and closing the editor in one go.

## Quality Checklist

- [X] **Linked issue:** #6098
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
