### PR TITLE
[ColorPicker] Improving keyboard navigation

### DIFF
--- a/src/modules/colorPicker/ColorPickerUI/Controls/ColorFormatControl.xaml
+++ b/src/modules/colorPicker/ColorPickerUI/Controls/ColorFormatControl.xaml
@@ -1,16 +1,11 @@
 ﻿<UserControl x:Class="ColorPicker.Controls.ColorFormatControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:p="clr-namespace:ColorPicker.Properties"
-             xmlns:ui="http://schemas.modernwpf.com/2019"
              mc:Ignorable="d">
-    <UserControl.Resources>
-        <SolidColorBrush x:Key="TextControlBorderBrushFocused"
-                         Color="Transparent" />
-    </UserControl.Resources>
-    
+
     <Border x:Name="MainBorder"
             Margin="12,16,12,0"
             Width="308"
@@ -49,28 +44,16 @@
             <Button x:Name="CopyToClipboardButton"
                     ToolTipService.ToolTip="{x:Static p:Resources.Copy_to_clipboard}"
                     Background="{DynamicResource ColorControlBackgroundBrush}"
+                    Foreground="{DynamicResource SecondaryForegroundBrush}"
                     Height="36"
                     Width="36"
                     Grid.Column="2"
-                    
                     AutomationProperties.HelpText="{Binding ElementName=FormatNameTextBlock, Path=Text}"
                     AutomationProperties.Name="{x:Static p:Resources.Copy_to_clipboard}"
                     FontSize="12"
                     Style="{StaticResource DefaultButtonStyle}"
                     FontFamily="Segoe MDL2 Assets"
-                    Content="&#xE16F;">
-                <Button.Resources>
-                    <Style TargetType="Button">
-                        <Style.Triggers>
-                            <DataTrigger Binding="{Binding Path=IsMouseOver, ElementName=MainBorder}"
-                                         Value="False">
-                                <Setter Property="Opacity"
-                                        Value="1" />
-                            </DataTrigger>
-                        </Style.Triggers>
-                    </Style>
-                </Button.Resources>
-            </Button>
+                    Content="&#xE16F;" />       
         </Grid>
         <Border.Effect>
             <DropShadowEffect BlurRadius="6" Opacity="0.24" ShadowDepth="1" />

--- a/src/modules/colorPicker/ColorPickerUI/Controls/ColorFormatControl.xaml
+++ b/src/modules/colorPicker/ColorPickerUI/Controls/ColorFormatControl.xaml
@@ -10,13 +10,14 @@
         <SolidColorBrush x:Key="TextControlBorderBrushFocused"
                          Color="Transparent" />
     </UserControl.Resources>
+    
     <Border x:Name="MainBorder"
-                    Margin="12,16,12,0"
-                    Width="308"
-                    Height="36"
-                    CornerRadius="2"
-                    HorizontalAlignment="Stretch"
-                    Background="{DynamicResource ColorControlBackgroundBrush}">
+            Margin="12,16,12,0"
+            Width="308"
+            Height="36"
+            CornerRadius="2"
+            HorizontalAlignment="Stretch"
+            Background="{DynamicResource ColorControlBackgroundBrush}">
         <Grid>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="64"/>
@@ -42,7 +43,7 @@
                        IsReadOnly="True"
                        VerticalAlignment="Center"
                        Padding="8"
-                       AutomationProperties.LabeledBy="{Binding FormatNameTextBlock}"
+                     AutomationProperties.LabeledBy="{Binding ElementName=FormatNameTextBlock, Path=Text}"
                      />
 
             <Button x:Name="CopyToClipboardButton"
@@ -51,18 +52,20 @@
                     Height="36"
                     Width="36"
                     Grid.Column="2"
+                    
                     AutomationProperties.HelpText="{Binding ElementName=FormatNameTextBlock, Path=Text}"
-                    AutomationProperties.Name="{x:Static p:Resources.Copy_to_clipboard}">
-                <Button.Content>
-                    <TextBlock FontFamily="Segoe MDL2 Assets"
-                           Text="&#xE16F;"
-                           FontSize="12" />
-                </Button.Content>
+                    AutomationProperties.Name="{x:Static p:Resources.Copy_to_clipboard}"
+                    FontSize="12"
+                    Style="{StaticResource DefaultButtonStyle}"
+                    FontFamily="Segoe MDL2 Assets"
+                    Content="&#xE16F;">
                 <Button.Resources>
-                    <Style TargetType="Button" BasedOn="{StaticResource DefaultButtonStyle}">
+                    <Style TargetType="Button">
                         <Style.Triggers>
-                            <DataTrigger Binding="{Binding Path=IsMouseOver, ElementName=MainBorder}" Value="False">
-                                <Setter Property="Opacity" Value="0"/>
+                            <DataTrigger Binding="{Binding Path=IsMouseOver, ElementName=MainBorder}"
+                                         Value="False">
+                                <Setter Property="Opacity"
+                                        Value="1" />
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>

--- a/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml
+++ b/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml
@@ -296,6 +296,7 @@
                     Style="{DynamicResource ColorShadeButtonStyle}">
                 <ui:FlyoutService.Flyout>
                     <ui:Flyout x:Name="DetailsFlyout"
+                               Placement="Bottom"
                                Closed="DetailsFlyout_Closed">
                         <Grid Margin="0,4,0,12"
                               KeyboardNavigation.TabNavigation="Contained"

--- a/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml
+++ b/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml
@@ -7,66 +7,281 @@
              xmlns:p="clr-namespace:ColorPicker.Properties"
              xmlns:ui="http://schemas.modernwpf.com/2019"
              mc:Ignorable="d"
-             Height="350"
+             TabIndex="3"
+             Focusable="True"
+             IsTabStop="True"
              Width="333">
