### PR TITLE
[Hotfix][FancyZones] Unable to start correctly

### DIFF
--- a/src/modules/fancyzones/FancyZonesModuleInterface/dllmain.cpp
+++ b/src/modules/fancyzones/FancyZonesModuleInterface/dllmain.cpp
@@ -98,6 +98,13 @@ public:
     virtual void destroy() override
     {
         Disable(false);
+
+        if (m_toggleEditorEvent)
+        {
+            CloseHandle(m_toggleEditorEvent);
+            m_toggleEditorEvent = nullptr;
+        }
+
         delete this;
     }
 
@@ -170,8 +177,6 @@ private:
         if (m_toggleEditorEvent)
         {
             ResetEvent(m_toggleEditorEvent);
-            CloseHandle(m_toggleEditorEvent);
-            m_toggleEditorEvent = nullptr;
         }
         
         if (m_hProcess)

--- a/src/modules/fancyzones/FancyZonesModuleInterface/dllmain.cpp
+++ b/src/modules/fancyzones/FancyZonesModuleInterface/dllmain.cpp
@@ -114,6 +114,15 @@ public:
         m_settings = MakeFancyZonesSettings(reinterpret_cast<HINSTANCE>(&__ImageBase), FancyZonesModuleInterface::get_name(), FancyZonesModuleInterface::get_key());
 
         m_toggleEditorEvent = CreateDefaultEvent(CommonSharedConstants::FANCY_ZONES_EDITOR_TOGGLE_EVENT);
+        if (!m_toggleEditorEvent)
+        {
+            Logger::error(L"Failed to create toggle editor event");
+            auto message = get_last_error_message(GetLastError());
+            if (message.has_value())
+            {
+                Logger::error(message.value());
+            }
+        }
     }
 
 private:
@@ -158,8 +167,12 @@ private:
             Trace::FancyZones::EnableFancyZones(false);
         }
 
-        ResetEvent(m_toggleEditorEvent);
-        CloseHandle(m_toggleEditorEvent);
+        if (m_toggleEditorEvent)
+        {
+            ResetEvent(m_toggleEditorEvent);
+            CloseHandle(m_toggleEditorEvent);
+            m_toggleEditorEvent = nullptr;
+        }
         
         if (m_hProcess)
         {


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

An exception was thrown on closing the `m_toggleEditorEvent`.
Added checks and logs in case if there was an error on creation.

**What is include in the PR:** 

**How does someone test / validate:** 

Enable/disable module multiple times. 
For me, it crashed on master after 3-10 reenablings. 

## Quality Checklist

- [x] **Linked issue:** #12031
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
