### PR TITLE
[Shortcut Guide] Close SG window when win shortcut was pressed

### DIFF
--- a/src/modules/ShortcutGuide/ShortcutGuide/d2d_window.cpp
+++ b/src/modules/ShortcutGuide/ShortcutGuide/d2d_window.cpp
@@ -191,17 +191,6 @@ LRESULT __stdcall D2DWindow::d2d_window_proc(HWND window, UINT message, WPARAM w
     auto self = this_from_hwnd(window);
     switch (message)
     {
-    case WM_KEYDOWN:
-    {
-        if (wparam == VK_ESCAPE)
-        {
-            Logger::trace(L"ESC key was pressed. Terminating process. PID={}", GetCurrentProcessId());
-            PostThreadMessage(GetCurrentThreadId(), WM_QUIT, 0, 0);
-            return 0;
-        }
-
-        return DefWindowProc(window, message, wparam, lparam);
-    }
     case WM_NCCREATE:
     {
         auto create_struct = reinterpret_cast<CREATESTRUCT*>(lparam);

--- a/src/modules/ShortcutGuide/ShortcutGuide/main.cpp
+++ b/src/modules/ShortcutGuide/ShortcutGuide/main.cpp
@@ -47,7 +47,7 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, 
     winrt::init_apartment();
     LoggerHelpers::init_logger(ShortcutGuideConstants::ModuleKey, L"ShortcutGuide", LogSettings::shortcutGuideLoggerName);
     InitUnhandledExceptionHandler_x64();
-    Logger::trace("Starting Shortcut Guide with pid={}", GetCurrentProcessId());
+    Logger::trace("Starting Shortcut Guide");
 
     if (!SetCurrentPath())
     {

--- a/src/modules/ShortcutGuide/ShortcutGuide/main.cpp
+++ b/src/modules/ShortcutGuide/ShortcutGuide/main.cpp
@@ -96,8 +96,10 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, 
         });
     }
 
+    auto hwnd = GetForegroundWindow();
+    auto window = OverlayWindow(hwnd);
     auto mainThreadId = GetCurrentThreadId();
-    EventWaiter exitEventWaiter(CommonSharedConstants::SHORTCUT_GUIDE_EXIT_EVENT, [mainThreadId](int err) {
+    EventWaiter exitEventWaiter(CommonSharedConstants::SHORTCUT_GUIDE_EXIT_EVENT, [mainThreadId, &window](int err) {
         if (err != ERROR_SUCCESS)
         {
             Logger::error(L"Failed to wait for {} event. {}", CommonSharedConstants::SHORTCUT_GUIDE_EXIT_EVENT, get_last_error_or_default(err));
@@ -107,11 +109,9 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, 
             Logger::trace(L"{} event was signaled", CommonSharedConstants::SHORTCUT_GUIDE_EXIT_EVENT);
         }
 
-        PostThreadMessage(mainThreadId, WM_QUIT, 0, 0);
+        window.CloseWindow(HideWindowType::THE_SHORTCUT_PRESSED, mainThreadId);
     });
 
-    auto hwnd = GetForegroundWindow();
-    auto window = OverlayWindow(hwnd);
     if (window.IsDisabled())
     {
         Logger::trace("SG is disabled for the current foreground app. Exiting SG");

--- a/src/modules/ShortcutGuide/ShortcutGuide/overlay_window.cpp
+++ b/src/modules/ShortcutGuide/ShortcutGuide/overlay_window.cpp
@@ -649,6 +649,11 @@ void D2DOverlayWindow::render(ID2D1DeviceContext5* d2d_dc)
     // Thumbnail logic:
     auto window_state = get_window_state(active_window);
     auto thumb_window = get_window_pos(active_window);
+    if (!thumb_window.has_value())
+    {
+        thumb_window = RECT();
+    }
+
     bool miniature_shown = active_window != nullptr && thumbnail != nullptr && thumb_window && window_state != MINIMIZED;
     RECT client_rect;
     if (thumb_window && GetClientRect(active_window, &client_rect))

--- a/src/modules/ShortcutGuide/ShortcutGuide/overlay_window.cpp
+++ b/src/modules/ShortcutGuide/ShortcutGuide/overlay_window.cpp
@@ -360,7 +360,6 @@ void D2DOverlayWindow::show(HWND active_window, bool snappable)
     shown_start_time = std::chrono::steady_clock::now();
     lock.unlock();
     D2DWindow::show(primary_screen.left(), primary_screen.top(), primary_screen.width(), primary_screen.height());
-    key_pressed.clear();
     // Check if taskbar is auto-hidden. If so, don't display the number arrows
     APPBARDATA param = {};
     param.cbSize = sizeof(APPBARDATA);
@@ -393,8 +392,9 @@ void D2DOverlayWindow::on_hide()
     // Trace the event only if the overlay window was visible.
     if (shown_start_time.time_since_epoch().count() > 0)
     {
-        Logger::trace("key_pressed.size()={}", key_pressed.size());
-        Trace::SendGuideSession(std::chrono::duration_cast<std::chrono::milliseconds>(shown_end_time - shown_start_time).count());
+        auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(shown_end_time - shown_start_time).count();
+        Logger::trace(L"Duration: {}. Close Type: {}", duration, windowCloseType);
+        Trace::SendGuideSession(duration, windowCloseType.c_str());
         shown_start_time = {};
     }
 }

--- a/src/modules/ShortcutGuide/ShortcutGuide/overlay_window.h
+++ b/src/modules/ShortcutGuide/ShortcutGuide/overlay_window.h
@@ -55,8 +55,13 @@ public:
     void quick_hide();
 
     HWND get_window_handle();
+    void SetWindowCloseType(std::wstring windowCloseType)
+    {
+        this->windowCloseType = windowCloseType;
+    }
 
 private:
+    std::wstring windowCloseType;
     bool show_thumbnail(const RECT& rect, double alpha);
     void hide_thumbnail();
     virtual void init() override;
@@ -68,7 +73,6 @@ private:
 
     bool running = true;
     std::vector<AnimateKeys> key_animations;
-    std::vector<int> key_pressed;
     std::vector<MonitorInfo> monitors;
     ScreenSize total_screen;
     int monitor_dx = 0, monitor_dy = 0;

--- a/src/modules/ShortcutGuide/ShortcutGuide/shortcut_guide.cpp
+++ b/src/modules/ShortcutGuide/ShortcutGuide/shortcut_guide.cpp
@@ -18,6 +18,7 @@
 #include <common/utils/winapi_error.h>
 #include <common/utils/window.h>
 #include <Psapi.h>
+#include <common/hooks/LowlevelKeyboardEvent.h>
 
 // TODO: refactor singleton
 OverlayWindow* instance = nullptr;
@@ -32,6 +33,7 @@ namespace
         bool disabled = false;
     };
 
+    // std::vector<int> modifierKeys = {VK_LSHIFT, VK_RSHIFT, VK_SHIFT, VK_LCONTROL, VK_RCONTROL, VK_CONTROL, VK}; 
     ShortcutGuideWindowInfo GetShortcutGuideWindowInfo(HWND active_window)
     {
         ShortcutGuideWindowInfo result;
@@ -86,11 +88,58 @@ namespace
     }
 
     const LPARAM eventActivateWindow = 1;
-}
+    
+    bool winPressed = false;
+    bool isWinPressed()
+    {
+        return (GetAsyncKeyState(VK_LWIN) & 0x8000) || (GetAsyncKeyState(VK_RWIN) & 0x8000);
+    }
 
-constexpr int alternative_switch_hotkey_id = 0x2;
-constexpr UINT alternative_switch_modifier_mask = MOD_WIN | MOD_SHIFT;
-constexpr UINT alternative_switch_vk_code = VK_OEM_2;
+    bool isWin(int key)
+    {
+        return key == VK_LWIN || key == VK_RWIN;
+    }
+
+    bool isKeyDown(LowlevelKeyboardEvent event)
+    {
+        return event.wParam == WM_KEYDOWN || event.wParam == WM_SYSKEYDOWN;
+    }
+
+    LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam)
+    {
+        LowlevelKeyboardEvent event;
+        if (nCode == HC_ACTION)
+        {
+            event.lParam = reinterpret_cast<KBDLLHOOKSTRUCT*>(lParam);
+            event.wParam = wParam;
+            
+            if (event.lParam->vkCode == VK_ESCAPE)
+            {
+                Logger::trace(L"ESC key was pressed. Terminating process. PID={}", GetCurrentProcessId());
+                PostThreadMessage(GetCurrentThreadId(), WM_QUIT, 0, 0);
+            }
+
+            if (winPressed && !isKeyDown(event) && isWin(event.lParam->vkCode))
+            {
+                Logger::trace(L"Win key was released. Terminating process. PID={}", GetCurrentProcessId());
+                PostThreadMessage(GetCurrentThreadId(), WM_QUIT, 0, 0);
+            }
+
+            if (isKeyDown(event) && isWin(event.lParam->vkCode))
+            {
+                winPressed = true;
+            }
+
+            if (isWinPressed() && isKeyDown(event) && !isWin(event.lParam->vkCode))
+            {
+                Logger::trace(L"Shortcut with win key was pressed. Terminating process. PID={}", GetCurrentProcessId());
+                PostThreadMessage(GetCurrentThreadId(), WM_QUIT, 0, 0);
+            }
+        }
+
+        return CallNextHookEx(NULL, nCode, wParam, lParam);
+    }
+}
 
 OverlayWindow::OverlayWindow(HWND activeWindow)
 {
@@ -100,6 +149,11 @@ OverlayWindow::OverlayWindow(HWND activeWindow)
 
     Logger::info("Overlay Window is creating");
     init_settings();
+    keyboardHook = SetWindowsHookEx(WH_KEYBOARD_LL, LowLevelKeyboardProc, GetModuleHandle(NULL), NULL);
+    if (!keyboardHook)
+    {
+        Logger::warn(L"Failed to create low level keyboard hook. {}", get_last_error_or_default(GetLastError()));
+    }
 }
 
 void OverlayWindow::ShowWindow()
