### PR TITLE
[Area-Build] Fix build for VS 16.10

### DIFF
--- a/src/common/interop/shared_constants.h
+++ b/src/common/interop/shared_constants.h
@@ -8,7 +8,7 @@ namespace CommonSharedConstants
     const uintptr_t KEYBOARDMANAGER_INJECTED_FLAG = 0x1;
 
     // Fake key code to represent VK_WIN.
-    inline const int VK_WIN_BOTH = 0x104;
+    inline const DWORD VK_WIN_BOTH = 0x104;
 
     const wchar_t APPDATA_PATH[] = L"Microsoft\\PowerToys";
 
@@ -27,5 +27,5 @@ namespace CommonSharedConstants
     const wchar_t SHORTCUT_GUIDE_EXIT_EVENT[] = L"Local\\ShortcutGuide-ExitEvent-35697cdd-a3d2-47d6-a246-34efcc73eac0";
 
     // Max DWORD for key code to disable keys.
-    const int VK_DISABLED = 0x100;
+    const DWORD VK_DISABLED = 0x100;
 }

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/BufferValidationHelpers.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/BufferValidationHelpers.cpp
@@ -56,17 +56,17 @@ namespace BufferValidationHelpers
             // If there is no error, set the buffer
             if (errorType == ShortcutErrorType::NoError)
             {
-                remapBuffer[rowIndex].first[colIndex] = selectedKeyCode;
+                remapBuffer[rowIndex].first[colIndex] = (DWORD)selectedKeyCode;
             }
             else
             {
-                remapBuffer[rowIndex].first[colIndex] = NULL;
+                remapBuffer[rowIndex].first[colIndex] = (DWORD)0;
             }
         }
         else
         {
             // Reset to null if the key is not found
-            remapBuffer[rowIndex].first[colIndex] = NULL;
+            remapBuffer[rowIndex].first[colIndex] = (DWORD)0;
         }
 
         return errorType;
