### PR TITLE
[Shortcut Guide] Start from module interface

### DIFF
--- a/src/modules/ShortcutGuide/ShortcutGuide/main.cpp
+++ b/src/modules/ShortcutGuide/ShortcutGuide/main.cpp
@@ -2,18 +2,57 @@
 #include <Windows.h>
 #include <common/utils/window.h>
 #include <common/SettingsAPI/settings_helpers.h>
+#include <common/utils/ProcessWaiter.h>
+#include <common/utils/winapi_error.h>
+#include <common/utils/UnhandledExceptionHandler_x64.h>
+#include <common/utils/logger_helper.h>
 
 #include "shortcut_guide.h"
 #include "target_state.h"
 #include "ShortcutGuideConstants.h"
+#include "trace.h" 
+
+const std::wstring instanceMutexName = L"Local\\PowerToys_ShortcutGuide_InstanceMutex";
 
 int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _In_ PWSTR lpCmdLine, _In_ int nCmdShow)
 {
     winrt::init_apartment();
+    LoggerHelpers::init_logger(ShortcutGuideConstants::ModuleKey, L"ShortcutGuide", LogSettings::shortcutGuideLoggerName);
+    InitUnhandledExceptionHandler_x64();
+    Logger::trace("Starting Shortcut Guide with pid={}", GetCurrentProcessId());
 
-    std::filesystem::path logFilePath(PTSettingsHelper::get_module_save_folder_location(ShortcutGuideConstants::ModuleKey));
-    logFilePath.append(LogSettings::shortcutGuideLogPath);
-    Logger::init(LogSettings::shortcutGuideLoggerName, logFilePath.wstring(), PTSettingsHelper::get_log_settings_file_location());
+    auto mutex = CreateMutex(nullptr, true, instanceMutexName.c_str());
+    if (mutex == nullptr)
+    {
+        Logger::error(L"Failed to create mutex. {}", get_last_error_or_default(GetLastError()));
+    }
+
+    if (GetLastError() == ERROR_ALREADY_EXISTS)
+    {
+        Logger::warn(L"Shortcut Guide instance is already running");
+        return 0;
+    }
+
+    Trace::RegisterProvider();
+
+    std::wstring pid = std::wstring(lpCmdLine);
+    if (!pid.empty())
+    {
+        auto mainThreadId = GetCurrentThreadId();
+        ProcessWaiter::OnProcessTerminate(pid, [mainThreadId](int err) {
+            if (err != ERROR_SUCCESS)
+            {
+                Logger::error(L"Failed to wait for parent process exit. {}", get_last_error_or_default(err));
+            }
+            else
+            {
+                Logger::trace(L"PowerToys runner exited.");
+            }
+
+            Logger::trace(L"Exiting Shortcut Guide");
+            PostThreadMessage(mainThreadId, WM_QUIT, 0, 0);
+        });
+    }
 
     instance = new OverlayWindow();
     instance->enable();
@@ -25,4 +64,6 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, 
     {
         delete instance;
     }
+
+    return 0;
 }