-    <StackPanel x:Name="PickerPanel"
-                Orientation="Vertical"
-                Background="{x:Null}" >
-        <!--Top panel-->
-        <Grid HorizontalAlignment="Stretch" Margin="12,0,12,0">
+    <UserControl.Resources>
+
+        <Style TargetType="Thumb"
+               x:Key="SliderThumbStyle">
+            <Setter Property="BorderThickness"
+                    Value="4" />
+            <Setter Property="Background"
+                    Value="{DynamicResource SliderThumbBackground}" />
+            <Setter Property="IsTabStop"
+                    Value="False" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Thumb">
+                        <Border Background="Transparent"
+                                BorderBrush="{DynamicResource PrimaryForegroundBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="{DynamicResource SliderThumbCornerRadius}" />
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <ControlTemplate x:Key="SliderHorizontal"
+                         TargetType="Slider">
+            <Grid Margin="{TemplateBinding Padding}"
+                  SnapsToDevicePixels="True">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
+
+
+                <Grid x:Name="SliderContainer"
+                      Grid.Row="1"
+                      Background="Transparent"
+                      ui:FocusVisualHelper.IsTemplateFocusTarget="True">
+                    <Border Background="{TemplateBinding Background}"
+                            Margin="1,0,1,0"
+                            CornerRadius="6"
+                            VerticalAlignment="Center"
+                            Height="12">
+                        <Border.Effect>
+                            <DropShadowEffect BlurRadius="6"
+                                              Opacity="0.32"
+                                              ShadowDepth="2" />
+                        </Border.Effect>
+                    </Border>
+                    <Grid x:Name="HorizontalTemplate"
+                          MinHeight="{DynamicResource SliderHorizontalHeight}">
+
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+
+
+
+                        <Rectangle x:Name="HorizontalTrackRect"
+                                   Fill="Transparent"
+                                   Height="{DynamicResource SliderTrackThemeHeight}"
+                                   Grid.Row="1"
+                                   Grid.ColumnSpan="3" />
+                        <Rectangle x:Name="HorizontalDecreaseRect"
+                                   Width="{Binding ActualWidth, ElementName=HorizontalDecrease}"
+                                   Fill="Transparent"
+                                   Grid.Row="1" />
+                        <TickBar x:Name="TopTickBar"
+                                 Placement="Top"
+                                 Visibility="Collapsed"
+                                 Fill="{DynamicResource SliderTickBarFill}"
+                                 Height="{DynamicResource SliderOutsideTickBarThemeHeight}"
+                                 VerticalAlignment="Bottom"
+                                 Margin="0,0,0,4"
+                                 Grid.ColumnSpan="3" />
+                        <TickBar x:Name="BottomTickBar"
+                                 Placement="Bottom"
+                                 Visibility="Collapsed"
+                                 Fill="{DynamicResource SliderTickBarFill}"
+                                 Height="{DynamicResource SliderOutsideTickBarThemeHeight}"
+                                 VerticalAlignment="Top"
+                                 Margin="0,4,0,0"
+                                 Grid.Row="2"
+                                 Grid.ColumnSpan="3" />
+                        <Track x:Name="PART_Track"
+                               Grid.Row="0"
+                               Grid.RowSpan="3"
+                               Grid.Column="0"
+                               Grid.ColumnSpan="3">
+                            <Track.DecreaseRepeatButton>
+                                <RepeatButton x:Name="HorizontalDecrease"
+                                              Command="{x:Static Slider.DecreaseLarge}"
+                                              Style="{StaticResource RepeatButtonTransparent}" />
+                            </Track.DecreaseRepeatButton>
+                            <Track.IncreaseRepeatButton>
+                                <RepeatButton Command="{x:Static Slider.IncreaseLarge}"
+                                              Style="{StaticResource RepeatButtonTransparent}" />
+                            </Track.IncreaseRepeatButton>
+                            <Track.Thumb>
+                                <Thumb x:Name="HorizontalThumb"
+                                       Style="{StaticResource SliderThumbStyle}"
+                                       DataContext="{TemplateBinding Value}"
+                                       Height="20"
+                                       VerticalAlignment="Center"
+                                       Margin="0,0,0,0"
+                                       Width="20"
+                                       ui:FocusVisualHelper.FocusVisualMargin="-14,-6,-14,-6">
+                                    <Thumb.Resources>
+                                        <Style TargetType="ToolTip"
+                                               BasedOn="{StaticResource SliderAutoToolTipStyle}" />
+                                    </Thumb.Resources>
+                                </Thumb>
+                            </Track.Thumb>
+                        </Track>
+                    </Grid>
+                </Grid>
+            </Grid>
+            <ControlTemplate.Triggers>
+                <Trigger Property="TickPlacement"
+                         Value="TopLeft">
+                    <Setter TargetName="TopTickBar"
+                            Property="Visibility"
+                            Value="Visible" />
+                </Trigger>
+                <Trigger Property="TickPlacement"
+                         Value="BottomRight">
+                    <Setter TargetName="BottomTickBar"
+                            Property="Visibility"
+                            Value="Visible" />
+                </Trigger>
+                <Trigger Property="TickPlacement"
+                         Value="Both">
+                    <Setter TargetName="TopTickBar"
+                            Property="Visibility"
+                            Value="Visible" />
+                    <Setter TargetName="BottomTickBar"
+                            Property="Visibility"
+                            Value="Visible" />
+                </Trigger>
+                <Trigger Property="IsMouseOver"
+                         Value="True">
+
+                    <Setter TargetName="HorizontalThumb"
+                            Property="Opacity"
+                            Value="0.8" />
+
+                </Trigger>
+                <Trigger SourceName="HorizontalThumb"
+                         Property="IsDragging"
+                         Value="True">
+
+                    <Setter TargetName="HorizontalThumb"
+                            Property="Opacity"
+                            Value="0.6" />
+
+                </Trigger>
+                <Trigger Property="IsEnabled"
+                         Value="False">
+
+                    <Setter TargetName="HorizontalDecreaseRect"
+                            Property="Fill"
+                            Value="{DynamicResource SliderTrackValueFillDisabled}" />
+                    <Setter TargetName="HorizontalTrackRect"
+                            Property="Fill"
+                            Value="{DynamicResource SliderTrackFillDisabled}" />
+                    <Setter TargetName="HorizontalThumb"
+                            Property="Background"
+                            Value="{DynamicResource SliderThumbBackgroundDisabled}" />
+                    <Setter TargetName="TopTickBar"
+                            Property="Fill"
+                            Value="{DynamicResource SliderTickBarFillDisabled}" />
+                    <Setter TargetName="BottomTickBar"
+                            Property="Fill"
+                            Value="{DynamicResource SliderTickBarFillDisabled}" />
+                    <Setter TargetName="SliderContainer"
+                            Property="Background"
+                            Value="{DynamicResource SliderContainerBackgroundDisabled}" />
+                </Trigger>
+            </ControlTemplate.Triggers>
+        </ControlTemplate>
+
+
+        <Style x:Key="CustomSLiderStyle"
+               TargetType="Slider">
+            <Setter Property="OverridesDefaultStyle"
+                    Value="True" />
+            <Setter Property="Stylus.IsPressAndHoldEnabled"
+                    Value="false" />
+            <Setter Property="Background"
+                    Value="{DynamicResource SliderTrackFill}" />
+            <Setter Property="BorderThickness"
+                    Value="{DynamicResource SliderBorderThemeThickness}" />
+            <Setter Property="Foreground"
+                    Value="{DynamicResource SliderTrackValueFill}" />
+            <Setter Property="FontFamily"
+                    Value="{DynamicResource ContentControlThemeFontFamily}" />
+            <Setter Property="FontSize"
+                    Value="{DynamicResource ControlContentThemeFontSize}" />
+            <!--<Setter Property="ManipulationMode" Value="None" />-->
+            <Setter Property="FocusVisualStyle"
+                    Value="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" />
+            <Setter Property="ui:FocusVisualHelper.UseSystemFocusVisuals"
+                    Value="{DynamicResource UseSystemFocusVisuals}" />
+            <Setter Property="ui:FocusVisualHelper.FocusVisualMargin"
+                    Value="-7,0,-7,0" />
+            <Setter Property="ui:ControlHelper.CornerRadius"
+                    Value="{DynamicResource ControlCornerRadius}" />
+            <Setter Property="Template"
+                    Value="{StaticResource SliderHorizontal}" />
+            <Style.Triggers>
+                <Trigger Property="Orientation"
+                         Value="Vertical">
+                    <Setter Property="Template"
+                            Value="{StaticResource SliderVertical}" />
+                </Trigger>
+            </Style.Triggers>
+        </Style>
+
+    </UserControl.Resources>
+    <Grid  x:Name="PickerPanel" HorizontalAlignment="Stretch"
+              Margin="12,2,12,2">
             <Grid.Effect>
