### PR TITLE
[OOBE] Added missing spacing for Image Resizer navview item

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -1215,7 +1215,7 @@ From there, simply click on a Markdown file or SVG icon in the File Explorer and
     <comment>Do not localize this string</comment>
   </data>
   <data name="Oobe_ImageResizer" xml:space="preserve">
-    <value>ImageResizer</value>
+    <value>Image Resizer</value>
     <comment>Do not localize this string</comment>
   </data>
   <data name="Oobe_KBM" xml:space="preserve">


### PR DESCRIPTION
## Summary of the Pull Request

Fixing label for Image Resizer in OOBE (was missing the space)

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
