### PR TITLE
[Run-Plugin] Divide into parse and convert

### DIFF
--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter.UnitTest/InputInterpreterTests.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter.UnitTest/InputInterpreterTests.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using NUnit.Framework;
+using Wox.Plugin;
 
 namespace Community.PowerToys.Run.Plugin.UnitConverter.UnitTest
 {
@@ -43,6 +44,24 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter.UnitTest
         {
             InputInterpreter.DegreePrefixer(ref input);
             Assert.AreEqual(expectedResult, input);
+        }
+
+        [TestCase("a f in c")]
+        [TestCase("12 f in")]
+        public void ParseInvalidQueries(string queryString)
+        {
+            Query query = new Query(queryString);
+            var result = InputInterpreter.Parse(query);
+            Assert.AreEqual(null, result);
+        }
+
+        [TestCase("12 f in c", 12)]
+        [TestCase("10m to cm", 10)]
+        public void ParseValidQueries(string queryString, double result)
+        {
+            Query query = new Query(queryString);
+            var convertModel = InputInterpreter.Parse(query);
+            Assert.AreEqual(result, convertModel.Value);
         }
     }
 }

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter.UnitTest/UnitHandlerTests.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter.UnitTest/UnitHandlerTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Globalization;
+using System.Linq;
 using NUnit.Framework;
 
 namespace Community.PowerToys.Run.Plugin.UnitConverter.UnitTest
