### PR TITLE
CPowerRenameManager::s_fileOpWorkerThread should initialize COM as STA not MTA

### DIFF
--- a/src/modules/powerrename/lib/PowerRenameManager.cpp
+++ b/src/modules/powerrename/lib/PowerRenameManager.cpp
@@ -646,7 +646,7 @@ HRESULT CPowerRenameManager::_PerformFileOperation()
         _OnRenameCompleted();
     }
 
-    return 0;
+    return S_OK;
 }
 
 HRESULT CPowerRenameManager::_CreateFileOpWorkerThread()
@@ -676,7 +676,7 @@ HRESULT CPowerRenameManager::_CreateFileOpWorkerThread()
 
 DWORD WINAPI CPowerRenameManager::s_fileOpWorkerThread(_In_ void* pv)
 {
-    if (SUCCEEDED(CoInitializeEx(NULL, 0)))
+    if (SUCCEEDED(CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE)))
     {
         WorkerThreadData* pwtd = reinterpret_cast<WorkerThreadData*>(pv);
         if (pwtd)


### PR DESCRIPTION
Change the CoInitializeEx call to initialize COM in a STA instead of MTA in s_fileOpWorkerThread.  This may resolve a crashing bug some users are experiencing where windows explorer crashes when starting a rename operation.  This also includes a small fix to return S_OK instead of 0 in _PerformFileOperation.