### PR TITLE
[File Explorer] fix enabling all add-ons at startup

### DIFF
--- a/src/modules/previewpane/powerpreview/powerpreview.cpp
+++ b/src/modules/previewpane/powerpreview/powerpreview.cpp
@@ -16,9 +16,7 @@ PowerPreviewModule::PowerPreviewModule() :
     m_moduleName(GET_RESOURCE_STRING(IDS_MODULE_NAME)),
     app_key(powerpreviewConstants::ModuleKey)
 {
-    // Initialize the toggle states for each module
-    init_settings();
-
+    // Initialize the preview modules.
     m_fileExplorerModules.emplace_back(std::make_unique<PreviewHandlerSettings>(
         true,
         L"svg-previewer-toggle-setting",
@@ -43,6 +41,9 @@ PowerPreviewModule::PowerPreviewModule() :
         L"Svg Thumbnail Provider",
         std::make_unique<RegistryWrapper>(),
         L".svg\\shellex\\{E357FCCD-A995-4576-B01F-234630154E96}"));
+
+    // Initialize the toggle states for each module.
+    init_settings();
 
     // File Explorer might be disabled if user updated from old to new settings.
     // Initialize the registry state in the constructor as PowerPreviewModule::enable/disable will not be called on startup


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
When starting PowerToys, it always tries to enable all File Explorer add-ons if they were disabled in settings, failing with a notification message when running normally and succeeding when running as Admin.
The reason for this is that the module tries to read the settings at setup before populating the list of add-ons, so the add-ons will always be populated with the default values.

**What is include in the PR:** 
Changes to apply the value in settings only after populating the list of add-ons. This way the registry state of the add-ons will be compared with the value in settings.

**How does someone test / validate:** 
Turn some File Explorer add-ons off and verify they stay off even after restarting PowerToys.

## Quality Checklist

- [x] **Linked issue:** #10524
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries
