### PR TITLE
[FancyZones] Allow single instance of "PowerToys.FancyZones.exe"

### DIFF
--- a/src/modules/fancyzones/FancyZones/main.cpp
+++ b/src/modules/fancyzones/FancyZones/main.cpp
@@ -19,6 +19,7 @@
 // Non-localizable
 const std::wstring moduleName = L"FancyZones";
 const std::wstring internalPath = L"";
+const std::wstring instanceMutexName = L"Local\\PowerToys_FancyZones_InstanceMutex";
 
 int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _In_ PWSTR lpCmdLine, _In_ int nCmdShow)
 {
@@ -26,6 +27,18 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, 
     InitUnhandledExceptionHandler_x64();
 
     LoggerHelpers::init_logger(moduleName, internalPath, LogSettings::fancyZonesLoggerName);
+
+    auto mutex = CreateMutex(nullptr, true, instanceMutexName.c_str());
+    if (mutex == nullptr)
+    {
+        Logger::error(L"Failed to create mutex. {}", get_last_error_or_default(GetLastError()));
+    }
+
+    if (GetLastError() == ERROR_ALREADY_EXISTS)
+    {
+        Logger::warn(L"FancyZones instance is already running");
+        return 0;
+    }
 
     Trace::RegisterProvider();
 


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

**What is include in the PR:** 

**How does someone test / validate:** 

* Build the `fancyzones/FancyZones`
* Try to run several instances of `x64\Debug\modules\FancyZones\PowerToys.FancyZones.exe`
* Verify there is only one `PowerToys.FancyZones.exe` instance running 
* Verify in the log file `\AppData\Local\Microsoft\PowerToys\FancyZones\Logs\v0.0.1\log_2021-06-01.txt` warning `[warning] FancyZones instance is already running`

## Quality Checklist

- [x] **Linked issue:** #11077
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
