### PR TITLE
StyleCop and warnings fix

### DIFF
--- a/src/modules/colorPicker/UnitTest-ColorPickerUI/Helpers/ColorConverterTest.cs
+++ b/src/modules/colorPicker/UnitTest-ColorPickerUI/Helpers/ColorConverterTest.cs
@@ -190,7 +190,7 @@ namespace Microsoft.ColorPicker.UnitTests
             }
 
             Assert.IsTrue(hexValue.Length >= 6);
-            
+
             var red = int.Parse(hexValue.Substring(0, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
             var green = int.Parse(hexValue.Substring(2, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
             var blue = int.Parse(hexValue.Substring(4, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
@@ -287,7 +287,7 @@ namespace Microsoft.ColorPicker.UnitTests
 
             Assert.IsTrue(hexValue.Length >= 6);
 
-            var red = int.Parse( hexValue.Substring(0, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+            var red = int.Parse(hexValue.Substring(0, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
             var green = int.Parse(hexValue.Substring(2, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
             var blue = int.Parse(hexValue.Substring(4, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
 
@@ -322,6 +322,7 @@ namespace Microsoft.ColorPicker.UnitTests
                             _ = ColorHelper.ConvertToCMYKColor(color);
                         }
 #pragma warning disable CA1031 // Do not catch general exception types
+
                         // intentionally trying to catch
                         catch (Exception ex)
 #pragma warning restore CA1031 // Do not catch general exception types

--- a/src/modules/colorPicker/UnitTest-ColorPickerUI/UnitTest-ColorPickerUI.csproj
+++ b/src/modules/colorPicker/UnitTest-ColorPickerUI/UnitTest-ColorPickerUI.csproj
@@ -35,6 +35,10 @@
     </PackageReference>
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
@@ -42,4 +46,12 @@
     <ProjectReference Include="..\ColorPickerUI\ColorPickerUI.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="..\..\..\codeAnalysis\GlobalSuppressions.cs">
+      <Link>GlobalSuppressions.cs</Link>
+    </Compile>
+    <AdditionalFiles Include="..\..\..\codeAnalysis\StyleCop.json">
+      <Link>StyleCop.json</Link>
+    </AdditionalFiles>
+  </ItemGroup>
 </Project>

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter.UnitTest/InputInterpreterTests.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter.UnitTest/InputInterpreterTests.cs
@@ -1,3 +1,7 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Globalization;
 using NUnit.Framework;
 using Wox.Plugin;

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter.UnitTest/UnitHandlerTests.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter.UnitTest/UnitHandlerTests.cs
@@ -1,4 +1,7 @@
-﻿using System.Globalization;
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Linq;
 using NUnit.Framework;
 

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/Community.PowerToys.Run.Plugin.UnitConverter.csproj
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/Community.PowerToys.Run.Plugin.UnitConverter.csproj
@@ -26,7 +26,7 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <WarningLevel>4</WarningLevel>
     <Optimize>false</Optimize>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -39,6 +39,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/InputInterpreter.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/InputInterpreter.cs
@@ -1,5 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/Main.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/Main.cs
@@ -1,13 +1,15 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Windows;
 using System.Windows.Input;
 using ManagedCommon;
-using UnitsNet;
 using Wox.Plugin;
 
 namespace Community.PowerToys.Run.Plugin.UnitConverter
@@ -142,7 +144,7 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
             return Properties.Resources.plugin_description;
         }
 
-        private void OnThemeChanged(Theme _, Theme newTheme)
+        private void OnThemeChanged(Theme currentTheme, Theme newTheme)
         {
             UpdateIconPath(newTheme);
         }

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/UnitConversionResult.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/UnitConversionResult.cs
@@ -1,4 +1,8 @@
-﻿using UnitsNet;
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using UnitsNet;
 
 namespace Community.PowerToys.Run.Plugin.UnitConverter
 {

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/UnitHandler.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/UnitHandler.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/Community.PowerToys.Run.Plugin.VSCodeWorkspaces.csproj
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/Community.PowerToys.Run.Plugin.VSCodeWorkspaces.csproj
@@ -25,6 +25,7 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <WarningLevel>4</WarningLevel>
     <Optimize>false</Optimize>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -37,6 +38,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   
   <ItemGroup>
@@ -51,9 +53,21 @@
   </ItemGroup>
   
   <ItemGroup>
+    <Compile Include="..\..\..\..\codeAnalysis\GlobalSuppressions.cs">
+      <Link>GlobalSuppressions.cs</Link>
+    </Compile>
+    <AdditionalFiles Include="..\..\..\..\codeAnalysis\StyleCop.json">
+      <Link>StyleCop.json</Link>
+    </AdditionalFiles>
+  </ItemGroup>
+  
+  <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2020.1.0" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="System.Runtime" Version="4.3.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/Main.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/Main.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -13,7 +17,7 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces
 {
     public class Main : IPlugin, IPluginI18n
     {
-        public PluginInitContext _context { get; private set; }
+        private PluginInitContext _context;
 
         public string Name => GetTranslatedPluginTitle();
 
@@ -24,9 +28,9 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces
             VSCodeInstances.LoadVSCodeInstances();
         }
 
-        public readonly VSCodeWorkspacesApi _workspacesApi = new VSCodeWorkspacesApi();
+        private readonly VSCodeWorkspacesApi _workspacesApi = new VSCodeWorkspacesApi();
 
-        public readonly VSCodeRemoteMachinesApi _machinesApi = new VSCodeRemoteMachinesApi();
+        private readonly VSCodeRemoteMachinesApi _machinesApi = new VSCodeRemoteMachinesApi();
 
         public List<Result> Query(Query query)
         {
@@ -49,12 +53,12 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces
                         title += $" - {(a.ExtraInfo != null ? $"{a.ExtraInfo} ({typeWorkspace})" : typeWorkspace)}";
                     }
 
-                    var tooltip = new ToolTipData(title, $"{Resources.Workspace}{(a.TypeWorkspace != TypeWorkspace.Local ? $" {Resources.In} {typeWorkspace}" : "")}: {SystemPath.RealPath(a.RelativePath)}");
+                    var tooltip = new ToolTipData(title, $"{Resources.Workspace}{(a.TypeWorkspace != TypeWorkspace.Local ? $" {Resources.In} {typeWorkspace}" : string.Empty)}: {SystemPath.RealPath(a.RelativePath)}");
 
                     results.Add(new Result
                     {
                         Title = title,
-                        SubTitle = $"{Resources.Workspace}{(a.TypeWorkspace != TypeWorkspace.Local ? $" {Resources.In} {typeWorkspace}" : "")}: {SystemPath.RealPath(a.RelativePath)}",
+                        SubTitle = $"{Resources.Workspace}{(a.TypeWorkspace != TypeWorkspace.Local ? $" {Resources.In} {typeWorkspace}" : string.Empty)}: {SystemPath.RealPath(a.RelativePath)}",
                         Icon = a.VSCodeInstance.WorkspaceIcon,
                         ToolTipData = tooltip,
                         Action = c =>
@@ -67,7 +71,7 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces
                                     FileName = a.VSCodeInstance.ExecutablePath,
                                     UseShellExecute = true,
                                     Arguments = $"--folder-uri {a.Path}",
-                                    WindowStyle = ProcessWindowStyle.Hidden
+                                    WindowStyle = ProcessWindowStyle.Hidden,
                                 };
                                 Process.Start(process);
 
@@ -80,12 +84,12 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces
                                 _context.API.ShowMsg(name, msg, string.Empty);
                                 hide = false;
                             }
+
                             return hide;
                         },
                         ContextData = a,
                     });
                 });
-
 
                 // Search opened remote machines
                 _machinesApi.Machines.ForEach(a =>
@@ -128,6 +132,7 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces
                                 _context.API.ShowMsg(name, msg, string.Empty);
                                 hide = false;
                             }
+
                             return hide;
                         },
                         ContextData = a,
@@ -147,20 +152,20 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces
                     x.Score = 100;
                 }
 
-                //intersect the title with the query
+                // intersect the title with the query
                 var intersection = Convert.ToInt32(x.Title.ToLowerInvariant().Intersect(query.Search.ToLowerInvariant()).Count() * query.Search.Count());
                 var differenceWithQuery = Convert.ToInt32((x.Title.Count() - intersection) * query.Search.Count() * 0.7);
                 x.Score = x.Score - differenceWithQuery + intersection;
 
-                //if is a remote machine give it 12 extra points
+                // if is a remote machine give it 12 extra points
                 if (x.ContextData is VSCodeRemoteMachine)
                 {
-                    x.Score = Convert.ToInt32(x.Score + intersection * 2);
+                    x.Score = Convert.ToInt32(x.Score + (intersection * 2));
                 }
             });
 
             results = results.OrderByDescending(x => x.Score).ToList();
-            if (query.Search == string.Empty || query.Search.Replace(" ", "") == string.Empty)
+            if (query.Search == string.Empty || query.Search.Replace(" ", string.Empty) == string.Empty)
             {
                 results = results.OrderBy(x => x.Title).ToList();
             }

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/RemoteMachinesHelper/VSCodeRemoteMachine.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/RemoteMachinesHelper/VSCodeRemoteMachine.cs
@@ -1,4 +1,8 @@
-﻿using Community.PowerToys.Run.Plugin.VSCodeWorkspaces.VSCodeHelper;
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Community.PowerToys.Run.Plugin.VSCodeWorkspaces.VSCodeHelper;
 
 namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.RemoteMachinesHelper
 {

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/RemoteMachinesHelper/VSCodeRemoteMachinesApi.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/RemoteMachinesHelper/VSCodeRemoteMachinesApi.cs
@@ -1,16 +1,22 @@
-﻿using Community.PowerToys.Run.Plugin.VSCodeWorkspaces.SshConfigParser;
-using Community.PowerToys.Run.Plugin.VSCodeWorkspaces.VSCodeHelper;
-using Newtonsoft.Json;
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.IO;
+using Community.PowerToys.Run.Plugin.VSCodeWorkspaces.SshConfigParser;
+using Community.PowerToys.Run.Plugin.VSCodeWorkspaces.VSCodeHelper;
+using Newtonsoft.Json;
 using Wox.Plugin.Logger;
 
 namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.RemoteMachinesHelper
 {
     public class VSCodeRemoteMachinesApi
     {
-        public VSCodeRemoteMachinesApi() { }
+        public VSCodeRemoteMachinesApi()
+        {
+        }
 
         public List<VSCodeRemoteMachine> Machines
         {
@@ -18,7 +24,7 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.RemoteMachinesHelper
             {
                 var results = new List<VSCodeRemoteMachine>();
 
-                foreach (var vscodeInstance in VSCodeInstances.instances)
+                foreach (var vscodeInstance in VSCodeInstances.Instances)
                 {
                     // settings.json contains path of ssh_config
                     var vscode_settings = Path.Combine(vscodeInstance.AppData, "User\\settings.json");
@@ -40,8 +46,8 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.RemoteMachinesHelper
                                         var machine = new VSCodeRemoteMachine();
                                         machine.Host = h.Host;
                                         machine.VSCodeInstance = vscodeInstance;
-                                        machine.HostName = h.HostName != null ? h.HostName : String.Empty;
-                                        machine.User = h.User != null ? h.User : String.Empty;
+                                        machine.HostName = h.HostName != null ? h.HostName : string.Empty;
+                                        machine.User = h.User != null ? h.User : string.Empty;
 
                                         results.Add(machine);
                                     }
@@ -57,7 +63,6 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.RemoteMachinesHelper
                 }
 
                 return results;
-
             }
         }
     }

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/SshConfigParser/SshConfig.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/SshConfigParser/SshConfig.cs
@@ -1,4 +1,8 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -7,8 +11,8 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.SshConfigParser
 {
     public class SshConfig
     {
-        private static readonly Regex SSH_CONFIG = new Regex(@"^(\w[\s\S]*?\w)$(?=(?:\s+^\w|\z))", RegexOptions.Multiline);
-        private static readonly Regex KEY_VALUE = new Regex(@"(\w+\s\S+)", RegexOptions.Multiline);
+        private static readonly Regex _sshConfig = new Regex(@"^(\w[\s\S]*?\w)$(?=(?:\s+^\w|\z))", RegexOptions.Multiline);
+        private static readonly Regex _keyValue = new Regex(@"(\w+\s\S+)", RegexOptions.Multiline);
 
         public static IEnumerable<SshHost> ParseFile(string path)
         {
@@ -17,22 +21,23 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.SshConfigParser
 
         public static IEnumerable<SshHost> Parse(string str)
         {
-
-            str = str.Replace("\r", "");
+            str = str.Replace('\r', '\0');
             var list = new List<SshHost>();
-            foreach (Match match in SSH_CONFIG.Matches(str))
+            foreach (Match match in _sshConfig.Matches(str))
             {
                 var sshHost = new SshHost();
                 string content = match.Groups.Values.ToList()[0].Value;
-                foreach (Match match1 in KEY_VALUE.Matches(content))
+                foreach (Match match1 in _keyValue.Matches(content))
                 {
                     var split = match1.Value.Split(" ");
                     var key = split[0];
                     var value = split[1];
                     sshHost.Properties[key] = value;
                 }
+
                 list.Add(sshHost);
             }
+
             return list;
         }
     }

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/SshConfigParser/SshHost.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/SshConfigParser/SshHost.cs
@@ -1,33 +1,39 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
 
 namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.SshConfigParser
 {
     public class SshHost
     {
-        public string IdentityFile 
+        public string IdentityFile
         {
             get => this[nameof(IdentityFile)]?.ToString();
             set => this[nameof(IdentityFile)] = value;
         }
 
-        public string Host 
+        public string Host
         {
             get => this[nameof(Host)]?.ToString();
             set => this[nameof(Host)] = value;
         }
 
-        public string HostName 
+        public string HostName
         {
             get => this[nameof(HostName)]?.ToString();
             set => this[nameof(HostName)] = value;
         }
 
-        public string User {
+        public string User
+        {
             get => this[nameof(User)]?.ToString();
             set => this[nameof(User)] = value;
         }
 
-        public string ForwardAgent {
+        public string ForwardAgent
+        {
             get => this[nameof(ForwardAgent)]?.ToString();
             set => this[nameof(ForwardAgent)] = value;
         }
@@ -36,7 +42,7 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.SshConfigParser
 
         public object this[string key]
         {
-            get 
+            get
             {
                 if (Properties.TryGetValue(key, out var value))
                 {
@@ -45,7 +51,11 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.SshConfigParser
 
                 return null;
             }
-            set { Properties[key] = value; }
+
+            set
+            {
+                Properties[key] = value;
+            }
         }
 
         public IEnumerable<string> Keys => Properties.Keys;

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/SystemPath.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/SystemPath.cs
@@ -1,9 +1,12 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Text.RegularExpressions;
 
 namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces
 {
-    class SystemPath
+    internal class SystemPath
     {
         private static readonly Regex WindowsPath = new Regex(@"^([a-zA-Z]:)", RegexOptions.Compiled);
 
@@ -11,8 +14,8 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces
         {
             if (WindowsPath.IsMatch(path))
             {
-                String windowsPath = path.Replace("/", "\\");
-                return $"{windowsPath[0]}".ToUpper() + windowsPath.Remove(0,1);
+                string windowsPath = path.Replace("/", "\\");
+                return $"{windowsPath[0]}".ToUpper() + windowsPath.Remove(0, 1);
             }
             else
             {

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/VSCodeHelper/VSCodeInstance.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/VSCodeHelper/VSCodeInstance.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 
@@ -8,20 +11,20 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.VSCodeHelper
     {
         Stable = 1,
         Insiders = 2,
-        Exploration = 3
+        Exploration = 3,
     }
 
     public class VSCodeInstance
     {
         public VSCodeVersion VSCodeVersion { get; set; }
 
-        public string ExecutablePath { get; set; } = String.Empty;
+        public string ExecutablePath { get; set; } = string.Empty;
 
-        public string AppData { get; set; } = String.Empty;
+        public string AppData { get; set; } = string.Empty;
 
-        public ImageSource WorkspaceIcon(){ return WorkspaceIconBitMap; }
+        public ImageSource WorkspaceIcon() => WorkspaceIconBitMap;
 
-        public ImageSource RemoteIcon(){ return RemoteIconBitMap; }
+        public ImageSource RemoteIcon() => RemoteIconBitMap;
 
         public BitmapImage WorkspaceIconBitMap { get; set; }
 

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/VSCodeHelper/VSCodeInstances.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/VSCodeHelper/VSCodeInstances.cs
@@ -1,28 +1,25 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Windows;
-using System.Windows.Interop;
-using System.Windows.Media;
 using System.Windows.Media.Imaging;
-using Windows.UI.Xaml;
-using Windows.UI.Xaml.Controls;
 
 namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.VSCodeHelper
 {
-    static class VSCodeInstances
+    public static class VSCodeInstances
     {
-        private static readonly string PathUserAppData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-
-        private static string _systemPath = String.Empty;
+        private static string _systemPath = string.Empty;
 
         private static string _userAppDataPath = Environment.GetEnvironmentVariable("AppData");
 
-        public static List<VSCodeInstance> instances = new List<VSCodeInstance>();
+        public static List<VSCodeInstance> Instances { get; set; } = new List<VSCodeInstance>();
 
         private static BitmapImage Bitmap2BitmapImage(Bitmap bitmap)
         {
@@ -42,15 +39,15 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.VSCodeHelper
             }
         }
 
-        public static Bitmap bitmapOverlayToCenter(Bitmap bitmap1, Bitmap overlayBitmap)
+        public static Bitmap BitmapOverlayToCenter(Bitmap bitmap1, Bitmap overlayBitmap)
         {
             int bitmap1Width = bitmap1.Width;
             int bitmap1Height = bitmap1.Height;
 
             Bitmap overlayBitmapResized = new Bitmap(overlayBitmap, new System.Drawing.Size(bitmap1Width / 2, bitmap1Height / 2));
 
-            float marginLeft = (float)(bitmap1Width * 0.7 - overlayBitmapResized.Width * 0.5);
-            float marginTop = (float)(bitmap1Height * 0.7 - overlayBitmapResized.Height * 0.5);
+            float marginLeft = (float)((bitmap1Width * 0.7) - (overlayBitmapResized.Width * 0.5));
+            float marginTop = (float)((bitmap1Height * 0.7) - (overlayBitmapResized.Height * 0.5));
 
             Bitmap finalBitmap = new Bitmap(bitmap1Width, bitmap1Height);
             using (Graphics g = Graphics.FromImage(finalBitmap))
@@ -58,6 +55,7 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.VSCodeHelper
                 g.DrawImage(bitmap1, System.Drawing.Point.Empty);
                 g.DrawImage(overlayBitmapResized, marginLeft, marginTop);
             }
+
             return finalBitmap;
         }
 
@@ -66,8 +64,7 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.VSCodeHelper
         {
             if (_systemPath != Environment.GetEnvironmentVariable("PATH"))
             {
-
-                instances = new List<VSCodeInstance>();
+                Instances = new List<VSCodeInstance>();
 
                 _systemPath = Environment.GetEnvironmentVariable("PATH");
                 var paths = _systemPath.Split(";");
@@ -83,7 +80,7 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.VSCodeHelper
                         if (files.Length > 0)
                         {
                             var file = files[0];
-                            var version = String.Empty;
+                            var version = string.Empty;
 
                             var instance = new VSCodeInstance
                             {
@@ -106,23 +103,23 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.VSCodeHelper
                                 instance.VSCodeVersion = VSCodeVersion.Exploration;
                             }
 
-                            if (version != String.Empty)
+                            if (version != string.Empty)
                             {
                                 instance.AppData = Path.Combine(_userAppDataPath, version);
                                 var iconVSCode = Path.Join(iconPath, $"{version}.exe");
 
                                 var bitmapIconVscode = Icon.ExtractAssociatedIcon(iconVSCode).ToBitmap();
 
-                                //workspace
+                                // workspace
                                 var folderIcon = (Bitmap)System.Drawing.Image.FromFile(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + "//Images//folder.png");
-                                instance.WorkspaceIconBitMap = Bitmap2BitmapImage(bitmapOverlayToCenter(folderIcon, bitmapIconVscode));
+                                instance.WorkspaceIconBitMap = Bitmap2BitmapImage(BitmapOverlayToCenter(folderIcon, bitmapIconVscode));
 
-                                //remote
+                                // remote
                                 var monitorIcon = (Bitmap)System.Drawing.Image.FromFile(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + "//Images//monitor.png");
 
-                                instance.RemoteIconBitMap = Bitmap2BitmapImage(bitmapOverlayToCenter(monitorIcon, bitmapIconVscode));
+                                instance.RemoteIconBitMap = Bitmap2BitmapImage(BitmapOverlayToCenter(monitorIcon, bitmapIconVscode));
 
-                                instances.Add(instance);
+                                Instances.Add(instance);
                             }
                         }
                     }

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/WorkspacesHelper/OpenedPathsList.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/WorkspacesHelper/OpenedPathsList.cs
@@ -2,10 +2,14 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+
 namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.WorkspacesHelper
 {
-    public class VSCodeStorageFile
+    public class OpenedPathsList
     {
-        public OpenedPathsList OpenedPathsList { get; set; }
+        public List<dynamic> Workspaces3 { get; set; }
+
+        public List<VSCodeWorkspaceEntry> Entries { get; set; }
     }
 }

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/WorkspacesHelper/ParseVSCodeUri.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/WorkspacesHelper/ParseVSCodeUri.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Text.RegularExpressions;
 
 namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.WorkspacesHelper
@@ -13,7 +16,7 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.WorkspacesHelper
 
         private static readonly Regex CodespacesWorkspace = new Regex(@"^vscode-remote://vsonline\+(.+?(?=\/))(.+)$", RegexOptions.Compiled);
 
-        public static (TypeWorkspace? TypeWorkspace, String MachineName, String Path) GetTypeWorkspace(string uri)
+        public static (TypeWorkspace? TypeWorkspace, string MachineName, string Path) GetTypeWorkspace(string uri)
         {
             if (LocalWorkspace.IsMatch(uri))
             {
@@ -48,7 +51,7 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.WorkspacesHelper
 
                 if (match.Groups.Count > 1)
                 {
-                    return (TypeWorkspace.Codespaces, String.Empty, match.Groups[2].Value);
+                    return (TypeWorkspace.Codespaces, string.Empty, match.Groups[2].Value);
                 }
             }
 

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/WorkspacesHelper/VSCodeWorkspace.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/WorkspacesHelper/VSCodeWorkspace.cs
@@ -1,4 +1,8 @@
-﻿using Community.PowerToys.Run.Plugin.VSCodeWorkspaces.Properties;
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Community.PowerToys.Run.Plugin.VSCodeWorkspaces.Properties;
 using Community.PowerToys.Run.Plugin.VSCodeWorkspaces.VSCodeHelper;
 
 namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.WorkspacesHelper
@@ -38,6 +42,6 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.WorkspacesHelper
         Codespaces = 2,
         RemoteWSL = 3,
         RemoteSSH = 4,
-        RemoteContainers = 5
+        RemoteContainers = 5,
     }
 }

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/WorkspacesHelper/VSCodeWorkspaceEntry.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/WorkspacesHelper/VSCodeWorkspaceEntry.cs
@@ -4,8 +4,10 @@
 
 namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.WorkspacesHelper
 {
-    public class VSCodeStorageFile
+    public class VSCodeWorkspaceEntry
     {
-        public OpenedPathsList OpenedPathsList { get; set; }
+        public string FolderUri { get; set; }
+
+        public string Label { get; set; }
     }
 }

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/WorkspacesHelper/VSCodeWorkspacesApi.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/WorkspacesHelper/VSCodeWorkspacesApi.cs
@@ -1,23 +1,29 @@
-using Community.PowerToys.Run.Plugin.VSCodeWorkspaces.VSCodeHelper;
-using Newtonsoft.Json;
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
+using Community.PowerToys.Run.Plugin.VSCodeWorkspaces.VSCodeHelper;
 using Wox.Plugin.Logger;
 
 namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.WorkspacesHelper
 {
     public class VSCodeWorkspacesApi
     {
-        public VSCodeWorkspacesApi() { }
-
-        private VSCodeWorkspace parseVSCodeUri(string uri, VSCodeInstance vscodeInstance)
+        public VSCodeWorkspacesApi()
         {
-            if (uri != null && uri is String)
+        }
+
+        private VSCodeWorkspace ParseVSCodeUri(string uri, VSCodeInstance vscodeInstance)
+        {
+            if (uri != null && uri is string)
             {
                 string unescapeUri = Uri.UnescapeDataString(uri);
-                var typeWorkspace = ParseVSCodeUri.GetTypeWorkspace(unescapeUri);
+                var typeWorkspace = WorkspacesHelper.ParseVSCodeUri.GetTypeWorkspace(unescapeUri);
                 if (typeWorkspace.TypeWorkspace.HasValue)
                 {
                     var folderName = Path.GetFileName(unescapeUri);
@@ -28,7 +34,7 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.WorkspacesHelper
                         FolderName = folderName,
                         ExtraInfo = typeWorkspace.MachineName,
                         TypeWorkspace = typeWorkspace.TypeWorkspace.Value,
-                        VSCodeInstance = vscodeInstance
+                        VSCodeInstance = vscodeInstance,
                     };
                 }
             }
@@ -40,10 +46,9 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.WorkspacesHelper
         {
             get
             {
-
                 var results = new List<VSCodeWorkspace>();
 
-                foreach (var vscodeInstance in VSCodeInstances.instances)
+                foreach (var vscodeInstance in VSCodeInstances.Instances)
                 {
                     // storage.json contains opened Workspaces
                     var vscode_storage = Path.Combine(vscodeInstance.AppData, "storage.json");
@@ -54,16 +59,21 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.WorkspacesHelper
 
                         try
                         {
-                            VSCodeStorageFile vscodeStorageFile = JsonConvert.DeserializeObject<VSCodeStorageFile>(fileContent);
+                            var options = new JsonSerializerOptions
+                            {
+                                PropertyNameCaseInsensitive = true,
+                            };
+
+                            VSCodeStorageFile vscodeStorageFile = JsonSerializer.Deserialize<VSCodeStorageFile>(fileContent, options);
 
                             if (vscodeStorageFile != null)
                             {
-                                //for previous versions of vscode
-                                if (vscodeStorageFile.openedPathsList.workspaces3 != null)
+                                // for previous versions of vscode
+                                if (vscodeStorageFile.OpenedPathsList.Workspaces3 != null)
                                 {
-                                    foreach (var workspaceUri in vscodeStorageFile.openedPathsList.workspaces3)
+                                    foreach (var workspaceUri in vscodeStorageFile.OpenedPathsList.Workspaces3)
                                     {
-                                        var uri = parseVSCodeUri(workspaceUri, vscodeInstance);
+                                        var uri = ParseVSCodeUri(workspaceUri, vscodeInstance);
                                         if (uri != null)
                                         {
                                             results.Add(uri);
@@ -71,19 +81,18 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.WorkspacesHelper
                                     }
                                 }
 
-                                //vscode v1.55.0 or later
-                                if (vscodeStorageFile.openedPathsList.entries != null)
+                                // vscode v1.55.0 or later
+                                if (vscodeStorageFile.OpenedPathsList.Entries != null)
                                 {
-                                    foreach (var workspaceUri in vscodeStorageFile.openedPathsList.entries.Select(x => x.folderUri))
+                                    foreach (var workspaceUri in vscodeStorageFile.OpenedPathsList.Entries.Select(x => x.FolderUri))
                                     {
-                                        var uri = parseVSCodeUri(workspaceUri, vscodeInstance);
+                                        var uri = ParseVSCodeUri(workspaceUri, vscodeInstance);
                                         if (uri != null)
                                         {
                                             results.Add(uri);
                                         }
                                     }
                                 }
-
                             }
                         }
                         catch (Exception ex)
@@ -91,11 +100,8 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.WorkspacesHelper
                             var message = $"Failed to deserialize ${vscode_storage}";
                             Log.Exception(message, ex, GetType());
                         }
-
                     }
-
                 }
-
 
                 return results;
             }

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/stylecop.json
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/stylecop.json
@@ -1,0 +1,14 @@
+﻿{
+  // ACTION REQUIRED: This file was automatically added to your project, but it
+  // will not take effect until additional steps are taken to enable it. See the
+  // following page for additional information:
+  //
+  // https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/EnableConfiguration.md
+
+  "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
+  "settings": {
+    "documentationRules": {
+      "companyName": "PlaceholderCompany"
+    }
+  }
+}


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
StyleCop instelled and warnings fix.

**What is include in the PR:** 
Installed StyleCop on missing projects and fixed build warnings.

**How does someone test / validate:** 
- PT Run VS Code Workspaces plugin working as expected
- PT Run Unit Converter plugin working as expected

## Quality Checklist

- [x] **Linked issue:** #12370 (StyleCop and warnings only)
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
