### PR TITLE
[bootstrapper] Allow msi extraction on 1809 and older

### DIFF
--- a/installer/PowerToysBootstrapper/bootstrapper/bootstrapper.cpp
+++ b/installer/PowerToysBootstrapper/bootstrapper/bootstrapper.cpp
@@ -219,16 +219,6 @@ int Bootstrapper(HINSTANCE hInstance)
 
     SetupLogger(logDir, severity);
     spdlog::debug("PowerToys Bootstrapper is launched\nnoFullUI: {}\nsilent: {}\nno_start_pt: {}\nskip_dotnet_install: {}\nlog_level: {}\ninstall_dir: {}\nextract_msi: {}\n", noFullUI, g_Silent, noStartPT, skipDotnetInstall, logLevel, installDirArg, extractMsiOnly);
-    
-    const VersionHelper myVersion(VERSION_MAJOR, VERSION_MINOR, VERSION_REVISION);
-
-    // Do not support installing on Windows < 1903
-    if (myVersion >= VersionHelper{0, 36, 0} && updating::is_old_windows_version())
-    {
-      ShowMessageBoxError(IDS_OLD_WINDOWS_ERROR);
-      spdlog::error("PowerToys {} requires at least Windows 1903 to run.", myVersion.toString());
-      return 1;
-    }
 
     // If a user requested an MSI -> extract it and exit
     if (extractMsiOnly)
@@ -241,7 +231,18 @@ int Bootstrapper(HINSTANCE hInstance)
         {
             spdlog::error("MSI installer couldn't be extracted");
         }
+
         return 0;
+    }
+
+    const VersionHelper myVersion(VERSION_MAJOR, VERSION_MINOR, VERSION_REVISION);
+
+    // Do not support installing on Windows < 1903
+    if (updating::is_1809_or_older())
+    {
+      ShowMessageBoxError(IDS_OLD_WINDOWS_ERROR);
+      spdlog::error("PowerToys {} requires at least Windows 1903 to run.", myVersion.toString());
+      return 1;
     }
 
     // Check if there's a newer version installed

--- a/src/common/updating/installer.cpp
+++ b/src/common/updating/installer.cpp
@@ -193,7 +193,7 @@ namespace updating
         co_return false;
     }
 
-    bool is_old_windows_version()
+    bool is_1809_or_older()
     {
         return !Is19H1OrHigher();
     }

--- a/src/common/updating/installer.h
+++ b/src/common/updating/installer.h
@@ -17,5 +17,5 @@ namespace updating
     std::optional<VersionHelper> get_installed_powertoys_version();
     std::future<bool> uninstall_previous_msix_version_async();
 
-    bool is_old_windows_version();
+    bool is_1809_or_older();
 }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
In 0.35 we dropped support for 1809 and older. We also stopped supporting the msi extraction on 1809 and older.

**What is include in the PR:** 
Allow to extract the msi on any version of Windows.

**How does someone test / validate:** 
Run `PowerToysSetup-0.0.1-x64.exe --extract_msi` on an older version of Windows and verify it extracts the msi.

## Quality Checklist

- [x] **Linked issue:** https://github.com/microsoft/PowerToys/issues/11017
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
