### PR TITLE
[PowerToys Run] Issues with elevation

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -1397,6 +1397,7 @@ NCRBUTTONDOWN
 NCRBUTTONUP
 NDEBUG
 ndp
+NEEDDISPATCH
 Nefario
 neq
 NESW
@@ -2056,8 +2057,11 @@ surfacehub
 sut
 SVE
 svg
+SVGIO
 SVGIn
 svgpreviewhandler
+SWC
+SWFO
 Switchbetweenvirtualdesktops
 SWP
 swprintf

--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -649,6 +649,7 @@ examplepowertoy
 EXCLUDEFILES
 EXCLUDEFOLDERS
 EXCLUDESUBFOLDERS
+exdisp
 exe
 Executables
 executionpolicy
@@ -1147,6 +1148,7 @@ Lessthan
 LEVELID
 LExit
 lhs
+lhwnd
 LIBID
 LIGHTBLUE
 LIGHTGRAY
@@ -1959,6 +1961,7 @@ Soref
 SORTDOWN
 SOURCECLIENTAREAONLY
 SOURCEHEADER
+spdisp
 spdlog
 spdo
 spdth
@@ -1975,6 +1978,7 @@ spsia
 spsrif
 spsrm
 spsrui
+spsv
 sql
 src
 SRCCOPY

--- a/src/common/utils/elevation.h
+++ b/src/common/utils/elevation.h
@@ -4,18 +4,16 @@
 #include <Windows.h>
 #include <shellapi.h>
 #include <sddl.h>
-
-#include <string>
-#include <common/logger/logger.h>
-#include <common/utils/winapi_error.h>
-
-#include <windows.h>
 #include <shldisp.h>
 #include <shlobj.h>
 #include <exdisp.h>
 #include <atlbase.h>
 #include <stdlib.h>
 #include <comdef.h>
