### PR TITLE
[FZ Editor] Keyboard support for canvas editor

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml
@@ -113,7 +113,7 @@
                 <Setter Property="Border.Background"
                         Value="{DynamicResource CanvasZoneBackgroundBrush}" />
                 <Setter Property="Border.BorderBrush"
-                        Value="Black" />
+                        Value="{DynamicResource CanvasZoneBorderBrush}" />
                 <Setter Property="Border.BorderThickness"
                         Value="1"/>
                 <Style.Triggers>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml
@@ -9,7 +9,6 @@
              KeyDown="Border_KeyDown"
              Background="Transparent"
              d:DesignHeight="450" d:DesignWidth="800">
-    
     <UserControl.Resources>
         <Style x:Key="CanvasZoneThumbStyle" TargetType="{x:Type Thumb}">
             <Setter Property="Stylus.IsPressAndHoldEnabled" Value="false"/>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml
@@ -99,10 +99,6 @@
         </Style>
     </UserControl.Resources>
 
-    
-    
-    
-    
     <Border CornerRadius="0"
             Focusable="True"
             x:Name="RootBorder"

--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml
@@ -5,8 +5,18 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:props="clr-namespace:FancyZonesEditor.Properties"
              xmlns:local="clr-namespace:FancyZonesEditor"
-             mc:Ignorable="d" 
+             mc:Ignorable="d"
+             FocusManager.IsFocusScope="True"
+             KeyDown="Border_KeyDown"
+             FocusVisualStyle="{DynamicResource MyFocusVisual}"
+             MouseDown="Border_MouseDown"
+             PreviewMouseDown="UserControl_PreviewMouseDown"
              Background="Transparent"
+             Focusable="True"
+             
+            GotFocus="UserControl_GotFocus" 
+             LostFocus="UserControl_LostFocus"
+             KeyboardNavigation.TabNavigation="Local"
              d:DesignHeight="450" d:DesignWidth="800">
 
     <UserControl.Resources>
@@ -84,11 +94,29 @@
                 </Setter.Value>
             </Setter>
         </Style>
+
+        <Style x:Key="MyFocusVisual">
+            <Setter Property="UserControl.Template">
+                <Setter.Value>
+                    <ControlTemplate>
+                        <Rectangle Margin="-2"
+                                   StrokeThickness="1"
+                                   Stroke="Red"
+                                   StrokeDashArray="1 2" />
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
     </UserControl.Resources>
 
+    
+    
+    
+    
     <Border BorderBrush="{DynamicResource SystemControlBackgroundAccentBrush}"
             Background="{DynamicResource CanvasZoneBackgroundBrush}"
             CornerRadius="0"
+        
             BorderThickness="1">
         <Grid x:Name="Frame">
             <Grid.RowDefinitions>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml
@@ -6,19 +6,10 @@
              xmlns:props="clr-namespace:FancyZonesEditor.Properties"
              xmlns:local="clr-namespace:FancyZonesEditor"
              mc:Ignorable="d"
-             FocusManager.IsFocusScope="True"
              KeyDown="Border_KeyDown"
-             FocusVisualStyle="{DynamicResource MyFocusVisual}"
-             MouseDown="Border_MouseDown"
-             PreviewMouseDown="UserControl_PreviewMouseDown"
              Background="Transparent"
-             Focusable="True"
-             
-            GotFocus="UserControl_GotFocus" 
-             LostFocus="UserControl_LostFocus"
-             KeyboardNavigation.TabNavigation="Local"
              d:DesignHeight="450" d:DesignWidth="800">
-
+    
     <UserControl.Resources>
         <Style x:Key="CanvasZoneThumbStyle" TargetType="{x:Type Thumb}">
             <Setter Property="Stylus.IsPressAndHoldEnabled" Value="false"/>
@@ -55,12 +46,18 @@
             </Setter>
         </Style>
 
