### PR TITLE
[Settings] Downgrade Microsoft.UI.Xaml to 2.6.0

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Microsoft.PowerToys.Settings.UI.csproj
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Microsoft.PowerToys.Settings.UI.csproj
@@ -279,7 +279,7 @@
       <Version>6.1.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.UI.Xaml">
-      <Version>2.6.1-prerelease.210709001</Version>
+      <Version>2.6.0-prerelease.210623001</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Xaml.Behaviors.Uwp.Managed">
       <Version>2.0.1</Version>


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Downgrade the Settings app dependency on `Microsoft.UI.Xaml` from `2.6.1-prerelease.210709001` to `2.6.0-prerelease.210623001`, to prevent a crashing error. https://github.com/microsoft/PowerToys/issues/12520

**What is included in the PR:** 
The downgrade change.

**How does someone test / validate:** 
Verify that Settings still works with this change.

## Quality Checklist

- [x] **Linked issue:** #12520
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries
