### PR TITLE
Adjust PowerToysUpdatingState based on PowerToysVersion

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/GeneralViewModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/GeneralViewModel.cs
@@ -545,6 +545,12 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             PowerToysNewAvailableVersionLink = UpdatingSettingsConfig.ReleasePageLink;
             UpdateCheckedDate = UpdatingSettingsConfig.LastCheckedDateLocalized;
 
+            if (PowerToysUpdatingState != UpdatingSettings.UpdatingState.UpToDate
+                && string.Compare(PowerToysNewAvailableVersion, PowerToysVersion, StringComparison.InvariantCultureIgnoreCase) <= 0)
+            {
+                PowerToysUpdatingState = UpdatingSettings.UpdatingState.UpToDate;
+            }
+
             _isNewVersionChecked = PowerToysUpdatingState == UpdatingSettings.UpdatingState.UpToDate && !IsNewVersionDownloading;
             NotifyPropertyChanged(nameof(IsNewVersionCheckedAndUpToDate));
 


### PR DESCRIPTION
## Summary of the Pull Request

This PR fixes a minor bug caused by a cancelled/failed update through the application followed by a manual update installed directely by the user. The failed update sets `"state":1` in `UpdateState.json`, and the version of the pending update is never compared to the version that is currently installed, resulting in this messaging in the UI:

![image](https://user-images.githubusercontent.com/20788820/128212531-548b34c2-3fa3-460e-a93e-eccf47bbd350.png)

This change double-checks that `PowerToysNewAvailableVersion` is greater than `PowerToysVersion` and, if the current version is at least as high as the available version, it forces `PowerToysUpdatingState` to `UpToDate`. Since the versions are stored as strings, an invariant string comparison is used to compare the versions.

**Unfortunately**, my organisation's group policies prevent unsigned powershell execution, so _I am unable to compile the PowerToys solution_ and so this change is untested.

This can be tested by replacing the contents of `%localappdata%\Microsoft\PowerToys\UpdateState.json` with a failed update state, e.g.:

``` JSON
{"githubUpdateLastCheckedDate":"1628143962","releasePageUrl":"https://github.com/microsoft/PowerToys/releases/tag/v0.43.0","state":1,"downloadedInstallerFilename":""}
```
Despite the error state recorded there, the interface should correctly report that the current version is up to date (assuming you do have v0.43.0 installed):

![image](https://user-images.githubusercontent.com/20788820/128300643-687608e5-32f2-443e-8890-1bdd80d0bf8a.png)

Altering the value of `releasePageUrl` to a lower version number (e.g. `v0.42.0`) should lead to the same result. Changes to `UpdateState.json` do not require restarting the application and should be detected and applied to the relevant UI components immediately.

Since it is uncompiled and untested, this PR is created as a draft until someone who can compile the project can confirm it.

## Quality Checklist

- [x] **Linked issue:** #12614
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
