### PR TITLE
[Draft][Keyboard Manager - Add shortcut window] Only allow alphanumeric chars for App name in shortcut remap window

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -40,6 +40,7 @@ ALIGNLEFT
 ALLAPPS
 Alloc
 ALLOWUNDO
+aplhanumeric
 ALPHATYPE
 Altdown
 altform

--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -978,6 +978,7 @@ IRegistry
 IReloadable
 IRepository
 IResult
+isalnum
 ISavable
 isbi
 ISearch

--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -40,7 +40,6 @@ ALIGNLEFT
 ALLAPPS
 Alloc
 ALLOWUNDO
-aplhanumeric
 ALPHATYPE
 Altdown
 altform

--- a/src/modules/keyboardmanager/KeyboardManagerEditor/Resources.resx
+++ b/src/modules/keyboardmanager/KeyboardManagerEditor/Resources.resx
@@ -368,6 +368,6 @@
     <comment>Key on a keyboard</comment>
   </data>
   <data name="ADD_SHORTCUT_TARGET_APP_TOOLTIP" xml:space="preserve">
-    <value>Only aplhanumeric characters, '.' and ' ' allowed</value>
+    <value>Only alphanumeric characters, '.' and ' ' allowed</value>
   </data>
 </root>

--- a/src/modules/keyboardmanager/KeyboardManagerEditor/Resources.resx
+++ b/src/modules/keyboardmanager/KeyboardManagerEditor/Resources.resx
@@ -367,4 +367,7 @@
     <value>Disable can not be an action or a modifier key</value>
     <comment>Key on a keyboard</comment>
   </data>
+  <data name="ADD_SHORTCUT_TARGET_APP_TOOLTIP" xml:space="preserve">
+    <value>Only aplhanumeric characters, '.' and ' ' allowed</value>
+  </data>
 </root>

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/ShortcutControl.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/ShortcutControl.cpp
@@ -72,6 +72,9 @@ void ShortcutControl::AddNewShortcutControlRow(StackPanel& parent, std::vector<s
 {
     // Textbox for target application
     TextBox targetAppTextBox;
+    ToolTip targetAppTextBoxToolTip;
+    targetAppTextBoxToolTip.Content(box_value(GET_RESOURCE_STRING(IDS_ADD_SHORTCUT_TARGET_APP_TOOLTIP)));
+    ToolTipService::SetToolTip(targetAppTextBox, targetAppTextBoxToolTip);
 
     // Create new ShortcutControl objects dynamically so that we does not get destructed
     std::vector<std::unique_ptr<ShortcutControl>> newrow;

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/ShortcutControl.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/ShortcutControl.cpp
@@ -113,6 +113,20 @@ void ShortcutControl::AddNewShortcutControlRow(StackPanel& parent, std::vector<s
     targetAppTextBox.Width(EditorConstants::ShortcutTableDropDownWidth);
     targetAppTextBox.PlaceholderText(KeyboardManagerEditorStrings::DefaultAppName);
     targetAppTextBox.Text(targetAppName);
+    targetAppTextBox.TextChanged([targetAppTextBox](const auto& sender, auto const& e) {
+        // Alphanumeric characters only
+        const std::wstring& text = std::wstring{ targetAppTextBox.Text() };
+        std::wstring newText;
+        for (auto c : text)
+        {
+            if (isalnum(c) || c == ' ' || c == '.')
+            {
+                newText += c;
+            }
+        }
+        targetAppTextBox.Text(newText);
+        targetAppTextBox.SelectionStart(static_cast<int32_t>(newText.size()));
+    });
 
     // GotFocus handler will be called whenever the user tabs into or clicks on the textbox
     targetAppTextBox.GotFocus([targetAppTextBox](auto const& sender, auto const& e) {


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Instead of announcing that app name is wrong, only allow alphanumeric chars for application name when adding new shortcut remapping.

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #7106 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