-                <DropShadowEffect BlurRadius="6" Opacity="0.32" ShadowDepth="2" />
+                <DropShadowEffect BlurRadius="6"
+                                  Opacity="0.32"
+                                  ShadowDepth="2" />
             </Grid.Effect>
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="36"/>
-                <ColumnDefinition Width="36"/>
-                <ColumnDefinition Width="165"/>
-                <ColumnDefinition Width="36"/>
-                <ColumnDefinition Width="36"/>
+                <ColumnDefinition Width="36" />
+                <ColumnDefinition Width="36" />
+                <ColumnDefinition Width="165" />
+                <ColumnDefinition Width="36" />
+                <ColumnDefinition Width="36" />
             </Grid.ColumnDefinitions>
 
             <Button x:Name="colorVariation1Button"
                     Grid.Column="0"
-                    TabIndex="4"
                     ui:ControlHelper.CornerRadius="2,0,0,2"
                     Background="LightPink"
                     Click="ColorVariationButton_Click"
                     AutomationProperties.Name="Color shade 1"
                     Style="{DynamicResource ColorShadeButtonStyle}"
-                    ToolTipService.ToolTip="{x:Static p:Resources.Select_color}"/>
+                    ToolTipService.ToolTip="{x:Static p:Resources.Select_color}" />
             <Button x:Name="colorVariation2Button"
                     Grid.Column="1"
                     ui:ControlHelper.CornerRadius="0"
-                    TabIndex="5"
                     Background="LightPink"
                     Click="ColorVariationButton_Click"
                     AutomationProperties.Name="Color shade 2"
                     Style="{DynamicResource ColorShadeButtonStyle}"
-                    ToolTipService.ToolTip="{x:Static p:Resources.Select_color}"/>
+                    ToolTipService.ToolTip="{x:Static p:Resources.Select_color}" />
             <Button x:Name="colorVariation3Button"
                     Grid.Column="3"
-                    TabIndex="7"
                     ui:ControlHelper.CornerRadius="0"
                     Background="LightPink"
                     Click="ColorVariationButton_Click"
                     AutomationProperties.Name="Color shade 3"
                     Style="{DynamicResource ColorShadeButtonStyle}"
-                    ToolTipService.ToolTip="{x:Static p:Resources.Select_color}"/>
+                    ToolTipService.ToolTip="{x:Static p:Resources.Select_color}" />
             <Button x:Name="colorVariation4Button"
                     Grid.Column="4"
-                    TabIndex="8"
                     ui:ControlHelper.CornerRadius="0,2,2,0"
                     Background="LightPink"
                     Click="ColorVariationButton_Click"
                     AutomationProperties.Name="Color shade 5"
                     Style="{DynamicResource ColorShadeButtonStyle}"
-                    ToolTipService.ToolTip="{x:Static p:Resources.Select_color}"/>
+                    ToolTipService.ToolTip="{x:Static p:Resources.Select_color}" />
+
             <Button x:Name="CurrentColorButton"
                     HorizontalAlignment="Left"
                     Grid.Column="0"
-                    TabIndex="6"
                     Grid.ColumnSpan="5"
-                    Opacity="1"
                     ui:ControlHelper.CornerRadius="0"
                     Background="Red"
                     Width="165"
@@ -77,221 +292,160 @@
                     ToolTipService.ToolTip="{x:Static p:Resources.Selected_color_tooltip}"
                     Click="CurrentColorButton_Click"
                     Style="{DynamicResource ColorShadeButtonStyle}">
