### PR TITLE
[ColorPicker] Accessibility: announce which color will be copied to c…

### DIFF
--- a/src/modules/colorPicker/ColorPickerUI/Controls/ColorFormatControl.xaml
+++ b/src/modules/colorPicker/ColorPickerUI/Controls/ColorFormatControl.xaml
@@ -48,12 +48,12 @@
                     Height="36"
                     Width="36"
                     Grid.Column="2"
-                    AutomationProperties.HelpText="{Binding ElementName=FormatNameTextBlock, Path=Text}"
                     AutomationProperties.Name="{x:Static p:Resources.Copy_to_clipboard}"
+                    AutomationProperties.HelpText="{Binding ElementName=ColorTextRepresentationTextBlock, Path=Text}"
                     FontSize="12"
                     Style="{StaticResource DefaultButtonStyle}"
                     FontFamily="Segoe MDL2 Assets"
-                    Content="&#xE16F;" />       
+                    Content="&#xE16F;" />
         </Grid>
         <Border.Effect>
             <DropShadowEffect BlurRadius="6" Opacity="0.24" ShadowDepth="1" />


### PR DESCRIPTION
…lipboard

## Summary of the Pull Request

**What is this about:**
Now the Narrator announces "Copy to clipboard button: `<color value>`".

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #12111
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
