### PR TITLE
 Implement System.Text.Json for ImageResizerUI

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -2413,6 +2413,7 @@ wprintf
 wprp
 wregex
 WResize
+writefile
 wsf
 wsh
 wsl

--- a/installer/PowerToysSetup/Product.wxs
+++ b/installer/PowerToysSetup/Product.wxs
@@ -526,7 +526,7 @@
       <Component Id="Module_ImageResizer" Guid="96E63289-759C-4A73-A56B-EE7429932F72" Win64="yes">
         <File Source="$(var.BinX64Dir)modules\$(var.ImageResizerProjectName)\ImageResizer.exe" />
         <File Source="$(var.BinX64Dir)modules\$(var.ImageResizerProjectName)\ImageResizerExt.dll" KeyPath="yes" />
-        <File Source="$(var.BinX64Dir)modules\$(var.ImageResizerProjectName)\Newtonsoft.Json.dll" />
+        <File Source="$(var.BinX64Dir)modules\$(var.ImageResizerProjectName)\System.Text.Json.dll" />
         <File Source="$(var.BinX64Dir)modules\$(var.ImageResizerProjectName)\ImageResizer.dll" />
         <File Source="$(var.BinX64Dir)modules\$(var.ImageResizerProjectName)\ImageResizer.deps.json" />
         <File Source="$(var.BinX64Dir)modules\$(var.ImageResizerProjectName)\ImageResizer.runtimeconfig.json" />

--- a/installer/PowerToysSetup/Product.wxs
+++ b/installer/PowerToysSetup/Product.wxs
@@ -526,7 +526,6 @@
       <Component Id="Module_ImageResizer" Guid="96E63289-759C-4A73-A56B-EE7429932F72" Win64="yes">
         <File Source="$(var.BinX64Dir)modules\$(var.ImageResizerProjectName)\ImageResizer.exe" />
         <File Source="$(var.BinX64Dir)modules\$(var.ImageResizerProjectName)\ImageResizerExt.dll" KeyPath="yes" />
-        <File Source="$(var.BinX64Dir)modules\$(var.ImageResizerProjectName)\System.Text.Json.dll" />
         <File Source="$(var.BinX64Dir)modules\$(var.ImageResizerProjectName)\ImageResizer.dll" />
         <File Source="$(var.BinX64Dir)modules\$(var.ImageResizerProjectName)\ImageResizer.deps.json" />
         <File Source="$(var.BinX64Dir)modules\$(var.ImageResizerProjectName)\ImageResizer.runtimeconfig.json" />

--- a/src/modules/imageresizer/tests/Properties/SettingsTests.cs
+++ b/src/modules/imageresizer/tests/Properties/SettingsTests.cs
@@ -7,6 +7,8 @@ using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using ImageResizer.Models;
 using ImageResizer.Test;
 using Xunit;
@@ -269,6 +271,34 @@ namespace ImageResizer.Properties
             Assert.PropertyChanged(settings, "FallbackEncoder", action);
             Assert.PropertyChanged(settings, "CustomSize", action);
             Assert.PropertyChanged(settings, "SelectedSizeIndex", action);
+        }
+
+        [Fact]
+        public void SystemTextJsonDeserializesCorrectly()
+        {
+            // Generated Settings file in 0.72
+            var defaultInput =
+                "{\r\n  \"properties\": {\r\n    \"imageresizer_selectedSizeIndex\": {\r\n      \"value\": 1\r\n    },\r\n    \"imageresizer_shrinkOnly\": {\r\n      \"value\": true\r\n    },\r\n    \"imageresizer_replace\": {\r\n      \"value\": true\r\n    },\r\n    \"imageresizer_ignoreOrientation\": {\r\n      \"value\": false\r\n    },\r\n    \"imageresizer_jpegQualityLevel\": {\r\n      \"value\": 91\r\n    },\r\n    \"imageresizer_pngInterlaceOption\": {\r\n      \"value\": 1\r\n    },\r\n    \"imageresizer_tiffCompressOption\": {\r\n      \"value\": 1\r\n    },\r\n    \"imageresizer_fileName\": {\r\n      \"value\": \"%1 %1 (%2)\"\r\n    },\r\n    \"imageresizer_sizes\": {\r\n      \"value\": [\r\n        {\r\n          \"Id\": 0,\r\n          \"ExtraBoxOpacity\": 100,\r\n          \"EnableEtraBoxes\": true,\r\n          \"name\": \"Small-NotDefault\",\r\n          \"fit\": 1,\r\n          \"width\": 854,\r\n          \"height\": 480,\r\n          \"unit\": 3\r\n        },\r\n        {\r\n          \"Id\": 3,\r\n          \"ExtraBoxOpacity\": 100,\r\n          \"EnableEtraBoxes\": true,\r\n          \"name\": \"Phone\",\r\n          \"fit\": 1,\r\n          \"width\": 320,\r\n          \"height\": 568,\r\n          \"unit\": 3\r\n        }\r\n      ]\r\n    },\r\n    \"imageresizer_keepDateModified\": {\r\n      \"value\": false\r\n    },\r\n    \"imageresizer_fallbackEncoder\": {\r\n      \"value\": \"19e4a5aa-5662-4fc5-a0c0-1758028e1057\"\r\n    },\r\n    \"imageresizer_customSize\": {\r\n      \"value\": {\r\n        \"Id\": 4,\r\n        \"ExtraBoxOpacity\": 100,\r\n        \"EnableEtraBoxes\": true,\r\n        \"name\": \"custom\",\r\n        \"fit\": 1,\r\n        \"width\": 1024,\r\n        \"height\": 640,\r\n        \"unit\": 3\r\n      }\r\n    }\r\n  },\r\n  \"name\": \"ImageResizer\",\r\n  \"version\": \"1\"\r\n}";
+
+            // Execute readFile/writefile twice and see if serialized string is still correct
+            var resultWrapper = JsonSerializer.Deserialize<SettingsWrapper>(defaultInput);
+            var serializedInput = JsonSerializer.Serialize(resultWrapper, new JsonSerializerOptions() { WriteIndented = true });
+            var resultWrapper2 = JsonSerializer.Deserialize<SettingsWrapper>(serializedInput);
+            var serializedInput2 = JsonSerializer.Serialize(resultWrapper2, new JsonSerializerOptions() { WriteIndented = true });
+
+            Assert.Equal(serializedInput, serializedInput2);
+            Assert.Equal("ImageResizer", resultWrapper2.Name);
+            Assert.Equal("1", resultWrapper2.Version);
+            Assert.NotNull(resultWrapper2.Properties);
+            Assert.True(resultWrapper2.Properties.ShrinkOnly);
+            Assert.True(resultWrapper2.Properties.Replace);
+            Assert.Equal(91, resultWrapper2.Properties.JpegQualityLevel);
+            Assert.Equal(1, (int)resultWrapper2.Properties.PngInterlaceOption);
+            Assert.Equal(1, (int)resultWrapper2.Properties.TiffCompressOption);
+            Assert.Equal("%1 %1 (%2)", resultWrapper2.Properties.FileName);
+            Assert.Equal(2, resultWrapper2.Properties.Sizes.Count);
+            Assert.False(resultWrapper2.Properties.KeepDateModified);
+            Assert.Equal("Small-NotDefault", resultWrapper2.Properties.Sizes[0].Name);
         }
 
         protected virtual void Dispose(bool disposing)

--- a/src/modules/imageresizer/ui/ImageResizerUI.csproj
+++ b/src/modules/imageresizer/ui/ImageResizerUI.csproj
@@ -66,13 +66,13 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.19" />
     <PackageReference Include="ModernWpfUI" Version="0.9.4" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="System.IO.Abstractions">
       <Version>12.2.5</Version>
     </PackageReference>
+    <PackageReference Include="System.Text.Json" Version="5.0.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\common\interop\PowerToysInterop.vcxproj" />

--- a/src/modules/imageresizer/ui/Models/CustomSize.cs
+++ b/src/modules/imageresizer/ui/Models/CustomSize.cs
@@ -2,8 +2,8 @@
 // The Brice Lambson licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.  Code forked from Brice Lambson's https://github.com/bricelam/ImageResizer/
 
+using System.Text.Json.Serialization;
 using ImageResizer.Properties;
-using Newtonsoft.Json;
 
 namespace ImageResizer.Models
 {
@@ -16,6 +16,7 @@ namespace ImageResizer.Models
             set { /* no-op */ }
         }
 
