### PR TITLE
[spell checker] add IObservable term

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -939,6 +939,7 @@ INVALIDARG
 invalidoperatioexception
 IObject
 iobjectwithsitesetsite
+IObservable
 IOle
 iolewindowcontextsensitivehelp
 iomanip


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
After updating and turning on the spell checker action, some PRs are giving an error because of the "IObservable" term.

**What is include in the PR:** 
Adds "IObservable" to the spell checker list of expected words.

**How does someone test / validate:** 
Let's wait for the action to be successful.
