### PR TITLE
Fix Incorrect HotKey for Color Picker in Welcome to PowerToys OOBE window

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -1045,7 +1045,7 @@ Take a moment to preview the various utilities listed or view our comprehensive 
     <value>release notes</value>
   </data>
   <data name="Oobe_ColorPicker_HowToUse.Text" xml:space="preserve">
-    <value>{Win} + {Ctrl} + {C} to open Color Picker.</value>
+    <value>{Win} + {Shift} + {C} to open Color Picker.</value>
   </data>
   <data name="Oobe_ColorPicker_TipsAndTricks.Text" xml:space="preserve">
     <value>To select a color with more precision, {scroll the mouse wheel} to zoom in.</value>


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Fixes incorrect default Keyboard Shortcut showing up in Welcome to PowerToys window for Color Picker upon fresh install, as mentioned in #11199

![image](https://user-images.githubusercontent.com/26640758/117904754-8191f700-b304-11eb-85dc-5bdda93afad1.png)


**What is include in the PR:** 

Just a change from {Ctrl} to Expected value of {Shift}, as of the default HotKey assigned to Color Picker in Resources.resw and the corresponding .lcl files


**How does someone test / validate:** 

Build the solution, install and open the Color Picker panel in the Welcome to PowerToys window. Ensure the keyboard combination to open Color Picker is shown as Win+Shift+C in every locale

## Quality Checklist

- [x] **Linked issue:** #11199
- [x] **Communication:** I've discussed this with core contributors in the issue. (Kind of?)
- [x] **Localization:** All end user facing strings can be localized

## Contributor License Agreement (CLA)

Signed.
