### PR TITLE
[PowerToys Run] Crash on exit, logs

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Main.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Plugin.Indexer
         // To save the configurations of plugins
         public void Save()
         {
-            _storage.Save();
+            _storage?.Save();
         }
 
         // This function uses the Windows indexer and returns the list of results obtained

--- a/src/modules/launcher/PowerLauncher/App.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/App.xaml.cs
@@ -170,9 +170,23 @@ namespace PowerLauncher
 
         private void RegisterExitEvents()
         {
-            AppDomain.CurrentDomain.ProcessExit += (s, e) => Dispose();
-            Current.Exit += (s, e) => Dispose();
-            Current.SessionEnding += (s, e) => Dispose();
+            AppDomain.CurrentDomain.ProcessExit += (s, e) =>
+            {
+                Log.Info("AppDomain.CurrentDomain.ProcessExit", GetType());
+                Dispose();
+            };
+
+            Current.Exit += (s, e) =>
+            {
+                Log.Info("Application.Current.Exit", GetType());
+                Dispose();
+            };
+
+            Current.SessionEnding += (s, e) =>
+            {
+                Log.Info("Application.Current.SessionEnding", GetType());
+                Dispose();
+            };
         }
 
         /// <summary>

--- a/src/modules/launcher/Wox.Plugin/PluginPair.cs
+++ b/src/modules/launcher/Wox.Plugin/PluginPair.cs
@@ -114,6 +114,7 @@ namespace Wox.Plugin
         private void LoadPlugin()
         {
             var stopWatch = new Stopwatch();
+            stopWatch.Start();
             CreatePluginInstance();
             stopWatch.Stop();
             Metadata.InitTime += stopWatch.ElapsedMilliseconds;


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

When PT Run exits we get null reference exception

```
System.NullReferenceException: Object reference not set to an instance of an object.
   Source: Microsoft.Plugin.Indexer
   TargetAssembly: Microsoft.Plugin.Indexer, Version=0.37.2.0, Culture=neutral, PublicKeyToken=null
   TargetModule: Microsoft.Plugin.Indexer.dll
   TargetSite: Void Save()
   at Microsoft.Plugin.Indexer.Main.Save()
   at PowerLauncher.Plugin.PluginManager.Save()
   at Wox.PublicAPIInstance.SaveAppAllSettings()
   at PowerLauncher.App.<>c__DisplayClass20_0.<Dispose>b__0()
   at Wox.Infrastructure.Stopwatch.Normal(String message, Action action)
   at PowerLauncher.App.Dispose(Boolean disposing)
   at PowerLauncher.App.Dispose()
   at PowerLauncher.App.<RegisterExitEvents>b__15_2(Object s, SessionEndingCancelEventArgs e)
   at System.Windows.Application.OnSessionEnding(SessionEndingCancelEventArgs e)
   at System.Windows.Application.WmQueryEndSession(IntPtr lParam, IntPtr& refInt)
   at System.Windows.Application.AppFilterMessage(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam, Boolean& handled)
   at MS.Win32.HwndWrapper.WndProc(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam, Boolean& handled)
   at MS.Win32.HwndSubclass.DispatcherCallbackOperation(Object o)
   at System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, Object args, Int32 numArgs)
   at System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, Delegate callback, Object args, Int32 numArgs, Delegate catchHandler)
```

Added logs to understand the exact reason for PT Run exit. We should only get `Application.SessionEnding` event. `AppDomain.ProcessExit` and `Application.Exit` events should not be triggered. 

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [X] **Linked issue:** #11390
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
