### PR TITLE
[FancyZones] Rename ZoneWindow -> WorkArea

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -1065,6 +1065,7 @@ IVector
 IView
 IVirtual
 IWeb
+IWork
 IXml
 IWindows
 ixx

--- a/src/modules/fancyzones/FancyZones/FancyZonesApp.cpp
+++ b/src/modules/fancyzones/FancyZones/FancyZonesApp.cpp
@@ -9,6 +9,7 @@
 #include <FancyZonesLib/Generated Files/resource.h>
 #include <FancyZonesLib/FancyZonesData.h>
 #include <FancyZonesLib/FancyZonesWinHookEventIDs.h>
+#include <FancyZonesLib/Settings.h>
 #include <FancyZonesLib/trace.h>
 
 

--- a/src/modules/fancyzones/FancyZonesLib/FancyZones.h
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZones.h
@@ -4,7 +4,7 @@
 
 #include <functional>
 
-interface IZoneWindow;
+interface IWorkArea;
 interface IFancyZonesSettings;
 interface IZoneSet;
 

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesData.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesData.cpp
@@ -196,7 +196,7 @@ bool FancyZonesData::AddDevice(const std::wstring& deviceId)
     std::scoped_lock lock{ dataLock };
     if (!deviceInfoMap.contains(deviceId))
     {
-        // Creates default entry in map when ZoneWindow is created
+        // Creates default entry in map when WorkArea is created
         GUID guid;
         auto result{ CoCreateGuid(&guid) };
         wil::unique_cotaskmem_string guidString;

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesData.h
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesData.h
@@ -34,8 +34,8 @@ namespace FancyZonesUnitTests
     class FancyZonesDataUnitTests;
     class FancyZonesIFancyZonesCallbackUnitTests;
     class ZoneSetCalculateZonesUnitTests;
-    class ZoneWindowUnitTests;
-    class ZoneWindowCreationUnitTests;
+    class WorkAreaUnitTests;
+    class WorkAreaCreationUnitTests;
 }
 #endif
 
@@ -96,8 +96,8 @@ private:
 #if defined(UNIT_TESTS)
     friend class FancyZonesUnitTests::FancyZonesDataUnitTests;
     friend class FancyZonesUnitTests::FancyZonesIFancyZonesCallbackUnitTests;
-    friend class FancyZonesUnitTests::ZoneWindowUnitTests;
-    friend class FancyZonesUnitTests::ZoneWindowCreationUnitTests;
+    friend class FancyZonesUnitTests::WorkAreaUnitTests;
+    friend class FancyZonesUnitTests::WorkAreaCreationUnitTests;
     friend class FancyZonesUnitTests::ZoneSetCalculateZonesUnitTests;
 
     inline void SetDeviceInfo(const std::wstring& deviceId, FancyZonesDataTypes::DeviceInfoData data)

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesLib.vcxproj
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesLib.vcxproj
@@ -60,7 +60,7 @@
     <ClInclude Include="Zone.h" />
     <ClInclude Include="ZoneColors.h" />
     <ClInclude Include="ZoneSet.h" />
-    <ClInclude Include="ZoneWindow.h" />
+    <ClInclude Include="WorkArea.h" />
     <ClInclude Include="ZoneWindowDrawing.h" />
   </ItemGroup>
   <ItemGroup>
@@ -85,7 +85,7 @@
     <ClCompile Include="WindowMoveHandler.cpp" />
     <ClCompile Include="Zone.cpp" />
     <ClCompile Include="ZoneSet.cpp" />
-    <ClCompile Include="ZoneWindow.cpp" />
+    <ClCompile Include="WorkArea.cpp" />
     <ClCompile Include="ZoneWindowDrawing.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesLib.vcxproj.filters
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesLib.vcxproj.filters
@@ -27,7 +27,7 @@
     <ClInclude Include="ZoneSet.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="ZoneWindow.h">
+    <ClInclude Include="WorkArea.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="FancyZones.h">
@@ -101,7 +101,7 @@
     <ClCompile Include="ZoneSet.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="ZoneWindow.cpp">
+    <ClCompile Include="WorkArea.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="FancyZones.cpp">

--- a/src/modules/fancyzones/FancyZonesLib/MonitorWorkAreaHandler.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/MonitorWorkAreaHandler.cpp
@@ -2,7 +2,7 @@
 #include "MonitorWorkAreaHandler.h"
 #include "VirtualDesktop.h"
 
