### PR TITLE
[Settings] Aligning XAML across all pages

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/SidePanel/SettingsPageControl.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/SidePanel/SettingsPageControl.xaml
@@ -1,0 +1,117 @@
+﻿<UserControl
+    x:Class="Microsoft.PowerToys.Settings.UI.Controls.SettingsPageControl"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Microsoft.PowerToys.Settings.UI.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:converters="using:Microsoft.Toolkit.Uwp.UI.Converters"
+    mc:Ignorable="d"
+    >
+
+    <UserControl.Resources>
+        <converters:DoubleToVisibilityConverter x:Name="doubleToVisibilityConverter" GreaterThan="0" TrueValue="Visible" FalseValue="Collapsed" />
+    </UserControl.Resources>
+
+    <Grid RowSpacing="{StaticResource DefaultRowSpacing}">
+        <VisualStateManager.VisualStateGroups>
+            <VisualStateGroup x:Name="LayoutVisualStates">
+                <VisualState x:Name="WideLayout">
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger MinWindowWidth="{StaticResource WideLayoutMinWidth}" />
+                    </VisualState.StateTriggers>
+                </VisualState>
+                <VisualState x:Name="SmallLayout">
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger MinWindowWidth="{StaticResource SmallLayoutMinWidth}" />
+                        <AdaptiveTrigger MinWindowWidth="0" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="SidePanel.(Grid.Column)" Value="0"/>
+                        <Setter Target="SidePanel.Width" Value="Auto"/>
+                        <Setter Target="ModuleContentPresenter.(Grid.Row)" Value="1" />
+                        <Setter Target="ModuleContentPresenter.Margin" Value="0" />
+                        <Setter Target="LinksPanel.(RelativePanel.RightOf)" Value="AboutImage" />
+                        <Setter Target="LinksPanel.(RelativePanel.AlignTopWith)" Value="AboutImage" />
+                        <Setter Target="LinksPanel.Margin" Value="0,12,0,0" />
+                        <Setter Target="AboutImage.Margin" Value="0,12,12,0" />
+                        <Setter Target="AboutTitle.Visibility" Value="Collapsed" />
+                    </VisualState.Setters>
+                </VisualState>
+            </VisualStateGroup>
+        </VisualStateManager.VisualStateGroups>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="Auto"/>
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <ContentPresenter x:Name="ModuleContentPresenter"
+                          Content="{x:Bind ModuleContent}"
+                           Margin="0,0,48,0"
+                          HorizontalAlignment="Left"
+                          MaxWidth="{StaticResource MaxContentWidth}"/>
+
+        <RelativePanel Grid.Column="1" x:Name="SidePanel" Width="{StaticResource SidePanelWidth}">
+            <StackPanel x:Name="DescriptionPanel">
+                <TextBlock  x:Name="AboutTitle"
+                        Text="{x:Bind ModuleTitle}"
+                        Style="{StaticResource SettingsGroupTitleStyle}"
+                        Margin="{StaticResource XSmallBottomMargin}"/>
+                <TextBlock Text="{x:Bind ModuleDescription}"
+                           TextWrapping="Wrap">
+                </TextBlock>
+            </StackPanel>
+
+            <HyperlinkButton x:Name="AboutImage"
+                         RelativePanel.Below="DescriptionPanel"
+                         MaxWidth="240"
+                         CornerRadius="4"
+                         NavigateUri="{x:Bind ModuleImageLink}"
+                         Margin="{StaticResource SmallTopBottomMargin}">
+                <Image>
+                    <Image.Source>
+                        <BitmapImage UriSource="{x:Bind ModuleImageSource}" />
+                    </Image.Source>
+                </Image>
+            </HyperlinkButton>
+
+            <StackPanel x:Name="LinksPanel"
+                    Margin="0,1,0,0"
+                    RelativePanel.Below="AboutImage"
+                    Orientation="Vertical">
+
+                <StackPanel x:Name="ModuleLinksPanel" Orientation="Vertical">
+                    <ItemsControl ItemsSource="{x:Bind ModuleLinks}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate x:DataType="local:SidePanelLink">
+                                <HyperlinkButton NavigateUri="{x:Bind Link}" Margin="0,-3,0,0">
+                                    <TextBlock Text="{x:Bind Label}" TextWrapping="Wrap" />
+                                </HyperlinkButton>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+
+                <StackPanel x:Name="AttributionPanel"
+                              Visibility="{x:Bind AttributionLinks.Count, Converter={StaticResource doubleToVisibilityConverter}}"
+                            Orientation="Vertical">
+                    <TextBlock x:Uid="AttributionTitle" Style="{StaticResource SettingsGroupTitleStyle}" />
+
+                    <ItemsControl x:Name="AttributionLinksItemControl" ItemsSource="{x:Bind AttributionLinks}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate x:DataType="local:SidePanelLink">
+                                <HyperlinkButton NavigateUri="{x:Bind Link}" Margin="0,-3,0,0">
+                                    <TextBlock Text="{x:Bind Label}" TextWrapping="Wrap" />
+                                </HyperlinkButton>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+            </StackPanel>
+        </RelativePanel>
+    </Grid>
+</UserControl>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/SidePanel/SettingsPageControl.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/SidePanel/SettingsPageControl.xaml.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Documents;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+namespace Microsoft.PowerToys.Settings.UI.Controls
+{
+    public sealed partial class SettingsPageControl : UserControl
+    {
+        public SettingsPageControl()
+        {
+            this.InitializeComponent();
+            ModuleLinks = new ObservableCollection<SidePanelLink>();
+            AttributionLinks = new ObservableCollection<SidePanelLink>();
+        }
+
+        public object ModuleContent
+        {
+            get { return (object)GetValue(ModuleContentProperty); }
+            set { SetValue(ModuleContentProperty, value); }
+        }
+
+        public static readonly DependencyProperty ModuleContentProperty = DependencyProperty.Register("Content", typeof(object), typeof(SettingsPageControl), new PropertyMetadata(new Grid()));
+
+        public string ModuleTitle
+        {
+            get => (string)GetValue(ModuleTitleProperty);
+            set => SetValue(ModuleTitleProperty, value);
+        }
+
+        public string ModuleDescription
+        {
+            get => (string)GetValue(ModuleDescriptionProperty);
+            set => SetValue(ModuleDescriptionProperty, value);
+        }
+
+        public string ModuleImageSource
+        {
+            get => (string)GetValue(ModuleImageSourceProperty);
+            set => SetValue(ModuleImageSourceProperty, value);
+        }
+
+        public Uri ModuleImageLink
+        {
+            get => (Uri)GetValue(ModuleImageLinkProperty);
+            set => SetValue(ModuleImageLinkProperty, value);
+        }
+
+#pragma warning disable CA2227 // Collection properties should be read only
+        public ObservableCollection<SidePanelLink> ModuleLinks
+#pragma warning restore CA2227 // Collection properties should be read only
+        {
+            get => (ObservableCollection<SidePanelLink>)GetValue(ModuleLinksProperty);
+            set => SetValue(ModuleLinksProperty, value);
+        }
+
+#pragma warning disable CA2227 // Collection properties should be read only
+        public ObservableCollection<SidePanelLink> AttributionLinks
+#pragma warning restore CA2227 // Collection properties should be read only
+        {
+            get => (ObservableCollection<SidePanelLink>)GetValue(AttributionLinksProperty);
+            set => SetValue(AttributionLinksProperty, value);
+        }
+
+        public static readonly DependencyProperty ModuleTitleProperty = DependencyProperty.Register("ModuleTitle", typeof(string), typeof(SettingsPageControl), new PropertyMetadata(default(string)));
+        public static readonly DependencyProperty ModuleDescriptionProperty = DependencyProperty.Register("ModuleDescription", typeof(string), typeof(SettingsPageControl), new PropertyMetadata(default(string)));
+        public static readonly DependencyProperty ModuleImageSourceProperty = DependencyProperty.Register("ModuleImageSource", typeof(string), typeof(SettingsPageControl), new PropertyMetadata(default(string)));
+        public static readonly DependencyProperty ModuleImageLinkProperty = DependencyProperty.Register("ModuleImageLink", typeof(string), typeof(SettingsPageControl), new PropertyMetadata(default(string)));
+        public static readonly DependencyProperty ModuleLinksProperty = DependencyProperty.Register("ModuleLinks", typeof(ObservableCollection<SidePanelLink>), typeof(SettingsPageControl), new PropertyMetadata(new ObservableCollection<SidePanelLink>()));
+        public static readonly DependencyProperty AttributionLinksProperty = DependencyProperty.Register("AttributionLinks", typeof(ObservableCollection<SidePanelLink>), typeof(SettingsPageControl), new PropertyMetadata(new ObservableCollection<SidePanelLink>()));
+    }
+}

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/SidePanel/SidePanelLink.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/SidePanel/SidePanelLink.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Documents;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+namespace Microsoft.PowerToys.Settings.UI.Controls
+{
+    public class SidePanelLink
+    {
+        public string Label { get; set; }
+
+        public Uri Link { get; set; }
+    }
+}

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/SidePanel/SidePanelLink.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/SidePanel/SidePanelLink.cs
@@ -3,21 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
-using Windows.UI.Xaml;
-using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Controls.Primitives;
-using Windows.UI.Xaml.Data;
-using Windows.UI.Xaml.Documents;
-using Windows.UI.Xaml.Input;
-using Windows.UI.Xaml.Media;
-using Windows.UI.Xaml.Navigation;
 
 namespace Microsoft.PowerToys.Settings.UI.Controls
 {

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Microsoft.PowerToys.Settings.UI.csproj
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Microsoft.PowerToys.Settings.UI.csproj
@@ -105,6 +105,10 @@
     <Compile Include="Controls\ShortcutVisualControl.xaml.cs">
       <DependentUpon>ShortcutVisualControl.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Controls\SidePanel\SettingsPageControl.xaml.cs">
+      <DependentUpon>SettingsPageControl.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Controls\SidePanel\SidePanelLink.cs" />
     <Compile Include="Converters\AwakeModeToBoolConverter.cs" />
     <Compile Include="Converters\ModuleEnabledToOpacityConverter.cs" />
     <Compile Include="Converters\UpdatingStateCannotDownloadToVisibilityConverter.cs" />
@@ -309,6 +313,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Controls\ShortcutVisualControl.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Controls\SidePanel\SettingsPageControl.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -1247,7 +1247,7 @@ From there, simply click on a Markdown file or SVG icon in the File Explorer and
   <data name="OOBE_Settings.Text" xml:space="preserve">
     <value>Settings</value>
   </data>
-  <data name="Oobe_Button.Label" xml:space="preserve">
+  <data name="Oobe_Button.Text" xml:space="preserve">
     <value>Welcome to PowerToys</value>
   </data>
   <data name="OobeWindow_Title" xml:space="preserve">

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -124,7 +124,7 @@
   <data name="VideoConference_Enable.Header" xml:space="preserve">
     <value>Enable Video Conference</value>
   </data>
-  <data name="VideoConference_Description.Text" xml:space="preserve">
+  <data name="About_VideoConference.ModuleDescription" xml:space="preserve">
     <value>Video Conference Mute is a quick and easy way to do an global "mute" of both your microphone and webcam.
 Disabling this module or closing PowerToys will unmute the microphone and camera.</value>
   </data>
@@ -185,7 +185,7 @@ Disabling this module or closing PowerToys will unmute the microphone and camera
   <data name="VideoConference_HideToolbarWhenUnmuted.Content" xml:space="preserve">
     <value>Hide toolbar when both camera and microphone are unmuted</value>
   </data>
-  <data name="About_VideoConference.Text" xml:space="preserve">
+  <data name="About_VideoConference.ModuleTitle" xml:space="preserve">
     <value>About Video Conference</value>
   </data>
   <data name="VideoConference_Camera.Text" xml:space="preserve">
@@ -253,7 +253,7 @@ Disabling this module or closing PowerToys will unmute the microphone and camera
     <value>Current configuration</value>
     <comment>Keyboard Manager current configuration header</comment>
   </data>
-  <data name="KeyboardManager_Description.Text" xml:space="preserve">
+  <data name="About_KeyboardManager.ModuleDescription" xml:space="preserve">
     <value>Reconfigure your keyboard by remapping keys and shortcuts.</value>
     <comment>Keyboard Manager page description</comment>
   </data>
@@ -311,7 +311,7 @@ Disabling this module or closing PowerToys will unmute the microphone and camera
     <value>Keyboard Manager</value>
     <comment>do not loc, product name</comment>
   </data>
-  <data name="ColorPicker_Description.Text" xml:space="preserve">
+  <data name="About_ColorPicker.ModuleDescription" xml:space="preserve">
     <value>Quick and simple system-wide color picker.</value>
   </data>
   <data name="ColorPicker_EnableColorPicker.Header" xml:space="preserve">
@@ -325,7 +325,7 @@ Disabling this module or closing PowerToys will unmute the microphone and camera
     <value>Activate Color Picker</value>
     <comment>do not loc product name</comment>
   </data>
-  <data name="PowerLauncher_Description.Text" xml:space="preserve">
+  <data name="About_PowerLauncher.ModuleDescription" xml:space="preserve">
     <value>A quick launcher that has additional capabilities without sacrificing performance.</value>
   </data>
   <data name="PowerLauncher_EnablePowerLauncher.Header" xml:space="preserve">
@@ -394,17 +394,14 @@ Disabling this module or closing PowerToys will unmute the microphone and camera
     <value>To:</value>
     <comment>Keyboard Manager mapping keys view right header</comment>
   </data>
-  <data name="About_This_Feature.Text" xml:space="preserve">
-    <value>About this feature</value>
-  </data>
   <data name="Appearance_GroupSettings.Text" xml:space="preserve">
     <value>Appearance</value>
   </data>
-  <data name="Fancyzones_Image.AutomationProperties.Name" xml:space="preserve">
+  <data name="Fancyzones_ImageHyperlinkToDocs.AutomationProperties.Name" xml:space="preserve">
     <value>FancyZones windows</value>
     <comment>do not loc the Product name</comment>
   </data>
-  <data name="FancyZones_Description.Text" xml:space="preserve">
+  <data name="About_FancyZones.ModuleDescription" xml:space="preserve">
     <value>Create window layouts to help make multi-tasking easy.</value>
     <comment>windows refers to application windows</comment>
   </data>
@@ -476,10 +473,10 @@ Disabling this module or closing PowerToys will unmute the microphone and camera
   <data name="FancyZones_ZoneSetChangeMoveWindows.Content" xml:space="preserve">
     <value>During zone layout changes, windows assigned to a zone will match new size/positions</value>
   </data>
-  <data name="Give_Feedback.Text" xml:space="preserve">
+  <data name="Give_Feedback.Label" xml:space="preserve">
     <value>Give feedback</value>
   </data>
-  <data name="Module_overview.Text" xml:space="preserve">
+  <data name="Learn_More.Label" xml:space="preserve">
     <value>Learn more</value>
     <comment>This label is there to point people to additional overview for how to use the product</comment>
   </data>
@@ -487,11 +484,8 @@ Disabling this module or closing PowerToys will unmute the microphone and camera
     <value>Attribution</value>
     <comment>giving credit to the projects this utility was based on</comment>
   </data>
-  <data name="GeneralPage_AboutPowerToysHeader.Text" xml:space="preserve">
+  <data name="About_PowerToys.ModuleTitle" xml:space="preserve">
     <value>About PowerToys</value>
-  </data>
-  <data name="PowerToys_Icon.AutomationProperties.Name" xml:space="preserve">
-    <value>PowerToys Icon</value>
   </data>
   <data name="GeneralPage_CheckForUpdates.Content" xml:space="preserve">
     <value>Check for updates</value>
@@ -499,14 +493,14 @@ Disabling this module or closing PowerToys will unmute the microphone and camera
   <data name="GeneralPage_UpdateNow.Content" xml:space="preserve">
     <value>Update now</value>
   </data>
-  <data name="GeneralPage_PrivacyStatement_URL.Text" xml:space="preserve">
+  <data name="GeneralPage_PrivacyStatement_URL.Label" xml:space="preserve">
     <value>Privacy statement</value>
   </data>
-  <data name="GeneralPage_ReportAbug.Text" xml:space="preserve">
+  <data name="GeneralPage_ReportAbug.Label" xml:space="preserve">
     <value>Report a bug</value>
     <comment>Report an issue inside powertoys</comment>
   </data>
-  <data name="GeneralPage_RequestAFeature_URL.Text" xml:space="preserve">
+  <data name="GeneralPage_RequestAFeature_URL.Label" xml:space="preserve">
     <value>Request a feature</value>
     <comment>Tell our team what we should build</comment>
   </data>
@@ -517,7 +511,7 @@ Disabling this module or closing PowerToys will unmute the microphone and camera
   <data name="GeneralPage_ToggleSwitch_RunAtStartUp.Header" xml:space="preserve">
     <value>Run at startup</value>
   </data>
-  <data name="PowerRename_Description.Text" xml:space="preserve">
+  <data name="About_PowerRename.ModuleDescription" xml:space="preserve">
     <value>A Windows Shell extension for more advanced bulk renaming using search and replace or regular expressions.</value>
   </data>
   <data name="PowerRename_ShellIntegration.Text" xml:space="preserve">
@@ -555,13 +549,13 @@ Disabling this module or closing PowerToys will unmute the microphone and camera
     <value>Enable SVG (.svg) thumbnails</value>
     <comment>Do you want this feature on / off</comment>
   </data>
-  <data name="FileExplorerPreview_Description.Text" xml:space="preserve">
+  <data name="About_FileExplorerPreview.ModuleDescription" xml:space="preserve">
     <value>These settings allow you to manage your Windows File Explorer custom preview handlers.</value>
   </data>
   <data name="PowerRename_AutoCompleteHeader.Text" xml:space="preserve">
     <value>Autocomplete</value>
   </data>
-  <data name="OpenSource_Notice.Text" xml:space="preserve">
+  <data name="OpenSource_Notice.Label" xml:space="preserve">
     <value>Open-source notice</value>
   </data>
   <data name="PowerRename_Toggle_AutoComplete.Content" xml:space="preserve">
@@ -573,7 +567,7 @@ Disabling this module or closing PowerToys will unmute the microphone and camera
   <data name="FancyZones_InActiveColor.Text" xml:space="preserve">
     <value>Zone inactive color</value>
   </data>
-  <data name="ShortcutGuide_Description.Text" xml:space="preserve">
+  <data name="About_ShortcutGuide.ModuleDescription" xml:space="preserve">
     <value>Shows a help overlay with Windows shortcuts when the Windows key is pressed.</value>
   </data>
   <data name="ShortcutGuide_PressTime.Header" xml:space="preserve">
@@ -603,7 +597,7 @@ Disabling this module or closing PowerToys will unmute the microphone and camera
   <data name="ImageResizer_CustomSizes.Text" xml:space="preserve">
     <value>Image sizes</value>
   </data>
-  <data name="ImageResizer_Description.Text" xml:space="preserve">
+  <data name="About_ImageResizer.ModuleDescription" xml:space="preserve">
     <value>Lets you resize images by right-clicking.</value>
   </data>
   <data name="ImageResizer_EnableToggle.Header" xml:space="preserve">
@@ -759,36 +753,32 @@ Disabling this module or closing PowerToys will unmute the microphone and camera
   <data name="GeneralSettings_RunningAsAdminText" xml:space="preserve">
     <value>Running as administrator</value>
   </data>
-  <data name="About_FancyZones.Text" xml:space="preserve">
+  <data name="About_FancyZones.ModuleTitle" xml:space="preserve">
     <value>About FancyZones</value>
   </data>
-  <data name="About_FileExplorerPreview.Text" xml:space="preserve">
+  <data name="About_FileExplorerPreview.ModuleTitle" xml:space="preserve">
     <value>About File Explorer</value>
   </data>
   <data name="FileExplorerPreview_Image.AutomationProperties.Name" xml:space="preserve">
     <value>File Explorer</value>
     <comment>Use same translation as Windows does for File Explorer</comment>
   </data>
-  <data name="About_ImageResizer.Text" xml:space="preserve">
+  <data name="About_ImageResizer.ModuleTitle" xml:space="preserve">
     <value>About Image Resizer</value>
   </data>
-  <data name="About_KeyboardManager.Text" xml:space="preserve">
+  <data name="About_KeyboardManager.ModuleTitle" xml:space="preserve">
     <value>About Keyboard Manager</value>
   </data>
-  <data name="About_ColorPicker.Text" xml:space="preserve">
+  <data name="About_ColorPicker.ModuleTitle" xml:space="preserve">
     <value>About Color Picker</value>
   </data>
-  <data name="ColorPicker_Image.AutomationProperties.Name" xml:space="preserve">
-    <value>Color Picker</value>
-    <comment>do not loc the Product name.</comment>
-  </data>
-  <data name="About_PowerLauncher.Text" xml:space="preserve">
+  <data name="About_PowerLauncher.ModuleTitle" xml:space="preserve">
     <value>About PowerToys Run</value>
   </data>
   <data name="PowerToys_Run_Image.AutomationProperties.Name" xml:space="preserve">
     <value>PowerToys Run</value>
   </data>
-  <data name="About_PowerRename.Text" xml:space="preserve">
+  <data name="About_PowerRename.ModuleTitle" xml:space="preserve">
     <value>About PowerRename</value>
     <comment>do not loc the product name</comment>
   </data>
@@ -796,13 +786,13 @@ Disabling this module or closing PowerToys will unmute the microphone and camera
     <value>PowerRename</value>
     <comment>do not loc</comment>
   </data>
-  <data name="About_ShortcutGuide.Text" xml:space="preserve">
+  <data name="About_ShortcutGuide.ModuleTitle" xml:space="preserve">
     <value>About Shortcut Guide</value>
   </data>
   <data name="Shortcut_Guide_Image.AutomationProperties.Name" xml:space="preserve">
     <value>Shortcut Guide</value>
   </data>
-  <data name="General_Repository.Text" xml:space="preserve">
+  <data name="General_Repository.Label" xml:space="preserve">
     <value>GitHub repository</value>
   </data>
   <data name="General_Updates.Text" xml:space="preserve">
@@ -851,8 +841,10 @@ Disabling this module or closing PowerToys will unmute the microphone and camera
   <data name="KeyboardManager_RemapShortcutsSubtitle.Text" xml:space="preserve">
     <value>Remap shortcuts to other shortcuts or keys. Additionally, mappings can be targeted to specific applications as well.</value>
   </data>
-  <data name="About_PowerToys.Text" xml:space="preserve">
-    <value>Microsoft PowerToys is a set of utilities for power users to tune and streamline their Windows experience for greater productivity.</value>
+  <data name="About_PowerToys.ModuleDescription" xml:space="preserve">
+    <value>Microsoft PowerToys is a set of utilities for power users to tune and streamline their Windows experience for greater productivity.
+
+Made with 💗 by Microsoft and the PowerToys community.</value>
     <comment>Windows refers to the OS</comment>
   </data>
   <data name="FancyZones_SpanZonesAcrossMonitorsCheckBoxControl.Content" xml:space="preserve">
@@ -999,50 +991,6 @@ Disabling this module or closing PowerToys will unmute the microphone and camera
   <data name="ImageResizer_DefaultSize_Small" xml:space="preserve">
     <value>Small</value>
     <comment>The size of the image</comment>
-  </data>
-  <data name="ColorPicker_ImageHyperlinkToDocs.NavigateUri" xml:space="preserve">
-    <value>https://aka.ms/PowerToysOverview_ColorPicker</value>
-    <comment>URL. Do not loc</comment>
-  </data>
-  <data name="Awake_ImageHyperlinkToDocs.NavigateUri" xml:space="preserve">
-    <value>https://aka.ms/PowerToysOverview_Awake</value>
-    <comment>URL. Do not loc</comment>
-  </data>
-  <data name="FancyZones_ImageHyperlinkToDocs.NavigateUri" xml:space="preserve">
-    <value>https://aka.ms/PowerToysOverview_FancyZones</value>
-    <comment>URL. Do not loc</comment>
-  </data>
-  <data name="GeneralPage_ImageHyperlinkToDocs.NavigateUri" xml:space="preserve">
-    <value>https://aka.ms/powertoys</value>
-    <comment>URL. Do not loc</comment>
-  </data>
-  <data name="ImageResizer_ImageHyperlinkToDocs.NavigateUri" xml:space="preserve">
-    <value>https://aka.ms/PowerToysOverview_ImageResizer</value>
-    <comment>URL. Do not loc</comment>
-  </data>
-  <data name="FileExplorerPreview_ImageHyperlinkToDocs.NavigateUri" xml:space="preserve">
-    <value>https://aka.ms/PowerToysOverview_FileExplorerAddOns</value>
-    <comment>URL. Do not loc</comment>
-  </data>
-  <data name="KeyboardManager_ImageHyperlinkToDocs.NavigateUri" xml:space="preserve">
-    <value>https://aka.ms/PowerToysOverview_KeyboardManager</value>
-    <comment>URL. Do not loc</comment>
-  </data>
-  <data name="PowerRename_ImageHyperlinkToDocs.NavigateUri" xml:space="preserve">
-    <value>https://aka.ms/PowerToysOverview_PowerRename</value>
-    <comment>URL. Do not loc</comment>
-  </data>
-  <data name="PowerToys_Run_ImageHyperlinkToDocs.NavigateUri" xml:space="preserve">
-    <value>https://aka.ms/PowerToysOverview_PowerToysRun</value>
-    <comment>URL. Do not loc</comment>
-  </data>
-  <data name="ShortcutGuide_ImageHyperlinkToDocs.NavigateUri" xml:space="preserve">
-    <value>https://aka.ms/PowerToysOverview_ShortcutGuide</value>
-    <comment>URL. Do not loc</comment>
-  </data>
-  <data name="VideoConference_ImageHyperlinkToDocs.NavigateUri" xml:space="preserve">
-    <value>https://aka.ms/PowerToysOverview_VideoConference</value>
-    <comment>URL. Do not loc</comment>
   </data>
   <data name="FancyZones_MoveWindowBasedOnRelativePosition.Content" xml:space="preserve">
     <value>Win + Up/Down/Left/Right to move windows based on relative position</value>
@@ -1299,7 +1247,7 @@ From there, simply click on a Markdown file or SVG icon in the File Explorer and
   <data name="OOBE_Settings.Text" xml:space="preserve">
     <value>Settings</value>
   </data>
-  <data name="Oobe_Button.Text" xml:space="preserve">
+  <data name="Oobe_Button.Label" xml:space="preserve">
     <value>Welcome to PowerToys</value>
   </data>
   <data name="OobeWindow_Title" xml:space="preserve">
@@ -1308,10 +1256,10 @@ From there, simply click on a Markdown file or SVG icon in the File Explorer and
   <data name="SettingsWindow_Title" xml:space="preserve">
     <value>PowerToys Settings</value>
   </data>
-  <data name="About_Awake.Text" xml:space="preserve">
+  <data name="About_Awake.ModuleTitle" xml:space="preserve">
     <value>About Awake</value>
   </data>
-  <data name="Awake_Description.Text" xml:space="preserve">
+  <data name="About_Awake.ModuleDescription" xml:space="preserve">
     <value>A convenient way to keep your PC awake on-demand.</value>
   </data>
   <data name="Awake_EnableAwake.Header" xml:space="preserve">
@@ -1349,13 +1297,6 @@ From there, simply click on a Markdown file or SVG icon in the File Explorer and
   </data>
   <data name="Awake_TemporaryKeepAwake_Minutes.Header" xml:space="preserve">
     <value>Minutes</value>
-  </data>
-  <data name="Awake_ModuleAttributionLabel.Text" xml:space="preserve">
-    <value>Den Delimarsky's Awake</value>
-  </data>
-  <data name="Awake_ModuleAttributionHyperlink.NavigateUri" xml:space="preserve">
-    <value>https://Awake.den.dev</value>
-    <comment>URL. Do not loc</comment>
   </data>
   <data name="Oobe_Awake" xml:space="preserve">
     <value>Awake</value>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/AwakePage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/AwakePage.xaml
@@ -5,10 +5,8 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:c="using:Microsoft.PowerToys.Settings.UI.Converters"
-    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls" xmlns:controls="using:Microsoft.PowerToys.Settings.UI.Controls"
     mc:Ignorable="d"
-    d:DesignHeight="300"
-    d:DesignWidth="400" 
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     AutomationProperties.LandmarkType="Main">
 
@@ -16,104 +14,71 @@
         <c:AwakeModeToBoolConverter x:Key="AwakeModeToBoolConverter" />
     </Page.Resources>
 
-    <Grid RowSpacing="{StaticResource DefaultRowSpacing}">
-        <VisualStateManager.VisualStateGroups>
-            <VisualStateGroup x:Name="LayoutVisualStates">
-                <VisualState x:Name="WideLayout">
-                    <VisualState.StateTriggers>
-                        <AdaptiveTrigger MinWindowWidth="{StaticResource WideLayoutMinWidth}" />
-                    </VisualState.StateTriggers>
-                </VisualState>
-                <VisualState x:Name="SmallLayout">
-                    <VisualState.StateTriggers>
-                        <AdaptiveTrigger MinWindowWidth="{StaticResource SmallLayoutMinWidth}" />
-                        <AdaptiveTrigger MinWindowWidth="0" />
-                    </VisualState.StateTriggers>
-                    <VisualState.Setters>
-                        <Setter Target="SidePanel.(Grid.Column)" Value="0" />
-                        <Setter Target="SidePanel.Width" Value="Auto" />
-                        <Setter Target="LinksPanel.(RelativePanel.RightOf)" Value="AboutImage" />
-                        <Setter Target="LinksPanel.(RelativePanel.AlignTopWith)" Value="AboutImage" />
-                        <Setter Target="AboutImage.Margin" Value="0,12,12,0" />
-                        <Setter Target="AboutTitle.Visibility" Value="Collapsed" />
-                    </VisualState.Setters>
-                </VisualState>
-            </VisualStateGroup>
-        </VisualStateManager.VisualStateGroups>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*"/>
-            <ColumnDefinition Width="Auto"/>
-        </Grid.ColumnDefinitions>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto" />
-        </Grid.RowDefinitions>
+    <controls:SettingsPageControl x:Uid="About_Awake"
+                                  ModuleImageSource="ms-appx:///Assets/Modules/Awake.png"
+                                  ModuleImageLink="https://aka.ms/PowerToysOverview_Awake">
+        <controls:SettingsPageControl.ModuleContent>
+            <StackPanel Orientation="Vertical">
+                <ToggleSwitch x:Uid="Awake_EnableAwake" IsOn="{x:Bind ViewModel.IsEnabled, Mode=TwoWay}" />
 
-        <StackPanel Orientation="Vertical"
-                    x:Name="AwakeView"
-                    HorizontalAlignment="Left"
-                    Margin="0,0,48,0"
-                    MaxWidth="{StaticResource MaxContentWidth}">
-            <ToggleSwitch x:Uid="Awake_EnableAwake" IsOn="{x:Bind ViewModel.IsEnabled, Mode=TwoWay}" />
-
-            <TextBlock x:Uid="Awake_Behavior_GroupSettings"
+                <TextBlock x:Uid="Awake_Behavior_GroupSettings"
                        Opacity="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToOpacityConverter}}"
                        Style="{StaticResource SettingsGroupTitleStyle}"/>
 
-            <CheckBox x:Uid="Awake_EnableDisplayKeepAwake"
+                <CheckBox x:Uid="Awake_EnableDisplayKeepAwake"
                       IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"
                       IsChecked="{x:Bind ViewModel.KeepDisplayOn, Mode=TwoWay}"
                       Margin="{StaticResource XSmallTopMargin}" />
-            
-            <TextBlock x:Uid="Awake_Mode"
+
+                <TextBlock x:Uid="Awake_Mode"
                        Margin="{StaticResource SmallTopMargin}"
                        x:Name="ModeTitleLabel"
                        Opacity="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToOpacityConverter}}" />
 
-            <StackPanel AutomationProperties.LabeledBy="{Binding ElementName=ModeTitleLabel}"
+                <StackPanel AutomationProperties.LabeledBy="{Binding ElementName=ModeTitleLabel}"
                         Margin="0,-8,0,0">
-                <RadioButton x:Uid="Awake_NoKeepAwake"
+                    <RadioButton x:Uid="Awake_NoKeepAwake"
                              Margin="{StaticResource SmallTopMargin}"
                              IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"
                              IsChecked="{x:Bind Path=ViewModel.Mode, Mode=TwoWay, Converter={StaticResource AwakeModeToBoolConverter}, ConverterParameter=0}">
-                    <RadioButton.Content>
-                        <TextBlock TextWrapping="WrapWholeWords" LineHeight="20">
+                        <RadioButton.Content>
+                            <TextBlock TextWrapping="WrapWholeWords" LineHeight="20">
                         <Run x:Uid="Awake_NoKeepAwakeContent"/>
                         <LineBreak/>
                         <Run Foreground="{ThemeResource SystemBaseMediumColor}"
                              x:Uid="Awake_NoKeepAwakeDescription"/>
-                        </TextBlock>
-                    </RadioButton.Content>
-                </RadioButton>
-                <RadioButton x:Uid="Awake_IndefiniteKeepAwake"
+                            </TextBlock>
+                        </RadioButton.Content>
+                    </RadioButton>
+                    <RadioButton x:Uid="Awake_IndefiniteKeepAwake"
                              Margin="{StaticResource SmallTopMargin}"
                              IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"
                              IsChecked="{x:Bind Path=ViewModel.Mode, Mode=TwoWay, Converter={StaticResource AwakeModeToBoolConverter}, ConverterParameter=1}">
-                    <RadioButton.Content>
-                        <TextBlock TextWrapping="WrapWholeWords" LineHeight="20">
+                        <RadioButton.Content>
+                            <TextBlock TextWrapping="WrapWholeWords" LineHeight="20">
                         <Run x:Uid="Awake_IndefiniteKeepAwakeContent"/>
                         <LineBreak/>
                         <Run Foreground="{ThemeResource SystemBaseMediumColor}"
                              x:Uid="Awake_IndefiniteKeepAwakeDescription"/>
-                        </TextBlock>
-                    </RadioButton.Content>
-                </RadioButton>
-                <RadioButton x:Uid="Awake_TemporaryKeepAwake"
+                            </TextBlock>
+                        </RadioButton.Content>
+                    </RadioButton>
+                    <RadioButton x:Uid="Awake_TemporaryKeepAwake"
                              Margin="{StaticResource SmallTopMargin}"
                              IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"
                              IsChecked="{x:Bind Path=ViewModel.Mode, Mode=TwoWay, Converter={StaticResource AwakeModeToBoolConverter}, ConverterParameter=2}">
-                    <RadioButton.Content>
-                        <TextBlock TextWrapping="WrapWholeWords" LineHeight="20">
+                        <RadioButton.Content>
+                            <TextBlock TextWrapping="WrapWholeWords" LineHeight="20">
                         <Run x:Uid="Awake_TemporaryKeepAwakeContent"/>
                         <LineBreak/>
                         <Run Foreground="{ThemeResource SystemBaseMediumColor}"
                              x:Uid="Awake_TemporaryKeepAwakeDescription"/>
-                        </TextBlock>
-                    </RadioButton.Content>
-                </RadioButton>
+                            </TextBlock>
+                        </RadioButton.Content>
+                    </RadioButton>
 
-                <StackPanel Margin="28,8,0,0" Orientation="Horizontal">
-                    <muxc:NumberBox x:Uid="Awake_TemporaryKeepAwake_Hours"
+                    <StackPanel Margin="28,8,0,0" Orientation="Horizontal">
+                        <muxc:NumberBox x:Uid="Awake_TemporaryKeepAwake_Hours"
                             Value="{x:Bind ViewModel.Hours, Mode=TwoWay}"
                             Minimum="0"
                             SpinButtonPlacementMode="Compact"
@@ -122,7 +87,7 @@
                             IsEnabled="{x:Bind ViewModel.IsTimeConfigurationEnabled, Mode=OneWay}"
                             SmallChange="1" 
                             LargeChange="5"/>
-                    <muxc:NumberBox x:Uid="Awake_TemporaryKeepAwake_Minutes"
+                        <muxc:NumberBox x:Uid="Awake_TemporaryKeepAwake_Minutes"
                             Value="{x:Bind ViewModel.Minutes, Mode=TwoWay}"
                             Minimum="0"
                             SpinButtonPlacementMode="Compact"
@@ -132,57 +97,17 @@
                             MinWidth="90"
                             SmallChange="1" 
                             LargeChange="5"/>
+                    </StackPanel>
                 </StackPanel>
             </StackPanel>
-        </StackPanel>
+        </controls:SettingsPageControl.ModuleContent>
 
-        <RelativePanel x:Name="SidePanel" 
-                    HorizontalAlignment="Left"
-                    Width="{StaticResource SidePanelWidth}"
-                    Grid.Column="1">
-            <StackPanel x:Name="DescriptionPanel">
-                <TextBlock x:Uid="About_Awake"
-                           x:Name="AboutTitle"
-                           Grid.ColumnSpan="2"
-                           Style="{StaticResource SettingsGroupTitleStyle}"
-                           Margin="{StaticResource XSmallBottomMargin}"/>
-                <TextBlock x:Uid="Awake_Description"
-                           TextWrapping="Wrap"
-                           Grid.Row="1" />
-            </StackPanel>
-
-            <Border x:Name="AboutImage"
-                    CornerRadius="4"
-                    Grid.Row="2"
-                    MaxWidth="240"
-                    HorizontalAlignment="Left"
-                    Margin="{StaticResource SmallTopBottomMargin}"
-                    RelativePanel.Below="DescriptionPanel">
-                <HyperlinkButton x:Uid="Awake_ImageHyperlinkToDocs">
-                    <Image x:Uid="Awake_Image" Source="ms-appx:///Assets/Modules/Awake.png" />
-                </HyperlinkButton>
-            </Border>
-            <StackPanel x:Name="LinksPanel"
-                        Margin="0,1,0,0"
-                        RelativePanel.Below="AboutImage"
-                        Orientation="Vertical" >
-                <HyperlinkButton x:Uid="Awake_ImageHyperlinkToDocs">
-                    <TextBlock x:Uid="Module_overview" />
-                </HyperlinkButton>
-                <HyperlinkButton NavigateUri="https://aka.ms/powerToysGiveFeedback">
-                    <TextBlock x:Uid="Give_Feedback" />
-                </HyperlinkButton>
-
-                <TextBlock 
-                x:Uid="AttributionTitle"
-                Style="{StaticResource SettingsGroupTitleStyle}" />
-
-                <HyperlinkButton Margin="0,-3,0,0"
-                                 x:Uid="Awake_ModuleAttributionHyperlink">
-                    <TextBlock x:Uid="Awake_ModuleAttributionLabel"
-                               TextWrapping="Wrap" />
-                </HyperlinkButton>
-            </StackPanel>
-        </RelativePanel>
-    </Grid>
+        <controls:SettingsPageControl.ModuleLinks>
+            <controls:SidePanelLink x:Uid="Learn_More" Link="https://aka.ms/PowerToysOverview_Awake"/>
+            <controls:SidePanelLink x:Uid="Give_Feedback" Link="https://aka.ms/powerToysGiveFeedback"/>
+        </controls:SettingsPageControl.ModuleLinks>
+        <controls:SettingsPageControl.AttributionLinks>
+            <controls:SidePanelLink Label="Den Delimarsky's Awake" Link="https://Awake.den.dev"/>
+        </controls:SettingsPageControl.AttributionLinks>
+    </controls:SettingsPageControl>
 </Page>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
@@ -2,51 +2,19 @@
     x:Class="Microsoft.PowerToys.Settings.UI.Views.ColorPickerPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:Microsoft.PowerToys.Settings.UI.Views"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:Custom="using:Microsoft.PowerToys.Settings.UI.Controls"
-    xmlns:Color="using:Microsoft.PowerToys.Settings.UI.Library.ViewModels" xmlns:Interactivity="using:Microsoft.Xaml.Interactivity" xmlns:Core="using:Microsoft.Xaml.Interactions.Core"
+    xmlns:controls="using:Microsoft.PowerToys.Settings.UI.Controls"
+    xmlns:Interactivity="using:Microsoft.Xaml.Interactivity"
+    xmlns:Core="using:Microsoft.Xaml.Interactions.Core"
     mc:Ignorable="d"
-    d:DesignHeight="300"
-    d:DesignWidth="400" 
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     AutomationProperties.LandmarkType="Main">
 
-    <Grid RowSpacing="{StaticResource DefaultRowSpacing}">
-        <VisualStateManager.VisualStateGroups>
-            <VisualStateGroup x:Name="LayoutVisualStates">
-                <VisualState x:Name="WideLayout">
-                    <VisualState.StateTriggers>
-                        <AdaptiveTrigger MinWindowWidth="{StaticResource WideLayoutMinWidth}" />
-                    </VisualState.StateTriggers>
-                </VisualState>
-                <VisualState x:Name="SmallLayout">
-                    <VisualState.StateTriggers>
-                        <AdaptiveTrigger MinWindowWidth="{StaticResource SmallLayoutMinWidth}" />
-                        <AdaptiveTrigger MinWindowWidth="0" />
-                    </VisualState.StateTriggers>
-                    <VisualState.Setters>
-                        <Setter Target="SidePanel.(Grid.Column)" Value="0" />
-                        <Setter Target="SidePanel.Width" Value="Auto" />
-                        <Setter Target="ColorPickerView.(Grid.Row)" Value="1" />
-                        <Setter Target="ColorPickerView.Margin" Value="0" />
-                        <Setter Target="LinksPanel.(RelativePanel.RightOf)" Value="AboutImage" />
-                        <Setter Target="LinksPanel.(RelativePanel.AlignTopWith)" Value="AboutImage" />
-                        <Setter Target="AboutImage.Margin" Value="0,12,12,0" />
-                        <Setter Target="AboutTitle.Visibility" Value="Collapsed" />
-                    </VisualState.Setters>
-                </VisualState>
-            </VisualStateGroup>
-        </VisualStateManager.VisualStateGroups>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*"/>
-            <ColumnDefinition Width="Auto"/>
-        </Grid.ColumnDefinitions>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto" />
-        </Grid.RowDefinitions>
+    <controls:SettingsPageControl x:Uid="About_ColorPicker"
+                                  ModuleImageSource="ms-appx:///Assets/Modules/ColorPicker.png"
+                                  ModuleImageLink="https://aka.ms/PowerToysOverview_ColorPicker">
+        <controls:SettingsPageControl.ModuleContent>
 
         <StackPanel Orientation="Vertical"
                     x:Name="ColorPickerView"
@@ -60,7 +28,7 @@
                        Style="{StaticResource SettingsGroupTitleStyle}"
                        Opacity="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToOpacityConverter}}"/>
             
-            <Custom:HotkeySettingsControl x:Uid="ColorPicker_ActivationShortcut"
+            <controls:HotkeySettingsControl x:Uid="ColorPicker_ActivationShortcut"
                                           Margin="{StaticResource SmallTopMargin}"
                                           HotkeySettings="{x:Bind Path=ViewModel.ActivationShortcut, Mode=TwoWay}"
                                           Keys="Win, Ctrl, Alt, Shift"
@@ -264,58 +232,15 @@
                           -->
         </StackPanel>
 
-        <RelativePanel x:Name="SidePanel" 
-                    HorizontalAlignment="Left"
-                    Width="{StaticResource SidePanelWidth}"
-                    Grid.Column="1">
-            <StackPanel x:Name="DescriptionPanel">
-                <TextBlock x:Uid="About_ColorPicker"
-                           x:Name="AboutTitle"
-                           Grid.ColumnSpan="2"
-                           Style="{StaticResource SettingsGroupTitleStyle}"
-                           Margin="{StaticResource XSmallBottomMargin}"/>
-                <TextBlock x:Uid="ColorPicker_Description"
-                           TextWrapping="Wrap"
-                           Grid.Row="1" />
-            </StackPanel>
+</controls:SettingsPageControl.ModuleContent>
 
-            <Border x:Name="AboutImage"
-                    CornerRadius="4"
-                    Grid.Row="2"
-                    MaxWidth="240"
-                    HorizontalAlignment="Left"
-                    Margin="{StaticResource SmallTopBottomMargin}"
-                    RelativePanel.Below="DescriptionPanel">
-                <HyperlinkButton x:Uid="ColorPicker_ImageHyperlinkToDocs">
-                    <Image x:Uid="ColorPicker_Image" Source="ms-appx:///Assets/Modules/ColorPicker.png" />
-                </HyperlinkButton>
-            </Border>
-            <StackPanel x:Name="LinksPanel"
-                        Margin="0,1,0,0"
-                        RelativePanel.Below="AboutImage"
-                        Orientation="Vertical" >
-                <HyperlinkButton x:Uid="ColorPicker_ImageHyperlinkToDocs">
-                    <TextBlock x:Uid="Module_overview" />
-                </HyperlinkButton>
-                <HyperlinkButton NavigateUri="https://aka.ms/powerToysGiveFeedback">
-                    <TextBlock x:Uid="Give_Feedback" />
-                </HyperlinkButton>
-
-                <TextBlock 
-                x:Uid="AttributionTitle"
-                Style="{StaticResource SettingsGroupTitleStyle}" />
-
-                <HyperlinkButton Margin="0,-3,0,0"
-                                NavigateUri="https://github.com/martinchrzan/ColorPicker/">
-                    <TextBlock Text="Martin Chrzan's Color Picker" TextWrapping="Wrap" />
-                </HyperlinkButton>
-
-                <HyperlinkButton Margin="0,-3,0,0"
-                                NavigateUri="https://medium.com/@Niels9001/a-fluent-color-meter-for-powertoys-20407ededf0c">
-                    <TextBlock Text="Niels Laute's UX concept" TextWrapping="Wrap" />
-                </HyperlinkButton>
-                
-            </StackPanel>
-        </RelativePanel>
-    </Grid>
+<controls:SettingsPageControl.ModuleLinks>
+            <controls:SidePanelLink x:Uid="Learn_More" Link="https://aka.ms/PowerToysOverview_ColorPicker"/>
+    <controls:SidePanelLink x:Uid="Give_Feedback" Link="https://aka.ms/powerToysGiveFeedback"/>
+</controls:SettingsPageControl.ModuleLinks>
+<controls:SettingsPageControl.AttributionLinks>
+    <controls:SidePanelLink Label="Martin Chrzan's Color Picker" Link="https://github.com/martinchrzan/ColorPicker/"/>
+    <controls:SidePanelLink Label="Niels Laute's UX concept" Link="https://medium.com/@Niels9001/a-fluent-color-meter-for-powertoys-20407ededf0c"/>
+</controls:SettingsPageControl.AttributionLinks>
+</controls:SettingsPageControl>
 </Page>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -2,15 +2,11 @@
     x:Class="Microsoft.PowerToys.Settings.UI.Views.FancyZonesPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:Microsoft.PowerToys.Settings.UI.Views"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:viewModel="using:Microsoft.PowerToys.Settings.UI.ViewModels"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
-    xmlns:CustomControls="using:Microsoft.PowerToys.Settings.UI.Controls"
-    xmlns:converters="using:Microsoft.Toolkit.Uwp.UI.Converters"
-    xmlns:Interactivity="using:Microsoft.Xaml.Interactivity"
-    xmlns:Core="using:Microsoft.Xaml.Interactions.Core"        
+    xmlns:controls="using:Microsoft.PowerToys.Settings.UI.Controls"
+    xmlns:converters="using:Microsoft.Toolkit.Uwp.UI.Converters"     
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     AutomationProperties.LandmarkType="Main">
@@ -19,46 +15,11 @@
         <converters:StringFormatConverter x:Key="StringFormatConverter"/>
     </Page.Resources>
 
-    <Grid x:Name="MainView" RowSpacing="{StaticResource DefaultRowSpacing}">
-        <VisualStateManager.VisualStateGroups>
-            <VisualStateGroup x:Name="LayoutVisualStates">
-                <VisualState x:Name="WideLayout">
-                    <VisualState.StateTriggers>
-                        <AdaptiveTrigger MinWindowWidth="{StaticResource WideLayoutMinWidth}" />
-                    </VisualState.StateTriggers>
-                </VisualState>
-                <VisualState x:Name="SmallLayout">
-                    <VisualState.StateTriggers>
-                        <AdaptiveTrigger MinWindowWidth="{StaticResource SmallLayoutMinWidth}" />
-                        <AdaptiveTrigger MinWindowWidth="0" />
-                    </VisualState.StateTriggers>
-                    <VisualState.Setters>
-                        <Setter Target="SidePanel.(Grid.Column)" Value="0"/>
-                        <Setter Target="SidePanel.Width" Value="Auto"/>
-                        <Setter Target="FZView.(Grid.Row)" Value="1" />
-                        <Setter Target="FZView.Margin" Value="0" />
-                        <Setter Target="LinksPanel.(RelativePanel.RightOf)" Value="AboutImage"/>
-                        <Setter Target="LinksPanel.(RelativePanel.AlignTopWith)" Value="AboutImage"/>
-                        <Setter Target="AboutImage.Margin" Value="0,12,12,0"/>
-                        <Setter Target="AboutTitle.Visibility" Value="Collapsed" />
-                    </VisualState.Setters>
-                </VisualState>
-            </VisualStateGroup>
-        </VisualStateManager.VisualStateGroups>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*"/>
-            <ColumnDefinition Width="Auto"/>
-        </Grid.ColumnDefinitions>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto" />
-        </Grid.RowDefinitions>
-
-        <StackPanel x:Name="FZView"
-                    Orientation="Vertical"
-                    HorizontalAlignment="Left"
-                    Margin="0,0,48,0"
-                    MaxWidth="{StaticResource MaxContentWidth}">
+    <controls:SettingsPageControl x:Uid="About_FancyZones"
+                                  ModuleImageSource="ms-appx:///Assets/Modules/FancyZones.png"
+                                  ModuleImageLink="https://aka.ms/PowerToysOverview_FancyZones">
+        <controls:SettingsPageControl.ModuleContent>
+            <StackPanel Orientation="Vertical">
             <ToggleSwitch x:Name="FancyZones_EnableToggleControl_HeaderText"
                             x:Uid="FancyZones_EnableToggleControl_HeaderText"
                             IsOn="{x:Bind Mode=TwoWay, Path=ViewModel.IsEnabled}"/>
@@ -82,7 +43,7 @@
                 </StackPanel>
             </Button>
             
-            <CustomControls:HotkeySettingsControl 
+            <controls:HotkeySettingsControl 
                 x:Uid="FancyZones_HotkeyEditorControl"
                 Margin="{StaticResource SmallTopMargin}"
                 HotkeySettings="{x:Bind Path=ViewModel.EditorHotkey, Mode=TwoWay}"
@@ -345,42 +306,12 @@
                      MinHeight="160" />
         </StackPanel>
 
-        <RelativePanel x:Name="SidePanel" 
-                    HorizontalAlignment="Left"
-                    Width="{StaticResource SidePanelWidth}"
-                    Grid.Column="1">
-            <StackPanel x:Name="DescriptionPanel">
-                <TextBlock x:Uid="About_FancyZones"
-                           x:Name="AboutTitle" Grid.ColumnSpan="2"
-                       Style="{StaticResource SettingsGroupTitleStyle}"
-                       Margin="{StaticResource XSmallBottomMargin}"/>
-                <TextBlock x:Uid="FancyZones_Description"
-                           TextWrapping="Wrap"/>
-            </StackPanel>
+        
+</controls:SettingsPageControl.ModuleContent>
 
-            <Border x:Name="AboutImage"
-                    CornerRadius="4"
-                    Grid.Row="2"
-                    MaxWidth="240"
-                    HorizontalAlignment="Left"
-                    Margin="{StaticResource SmallTopBottomMargin}"
-                    RelativePanel.Below="DescriptionPanel">
-                <HyperlinkButton x:Uid="FancyZones_ImageHyperlinkToDocs">
-                    <Image x:Uid="Fancyzones_Image" Source="ms-appx:///Assets/Modules/FancyZones.png" />
-                </HyperlinkButton>
-            </Border>
-
-            <StackPanel x:Name="LinksPanel"
-                        Margin="0,1,0,0"
-                        RelativePanel.Below="AboutImage"
-                        Orientation="Vertical" >
-                <HyperlinkButton x:Uid="FancyZones_ImageHyperlinkToDocs">
-                    <TextBlock x:Uid="Module_overview" />
-                </HyperlinkButton>
-                <HyperlinkButton NavigateUri="https://aka.ms/powerToysGiveFeedback">
-                    <TextBlock x:Uid="Give_Feedback" />
-                </HyperlinkButton>
-            </StackPanel>
-        </RelativePanel>
-    </Grid>
+<controls:SettingsPageControl.ModuleLinks>
+    <controls:SidePanelLink x:Uid="Learn_More" Link="https://aka.ms/PowerToysOverview_FancyZones"/>
+    <controls:SidePanelLink x:Uid="Give_Feedback" Link="https://aka.ms/powerToysGiveFeedback"/>
+</controls:SettingsPageControl.ModuleLinks>
+</controls:SettingsPageControl>
 </Page>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml
@@ -2,12 +2,11 @@
     x:Class="Microsoft.PowerToys.Settings.UI.Views.GeneralPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:Microsoft.PowerToys.Settings.UI.Views"
+    xmlns:controls="using:Microsoft.PowerToys.Settings.UI.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:converters="using:Microsoft.Toolkit.Uwp.UI.Converters"
     xmlns:localConverters="using:Microsoft.PowerToys.Settings.UI.Converters"
-    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     AutomationProperties.LandmarkType="Main">
@@ -21,334 +20,257 @@
         <localConverters:UpdatingStateReadyToInstallToVisibilityConverter x:Key="UpdatingStateReadyToInstallToVisibilityConverter" />
     </Page.Resources>
 
-    <Grid RowSpacing="{StaticResource DefaultRowSpacing}">
-        <VisualStateManager.VisualStateGroups>
-            <VisualStateGroup x:Name="LayoutVisualStates">
-                <VisualState x:Name="WideLayout">
-                    <VisualState.StateTriggers>
-                        <AdaptiveTrigger MinWindowWidth="{StaticResource WideLayoutMinWidth}" />
-                    </VisualState.StateTriggers>
-                </VisualState>
-                <VisualState x:Name="SmallLayout">
-                    <VisualState.StateTriggers>
-                        <AdaptiveTrigger MinWindowWidth="{StaticResource SmallLayoutMinWidth}" />
-                        <AdaptiveTrigger MinWindowWidth="0" />
-                    </VisualState.StateTriggers>
-                    <VisualState.Setters>
-                        <Setter Target="SidePanel.(Grid.Column)" Value="0"/>
-                        <Setter Target="SidePanel.Width" Value="Auto"/>
-                        <Setter Target="GeneralView.(Grid.Row)" Value="1" />
-                        <Setter Target="GeneralView.Margin" Value="0" />
-                        <Setter Target="LinksPanel.(RelativePanel.RightOf)" Value="AboutImage"/>
-                        <Setter Target="LinksPanel.(RelativePanel.AlignTopWith)" Value="AboutImage"/>
-                        <Setter Target="AboutImage.Margin" Value="0,12,12,0"/>
-                        <Setter Target="AboutTitle.Visibility" Value="Collapsed" />
-                    </VisualState.Setters>
-                </VisualState>
-            </VisualStateGroup>
-        </VisualStateManager.VisualStateGroups>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*"/>
-            <ColumnDefinition Width="Auto"/>
-        </Grid.ColumnDefinitions>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto" />
-        </Grid.RowDefinitions>
-
-        <StackPanel Orientation="Vertical"
-                    x:Name="GeneralView"
-                    Margin="0,0,48,0"
-                    HorizontalAlignment="Left"
-                    MaxWidth="{StaticResource MaxContentWidth}">
-            <TextBlock x:Uid="Admin_Mode" 
+    <controls:SettingsPageControl x:Uid="About_PowerToys"
+                                  ModuleImageSource="ms-appx:///Assets/Modules/PT.png"
+                                  ModuleImageLink="https://aka.ms/powertoys">
+        <controls:SettingsPageControl.ModuleContent>
+            <StackPanel Orientation="Vertical">
+                <TextBlock x:Uid="Admin_Mode" 
                        FontWeight="SemiBold"
                        TextWrapping="Wrap"
                        AutomationProperties.HeadingLevel="Level2"
                        Style="{StaticResource SubtitleTextBlockStyle}"/>
 
-            <TextBlock Text="{Binding Mode=TwoWay, Path=RunningAsText}"
+                <TextBlock Text="{Binding Mode=TwoWay, Path=RunningAsText}"
                        TextWrapping="Wrap"
                        Margin="{StaticResource SmallTopMargin}"/>
 
-            <Button x:Uid="GeneralPage_RestartAsAdmin_Button"
+                <Button x:Uid="GeneralPage_RestartAsAdmin_Button"
                     Margin="{StaticResource SmallTopMargin}"
                     Style="{StaticResource AccentButtonStyle}"
                     Command = "{Binding RestartElevatedButtonEventHandler}"
                     IsEnabled="{Binding Mode=TwoWay, Path=IsAdminButtonEnabled}"
                     />
 
-            <TextBlock x:Uid="General_RunAsAdminRequired"
+                <TextBlock x:Uid="General_RunAsAdminRequired"
                        Foreground="{ThemeResource SystemControlErrorTextForegroundBrush}"
                        TextWrapping="Wrap"
                        Visibility="{Binding Mode=TwoWay, Path=IsElevated, Converter={StaticResource BoolToVisibilityConverter}}"
                        Margin="0,24,0,-8" />
 
-            <ToggleSwitch Margin="{StaticResource SmallTopMargin}"
+                <ToggleSwitch Margin="{StaticResource SmallTopMargin}"
                           x:Uid="GeneralSettings_AlwaysRunAsAdminText"
                           IsEnabled="{Binding Mode=TwoWay, Path=IsElevated}"
                           IsOn="{Binding Mode=TwoWay, Path=RunElevated}"/>
 
-            <HyperlinkButton NavigateUri="https://aka.ms/powertoysDetectedElevatedHelp">
-                <TextBlock x:Uid="GeneralPage_ToggleSwitch_AlwaysRunElevated_Link" TextWrapping="Wrap" />
-            </HyperlinkButton>
+                <HyperlinkButton NavigateUri="https://aka.ms/powertoysDetectedElevatedHelp">
+                    <TextBlock x:Uid="GeneralPage_ToggleSwitch_AlwaysRunElevated_Link" TextWrapping="Wrap" />
+                </HyperlinkButton>
 
 
-            <TextBlock x:Uid="ShortcutGuide_Appearance_Behavior"
+                <TextBlock x:Uid="ShortcutGuide_Appearance_Behavior"
                        Style="{StaticResource SettingsGroupTitleStyle}"/>
 
-            <!-- Replaced the Radiobuttons parent control with a StackPanel to mitigate the Tab and Arrow key related keyboard navigation issues due to XAML Islands
+                <!-- Replaced the Radiobuttons parent control with a StackPanel to mitigate the Tab and Arrow key related keyboard navigation issues due to XAML Islands
             Tracking issue in the winui repository - https://github.com/microsoft/microsoft-ui-xaml/issues/3156 -->
-            <TextBlock x:Name="RadioButtons_Name_Theme" 
+                <TextBlock x:Name="RadioButtons_Name_Theme" 
                        x:Uid="ColorModeHeader"
                        Margin="{StaticResource SmallTopMargin}"/>
-            <StackPanel AutomationProperties.LabeledBy="{Binding ElementName=RadioButtons_Name_Theme}">
-                <RadioButton x:Uid="Radio_Theme_Dark"
+                <StackPanel AutomationProperties.LabeledBy="{Binding ElementName=RadioButtons_Name_Theme}">
+                    <RadioButton x:Uid="Radio_Theme_Dark"
                              IsChecked="{ Binding Mode=TwoWay, Path=IsDarkThemeRadioButtonChecked}"/>
 
-                <RadioButton x:Uid="Radio_Theme_Light" 
+                    <RadioButton x:Uid="Radio_Theme_Light" 
                              IsChecked="{ Binding Mode=TwoWay, Path=IsLightThemeRadioButtonChecked}"/>
 
-                <RadioButton x:Uid="Radio_Theme_Default"
+                    <RadioButton x:Uid="Radio_Theme_Default"
                              IsChecked="{ Binding Mode=TwoWay, Path=IsSystemThemeRadioButtonChecked}"/>
-                <HyperlinkButton Click="OpenColorsSettings_Click">
-                    <TextBlock x:Uid="Windows_Color_Settings" />
-                </HyperlinkButton>
-            </StackPanel>
+                    <HyperlinkButton Click="OpenColorsSettings_Click">
+                        <TextBlock x:Uid="Windows_Color_Settings" />
+                    </HyperlinkButton>
+                </StackPanel>
 
-            <ToggleSwitch x:Uid="GeneralPage_ToggleSwitch_RunAtStartUp"  
+                <ToggleSwitch x:Uid="GeneralPage_ToggleSwitch_RunAtStartUp"  
                           Margin="{StaticResource SmallTopMargin}" 
                           IsOn="{Binding Mode=TwoWay, Path=Startup}"/>
 
 
-            <TextBlock x:Uid="General_Updates"
+                <TextBlock x:Uid="General_Updates"
                        Style="{StaticResource SettingsGroupTitleStyle}"/>
 
-            <StackPanel Visibility="{Binding PowerToysUpdatingState, Converter={StaticResource UpdatingStateUpToDateToVisibilityConverter}}">
-                <StackPanel Orientation="Horizontal"
+                <StackPanel Visibility="{Binding PowerToysUpdatingState, Converter={StaticResource UpdatingStateUpToDateToVisibilityConverter}}">
+                    <StackPanel Orientation="Horizontal"
                             Margin="{StaticResource SmallTopMargin}"
                             AutomationProperties.LabeledBy="{Binding ElementName=General_Version}">
-                    <TextBlock x:Name="General_Version_UpToDate" 
+                        <TextBlock x:Name="General_Version_UpToDate" 
                                x:Uid="General_Version" 
                                Opacity="{Binding AutoUpdatesEnabled, Converter={StaticResource ModuleEnabledToOpacityConverter}}"/>
-                    <TextBlock Text="{Binding PowerToysVersion }"
+                        <TextBlock Text="{Binding PowerToysVersion }"
                                Margin="4,0,0,0"
                                Opacity="{Binding AutoUpdatesEnabled, Converter={StaticResource ModuleEnabledToOpacityConverter}}"/>
-                </StackPanel>
+                    </StackPanel>
 
-                <StackPanel Orientation="Horizontal"
+                    <StackPanel Orientation="Horizontal"
                             Margin="{StaticResource SmallTopMargin}"
                             AutomationProperties.LabeledBy="{Binding ElementName=General_VersionLastChecked}"
                             Visibility="{Binding AutoUpdatesEnabled, Converter={StaticResource VisibleIfTrueConverter}}">
-                    
-                    <TextBlock x:Name="General_VersionLastChecked"
+
+                        <TextBlock x:Name="General_VersionLastChecked"
                                x:Uid="General_VersionLastChecked"
                                Opacity="{Binding AutoUpdatesEnabled, Converter={StaticResource ModuleEnabledToOpacityConverter}}"/>
 
-                    <TextBlock Text="{Binding UpdateCheckedDate, Mode=OneWay}"
+                        <TextBlock Text="{Binding UpdateCheckedDate, Mode=OneWay}"
                                Opacity="{Binding AutoUpdatesEnabled, Converter={StaticResource ModuleEnabledToOpacityConverter}}"
                                Margin="6,0" />
-                </StackPanel>
+                    </StackPanel>
 
-                <TextBlock x:Name="General_CheckingForUpdates"
+                    <TextBlock x:Name="General_CheckingForUpdates"
                            x:Uid="General_CheckingForUpdates"
                            Margin="{StaticResource SmallTopMargin}"
                            Visibility="{Binding IsNewVersionDownloading, Converter={StaticResource VisibleIfTrueConverter}}"/>
 
-                <TextBlock x:Name="General_UpToDate"
+                    <TextBlock x:Name="General_UpToDate"
                            x:Uid="General_UpToDate"
                            Margin="{StaticResource SmallTopMargin}"
                            Opacity="{Binding AutoUpdatesEnabled, Converter={StaticResource ModuleEnabledToOpacityConverter}}"
                            Visibility="{Binding IsNewVersionCheckedAndUpToDate, Converter={StaticResource VisibleIfTrueConverter}}"/>
 
-                <Button x:Uid="GeneralPage_CheckForUpdates"
+                    <Button x:Uid="GeneralPage_CheckForUpdates"
                         Style="{StaticResource AccentButtonStyle}"
                         Foreground="White"
                         Margin="{StaticResource SmallTopMargin}"
                         Command="{Binding CheckForUpdatesEventHandler}"
                         IsEnabled="{Binding IsDownloadAllowed}"
                         />
-            </StackPanel>
-
-            <StackPanel Visibility="{Binding PowerToysUpdatingState, Converter={StaticResource UpdatingStateReadyToDownloadToVisibilityConverter}}">
-                <StackPanel Orientation="Horizontal"
-                            Margin="{StaticResource SmallTopMargin}"
-                            AutomationProperties.LabeledBy="{Binding ElementName=General_Version}">
-                    <TextBlock x:Name="General_Version_ReadyToDownload" 
-                               x:Uid="General_Version" 
-                               Opacity="{Binding AutoUpdatesEnabled, Converter={StaticResource ModuleEnabledToOpacityConverter}}"/>
-                    <TextBlock Text="{Binding PowerToysVersion }"
-                               Margin="4,0,0,0"
-                               Opacity="{Binding AutoUpdatesEnabled, Converter={StaticResource ModuleEnabledToOpacityConverter}}"/>
                 </StackPanel>
 
-                <StackPanel Orientation="Horizontal"
+                <StackPanel Visibility="{Binding PowerToysUpdatingState, Converter={StaticResource UpdatingStateReadyToDownloadToVisibilityConverter}}">
+                    <StackPanel Orientation="Horizontal"
                             Margin="{StaticResource SmallTopMargin}"
                             AutomationProperties.LabeledBy="{Binding ElementName=General_Version}">
-                    <TextBlock x:Name="General_NewVersionAvailable"
+                        <TextBlock x:Name="General_Version_ReadyToDownload" 
+                               x:Uid="General_Version" 
+                               Opacity="{Binding AutoUpdatesEnabled, Converter={StaticResource ModuleEnabledToOpacityConverter}}"/>
+                        <TextBlock Text="{Binding PowerToysVersion }"
+                               Margin="4,0,0,0"
+                               Opacity="{Binding AutoUpdatesEnabled, Converter={StaticResource ModuleEnabledToOpacityConverter}}"/>
+                    </StackPanel>
+
+                    <StackPanel Orientation="Horizontal"
+                            Margin="{StaticResource SmallTopMargin}"
+                            AutomationProperties.LabeledBy="{Binding ElementName=General_Version}">
+                        <TextBlock x:Name="General_NewVersionAvailable"
                                x:Uid="General_NewVersionAvailable"
                                FontWeight="SemiBold"
                                Opacity="{Binding AutoUpdatesEnabled, Converter={StaticResource ModuleEnabledToOpacityConverter}}"/>
-                    
-                    <HyperlinkButton NavigateUri="{Binding PowerToysNewAvailableVersionLink }" Margin="4,-6,0,0" IsEnabled="{Binding AutoUpdatesEnabled}">
-                        <TextBlock Text="{Binding PowerToysNewAvailableVersion }" Style="{StaticResource SemiBoldBody}"/>
-                    </HyperlinkButton>
-                    
-                    <HyperlinkButton NavigateUri="{Binding PowerToysNewAvailableVersionLink}" 
+
+                        <HyperlinkButton NavigateUri="{Binding PowerToysNewAvailableVersionLink }" Margin="4,-6,0,0" IsEnabled="{Binding AutoUpdatesEnabled}">
+                            <TextBlock Text="{Binding PowerToysNewAvailableVersion }" Style="{StaticResource SemiBoldBody}"/>
+                        </HyperlinkButton>
+
+                        <HyperlinkButton NavigateUri="{Binding PowerToysNewAvailableVersionLink}" 
                                      Margin="4,-6,0,0" 
                                      IsEnabled="{Binding AutoUpdatesEnabled}">
-                        <TextBlock x:Name="General_ReadMore_ReadyToDownload" x:Uid="General_ReadMore" />
-                    </HyperlinkButton>
-                </StackPanel>
+                            <TextBlock x:Name="General_ReadMore_ReadyToDownload" x:Uid="General_ReadMore" />
+                        </HyperlinkButton>
+                    </StackPanel>
 
-                <TextBlock x:Name="General_Downloading"
+                    <TextBlock x:Name="General_Downloading"
                            x:Uid="General_Downloading"
                            Visibility="{Binding Mode=OneWay, Path=IsNewVersionDownloading, Converter={StaticResource VisibleIfTrueConverter}}"
                            Opacity="{Binding AutoUpdatesEnabled, Converter={StaticResource ModuleEnabledToOpacityConverter}}"/>
 
-                <Button x:Uid="General_DownloadAndInstall"
+                    <Button x:Uid="General_DownloadAndInstall"
                         Margin="{StaticResource SmallTopMargin}"
                         Style="{StaticResource AccentButtonStyle}"
                         Foreground="White"
                         Command="{Binding UpdateNowButtonEventHandler}"
                         IsEnabled="{Binding IsDownloadAllowed}"/>
-            </StackPanel>
+                </StackPanel>
 
-            <StackPanel Visibility="{Binding PowerToysUpdatingState, Converter={StaticResource UpdatingStateReadyToInstallToVisibilityConverter}}">
-                <StackPanel Orientation="Horizontal"
+                <StackPanel Visibility="{Binding PowerToysUpdatingState, Converter={StaticResource UpdatingStateReadyToInstallToVisibilityConverter}}">
+                    <StackPanel Orientation="Horizontal"
                             Margin="{StaticResource SmallTopMargin}"
                             AutomationProperties.LabeledBy="{Binding ElementName=General_Version}">
-                    <TextBlock x:Name="General_Version_ReadyToInstall" 
+                        <TextBlock x:Name="General_Version_ReadyToInstall" 
                                x:Uid="General_Version" 
                                Opacity="{Binding AutoUpdatesEnabled, Converter={StaticResource ModuleEnabledToOpacityConverter}}"/>
-                    <TextBlock Text="{Binding PowerToysVersion }"
+                        <TextBlock Text="{Binding PowerToysVersion }"
                                Margin="4,0,0,0"
                                Opacity="{Binding AutoUpdatesEnabled, Converter={StaticResource ModuleEnabledToOpacityConverter}}"/>
-                </StackPanel>
-                
-                <StackPanel Orientation="Horizontal"
+                    </StackPanel>
+
+                    <StackPanel Orientation="Horizontal"
                             Margin="{StaticResource SmallTopMargin}"
                             AutomationProperties.LabeledBy="{Binding ElementName=General_Version}">
-                    <TextBlock x:Name="General_NewVersionReadyToInstall"
+                        <TextBlock x:Name="General_NewVersionReadyToInstall"
                                x:Uid="General_NewVersionReadyToInstall"
                                Style="{StaticResource SemiBoldBody}"
                                Opacity="{Binding AutoUpdatesEnabled, Converter={StaticResource ModuleEnabledToOpacityConverter}}"/>
-                    <HyperlinkButton NavigateUri="{Binding PowerToysNewAvailableVersionLink }" Margin="4,-6,0,0" IsEnabled="{Binding AutoUpdatesEnabled}">
-                        <TextBlock Text="{Binding PowerToysNewAvailableVersion }" Style="{StaticResource SemiBoldBody}"/>
-                    </HyperlinkButton>
+                        <HyperlinkButton NavigateUri="{Binding PowerToysNewAvailableVersionLink }" Margin="4,-6,0,0" IsEnabled="{Binding AutoUpdatesEnabled}">
+                            <TextBlock Text="{Binding PowerToysNewAvailableVersion }" Style="{StaticResource SemiBoldBody}"/>
+                        </HyperlinkButton>
 
-                    <HyperlinkButton NavigateUri="{Binding PowerToysNewAvailableVersionLink}" 
+                        <HyperlinkButton NavigateUri="{Binding PowerToysNewAvailableVersionLink}" 
                                      Margin="4,-6,0,0" 
                                      IsEnabled="{Binding AutoUpdatesEnabled}">
-                        <TextBlock x:Name="General_ReadMore_ReadyToInstall" x:Uid="General_ReadMore" />
-                    </HyperlinkButton>
-                </StackPanel>
+                            <TextBlock x:Name="General_ReadMore_ReadyToInstall" x:Uid="General_ReadMore" />
+                        </HyperlinkButton>
+                    </StackPanel>
 
-                <Button x:Uid="General_InstallNow"
+                    <Button x:Uid="General_InstallNow"
                         Margin="{StaticResource SmallTopMargin}"
                         Style="{StaticResource AccentButtonStyle}"
                         Foreground="White"
                         Command="{Binding UpdateNowButtonEventHandler}"
                         IsEnabled="{Binding AutoUpdatesEnabled}"/>
-            </StackPanel>
+                </StackPanel>
 
-            <StackPanel Visibility="{Binding PowerToysUpdatingState, Converter={StaticResource UpdatingStateCannotDownloadToVisibilityConverter}}">
-                <StackPanel Orientation="Horizontal"
+                <StackPanel Visibility="{Binding PowerToysUpdatingState, Converter={StaticResource UpdatingStateCannotDownloadToVisibilityConverter}}">
+                    <StackPanel Orientation="Horizontal"
                             Margin="{StaticResource SmallTopMargin}"
                             AutomationProperties.LabeledBy="{Binding ElementName=General_Version}">
-                    <TextBlock x:Name="General_Version_Error" 
+                        <TextBlock x:Name="General_Version_Error" 
                                x:Uid="General_Version" 
                                Opacity="{Binding AutoUpdatesEnabled, Converter={StaticResource ModuleEnabledToOpacityConverter}}"/>
-                    <TextBlock Text="{Binding PowerToysVersion }"
+                        <TextBlock Text="{Binding PowerToysVersion }"
                                Margin="4,0,0,0"
                                Opacity="{Binding AutoUpdatesEnabled, Converter={StaticResource ModuleEnabledToOpacityConverter}}"/>
-                </StackPanel>
+                    </StackPanel>
 
-                <StackPanel Orientation="Horizontal"
+                    <StackPanel Orientation="Horizontal"
                             Margin="{StaticResource SmallTopMargin}"
                             AutomationProperties.LabeledBy="{Binding ElementName=General_Version}">
-                    <TextBlock x:Name="General_FailedToDownloadTheNewVersion" 
+                        <TextBlock x:Name="General_FailedToDownloadTheNewVersion" 
                                x:Uid="General_FailedToDownloadTheNewVersion"
                                Foreground="{ThemeResource SystemControlErrorTextForegroundBrush}"/>
-                    <HyperlinkButton NavigateUri="{Binding PowerToysNewAvailableVersionLink }" Margin="4,-6,0,0" IsEnabled="{Binding AutoUpdatesEnabled}">
-                        <TextBlock Text="{Binding PowerToysNewAvailableVersion }" />
-                    </HyperlinkButton>
-                </StackPanel>
+                        <HyperlinkButton NavigateUri="{Binding PowerToysNewAvailableVersionLink }" Margin="4,-6,0,0" IsEnabled="{Binding AutoUpdatesEnabled}">
+                            <TextBlock Text="{Binding PowerToysNewAvailableVersion }" />
+                        </HyperlinkButton>
+                    </StackPanel>
 
-                <TextBlock x:Name="General_Downloading_TryAgain"
+                    <TextBlock x:Name="General_Downloading_TryAgain"
                            x:Uid="General_Downloading"
                            Visibility="{Binding Mode=OneWay, Path=IsNewVersionDownloading, Converter={StaticResource VisibleIfTrueConverter}}"
                            Opacity="{Binding AutoUpdatesEnabled, Converter={StaticResource ModuleEnabledToOpacityConverter}}"/>
-                
-                <Button x:Uid="General_TryAgainToDownloadAndInstall"
+
+                    <Button x:Uid="General_TryAgainToDownloadAndInstall"
                         Margin="{StaticResource SmallTopMargin}"
                         Style="{StaticResource AccentButtonStyle}"
                         Foreground="White"
                         Command="{Binding UpdateNowButtonEventHandler}"
                         IsEnabled="{Binding IsDownloadAllowed}"/>
-            </StackPanel>
+                </StackPanel>
 
-            <ToggleSwitch x:Uid="GeneralPage_ToggleSwitch_AutoDownloadUpdates" 
+                <ToggleSwitch x:Uid="GeneralPage_ToggleSwitch_AutoDownloadUpdates" 
                           Margin="{StaticResource MediumTopMargin}"
                           Visibility="{Binding Mode=TwoWay, Path=IsAdmin, Converter={StaticResource VisibleIfTrueConverter}}"
                           IsOn="{Binding Mode=TwoWay, Path=AutoDownloadUpdates}"
                           IsEnabled="{Binding AutoUpdatesEnabled}" />
-        </StackPanel>
-
-        <RelativePanel x:Name="SidePanel" 
-                    HorizontalAlignment="Left"
-                    Width="{StaticResource SidePanelWidth}"
-                    Grid.Column="1">
-            <StackPanel x:Name="DescriptionPanel">
-                <TextBlock x:Uid="GeneralPage_AboutPowerToysHeader" 
-                           x:Name="AboutTitle" 
-                           Grid.ColumnSpan="2"
-                           Style="{StaticResource SettingsGroupTitleStyle}"
-                           Margin="{StaticResource XSmallBottomMargin}"/>
-                <TextBlock x:Uid="About_PowerToys" TextWrapping="Wrap" />
-                <TextBlock x:Uid="MadeWithOssLove" TextWrapping="Wrap" Margin="0, 10, 0, 0" />
             </StackPanel>
-
-            <Border x:Name="AboutImage"
-                    CornerRadius="4"
-                    Grid.Row="2"
-                    MaxWidth="240"
-                    HorizontalAlignment="Left"
-                    Margin="{StaticResource SmallTopBottomMargin}"
-                    RelativePanel.Below="DescriptionPanel">
-                <HyperlinkButton x:Uid="GeneralPage_ImageHyperlinkToDocs">
-                    <Image x:Uid="PowerToys_Icon" Source="ms-appx:///Assets/Modules/PT.png"/>
-                </HyperlinkButton>
-            </Border>
-            <StackPanel x:Name="LinksPanel"
-                        Margin="0,1,0,0"
-                        RelativePanel.Below="AboutImage"
-                        Orientation="Vertical" >
-
+        </controls:SettingsPageControl.ModuleContent>
+        <!-- 
                 <HyperlinkButton Click="OobeButton_Click">
                     <TextBlock x:Uid="Oobe_Button"/>
-                </HyperlinkButton>
-                
-                <HyperlinkButton x:Uid="GeneralPage_ImageHyperlinkToDocs">
-                    <TextBlock x:Uid="General_Repository"/>
-                </HyperlinkButton>
+                </HyperlinkButton> -->
+        <!-- Side panel -->
 
-                <HyperlinkButton NavigateUri="https://aka.ms/powerToysReportBug">
-                    <TextBlock x:Uid="GeneralPage_ReportAbug"/>
-                </HyperlinkButton>
-
-                <HyperlinkButton NavigateUri="https://aka.ms/powerToysRequestFeature">
-                    <TextBlock x:Uid="GeneralPage_RequestAFeature_URL"/>
-                </HyperlinkButton>
-
-                <HyperlinkButton NavigateUri=" http://go.microsoft.com/fwlink/?LinkId=521839">
-                    <TextBlock x:Uid="GeneralPage_PrivacyStatement_URL"/>
-                </HyperlinkButton>
-
-                <HyperlinkButton NavigateUri="https://github.com/microsoft/PowerToys/blob/master/NOTICE.md">
-                    <TextBlock x:Uid="OpenSource_Notice"/>
-                </HyperlinkButton>
-            </StackPanel>
-        </RelativePanel>
-    </Grid>
+        <controls:SettingsPageControl.ModuleLinks>
+            <controls:SidePanelLink x:Uid="General_Repository" Link="https://aka.ms/powertoys"/>
+            <controls:SidePanelLink x:Uid="GeneralPage_ReportAbug" Link="https://aka.ms/powerToysReportBug"/>
+            <controls:SidePanelLink x:Uid="GeneralPage_RequestAFeature_URL" Link="https://aka.ms/powerToysRequestFeature"/>
+            <controls:SidePanelLink x:Uid="GeneralPage_PrivacyStatement_URL" Link="http://go.microsoft.com/fwlink/?LinkId=521839"/>
+            <controls:SidePanelLink x:Uid="OpenSource_Notice" Link="https://github.com/microsoft/PowerToys/blob/master/NOTICE.md"/>
+        </controls:SettingsPageControl.ModuleLinks>
+    </controls:SettingsPageControl>
 </Page>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml
@@ -25,6 +25,19 @@
                                   ModuleImageLink="https://aka.ms/powertoys">
         <controls:SettingsPageControl.ModuleContent>
             <StackPanel Orientation="Vertical">
+                <Button Click="OobeButton_Click"
+                        Style="{StaticResource AccentButtonStyle}"
+                        Margin="0,12,0,24">
+                    <Button.Content>
+                        <StackPanel Orientation="Horizontal">
+                            <FontIcon FontSize="13" Glyph="&#xF133;" />
+                            <TextBlock Margin="8,0,0,0"
+                               x:Uid="Oobe_Button"/>
+                    </StackPanel>
+                    </Button.Content>
+                </Button>
+                
+                
                 <TextBlock x:Uid="Admin_Mode" 
                        FontWeight="SemiBold"
                        TextWrapping="Wrap"
@@ -37,7 +50,6 @@
 
                 <Button x:Uid="GeneralPage_RestartAsAdmin_Button"
                     Margin="{StaticResource SmallTopMargin}"
-                    Style="{StaticResource AccentButtonStyle}"
                     Command = "{Binding RestartElevatedButtonEventHandler}"
                     IsEnabled="{Binding Mode=TwoWay, Path=IsAdminButtonEnabled}"
                     />
@@ -126,8 +138,6 @@
                            Visibility="{Binding IsNewVersionCheckedAndUpToDate, Converter={StaticResource VisibleIfTrueConverter}}"/>
 
                     <Button x:Uid="GeneralPage_CheckForUpdates"
-                        Style="{StaticResource AccentButtonStyle}"
-                        Foreground="White"
                         Margin="{StaticResource SmallTopMargin}"
                         Command="{Binding CheckForUpdatesEventHandler}"
                         IsEnabled="{Binding IsDownloadAllowed}"
@@ -172,8 +182,6 @@
 
                     <Button x:Uid="General_DownloadAndInstall"
                         Margin="{StaticResource SmallTopMargin}"
-                        Style="{StaticResource AccentButtonStyle}"
-                        Foreground="White"
                         Command="{Binding UpdateNowButtonEventHandler}"
                         IsEnabled="{Binding IsDownloadAllowed}"/>
                 </StackPanel>
@@ -210,8 +218,6 @@
 
                     <Button x:Uid="General_InstallNow"
                         Margin="{StaticResource SmallTopMargin}"
-                        Style="{StaticResource AccentButtonStyle}"
-                        Foreground="White"
                         Command="{Binding UpdateNowButtonEventHandler}"
                         IsEnabled="{Binding AutoUpdatesEnabled}"/>
                 </StackPanel>
@@ -246,8 +252,6 @@
 
                     <Button x:Uid="General_TryAgainToDownloadAndInstall"
                         Margin="{StaticResource SmallTopMargin}"
-                        Style="{StaticResource AccentButtonStyle}"
-                        Foreground="White"
                         Command="{Binding UpdateNowButtonEventHandler}"
                         IsEnabled="{Binding IsDownloadAllowed}"/>
                 </StackPanel>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
@@ -1,10 +1,9 @@
-﻿  <Page
+﻿<Page
     x:Class="Microsoft.PowerToys.Settings.UI.Views.ImageResizerPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:CustomControls="using:Microsoft.PowerToys.Settings.UI.Controls"    
+    xmlns:controls="using:Microsoft.PowerToys.Settings.UI.Controls"    
     xmlns:models="using:Microsoft.PowerToys.Settings.UI.Library"
-    xmlns:viewModels="using:Microsoft.PowerToys.Settings.UI.Library.ViewModels"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls" 
@@ -12,55 +11,20 @@
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     AutomationProperties.LandmarkType="Main">
 
-    <Page.Resources>
-        <!--<viewModel:ImageResizerViewModel x:Key="ViewModel"/>-->
-    </Page.Resources>
+    <controls:SettingsPageControl x:Uid="About_ImageResizer"
+                                  ModuleImageSource="ms-appx:///Assets/Modules/ImageResizer.png"
+                                  ModuleImageLink="https://aka.ms/PowerToysOverview_ImageResizer">
+        <controls:SettingsPageControl.ModuleContent>
+            <StackPanel>
 
-    <Grid RowSpacing="{StaticResource DefaultRowSpacing}">
-        <VisualStateManager.VisualStateGroups>
-            <VisualStateGroup x:Name="LayoutVisualStates">
-                <VisualState x:Name="WideLayout">
-                    <VisualState.StateTriggers>
-                        <AdaptiveTrigger MinWindowWidth="{StaticResource WideLayoutMinWidth}" />
-                    </VisualState.StateTriggers>
-                </VisualState>
-                <VisualState x:Name="SmallLayout">
-                    <VisualState.StateTriggers>
-                        <AdaptiveTrigger MinWindowWidth="{StaticResource SmallLayoutMinWidth}" />
-                        <AdaptiveTrigger MinWindowWidth="0" />
-                    </VisualState.StateTriggers>
-                    <VisualState.Setters>
-                        <Setter Target="SidePanel.(Grid.Column)" Value="0"/>
-                        <Setter Target="SidePanel.Width" Value="Auto"/>
-                        <Setter Target="ImageResizerView.(Grid.Row)" Value="1" />
-                        <Setter Target="ImageResizerView.Margin" Value="0" />
-                        <Setter Target="LinksPanel.(RelativePanel.RightOf)" Value="AboutImage"/>
-                        <Setter Target="LinksPanel.(RelativePanel.AlignTopWith)" Value="AboutImage"/>
-                        <Setter Target="AboutImage.Margin" Value="0,12,12,0"/>
-                        <Setter Target="AboutTitle.Visibility" Value="Collapsed" />
-                    </VisualState.Setters>
-                </VisualState>
-            </VisualStateGroup>
-        </VisualStateManager.VisualStateGroups>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*"/>
-            <ColumnDefinition Width="Auto"/>
-        </Grid.ColumnDefinitions>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto" />
-        </Grid.RowDefinitions>
-        <StackPanel Orientation="Vertical" x:Name="ImageResizerView"
-                    Margin="0,0,48,0">
-
-            <ToggleSwitch x:Uid="ImageResizer_EnableToggle"
+                <ToggleSwitch x:Uid="ImageResizer_EnableToggle"
                           IsOn="{x:Bind Mode=TwoWay, Path=ViewModel.IsEnabled}"/>
 
-            <TextBlock x:Uid="ImageResizer_CustomSizes"
+                <TextBlock x:Uid="ImageResizer_CustomSizes"
                        Style="{StaticResource SettingsGroupTitleStyle}"
                        Opacity="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToOpacityConverter}}"/>
 
-            <ListView x:Name="ImagesSizesListView" 
+                <ListView x:Name="ImagesSizesListView" 
                       x:Uid="ImagesSizesListView"
                       ItemsSource="{x:Bind ViewModel.Sizes, Mode=TwoWay}"
                       Padding="0,0,0,24"
@@ -71,30 +35,30 @@
                       ScrollViewer.IsHorizontalRailEnabled="True"
                       ContainerContentChanging="ImagesSizesListView_ContainerContentChanging">
 
-                <ListView.ItemContainerStyle>
-                    <Style TargetType="ListViewItem">
-                        <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}"/>
-                        <Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}"/>
-                        <Setter Property="Background" Value="{ThemeResource ListViewItemBackground}"/>
-                        <Setter Property="Foreground" Value="{ThemeResource ListViewItemForeground}"/>
-                        <Setter Property="TabNavigation" Value="Local"/>
-                        <Setter Property="IsHoldingEnabled" Value="True"/>
-                        <Setter Property="Padding" Value="0"/>
-                        <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
-                        <Setter Property="VerticalContentAlignment" Value="Center"/>
-                        <Setter Property="MinWidth" Value="{ThemeResource ListViewItemMinWidth}"/>
-                        <Setter Property="MinHeight" Value="0"/>
-                        <Setter Property="AllowDrop" Value="False"/>
-                        <Setter Property="UseSystemFocusVisuals" Value="True"/>
-                        <Setter Property="FocusVisualMargin" Value="0"/>
-                        <Setter Property="FocusVisualPrimaryBrush" Value="{ThemeResource ListViewItemFocusVisualPrimaryBrush}"/>
-                        <Setter Property="FocusVisualPrimaryThickness" Value="2"/>
-                        <Setter Property="FocusVisualSecondaryBrush" Value="{ThemeResource ListViewItemFocusVisualSecondaryBrush}"/>
-                        <Setter Property="FocusVisualSecondaryThickness" Value="1"/>
-                        <Setter Property="Template">
-                            <Setter.Value>
-                                <ControlTemplate TargetType="ListViewItem">
-                                    <ListViewItemPresenter 
+                    <ListView.ItemContainerStyle>
+                        <Style TargetType="ListViewItem">
+                            <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}"/>
+                            <Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}"/>
+                            <Setter Property="Background" Value="{ThemeResource ListViewItemBackground}"/>
+                            <Setter Property="Foreground" Value="{ThemeResource ListViewItemForeground}"/>
+                            <Setter Property="TabNavigation" Value="Local"/>
+                            <Setter Property="IsHoldingEnabled" Value="True"/>
+                            <Setter Property="Padding" Value="0"/>
+                            <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                            <Setter Property="VerticalContentAlignment" Value="Center"/>
+                            <Setter Property="MinWidth" Value="{ThemeResource ListViewItemMinWidth}"/>
+                            <Setter Property="MinHeight" Value="0"/>
+                            <Setter Property="AllowDrop" Value="False"/>
+                            <Setter Property="UseSystemFocusVisuals" Value="True"/>
+                            <Setter Property="FocusVisualMargin" Value="0"/>
+                            <Setter Property="FocusVisualPrimaryBrush" Value="{ThemeResource ListViewItemFocusVisualPrimaryBrush}"/>
+                            <Setter Property="FocusVisualPrimaryThickness" Value="2"/>
+                            <Setter Property="FocusVisualSecondaryBrush" Value="{ThemeResource ListViewItemFocusVisualSecondaryBrush}"/>
+                            <Setter Property="FocusVisualSecondaryThickness" Value="1"/>
+                            <Setter Property="Template">
+                                <Setter.Value>
+                                    <ControlTemplate TargetType="ListViewItem">
+                                        <ListViewItemPresenter 
                                         CheckBrush="{ThemeResource ListViewItemCheckBrush}" 
                                         ContentMargin="{TemplateBinding Padding}" 
                                         CheckMode="{ThemeResource ListViewItemCheckMode}" 
