### PR TITLE
[runner] removed outdated MSIX code

### DIFF
--- a/src/common/utils/appMutex.h
+++ b/src/common/utils/appMutex.h
@@ -11,7 +11,6 @@
 namespace
 {
     constexpr inline wchar_t POWERTOYS_MSI_MUTEX_NAME[] = L"Local\\PowerToys_Runner_MSI_InstanceMutex";
-    constexpr inline wchar_t POWERTOYS_MSIX_MUTEX_NAME[] = L"Local\\PowerToys_Runner_MSIX_InstanceMutex";
     constexpr inline wchar_t POWERTOYS_BOOTSTRAPPER_MUTEX_NAME[] = L"Local\\PowerToys_Bootstrapper_InstanceMutex";
 }
 

--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -70,11 +70,6 @@ inline wil::unique_mutex_nothrow create_msi_mutex()
     return createAppMutex(POWERTOYS_MSI_MUTEX_NAME);
 }
 
-inline wil::unique_mutex_nothrow create_msix_mutex()
-{
-    return createAppMutex(POWERTOYS_MSIX_MUTEX_NAME);
-}
-
 void open_menu_from_another_instance()
 {
     const HWND hwnd_main = FindWindowW(L"PToyTrayIconWindow", nullptr);
@@ -329,69 +324,12 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     logFilePath.append(LogSettings::runnerLogPath);
     Logger::init(LogSettings::runnerLoggerName, logFilePath.wstring(), PTSettingsHelper::get_log_settings_file_location());
 
-    wil::unique_mutex_nothrow msi_mutex;
-    wil::unique_mutex_nothrow msix_mutex;
-
-    if (winstore::running_as_packaged())
+    // Check if another instance is already running.
+    wil::unique_mutex_nothrow msi_mutex = create_msi_mutex();
+    if (!msi_mutex)
     {
-        msix_mutex = create_msix_mutex();
-        if (!msix_mutex)
-        {
-            // The MSIX version is already running.
-            open_menu_from_another_instance();
-            return 0;
-        }
-
-        // Check if the MSI version is running, if not, hold the
-        // mutex to prevent the old MSI versions to start.
-        msi_mutex = create_msi_mutex();
-        if (!msi_mutex)
-        {
-            // The MSI version is running, warn the user and offer to uninstall it.
-            const bool declined_uninstall = !start_msi_uninstallation_sequence();
-            if (declined_uninstall)
-            {
-                // Check again if the MSI version is still running.
-                msi_mutex = create_msi_mutex();
-                if (!msi_mutex)
-                {
-                    open_menu_from_another_instance();
-                    return 0;
-                }
-            }
-        }
-        else
-        {
-            // Older MSI versions are not aware of the MSIX mutex, therefore
-            // hold the MSI mutex to prevent an old instance to start.
-        }
-    }
-    else
-    {
-        // Check if another instance of the MSI version is already running.
-        msi_mutex = create_msi_mutex();
-        if (!msi_mutex)
-        {
-            // The MSI version is already running.
-            open_menu_from_another_instance();
-            return 0;
-        }
-
-        // Check if an instance of the MSIX version is already running.
-        // Note: this check should always be negative since the MSIX version
-        // is holding both mutexes.
-        msix_mutex = create_msix_mutex();
-        if (!msix_mutex)
-        {
-            // The MSIX version is already running.
-            open_menu_from_another_instance();
-            return 0;
-        }
-        else
-        {
-            // The MSIX version isn't running, release the mutex.
-            msix_mutex.reset(nullptr);
-        }
+        open_menu_from_another_instance();
+        return 0;
     }
 
     bool openOobe = false;
@@ -445,11 +383,6 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     if (msi_mutex)
     {
         msi_mutex.reset(nullptr);
-    }
-
-    if (msix_mutex)
-    {
-        msix_mutex.reset(nullptr);
     }
 
     if (is_restart_scheduled())


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Clean up runner's outdated code.

**What is include in the PR:** 
Remove outdated code that was detecting the MSIX version

**How does someone test / validate:** 
Test the core main functionality at startup:
 - check if when a second instance is started, the Settings app is opened
 - check that a toast notification is correctly handled
 - check that a first time run opens OOBE

## Quality Checklist

- [x] **Linked issue:** #11352
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
