### PR TITLE
Log to appdata folder from the bootstrapper and the msi

### DIFF
--- a/installer/PowerToysBootstrapper/bootstrapper/bootstrapper.cpp
+++ b/installer/PowerToysBootstrapper/bootstrapper/bootstrapper.cpp
@@ -232,7 +232,7 @@ int Bootstrapper(HINSTANCE hInstance)
         installFolderProp = L"INSTALLFOLDER=" + installFolderProp;
     }
 
-    fs::path logDir = ".";
+    fs::path logDir = PTSettingsHelper::get_root_save_folder_location();
     try
     {
         fs::path logDirArgPath = logDirArg;

--- a/tools/BugReportTool/BugReportTool/Main.cpp
+++ b/tools/BugReportTool/BugReportTool/Main.cpp
@@ -245,26 +245,6 @@ void ReportDotNetInstallationInfo(const filesystem::path& tmpDir)
     }
 }
 
-void ReportBootstrapperLog(const filesystem::path& targetDir)
-{
-  for (const auto entry : filesystem::directory_iterator{temp_directory_path()})
-  {
-      if (!entry.is_regular_file() || !entry.path().has_filename())
-      {
-          continue;
-      }
-
-      const std::wstring filename = entry.path().filename().native();
-      if (!filename.starts_with(L"powertoys-bootstrapper-") || !filename.ends_with(L".log"))
-      {
-          continue;
-      }
-      
-      std::error_code _;
-      copy(entry.path(), targetDir, _);
-  }
-}
-
 int wmain(int argc, wchar_t* argv[], wchar_t*)
 {
     // Get path to save zip
@@ -335,8 +315,6 @@ int wmain(int argc, wchar_t* argv[], wchar_t*)
 
     // Write event viewer logs info to the temporary folder
     EventViewer::ReportEventViewerInfo(tmpDir);
-
-    ReportBootstrapperLog(tmpDir);
 
     // Zip folder
     auto zipPath = path::path(saveZipPath);


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Bootstrapper logs are not always picked up by the bootstrapper. So we log directly into the AppData folder.

**What is include in the PR:** 
- Change log directory to the appdata folder
- Remove copy of the bootstrapper logs from the temp folder into the bug report

**How does someone test / validate:** 
Build the bootstrapper and verify that logs are present in the AppData folder

## Quality Checklist

- [X] **Linked issue:** #11645
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