@@ -123,34 +87,34 @@
                                         SelectedPointerOverBackground="{ThemeResource ListViewItemBackgroundSelectedPointerOver}" 
                                         SelectedBackground="{ThemeResource ListViewItemBackgroundSelected}" 
                                         VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"/>
-                                </ControlTemplate>
-                            </Setter.Value>
-                        </Setter>
-                    </Style>
+                                    </ControlTemplate>
+                                </Setter.Value>
+                            </Setter>
+                        </Style>
 
-                </ListView.ItemContainerStyle>
-                <ListView.ItemTemplate>
-                    <DataTemplate x:Name="SingleLineDataTemplate" x:DataType="models:ImageSize" >
-                        <StackPanel Name="ImageResizer_Configurations" x:Uid="ImageResizer_Configurations" Orientation="Horizontal" Padding="0" Spacing="4">
-                            <TextBox Name="ImageResizer_Name"
+                    </ListView.ItemContainerStyle>
+                    <ListView.ItemTemplate>
+                        <DataTemplate x:Name="SingleLineDataTemplate" x:DataType="models:ImageSize" >
+                            <StackPanel Name="ImageResizer_Configurations" x:Uid="ImageResizer_Configurations" Orientation="Horizontal" Padding="0" Spacing="4">
+                                <TextBox Name="ImageResizer_Name"
                                      x:Uid="ImageResizer_Name"
                                      Text="{x:Bind Path=Name, Mode=TwoWay}" 
                                      Width="90"
                                      VerticalAlignment="Center"
                                      Margin="{StaticResource SmallTopMargin}"/>
 
