### PR TITLE
Fix race-condition in PowerRename progress UI

### DIFF
--- a/src/modules/powerrename/ui/PowerRenameUI.h
+++ b/src/modules/powerrename/ui/PowerRenameUI.h
@@ -68,6 +68,7 @@ private:
 
     long m_refCount = 0;
     bool m_canceled = false;
+    std::atomic<bool> m_loadingThread{ false };
     HANDLE m_workerThreadHandle = nullptr;
     CComPtr<IProgressDialog> m_sppd;
 };


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
There was a race condition in the PowerRename progress UI that meant that sometimes the progress dialog would continue running for the lifetime of the PowerRename UI. This could lead to a crash when the `CPowerRenameProgressUI` was deallocated as the progress box would continue to call methods on the deallocated object.

**What is include in the PR:**
A fix that prevents the crash from occurring.

The issue stems from `Start()` and `Stop()` being called in quick succession here:
https://github.com/microsoft/PowerToys/blob/v0.43.0/src/modules/powerrename/ui/PowerRenameUI.cpp#L402-L404

The `Start()` method starts a thread that when it has initialised goes on to set a pointer to the progress dialog in the `m_sppd` field on the `CPowerRenameProgressUI` object.

The `Stop()` method checks to see if the `m_sppd` field is truthy, and if it is, stops the dialog and then attempts to stop the thread.

There is a race condition here if the `Stop()` method runs _before_ the thread has started and initialised the `m_sppd` field on the `CPowerRenameProgressUI` object.

The solution is to add in synchronisation to ensure the thread has properly started before `Stop()` attempts to clear up.

**How does someone test / validate:**
Run the PowerRename tool and find that it no longer crashes.

## Quality Checklist

- [x] **Linked issue:** #12391
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
