### PR TITLE
[Updating] Do not reset update state when msi cancellation detected

### DIFF
--- a/installer/PowerToysBootstrapper/bootstrapper/bootstrapper.cpp
+++ b/installer/PowerToysBootstrapper/bootstrapper/bootstrapper.cpp
@@ -354,6 +354,7 @@ int Bootstrapper(HINSTANCE hInstance)
     {
         spdlog::error("Couldn't install the existing MSI package ({})", GetLastError());
         ShowMessageBoxError(IDS_UNINSTALL_PREVIOUS_VERSION_ERROR);
+        return 1;
     }
 
     const bool installDotnet = !skipDotnetInstall;

--- a/src/ActionRunner/actionRunner.cpp
+++ b/src/ActionRunner/actionRunner.cpp
@@ -195,13 +195,21 @@ bool InstallNewVersionStage2(std::wstring installer_path, std::wstring_view inst
         sei.lpParameters = parameters.c_str();
 
         success = ShellExecuteExW(&sei) == TRUE;
-        
+
         // Wait for the install completion
         if (success)
         {
             WaitForSingleObject(sei.hProcess, INFINITE);
+            DWORD exitCode = 0;
+            GetExitCodeProcess(sei.hProcess, &exitCode);
+            success = exitCode == 0;
             CloseHandle(sei.hProcess);
         }
+    }
+
+    if (!success)
+    {
+        return false;
     }
 
     std::error_code _;
@@ -212,11 +220,6 @@ bool InstallNewVersionStage2(std::wstring installer_path, std::wstring_view inst
         state.githubUpdateLastCheckedDate.emplace(timeutil::now());
         state.state = UpdateState::upToDate;
     });
-
-    if (!success)
-    {
-        return false;
-    }
 
     if (launch_powertoys)
     {


### PR DESCRIPTION
## Summary of the Pull Request
We shouldn't reset update state to UpToDate if a user cancels the installation manually. We already check resulting status after launching the MSI in bootstrapper [here](https://github.com/microsoft/PowerToys/blob/c948c1fca8eccc7adec01684752074aba13828ab/installer/PowerToysBootstrapper/bootstrapper/bootstrapper.cpp#L413-L418). Since we launch bootstrapper from ActionRunner and reset update state there, we need to add exit code checking. Bootstrapper works by uninstalling the previous version first if it was detected, so if uninstallation was cancelled, we need to exit early there.

**What is this about:**

**What is include in the PR:** 

**How does someone test / validate:** 
- set version in version.props to e.g. 0.32
- open settings and check for updates
- press Install now button
- cancel uninstallation
- reopen PowerToys and observe that update state is still ReadyToInstall
## Quality Checklist

- [ ] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
