### PR TITLE
[FancyZones Editor] Crash when changing between zone layouts: refactoring

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -30,7 +30,6 @@ namespace FancyZonesEditor
 
         private ContentDialog _openedDialog;
         private TextBlock _createLayoutAnnounce;
-        private bool _openingDialog = false; // Is the dialog being opened.
 
         public int WrapPanelItemSize { get; set; } = DefaultWrapPanelItemSize;
 
@@ -267,31 +266,24 @@ namespace FancyZonesEditor
         private async void EditLayout_Click(object sender, RoutedEventArgs e)
         {
             // Avoid trying to open the same dialog twice.
-            if (!_openingDialog)
+            if (_openedDialog != null)
             {
-                _openingDialog = true;
-                try
-                {
-                    var dataContext = ((FrameworkElement)sender).DataContext;
-                    Select((LayoutModel)dataContext);
-
-                    if (_settings.SelectedModel is GridLayoutModel grid)
-                    {
-                        _backup = new GridLayoutModel(grid, false);
-                    }
-                    else if (_settings.SelectedModel is CanvasLayoutModel canvas)
-                    {
-                        _backup = new CanvasLayoutModel(canvas, false);
-                    }
-
-                    await EditLayoutDialog.ShowAsync();
-                }
-                catch
-                {
-                    _openingDialog = false;
-                    throw;
-                }
+                return;
             }
+
+            var dataContext = ((FrameworkElement)sender).DataContext;
+            Select((LayoutModel)dataContext);
+
+            if (_settings.SelectedModel is GridLayoutModel grid)
+            {
+                _backup = new GridLayoutModel(grid, false);
+            }
+            else if (_settings.SelectedModel is CanvasLayoutModel canvas)
+            {
+                _backup = new CanvasLayoutModel(canvas, false);
+            }
+
+            await EditLayoutDialog.ShowAsync();
         }
 
         private void EditZones_Click(object sender, RoutedEventArgs e)
@@ -440,7 +432,6 @@ namespace FancyZonesEditor
 
         private void Dialog_Closed(ContentDialog sender, ContentDialogClosedEventArgs args)
         {
-            _openingDialog = false;
             _openedDialog = null;
         }
 


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Actually, the crash in not reproducible on current master due to https://github.com/microsoft/PowerToys/commit/37e130a1a81f85ae4aedd644fbdffe36f76e1ba4.
Just replaced a boolean flag that turned up redundant. 

**What is include in the PR:** 

**How does someone test / validate:** 

* Open edit dialog, close it and reopen quickly.
* Double click on the edit button.

![image](https://user-images.githubusercontent.com/8949536/130081133-ec7a851d-e509-43bf-990e-70ed8ad15ee2.png)


## Quality Checklist

- [x] **Linked issue:** #12687 #12615
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
