### PR TITLE
[FancyZones] "Match not found" error fix

### DIFF
--- a/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
@@ -683,8 +683,10 @@ void FancyZones::ToggleEditor() noexcept
     * Data for each monitor:
     * (5) Monitor id
     * (6) DPI
-    * (7) monitor left
-    * (8) monitor top
+    * (7) work area left
+    * (8) work area top
+    * (9) work area width
+    * (10) work area height
     * ...
     */
     std::wstring params;
@@ -736,6 +738,10 @@ void FancyZones::ToggleEditor() noexcept
 
         monitorsDataStr += std::to_wstring(monitorInfo.rcMonitor.left) + divider; /* Top coordinate */
         monitorsDataStr += std::to_wstring(monitorInfo.rcMonitor.top) + divider; /* Left coordinate */
+        monitorsDataStr += std::to_wstring(monitorInfo.rcWork.left) + divider; /* Top coordinate */
+        monitorsDataStr += std::to_wstring(monitorInfo.rcWork.top) + divider; /* Left coordinate */
+        monitorsDataStr += std::to_wstring(monitorInfo.rcWork.right - monitorInfo.rcWork.left) + divider; /* Width */
+        monitorsDataStr += std::to_wstring(monitorInfo.rcWork.bottom - monitorInfo.rcWork.top) + divider; /* Height */
     }
 
     params += std::to_wstring(allMonitors.size()) + divider; /* Monitors count */

--- a/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
@@ -695,7 +695,10 @@ void FancyZones::ToggleEditor() noexcept
     const bool spanZonesAcrossMonitors = m_settings->GetSettings()->spanZonesAcrossMonitors;
     params += std::to_wstring(spanZonesAcrossMonitors) + divider; /* Span zones */
     std::vector<std::pair<HMONITOR, MONITORINFOEX>> allMonitors;