+
+#include <string>
+#include <common/logger/logger.h>
+#include <common/utils/winapi_error.h>
 
 namespace 
 {
@@ -252,7 +250,6 @@ inline bool run_non_elevated(const std::wstring& file, const std::wstring& param
         return false;
     }
 
-    Logger::trace(L"pptal.size={}", size);
     HANDLE process_handle = process.get();
     if (!UpdateProcThreadAttribute(pptal,
                                    0,

--- a/src/common/utils/elevation.h
+++ b/src/common/utils/elevation.h
@@ -17,13 +17,13 @@
 
 namespace 
 {
-    std::wstring GetErrorString(HRESULT handle)
+    inline std::wstring GetErrorString(HRESULT handle)
     {
          _com_error err(handle);
          return err.ErrorMessage();
     }
 
-    bool FindDesktopFolderView(REFIID riid, void** ppv)
+    inline bool FindDesktopFolderView(REFIID riid, void** ppv)
     {
         CComPtr<IShellWindows> spShellWindows;
         auto result = spShellWindows.CoCreateInstance(CLSID_ShellWindows);
@@ -73,7 +73,7 @@ namespace
         return true;
     }
 
-    bool GetDesktopAutomationObject(REFIID riid, void** ppv)
+    inline bool GetDesktopAutomationObject(REFIID riid, void** ppv)
     {
         CComPtr<IShellView> spsv;
         if (!FindDesktopFolderView(IID_PPV_ARGS(&spsv)))
@@ -99,7 +99,7 @@ namespace
         return true;
     }
 
-    bool ShellExecuteFromExplorer(
+    inline bool ShellExecuteFromExplorer(
         PCWSTR pszFile,
         PCWSTR pszParameters = nullptr)
     {

--- a/src/common/utils/elevation.h
+++ b/src/common/utils/elevation.h
@@ -320,7 +320,7 @@ inline bool RunNonElevatedEx(const std::wstring& file, const std::wstring& param
 
     if (failedToStart)
     {
-        Logger::warn(L"Failed to delegete process creation. Try a fallback");
+        Logger::warn(L"Failed to delegate process creation. Try a fallback");
         DWORD returnPid;
         return run_non_elevated(file, params, &returnPid);
     }

--- a/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
+++ b/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
@@ -59,8 +59,7 @@ private:
     // Load initial settings from the persisted values.
     void init_settings();
 
-    // Handle to launch and terminate the launcher
-    HANDLE m_hProcess = nullptr;
+    bool processStarted = false;
 
     //contains the name of the powerToys
     std::wstring app_name;
@@ -122,10 +121,6 @@ public:
     ~Microsoft_Launcher()
     {
         Logger::info("Launcher object is destroying");
-        if (m_enabled)
-        {
-            terminateProcess();
-        }
         m_enabled = false;
     }
 
@@ -225,8 +220,8 @@ public:
 
             if (ShellExecuteExW(&sei))
             {
-                m_hProcess = sei.hProcess;
-                Logger::trace("Started PowerToys Run. Handle {}", m_hProcess);
+                processStarted = true;
+                Logger::trace("Started PowerToys Run");
             }
             else
             {
@@ -236,55 +231,20 @@ public:
         else
         {
             Logger::trace("Starting PowerToys Run from elevated process");
-            std::wstring action_runner_path = get_module_folderpath();
-
+            std::wstring runExecutablePath = get_module_folderpath();
             std::wstring params;
-            params += L"-run-non-elevated ";
-            params += L"-target modules\\launcher\\PowerLauncher.exe ";
-            params += L"-pidFile ";
-            params += POWER_LAUNCHER_PID_SHARED_FILE;
             params += L" -powerToysPid " + std::to_wstring(powertoys_pid) + L" ";
             params += L"--centralized-kb-hook ";
-
-            action_runner_path += L"\\PowerToys.ActionRunner.exe";
-            // Set up the shared file from which to retrieve the PID of PowerLauncher
-            HANDLE hMapFile = CreateFileMappingW(INVALID_HANDLE_VALUE, NULL, PAGE_READWRITE, 0, sizeof(DWORD), POWER_LAUNCHER_PID_SHARED_FILE);
-            if (!hMapFile)
+            runExecutablePath += L"\\modules\\launcher\\PowerLauncher.exe";
+            if (RunNonElevatedEx(runExecutablePath, params))
             {
-                auto err = get_last_error_message(GetLastError());
-                Logger::error(L"Failed to create FileMapping {}. {}", POWER_LAUNCHER_PID_SHARED_FILE, err.has_value() ? err.value() : L"");
-                return;
+                processStarted = true;
+                Logger::trace(L"The process started successfully");
             }
-
-            PDWORD pidBuffer = reinterpret_cast<PDWORD>(MapViewOfFile(hMapFile, FILE_MAP_ALL_ACCESS, 0, 0, sizeof(DWORD)));
-            if (pidBuffer)
+            else
             {
-                *pidBuffer = 0;
-                m_hProcess = NULL;
-
-                if (run_non_elevated(action_runner_path, params, pidBuffer))
-                {
-                    Logger::trace("Started PowerToys Run Process");
-                    const int maxRetries = 80;
-                    for (int retry = 0; retry < maxRetries; ++retry)
-                    {
-                        Sleep(50);
-                        DWORD pid = *pidBuffer;
-                        if (pid)
-                        {
-                            m_hProcess = OpenProcess(PROCESS_TERMINATE | PROCESS_QUERY_INFORMATION | SYNCHRONIZE, FALSE, pid);
-                            Logger::trace("Opened PowerToys Run Process. Handle {}", m_hProcess);
-                            break;
-                        }
-                    }
-                }
-                else
-                {
-                    // We expect it to fail if the shell window is not available. It can happen on startup
-                    Logger::warn("Failed to start PowerToys Run");
-                }
+                Logger::error(L"Failed to start the process");
             }
-            CloseHandle(hMapFile);
         }
     }
 
@@ -294,9 +254,10 @@ public:
         Logger::info("Launcher is disabling");
         if (m_enabled)
         {
+            TerminateRunningInstance();
+            processStarted = false;
             ResetEvent(m_hEvent);
             ResetEvent(send_telemetry_event);
-            terminateProcess();
         }
 
         m_enabled = false;
@@ -332,17 +293,13 @@ public:
         // For now, hotkeyId will always be zero
         if (m_enabled)
         {
-            if (m_hProcess == nullptr)
+            if (!processStarted)
             {
                 Logger::warn("PowerToys Run hasn't been started. Starting PowerToys Run");
                 enable();
-            } else if (WaitForSingleObject(m_hProcess, 0) == WAIT_OBJECT_0)
-            {
-                Logger::warn("PowerToys Run has exited unexpectedly, restarting PowerToys Run.");
-                enable();
             }
 
-            Logger::trace("Set POWER_LAUNCHER_SHARED_EVENT. Handle {}", m_hProcess);
+            Logger::trace("Set POWER_LAUNCHER_SHARED_EVENT");
             SetEvent(m_hEvent);
             return true;
         }
@@ -360,34 +317,6 @@ public:
             ::PostMessage(nextWindow, WM_CLOSE, 0, 0);
 
         return true;
-    }
-
-    // Terminate process by sending WM_CLOSE signal and if it fails, force terminate.
-    void terminateProcess()
-    {
-        Logger::trace(L"Terminating PowerToys Run process. Handle {}.", m_hProcess);
-        if (WaitForSingleObject(m_hProcess, 0) == WAIT_OBJECT_0)
-        {
-            Logger::warn("PowerToys Run has exited unexpectedly, so there is no need to terminate it.");
-            return;
-        }
-
-        DWORD processID = GetProcessId(m_hProcess);
-        if (TerminateProcess(m_hProcess, 1) == 0)
-        {
-            auto err = get_last_error_message(GetLastError());
-            Logger::error(L"Launcher process was not terminated. {}", err.has_value() ? err.value() : L"");
-        }
-
-        // Temporarily disable sending a message to close
-        /*
-        EnumWindows(&requestMainWindowClose, processID);
-        const DWORD result = WaitForSingleObject(m_hProcess, MAX_WAIT_MILLISEC);
-        if (result == WAIT_TIMEOUT || result == WAIT_FAILED)
-        {
-            TerminateProcess(m_hProcess, 1);
-        }
-        */
     }
 
     virtual void send_settings_telemetry() override

--- a/src/modules/launcher/PowerLauncher/App.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/App.xaml.cs
@@ -6,6 +6,7 @@ using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Windows;
 using interop;
 using ManagedCommon;
@@ -43,34 +44,46 @@ namespace PowerLauncher
         public static void Main()
         {
             Log.Info($"Starting PowerToys Run with PID={Process.GetCurrentProcess().Id}", typeof(App));
-            if (SingleInstance<App>.InitializeAsFirstInstance())
+            int powerToysPid = GetPowerToysPId();
+            if (powerToysPid != 0)
             {
-                using (var application = new App())
-                {
-                    application.InitializeComponent();
-                    NativeEventWaiter.WaitForEventLoop(Constants.RunExitEvent(), () =>
-                    {
-                        Log.Warn("RunExitEvent was signaled. Exiting PowerToys", typeof(App));
-                        ExitPowerToys(application);
-                    });
-
-                    int powerToysPid = GetPowerToysPId();
-                    if (powerToysPid != 0)
-                    {
-                        Log.Info($"Runner pid={powerToysPid}", typeof(App));
-                        RunnerHelper.WaitForPowerToysRunner(powerToysPid, () =>
-                        {
-                            Log.Info($"Runner with pid={powerToysPid} exited. Exiting PowerToys Run", typeof(App));
-                            ExitPowerToys(application);
-                        });
-                    }
-
-                    application.Run();
-                }
+                // The process started from the PT Run module interface. One instance is handled there.
+                Log.Info($"Runner pid={powerToysPid}", typeof(App));
+                SingleInstance<App>.CreateInstanceMutex();
             }
             else
             {
-                Log.Error("There is already running PowerToys Run instance. Exiting PowerToys Run", typeof(App));
+                // If PT Run is started as standalone application check if there is already running instance
+                if (!SingleInstance<App>.InitializeAsFirstInstance())
+                {
+                    Log.Warn("There is already running PowerToys Run instance. Exiting PowerToys Run", typeof(App));
+                    return;
+                }
+            }
+
+            using (var application = new App())
+            {
+                application.InitializeComponent();
+                new Thread(() =>
+                {
+                    var eventHandle = new EventWaitHandle(false, EventResetMode.AutoReset, Constants.RunExitEvent());
+                    if (eventHandle.WaitOne())
+                    {
+                        Log.Warn("RunExitEvent was signaled. Exiting PowerToys", typeof(App));
+                        ExitPowerToys(application);
+                    }
+                }).Start();
+
+                if (powerToysPid != 0)
+                {
+                    RunnerHelper.WaitForPowerToysRunner(powerToysPid, () =>
+                    {
+                        Log.Info($"Runner with pid={powerToysPid} exited. Exiting PowerToys Run", typeof(App));
+                        ExitPowerToys(application);
+                    });
+                }
+
+                application.Run();
             }
         }
 

--- a/src/modules/launcher/PowerLauncher/Helper/SingleInstance`1.cs
+++ b/src/modules/launcher/PowerLauncher/Helper/SingleInstance`1.cs
@@ -44,11 +44,17 @@ namespace PowerLauncher.Helper
         /// Suffix to the channel name.
         /// </summary>
         private const string ChannelNameSuffix = "SingeInstanceIPCChannel";
+        private const string InstanceMutexName = @"Local\PowerToys_Run_InstanceMutex";
 
         /// <summary>
         /// Gets or sets application mutex.
         /// </summary>
         internal static Mutex SingleInstanceMutex { get; set; }
+
+        internal static void CreateInstanceMutex()
+        {
+            SingleInstanceMutex = new Mutex(true, InstanceMutexName, out bool firstInstance);
+        }
 
         /// <summary>
         /// Checks if the instance of the application attempting to start is the first instance.
@@ -57,14 +63,12 @@ namespace PowerLauncher.Helper
         /// <returns>True if this is the first instance of the application.</returns>
         internal static bool InitializeAsFirstInstance()
         {
-            string mutexName = @"Local\PowerToys_Run_InstanceMutex";
-
             // Build unique application Id and the IPC channel name.
-            string applicationIdentifier = mutexName + Environment.UserName;
+            string applicationIdentifier = InstanceMutexName + Environment.UserName;
 
             string channelName = string.Concat(applicationIdentifier, Delimiter, ChannelNameSuffix);
 
-            SingleInstanceMutex = new Mutex(true, mutexName, out bool firstInstance);
+            SingleInstanceMutex = new Mutex(true, InstanceMutexName, out bool firstInstance);
             if (firstInstance)
             {
                 _ = CreateRemoteService(channelName);

--- a/src/modules/previewpane/powerpreview/powerpreview.vcxproj
+++ b/src/modules/previewpane/powerpreview/powerpreview.vcxproj
@@ -77,6 +77,9 @@
     <ProjectReference Include="..\..\..\common\Display\Display.vcxproj">
       <Project>{caba8dfb-823b-4bf2-93ac-3f31984150d9}</Project>
     </ProjectReference>
+    <ProjectReference Include="..\..\..\common\logger\logger.vcxproj">
+      <Project>{d9b8fc84-322a-4f9f-bbb9-20915c47ddfd}</Project>
+    </ProjectReference>
     <ProjectReference Include="..\..\..\common\notifications\notifications.vcxproj">
       <Project>{1d5be09d-78c0-4fd7-af00-ae7c1af7c525}</Project>
     </ProjectReference>


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
We have issues with starting PT Run where PT is elevated through the compatibility tab of the properties of the PowerToys.exe(#10400). PT Run can not be started because the system requires the `explorer.exe` to be elevated to start it. And if the `explorer.exe` is elevated PT Run starts elevated as well. So I think in this case PT Run inherits elevation from PT and there's nothing we can do because those structures are opaque. 

Also, PT Run cannot be started when PT is run elevated from a user account (#11038). PT runs on behalf of an admin account and can not access `explorer.exe` process of a user account.

We fixed it by choosing different approach to start a process unelevated from the elevated one(https://devblogs.microsoft.com/oldnewthing/20131118-00/?p=2643).

**What is include in the PR:** 
- Delegate creating of PT Run process to the `explorer.exe`. Use old approach as fallback.
- Remove PT Run process handle from the module interface as with the new approach we can not get it without inner process communication
- Rewrite PT Run process main in order to handle possible race conditions. A race condition can happen when restarting PT as administrator and a new process is not created because the old one hasn't been destroyed yet

**How does someone test / validate:** 
Compatibility tab:
- Set `Run this program as an administrator` in the compatibility tab of the properties of the PowerToys.exe
- Start PowerToys
- Verify that PowerToys Run is working. That is check the presence of `PowerLauncher.exe` or press `Alt+Space`

Running on behalf of an admin account:
- Login a user account
- Launch PowerToys as an administrator(Should ask credentials of an administrator)
- Verify that `PowerToys.exe` is elevated and runs under the admin account
- Verify that `PowerLauncher.exe` is not elevated and runs under the user account

Possible regressions.
Enable PT Run in settings and ensure that the hotkey brings up PT Run:
   - when PowerToys is running unelevated on start-up
   - when PowerToys is running as admin on start-up
   - when PowerToys is restarted as admin, by clicking the restart as admin button in settings
   
Race condition:
   - Try to enable/disalbe PT Run at least ten times quickly
   - Verify that PT Run is still working
   - Restart PT as administrator
   - Verify that PT Run is still working
   - Try to enable/disalbe PT Run at least ten times quickly again
   - Verify that PT Run is still working
   
## Quality Checklist

- [X] **Linked issue:** #10400, #11723, #11038
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
