### PR TITLE
[PowerToys Run] Start PowerToys Run through the ActionRunner 

### DIFF
--- a/src/common/utils/elevation.h
+++ b/src/common/utils/elevation.h
@@ -307,25 +307,17 @@ inline bool run_non_elevated(const std::wstring& file, const std::wstring& param
 
 inline bool RunNonElevatedEx(const std::wstring& file, const std::wstring& params)
 {
-    bool failedToStart = false;
     try
     {
         CoInitialize(nullptr);
         if (!ShellExecuteFromExplorer(file.c_str(), params.c_str()))
         {
-            failedToStart = true;
+            return false;
         }
     }
     catch(...)
     {
-        failedToStart = true;
-    }
-
-    if (failedToStart)
-    {
-        Logger::warn(L"Failed to delegate process creation. Try a fallback");
-        DWORD returnPid;
-        return run_non_elevated(file, params, &returnPid);
+        return false;
     }
 
     return true;

--- a/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
+++ b/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
@@ -243,7 +243,18 @@ public:
             }
             else
             {
-                Logger::error(L"Failed to start the process");
+                Logger::warn(L"RunNonElevatedEx() failed. Trying fallback");
+                std::wstring action_runner_path = get_module_folderpath() + L"\\PowerToys.ActionRunner.exe";
+                std::wstring newParams = L"-run-non-elevated -target modules\\launcher\\PowerLauncher.exe " + params;
+                if (run_non_elevated(action_runner_path, newParams, nullptr))
+                {
+                    processStarted = true;
+                    Logger::trace("Started PowerToys Run Process");
+                }
+                else
+                {
+                    Logger::warn("Failed to start PowerToys Run");
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
We have the fallback implementation for starting PT Run process if we can not delegate it to the `explorer.exe`. 
We decided to remove ActionRunner as a middle process for starting PT Run and because it was made in the fallback this scenario hasn't been tested. Here we kind of revert it.

**What is include in the PR:** 

**How does someone test / validate:** 
It can be tested artificially by returning false from `RunNonElevatedEx`.

## Quality Checklist

- [X] **Linked issue:** #11955
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
