### PR TITLE
[PowerToys Run] Keyboard shows command tooltips

### DIFF
--- a/src/modules/launcher/PowerLauncher/ResultList.xaml
+++ b/src/modules/launcher/PowerLauncher/ResultList.xaml
@@ -176,6 +176,7 @@
             ScrollViewer.VerticalScrollBarVisibility="Auto"       
             SelectionMode="Single"
             SelectedIndex="{Binding Results.SelectedIndex, Mode=TwoWay}"
+            SelectionChanged="SuggestionsListView_SelectionChanged"
             ItemContainerStyle="{StaticResource ResultsListViewItemContainerStyle}"
             AutomationProperties.Name="{x:Static p:Resources.Results}">
             
@@ -208,7 +209,7 @@
                             <RowDefinition Height="*"/>
                         </Grid.RowDefinitions>
                         <Grid.ToolTip>
-                            <ToolTip Visibility="{Binding Result.ToolTipVisibility}">
+                            <ToolTip Visibility="{Binding Result.ToolTipVisibility}" Opened="ToolTip_Opened">
                                 <StackPanel>
                                     <TextBlock 
                                         Style="{DynamicResource CollapsableTextblock}"
@@ -270,6 +271,7 @@
                             SelectionMode="Single"
                             Margin="0,0,-8,0"
                             SelectedIndex="{Binding ContextMenuSelectedIndex}"
+                            SelectionChanged="ContextMenuListView_SelectionChanged"
                             Visibility="{Binding AreContextButtonsActive, Converter={StaticResource BooleanToVisibilityConverter}}"
                             ItemContainerStyle="{StaticResource CommandButtonListViewItemContainerStyle}">
                             <ItemsControl.ItemsPanel>
@@ -288,9 +290,10 @@
                                         VerticalAlignment="Center"
                                         Height="42"
                                         Width="42"
+                                        Name="commandButton"
                                         BorderThickness="1" >
                                         <ToolTipService.ToolTip>
-                                            <ToolTip >
+                                            <ToolTip Opened="ToolTip_Opened">
                                                 <TextBlock
                                                     AutomationProperties.Name="{x:Static p:Resources.ContextMenuItemAdditionalInformation}"
                                                     Text="{Binding Title}"/>

