### PR TITLE
[Run-Plugin Manager] Save relative path to settings

### DIFF
--- a/src/modules/launcher/PowerLauncher/SettingsReader.cs
+++ b/src/modules/launcher/PowerLauncher/SettingsReader.cs
@@ -193,6 +193,12 @@ namespace PowerLauncher
             return results.Values.ToList();
         }
 
+        private static string GetIcon(PluginMetadata metadata, string iconPath)
+        {
+            var pluginDirectory = Path.GetFileName(metadata.PluginDirectory);
+            return Path.Combine(pluginDirectory, iconPath);
+        }
+
         private static IEnumerable<PowerLauncherPluginSettings> GetDefaultPluginsSettings()
         {
             return PluginManager.AllPlugins.Select(x => new PowerLauncherPluginSettings()
@@ -204,8 +210,8 @@ namespace PowerLauncher
                 Disabled = x.Metadata.Disabled,
                 IsGlobal = x.Metadata.IsGlobal,
                 ActionKeyword = x.Metadata.ActionKeyword,
-                IconPathDark = x.Metadata.IcoPathDark,
-                IconPathLight = x.Metadata.IcoPathLight,
+                IconPathDark = GetIcon(x.Metadata, x.Metadata.IcoPathDark),
+                IconPathLight = GetIcon(x.Metadata, x.Metadata.IcoPathLight),
                 AdditionalOptions = x.Plugin is ISettingProvider ? (x.Plugin as ISettingProvider).AdditionalOptions : new List<PluginAdditionalOption>(),
             });
         }

--- a/src/modules/launcher/Wox.Plugin/PluginMetadata.cs
+++ b/src/modules/launcher/Wox.Plugin/PluginMetadata.cs
@@ -51,8 +51,6 @@ namespace Wox.Plugin
             {
                 _pluginDirectory = value;
                 ExecuteFilePath = Path.Combine(value, ExecuteFileName);
-                IcoPathDark = Path.Combine(value, IcoPathDark);
-                IcoPathLight = Path.Combine(value, IcoPathLight);
             }
         }
 

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/PowerLauncherPluginViewModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/PowerLauncherPluginViewModel.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 
@@ -128,7 +129,15 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             return $"{Name}. {Description}";
         }
 
-        public string IconPath { get => isDark() ? settings.IconPathDark : settings.IconPathLight; }
+        public string IconPath
+        {
+            get
+            {
+                var path = isDark() ? settings.IconPathDark : settings.IconPathLight;
+                path = Path.Combine(Directory.GetCurrentDirectory(), @"modules\launcher\Plugins", path);
+                return path;
+            }
+        }
 
         private bool _showAdditionalInfoPanel;
 


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Before we stored absolute paths for icons to the settings file. It usually causes problems for a developer. 
Steps to reproduce:
- Delete `PowerToys Run\settings.json`
- Start PT from visual studio(PT saves absolute paths)
- Clean solution 
- Start installed PT
- Check that plugin icons are not shown in the settings

We store relative paths to resolve this issue.

**What is include in the PR:** 

**How does someone test / validate:** 
- Test with old settings
- Test with a clean settings
 
## Quality Checklist

- [X] **Linked issue:** #10099
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
