### PR TITLE
[PT Run] Improve First Call Performance

### DIFF
--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -7,7 +7,6 @@ using System.ComponentModel;
 using System.Linq;
 using System.Timers;
 using System.Windows;
-using System.Windows.Automation.Peers;
 using System.Windows.Controls;
 using System.Windows.Input;
 using interop;
@@ -116,6 +115,7 @@ namespace PowerLauncher
             ListBox.SuggestionsList.SelectionChanged += SuggestionsList_SelectionChanged;
             ListBox.SuggestionsList.PreviewMouseLeftButtonUp += SuggestionsList_PreviewMouseLeftButtonUp;
             _viewModel.PropertyChanged += ViewModel_PropertyChanged;
+            _viewModel.MainWindowVisibility = Visibility.Collapsed;
 
             BringProcessToForeground();
         }

--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -910,7 +910,6 @@ namespace PowerLauncher.ViewModel
             list.Add(r);
             Results.AddResults(list, _updateToken);
             Results.Clear();
-            MainWindowVisibility = System.Windows.Visibility.Collapsed;
 
             // Fix Cold start for plugins, "m" is just a random string needed to query results
             var pluginQueryPairs = QueryBuilder.Build("m");


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
> since during startup the visibility of the MainViewModel is set to Visibility.Collapsed the OnLoaded for the MainWindow is called only when the PT Run shortcut is pressed for the first time.

**What is include in the PR:** 
Moved the set of the visibility of the MainWindow to Collapsed after OnLoaded has been called.

**How does someone test / validate:** 
This should improve performance when user press PT Run shortcut for the first time: https://github.com/microsoft/PowerToys/issues/8873#issuecomment-874226749 https://github.com/microsoft/PowerToys/issues/8873#issuecomment-856371692
Slightly noticeable on my computer.

## Quality Checklist

- [x] **Linked issue:** #8873
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