@@ -214,7 +214,7 @@ namespace BufferValidationHelpers
             KeyShortcutUnion tempShortcut;
             if (isHybridControl && KeyDropDownControl::GetNumberOfSelectedKeys(selectedCodes) == 1)
             {
-                tempShortcut = *std::find_if(selectedCodes.begin(), selectedCodes.end(), [](int32_t a) { return a != -1 && a != 0; });
+                tempShortcut = (DWORD)*std::find_if(selectedCodes.begin(), selectedCodes.end(), [](int32_t a) { return a != -1 && a != 0; });
             }
             else
             {

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/KeyDropDownControl.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/KeyDropDownControl.cpp
@@ -255,7 +255,7 @@ void KeyDropDownControl::SetSelectionHandler(StackPanel& table, StackPanel row, 
                 // If exactly one key is selected consider it to be a key remap
                 if (GetNumberOfSelectedKeys(selectedKeyCodes) == 1)
                 {
-                    shortcutRemapBuffer[validationResult.second].first[colIndex] = selectedKeyCodes[0];
+                    shortcutRemapBuffer[validationResult.second].first[colIndex] = (DWORD)selectedKeyCodes[0];
                 }
                 else
                 {
@@ -357,7 +357,7 @@ void KeyDropDownControl::ValidateShortcutFromDropDownList(StackPanel table, Stac
         KeyShortcutUnion currentShortcut;
         if (GetNumberOfSelectedKeys(selectedKeyCodes) == 1 && isHybridControl)
         {
-            currentShortcut = selectedKeyCodes[0];
+            currentShortcut = (DWORD)selectedKeyCodes[0];
         }
         else
         {

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/ShortcutControl.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/ShortcutControl.cpp
@@ -148,7 +148,7 @@ void ShortcutControl::AddNewShortcutControlRow(StackPanel& parent, std::vector<s
         // If exactly one key is selected consider it to be a key remap
         if (selectedKeyCodes.size() == 1)
         {
-            shortcutRemapBuffer[rowIndex].first[1] = selectedKeyCodes[0];
+            shortcutRemapBuffer[rowIndex].first[1] = (DWORD)selectedKeyCodes[0];
         }
         else
         {

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/SingleKeyRemapControl.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/SingleKeyRemapControl.cpp
@@ -124,7 +124,7 @@ void SingleKeyRemapControl::AddNewControlKeyRemapRow(StackPanel& parent, std::ve
     else
     {
         // Initialize both keys to NULL
-        singleKeyRemapBuffer.push_back(std::make_pair<RemapBufferItem, std::wstring>(RemapBufferItem{ NULL, NULL }, L""));
+        singleKeyRemapBuffer.push_back(std::make_pair<RemapBufferItem, std::wstring>(RemapBufferItem{ (DWORD)0, (DWORD)0 }, L""));
     }
 
     // Delete row button

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/SingleKeyRemapControl.h
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/SingleKeyRemapControl.h
@@ -52,7 +52,7 @@ public:
     SingleKeyRemapControl(StackPanel table, StackPanel row, const int colIndex);
 
     // Function to add a new row to the remap keys table. If the originalKey and newKey args are provided, then the displayed remap keys are set to those values.
-    static void AddNewControlKeyRemapRow(StackPanel& parent, std::vector<std::vector<std::unique_ptr<SingleKeyRemapControl>>>& keyboardRemapControlObjects, const DWORD originalKey = NULL, const KeyShortcutUnion newKey = NULL);
+    static void AddNewControlKeyRemapRow(StackPanel& parent, std::vector<std::vector<std::unique_ptr<SingleKeyRemapControl>>>& keyboardRemapControlObjects, const DWORD originalKey = 0, const KeyShortcutUnion newKey = (DWORD)0);
 
     // Function to return the stack panel element of the SingleKeyRemapControl. This is the externally visible UI element which can be used to add it to other layouts
     winrt::Windows::UI::Xaml::Controls::StackPanel getSingleKeyRemapControl();

--- a/src/modules/keyboardmanager/KeyboardManagerEditorTest/BufferValidationTests.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorTest/BufferValidationTests.cpp
@@ -54,8 +54,8 @@ namespace RemappingUITests
             RemapBuffer remapBuffer;
 
             // Add 2 empty rows
-            remapBuffer.push_back(std::make_pair(RemapBufferItem({ NULL, NULL }), std::wstring()));
-            remapBuffer.push_back(std::make_pair(RemapBufferItem({ NULL, NULL }), std::wstring()));
+            remapBuffer.push_back(std::make_pair(RemapBufferItem({ (DWORD)0, (DWORD)0 }), std::wstring()));
+            remapBuffer.push_back(std::make_pair(RemapBufferItem({ (DWORD)0, (DWORD)0 }), std::wstring()));
 
             // Validate and update the element when -1 i.e. null selection is made on an empty row.
             ValidateAndUpdateKeyBufferElementArgs args = { 0, 0, -1 };
@@ -75,7 +75,7 @@ namespace RemappingUITests
             RemapBuffer remapBuffer;
 
             // Add an empty row
-            remapBuffer.push_back(std::make_pair(RemapBufferItem({ NULL, NULL }), std::wstring()));
+            remapBuffer.push_back(std::make_pair(RemapBufferItem({ (DWORD)0, (DWORD)0 }), std::wstring()));
 
             // Validate and update the element when selecting B on an empty row
             ValidateAndUpdateKeyBufferElementArgs args = { 0, 0, 0x42 };
@@ -93,7 +93,7 @@ namespace RemappingUITests
             RemapBuffer remapBuffer;
 
             // Add a row with A as the target
-            remapBuffer.push_back(std::make_pair(RemapBufferItem({ NULL, 0x41 }), std::wstring()));
+            remapBuffer.push_back(std::make_pair(RemapBufferItem({ (DWORD)0, (DWORD)0x41 }), std::wstring()));
 
             // Validate and update the element when selecting B on a row
             ValidateAndUpdateKeyBufferElementArgs args = { 0, 0, 0x42 };
@@ -111,7 +111,7 @@ namespace RemappingUITests
             RemapBuffer remapBuffer;
 
             // Add a row with Ctrl+A as the target
-            remapBuffer.push_back(std::make_pair(RemapBufferItem({ NULL, Shortcut(std::vector<int32_t>{ VK_CONTROL, 0x41 }) }), std::wstring()));
+            remapBuffer.push_back(std::make_pair(RemapBufferItem({ (DWORD)0, Shortcut(std::vector<int32_t>{ VK_CONTROL, 0x41 }) }), std::wstring()));
 
             // Validate and update the element when selecting B on a row
             ValidateAndUpdateKeyBufferElementArgs args = { 0, 0, 0x42 };
@@ -129,7 +129,7 @@ namespace RemappingUITests
             RemapBuffer remapBuffer;
 
             // Add a row with A as the target
-            remapBuffer.push_back(std::make_pair(RemapBufferItem({ NULL, 0x41 }), std::wstring()));
+            remapBuffer.push_back(std::make_pair(RemapBufferItem({ (DWORD)0, (DWORD)0x41 }), std::wstring()));
 
             // Validate and update the element when selecting A on a row
             ValidateAndUpdateKeyBufferElementArgs args = { 0, 0, 0x41 };
@@ -147,8 +147,8 @@ namespace RemappingUITests
             RemapBuffer remapBuffer;
 
             // Add a row from A->B and a row with C as target
-            remapBuffer.push_back(std::make_pair(RemapBufferItem({ 0x41, 0x42 }), std::wstring()));
-            remapBuffer.push_back(std::make_pair(RemapBufferItem({ NULL, 0x43 }), std::wstring()));
+            remapBuffer.push_back(std::make_pair(RemapBufferItem({ (DWORD)0x41, (DWORD)0x42 }), std::wstring()));
+            remapBuffer.push_back(std::make_pair(RemapBufferItem({ (DWORD)0, (DWORD)0x43 }), std::wstring()));
 
             // Validate and update the element when selecting A on second row
             ValidateAndUpdateKeyBufferElementArgs args = { 1, 0, 0x41 };
@@ -166,8 +166,8 @@ namespace RemappingUITests
             RemapBuffer remapBuffer;
 
             // Add a row from A->B and a row with Ctrl+A as target
-            remapBuffer.push_back(std::make_pair(RemapBufferItem({ 0x41, 0x42 }), std::wstring()));
-            remapBuffer.push_back(std::make_pair(RemapBufferItem({ NULL, Shortcut(std::vector<int32_t>{ VK_CONTROL, 0x41 }) }), std::wstring()));
+            remapBuffer.push_back(std::make_pair(RemapBufferItem({ (DWORD)0x41, (DWORD)0x42 }), std::wstring()));
+            remapBuffer.push_back(std::make_pair(RemapBufferItem({ (DWORD)0, Shortcut(std::vector<int32_t>{ VK_CONTROL, 0x41 }) }), std::wstring()));
 
             // Validate and update the element when selecting A on second row
             ValidateAndUpdateKeyBufferElementArgs args = { 1, 0, 0x41 };
@@ -185,8 +185,8 @@ namespace RemappingUITests
             RemapBuffer remapBuffer;
 
             // Add a row from Ctrl->B and a row with C as target
-            remapBuffer.push_back(std::make_pair(RemapBufferItem({ VK_CONTROL, 0x42 }), std::wstring()));
-            remapBuffer.push_back(std::make_pair(RemapBufferItem({ NULL, 0x43 }), std::wstring()));
+            remapBuffer.push_back(std::make_pair(RemapBufferItem({ (DWORD)VK_CONTROL, (DWORD)0x42 }), std::wstring()));
+            remapBuffer.push_back(std::make_pair(RemapBufferItem({ (DWORD)0, (DWORD)0x43 }), std::wstring()));
 
             // Validate and update the element when selecting LCtrl on second row
             ValidateAndUpdateKeyBufferElementArgs args = { 1, 0, VK_LCONTROL };
@@ -204,8 +204,8 @@ namespace RemappingUITests
             RemapBuffer remapBuffer;
 
             // Add a row from Ctrl->B and a row with Ctrl+A as target
-            remapBuffer.push_back(std::make_pair(RemapBufferItem({ VK_CONTROL, 0x42 }), std::wstring()));
-            remapBuffer.push_back(std::make_pair(RemapBufferItem({ NULL, Shortcut(std::vector<int32_t>{ VK_CONTROL, 0x41 }) }), std::wstring()));
+            remapBuffer.push_back(std::make_pair(RemapBufferItem({ (DWORD)VK_CONTROL, (DWORD)0x42 }), std::wstring()));
+            remapBuffer.push_back(std::make_pair(RemapBufferItem({ (DWORD)0, Shortcut(std::vector<int32_t>{ VK_CONTROL, 0x41 }) }), std::wstring()));
 
             // Validate and update the element when selecting LCtrl on second row
             ValidateAndUpdateKeyBufferElementArgs args = { 1, 0, VK_LCONTROL };
@@ -226,9 +226,9 @@ namespace RemappingUITests
             // Case 2: Validate the element when making null-selection (-1 index) on second column of empty shortcut to shortcut row
             testCases.push_back({ 0, 1, 0, std::vector<int32_t>{ -1 }, std::wstring(), false, std::make_pair(RemapBufferItem{ Shortcut(), Shortcut() }, std::wstring()) });
             // Case 3: Validate the element when making null-selection (-1 index) on first column of empty shortcut to key row
-            testCases.push_back({ 0, 0, 0, std::vector<int32_t>{ -1 }, std::wstring(), false, std::make_pair(RemapBufferItem{ Shortcut(), NULL }, std::wstring()) });
+            testCases.push_back({ 0, 0, 0, std::vector<int32_t>{ -1 }, std::wstring(), false, std::make_pair(RemapBufferItem{ Shortcut(), (DWORD)0 }, std::wstring()) });
             // Case 4: Validate the element when making null-selection (-1 index) on second column of empty shortcut to key row
-            testCases.push_back({ 0, 1, 0, std::vector<int32_t>{ -1 }, std::wstring(), true, std::make_pair(RemapBufferItem{ Shortcut(), NULL }, std::wstring()) });
+            testCases.push_back({ 0, 1, 0, std::vector<int32_t>{ -1 }, std::wstring(), true, std::make_pair(RemapBufferItem{ Shortcut(), (DWORD)0 }, std::wstring()) });
             // Case 5: Validate the element when making null-selection (-1 index) on first dropdown of first column of valid shortcut to shortcut row
             testCases.push_back({ 0, 0, 0, std::vector<int32_t>({ -1, 0x43 }), std::wstring(), false, std::make_pair(RemapBufferItem{ std::vector<int32_t>{ VK_CONTROL, 0x43 }, std::vector<int32_t>{ VK_CONTROL, 0x41 } }, std::wstring()) });
             // Case 6: Validate the element when making null-selection (-1 index) on first dropdown of second column of valid shortcut to shortcut row
@@ -283,7 +283,7 @@ namespace RemappingUITests
             // Case 2: Validate the element when selecting A (0x41) on first dropdown of second column of empty shortcut to shortcut row
             testCases.push_back({ 0, 1, 0, std::vector<int32_t>{ 0x41 }, std::wstring(), false, std::make_pair(RemapBufferItem{ Shortcut(), Shortcut() }, std::wstring()) });
             // Case 3: Validate the element when selecting A (0x41) on first dropdown of first column of empty shortcut to key row
-            testCases.push_back({ 0, 0, 0, std::vector<int32_t>{ 0x41 }, std::wstring(), false, std::make_pair(RemapBufferItem{ Shortcut(), NULL }, std::wstring()) });
+            testCases.push_back({ 0, 0, 0, std::vector<int32_t>{ 0x41 }, std::wstring(), false, std::make_pair(RemapBufferItem{ Shortcut(), (DWORD)0 }, std::wstring()) });
             // Case 4: Validate the element when selecting A (0x41) on first dropdown of first column of valid shortcut to shortcut row
             testCases.push_back({ 0, 0, 0, std::vector<int32_t>{ 0x41, 0x43 }, std::wstring(), false, std::make_pair(RemapBufferItem{ std::vector<int32_t>{ VK_CONTROL, 0x43 }, std::vector<int32_t>{ VK_CONTROL, 0x41 } }, std::wstring()) });
 
@@ -308,7 +308,7 @@ namespace RemappingUITests
             // Case 1: Validate the element when selecting A (0x41) on first dropdown of second column of empty shortcut to shortcut row
             testCases.push_back({ 0, 1, 0, std::vector<int32_t>{ 0x41 }, std::wstring(), true, std::make_pair(RemapBufferItem{ Shortcut(), Shortcut() }, std::wstring()) });
             // Case 2: Validate the element when selecting A (0x41) on first dropdown of second column of empty shortcut to key row
-            testCases.push_back({ 0, 1, 0, std::vector<int32_t>{ 0x41 }, std::wstring(), true, std::make_pair(RemapBufferItem{ Shortcut(), NULL }, std::wstring()) });
+            testCases.push_back({ 0, 1, 0, std::vector<int32_t>{ 0x41 }, std::wstring(), true, std::make_pair(RemapBufferItem{ Shortcut(), (DWORD)0 }, std::wstring()) });
 
             RunTestCases(testCases, [this](const ValidateShortcutBufferElementArgs& testCase) {
                 // Arrange
@@ -472,7 +472,7 @@ namespace RemappingUITests
             // Case 6: Validate the element when selecting Shift (VK_SHIFT) on first dropdown of second column of 1 dropdown hybrid shortcut to shortcut row
             testCases.push_back({ 0, 1, 0, std::vector<int32_t>{ VK_SHIFT }, std::wstring(), true, std::make_pair(RemapBufferItem{ Shortcut(), Shortcut() }, std::wstring()) });
             // Case 7: Validate the element when selecting Shift (VK_SHIFT) on first dropdown of second column of 1 dropdown hybrid shortcut to key row with an action key selected
-            testCases.push_back({ 0, 1, 0, std::vector<int32_t>{ VK_SHIFT }, std::wstring(), true, std::make_pair(RemapBufferItem{ Shortcut(), 0x44 }, std::wstring()) });
+            testCases.push_back({ 0, 1, 0, std::vector<int32_t>{ VK_SHIFT }, std::wstring(), true, std::make_pair(RemapBufferItem{ Shortcut(), (DWORD)0x44 }, std::wstring()) });
 
             RunTestCases(testCases, [this](const ValidateShortcutBufferElementArgs& testCase) {
                 // Arrange
@@ -963,21 +963,21 @@ namespace RemappingUITests
         {
             std::vector<ValidateShortcutBufferElementArgs> testCases;
             // Case 1: Validate the element when selecting A (0x41) on first dropdown of empty hybrid second column
-            testCases.push_back({ 0, 1, 0, std::vector<int32_t>{ 0x41, -1, -1 }, std::wstring(), true, std::make_pair(RemapBufferItem{ 0x41, NULL }, std::wstring()) });
+            testCases.push_back({ 0, 1, 0, std::vector<int32_t>{ 0x41, -1, -1 }, std::wstring(), true, std::make_pair(RemapBufferItem{ (DWORD)0x41, (DWORD)0 }, std::wstring()) });
             // Case 2: Validate the element when selecting A (0x41) on second dropdown of empty hybrid second column
-            testCases.push_back({ 0, 1, 1, std::vector<int32_t>{ -1, 0x41, -1 }, std::wstring(), true, std::make_pair(RemapBufferItem{ 0x41, NULL }, std::wstring()) });
+            testCases.push_back({ 0, 1, 1, std::vector<int32_t>{ -1, 0x41, -1 }, std::wstring(), true, std::make_pair(RemapBufferItem{ (DWORD)0x41, (DWORD)0 }, std::wstring()) });
             // Case 3: Validate the element when selecting A (0x41) on third dropdown of empty hybrid second column
-            testCases.push_back({ 0, 1, 2, std::vector<int32_t>{ -1, -1, 0x41 }, std::wstring(), true, std::make_pair(RemapBufferItem{ 0x41, NULL }, std::wstring()) });
+            testCases.push_back({ 0, 1, 2, std::vector<int32_t>{ -1, -1, 0x41 }, std::wstring(), true, std::make_pair(RemapBufferItem{ (DWORD)0x41, (DWORD)0 }, std::wstring()) });
             // Case 4: Validate the element when selecting A (0x41) on first dropdown of hybrid second column with key
-            testCases.push_back({ 0, 1, 0, std::vector<int32_t>{ 0x41 }, std::wstring(), true, std::make_pair(RemapBufferItem{ 0x41, 0x43 }, std::wstring()) });
+            testCases.push_back({ 0, 1, 0, std::vector<int32_t>{ 0x41 }, std::wstring(), true, std::make_pair(RemapBufferItem{ (DWORD)0x41, (DWORD)0x43 }, std::wstring()) });
             // Case 5: Validate the element when selecting Null (-1) on first dropdown of hybrid second column with shortcut
-            testCases.push_back({ 0, 1, 0, std::vector<int32_t>{ -1, 0x41 }, std::wstring(), true, std::make_pair(RemapBufferItem{ 0x41, std::vector<int32_t>{ VK_CONTROL, 0x41 } }, std::wstring()) });
+            testCases.push_back({ 0, 1, 0, std::vector<int32_t>{ -1, 0x41 }, std::wstring(), true, std::make_pair(RemapBufferItem{ (DWORD)0x41, std::vector<int32_t>{ VK_CONTROL, 0x41 } }, std::wstring()) });
             // Case 6: Validate the element when selecting None (0) on first dropdown of hybrid second column with shortcut
-            testCases.push_back({ 0, 1, 0, std::vector<int32_t>{ 0, 0x41 }, std::wstring(), true, std::make_pair(RemapBufferItem{ 0x41, std::vector<int32_t>{ VK_CONTROL, 0x41 } }, std::wstring()) });
+            testCases.push_back({ 0, 1, 0, std::vector<int32_t>{ 0, 0x41 }, std::wstring(), true, std::make_pair(RemapBufferItem{ (DWORD)0x41, std::vector<int32_t>{ VK_CONTROL, 0x41 } }, std::wstring()) });
             // Case 7: Validate the element when selecting Null (-1) on second dropdown of hybrid second column with shortcut
-            testCases.push_back({ 0, 1, 1, std::vector<int32_t>{ -1, VK_CONTROL }, std::wstring(), true, std::make_pair(RemapBufferItem{ VK_CONTROL, std::vector<int32_t>{ VK_CONTROL, 0x41 } }, std::wstring()) });
+            testCases.push_back({ 0, 1, 1, std::vector<int32_t>{ -1, VK_CONTROL }, std::wstring(), true, std::make_pair(RemapBufferItem{ (DWORD)VK_CONTROL, std::vector<int32_t>{ VK_CONTROL, 0x41 } }, std::wstring()) });
             // Case 8: Validate the element when selecting None (0) on second dropdown of hybrid second column with shortcut
-            testCases.push_back({ 0, 1, 1, std::vector<int32_t>{ 0, VK_CONTROL }, std::wstring(), true, std::make_pair(RemapBufferItem{ VK_CONTROL, std::vector<int32_t>{ VK_CONTROL, 0x41 } }, std::wstring()) });
+            testCases.push_back({ 0, 1, 1, std::vector<int32_t>{ 0, VK_CONTROL }, std::wstring(), true, std::make_pair(RemapBufferItem{ (DWORD)VK_CONTROL, std::vector<int32_t>{ VK_CONTROL, 0x41 } }, std::wstring()) });
 
             RunTestCases(testCases, [this](const ValidateShortcutBufferElementArgs& testCase) {
                 // Arrange

--- a/src/modules/keyboardmanager/KeyboardManagerEditorTest/LoadingAndSavingRemappingTests.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorTest/LoadingAndSavingRemappingTests.cpp
@@ -36,8 +36,8 @@ namespace RemappingUITests
             RemapBuffer remapBuffer;
 
             // Remap A to B and B to C
-            remapBuffer.push_back(std::make_pair(RemapBufferItem({ 0x41, 0x42 }), std::wstring()));
-            remapBuffer.push_back(std::make_pair(RemapBufferItem({ 0x42, 0x43 }), std::wstring()));
+            remapBuffer.push_back(std::make_pair(RemapBufferItem({ (DWORD)0x41, (DWORD)0x42 }), std::wstring()));
+            remapBuffer.push_back(std::make_pair(RemapBufferItem({ (DWORD)0x42, (DWORD)0x43 }), std::wstring()));
 
             // Assert that remapping set is valid
             bool isSuccess = (LoadingAndSavingRemappingHelper::CheckIfRemappingsAreValid(remapBuffer) == ShortcutErrorType::NoError);
@@ -56,8 +56,8 @@ namespace RemappingUITests
             Shortcut s2;
             s2.SetKey(VK_MENU);
             s2.SetKey(VK_TAB);
-            remapBuffer.push_back(std::make_pair(RemapBufferItem({ 0x41, s1 }), std::wstring()));
-            remapBuffer.push_back(std::make_pair(RemapBufferItem({ 0x42, s2 }), std::wstring()));
+            remapBuffer.push_back(std::make_pair(RemapBufferItem({ (DWORD)0x41, s1 }), std::wstring()));
+            remapBuffer.push_back(std::make_pair(RemapBufferItem({ (DWORD)0x42, s2 }), std::wstring()));
 
             // Assert that remapping set is valid
             bool isSuccess = (LoadingAndSavingRemappingHelper::CheckIfRemappingsAreValid(remapBuffer) == ShortcutErrorType::NoError);
@@ -76,8 +76,8 @@ namespace RemappingUITests
             Shortcut s2;
             s2.SetKey(VK_MENU);
             s2.SetKey(VK_TAB);
-            remapBuffer.push_back(std::make_pair(RemapBufferItem({ s1, 0x41 }), std::wstring()));
-            remapBuffer.push_back(std::make_pair(RemapBufferItem({ s2, 0x42 }), std::wstring()));
+            remapBuffer.push_back(std::make_pair(RemapBufferItem({ s1, (DWORD)0x41 }), std::wstring()));
+            remapBuffer.push_back(std::make_pair(RemapBufferItem({ s2, (DWORD)0x42 }), std::wstring()));
 
             // Assert that remapping set is valid
             bool isSuccess = (LoadingAndSavingRemappingHelper::CheckIfRemappingsAreValid(remapBuffer) == ShortcutErrorType::NoError);
@@ -129,9 +129,9 @@ namespace RemappingUITests
             dest2.SetKey(CommonSharedConstants::VK_WIN_BOTH);
             dest2.SetKey(0x41);
             remapBuffer.push_back(std::make_pair(RemapBufferItem({ src1, dest1 }), std::wstring()));
-            remapBuffer.push_back(std::make_pair(RemapBufferItem({ src2, 0x41 }), std::wstring()));
-            remapBuffer.push_back(std::make_pair(RemapBufferItem({ 0x41, 0x42 }), std::wstring()));
-            remapBuffer.push_back(std::make_pair(RemapBufferItem({ 0x42, dest2 }), std::wstring()));
+            remapBuffer.push_back(std::make_pair(RemapBufferItem({ src2, (DWORD)0x41 }), std::wstring()));
+            remapBuffer.push_back(std::make_pair(RemapBufferItem({ (DWORD)0x41, (DWORD)0x42 }), std::wstring()));
+            remapBuffer.push_back(std::make_pair(RemapBufferItem({ (DWORD)0x42, dest2 }), std::wstring()));
 
             // Assert that remapping set is valid
             bool isSuccess = (LoadingAndSavingRemappingHelper::CheckIfRemappingsAreValid(remapBuffer) == ShortcutErrorType::NoError);
@@ -144,7 +144,7 @@ namespace RemappingUITests
             RemapBuffer remapBuffer;
 
             // Remap A to NULL
-            remapBuffer.push_back(std::make_pair(RemapBufferItem({ 0x41, NULL }), std::wstring()));
+            remapBuffer.push_back(std::make_pair(RemapBufferItem({ (DWORD)0x41, (DWORD)0 }), std::wstring()));
 
             // Assert that remapping set is invalid
             bool isSuccess = (LoadingAndSavingRemappingHelper::CheckIfRemappingsAreValid(remapBuffer) == ShortcutErrorType::RemapUnsuccessful);
@@ -159,7 +159,7 @@ namespace RemappingUITests
             // Remap A to incomplete shortcut (Ctrl)
             Shortcut src1;
             src1.SetKey(VK_CONTROL);
-            remapBuffer.push_back(std::make_pair(RemapBufferItem({ 0x41, src1 }), std::wstring()));
+            remapBuffer.push_back(std::make_pair(RemapBufferItem({ (DWORD)0x41, src1 }), std::wstring()));
 
             // Assert that remapping set is invalid
             bool isSuccess = (LoadingAndSavingRemappingHelper::CheckIfRemappingsAreValid(remapBuffer) == ShortcutErrorType::RemapUnsuccessful);
@@ -175,8 +175,8 @@ namespace RemappingUITests
             Shortcut src1;
             src1.SetKey(VK_CONTROL);
             src1.SetKey(0x43);
-            remapBuffer.push_back(std::make_pair(RemapBufferItem({ 0x41, 0x42 }), std::wstring()));
-            remapBuffer.push_back(std::make_pair(RemapBufferItem({ 0x41, src1 }), std::wstring()));
+            remapBuffer.push_back(std::make_pair(RemapBufferItem({ (DWORD)0x41, (DWORD)0x42 }), std::wstring()));
+            remapBuffer.push_back(std::make_pair(RemapBufferItem({ (DWORD)0x41, src1 }), std::wstring()));
 
             // Assert that remapping set is invalid
             bool isSuccess = (LoadingAndSavingRemappingHelper::CheckIfRemappingsAreValid(remapBuffer) == ShortcutErrorType::RemapUnsuccessful);
@@ -195,7 +195,7 @@ namespace RemappingUITests
             Shortcut dest1;
             dest1.SetKey(VK_CONTROL);
             dest1.SetKey(0x56);
-            remapBuffer.push_back(std::make_pair(RemapBufferItem({ src1, 0x42 }), std::wstring()));
+            remapBuffer.push_back(std::make_pair(RemapBufferItem({ src1, (DWORD)0x42 }), std::wstring()));
             remapBuffer.push_back(std::make_pair(RemapBufferItem({ src1, dest1 }), std::wstring()));
 
             // Assert that remapping set is invalid
@@ -215,7 +215,7 @@ namespace RemappingUITests
             Shortcut dest1;
             dest1.SetKey(VK_CONTROL);
             dest1.SetKey(0x56);
-            remapBuffer.push_back(std::make_pair(RemapBufferItem({ src1, 0x42 }), testApp1));
+            remapBuffer.push_back(std::make_pair(RemapBufferItem({ src1, (DWORD)0x42 }), testApp1));
             remapBuffer.push_back(std::make_pair(RemapBufferItem({ src1, dest1 }), testApp1));
 
             // Assert that remapping set is invalid
@@ -235,7 +235,7 @@ namespace RemappingUITests
             Shortcut dest1;
             dest1.SetKey(VK_CONTROL);
             dest1.SetKey(0x56);
-            remapBuffer.push_back(std::make_pair(RemapBufferItem({ src1, 0x42 }), testApp1));
+            remapBuffer.push_back(std::make_pair(RemapBufferItem({ src1, (DWORD)0x42 }), testApp1));
             remapBuffer.push_back(std::make_pair(RemapBufferItem({ src1, dest1 }), testApp2));
 
             // Assert that remapping set is valid
@@ -258,7 +258,7 @@ namespace RemappingUITests
             RemapBuffer remapBuffer;
 
             // Remap A to B
-            remapBuffer.push_back(std::make_pair(RemapBufferItem({ 0x41, 0x42 }), std::wstring()));
+            remapBuffer.push_back(std::make_pair(RemapBufferItem({ (DWORD)0x41, (DWORD)0x42 }), std::wstring()));
 
             // Assert that only A is orphaned
             Assert::AreEqual((size_t)1, LoadingAndSavingRemappingHelper::GetOrphanedKeys(remapBuffer).size());
@@ -271,8 +271,8 @@ namespace RemappingUITests
             RemapBuffer remapBuffer;
 
             // Remap A to B and B to A
-            remapBuffer.push_back(std::make_pair(RemapBufferItem({ 0x41, 0x42 }), std::wstring()));
-            remapBuffer.push_back(std::make_pair(RemapBufferItem({ 0x42, 0x41 }), std::wstring()));
+            remapBuffer.push_back(std::make_pair(RemapBufferItem({ (DWORD)0x41, (DWORD)0x42 }), std::wstring()));
+            remapBuffer.push_back(std::make_pair(RemapBufferItem({ (DWORD)0x42, (DWORD)0x41 }), std::wstring()));
 
             // Assert that there are no orphaned keys
             Assert::AreEqual(true, LoadingAndSavingRemappingHelper::GetOrphanedKeys(remapBuffer).empty());
@@ -287,8 +287,8 @@ namespace RemappingUITests
             Shortcut dest1;
             dest1.SetKey(VK_CONTROL);
             dest1.SetKey(0x42);
-            remapBuffer.push_back(std::make_pair(RemapBufferItem({ 0x41, dest1 }), std::wstring()));
-            remapBuffer.push_back(std::make_pair(RemapBufferItem({ 0x43, 0x41 }), std::wstring()));
+            remapBuffer.push_back(std::make_pair(RemapBufferItem({ (DWORD)0x41, dest1 }), std::wstring()));
+            remapBuffer.push_back(std::make_pair(RemapBufferItem({ (DWORD)0x43, (DWORD)0x41 }), std::wstring()));
 
             // Assert that only C is orphaned
             Assert::AreEqual((size_t)1, LoadingAndSavingRemappingHelper::GetOrphanedKeys(remapBuffer).size());
@@ -301,24 +301,24 @@ namespace RemappingUITests
             SingleKeyRemapTable remapTable;
 
             // Remap LCtrl and RCtrl to A, LAlt and RAlt to B, LShift and RShift to C, LWin and RWin to D
-            remapTable[VK_LCONTROL] = 0x41;
-            remapTable[VK_RCONTROL] = 0x41;
-            remapTable[VK_LMENU] = 0x42;
-            remapTable[VK_RMENU] = 0x42;
-            remapTable[VK_LSHIFT] = 0x43;
-            remapTable[VK_RSHIFT] = 0x43;
-            remapTable[VK_LWIN] = 0x44;
-            remapTable[VK_RWIN] = 0x44;
+            remapTable[VK_LCONTROL] = (DWORD)0x41;
+            remapTable[VK_RCONTROL] = (DWORD)0x41;
+            remapTable[VK_LMENU] = (DWORD)0x42;
+            remapTable[VK_RMENU] = (DWORD)0x42;
+            remapTable[VK_LSHIFT] = (DWORD)0x43;
+            remapTable[VK_RSHIFT] = (DWORD)0x43;
+            remapTable[VK_LWIN] = (DWORD)0x44;
+            remapTable[VK_RWIN] = (DWORD)0x44;
 
             // Pre process table
             LoadingAndSavingRemappingHelper::PreProcessRemapTable(remapTable);
 
             // Expected Ctrl remapped to A, Alt to B, Shift to C, Win to D
             SingleKeyRemapTable expectedTable;
-            expectedTable[VK_CONTROL] = 0x41;
-            expectedTable[VK_MENU] = 0x42;
-            expectedTable[VK_SHIFT] = 0x43;
-            expectedTable[CommonSharedConstants::VK_WIN_BOTH] = 0x44;
+            expectedTable[VK_CONTROL] = (DWORD)0x41;
+            expectedTable[VK_MENU] = (DWORD)0x42;
+            expectedTable[VK_SHIFT] = (DWORD)0x43;
+            expectedTable[CommonSharedConstants::VK_WIN_BOTH] = (DWORD)0x44;
 
             bool areTablesEqual = (expectedTable == remapTable);
             Assert::AreEqual(true, areTablesEqual);
@@ -330,28 +330,28 @@ namespace RemappingUITests
             SingleKeyRemapTable remapTable;
 
             // Remap left modifiers to A and right modifiers to B
-            remapTable[VK_LCONTROL] = 0x41;
-            remapTable[VK_RCONTROL] = 0x42;
-            remapTable[VK_LMENU] = 0x41;
-            remapTable[VK_RMENU] = 0x42;
-            remapTable[VK_LSHIFT] = 0x41;
-            remapTable[VK_RSHIFT] = 0x42;
-            remapTable[VK_LWIN] = 0x41;
-            remapTable[VK_RWIN] = 0x42;
+            remapTable[VK_LCONTROL] = (DWORD)0x41;
+            remapTable[VK_RCONTROL] = (DWORD)0x42;
+            remapTable[VK_LMENU] = (DWORD)0x41;
+            remapTable[VK_RMENU] = (DWORD)0x42;
+            remapTable[VK_LSHIFT] = (DWORD)0x41;
+            remapTable[VK_RSHIFT] = (DWORD)0x42;
+            remapTable[VK_LWIN] = (DWORD)0x41;
+            remapTable[VK_RWIN] = (DWORD)0x42;
 
             // Pre process table
             LoadingAndSavingRemappingHelper::PreProcessRemapTable(remapTable);
 
             // Expected unchanged table
             SingleKeyRemapTable expectedTable;
-            expectedTable[VK_LCONTROL] = 0x41;
-            expectedTable[VK_RCONTROL] = 0x42;
-            expectedTable[VK_LMENU] = 0x41;
-            expectedTable[VK_RMENU] = 0x42;
-            expectedTable[VK_LSHIFT] = 0x41;
-            expectedTable[VK_RSHIFT] = 0x42;
-            expectedTable[VK_LWIN] = 0x41;
-            expectedTable[VK_RWIN] = 0x42;
+            expectedTable[VK_LCONTROL] = (DWORD)0x41;
+            expectedTable[VK_RCONTROL] = (DWORD)0x42;
+            expectedTable[VK_LMENU] = (DWORD)0x41;
+            expectedTable[VK_RMENU] = (DWORD)0x42;
+            expectedTable[VK_LSHIFT] = (DWORD)0x41;
+            expectedTable[VK_RSHIFT] = (DWORD)0x42;
+            expectedTable[VK_LWIN] = (DWORD)0x41;
+            expectedTable[VK_RWIN] = (DWORD)0x42;
 
             bool areTablesEqual = (expectedTable == remapTable);
             Assert::AreEqual(true, areTablesEqual);
@@ -364,7 +364,7 @@ namespace RemappingUITests
             RemapBuffer remapBuffer;
 
             // Remap A to B
-            testShortcuts.AddSingleKeyRemap(0x41, 0x42);
+            testShortcuts.AddSingleKeyRemap(0x41, (DWORD)0x42);
 
             // Apply the single key remaps from the buffer to the keyboard manager state variable
             LoadingAndSavingRemappingHelper::ApplySingleKeyRemappings(testShortcuts, remapBuffer, false);
@@ -385,17 +385,17 @@ namespace RemappingUITests
             s1.SetKey(0x56);
             Shortcut s2;
             s2.SetKey(VK_LMENU);
-            remapBuffer.push_back(std::make_pair(RemapBufferItem({ 0x41, 0x42 }), std::wstring()));
-            remapBuffer.push_back(std::make_pair(RemapBufferItem({ 0x42, s1 }), std::wstring()));
-            remapBuffer.push_back(std::make_pair(RemapBufferItem({ 0x43, NULL }), std::wstring()));
-            remapBuffer.push_back(std::make_pair(RemapBufferItem({ 0x44, s2 }), std::wstring()));
+            remapBuffer.push_back(std::make_pair(RemapBufferItem({ (DWORD)0x41, (DWORD)0x42 }), std::wstring()));
+            remapBuffer.push_back(std::make_pair(RemapBufferItem({ (DWORD)0x42, s1 }), std::wstring()));
+            remapBuffer.push_back(std::make_pair(RemapBufferItem({ (DWORD)0x43, (DWORD)0 }), std::wstring()));
+            remapBuffer.push_back(std::make_pair(RemapBufferItem({ (DWORD)0x44, s2 }), std::wstring()));
 
             // Apply the single key remaps from the buffer to the keyboard manager state variable
             LoadingAndSavingRemappingHelper::ApplySingleKeyRemappings(testShortcuts, remapBuffer, false);
 
             // Expected A remapped to B, B remapped to Ctrl+V
             SingleKeyRemapTable expectedTable;
-            expectedTable[0x41] = 0x42;
+            expectedTable[0x41] = (DWORD)0x42;
             expectedTable[0x42] = s1;
 
             bool areTablesEqual = (expectedTable == testShortcuts.singleKeyReMap);
@@ -409,24 +409,24 @@ namespace RemappingUITests
             RemapBuffer remapBuffer;
 
             // Add Ctrl->A, Alt->B, Shift->C and Win->D remappings to the buffer
-            remapBuffer.push_back(std::make_pair(RemapBufferItem({ VK_CONTROL, 0x41 }), std::wstring()));
-            remapBuffer.push_back(std::make_pair(RemapBufferItem({ VK_MENU, 0x42 }), std::wstring()));
-            remapBuffer.push_back(std::make_pair(RemapBufferItem({ VK_SHIFT, 0x43 }), std::wstring()));
-            remapBuffer.push_back(std::make_pair(RemapBufferItem({ CommonSharedConstants::VK_WIN_BOTH, 0x44 }), std::wstring()));
+            remapBuffer.push_back(std::make_pair(RemapBufferItem({ (DWORD)VK_CONTROL, (DWORD)0x41 }), std::wstring()));
+            remapBuffer.push_back(std::make_pair(RemapBufferItem({ (DWORD)VK_MENU, (DWORD)0x42 }), std::wstring()));
+            remapBuffer.push_back(std::make_pair(RemapBufferItem({ (DWORD)VK_SHIFT, (DWORD)0x43 }), std::wstring()));
+            remapBuffer.push_back(std::make_pair(RemapBufferItem({ (DWORD)CommonSharedConstants::VK_WIN_BOTH, (DWORD)0x44 }), std::wstring()));
 
             // Apply the single key remaps from the buffer to the keyboard manager state variable
             LoadingAndSavingRemappingHelper::ApplySingleKeyRemappings(testShortcuts, remapBuffer, false);
 
             // Expected LCtrl/RCtrl remapped to A, LAlt/RAlt to B, LShift/RShift to C, LWin/RWin to D
             SingleKeyRemapTable expectedTable;
-            expectedTable[VK_LCONTROL] = 0x41;
-            expectedTable[VK_RCONTROL] = 0x41;
-            expectedTable[VK_LMENU] = 0x42;
-            expectedTable[VK_RMENU] = 0x42;
-            expectedTable[VK_LSHIFT] = 0x43;
-            expectedTable[VK_RSHIFT] = 0x43;
-            expectedTable[VK_LWIN] = 0x44;
-            expectedTable[VK_RWIN] = 0x44;
+            expectedTable[VK_LCONTROL] = (DWORD)0x41;
+            expectedTable[VK_RCONTROL] = (DWORD)0x41;
+            expectedTable[VK_LMENU] = (DWORD)0x42;
+            expectedTable[VK_RMENU] = (DWORD)0x42;
+            expectedTable[VK_LSHIFT] = (DWORD)0x43;
+            expectedTable[VK_RSHIFT] = (DWORD)0x43;
+            expectedTable[VK_LWIN] = (DWORD)0x44;
+            expectedTable[VK_RWIN] = (DWORD)0x44;
 
             bool areTablesEqual = (expectedTable == testShortcuts.singleKeyReMap);
             Assert::AreEqual(true, areTablesEqual);
@@ -492,11 +492,11 @@ namespace RemappingUITests
             dest4.SetKey(VK_CONTROL);
             remapBuffer.push_back(std::make_pair(RemapBufferItem({ src1, dest1 }), std::wstring()));
             remapBuffer.push_back(std::make_pair(RemapBufferItem({ src2, dest2 }), std::wstring()));
-            remapBuffer.push_back(std::make_pair(RemapBufferItem({ src3, NULL }), std::wstring()));
+            remapBuffer.push_back(std::make_pair(RemapBufferItem({ src3, (DWORD)0 }), std::wstring()));
             remapBuffer.push_back(std::make_pair(RemapBufferItem({ src4, dest4 }), std::wstring()));
             remapBuffer.push_back(std::make_pair(RemapBufferItem({ src3, dest2 }), testApp1));
             remapBuffer.push_back(std::make_pair(RemapBufferItem({ src4, dest1 }), testApp1));
-            remapBuffer.push_back(std::make_pair(RemapBufferItem({ src1, NULL }), testApp1));
+            remapBuffer.push_back(std::make_pair(RemapBufferItem({ src1, (DWORD)0 }), testApp1));
             remapBuffer.push_back(std::make_pair(RemapBufferItem({ src2, dest4 }), testApp1));
 
             // Apply the shortcut remaps from the buffer to the keyboard manager state variable

--- a/src/modules/keyboardmanager/KeyboardManagerEngineTest/AppSpecificShortcutRemappingTests.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineTest/AppSpecificShortcutRemappingTests.cpp
@@ -187,7 +187,7 @@ namespace RemappingLogicTests
             Shortcut src;
             src.SetKey(VK_CONTROL);
             src.SetKey(0x41);
-            testState.AddAppSpecificShortcut(testApp1, src, 0x56);
+            testState.AddAppSpecificShortcut(testApp1, src, (DWORD)0x56);
 
             // Set the testApp as the foreground process
             mockedInputHandler.SetForegroundProcess(testApp1);
@@ -215,7 +215,7 @@ namespace RemappingLogicTests
             Shortcut src;
             src.SetKey(VK_CONTROL);
             src.SetKey(0x41);
-            testState.AddAppSpecificShortcut(testApp1, src, 0x56);
+            testState.AddAppSpecificShortcut(testApp1, src, (DWORD)0x56);
 
             // Set the testApp as the foreground process
             mockedInputHandler.SetForegroundProcess(testApp2);
@@ -243,7 +243,7 @@ namespace RemappingLogicTests
             Shortcut src;
             src.SetKey(VK_CONTROL);
             src.SetKey(0x41);
-            testState.AddAppSpecificShortcut(testApp1, src, 0x56);
+            testState.AddAppSpecificShortcut(testApp1, src, (DWORD)0x56);
 
             // Set the testApp as the foreground process
             mockedInputHandler.SetForegroundProcess(testApp1);
@@ -281,7 +281,7 @@ namespace RemappingLogicTests
             Shortcut src;
             src.SetKey(VK_CONTROL);
             src.SetKey(0x41);
-            testState.AddAppSpecificShortcut(testApp1, src, 0x56);
+            testState.AddAppSpecificShortcut(testApp1, src, (DWORD)0x56);
 
             // Set the testApp as the foreground process
             mockedInputHandler.SetForegroundProcess(testApp1);

--- a/src/modules/keyboardmanager/KeyboardManagerEngineTest/OSLevelShortcutRemappingTests.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineTest/OSLevelShortcutRemappingTests.cpp
@@ -1126,7 +1126,7 @@ namespace RemappingLogicTests
             Shortcut src;
             src.SetKey(VK_CONTROL);
             src.SetKey(0x41);
-            testState.AddOSLevelShortcut(src, VK_MENU);
+            testState.AddOSLevelShortcut(src, (DWORD)VK_MENU);
 
             const int nInputs = 2;
             INPUT input[nInputs] = {};
@@ -1167,7 +1167,7 @@ namespace RemappingLogicTests
             src.SetKey(VK_CONTROL);
             src.SetKey(VK_SHIFT);
             src.SetKey(0x41);
-            testState.AddOSLevelShortcut(src, VK_MENU);
+            testState.AddOSLevelShortcut(src, (DWORD)VK_MENU);
 
             const int nInputs = 3;
             INPUT input[nInputs] = {};
@@ -1214,7 +1214,7 @@ namespace RemappingLogicTests
             Shortcut src;
             src.SetKey(VK_CONTROL);
             src.SetKey(0x41);
-            testState.AddOSLevelShortcut(src, VK_CONTROL);
+            testState.AddOSLevelShortcut(src, (DWORD)VK_CONTROL);
 
             const int nInputs = 2;
             INPUT input[nInputs] = {};
@@ -1253,7 +1253,7 @@ namespace RemappingLogicTests
             src.SetKey(VK_CONTROL);
             src.SetKey(VK_SHIFT);
             src.SetKey(0x41);
-            testState.AddOSLevelShortcut(src, VK_CONTROL);
+            testState.AddOSLevelShortcut(src, (DWORD)VK_CONTROL);
 
             const int nInputs = 3;
             INPUT input[nInputs] = {};
@@ -1298,7 +1298,7 @@ namespace RemappingLogicTests
             Shortcut src;
             src.SetKey(VK_CONTROL);
             src.SetKey(0x41);
-            testState.AddOSLevelShortcut(src, VK_MENU);
+            testState.AddOSLevelShortcut(src, (DWORD)VK_MENU);
 
             const int nInputs = 3;
             INPUT input[nInputs] = {};
@@ -1328,7 +1328,7 @@ namespace RemappingLogicTests
             Shortcut src;
             src.SetKey(VK_CONTROL);
             src.SetKey(0x41);
-            testState.AddOSLevelShortcut(src, VK_CONTROL);
+            testState.AddOSLevelShortcut(src, (DWORD)VK_CONTROL);
 
             const int nInputs = 3;
             INPUT input[nInputs] = {};
@@ -1357,7 +1357,7 @@ namespace RemappingLogicTests
             Shortcut src;
             src.SetKey(VK_CONTROL);
             src.SetKey(0x41);
-            testState.AddOSLevelShortcut(src, 0x41);
+            testState.AddOSLevelShortcut(src, (DWORD)0x41);
 
             const int nInputs = 3;
             INPUT input[nInputs] = {};
@@ -1386,7 +1386,7 @@ namespace RemappingLogicTests
             Shortcut src;
             src.SetKey(VK_CONTROL);
             src.SetKey(0x41);
-            testState.AddOSLevelShortcut(src, VK_MENU);
+            testState.AddOSLevelShortcut(src, (DWORD)VK_MENU);
 
             const int nInputs = 3;
             INPUT input[nInputs] = {};
@@ -1416,7 +1416,7 @@ namespace RemappingLogicTests
             Shortcut src;
             src.SetKey(VK_CONTROL);
             src.SetKey(0x41);
-            testState.AddOSLevelShortcut(src, VK_CONTROL);
+            testState.AddOSLevelShortcut(src, (DWORD)VK_CONTROL);
 
             const int nInputs = 3;
             INPUT input[nInputs] = {};
@@ -1445,7 +1445,7 @@ namespace RemappingLogicTests
             Shortcut src;
             src.SetKey(VK_CONTROL);
             src.SetKey(0x41);
-            testState.AddOSLevelShortcut(src, 0x41);
+            testState.AddOSLevelShortcut(src, (DWORD)0x41);
 
             const int nInputs = 3;
             INPUT input[nInputs] = {};
@@ -1472,7 +1472,7 @@ namespace RemappingLogicTests
             Shortcut src;
             src.SetKey(VK_CONTROL);
             src.SetKey(0x41);
-            testState.AddOSLevelShortcut(src, VK_MENU);
+            testState.AddOSLevelShortcut(src, (DWORD)VK_MENU);
 
             const int nInputs = 3;
             INPUT input[nInputs] = {};
@@ -1500,7 +1500,7 @@ namespace RemappingLogicTests
             Shortcut src;
             src.SetKey(VK_CONTROL);
             src.SetKey(0x41);
-            testState.AddOSLevelShortcut(src, VK_MENU);
+            testState.AddOSLevelShortcut(src, (DWORD)VK_MENU);
 
             const int nInputs = 4;
             INPUT input[nInputs] = {};
@@ -1533,7 +1533,7 @@ namespace RemappingLogicTests
             Shortcut src;
             src.SetKey(VK_CONTROL);
             src.SetKey(0x41);
-            testState.AddOSLevelShortcut(src, VK_MENU);
+            testState.AddOSLevelShortcut(src, (DWORD)VK_MENU);
             // Remap Shift+Ctrl+A to Ctrl+V
             src.SetKey(VK_SHIFT);
             Shortcut dest;
@@ -1568,10 +1568,10 @@ namespace RemappingLogicTests
             Shortcut src;
             src.SetKey(VK_CONTROL);
             src.SetKey(0x41);
-            testState.AddOSLevelShortcut(src, VK_MENU);
+            testState.AddOSLevelShortcut(src, (DWORD)VK_MENU);
             // Remap Shift+Ctrl+A to B
             src.SetKey(VK_SHIFT);
-            testState.AddOSLevelShortcut(src, 0x42);
+            testState.AddOSLevelShortcut(src, (DWORD)0x42);
 
             const int nInputs = 3;
             INPUT input[nInputs] = {};
@@ -1600,7 +1600,7 @@ namespace RemappingLogicTests
             Shortcut src;
             src.SetKey(VK_CONTROL);
             src.SetKey(0x41);
-            testState.AddOSLevelShortcut(src, VK_MENU);
+            testState.AddOSLevelShortcut(src, (DWORD)VK_MENU);
 
             const int nInputs = 3;
             INPUT input[nInputs] = {};
@@ -1645,7 +1645,7 @@ namespace RemappingLogicTests
             Shortcut src;
             src.SetKey(VK_CONTROL);
             src.SetKey(0x41);
-            testState.AddOSLevelShortcut(src, VK_MENU);
+            testState.AddOSLevelShortcut(src, (DWORD)VK_MENU);
 
             const int nInputs = 3;
             INPUT input[nInputs] = {};
@@ -1690,7 +1690,7 @@ namespace RemappingLogicTests
             Shortcut src;
             src.SetKey(VK_CONTROL);
             src.SetKey(0x41);
-            testState.AddOSLevelShortcut(src, VK_MENU);
+            testState.AddOSLevelShortcut(src, (DWORD)VK_MENU);
 
             const int nInputs = 3;
             INPUT input[nInputs] = {};
@@ -1735,7 +1735,7 @@ namespace RemappingLogicTests
             Shortcut src;
             src.SetKey(VK_CONTROL);
             src.SetKey(0x41);
-            testState.AddOSLevelShortcut(src, CommonSharedConstants::VK_WIN_BOTH);
+            testState.AddOSLevelShortcut(src, (DWORD)CommonSharedConstants::VK_WIN_BOTH);
 
             const int nInputs = 2;
             INPUT input[nInputs] = {};
@@ -1777,7 +1777,7 @@ namespace RemappingLogicTests
             Shortcut src;
             src.SetKey(VK_MENU);
             src.SetKey(0x41);
-            testState.AddOSLevelShortcut(src, 0x44);
+            testState.AddOSLevelShortcut(src, (DWORD)0x44);
 
             // Remap Alt+V to Ctrl+X
             Shortcut src1;
@@ -1822,13 +1822,13 @@ namespace RemappingLogicTests
             Shortcut src;
             src.SetKey(VK_MENU);
             src.SetKey(0x41);
-            testState.AddOSLevelShortcut(src, 0x44);
+            testState.AddOSLevelShortcut(src, (DWORD)0x44);
 
             // Remap Alt+V to X
             Shortcut src1;
             src1.SetKey(VK_MENU);
             src1.SetKey(0x56);
-            testState.AddOSLevelShortcut(src1, 0x58);
+            testState.AddOSLevelShortcut(src1, (DWORD)0x58);
 
             const int nInputs = 4;
             INPUT input[nInputs] = {};
@@ -1872,7 +1872,7 @@ namespace RemappingLogicTests
             Shortcut src1;
             src1.SetKey(VK_MENU);
             src1.SetKey(0x56);
-            testState.AddOSLevelShortcut(src1, 0x58);
+            testState.AddOSLevelShortcut(src1, (DWORD)0x58);
 
             const int nInputs = 4;
             INPUT input[nInputs] = {};
@@ -1908,7 +1908,7 @@ namespace RemappingLogicTests
             Shortcut src;
             src.SetKey(VK_CONTROL);
             src.SetKey(0x41);
-            testState.AddOSLevelShortcut(src, 0x56);
+            testState.AddOSLevelShortcut(src, (DWORD)0x56);
 
             const int nInputs = 4;
             INPUT input[nInputs] = {};
@@ -1984,7 +1984,7 @@ namespace RemappingLogicTests
             Shortcut src;
             src.SetKey(CommonSharedConstants::VK_WIN_BOTH);
             src.SetKey(VK_CAPITAL);
-            testState.AddOSLevelShortcut(src, VK_CONTROL);
+            testState.AddOSLevelShortcut(src, (DWORD)VK_CONTROL);
 
             const int nInputs = 2;
 
@@ -2090,7 +2090,7 @@ namespace RemappingLogicTests
             Shortcut src;
             src.SetKey(VK_CONTROL);
             src.SetKey(0x41);
-            testState.AddOSLevelShortcut(src, VK_CAPITAL);
+            testState.AddOSLevelShortcut(src, (DWORD)VK_CAPITAL);
 
             const int nInputs = 3;
 
@@ -2124,7 +2124,7 @@ namespace RemappingLogicTests
             Shortcut src;
             src.SetKey(VK_CONTROL);
             src.SetKey(0x41);
-            testState.AddOSLevelShortcut(src, VK_CAPITAL);
+            testState.AddOSLevelShortcut(src, (DWORD)VK_CAPITAL);
 
             const int nInputs = 3;
 
@@ -2582,7 +2582,7 @@ namespace RemappingLogicTests
             Shortcut src;
             src.SetKey(CommonSharedConstants::VK_WIN_BOTH);
             src.SetKey(0x41);
-            testState.AddOSLevelShortcut(src, 0x56);
+            testState.AddOSLevelShortcut(src, (DWORD)0x56);
 
             const int nInputs = 2;
 
@@ -2609,7 +2609,7 @@ namespace RemappingLogicTests
             src.SetKey(CommonSharedConstants::VK_WIN_BOTH);
             src.SetKey(VK_CONTROL);
             src.SetKey(0x41);
-            testState.AddOSLevelShortcut(src, 0x56);
+            testState.AddOSLevelShortcut(src, (DWORD)0x56);
 
             const int nInputs = 3;
 
@@ -2652,7 +2652,7 @@ namespace RemappingLogicTests
             Shortcut src;
             src.SetKey(CommonSharedConstants::VK_WIN_BOTH);
             src.SetKey(0x41);
-            testState.AddOSLevelShortcut(src, 0x56);
+            testState.AddOSLevelShortcut(src, (DWORD)0x56);
 
             const int nInputs = 3;
 

--- a/src/modules/keyboardmanager/KeyboardManagerEngineTest/SingleKeyRemappingTests.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineTest/SingleKeyRemappingTests.cpp
@@ -32,7 +32,7 @@ namespace RemappingLogicTests
         TEST_METHOD (RemappedKey_ShouldSetTargetKeyState_OnKeyEvent)
         {
             // Remap A to B
-            testState.AddSingleKeyRemap(0x41, 0x42);
+            testState.AddSingleKeyRemap(0x41, (DWORD)0x42);
             const int nInputs = 1;
 
             INPUT input[nInputs] = {};
@@ -119,7 +119,7 @@ namespace RemappingLogicTests
             });
 
             // Remap Caps Lock to Ctrl
-            testState.AddSingleKeyRemap(VK_CAPITAL, VK_CONTROL);
+            testState.AddSingleKeyRemap(VK_CAPITAL, (DWORD)VK_CONTROL);
             const int nInputs = 1;
 
             INPUT input[nInputs] = {};
@@ -145,7 +145,7 @@ namespace RemappingLogicTests
             });
 
             // Remap Ctrl to Caps Lock
-            testState.AddSingleKeyRemap(VK_CONTROL, VK_CAPITAL);
+            testState.AddSingleKeyRemap(VK_CONTROL, (DWORD)VK_CAPITAL);
             const int nInputs = 1;
 
             INPUT input[nInputs] = {};


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
After updating to VS 16.10 KBM module fails to build. 
There are two issues:
- `int` can't be implicitly converted to `DWORD`. I'm not sure what is the reason behind it as both are 32-bit integers
- There are issues with initializing `RemapBufferItem({ 0x41, 0x42 }`. It produces an empty vector. I guess it's going to be fixed soon but we need to fix it to unblock master.

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [X] **Linked issue:** #11545
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
