### PR TITLE
[KBM] Fix for handle leak

### DIFF
--- a/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardManager.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardManager.cpp
@@ -50,6 +50,7 @@ KeyboardManager::KeyboardManager()
         loadingSettings = false;
     };
 
+    editorIsRunningEvent = CreateEvent(nullptr, true, false, KeyboardManagerConstants::EditorWindowEventName.c_str());
     settingsEventWaiter = EventWaiter(KeyboardManagerConstants::SettingsEventName, changeSettingsCallback);
 }
 
@@ -126,8 +127,7 @@ intptr_t KeyboardManager::HandleKeyboardHookEvent(LowlevelKeyboardEvent* data) n
     }
 
     // Suspend remapping if remap key/shortcut window is opened
-    auto h = CreateEvent(nullptr, true, false, KeyboardManagerConstants::EditorWindowEventName.c_str());
-    if (h != nullptr && WaitForSingleObject(h, 0) == WAIT_OBJECT_0)
+    if (editorIsRunningEvent != nullptr && WaitForSingleObject(editorIsRunningEvent, 0) == WAIT_OBJECT_0)
     {
         return 0;
     }

--- a/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardManager.h
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardManager.h
@@ -9,7 +9,15 @@ class KeyboardManager
 public:
     // Constructor
     KeyboardManager();
-
+    
+    ~KeyboardManager()
+    {
+        if (editorIsRunningEvent)
+        {
+            CloseHandle(editorIsRunningEvent);
+        }
+    }
+    
     void StartLowlevelKeyboardHook();
     void StopLowlevelKeyboardHook();
 
@@ -37,6 +45,8 @@ private:
     EventWaiter settingsEventWaiter;
 
     std::atomic_bool loadingSettings = false;
+
+    HANDLE editorIsRunningEvent = nullptr;
 
     // Hook procedure definition
     static LRESULT CALLBACK HookProc(int nCode, WPARAM wParam, LPARAM lParam);


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
After moving the KBM engine our of the runner process, the mechanism to detect when the KBM editor is running, was leaking a handle.

**What is include in the PR:** 
Move the handle creation to the constructor instead of creating the event handle every time the kb hook is invoked.

**How does someone test / validate:** 
Verify the handle is not leaked:
 - open the task manager, go to the `Details` tab and add the `Handle` column to the list view.
 - open notepad and type any letter, check if the engine's handle count increases.

Verify that the engine is correctly suspended when the editor is open:
 - create a key mapping
 - verify the key mapping is working
 - open the editor and verify the key mapping is suspended
 - close the editor and verify the key mapping is resumed

## Quality Checklist

- [x] **Linked issue:** #11162
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
