### PR TITLE
Fix crash with VS Code Plugin and C Drive

### DIFF
--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/WorkspacesHelper/VSCodeWorkspacesApi.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/WorkspacesHelper/VSCodeWorkspacesApi.cs
@@ -27,6 +27,14 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.WorkspacesHelper
                 if (typeWorkspace.TypeWorkspace.HasValue)
                 {
                     var folderName = Path.GetFileName(unescapeUri);
+
+                    // Check we haven't returned '' if we have a path like C:\
+                    if (string.IsNullOrEmpty(folderName))
+                    {
+                        DirectoryInfo dirInfo = new DirectoryInfo(unescapeUri);
+                        folderName = dirInfo.Name.TrimEnd(':');
+                    }
+
                     return new VSCodeWorkspace()
                     {
                         Path = uri,


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Fix the crash when a drive is opened as a work space.

**What is include in the PR:** 

Check if the return is null or empty and if so find the directory name instead.

**How does someone test / validate:** 

1. Open C drive in VS Code
2. Test with { in current release. There should be a crash or no results shown
3. Test with { in this PR and see results are shown. C drive should be in list

![image](https://user-images.githubusercontent.com/15877083/129353832-ee89afce-35be-4a53-8116-95fc90e6df47.png)


## Quality Checklist

- [x] **Linked issue:** #11910
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
