### PR TITLE
[PT Run] Move launcher using win arrow keys

### DIFF
--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -253,6 +253,9 @@ namespace PowerLauncher
 
         private void Launcher_KeyDown(object sender, KeyEventArgs e)
         {
+            int delta = 8;
+            Screen screen = Screen.FromPoint(new System.Drawing.Point((int)(this.Left + ((ActualWidth - SearchBox.ActualWidth) / 2)), (int)this.Top));
+
             if (e.Key == Key.Tab && Keyboard.IsKeyDown(Key.LeftShift))
             {
                 _viewModel.SelectPrevTabItemCommand.Execute(null);
@@ -267,18 +270,42 @@ namespace PowerLauncher
             }
             else if (e.Key == Key.Down)
             {
+                if (_viewModel.QueryText.Length == 0)
+                {
+                    if (Top + Height + delta < screen.Bounds.Height)
+                    {
+                        Top += delta;
+                    }
+                }
+
                 _viewModel.SelectNextItemCommand.Execute(null);
                 UpdateTextBoxToSelectedItem();
                 e.Handled = true;
             }
             else if (e.Key == Key.Up)
             {
+                if (_viewModel.QueryText.Length == 0)
+                {
+                    if (Top - delta > screen.Bounds.Y)
+                    {
+                        Top -= delta;
+                    }
+                }
+
                 _viewModel.SelectPrevItemCommand.Execute(null);
                 UpdateTextBoxToSelectedItem();
                 e.Handled = true;
             }
             else if (e.Key == Key.Right)
             {
+                if (_viewModel.QueryText.Length == 0)
+                {
+                    if (Left + ActualWidth + delta < screen.WorkingArea.X + screen.WorkingArea.Width + ((ActualWidth - SearchBox.ActualWidth) / 2))
+                    {
+                        Left += delta;
+                    }
+                }
+
                 if (SearchBox.QueryTextBox.CaretIndex == SearchBox.QueryTextBox.Text.Length)
                 {
                     _viewModel.SelectNextContextMenuItemCommand.Execute(null);
@@ -287,6 +314,14 @@ namespace PowerLauncher
             }
             else if (e.Key == Key.Left)
             {
+                if (_viewModel.QueryText.Length == 0)
+                {
+                    if (Left - delta > screen.WorkingArea.X - ((ActualWidth - SearchBox.ActualWidth) / 2))
+                    {
+                        Left -= delta;
+                    }
+                }
+
                 if (SearchBox.QueryTextBox.CaretIndex == SearchBox.QueryTextBox.Text.Length)
                 {
                     if (_viewModel.Results != null && _viewModel.Results.IsContextMenuItemSelected())


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Move PT Run search box using arrow keys. Search box is only moved if query text is empty.

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #12104 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
