### PR TITLE
[PowerToys Run] Fix corrupt/outdated plugins load crash

### DIFF
--- a/src/modules/launcher/PowerLauncher/Plugin/PluginConfig.cs
+++ b/src/modules/launcher/PowerLauncher/Plugin/PluginConfig.cs
@@ -94,6 +94,12 @@ namespace PowerLauncher.Plugin
                 return null;
             }
 
+            if (string.IsNullOrEmpty(metadata.IcoPathDark) || string.IsNullOrEmpty(metadata.IcoPathLight))
+            {
+                Log.Error($"|PluginConfig.GetPluginMetadata|couldn't get icon information for config <{configPath}>", MethodBase.GetCurrentMethod().DeclaringType);
+                return null;
+            }
+
             if (!File.Exists(metadata.ExecuteFilePath))
             {
                 Log.Error($"|PluginConfig.GetPluginMetadata|execute file path didn't exist <{metadata.ExecuteFilePath}> for config <{configPath}", MethodBase.GetCurrentMethod().DeclaringType);

--- a/src/modules/launcher/Wox.Plugin/PluginPair.cs
+++ b/src/modules/launcher/Wox.Plugin/PluginPair.cs
@@ -137,11 +137,21 @@ namespace Wox.Plugin
             catch (Exception e)
 #pragma warning restore CA1031 // Do not catch general exception types
             {
-                Log.Exception($"Couldn't load assembly for {Metadata.Name}", e, MethodBase.GetCurrentMethod().DeclaringType);
+                Log.Exception($"Couldn't load assembly for {Metadata.Name} in {Metadata.ExecuteFilePath}", e, MethodBase.GetCurrentMethod().DeclaringType);
                 return false;
             }
 
-            var types = _assembly.GetTypes();
+            Type[] types;
+            try
+            {
+                types = _assembly.GetTypes();
+            }
+            catch (ReflectionTypeLoadException e)
+            {
+                Log.Exception($"Couldn't get assembly types for {Metadata.Name} in {Metadata.ExecuteFilePath}. The plugin might be corrupted. Uninstall PowerToys, manually delete the install folder and reinstall.", e, MethodBase.GetCurrentMethod().DeclaringType);
+                return false;
+            }
+
             Type type;
             try
             {
@@ -149,7 +159,7 @@ namespace Wox.Plugin
             }
             catch (InvalidOperationException e)
             {
-                Log.Exception($"Can't find class implement IPlugin for <{Metadata.Name}>", e, MethodBase.GetCurrentMethod().DeclaringType);
+                Log.Exception($"Can't find class implement IPlugin for <{Metadata.Name}> in {Metadata.ExecuteFilePath}", e, MethodBase.GetCurrentMethod().DeclaringType);
                 return false;
             }
 
@@ -161,7 +171,7 @@ namespace Wox.Plugin
             catch (Exception e)
 #pragma warning restore CA1031 // Do not catch general exception types
             {
-                Log.Exception($"Can't create instance for <{Metadata.Name}>", e, MethodBase.GetCurrentMethod().DeclaringType);
+                Log.Exception($"Can't create instance for <{Metadata.Name}> in {Metadata.ExecuteFilePath}", e, MethodBase.GetCurrentMethod().DeclaringType);
                 return false;
             }
 


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
The existence of outdated plugins that were not correctly uninstalled causes some run time errors due to not being able to load the types in the plugin's assembly.

**What is include in the PR:** 
A check for the inability to load the types in the assembly, with an appropriate log error message.
Doesn't load plugins that don't contain the new plugin config format containing "IcoPathDark" and "IcoPathLight" fields.
Also adds the file location to the error messages for loading the plugins.

**How does someone test / validate:** 
We've been unable to reproduce the error through normal means.
Copying the Calculator plugin from v0.29.3 to the PowerToys run plugin folder and trying to use PowerToys Run should be enough to verify this no longer crashes PowerToys.

## Quality Checklist

- [x] **Linked issue:** #11916
- [x] **Communication:** I've discussed this with core contributors in the issue. 