--- a/src/modules/launcher/PowerLauncher/ResultList.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/ResultList.xaml.cs
@@ -2,7 +2,9 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Media;
 
 namespace PowerLauncher
 {
@@ -14,6 +16,74 @@ namespace PowerLauncher
         public ResultList()
         {
             InitializeComponent();
+        }
+
+        private ToolTip _previouslyOpenedToolTip;
+
+        // From https://docs.microsoft.com/en-us/dotnet/desktop/wpf/data/how-to-find-datatemplate-generated-elements
+        private TchildItem FindVisualChild<TchildItem>(DependencyObject obj)
+    where TchildItem : DependencyObject
+        {
+            for (int i = 0; i < VisualTreeHelper.GetChildrenCount(obj); i++)
+            {
+                DependencyObject child = VisualTreeHelper.GetChild(obj, i);
+                if (child != null && child is TchildItem)
+                {
+                    return (TchildItem)child;
+                }
+                else
+                {
+                    TchildItem childOfChild = FindVisualChild<TchildItem>(child);
+                    if (childOfChild != null)
+                    {
+                        return childOfChild;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private void HideCurrentToolTip()
+        {
+            if (_previouslyOpenedToolTip != null)
+            {
+                _previouslyOpenedToolTip.IsOpen = false;
+            }
+        }
+
+        private void ContextMenuListView_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            var listView = sender as ListView;
+            if (listView.SelectedItem != null)
+            {
+                ListBoxItem listBoxItem = (ListBoxItem)listView.ItemContainerGenerator.ContainerFromItem(listView.SelectedItem);
+                ContentPresenter contentPresenter = FindVisualChild<ContentPresenter>(listBoxItem);
+                DataTemplate dataTemplate = contentPresenter.ContentTemplate;
+                Button button = (Button)dataTemplate.FindName("commandButton", contentPresenter);
+                ToolTip tooltip = button.ToolTip as ToolTip;
+                tooltip.PlacementTarget = button;
+                tooltip.Placement = System.Windows.Controls.Primitives.PlacementMode.Right;
+                tooltip.PlacementRectangle = new Rect(0, button.Height, 0, 0);
+                tooltip.IsOpen = true;
+            }
+        }
+
+        private void ToolTip_Opened(object sender, RoutedEventArgs e)
+        {
+            if (string.Equals(sender.GetType().FullName, "System.Windows.Controls.ToolTip", System.StringComparison.InvariantCulture))
+            {
+                HideCurrentToolTip();
+                _previouslyOpenedToolTip = (ToolTip)sender;
+            }
+        }
+
+        private void SuggestionsListView_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (string.Equals(((ListView)e.OriginalSource).Name, "SuggestionsList", System.StringComparison.InvariantCulture))
+            {
+                HideCurrentToolTip();
+            }
         }
     }
 }

--- a/src/modules/launcher/PowerLauncher/ResultList.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/ResultList.xaml.cs
@@ -21,19 +21,19 @@ namespace PowerLauncher
         private ToolTip _previouslyOpenedToolTip;
 
         // From https://docs.microsoft.com/en-us/dotnet/desktop/wpf/data/how-to-find-datatemplate-generated-elements
-        private TChildItem FindVisualChild<TChildItem>(DependencyObject obj)
-    where TChildItem : DependencyObject
+        private TypeChildItem FindVisualChild<TypeChildItem>(DependencyObject obj)
+    where TypeChildItem : DependencyObject
         {
             for (int i = 0; i < VisualTreeHelper.GetChildrenCount(obj); i++)
             {
                 DependencyObject child = VisualTreeHelper.GetChild(obj, i);
-                if (child != null && child is TChildItem)
+                if (child != null && child is TypeChildItem)
                 {
-                    return (TChildItem)child;
+                    return (TypeChildItem)child;
                 }
                 else
                 {
-                    TChildItem childOfChild = FindVisualChild<TChildItem>(child);
+                    TypeChildItem childOfChild = FindVisualChild<TypeChildItem>(child);
                     if (childOfChild != null)
                     {
                         return childOfChild;

--- a/src/modules/launcher/PowerLauncher/ResultList.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/ResultList.xaml.cs
@@ -21,19 +21,19 @@ namespace PowerLauncher
         private ToolTip _previouslyOpenedToolTip;
 
         // From https://docs.microsoft.com/en-us/dotnet/desktop/wpf/data/how-to-find-datatemplate-generated-elements
-        private TchildItem FindVisualChild<TchildItem>(DependencyObject obj)
-    where TchildItem : DependencyObject
+        private TChildItem FindVisualChild<TChildItem>(DependencyObject obj)
+    where TChildItem : DependencyObject
         {
             for (int i = 0; i < VisualTreeHelper.GetChildrenCount(obj); i++)
             {
                 DependencyObject child = VisualTreeHelper.GetChild(obj, i);
-                if (child != null && child is TchildItem)
+                if (child != null && child is TChildItem)
                 {
-                    return (TchildItem)child;
+                    return (TChildItem)child;
                 }
                 else
                 {
-                    TchildItem childOfChild = FindVisualChild<TchildItem>(child);
+                    TChildItem childOfChild = FindVisualChild<TChildItem>(child);
                     if (childOfChild != null)
                     {
                         return childOfChild;


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
The PowerToys Run result suggestion list contains some icons for commands on the right. Those buttons have tooltips which show on mouse over but don't show when the keyboard is used to select them.

**What is include in the PR:** 
Trigger the tooltips in code behind when the command icons are selected with the keyboard.

**How does someone test / validate:** 
Test PowerToys Run using only the keyboard and verify the tooltips appear when selecting the commands from the results list.

## Quality Checklist

- [x] **Linked issue:** #7060
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
