### PR TITLE
[Shortcut Guide] Start on demand

### DIFF
--- a/src/common/interop/interop.cpp
+++ b/src/common/interop/interop.cpp
@@ -150,10 +150,6 @@ public
 
         static String ^ ShowColorPickerSharedEvent() {
             return gcnew String(CommonSharedConstants::SHOW_COLOR_PICKER_SHARED_EVENT);
-        } 
-        
-        static String ^ ShowShortcutGuideSharedEvent() {
-            return gcnew String(CommonSharedConstants::SHOW_SHORTCUT_GUIDE_SHARED_EVENT);
         }
     };
 }

--- a/src/common/interop/shared_constants.h
+++ b/src/common/interop/shared_constants.h
@@ -22,9 +22,6 @@ namespace CommonSharedConstants
     // Path to the event used to show Color Picker
     const wchar_t SHOW_COLOR_PICKER_SHARED_EVENT[] = L"Local\\ShowColorPickerEvent-8c46be2a-3e05-4186-b56b-4ae986ef2525";
 
-    // Path to the event used to show Shortcut Guide
-    const wchar_t SHOW_SHORTCUT_GUIDE_SHARED_EVENT[] = L"Local\\ShowShortcutGuideEvent-6982d682-7462-404f-95af-86ae3f089c4f";
-
     // Max DWORD for key code to disable keys.
     const int VK_DISABLED = 0x100;
 }

--- a/src/modules/ShortcutGuide/ShortcutGuide/Resources.resx
+++ b/src/modules/ShortcutGuide/ShortcutGuide/Resources.resx
@@ -117,9 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Setting_Description_Press_Time" xml:space="preserve">
-    <value>How long to press the Windows key before showing the Shortcut Guide (ms)</value>
-  </data>
   <data name="Setting_Description_Overlay_Opacity" xml:space="preserve">
     <value>Opacity of the Shortcut Guide's overlay background (%)</value>
   </data>

--- a/src/modules/ShortcutGuide/ShortcutGuide/main.cpp
+++ b/src/modules/ShortcutGuide/ShortcutGuide/main.cpp
@@ -54,7 +54,7 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, 
         });
     }
 
-    auto ov = OverlayWindow();
+    auto window = OverlayWindow();
     run_message_loop();
 
     return 0;

--- a/src/modules/ShortcutGuide/ShortcutGuide/main.cpp
+++ b/src/modules/ShortcutGuide/ShortcutGuide/main.cpp
@@ -52,13 +52,15 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, 
             Logger::trace(L"Exiting Shortcut Guide");
             PostThreadMessage(mainThreadId, WM_QUIT, 0, 0);
         });
+
+        instance = new OverlayWindow(true);
+    }
+    else
+    {
+        instance = new OverlayWindow(false);
     }
 
-    instance = new OverlayWindow();
-    instance->enable();
-
     run_message_loop();
-    instance->disable();
 
     if (instance)
     {

--- a/src/modules/ShortcutGuide/ShortcutGuide/main.cpp
+++ b/src/modules/ShortcutGuide/ShortcutGuide/main.cpp
@@ -52,20 +52,10 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, 
             Logger::trace(L"Exiting Shortcut Guide");
             PostThreadMessage(mainThreadId, WM_QUIT, 0, 0);
         });
-
-        instance = new OverlayWindow(true);
-    }
-    else
-    {
-        instance = new OverlayWindow(false);
     }
 
+    auto ov = OverlayWindow();
     run_message_loop();
-
-    if (instance)
-    {
-        delete instance;
-    }
 
     return 0;
 }

--- a/src/modules/ShortcutGuide/ShortcutGuide/shortcut_guide.cpp
+++ b/src/modules/ShortcutGuide/ShortcutGuide/shortcut_guide.cpp
@@ -106,64 +106,29 @@ constexpr int alternative_switch_hotkey_id = 0x2;
 constexpr UINT alternative_switch_modifier_mask = MOD_WIN | MOD_SHIFT;
 constexpr UINT alternative_switch_vk_code = VK_OEM_2;
 