+                <ui:FlyoutService.Flyout>
+                    <ui:Flyout x:Name="DetailsFlyout"
+                               Closed="DetailsFlyout_Closed">
+                        <Grid Margin="0,4,0,12"
+                              KeyboardNavigation.TabNavigation="Contained"
+                              x:Name="detailsGrid">
+                            <StackPanel x:Name="detailsStackPanel">
+
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBlock Text="H"
+                                               Width="38"
+                                               FontWeight="SemiBold"
+                                               TextAlignment="Center"
+                                               VerticalAlignment="Center" />
+
+                                    <Slider x:Name="HueGradientSlider"
+                                            Width="214"
+                                            IsMoveToPointEnabled="True"
+                                            AutomationProperties.Name="{x:Static p:Resources.Hue_slider}"
+                                            Style="{StaticResource CustomSLiderStyle}"
+                                            ValueChanged="HueGradientSlider_ValueChanged"
+                                            VerticalAlignment="Center"
+                                            Grid.Column="1"
+                                            Minimum="0"
+                                            Maximum="289" />
+                                </StackPanel>
+
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBlock Text="S"
+                                               Grid.Row="1"
+                                               Width="38"
+                                               TextAlignment="Center"
+                                               FontWeight="SemiBold"
+                                               VerticalAlignment="Center" />
+
+                                    <Slider x:Name="SaturationGradientSlider"
+                                            AutomationProperties.Name="{x:Static p:Resources.Saturation_slider}"
+                                            Style="{StaticResource CustomSLiderStyle}"
+                                            ValueChanged="SaturationGradientSlider_ValueChanged"
+                                            Grid.Column="1"
+                                            Width="214"
+                                            IsMoveToPointEnabled="True"
+                                            Grid.Row="1"
+                                            Minimum="0"
+                                            Maximum="289">
+                                        <Slider.Background>
+                                            <LinearGradientBrush EndPoint="1,0.5"
+                                                                 StartPoint="0, 0.5">
+                                                <GradientStop x:Name="SaturationStartColor"
+                                                              Color="Black" />
+                                                <GradientStop x:Name="SaturationStopColor"
+                                                              Color="Red"
+                                                              Offset="1" />
+                                            </LinearGradientBrush>
+                                        </Slider.Background>
+                                    </Slider>
+                                </StackPanel>
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBlock Text="V"
+                                               Grid.Row="2"
+                                               Width="38"
+                                               TextAlignment="Center"
+                                               FontWeight="SemiBold"
+                                               VerticalAlignment="Center" />
+
+                                    <Slider x:Name="ValueGradientSlider"
+                                            AutomationProperties.Name="{x:Static p:Resources.Value_slider}"
+                                            Style="{StaticResource CustomSLiderStyle}"
+                                            ValueChanged="ValueGradientSlider_ValueChanged"
+                                            Grid.Column="1"
+                                            IsMoveToPointEnabled="True"
+                                            Grid.Row="2"
+                                            Width="214"
+                                            Minimum="0"
+                                            Maximum="289">
+                                        <Slider.Background>
+                                            <LinearGradientBrush EndPoint="1,0.5"
+                                                                 StartPoint="0, 0.5">
+                                                <GradientStop x:Name="ValueStartColor"
+                                                              Color="Black" />
+                                                <GradientStop x:Name="ValueStopColor"
+                                                              Color="Red"
+                                                              Offset="1" />
+                                            </LinearGradientBrush>
+                                        </Slider.Background>
+                                    </Slider>
+                                </StackPanel>
+
+
+                                <StackPanel Orientation="Horizontal"
+                                            Margin="0,16,0,0">
+                                    <TextBlock Text="RGB"
+                                               Width="38"
+                                               FontWeight="SemiBold"
+                                               TextAlignment="Center"
+                                               VerticalAlignment="Center" />
+
+                                    <ui:NumberBox x:Name="RNumberBox"
+                                                  Height="32"
+                                                  Width="72"
+                                                  ui:ControlHelper.CornerRadius="2,0,0,2"
+                                                  AutomationProperties.Name="{x:Static p:Resources.Red_value}"
+                                                  ValueChanged="RGBNumberBox_ValueChanged"
+                                                  Minimum="0"
+                                                  Maximum="255" />
+
+                                    <ui:NumberBox x:Name="GNumberBox"
+                                                  Height="32"
+                                                  Margin="-1,0,0,0"
+                                                  Width="72"
+                                                  ui:ControlHelper.CornerRadius="0"
+                                                  AutomationProperties.Name="{x:Static p:Resources.Green_value}"
+                                                  ValueChanged="RGBNumberBox_ValueChanged"
+                                                  Minimum="0"
+                                                  Maximum="255" />
+
+                                    <ui:NumberBox x:Name="BNumberBox"
+                                                  Height="32"
+                                                  Width="72"
+                                                  Margin="-1,0,0,0"
+                                                  ui:ControlHelper.CornerRadius="0,2,2,0"
+                                                  AutomationProperties.Name="{x:Static p:Resources.Blue_value}"
+                                                  ValueChanged="RGBNumberBox_ValueChanged"
+                                                  Minimum="0"
+                                                  Maximum="255" />
+                                </StackPanel>
+
+                                <StackPanel Orientation="Horizontal"
+                                            Margin="0,16,0,0">
+                                    <TextBlock Text="HEX"
+                                               Width="38"
+                                               TextAlignment="Center"
+                                               FontWeight="SemiBold"
+                                               VerticalAlignment="Center" />
+                                    <TextBox x:Name="HexCode"
+                                             Height="32"
+                                             Width="214"
+                                             AutomationProperties.Name="{x:Static p:Resources.Hex_value}"
+                                             GotKeyboardFocus="HexCode_GotKeyboardFocus"
+                                             TextChanged="HexCode_TextChanged"
+                                             TextWrapping="Wrap" />
+                                </StackPanel>
+
+                                <Button Margin="0,32,0,0"
+                                        x:Name="OKButton"
+                                        Click="OKButton_Click"
+                                        Style="{StaticResource AccentButtonStyle}"
+                                        AutomationProperties.Name="{x:Static p:Resources.OK}"
+                                        Content="{x:Static p:Resources.OK}"
+                                        HorizontalAlignment="Stretch" />
+                            </StackPanel>
+                        </Grid>
+                    </ui:Flyout>
+                </ui:FlyoutService.Flyout>
             </Button>
         </Grid>
