### PR TITLE
PowerToys Awake - Fix right click menu actions on Awake tray icon

### DIFF
--- a/src/modules/awake/Awake/Core/TrayHelper.cs
+++ b/src/modules/awake/Awake/Core/TrayHelper.cs
@@ -44,16 +44,16 @@ namespace Awake.Core
             }, TrayIcon);
         }
 
-        internal static void SetTray(string text, AwakeSettings settings)
+        internal static void SetTray(string text, AwakeSettings settings, string moduleName)
         {
             SetTray(
                 text,
                 settings.Properties.KeepDisplayOn,
                 settings.Properties.Mode,
-                PassiveKeepAwakeCallback(text),
-                IndefiniteKeepAwakeCallback(text),
-                TimedKeepAwakeCallback(text),
-                KeepDisplayOnCallback(text),
+                PassiveKeepAwakeCallback(moduleName),
+                IndefiniteKeepAwakeCallback(moduleName),
+                TimedKeepAwakeCallback(moduleName),
+                KeepDisplayOnCallback(moduleName),
                 ExitCallback());
         }
 

--- a/src/modules/awake/Awake/Program.cs
+++ b/src/modules/awake/Awake/Program.cs
@@ -180,7 +180,7 @@ namespace Awake
                         .Select(e => e.EventArgs)
                         .Subscribe(HandleAwakeConfigChange);
 
-                    TrayHelper.SetTray(FullAppName, new AwakeSettings());
+                    TrayHelper.SetTray(FullAppName, new AwakeSettings(), AppName);
 
                     // Initially the file might not be updated, so we need to start processing
                     // settings right away.
@@ -274,7 +274,7 @@ namespace Awake
                             }
                     }
 
-                    TrayHelper.SetTray(FullAppName, settings);
+                    TrayHelper.SetTray(FullAppName, settings, AppName);
                 }
                 else
                 {


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Changing options through the menu on PowerToys Awake's tray icon isn't applying any changes after the icon name change from "Awake" to "PowerToys Awake".
This PR fixes this.
## Quality Checklist

- [x] **Linked issue:** #12145
