### PR TITLE
[FZ Editor] Switch between zone and dialog with Ctrl + Tab

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditor.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditor.xaml.cs
@@ -25,6 +25,15 @@ namespace FancyZonesEditor
             Loaded += OnLoaded;
         }
 
+        public void FocusZone()
+        {
+            if (Preview.Children.Count > 0)
+            {
+                var canvas = Preview.Children[0] as CanvasZone;
+                canvas.FocusZone();
+            }
+        }
+
         private void OnLoaded(object sender, RoutedEventArgs e)
         {
             CanvasLayoutModel model = (CanvasLayoutModel)DataContext;

--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditor.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditor.xaml.cs
@@ -4,6 +4,7 @@
 
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
 using FancyZonesEditor.Models;
 using FancyZonesEditor.Utils;
 
@@ -23,6 +24,16 @@ namespace FancyZonesEditor
         {
             InitializeComponent();
             Loaded += OnLoaded;
+            KeyDown += CanvasEditor_KeyDown;
+        }
+
+        private void CanvasEditor_KeyDown(object sender, System.Windows.Input.KeyEventArgs e)
+        {
+            if (e.Key == Key.Tab && (Keyboard.IsKeyDown(Key.LeftCtrl) || Keyboard.IsKeyDown(Key.RightCtrl)))
+            {
+                e.Handled = true;
+                App.Overlay.FocusEditorWindow();
+            }
         }
 
         public void FocusZone()

--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditorWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditorWindow.xaml.cs
@@ -18,6 +18,7 @@ namespace FancyZonesEditor
             InitializeComponent();
 
             KeyUp += CanvasEditorWindow_KeyUp;
+            KeyDown += CanvasEditorWindow_KeyDown;
 
             _model = App.Overlay.CurrentDataContext as CanvasLayoutModel;
             _stashedModel = (CanvasLayoutModel)_model.Clone();
@@ -47,6 +48,15 @@ namespace FancyZonesEditor
             if (e.Key == Key.Escape)
             {
                 OnCancel(sender, null);
+            }
+        }
+
+        private void CanvasEditorWindow_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Tab && (Keyboard.IsKeyDown(Key.LeftCtrl) || Keyboard.IsKeyDown(Key.RightCtrl)))
+            {
+                e.Handled = true;
+                App.Overlay.FocusEditor();
             }
         }
     }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasZone.xaml.cs
@@ -341,6 +341,11 @@ namespace FancyZonesEditor
 
         public int ZoneIndex { get => zoneIndex; set => zoneIndex = value; }
 
+        public void FocusZone()
+        {
+            Keyboard.Focus(RootBorder);
+        }
+
         private void NWResize_DragStarted(object sender, System.Windows.Controls.Primitives.DragStartedEventArgs e)
         {
             snappyX = NewMagneticSnapper(true, ResizeMode.BottomEdge);

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Overlay.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Overlay.cs
@@ -14,7 +14,8 @@ namespace FancyZonesEditor
     {
         private MainWindow _mainWindow;
         private LayoutPreview _layoutPreview;
-        private UserControl _editor;
+        private UserControl _editorLayout;
+        private EditorWindow _editorWindow;
 
         public List<Monitor> Monitors { get; private set; }
 
@@ -228,34 +229,32 @@ namespace FancyZonesEditor
             _layoutPreview = null;
             if (CurrentDataContext is GridLayoutModel)
             {
-                _editor = new GridEditor();
+                _editorLayout = new GridEditor();
             }
             else if (CurrentDataContext is CanvasLayoutModel)
             {
-                _editor = new CanvasEditor();
+                _editorLayout = new CanvasEditor();
             }
 
-            CurrentLayoutWindow.Content = _editor;
-
-            EditorWindow window;
+            CurrentLayoutWindow.Content = _editorLayout;
 
             if (model is GridLayoutModel)
             {
-                window = new GridEditorWindow();
+                _editorWindow = new GridEditorWindow();
             }
             else
             {
-                window = new CanvasEditorWindow();
+                _editorWindow = new CanvasEditorWindow();
             }
 
-            window.Owner = Monitors[App.Overlay.CurrentDesktop].Window;
-            window.DataContext = model;
-            window.Show();
+            _editorWindow.Owner = Monitors[App.Overlay.CurrentDesktop].Window;
+            _editorWindow.DataContext = model;
+            _editorWindow.Show();
         }
 
         public void CloseEditor()
         {
-            _editor = null;
+            _editorLayout = null;
             _layoutPreview = new LayoutPreview
             {
                 IsActualSize = true,
@@ -269,9 +268,17 @@ namespace FancyZonesEditor
 
         public void FocusEditor()
         {
-            if (_editor != null && _editor is CanvasEditor canvasEditor)
+            if (_editorLayout != null && _editorLayout is CanvasEditor canvasEditor)
             {
                 canvasEditor.FocusZone();
+            }
+        }
+
+        public void FocusEditorWindow()
+        {
+            if (_editorWindow != null)
+            {
+                _editorWindow.Focus();
             }
         }
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Overlay.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Overlay.cs
@@ -267,6 +267,14 @@ namespace FancyZonesEditor
             OpenMainWindow();
         }
 
+        public void FocusEditor()
+        {
+            if (_editor != null && _editor is CanvasEditor canvasEditor)
+            {
+                canvasEditor.FocusZone();
+            }
+        }
+
         public void CloseLayoutWindow()
         {
             for (int i = 0; i < DesktopsCount; i++)


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Added support to switch focus between the zones and the dialog using `Ctrl + Tab`.

![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/8949536/119369962-a85d0f80-bcac-11eb-9c9a-6d14b4c3d505.gif)

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #11249
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