-        <Style x:Key="CloseButtonStyle" TargetType="{x:Type Button}">
-            <Setter Property="BorderThickness" Value="1"/>
-            <Setter Property="HorizontalContentAlignment" Value="Center"/>
-            <Setter Property="VerticalContentAlignment" Value="Center"/>
-            <Setter Property="Foreground" Value="{DynamicResource PrimaryForegroundBrush}" />
-            <Setter Property="Padding" Value="1"/>
+        <Style x:Key="CloseButtonStyle"
+               TargetType="{x:Type Button}">
+            <Setter Property="BorderThickness"
+                    Value="1" />
+            <Setter Property="HorizontalContentAlignment"
+                    Value="Center" />
+            <Setter Property="VerticalContentAlignment"
+                    Value="Center" />
+            <Setter Property="Foreground"
+                    Value="{DynamicResource PrimaryForegroundBrush}" />
+            <Setter Property="Padding"
+                    Value="1" />
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="{x:Type Button}">
@@ -75,34 +72,28 @@
                                               Margin="{TemplateBinding Padding}"
                                               RecognizesAccessKey="True"
                                               SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
                         </Border>
                         <ControlTemplate.Triggers>
-                            <Trigger Property="IsDefaulted" Value="true">
+                            <Trigger Property="IsDefaulted"
+                                     Value="true">
                                 <Setter Property="BorderBrush"
                                         TargetName="border"
-                                        Value="{DynamicResource SystemControlBackgroundAccentBrush}"/>
+                                        Value="{DynamicResource SystemControlBackgroundAccentBrush}" />
                             </Trigger>
-                            <Trigger Property="IsMouseOver" Value="true">
-                                <Setter Property="Opacity" TargetName="contentPresenter" Value="0.6"/>
+                            <Trigger Property="IsMouseOver"
+                                     Value="true">
+                                <Setter Property="Opacity"
+                                        TargetName="contentPresenter"
+                                        Value="0.6" />
                             </Trigger>
-                            <Trigger Property="IsPressed" Value="true">
-                                <Setter Property="Opacity" TargetName="contentPresenter" Value="0.4"/>
+                            <Trigger Property="IsPressed"
+                                     Value="true">
+                                <Setter Property="Opacity"
+                                        TargetName="contentPresenter"
+                                        Value="0.4" />
                             </Trigger>
                         </ControlTemplate.Triggers>
-                    </ControlTemplate>
-                </Setter.Value>
-            </Setter>
-        </Style>
-
-        <Style x:Key="MyFocusVisual">
-            <Setter Property="UserControl.Template">
-                <Setter.Value>
-                    <ControlTemplate>
-                        <Rectangle Margin="-2"
-                                   StrokeThickness="1"
-                                   Stroke="Red"
-                                   StrokeDashArray="1 2" />
                     </ControlTemplate>
                 </Setter.Value>
             </Setter>
@@ -113,11 +104,29 @@
     
     
     
-    <Border BorderBrush="{DynamicResource SystemControlBackgroundAccentBrush}"
-            Background="{DynamicResource CanvasZoneBackgroundBrush}"
-            CornerRadius="0"
-        
-            BorderThickness="1">
+    <Border CornerRadius="0"
+            Focusable="True"
+            x:Name="RootBorder"
+            PreviewMouseDown="Border_PreviewMouseDown">
+        <Border.Style>
+            <Style>
+                <Setter Property="Border.Background"
+                        Value="{DynamicResource CanvasZoneBackgroundBrush}" />
+                <Setter Property="Border.BorderBrush"
+                        Value="Black" />
+                <Setter Property="Border.BorderThickness"
+                        Value="1"/>
+                <Style.Triggers>
+                    <Trigger Property="Border.IsKeyboardFocused"
+                             Value="true">
+                        <Setter Property="Border.BorderThickness"
+                                Value="4" />
+                        <Setter Property="Border.BorderBrush"
+                                Value="{DynamicResource SystemControlBackgroundAccentBrush}" />
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
+        </Border.Style>
         <Grid x:Name="Frame">
             <Grid.RowDefinitions>
                 <RowDefinition Height="8"/>
@@ -146,9 +155,10 @@
                     Content="ID"
                     FontWeight="SemiBold"
                     FontSize="64"
-                    Foreground="{DynamicResource PrimaryForegroundBrush}" />
+                    Foreground="{Binding ElementName=RootBorder, Path=BorderBrush}" />
                 <TextBlock FontSize="16"
