### PR TITLE
[PT Run] Implement quick browser open in PT-run

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Uri/Properties/Resources.Designer.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Uri/Properties/Resources.Designer.cs
@@ -61,6 +61,24 @@ namespace Microsoft.Plugin.Uri.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to open default browser.
+        /// </summary>
+        public static string Microsoft_plugin_default_browser_open_failed {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_default_browser_open_failed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Open Default Browser.
+        /// </summary>
+        public static string Microsoft_plugin_uri_default_browser {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_uri_default_browser", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to open URL.
         /// </summary>
         public static string Microsoft_plugin_uri_open_failed {
@@ -88,7 +106,7 @@ namespace Microsoft.Plugin.Uri.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Open in browser.
+        ///   Looks up a localized string similar to Open in default browser.
         /// </summary>
         public static string Microsoft_plugin_uri_website {
             get {

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Uri/Properties/Resources.resx
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Uri/Properties/Resources.resx
@@ -121,7 +121,7 @@
     <value>Failed to open default browser</value>
   </data>
   <data name="Microsoft_plugin_uri_default_browser" xml:space="preserve">
-    <value>Open Default Browser</value>
+    <value>Open default browser</value>
   </data>
   <data name="Microsoft_plugin_uri_open_failed" xml:space="preserve">
     <value>Failed to open URL</value>

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Uri/Properties/Resources.resx
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Uri/Properties/Resources.resx
@@ -117,6 +117,12 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="Microsoft_plugin_default_browser_open_failed" xml:space="preserve">
+    <value>Failed to open default browser</value>
+  </data>
+  <data name="Microsoft_plugin_uri_default_browser" xml:space="preserve">
+    <value>Open Default Browser</value>
+  </data>
   <data name="Microsoft_plugin_uri_open_failed" xml:space="preserve">
     <value>Failed to open URL</value>
   </data>
@@ -127,6 +133,6 @@
     <value>URI Handler</value>
   </data>
   <data name="Microsoft_plugin_uri_website" xml:space="preserve">
-    <value>Open in browser</value>
+    <value>Open in default browser</value>
   </data>
 </root>


### PR DESCRIPTION
## Implement quick browser open in PT-run 

**What is this about:**
Added quick default browser launch function in Uri plugin

**What is include in the PR:** 
source code 

**How does someone test / validate:** 
Type only direct activation phrase (by default "//") in PT run and check if the item that open default browser is displayed.

***Quick browser***
![image](https://user-images.githubusercontent.com/10369528/118287022-07cd5980-b50e-11eb-8bfd-1a1f88e30cb2.png)

***Original plugin***
![image](https://user-images.githubusercontent.com/10369528/118286971-fc7a2e00-b50d-11eb-8fcb-df91e4607cdd.png)

review plz!

## Quality Checklist

- [x] **Linked issue:** #11223 
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** No updated tests /Microsoft.Plugin.Uri.UnitTests test passed
- [ ] **Installer:** 
- [ ] **Localization:**
- [ ] **Docs:** 
- [ ] **Binaries:** 
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
