### PR TITLE
[PowerToys Run] Don't crash if `UserSelectedRecord.json` can not be updated

### DIFF
--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -169,9 +169,24 @@ namespace PowerLauncher.ViewModel
                         {
                             // todo: revert _userSelectedRecordStorage.Save() and _historyItemsStorage.Save() after https://github.com/microsoft/PowerToys/issues/9164 is done
                             _userSelectedRecord.Add(result);
-                            _userSelectedRecordStorage.Save();
+                            try
+                            {
+                                _userSelectedRecordStorage.Save();
+                            }
+                            catch (UnauthorizedAccessException ex)
+                            {
+                                Log.Warn($"Failed to save file. ${ex.Message}", this.GetType());
+                            }
+
                             _history.Add(result.OriginQuery.RawQuery);
-                            _historyItemsStorage.Save();
+                            try
+                            {
+                                _historyItemsStorage.Save();
+                            }
+                            catch (UnauthorizedAccessException ex)
+                            {
+                                Log.Warn($"Failed to save file. ${ex.Message}", this.GetType());
+                            }
                         }
                         else
                         {


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Don't crash if `UserSelectedRecord.json` or `QueryHistory.json` failed to update as it's not essential functionality. 

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [X] **Linked issue:** #10917
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
