### PR TITLE
Raise notification event on delete key/shortcut button click

### DIFF
--- a/src/modules/keyboardmanager/KeyboardManagerEditor/Resources.resx
+++ b/src/modules/keyboardmanager/KeyboardManagerEditor/Resources.resx
@@ -357,6 +357,9 @@
   <data name="Delete_Remapping_Button" xml:space="preserve">
     <value>Delete Remapping</value>
   </data>
+  <data name="Delete_Remapping_Event" xml:space="preserve">
+    <value>Remapping deleted</value>
+  </data>
   <data name="AutomationProperties_Row" xml:space="preserve">
     <value>Row </value>
   </data>

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/ShortcutControl.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/ShortcutControl.cpp
@@ -191,7 +191,7 @@ void ShortcutControl::AddNewShortcutControlRow(StackPanel& parent, std::vector<s
     deleteShortcut.Content(deleteSymbol);
     deleteShortcut.Background(Media::SolidColorBrush(Colors::Transparent()));
     deleteShortcut.HorizontalAlignment(HorizontalAlignment::Center);
-    deleteShortcut.Click([&, parent, row, brush](winrt::Windows::Foundation::IInspectable const& sender, RoutedEventArgs const&) {
+    deleteShortcut.Click([&, parent, row, brush, deleteShortcut](winrt::Windows::Foundation::IInspectable const& sender, RoutedEventArgs const&) {
         Button currentButton = sender.as<Button>();
         uint32_t rowIndex;
         // Get index of delete button
@@ -213,6 +213,15 @@ void ShortcutControl::AddNewShortcutControlRow(StackPanel& parent, std::vector<s
             TextBox targetApp = row.Children().GetAt(3).as<StackPanel>().Children().GetAt(0).as<StackPanel>().Children().GetAt(0).as<TextBox>();
             Button delButton = row.Children().GetAt(4).as<StackPanel>().Children().GetAt(0).as<Button>();
             UpdateAccessibleNames(sourceCol, targetCol, targetApp, delButton, i);
+        }
+
+        if (auto automationPeer{ Automation::Peers::FrameworkElementAutomationPeer::FromElement(deleteShortcut) })
+        {
+            automationPeer.RaiseNotificationEvent(
+                Automation::Peers::AutomationNotificationKind::ActionCompleted,
+                Automation::Peers::AutomationNotificationProcessing::ImportantMostRecent,
+                GET_RESOURCE_STRING(IDS_DELETE_REMAPPING_EVENT),
+                L"ShortcutRemappingDeletedNotificationEvent" /* unique name for this notification category */);
         }
 
         children.RemoveAt(rowIndex);

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/SingleKeyRemapControl.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/SingleKeyRemapControl.cpp
@@ -135,7 +135,7 @@ void SingleKeyRemapControl::AddNewControlKeyRemapRow(StackPanel& parent, std::ve
     deleteRemapKeys.Content(deleteSymbol);
     deleteRemapKeys.Background(Media::SolidColorBrush(Colors::Transparent()));
     deleteRemapKeys.HorizontalAlignment(HorizontalAlignment::Center);
-    deleteRemapKeys.Click([&, parent, row, brush](winrt::Windows::Foundation::IInspectable const& sender, RoutedEventArgs const&) {
+    deleteRemapKeys.Click([&, parent, row, brush, deleteRemapKeys](winrt::Windows::Foundation::IInspectable const& sender, RoutedEventArgs const&) {
         uint32_t rowIndex;
         // Get index of delete button
         UIElementCollection children = parent.Children();
@@ -156,6 +156,15 @@ void SingleKeyRemapControl::AddNewControlKeyRemapRow(StackPanel& parent, std::ve
             StackPanel targetCol = row.Children().GetAt(2).as<StackPanel>();
             Button delButton = row.Children().GetAt(3).as<Button>();
             UpdateAccessibleNames(sourceCol, targetCol, delButton, i);
+        }
+
+        if (auto automationPeer{ Automation::Peers::FrameworkElementAutomationPeer::FromElement(deleteRemapKeys) })
+        {
+            automationPeer.RaiseNotificationEvent(
+                Automation::Peers::AutomationNotificationKind::ActionCompleted,
+                Automation::Peers::AutomationNotificationProcessing::ImportantMostRecent,
+                GET_RESOURCE_STRING(IDS_DELETE_REMAPPING_EVENT),
+                L"KeyRemappingDeletedNotificationEvent" /* unique name for this notification category */);
         }
 
         children.RemoveAt(rowIndex);

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/pch.h
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/pch.h
@@ -16,6 +16,7 @@
 #pragma push_macro("GetCurrentTime")
 #undef GetCurrentTime
 #include <winrt/Windows.UI.Xaml.Automation.h>
+#include <winrt/Windows.UI.Xaml.Automation.Peers.h>
 #include <winrt/Windows.UI.Xaml.Controls.Primitives.h>
 #include <winrt/Windows.UI.Xaml.Hosting.h>
 #include <winrt/Windows.UI.Xaml.Interop.h>


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Screen reader is now announcing confirmation after deleting key/shortcut remapping.

**What is include in the PR:** 

**How does someone test / validate:** 
 - Turn on Narrator
 - Open PT settings and navigate to Keyboard Manager page
 - Open Remap a key window and add any key remapping
 - Navigate to Delete button of key remapping
 - Press Delete key and observe that Narrator announce "Remapping deleted"
 - Do the same within Remap a shortcut window
## Quality Checklist

- [x] **Linked issue:** #7026
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