-
-        <!--Details panel-->
-        <Grid Margin="0,4,0,12"
-              Height="0"
-              Visibility="Collapsed"
-              x:Name="detailsGrid">
-            <Border Background="{DynamicResource PrimaryBackgroundBrush}"/>
-            <StackPanel x:Name="detailsStackPanel" 
-                        Opacity="0">
-
-                <Grid Margin="12,0,0,0">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="20"/>
-                        <ColumnDefinition Width="*"/>
-                    </Grid.ColumnDefinitions>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="36"/>
-                        <RowDefinition Height="36"/>
-                        <RowDefinition Height="36"/>
-                    </Grid.RowDefinitions>
-
-                    <TextBlock Text="H"
-                               FontWeight="SemiBold"
-                               Margin="0,10,0,0"
-                               VerticalAlignment="Center"/>
-
-                    <Border Grid.Column="1" 
-                      Margin="0,12,12,0"  
-                      x:Name="HueGradientGrid"
-                      HorizontalAlignment="Left"
-                      VerticalAlignment="Center"
-                      Height="24"
-                      AutomationProperties.Name="{x:Static p:Resources.Hue_slider}"
-                      Width="289"
-                      CornerRadius="2"
-                      MouseLeftButtonDown="HueGradientGrid_MouseLeftButtonDown"
-                      MouseMove="HueGradientGrid_MouseMove">
-                        <Border.Effect>
-                            <DropShadowEffect BlurRadius="6" Opacity="0.32" ShadowDepth="2" />
-                        </Border.Effect>
-                        <Border VerticalAlignment="Stretch"
-                            Width="6"
-                            x:Name="hueGradientPointer"
-                            Margin="154,0,0,0"
-                            Background="#88FFFFFF"
-                            BorderBrush="Black"
-                            CornerRadius="2"
-                            BorderThickness="1"
-                            HorizontalAlignment="Left"/>
-                    </Border>
-
-                    <TextBlock Text="S"
-                               Grid.Row="1"
-                               Margin="0,10,0,0"
-                               FontWeight="SemiBold"
-                               VerticalAlignment="Center"/>
-
-                    <Border HorizontalAlignment="Left"
-                      Grid.Column="1"
-                      Grid.Row="1"
-                      Margin="0,12,12,0"
-                      VerticalAlignment="Center"
-                      Height="24"
-                      AutomationProperties.Name="{x:Static p:Resources.Saturation_slider}"
-                      x:Name="SaturationGradientGrid"
-                      Width="289"
-                      CornerRadius="2"
-                      MouseLeftButtonDown="SaturationGradientGrid_MouseLeftButtonDown"
-                      MouseMove="SaturationGradientGrid_MouseMove">
-                        <Border.Effect>
-                            <DropShadowEffect BlurRadius="6" Opacity="0.32" ShadowDepth="2" />
-                        </Border.Effect>
-                        <Border.Background>
-                            <LinearGradientBrush EndPoint="1,0.5" StartPoint="0, 0.5">
-                                <GradientStop x:Name="SaturationStartColor" Color="Black"/>
-                                <GradientStop x:Name="SaturationStopColor" Color="Red" Offset="1"/>
-                            </LinearGradientBrush>
-                        </Border.Background>
-                        <Border HorizontalAlignment="Left"
-                            x:Name="saturationGradientPointer"
-                            BorderBrush="Black"
-                            BorderThickness="1"
-                            Margin="154,0,0,0"
-                            CornerRadius="2"
-                            Width="6"
-                            VerticalAlignment="Stretch"
-                            Background="#88FFFFFF"/>
-                    </Border>
-
-                    <TextBlock Text="V"
-                               Grid.Row="2"
-                               Margin="0,10,0,0"
-                               FontWeight="SemiBold"
-                               VerticalAlignment="Center"/>
-
-                    <Border HorizontalAlignment="Left"
-                      Grid.Column="1"
-                      Grid.Row="2"
-                      Margin="0,12,12,0"
-                      Height="24"
-                      VerticalAlignment="Center"
-                      CornerRadius="2"
-                      x:Name="ValueGradientGrid"
-                      Width="289"
-                      AutomationProperties.Name="{x:Static p:Resources.Value_slider}"
-                      MouseLeftButtonDown="ValueGradientGrid_MouseLeftButtonDown"
-                      MouseMove="ValueGradientGrid_MouseMove">
-                        <Border.Effect>
-                            <DropShadowEffect BlurRadius="6" Opacity="0.32" ShadowDepth="2" />
-                        </Border.Effect>
-                        <Border.Background>
-                            <LinearGradientBrush EndPoint="1,0.5" StartPoint="0, 0.5">
-                                <GradientStop x:Name="ValueStartColor" Color="Red"/>
-                                <GradientStop x:Name="ValueStopColor" Color="White" Offset="1"/>
-                            </LinearGradientBrush>
-                        </Border.Background>
-                        <Border HorizontalAlignment="Left"
-                            x:Name="valueGradientPointer"
-                            BorderBrush="Black"
-                            BorderThickness="1"
-                            Margin="154,0,0,0"
-                            Width="6"
-                            CornerRadius="2"
-                            VerticalAlignment="Stretch"
-                            Background="#88FFFFFF"/>
-                    </Border>
-                </Grid>
-
-                <Grid HorizontalAlignment="Stretch"
-                      Margin="12,16,12,8">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="20" />
-                        <ColumnDefinition Width="86" />
-                        <ColumnDefinition Width="*" />
-                        <ColumnDefinition Width="*" />
-                    </Grid.ColumnDefinitions>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="36" />
-                        <RowDefinition Height="36" />
-                        <RowDefinition Height="36" />
-                    </Grid.RowDefinitions>
-
-                    <TextBlock Text="R"
-                               FontWeight="SemiBold"
-                               VerticalAlignment="Center" />
-                    <ui:NumberBox x:Name="RNumberBox"
-                                  Grid.Column="1"
-                                  Height="32"
-                                  AutomationProperties.Name="{x:Static p:Resources.Red_value}"
-                                  ValueChanged="RGBNumberBox_ValueChanged"
-                                  Minimum="0"
-                                  Maximum="255" />
-
-                    <TextBlock Text="G"
-                               FontWeight="SemiBold"
-                               Grid.Row="1"
-                               VerticalAlignment="Center" />
-
-                    <ui:NumberBox x:Name="GNumberBox"
-                                  Height="32"
-                                  Grid.Row="1"
-                                  Grid.Column="1"
-                                  AutomationProperties.Name="{x:Static p:Resources.Green_value}"
-                                  ValueChanged="RGBNumberBox_ValueChanged"
-                                  Minimum="0"
-                                  Maximum="255" />
-
-                    <TextBlock Text="B"
-                               FontWeight="SemiBold"
-                               Grid.Row="2"
-                               VerticalAlignment="Center" />
-
-                    <ui:NumberBox x:Name="BNumberBox"
-                                  Height="32"
-                                  Grid.Column="1"
-                                  Grid.Row="2"
-                                  AutomationProperties.Name="{x:Static p:Resources.Blue_value}"
-                                  ValueChanged="RGBNumberBox_ValueChanged"
-                                  Minimum="0"
-                                  Maximum="255" />
-
-                    <TextBlock Text="HEX"
-                               Grid.Column="2"
-                               HorizontalAlignment="Right"
-                               FontWeight="SemiBold"
-                               VerticalAlignment="Center" />
-                    <TextBox x:Name="HexCode"
-                             HorizontalAlignment="Stretch"
-                             Margin="8,0,0,0"
-                             Height="32"
-                             Grid.Column="3"
-                             AutomationProperties.Name="{x:Static p:Resources.Hex_value}"
-                             GotKeyboardFocus="HexCode_GotKeyboardFocus"
-                             TextChanged="HexCode_TextChanged"
-                             TextWrapping="Wrap" />
-                </Grid>
-                <WrapPanel HorizontalAlignment="Right"
-                           Margin="0,0,0,0"
-                           VerticalAlignment="Top">
-                    <Button x:Name="CancelButton"
-                            Click="CancelButton_Click"
-                            AutomationProperties.Name="{x:Static p:Resources.Cancel}"
-                            Content="{x:Static p:Resources.Cancel}"
-                            Width="80"/>
-                    <Button Margin="12,0,12,0"
-                            x:Name="OKButton"
-                            Click="OKButton_Click"
-                            Style="{StaticResource AccentButtonStyle}"
-                            AutomationProperties.Name="{x:Static p:Resources.OK}"
-                            Content="{x:Static p:Resources.OK}"
-                            Width="80"/>
-                </WrapPanel>
-            </StackPanel>
-        </Grid>
-    </StackPanel>
 </UserControl>

