### PR TITLE
[Setup] Add support for installing both dotnet 3 and 5

### DIFF
--- a/installer/PowerToysBootstrapper/bootstrapper/DotnetInstallation.h
+++ b/installer/PowerToysBootstrapper/bootstrapper/DotnetInstallation.h
@@ -6,7 +6,7 @@
 namespace fs = std::filesystem;
 namespace updating
 {
-    bool dotnet_is_installed();
-    std::optional<fs::path> download_dotnet();
+    bool dotnet_is_installed(const size_t major, const size_t minor, const size_t requiredMinimalPatch);
+    std::optional<fs::path> download_dotnet(const wchar_t* dotnetDesktopDownloadLink);
     bool install_dotnet(fs::path dotnet_download_path, const bool silent);
 }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
