### PR TITLE
[FancyZones] Focus layout type instead of activating it on enter press

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -42,6 +42,20 @@ namespace FancyZonesEditor
 
             KeyUp += MainWindow_KeyUp;
 
+            // Prevent closing the dialog with enter
+            PreviewKeyDown += (object sender, KeyEventArgs e) =>
+            {
+                if (e.Key == Key.Enter && _openedDialog != null && _openedDialog.IsVisible)
+                {
+                    var source = e.OriginalSource as RadioButton;
+                    if (source != null && source.IsChecked != true)
+                    {
+                        source.IsChecked = true;
+                        e.Handled = true;
+                    }
+                }
+            };
+
             if (spanZonesAcrossMonitors)
             {
                 WindowStartupLocation = WindowStartupLocation.CenterScreen;


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

**What is include in the PR:** 

**How does someone test / validate:** 
- Use tab for navigation, verify that it works when something is selected, e.g. layout type. 
- When you open the "Create new layout dialog" and press enter, on an unselected layout type, it should get selected.

## Quality Checklist

- [x] **Linked issue:** #10850
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
