### PR TITLE
[Settings] Fix PowerToys run plugin toggle boxes

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
@@ -256,7 +256,8 @@
 
                                 <ToggleSwitch x:Uid="PowerLauncher_EnablePluginToggle"
                                               x:Name="ToggleSwitch"
-                                              HorizontalAlignment="Center"
+                                              OnContent=""
+                                              OffContent=""
                                               IsOn="{x:Bind Path=Disabled, Converter={StaticResource BoolNegationConverter}, Mode=TwoWay}"
                                               Grid.Column="2" />
                             </Grid>


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Fixes the issue that appeared after updating the `Microsoft.UI.Xaml` version which seems to have caused the PowerToys Run plugin toggle boxes in the Settings to only show the labels:

![image](https://user-images.githubusercontent.com/17161067/126780141-674a8806-5b7c-46d1-8e3a-56468b0d89aa.png)

**What is include in the PR:** 
This PR applies a fix it to show the toggle boxes instead:

![image](https://user-images.githubusercontent.com/26118718/126819896-b879829c-e642-4bc9-b96b-6cf5da2d7645.png)

**How does someone test / validate:** 
Build and verify that the toggle boxes are rendered as intended.

## Quality Checklist

- [x] **Linked issue:** #12484
- [x] **Communication:** I've discussed this with core contributors in the issue. 
