### PR TITLE
[PowerToys Run] URI Plugin: handle numeric input

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Uri.UnitTests/UriHelper/ExtendedUriParserTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Uri.UnitTests/UriHelper/ExtendedUriParserTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Plugin.Uri.UnitTests.UriHelper
         [TestCase("localhost", true, "http://localhost/")]
         [TestCase("127.0.0.1", true, "http://127.0.0.1/")]
         [TestCase("127.0.0.1:80", true, "http://127.0.0.1/")]
-        [TestCase("127", true, "http://0.0.0.127/")]
+        [TestCase("127", false, null)]
         [TestCase("", false, null)]
         [TestCase("https://google.com", true, "https://google.com/")]
         [TestCase("ftps://google.com", true, "ftps://google.com/")]

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Uri/UriHelper/ExtendedUriParser.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Uri/UriHelper/ExtendedUriParser.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Linq;
 using Microsoft.Plugin.Uri.Interfaces;
 
 namespace Microsoft.Plugin.Uri.UriHelper
@@ -21,7 +22,8 @@ namespace Microsoft.Plugin.Uri.UriHelper
             // Using CurrentCulture since this is a user typed string
             if (input.EndsWith(":", StringComparison.CurrentCulture)
                 || input.EndsWith(".", StringComparison.CurrentCulture)
-                || input.EndsWith(":/", StringComparison.CurrentCulture))
+                || input.EndsWith(":/", StringComparison.CurrentCulture)
+                || input.All(char.IsDigit))
             {
                 result = default;
                 return false;


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Handle numeric input for URI plugin.

**What is include in the PR:** 
Numeric input was converted into an IP address. This is the behaviour of `System.Uri`.

**How does someone test / validate:** 
- Search in PT Run for:
  - `12345` should display no results.
  - `12345.com` should display `http://12345.com/` as result.

## Quality Checklist

- [x] **Linked issue:** #11796
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [x] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
