### PR TITLE
[FancyZones] "Match not found" fix update for the single layout for all monitors.

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/Overlay.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Overlay.cs
@@ -116,35 +116,7 @@ namespace FancyZonesEditor
 
         private int _currentDesktop;
 
-        public bool SpanZonesAcrossMonitors
-        {
-            get
-            {
-                return _spanZonesAcrossMonitors;
-            }
-
-            set
-            {
-                _spanZonesAcrossMonitors = value;
-
-                if (_spanZonesAcrossMonitors)
-                {
-                    Rect workArea = default;
-                    Rect bounds = default;
-
-                    foreach (Monitor monitor in Monitors)
-                    {
-                        workArea = Rect.Union(workArea, monitor.Device.WorkAreaRect);
-                        bounds = Rect.Union(bounds, monitor.Device.ScaledBounds);
-                    }
-
-                    Monitors.Clear();
-                    Monitors.Add(new Monitor(bounds, workArea));
-                }
-            }
-        }
-
-        private bool _spanZonesAcrossMonitors;
+        public bool SpanZonesAcrossMonitors { get; set; }
 
         public bool MultiMonitorMode
         {

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
@@ -419,6 +419,19 @@ namespace FancyZonesEditor.Utils
                             }
                         }
                     }
+                    else
+                    {
+                        Rect workArea = default;
+
+                        foreach (NativeMonitorData nativeData in editorParams.Monitors)
+                        {
+                            Rect monitorWorkArea = new Rect(nativeData.LeftCoordinate, nativeData.TopCoordinate, nativeData.Width, nativeData.Height);
+                            workArea = Rect.Union(workArea, monitorWorkArea);
+                        }
+
+                        var monitor = new Monitor(workArea, workArea);
+                        App.Overlay.AddMonitor(monitor);
+                    }
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Prevent wrong work area size with the `Allow zones to span across monitors` flag on.

**What is include in the PR:** 

**How does someone test / validate:** 

* Turn on `Allow zones to span across monitors`, open Editor, verify the layout placed correctly.
* Turn the flag off, open Editor again, verify that all layouts are placed correctly.

![image](https://user-images.githubusercontent.com/8949536/123135485-c2c00f80-d449-11eb-9317-640b2f5e2bb4.png)

## Quality Checklist

- [x] **Linked issue:** #11840
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