@@ -6,19 +7,36 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter.UnitTest
     [TestFixture]
     public class UnitHandlerTests
     {
-        [TestCase(new string[] { "1", "meter", "in", "centimeter" }, UnitsNet.QuantityType.Length, 100d)]
-        [TestCase(new string[] { "1", "DegreeCelsius", "in", "DegreeFahrenheit" }, UnitsNet.QuantityType.Temperature, 33.79999999999999d)]
-        public void ConvertsInput(string[] input, UnitsNet.QuantityType unit, double expectedResult)
+        [Test]
+        public void HandleTempreture()
         {
-            double result = UnitHandler.ConvertInput(input, unit, CultureInfo.InvariantCulture);
-            Assert.AreEqual(expectedResult, result);
+            var convertModel = new ConvertModel(1, "DegreeCelsius", "DegreeFahrenheit");
+            double result = UnitHandler.ConvertInput(convertModel, UnitsNet.QuantityType.Temperature);
+            Assert.AreEqual(33.79999999999999d, result);
         }
 
-        [TestCase(new string[] { "1", "kB", "in", "kb" }, 8)]
-        public void HandlesByteCapitals(string[] input, double expectedResult)
+        [Test]
+        public void HandleLength()
         {
-            double result = UnitHandler.ConvertInput(input, UnitsNet.QuantityType.Information, CultureInfo.InvariantCulture);
-            Assert.AreEqual(expectedResult, result);
+            var convertModel = new ConvertModel(1, "meter", "centimeter");
+            double result = UnitHandler.ConvertInput(convertModel, UnitsNet.QuantityType.Length);
+            Assert.AreEqual(100, result);
+        }
+
+        [Test]
+        public void HandlesByteCapitals()
+        {
+            var convertModel = new ConvertModel(1, "kB", "kb");
+            double result = UnitHandler.ConvertInput(convertModel, UnitsNet.QuantityType.Information);
+            Assert.AreEqual(8, result);
+        }
+
+        [Test]
+        public void HandleInvalidModel()
+        {
+            var convertModel = new ConvertModel(1, "aa", "bb");
+            var results = UnitHandler.Convert(convertModel);
+            Assert.AreEqual(0, results.Count());
         }
     }
 }

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter.UnitTest/UnitHandlerTests.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter.UnitTest/UnitHandlerTests.cs
@@ -8,7 +8,7 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter.UnitTest
     public class UnitHandlerTests
     {
         [Test]
-        public void HandleTempreture()
+        public void HandleTemperature()
         {
             var convertModel = new ConvertModel(1, "DegreeCelsius", "DegreeFahrenheit");
             double result = UnitHandler.ConvertInput(convertModel, UnitsNet.QuantityType.Temperature);

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/ConvertModel.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/ConvertModel.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Community.PowerToys.Run.Plugin.UnitConverter
+{
+    public class ConvertModel
+    {
+        public double Value { get; set; }
+
+        public string FromUnit { get; set; }
+
+        public string ToUnit { get; set; }
+
+        public ConvertModel()
+        {
+        }
+
+        public ConvertModel(double value, string fromUnit, string toUnit)
+        {
+            Value = value;
+            FromUnit = fromUnit;
+            ToUnit = toUnit;
+        }
+    }
+}

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/UnitHandler.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/UnitHandler.cs
@@ -1,11 +1,32 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using UnitsNet;
 
 namespace Community.PowerToys.Run.Plugin.UnitConverter
 {
     public static class UnitHandler
     {
+        private static readonly int _roundingFractionalDigits = 4;
+
+        private static readonly QuantityType[] _included = new QuantityType[]
+        {
+            QuantityType.Acceleration,
+            QuantityType.Angle,
+            QuantityType.Area,
+            QuantityType.Duration,
+            QuantityType.Energy,
+            QuantityType.Information,
+            QuantityType.Length,
+            QuantityType.Mass,
+            QuantityType.Power,
+            QuantityType.Pressure,
+            QuantityType.Speed,
+            QuantityType.Temperature,
+            QuantityType.Volume,
+        };
+
         /// <summary>
         /// Given string representation of unit, converts it to the enum.
         /// </summary>
@@ -27,24 +48,43 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
         }
 
         /// <summary>
-        /// Given user unit input, converts it. (E.g "1 foot in cm").
+        /// Given parsed ConvertModel, computes result. (E.g "1 foot in cm").
         /// </summary>
         /// <returns>The converted value as a double.</returns>
-        public static double ConvertInput(string[] split, QuantityType quantityType, CultureInfo currentCulture)
+        public static double ConvertInput(ConvertModel convertModel, QuantityType quantityType)
         {
-            string firstUnitString = split[1];
-            string secondUnitString = split[3];
             QuantityInfo unitInfo = Quantity.GetInfo(quantityType);
 
-            var firstUnit = GetUnitEnum(firstUnitString, unitInfo);
-            var secondUnit = GetUnitEnum(secondUnitString, unitInfo);
+            var fromUnit = GetUnitEnum(convertModel.FromUnit, unitInfo);
+            var toUnit = GetUnitEnum(convertModel.ToUnit, unitInfo);
 
-            if (firstUnit != null && secondUnit != null)
+            if (fromUnit != null && toUnit != null)
             {
-                return UnitsNet.UnitConverter.Convert(double.Parse(split[0], currentCulture), firstUnit, secondUnit);
+                return UnitsNet.UnitConverter.Convert(convertModel.Value, fromUnit, toUnit);
             }
 
             return double.NaN;
+        }
+
+        /// <summary>
+        /// Given ConvertModel returns collection of possible results.
+        /// </summary>
+        /// <returns>The converted value as a double.</returns>
+        public static IEnumerable<UnitConversionResult> Convert(ConvertModel convertModel)
+        {
+            var results = new List<UnitConversionResult>();
+            foreach (QuantityType quantityType in _included)
+            {
+                double convertedValue = UnitHandler.ConvertInput(convertModel, quantityType);
+
+                if (!double.IsNaN(convertedValue))
+                {
+                    UnitConversionResult result = new UnitConversionResult(Math.Round(convertedValue, _roundingFractionalDigits), convertModel.ToUnit, quantityType);
+                    results.Add(result);
+                }
+            }
+
+            return results;
         }
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Parse and convert logic was not divided well enough. Also, there was access to elements of an array(e.g. `split[3]`). Obviously, it is not a robust solution and will be probably hard to maintain. 

**What is include in the PR:** 
- Divide convert and parse logic. Added `ConvertModel` as an intermediate structure between parse and convert
- Updated tests. Added negative cases

**How does someone test / validate:** 
- Test allowed conversions 

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
