### PR TITLE
[Bug Report Tool] Report event viewer logs

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -955,6 +955,7 @@ IVector
 IView
 IVirtual
 IWeb
+IXml
 ixx
 IZone
 IZoom

--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -541,6 +541,7 @@ EUQ
 evenodd
 eventlog
 everytime
+evt
 EWXFORCE
 EWXFORCEIFHUNG
 EWXLOGOFF
@@ -1785,6 +1786,7 @@ sln
 SMALLICON
 SMTO
 snd
+snwprintf
 softline
 somil
 Soref
@@ -1944,6 +1946,7 @@ THISCOMPONENT
 thre
 tif
 TILEDWINDOW
+timediff
 TIMERID
 timeunion
 timeutil
@@ -2127,6 +2130,7 @@ webpack
 webpage
 website
 wekyb
+Wevtapi
 Whichdoes
 whitespaces
 WIC
@@ -2156,6 +2160,7 @@ windowwalker
 winerror
 WINEVENT
 winexe
+winevt
 winforms
 winfx
 winget

--- a/tools/BugReportTool/BugReportTool/BugReportTool.vcxproj
+++ b/tools/BugReportTool/BugReportTool/BugReportTool.vcxproj
@@ -41,6 +41,7 @@
     <ClCompile Include="ReportMonitorInfo.cpp" />
     <ClCompile Include="Main.cpp" />
     <ClCompile Include="RegistryUtils.cpp" />
+    <ClCompile Include="XmlDocumentEx.cpp" />
     <ClCompile Include="ZipTools\ZipFolder.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -58,6 +59,7 @@
     <ClInclude Include="ReportMonitorInfo.h" />
     <ClInclude Include="..\..\..\common\utils\json.h" />
     <ClInclude Include="RegistryUtils.h" />
+    <ClInclude Include="XmlDocumentEx.h" />
     <ClInclude Include="ZipTools\ZipFolder.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/tools/BugReportTool/BugReportTool/BugReportTool.vcxproj
+++ b/tools/BugReportTool/BugReportTool/BugReportTool.vcxproj
@@ -30,12 +30,14 @@
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
+      <AdditionalDependencies>Wevtapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\deps\cziplib\src\zip.c">
       <WarningLevel>TurnOffAllWarnings</WarningLevel>
     </ClCompile>
+    <ClCompile Include="EventViewer.cpp" />
     <ClCompile Include="ReportMonitorInfo.cpp" />
     <ClCompile Include="Main.cpp" />
     <ClCompile Include="RegistryUtils.cpp" />
@@ -52,6 +54,7 @@
   <ItemGroup>
     <ClInclude Include="..\..\..\deps\cziplib\src\miniz.h" />
     <ClInclude Include="..\..\..\deps\cziplib\src\zip.h" />
+    <ClInclude Include="EventViewer.h" />
     <ClInclude Include="ReportMonitorInfo.h" />
     <ClInclude Include="..\..\..\common\utils\json.h" />
     <ClInclude Include="RegistryUtils.h" />

--- a/tools/BugReportTool/BugReportTool/BugReportTool.vcxproj.filters
+++ b/tools/BugReportTool/BugReportTool/BugReportTool.vcxproj.filters
@@ -11,6 +11,7 @@
     <ClCompile Include="..\..\..\deps\cziplib\src\zip.c" />
     <ClCompile Include="ReportMonitorInfo.cpp" />
     <ClCompile Include="RegistryUtils.cpp" />
+    <ClCompile Include="EventViewer.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="ZipTools">
@@ -26,5 +27,6 @@
     <ClInclude Include="..\..\..\deps\cziplib\src\zip.h" />
     <ClInclude Include="ReportMonitorInfo.h" />
     <ClInclude Include="RegistryUtils.h" />
+    <ClInclude Include="EventViewer.h" />
   </ItemGroup>
 </Project>

--- a/tools/BugReportTool/BugReportTool/BugReportTool.vcxproj.filters
+++ b/tools/BugReportTool/BugReportTool/BugReportTool.vcxproj.filters
@@ -12,6 +12,7 @@
     <ClCompile Include="ReportMonitorInfo.cpp" />
     <ClCompile Include="RegistryUtils.cpp" />
     <ClCompile Include="EventViewer.cpp" />
+    <ClCompile Include="XmlDocumentEx.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="ZipTools">
@@ -28,5 +29,6 @@
     <ClInclude Include="ReportMonitorInfo.h" />
     <ClInclude Include="RegistryUtils.h" />
     <ClInclude Include="EventViewer.h" />
