### PR TITLE
Image resizer checking for NaN, not just zero

### DIFF
--- a/src/modules/imageresizer/ui/Models/ResizeSize.cs
+++ b/src/modules/imageresizer/ui/Models/ResizeSize.cs
@@ -84,7 +84,7 @@ namespace ImageResizer.Models
         }
 
         public bool HasAuto
-            => Width == 0 || Height == 0;
+            => Width == 0 || Height == 0 || double.IsNaN(Width) || double.IsNaN(Height);
 
         [JsonProperty(PropertyName = "unit")]
         public ResizeUnit Unit
@@ -125,7 +125,7 @@ namespace ImageResizer.Models
 
         private double ConvertToPixels(double value, ResizeUnit unit, int originalValue, double dpi)
         {
-            if (value == 0)
+            if (value == 0 || double.IsNaN(value))
             {
                 if (Fit == ResizeFit.Fit)
                 {


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
new numberbox control will NaN if left blank versus resetting to a zero.  This fix will check that.  If NaN, it makes the image a 1px sizing for pretty much all permutations

**What is include in the PR:** 
verifying if NaN and treating it like we do with a 0

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #https://github.com/microsoft/PowerToys/issues/12044
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
