### PR TITLE
[OOBE] Open minimized settings

### DIFF
--- a/src/settings-ui/PowerToys.Settings/App.xaml.cs
+++ b/src/settings-ui/PowerToys.Settings/App.xaml.cs
@@ -24,6 +24,10 @@ namespace PowerToys.Settings
             {
                 settingsWindow = new MainWindow();
             }
+            else if (settingsWindow.WindowState == WindowState.Minimized)
+            {
+                settingsWindow.WindowState = WindowState.Normal;
+            }
 
             settingsWindow.Show();
             settingsWindow.NavigateToSection(type);


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Small fix for minimized settings window not brought to front when opened from OOBE.

**How does someone test / validate:** 
- Open Settings window from tray icon
- Open OOBE window from "Welcome to PowerToys" link
- Minimize Settings window
- Open Settings from the OOBE window > Welcome > Settings button
- Settings window should be brought to front and displayed

## Quality Checklist

- [x] **Linked issue:** #10994
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