-                            <ComboBox Name="ImageResizer_Fit_Property"
+                                <ComboBox Name="ImageResizer_Fit_Property"
                                       x:Uid="ImageResizer_Fit_Property"
                                       SelectedIndex="{x:Bind Path=Fit, Mode=TwoWay}"
                                       Width="90"
                                       VerticalAlignment="Center"
                                       Margin="{StaticResource SmallTopMargin}">
-                                <ComboBoxItem x:Uid="ImageResizer_Sizes_Fit_Fill" />
-                                <ComboBoxItem x:Uid="ImageResizer_Sizes_Fit_Fit" />
-                                <ComboBoxItem x:Uid="ImageResizer_Sizes_Fit_Stretch" />
-                            </ComboBox>
+                                    <ComboBoxItem x:Uid="ImageResizer_Sizes_Fit_Fill" />
+                                    <ComboBoxItem x:Uid="ImageResizer_Sizes_Fit_Fit" />
+                                    <ComboBoxItem x:Uid="ImageResizer_Sizes_Fit_Stretch" />
+                                </ComboBox>
 
-                            <muxc:NumberBox Name="ImageResizer_Width_Property"
+                                <muxc:NumberBox Name="ImageResizer_Width_Property"
                                             x:Uid="ImageResizer_Width_Property"
                                             Value="{x:Bind Path=Width, Mode=TwoWay}" 
                                             Minimum="0"