-                           Foreground="{DynamicResource SecondaryForegroundBrush}"
+                           Foreground="{Binding ElementName=RootBorder, Path=BorderBrush}"
+                           Opacity="0.6"
                            DockPanel.Dock="Bottom"
                            FontWeight="SemiBold"
                            HorizontalAlignment="Center"
@@ -180,6 +190,8 @@
                     FontSize="16"
                     Padding="4"
                     Click="OnClose"
+                    IsTabStop="False"
+                    Focusable="False"
                     Grid.Row="2"
                     Grid.Column="2"
                     FontFamily="Segoe MDL2 Assets"

--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml.cs
@@ -303,12 +303,6 @@ namespace FancyZonesEditor
             UpdateFromSnappyHelpers();
         }
 
-        private void OnClose(object sender, RoutedEventArgs e)
-        {
-            ((Panel)Parent).Children.Remove(this);
-            Model.RemoveZoneAt(ZoneIndex);
-        }
-
         // Corner dragging
         private void Caption_DragStarted(object sender, System.Windows.Controls.Primitives.DragStartedEventArgs e)
         {
@@ -369,14 +363,28 @@ namespace FancyZonesEditor
             snappyY = null;
         }
 
+        private void OnClose(object sender, RoutedEventArgs e)
+        {
+            RemoveZone();
+        }
+
+        private void RemoveZone()
+        {
+            ((Panel)Parent).Children.Remove(this);
+            Model.RemoveZoneAt(ZoneIndex);
+        }
+
         private void Border_KeyDown(object sender, KeyEventArgs e)
         {
             if (e.Key != Key.Tab)
             {
                 e.Handled = true;
                 System.Diagnostics.Debug.WriteLine(e.Key);
-
-                if (e.Key == Key.Right)
+                if (e.Key == Key.Delete)
+                {
+                    RemoveZone();
+                }
+                else if (e.Key == Key.Right)
                 {
                     if (IsShiftKeyDown())
                     {
@@ -463,25 +471,12 @@ namespace FancyZonesEditor
             }
         }
 
-        private void Border_MouseDown(object sender, MouseButtonEventArgs e)
+        private void Border_PreviewMouseDown(object sender, MouseButtonEventArgs e)
         {
-            System.Diagnostics.Debug.WriteLine("Mouse down!");
-        }
-
-        private void UserControl_GotFocus(object sender, RoutedEventArgs e)
-        {
-            System.Diagnostics.Debug.WriteLine("Got focus: " + LabelID.Content);
-        }
-
-        private void UserControl_LostFocus(object sender, RoutedEventArgs e)
-        {
-            System.Diagnostics.Debug.WriteLine("Lost focus: " + LabelID.Content);
-        }
-
-        private void UserControl_PreviewMouseDown(object sender, MouseButtonEventArgs e)
-        {
-            this.Focus();
-            System.Diagnostics.Debug.WriteLine("Preview Mouse down!");
+            // Set (keyboard)focus on this zone when click
+            Border selectedBorder = sender as Border;
+            selectedBorder.Focus();
+            Keyboard.Focus(selectedBorder);
         }
     }
 }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml.cs
@@ -368,5 +368,120 @@ namespace FancyZonesEditor
             snappyX = NewDefaultSnappyHelper(true, ResizeMode.TopEdge);
             snappyY = null;
         }