-winrt::com_ptr<IZoneWindow> MonitorWorkAreaHandler::GetWorkArea(const GUID& desktopId, HMONITOR monitor)
+winrt::com_ptr<IWorkArea> MonitorWorkAreaHandler::GetWorkArea(const GUID& desktopId, HMONITOR monitor)
 {
     auto desktopIt = workAreaMap.find(desktopId);
     if (desktopIt != std::end(workAreaMap))
@@ -17,7 +17,7 @@ winrt::com_ptr<IZoneWindow> MonitorWorkAreaHandler::GetWorkArea(const GUID& desk
     return nullptr;
 }
 
-winrt::com_ptr<IZoneWindow> MonitorWorkAreaHandler::GetWorkAreaFromCursor(const GUID& desktopId)
+winrt::com_ptr<IWorkArea> MonitorWorkAreaHandler::GetWorkAreaFromCursor(const GUID& desktopId)
 {
     auto allMonitorsWorkArea = GetWorkArea(desktopId, NULL);
     if (allMonitorsWorkArea)
@@ -38,7 +38,7 @@ winrt::com_ptr<IZoneWindow> MonitorWorkAreaHandler::GetWorkAreaFromCursor(const 
     }
 }
 
-winrt::com_ptr<IZoneWindow> MonitorWorkAreaHandler::GetWorkArea(HWND window, const GUID& desktopId)
+winrt::com_ptr<IWorkArea> MonitorWorkAreaHandler::GetWorkArea(HWND window, const GUID& desktopId)
 {
     auto allMonitorsWorkArea = GetWorkArea(desktopId, NULL);
     if (allMonitorsWorkArea)
@@ -54,19 +54,19 @@ winrt::com_ptr<IZoneWindow> MonitorWorkAreaHandler::GetWorkArea(HWND window, con
     }
 }
 
-const std::unordered_map<HMONITOR, winrt::com_ptr<IZoneWindow>>& MonitorWorkAreaHandler::GetWorkAreasByDesktopId(const GUID& desktopId)
+const std::unordered_map<HMONITOR, winrt::com_ptr<IWorkArea>>& MonitorWorkAreaHandler::GetWorkAreasByDesktopId(const GUID& desktopId)
 {
     if (workAreaMap.contains(desktopId))
     {
         return workAreaMap[desktopId];
     }
-    static const std::unordered_map<HMONITOR, winrt::com_ptr<IZoneWindow>> empty;
+    static const std::unordered_map<HMONITOR, winrt::com_ptr<IWorkArea>> empty;
     return empty;
 }
 
-std::vector<winrt::com_ptr<IZoneWindow>> MonitorWorkAreaHandler::GetAllWorkAreas()
+std::vector<winrt::com_ptr<IWorkArea>> MonitorWorkAreaHandler::GetAllWorkAreas()
 {
-    std::vector<winrt::com_ptr<IZoneWindow>> workAreas{};
+    std::vector<winrt::com_ptr<IWorkArea>> workAreas{};
     for (const auto& [desktopId, perDesktopData] : workAreaMap)
     {
         std::transform(std::begin(perDesktopData),
@@ -77,7 +77,7 @@ std::vector<winrt::com_ptr<IZoneWindow>> MonitorWorkAreaHandler::GetAllWorkAreas
     return workAreas;
 }
 
-void MonitorWorkAreaHandler::AddWorkArea(const GUID& desktopId, HMONITOR monitor, winrt::com_ptr<IZoneWindow>& workArea)
+void MonitorWorkAreaHandler::AddWorkArea(const GUID& desktopId, HMONITOR monitor, winrt::com_ptr<IWorkArea>& workArea)
 {
     if (!workAreaMap.contains(desktopId))
     {

--- a/src/modules/fancyzones/FancyZonesLib/MonitorWorkAreaHandler.h
+++ b/src/modules/fancyzones/FancyZonesLib/MonitorWorkAreaHandler.h
@@ -1,6 +1,6 @@
 #pragma once
 
-interface IZoneWindow;
+interface IWorkArea;
 struct ZoneColors;
 enum struct OverlappingZonesAlgorithm;
 
@@ -29,7 +29,7 @@ public:
      * @returns    Object representing single work area, interface to all actions available on work area
      *             (e.g. moving windows through zone layout specified for that work area).
      */
-    winrt::com_ptr<IZoneWindow> GetWorkArea(const GUID& desktopId, HMONITOR monitor);
+    winrt::com_ptr<IWorkArea> GetWorkArea(const GUID& desktopId, HMONITOR monitor);
 
     /**
      * Get work area based on virtual desktop id and the current cursor position.
@@ -39,7 +39,7 @@ public:
      * @returns    Object representing single work area, interface to all actions available on work area
      *             (e.g. moving windows through zone layout specified for that work area).
      */
-    winrt::com_ptr<IZoneWindow> GetWorkAreaFromCursor(const GUID& desktopId);
+    winrt::com_ptr<IWorkArea> GetWorkAreaFromCursor(const GUID& desktopId);
 
     /**
      * Get work area on which specified window is located.
@@ -50,7 +50,7 @@ public:
      * @returns    Object representing single work area, interface to all actions available on work area
      *             (e.g. moving windows through zone layout specified for that work area).
      */
-    winrt::com_ptr<IZoneWindow> GetWorkArea(HWND window, const GUID& desktopId);
+    winrt::com_ptr<IWorkArea> GetWorkArea(HWND window, const GUID& desktopId);
 
     /**
      * Get map of all work areas on single virtual desktop. Key in the map is monitor handle, while value
@@ -60,12 +60,12 @@ public:
      *
      * @returns    Map containing pairs of monitor and work area for that monitor (within same virtual desktop).
      */
-    const std::unordered_map<HMONITOR, winrt::com_ptr<IZoneWindow>>& GetWorkAreasByDesktopId(const GUID& desktopId);
+    const std::unordered_map<HMONITOR, winrt::com_ptr<IWorkArea>>& GetWorkAreasByDesktopId(const GUID& desktopId);
 
     /**
      * @returns    All registered work areas.
      */
-    std::vector<winrt::com_ptr<IZoneWindow>> GetAllWorkAreas();
+    std::vector<winrt::com_ptr<IWorkArea>> GetAllWorkAreas();
 
     /**
      * Register new work area.
@@ -74,7 +74,7 @@ public:
      * @param[in]  monitor   Monitor handle.
      * @param[in]  workAra   Object representing single work area.
      */
-    void AddWorkArea(const GUID& desktopId, HMONITOR monitor, winrt::com_ptr<IZoneWindow>& workArea);
+    void AddWorkArea(const GUID& desktopId, HMONITOR monitor, winrt::com_ptr<IWorkArea>& workArea);
 
     /**
      * Check if work area is already registered.
@@ -110,5 +110,5 @@ public:
     
 private:
     // Work area is uniquely defined by monitor and virtual desktop id.
-    std::unordered_map<GUID, std::unordered_map<HMONITOR, winrt::com_ptr<IZoneWindow>>> workAreaMap;
+    std::unordered_map<GUID, std::unordered_map<HMONITOR, winrt::com_ptr<IWorkArea>>> workAreaMap;
 };

--- a/src/modules/fancyzones/FancyZonesLib/VirtualDesktop.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/VirtualDesktop.cpp
@@ -77,7 +77,7 @@ std::optional<GUID> GetDesktopIdFromCurrentSession()
     return std::nullopt;
 }
 
-bool GetZoneWindowDesktopId(IZoneWindow* zoneWindow, GUID* desktopId)
+bool GetZoneWindowDesktopId(IWorkArea* zoneWindow, GUID* desktopId)
 {
     // Format: <device-id>_<resolution>_<virtual-desktop-id>
     std::wstring uniqueId = zoneWindow->UniqueId();

--- a/src/modules/fancyzones/FancyZonesLib/VirtualDesktop.h
+++ b/src/modules/fancyzones/FancyZonesLib/VirtualDesktop.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "ZoneWindow.h"
+#include "WorkArea.h"
 #include "on_thread_executor.h"
 
 class VirtualDesktop

--- a/src/modules/fancyzones/FancyZonesLib/WindowMoveHandler.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WindowMoveHandler.cpp
@@ -9,7 +9,7 @@
 
 #include "FancyZonesData.h"
 #include "Settings.h"
-#include "ZoneWindow.h"
+#include "WorkArea.h"
 #include "util.h"
 
 // Non-Localizable strings
@@ -59,7 +59,7 @@ WindowMoveHandler::WindowMoveHandler(const winrt::com_ptr<IFancyZonesSettings>& 
 {
 }
 
-void WindowMoveHandler::MoveSizeStart(HWND window, HMONITOR monitor, POINT const& ptScreen, const std::unordered_map<HMONITOR, winrt::com_ptr<IZoneWindow>>& zoneWindowMap) noexcept
+void WindowMoveHandler::MoveSizeStart(HWND window, HMONITOR monitor, POINT const& ptScreen, const std::unordered_map<HMONITOR, winrt::com_ptr<IWorkArea>>& zoneWindowMap) noexcept
 {
     if (!FancyZonesUtils::IsCandidateForZoning(window, m_settings->GetSettings()->excludedAppsArray) || WindowMoveHandlerUtils::IsCursorTypeIndicatingSizeEvent())
     {
@@ -125,7 +125,7 @@ void WindowMoveHandler::MoveSizeStart(HWND window, HMONITOR monitor, POINT const
     }
 }
 
-void WindowMoveHandler::MoveSizeUpdate(HMONITOR monitor, POINT const& ptScreen, const std::unordered_map<HMONITOR, winrt::com_ptr<IZoneWindow>>& zoneWindowMap) noexcept
+void WindowMoveHandler::MoveSizeUpdate(HMONITOR monitor, POINT const& ptScreen, const std::unordered_map<HMONITOR, winrt::com_ptr<IWorkArea>>& zoneWindowMap) noexcept
 {
     if (!m_inMoveSize)
     {
@@ -137,7 +137,7 @@ void WindowMoveHandler::MoveSizeUpdate(HMONITOR monitor, POINT const& ptScreen, 
 
     if (m_zoneWindowMoveSize)
     {
-        // Update the ZoneWindow already handling move/size
+        // Update the WorkArea already handling move/size
         if (!m_dragEnabled)
         {
             // Drag got disabled, tell it to cancel and hide all windows
@@ -180,7 +180,7 @@ void WindowMoveHandler::MoveSizeUpdate(HMONITOR monitor, POINT const& ptScreen, 
     else if (m_dragEnabled)
     {
         // We'll get here if the user presses/releases shift while dragging.
-        // Restart the drag on the ZoneWindow that m_windowMoveSize is on
+        // Restart the drag on the WorkArea that m_windowMoveSize is on
         MoveSizeStart(m_windowMoveSize, monitor, ptScreen, zoneWindowMap);
 
         // m_dragEnabled could get set to false if we're moving an elevated window.
@@ -192,7 +192,7 @@ void WindowMoveHandler::MoveSizeUpdate(HMONITOR monitor, POINT const& ptScreen, 
     }
 }
 
-void WindowMoveHandler::MoveSizeEnd(HWND window, POINT const& ptScreen, const std::unordered_map<HMONITOR, winrt::com_ptr<IZoneWindow>>& zoneWindowMap) noexcept
+void WindowMoveHandler::MoveSizeEnd(HWND window, POINT const& ptScreen, const std::unordered_map<HMONITOR, winrt::com_ptr<IWorkArea>>& zoneWindowMap) noexcept
 {
     if (window != m_windowMoveSize)
     {
@@ -273,7 +273,7 @@ void WindowMoveHandler::MoveSizeEnd(HWND window, POINT const& ptScreen, const st
     }
 }
 
-void WindowMoveHandler::MoveWindowIntoZoneByIndexSet(HWND window, const std::vector<size_t>& indexSet, winrt::com_ptr<IZoneWindow> zoneWindow) noexcept
+void WindowMoveHandler::MoveWindowIntoZoneByIndexSet(HWND window, const std::vector<size_t>& indexSet, winrt::com_ptr<IWorkArea> zoneWindow) noexcept
 {
     if (window != m_windowMoveSize)
     {
@@ -281,17 +281,17 @@ void WindowMoveHandler::MoveWindowIntoZoneByIndexSet(HWND window, const std::vec
     }
 }
 
-bool WindowMoveHandler::MoveWindowIntoZoneByDirectionAndIndex(HWND window, DWORD vkCode, bool cycle, winrt::com_ptr<IZoneWindow> zoneWindow) noexcept
+bool WindowMoveHandler::MoveWindowIntoZoneByDirectionAndIndex(HWND window, DWORD vkCode, bool cycle, winrt::com_ptr<IWorkArea> zoneWindow) noexcept
 {
     return zoneWindow && zoneWindow->MoveWindowIntoZoneByDirectionAndIndex(window, vkCode, cycle);
 }
 
-bool WindowMoveHandler::MoveWindowIntoZoneByDirectionAndPosition(HWND window, DWORD vkCode, bool cycle, winrt::com_ptr<IZoneWindow> zoneWindow) noexcept
+bool WindowMoveHandler::MoveWindowIntoZoneByDirectionAndPosition(HWND window, DWORD vkCode, bool cycle, winrt::com_ptr<IWorkArea> zoneWindow) noexcept
 {
     return zoneWindow && zoneWindow->MoveWindowIntoZoneByDirectionAndPosition(window, vkCode, cycle);
 }
 
-bool WindowMoveHandler::ExtendWindowByDirectionAndPosition(HWND window, DWORD vkCode, winrt::com_ptr<IZoneWindow> zoneWindow) noexcept
+bool WindowMoveHandler::ExtendWindowByDirectionAndPosition(HWND window, DWORD vkCode, winrt::com_ptr<IWorkArea> zoneWindow) noexcept
 {
     return zoneWindow && zoneWindow->ExtendWindowByDirectionAndPosition(window, vkCode);
 }

--- a/src/modules/fancyzones/FancyZonesLib/WindowMoveHandler.h
+++ b/src/modules/fancyzones/FancyZonesLib/WindowMoveHandler.h
@@ -6,21 +6,21 @@
 #include <functional>
 
 interface IFancyZonesSettings;
-interface IZoneWindow;
+interface IWorkArea;
 
 class WindowMoveHandler
 {
 public:
     WindowMoveHandler(const winrt::com_ptr<IFancyZonesSettings>& settings, const std::function<void()>& keyUpdateCallback);
 
-    void MoveSizeStart(HWND window, HMONITOR monitor, POINT const& ptScreen, const std::unordered_map<HMONITOR, winrt::com_ptr<IZoneWindow>>& zoneWindowMap) noexcept;
-    void MoveSizeUpdate(HMONITOR monitor, POINT const& ptScreen, const std::unordered_map<HMONITOR, winrt::com_ptr<IZoneWindow>>& zoneWindowMap) noexcept;
-    void MoveSizeEnd(HWND window, POINT const& ptScreen, const std::unordered_map<HMONITOR, winrt::com_ptr<IZoneWindow>>& zoneWindowMap) noexcept;
+    void MoveSizeStart(HWND window, HMONITOR monitor, POINT const& ptScreen, const std::unordered_map<HMONITOR, winrt::com_ptr<IWorkArea>>& zoneWindowMap) noexcept;
+    void MoveSizeUpdate(HMONITOR monitor, POINT const& ptScreen, const std::unordered_map<HMONITOR, winrt::com_ptr<IWorkArea>>& zoneWindowMap) noexcept;
+    void MoveSizeEnd(HWND window, POINT const& ptScreen, const std::unordered_map<HMONITOR, winrt::com_ptr<IWorkArea>>& zoneWindowMap) noexcept;
 
-    void MoveWindowIntoZoneByIndexSet(HWND window, const std::vector<size_t>& indexSet, winrt::com_ptr<IZoneWindow> zoneWindow) noexcept;
-    bool MoveWindowIntoZoneByDirectionAndIndex(HWND window, DWORD vkCode, bool cycle, winrt::com_ptr<IZoneWindow> zoneWindow) noexcept;
-    bool MoveWindowIntoZoneByDirectionAndPosition(HWND window, DWORD vkCode, bool cycle, winrt::com_ptr<IZoneWindow> zoneWindow) noexcept;
-    bool ExtendWindowByDirectionAndPosition(HWND window, DWORD vkCode, winrt::com_ptr<IZoneWindow> zoneWindow) noexcept;
+    void MoveWindowIntoZoneByIndexSet(HWND window, const std::vector<size_t>& indexSet, winrt::com_ptr<IWorkArea> zoneWindow) noexcept;
+    bool MoveWindowIntoZoneByDirectionAndIndex(HWND window, DWORD vkCode, bool cycle, winrt::com_ptr<IWorkArea> zoneWindow) noexcept;
+    bool MoveWindowIntoZoneByDirectionAndPosition(HWND window, DWORD vkCode, bool cycle, winrt::com_ptr<IWorkArea> zoneWindow) noexcept;
+    bool ExtendWindowByDirectionAndPosition(HWND window, DWORD vkCode, winrt::com_ptr<IWorkArea> zoneWindow) noexcept;
 
     inline void OnMouseDown() noexcept
     {
@@ -68,7 +68,7 @@ private:
     HWND m_windowMoveSize{}; // The window that is being moved/sized
     bool m_inMoveSize{}; // Whether or not a move/size operation is currently active
     MoveSizeWindowInfo m_moveSizeWindowInfo; // MoveSizeWindowInfo of the window at the moment when dragging started
-    winrt::com_ptr<IZoneWindow> m_zoneWindowMoveSize; // "Active" ZoneWindow, where the move/size is happening. Will update as drag moves between monitors.
+    winrt::com_ptr<IWorkArea> m_zoneWindowMoveSize; // "Active" WorkArea, where the move/size is happening. Will update as drag moves between monitors.
     bool m_dragEnabled{}; // True if we should be showing zone hints while dragging
 
     WindowTransparencyProperties m_windowTransparencyProperties;

--- a/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
@@ -1,10 +1,10 @@
 #include "pch.h"
+#include "WorkArea.h"
 
 #include <common/logger/logger.h>
 
 #include "FancyZonesData.h"
 #include "FancyZonesDataTypes.h"
-#include "ZoneWindow.h"
 #include "ZoneWindowDrawing.h"
 #include "trace.h"
 #include "util.h"
@@ -26,7 +26,7 @@ namespace NonLocalizable
 
 using namespace FancyZonesUtils;
 
-struct ZoneWindow;
+struct WorkArea;
 
 namespace
 {
@@ -57,7 +57,7 @@ namespace
 
     public:
 
-        HWND NewZoneWindow(Rect position, HINSTANCE hinstance, ZoneWindow* owner)
+        HWND NewZoneWindow(Rect position, HINSTANCE hinstance, WorkArea* owner)
         {
             HWND windowFromPool = ExtractWindow();
             if (windowFromPool == NULL)
@@ -103,11 +103,11 @@ namespace
     WindowPool windowPool;
 }
 
-struct ZoneWindow : public winrt::implements<ZoneWindow, IZoneWindow>
+struct WorkArea : public winrt::implements<WorkArea, IWorkArea>
 {
 public:
-    ZoneWindow(HINSTANCE hinstance);
-    ~ZoneWindow();
+    WorkArea(HINSTANCE hinstance);
+    ~WorkArea();
 
     bool Init(HINSTANCE hinstance, HMONITOR monitor, const std::wstring& uniqueId, const std::wstring& parentUniqueId, const ZoneColors& zoneColors, OverlappingZonesAlgorithm overlappingAlgorithm);
 
@@ -171,7 +171,7 @@ private:
     OverlappingZonesAlgorithm m_overlappingAlgorithm;
 };
 
-ZoneWindow::ZoneWindow(HINSTANCE hinstance)
+WorkArea::WorkArea(HINSTANCE hinstance)
 {
     WNDCLASSEXW wcex{};
     wcex.cbSize = sizeof(WNDCLASSEX);
@@ -182,12 +182,12 @@ ZoneWindow::ZoneWindow(HINSTANCE hinstance)
     RegisterClassExW(&wcex);
 }
 
-ZoneWindow::~ZoneWindow()
+WorkArea::~WorkArea()
 {
     windowPool.FreeZoneWindow(m_window);
 }
 
-bool ZoneWindow::Init(HINSTANCE hinstance, HMONITOR monitor, const std::wstring& uniqueId, const std::wstring& parentUniqueId, const ZoneColors& zoneColors, OverlappingZonesAlgorithm overlappingAlgorithm)
+bool WorkArea::Init(HINSTANCE hinstance, HMONITOR monitor, const std::wstring& uniqueId, const std::wstring& parentUniqueId, const ZoneColors& zoneColors, OverlappingZonesAlgorithm overlappingAlgorithm)
 {
     m_zoneColors = zoneColors;
     m_overlappingAlgorithm = overlappingAlgorithm;
@@ -224,7 +224,7 @@ bool ZoneWindow::Init(HINSTANCE hinstance, HMONITOR monitor, const std::wstring&
     return true;
 }
 
-IFACEMETHODIMP ZoneWindow::MoveSizeEnter(HWND window) noexcept
+IFACEMETHODIMP WorkArea::MoveSizeEnter(HWND window) noexcept
 {
     m_windowMoveSize = window;
     m_highlightZone = {};
@@ -233,7 +233,7 @@ IFACEMETHODIMP ZoneWindow::MoveSizeEnter(HWND window) noexcept
     return S_OK;
 }
 
-IFACEMETHODIMP ZoneWindow::MoveSizeUpdate(POINT const& ptScreen, bool dragEnabled, bool selectManyZones) noexcept
+IFACEMETHODIMP WorkArea::MoveSizeUpdate(POINT const& ptScreen, bool dragEnabled, bool selectManyZones) noexcept
 {
     bool redraw = false;
     POINT ptClient = ptScreen;
@@ -277,7 +277,7 @@ IFACEMETHODIMP ZoneWindow::MoveSizeUpdate(POINT const& ptScreen, bool dragEnable
     return S_OK;
 }
 
-IFACEMETHODIMP ZoneWindow::MoveSizeEnd(HWND window, POINT const& ptScreen) noexcept
+IFACEMETHODIMP WorkArea::MoveSizeEnd(HWND window, POINT const& ptScreen) noexcept
 {
     if (m_windowMoveSize != window)
     {
@@ -295,7 +295,7 @@ IFACEMETHODIMP ZoneWindow::MoveSizeEnd(HWND window, POINT const& ptScreen) noexc
             SaveWindowProcessToZoneIndex(window);
         }
     }
-    Trace::ZoneWindow::MoveSizeEnd(m_activeZoneSet);
+    Trace::WorkArea::MoveSizeEnd(m_activeZoneSet);
 
     HideZoneWindow();
     m_windowMoveSize = nullptr;
@@ -303,13 +303,13 @@ IFACEMETHODIMP ZoneWindow::MoveSizeEnd(HWND window, POINT const& ptScreen) noexc
 }
 
 IFACEMETHODIMP_(void)
-ZoneWindow::MoveWindowIntoZoneByIndex(HWND window, size_t index) noexcept
+WorkArea::MoveWindowIntoZoneByIndex(HWND window, size_t index) noexcept
 {
     MoveWindowIntoZoneByIndexSet(window, { index });
 }
 
 IFACEMETHODIMP_(void)
-ZoneWindow::MoveWindowIntoZoneByIndexSet(HWND window, const std::vector<size_t>& indexSet) noexcept
+WorkArea::MoveWindowIntoZoneByIndexSet(HWND window, const std::vector<size_t>& indexSet) noexcept
 {
     if (m_activeZoneSet)
     {
@@ -318,7 +318,7 @@ ZoneWindow::MoveWindowIntoZoneByIndexSet(HWND window, const std::vector<size_t>&
 }
 
 IFACEMETHODIMP_(bool)
-ZoneWindow::MoveWindowIntoZoneByDirectionAndIndex(HWND window, DWORD vkCode, bool cycle) noexcept
+WorkArea::MoveWindowIntoZoneByDirectionAndIndex(HWND window, DWORD vkCode, bool cycle) noexcept
 {
     if (m_activeZoneSet)
     {
@@ -335,7 +335,7 @@ ZoneWindow::MoveWindowIntoZoneByDirectionAndIndex(HWND window, DWORD vkCode, boo
 }
 
 IFACEMETHODIMP_(bool)
-ZoneWindow::MoveWindowIntoZoneByDirectionAndPosition(HWND window, DWORD vkCode, bool cycle) noexcept
+WorkArea::MoveWindowIntoZoneByDirectionAndPosition(HWND window, DWORD vkCode, bool cycle) noexcept
 {
     if (m_activeZoneSet)
     {
@@ -349,7 +349,7 @@ ZoneWindow::MoveWindowIntoZoneByDirectionAndPosition(HWND window, DWORD vkCode, 
 }
 
 IFACEMETHODIMP_(bool)
-ZoneWindow::ExtendWindowByDirectionAndPosition(HWND window, DWORD vkCode) noexcept
+WorkArea::ExtendWindowByDirectionAndPosition(HWND window, DWORD vkCode) noexcept
 {
     if (m_activeZoneSet)
     {
@@ -363,7 +363,7 @@ ZoneWindow::ExtendWindowByDirectionAndPosition(HWND window, DWORD vkCode) noexce
 }
 
 IFACEMETHODIMP_(void)
-ZoneWindow::SaveWindowProcessToZoneIndex(HWND window) noexcept
+WorkArea::SaveWindowProcessToZoneIndex(HWND window) noexcept
 {
     if (m_activeZoneSet)
     {
@@ -382,7 +382,7 @@ ZoneWindow::SaveWindowProcessToZoneIndex(HWND window) noexcept
 }
 
 IFACEMETHODIMP_(void)
-ZoneWindow::ShowZoneWindow() noexcept
+WorkArea::ShowZoneWindow() noexcept
 {
     if (m_window)
     {
@@ -393,7 +393,7 @@ ZoneWindow::ShowZoneWindow() noexcept
 }
 
 IFACEMETHODIMP_(void)
-ZoneWindow::HideZoneWindow() noexcept
+WorkArea::HideZoneWindow() noexcept
 {
     if (m_window)
     {
@@ -405,7 +405,7 @@ ZoneWindow::HideZoneWindow() noexcept
 }
 
 IFACEMETHODIMP_(void)
-ZoneWindow::UpdateActiveZoneSet() noexcept
+WorkArea::UpdateActiveZoneSet() noexcept
 {
     CalculateZoneSet(m_overlappingAlgorithm);
     if (m_window)
@@ -416,7 +416,7 @@ ZoneWindow::UpdateActiveZoneSet() noexcept
 }
 
 IFACEMETHODIMP_(void)
-ZoneWindow::ClearSelectedZones() noexcept
+WorkArea::ClearSelectedZones() noexcept
 {
     if (m_highlightZone.size())
     {
@@ -426,7 +426,7 @@ ZoneWindow::ClearSelectedZones() noexcept
 }
 
 IFACEMETHODIMP_(void)
-ZoneWindow::FlashZones() noexcept
+WorkArea::FlashZones() noexcept
 {
     if (m_window)
     {
@@ -437,13 +437,13 @@ ZoneWindow::FlashZones() noexcept
 }
 
 IFACEMETHODIMP_(void)
-ZoneWindow::SetZoneColors(const ZoneColors& colors) noexcept
+WorkArea::SetZoneColors(const ZoneColors& colors) noexcept
 {
     m_zoneColors = colors;
 }
 
 IFACEMETHODIMP_(void)
-ZoneWindow::SetOverlappingZonesAlgorithm(OverlappingZonesAlgorithm overlappingAlgorithm) noexcept
+WorkArea::SetOverlappingZonesAlgorithm(OverlappingZonesAlgorithm overlappingAlgorithm) noexcept
 {
     m_overlappingAlgorithm = overlappingAlgorithm;
 }
@@ -451,7 +451,7 @@ ZoneWindow::SetOverlappingZonesAlgorithm(OverlappingZonesAlgorithm overlappingAl
 
 #pragma region private
 
-void ZoneWindow::InitializeZoneSets(const std::wstring& parentUniqueId) noexcept
+void WorkArea::InitializeZoneSets(const std::wstring& parentUniqueId) noexcept
 {
     bool deviceAdded = FancyZonesDataInstance().AddDevice(m_uniqueId);
     // If the device has been added, check if it should inherit the parent's layout
@@ -462,7 +462,7 @@ void ZoneWindow::InitializeZoneSets(const std::wstring& parentUniqueId) noexcept
     CalculateZoneSet(m_overlappingAlgorithm);
 }
 
-void ZoneWindow::CalculateZoneSet(OverlappingZonesAlgorithm overlappingAlgorithm) noexcept
+void WorkArea::CalculateZoneSet(OverlappingZonesAlgorithm overlappingAlgorithm) noexcept
 {
     const auto& fancyZonesData = FancyZonesDataInstance();
     const auto deviceInfoData = fancyZonesData.FindDeviceInfo(m_uniqueId);
@@ -519,7 +519,7 @@ void ZoneWindow::CalculateZoneSet(OverlappingZonesAlgorithm overlappingAlgorithm
     }
 }
 
-void ZoneWindow::UpdateActiveZoneSet(_In_opt_ IZoneSet* zoneSet) noexcept
+void WorkArea::UpdateActiveZoneSet(_In_opt_ IZoneSet* zoneSet) noexcept
 {
     m_activeZoneSet.copy_from(zoneSet);
 
@@ -537,7 +537,7 @@ void ZoneWindow::UpdateActiveZoneSet(_In_opt_ IZoneSet* zoneSet) noexcept
     }
 }
 
-LRESULT ZoneWindow::WndProc(UINT message, WPARAM wparam, LPARAM lparam) noexcept
+LRESULT WorkArea::WndProc(UINT message, WPARAM wparam, LPARAM lparam) noexcept
 {
     switch (message)
     {
@@ -559,7 +559,7 @@ LRESULT ZoneWindow::WndProc(UINT message, WPARAM wparam, LPARAM lparam) noexcept
     return 0;
 }
 
-std::vector<size_t> ZoneWindow::ZonesFromPoint(POINT pt) noexcept
+std::vector<size_t> WorkArea::ZonesFromPoint(POINT pt) noexcept
 {
     if (m_activeZoneSet)
     {
@@ -568,7 +568,7 @@ std::vector<size_t> ZoneWindow::ZonesFromPoint(POINT pt) noexcept
     return {};
 }
 
-void ZoneWindow::SetAsTopmostWindow() noexcept
+void WorkArea::SetAsTopmostWindow() noexcept
 {
     if (!m_window)
     {
@@ -588,13 +588,13 @@ void ZoneWindow::SetAsTopmostWindow() noexcept
 
 #pragma endregion
 
-LRESULT CALLBACK ZoneWindow::s_WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lparam) noexcept
+LRESULT CALLBACK WorkArea::s_WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lparam) noexcept
 {
-    auto thisRef = reinterpret_cast<ZoneWindow*>(GetWindowLongPtr(window, GWLP_USERDATA));
+    auto thisRef = reinterpret_cast<WorkArea*>(GetWindowLongPtr(window, GWLP_USERDATA));
     if ((thisRef == nullptr) && (message == WM_CREATE))
     {
         auto createStruct = reinterpret_cast<LPCREATESTRUCT>(lparam);
-        thisRef = reinterpret_cast<ZoneWindow*>(createStruct->lpCreateParams);
+        thisRef = reinterpret_cast<WorkArea*>(createStruct->lpCreateParams);
         SetWindowLongPtr(window, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(thisRef));
     }
 
@@ -602,9 +602,9 @@ LRESULT CALLBACK ZoneWindow::s_WndProc(HWND window, UINT message, WPARAM wparam,
                                   DefWindowProc(window, message, wparam, lparam);
 }
 
-winrt::com_ptr<IZoneWindow> MakeZoneWindow(HINSTANCE hinstance, HMONITOR monitor, const std::wstring& uniqueId, const std::wstring& parentUniqueId, const ZoneColors& zoneColors, OverlappingZonesAlgorithm overlappingAlgorithm) noexcept
+winrt::com_ptr<IWorkArea> MakeWorkArea(HINSTANCE hinstance, HMONITOR monitor, const std::wstring& uniqueId, const std::wstring& parentUniqueId, const ZoneColors& zoneColors, OverlappingZonesAlgorithm overlappingAlgorithm) noexcept
 {
-    auto self = winrt::make_self<ZoneWindow>(hinstance);
+    auto self = winrt::make_self<WorkArea>(hinstance);
     if (self->Init(hinstance, monitor, uniqueId, parentUniqueId, zoneColors, overlappingAlgorithm))
     {
         return self;

--- a/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
@@ -125,11 +125,13 @@ public:
     IFACEMETHODIMP_(bool)
     ExtendWindowByDirectionAndPosition(HWND window, DWORD vkCode) noexcept;
     IFACEMETHODIMP_(std::wstring)
-    UniqueId() noexcept { return { m_uniqueId }; }
+    UniqueId() const noexcept { return { m_uniqueId }; }
     IFACEMETHODIMP_(void)
     SaveWindowProcessToZoneIndex(HWND window) noexcept;
     IFACEMETHODIMP_(IZoneSet*)
-    ActiveZoneSet() noexcept { return m_activeZoneSet.get(); }
+    ActiveZoneSet() const noexcept { return m_activeZoneSet.get(); }
+    IFACEMETHODIMP_(std::vector<size_t>)
+    GetWindowZoneIndexes(HWND window) const noexcept;
     IFACEMETHODIMP_(void)
     ShowZoneWindow() noexcept;
     IFACEMETHODIMP_(void)
@@ -379,6 +381,20 @@ WorkArea::SaveWindowProcessToZoneIndex(HWND window) noexcept
             CoTaskMemFree(guidString);
         }
     }
+}
+
+IFACEMETHODIMP_(std::vector<size_t>)
+WorkArea::GetWindowZoneIndexes(HWND window) const noexcept
+{
+    if (m_activeZoneSet)
+    {
+        wil::unique_cotaskmem_string zoneSetId;
+        if (SUCCEEDED(StringFromCLSID(m_activeZoneSet->Id(), &zoneSetId)))
+        {
+            return FancyZonesDataInstance().GetAppLastZoneIndexSet(window, m_uniqueId, zoneSetId.get());
+        }
+    }
+    return {};
 }
 
 IFACEMETHODIMP_(void)

--- a/src/modules/fancyzones/FancyZonesLib/WorkArea.h
+++ b/src/modules/fancyzones/FancyZonesLib/WorkArea.h
@@ -6,7 +6,7 @@
 /**
  * Class representing single work area, which is defined by monitor and virtual desktop.
  */
-interface __declspec(uuid("{7F017528-8110-4FB3-BE41-F472969C2560}")) IZoneWindow : public IUnknown
+interface __declspec(uuid("{7F017528-8110-4FB3-BE41-F472969C2560}")) IWorkArea : public IUnknown
 {
     /**
      * A window is being moved or resized. Track down window position and give zone layout
@@ -109,7 +109,7 @@ interface __declspec(uuid("{7F017528-8110-4FB3-BE41-F472969C2560}")) IZoneWindow
      */
     IFACEMETHOD_(void, UpdateActiveZoneSet)() = 0;
     /**
-     * Clear the selected zones when this ZoneWindow loses focus.
+     * Clear the selected zones when this WorkArea loses focus.
      */
     IFACEMETHOD_(void, ClearSelectedZones)() = 0;
     /*
@@ -126,4 +126,4 @@ interface __declspec(uuid("{7F017528-8110-4FB3-BE41-F472969C2560}")) IZoneWindow
     IFACEMETHOD_(void, SetOverlappingZonesAlgorithm)(OverlappingZonesAlgorithm overlappingAlgorithm) = 0;
 };
 
-winrt::com_ptr<IZoneWindow> MakeZoneWindow(HINSTANCE hinstance, HMONITOR monitor, const std::wstring& uniqueId, const std::wstring& parentUniqueId, const ZoneColors& zoneColors, OverlappingZonesAlgorithm overlappingAlgorithm) noexcept;
+winrt::com_ptr<IWorkArea> MakeWorkArea(HINSTANCE hinstance, HMONITOR monitor, const std::wstring& uniqueId, const std::wstring& parentUniqueId, const ZoneColors& zoneColors, OverlappingZonesAlgorithm overlappingAlgorithm) noexcept;

--- a/src/modules/fancyzones/FancyZonesLib/WorkArea.h
+++ b/src/modules/fancyzones/FancyZonesLib/WorkArea.h
@@ -97,11 +97,15 @@ interface __declspec(uuid("{7F017528-8110-4FB3-BE41-F472969C2560}")) IWorkArea :
     /**
      * @returns Unique work area identifier. Format: <device-id>_<resolution>_<virtual-desktop-id>
      */
-    IFACEMETHOD_(std::wstring, UniqueId)() = 0;
+    IFACEMETHOD_(std::wstring, UniqueId)() const = 0;
     /**
      * @returns Active zone layout for this work area.
      */
-    IFACEMETHOD_(IZoneSet*, ActiveZoneSet)() = 0;
+    IFACEMETHOD_(IZoneSet*, ActiveZoneSet)() const = 0;
+    /*
+    * @returns Zone index of the window
+    */
+    IFACEMETHOD_(std::vector<size_t>, GetWindowZoneIndexes)(HWND window) const = 0;
     IFACEMETHOD_(void, ShowZoneWindow)() = 0;
     IFACEMETHOD_(void, HideZoneWindow)() = 0;
     /**

--- a/src/modules/fancyzones/FancyZonesLib/Zone.h
+++ b/src/modules/fancyzones/FancyZonesLib/Zone.h
@@ -26,7 +26,7 @@ interface __declspec(uuid("{8228E934-B6EF-402A-9892-15A1441BF8B0}")) IZone : pub
      * Compute the coordinates of the rectangle to which a window should be resized.
      *
      * @param   window     Handle of window which should be assigned to zone.
-     * @param   zoneWindow The m_window of a ZoneWindow, it's a hidden window representing the
+     * @param   zoneWindow The m_window of a WorkArea, it's a hidden window representing the
      *                     current monitor desktop work area.
      * @returns a RECT structure, describing global coordinates to which a window should be resized
      */

--- a/src/modules/fancyzones/FancyZonesLib/ZoneSet.h
+++ b/src/modules/fancyzones/FancyZonesLib/ZoneSet.h
@@ -53,7 +53,7 @@ interface __declspec(uuid("{E4839EB7-669D-49CF-84A9-71A2DFD851A3}")) IZoneSet : 
      * Assign window to the zone based on zone index inside zone layout.
      *
      * @param   window         Handle of window which should be assigned to zone.
-     * @param   workAreaWindow The m_window of a ZoneWindow, it's a hidden window representing the
+     * @param   workAreaWindow The m_window of a WorkArea, it's a hidden window representing the
      *                         current monitor desktop work area.
      * @param   index          Zone index within zone layout.
      */
@@ -63,7 +63,7 @@ interface __declspec(uuid("{E4839EB7-669D-49CF-84A9-71A2DFD851A3}")) IZoneSet : 
      * Assign window to the zones based on the set of zone indices inside zone layout.
      *
      * @param   window         Handle of window which should be assigned to zone.
-     * @param   workAreaWindow The m_window of a ZoneWindow, it's a hidden window representing the
+     * @param   workAreaWindow The m_window of a WorkArea, it's a hidden window representing the
      *                         current monitor desktop work area.
      * @param   indexSet       The set of zone indices within zone layout.
      */
@@ -74,7 +74,7 @@ interface __declspec(uuid("{E4839EB7-669D-49CF-84A9-71A2DFD851A3}")) IZoneSet : 
      * not their on-screen position.
      *
      * @param   window         Handle of window which should be assigned to zone.
-     * @param   workAreaWindow The m_window of a ZoneWindow, it's a hidden window representing the
+     * @param   workAreaWindow The m_window of a WorkArea, it's a hidden window representing the
      *                         current monitor desktop work area.
      * @param   vkCode         Pressed arrow key.
      * @param   cycle          Whether we should move window to the first zone if we reached last zone in layout.
@@ -89,7 +89,7 @@ interface __declspec(uuid("{E4839EB7-669D-49CF-84A9-71A2DFD851A3}")) IZoneSet : 
      * their on-screen position.
      *
      * @param   window         Handle of window which should be assigned to zone.
-     * @param   workAreaWindow The m_window of a ZoneWindow, it's a hidden window representing the
+     * @param   workAreaWindow The m_window of a WorkArea, it's a hidden window representing the
      *                         current monitor desktop work area.
      * @param   vkCode         Pressed arrow key.
      * @param   cycle          Whether we should move window to the first zone if we reached last zone in layout.
@@ -104,7 +104,7 @@ interface __declspec(uuid("{E4839EB7-669D-49CF-84A9-71A2DFD851A3}")) IZoneSet : 
      * their on-screen position.
      *
      * @param   window         Handle of window which should be assigned to zone.
-     * @param   workAreaWindow The m_window of a ZoneWindow, it's a hidden window representing the
+     * @param   workAreaWindow The m_window of a WorkArea, it's a hidden window representing the
      *                         current monitor desktop work area.
      * @param   vkCode         Pressed arrow key.
      *
@@ -117,7 +117,7 @@ interface __declspec(uuid("{E4839EB7-669D-49CF-84A9-71A2DFD851A3}")) IZoneSet : 
      * Assign window to the zone based on cursor coordinates.
      *
      * @param   window         Handle of window which should be assigned to zone.
-     * @param   workAreaWindow The m_window of a ZoneWindow, it's a hidden window representing the
+     * @param   workAreaWindow The m_window of a WorkArea, it's a hidden window representing the
      *                         current monitor desktop work area.
      * @param   pt             Cursor coordinates.
      */

--- a/src/modules/fancyzones/FancyZonesLib/trace.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/trace.cpp
@@ -294,7 +294,7 @@ void Trace::VirtualDesktopChanged() noexcept
         TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));
 }
 
-void Trace::ZoneWindow::KeyUp(WPARAM wParam) noexcept
+void Trace::WorkArea::KeyUp(WPARAM wParam) noexcept
 {
     TraceLoggingWrite(
         g_hProvider,
@@ -304,7 +304,7 @@ void Trace::ZoneWindow::KeyUp(WPARAM wParam) noexcept
         TraceLoggingValue(wParam, KeyboardValueKey));
 }
 
-void Trace::ZoneWindow::MoveSizeEnd(_In_opt_ winrt::com_ptr<IZoneSet> activeSet) noexcept
+void Trace::WorkArea::MoveSizeEnd(_In_opt_ winrt::com_ptr<IZoneSet> activeSet) noexcept
 {
     auto const zoneInfo = GetZoneSetInfo(activeSet);
     TraceLoggingWrite(
@@ -317,7 +317,7 @@ void Trace::ZoneWindow::MoveSizeEnd(_In_opt_ winrt::com_ptr<IZoneSet> activeSet)
         TraceLoggingValue(zoneInfo.NumberOfWindows, NumberOfWindowsKey));
 }
 
-void Trace::ZoneWindow::CycleActiveZoneSet(_In_opt_ winrt::com_ptr<IZoneSet> activeSet, InputMode mode) noexcept
+void Trace::WorkArea::CycleActiveZoneSet(_In_opt_ winrt::com_ptr<IZoneSet> activeSet, InputMode mode) noexcept
 {
     auto const zoneInfo = GetZoneSetInfo(activeSet);
     TraceLoggingWrite(

--- a/src/modules/fancyzones/FancyZonesLib/trace.h
+++ b/src/modules/fancyzones/FancyZonesLib/trace.h
@@ -23,7 +23,7 @@ public:
     static void SettingsTelemetry(const Settings& settings) noexcept;
     static void VirtualDesktopChanged() noexcept;
 
-    class ZoneWindow
+    class WorkArea
     {
     public:
         enum class InputMode

--- a/src/modules/fancyzones/FancyZonesTests/UnitTests/UnitTests.vcxproj
+++ b/src/modules/fancyzones/FancyZonesTests/UnitTests/UnitTests.vcxproj
@@ -49,9 +49,9 @@
     </ClCompile>
     <ClCompile Include="Util.Spec.cpp" />
     <ClCompile Include="Util.cpp" />
+    <ClCompile Include="WorkArea.Spec.cpp" />
     <ClCompile Include="Zone.Spec.cpp" />
     <ClCompile Include="ZoneSet.Spec.cpp" />
-    <ClCompile Include="ZoneWindow.Spec.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />

--- a/src/modules/fancyzones/FancyZonesTests/UnitTests/UnitTests.vcxproj.filters
+++ b/src/modules/fancyzones/FancyZonesTests/UnitTests/UnitTests.vcxproj.filters
@@ -27,9 +27,6 @@
     <ClCompile Include="Util.Spec.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="ZoneWindow.Spec.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="JsonHelpers.Tests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -40,6 +37,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="FancyZones.Spec.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="WorkArea.Spec.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/modules/fancyzones/FancyZonesTests/UnitTests/WorkArea.Spec.cpp
+++ b/src/modules/fancyzones/FancyZonesTests/UnitTests/WorkArea.Spec.cpp
@@ -4,7 +4,7 @@
 
 #include <FancyZonesLib/util.h>
 #include <FancyZonesLib/ZoneSet.h>
-#include <FancyZonesLib/ZoneWindow.h>
+#include <FancyZonesLib/WorkArea.h>
 #include <FancyZonesLib/FancyZones.h>
 #include <FancyZonesLib/FancyZonesData.h>
 #include <FancyZonesLib/FancyZonesDataTypes.h>
@@ -21,7 +21,7 @@ namespace FancyZonesUnitTests
     const std::wstring m_deviceId = L"\\\\?\\DISPLAY#DELA026#5&10a58c63&0&UID16777488#{e6f07b5f-ee97-4a90-b076-33f57bf4eaa7}";
     const std::wstring m_virtualDesktopId = L"MyVirtualDesktopId";
 
-    TEST_CLASS (ZoneWindowCreationUnitTests)
+    TEST_CLASS (WorkAreaCreationUnitTests)
     {
         std::wstringstream m_parentUniqueId;
         std::wstringstream m_uniqueId;
@@ -35,12 +35,12 @@ namespace FancyZonesUnitTests
 
         FancyZonesData& m_fancyZonesData = FancyZonesDataInstance();
 
-        void testZoneWindow(winrt::com_ptr<IZoneWindow> zoneWindow)
+        void testWorkArea(winrt::com_ptr<IWorkArea> workArea)
         {
             const std::wstring expectedWorkArea = std::to_wstring(m_monitorInfo.rcMonitor.right) + L"_" + std::to_wstring(m_monitorInfo.rcMonitor.bottom);
 
-            Assert::IsNotNull(zoneWindow.get());
-            Assert::AreEqual(m_uniqueId.str().c_str(), zoneWindow->UniqueId().c_str());
+            Assert::IsNotNull(workArea.get());
+            Assert::AreEqual(m_uniqueId.str().c_str(), workArea->UniqueId().c_str());
         }
 
         TEST_METHOD_INITIALIZE(Init)
@@ -69,80 +69,80 @@ namespace FancyZonesUnitTests
                 };
             }
 
-            TEST_METHOD (CreateZoneWindow)
+            TEST_METHOD (CreateWorkArea)
             {
-                auto zoneWindow = MakeZoneWindow(m_hInst, m_monitor, m_uniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
-                testZoneWindow(zoneWindow);
+                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
+                testWorkArea(workArea);
 
-                auto* activeZoneSet{ zoneWindow->ActiveZoneSet() };
+                auto* activeZoneSet{ workArea->ActiveZoneSet() };
                 Assert::IsNotNull(activeZoneSet);
                 Assert::AreEqual(static_cast<int>(activeZoneSet->LayoutType()), static_cast<int>(FancyZonesDataTypes::ZoneSetLayoutType::PriorityGrid));
                 Assert::AreEqual(activeZoneSet->GetZones().size(), static_cast<size_t>(3));
             }
 
-            TEST_METHOD (CreateZoneWindowNoHinst)
+            TEST_METHOD (CreateWorkAreaNoHinst)
             {
-                auto zoneWindow = MakeZoneWindow({}, m_monitor, m_uniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
-                testZoneWindow(zoneWindow);
+                auto workArea = MakeWorkArea({}, m_monitor, m_uniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
+                testWorkArea(workArea);
 
-                auto* activeZoneSet{ zoneWindow->ActiveZoneSet() };
+                auto* activeZoneSet{ workArea->ActiveZoneSet() };
                 Assert::IsNotNull(activeZoneSet);
                 Assert::AreEqual(static_cast<int>(activeZoneSet->LayoutType()), static_cast<int>(FancyZonesDataTypes::ZoneSetLayoutType::PriorityGrid));
                 Assert::AreEqual(activeZoneSet->GetZones().size(), static_cast<size_t>(3));
             }
 
-            TEST_METHOD (CreateZoneWindowNoHinstFlashZones)
+            TEST_METHOD (CreateWorkAreaNoHinstFlashZones)
             {
-                auto zoneWindow = MakeZoneWindow({}, m_monitor, m_uniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
-                testZoneWindow(zoneWindow);
+                auto workArea = MakeWorkArea({}, m_monitor, m_uniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
+                testWorkArea(workArea);
 
-                auto* activeZoneSet{ zoneWindow->ActiveZoneSet() };
+                auto* activeZoneSet{ workArea->ActiveZoneSet() };
                 Assert::IsNotNull(activeZoneSet);
                 Assert::AreEqual(static_cast<int>(activeZoneSet->LayoutType()), static_cast<int>(FancyZonesDataTypes::ZoneSetLayoutType::PriorityGrid));
                 Assert::AreEqual(activeZoneSet->GetZones().size(), static_cast<size_t>(3));
             }
 
-            TEST_METHOD (CreateZoneWindowNoMonitor)
+            TEST_METHOD (CreateWorkAreaNoMonitor)
             {
-                auto zoneWindow = MakeZoneWindow(m_hInst, {}, m_uniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
-                testZoneWindow(zoneWindow);
+                auto workArea = MakeWorkArea(m_hInst, {}, m_uniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
+                testWorkArea(workArea);
             }
 
-            TEST_METHOD (CreateZoneWindowNoDeviceId)
+            TEST_METHOD (CreateWorkAreaNoDeviceId)
             {
                 // Generate unique id without device id
                 std::wstring uniqueId = FancyZonesUtils::GenerateUniqueId(m_monitor, {}, m_virtualDesktopId);
-                auto zoneWindow = MakeZoneWindow(m_hInst, m_monitor, uniqueId, {}, m_zoneColors, m_overlappingAlgorithm);
+                auto workArea = MakeWorkArea(m_hInst, m_monitor, uniqueId, {}, m_zoneColors, m_overlappingAlgorithm);
 
                 const std::wstring expectedWorkArea = std::to_wstring(m_monitorInfo.rcMonitor.right) + L"_" + std::to_wstring(m_monitorInfo.rcMonitor.bottom);
                 const std::wstring expectedUniqueId = L"FallbackDevice_" + std::to_wstring(m_monitorInfo.rcMonitor.right) + L"_" + std::to_wstring(m_monitorInfo.rcMonitor.bottom) + L"_" + m_virtualDesktopId;
 
-                Assert::IsNotNull(zoneWindow.get());
-                Assert::AreEqual(expectedUniqueId.c_str(), zoneWindow->UniqueId().c_str());
+                Assert::IsNotNull(workArea.get());
+                Assert::AreEqual(expectedUniqueId.c_str(), workArea->UniqueId().c_str());
 
-                auto* activeZoneSet{ zoneWindow->ActiveZoneSet() };
+                auto* activeZoneSet{ workArea->ActiveZoneSet() };
                 Assert::IsNotNull(activeZoneSet);
                 Assert::AreEqual(static_cast<int>(activeZoneSet->LayoutType()), static_cast<int>(FancyZonesDataTypes::ZoneSetLayoutType::PriorityGrid));
                 Assert::AreEqual(activeZoneSet->GetZones().size(), static_cast<size_t>(3));
             }
 
-            TEST_METHOD (CreateZoneWindowNoDesktopId)
+            TEST_METHOD (CreateWorkAreaNoDesktopId)
             {
                 // Generate unique id without virtual desktop id
                 std::wstring uniqueId = FancyZonesUtils::GenerateUniqueId(m_monitor, m_deviceId, {});
-                auto zoneWindow = MakeZoneWindow(m_hInst, m_monitor, uniqueId, {}, m_zoneColors, m_overlappingAlgorithm);
+                auto workArea = MakeWorkArea(m_hInst, m_monitor, uniqueId, {}, m_zoneColors, m_overlappingAlgorithm);
 
                 const std::wstring expectedWorkArea = std::to_wstring(m_monitorInfo.rcMonitor.right) + L"_" + std::to_wstring(m_monitorInfo.rcMonitor.bottom);
-                Assert::IsNotNull(zoneWindow.get());
-                Assert::IsTrue(zoneWindow->UniqueId().empty());
+                Assert::IsNotNull(workArea.get());
+                Assert::IsTrue(workArea->UniqueId().empty());
 
-                auto* activeZoneSet{ zoneWindow->ActiveZoneSet() };
+                auto* activeZoneSet{ workArea->ActiveZoneSet() };
                 Assert::IsNotNull(activeZoneSet);
                 Assert::AreEqual(static_cast<int>(activeZoneSet->LayoutType()), static_cast<int>(FancyZonesDataTypes::ZoneSetLayoutType::PriorityGrid));
                 Assert::AreEqual(activeZoneSet->GetZones().size(), static_cast<size_t>(3));
             }
 
-        TEST_METHOD (CreateZoneWindowClonedFromParent)
+        TEST_METHOD (CreateWorkAreaClonedFromParent)
         {
             using namespace FancyZonesDataTypes;
 
@@ -154,12 +154,12 @@ namespace FancyZonesUnitTests
                 const auto parentDeviceInfo = DeviceInfoData{ parentZoneSet, true, spacing, zoneCount };
                 m_fancyZonesData.SetDeviceInfo(m_parentUniqueId.str(), parentDeviceInfo);
 
-                auto parentZoneWindow = MakeZoneWindow(m_hInst, m_monitor, m_parentUniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
+                auto parentWorkArea = MakeWorkArea(m_hInst, m_monitor, m_parentUniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
                 
-                // newWorkArea = false - zoneWindow won't be cloned from parent
-                auto actualZoneWindow = MakeZoneWindow(m_hInst, m_monitor, m_uniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
+                // newWorkArea = false - workArea won't be cloned from parent
+                auto actualWorkArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
 
-                Assert::IsNotNull(actualZoneWindow->ActiveZoneSet());
+                Assert::IsNotNull(actualWorkArea->ActiveZoneSet());
 
                 Assert::IsTrue(m_fancyZonesData.GetDeviceInfoMap().contains(m_uniqueId.str()));
                 auto currentDeviceInfo = m_fancyZonesData.GetDeviceInfoMap().at(m_uniqueId.str());
@@ -171,7 +171,7 @@ namespace FancyZonesUnitTests
             }
     };
 
-    TEST_CLASS (ZoneWindowUnitTests)
+    TEST_CLASS (WorkAreaUnitTests)
     {
         std::wstringstream m_uniqueId;
 
@@ -207,68 +207,68 @@ namespace FancyZonesUnitTests
         public:
             TEST_METHOD (MoveSizeEnter)
             {
-                auto zoneWindow = MakeZoneWindow(m_hInst, m_monitor, m_uniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
+                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
 
                 const auto expected = S_OK;
-                const auto actual = zoneWindow->MoveSizeEnter(Mocks::Window());
+                const auto actual = workArea->MoveSizeEnter(Mocks::Window());
 
                 Assert::AreEqual(expected, actual);
             }
 
             TEST_METHOD (MoveSizeEnterTwice)
             {
-                auto zoneWindow = MakeZoneWindow(m_hInst, m_monitor, m_uniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
+                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
 
                 const auto expected = S_OK;
 
-                zoneWindow->MoveSizeEnter(Mocks::Window());
-                const auto actual = zoneWindow->MoveSizeEnter(Mocks::Window());
+                workArea->MoveSizeEnter(Mocks::Window());
+                const auto actual = workArea->MoveSizeEnter(Mocks::Window());
 
                 Assert::AreEqual(expected, actual);
             }
 
             TEST_METHOD (MoveSizeUpdate)
             {
-                auto zoneWindow = MakeZoneWindow(m_hInst, m_monitor, m_uniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
+                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
 
                 const auto expected = S_OK;
-                const auto actual = zoneWindow->MoveSizeUpdate(POINT{ 0, 0 }, true, false);
+                const auto actual = workArea->MoveSizeUpdate(POINT{ 0, 0 }, true, false);
 
                 Assert::AreEqual(expected, actual);
             }
 
             TEST_METHOD (MoveSizeUpdatePointNegativeCoordinates)
             {
-                auto zoneWindow = MakeZoneWindow(m_hInst, m_monitor, m_uniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
+                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
 
                 const auto expected = S_OK;
-                const auto actual = zoneWindow->MoveSizeUpdate(POINT{ -10, -10 }, true, false);
+                const auto actual = workArea->MoveSizeUpdate(POINT{ -10, -10 }, true, false);
 
                 Assert::AreEqual(expected, actual);
             }
 
             TEST_METHOD (MoveSizeUpdatePointBigCoordinates)
             {
-                auto zoneWindow = MakeZoneWindow(m_hInst, m_monitor, m_uniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
+                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
 
                 const auto expected = S_OK;
-                const auto actual = zoneWindow->MoveSizeUpdate(POINT{ m_monitorInfo.rcMonitor.right + 1, m_monitorInfo.rcMonitor.bottom + 1 }, true, false);
+                const auto actual = workArea->MoveSizeUpdate(POINT{ m_monitorInfo.rcMonitor.right + 1, m_monitorInfo.rcMonitor.bottom + 1 }, true, false);
 
                 Assert::AreEqual(expected, actual);
             }
 
             TEST_METHOD (MoveSizeEnd)
             {
-                auto zoneWindow = MakeZoneWindow(m_hInst, m_monitor, m_uniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
+                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
 
                 const auto window = Mocks::Window();
-                zoneWindow->MoveSizeEnter(window);
+                workArea->MoveSizeEnter(window);
 
                 const auto expected = S_OK;
-                const auto actual = zoneWindow->MoveSizeEnd(window, POINT{ 0, 0 });
+                const auto actual = workArea->MoveSizeEnd(window, POINT{ 0, 0 });
                 Assert::AreEqual(expected, actual);
 
-                const auto zoneSet = zoneWindow->ActiveZoneSet();
+                const auto zoneSet = workArea->ActiveZoneSet();
                 zoneSet->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0);
                 const auto actualZoneIndexSet = zoneSet->GetZoneIndexSetFromWindow(window);
                 Assert::IsFalse(std::vector<size_t>{} == actualZoneIndexSet);
@@ -276,55 +276,55 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (MoveSizeEndWindowNotAdded)
             {
-                auto zoneWindow = MakeZoneWindow(m_hInst, m_monitor, m_uniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
+                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
 
                 const auto window = Mocks::Window();
-                zoneWindow->MoveSizeEnter(window);
+                workArea->MoveSizeEnter(window);
 
                 const auto expected = S_OK;
-                const auto actual = zoneWindow->MoveSizeEnd(window, POINT{ -100, -100 });
+                const auto actual = workArea->MoveSizeEnd(window, POINT{ -100, -100 });
                 Assert::AreEqual(expected, actual);
 
-                const auto zoneSet = zoneWindow->ActiveZoneSet();
+                const auto zoneSet = workArea->ActiveZoneSet();
                 const auto actualZoneIndexSet = zoneSet->GetZoneIndexSetFromWindow(window);
                 Assert::IsTrue(std::vector<size_t>{} == actualZoneIndexSet);
             }
 
             TEST_METHOD (MoveSizeEndDifferentWindows)
             {
-                auto zoneWindow = MakeZoneWindow(m_hInst, m_monitor, m_uniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
+                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
 
                 const auto window = Mocks::Window();
-                zoneWindow->MoveSizeEnter(window);
+                workArea->MoveSizeEnter(window);
 
                 const auto expected = E_INVALIDARG;
-                const auto actual = zoneWindow->MoveSizeEnd(Mocks::Window(), POINT{ 0, 0 });
+                const auto actual = workArea->MoveSizeEnd(Mocks::Window(), POINT{ 0, 0 });
 
                 Assert::AreEqual(expected, actual);
             }
 
             TEST_METHOD (MoveSizeEndWindowNotSet)
             {
-                auto zoneWindow = MakeZoneWindow(m_hInst, m_monitor, m_uniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
+                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
 
                 const auto expected = E_INVALIDARG;
-                const auto actual = zoneWindow->MoveSizeEnd(Mocks::Window(), POINT{ 0, 0 });
+                const auto actual = workArea->MoveSizeEnd(Mocks::Window(), POINT{ 0, 0 });
 
                 Assert::AreEqual(expected, actual);
             }
 
             TEST_METHOD (MoveSizeEndInvalidPoint)
             {
-                auto zoneWindow = MakeZoneWindow(m_hInst, m_monitor, m_uniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
+                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
 
                 const auto window = Mocks::Window();
-                zoneWindow->MoveSizeEnter(window);
+                workArea->MoveSizeEnter(window);
 
                 const auto expected = S_OK;
-                const auto actual = zoneWindow->MoveSizeEnd(window, POINT{ -1, -1 });
+                const auto actual = workArea->MoveSizeEnd(window, POINT{ -1, -1 });
                 Assert::AreEqual(expected, actual);
 
-                const auto zoneSet = zoneWindow->ActiveZoneSet();
+                const auto zoneSet = workArea->ActiveZoneSet();
                 zoneSet->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0);
                 const auto actualZoneIndex = zoneSet->GetZoneIndexSetFromWindow(window);
                 Assert::IsFalse(std::vector<size_t>{} == actualZoneIndex); // with invalid point zone remains the same
@@ -332,21 +332,21 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (MoveWindowIntoZoneByIndex)
             {
-                auto zoneWindow = MakeZoneWindow(m_hInst, m_monitor, m_uniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
-                Assert::IsNotNull(zoneWindow->ActiveZoneSet());
+                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
+                Assert::IsNotNull(workArea->ActiveZoneSet());
 
-                zoneWindow->MoveWindowIntoZoneByIndex(Mocks::Window(), 0);
+                workArea->MoveWindowIntoZoneByIndex(Mocks::Window(), 0);
 
-                const auto actual = zoneWindow->ActiveZoneSet();
+                const auto actual = workArea->ActiveZoneSet();
             }
 
             TEST_METHOD (MoveWindowIntoZoneByDirectionAndIndex)
             {
-                auto zoneWindow = MakeZoneWindow(m_hInst, m_monitor, m_uniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
-                Assert::IsNotNull(zoneWindow->ActiveZoneSet());
+                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
+                Assert::IsNotNull(workArea->ActiveZoneSet());
 
                 const auto window = Mocks::WindowCreate(m_hInst);
-                zoneWindow->MoveWindowIntoZoneByDirectionAndIndex(window, VK_RIGHT, true);
+                workArea->MoveWindowIntoZoneByDirectionAndIndex(window, VK_RIGHT, true);
 
                 const auto& actualAppZoneHistory = m_fancyZonesData.GetAppZoneHistoryMap();
                 Assert::AreEqual((size_t)1, actualAppZoneHistory.size());
@@ -357,13 +357,13 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (MoveWindowIntoZoneByDirectionManyTimes)
             {
-                auto zoneWindow = MakeZoneWindow(m_hInst, m_monitor, m_uniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
-                Assert::IsNotNull(zoneWindow->ActiveZoneSet());
+                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
+                Assert::IsNotNull(workArea->ActiveZoneSet());
 
                 const auto window = Mocks::WindowCreate(m_hInst);
-                zoneWindow->MoveWindowIntoZoneByDirectionAndIndex(window, VK_RIGHT, true);
-                zoneWindow->MoveWindowIntoZoneByDirectionAndIndex(window, VK_RIGHT, true);
-                zoneWindow->MoveWindowIntoZoneByDirectionAndIndex(window, VK_RIGHT, true);
+                workArea->MoveWindowIntoZoneByDirectionAndIndex(window, VK_RIGHT, true);
+                workArea->MoveWindowIntoZoneByDirectionAndIndex(window, VK_RIGHT, true);
+                workArea->MoveWindowIntoZoneByDirectionAndIndex(window, VK_RIGHT, true);
 
                 const auto& actualAppZoneHistory = m_fancyZonesData.GetAppZoneHistoryMap();
                 Assert::AreEqual((size_t)1, actualAppZoneHistory.size());
@@ -374,10 +374,10 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (SaveWindowProcessToZoneIndexNullptrWindow)
             {
-                auto zoneWindow = MakeZoneWindow(m_hInst, m_monitor, m_uniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
-                Assert::IsNotNull(zoneWindow->ActiveZoneSet());
+                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
+                Assert::IsNotNull(workArea->ActiveZoneSet());
 
-                zoneWindow->SaveWindowProcessToZoneIndex(nullptr);
+                workArea->SaveWindowProcessToZoneIndex(nullptr);
 
                 const auto actualAppZoneHistory = m_fancyZonesData.GetAppZoneHistoryMap();
                 Assert::IsTrue(actualAppZoneHistory.empty());
@@ -385,14 +385,14 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (SaveWindowProcessToZoneIndexNoWindowAdded)
             {
-                auto zoneWindow = MakeZoneWindow(m_hInst, m_monitor, m_uniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
-                Assert::IsNotNull(zoneWindow->ActiveZoneSet());
+                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
+                Assert::IsNotNull(workArea->ActiveZoneSet());
 
                 auto window = Mocks::WindowCreate(m_hInst);
                 auto zone = MakeZone(RECT{ 0, 0, 100, 100 }, 1);
-                zoneWindow->ActiveZoneSet()->AddZone(zone);
+                workArea->ActiveZoneSet()->AddZone(zone);
 
-                zoneWindow->SaveWindowProcessToZoneIndex(window);
+                workArea->SaveWindowProcessToZoneIndex(window);
 
                 const auto actualAppZoneHistory = m_fancyZonesData.GetAppZoneHistoryMap();
                 Assert::IsTrue(actualAppZoneHistory.empty());
@@ -400,13 +400,13 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (SaveWindowProcessToZoneIndexNoWindowAddedWithFilledAppZoneHistory)
             {
-                auto zoneWindow = MakeZoneWindow(m_hInst, m_monitor, m_uniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
-                Assert::IsNotNull(zoneWindow->ActiveZoneSet());
+                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
+                Assert::IsNotNull(workArea->ActiveZoneSet());
 
                 const auto window = Mocks::WindowCreate(m_hInst);
                 const auto processPath = get_process_path(window);
-                const auto deviceId = zoneWindow->UniqueId();
-                const auto zoneSetId = zoneWindow->ActiveZoneSet()->Id();
+                const auto deviceId = workArea->UniqueId();
+                const auto zoneSetId = workArea->ActiveZoneSet()->Id();
 
                 // fill app zone history map
                 Assert::IsTrue(m_fancyZonesData.SetAppLastZones(window, deviceId, Helpers::GuidToString(zoneSetId), { 0 }));
@@ -417,9 +417,9 @@ namespace FancyZonesUnitTests
 
                 // add zone without window
                 const auto zone = MakeZone(RECT{ 0, 0, 100, 100 }, 1);
-                zoneWindow->ActiveZoneSet()->AddZone(zone);
+                workArea->ActiveZoneSet()->AddZone(zone);
 
-                zoneWindow->SaveWindowProcessToZoneIndex(window);
+                workArea->SaveWindowProcessToZoneIndex(window);
                 Assert::AreEqual((size_t)1, m_fancyZonesData.GetAppZoneHistoryMap().size());
                 const auto& appHistoryArray2 = m_fancyZonesData.GetAppZoneHistoryMap().at(processPath);
                 Assert::AreEqual((size_t)1, appHistoryArray2.size());
@@ -428,17 +428,17 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (SaveWindowProcessToZoneIndexWindowAdded)
             {
-                auto zoneWindow = MakeZoneWindow(m_hInst, m_monitor, m_uniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
-                Assert::IsNotNull(zoneWindow->ActiveZoneSet());
+                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
+                Assert::IsNotNull(workArea->ActiveZoneSet());
 
                 auto window = Mocks::WindowCreate(m_hInst);
                 const auto processPath = get_process_path(window);
-                const auto deviceId = zoneWindow->UniqueId();
-                const auto zoneSetId = zoneWindow->ActiveZoneSet()->Id();
+                const auto deviceId = workArea->UniqueId();
+                const auto zoneSetId = workArea->ActiveZoneSet()->Id();
 
                 auto zone = MakeZone(RECT{ 0, 0, 100, 100 }, 1);
-                zoneWindow->ActiveZoneSet()->AddZone(zone);
-                zoneWindow->MoveWindowIntoZoneByIndex(window, 0);
+                workArea->ActiveZoneSet()->AddZone(zone);
+                workArea->MoveWindowIntoZoneByIndex(window, 0);
 
                 //fill app zone history map
                 Assert::IsTrue(m_fancyZonesData.SetAppLastZones(window, deviceId, Helpers::GuidToString(zoneSetId), { 2 }));
@@ -447,19 +447,19 @@ namespace FancyZonesUnitTests
                 Assert::AreEqual((size_t)1, appHistoryArray.size());
                 Assert::IsTrue(std::vector<size_t>{ 2 } == appHistoryArray[0].zoneIndexSet);
 
-                zoneWindow->SaveWindowProcessToZoneIndex(window);
+                workArea->SaveWindowProcessToZoneIndex(window);
 
                 const auto& actualAppZoneHistory = m_fancyZonesData.GetAppZoneHistoryMap();
                 Assert::AreEqual((size_t)1, actualAppZoneHistory.size());
-                const auto& expected = zoneWindow->ActiveZoneSet()->GetZoneIndexSetFromWindow(window);
+                const auto& expected = workArea->ActiveZoneSet()->GetZoneIndexSetFromWindow(window);
                 const auto& actual = appHistoryArray[0].zoneIndexSet;
                 Assert::IsTrue(expected == actual);
             }
 
             TEST_METHOD (WhenWindowIsNotResizablePlacingItIntoTheZoneShouldNotResizeIt)
             {
-                auto zoneWindow = MakeZoneWindow(m_hInst, m_monitor, m_uniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
-                Assert::IsNotNull(zoneWindow->ActiveZoneSet());
+                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId.str(), {}, m_zoneColors, m_overlappingAlgorithm);
+                Assert::IsNotNull(workArea->ActiveZoneSet());
 
                 auto window = Mocks::WindowCreate(m_hInst);
 
@@ -470,9 +470,9 @@ namespace FancyZonesUnitTests
                 SetWindowLong(window, GWL_STYLE, GetWindowLong(window, GWL_STYLE) & ~WS_SIZEBOX);
 
                 auto zone = MakeZone(RECT{ 50, 50, 300, 300 }, 1);
-                zoneWindow->ActiveZoneSet()->AddZone(zone);
+                workArea->ActiveZoneSet()->AddZone(zone);
 
-                zoneWindow->MoveWindowIntoZoneByDirectionAndIndex(window, VK_LEFT, true);
+                workArea->MoveWindowIntoZoneByDirectionAndIndex(window, VK_LEFT, true);
 
                 RECT inZoneRect;
                 GetWindowRect(window, &inZoneRect);


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

* Changed `ZoneWindow` to a more clear and suitable `WorkArea`.
* Moved method related to WorkArea.

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #11892
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
