### PR TITLE
[FZ Editor] Turn off magnetic snapping when moving/resizing a zone with the keyboard

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation
+﻿// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -237,7 +237,7 @@ namespace FancyZonesEditor
         private SnappyHelperBase snappyX;
         private SnappyHelperBase snappyY;
 
-        private SnappyHelperBase NewDefaultSnappyHelper(bool isX, ResizeMode mode)
+        private SnappyHelperBase NewMagneticSnapper(bool isX, ResizeMode mode)
         {
             Rect workingArea = App.Overlay.WorkArea;
             int screenAxisOrigin = (int)(isX ? workingArea.Left : workingArea.Top);
@@ -332,8 +332,8 @@ namespace FancyZonesEditor
         // Corner dragging
         private void Caption_DragStarted(object sender, System.Windows.Controls.Primitives.DragStartedEventArgs e)
         {
-            snappyX = NewDefaultSnappyHelper(true, ResizeMode.BothEdges);
-            snappyY = NewDefaultSnappyHelper(false, ResizeMode.BothEdges);
+            snappyX = NewMagneticSnapper(true, ResizeMode.BothEdges);
+            snappyY = NewMagneticSnapper(false, ResizeMode.BothEdges);
         }
 
         public CanvasLayoutModel Model { get => model; set => model = value; }
@@ -342,50 +342,50 @@ namespace FancyZonesEditor
 
         private void NWResize_DragStarted(object sender, System.Windows.Controls.Primitives.DragStartedEventArgs e)
         {
-            snappyX = NewDefaultSnappyHelper(true, ResizeMode.BottomEdge);
-            snappyY = NewDefaultSnappyHelper(false, ResizeMode.BottomEdge);
+            snappyX = NewMagneticSnapper(true, ResizeMode.BottomEdge);
+            snappyY = NewMagneticSnapper(false, ResizeMode.BottomEdge);
         }
 
         private void NEResize_DragStarted(object sender, System.Windows.Controls.Primitives.DragStartedEventArgs e)
         {
-            snappyX = NewDefaultSnappyHelper(true, ResizeMode.TopEdge);
-            snappyY = NewDefaultSnappyHelper(false, ResizeMode.BottomEdge);
+            snappyX = NewMagneticSnapper(true, ResizeMode.TopEdge);
+            snappyY = NewMagneticSnapper(false, ResizeMode.BottomEdge);
         }
 
         private void SWResize_DragStarted(object sender, System.Windows.Controls.Primitives.DragStartedEventArgs e)
         {
-            snappyX = NewDefaultSnappyHelper(true, ResizeMode.BottomEdge);
-            snappyY = NewDefaultSnappyHelper(false, ResizeMode.TopEdge);
+            snappyX = NewMagneticSnapper(true, ResizeMode.BottomEdge);
+            snappyY = NewMagneticSnapper(false, ResizeMode.TopEdge);
         }
 
         private void SEResize_DragStarted(object sender, System.Windows.Controls.Primitives.DragStartedEventArgs e)
         {
-            snappyX = NewDefaultSnappyHelper(true, ResizeMode.TopEdge);
-            snappyY = NewDefaultSnappyHelper(false, ResizeMode.TopEdge);
+            snappyX = NewMagneticSnapper(true, ResizeMode.TopEdge);
+            snappyY = NewMagneticSnapper(false, ResizeMode.TopEdge);
         }
 
         // Edge dragging
         private void NResize_DragStarted(object sender, System.Windows.Controls.Primitives.DragStartedEventArgs e)
         {
             snappyX = null;
-            snappyY = NewDefaultSnappyHelper(false, ResizeMode.BottomEdge);
+            snappyY = NewMagneticSnapper(false, ResizeMode.BottomEdge);
         }
 
         private void SResize_DragStarted(object sender, System.Windows.Controls.Primitives.DragStartedEventArgs e)
         {
             snappyX = null;
-            snappyY = NewDefaultSnappyHelper(false, ResizeMode.TopEdge);
+            snappyY = NewMagneticSnapper(false, ResizeMode.TopEdge);
         }
 
         private void WResize_DragStarted(object sender, System.Windows.Controls.Primitives.DragStartedEventArgs e)
         {
-            snappyX = NewDefaultSnappyHelper(true, ResizeMode.BottomEdge);
+            snappyX = NewMagneticSnapper(true, ResizeMode.BottomEdge);
             snappyY = null;
         }
 
         private void EResize_DragStarted(object sender, System.Windows.Controls.Primitives.DragStartedEventArgs e)
         {
-            snappyX = NewDefaultSnappyHelper(true, ResizeMode.TopEdge);
+            snappyX = NewMagneticSnapper(true, ResizeMode.TopEdge);
             snappyY = null;
         }
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml.cs
@@ -19,7 +19,8 @@ namespace FancyZonesEditor
     /// </summary>
     public partial class CanvasZone : UserControl
     {
-        private readonly int moveAmount = 10;
+        private readonly int defaultMoveAmount = 10;
+        private readonly int smallMoveAmount = 1;
 
         public CanvasZone()
         {
@@ -408,36 +409,45 @@ namespace FancyZonesEditor
             }
 
             e.Handled = true;
+
             if (e.Key == Key.Delete)
             {
                 RemoveZone();
+                return;
             }
-            else if (e.Key == Key.Right)
+
+            var moveValue = IsCtrlKeyDown() ? smallMoveAmount : defaultMoveAmount;
+            if (IsShiftKeyDown())
+            {
+                moveValue = Math.Max(1, moveValue / 2);
+            }
+
+            if (e.Key == Key.Right)
             {
                 if (IsShiftKeyDown())
                 {
-                    // Make the zone larger (height)
-                    MoveZoneX(moveAmount / 2, ResizeMode.TopEdge, ResizeMode.BottomEdge);
-                    MoveZoneX(-moveAmount / 2, ResizeMode.BottomEdge, ResizeMode.BottomEdge);
+                    // Make the zone larger (width)
+                    MoveZoneX(moveValue, ResizeMode.TopEdge, ResizeMode.BottomEdge);
+                    MoveZoneX(-moveValue, ResizeMode.BottomEdge, ResizeMode.BottomEdge);
                 }
                 else
                 {
                     // Move zone right
-                    MoveZoneX(moveAmount, ResizeMode.BothEdges, ResizeMode.BothEdges);
+                    MoveZoneX(moveValue, ResizeMode.BothEdges, ResizeMode.BothEdges);
                 }
             }
             else if (e.Key == Key.Left)
             {
                 if (IsShiftKeyDown())
                 {
-                    // Make the zone smaller (height)
-                    MoveZoneX(-moveAmount / 2, ResizeMode.TopEdge, ResizeMode.BottomEdge);
-                    MoveZoneX(moveAmount / 2, ResizeMode.BottomEdge, ResizeMode.BottomEdge);
+                    // Make the zone smaller (width)
+                    MoveZoneX(-moveValue, ResizeMode.TopEdge, ResizeMode.BottomEdge);
+                    MoveZoneX(moveValue, ResizeMode.BottomEdge, ResizeMode.BottomEdge);
                 }
                 else
                 {
                     // Move zone left
-                    MoveZoneX(-moveAmount, ResizeMode.BothEdges, ResizeMode.BothEdges);
+                    MoveZoneX(-moveValue, ResizeMode.BothEdges, ResizeMode.BothEdges);
                 }
             }
             else if (e.Key == Key.Up)
@@ -445,13 +455,13 @@ namespace FancyZonesEditor
                 if (IsShiftKeyDown())
                 {
                     // Make the zone larger (height)
-                    MoveZoneY(moveAmount / 2, ResizeMode.TopEdge, ResizeMode.BottomEdge);
-                    MoveZoneY(-moveAmount / 2, ResizeMode.BottomEdge, ResizeMode.BottomEdge);
+                    MoveZoneY(moveValue, ResizeMode.TopEdge, ResizeMode.BottomEdge);
+                    MoveZoneY(-moveValue, ResizeMode.BottomEdge, ResizeMode.BottomEdge);
                 }
                 else
                 {
                     // Move zone up
-                    MoveZoneY(-moveAmount, ResizeMode.BothEdges, ResizeMode.BothEdges);
+                    MoveZoneY(-moveValue, ResizeMode.BothEdges, ResizeMode.BothEdges);
                 }
             }
             else if (e.Key == Key.Down)
@@ -459,13 +469,13 @@ namespace FancyZonesEditor
                 if (IsShiftKeyDown())
                 {
                     // Make the zone smaller (height)
-                    MoveZoneY(-moveAmount / 2, ResizeMode.TopEdge, ResizeMode.BottomEdge);
-                    MoveZoneY(moveAmount / 2, ResizeMode.BottomEdge, ResizeMode.BottomEdge);
+                    MoveZoneY(-moveValue, ResizeMode.TopEdge, ResizeMode.BottomEdge);
+                    MoveZoneY(moveValue, ResizeMode.BottomEdge, ResizeMode.BottomEdge);
                 }
                 else
                 {
                     // Move zone down
-                    MoveZoneY(moveAmount, ResizeMode.BothEdges, ResizeMode.BothEdges);
+                    MoveZoneY(moveValue, ResizeMode.BothEdges, ResizeMode.BothEdges);
                 }
             }
         }
@@ -489,6 +499,18 @@ namespace FancyZonesEditor
         private bool IsShiftKeyDown()
         {
             if (Keyboard.IsKeyDown(Key.LeftShift) || Keyboard.IsKeyDown(Key.RightShift))
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        private bool IsCtrlKeyDown()
+        {
+            if (Keyboard.IsKeyDown(Key.LeftCtrl) || Keyboard.IsKeyDown(Key.RightCtrl))
             {
                 return true;
             }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Fixed an issue with a stucked zone caused by the default magnetic snapper when the zone is moved with a keyboard. 

![ezgif com-gif-maker](https://user-images.githubusercontent.com/8949536/119336925-23f79600-bc86-11eb-96cc-c60d454d0697.gif)

**What is include in the PR:** 

**How does someone test / validate:** 

* Open the canvas layout editor and select any zone
* Move the zone with arrows
* Resize the zone with `Shift + Arrow`
* Drag the zone with a mouse to verify that magnetic snapping is working.

## Quality Checklist

- [x] **Linked issue:** #11250
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