-OverlayWindow::OverlayWindow(bool hasParent)
+OverlayWindow::OverlayWindow()
 {
+    instance = this;
     app_name = GET_RESOURCE_STRING(IDS_SHORTCUT_GUIDE);
     app_key = ShortcutGuideConstants::ModuleKey;
 
     Logger::info("Overlay Window is creating");
     init_settings();
 
-    auto switcher = [&, hasParent](HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam) -> LRESULT {
-        if (terminationInvoked)
+    auto switcher = [&](HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam) -> LRESULT {
+        if (msg == WM_KEYDOWN && wparam == VK_ESCAPE)
         {
+            PostQuitMessage(0);
             return 0;
         }
 
-        if (msg == WM_KEYDOWN && wparam == VK_ESCAPE && instance->target_state->active())
-        {
-            instance->target_state->toggle_force_shown();
-            if (hasParent)
-            {
-                terminationInvoked = true;
-                PostQuitMessage(0);
-            }
-
-            return 0;
-        }
-
-        if (msg == WM_APP && lparam == eventActivateWindow)
-        {
-            instance->target_state->toggle_force_shown();
-            if (!instance->target_state->active() && hasParent)
-            {
-                terminationInvoked = true;
-                PostQuitMessage(0);
-            }
-
-            return 0;
-        }
-
-        if (msg != WM_HOTKEY)
-        {
-            return 0;
-        }
-
-        const auto vk_code = HIWORD(lparam);
-        const auto modifiers_mask = LOWORD(lparam);
-        if (alternative_switch_vk_code != vk_code || alternative_switch_modifier_mask != modifiers_mask)
-        {
-            return 0;
-        }
-        
-        instance->target_state->toggle_force_shown();
         return 0;
     };
 
     winkey_popup = std::make_unique<D2DOverlayWindow>(std::move(switcher));
     winkey_popup->apply_overlay_opacity(((float)overlayOpacity.value) / 100.0f);
     winkey_popup->set_theme(theme.value);
-    target_state = std::make_unique<TargetState>(pressTime.value);
+    target_state = std::make_unique<TargetState>();
     try
     {
         winkey_popup->initialize();
@@ -174,16 +139,7 @@ OverlayWindow::OverlayWindow(bool hasParent)
         return;
     }
 
-    if (!hasParent)
-    {
-        RegisterHotKey(winkey_popup->get_window_handle(), alternative_switch_hotkey_id, alternative_switch_modifier_mask, alternative_switch_vk_code);
-    }
-
-    auto show_action = [&]() {
-        PostMessageW(winkey_popup->get_window_handle(), WM_APP, 0, eventActivateWindow);
-    };
-
-    event_waiter = std::make_unique<NativeEventWaiter>(CommonSharedConstants::SHOW_SHORTCUT_GUIDE_SHARED_EVENT, show_action);
+    target_state->toggle_force_shown();
 }
 
 bool OverlayWindow::get_config(wchar_t* buffer, int* buffer_size)
@@ -194,14 +150,6 @@ bool OverlayWindow::get_config(wchar_t* buffer, int* buffer_size)
     settings.set_description(GET_RESOURCE_STRING(IDS_SETTINGS_DESCRIPTION));
     settings.set_overview_link(L"https://aka.ms/PowerToysOverview_ShortcutGuide");
     settings.set_icon_key(L"pt-shortcut-guide");
-
-    settings.add_int_spinner(
-        pressTime.name,
-        pressTime.resourceId,
-        pressTime.value,
-        100,
-        10000,
-        100);
 
     settings.add_int_spinner(
         overlayOpacity.name,
@@ -228,16 +176,8 @@ void OverlayWindow::set_config(const wchar_t* config)
         PowerToysSettings::PowerToyValues _values =
             PowerToysSettings::PowerToyValues::from_json_string(config, app_key);
         _values.save_to_settings_file();
-        Trace::SettingsChanged(pressTime.value, overlayOpacity.value, theme.value);
+        Trace::SettingsChanged(overlayOpacity.value, theme.value);
 
-        if (const auto press_delay_time = _values.get_int_value(pressTime.name))
-        {
-            pressTime.value = *press_delay_time;
-            if (target_state)
-            {
-                target_state->set_delay(*press_delay_time);
-            }
-        }
         if (const auto overlay_opacity = _values.get_int_value(overlayOpacity.name))
         {
             overlayOpacity.value = *overlay_opacity;
@@ -313,10 +253,7 @@ void OverlayWindow::init_settings()
     {
         PowerToysSettings::PowerToyValues settings =
             PowerToysSettings::PowerToyValues::load_from_settings_file(app_key);
-        if (const auto val = settings.get_int_value(pressTime.name))
-        {
-            pressTime.value = *val;
-        }
+
         if (const auto val = settings.get_int_value(overlayOpacity.name))
         {
             overlayOpacity.value = *val;

--- a/src/modules/ShortcutGuide/ShortcutGuide/shortcut_guide.cpp
+++ b/src/modules/ShortcutGuide/ShortcutGuide/shortcut_guide.cpp
@@ -118,6 +118,7 @@ OverlayWindow::OverlayWindow()
     auto switcher = [&](HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam) -> LRESULT {
         if (msg == WM_KEYDOWN && wparam == VK_ESCAPE)
         {
+            Logger::trace(L"ESC key was pressed. Terminating process. PID={}", GetCurrentProcessId());
             PostQuitMessage(0);
             return 0;
         }

--- a/src/modules/ShortcutGuide/ShortcutGuide/shortcut_guide.cpp
+++ b/src/modules/ShortcutGuide/ShortcutGuide/shortcut_guide.cpp
@@ -119,7 +119,7 @@ OverlayWindow::OverlayWindow()
         if (msg == WM_KEYDOWN && wparam == VK_ESCAPE)
         {
             Logger::trace(L"ESC key was pressed. Terminating process. PID={}", GetCurrentProcessId());
-            PostQuitMessage(0);
+            PostThreadMessage(GetCurrentThreadId(), WM_QUIT, 0, 0);
             return 0;
         }
 

--- a/src/modules/ShortcutGuide/ShortcutGuide/shortcut_guide.cpp
+++ b/src/modules/ShortcutGuide/ShortcutGuide/shortcut_guide.cpp
@@ -115,11 +115,17 @@ OverlayWindow::OverlayWindow(bool hasParent)
     init_settings();
 
     auto switcher = [&, hasParent](HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam) -> LRESULT {
+        if (terminationInvoked)
+        {
+            return 0;
+        }
+
         if (msg == WM_KEYDOWN && wparam == VK_ESCAPE && instance->target_state->active())
         {
             instance->target_state->toggle_force_shown();
             if (hasParent)
             {
+                terminationInvoked = true;
                 PostQuitMessage(0);
             }
 
@@ -131,6 +137,7 @@ OverlayWindow::OverlayWindow(bool hasParent)
             instance->target_state->toggle_force_shown();
             if (!instance->target_state->active() && hasParent)
             {
+                terminationInvoked = true;
                 PostQuitMessage(0);
             }
 

--- a/src/modules/ShortcutGuide/ShortcutGuide/shortcut_guide.h
+++ b/src/modules/ShortcutGuide/ShortcutGuide/shortcut_guide.h
@@ -16,12 +16,10 @@ class TargetState;
 class OverlayWindow
 {
 public:
-    OverlayWindow();
+    OverlayWindow(bool hasParent);
     bool get_config(wchar_t* buffer, int* buffer_size);
 
     void set_config(const wchar_t* config);
-    void enable();
-    void disable();
 
     void on_held();
     void on_held_press(DWORD vkCode);
@@ -33,7 +31,7 @@ public:
     bool is_disabled_app(wchar_t* exePath);
 
     void get_exe_path(HWND window, wchar_t* exePath);
-
+    ~OverlayWindow();
 private:
     std::wstring app_name;
     //contains the non localized key of the powertoy

--- a/src/modules/ShortcutGuide/ShortcutGuide/shortcut_guide.h
+++ b/src/modules/ShortcutGuide/ShortcutGuide/shortcut_guide.h
@@ -16,7 +16,7 @@ class TargetState;
 class OverlayWindow
 {
 public:
-    OverlayWindow(bool hasParent);
+    OverlayWindow();
     bool get_config(wchar_t* buffer, int* buffer_size);
 
     void set_config(const wchar_t* config);
@@ -40,16 +40,8 @@ private:
     std::unique_ptr<D2DOverlayWindow> winkey_popup;
     std::unique_ptr<NativeEventWaiter> event_waiter;
     std::vector<std::wstring> disabled_apps_array;
-    std::atomic_bool terminationInvoked = false;
     void init_settings();
     void update_disabled_apps();
-
-    struct PressTime
-    {
-        PCWSTR name = L"press_time";
-        int value = 900; // ms
-        int resourceId = IDS_SETTING_DESCRIPTION_PRESS_TIME;
-    } pressTime;
 
     struct OverlayOpacity
     {

--- a/src/modules/ShortcutGuide/ShortcutGuide/shortcut_guide.h
+++ b/src/modules/ShortcutGuide/ShortcutGuide/shortcut_guide.h
@@ -40,7 +40,7 @@ private:
     std::unique_ptr<D2DOverlayWindow> winkey_popup;
     std::unique_ptr<NativeEventWaiter> event_waiter;
     std::vector<std::wstring> disabled_apps_array;
-
+    std::atomic_bool terminationInvoked = false;
     void init_settings();
     void update_disabled_apps();
 

--- a/src/modules/ShortcutGuide/ShortcutGuide/target_state.cpp
+++ b/src/modules/ShortcutGuide/ShortcutGuide/target_state.cpp
@@ -5,13 +5,6 @@
 #include <common/interop/shared_constants.h>
 #include <common/logger/logger.h>
 
-TargetState::TargetState(int ms_delay) :
-    // TODO: All this processing should be done w/o a separate thread etc. in pre_wnd_proc of winkey_popup to avoid
-    //       multithreading. Use SetTimer for delayed events
-    delay(std::chrono::milliseconds(ms_delay))
-{
-}
-
 constexpr unsigned VK_S = 0x53;
 
 void TargetState::was_hidden()
@@ -33,12 +26,6 @@ void TargetState::exit()
     state = Exiting;
     lock.unlock();
     cv.notify_one();
-}
-
-void TargetState::set_delay(int ms_delay)
-{
-    std::unique_lock lock(mutex);
-    delay = std::chrono::milliseconds(ms_delay);
 }
 
 void TargetState::toggle_force_shown()

--- a/src/modules/ShortcutGuide/ShortcutGuide/target_state.h
+++ b/src/modules/ShortcutGuide/ShortcutGuide/target_state.h
@@ -12,10 +12,9 @@ struct KeyEvent
 class TargetState
 {
 public:
-    TargetState(int ms_delay);
+    TargetState() = default;
     void was_hidden();
     void exit();
-    void set_delay(int ms_delay);
 
     void toggle_force_shown();
     bool active() const;

--- a/src/modules/ShortcutGuide/ShortcutGuide/trace.cpp
+++ b/src/modules/ShortcutGuide/ShortcutGuide/trace.cpp
@@ -53,12 +53,11 @@ void Trace::EnableShortcutGuide(const bool enabled) noexcept
         TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));
 }
 
-void Trace::SettingsChanged(const int press_delay_time, const int overlay_opacity, const std::wstring& theme) noexcept
+void Trace::SettingsChanged(const int overlay_opacity, const std::wstring& theme) noexcept
 {
     TraceLoggingWrite(
         g_hProvider,
         "ShortcutGuide_SettingsChanged",
-        TraceLoggingInt32(press_delay_time, "PressDelayTime"),
         TraceLoggingInt32(overlay_opacity, "OverlayOpacity"),
         TraceLoggingWideString(theme.c_str(), "Theme"),
         ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),

--- a/src/modules/ShortcutGuide/ShortcutGuide/trace.h
+++ b/src/modules/ShortcutGuide/ShortcutGuide/trace.h
@@ -7,6 +7,6 @@ public:
     static void UnregisterProvider() noexcept;
     static void HideGuide(const __int64 duration_ms, std::vector<int>& key_pressed) noexcept;
     static void EnableShortcutGuide(const bool enabled) noexcept;
-    static void SettingsChanged(const int press_delay_time, const int overlay_opacity, const std::wstring& theme) noexcept;
+    static void SettingsChanged(const int overlay_opacity, const std::wstring& theme) noexcept;
     static void Error(const DWORD errorCode, std::wstring errorMessage, std::wstring methodName) noexcept;
 };

--- a/src/modules/ShortcutGuide/ShortcutGuideModuleInterface/shortcut_guide.h
+++ b/src/modules/ShortcutGuide/ShortcutGuideModuleInterface/shortcut_guide.h
@@ -28,9 +28,9 @@ private:
     std::wstring app_key;
     bool _enabled = false;
     HANDLE m_hProcess = nullptr;
-    HANDLE shortcutEvent;
 
     void disable(bool trace_event);
     bool StartProcess();
     void TerminateProcess();
+    bool IsProcessActive();
 };

--- a/src/modules/ShortcutGuide/ShortcutGuideModuleInterface/shortcut_guide.h
+++ b/src/modules/ShortcutGuide/ShortcutGuideModuleInterface/shortcut_guide.h
@@ -19,12 +19,16 @@ public:
     virtual void disable() override;
     virtual bool is_enabled() override;
     virtual void destroy() override;
+    virtual size_t get_hotkeys(Hotkey* buffer, size_t buffer_size) override;
+    virtual bool on_hotkey(size_t hotkeyId) override;
+
 private:
     std::wstring app_name;
     //contains the non localized key of the powertoy
     std::wstring app_key;
     bool _enabled = false;
-    HANDLE m_hProcess;
+    HANDLE m_hProcess = nullptr;
+    HANDLE shortcutEvent;
 
     void disable(bool trace_event);
     bool StartProcess();

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeShellPage.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeShellPage.xaml.cs
@@ -28,13 +28,6 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
             ColorPickerSharedEventCallback = implementation;
         }
 
-        public static Func<string> ShortcutGuideSharedEventCallback { get; set; }
-
-        public static void SetShortcutGuideSharedEventCallback(Func<string> implementation)
-        {
-            ShortcutGuideSharedEventCallback = implementation;
-        }
-
         public static Action<Type> OpenMainWindowCallback { get; set; }
 
         public static void SetOpenMainWindowCallback(Action<Type> implementation)

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeShortcutGuide.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeShortcutGuide.xaml.cs
@@ -2,6 +2,9 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
 using System.Threading;
 using Microsoft.PowerToys.Settings.UI.OOBE.Enums;
 using Microsoft.PowerToys.Settings.UI.OOBE.ViewModel;
@@ -27,12 +30,12 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
 
         private void Start_ShortcutGuide_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
         {
-            if (OobeShellPage.ShortcutGuideSharedEventCallback != null)
+            var executablePath = Path.Combine(System.AppDomain.CurrentDomain.BaseDirectory, @"..\modules\ShortcutGuide\ShortcutGuide\PowerToys.ShortcutGuide.exe");
+            var id = Process.GetCurrentProcess().Id.ToString(CultureInfo.InvariantCulture);
+            var p = Process.Start(executablePath, id);
+            if (p != null)
             {
-                using (var eventHandle = new EventWaitHandle(false, EventResetMode.AutoReset, OobeShellPage.ShortcutGuideSharedEventCallback()))
-                {
-                    eventHandle.Set();
-                }
+                p.Close();
             }
 
             ViewModel.LogRunningModuleEvent();

--- a/src/settings-ui/PowerToys.Settings/OobeWindow.xaml.cs
+++ b/src/settings-ui/PowerToys.Settings/OobeWindow.xaml.cs
@@ -78,12 +78,6 @@ namespace PowerToys.Settings
                 return Constants.ShowColorPickerSharedEvent();
             });
 
-            OobeShellPage.SetShortcutGuideSharedEventCallback(() =>
-            {
-                NativeMethods.AllowSetForegroundWindow(PowerToys.Settings.Program.PowerToysPID);
-                return Constants.ShowShortcutGuideSharedEvent();
-            });
-
             OobeShellPage.SetOpenMainWindowCallback((Type type) =>
             {
                 ((App)Application.Current).OpenSettingsWindow(type);


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Every time `Shift+Win+?` is pressed we start `PowerToys.ShortcutGuide.exe` process. And if `ESC` or  `Shift+Win+?` is pressed the second time we terminate the process. For now, we use a centralized keyboard hook in the runner.

**What is include in the PR:** 
- Added SG shortcut to centralized keyboard hook
- Start SG process on SG hotkey
- Show SG window on start
- Terminate SG process on ESC
- Updated OOBE to use a new approach
- Remove remainings of press delay time for win key

**How does someone test / validate:** 
- Test for race conditions
- Try to start from OOBE

Known issues:
- The focused window is not shown in the ShortcutGuide
- `Disable for apps` does not work

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
