### PR TITLE
[FZE] Fix dialog number box input automation name

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -480,6 +480,7 @@
                                       KeyDown="EditDialogNumberBox_KeyDown"
                                       Margin="12,0,0,0"
                                       Header="{x:Static props:Resources.Number_of_zones}"
+                                      Loaded="NumberBox_Loaded"
                                       AutomationProperties.Name="{x:Static props:Resources.Number_of_zones}"
                                       SpinButtonPlacementMode="Compact"
                                       Text="{Binding TemplateZoneCount}" />
@@ -508,6 +509,7 @@
                                           SpinButtonPlacementMode="Compact"
                                           HorizontalAlignment="Left"
                                           VerticalAlignment="Center"
+                                          Loaded="NumberBox_Loaded"
                                           AutomationProperties.Name="{x:Static props:Resources.Space_Around_Zones}"
                                           AutomationProperties.LabeledBy="{Binding ElementName=spacingTitle}" />
                             <TextBlock Text="{x:Static props:Resources.Pixels}"
@@ -554,6 +556,7 @@
                                           Maximum="1000"
                                           KeyDown="EditDialogNumberBox_KeyDown"
                                           Margin="12,0,0,0"
+                                          Loaded="NumberBox_Loaded"
                                           AutomationProperties.Name="{x:Static props:Resources.Distance_adjacent_zones}"
                                           AutomationProperties.LabeledBy="{Binding ElementName=distanceTitle}"
                                           SpinButtonPlacementMode="Compact"

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -491,5 +491,15 @@ namespace FancyZonesEditor
                 _backup = null;
             }
         }
+
+        private void NumberBox_Loaded(object sender, RoutedEventArgs e)
+        {
+            // The TextBox inside a NumberBox doesn't inherit the Automation Properties name, so we have to set it.
+            var numberBox = sender as NumberBox;
+            const string numberBoxTextBoxName = "InputBox"; // Text box template part name given by ModernWPF.
+            numberBox.ApplyTemplate(); // Apply template to be able to change child's property.
+            var numberBoxTextBox = numberBox.Template.FindName(numberBoxTextBoxName, numberBox) as TextBox;
+            numberBoxTextBox.SetValue(AutomationProperties.NameProperty, numberBox.GetValue(AutomationProperties.NameProperty));
+        }
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
ModernWPF's Number Box controls used in FancyZonesEditor's Edit Layout dialog contain a focusable Text Box which doesn't inherit the `AutomationProperty.Name` of the Number Box. This leads to a accessibility issues.

**What is include in the PR:** 
Changes to set the Text Boxes' automation name after being loaded and having the template applied.

**How does someone test / validate:** 
Use Accessibility Insight for Windows to verify the textbox doesn't generate the error described in the linked issue.

## Quality Checklist

- [x] **Linked issue:** #10783
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries
