### PR TITLE
[PowerToys Run] Disable module on startup

### DIFF
--- a/src/common/utils/elevation.h
+++ b/src/common/utils/elevation.h
@@ -93,7 +93,15 @@ inline bool run_non_elevated(const std::wstring& file, const std::wstring& param
     HWND hwnd = GetShellWindow();
     if (!hwnd)
     {
-        Logger::error(L"GetShellWindow() failed. {}", get_last_error_or_default(GetLastError()));
+        if (GetLastError() == ERROR_SUCCESS)
+        {
+            Logger::warn(L"GetShellWindow() returned null. Shell window is not available");
+        }
+        else
+        {
+            Logger::error(L"GetShellWindow() failed. {}", get_last_error_or_default(GetLastError()));
+        }
+        
         return false;
     }
     DWORD pid;


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
We disable the PT Run module if the PT Run process fails to start. In this PR we make it more robust. For some users, the process can not be started because the shell window is not available yet, and `GetShellWindow()` returns null. We've seen it happen on windows starup. So we should recover if `GetShellWindow()` fails. Take into account that we only use the shell window to start unelevated PT Run from elevated PT.

**What is include in the PR:** 
- Don't disable the module If the process can not be started
- Log a warning if `GetShellWindow()` returns null
- Log a warning if the process can not be started and PT is elevated. It is expected behavior
 
**How does someone test / validate:** 
Can be tested artificially. Try to fail `GetShellWindow()`
## Quality Checklist

- [X] **Linked issue:** #11475 #11159
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
