### PR TITLE
[Run Plugin] Rewrite ConvertInput

### DIFF
--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter.UnitTest/UnitHandlerTests.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter.UnitTest/UnitHandlerTests.cs
@@ -6,16 +6,6 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter.UnitTest
     [TestFixture]
     public class UnitHandlerTests
     {
-        [TestCase(new string[] { "1", "meter", "in", "centimeter" }, UnitsNet.QuantityType.Length, UnitHandler.Abbreviated.Neither)]
-        [TestCase(new string[] { "1", "m", "in", "cm" }, UnitsNet.QuantityType.Length, UnitHandler.Abbreviated.Both)]
-        [TestCase(new string[] { "1", "m", "in", "centimeter" }, UnitsNet.QuantityType.Length, UnitHandler.Abbreviated.First)]
-        [TestCase(new string[] { "1", "meter", "in", "cm" }, UnitsNet.QuantityType.Length, UnitHandler.Abbreviated.Second)]
-        public void ParsesInputForAbbreviations(string[] input, UnitsNet.QuantityType qType, UnitHandler.Abbreviated expectedResult)
-        {
-            (UnitHandler.Abbreviated abbreviated, UnitsNet.QuantityInfo quantityInfo) result = UnitHandler.ParseInputForAbbreviation(input, qType);
-            Assert.AreEqual(expectedResult, result.abbreviated);
-        }
-
         [TestCase(new string[] { "1", "meter", "in", "centimeter" }, UnitsNet.QuantityType.Length, 100d)]
         [TestCase(new string[] { "1", "DegreeCelsius", "in", "DegreeFahrenheit" }, UnitsNet.QuantityType.Temperature, 33.79999999999999d)]
         public void ConvertsInput(string[] input, UnitsNet.QuantityType unit, double expectedResult)

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/UnitHandler.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/UnitHandler.cs
@@ -6,13 +6,24 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
 {
     public static class UnitHandler
     {
-        public enum Abbreviated
+        /// <summary>
+        /// Given string representation of unit, converts it to the enum.
+        /// </summary>
+        /// <returns>Corresponding enum or null.</returns>
+        private static Enum GetUnitEnum(string unit, QuantityInfo unitInfo)
         {
-            First,
-            Second,
-            Both,
-            Neither,
-            NotFound,
+            UnitInfo first = Array.Find(unitInfo.UnitInfos, info => info.Name.ToLower() == unit.ToLower());
+            if (first != null)
+            {
+                return first.Value;
+            }
+
+            if (UnitParser.Default.TryParse(unit, unitInfo.UnitType, out Enum enum_unit))
+            {
+                return enum_unit;
+            }
+
+            return null;
         }
 
         /// <summary>
@@ -21,93 +32,19 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
         /// <returns>The converted value as a double.</returns>
         public static double ConvertInput(string[] split, QuantityType quantityType, CultureInfo currentCulture)
         {
-            string input_first_unit = split[1];
-            string input_second_unit = split[3];
+            string firstUnitString = split[1];
+            string secondUnitString = split[3];
+            QuantityInfo unitInfo = Quantity.GetInfo(quantityType);
 
-            (Abbreviated abbreviated, QuantityInfo unitInfo) = ParseInputForAbbreviation(split, quantityType);
+            var firstUnit = GetUnitEnum(firstUnitString, unitInfo);
+            var secondUnit = GetUnitEnum(secondUnitString, unitInfo);
 
-            switch (abbreviated)
+            if (firstUnit != null && secondUnit != null)
             {
-                case Abbreviated.Both:
-                    return UnitsNet.UnitConverter.ConvertByAbbreviation(double.Parse(split[0], currentCulture), unitInfo.Name, input_first_unit, input_second_unit);
-
-                case Abbreviated.Neither:
-                    return UnitsNet.UnitConverter.ConvertByName(double.Parse(split[0], currentCulture), unitInfo.Name, input_first_unit, input_second_unit);
-
-                case Abbreviated.Second:
-                    UnitInfo first = Array.Find(unitInfo.UnitInfos, info => info.Name.ToLower() == input_first_unit.ToLower());
-                    UnitParser.Default.TryParse(split[3], unitInfo.UnitType, out Enum second_unit);
-                    return UnitsNet.UnitConverter.Convert(double.Parse(split[0], currentCulture), first.Value, second_unit);
-
-                case Abbreviated.First:
-                    UnitParser.Default.TryParse(split[1], unitInfo.UnitType, out Enum first_unit);
-                    UnitInfo second = Array.Find(unitInfo.UnitInfos, info => info.Name.ToLower() == input_second_unit.ToLower());
-                    return UnitsNet.UnitConverter.Convert(double.Parse(split[0], currentCulture), first_unit, second.Value);
-
-                case Abbreviated.NotFound:
-                default:
-                    return double.NaN;
-            }
-        }
-
-        /// <summary>
-        /// Given a split array of user input, parses the input for abbreviations (e.g. "1 cm in meters").
-        /// </summary>
-        /// <returns>A tuple consisting of an Abbreviated enum and QuantityInfo.</returns>
-        public static (Abbreviated Abbreviated, QuantityInfo UnitInfo) ParseInputForAbbreviation(string[] split, QuantityType quantityType)
-        {
-            string input_first_unit = split[1];
-            string input_second_unit = split[3];
-
-            QuantityInfo unit_info = Quantity.GetInfo(quantityType);
-            bool first_unit_is_abbreviated = UnitParser.Default.TryParse(split[1], unit_info.UnitType, out Enum _);
-            bool second_unit_is_abbreviated = UnitParser.Default.TryParse(split[3], unit_info.UnitType, out Enum _);
-
-            // 3 types of matches:
-            // a) 10 ft in cm (double abbreviation)
-            // b) 10 feet in centimeter (double unabbreviated)
-            // c) 10 feet in cm (single abbreviation)
-
-            if (first_unit_is_abbreviated && second_unit_is_abbreviated)
-            {
-                // a
-                return (Abbreviated.Both, unit_info);
-            }
-            else if ((!first_unit_is_abbreviated) && (!second_unit_is_abbreviated))
-            {
-                // b
-                bool first_unabbreviated = Array.Exists(unit_info.UnitInfos, unitName => unitName.Name.ToLower() == input_first_unit.ToLower());
-                bool second_unabbreviated = Array.Exists(unit_info.UnitInfos, unitName => unitName.Name.ToLower() == input_second_unit.ToLower());
-
-                if (first_unabbreviated && second_unabbreviated)
-                {
-                    return (Abbreviated.Neither, unit_info);
-                }
-            }
-            else if ((first_unit_is_abbreviated && !second_unit_is_abbreviated) || (!first_unit_is_abbreviated && second_unit_is_abbreviated))
-            {
-                // c
-                if (first_unit_is_abbreviated)
-                {
-                    bool second_unabbreviated = Array.Exists(unit_info.UnitInfos, unitName => unitName.Name.ToLower() == input_second_unit.ToLower());
-
-                    if (second_unabbreviated)
-                    {
-                        return (Abbreviated.First, unit_info);
-                    }
-                }
-                else if (second_unit_is_abbreviated)
-                {
-                    bool first_unabbreviated = Array.Exists(unit_info.UnitInfos, unitName => unitName.Name.ToLower() == input_first_unit.ToLower());
-
-                    if (first_unabbreviated)
-                    {
-                        return (Abbreviated.Second, unit_info);
-                    }
-                }
+                return UnitsNet.UnitConverter.Convert(double.Parse(split[0], currentCulture), firstUnit, secondUnit);
             }
 
-            return (Abbreviated.NotFound, null);
+            return double.NaN;
         }
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Convert string unit representation to enum and then use single `UnitsNet.UnitConverter.Convert`

**What is include in the PR:** 
- Removed `ParsesInputForAbbreviations` and its tests as it's not needed for the new implementation
 
**How does someone test / validate:** 
- Run tests
- Test manually for regressions 

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
