### PR TITLE
Add image hyperlink for Video Conference settings page 

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -1017,6 +1017,10 @@ Disabling this module or closing PowerToys will unmute the microphone and camera
     <value>https://aka.ms/PowerToysOverview_ShortcutGuide</value>
     <comment>URL. Do not loc</comment>
   </data>
+  <data name="VideoConference_ImageHyperlinkToDocs.NavigateUri" xml:space="preserve">
+    <value>https://aka.ms/PowerToysOverview_VideoConference</value>
+    <comment>URL. Do not loc</comment>
+  </data>
   <data name="FancyZones_MoveWindowBasedOnRelativePosition.Content" xml:space="preserve">
     <value>Win + Up/Down/Left/Right to move windows based on relative position</value>
   </data>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/VideoConference.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/VideoConference.xaml
@@ -189,14 +189,16 @@
                     HorizontalAlignment="Left"
                     Margin="{StaticResource SmallTopBottomMargin}"
                     RelativePanel.Below="DescriptionPanel">
-                <Image Source="ms-appx:///Assets/Modules/VideoConference.png" />
+                <HyperlinkButton x:Uid="VideoConference_ImageHyperlinkToDocs">
+                    <Image Source="ms-appx:///Assets/Modules/VideoConference.png" />
+                </HyperlinkButton>
             </Border>
 
             <StackPanel x:Name="LinksPanel"
                         Margin="0,1,0,0"
                         RelativePanel.Below="AboutImage"
                         Orientation="Vertical" >
-                <HyperlinkButton NavigateUri="https://aka.ms/PowerToysOverview_VideoConference">
+                <HyperlinkButton x:Uid="VideoConference_ImageHyperlinkToDocs">
                     <TextBlock x:Uid="Module_overview" />
                 </HyperlinkButton>
                 <HyperlinkButton NavigateUri="https://aka.ms/powerToysGiveFeedback">


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Make the image clickable in Video Conference settings page.


**How does someone test / validate:** 

Build and click on "Learn more" and the image itself.

## Quality Checklist

- [x] **Linked issue:** #6703
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