--- a/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml
+++ b/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml
@@ -8,9 +8,9 @@
              xmlns:ui="http://schemas.modernwpf.com/2019"
              mc:Ignorable="d"
              TabIndex="3"
-             Focusable="True"
-             IsTabStop="True"
-             Width="333">
+             FocusManager.IsFocusScope="True"
+             KeyboardNavigation.TabNavigation="Once"
+             >
     <UserControl.Resources>
 
         <Style TargetType="Thumb"
@@ -230,8 +230,9 @@
         </Style>
 
     </UserControl.Resources>
-    <Grid  x:Name="PickerPanel" HorizontalAlignment="Stretch"
-              Margin="12,2,12,2">
+    <Grid x:Name="PickerPanel"
+          HorizontalAlignment="Stretch"
+          Margin="12,2,12,2">
             <Grid.Effect>
                 <DropShadowEffect BlurRadius="6"
                                   Opacity="0.32"
@@ -247,6 +248,7 @@
 
             <Button x:Name="colorVariation1Button"
                     Grid.Column="0"
+                    TabIndex="3"
                     ui:ControlHelper.CornerRadius="2,0,0,2"
                     Background="LightPink"
                     Click="ColorVariationButton_Click"
@@ -439,8 +441,8 @@
                                         x:Name="OKButton"
                                         Click="OKButton_Click"
                                         Style="{StaticResource AccentButtonStyle}"
-                                        AutomationProperties.Name="{x:Static p:Resources.OK}"
-                                        Content="{x:Static p:Resources.OK}"
+                                    AutomationProperties.Name="{x:Static p:Resources.Select}"
+                                    Content="{x:Static p:Resources.Select}"
                                         HorizontalAlignment="Stretch" />
                             </StackPanel>
                         </Grid>

