### PR TITLE
[Hotfix] PowerToys Awake - Show full name on tray

### DIFF
--- a/src/modules/awake/Awake/Program.cs
+++ b/src/modules/awake/Awake/Program.cs
@@ -151,7 +151,7 @@ namespace Awake
                 try
                 {
 #pragma warning disable CS8604 // Possible null reference argument.
-                    TrayHelper.InitializeTray(AppName, new Icon(Application.GetResourceStream(new Uri("/Images/Awake.ico", UriKind.Relative)).Stream));
+                    TrayHelper.InitializeTray(FullAppName, new Icon(Application.GetResourceStream(new Uri("/Images/Awake.ico", UriKind.Relative)).Stream));
 #pragma warning restore CS8604 // Possible null reference argument.
 
                     var settingsPath = _settingsUtils.GetSettingsFilePath(AppName);
@@ -274,7 +274,7 @@ namespace Awake
                             }
                     }
 
-                    TrayHelper.SetTray(AppName, settings);
+                    TrayHelper.SetTray(FullAppName, settings);
                 }
                 else
                 {


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Fix the string in the system tray to show "PowerToys Awake" instead of "Awake" on more code paths.

## Quality Checklist

- [x] **Linked issue:** #11964
- [x] **Communication:** I've discussed this with core contributors in the issue. 
