### PR TITLE
[devdocs] new plugin localization steps

### DIFF
--- a/doc/devdocs/modules/launcher/new-plugin-checklist.md
+++ b/doc/devdocs/modules/launcher/new-plugin-checklist.md
@@ -28,3 +28,10 @@
 - [ ] Test the plugin with a local build. Build the installer, install, check that the plugin works as expected
 - [ ] All plugin's binaries have to be included in the signed build [`pipeline.user.windows.yml`](/.pipelines/pipeline.user.windows.yml)
 - [ ] The plugin target framework has to be .NET Core 3.1. All dependencies have to have .NET 5 version
+
+Some localization steps can only be done after the first pass by the localization team to provide the localized resources.
+In the PR that adds a new plugin, reference a new issue to track the work for fully enabling localization for the new plugin.
+
+ - [ ] Add the resource folder to https://github.com/microsoft/PowerToys/blob/21247c0bb09a1bee3d14d6efa53d0c247f7236af/installer/PowerToysSetup/Product.wxs#L825
+ - [ ] Add the resource files under the section https://github.com/microsoft/PowerToys/blob/21247c0bb09a1bee3d14d6efa53d0c247f7236af/installer/PowerToysSetup/Product.wxs#L882
+ 


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
PT Run new plugins needs extra steps for localization that can only be done after the first localization phase is done.

**What is include in the PR:** 
Update the new plugin checklist to add the extra localization steps.

**How does someone test / validate:** 

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
