### PR TITLE
[Settings] Announces open/close navigation pane

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -249,6 +249,14 @@ Disabling this module or closing PowerToys will unmute the microphone and camera
     <value>Keyboard Manager</value>
     <comment>Product name: Navigation view item name for Keyboard Manager</comment>
   </data>
+  <data name="Shell_NavigationMenu_Announce_Collapse" xml:space="preserve">
+    <value>Navigation closed</value>
+    <comment>Accessibility announcement when the navigation pane collapses</comment>
+  </data>
+  <data name="Shell_NavigationMenu_Announce_Open" xml:space="preserve">
+    <value>Navigation opened</value>
+    <comment>Accessibility announcement when the navigation pane opens</comment>
+  </data>
   <data name="KeyboardManager_ConfigHeader.Text" xml:space="preserve">
     <value>Current configuration</value>
     <comment>Keyboard Manager current configuration header</comment>
@@ -1376,14 +1384,14 @@ From there, simply click on a Markdown file or SVG icon in the File Explorer and
   <data name="Delete_Dialog_Description" xml:space="preserve">
     <value>Are you sure you want to delete this item?</value>
   </data>
-	<data name="Yes" xml:space="preserve">
+  <data name="Yes" xml:space="preserve">
     <value>Yes</value>
     <comment>Label of a confirmation button</comment>
-	  </data>
+  </data>
   <data name="Learn_More_Description.AutomationProperties.Name" xml:space="preserve">
     <value>Learn more</value>
   </data>
-    <data name="ColorPicker_ColorFormat_ToggleSwitch.AutomationProperties.Name" xml:space="preserve">
+  <data name="ColorPicker_ColorFormat_ToggleSwitch.AutomationProperties.Name" xml:space="preserve">
     <value>Show format in editor</value>
   </data>
 </root>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ShellPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ShellPage.xaml
@@ -28,6 +28,8 @@
         OpenPaneLength="296"
         CompactModeThresholdWidth="0"
         Background="{ThemeResource SystemControlBackgroundAltHighBrush}"
+        PaneOpened="NavigationView_PaneOpened"
+        PaneClosed="NavigationView_PaneClosed"
         SelectionChanged="NavigationView_SelectionChanged">
             <winui:NavigationView.MenuItems>
                 <winui:NavigationViewItem x:Uid="Shell_General" helpers:NavHelper.NavigateTo="views:GeneralPage">

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ShellPage.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ShellPage.xaml.cs
@@ -8,6 +8,7 @@ using System.Diagnostics.CodeAnalysis;
 using Microsoft.PowerToys.Settings.UI.Services;
 using Microsoft.PowerToys.Settings.UI.ViewModels;
 using Windows.Data.Json;
+using Windows.UI.Xaml.Automation.Peers;
 using Windows.UI.Xaml.Controls;
 
 namespace Microsoft.PowerToys.Settings.UI.Views
@@ -161,5 +162,59 @@ namespace Microsoft.PowerToys.Settings.UI.Views
         {
             scrollViewer.ChangeView(null, 0, null, true);
         }
+
+        private bool navigationViewInitialStateProcessed; // avoid announcing initial state of the navigation pane.
+
+        [SuppressMessage("Usage", "CA1801:Review unused parameters", Justification = "Params are required for event handler signature requirements.")]
+#pragma warning disable CA1822 // Mark members as static
+        private void NavigationView_PaneOpened(Microsoft.UI.Xaml.Controls.NavigationView sender, object args)
+        {
+            if (!navigationViewInitialStateProcessed)
+            {
+                navigationViewInitialStateProcessed = true;
+                return;
+            }
+
+            var peer = FrameworkElementAutomationPeer.FromElement(sender);
+            if (peer == null)
+            {
+                peer = FrameworkElementAutomationPeer.CreatePeerForElement(sender);
+            }
+
+            if (AutomationPeer.ListenerExists(AutomationEvents.MenuOpened))
+            {
+                peer.RaiseNotificationEvent(
+                    AutomationNotificationKind.ActionCompleted,
+                    AutomationNotificationProcessing.ImportantMostRecent,
+                    "Navigation opened",
+                    "navigationMenuPaneOpened");
+            }
+        }
+
+        [SuppressMessage("Usage", "CA1801:Review unused parameters", Justification = "Params are required for event handler signature requirements.")]
+        private void NavigationView_PaneClosed(Microsoft.UI.Xaml.Controls.NavigationView sender, object args)
+        {
+            if (!navigationViewInitialStateProcessed)
+            {
+                navigationViewInitialStateProcessed = true;
+                return;
+            }
+
+            var peer = FrameworkElementAutomationPeer.FromElement(sender);
+            if (peer == null)
+            {
+                peer = FrameworkElementAutomationPeer.CreatePeerForElement(sender);
+            }
+
+            if (AutomationPeer.ListenerExists(AutomationEvents.MenuClosed))
+            {
+                peer.RaiseNotificationEvent(
+                    AutomationNotificationKind.ActionCompleted,
+                    AutomationNotificationProcessing.ImportantMostRecent,
+                    "Navigation closed",
+                    "navigationMenuPaneClosed");
+            }
+        }
+#pragma warning restore CA1822 // Mark members as static
     }
 }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ShellPage.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ShellPage.xaml.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.PowerToys.Settings.UI.Services;
 using Microsoft.PowerToys.Settings.UI.ViewModels;
+using Windows.ApplicationModel.Resources;
 using Windows.Data.Json;
 using Windows.UI.Xaml.Automation.Peers;
 using Windows.UI.Xaml.Controls;
@@ -183,10 +184,11 @@ namespace Microsoft.PowerToys.Settings.UI.Views
 
             if (AutomationPeer.ListenerExists(AutomationEvents.MenuOpened))
             {
+                var loader = Windows.ApplicationModel.Resources.ResourceLoader.GetForCurrentView();
                 peer.RaiseNotificationEvent(
                     AutomationNotificationKind.ActionCompleted,
                     AutomationNotificationProcessing.ImportantMostRecent,
-                    "Navigation opened",
+                    loader.GetString("Shell_NavigationMenu_Announce_Open"),
                     "navigationMenuPaneOpened");
             }
         }
@@ -208,10 +210,11 @@ namespace Microsoft.PowerToys.Settings.UI.Views
 
             if (AutomationPeer.ListenerExists(AutomationEvents.MenuClosed))
             {
+                var loader = Windows.ApplicationModel.Resources.ResourceLoader.GetForCurrentView();
                 peer.RaiseNotificationEvent(
                     AutomationNotificationKind.ActionCompleted,
                     AutomationNotificationProcessing.ImportantMostRecent,
-                    "Navigation closed",
+                    loader.GetString("Shell_NavigationMenu_Announce_Collapse"),
                     "navigationMenuPaneClosed");
             }
         }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Have narrator announce when we close or open the Navigation View pane in the main settings screen.

**What is include in the PR:** 
AutomationPeer instructions to raise a notification when opening or closing the Navigation View pane.

**How does someone test / validate:** 

With narrator turned on, open/close the navigation pane in settings.

## Quality Checklist

- [x] **Linked issue:** #7024
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

