### PR TITLE
[Bug Report Tool] Get Settings event viewer data

### DIFF
--- a/tools/BugReportTool/BugReportTool/EventViewer.cpp
+++ b/tools/BugReportTool/BugReportTool/EventViewer.cpp
@@ -15,6 +15,7 @@ namespace
     std::vector<std::wstring> processes = 
     {
         L"PowerToys.exe",
+        L"PowerToys.Settings.exe",
         L"ColorPickerUI.exe",
         L"PowerToys.Awake.exe",
         L"FancyZonesEditor.exe",


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Adds the event viewer events of PowerToys.Settings.exe to bug reports.

**What is include in the PR:** 
Adds the event viewer events of PowerToys.Settings.exe to bug reports.

**How does someone test / validate:** 
Run the bug report tool, an entry for PowerToys.Settings.exe should be created in the report.
This allows catching errors such as https://github.com/microsoft/PowerToys/issues/12520

## Quality Checklist

- [x] **Linked issue:** #12520
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries
