### PR TITLE
[FancyZones Editor] Reset layout shortcut key after canceling changes

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -235,6 +235,8 @@ namespace FancyZonesEditor
 
         private void OnClosing(object sender, EventArgs e)
         {
+            CancelLayoutChanges();
+
             App.FancyZonesEditorIO.SerializeZoneSettings();
             App.Overlay.CloseLayoutWindow();
             App.Current.Shutdown();
@@ -354,10 +356,7 @@ namespace FancyZonesEditor
         // EditLayout: Cancel changes
         private void EditLayoutDialog_SecondaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
         {
-            // restore model properties from settings
-            _settings.RestoreSelectedModel(_backup);
-            _backup = null;
-
+            CancelLayoutChanges();
             Select(_settings.AppliedModel);
         }
 
@@ -466,6 +465,15 @@ namespace FancyZonesEditor
         {
             TextBox tb = sender as TextBox;
             tb.SelectionStart = tb.Text.Length;
+        }
+
+        private void CancelLayoutChanges()
+        {
+            if (_backup != null)
+            {
+                _settings.RestoreSelectedModel(_backup);
+                _backup = null;
+            }
         }
     }
 }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -259,11 +259,11 @@ namespace FancyZonesEditor
 
                     if (_settings.SelectedModel is GridLayoutModel grid)
                     {
-                        _backup = new GridLayoutModel(grid);
+                        _backup = new GridLayoutModel(grid, false);
                     }
                     else if (_settings.SelectedModel is CanvasLayoutModel canvas)
                     {
-                        _backup = new CanvasLayoutModel(canvas);
+                        _backup = new CanvasLayoutModel(canvas, false);
                     }
 
                     await EditLayoutDialog.ShowAsync();

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/CanvasLayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/CanvasLayoutModel.cs
@@ -52,8 +52,8 @@ namespace FancyZonesEditor.Models
         {
         }
 
-        public CanvasLayoutModel(CanvasLayoutModel other)
-            : base(other)
+        public CanvasLayoutModel(CanvasLayoutModel other, bool enableQuickKeysPropertyChangedSubscribe = true)
+            : base(other, enableQuickKeysPropertyChangedSubscribe)
         {
             CanvasRect = new Rect(other.CanvasRect.X, other.CanvasRect.Y, other.CanvasRect.Width, other.CanvasRect.Height);
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/GridLayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/GridLayoutModel.cs
@@ -146,8 +146,8 @@ namespace FancyZonesEditor.Models
             CellChildMap = cellChildMap;
         }
 
-        public GridLayoutModel(GridLayoutModel other)
-            : base(other)
+        public GridLayoutModel(GridLayoutModel other, bool enableQuickKeysPropertyChangedSubscribe = true)
+            : base(other, enableQuickKeysPropertyChangedSubscribe)
         {
             _rows = other._rows;
             _cols = other._cols;

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
@@ -42,7 +42,7 @@ namespace FancyZonesEditor.Models
             Type = type;
         }
 
-        protected LayoutModel(LayoutModel other)
+        protected LayoutModel(LayoutModel other, bool enableQuickKeysPropertyChangedSubscribe)
         {
             _guid = other._guid;
             _name = other._name;
@@ -53,7 +53,10 @@ namespace FancyZonesEditor.Models
             _zoneCount = other._zoneCount;
             _quickKey = other._quickKey;
 
-            MainWindowSettingsModel.QuickKeys.PropertyChanged += QuickSwitchKeys_PropertyChanged;
+            if (enableQuickKeysPropertyChangedSubscribe)
+            {
+                MainWindowSettingsModel.QuickKeys.PropertyChanged += QuickSwitchKeys_PropertyChanged;
+            }
         }
 
         // Name - the display name for this layout model - is also used as the key in the registry


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Layout shortcut key wasn't reset after canceling changes while editing the layout.

**What is include in the PR:** 

**How does someone test / validate:** 

* Set layout shortcut key
* Click Cancel
* Reopen layout settings
* Verify that shortcut key was reset to the previous value.

## Quality Checklist

- [x] **Linked issue:** #12554
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