+    <ClInclude Include="XmlDocumentEx.h" />
   </ItemGroup>
 </Project>

--- a/tools/BugReportTool/BugReportTool/EventViewer.cpp
+++ b/tools/BugReportTool/BugReportTool/EventViewer.cpp
@@ -86,7 +86,9 @@ namespace
 
             report << std::endl << formattedXml << std::endl;
             if (pRenderedContent)
+            {
                 free(pRenderedContent);
+            }
         }
 
         // Enumerate all the events in the result set. 

--- a/tools/BugReportTool/BugReportTool/EventViewer.cpp
+++ b/tools/BugReportTool/BugReportTool/EventViewer.cpp
@@ -1,0 +1,163 @@
+#include "EventViewer.h"
+
+#include <windows.h>
+#include <sddl.h>
+#include <stdio.h>
+#include <winevt.h>
+#include <fstream>
+#include <common/utils/winapi_error.h>
+
+namespace
+{
+    std::vector<std::wstring> processes = { L"PowerToys.exe", L"PowerLauncher.exe" };
+
+    // Batch size for number of events queried at once
+    constexpr int BATCH_SIZE = 50;
+
+    class EventViwerReporter
+    {
+    private:
+        // Report last 30 days
+        const long long PERIOD = 30 * 24 * 3600ll * 1000;
+
+        const std::wstring QUERY = L"<QueryList>" \
+            L"  <Query Id='0'>" \
+            L"    <Select Path='Application'>" \
+            L"        *[System[TimeCreated[timediff(@SystemTime)&lt;%I64u]]] " \
+            L"        and *[EventData[Data and (Data='%s')]]" \
+            L"    </Select>" \
+            L"  </Query>" \
+            L"</QueryList>";
+
+        std::wstring GetQuery(std::wstring processName)
+        {
+            wchar_t buff[1000];
+            memset(buff, 0, sizeof(buff));
+            _snwprintf_s(buff, sizeof(buff), QUERY.c_str(), PERIOD, processName.c_str());
+            return buff;
+        }
+
+        std::wofstream report;
+        EVT_HANDLE hResults;
+
+        void PrintEvent(EVT_HANDLE hEvent)
+        {
+            DWORD status = ERROR_SUCCESS;
+            DWORD dwBufferSize = 0;
+            DWORD dwBufferUsed = 0;
+            DWORD dwPropertyCount = 0;
+            LPWSTR pRenderedContent = NULL;
+
+            // The EvtRenderEventXml flag tells EvtRender to render the event as an XML string.
+            if (!EvtRender(NULL, hEvent, EvtRenderEventXml, dwBufferSize, pRenderedContent, &dwBufferUsed, &dwPropertyCount))
+            {
+                if (ERROR_INSUFFICIENT_BUFFER == (status = GetLastError()))
+                {
+                    dwBufferSize = dwBufferUsed;
+                    pRenderedContent = (LPWSTR)malloc(dwBufferSize);
+                    if (pRenderedContent)
+                    {
+                        EvtRender(NULL, hEvent, EvtRenderEventXml, dwBufferSize, pRenderedContent, &dwBufferUsed, &dwPropertyCount);
+                    }
+                }
+
+                if (ERROR_SUCCESS != (status = GetLastError()))
+                {
+                    report << L"--------------------------------------------------------------------------------------------" << std::endl;
+                    report << L"EvtRender failed with " << get_last_error_or_default(GetLastError()) << std::endl << std::endl;
+                    if (pRenderedContent)
+                        free(pRenderedContent);
+                    return;
+                }
+            }
+
+            report << L"--------------------------------------------------------------------------------------------" << std::endl;
+            report << pRenderedContent << std::endl << std::endl;
+            if (pRenderedContent)
+                free(pRenderedContent);
+        }
+
+        // Enumerate all the events in the result set. 
+        void PrintResults(EVT_HANDLE hResults)
+        {
+            DWORD status = ERROR_SUCCESS;
+            EVT_HANDLE hEvents[BATCH_SIZE];
+            DWORD dwReturned = 0;
+
+            while (true)
+            {
+                // Get a block of events from the result set.
+                if (!EvtNext(hResults, BATCH_SIZE, hEvents, INFINITE, 0, &dwReturned))
+                {
+                    if (ERROR_NO_MORE_ITEMS != (status = GetLastError()))
+                    {
+                        report << L"EvtNext failed with " << status << std::endl;
+                    }
+
+                    break;
+                }
+
+                // For each event, call the PrintEvent function which renders the
+                // event for display. PrintEvent is shown in RenderingEvents.
+                for (DWORD i = 0; i < dwReturned; i++)
+                {
+                    PrintEvent(hEvents[i]);
+                }
+            }
+
+            for (DWORD i = 0; i < dwReturned; i++)
+            {
+                if (nullptr != hEvents[i])
+                    EvtClose(hEvents[i]);
+            }
+        }
+
+    public:
+        EventViwerReporter(const std::filesystem::path& tmpDir, std::wstring processName)
+        {
+            auto query = GetQuery(processName);
+            auto reportPath = tmpDir;
+            reportPath.append(L"EventViewer-" + processName + L".txt");
+            report = std::wofstream(reportPath);
+
+            hResults = EvtQuery(NULL, NULL, GetQuery(processName).c_str(), EvtQueryChannelPath);
+            if (NULL == hResults)
+            {
+                report << "Failed to report info for " << processName << ". " << get_last_error_or_default(GetLastError()) << std::endl;
+                return;
+            }
+        }
+
+        ~EventViwerReporter()
+        {
+            if (hResults)
+            {
+                EvtClose(hResults);
+                hResults = nullptr;
+            }
+        }
+
+        void Report()
+        {
+            try
+            {
+                if (hResults)
+                {
+                    PrintResults(hResults);
+                }
+            }
+            catch (...)
+            {
+                report << "Failed to report info" << std::endl;
+            }
+        }
+    };
+}
+
+void EventViewer::ReportEventViewerInfo(const std::filesystem::path& tmpDir)
+{
+    for (auto& process : processes)
+    {
+        EventViwerReporter(tmpDir, process).Report();
+    }
+}

