### PR TITLE
[Telemetry] Fix show hide events on PT Run cold boot

### DIFF
--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -116,6 +116,7 @@ namespace PowerLauncher
             ListBox.SuggestionsList.PreviewMouseLeftButtonUp += SuggestionsList_PreviewMouseLeftButtonUp;
             _viewModel.PropertyChanged += ViewModel_PropertyChanged;
             _viewModel.MainWindowVisibility = Visibility.Collapsed;
+            _viewModel.LoadedAtLeastOnce = true;
 
             BringProcessToForeground();
         }

--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -376,6 +376,8 @@ namespace PowerLauncher.ViewModel
             }
         }
 
+        public bool LoadedAtLeastOnce { get; set; }
+
         private Visibility _visibility;
 
         public Visibility MainWindowVisibility
@@ -390,16 +392,20 @@ namespace PowerLauncher.ViewModel
                 if (_visibility != value)
                 {
                     _visibility = value;
-                    OnPropertyChanged(nameof(MainWindowVisibility));
-                }
+                    if (LoadedAtLeastOnce)
+                    {
+                        // Don't trigger telemetry on cold boot. Must've been loaded at least once.
+                        if (value == Visibility.Visible)
+                        {
+                            PowerToysTelemetry.Log.WriteEvent(new LauncherShowEvent());
+                        }
+                        else
+                        {
+                            PowerToysTelemetry.Log.WriteEvent(new LauncherHideEvent());
+                        }
+                    }
 
-                if (value == Visibility.Visible)
-                {
-                    PowerToysTelemetry.Log.WriteEvent(new LauncherShowEvent());
-                }
-                else
-                {
-                    PowerToysTelemetry.Log.WriteEvent(new LauncherHideEvent());
+                    OnPropertyChanged(nameof(MainWindowVisibility));
                 }
             }
         }

--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -394,7 +394,7 @@ namespace PowerLauncher.ViewModel
                     _visibility = value;
                     if (LoadedAtLeastOnce)
                     {
-                        // Don't trigger telemetry on cold boot. Must've been loaded at least once.
+                        // Don't trigger telemetry on cold boot. Must have been loaded at least once.
                         if (value == Visibility.Visible)
                         {
                             PowerToysTelemetry.Log.WriteEvent(new LauncherShowEvent());


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
When PowerToys Run starts, it triggers the "LauncherHideEvent" and "LauncherShowEvent" telemetry events, even if the window was not invoked by the user. These should be invoked only when the launcher is really "shown"/"hidden".

**What is include in the PR:** 
Setting a flag after the cold boot so that the telemetry events are only triggered after that.

**How does someone test / validate:** 
Looking for code review, mostly.
This can be validated by debugging if needed to see if the telemetry is called or not.

## Quality Checklist

- [x] **Linked issue:** #12795
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries
