### PR TITLE
[Settings] Fix VCM page converters

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/VideoConference.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/VideoConference.xaml
@@ -22,7 +22,7 @@
 
                 <TextBlock x:Uid="VideoConference_Shortcuts"
                        Style="{StaticResource SettingsGroupTitleStyle}"
-                       Foreground="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToForegroundConverter}}" />
+                       Opacity="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToOpacityConverter}}" />
 
                 <controls:HotkeySettingsControl 
                                           x:Uid="VideoConference_CameraAndMicrophoneMuteHotkeyControl_Header"
@@ -55,7 +55,7 @@
                                           />
                 <TextBlock x:Uid="VideoConference_Microphone"
                        Style="{StaticResource SettingsGroupTitleStyle}"
-                       Foreground="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToForegroundConverter}}"/>
+                       Opacity="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToOpacityConverter}}"/>
 
                 <ComboBox x:Uid="VideoConference_SelectedMicrophone"
                       Width="240"
@@ -67,7 +67,7 @@
 
                 <TextBlock x:Uid="VideoConference_Camera"
                        Style="{StaticResource SettingsGroupTitleStyle}"
-                       Foreground="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToForegroundConverter}}"/>
+                       Opacity="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToOpacityConverter}}"/>
 
                 <ComboBox x:Uid="VideoConference_SelectedCamera"
                       Width="240"
@@ -109,7 +109,7 @@
 
                 <TextBlock x:Uid="VideoConference_Toolbar"
                        Style="{StaticResource SettingsGroupTitleStyle}"
-                       Foreground="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToForegroundConverter}}"/>
+                       Opacity="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled, Converter={StaticResource ModuleEnabledToOpacityConverter}}"/>
 
                 <ComboBox x:Uid="VideoConference_ToolbarPosition" 
                       MinWidth="240"


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Converts the uses of ModuleEnabledToForegroundConverter to ModuleEnabledToOpacityConverter in line with the rest of the settings pages.
This applies the changes of https://github.com/microsoft/PowerToys/pull/11843 to the VCM settings page, which was not in master at the time, so that it doesn't crash the Settings application.

**How does someone test / validate:** 
- Uncomment what's needed to turn on the VCM module. (Look for `uncomment when VCM should be enabled` comments in the code)
- Access the VCM Settings page and verify it doesn't crash.

## Quality Checklist

- [x] **Linked issue:** #12381
- [x] **Communication:** I've discussed this with core contributors in the issue. 
