### PR TITLE
[Auto-update][PT Settings] Updated UI

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/GeneralViewModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/GeneralViewModel.cs
@@ -124,6 +124,8 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
         private string _latestAvailableVersion = string.Empty;
         private string _updateCheckedDate = string.Empty;
 
+        private bool _isNewVersionDownloading;
+
         // Gets or sets a value indicating whether packaged.
         public bool Packaged
         {
@@ -452,6 +454,31 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             }
         }
 
+        public bool IsNewVersionDownloading
+        {
+            get
+            {
+                return _isNewVersionDownloading;
+            }
+
+            set
+            {
+                if (value != _isNewVersionDownloading)
+                {
+                    _isNewVersionDownloading = value;
+                    NotifyPropertyChanged();
+                }
+            }
+        }
+
+        public bool IsDownloadAllowed
+        {
+            get
+            {
+                return AutoUpdatesEnabled && !IsNewVersionDownloading;
+            }
+        }
+
         public void NotifyPropertyChanged([CallerMemberName] string propertyName = null)
         {
             // Notify UI of property change
@@ -474,6 +501,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
 
         private void UpdateNowClick()
         {
+            IsNewVersionDownloading = string.IsNullOrEmpty(UpdatingSettingsConfig.DownloadedInstallerFilename);
+            NotifyPropertyChanged(nameof(IsDownloadAllowed));
+
             Process.Start(new ProcessStartInfo("powertoys://update_now") { UseShellExecute = true });
         }
 
@@ -505,6 +535,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             PowerToysNewAvailableVersion = UpdatingSettingsConfig.NewVersion;
             PowerToysNewAvailableVersionLink = UpdatingSettingsConfig.ReleasePageLink;
             UpdateCheckedDate = UpdatingSettingsConfig.LastCheckedDateLocalized;
+
+            IsNewVersionDownloading = string.IsNullOrEmpty(UpdatingSettingsConfig.DownloadedInstallerFilename);
+            NotifyPropertyChanged(nameof(IsDownloadAllowed));
         }
     }
 }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/GeneralViewModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/GeneralViewModel.cs
@@ -125,6 +125,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
         private string _updateCheckedDate = string.Empty;
 
         private bool _isNewVersionDownloading;
+        private bool _isDownloadButtonClicked;
 
         // Gets or sets a value indicating whether packaged.
         public bool Packaged
@@ -501,6 +502,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
 
         private void UpdateNowClick()
         {
+            _isDownloadButtonClicked = UpdatingSettingsConfig.State == UpdatingSettings.UpdatingState.ReadyToDownload;
             IsNewVersionDownloading = string.IsNullOrEmpty(UpdatingSettingsConfig.DownloadedInstallerFilename);
             NotifyPropertyChanged(nameof(IsDownloadAllowed));
 
@@ -536,7 +538,13 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             PowerToysNewAvailableVersionLink = UpdatingSettingsConfig.ReleasePageLink;
             UpdateCheckedDate = UpdatingSettingsConfig.LastCheckedDateLocalized;
 
-            IsNewVersionDownloading = UpdatingSettingsConfig.State == UpdatingSettings.UpdatingState.ReadyToDownload && string.IsNullOrEmpty(UpdatingSettingsConfig.DownloadedInstallerFilename);
+            // reset _isDownloadButtonClicked state if the UpdatingState was changed
+            if (_isDownloadButtonClicked)
+            {
+                _isDownloadButtonClicked = UpdatingSettingsConfig.State == UpdatingSettings.UpdatingState.ReadyToDownload;
+            }
+
+            IsNewVersionDownloading = _isDownloadButtonClicked && string.IsNullOrEmpty(UpdatingSettingsConfig.DownloadedInstallerFilename);
             NotifyPropertyChanged(nameof(IsDownloadAllowed));
         }
     }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/GeneralViewModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/GeneralViewModel.cs
@@ -536,7 +536,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             PowerToysNewAvailableVersionLink = UpdatingSettingsConfig.ReleasePageLink;
             UpdateCheckedDate = UpdatingSettingsConfig.LastCheckedDateLocalized;
 
