### PR TITLE
[PowerToys Run] Settings watcher logging

### DIFF
--- a/src/modules/launcher/PowerLauncher/SettingsReader.cs
+++ b/src/modules/launcher/PowerLauncher/SettingsReader.cs
@@ -57,7 +57,14 @@ namespace PowerLauncher
 
         public void ReadSettingsOnChange()
         {
-            _watcher = Microsoft.PowerToys.Settings.UI.Library.Utilities.Helper.GetFileWatcher(PowerLauncherSettings.ModuleName, "settings.json", ReadSettings);
+            _watcher = Microsoft.PowerToys.Settings.UI.Library.Utilities.Helper.GetFileWatcher(
+                PowerLauncherSettings.ModuleName,
+                "settings.json",
+                () =>
+                {
+                    Log.Info("Settings were changed. Read settings.", GetType());
+                    ReadSettings();
+                });
         }
 
         public void ReadSettings()
@@ -73,6 +80,10 @@ namespace PowerLauncher
                     CreateSettingsIfNotExists();
 
                     var overloadSettings = _settingsUtils.GetSettingsOrDefault<PowerLauncherSettings>(PowerLauncherSettings.ModuleName);
+                    if (overloadSettings != null)
+                    {
+                        Log.Info($"Successfully read new settings. retryCount={retryCount}", GetType());
+                    }
 
                     if (overloadSettings.Plugins == null || overloadSettings.Plugins.Count() != PluginManager.AllPlugins.Count)
                     {


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
We have experienced an issue when settings are updated in the settings app but PT Run process is not updated accordingly. These logs would help us to determine if it is a file watcher issue or PT Run issue.

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
