### PR TITLE
[CDPx] fix for build break

### DIFF
--- a/src/modules/keyboardmanager/common/Shortcut.cpp
+++ b/src/modules/keyboardmanager/common/Shortcut.cpp
@@ -4,7 +4,8 @@
 #include <common/interop/shared_constants.h>
 #include "Helpers.h"
 #include "InputInterface.h"
-
+#include <string>
+#include <sstream>
 
 // Function to split a wstring based on a delimiter and return a vector of split strings
 std::vector<std::wstring> Shortcut::splitwstring(const std::wstring& input, wchar_t delimiter)


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Fix for the internal build farm build break.

**What is include in the PR:** 
Added standard headers for strings and streams.

**How does someone test / validate:** 
Already tested with a CDPx build.

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
