### PR TITLE
[PT Run] UWP Icons are not initialized

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Main.cs
@@ -103,8 +103,6 @@ namespace Microsoft.Plugin.Program
             _context = context ?? throw new ArgumentNullException(nameof(context));
             _context.API.ThemeChanged += OnThemeChanged;
 
-            UpdateUWPIconPath(_context.API.GetCurrentTheme());
-
             var a = Task.Run(() =>
             {
                 Stopwatch.Normal("Microsoft.Plugin.Program.Main - Win32Program index cost", _win32ProgramRepository.IndexPrograms);
@@ -113,6 +111,7 @@ namespace Microsoft.Plugin.Program
             var b = Task.Run(() =>
             {
                 Stopwatch.Normal("Microsoft.Plugin.Program.Main - Package index cost", _packageRepository.IndexPrograms);
+                UpdateUWPIconPath(_context.API.GetCurrentTheme());
             });
 
             Task.WaitAll(a, b);


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
#11364 changed the indexing to the "Init" function, but that means that the ```UpdateUWPIconPath(_context.API.GetCurrentTheme()); function```  was called before the UWP applications were indexed, resulting in no icons being initialized

**What is include in the PR:** 
Move ```UpdateUWPIconPath(_context.API.GetCurrentTheme());``` after initializing the packageRepository has been completed

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #11685
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.


![image](https://user-images.githubusercontent.com/16852398/121408024-32b99a80-c960-11eb-84ba-2689c5ed17bc.png)