-            IsNewVersionDownloading = string.IsNullOrEmpty(UpdatingSettingsConfig.DownloadedInstallerFilename);
+            IsNewVersionDownloading = UpdatingSettingsConfig.State == UpdatingSettings.UpdatingState.ReadyToDownload && string.IsNullOrEmpty(UpdatingSettingsConfig.DownloadedInstallerFilename);
             NotifyPropertyChanged(nameof(IsDownloadAllowed));
         }
     }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/GeneralViewModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/GeneralViewModel.cs
@@ -503,7 +503,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
         private void UpdateNowClick()
         {
             _isDownloadButtonClicked = UpdatingSettingsConfig.State == UpdatingSettings.UpdatingState.ReadyToDownload;
-            IsNewVersionDownloading = string.IsNullOrEmpty(UpdatingSettingsConfig.DownloadedInstallerFilename);
+            IsNewVersionDownloading = _isDownloadButtonClicked && string.IsNullOrEmpty(UpdatingSettingsConfig.DownloadedInstallerFilename);
             NotifyPropertyChanged(nameof(IsDownloadAllowed));
 
             Process.Start(new ProcessStartInfo("powertoys://update_now") { UseShellExecute = true });

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -1219,4 +1219,7 @@ From there, simply click on a Markdown file or SVG icon in the File Explorer and
   <data name="General_IsReadyToInstall.Text" xml:space="preserve">
     <value>is ready to install.</value>
   </data>
+  <data name="General_Downloading.Text" xml:space="preserve">
+    <value>Downloading...</value>
+  </data>
 </root>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -1222,4 +1222,7 @@ From there, simply click on a Markdown file or SVG icon in the File Explorer and
   <data name="General_Downloading.Text" xml:space="preserve">
     <value>Downloading...</value>
   </data>
+  <data name="General_TryAgainToDownloadAndInstall.Content" xml:space="preserve">
+    <value>Try again to download and install</value>
+  </data>
 </root>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml
@@ -181,12 +181,17 @@
                     <TextBlock x:Name="General_ReadMore_ReadyToDownload" x:Uid="General_ReadMore" />
                 </HyperlinkButton>
 
+                <TextBlock x:Name="General_Downloading"
+                           x:Uid="General_Downloading"
+                           Visibility="{Binding Mode=OneWay, Path=IsNewVersionDownloading, Converter={StaticResource VisibleIfTrueConverter}}"
+                           Foreground="{Binding AutoUpdatesEnabled, Converter={StaticResource ModuleEnabledToForegroundConverter}}"/>
+
                 <Button x:Uid="General_DownloadAndInstall"
                         Margin="{StaticResource SmallTopMargin}"
                         Style="{StaticResource AccentButtonStyle}"
                         Foreground="White"
                         Command="{Binding UpdateNowButtonEventHandler}"
-                        IsEnabled="{Binding AutoUpdatesEnabled}"/>
+                        IsEnabled="{Binding IsDownloadAllowed}"/>
             </StackPanel>
 
             <StackPanel Visibility="{Binding PowerToysUpdatingState, Converter={StaticResource UpdatingStateReadyToInstallToVisibilityConverter}}">

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml
@@ -235,11 +235,7 @@
                     </HyperlinkButton>
                 </StackPanel>
 
-                <HyperlinkButton NavigateUri="{Binding PowerToysNewAvailableVersionLink}" Margin="0,-6,0,0" IsEnabled="{Binding AutoUpdatesEnabled}">
-                    <TextBlock x:Name="General_ReadMore_CannotDownload" x:Uid="General_ReadMore" />
-                </HyperlinkButton>
-
-                <Button x:Uid="General_DownloadAndInstall"
+                <Button x:Uid="General_TryAgainToDownloadAndInstall"
                         Margin="{StaticResource SmallTopMargin}"
                         Style="{StaticResource AccentButtonStyle}"
                         Foreground="White"


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

* Added `Downloading...` text.
* Mute the` Download and install` button after downloading started.
* Removed `Read more` for the error state.
* Changed button text to `Try to download and install` in the error state.

![image](https://user-images.githubusercontent.com/8949536/118613354-95cb6d80-b7b6-11eb-80cf-940cd44b0f84.png)

![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/8949536/118613405-a24fc600-b7b6-11eb-9860-cae654bdb302.gif)

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
