### PR TITLE
Change markdown files to treat soft endings as hard

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -676,6 +676,7 @@ hangeul
 hanja
 hanselman
 hardcoded
+Hardlines
 HARDWAREINPUT
 hashcode
 hbitmap
@@ -1809,6 +1810,7 @@ sln
 SMALLICON
 SMTO
 snd
+softline
 somil
 Soref
 SORTDOWN

--- a/src/modules/previewpane/MarkdownPreviewHandler/MarkdownPreviewHandlerControl.cs
+++ b/src/modules/previewpane/MarkdownPreviewHandler/MarkdownPreviewHandlerControl.cs
@@ -66,7 +66,7 @@ namespace Microsoft.PowerToys.PreviewHandler.Markdown
         public MarkdownPreviewHandlerControl()
         {
             // if you have a string with double space, some people view it as a new line.
-            // while this is against spec, even GH supports this.  Techinically looks like GH just trims whitespace
+            // while this is against spec, even GH supports this. Technically looks like GH just trims whitespace
             // https://github.com/microsoft/PowerToys/issues/10354
             var softlineBreak = new Markdig.Extensions.Hardlines.SoftlineBreakAsHardlineExtension();
             _extension = new HTMLParsingExtension(ImagesBlockedCallBack);

--- a/src/modules/previewpane/MarkdownPreviewHandler/MarkdownPreviewHandlerControl.cs
+++ b/src/modules/previewpane/MarkdownPreviewHandler/MarkdownPreviewHandlerControl.cs
@@ -66,7 +66,7 @@ namespace Microsoft.PowerToys.PreviewHandler.Markdown
         public MarkdownPreviewHandlerControl()
         {
             // if you have a string with double space, some people view it as a new line.
-            // while this is against spec, even GH supports this.  Techincially looks like GH just trims whitespace
+            // while this is against spec, even GH supports this.  Techinically looks like GH just trims whitespace
             // https://github.com/microsoft/PowerToys/issues/10354
             var softlineBreak = new Markdig.Extensions.Hardlines.SoftlineBreakAsHardlineExtension();
             _extension = new HTMLParsingExtension(ImagesBlockedCallBack);

--- a/src/modules/previewpane/MarkdownPreviewHandler/MarkdownPreviewHandlerControl.cs
+++ b/src/modules/previewpane/MarkdownPreviewHandler/MarkdownPreviewHandlerControl.cs
@@ -65,9 +65,15 @@ namespace Microsoft.PowerToys.PreviewHandler.Markdown
         /// </summary>
         public MarkdownPreviewHandlerControl()
         {
+            // if you have a string with double space, some people view it as a new line.
+            // while this is against spec, even GH supports this.  Techincially looks like GH just trims whitespace
+            // https://github.com/microsoft/PowerToys/issues/10354
+            var softlineBreak = new Markdig.Extensions.Hardlines.SoftlineBreakAsHardlineExtension();
             _extension = new HTMLParsingExtension(ImagesBlockedCallBack);
+
             _pipelineBuilder = new MarkdownPipelineBuilder().UseAdvancedExtensions().UseEmojiAndSmiley().UseYamlFrontMatter().UseMathematics();
             _pipelineBuilder.Extensions.Add(_extension);
+            _pipelineBuilder.Extensions.Add(softlineBreak);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
while we are spec compliant with Markdown, most people use soft as hard endings.  GitHub for instance does

Adding in this

**What is include in the PR:** 
Change to make soft returns into hard returns.

**How does someone test / validate:** 

Use a markdown file that had returns.
```
testline no space 1
testline single space 2 
test line double space enting 3  
more text more text
```

## Quality Checklist

- [x] **Linked issue:** #10354
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
