### PR TITLE
[Run] Highlight search text

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -844,6 +844,7 @@ IMoniker
 IMonitor
 IMouse
 impl
+IMulti
 INDEXTOSTATEIMAGEMASK
 indierawk
 Infobar

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/UWPApplication.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/UWPApplication.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Plugin.Program.Programs
 
             // To set the title to always be the displayname of the packaged application
             result.Title = DisplayName;
-            result.SetTitleHighlightData(StringMatcher.FuzzySearch(query, Name).MatchData);
+            result.TitleHighlightData = StringMatcher.FuzzySearch(query, Name).MatchData;
 
             // Using CurrentCulture since this is user facing
             var toolTipTitle = string.Format(CultureInfo.CurrentCulture, "{0}: {1}", Properties.Resources.powertoys_run_plugin_program_file_name, result.Title);

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32Program.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32Program.cs
@@ -234,7 +234,7 @@ namespace Microsoft.Plugin.Program.Programs
                 },
             };
 
-            result.SetTitleHighlightData(StringMatcher.FuzzySearch(query, Name).MatchData);
+            result.TitleHighlightData = StringMatcher.FuzzySearch(query, Name).MatchData;
 
             // Using CurrentCulture since this is user facing
             var toolTipTitle = string.Format(CultureInfo.CurrentCulture, "{0}: {1}", Properties.Resources.powertoys_run_plugin_program_file_name, result.Title);

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.System/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.System/Main.cs
@@ -53,7 +53,7 @@ namespace Microsoft.PowerToys.Run.Plugin.System
                 if (titleMatch.Score > 0)
                 {
                     c.Score = titleMatch.Score;
-                    c.SetTitleHighlightData(titleMatch.MatchData);
+                    c.TitleHighlightData = titleMatch.MatchData;
                     results.Add(c);
                 }
             }

--- a/src/modules/launcher/PowerLauncher/Converters/HighlightTextConverter.cs
+++ b/src/modules/launcher/PowerLauncher/Converters/HighlightTextConverter.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Media;
+
+namespace PowerLauncher.Converters
+{
+    public class HighlightTextConverter : IMultiValueConverter
+    {
+        public object Convert(object[] value, Type targetType, object parameter, CultureInfo cultureInfo)
+        {
+#pragma warning disable CA1062 // Validate arguments of public methods
+            var text = value[0] as string;
+#pragma warning restore CA1062 // Validate arguments of public methods
+            var highlightData = value[1] as List<int>;
+            var selected = value[2] as bool? == true;
+
+            if (highlightData == null || !highlightData.Any())
+            {
+                // No highlight data, just return the text
+                return new Run(text);
+            }
+
+            var textBlock = new Span();
+            for (var i = 0; i < text.Length; i++)
+            {
+                var currentCharacter = text.Substring(i, 1);
+                if (ShouldHighlight(highlightData, i))
+                {
+                    textBlock.Inlines.Add(new Run(currentCharacter)
+                    {
+                        FontWeight = FontWeights.SemiBold,
+                    });
+                }
+                else
+                {
+                    textBlock.Inlines.Add(new Run(currentCharacter));
+                }
+            }
+
+            return textBlock;
+        }
+
+        public object[] ConvertBack(object value, Type[] targetType, object parameter, CultureInfo culture)
+        {
+            return new[] { DependencyProperty.UnsetValue, DependencyProperty.UnsetValue };
+        }
+
+        private static bool ShouldHighlight(List<int> highlightData, int index)
+        {
+            return highlightData.Contains(index);
+        }
+    }
+}

--- a/src/modules/launcher/PowerLauncher/ResultList.xaml
+++ b/src/modules/launcher/PowerLauncher/ResultList.xaml
@@ -6,13 +6,18 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:Behaviors="http://schemas.microsoft.com/xaml/behaviors"
     xmlns:p="clr-namespace:PowerLauncher.Properties"
-    mc:Ignorable="d"
+             xmlns:helper="clr-namespace:PowerLauncher.Helper"
+             xmlns:converters="clr-namespace:PowerLauncher.Converters"
+             xmlns:viewmodel="clr-namespace:PowerLauncher.ViewModel"
+             mc:Ignorable="d"
     d:DesignHeight="300"
     d:DesignWidth="720">
 
     <UserControl.Resources>
-        <ResourceDictionary>
 
+        <ResourceDictionary>
+            <converters:HighlightTextConverter x:Key="highlightTextConverter" />
+            
             <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
             <Style x:Key="FocusVisual">
                 <Setter Property="Control.Template">
@@ -226,14 +231,21 @@
                                Margin="-6,-2,0,0"
                                HorizontalAlignment="Center"
                                Source="{Binding Image}" />
-                        <TextBlock
-                            AutomationProperties.Name="{x:Static p:Resources.Title}"
-                            x:Name="Title" Grid.Column="1"
-                            Text="{Binding Result.Title}"
-                            FontWeight="SemiBold"
-                            FontSize="20"
-                            Margin="0,0,0,-2"
-                            VerticalAlignment="Bottom"/>
+                        <TextBlock AutomationProperties.Name="{x:Static p:Resources.Title}"
+                                   x:Name="Title"
+                                   Grid.Column="1"
+                                   FontSize="20"
+                                   Margin="0,0,0,-2"
+                                   VerticalAlignment="Bottom">
+                               <viewmodel:ResultsViewModel.FormattedText>
+                                    <MultiBinding Converter="{StaticResource highlightTextConverter}">
+                                        <Binding Path="Result.Title" />
+                                        <Binding Path="Result.TitleHighlightData" />
+                                        <Binding RelativeSource="{RelativeSource Mode=FindAncestor,AncestorType={x:Type ListViewItem}}"
+                                                 Path="IsSelected" />
+                                    </MultiBinding>
+                                </viewmodel:ResultsViewModel.FormattedText>
+                        </TextBlock>
                         <TextBlock
                             AutomationProperties.Name="{x:Static p:Resources.Subtitle}"
                             x:Name="Path"