--- a/src/modules/ShortcutGuide/ShortcutGuide/shortcut_guide.cpp
+++ b/src/modules/ShortcutGuide/ShortcutGuide/shortcut_guide.cpp
@@ -212,8 +212,6 @@ constexpr UINT alternative_switch_vk_code = VK_OEM_2;
 
 void OverlayWindow::enable()
 {
-    Logger::info("Shortcut Guide is enabling");
-
     auto switcher = [&](HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam) -> LRESULT {
         if (msg == WM_KEYDOWN && wparam == VK_ESCAPE && instance->target_state->active())
         {

--- a/src/modules/ShortcutGuide/ShortcutGuideModuleInterface/shortcut_guide.cpp
+++ b/src/modules/ShortcutGuide/ShortcutGuideModuleInterface/shortcut_guide.cpp
@@ -2,6 +2,8 @@
 #include "shortcut_guide.h"
 
 #include <common/SettingsAPI/settings_helpers.h>
+#include <common/utils/winapi_error.h>
+#include <common/utils/logger_helper.h>
 
 #include "trace.h"
 
@@ -12,9 +14,12 @@ OverlayWindow::OverlayWindow()
 {
     app_name = GET_RESOURCE_STRING(IDS_SHORTCUT_GUIDE);
     app_key = L"Shortcut Guide";
-    std::filesystem::path logFilePath(PTSettingsHelper::get_module_save_folder_location(app_key));
-    logFilePath.append(LogSettings::shortcutGuideLogPath);
-    Logger::init(LogSettings::shortcutGuideLoggerName, logFilePath.wstring(), PTSettingsHelper::get_log_settings_file_location());
+    LoggerHelpers::init_logger(app_key, L"ModuleInterface", LogSettings::shortcutGuideLoggerName);
+    
+    std::filesystem::path oldLogPath(PTSettingsHelper::get_module_save_folder_location(app_key));
+    oldLogPath.append("ShortcutGuideLogs");
+    LoggerHelpers::delete_old_log_folder(oldLogPath);
+
     Logger::info("Overlay Window is creating");
 }
 
@@ -45,6 +50,54 @@ constexpr int alternative_switch_hotkey_id = 0x2;
 constexpr UINT alternative_switch_modifier_mask = MOD_WIN | MOD_SHIFT;
 constexpr UINT alternative_switch_vk_code = VK_OEM_2;
 
+bool OverlayWindow::StartProcess()
+{
+    unsigned long powertoys_pid = GetCurrentProcessId();
+    std::wstring executable_args = L"";
+    executable_args.append(std::to_wstring(powertoys_pid));
+
+    SHELLEXECUTEINFOW sei{ sizeof(sei) };
+    sei.fMask = { SEE_MASK_NOCLOSEPROCESS | SEE_MASK_FLAG_NO_UI };
+    sei.lpFile = L"modules\\ShortcutGuide\\ShortcutGuide\\PowerToys.ShortcutGuide.exe";
+    sei.nShow = SW_SHOWNORMAL;
+    sei.lpParameters = executable_args.data();
+    if (ShellExecuteExW(&sei) == false)
+    {
+        Logger::error(L"Failed to start SG process. {}", get_last_error_or_default(GetLastError()));
+        auto message = get_last_error_message(GetLastError());
+        if (message.has_value())
+        {
+            Logger::error(message.value());
+        }
+
+        return false;
+    }
+
+    Logger::trace(L"Started SG process with pid={}", GetProcessId(sei.hProcess));
+    m_hProcess = sei.hProcess;
+    return true;
+}
+
+void OverlayWindow::TerminateProcess()
+{
+    if (m_hProcess)
+    {
+        if (WaitForSingleObject(m_hProcess, 0) != WAIT_OBJECT_0)
+        {
+            ::TerminateProcess(m_hProcess, 0);
+            m_hProcess = nullptr;
+        }
+        else
+        {
+            Logger::warn("SG process was already terminated");
+        }
+    }
+    else
+    {
+        Logger::warn("Process handle is not initialized");
+    }
+}
+
 void OverlayWindow::enable()
 {
     Logger::info("Shortcut Guide is enabling");
@@ -52,16 +105,20 @@ void OverlayWindow::enable()
     if (!_enabled)
     {
         Trace::EnableShortcutGuide(true);
-
-        // todo: start Shortcut Guide process
-        _enabled = true;
+        if (StartProcess())
+        {
+            _enabled = true;
+        }
+    }
+    else
+    {
+        Logger::warn("Shortcut guide is already enabled");    
     }
 }
 
 void OverlayWindow::disable(bool trace_event)
 {
     Logger::info("Shortcut Guide is disabling");
-
     if (_enabled)
     {
         _enabled = false;
@@ -70,7 +127,11 @@ void OverlayWindow::disable(bool trace_event)
             Trace::EnableShortcutGuide(false);
         }
 
-        // todo: stop Shortcut guide process
+        TerminateProcess();
+    }
+    else
+    {
+        Logger::warn("Shortcut Guide is already disabled");
     }
 }
 

--- a/src/modules/ShortcutGuide/ShortcutGuideModuleInterface/shortcut_guide.h
+++ b/src/modules/ShortcutGuide/ShortcutGuideModuleInterface/shortcut_guide.h
@@ -24,6 +24,9 @@ private:
     //contains the non localized key of the powertoy
     std::wstring app_key;
     bool _enabled = false;
+    HANDLE m_hProcess;
 
     void disable(bool trace_event);
+    bool StartProcess();
+    void TerminateProcess();
 };


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

**What is include in the PR:** 
- Start SG process from module interface
- Run only one instance of SG process
- Unhandled exception handling
- Apply new log structure and delete old log folder
- Exit SG process if the runner exited

**How does someone test / validate:** 
- Run PT and check that SG works
- Try to start few SG processes manually
- Verify that old logs are deleted and `Shortcut Guide` and `Module Interface` folders contain new logs
- Terminate the runner process(from Task Manager) and verify that SG process terminates as well 

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