@@ -159,7 +123,7 @@
                                             VerticalAlignment="Center"
                                             Margin="{StaticResource SmallTopMargin}"/>
 
-                            <TextBlock Name="ImageResizer_Times_Symbol"
+                                <TextBlock Name="ImageResizer_Times_Symbol"
                                        x:Uid="ImageResizer_Times_Symbol"
                                        Text="&#xE711;"
                                        FontFamily="Segoe MDL2 Assets"
@@ -169,7 +133,7 @@
                                        Opacity="{x:Bind Path=ExtraBoxOpacity, Mode=OneWay}"                                    
                                        Width="25"/>
 
-                            <muxc:NumberBox Name="ImageResizer_Height_Property"
+                                <muxc:NumberBox Name="ImageResizer_Height_Property"
                                             x:Uid="ImageResizer_Height_Property"
                                             Value="{x:Bind Path=Height, Mode=TwoWay}" 
                                             MinWidth="68"
@@ -180,18 +144,18 @@
                                             IsEnabled="{x:Bind Path=EnableEtraBoxes, Mode=OneWay}"
                                             Margin="{StaticResource SmallTopMargin}"/>
 
-                            <ComboBox Name="ImageResizer_Size_Property"
+                                <ComboBox Name="ImageResizer_Size_Property"
                                       x:Uid="ImageResizer_Size_Property"
                                       SelectedIndex="{Binding Path=Unit, Mode=TwoWay}"
                                       MinWidth="120"
                                       VerticalAlignment="Center"
                                       Margin="{StaticResource SmallTopMargin}">