-    allMonitors = FancyZonesUtils::GetAllMonitorInfo<&MONITORINFOEX::rcWork>();
+
+    m_dpiUnawareThread.submit(OnThreadExecutor::task_t{ [&] {
+        allMonitors = FancyZonesUtils::GetAllMonitorInfo<&MONITORINFOEX::rcWork>();
+    } }).wait();
 
     if (spanZonesAcrossMonitors)
     {
@@ -744,7 +747,7 @@ void FancyZones::ToggleEditor() noexcept
     params += std::to_wstring(allMonitors.size()) + divider; /* Monitors count */
     params += monitorsDataStr;
 
-    FancyZonesDataInstance().SaveFancyZonesEditorParameters(spanZonesAcrossMonitors, virtualDesktopId.get(), targetMonitor); /* Write parameters to json file */
+    FancyZonesDataInstance().SaveFancyZonesEditorParameters(spanZonesAcrossMonitors, virtualDesktopId.get(), targetMonitor, allMonitors); /* Write parameters to json file */
 
     if (showDpiWarning)
     {

--- a/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
@@ -706,8 +706,9 @@ void FancyZones::ToggleEditor() noexcept
     std::unordered_map<std::wstring, DWORD> displayDeviceIdxMap;
 
     bool showDpiWarning = false;
-    int prevDpiX = -1, prevDpiY = -1;
+    int prevDpi = -1;
     std::wstring monitorsDataStr;
+
     for (auto& monitorData : allMonitors)
     {
         HMONITOR monitor = monitorData.first;
@@ -720,24 +721,20 @@ void FancyZones::ToggleEditor() noexcept
         {
             params += monitorId + divider; /* Monitor id where the Editor should be opened */
         }
-
-        monitorsDataStr += std::move(monitorId) + divider; /* Monitor id */
-        UINT dpiX = 0;
-        UINT dpiY = 0;
-        if (GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &dpiX, &dpiY) == S_OK)
+        
+        UINT dpi = 0;
+        if (DPIAware::GetScreenDPIForMonitor(monitor, dpi) != S_OK)
         {
-            monitorsDataStr += std::to_wstring(dpiX) + divider; /* DPI */
-            if (spanZonesAcrossMonitors && prevDpiX != -1 && (prevDpiX != dpiX || prevDpiY != dpiY))
-            {
-                showDpiWarning = true;
-            }
-
-            prevDpiX = dpiX;
-            prevDpiY = dpiY;
+            continue;
+        }
+        
+        if (spanZonesAcrossMonitors && prevDpi != -1 && prevDpi != dpi)
+        {
+            showDpiWarning = true;
         }
 
-        monitorsDataStr += std::to_wstring(monitorInfo.rcMonitor.left) + divider; /* Top coordinate */
-        monitorsDataStr += std::to_wstring(monitorInfo.rcMonitor.top) + divider; /* Left coordinate */
+        monitorsDataStr += std::move(monitorId) + divider; /* Monitor id */
+        monitorsDataStr += std::to_wstring(dpi) + divider; /* DPI */
         monitorsDataStr += std::to_wstring(monitorInfo.rcWork.left) + divider; /* Top coordinate */
         monitorsDataStr += std::to_wstring(monitorInfo.rcWork.top) + divider; /* Left coordinate */
         monitorsDataStr += std::to_wstring(monitorInfo.rcWork.right - monitorInfo.rcWork.left) + divider; /* Width */

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesData.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesData.cpp
@@ -599,6 +599,8 @@ void FancyZonesData::SaveFancyZonesEditorParameters(bool spanZonesAcrossMonitors
         monitorJson.id = monitorId;
         monitorJson.top = monitorRect.top;
         monitorJson.left = monitorRect.left;
+        monitorJson.width = monitorRect.right - monitorRect.left;
+        monitorJson.height = monitorRect.bottom - monitorRect.top;
         monitorJson.isSelected = true;
         monitorJson.dpi = 0; // unused
 
@@ -637,8 +639,10 @@ void FancyZonesData::SaveFancyZonesEditorParameters(bool spanZonesAcrossMonitors
             }
 
             monitorJson.top = monitorInfo.rcMonitor.top; /* Top coordinate */
-            monitorJson.left = monitorInfo.rcMonitor.left; /* Left coordinate */
-
+            monitorJson.top = monitorInfo.rcWork.top; /* Top coordinate */
+            monitorJson.left = monitorInfo.rcWork.left; /* Left coordinate */
+            monitorJson.width = monitorInfo.rcWork.right - monitorInfo.rcWork.left; /* Width */
+            monitorJson.height = monitorInfo.rcWork.bottom - monitorInfo.rcWork.top; /* Height */
             argsJson.monitors.emplace_back(std::move(monitorJson)); /* add monitor data */
         }
     }

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesData.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesData.cpp
@@ -6,6 +6,7 @@
 #include "Settings.h"
 #include "CallTracer.h"
 
+#include <common/Display/dpi_aware.h>
 #include <common/utils/json.h>
 #include <FancyZonesLib/util.h>
 
@@ -631,18 +632,18 @@ void FancyZonesData::SaveFancyZonesEditorParameters(bool spanZonesAcrossMonitors
 
             monitorJson.id = monitorId; /* Monitor id */
 
-            UINT dpiX = 0;
-            UINT dpiY = 0;
-            if (GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &dpiX, &dpiY) == S_OK)
+            UINT dpi = 0;
+            if (DPIAware::GetScreenDPIForMonitor(monitor, dpi) != S_OK)
             {
-                monitorJson.dpi = dpiX; /* DPI */
+                continue;
             }
 
-            monitorJson.top = monitorInfo.rcMonitor.top; /* Top coordinate */
+            monitorJson.dpi = dpi; /* DPI */
             monitorJson.top = monitorInfo.rcWork.top; /* Top coordinate */
             monitorJson.left = monitorInfo.rcWork.left; /* Left coordinate */
             monitorJson.width = monitorInfo.rcWork.right - monitorInfo.rcWork.left; /* Width */
             monitorJson.height = monitorInfo.rcWork.bottom - monitorInfo.rcWork.top; /* Height */
+            
             argsJson.monitors.emplace_back(std::move(monitorJson)); /* add monitor data */
         }
     }

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesData.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesData.cpp
@@ -585,7 +585,7 @@ void FancyZonesData::SaveAppZoneHistory() const
     JSONHelpers::SaveAppZoneHistory(appZoneHistoryFileName, appZoneHistoryMap);
 }
 
