### PR TITLE
[Shortcut Guide] Set current path to the executable's directory

### DIFF
--- a/src/modules/ShortcutGuide/ShortcutGuide/main.cpp
+++ b/src/modules/ShortcutGuide/ShortcutGuide/main.cpp
@@ -15,7 +15,7 @@
 const std::wstring instanceMutexName = L"Local\\PowerToys_ShortcutGuide_InstanceMutex";
 
 // set current path to the executable path
-bool setCurrentPath() 
+bool SetCurrentPath() 
 {
     TCHAR buffer[MAX_PATH] = { 0 };
     if (!GetModuleFileName(NULL, buffer, MAX_PATH))
@@ -48,7 +48,7 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, 
     InitUnhandledExceptionHandler_x64();
     Logger::trace("Starting Shortcut Guide with pid={}", GetCurrentProcessId());
 
-    if (!setCurrentPath())
+    if (!SetCurrentPath())
     {
         return false;
     }

--- a/src/modules/ShortcutGuide/ShortcutGuide/main.cpp
+++ b/src/modules/ShortcutGuide/ShortcutGuide/main.cpp
@@ -26,7 +26,7 @@ bool setCurrentPath()
 
     if (!PathRemoveFileSpec(buffer))
     {
-        Logger::error(L"Failed to fail file from module path. {}", get_last_error_or_default(GetLastError()));
+        Logger::error(L"Failed to remove file from module path. {}", get_last_error_or_default(GetLastError()));
         return false;
     }
 
@@ -34,7 +34,7 @@ bool setCurrentPath()
     std::filesystem::current_path(buffer, err);
     if (err.value())
     {
-        Logger::error("Failed to fail file from module path. {}", err.message());
+        Logger::error("Failed to set current path. {}", err.message());
         return false;
     }
 

--- a/src/modules/ShortcutGuide/ShortcutGuide/main.cpp
+++ b/src/modules/ShortcutGuide/ShortcutGuide/main.cpp
@@ -14,6 +14,33 @@
 
 const std::wstring instanceMutexName = L"Local\\PowerToys_ShortcutGuide_InstanceMutex";
 
+// set current path to the executable path
+bool setCurrentPath() 
+{
+    TCHAR buffer[MAX_PATH] = { 0 };
+    if (!GetModuleFileName(NULL, buffer, MAX_PATH))
+    {
+        Logger::error(L"Failed to get module path. {}", get_last_error_or_default(GetLastError()));
+        return false;
+    }
+
+    if (!PathRemoveFileSpec(buffer))
+    {
+        Logger::error(L"Failed to fail file from module path. {}", get_last_error_or_default(GetLastError()));
+        return false;
+    }
+
+    std::error_code err;
+    std::filesystem::current_path(buffer, err);
+    if (err.value())
+    {
+        Logger::error("Failed to fail file from module path. {}", err.message());
+        return false;
+    }
+
+    return true;
+}
+
 int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _In_ PWSTR lpCmdLine, _In_ int nCmdShow)
 {
     winrt::init_apartment();
@@ -21,6 +48,11 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, 
     InitUnhandledExceptionHandler_x64();
     Logger::trace("Starting Shortcut Guide with pid={}", GetCurrentProcessId());
 
+    if (!setCurrentPath())
+    {
+        return false;
+    }
+    
     auto mutex = CreateMutex(nullptr, true, instanceMutexName.c_str());
     if (mutex == nullptr)
     {


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
If SG process is started from the runner, the current path is set to the runner executable path. Current code assumes that the current path is the executable path.

**What is include in the PR:** 

**How does someone test / validate:** 
- Make a clean build of PowerToys
- Start PowerToys
- Press `Shift+Win+/`
- Verify that SG window is brought to the front

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
