### PR TITLE
Fix merged process names in bug report tool

### DIFF
--- a/tools/BugReportTool/BugReportTool/EventViewer.cpp
+++ b/tools/BugReportTool/BugReportTool/EventViewer.cpp
@@ -16,7 +16,7 @@ namespace
     {
         L"PowerToys.exe",
         L"ColorPickerUI.exe",
-        L"PowerToys.Awake.exe"
+        L"PowerToys.Awake.exe",
         L"FancyZonesEditor.exe",
         L"PowerToys.FancyZones.exe",
         L"PowerToys.KeyboardManagerEngine.exe",


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Clicking "Report Bug" creates a "EventViewer-PowerToys.Awake.exeFancyZonesEditor.exe.xml" file inside the zip, instead of two separate files for PowerToys Awake and FancyZonesEditor.

This PR fixes it.

## Quality Checklist

- [x] **Linked issue:** #12118

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