+
+        private void Border_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key != Key.Tab)
+            {
+                e.Handled = true;
+                System.Diagnostics.Debug.WriteLine(e.Key);
+
+                if (e.Key == Key.Right)
+                {
+                    if (IsShiftKeyDown())
+                    {
+                        // Make the zone larger (height)
+                        MoveZoneX(6, ResizeMode.TopEdge, ResizeMode.BottomEdge);
+                        MoveZoneX(-6, ResizeMode.BottomEdge, ResizeMode.BottomEdge);
+                    }
+                    else
+                    {
+                        // Move zone right
+                        MoveZoneX(12, ResizeMode.BothEdges, ResizeMode.BothEdges);
+                    }
+                }
+                else if (e.Key == Key.Left)
+                {
+                    if (IsShiftKeyDown())
+                    {
+                        // Make the zone smaller (height)
+                        MoveZoneX(-6, ResizeMode.TopEdge, ResizeMode.BottomEdge);
+                        MoveZoneX(6, ResizeMode.BottomEdge, ResizeMode.BottomEdge);
+                    }
+                    else
+                    {
+                        // Move zone left
+                        MoveZoneX(-12, ResizeMode.BothEdges, ResizeMode.BothEdges);
+                    }
+                }
+                else if (e.Key == Key.Up)
+                {
+                    if (IsShiftKeyDown())
+                    {
+                        // Make the zone larger (height)
+                        MoveZoneY(6, ResizeMode.TopEdge, ResizeMode.BottomEdge);
+                        MoveZoneY(-6, ResizeMode.BottomEdge, ResizeMode.BottomEdge);
+                    }
+                    else
+                    {
+                        // Move zone up
+                        MoveZoneY(-12, ResizeMode.BothEdges, ResizeMode.BothEdges);
+                    }
+                }
+                else if (e.Key == Key.Down)
+                {
+                    if (IsShiftKeyDown())
+                    {
+                        // Make the zone smaller (height)
+                        MoveZoneY(-6, ResizeMode.TopEdge, ResizeMode.BottomEdge);
+                        MoveZoneY(6, ResizeMode.BottomEdge, ResizeMode.BottomEdge);
+                    }
+                    else
+                    {
+                        // Move zone down
+                        MoveZoneY(12, ResizeMode.BothEdges, ResizeMode.BothEdges);
+                    }
+                }
+            }
+        }
+
+        private void MoveZoneX(int value, ResizeMode top, ResizeMode bottom)
+        {
+            snappyX = NewDefaultSnappyHelper(true, top);
+            snappyY = NewDefaultSnappyHelper(false, bottom);
+            snappyX.Move(value);
+            UpdateFromSnappyHelpers();
+        }
+
+        private void MoveZoneY(int value, ResizeMode top, ResizeMode bottom)
+        {
+            snappyX = NewDefaultSnappyHelper(true, bottom);
+            snappyY = NewDefaultSnappyHelper(false, top);
+            snappyY.Move(value);
+            UpdateFromSnappyHelpers();
+        }
+
+        private bool IsShiftKeyDown()
+        {
+            if (Keyboard.IsKeyDown(Key.LeftShift) || Keyboard.IsKeyDown(Key.RightShift))
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        private void Border_MouseDown(object sender, MouseButtonEventArgs e)
+        {
+            System.Diagnostics.Debug.WriteLine("Mouse down!");
+        }
+
+        private void UserControl_GotFocus(object sender, RoutedEventArgs e)
+        {
+            System.Diagnostics.Debug.WriteLine("Got focus: " + LabelID.Content);
+        }
+
+        private void UserControl_LostFocus(object sender, RoutedEventArgs e)
+        {
+            System.Diagnostics.Debug.WriteLine("Lost focus: " + LabelID.Content);
+        }
+
+        private void UserControl_PreviewMouseDown(object sender, MouseButtonEventArgs e)
+        {
+            this.Focus();
+            System.Diagnostics.Debug.WriteLine("Preview Mouse down!");
+        }
     }
 }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml.cs