-                                <ComboBoxItem x:Uid="ImageResizer_Sizes_Units_CM" />
-                                <ComboBoxItem x:Uid="ImageResizer_Sizes_Units_Inches" />
-                                <ComboBoxItem x:Uid="ImageResizer_Sizes_Units_Percent" />
-                                <ComboBoxItem x:Uid="ImageResizer_Sizes_Units_Pixels" />
-                            </ComboBox>
-                            <Button x:Name="RemoveButton"
+                                    <ComboBoxItem x:Uid="ImageResizer_Sizes_Units_CM" />
+                                    <ComboBoxItem x:Uid="ImageResizer_Sizes_Units_Inches" />
+                                    <ComboBoxItem x:Uid="ImageResizer_Sizes_Units_Percent" />
+                                    <ComboBoxItem x:Uid="ImageResizer_Sizes_Units_Pixels" />
+                                </ComboBox>
+                                <Button x:Name="RemoveButton"
                                     x:Uid="RemoveButton"
                                     Background="Transparent"
                                     FontFamily="Segoe MDL2 Assets"
@@ -202,18 +166,18 @@
                                     UseLayoutRounding="False"
                                     Click="DeleteCustomSize"
                                     CommandParameter="{Binding Id}">
-                                <ToolTipService.ToolTip>
-                                    <TextBlock x:Uid="RemoveTooltip"/>
-                                </ToolTipService.ToolTip>
-                            </Button>
-                        </StackPanel>
-                    </DataTemplate>
-                </ListView.ItemTemplate>
-            </ListView>
+                                    <ToolTipService.ToolTip>
+                                        <TextBlock x:Uid="RemoveTooltip"/>
+                                    </ToolTipService.ToolTip>
+                                </Button>
+                            </StackPanel>
+                        </DataTemplate>
+                    </ListView.ItemTemplate>
+                </ListView>
 
 
-            <StackPanel Orientation="Horizontal">
-                <AppBarButton Icon="Add"
+                <StackPanel Orientation="Horizontal">
+                    <AppBarButton Icon="Add"
                               x:Name="AddSizeButton"
                               Style="{StaticResource AddItemAppBarButtonStyle}"
                               IsEnabled="{x:Bind Mode=TwoWay, Path=ViewModel.IsEnabled}" 
@@ -222,26 +186,26 @@
                               Margin="{StaticResource AddItemButtonMargin}"
                               
                           />
-            </StackPanel>
+                </StackPanel>
 
-            <TextBlock x:Uid="Encoding"
+                <TextBlock x:Uid="Encoding"
                        Style="{StaticResource SettingsGroupTitleStyle}"
                        Opacity="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToOpacityConverter}}"/>
 
-            <ComboBox x:Uid="ImageResizer_FallBackEncoderText"
+                <ComboBox x:Uid="ImageResizer_FallBackEncoderText"
                           SelectedIndex="{x:Bind Path=ViewModel.Encoder, Mode=TwoWay}"
                           MinWidth="240"
                           Margin="{StaticResource SmallTopMargin}"
                           IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}">
-                <ComboBoxItem x:Uid="ImageResizer_FallbackEncoder_PNG" />
-                <ComboBoxItem x:Uid="ImageResizer_FallbackEncoder_BMP" />
-                <ComboBoxItem x:Uid="ImageResizer_FallbackEncoder_JPEG" />
-                <ComboBoxItem x:Uid="ImageResizer_FallbackEncoder_TIFF" />
-                <ComboBoxItem x:Uid="ImageResizer_FallbackEncoder_WMPhoto" />
-                <ComboBoxItem x:Uid="ImageResizer_FallbackEncoder_GIF" />
-            </ComboBox>
+                    <ComboBoxItem x:Uid="ImageResizer_FallbackEncoder_PNG" />
+                    <ComboBoxItem x:Uid="ImageResizer_FallbackEncoder_BMP" />
+                    <ComboBoxItem x:Uid="ImageResizer_FallbackEncoder_JPEG" />
+                    <ComboBoxItem x:Uid="ImageResizer_FallbackEncoder_TIFF" />
+                    <ComboBoxItem x:Uid="ImageResizer_FallbackEncoder_WMPhoto" />
+                    <ComboBoxItem x:Uid="ImageResizer_FallbackEncoder_GIF" />
+                </ComboBox>
 
-            <muxc:NumberBox x:Uid="ImageResizer_Encoding"
+                <muxc:NumberBox x:Uid="ImageResizer_Encoding"
                             Minimum="0"
                             Maximum="100"
                             Value="{x:Bind Mode=TwoWay, Path=ViewModel.JPEGQualityLevel}"
@@ -253,35 +217,35 @@
                             AutomationProperties.LabeledBy="{Binding ElementName=ImageResizer_Encoding}"
                             />
 
-            <ComboBox x:Uid="ImageResizer_PNGInterlacing"
+                <ComboBox x:Uid="ImageResizer_PNGInterlacing"
                           SelectedIndex="{x:Bind Mode=TwoWay, Path=ViewModel.PngInterlaceOption}"
                           MinWidth="240"
                           Margin="{StaticResource SmallTopMargin}"
                           IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}">
-                <ComboBoxItem x:Uid="Default"/>
-                <ComboBoxItem x:Uid="On"/>
-                <ComboBoxItem x:Uid="Off"/>
-            </ComboBox>
+                    <ComboBoxItem x:Uid="Default"/>
+                    <ComboBoxItem x:Uid="On"/>
+                    <ComboBoxItem x:Uid="Off"/>
+                </ComboBox>
 
-            <ComboBox x:Uid="ImageResizer_TIFFCompression"
+                <ComboBox x:Uid="ImageResizer_TIFFCompression"
                           SelectedIndex="{x:Bind Mode=TwoWay, Path=ViewModel.TiffCompressOption}"
                           MinWidth="240"
                           Margin="{StaticResource SmallTopMargin}"
                           IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}">
-                <ComboBoxItem x:Uid="ImageResizer_ENCODER_TIFF_Default"/>
-                <ComboBoxItem x:Uid="ImageResizer_ENCODER_TIFF_None"/>
-                <ComboBoxItem x:Uid="ImageResizer_ENCODER_TIFF_CCITT3"/>
-                <ComboBoxItem x:Uid="ImageResizer_ENCODER_TIFF_CCITT4"/>
-                <ComboBoxItem x:Uid="ImageResizer_ENCODER_TIFF_LZW"/>
-                <ComboBoxItem x:Uid="ImageResizer_ENCODER_TIFF_RLE"/>
-                <ComboBoxItem x:Uid="ImageResizer_ENCODER_TIFF_Zip"/>
-            </ComboBox>
+                    <ComboBoxItem x:Uid="ImageResizer_ENCODER_TIFF_Default"/>
+                    <ComboBoxItem x:Uid="ImageResizer_ENCODER_TIFF_None"/>
+                    <ComboBoxItem x:Uid="ImageResizer_ENCODER_TIFF_CCITT3"/>
+                    <ComboBoxItem x:Uid="ImageResizer_ENCODER_TIFF_CCITT4"/>
+                    <ComboBoxItem x:Uid="ImageResizer_ENCODER_TIFF_LZW"/>
+                    <ComboBoxItem x:Uid="ImageResizer_ENCODER_TIFF_RLE"/>
+                    <ComboBoxItem x:Uid="ImageResizer_ENCODER_TIFF_Zip"/>
+                </ComboBox>
 
-            <TextBlock x:Uid="File"
+                <TextBlock x:Uid="File"
                        Style="{StaticResource SettingsGroupTitleStyle}"
                        Opacity="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToOpacityConverter}}"/>
 
-            <TextBox Text="{x:Bind Mode=TwoWay, Path=ViewModel.FileName}"
+                <TextBox Text="{x:Bind Mode=TwoWay, Path=ViewModel.FileName}"
                       HorizontalAlignment="Left"
                       MinWidth="240"
                       x:Uid="ImageResizer_FilenameFormatPlaceholder"
@@ -290,19 +254,19 @@
                       AutomationProperties.LabeledBy="{Binding ElementName=ImageResizer_FilenameFormatHeader}"
                       AutomationProperties.HelpText="{Binding ElementName=FileFormatTextBlock, Path=Text}"
                      >
