### PR TITLE
Ensure the lifetime of CPowerRenameProcessUI on the worker thread

### DIFF
--- a/src/modules/powerrename/ui/PowerRenameUI.cpp
+++ b/src/modules/powerrename/ui/PowerRenameUI.cpp
@@ -1523,7 +1523,12 @@ HRESULT CPowerRenameProgressUI::Start()
 {
     _Cleanup();
     m_canceled = false;
+    AddRef();
     m_workerThreadHandle = CreateThread(nullptr, 0, s_workerThread, this, 0, nullptr);
+    if (!m_workerThreadHandle)
+    {
+        Release();
+    }
     return (m_workerThreadHandle) ? S_OK : E_FAIL;
 }
 
@@ -1563,6 +1568,8 @@ DWORD WINAPI CPowerRenameProgressUI::s_workerThread(_In_ void* pv)
 
             KillTimer(hwndMessage, TIMERID_CHECKCANCELED);
             DestroyWindow(hwndMessage);
+
+            pThis->Release();
         }
 
         CoUninitialize();


### PR DESCRIPTION
Take an AddRef on the CPowerRenameProcessUI before passing it to the worker thread which runs the progress dialog.  We were seeing crashes due to a narrow timing window in the progress UI startup and teardown.  This should ensure that no longer happens.

Applies to https://github.com/microsoft/PowerToys/issues/11068