### PR TITLE
[VCM] do not reinit microphone if it wasn't changed

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -728,6 +728,7 @@ FILEFLAGS
 FILEFLAGSMASK
 FILEOP
 FILEOS
+filepath
 FILESUBTYPE
 FILESYSPATH
 filesystem
@@ -1799,6 +1800,8 @@ rectp
 rects
 recyclebin
 redirectedfrom
+reencode
+reencoded
 refactor
 refactoring
 REFCLSID
@@ -1918,6 +1921,7 @@ SEARCHFOR
 SEARCHREPLACEGROUP
 searchterm
 Secur
+seekg
 Segoe
 Sekan
 SENDCHANGE
@@ -2083,6 +2087,7 @@ stoll
 stoul
 stoull
 strcmp
+streampos
 strftime
 Strikethrough
 Stringified
@@ -2164,6 +2169,7 @@ TCustom
 td
 TDevice
 Telemarketer
+tellg
 Templated
 templatenamespace
 Temporarilypeekatthedesktop

--- a/src/modules/videoconference/VideoConferenceModule/VideoConferenceModule.cpp
+++ b/src/modules/videoconference/VideoConferenceModule/VideoConferenceModule.cpp
@@ -251,9 +251,11 @@ void VideoConferenceModule::onModuleSettingsChanged()
             {
                 toolbar.setHideToolbarWhenUnmuted(val.value());
             }
-            if (const auto val = values.get_string_value(L"selected_mic"))
+            
+            const auto selectedMic = values.get_string_value(L"selected_mic");
+            if (selectedMic && selectedMic != settings.selectedMicrophone)
             {
-                settings.selectedMicrophone = *val;
+                settings.selectedMicrophone = *selectedMic;
                 updateControlledMicrophones(settings.selectedMicrophone);
             }
 


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Reiniting `_controlledMicrophones` from `updateControlledMicrophones` unmutes them, which is an intended behavior. However, we shouldn't update microphone when in fact it wasn't changed.

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #10860
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
