### PR TITLE
[Run-Plugin][Windows Search] Don't crash if URI can't be parsed

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/SearchHelper/WindowsSearchAPI.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/SearchHelper/WindowsSearchAPI.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using Microsoft.Search.Interop;
+using Wox.Plugin.Logger;
 
 namespace Microsoft.Plugin.Indexer.SearchHelper
 {
@@ -49,7 +50,12 @@ namespace Microsoft.Plugin.Indexer.SearchHelper
                 // # is URI syntax for the fragment component, need to be encoded so LocalPath returns complete path
                 // Using OrdinalIgnoreCase since this is internal and used with symbols
                 var string_path = ((string)oleDBResult.FieldData[0]).Replace("#", "%23", StringComparison.OrdinalIgnoreCase);
-                var uri_path = new Uri(string_path);
+
+                if (!Uri.TryCreate(string_path, UriKind.RelativeOrAbsolute, out Uri uri_path))
+                {
+                    Log.Warn($"Failed to parse URI '${string_path}'", typeof(WindowsSearchAPI));
+                    continue;
+                }
 
                 var result = new SearchResult
                 {


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
If URI parsing fails we fail to get any results from the Windows search plugin. 

**What is include in the PR:** 
If parsing of the URI fails log warning and skip the item.

**How does someone test / validate:** 

## Quality Checklist

- [X] **Linked issue:** #11506
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
