### PR TITLE
remove unused namespace alias

### DIFF
--- a/src/ActionRunner/actionRunner.cpp
+++ b/src/ActionRunner/actionRunner.cpp
@@ -28,8 +28,6 @@
 
 using namespace cmdArg;
 
-namespace fs = std::filesystem;
-
 int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int)
 {
     int nArgs = 0;


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
This PR includes a removal of an unused namespace alias in `actionRunner.cpp`.

**What is include in the PR:** 
A simple change removing the unused alias

**How does someone test / validate:** 
Compile the modified file

## Quality Checklist

- [x] **Linked issue:** #12669 
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [x] **Tests:** Added/updated and all pass
- [x] **Installer:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [x] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
