### PR TITLE
[PT Run] Register the hotkey after PT Run is initialized

### DIFF
--- a/src/modules/launcher/PowerLauncher/App.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/App.xaml.cs
@@ -138,6 +138,7 @@ namespace PowerLauncher
                 bootTime.Stop();
 
                 Log.Info(textToLog.ToString(), GetType());
+                _mainVM.RegisterHotkey();
                 PowerToysTelemetry.Log.WriteEvent(new LauncherBootEvent() { BootTimeMs = bootTime.ElapsedMilliseconds });
 
                 // [Conditional("RELEASE")]

--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -74,8 +74,12 @@ namespace PowerLauncher.ViewModel
 
             InitializeKeyCommands();
             RegisterResultsUpdatedEvent();
+        }
 
-            if (settings != null && settings.UsePowerToysRunnerKeyboardHook)
+        public void RegisterHotkey()
+        {
+            Log.Info("RegisterHotkey()", GetType());
+            if (_settings != null && _settings.UsePowerToysRunnerKeyboardHook)
             {
                 NativeEventWaiter.WaitForEventLoop(Constants.PowerLauncherSharedEvent(), OnHotkey);
                 _hotkeyHandle = 0;


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
If a user invokes PT Run while it's initializing the behaviour is undefined. 

**What is include in the PR:** 
Move hotkey registration to the end of the startup method.

**How does someone test / validate:** 
- Run as a user, set run on startup
- Restart window
- Right after Windows started start pressing `Alt+space`
- Verify that PT Run doesn't crash and the search window is visible after pressing `Alt+Space`

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