@@ -18,6 +18,8 @@ namespace FancyZonesEditor
     /// </summary>
     public partial class CanvasZone : UserControl
     {
+        private readonly int moveAmount = 10;
+
         public CanvasZone()
         {
             InitializeComponent();
@@ -379,7 +381,6 @@ namespace FancyZonesEditor
             if (e.Key != Key.Tab)
             {
                 e.Handled = true;
-                System.Diagnostics.Debug.WriteLine(e.Key);
                 if (e.Key == Key.Delete)
                 {
                     RemoveZone();
@@ -389,13 +390,13 @@ namespace FancyZonesEditor
                     if (IsShiftKeyDown())
                     {
                         // Make the zone larger (height)
-                        MoveZoneX(6, ResizeMode.TopEdge, ResizeMode.BottomEdge);
-                        MoveZoneX(-6, ResizeMode.BottomEdge, ResizeMode.BottomEdge);
+                        MoveZoneX(moveAmount / 2, ResizeMode.TopEdge, ResizeMode.BottomEdge);
+                        MoveZoneX(-moveAmount / 2, ResizeMode.BottomEdge, ResizeMode.BottomEdge);
                     }
                     else
                     {
                         // Move zone right
-                        MoveZoneX(12, ResizeMode.BothEdges, ResizeMode.BothEdges);
+                        MoveZoneX(moveAmount, ResizeMode.BothEdges, ResizeMode.BothEdges);
                     }
                 }
                 else if (e.Key == Key.Left)
@@ -403,13 +404,13 @@ namespace FancyZonesEditor
                     if (IsShiftKeyDown())
                     {
                         // Make the zone smaller (height)
-                        MoveZoneX(-6, ResizeMode.TopEdge, ResizeMode.BottomEdge);
-                        MoveZoneX(6, ResizeMode.BottomEdge, ResizeMode.BottomEdge);
+                        MoveZoneX(-moveAmount / 2, ResizeMode.TopEdge, ResizeMode.BottomEdge);
+                        MoveZoneX(moveAmount / 2, ResizeMode.BottomEdge, ResizeMode.BottomEdge);
                     }
                     else
                     {
                         // Move zone left
-                        MoveZoneX(-12, ResizeMode.BothEdges, ResizeMode.BothEdges);
+                        MoveZoneX(-moveAmount, ResizeMode.BothEdges, ResizeMode.BothEdges);
                     }
                 }
                 else if (e.Key == Key.Up)
@@ -417,13 +418,13 @@ namespace FancyZonesEditor
                     if (IsShiftKeyDown())
                     {
                         // Make the zone larger (height)
-                        MoveZoneY(6, ResizeMode.TopEdge, ResizeMode.BottomEdge);
-                        MoveZoneY(-6, ResizeMode.BottomEdge, ResizeMode.BottomEdge);
+                        MoveZoneY(moveAmount / 2, ResizeMode.TopEdge, ResizeMode.BottomEdge);
+                        MoveZoneY(-moveAmount / 2, ResizeMode.BottomEdge, ResizeMode.BottomEdge);
                     }
                     else
                     {
                         // Move zone up
-                        MoveZoneY(-12, ResizeMode.BothEdges, ResizeMode.BothEdges);
+                        MoveZoneY(-moveAmount, ResizeMode.BothEdges, ResizeMode.BothEdges);
                     }
                 }
                 else if (e.Key == Key.Down)
@@ -431,13 +432,13 @@ namespace FancyZonesEditor
                     if (IsShiftKeyDown())
                     {
                         // Make the zone smaller (height)
-                        MoveZoneY(-6, ResizeMode.TopEdge, ResizeMode.BottomEdge);
-                        MoveZoneY(6, ResizeMode.BottomEdge, ResizeMode.BottomEdge);
+                        MoveZoneY(-moveAmount / 2, ResizeMode.TopEdge, ResizeMode.BottomEdge);
+                        MoveZoneY(moveAmount / 2, ResizeMode.BottomEdge, ResizeMode.BottomEdge);
                     }
                     else
                     {
                         // Move zone down
-                        MoveZoneY(12, ResizeMode.BothEdges, ResizeMode.BothEdges);
+                        MoveZoneY(moveAmount, ResizeMode.BothEdges, ResizeMode.BothEdges);
                     }
                 }
             }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Themes/Dark.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Themes/Dark.xaml
@@ -31,5 +31,6 @@
     <SolidColorBrush x:Key="LayoutPreviewSmallScaleZoneBackgroundBrush" Color="#FF202020" />
 
     <SolidColorBrush x:Key="CanvasZoneBackgroundBrush" Color="#B0202020" />
+    <SolidColorBrush x:Key="CanvasZoneBorderBrush" Color="#CCFFFFFF" />
     <SolidColorBrush x:Key="GridZoneBackgroundBrush" Color="#B0202020" />
 </ResourceDictionary>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Themes/HighContrast1.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Themes/HighContrast1.xaml
@@ -25,5 +25,6 @@
     <SolidColorBrush x:Key="LayoutPreviewActualScaleZoneBackgroundBrush" Color="#E5202020" />
     <SolidColorBrush x:Key="LayoutPreviewSmallScaleZoneBackgroundBrush" Color="#FF202020" />
     <SolidColorBrush x:Key="CanvasZoneBackgroundBrush" Color="#E5202020" />