-                <TextBox.Header>
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock Name="ImageResizer_FilenameFormatHeader"
+                    <TextBox.Header>
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Name="ImageResizer_FilenameFormatHeader"
                             x:Uid="ImageResizer_FilenameFormatHeader"
                             Margin="0,0,0,0"
                             Opacity="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToOpacityConverter}}"/>
-                        <TextBlock Text="&#xE946;"
+                            <TextBlock Text="&#xE946;"
                            FontFamily="Segoe MDL2 Assets"
                            Margin="4,4,0,0"/>
-                    </StackPanel>
-                </TextBox.Header>
-                <ToolTipService.ToolTip>
-                    <TextBlock x:Name="FileFormatTextBlock">
+                        </StackPanel>
+                    </TextBox.Header>
+                    <ToolTipService.ToolTip>
+                        <TextBlock x:Name="FileFormatTextBlock">
                         <Run x:Uid="ImageResizer_FileFormatDescription"/>
                         <LineBreak/>
                         <LineBreak/>
@@ -329,61 +293,24 @@
                         <Run Text="%6" FontWeight="Bold" />
                         <Run Text=" - "/>
                         <Run x:Uid="ImageResizer_Formatting_ActualHeight"/>
-                    </TextBlock>
-                </ToolTipService.ToolTip>
-            </TextBox>
+                        </TextBlock>
+                    </ToolTipService.ToolTip>
+                </TextBox>
 
-            <CheckBox x:Uid="ImageResizer_UseOriginalDate"
+                <CheckBox x:Uid="ImageResizer_UseOriginalDate"
                       IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"
                       Margin="{StaticResource SmallTopMargin}"
                       IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.KeepDateModified}"/>
-        </StackPanel>
-
-        <RelativePanel x:Name="SidePanel" 
-                    HorizontalAlignment="Left"
-                    Width="{StaticResource SidePanelWidth}"
-                    Grid.Column="1">
-            <StackPanel x:Name="DescriptionPanel">
-                <TextBlock x:Uid="About_ImageResizer" x:Name="AboutTitle" Grid.ColumnSpan="2"
-                       Style="{StaticResource SettingsGroupTitleStyle}"
-                       Margin="{StaticResource XSmallBottomMargin}"/>
-                <TextBlock x:Uid="ImageResizer_Description"
-                           TextWrapping="Wrap"
-                           Grid.Row="1" />
             </StackPanel>
 
-            <Border x:Name="AboutImage"
-                    CornerRadius="4"
-                    Grid.Row="2"
-                    MaxWidth="240"
-                    HorizontalAlignment="Left"
-                    Margin="{StaticResource SmallTopBottomMargin}"
-                    RelativePanel.Below="DescriptionPanel">
-                <HyperlinkButton x:Uid="ImageResizer_ImageHyperlinkToDocs">
-                    <Image x:Uid="ImageResizer_Image" Source="ms-appx:///Assets/Modules/ImageResizer.png" />
-                </HyperlinkButton>
-            </Border>
+        </controls:SettingsPageControl.ModuleContent>
 
-            <StackPanel x:Name="LinksPanel"
-                        Margin="0,1,0,0"
-                        RelativePanel.Below="AboutImage"
-                        Orientation="Vertical" >
-                <HyperlinkButton x:Uid="ImageResizer_ImageHyperlinkToDocs">
-                    <TextBlock x:Uid="Module_overview" />
-                </HyperlinkButton>
-                <HyperlinkButton NavigateUri="https://aka.ms/powerToysGiveFeedback">
-                    <TextBlock x:Uid="Give_Feedback" />
-                </HyperlinkButton>
-
-                <TextBlock 
-                x:Uid="AttributionTitle"
-                Style="{StaticResource SettingsGroupTitleStyle}"/>
-
-                <HyperlinkButton Margin="0,-3,0,0"
-                NavigateUri="https://github.com/bricelam/ImageResizer/">
-                    <TextBlock Text="Brice Lambson's ImageResizer" TextWrapping="Wrap" />
-                </HyperlinkButton>
-            </StackPanel>
-        </RelativePanel>
-    </Grid>
+        <controls:SettingsPageControl.ModuleLinks>
+            <controls:SidePanelLink x:Uid="Learn_More" Link="https://aka.ms/PowerToysOverview_ImageResizer"/>
+            <controls:SidePanelLink x:Uid="Give_Feedback" Link="https://aka.ms/powerToysGiveFeedback"/>
+        </controls:SettingsPageControl.ModuleLinks>
+        <controls:SettingsPageControl.AttributionLinks>
+            <controls:SidePanelLink Label="Brice Lambson's ImageResizer" Link="https://github.com/bricelam/ImageResizer/"/>
+        </controls:SettingsPageControl.AttributionLinks>
+    </controls:SettingsPageControl>
 </Page>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/KeyboardManagerPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/KeyboardManagerPage.xaml
@@ -223,8 +223,8 @@
 
                 <Button x:Uid="KeyboardManager_RemapKeyboardButton"
                     Margin="{StaticResource SmallTopMargin}"
-                    Style="{StaticResource AccentButtonStyle}"
                     Command="{Binding Path=RemapKeyboardCommand}"
+                    Style="{StaticResource AccentButtonStyle}"
                     IsEnabled="{x:Bind Path=ViewModel.Enabled, Mode=OneWay}"/>
 
                 <ListView x:Name="RemapKeysList"

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/KeyboardManagerPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/KeyboardManagerPage.xaml
@@ -5,9 +5,8 @@
     xmlns:local="using:Microsoft.PowerToys.Settings.UI.Views"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:viewModel="using:Microsoft.PowerToys.Settings.UI.Library.ViewModels"
     xmlns:extensions="using:Microsoft.Toolkit.Uwp.UI.Extensions"
-    xmlns:CustomControls="using:Microsoft.PowerToys.Settings.UI.Controls"
+    xmlns:controls="using:Microsoft.PowerToys.Settings.UI.Controls"
     xmlns:Lib="using:Microsoft.PowerToys.Settings.UI.Library"
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
@@ -189,54 +188,19 @@
         </DataTemplate>
     </Page.Resources>
 
-    <Grid RowSpacing="{StaticResource DefaultRowSpacing}">
-        <VisualStateManager.VisualStateGroups>
-            <VisualStateGroup x:Name="LayoutVisualStates">
-                <VisualState x:Name="WideLayout">
-                    <VisualState.StateTriggers>
-                        <AdaptiveTrigger MinWindowWidth="{StaticResource WideLayoutMinWidth}" />
-                    </VisualState.StateTriggers>
-                </VisualState>
-                <VisualState x:Name="SmallLayout">
-                    <VisualState.StateTriggers>
-                        <AdaptiveTrigger MinWindowWidth="{StaticResource SmallLayoutMinWidth}" />
-                        <AdaptiveTrigger MinWindowWidth="0" />
-                    </VisualState.StateTriggers>
-                    <VisualState.Setters>
-                        <Setter Target="SidePanel.(Grid.Column)" Value="0"/>
-                        <Setter Target="SidePanel.Width" Value="Auto"/>
-                        <Setter Target="KeyboardManagerView.(Grid.Row)" Value="1" />
-                        <Setter Target="KeyboardManagerView.Margin" Value="0" />
-                        <Setter Target="LinksPanel.(RelativePanel.RightOf)" Value="AboutImage"/>
-                        <Setter Target="LinksPanel.(RelativePanel.AlignTopWith)" Value="AboutImage"/>
-                        <Setter Target="AboutImage.Margin" Value="0,12,12,0"/>
-                        <Setter Target="AboutTitle.Visibility" Value="Collapsed" />
-                    </VisualState.Setters>
-                </VisualState>
-            </VisualStateGroup>
-        </VisualStateManager.VisualStateGroups>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*"/>
-            <ColumnDefinition Width="Auto"/>
-        </Grid.ColumnDefinitions>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto" />
-        </Grid.RowDefinitions>
-
-        <StackPanel Orientation="Vertical"
-                    x:Name="KeyboardManagerView"
-                    HorizontalAlignment="Left"
-                    Margin="0,0,48,0"
-                    MaxWidth="{StaticResource MaxContentWidth}">
-            <ToggleSwitch x:Uid="KeyboardManager_EnableToggle"
+    <controls:SettingsPageControl x:Uid="About_KeyboardManager"
+                                  ModuleImageSource="ms-appx:///Assets/Modules/KBM.png"
+                                  ModuleImageLink="https://aka.ms/PowerToysOverview_KeyboardManage">
+        <controls:SettingsPageControl.ModuleContent>
+            <StackPanel Orientation="Vertical">
+                <ToggleSwitch x:Uid="KeyboardManager_EnableToggle"
                           IsOn="{x:Bind Path=ViewModel.Enabled, Mode=TwoWay}"/>
 
-            <HyperlinkButton NavigateUri="https://aka.ms/powerToysCannotRemapKeys" Margin="{StaticResource XSmallTopMargin}">
-                <TextBlock x:Uid="KBM_KeysCannotBeRemapped" />
-            </HyperlinkButton>
-            
-            <!--<TextBlock x:Uid="KeyboardManager_ConfigHeader"
+                <HyperlinkButton NavigateUri="https://aka.ms/powerToysCannotRemapKeys" Margin="{StaticResource XSmallTopMargin}">
+                    <TextBlock x:Uid="KBM_KeysCannotBeRemapped" />
+                </HyperlinkButton>
+
+                <!--<TextBlock x:Uid="KeyboardManager_ConfigHeader"
                        Style="{StaticResource SettingsGroupTitleStyle}"/>
 
             <TextBlock x:Uid="KeyboardManager_ProfileDescription"
@@ -249,21 +213,21 @@
                 <ComboBoxItem Content="Config-3"/>
             </ComboBox>-->
 
-            <TextBlock x:Uid="KeyboardManager_RemapKeyboardHeader"
+                <TextBlock x:Uid="KeyboardManager_RemapKeyboardHeader"
                        Style="{StaticResource SettingsGroupTitleStyle}"
                        Opacity="{x:Bind Mode=OneWay, Path=ViewModel.Enabled, Converter={StaticResource ModuleEnabledToOpacityConverter}}"/>
 
-            <TextBlock x:Uid="KeyboardManager_RemapKeyboardSubtitle"
+                <TextBlock x:Uid="KeyboardManager_RemapKeyboardSubtitle"
                        Margin="{StaticResource SmallTopMargin}"
                        Opacity="{x:Bind Mode=OneWay, Path=ViewModel.Enabled, Converter={StaticResource ModuleEnabledToOpacityConverter}}"/>
 
-            <Button x:Uid="KeyboardManager_RemapKeyboardButton"
+                <Button x:Uid="KeyboardManager_RemapKeyboardButton"
                     Margin="{StaticResource SmallTopMargin}"
                     Style="{StaticResource AccentButtonStyle}"
                     Command="{Binding Path=RemapKeyboardCommand}"
                     IsEnabled="{x:Bind Path=ViewModel.Enabled, Mode=OneWay}"/>
 
-            <ListView x:Name="RemapKeysList"
+                <ListView x:Name="RemapKeysList"
                       x:Uid="RemapKeysList"
                       extensions:ListViewExtensions.AlternateColor="{ThemeResource SystemControlBackgroundListLowBrush}"
                       ItemsSource="{x:Bind Path=ViewModel.RemapKeys, Mode=OneWay}"
@@ -282,7 +246,7 @@
                       ItemContainerStyle="{StaticResource KeysListViewContainerStyle}"
                       />
 
-            <!--<AppBarButton x:Uid="KeyboardManager_RemapKeyboardButton"
+                <!--<AppBarButton x:Uid="KeyboardManager_RemapKeyboardButton"
                     Icon="Add"
                     Width="370"
                     Style="{StaticResource AddItemAppBarButtonStyle}"
@@ -291,23 +255,23 @@
                     HorizontalAlignment="Left"
                     IsEnabled="{x:Bind Path=ViewModel.Enabled, Mode=OneWay}"/>-->
 
-            <TextBlock x:Uid="KeyboardManager_RemapShortcutsHeader"
+                <TextBlock x:Uid="KeyboardManager_RemapShortcutsHeader"
                        Style="{StaticResource SettingsGroupTitleStyle}"
                        Opacity="{x:Bind Mode=OneWay, Path=ViewModel.Enabled, Converter={StaticResource ModuleEnabledToOpacityConverter}}"/>
 
-            <TextBlock x:Uid="KeyboardManager_RemapShortcutsSubtitle"
+                <TextBlock x:Uid="KeyboardManager_RemapShortcutsSubtitle"
                        Margin="{StaticResource SmallTopMargin}"
                        TextWrapping="WrapWholeWords"
                        Opacity="{x:Bind Mode=OneWay, Path=ViewModel.Enabled, Converter={StaticResource ModuleEnabledToOpacityConverter}}"/>
 
-            <Button x:Uid="KeyboardManager_RemapShortcutsButton"
+                <Button x:Uid="KeyboardManager_RemapShortcutsButton"
                     Margin="{StaticResource SmallTopMargin}"
                     Style="{StaticResource AccentButtonStyle}"
                     Command="{Binding Path=EditShortcutCommand}"
                     IsEnabled="{x:Bind Path=ViewModel.Enabled, Mode=OneWay}"
                     />
 
-            <ListView x:Name="RemapShortcutsList"
+                <ListView x:Name="RemapShortcutsList"
                       x:Uid="RemapShortcutsList"
                       extensions:ListViewExtensions.AlternateColor="{ThemeResource SystemControlBackgroundListLowBrush}"
                       ItemsSource="{x:Bind Path=ViewModel.RemapShortcuts, Mode=OneWay}"
@@ -329,7 +293,7 @@
                       ItemContainerStyle="{StaticResource KeysListViewContainerStyle}"
                       />
 
-            <!--<AppBarButton x:Uid="KeyboardManager_RemapShortcutsButton"
+                <!--<AppBarButton x:Uid="KeyboardManager_RemapShortcutsButton"
                     Icon="Add"
                     Width="370"
                     Style="{StaticResource AddItemAppBarButtonStyle}"
@@ -338,46 +302,11 @@
                     Margin="{StaticResource AddItemButtonMargin}"
                     HorizontalAlignment="Left"
                     />-->
-        </StackPanel>
-
-        <RelativePanel x:Name="SidePanel" 
-                    HorizontalAlignment="Left"
-                    Width="{StaticResource SidePanelWidth}"
-                    Grid.Column="1">
-            <StackPanel x:Name="DescriptionPanel">
-                <TextBlock x:Uid="About_KeyboardManager"
-                           x:Name="AboutTitle"
-                           Grid.ColumnSpan="2"
-                           Style="{StaticResource SettingsGroupTitleStyle}"
-                           Margin="{StaticResource XSmallBottomMargin}"/>
-                <TextBlock x:Uid="KeyboardManager_Description"
-                           TextWrapping="Wrap"
-                           Grid.Row="1" />
             </StackPanel>
-
-            <Border x:Name="AboutImage"
-                    CornerRadius="4"
-                    Grid.Row="2"
-                    MaxWidth="240"
-                    HorizontalAlignment="Left"
-                    Margin="{StaticResource SmallTopBottomMargin}"
-                    RelativePanel.Below="DescriptionPanel">
-                <HyperlinkButton x:Uid="KeyboardManager_ImageHyperlinkToDocs">
-                    <Image x:Uid="KeyboardManager_Image" Source="ms-appx:///Assets/Modules/KBM.png" />
-                </HyperlinkButton>
-            </Border>
-
-            <StackPanel x:Name="LinksPanel"
-                        Margin="0,1,0,0"
-                        RelativePanel.Below="AboutImage"
-                        Orientation="Vertical" >
-                <HyperlinkButton x:Uid="KeyboardManager_ImageHyperlinkToDocs">
-                    <TextBlock x:Uid="Module_overview" />
-                </HyperlinkButton>
-                <HyperlinkButton NavigateUri="https://aka.ms/powerToysGiveFeedback">
-                    <TextBlock x:Uid="Give_Feedback" />
-                </HyperlinkButton>
-            </StackPanel>
-        </RelativePanel>
-    </Grid>
+        </controls:SettingsPageControl.ModuleContent>
+        <controls:SettingsPageControl.ModuleLinks>
+            <controls:SidePanelLink x:Uid="Learn_More" Link="https://aka.ms/PowerToysOverview_KeyboardManager"/>
+            <controls:SidePanelLink x:Uid="Give_Feedback" Link="https://aka.ms/powerToysGiveFeedback"/>
+        </controls:SettingsPageControl.ModuleLinks>
+    </controls:SettingsPageControl>
 </Page>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
@@ -6,64 +6,31 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     x:Class="Microsoft.PowerToys.Settings.UI.Views.PowerLauncherPage"
-    xmlns:CustomControls="using:Microsoft.PowerToys.Settings.UI.Controls"
+    xmlns:controls="using:Microsoft.PowerToys.Settings.UI.Controls"
     xmlns:converters="using:Microsoft.Toolkit.Uwp.UI.Converters"
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     AutomationProperties.LandmarkType="Main">
+    
     <Page.Resources>
         <converters:BoolToObjectConverter x:Key="BoolToVisibilityConverter" TrueValue="Visible" FalseValue="Collapsed"/>
         <converters:BoolNegationConverter x:Key="BoolNegationConverter"/>
     </Page.Resources>
 
-    <Grid RowSpacing="{StaticResource DefaultRowSpacing}" >
-        <VisualStateManager.VisualStateGroups>
-            <VisualStateGroup x:Name="LayoutVisualStates">
-                <VisualState x:Name="WideLayout">
-                    <VisualState.StateTriggers>
-                        <AdaptiveTrigger MinWindowWidth="{StaticResource WideLayoutMinWidth}" />
-                    </VisualState.StateTriggers>
-                </VisualState>
-                <VisualState x:Name="SmallLayout">
-                    <VisualState.StateTriggers>
-                        <AdaptiveTrigger MinWindowWidth="{StaticResource SmallLayoutMinWidth}" />
-                        <AdaptiveTrigger MinWindowWidth="0" />
-                    </VisualState.StateTriggers>
-                    <VisualState.Setters>
-                        <Setter Target="SidePanel.(Grid.Column)" Value="0"/>
-                        <Setter Target="SidePanel.Width" Value="Auto"/>
-                        <Setter Target="LauncherView.(Grid.Row)" Value="1" />
-                        <Setter Target="LauncherView.Margin" Value="0" />
-                        <Setter Target="LinksPanel.(RelativePanel.RightOf)" Value="AboutImage"/>
-                        <Setter Target="LinksPanel.(RelativePanel.AlignTopWith)" Value="AboutImage"/>
-                        <Setter Target="AboutImage.Margin" Value="0,12,12,0"/>
-                        <Setter Target="AboutTitle.Visibility" Value="Collapsed" />
-                    </VisualState.Setters>
-                </VisualState>
-            </VisualStateGroup>
-        </VisualStateManager.VisualStateGroups>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*"/>
-            <ColumnDefinition Width="Auto"/>
-        </Grid.ColumnDefinitions>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto" />
-        </Grid.RowDefinitions>
+    <controls:SettingsPageControl x:Uid="About_PowerLauncher"
+                                  ModuleImageSource="ms-appx:///Assets/Modules/PowerLauncher.png"
+                                  ModuleImageLink="https://aka.ms/PowerToysOverview_PowerToysRun">
+        <controls:SettingsPageControl.ModuleContent>
 
-        <StackPanel Orientation="Vertical"
-                    x:Name="LauncherView"
-                    HorizontalAlignment="Left"
-                    Margin="0,0,48,0"
-                    MaxWidth="{StaticResource MaxContentWidth}">
-            <ToggleSwitch x:Uid="PowerLauncher_EnablePowerLauncher" 
+            <StackPanel Orientation="Vertical">
+                <ToggleSwitch x:Uid="PowerLauncher_EnablePowerLauncher" 
                           IsOn="{x:Bind Mode=TwoWay, Path=ViewModel.EnablePowerLauncher}"/>
 
             <TextBlock x:Uid="Shortcuts"
                        Style="{StaticResource SettingsGroupTitleStyle}"
                        Opacity="{x:Bind Mode=OneWay, Path=ViewModel.EnablePowerLauncher, Converter={StaticResource ModuleEnabledToOpacityConverter}}"/>
 
-            <CustomControls:HotkeySettingsControl x:Uid="PowerLauncher_OpenPowerLauncher"
+            <controls:HotkeySettingsControl x:Uid="PowerLauncher_OpenPowerLauncher"
                                                   HorizontalAlignment="Left"
                                                   MinWidth="240"
                                                   Margin="{StaticResource SmallTopMargin}"
@@ -359,55 +326,14 @@
             </ListView>
         </StackPanel>
 
