### PR TITLE
[FancyZones] Windows resize on switching layout.

### DIFF
--- a/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
@@ -722,6 +722,11 @@ void FancyZones::OnDisplayChange(DisplayChangeType changeType) noexcept
             {
                 Trace::VirtualDesktopChanged();
             }
+
+            if (m_currentDesktopId == GUID_NULL)
+            {
+                Logger::warn("Couldn't retrieve virtual desktop id");
+            }
         }
 
         if (changeType == DisplayChangeType::Initialization)

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesWindowProperties.h
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesWindowProperties.h
@@ -21,7 +21,7 @@ inline ZoneIndexSet GetZoneIndexSet(HWND window)
 
     std::array<int, 2> data;
     memcpy(data.data(), &handle, sizeof data);
-    uint64_t bitmask = ((uint64_t)data[0] << 32) + data[1];
+    uint64_t bitmask = ((uint64_t)data[1] << 32) + data[0];
     
     if (bitmask != 0)
     {
@@ -39,7 +39,7 @@ inline ZoneIndexSet GetZoneIndexSet(HWND window)
 
 inline void StampWindow(HWND window, Bitmask bitmask) noexcept
 {
-    std::array<int, 2> data = { (bitmask >> 32), static_cast<int>(bitmask) };
+    std::array<int, 2> data = { static_cast<int>(bitmask), (bitmask >> 32) };
     HANDLE rawData;
     memcpy(&rawData, data.data(), sizeof data);
     SetProp(window, ZonedWindowProperties::PropertyMultipleZoneID, rawData);

--- a/src/modules/fancyzones/FancyZonesLib/VirtualDesktop.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/VirtualDesktop.cpp
@@ -167,6 +167,8 @@ std::optional<GUID> VirtualDesktop::GetCurrentVirtualDesktopId() const
         }
     }
 
+    desktopId = GetDesktopIdByTopLevelWindows();
+        
     return std::nullopt;
 }
 
@@ -206,6 +208,34 @@ std::optional<std::vector<GUID>> VirtualDesktop::GetVirtualDesktopIds(HKEY hKey)
 std::optional<std::vector<GUID>> VirtualDesktop::GetVirtualDesktopIds() const
 {
     return GetVirtualDesktopIds(GetVirtualDesktopsRegKey());
+}
+
+std::optional<GUID> VirtualDesktop::GetDesktopIdByTopLevelWindows() const
+{
+    using result_t = std::vector<HWND>;
+    result_t result;
+
+    auto callback = [](HWND window, LPARAM data) -> BOOL {
+        result_t& result = *reinterpret_cast<result_t*>(data);
+        result.push_back(window);
+        return TRUE;
+    };
+    EnumWindows(callback, reinterpret_cast<LPARAM>(&result));
+
+    GUID id;
+    BOOL isWindowOnCurrentDesktop = false;
+    for (const auto window : result)
+    {
+        if (m_vdManager->IsWindowOnCurrentVirtualDesktop(window, &isWindowOnCurrentDesktop) == ERROR_SUCCESS && isWindowOnCurrentDesktop)
+        {
+            if (m_vdManager->GetWindowDesktopId(window, &id) == ERROR_SUCCESS && id != GUID_NULL)
+            {
+                return id;
+            }
+        }
+    }
+
+    return std::nullopt;
 }
 
 void VirtualDesktop::HandleVirtualDesktopUpdates()

--- a/src/modules/fancyzones/FancyZonesLib/VirtualDesktop.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/VirtualDesktop.cpp
@@ -169,7 +169,7 @@ std::optional<GUID> VirtualDesktop::GetCurrentVirtualDesktopId() const
 
     desktopId = GetDesktopIdByTopLevelWindows();
         
-    return std::nullopt;
+    return desktopId;
 }
 
 std::optional<std::vector<GUID>> VirtualDesktop::GetVirtualDesktopIds(HKEY hKey) const

--- a/src/modules/fancyzones/FancyZonesLib/VirtualDesktop.h
+++ b/src/modules/fancyzones/FancyZonesLib/VirtualDesktop.h
@@ -25,6 +25,7 @@ private:
     OnThreadExecutor m_virtualDesktopTrackerThread;
     wil::unique_handle m_terminateVirtualDesktopTrackerEvent;
 
-    std::optional<std::vector<GUID>> GetVirtualDesktopIds(HKEY hKey) const;    
+    std::optional<std::vector<GUID>> GetVirtualDesktopIds(HKEY hKey) const;
+    std::optional<GUID> GetDesktopIdByTopLevelWindows() const;
     void HandleVirtualDesktopUpdates();
 };


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Virtual desktop id could not be found in the registry in some cases. So initially work area is associated with the empty virtual desktop GUID. For that reason, we couldn't find a work area associated with the desktop id when the layout was changed. This work area is required to resize the window according to zone size.

Added possibility to retrieve the current virtual desktop id using `IVirtualDesktopManager`.

**What is include in the PR:** 

**How does someone test / validate:** 

Could be reproduced on a fresh system.
Test the layout change with `During zone layout changes, windows assigned to a zone will match new size/positions` on.
Verify that there's no `Couldn't retrieve virtual desktop id` message in logs.

## Quality Checklist

- [x] **Linked issue:** #8552, #10939
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
