### PR TITLE
[Updating] Simple UI to test UpdateState

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/GeneralViewModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/GeneralViewModel.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Microsoft.PowerToys.Settings.UI.Library.Helpers;
@@ -19,6 +20,8 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
         public ButtonClickCommand CheckForUpdatesEventHandler { get; set; }
 
         public ButtonClickCommand RestartElevatedButtonEventHandler { get; set; }
+
+        public ButtonClickCommand UpdateNowButtonEventHandler { get; set; }
 
         public Func<string, int> UpdateUIThemeCallBack { get; }
 
@@ -38,6 +41,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
         {
             CheckForUpdatesEventHandler = new ButtonClickCommand(CheckForUpdatesClick);
             RestartElevatedButtonEventHandler = new ButtonClickCommand(RestartElevated);
+            UpdateNowButtonEventHandler = new ButtonClickCommand(UpdateNowClick);
 
             // To obtain the general settings configuration of PowerToys if it exists, else to create a new file and return the default configurations.
             if (settingsRepository == null)
@@ -396,6 +400,11 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             GeneralSettingsCustomAction customaction = new GeneralSettingsCustomAction(outsettings);
 
             SendCheckForUpdatesConfigMSG(customaction.ToString());
+        }
+
+        private void UpdateNowClick()
+        {
+            Process.Start(new ProcessStartInfo("powertoys://update_now") { UseShellExecute = true });
         }
 
         public void RequestUpdateCheckedDate()

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -400,6 +400,9 @@
   <data name="GeneralPage_CheckForUpdates.Content" xml:space="preserve">
     <value>Check for updates</value>
   </data>
+  <data name="GeneralPage_UpdateNow.Content" xml:space="preserve">
+    <value>Update now</value>
+  </data>  
   <data name="GeneralPage_PrivacyStatement_URL.Text" xml:space="preserve">
     <value>Privacy statement</value>
   </data>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml
@@ -149,6 +149,12 @@
                     IsEnabled="{Binding AutoUpdatesEnabled}"
                     />
 
+            <Button x:Uid="GeneralPage_UpdateNow"
+                    Style="{StaticResource AccentButtonStyle}"
+                    Foreground="White"
+                    Command="{Binding UpdateNowButtonEventHandler}"
+                    IsEnabled="{Binding AutoUpdatesEnabled}" />
+
             <ToggleSwitch x:Uid="GeneralPage_ToggleSwitch_AutoDownloadUpdates" 
                           Margin="{StaticResource MediumTopMargin}"
                           Visibility="{Binding Mode=TwoWay, Path=IsAdmin, Converter={StaticResource VisibleIfTrueConverter}}"


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
- set Version.props to a low version, install built msi
- Clicking "Update now" button will execute `powertoys://update_now`
- It in turn will launch action runner, which will update PT on the UpdateState if it's readyToDownload/readyToInstall

**What is include in the PR:** 

**How does someone test / validate:** 
- test when download updates automatically is on/off
- test when there's no internet available

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
