### PR TITLE
[PowerToys Run] Fix clicking on text

### DIFF
--- a/src/modules/launcher/PowerLauncher/ResultList.xaml
+++ b/src/modules/launcher/PowerLauncher/ResultList.xaml
@@ -236,7 +236,8 @@
                                    Grid.Column="1"
                                    FontSize="20"
                                    Margin="0,0,0,-2"
-                                   VerticalAlignment="Bottom">
+                                   VerticalAlignment="Bottom"
+                                   IsHitTestVisible="False">
                                <viewmodel:ResultsViewModel.FormattedText>
                                     <MultiBinding Converter="{StaticResource highlightTextConverter}">
                                         <Binding Path="Result.Title" />


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Currently, if a user clicks on the result's text PowerToys crashes because our callback expects `FrameworkElement` element and not `System.Windows.Documents.Run`.

**What is include in the PR:** 

**How does someone test / validate:** 
- Search for something in PT Run
- Click on Title's test
- Verify that a result opens and PT Run doesn't crash

## Quality Checklist

- [X] **Linked issue:** #11967 #11938
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
