### PR TITLE
[Auto-update][Settings] Bolden update ready/available info line

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Styles/TextBlock.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Styles/TextBlock.xaml
@@ -34,4 +34,8 @@
         <Setter Property="FontSize" Value="16" />
         <Setter Property="Margin" Value="0,16,0,0" />
     </Style>
+
+    <Style x:Key="SemiBoldBody" TargetType="TextBlock">
+        <Setter Property="FontWeight" Value="SemiBold"/>
+    </Style>
 </ResourceDictionary>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml
@@ -185,12 +185,13 @@
                 <StackPanel Orientation="Horizontal"
                             Margin="{StaticResource SmallTopMargin}"
                             AutomationProperties.LabeledBy="{Binding ElementName=General_Version}">
-                    <TextBlock x:Name="General_NewVersionAvailable" 
-                               x:Uid="General_NewVersionAvailable" 
+                    <TextBlock x:Name="General_NewVersionAvailable"
+                               x:Uid="General_NewVersionAvailable"
+                               FontWeight="SemiBold"
                                Foreground="{Binding AutoUpdatesEnabled, Converter={StaticResource ModuleEnabledToForegroundConverter}}"/>
                     
                     <HyperlinkButton NavigateUri="{Binding PowerToysNewAvailableVersionLink }" Margin="4,-6,0,0" IsEnabled="{Binding AutoUpdatesEnabled}">
-                        <TextBlock Text="{Binding PowerToysNewAvailableVersion }" />
+                        <TextBlock Text="{Binding PowerToysNewAvailableVersion }" Style="{StaticResource SemiBoldBody}"/>
                     </HyperlinkButton>
                     
                     <HyperlinkButton NavigateUri="{Binding PowerToysNewAvailableVersionLink}" 
@@ -228,11 +229,12 @@
                 <StackPanel Orientation="Horizontal"
                             Margin="{StaticResource SmallTopMargin}"
                             AutomationProperties.LabeledBy="{Binding ElementName=General_Version}">
-                    <TextBlock x:Name="General_NewVersionReadyToInstall" 
-                               x:Uid="General_NewVersionReadyToInstall" 
+                    <TextBlock x:Name="General_NewVersionReadyToInstall"
+                               x:Uid="General_NewVersionReadyToInstall"
+                               Style="{StaticResource SemiBoldBody}"
                                Foreground="{Binding AutoUpdatesEnabled, Converter={StaticResource ModuleEnabledToForegroundConverter}}"/>
                     <HyperlinkButton NavigateUri="{Binding PowerToysNewAvailableVersionLink }" Margin="4,-6,0,0" IsEnabled="{Binding AutoUpdatesEnabled}">
-                        <TextBlock Text="{Binding PowerToysNewAvailableVersion }" />
+                        <TextBlock Text="{Binding PowerToysNewAvailableVersion }" Style="{StaticResource SemiBoldBody}"/>
                     </HyperlinkButton>
 
                     <HyperlinkButton NavigateUri="{Binding PowerToysNewAvailableVersionLink}" 


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

![2](https://user-images.githubusercontent.com/8949536/119138695-0f26c280-ba3a-11eb-9b89-760b6dbbd75f.PNG)
![3](https://user-images.githubusercontent.com/8949536/119138698-0fbf5900-ba3a-11eb-9d3c-dbc0b0c45262.PNG)

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #11366
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
