### PR TITLE
[FanzyZones] Zone activation based on zone center

### DIFF
--- a/src/modules/fancyzones/lib/Settings.h
+++ b/src/modules/fancyzones/lib/Settings.h
@@ -20,7 +20,8 @@ struct Settings
         Smallest = 0,
         Largest = 1,
         Positional = 2,
-        EnumElements = 3, // number of elements in the enum, not counting this
+        ClosestCenter = 3,
+        EnumElements = 4, // number of elements in the enum, not counting this
     };
 
     // The values specified here are the defaults.

--- a/src/modules/fancyzones/lib/ZoneSet.cpp
+++ b/src/modules/fancyzones/lib/ZoneSet.cpp
@@ -20,6 +20,7 @@ using namespace FancyZonesUtils;
 namespace
 {
     constexpr int C_MULTIPLIER = 10000;
+    constexpr int OVERLAPPING_CENTRES_SENSITIVITY = 75;
 
     // PriorityGrid layout is unique for zoneCount <= 11. For zoneCount > 11 PriorityGrid is same as Grid
     FancyZonesDataTypes::GridLayoutInfo predefinedPriorityGridLayouts[11] = {
@@ -196,8 +197,8 @@ ZoneSet::ZonesFromPoint(POINT pt) const noexcept
     for (const auto& [zoneId, zone] : m_zones)
     {
         const RECT& zoneRect = zone->GetZoneRect();
-        if (zoneRect.left - m_config.SensitivityRadius <= pt.x && pt.x <= zoneRect.right &&
-            zoneRect.top <= pt.y && pt.y <= zoneRect.bottom)
+        if (zoneRect.left - m_config.SensitivityRadius <= pt.x && pt.x <= zoneRect.right + m_config.SensitivityRadius &&
+            zoneRect.top - m_config.SensitivityRadius <= pt.y && pt.y <= zoneRect.bottom + m_config.SensitivityRadius)
         {
             capturedZones.emplace_back(zoneId);
         }
@@ -266,9 +267,8 @@ ZoneSet::ZonesFromPoint(POINT pt) const noexcept
             POINT center = getCenter(zone);
             return pointDifference(center, pt);
         };
-        auto sensitivity = 75;
         auto closerToCenter = [&](auto zone1, auto zone2) {
-            if (pointDifference(getCenter(zone1), getCenter(zone2)) > sensitivity)
+            if (pointDifference(getCenter(zone1), getCenter(zone2)) > OVERLAPPING_CENTRES_SENSITIVITY)
             {
                 return distanceFromCenter(zone1) < distanceFromCenter(zone2);
             }

--- a/src/modules/fancyzones/lib/ZoneSet.cpp
+++ b/src/modules/fancyzones/lib/ZoneSet.cpp
@@ -20,7 +20,7 @@ using namespace FancyZonesUtils;
 namespace
 {
     constexpr int C_MULTIPLIER = 10000;
-    constexpr int OVERLAPPING_CENTRES_SENSITIVITY = 75;
+    constexpr int OVERLAPPING_CENTERS_SENSITIVITY = 75;
 
     // PriorityGrid layout is unique for zoneCount <= 11. For zoneCount > 11 PriorityGrid is same as Grid
     FancyZonesDataTypes::GridLayoutInfo predefinedPriorityGridLayouts[11] = {
@@ -268,7 +268,7 @@ ZoneSet::ZonesFromPoint(POINT pt) const noexcept
             return pointDifference(center, pt);
         };
         auto closerToCenter = [&](auto zone1, auto zone2) {
-            if (pointDifference(getCenter(zone1), getCenter(zone2)) > OVERLAPPING_CENTRES_SENSITIVITY)
+            if (pointDifference(getCenter(zone1), getCenter(zone2)) > OVERLAPPING_CENTERS_SENSITIVITY)
             {
                 return distanceFromCenter(zone1) < distanceFromCenter(zone2);
             }

--- a/src/modules/fancyzones/lib/ZoneSet.cpp
+++ b/src/modules/fancyzones/lib/ZoneSet.cpp
@@ -255,6 +255,12 @@ ZoneSet::ZonesFromPoint(POINT pt) const noexcept
             return max(rect.bottom - rect.top, 0) * max(rect.right - rect.left, 0);
         };
 
+        auto distanceFromCenter = [&](auto zone) {
+            RECT rect = zone->GetZoneRect();
+            POINT center = POINT{ (rect.right - rect.left) / 2, (rect.top - rect.bottom) / 2 };
+            return (pt.x - center.x)*(pt.x - center.x) + (pt.y - center.y)*(pt.y - center.y);
+        };
+
         try
         {
             using Algorithm = Settings::OverlappingZonesAlgorithm;
@@ -267,6 +273,8 @@ ZoneSet::ZonesFromPoint(POINT pt) const noexcept
                 return ZoneSelectPriority(capturedZones, [&](auto zone1, auto zone2) { return zoneArea(zone1) > zoneArea(zone2); });
             case Algorithm::Positional:
                 return ZoneSelectSubregion(capturedZones, pt);
+            case Algorithm::ClosestCenter:
+                return ZoneSelectPriority(capturedZones, [&](auto zone1, auto zone2) { return distanceFromCenter(zone1) < distanceFromCenter(zone2); });
             }
         }
         catch (std::out_of_range)

--- a/src/modules/fancyzones/lib/ZoneSet.cpp
+++ b/src/modules/fancyzones/lib/ZoneSet.cpp
@@ -257,7 +257,7 @@ ZoneSet::ZonesFromPoint(POINT pt) const noexcept
 
         auto distanceFromCenter = [&](auto zone) {
             RECT rect = zone->GetZoneRect();
-            POINT center = POINT{ (rect.right - rect.left) / 2, (rect.top - rect.bottom) / 2 };
+            POINT center = POINT{ (rect.right + rect.left) / 2, (rect.top + rect.bottom) / 2 };
             return (pt.x - center.x)*(pt.x - center.x) + (pt.y - center.y)*(pt.y - center.y);
         };
 

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -946,6 +946,9 @@
   <data name="ColorPicker_Editor.Text" xml:space="preserve">
     <value>Editor</value>
   </data>
+  <data name="FancyZones_OverlappingZonesClosestCenter.Content" xml:space="preserve">
+    <value>Activate the zone whose center is closest to the cursor</value>
+  </data>
   <data name="FancyZones_OverlappingZonesLargest.Content" xml:space="preserve">
     <value>Activate the largest zone by area</value>
   </data>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -125,8 +125,6 @@
                       Margin="{StaticResource XSmallTopMargin}"
                       IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}" />
 
-            <TextBlock Text="asdlkjfalksdjflaksjdf"></TextBlock>
-
             <ComboBox x:Uid="FancyZones_OverlappingZones"
                       SelectedIndex="{x:Bind Path=ViewModel.OverlappingZonesAlgorithmIndex, Mode=TwoWay}"
                       IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -125,6 +125,8 @@
                       Margin="{StaticResource XSmallTopMargin}"
                       IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}" />
 
+            <TextBlock Text="asdlkjfalksdjflaksjdf"></TextBlock>
+
             <ComboBox x:Uid="FancyZones_OverlappingZones"
                       SelectedIndex="{x:Bind Path=ViewModel.OverlappingZonesAlgorithmIndex, Mode=TwoWay}"
                       IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"
@@ -134,6 +136,7 @@
                 <ComboBoxItem x:Uid="FancyZones_OverlappingZonesSmallest" />
                 <ComboBoxItem x:Uid="FancyZones_OverlappingZonesLargest" />
                 <ComboBoxItem x:Uid="FancyZones_OverlappingZonesPositional" />
+                <ComboBoxItem x:Uid="FancyZones_OverlappingZonesClosestCenter" />
             </ComboBox>
 
             <TextBlock x:Uid="FancyZones_WindowBehavior_GroupSettings"


### PR DESCRIPTION
## Summary of the Pull Request

I have implemented a new algorithm for dealing with snapping overlapping tiles. What I'm proposing snaps to the tile with the closest center, unless the centers of the tiles are too close in which case it falls back to taking the smallest tile. I still need to add  a setting to adjust the level at which the algorithm falls back to taking the smallest tile.

**What is include in the PR:**
A new setting algorithm to select a zone when they overlap.
Temporarily disabled buffering of windows when selecting.

**How does someone test / validate:** 
Change the "When multiple zones overlap:" setting to "Activate the zone whose center is closest to the cursor" in the Fancy zones settings. Here are some before and after gifs:

Before, split the overlapped area into multiple activation targets:
![gif1](https://user-images.githubusercontent.com/83034407/118861820-f1772300-b8aa-11eb-8ca0-e4a10ac1bfbc.gif)
Now, activate the zone whose center is closest to the cursor:
![gif2](https://user-images.githubusercontent.com/83034407/118861856-fe941200-b8aa-11eb-82f4-ed0ae8a7f96f.gif)

Before, split the overlapped area into multiple activation targets:
![gif3](https://user-images.githubusercontent.com/83034407/118861885-0489f300-b8ab-11eb-96bb-31dc03301fa2.gif)
Now, activate the zone whose center is closest to the cursor:
![gif4](https://user-images.githubusercontent.com/83034407/118861893-0784e380-b8ab-11eb-90f1-5eaf2c0a97b5.gif)

Now, when centers are too close, the algorithm reverts to taking the smallest window:
![gif5](https://user-images.githubusercontent.com/83034407/118861945-14093c00-b8ab-11eb-862a-59817ce8516f.gif)

## Quality Checklist

- [x] **Linked issue:** #11322
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
