### PR TITLE
[ColorPicker] Accessibility: Close only flyout with escape key

### DIFF
--- a/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml
+++ b/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml
@@ -297,6 +297,7 @@
                 <ui:FlyoutService.Flyout>
                     <ui:Flyout x:Name="DetailsFlyout"
                                Placement="Bottom"
+                               Opened="DetailsFlyout_Opened"
                                Closed="DetailsFlyout_Closed">
                         <Grid Margin="0,4,0,12"
                               KeyboardNavigation.TabNavigation="Contained"

--- a/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml.cs
@@ -242,12 +242,22 @@ namespace ColorPicker.Controls
 #pragma warning restore CA1801 // Review unused parameters
         {
             HideDetails();
+            AppStateHandler.BlockEscapeKeyClosingColorPickerEditor = false;
 
             // Revert to original color
             var originalColorBackground = new SolidColorBrush(_originalColor);
             CurrentColorButton.Background = originalColorBackground;
 
             HexCode.Text = ColorToHex(_originalColor);
+        }
+
+#pragma warning disable CA1822 // Mark members as static
+#pragma warning disable CA1801 // Review unused parameters
+        private void DetailsFlyout_Opened(object sender, object e)
+#pragma warning restore CA1801 // Review unused parameters
+#pragma warning restore CA1822 // Mark members as static
+        {
+            AppStateHandler.BlockEscapeKeyClosingColorPickerEditor = true;
         }
 
         private void ColorVariationButton_Click(object sender, RoutedEventArgs e)

--- a/src/modules/colorPicker/ColorPickerUI/Helpers/AppStateHandler.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/AppStateHandler.cs
@@ -20,6 +20,9 @@ namespace ColorPicker.Helpers
         private bool _colorPickerShown;
         private object _colorPickerVisibilityLock = new object();
 
+        // Blocks using the escape key to close the color picker editor when the adjust color flyout is open.
+        public static bool BlockEscapeKeyClosingColorPickerEditor { get; set; }
+
         [ImportingConstructor]
         public AppStateHandler(IColorEditorViewModel colorEditorViewModel, IUserSettings userSettings)
         {
@@ -36,6 +39,7 @@ namespace ColorPicker.Helpers
 
         public void StartUserSession()
         {
+            EndUserSession(); // Ends current user session if there's an active one.
             lock (_colorPickerVisibilityLock)
             {
                 if (!_colorPickerShown && !IsColorPickerEditorVisible())
@@ -149,7 +153,7 @@ namespace ColorPicker.Helpers
             }
         }
 
-        private bool IsColorPickerEditorVisible()
+        public bool IsColorPickerEditorVisible()
         {
             if (_colorEditorWindow != null)
             {
@@ -158,6 +162,11 @@ namespace ColorPicker.Helpers
             }
 
             return false;
+        }
+
+        public bool IsColorPickerVisible()
+        {
+            return _colorPickerShown;
         }
 
         private void MainWindow_Closed(object sender, EventArgs e)

--- a/src/modules/colorPicker/ColorPickerUI/Keyboard/KeyboardMonitor.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Keyboard/KeyboardMonitor.cs
@@ -70,10 +70,17 @@ namespace ColorPicker.Keyboard
             var virtualCode = e.KeyboardData.VirtualCode;
 
             // ESC pressed
-            if (virtualCode == KeyInterop.VirtualKeyFromKey(Key.Escape))
+            if (virtualCode == KeyInterop.VirtualKeyFromKey(Key.Escape)
+                && e.KeyboardState == GlobalKeyboardHook.KeyboardState.KeyDown
+                )
             {
-                e.Handled = _appStateHandler.EndUserSession();
-                return;
+                if (_appStateHandler.IsColorPickerVisible()
+                    || !AppStateHandler.BlockEscapeKeyClosingColorPickerEditor
+                    )
+                {
+                    e.Handled = _appStateHandler.EndUserSession();
+                    return;
+                }
             }
 
             if ((System.Windows.Application.Current as ColorPickerUI.App).IsRunningDetachedFromPowerToys())


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
When the escape key is pressed in the Color Picker editor, only the adjust color flyout should be closed instead of the whole window.

**What is include in the PR:** 
Some code blocking the global key event hook from processing the escape key if the flyout is open.
Also some code to end the current session before starting a new one if the user presses the shortcut again.

**How does someone test / validate:** 
Press the escape key when the flyout is open.

## Quality Checklist

- [x] **Linked issue:** #12097
