### PR TITLE
[Runner] Open Settings Running Elevated

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -1299,6 +1299,7 @@ mscorlib
 msdata
 MSDN
 msedge
+MSGFLT
 mshtmdid
 msi
 MSIFASTINSTALL

--- a/src/runner/tray_icon.cpp
+++ b/src/runner/tray_icon.cpp
@@ -246,6 +246,7 @@ void start_tray_icon()
         std::wstring about_msg_pt_version = L"PowerToys " + get_product_version();
         wcscpy_s(tray_icon_data.szTip, sizeof(tray_icon_data.szTip) / sizeof(WCHAR), about_msg_pt_version.c_str());
         tray_icon_data.uFlags = NIF_ICON | NIF_TIP | NIF_MESSAGE;
+        ChangeWindowMessageFilterEx(hwnd, WM_COMMAND, MSGFLT_ALLOW, nullptr);
 
         tray_icon_created = Shell_NotifyIcon(NIM_ADD, &tray_icon_data) == TRUE;
     }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Click on PowerToys icon should open settings if PowerToys is already running in the system tray.
This is not working if PowerToys is running elevated.

**What is include in the PR:** 
This is returning ERROR_ACCESS_DENIED.
https://github.com/microsoft/PowerToys/blob/c8f04923539f6136a37c9bd6e5e784636ea642a2/src/runner/main.cpp#L77
This fix allow a process running with lower privileges to send WM_COMMAND to PowerToys.

**How does someone test / validate:** 
- Open PowerToys
- Ensure PowerToys is running in the system tray
- Open PowerToys a second time
- Settings should be opened

Test as normal user and elevated.

## Quality Checklist

- [x] **Linked issue:** #9567
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
