### PR TITLE
[FZ Editor] Place cursor in the end of the name on textbox focus

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -390,7 +390,8 @@
                                  Margin="12,0,0,0"
                                  ui:ControlHelper.Header="{x:Static props:Resources.Name}"
                                  MinWidth="286"
-                                 HorizontalAlignment="Stretch" />
+                                 HorizontalAlignment="Stretch"
+                                 GotKeyboardFocus="TextBox_GotKeyboardFocus"/>
                     </StackPanel>
 
                     <!-- Shortcut panel -->

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -446,5 +446,11 @@ namespace FancyZonesEditor
                 }
             }
         }
+
+        private void TextBox_GotKeyboardFocus(object sender, RoutedEventArgs e)
+        {
+            TextBox tb = sender as TextBox;
+            tb.SelectionStart = tb.Text.Length;
+        }
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Place cursor in the end of the layout name of the textbox manually

**What is include in the PR:** 

**How does someone test / validate:** 
 - Open FZ editor
 - Create one custom layout (if there aren't any)
 - Navigate to custom layout and select Edit layout
 - Using keyboard (Tab) navigate to layout name TextBox
 - Observe that cursor is located in the end of the name

## Quality Checklist

- [x] **Linked issue:** #10843 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