-void FancyZonesData::SaveFancyZonesEditorParameters(bool spanZonesAcrossMonitors, const std::wstring& virtualDesktopId, const HMONITOR& targetMonitor) const
+void FancyZonesData::SaveFancyZonesEditorParameters(bool spanZonesAcrossMonitors, const std::wstring& virtualDesktopId, const HMONITOR& targetMonitor, const std::vector<std::pair<HMONITOR, MONITORINFOEX>>& allMonitors) const
 {
     JSONHelpers::EditorArgs argsJson; /* json arguments */
     argsJson.processId = GetCurrentProcessId(); /* Process id */
@@ -609,9 +609,6 @@ void FancyZonesData::SaveFancyZonesEditorParameters(bool spanZonesAcrossMonitors
     }
     else
     {
-        std::vector<std::pair<HMONITOR, MONITORINFOEX>> allMonitors;
-        allMonitors = FancyZonesUtils::GetAllMonitorInfo<&MONITORINFOEX::rcWork>();
-
         // device id map for correct device ids
         std::unordered_map<std::wstring, DWORD> displayDeviceIdxMap;
 

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesData.h
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesData.h
@@ -90,7 +90,7 @@ public:
     void SaveZoneSettings() const;
     void SaveAppZoneHistory() const;
 
-    void SaveFancyZonesEditorParameters(bool spanZonesAcrossMonitors, const std::wstring& virtualDesktopId, const HMONITOR& targetMonitor) const;
+    void SaveFancyZonesEditorParameters(bool spanZonesAcrossMonitors, const std::wstring& virtualDesktopId, const HMONITOR& targetMonitor, const std::vector<std::pair<HMONITOR, MONITORINFOEX>>& allMonitors) const;
 
 private:
 #if defined(UNIT_TESTS)

--- a/src/modules/fancyzones/FancyZonesLib/JsonHelpers.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/JsonHelpers.cpp
@@ -514,6 +514,8 @@ namespace JSONHelpers
         result.SetNamedValue(NonLocalizable::MonitorId, json::value(monitor.id));
         result.SetNamedValue(NonLocalizable::TopCoordinate, json::value(monitor.top));
         result.SetNamedValue(NonLocalizable::LeftCoordinate, json::value(monitor.left));
+        result.SetNamedValue(L"width", json::value(monitor.width));
+        result.SetNamedValue(L"height", json::value(monitor.height));
         result.SetNamedValue(NonLocalizable::IsSelected, json::value(monitor.isSelected));
 
         return result;

--- a/src/modules/fancyzones/FancyZonesLib/JsonHelpers.h
+++ b/src/modules/fancyzones/FancyZonesLib/JsonHelpers.h
@@ -75,6 +75,8 @@ namespace JSONHelpers
         std::wstring id;
         int top;
         int left;
+        int width;
+        int height;
         bool isSelected = false;
 
         static json::JsonObject ToJson(const MonitorInfo& monitor);

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/Device.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/Device.cs
@@ -21,24 +21,20 @@ namespace FancyZonesEditor.Utils
 
         public int Dpi { get; set; }
 
-        public bool Primary { get; private set; }
-
-        public Device(string id, int dpi, Rect bounds, Rect workArea, bool primary)
+        public Device(string id, int dpi, Rect bounds, Rect workArea)
         {
             Id = id;
             Dpi = dpi;
             WorkAreaRect = workArea;
             UnscaledBounds = bounds;
             ScaledBounds = bounds;
-            Primary = primary;
         }
 
-        public Device(Rect bounds, Rect workArea, bool primary)
+        public Device(Rect bounds, Rect workArea)
         {
             WorkAreaRect = workArea;
             UnscaledBounds = bounds;
             ScaledBounds = bounds;
-            Primary = primary;
         }
 
         public void Scale(double scaleFactor)
@@ -61,7 +57,6 @@ namespace FancyZonesEditor.Utils
 
             sb.AppendFormat(CultureInfo.InvariantCulture, "ID: {0}{1}", Id, Environment.NewLine);
             sb.AppendFormat(CultureInfo.InvariantCulture, "DPI: {0}{1}", Dpi, Environment.NewLine);
-            sb.AppendFormat(CultureInfo.InvariantCulture, "Is primary: {0}{1}", Primary, Environment.NewLine);
 
             string workArea = string.Format(CultureInfo.InvariantCulture, "({0}, {1}, {2}, {3})", WorkAreaRect.X, WorkAreaRect.Y, WorkAreaRect.Width, WorkAreaRect.Height);
             string bounds = string.Format(CultureInfo.InvariantCulture, "({0}, {1}, {2}, {3})", UnscaledBounds.X, UnscaledBounds.Y, UnscaledBounds.Width, UnscaledBounds.Height);

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/MainWindowSettingsModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/MainWindowSettingsModel.cs
@@ -187,6 +187,14 @@ namespace FancyZonesEditor
             return model.Type != LayoutType.Custom;
         }
 
+        public void InitModels()
+        {
+            foreach (var model in DefaultModels)
+            {
+                model.InitTemplateZones();
+            }
+        }
+
         public LayoutModel UpdateSelectedLayoutModel()
         {
             LayoutModel foundModel = null;

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/Monitor.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/Monitor.cs
@@ -18,11 +18,11 @@ namespace FancyZonesEditor.Models
 
         public Device Device { get; set; }
 
-        public Monitor(Rect bounds, Rect workArea, bool primary)
+        public Monitor(Rect bounds, Rect workArea)
         {
             Window = new LayoutOverlayWindow();
             Settings = new LayoutSettings();
-            Device = new Device(bounds, workArea, primary);
+            Device = new Device(bounds, workArea);
 
             if (App.DebugMode)
             {
@@ -41,10 +41,10 @@ namespace FancyZonesEditor.Models
             Window.Height = workArea.Height;
         }
 
-        public Monitor(string id, int dpi, Rect bounds, Rect workArea, bool primary)
-            : this(bounds, workArea, primary)
+        public Monitor(string id, int dpi, Rect bounds, Rect workArea)
+            : this(bounds, workArea)
         {
-            Device = new Device(id, dpi, bounds, workArea, primary);
+            Device = new Device(id, dpi, bounds, workArea);
         }
 
         public void Scale(double scaleFactor)

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Overlay.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Overlay.cs
@@ -139,7 +139,7 @@ namespace FancyZonesEditor
                     }
 
                     Monitors.Clear();
-                    Monitors.Add(new Monitor(bounds, workArea, true));
+                    Monitors.Add(new Monitor(bounds, workArea));
                 }
             }
         }