-        <RelativePanel x:Name="SidePanel" 
-                    HorizontalAlignment="Left"
-                    Width="{StaticResource SidePanelWidth}"
-                    Grid.Column="1">
-            <StackPanel x:Name="DescriptionPanel">
-                <TextBlock x:Uid="About_PowerLauncher" x:Name="AboutTitle" Grid.ColumnSpan="2"
-                       Style="{StaticResource SettingsGroupTitleStyle}"
-                       Margin="{StaticResource XSmallBottomMargin}"/>
-                <TextBlock x:Uid="PowerLauncher_Description"
-                           TextWrapping="Wrap"
-                           Grid.Row="1" />
-            </StackPanel>
-
-            <Border x:Name="AboutImage"
-                    CornerRadius="4"
-                    Grid.Row="2"
-                    MaxWidth="240"
-                    HorizontalAlignment="Left"
-                    Margin="{StaticResource SmallTopBottomMargin}"
-                    RelativePanel.Below="DescriptionPanel">
-                <HyperlinkButton x:Uid="PowerToys_Run_ImageHyperlinkToDocs">
-                    <Image x:Uid="PowerToys_Run_Image" Source="ms-appx:///Assets/Modules/PowerLauncher.png" />
-                </HyperlinkButton>
-            </Border>
-
-            <StackPanel x:Name="LinksPanel"
-                        Margin="0,1,0,0"
-                        RelativePanel.Below="AboutImage"
-                        Orientation="Vertical" >
-                <HyperlinkButton x:Uid="PowerToys_Run_ImageHyperlinkToDocs">
-                    <TextBlock x:Uid="Module_overview" />
-                </HyperlinkButton>
-                <HyperlinkButton NavigateUri="https://aka.ms/powerToysGiveFeedback">
-                    <TextBlock x:Uid="Give_Feedback" />
-                </HyperlinkButton>
-
-                <TextBlock x:Uid="AttributionTitle"
-                           Style="{StaticResource SettingsGroupTitleStyle}"
-                           Foreground="{ Binding Mode=TwoWay, Path=TextColor}"/>
-
-                <HyperlinkButton Margin="0,-3,0,0" NavigateUri="https://github.com/Wox-launcher/Wox/">
-                    <TextBlock Text="Wox"/>
-                </HyperlinkButton>
-
-                <HyperlinkButton NavigateUri="https://github.com/betsegaw/windowwalker/">
-                    <TextBlock Text="Beta Tadele's Window Walker" />
-                </HyperlinkButton>
-
-            </StackPanel>
-        </RelativePanel>
-    </Grid>
+    </controls:SettingsPageControl.ModuleContent>
+        <controls:SettingsPageControl.ModuleLinks>
+            <controls:SidePanelLink x:Uid="Learn_More" Link="https://aka.ms/PowerToysOverview_PowerToysRun"/>
+            <controls:SidePanelLink x:Uid="Give_Feedback" Link="https://aka.ms/powerToysGiveFeedback"/>
+        </controls:SettingsPageControl.ModuleLinks>
+        <controls:SettingsPageControl.AttributionLinks>
+            <controls:SidePanelLink Label="Wox" Link="https://github.com/Wox-launcher/Wox/"/>
+            <controls:SidePanelLink Label="Beta Tadele's Window Walker" Link="https://github.com/betsegaw/windowwalker/"/>
+        </controls:SettingsPageControl.AttributionLinks>
+    </controls:SettingsPageControl>
 </Page>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerPreviewPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerPreviewPage.xaml
@@ -5,6 +5,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:converters="using:Microsoft.Toolkit.Uwp.UI.Converters"
+    xmlns:controls="using:Microsoft.PowerToys.Settings.UI.Controls"
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     AutomationProperties.LandmarkType="Main">
@@ -13,46 +14,12 @@
         <converters:BoolToObjectConverter x:Key="BoolToVisibilityConverter" TrueValue="Collapsed" FalseValue="Visible"/>
     </Page.Resources>
 
-    <Grid RowSpacing="{StaticResource DefaultRowSpacing}">
-        <VisualStateManager.VisualStateGroups>
-            <VisualStateGroup x:Name="LayoutVisualStates">
-                <VisualState x:Name="WideLayout">
-                    <VisualState.StateTriggers>
-                        <AdaptiveTrigger MinWindowWidth="{StaticResource WideLayoutMinWidth}" />
-                    </VisualState.StateTriggers>
-                </VisualState>
-                <VisualState x:Name="SmallLayout">
-                    <VisualState.StateTriggers>
-                        <AdaptiveTrigger MinWindowWidth="{StaticResource SmallLayoutMinWidth}" />
-                        <AdaptiveTrigger MinWindowWidth="0" />
-                    </VisualState.StateTriggers>
-                    <VisualState.Setters>
-                        <Setter Target="SidePanel.(Grid.Column)" Value="0"/>
-                        <Setter Target="SidePanel.Width" Value="Auto"/>
-                        <Setter Target="PowerPreviewView.(Grid.Row)" Value="1" />
-                        <Setter Target="PowerPreviewView.Margin" Value="0" />
-                        <Setter Target="LinksPanel.(RelativePanel.RightOf)" Value="AboutImage"/>
-                        <Setter Target="LinksPanel.(RelativePanel.AlignTopWith)" Value="AboutImage"/>
-                        <Setter Target="AboutImage.Margin" Value="0,12,12,0"/>
-                        <Setter Target="AboutTitle.Visibility" Value="Collapsed" />
-                    </VisualState.Setters>
-                </VisualState>
-            </VisualStateGroup>
-        </VisualStateManager.VisualStateGroups>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*"/>
-            <ColumnDefinition Width="Auto"/>
-        </Grid.ColumnDefinitions>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto" />
-        </Grid.RowDefinitions>
-
-        <StackPanel Orientation="Vertical"
-                    x:Name="PowerPreviewView"
-                    HorizontalAlignment="Left"
-                    Margin="0,0,48,0"
-                    MaxWidth="{StaticResource MaxContentWidth}">
+    <controls:SettingsPageControl x:Uid="About_FileExplorerPreview"
+                                  ModuleImageSource="ms-appx:///Assets/Modules/PowerPreview.png"
+                                  ModuleImageLink="https://aka.ms/PowerToysOverview_FileExplorerAddOns">
+        <controls:SettingsPageControl.ModuleContent>
+            
+            <StackPanel Orientation="Vertical">
             <TextBlock x:Uid="FileExplorerPreview_RunAsAdminRequired"
                        Foreground="{ThemeResource SystemControlErrorTextForegroundBrush}"
                        Visibility="{Binding Mode=OneWay, Path=IsElevated, Converter={StaticResource BoolToVisibilityConverter}}"
@@ -91,42 +58,11 @@
                           IsOn="{Binding Mode=TwoWay, Path=SVGThumbnailIsEnabled}"
                           IsEnabled="{Binding Mode=OneWay, Path=IsElevated}"/>
         </StackPanel>
-        <RelativePanel x:Name="SidePanel" 
-                    HorizontalAlignment="Left"
-                    Width="{StaticResource SidePanelWidth}"
-                    Grid.Column="1">
-            <StackPanel x:Name="DescriptionPanel">
-                <TextBlock x:Uid="About_FileExplorerPreview" x:Name="AboutTitle" Grid.ColumnSpan="2"
-                       Style="{StaticResource SettingsGroupTitleStyle}"
-                       Margin="{StaticResource XSmallBottomMargin}"/>
-                <TextBlock x:Uid="FileExplorerPreview_Description"
-                           TextWrapping="Wrap"
-                           Grid.Row="1" />
-            </StackPanel>
+        </controls:SettingsPageControl.ModuleContent>
 
-            <Border x:Name="AboutImage"
-                    CornerRadius="4"
-                    Grid.Row="2"
-                    MaxWidth="240"
-                    HorizontalAlignment="Left"
-                    Margin="{StaticResource SmallTopBottomMargin}"
-                    RelativePanel.Below="DescriptionPanel">
-                <HyperlinkButton x:Uid="FileExplorerPreview_ImageHyperlinkToDocs">
-                    <Image x:Uid="FileExplorerPreview_Image" Source="ms-appx:///Assets/Modules/PowerPreview.png" />
-                </HyperlinkButton>
-            </Border>
-
-            <StackPanel x:Name="LinksPanel"
-                        Margin="0,1,0,0"
-                        RelativePanel.Below="AboutImage"
-                        Orientation="Vertical" >
-                <HyperlinkButton x:Uid="FileExplorerPreview_ImageHyperlinkToDocs">
-                    <TextBlock x:Uid="Module_overview" />
-                </HyperlinkButton>
-                <HyperlinkButton NavigateUri="https://aka.ms/powerToysGiveFeedback">
-                    <TextBlock x:Uid="Give_Feedback" />
-                </HyperlinkButton>
-            </StackPanel>
-        </RelativePanel>
-    </Grid>
+        <controls:SettingsPageControl.ModuleLinks>
+            <controls:SidePanelLink x:Uid="Learn_More" Link="https://aka.ms/PowerToysOverview_FileExplorerAddOns"/>
+            <controls:SidePanelLink x:Uid="Give_Feedback" Link="https://aka.ms/powerToysGiveFeedback"/>
+        </controls:SettingsPageControl.ModuleLinks>
+    </controls:SettingsPageControl>
 </Page>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerRenamePage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerRenamePage.xaml
@@ -4,83 +4,53 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:CustomControls="using:Microsoft.PowerToys.Settings.UI.Controls"
+    xmlns:controls="using:Microsoft.PowerToys.Settings.UI.Controls"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     AutomationProperties.LandmarkType="Main">
 
-    <Grid RowSpacing="{StaticResource DefaultRowSpacing}">
-        <VisualStateManager.VisualStateGroups>
-            <VisualStateGroup x:Name="LayoutVisualStates">
-                <VisualState x:Name="WideLayout">
-                    <VisualState.StateTriggers>
-                        <AdaptiveTrigger MinWindowWidth="{StaticResource WideLayoutMinWidth}" />
-                    </VisualState.StateTriggers>
-                </VisualState>
-                <VisualState x:Name="SmallLayout">
-                    <VisualState.StateTriggers>
-                        <AdaptiveTrigger MinWindowWidth="{StaticResource SmallLayoutMinWidth}" />
-                        <AdaptiveTrigger MinWindowWidth="0" />
-                    </VisualState.StateTriggers>
-                    <VisualState.Setters>
-                        <Setter Target="SidePanel.(Grid.Column)" Value="0"/>
-                        <Setter Target="SidePanel.Width" Value="Auto"/>
-                        <Setter Target="PowerRenameView.(Grid.Row)" Value="1" />
-                        <Setter Target="PowerRenameView.Margin" Value="0" />
-                        <Setter Target="LinksPanel.(RelativePanel.RightOf)" Value="AboutImage"/>
-                        <Setter Target="LinksPanel.(RelativePanel.AlignTopWith)" Value="AboutImage"/>
-                        <Setter Target="AboutImage.Margin" Value="0,12,12,0"/>
-                        <Setter Target="AboutTitle.Visibility" Value="Collapsed" />
-                    </VisualState.Setters>
-                </VisualState>
-            </VisualStateGroup>
-        </VisualStateManager.VisualStateGroups>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*"/>
-            <ColumnDefinition Width="Auto"/>
-        </Grid.ColumnDefinitions>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto" />
-        </Grid.RowDefinitions>
-        <StackPanel Orientation="Vertical"
+    <controls:SettingsPageControl x:Uid="About_PowerRename"
+                                  ModuleImageSource="ms-appx:///Assets/Modules/PowerRename.png"
+                                  ModuleImageLink="https://aka.ms/PowerToysOverview_PowerRename">
+        <controls:SettingsPageControl.ModuleContent>
+            <StackPanel Orientation="Vertical"
                     x:Name="PowerRenameView"
                     HorizontalAlignment="Left"
                     Margin="0,0,48,0"
                     MaxWidth="{StaticResource MaxContentWidth}">
 
-            <ToggleSwitch x:Uid="PowerRename_Toggle_Enable"
+                <ToggleSwitch x:Uid="PowerRename_Toggle_Enable"
                           IsOn="{x:Bind Mode=TwoWay, Path=ViewModel.IsEnabled}"                          
                            />
 
-            <TextBlock x:Uid="PowerRename_ShellIntegration"
+                <TextBlock x:Uid="PowerRename_ShellIntegration"
                        Style="{StaticResource SettingsGroupTitleStyle}"
                        Opacity="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToOpacityConverter}}"/>
 
-            <ToggleSwitch x:Uid="PowerRename_Toggle_EnableOnContextMenu"
+                <ToggleSwitch x:Uid="PowerRename_Toggle_EnableOnContextMenu"
                           Margin="{StaticResource SmallTopMargin}" 
                           IsOn="{x:Bind Mode=TwoWay, Path=ViewModel.EnabledOnContextMenu}"
                           IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"
                            />
 
-            <ToggleSwitch x:Uid="PowerRename_Toggle_EnableOnExtendedContextMenu"
+                <ToggleSwitch x:Uid="PowerRename_Toggle_EnableOnExtendedContextMenu"
                           Margin="{StaticResource SmallTopMargin}"
                           IsOn="{x:Bind Mode=TwoWay, Path=ViewModel.EnabledOnContextExtendedMenu}"
                           IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"
                            />
 
-            <TextBlock x:Uid="PowerRename_AutoCompleteHeader"
+                <TextBlock x:Uid="PowerRename_AutoCompleteHeader"
                        Style="{StaticResource SettingsGroupTitleStyle}"
                        Opacity="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToOpacityConverter}}"/>
 
-            <CheckBox x:Uid="PowerRename_Toggle_AutoComplete"
+                <CheckBox x:Uid="PowerRename_Toggle_AutoComplete"
                           Margin="{StaticResource SmallTopMargin}" 
                           IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.MRUEnabled}"
                           IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"
                            />
 
-            <muxc:NumberBox x:Uid="PowerRename_Toggle_MaxDispListNum"
+                <muxc:NumberBox x:Uid="PowerRename_Toggle_MaxDispListNum"
                             SpinButtonPlacementMode="Compact"
                             HorizontalAlignment="Left"
                             Margin="{StaticResource SmallTopMargin}"
@@ -90,68 +60,29 @@
                             Maximum="20"
                             IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.GlobalAndMruEnabled}"/>
 
-            <CheckBox x:Uid="PowerRename_Toggle_RestoreFlagsOnLaunch"
+                <CheckBox x:Uid="PowerRename_Toggle_RestoreFlagsOnLaunch"
                           Margin="0, 17, 0, 0" 
                           IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.RestoreFlagsOnLaunch}"
                           IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"/>
 
-            <TextBlock x:Uid="PowerRename_BehaviorHeader"
+                <TextBlock x:Uid="PowerRename_BehaviorHeader"
                        Style="{StaticResource SettingsGroupTitleStyle}"
                        Opacity="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToOpacityConverter}}"/>
 
-            <CheckBox x:Uid="PowerRename_Toggle_UseBoostLib"
+                <CheckBox x:Uid="PowerRename_Toggle_UseBoostLib"
                       Margin="{StaticResource SmallTopMargin}"
                       IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.UseBoostLib}"
                       IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"/>
-        </StackPanel>
-
-
-        <RelativePanel x:Name="SidePanel" 
-                    HorizontalAlignment="Left"
-                    Width="{StaticResource SidePanelWidth}"
-                    Grid.Column="1">
-            <StackPanel x:Name="DescriptionPanel">
-                <TextBlock x:Uid="About_PowerRename" x:Name="AboutTitle" Grid.ColumnSpan="2"
-                       Style="{StaticResource SettingsGroupTitleStyle}"
-                       Margin="{StaticResource XSmallBottomMargin}"/>
-                <TextBlock x:Uid="PowerRename_Description"
-                           TextWrapping="Wrap"
-                           Grid.Row="1" />
             </StackPanel>
 
-            <Border x:Name="AboutImage"
-                    CornerRadius="4"
-                    Grid.Row="2"
-                    MaxWidth="240"
-                    HorizontalAlignment="Left"
-                    Margin="{StaticResource SmallTopBottomMargin}"
-                    RelativePanel.Below="DescriptionPanel">
-                <HyperlinkButton x:Uid="PowerRename_ImageHyperlinkToDocs">
-                    <Image x:Uid="PowerRename_Image" Source="ms-appx:///Assets/Modules/PowerRename.png" />
-                </HyperlinkButton>
-            </Border>
+        </controls:SettingsPageControl.ModuleContent>
 
-            <StackPanel x:Name="LinksPanel"
-                        Margin="0,1,0,0"
-                        RelativePanel.Below="AboutImage"
-                        Orientation="Vertical" >
-                <HyperlinkButton x:Uid="PowerRename_ImageHyperlinkToDocs">
-                    <TextBlock x:Uid="Module_overview" />
-                </HyperlinkButton>
-                <HyperlinkButton NavigateUri="https://aka.ms/powerToysGiveFeedback">
-                    <TextBlock x:Uid="Give_Feedback" />
-                </HyperlinkButton>
-
-                <TextBlock 
-                x:Uid="AttributionTitle"
-                Style="{StaticResource SettingsGroupTitleStyle}" 
-                Foreground="{ Binding Mode=TwoWay, Path=TextColor}"/>
-
-                <HyperlinkButton NavigateUri="https://github.com/chrdavis/SmartRename" Margin="0,-3,0,0">
-                    <TextBlock Text="Chris Davis's SmartRenamer" TextWrapping="Wrap" />
-                </HyperlinkButton>
-
-            </StackPanel>
-        </RelativePanel>
-    </Grid>
+        <controls:SettingsPageControl.ModuleLinks>
+            <controls:SidePanelLink x:Uid="Learn_More" Link="https://aka.ms/PowerToysOverview_PowerRename"/>
+            <controls:SidePanelLink x:Uid="Give_Feedback" Link="https://aka.ms/powerToysGiveFeedback"/>
+        </controls:SettingsPageControl.ModuleLinks>
+        <controls:SettingsPageControl.AttributionLinks>
+            <controls:SidePanelLink Label="Chris Davis's SmartRenamer" Link="https://github.com/chrdavis/SmartRename"/>
+        </controls:SettingsPageControl.AttributionLinks>
+    </controls:SettingsPageControl>
 </Page>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ShortcutGuidePage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ShortcutGuidePage.xaml
@@ -4,7 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:CustomControls="using:Microsoft.PowerToys.Settings.UI.Controls"
+    xmlns:controls="using:Microsoft.PowerToys.Settings.UI.Controls"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls" 
     xmlns:converters="using:Microsoft.Toolkit.Uwp.UI.Converters"
     mc:Ignorable="d"
@@ -15,53 +15,25 @@
         <converters:StringFormatConverter x:Key="StringFormatConverter"/>
     </Page.Resources>
 
-    <Grid RowSpacing="{StaticResource DefaultRowSpacing}">
-        <VisualStateManager.VisualStateGroups>
-            <VisualStateGroup x:Name="LayoutVisualStates">
-                <VisualState x:Name="WideLayout">
-                    <VisualState.StateTriggers>
-                        <AdaptiveTrigger MinWindowWidth="{StaticResource WideLayoutMinWidth}" />
-                    </VisualState.StateTriggers>
-                </VisualState>
-                <VisualState x:Name="SmallLayout">
-                    <VisualState.StateTriggers>
-                        <AdaptiveTrigger MinWindowWidth="{StaticResource SmallLayoutMinWidth}" />
-                        <AdaptiveTrigger MinWindowWidth="0" />
-                    </VisualState.StateTriggers>
-                    <VisualState.Setters>
-                        <Setter Target="SidePanel.(Grid.Column)" Value="0"/>
-                        <Setter Target="SidePanel.Width" Value="Auto"/>
-                        <Setter Target="ShortcutGuideView.(Grid.Row)" Value="1" />
-                        <Setter Target="ShortcutGuideView.Margin" Value="0" />
-                        <Setter Target="LinksPanel.(RelativePanel.RightOf)" Value="AboutImage"/>
-                        <Setter Target="LinksPanel.(RelativePanel.AlignTopWith)" Value="AboutImage"/>
-                        <Setter Target="AboutImage.Margin" Value="0,12,12,0"/>
-                        <Setter Target="AboutTitle.Visibility" Value="Collapsed" />
-                    </VisualState.Setters>
-                </VisualState>
-            </VisualStateGroup>
-        </VisualStateManager.VisualStateGroups>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*"/>
-            <ColumnDefinition Width="Auto"/>
-        </Grid.ColumnDefinitions>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto" />
-        </Grid.RowDefinitions>
-        <StackPanel Orientation="Vertical"
+    <controls:SettingsPageControl x:Uid="About_ShortcutGuide"
+                                  ModuleImageSource="ms-appx:///Assets/Modules/ShortcutGuide.png"
+                                  ModuleImageLink="https://aka.ms/PowerToysOverview_ShortcutGuide">
+        <controls:SettingsPageControl.ModuleContent>
+
+
+            <StackPanel Orientation="Vertical"
                     x:Name="ShortcutGuideView"
                     HorizontalAlignment="Left"
                     Margin="0,0,48,0"
                     MaxWidth="{StaticResource MaxContentWidth}">