--- a/src/modules/launcher/Wox.Plugin/Result.cs
+++ b/src/modules/launcher/Wox.Plugin/Result.cs
@@ -106,33 +106,16 @@ namespace Wox.Plugin
             SubTitleHighlightData = subTitleHighlightData;
         }
 
-        /// <summary>
-        /// Gets a list of indexes for the characters to be highlighted in Title
-        /// </summary>
-        public IList<int> GetTitleHighlightData()
-        {
-            return TitleHighlightData;
-        }
+#pragma warning disable CA2227 // Collection properties should be read only
+        public IList<int> TitleHighlightData { get; set; }
+#pragma warning restore CA2227 // Collection properties should be read only
 
         /// <summary>
-        /// Sets a list of indexes for the characters to be highlighted in Title
+        /// Gets or sets a list of indexes for the characters to be highlighted in SubTitle
         /// </summary>
-        public void SetTitleHighlightData(IList<int> value)
-        {
-            TitleHighlightData = value;
-        }
-
-        /// <summary>
-        /// Gets a list of indexes for the characters to be highlighted in Title
-        /// </summary>
-        #pragma warning disable CA1721 // Property names should not match get methods
-        public IList<int> TitleHighlightData { get; private set; }
-        #pragma warning restore CA1721 // Property names should not match get methods
-
-        /// <summary>
-        /// Gets a list of indexes for the characters to be highlighted in SubTitle
-        /// </summary>
-        public IList<int> SubTitleHighlightData { get; private set; }
+#pragma warning disable CA2227 // Collection properties should be read only
+        public IList<int> SubTitleHighlightData { get; set; }
+#pragma warning restore CA2227 // Collection properties should be read only
 
         /// <summary>
         /// Gets or sets only results that originQuery match with current query will be displayed in the panel
@@ -167,7 +150,6 @@ namespace Wox.Plugin
             var equality = string.Equals(r?.Title, Title, StringComparison.Ordinal) &&
                            string.Equals(r?.SubTitle, SubTitle, StringComparison.Ordinal) &&
                            string.Equals(r?.IcoPath, IcoPath, StringComparison.Ordinal) &&
-                           GetTitleHighlightData() == r.GetTitleHighlightData() &&
                            TitleHighlightData == r.TitleHighlightData &&
                            SubTitleHighlightData == r.SubTitleHighlightData;
 

--- a/src/modules/launcher/Wox.Plugin/Result.cs
+++ b/src/modules/launcher/Wox.Plugin/Result.cs
@@ -20,7 +20,6 @@ namespace Wox.Plugin
         private ToolTipData _toolTipData;
         private string _pluginDirectory;
         private string _icoPath;
-        private IList<int> _titleHighlightData;
 
         public string Title
         {
@@ -103,7 +102,7 @@ namespace Wox.Plugin
 
         public Result(IList<int> titleHighlightData = null, IList<int> subTitleHighlightData = null)
         {
-            _titleHighlightData = titleHighlightData;
+            TitleHighlightData = titleHighlightData;
             SubTitleHighlightData = subTitleHighlightData;
         }
 
@@ -112,7 +111,7 @@ namespace Wox.Plugin
         /// </summary>
         public IList<int> GetTitleHighlightData()
         {
-            return _titleHighlightData;
+            return TitleHighlightData;
         }
 
         /// <summary>
@@ -120,8 +119,15 @@ namespace Wox.Plugin
         /// </summary>
         public void SetTitleHighlightData(IList<int> value)
         {
-            _titleHighlightData = value;
+            TitleHighlightData = value;
         }
+
+        /// <summary>
+        /// Gets a list of indexes for the characters to be highlighted in Title
+        /// </summary>
+        #pragma warning disable CA1721 // Property names should not match get methods
+        public IList<int> TitleHighlightData { get; private set; }
+        #pragma warning restore CA1721 // Property names should not match get methods
 
         /// <summary>
         /// Gets a list of indexes for the characters to be highlighted in SubTitle
@@ -162,6 +168,7 @@ namespace Wox.Plugin
                            string.Equals(r?.SubTitle, SubTitle, StringComparison.Ordinal) &&
                            string.Equals(r?.IcoPath, IcoPath, StringComparison.Ordinal) &&
                            GetTitleHighlightData() == r.GetTitleHighlightData() &&
+                           TitleHighlightData == r.TitleHighlightData &&
                            SubTitleHighlightData == r.SubTitleHighlightData;
 
             return equality;


### PR DESCRIPTION
This PR introduces some existing Wox code to highlight the query in the search results text.

![PT Run bolded type](https://user-images.githubusercontent.com/9866362/120930963-d3555380-c6ef-11eb-9f59-251591edf42e.gif)


## Quality Checklist

- [X] **Linked issue:** #3873
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
