### PR TITLE
[Color Picker] Logs

### DIFF
--- a/src/modules/colorPicker/ColorPicker/dllmain.cpp
+++ b/src/modules/colorPicker/ColorPicker/dllmain.cpp
@@ -10,6 +10,7 @@
 
 #include <colorPicker/ColorPicker/ColorPickerConstants.h>
 #include <common/interop/shared_constants.h>
+#include <common/utils/logger_helper.h>
 
 BOOL APIENTRY DllMain(HMODULE hModule,
                       DWORD ul_reason_for_call,
@@ -108,7 +109,7 @@ private:
 
     void launch_process()
     {
-        Logger::trace(L"Launching ColorPicker process");
+        Logger::trace(L"Starting ColorPicker process");
         unsigned long powertoys_pid = GetCurrentProcessId();
 
         std::wstring executable_args = L"";
@@ -119,7 +120,11 @@ private:
         sei.lpFile = L"modules\\ColorPicker\\ColorPickerUI.exe";
         sei.nShow = SW_SHOWNORMAL;
         sei.lpParameters = executable_args.data();
-        if (!ShellExecuteExW(&sei))
+        if (ShellExecuteExW(&sei))
+        {
+            Logger::trace("Successfully started the Color Picker process");
+        }
+        else
         {
             DWORD error = GetLastError();
             std::wstring message = L"ColorPicker failed to start with error = ";
@@ -153,6 +158,7 @@ public:
     {
         app_name = GET_RESOURCE_STRING(IDS_COLORPICKER_NAME);
         app_key = ColorPickerConstants::ModuleKey;
+        LoggerHelpers::init_logger(app_key, L"ModuleInterface", "ColorPicker");
         send_telemetry_event = CreateDefaultEvent(CommonSharedConstants::COLOR_PICKER_SEND_SETTINGS_TELEMETRY_EVENT);
         m_hInvokeEvent = CreateDefaultEvent(CommonSharedConstants::SHOW_COLOR_PICKER_SHARED_EVENT);
         init_settings();
@@ -224,6 +230,7 @@ public:
 
     virtual void enable()
     {
+        Logger::trace("ColorPicker::enable()");
         ResetEvent(send_telemetry_event);
         ResetEvent(m_hInvokeEvent);
         launch_process();
@@ -232,6 +239,7 @@ public:
 
     virtual void disable()
     {
+        Logger::trace("ColorPicker::disable()");
         if (m_enabled)
         {
             ResetEvent(send_telemetry_event);

--- a/src/modules/colorPicker/ColorPicker/dllmain.cpp
+++ b/src/modules/colorPicker/ColorPicker/dllmain.cpp
@@ -11,6 +11,7 @@
 #include <colorPicker/ColorPicker/ColorPickerConstants.h>
 #include <common/interop/shared_constants.h>
 #include <common/utils/logger_helper.h>
+#include <common/utils/winapi_error.h>
 
 BOOL APIENTRY DllMain(HMODULE hModule,
                       DWORD ul_reason_for_call,
@@ -126,10 +127,7 @@ private:
         }
         else
         {
-            DWORD error = GetLastError();
-            std::wstring message = L"ColorPicker failed to start with error = ";
-            message += std::to_wstring(error);
-            Logger::error(message);
+            Logger::error( L"ColorPicker failed to start. {}", get_last_error_or_default(GetLastError()));
         }
 
         m_hProcess = sei.hProcess;
@@ -175,6 +173,7 @@ public:
     // Destroy the powertoy and free memory
     virtual void destroy() override
     {
+        Logger::trace("ColorPicker::destroy()");
         delete this;
     }
 

--- a/src/modules/colorPicker/ColorPickerUI/App.xaml.cs
+++ b/src/modules/colorPicker/ColorPickerUI/App.xaml.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Threading;
 using System.Windows;
+using ColorPicker.Helpers;
 using ColorPicker.Mouse;
 using ManagedCommon;
 using Microsoft.PowerToys.Common.UI;
@@ -30,6 +31,7 @@ namespace ColorPickerUI
             _instanceMutex = new Mutex(true, @"Local\PowerToys_ColorPicker_InstanceMutex", out bool createdNew);
             if (!createdNew)
             {
+                Logger.LogWarning("There is ColorPicker instance running. Exiting Color Picker");
                 _instanceMutex = null;
                 Environment.Exit(0);
                 return;
@@ -39,8 +41,10 @@ namespace ColorPickerUI
             {
                 _ = int.TryParse(_args[0], out _powerToysRunnerPid);
 
+                Logger.LogInfo($"Color Picker started from the PowerToys Runner. Runner pid={_powerToysRunnerPid}");
                 RunnerHelper.WaitForPowerToysRunner(_powerToysRunnerPid, () =>
                 {
+                    Logger.LogInfo("PowerToys Runner exited. Exiting ColorPicker");
                     Environment.Exit(0);
                 });
             }

--- a/src/modules/colorPicker/ColorPickerUI/Program.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Program.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-
+using System.Diagnostics;
 using ColorPicker.Helpers;
 using ColorPicker.Mouse;
 
@@ -19,6 +19,7 @@ namespace ColorPicker
         public static void Main(string[] args)
         {
             _args = args;
+            Logger.LogInfo($"Color Picker started with pid={Process.GetCurrentProcess().Id}");
             AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
             try
             {


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
In #11942 it is hard to understand if the ColorPicker process started and doesn't work or it hasn't started on the startup. Here, we update logging to correlate between the runner logs and the ColorPicker process logs. 

**What is include in the PR:** 
- Initialize logger on the module interface initialization. It was not initialized and we didn't get any logs before
- Add logs to understand how the ColorPicker process is created and destroyed 

**How does someone test / validate:** 
- Run Color Picker
- Verify `ColorPicker` for logs

## Quality Checklist

- [X] **Linked issue:** #11942
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