@@ -158,14 +158,6 @@ namespace FancyZonesEditor
         {
             WorkAreas = new List<Rect>();
             Monitors = new List<Monitor>();
-
-            var screens = System.Windows.Forms.Screen.AllScreens;
-            foreach (System.Windows.Forms.Screen screen in screens)
-            {
-                Rect bounds = new Rect(screen.Bounds.X, screen.Bounds.Y, screen.Bounds.Width, screen.Bounds.Height);
-                Rect workArea = new Rect(screen.WorkingArea.X, screen.WorkingArea.Y, screen.WorkingArea.Width, screen.WorkingArea.Height);
-                Add(bounds, workArea, screen.Primary);
-            }
         }
 
         public void Show()
@@ -352,12 +344,10 @@ namespace FancyZonesEditor
             _mainWindow.Topmost = false;
         }
 
-        private void Add(Rect bounds, Rect workArea, bool primary)
+        public void AddMonitor(Monitor monitor)
         {
-            var monitor = new Monitor(bounds, workArea, primary);
-
             bool inserted = false;
-            var workAreaRect = workArea;
+            var workAreaRect = monitor.Device.WorkAreaRect;
             for (int i = 0; i < Monitors.Count && !inserted; i++)
             {
                 var rect = Monitors[i].Device.WorkAreaRect;

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
@@ -56,6 +56,8 @@ namespace FancyZonesEditor.Utils
             DPI,
             MonitorLeft,
             MonitorTop,
+            MonitorWidth,
+            MonitorHeight,
         }
 
         // parsing cmd args
@@ -68,6 +70,10 @@ namespace FancyZonesEditor.Utils
             public int LeftCoordinate { get; set; }
 
             public int TopCoordinate { get; set; }
+
+            public int Width { get; set; }
+
+            public int Height { get; set; }
 
             public bool IsSelected { get; set; }
 
@@ -258,8 +264,10 @@ namespace FancyZonesEditor.Utils
                 * Data for each monitor:
                 * (5) Monitor id
                 * (6) DPI
-                * (7) monitor left
-                * (8) monitor top
+                * (7) work area left
+                * (8) work area top
+                * (9) work area width
+                * (10) work area height
                 * ...
                 * Using CultureInfo.InvariantCulture since this is us parsing our own data
                 */
@@ -285,18 +293,10 @@ namespace FancyZonesEditor.Utils
 
                     // Monitors count
                     int count = int.Parse(argsParts[(int)CmdArgs.MonitorsCount], CultureInfo.InvariantCulture);
-                    if (count != App.Overlay.DesktopsCount && !isCustomMonitorConfigurationMode)
-                    {
-                        MessageBox.Show(Properties.Resources.Error_Invalid_Arguments, Properties.Resources.Error_Message_Box_Title);
-                        ((App)Application.Current).Shutdown();
-                    }
-
-                    double primaryMonitorDPI = 96f;
-                    double minimalUsedMonitorDPI = double.MaxValue;
 
                     // Parse the native monitor data
                     List<NativeMonitorData> nativeMonitorData = new List<NativeMonitorData>();
-                    const int monitorArgsCount = 4;
+                    const int monitorArgsCount = 6;
                     for (int i = 0; i < count; i++)
                     {
                         var nativeData = default(NativeMonitorData);
@@ -304,23 +304,13 @@ namespace FancyZonesEditor.Utils
                         nativeData.Dpi = int.Parse(argsParts[(int)CmdArgs.DPI + (i * monitorArgsCount)], CultureInfo.InvariantCulture);
                         nativeData.LeftCoordinate = int.Parse(argsParts[(int)CmdArgs.MonitorLeft + (i * monitorArgsCount)], CultureInfo.InvariantCulture);
                         nativeData.TopCoordinate = int.Parse(argsParts[(int)CmdArgs.MonitorTop + (i * monitorArgsCount)], CultureInfo.InvariantCulture);
+                        nativeData.Width = int.Parse(argsParts[(int)CmdArgs.MonitorWidth + (i * monitorArgsCount)], CultureInfo.InvariantCulture);
+                        nativeData.Height = int.Parse(argsParts[(int)CmdArgs.MonitorHeight + (i * monitorArgsCount)], CultureInfo.InvariantCulture);
 
                         nativeMonitorData.Add(nativeData);
-
-                        if (nativeData.LeftCoordinate == 0 && nativeData.TopCoordinate == 0)
-                        {
-                            primaryMonitorDPI = nativeData.Dpi;
-                        }
-
-                        if (minimalUsedMonitorDPI > nativeData.Dpi)
-                        {
-                            minimalUsedMonitorDPI = nativeData.Dpi;
-                        }
                     }
 
                     var monitors = App.Overlay.Monitors;
-                    double identifyScaleFactor = minimalUsedMonitorDPI / primaryMonitorDPI;
-                    double scaleFactor = 96f / primaryMonitorDPI;
 
                     // Update monitors data
                     if (isCustomMonitorConfigurationMode)
@@ -331,10 +321,9 @@ namespace FancyZonesEditor.Utils
                             int width = int.Parse(splittedId[1], CultureInfo.InvariantCulture);
                             int height = int.Parse(splittedId[2], CultureInfo.InvariantCulture);
 
-                            Rect bounds = new Rect(nativeData.LeftCoordinate, nativeData.TopCoordinate, width, height);
-                            bool isPrimary = nativeData.LeftCoordinate == 0 && nativeData.TopCoordinate == 0;
+                            Rect bounds = new Rect(nativeData.LeftCoordinate, nativeData.TopCoordinate, nativeData.Width, nativeData.Height);
 
-                            Monitor monitor = new Monitor(bounds, bounds, isPrimary);
+                            Monitor monitor = new Monitor(bounds, bounds);
                             monitor.Device.Id = nativeData.MonitorId;
                             monitor.Device.Dpi = nativeData.Dpi;
 
@@ -343,31 +332,19 @@ namespace FancyZonesEditor.Utils
                     }
                     else
                     {
-                        foreach (Monitor monitor in monitors)
+                        foreach (NativeMonitorData nativeData in nativeMonitorData)
                         {
-                            bool matchFound = false;
-                            monitor.Scale(scaleFactor);
-
-                            double scaledBoundX = (int)(monitor.Device.UnscaledBounds.X * identifyScaleFactor);
-                            double scaledBoundY = (int)(monitor.Device.UnscaledBounds.Y * identifyScaleFactor);
-
-                            foreach (NativeMonitorData nativeData in nativeMonitorData)
+                            Rect workArea = new Rect(nativeData.LeftCoordinate, nativeData.TopCoordinate, nativeData.Width, nativeData.Height);
+                            if (nativeData.IsSelected)
                             {
-                                // Can't do an exact match since the rounding algorithm used by the framework is different from ours
-                                if (scaledBoundX >= (nativeData.LeftCoordinate - 1) && scaledBoundX <= (nativeData.LeftCoordinate + 1) &&
-                                    scaledBoundY >= (nativeData.TopCoordinate - 1) && scaledBoundY <= (nativeData.TopCoordinate + 1))
-                                {
-                                    monitor.Device.Id = nativeData.MonitorId;
-                                    monitor.Device.Dpi = nativeData.Dpi;
-                                    matchFound = true;
-                                    break;
-                                }
+                                targetMonitorName = nativeData.MonitorId;
                             }
 
-                            if (matchFound == false)
-                            {
-                                MessageBox.Show(string.Format(Properties.Resources.Error_Monitor_Match_Not_Found, monitor.Device.UnscaledBounds.ToString()));
-                            }
+                            var monitor = new Monitor(workArea, workArea);
+                            monitor.Device.Id = nativeData.MonitorId;
+                            monitor.Device.Dpi = nativeData.Dpi;
+
+                            App.Overlay.AddMonitor(monitor);
                         }
                     }
 
