### PR TITLE
[FZEditor] Editor closing fix

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/App.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/App.xaml
@@ -3,7 +3,8 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:FancyZonesEditor"
              xmlns:ui="http://schemas.modernwpf.com/2019"
-             Startup="OnStartup">
+             Startup="OnStartup"
+             Exit="OnExit">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/App.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/App.xaml.cs
@@ -57,6 +57,8 @@ namespace FancyZonesEditor
 
         private ThemeManager _themeManager;
 
+        private EventWaitHandle _eventHandle;
+
         public static bool DebugMode
         {
             get
@@ -83,8 +85,8 @@ namespace FancyZonesEditor
 
             new Thread(() =>
             {
-                var eventHandle = new EventWaitHandle(false, EventResetMode.AutoReset, interop.Constants.FZEExitEvent());
-                if (eventHandle.WaitOne())
+                _eventHandle = new EventWaitHandle(false, EventResetMode.AutoReset, interop.Constants.FZEExitEvent());
+                if (_eventHandle.WaitOne())
                 {
                     Environment.Exit(0);
                 }
@@ -152,6 +154,14 @@ namespace FancyZonesEditor
             settings.UpdateSelectedLayoutModel();
 
             Overlay.Show();
+        }
+
+        private void OnExit(object sender, ExitEventArgs e)
+        {
+            if (_eventHandle != null)
+            {
+                _eventHandle.Set();
+            }
         }
 
         public void App_KeyUp(object sender, System.Windows.Input.KeyEventArgs e)


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

After https://github.com/microsoft/PowerToys/pull/12510 Editor won't be closed via clicking on the `Close` button and stays open. `EventWaitHandle` keeps it alive, so we need to stop it on closing.

**What is include in the PR:** 

**How does someone test / validate:** 

* Open Editor
* Close Editor
* Verify in the Task Manager that Editor was closed.

## Quality Checklist

- [x] **Linked issue:** #12528
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