--- a/tools/BugReportTool/BugReportTool/EventViewer.cpp
+++ b/tools/BugReportTool/BugReportTool/EventViewer.cpp
@@ -11,7 +11,17 @@
 
 namespace
 {
-    std::vector<std::wstring> processes = { L"PowerToys.exe", L"PowerLauncher.exe" };
+    std::vector<std::wstring> processes = 
+    {
+        L"PowerToys.exe",
+        L"ColorPickerUI.exe",
+        L"PowerToys.Espresso.exe"
+        L"FancyZonesEditor.exe",
+        L"PowerToys.KeyboardManagerEngine.exe",
+        L"PowerToys.KeyboardManagerEditor.exe",
+        L"PowerLauncher.exe",
+        L"PowerToys.ShortcutGuide.exe"
+    };
 
     // Batch size for number of events queried at once
     constexpr int BATCH_SIZE = 50;
@@ -20,7 +30,7 @@ namespace
     {
     private:
         // Report last 30 days
-        const long long PERIOD = 30 * 24 * 3600ll * 1000;
+        const long long PERIOD = 10 * 24 * 3600ll * 1000;
 
         const std::wstring QUERY = L"<QueryList>" \
             L"  <Query Id='0'>" \

--- a/tools/BugReportTool/BugReportTool/EventViewer.cpp
+++ b/tools/BugReportTool/BugReportTool/EventViewer.cpp
@@ -67,7 +67,9 @@ namespace
                 {
                     report << std::endl << L"EvtRender failed with " << get_last_error_or_default(GetLastError()) << std::endl << std::endl;
                     if (pRenderedContent)
+                    {
                         free(pRenderedContent);
+                    }
                     return;
                 }
             }

--- a/tools/BugReportTool/BugReportTool/EventViewer.cpp
+++ b/tools/BugReportTool/BugReportTool/EventViewer.cpp
@@ -14,7 +14,7 @@ namespace
     // Batch size for number of events queried at once
     constexpr int BATCH_SIZE = 50;
 
-    class EventViwerReporter
+    class EventViewerReporter
     {
     private:
         // Report last 30 days
@@ -113,7 +113,7 @@ namespace
         }
 
     public:
-        EventViwerReporter(const std::filesystem::path& tmpDir, std::wstring processName)
+        EventViewerReporter(const std::filesystem::path& tmpDir, std::wstring processName)
         {
             auto query = GetQuery(processName);
             auto reportPath = tmpDir;
@@ -128,7 +128,7 @@ namespace
             }
         }
 
-        ~EventViwerReporter()
+        ~EventViewerReporter()
         {
             if (hResults)
             {
@@ -158,6 +158,6 @@ void EventViewer::ReportEventViewerInfo(const std::filesystem::path& tmpDir)
 {
     for (auto& process : processes)
     {
-        EventViwerReporter(tmpDir, process).Report();
+        EventViewerReporter(tmpDir, process).Report();
     }
 }

--- a/tools/BugReportTool/BugReportTool/EventViewer.h
+++ b/tools/BugReportTool/BugReportTool/EventViewer.h
@@ -1,0 +1,7 @@
+#pragma once
+#include <filesystem>
+
+namespace EventViewer
+{
+    void ReportEventViewerInfo(const std::filesystem::path& tmpDir);
+}

--- a/tools/BugReportTool/BugReportTool/Main.cpp
+++ b/tools/BugReportTool/BugReportTool/Main.cpp
@@ -16,6 +16,8 @@
 
 #include "ReportMonitorInfo.h"
 #include "RegistryUtils.h"
+#include "EventViewer.h"
+
 using namespace std;
 using namespace std::filesystem;
 using namespace winrt::Windows::Data::Json;
@@ -330,6 +332,9 @@ int wmain(int argc, wchar_t* argv[], wchar_t*)
 
     // Write compatibility tab info to the temporary folder
     ReportCompatibilityTab(tmpDir);
+
+    // Write event viewer logs info to the temporary folder
+    EventViewer::ReportEventViewerInfo(tmpDir);
 
     ReportBootstrapperLog(tmpDir);
 

--- a/tools/BugReportTool/BugReportTool/XmlDocumentEx.cpp
+++ b/tools/BugReportTool/BugReportTool/XmlDocumentEx.cpp
@@ -1,0 +1,56 @@
+#include "XmlDocumentEx.h"
+
+#include <winrt/Windows.Foundation.Collections.h>
+
+std::wstring XmlDocumentEx::GetFormatedXml()
+{
+    stream.clear();
+    Print(FirstChild(), 0);
+    return stream.str();
+}
+
+void XmlDocumentEx::Print(winrt::Windows::Data::Xml::Dom::IXmlNode node, int indentation)
+{
+    for (int i = 0; i < indentation; i++)
+    {
+        stream << " ";
+    }
+
+    PrintTagWithAttributes(node);
+    if (!node.HasChildNodes())
+    {
+        stream << L"<\\" << node.NodeName().c_str() << ">" << std::endl;
+        return;
+    }
+
+    if (node.ChildNodes().Size() == 1 && !node.FirstChild().HasChildNodes())
+    {
+        stream << node.InnerText().c_str() << L"<\\" << node.NodeName().c_str() << ">" << std::endl;
+        return;
+    }
+
+    stream << std::endl;
+    auto child = node.FirstChild();
+    do
+    {
+        Print(child, indentation + 2);
+    } while (child = child.NextSibling());
+
+    for (int i = 0; i < indentation; i++)
+    {
+        stream << " ";
+    }
+    stream << L"<\\" << node.NodeName().c_str() << ">" << std::endl;
+}
+
+void XmlDocumentEx::PrintTagWithAttributes(winrt::Windows::Data::Xml::Dom::IXmlNode node)
+{
+    stream << L"<" << node.NodeName().c_str();
+    for (int i = 0; i < (int)node.Attributes().Size(); i++)
+    {
+        auto attr = node.Attributes().GetAt(i);
+        stream << L" " << attr.NodeName().c_str() << L"='" << attr.InnerText().c_str() << L"'";
+    }
+
+    stream << L">";
+}

--- a/tools/BugReportTool/BugReportTool/XmlDocumentEx.h
+++ b/tools/BugReportTool/BugReportTool/XmlDocumentEx.h
@@ -1,0 +1,13 @@
+#pragma once
+#include <winrt/Windows.Data.Xml.Dom.h>
+
+class XmlDocumentEx : public winrt::Windows::Data::Xml::Dom::XmlDocument
+{
+private:
+	std::wstringstream stream;
+	void Print(winrt::Windows::Data::Xml::Dom::IXmlNode node, int indentation);
+	void PrintTagWithAttributes(winrt::Windows::Data::Xml::Dom::IXmlNode node);
+
+public:
+	std::wstring GetFormatedXml();
+};


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
We query for event viewer logs specific to PowerToys and report them. It is useful to correlate bug reports with Watson. Usually, Watson has memory dumps of crashes that are useful. Also, some crashes are not logged so it is useful to have at least some information about crashes. 

We report XAML view from the event viewer.

![image](https://user-images.githubusercontent.com/17161067/119662158-bd1ade00-be39-11eb-876d-faeced596b83.png)

Based on https://docs.microsoft.com/en-us/windows/win32/wes/querying-for-events

Take into account, that xaml isn't very readable especially `EventData` section. For example, to get a Hashed bucket(correlation id for watson) we need to go to `Windows Error Reporting` xaml and take second to the end `Data` in `EventData` section.

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