--- a/src/modules/colorPicker/ColorPickerUI/Properties/Resources.Designer.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Properties/Resources.Designer.cs
@@ -142,15 +142,6 @@ namespace ColorPicker.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to OK.
-        /// </summary>
-        public static string OK {
-            get {
-                return ResourceManager.GetString("OK", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Open settings.
         /// </summary>
         public static string Open_settings {
@@ -192,6 +183,15 @@ namespace ColorPicker.Properties {
         public static string Saturation_slider {
             get {
                 return ResourceManager.GetString("Saturation_slider", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select.
+        /// </summary>
+        public static string Select {
+            get {
+                return ResourceManager.GetString("Select", resourceCulture);
             }
         }
         

--- a/src/modules/colorPicker/ColorPickerUI/Properties/Resources.resx
+++ b/src/modules/colorPicker/ColorPickerUI/Properties/Resources.resx
@@ -153,9 +153,9 @@
     <value>Press the Color Picker icon to capture a color from your screen.</value>
     <comment>Message that shows when the user launches the window for the first time or when no colors have been selected</comment>
   </data>
-  <data name="OK" xml:space="preserve">
-    <value>OK</value>
-    <comment>OK button content</comment>
+  <data name="Select" xml:space="preserve">
+    <value>Select</value>
+    <comment>Select button content</comment>
   </data>
   <data name="Open_settings" xml:space="preserve">
     <value>Open settings</value>

--- a/src/modules/colorPicker/ColorPickerUI/Resources/Styles.xaml
+++ b/src/modules/colorPicker/ColorPickerUI/Resources/Styles.xaml
@@ -8,33 +8,23 @@
     <converters:ColorToBrushConverter x:Key="colorToBrushConverter"/>
     <converters:ColorToStringConverter x:Key="colorToStringConverter"/>
     <converters:NumberToVisibilityConverter x:Key="numberToVisibilityConverter"/>
-    <converters:NumberToInvertedVisibilityConverter x:Key="numberToInvertedVisibilityConverter"/>
-
+    <converters:NumberToInvertedVisibilityConverter x:Key="numberToInvertedVisibilityConverter" />
     <Style x:Key="ColorHistoryListViewStyle" TargetType="{x:Type ListBoxItem}">
         <Setter Property="SnapsToDevicePixels" Value="True"/>
-        <Setter Property="Padding" Value="0"/>
+        <Setter Property="Padding" Value="0" />
         <Setter Property="HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource FindAncestor, AncestorLevel=1, AncestorType={x:Type ItemsControl}}}"/>
         <Setter Property="VerticalContentAlignment" Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource FindAncestor, AncestorLevel=1, AncestorType={x:Type ItemsControl}}}"/>
         <Setter Property="Background" Value="Transparent"/>
         <Setter Property="BorderBrush" Value="Transparent"/>
-        <Setter Property="BorderThickness" Value="0"/>
-        <Setter Property="FocusVisualStyle">
-            <Setter.Value>
-                <Style>
-                    <Setter Property="Control.Template">
-                        <Setter.Value>
-                            <ControlTemplate>
-                                <Rectangle Margin="2" SnapsToDevicePixels="True" Stroke="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" StrokeThickness="1" StrokeDashArray="1 2"/>
-                            </ControlTemplate>
-                        </Setter.Value>
-                    </Setter>
-                </Style>
-            </Setter.Value>
-        </Setter>
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="MinWidth"
+                Value="0" />
+        <Setter Property="ui:FocusVisualHelper.FocusVisualMargin"
+                Value="0" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ListBoxItem}">
-                    <Border x:Name="Bd" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" Padding="{TemplateBinding Padding}" SnapsToDevicePixels="True">
+                    <Border x:Name="Bd" Width="64" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" Padding="0" SnapsToDevicePixels="True">
                         <ContentPresenter ContentTemplate="{TemplateBinding ContentTemplate}" Content="{TemplateBinding Content}" ContentStringFormat="{TemplateBinding ContentStringFormat}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
                     </Border>
                     <ControlTemplate.Triggers>
@@ -83,7 +73,7 @@
         <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}" />
         <Setter Property="FocusVisualStyle" Value="{DynamicResource {x:Static SystemParameters.FocusVisualStyleKey}}" />
         <Setter Property="ui:FocusVisualHelper.UseSystemFocusVisuals" Value="{DynamicResource UseSystemFocusVisuals}" />
-        <Setter Property="ui:FocusVisualHelper.FocusVisualMargin" Value="-3" />
+        <Setter Property="ui:FocusVisualHelper.FocusVisualMargin" Value="-2" />
         <Setter Property="ui:ControlHelper.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
         <Setter Property="Stylus.IsPressAndHoldEnabled" Value="False" />
         <Setter Property="Template">
@@ -105,7 +95,7 @@
                                 HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                 Focusable="False"
-                                Opacity="0"
+                                Visibility="Collapsed"
                                 RecognizesAccessKey="True"
                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                         </Border>
@@ -114,12 +104,13 @@
                         <Trigger Property="IsMouseOver" Value="True">
                             <Setter TargetName="Background" Property="Opacity" Value="0.8" />
                             <Setter TargetName="Border" Property="BorderBrush" Value="{DynamicResource ButtonBorderBrushPointerOver}" />
-                            <Setter TargetName="ContentPresenter" Property="Opacity" Value="1" />
+                            <Setter TargetName="ContentPresenter"
+                                    Property="Visibility" Value="Visible" />
                         </Trigger>
                         <Trigger Property="IsPressed" Value="True">
                             <Setter TargetName="Background" Property="Opacity" Value="0.9" />
                             <Setter TargetName="Border" Property="BorderBrush" Value="{DynamicResource ButtonBorderBrushPressed}" />
-                            <Setter TargetName="ContentPresenter" Property="Opacity" Value="1" />
+                            
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>

--- a/src/modules/colorPicker/ColorPickerUI/Views/ColorEditorView.xaml
+++ b/src/modules/colorPicker/ColorPickerUI/Views/ColorEditorView.xaml
@@ -1,16 +1,15 @@
 ﻿<UserControl x:Class="ColorPicker.Views.ColorEditorView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:p="clr-namespace:ColorPicker.Properties"
              mc:Ignorable="d"
-
              xmlns:ui="http://schemas.modernwpf.com/2019"
              xmlns:e="http://schemas.microsoft.com/xaml/behaviors"
              xmlns:controls="clr-namespace:ColorPicker.Controls"
              xmlns:behaviors="clr-namespace:ColorPicker.Behaviors"
-             WindowChrome.IsHitTestVisibleInChrome="True"           
+             WindowChrome.IsHitTestVisibleInChrome="True"
              x:Name="colorEditorControl">
     <Grid>
         <Grid.ColumnDefinitions>
@@ -24,7 +23,10 @@
                          Margin="0,48,0,0"
                          Grid.Row="1"
                          Padding="0"
-                         TabIndex="3"
+                         TabIndex="2"
+                         Width="64"
+                         HorizontalAlignment="Center"
+                         ui:FocusVisualHelper.UseSystemFocusVisuals="True"
                          ItemsSource="{Binding ColorsHistory}"
                          SelectedIndex="{Binding SelectedColorIndex}"
                          ItemContainerStyle="{DynamicResource ColorHistoryListViewStyle}"
@@ -93,20 +95,36 @@
 
             <Button Width="64"
                     Height="32"
-                    TabIndex="1"
+                    TabIndex="0"
                     Content="&#xEF3C;"
                     Command="{Binding OpenColorPickerCommand}"
                     Background="Transparent"
                     FontFamily="Segoe MDL2 Assets"
+                    ui:FocusVisualHelper.FocusVisualMargin="-1"
                     ToolTipService.ToolTip="{x:Static p:Resources.Pick_color}"
                     AutomationProperties.Name="{x:Static p:Resources.Pick_color}"/>
         </Grid>
 
+        <controls:ColorPickerControl HorizontalAlignment="Left"
+                                     Margin="0,44,0,0"
+                                     Focusable="True"
+                                     IsTabStop="True"
+                                     TabIndex="2"
+                                     SelectedColor="{Binding SelectedColor}"
+                                     SelectedColorChangedCommand="{Binding SelectedColorChangedCommand}"
+                                     Grid.Column="1"
+                                     VerticalAlignment="Top" />
         <!-- Main grid -->
-        <Grid Grid.Column="1" Visibility="{Binding ColorsHistory.Count, Converter={StaticResource numberToVisibilityConverter}}">
-            <ScrollViewer Grid.Column="1" Margin="0,90,0,0">
+        <Grid Grid.Column="1"
+              Visibility="{Binding ColorsHistory.Count, Converter={StaticResource numberToVisibilityConverter}}">
+            <ScrollViewer IsTabStop="False"
+                          Margin="0,90,0,0">
                 <StackPanel>
-                    <ItemsControl ItemsSource="{Binding ColorRepresentations}">
+                    <ItemsControl IsTabStop="False"
+                                  TabIndex="4"
+                                  FocusManager.IsFocusScope="True"
+                                  KeyboardNavigation.TabNavigation="Once"   
+                                  ItemsSource="{Binding ColorRepresentations}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
                                 <controls:ColorFormatControl
@@ -126,13 +144,7 @@
                 </StackPanel>
             </ScrollViewer>
 
-            <controls:ColorPickerControl
-            HorizontalAlignment="Left"
-            Margin="0,44,0,0"
-            SelectedColor="{Binding SelectedColor}"
-            SelectedColorChangedCommand="{Binding SelectedColorChangedCommand}"
-            Grid.Column="1"
-            VerticalAlignment="Top"/>
+
         </Grid>
 
         <!-- Empty history -->

--- a/src/modules/colorPicker/ColorPickerUI/Views/ColorEditorView.xaml
+++ b/src/modules/colorPicker/ColorPickerUI/Views/ColorEditorView.xaml
@@ -107,7 +107,7 @@
 
         <controls:ColorPickerControl HorizontalAlignment="Left"
                                      Margin="0,44,0,0"
-                                     Focusable="True"
+                                     Visibility="{Binding ColorsHistory.Count, Converter={StaticResource numberToVisibilityConverter}}"
                                      IsTabStop="True"
                                      TabIndex="2"
                                      SelectedColor="{Binding SelectedColor}"
@@ -148,7 +148,7 @@
         </Grid>
 
         <!-- Empty history -->
-        <StackPanel Grid.Column="1" Margin="12" VerticalAlignment="Center" Orientation="Vertical" Visibility="{Binding ColorsHistory.Count, Converter={StaticResource numberToInvertedVisibilityConverter}}">
+        <StackPanel Grid.Column="1" Margin="24, 12" VerticalAlignment="Center" Orientation="Vertical" Visibility="{Binding ColorsHistory.Count, Converter={StaticResource numberToInvertedVisibilityConverter}}">
             <TextBlock Text="&#xEF3C;"
                        FontFamily="Segoe MDL2 Assets"
                        FontSize="44"

--- a/src/modules/colorPicker/ColorPickerUI/Views/ColorEditorView.xaml
+++ b/src/modules/colorPicker/ColorPickerUI/Views/ColorEditorView.xaml
@@ -105,15 +105,7 @@
                     AutomationProperties.Name="{x:Static p:Resources.Pick_color}"/>
         </Grid>
 
-        <controls:ColorPickerControl HorizontalAlignment="Left"
-                                     Margin="0,44,0,0"
-                                     Visibility="{Binding ColorsHistory.Count, Converter={StaticResource numberToVisibilityConverter}}"
-                                     IsTabStop="True"
-                                     TabIndex="2"
-                                     SelectedColor="{Binding SelectedColor}"
-                                     SelectedColorChangedCommand="{Binding SelectedColorChangedCommand}"
-                                     Grid.Column="1"
-                                     VerticalAlignment="Top" />
+
         <!-- Main grid -->
         <Grid Grid.Column="1"
               Visibility="{Binding ColorsHistory.Count, Converter={StaticResource numberToVisibilityConverter}}">
@@ -144,7 +136,15 @@
                 </StackPanel>
             </ScrollViewer>
 
-
+            <controls:ColorPickerControl HorizontalAlignment="Left"
+                                         Margin="0,44,0,0"
+                                         Visibility="{Binding ColorsHistory.Count, Converter={StaticResource numberToVisibilityConverter}}"
+                                         IsTabStop="True"
+                                         TabIndex="2"
+                                         SelectedColor="{Binding SelectedColor}"
+                                         SelectedColorChangedCommand="{Binding SelectedColorChangedCommand}"
+                                         Grid.Column="1"
+                                         VerticalAlignment="Top" />
         </Grid>
 
         <!-- Empty history -->


### PR DESCRIPTION
## Summary of the Pull Request
This PR improves keyboard navigation for the ColorPicker Editor:

- Replaces the custom sliders with styled WPF sliders, making them keyboard-controllable.
- The colorpicker-mixer is now within a flyout, more suitable for keyboard navigation.
- Correct tab behavior (tab to switch between controls, arrow keys to navigate within the control)
- Overall visual / layout improvements
- Improvements to the focus visual of all controls
- Solving keyboard issue: #10987

![ColorPicker2](https://user-images.githubusercontent.com/9866362/119050467-30e46300-b9c2-11eb-919e-7281996855b0.gif)



## Quality Checklist

- [X] **Linked issue:** #10987
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
