### PR TITLE
[PowerToys Run] Single instance

### DIFF
--- a/src/common/interop/interop.cpp
+++ b/src/common/interop/interop.cpp
@@ -144,6 +144,10 @@ public
             return gcnew String(CommonSharedConstants::RUN_SEND_SETTINGS_TELEMETRY_EVENT);
         }
 
+        static String ^ RunExitEvent() {
+            return gcnew String(CommonSharedConstants::RUN_EXIT_EVENT);
+        }
+
         static String ^ ColorPickerSendSettingsTelemetryEvent() {
             return gcnew String(CommonSharedConstants::COLOR_PICKER_SEND_SETTINGS_TELEMETRY_EVENT);
         }

--- a/src/common/interop/shared_constants.h
+++ b/src/common/interop/shared_constants.h
@@ -17,6 +17,8 @@ namespace CommonSharedConstants
 
     const wchar_t RUN_SEND_SETTINGS_TELEMETRY_EVENT[] = L"Local\\PowerToysRunInvokeEvent-638ec522-0018-4b96-837d-6bd88e06f0d6";
 
+    const wchar_t RUN_EXIT_EVENT[] = L"Local\\PowerToysRunExitEvent-3e38e49d-a762-4ef1-88f2-fd4bc7481516";
+
     const wchar_t COLOR_PICKER_SEND_SETTINGS_TELEMETRY_EVENT[] = L"Local\\ColorPickerSettingsTelemetryEvent-6c7071d8-4014-46ec-b687-913bd8a422f1";
 
     // Path to the event used to show Color Picker

--- a/src/modules/launcher/PowerLauncher/Helper/SingleInstance`1.cs
+++ b/src/modules/launcher/PowerLauncher/Helper/SingleInstance`1.cs
@@ -11,6 +11,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
+using interop;
 
 // http://blogs.microsoft.co.il/arik/2010/05/28/wpf-single-instance-application/
 // modified to allow single instance restart
@@ -45,11 +46,6 @@ namespace PowerLauncher.Helper
         private const string ChannelNameSuffix = "SingeInstanceIPCChannel";
 
         /// <summary>
-        /// Prefix to the names of mutexes which ensures they are unique in a Windows session.
-        /// </summary>
-        private const string LocalMutexPrefix = @"Local\";
-
-        /// <summary>
         /// Gets or sets application mutex.
         /// </summary>
         internal static Mutex SingleInstanceMutex { get; set; }
@@ -59,15 +55,15 @@ namespace PowerLauncher.Helper
         /// If not, activates the first instance.
         /// </summary>
         /// <returns>True if this is the first instance of the application.</returns>
-        internal static bool InitializeAsFirstInstance(string uniqueName)
+        internal static bool InitializeAsFirstInstance()
         {
+            string mutexName = @"Local\PowerToys_Run_InstanceMutex";
+
             // Build unique application Id and the IPC channel name.
-            string applicationIdentifier = uniqueName + Environment.UserName;
+            string applicationIdentifier = mutexName + Environment.UserName;
 
             string channelName = string.Concat(applicationIdentifier, Delimiter, ChannelNameSuffix);
 
-            // Create mutex based on unique application Id to check if this is the first instance of the application.
-            string mutexName = string.Concat(LocalMutexPrefix, uniqueName);
             SingleInstanceMutex = new Mutex(true, mutexName, out bool firstInstance);
             if (firstInstance)
             {


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Sometimes a user manually starts PowerToys Run or for some reason, there is a leaked process. Take into account, that even if we leak PT Run process it is a rare bug. Before starting PT Run we signal the exit event to close an existing process. Also, it fixes random poping up of PT Run.
 
**What is include in the PR:** 
- Close PT Run process before starting new by signaling the exit event
- Move `WaitForPowerToysRunner` to the main from Startup

**How does someone test / validate:** 
First scenario:
- Start standalone PT Run
- Start PT
- Verify that the standalone PT Run was terminated. Check logs for errors.

Second scenario:
- Start PT 
- Restart PT
- Verify that new PT Run was started

## Quality Checklist

- [X] **Linked issue:** #11213
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