@@ -135,12 +189,15 @@ bool OverlayWindow::IsDisabled()
 
 OverlayWindow::~OverlayWindow()
 {
-    UnregisterHotKey(winkey_popup->get_window_handle(), alternative_switch_hotkey_id);
     event_waiter.reset();
     winkey_popup->hide();
     target_state->exit();
     target_state.reset();
     winkey_popup.reset();
+    if (keyboardHook)
+    {
+        UnhookWindowsHookEx(keyboardHook);
+    }
 }
 
 void OverlayWindow::on_held()

--- a/src/modules/ShortcutGuide/ShortcutGuide/shortcut_guide.h
+++ b/src/modules/ShortcutGuide/ShortcutGuide/shortcut_guide.h
@@ -13,11 +13,20 @@ extern class OverlayWindow* instance;
 
 class TargetState;
 
+enum class HideWindowType
+{
+    ESC_PRESSED,
+    WIN_RELEASED,
+    WIN_SHORTCUT_PRESSED,
+    THE_SHORTCUT_PRESSED
+};
+
 class OverlayWindow
 {
 public:
     OverlayWindow(HWND activeWindow);
     void ShowWindow();
+    void CloseWindow(HideWindowType type, int mainThreadId = 0);
     bool IsDisabled();
 
     void on_held();
@@ -31,7 +40,6 @@ public:
     void get_exe_path(HWND window, wchar_t* exePath);
     ~OverlayWindow();
     static ShortcutGuideSettings GetSettings() noexcept;
-
 private:
     std::wstring app_name;
     //contains the non localized key of the powertoy

--- a/src/modules/ShortcutGuide/ShortcutGuide/shortcut_guide.h
+++ b/src/modules/ShortcutGuide/ShortcutGuide/shortcut_guide.h
@@ -43,6 +43,7 @@ private:
     void init_settings();
     void update_disabled_apps();
     HWND activeWindow;
+    HHOOK keyboardHook;
 
     struct OverlayOpacity
     {

--- a/src/modules/ShortcutGuide/ShortcutGuide/trace.cpp
+++ b/src/modules/ShortcutGuide/ShortcutGuide/trace.cpp
@@ -18,12 +18,13 @@ void Trace::UnregisterProvider() noexcept
     TraceLoggingUnregister(g_hProvider);
 }
 
-void Trace::SendGuideSession(const __int64 duration_ms) noexcept
+void Trace::SendGuideSession(const __int64 duration_ms, const wchar_t* close_type) noexcept
 {
     TraceLoggingWrite(
         g_hProvider,
         "ShortcutGuide_GuideSession",
         TraceLoggingInt64(duration_ms, "DurationInMs"),
+        TraceLoggingWideString(close_type, "CloseType"),
         ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
         TraceLoggingBoolean(TRUE, "UTCReplace_AppSessionGuid"),
         TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));

--- a/src/modules/ShortcutGuide/ShortcutGuide/trace.h
+++ b/src/modules/ShortcutGuide/ShortcutGuide/trace.h
@@ -6,6 +6,6 @@ class Trace
 public:
     static void RegisterProvider() noexcept;
     static void UnregisterProvider() noexcept;
-    static void SendGuideSession(const __int64 duration_ms) noexcept;
+    static void SendGuideSession(const __int64 duration_ms, const wchar_t* close_type) noexcept;
     static void SendSettings(ShortcutGuideSettings settings) noexcept;
 };


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

**What is include in the PR:** 
1. Close SG window if
- Win key was pressed and released
- Win+key is pressed(e.g Win+A, Win+Shift)
- ESC was pressed. Moved it from the window procedure
- The shortcut is pressed again
2. Update ShortcutSession telemetry event with close type
3. Fix crash  when `thumb_window` is not initialized. To reproduce it start PT in debug mode, press `Win+D` and try to open SG window.

**How does someone test / validate:** 
Try to close SG window with `ESC` key, pressing the shortcut again, pressing `Win+key` shortcut, pressing and releasing just win key

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