@@ -413,68 +390,25 @@ namespace FancyZonesEditor.Utils
 
                     if (!App.Overlay.SpanZonesAcrossMonitors)
                     {
-                        // Monitors count
-                        if (editorParams.Monitors.Count != App.Overlay.DesktopsCount)
-                        {
-                            MessageBox.Show(Properties.Resources.Error_Invalid_Arguments, Properties.Resources.Error_Message_Box_Title);
-                            ((App)Application.Current).Shutdown();
-                        }
-
                         string targetMonitorName = string.Empty;
 
-                        double primaryMonitorDPI = 96f;
-                        double minimalUsedMonitorDPI = double.MaxValue;
                         foreach (NativeMonitorData nativeData in editorParams.Monitors)
                         {
-                            if (nativeData.LeftCoordinate == 0 && nativeData.TopCoordinate == 0)
-                            {
-                                primaryMonitorDPI = nativeData.Dpi;
-                            }
-
-                            if (minimalUsedMonitorDPI > nativeData.Dpi)
-                            {
-                                minimalUsedMonitorDPI = nativeData.Dpi;
-                            }
-
+                            Rect workArea = new Rect(nativeData.LeftCoordinate, nativeData.TopCoordinate, nativeData.Width, nativeData.Height);
                             if (nativeData.IsSelected)
                             {
                                 targetMonitorName = nativeData.MonitorId;
                             }
-                        }
 
-                        var monitors = App.Overlay.Monitors;
-                        double identifyScaleFactor = minimalUsedMonitorDPI / primaryMonitorDPI;
-                        double scaleFactor = 96f / primaryMonitorDPI;
+                            var monitor = new Monitor(workArea, workArea);
+                            monitor.Device.Id = nativeData.MonitorId;
+                            monitor.Device.Dpi = nativeData.Dpi;
 
-                        // Update monitors data
-                        foreach (Monitor monitor in monitors)
-                        {
-                            bool matchFound = false;
-                            monitor.Scale(scaleFactor);
-
-                            double scaledBoundX = (int)(monitor.Device.UnscaledBounds.X * identifyScaleFactor);
-                            double scaledBoundY = (int)(monitor.Device.UnscaledBounds.Y * identifyScaleFactor);
-
-                            foreach (NativeMonitorData nativeData in editorParams.Monitors)
-                            {
-                                // Can't do an exact match since the rounding algorithm used by the framework is different from ours
-                                if (scaledBoundX >= (nativeData.LeftCoordinate - 1) && scaledBoundX <= (nativeData.LeftCoordinate + 1) &&
-                                    scaledBoundY >= (nativeData.TopCoordinate - 1) && scaledBoundY <= (nativeData.TopCoordinate + 1))
-                                {
-                                    monitor.Device.Id = nativeData.MonitorId;
-                                    monitor.Device.Dpi = nativeData.Dpi;
-                                    matchFound = true;
-                                    break;
-                                }
-                            }
-
-                            if (matchFound == false)
-                            {
-                                MessageBox.Show(string.Format(Properties.Resources.Error_Monitor_Match_Not_Found, monitor.Device.UnscaledBounds.ToString()));
-                            }
+                            App.Overlay.AddMonitor(monitor);
                         }
 
                         // Set active desktop
+                        var monitors = App.Overlay.Monitors;
                         for (int i = 0; i < monitors.Count; i++)
                         {
                             var monitor = monitors[i];
@@ -482,31 +416,6 @@ namespace FancyZonesEditor.Utils
                             {
                                 App.Overlay.CurrentDesktop = i;
                                 break;
-                            }
-                        }
-                    }
-                    else
-                    {
-                        // Update monitors data
-                        foreach (Monitor monitor in App.Overlay.Monitors)
-                        {
-                            bool matchFound = false;
-                            foreach (NativeMonitorData nativeData in editorParams.Monitors)
-                            {
-                                // Can't do an exact match since the rounding algorithm used by the framework is different from ours
-                                if (monitor.Device.UnscaledBounds.X >= (nativeData.LeftCoordinate - 1) && monitor.Device.UnscaledBounds.X <= (nativeData.LeftCoordinate + 1) &&
-                                    monitor.Device.UnscaledBounds.Y >= (nativeData.TopCoordinate - 1) && monitor.Device.UnscaledBounds.Y <= (nativeData.TopCoordinate + 1))
-                                {
-                                    monitor.Device.Id = nativeData.MonitorId;
-                                    monitor.Device.Dpi = nativeData.Dpi;
-                                    matchFound = true;
-                                    break;
-                                }
-                            }
-
-                            if (matchFound == false)
-                            {
-                                MessageBox.Show(string.Format(Properties.Resources.Error_Monitor_Match_Not_Found, monitor.Device.UnscaledBounds.ToString()));
                             }
                         }
                     }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Changed work area initialization in the Editor. Passing all the necessary data from the C++ side.

**What is include in the PR:** 

**How does someone test / validate:** 

Open FancyZones Editor with different monitor scaling, verify that layouts are placed correctly. To be sure, set any template grid layout, remove spacing and observe that layout borders match screen borders.

The bug is reproducible with scaling different from 100%, so at least one of the monitors should be scaled (Settings -> System -> Display -> Scale and layout).

## Quality Checklist

- [x] **Linked issue:** #11717
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