-            <ToggleSwitch x:Uid="ShortcutGuide_Enable"
+                <ToggleSwitch x:Uid="ShortcutGuide_Enable"
                           IsOn="{x:Bind Mode=TwoWay, Path=ViewModel.IsEnabled}"/>
 
-            <TextBlock x:Uid="Shortcuts"
+                <TextBlock x:Uid="Shortcuts"
                        Style="{StaticResource SettingsGroupTitleStyle}"
                        Opacity="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToOpacityConverter}}"/>
-            
-            <CustomControls:HotkeySettingsControl x:Uid="ShortcutGuide_OpenShortcutGuide"
+
+                <controls:HotkeySettingsControl x:Uid="ShortcutGuide_OpenShortcutGuide"
                                                   HorizontalAlignment="Left"
                                                   MinWidth="240"
                                                   Margin="{StaticResource SmallTopMargin}"
@@ -69,12 +41,12 @@
                                                   Keys="Win, Ctrl, Alt, Shift"
                                                   Enabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"/>
 
-            <TextBlock x:Uid="ShortcutGuide_Appearance_Behavior"
+                <TextBlock x:Uid="ShortcutGuide_Appearance_Behavior"
                        Style="{StaticResource SettingsGroupTitleStyle}"
                        Opacity="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToOpacityConverter}}"/>
 
-            <StackPanel Orientation="Horizontal" Margin="{StaticResource MediumTopMargin}" Spacing="12">
-                <Slider x:Uid="ShortcutGuide_OverlayOpacity"
+                <StackPanel Orientation="Horizontal" Margin="{StaticResource MediumTopMargin}" Spacing="12">
+                    <Slider x:Uid="ShortcutGuide_OverlayOpacity"
                     Minimum="0"
                     Maximum="100"
                     Width="240"
@@ -83,39 +55,39 @@
                     HorizontalAlignment="Left"
                     IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"/>
 
-                <TextBlock
-                    Text="{x:Bind Mode=OneWay, Path=ViewModel.OverlayOpacity, Converter={StaticResource StringFormatConverter}, ConverterParameter=' {0}%' }"
-                    VerticalAlignment="Center"
-                    FontSize="16"
-                    FontWeight="SemiBold"
-                    Margin="0,16,0,0"
-                    Opacity="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToOpacityConverter}}"/>
-            </StackPanel>
+                    <TextBlock
+                        Text="{x:Bind Mode=OneWay, Path=ViewModel.OverlayOpacity, Converter={StaticResource StringFormatConverter}, ConverterParameter=' {0}%' }"
+                        VerticalAlignment="Center"
+                        FontSize="16"
+                        FontWeight="SemiBold"
+                        Margin="0,16,0,0"
+                        Opacity="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToOpacityConverter}}"/>
+                </StackPanel>
 
-            <!-- We cannot navigate to all the radio buttons using the arrow keys because of an XYNavigation issue in the RadioButtons control.
+                <!-- We cannot navigate to all the radio buttons using the arrow keys because of an XYNavigation issue in the RadioButtons control.
             The screen reader does not read the heading when we tab into a radio button, even though the LabeledBy automation property is set.
             Link to the issue in the winui repository - https://github.com/microsoft/microsoft-ui-xaml/issues/3156 -->
-            <TextBlock Name="ShortcutGuide_Theme"
+                <TextBlock Name="ShortcutGuide_Theme"
                 x:Uid="ColorModeHeader"
                 Margin="{StaticResource SmallTopMargin}"
                 Opacity="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToOpacityConverter}}"/>
-            <muxc:RadioButtons IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"
+                <muxc:RadioButtons IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"
                                SelectedIndex="{x:Bind Mode=TwoWay, Path=ViewModel.ThemeIndex}"
                                AutomationProperties.LabeledBy="{Binding ElementName=ShortcutGuide_Theme}">
-                <RadioButton x:Uid="Radio_Theme_Dark" />
-                <RadioButton x:Uid="Radio_Theme_Light" />
-                <RadioButton x:Uid="Radio_Theme_Default"/>
-            </muxc:RadioButtons>
-            <HyperlinkButton Click="OpenColorsSettings_Click"
+                    <RadioButton x:Uid="Radio_Theme_Dark" />
+                    <RadioButton x:Uid="Radio_Theme_Light" />
+                    <RadioButton x:Uid="Radio_Theme_Default"/>
+                </muxc:RadioButtons>
+                <HyperlinkButton Click="OpenColorsSettings_Click"
                              IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}">
-                <TextBlock x:Uid="Windows_Color_Settings" />
-            </HyperlinkButton>
-            
-            <TextBlock x:Uid="ShortcutGuide_DisabledApps"
+                    <TextBlock x:Uid="Windows_Color_Settings" />
+                </HyperlinkButton>
+
+                <TextBlock x:Uid="ShortcutGuide_DisabledApps"
                        Style="{StaticResource SettingsGroupTitleStyle}"
                        Opacity="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToOpacityConverter}}"/>
-            
-            <TextBox x:Uid="ShortcutGuide_DisabledApps_TextBoxControl"
+
+                <TextBox x:Uid="ShortcutGuide_DisabledApps_TextBoxControl"
                      Margin="{StaticResource SmallTopMargin}"
                      Text="{x:Bind Mode=TwoWay, Path=ViewModel.DisabledApps}"
                      IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"
@@ -127,46 +99,11 @@
                      HorizontalAlignment="Left"
                      MinWidth="240"
                      MinHeight="160" />
-        </StackPanel>
-
-        <RelativePanel x:Name="SidePanel" 
-                    HorizontalAlignment="Left"
-                    Width="{StaticResource SidePanelWidth}"
-                    Grid.Column="1">
-            <StackPanel x:Name="DescriptionPanel">
-                <TextBlock x:Uid="About_ShortcutGuide"
-                           x:Name="AboutTitle"
-                           Grid.ColumnSpan="2"
-                           Style="{StaticResource SettingsGroupTitleStyle}"
-                           Margin="{StaticResource XSmallBottomMargin}"/>
-                <TextBlock x:Uid="ShortcutGuide_Description"
-                           TextWrapping="Wrap"
-                           Grid.Row="1" />
             </StackPanel>
-
-            <Border x:Name="AboutImage"
-                    CornerRadius="4"
-                    Grid.Row="2"
-                    MaxWidth="240"
-                    HorizontalAlignment="Left"
-                    Margin="{StaticResource SmallTopBottomMargin}"
-                    RelativePanel.Below="DescriptionPanel">
-                <HyperlinkButton x:Uid="ShortcutGuide_ImageHyperlinkToDocs">
-                    <Image x:Uid="Shortcut_Guide_Image" Source="ms-appx:///Assets/Modules/ShortcutGuide.png" />
-                </HyperlinkButton>
-            </Border>
-
-            <StackPanel x:Name="LinksPanel"
-                        Margin="0,1,0,0"
-                        RelativePanel.Below="AboutImage"
-                        Orientation="Vertical" >
-                <HyperlinkButton x:Uid="ShortcutGuide_ImageHyperlinkToDocs">
-                    <TextBlock x:Uid="Module_overview" />
-                </HyperlinkButton>
-                <HyperlinkButton NavigateUri="https://aka.ms/powerToysGiveFeedback">
-                    <TextBlock x:Uid="Give_Feedback" />
-                </HyperlinkButton>
-            </StackPanel>
-        </RelativePanel>
-    </Grid>
+        </controls:SettingsPageControl.ModuleContent>
+        <controls:SettingsPageControl.ModuleLinks>
+            <controls:SidePanelLink x:Uid="Learn_More" Link="https://aka.ms/PowerToysOverview_ShortcutGuide"/>
+            <controls:SidePanelLink x:Uid="Give_Feedback" Link="https://aka.ms/powerToysGiveFeedback"/>
+        </controls:SettingsPageControl.ModuleLinks>
+    </controls:SettingsPageControl>
 </Page>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/VideoConference.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/VideoConference.xaml
@@ -4,55 +4,27 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:CustomControls="using:Microsoft.PowerToys.Settings.UI.Controls"
+    xmlns:controls="using:Microsoft.PowerToys.Settings.UI.Controls"
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-    <Grid RowSpacing="{StaticResource DefaultRowSpacing}">
-        <VisualStateManager.VisualStateGroups>
-            <VisualStateGroup x:Name="LayoutVisualStates">
-                <VisualState x:Name="WideLayout">
-                    <VisualState.StateTriggers>
-                        <AdaptiveTrigger MinWindowWidth="{StaticResource WideLayoutMinWidth}" />
-                    </VisualState.StateTriggers>
-                </VisualState>
-                <VisualState x:Name="SmallLayout">
-                    <VisualState.StateTriggers>
-                        <AdaptiveTrigger MinWindowWidth="{StaticResource SmallLayoutMinWidth}" />
-                        <AdaptiveTrigger MinWindowWidth="0" />
-                    </VisualState.StateTriggers>
-                    <VisualState.Setters>
-                        <Setter Target="SidePanel.(Grid.Column)" Value="0"/>
-                        <Setter Target="SidePanel.Width" Value="Auto"/>
-                        <Setter Target="VideoConferenceView.(Grid.Row)" Value="1" />
-                        <Setter Target="LinksPanel.(RelativePanel.RightOf)" Value="AboutImage"/>
-                        <Setter Target="LinksPanel.(RelativePanel.AlignTopWith)" Value="AboutImage"/>
-                        <Setter Target="AboutImage.Margin" Value="0,12,12,0"/>
-                        <Setter Target="AboutTitle.Visibility" Value="Collapsed" />
-                    </VisualState.Setters>
-                </VisualState>
-            </VisualStateGroup>
-        </VisualStateManager.VisualStateGroups>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*"/>
-            <ColumnDefinition Width="Auto"/>
-        </Grid.ColumnDefinitions>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto" />
-        </Grid.RowDefinitions>
-        <StackPanel Orientation="Vertical" x:Name="VideoConferenceView">
+    <controls:SettingsPageControl x:Uid="About_VideoConference"
+                                  ModuleImageSource="ms-appx:///Assets/Modules/VideoConference.png"
+                                  ModuleImageLink="https://aka.ms/PowerToysOverview_VideoConference">
+        <controls:SettingsPageControl.ModuleContent>
 
-            <ToggleSwitch x:Uid="VideoConference_Enable"
+            <StackPanel Orientation="Vertical">
+
+                <ToggleSwitch x:Uid="VideoConference_Enable"
                           IsOn="{ Binding Mode=TwoWay, Path=IsEnabled}"
                           IsEnabled="{ Binding Mode=OneWay, Path=IsElevated }"
                           />
 
-            <TextBlock x:Uid="VideoConference_Shortcuts"
+                <TextBlock x:Uid="VideoConference_Shortcuts"
                        Style="{StaticResource SettingsGroupTitleStyle}"
                        Foreground="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToForegroundConverter}}" />
-            
-            <CustomControls:HotkeySettingsControl 
+
+                <controls:HotkeySettingsControl 
                                           x:Uid="VideoConference_CameraAndMicrophoneMuteHotkeyControl_Header"
                                           Width="240"
                                           HorizontalAlignment="Left"
@@ -62,7 +34,7 @@
                                           IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"
                                           />
 
-            <CustomControls:HotkeySettingsControl 
+                <controls:HotkeySettingsControl 
                                           x:Uid="VideoConference_MicrophoneMuteHotkeyControl_Header"
                                           Width="240"
                                           HorizontalAlignment="Left"
@@ -72,7 +44,7 @@
                                           IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"
                                           />
 
-            <CustomControls:HotkeySettingsControl 
+                <controls:HotkeySettingsControl 
                                           x:Uid="VideoConference_CameraMuteHotkeyControl_Header"
                                           Width="240"
                                           HorizontalAlignment="Left"
@@ -81,11 +53,11 @@
                                           HotkeySettings="{x:Bind Path=ViewModel.CameraMuteHotkey, Mode=TwoWay}"
                                           IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"
                                           />
-            <TextBlock x:Uid="VideoConference_Microphone"
+                <TextBlock x:Uid="VideoConference_Microphone"
                        Style="{StaticResource SettingsGroupTitleStyle}"
                        Foreground="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToForegroundConverter}}"/>
 
-            <ComboBox x:Uid="VideoConference_SelectedMicrophone"
+                <ComboBox x:Uid="VideoConference_SelectedMicrophone"
                       Width="240"
                       HorizontalAlignment="Left"
                       Margin="{StaticResource SmallTopMargin}"
@@ -93,11 +65,11 @@
                       ItemsSource="{Binding MicrophoneNames, Mode=OneTime}"
                       IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"/>
 
-            <TextBlock x:Uid="VideoConference_Camera"
+                <TextBlock x:Uid="VideoConference_Camera"
                        Style="{StaticResource SettingsGroupTitleStyle}"
                        Foreground="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToForegroundConverter}}"/>
-            
-            <ComboBox x:Uid="VideoConference_SelectedCamera"
+
+                <ComboBox x:Uid="VideoConference_SelectedCamera"
                       Width="240"
                       HorizontalAlignment="Left"
                       Margin="{StaticResource SmallTopMargin}"
@@ -105,106 +77,73 @@
                       ItemsSource="{Binding CameraNames, Mode=OneTime}"
                       IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"/>
 
-            <TextBlock x:Uid="VideoConference_CameraOverlayImagePathHeader"
+                <TextBlock x:Uid="VideoConference_CameraOverlayImagePathHeader"
                        Margin="{StaticResource SmallTopMargin}"/>
 
-            <Border CornerRadius="4"
+                <Border CornerRadius="4"
                     HorizontalAlignment="Left"
                     Margin="{StaticResource XXSmallTopMargin}">
-                <Image Width="240"
+                    <Image Width="240"
                        x:Uid="VideoConference_CameraOverlayImageAlt"
                        ToolTipService.ToolTip="{Binding Mode=OneWay, Path=CameraImageOverlayPath}"
                        Source="{Binding Mode=OneWay, Path=CameraImageOverlayPath}"/>
-            </Border>
+                </Border>
 
-            <StackPanel Orientation="Horizontal"
+                <StackPanel Orientation="Horizontal"
                         Padding="0"
                         Spacing="8"
                         Margin="{StaticResource SmallTopMargin}">
-                <Button Height="32"
+                    <Button Height="32"
                         IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}"
                         x:Uid="VideoConference_CameraOverlayImageBrowse"
                         Command="{Binding Mode=OneWay, Path=SelectOverlayImage}"
                         HorizontalContentAlignment="Left"
                         HorizontalAlignment="Left" />
-                
-                <Button IsEnabled="{Binding Mode=TwoWay, Path=IsEnabled}"
+
+                    <Button IsEnabled="{Binding Mode=TwoWay, Path=IsEnabled}"
                         Height="32"
                         x:Uid="VideoConference_CameraOverlayImageClear"
                         Command="{Binding Mode=OneWay, Path=ClearOverlayImage}"
                         HorizontalAlignment="Left" />
-            </StackPanel>
+                </StackPanel>
 
-            <TextBlock x:Uid="VideoConference_Toolbar"
+                <TextBlock x:Uid="VideoConference_Toolbar"
                        Style="{StaticResource SettingsGroupTitleStyle}"
                        Foreground="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToForegroundConverter}}"/>
-            
-            <ComboBox x:Uid="VideoConference_ToolbarPosition" 
+
+                <ComboBox x:Uid="VideoConference_ToolbarPosition" 
                       MinWidth="240"
                       Margin="{StaticResource SmallTopMargin}"
                       SelectedIndex="{ Binding Mode=TwoWay, Path=ToolbarPostionIndex}"
                       IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}">
-                <ComboBoxItem x:Uid="VideoConference_ToolbarPosition_TopLeftCorner"/>
-                <ComboBoxItem x:Uid="VideoConference_ToolbarPosition_TopCenter"/>
-                <ComboBoxItem x:Uid="VideoConference_ToolbarPosition_TopRightCorner"/>
-                <ComboBoxItem x:Uid="VideoConference_ToolbarPosition_BottomLeftCorner"/>
-                <ComboBoxItem x:Uid="VideoConference_ToolbarPosition_BottomCenter"/>
-                <ComboBoxItem x:Uid="VideoConference_ToolbarPosition_BottomRightCorner"/>
-            </ComboBox>
+                    <ComboBoxItem x:Uid="VideoConference_ToolbarPosition_TopLeftCorner"/>
+                    <ComboBoxItem x:Uid="VideoConference_ToolbarPosition_TopCenter"/>
+                    <ComboBoxItem x:Uid="VideoConference_ToolbarPosition_TopRightCorner"/>
+                    <ComboBoxItem x:Uid="VideoConference_ToolbarPosition_BottomLeftCorner"/>
+                    <ComboBoxItem x:Uid="VideoConference_ToolbarPosition_BottomCenter"/>
+                    <ComboBoxItem x:Uid="VideoConference_ToolbarPosition_BottomRightCorner"/>
+                </ComboBox>
 
-            <ComboBox x:Uid="VideoConference_ToolbarMonitor" 
+                <ComboBox x:Uid="VideoConference_ToolbarMonitor" 
                       MinWidth="240"
                       Margin="{StaticResource SmallTopMargin}"
                       SelectedIndex="{ Binding Mode=TwoWay, Path=ToolbarMonitorIndex}"
                       IsEnabled="{ Binding Mode=TwoWay, Path=IsEnabled}">
-                <ComboBoxItem x:Uid="VideoConference_ToolbarMonitor_Main"/>
-                <ComboBoxItem x:Uid="VideoConference_ToolbarMonitor_All"/>
-            </ComboBox>
+                    <ComboBoxItem x:Uid="VideoConference_ToolbarMonitor_Main"/>
+                    <ComboBoxItem x:Uid="VideoConference_ToolbarMonitor_All"/>
+                </ComboBox>
 
-            <CheckBox x:Uid="VideoConference_HideToolbarWhenUnmuted"
+                <CheckBox x:Uid="VideoConference_HideToolbarWhenUnmuted"
                       IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.HideToolbarWhenUnmuted}"
                       Margin="{StaticResource SmallTopMargin}"
                       IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}"
                       />
-        </StackPanel>
-        <RelativePanel x:Name="SidePanel" 
-                    HorizontalAlignment="Left"
-                    Width="{StaticResource SidePanelWidth}"
-                    Grid.Column="1">
-            <StackPanel x:Name="DescriptionPanel">
-                <TextBlock x:Uid="About_VideoConference"
-                           x:Name="AboutTitle"
-                           Grid.ColumnSpan="2"
-                           Style="{StaticResource SettingsGroupTitleStyle}"
-                           Margin="{StaticResource XSmallBottomMargin}"/>
-                <TextBlock x:Uid="VideoConference_Description"
-                           TextWrapping="Wrap"
-                           Grid.Row="1" />
             </StackPanel>
+        </controls:SettingsPageControl.ModuleContent>
 
-            <Border x:Name="AboutImage"
-                    CornerRadius="4"
-                    Grid.Row="2"
-                    MaxWidth="240"
-                    HorizontalAlignment="Left"
-                    Margin="{StaticResource SmallTopBottomMargin}"
-                    RelativePanel.Below="DescriptionPanel">
-                <HyperlinkButton x:Uid="VideoConference_ImageHyperlinkToDocs">
-                    <Image Source="ms-appx:///Assets/Modules/VideoConference.png" />
-                </HyperlinkButton>
-            </Border>
-
-            <StackPanel x:Name="LinksPanel"
-                        Margin="0,1,0,0"
-                        RelativePanel.Below="AboutImage"
-                        Orientation="Vertical" >
-                <HyperlinkButton x:Uid="VideoConference_ImageHyperlinkToDocs">
-                    <TextBlock x:Uid="Module_overview" />
-                </HyperlinkButton>
-                <HyperlinkButton NavigateUri="https://aka.ms/powerToysGiveFeedback">
-                    <TextBlock x:Uid="Give_Feedback" />
-                </HyperlinkButton>
-            </StackPanel>
-        </RelativePanel>
-    </Grid>
+        <controls:SettingsPageControl.ModuleLinks>
+            <controls:SidePanelLink x:Uid="Learn_More" Link="https://aka.ms/PowerToysOverview_VideoConference"/>
+            <controls:SidePanelLink x:Uid="Give_Feedback" Link="https://aka.ms/powerToysGiveFeedback"/>
+        </controls:SettingsPageControl.ModuleLinks>
+    </controls:SettingsPageControl>
 </Page>


### PR DESCRIPTION
## Summary of the Pull Request
This PR introduces a re-usable user control that contains the entire page layout and re-sizing logic. Instead of having the same XAML on 11 pages, we now have 1 control we can adjust so making UI tweaks in the future is easier and we reduce any inconsistency. It also makes the pages easier to read and re-use.

Fixed with this issue: #12073

This paves the way of solving (and reducing) accessibility issues in the future such as #12023

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