+    <SolidColorBrush x:Key="CanvasZoneBorderBrush" Color="#CCFFFFFF" />
     <SolidColorBrush x:Key="GridZoneBackgroundBrush" Color="#E5202020" />
 </ResourceDictionary>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Themes/HighContrast2.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Themes/HighContrast2.xaml
@@ -25,5 +25,6 @@
     <SolidColorBrush x:Key="LayoutPreviewActualScaleZoneBackgroundBrush" Color="#E5202020" />
     <SolidColorBrush x:Key="LayoutPreviewSmallScaleZoneBackgroundBrush" Color="#FF202020" />
     <SolidColorBrush x:Key="CanvasZoneBackgroundBrush" Color="#E5202020" />
+    <SolidColorBrush x:Key="CanvasZoneBorderBrush" Color="#CCFFFFFF" />
     <SolidColorBrush x:Key="GridZoneBackgroundBrush" Color="#E5202020" />
 </ResourceDictionary>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Themes/HighContrastBlack.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Themes/HighContrastBlack.xaml
@@ -25,5 +25,6 @@
     <SolidColorBrush x:Key="LayoutPreviewActualScaleZoneBackgroundBrush" Color="#E5202020" />
     <SolidColorBrush x:Key="LayoutPreviewSmallScaleZoneBackgroundBrush" Color="#FF202020" />
     <SolidColorBrush x:Key="CanvasZoneBackgroundBrush" Color="#E5202020" />
+    <SolidColorBrush x:Key="CanvasZoneBorderBrush" Color="#CCFFFFFF" />
     <SolidColorBrush x:Key="GridZoneBackgroundBrush" Color="#E5202020" />
 </ResourceDictionary>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Themes/HighContrastWhite.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Themes/HighContrastWhite.xaml
@@ -25,5 +25,6 @@
     <SolidColorBrush x:Key="LayoutPreviewActualScaleZoneBackgroundBrush" Color="#EFF3F3F3" />
     <SolidColorBrush x:Key="LayoutPreviewSmallScaleZoneBackgroundBrush" Color="#FFDCDCDC" />
     <SolidColorBrush x:Key="CanvasZoneBackgroundBrush" Color="#E5F3F3F3" />
+    <SolidColorBrush x:Key="CanvasZoneBorderBrush" Color="#CC000000" />
     <SolidColorBrush x:Key="GridZoneBackgroundBrush" Color="#E5F3F3F3" />
 </ResourceDictionary>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Themes/Light.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Themes/Light.xaml
@@ -31,5 +31,6 @@
     <SolidColorBrush x:Key="LayoutPreviewSmallScaleZoneBackgroundBrush" Color="#FFDCDCDC" />
     
     <SolidColorBrush x:Key="CanvasZoneBackgroundBrush" Color="#C5F8F8F8" />
+    <SolidColorBrush x:Key="CanvasZoneBorderBrush" Color="#CC000000" />
     <SolidColorBrush x:Key="GridZoneBackgroundBrush" Color="#C5F8F8F8" />
 </ResourceDictionary>


### PR DESCRIPTION
## Summary of the Pull Request
This PR enables keyboard navigation and manipulation of the canvas editor. The following things were changed/updated:
- Added keyboard logic.
**Tab**: move between zones
**Arrow keys**: change the position
**Shift + arrows keys**: make the canvas zone smaller or larger (following PowerPoint shape logic).
**Del**: delete the zone
- Updated canvas-selection styles.


**Things still need to fixed before merging in** (@enricogior can you team look at these items?):
- Due to the automatic snapping, canvas zones can get stuck when snapped together.
- It now requires to click on a canvas zone first to get the focus on the canvas zones window and vice-versa. Ideally, users can use tab to navigate through the zones and back to the little dialog window.


![FZEditorcanvaszonekeyboard](https://user-images.githubusercontent.com/9866362/117878272-df432680-b2a5-11eb-8663-924c56d7d964.gif)



## Quality Checklist

- [X] **Linked issue:** #10839
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
