### PR TITLE
[FZE] Fix crash when double clicking edit layout

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -26,6 +26,7 @@ namespace FancyZonesEditor
         private LayoutModel _backup;
 
         private ContentDialog _openedDialog;
+        private bool _openingDialog = false; // Is the dialog being opened.
 
         public int WrapPanelItemSize { get; set; } = DefaultWrapPanelItemSize;
 
@@ -247,19 +248,32 @@ namespace FancyZonesEditor
 
         private async void EditLayout_Click(object sender, RoutedEventArgs e)
         {
-            var dataContext = ((FrameworkElement)sender).DataContext;
-            Select((LayoutModel)dataContext);
-
-            if (_settings.SelectedModel is GridLayoutModel grid)
+            // Avoid trying to open the same dialog twice.
+            if (!_openingDialog)
             {
-                _backup = new GridLayoutModel(grid);
-            }
-            else if (_settings.SelectedModel is CanvasLayoutModel canvas)
-            {
-                _backup = new CanvasLayoutModel(canvas);
-            }
+                _openingDialog = true;
+                try
+                {
+                    var dataContext = ((FrameworkElement)sender).DataContext;
+                    Select((LayoutModel)dataContext);
 
-            await EditLayoutDialog.ShowAsync();
+                    if (_settings.SelectedModel is GridLayoutModel grid)
+                    {
+                        _backup = new GridLayoutModel(grid);
+                    }
+                    else if (_settings.SelectedModel is CanvasLayoutModel canvas)
+                    {
+                        _backup = new CanvasLayoutModel(canvas);
+                    }
+
+                    await EditLayoutDialog.ShowAsync();
+                }
+                catch
+                {
+                    _openingDialog = false;
+                    throw;
+                }
+            }
         }
 
         private void EditZones_Click(object sender, RoutedEventArgs e)
@@ -411,6 +425,7 @@ namespace FancyZonesEditor
 
         private void Dialog_Closed(ContentDialog sender, ContentDialogClosedEventArgs args)
         {
+            _openingDialog = false;
             _openedDialog = null;
         }
 


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
FancyZones Editor is crashing when clicking an edit layout button two times fast, due to trying to open the dialog twice.

**What is include in the PR:** 
Code to try and avoid opening the edit layout dialog twice.

**How does someone test / validate:** 
Try clicking the edit layout dialog twice and verify it doesn't crash FZE.

## Quality Checklist

- [x] **Linked issue:** #10571
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries
