### PR TITLE
[VCM] Tweak toolbar top right vertical offset to allow closing apps

### DIFF
--- a/src/modules/videoconference/VideoConferenceModule/Toolbar.cpp
+++ b/src/modules/videoconference/VideoConferenceModule/Toolbar.cpp
@@ -13,6 +13,7 @@ Toolbar* toolbar = nullptr;
 const int REFRESH_RATE = 100;
 const int OVERLAY_SHOW_TIME = 500;
 const int BORDER_OFFSET = 12;
+const int TOP_RIGHT_BORDER_OFFSET = 40;
 
 Toolbar::Toolbar()
 {
@@ -256,7 +257,7 @@ void Toolbar::show(std::wstring position, std::wstring monitorString)
         else //"Top right corner" or non-present
         {
             positionX = monitorInfo.right() - overlayWidth - BORDER_OFFSET;
-            positionY = monitorInfo.top() + BORDER_OFFSET;
+            positionY = monitorInfo.top() + TOP_RIGHT_BORDER_OFFSET;
         }
 
         HWND hwnd;


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

**What is include in the PR:** 

**How does someone test / validate:** 
enable VCM (uncommenting module loading in src/runner/main.cpp should be enough) and mute mic. Observe the toolbar doesn't hide 'X' window button.
## Quality Checklist

- [x] **Linked issue:** #12371
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