+        [JsonConstructor]
         public CustomSize(ResizeFit fit, double width, double height, ResizeUnit unit)
         {
             Fit = fit;

--- a/src/modules/imageresizer/ui/Models/ResizeSize.cs
+++ b/src/modules/imageresizer/ui/Models/ResizeSize.cs
@@ -1,16 +1,15 @@
-// Copyright (c) Brice Lambson
+﻿// Copyright (c) Brice Lambson
 // The Brice Lambson licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.  Code forked from Brice Lambson's https://github.com/bricelam/ImageResizer/
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Text.Json.Serialization;
 using ImageResizer.Helpers;
 using ImageResizer.Properties;
-using Newtonsoft.Json;
 
 namespace ImageResizer.Models
 {
-    [JsonObject(MemberSerialization.OptIn)]
     public class ResizeSize : Observable
     {
         private static readonly IDictionary<string, string> _tokens = new Dictionary<string, string>
@@ -41,14 +40,14 @@ namespace ImageResizer.Models
         {
         }
 
-        [JsonProperty(PropertyName = "name")]
+        [JsonPropertyName("name")]
         public virtual string Name
         {
             get => _name;
             set => Set(ref _name, ReplaceTokens(value));
         }
 
-        [JsonProperty(PropertyName = "fit")]
+        [JsonPropertyName("fit")]
         public ResizeFit Fit
         {
             get => _fit;
@@ -63,14 +62,14 @@ namespace ImageResizer.Models
             }
         }
 
-        [JsonProperty(PropertyName = "width")]
+        [JsonPropertyName("width")]
         public double Width
         {
             get => _width;
             set => Set(ref _width, value);
         }
 
-        [JsonProperty(PropertyName = "height")]
+        [JsonPropertyName("height")]
         public double Height
         {
             get => _height;
@@ -86,7 +85,7 @@ namespace ImageResizer.Models
         public bool HasAuto
             => Width == 0 || Height == 0;
 
-        [JsonProperty(PropertyName = "unit")]
+        [JsonPropertyName("unit")]
         public ResizeUnit Unit
         {
             get => _unit;

--- a/src/modules/imageresizer/ui/Properties/SettingsWrapper.cs
+++ b/src/modules/imageresizer/ui/Properties/SettingsWrapper.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Brice Lambson
+// The Brice Lambson licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.  Code forked from Brice Lambson's https://github.com/bricelam/ImageResizer/
+
+using System.Text.Json.Serialization;
+
+namespace ImageResizer.Properties
+{
+    public class SettingsWrapper
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = "ImageResizer";
+
+        [JsonPropertyName("version")]
+        public string Version { get; set; } = "1";
+
+        [JsonPropertyName("properties")]
+        public Settings Properties { get; set; }
+    }
+}

--- a/src/modules/imageresizer/ui/Properties/WrappedJsonConverter`1.cs
+++ b/src/modules/imageresizer/ui/Properties/WrappedJsonConverter`1.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Brice Lambson
+// The Brice Lambson licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.  Code forked from Brice Lambson's https://github.com/bricelam/ImageResizer/
+
+using System;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace ImageResizer.Properties
+{
+    public class WrappedJsonConverter<T> : JsonConverter<T>
+    {
+        public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            while (reader.Read())
+            {
+                if (reader.GetString() != "value")
+                {
+                    continue;
+                }
+
+                var result = (T)JsonSerializer.Deserialize(ref reader, typeof(T), options);
+                reader.Read();
+                return result;
+            }
+
+            return default;
+        }
+
+        public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+        {
+            if (writer == default)
+            {
+                return;
+            }
+
+            writer.WriteStartObject();
+            writer.WritePropertyName("value");
+
+            JsonSerializer.Serialize(writer, value, typeof(T), options);
+
+            writer.WriteEndObject();
+        }
+    }
+}

--- a/src/modules/imageresizer/ui/Properties/WrappedJsonValueConverter.cs
+++ b/src/modules/imageresizer/ui/Properties/WrappedJsonValueConverter.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Brice Lambson
+// The Brice Lambson licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.  Code forked from Brice Lambson's https://github.com/bricelam/ImageResizer/
+
+using System;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace ImageResizer.Properties
+{
+    public class WrappedJsonValueConverter : JsonConverterFactory
+    {
+        public override bool CanConvert(Type typeToConvert)
+        {
+            return true;
+        }
+
+        public override JsonConverter CreateConverter(
+            Type type,
+            JsonSerializerOptions options)
+        {
+            if (type == null)
+            {
+                return null;
+            }
+
+            Type keyType = type.UnderlyingSystemType;
+
+            JsonConverter converter = (JsonConverter)Activator.CreateInstance(
+                typeof(WrappedJsonConverter<>).MakeGenericType(keyType));
+
+            return converter;
+        }
+    }
+}


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
This PR implements System.Text.Json for ImageRezierUI

I noticed though, the settings file generated by ImageRezierUI vs the actual SettingsUI differ
(Mainly the "Id": 0,   "ExtraBoxOpacity": 100,  "EnableEtraBoxes": true properties on the imageresizer_sizes property)

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [X] **Linked issue:** #1675
- [X] **Communication:** I've discussed this with core contributors in the issue. 
- [X] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
