### PR TITLE
[FancyZones] Window opening on the last zone

### DIFF
--- a/src/common/utils/process_path.h
+++ b/src/common/utils/process_path.h
@@ -4,6 +4,7 @@
 #include <shlwapi.h>
 
 #include <string>
+#include <thread>
 
 // Get the executable path or module name for modern apps
 inline std::wstring get_process_path(DWORD pid) noexcept
@@ -28,14 +29,18 @@ inline std::wstring get_process_path(DWORD pid) noexcept
 inline std::wstring get_process_path(HWND window) noexcept
 {
     const static std::wstring app_frame_host = L"ApplicationFrameHost.exe";
+    static int retryLoopCounter = 0;
+
     DWORD pid{};
     GetWindowThreadProcessId(window, &pid);
     auto name = get_process_path(pid);
+
     if (name.length() >= app_frame_host.length() &&
         name.compare(name.length() - app_frame_host.length(), app_frame_host.length(), app_frame_host) == 0)
     {
         // It is a UWP app. We will enumerate the windows and look for one created
         // by something with a different PID
+        // It might take a time to connect the process. That's the reason for the retry loop here
         DWORD new_pid = pid;
         EnumChildWindows(
             window, [](HWND hwnd, LPARAM param) -> BOOL {
@@ -53,12 +58,25 @@ inline std::wstring get_process_path(HWND window) noexcept
                 }
             },
             reinterpret_cast<LPARAM>(&new_pid));
+
         // If we have a new pid, get the new name.
         if (new_pid != pid)
         {
+            retryLoopCounter = 0;
             return get_process_path(new_pid);
         }
+        else
+        {
+            if (retryLoopCounter < 10)
+            {
+                retryLoopCounter++;
+                std::this_thread::sleep_for(std::chrono::milliseconds(100));
+                return get_process_path(pid);
+            }
+        }
     }
+
+    retryLoopCounter = 0;
     return name;
 }
 

--- a/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
@@ -156,7 +156,6 @@ private:
 
     void OnSettingsChanged() noexcept;
 
-    std::pair<winrt::com_ptr<IWorkArea>, std::vector<size_t>> GetAppZoneHistoryInfo(HWND window, HMONITOR monitor, std::unordered_map<HMONITOR, winrt::com_ptr<IWorkArea>>& workAreaMap) noexcept;
     std::pair<winrt::com_ptr<IWorkArea>, std::vector<size_t>> GetAppZoneHistoryInfo(HWND window, HMONITOR monitor, bool isPrimaryMonitor) noexcept;
     void MoveWindowIntoZone(HWND window, winrt::com_ptr<IWorkArea> zoneWindow, const std::vector<size_t>& zoneIndexSet) noexcept;
 
@@ -266,27 +265,25 @@ FancyZones::VirtualDesktopChanged() noexcept
     PostMessage(m_window, WM_PRIV_VD_SWITCH, 0, 0);
 }
 
-std::pair<winrt::com_ptr<IWorkArea>, std::vector<size_t>> FancyZones::GetAppZoneHistoryInfo(
-    HWND window,
-    HMONITOR monitor,
-    std::unordered_map<HMONITOR, winrt::com_ptr<IWorkArea>>& workAreaMap) noexcept
-{
-    if (workAreaMap.contains(monitor))
-    {
-        auto workArea = workAreaMap[monitor];
-        workAreaMap.erase(monitor); // monitor processed, remove entry from the map
-        return { workArea, workArea->GetWindowZoneIndexes(window) };
-    }
-    return { nullptr, {} };
-}
-
 std::pair<winrt::com_ptr<IWorkArea>, std::vector<size_t>> FancyZones::GetAppZoneHistoryInfo(HWND window, HMONITOR monitor, bool isPrimaryMonitor) noexcept
 {
     std::pair<winrt::com_ptr<IWorkArea>, std::vector<size_t>> appZoneHistoryInfo{ nullptr, {} };
     auto workAreaMap = m_workAreaHandler.GetWorkAreasByDesktopId(m_currentDesktopId);
+    if (workAreaMap.empty())
+    {
+        Logger::debug(L"No work area for the current desktop.");
+    }
 
     // Search application history on currently active monitor.
-    appZoneHistoryInfo = GetAppZoneHistoryInfo(window, monitor, workAreaMap);
+    if (workAreaMap.contains(monitor))
+    {
+        auto workArea = workAreaMap[monitor];
+        appZoneHistoryInfo = { workArea, workArea->GetWindowZoneIndexes(window) };
+    }
+    else
+    {
+        Logger::debug(L"No work area for the current desktop.");
+    }
 
     if (isPrimaryMonitor && appZoneHistoryInfo.second.empty())
     {
@@ -351,13 +348,22 @@ void FancyZones::WindowCreated(HWND window) noexcept
         {
             const bool primaryActive = (primary == active);
             std::pair<winrt::com_ptr<IWorkArea>, std::vector<size_t>> appZoneHistoryInfo = GetAppZoneHistoryInfo(window, active, primaryActive);
-            const bool windowMinimized = IsIconic(window);
-            if (!appZoneHistoryInfo.second.empty() && !windowMinimized)
+            
+            if (!appZoneHistoryInfo.second.empty())
             {
-                MoveWindowIntoZone(window, appZoneHistoryInfo.first, appZoneHistoryInfo.second);
-                windowZoned = true;
+                const bool windowMinimized = IsIconic(window);
+                if (!windowMinimized)
+                {
+                    MoveWindowIntoZone(window, appZoneHistoryInfo.first, appZoneHistoryInfo.second);
+                    windowZoned = true;
+                }
+            }
+            else
+            {
+                Logger::warn(L"App zone history is empty for the processing window on a current virtual desktop");
             }
         }
+
         if (!windowZoned && openOnActiveMonitor)
         {
             m_dpiUnawareThread.submit(OnThreadExecutor::task_t{ [&] { MonitorUtils::OpenWindowOnActiveMonitor(window, active); } }).wait();

--- a/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
@@ -282,7 +282,7 @@ std::pair<winrt::com_ptr<IWorkArea>, std::vector<size_t>> FancyZones::GetAppZone
     }
     else
     {
-        Logger::debug(L"No work area for the current desktop.");
+        Logger::debug(L"No work area for the currently active monitor.");
     }
 
     if (isPrimaryMonitor && appZoneHistoryInfo.second.empty())


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

* Added retry loop in the `process_path`. The reason is that for UWP apps `EnumChildWindows` may not find the `ApplicationFrameHost` child immediately.
* Added logs

**What is include in the PR:** 

**How does someone test / validate:** 

On my machine the bug is nearly always reproducible with this scenario:
* Set 4-zones grid layout
* Assign Settings window to several zones (I selected 1,3).
* Close Settings
* Reopen Settings

Settings may be opened fullscreen at first, but resized within a second.
Verify that Settings was resized every reopening. 

## Quality Checklist

- [x] **Linked issue:** #9590
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
