### PR TITLE
[KBM Editor] Remove UpdateLayout calls from shortcut UI

### DIFF
--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/EditShortcutsWindow.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/EditShortcutsWindow.cpp
@@ -325,6 +325,7 @@ inline void CreateEditShortcutsWindowImpl(HINSTANCE hInst, KBMEditor::KeyboardMa
     xamlContainer.Children().Append(header);
     xamlContainer.Children().Append(helperText);
     xamlContainer.Children().Append(scrollViewer);
+    xamlContainer.UpdateLayout();
 
     desktopSource.Content(xamlContainer);
 

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/EditShortcutsWindow.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/EditShortcutsWindow.cpp
@@ -325,7 +325,6 @@ inline void CreateEditShortcutsWindowImpl(HINSTANCE hInst, KBMEditor::KeyboardMa
     xamlContainer.Children().Append(header);
     xamlContainer.Children().Append(helperText);
     xamlContainer.Children().Append(scrollViewer);
-    xamlContainer.UpdateLayout();
 
     desktopSource.Content(xamlContainer);
 

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/KeyDropDownControl.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/KeyDropDownControl.cpp
@@ -186,7 +186,6 @@ std::pair<ShortcutErrorType, int> KeyDropDownControl::ValidateShortcutSelection(
                 parent.Children().RemoveAtEnd();
                 keyDropDownControlObjects.erase(keyDropDownControlObjects.end() - 1);
             }
-            parent.UpdateLayout();
         }
 
         // If ignore key to shortcut warning flag is true and it is a hybrid control in SingleKeyRemapControl, then skip MapToSameKey error
@@ -215,7 +214,6 @@ std::pair<ShortcutErrorType, int> KeyDropDownControl::ValidateShortcutSelection(
             
             // delete drop down control object from the vector so that it can be destructed
             keyDropDownControlObjects.erase(keyDropDownControlObjects.begin() + dropDownIndex);
-            parent.UpdateLayout();
         }
     }
 
@@ -325,7 +323,6 @@ void KeyDropDownControl::AddDropDown(StackPanel& table, StackPanel row, StackPan
     uint32_t index;
     bool found = table.Children().IndexOf(row, index);
     keyDropDownControlObjects[keyDropDownControlObjects.size() - 1]->SetSelectionHandler(table, row, parent, colIndex, shortcutRemapBuffer, keyDropDownControlObjects, targetApp, isHybridControl, isSingleKeyWindow);
-    parent.UpdateLayout();
 
     // Update accessible name
     SetAccessibleNameForComboBox(keyDropDownControlObjects[keyDropDownControlObjects.size() - 1]->GetComboBox(), (int)keyDropDownControlObjects.size());
@@ -413,8 +410,6 @@ void KeyDropDownControl::AddShortcutToControl(Shortcut shortcut, StackPanel tabl
             }
         }
     }
-    
-    parent.UpdateLayout();
 }
 
 // Get number of selected keys. Do not count -1 and 0 values as they stand for Not selected and None

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/ShortcutControl.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/ShortcutControl.cpp
@@ -42,7 +42,6 @@ ShortcutControl::ShortcutControl(StackPanel table, StackPanel row, const int col
     shortcutControlLayout.as<StackPanel>().Children().Append(typeShortcut.as<Button>());
     shortcutControlLayout.as<StackPanel>().Children().Append(shortcutDropDownStackPanel.as<StackPanel>());
     KeyDropDownControl::AddDropDown(table, row, shortcutDropDownStackPanel.as<StackPanel>(), colIndex, shortcutRemapBuffer, keyDropDownControlObjects, targetApp, isHybridControl, false);
-    shortcutControlLayout.as<StackPanel>().UpdateLayout();
 }
 
 // Function to set the accessible name of the target App text box
@@ -225,7 +224,6 @@ void ShortcutControl::AddNewShortcutControlRow(StackPanel& parent, std::vector<s
         }
 
         children.RemoveAt(rowIndex);
-        parent.UpdateLayout();
         shortcutRemapBuffer.erase(shortcutRemapBuffer.begin() + rowIndex);
         // delete the SingleKeyRemapControl objects so that they get destructed
         keyboardRemapControlObjects.erase(keyboardRemapControlObjects.begin() + rowIndex);
@@ -244,7 +242,6 @@ void ShortcutControl::AddNewShortcutControlRow(StackPanel& parent, std::vector<s
     deleteShortcutContainer.Orientation(Orientation::Vertical);
     deleteShortcutContainer.VerticalAlignment(VerticalAlignment::Center);
     row.Children().Append(deleteShortcutContainer);
-    parent.UpdateLayout();
 
     // Set accessible names
     UpdateAccessibleNames(keyboardRemapControlObjects[keyboardRemapControlObjects.size() - 1][0]->GetShortcutControl(), keyboardRemapControlObjects[keyboardRemapControlObjects.size() - 1][1]->GetShortcutControl(), targetAppTextBox, deleteShortcut, (int)keyboardRemapControlObjects.size());
@@ -482,7 +479,6 @@ void ShortcutControl::CreateDetectShortcutWindow(winrt::Windows::Foundation::IIn
     buttonPanel.Children().Append(cancelButton);
 
     stackPanel.Children().Append(buttonPanel);
-    stackPanel.UpdateLayout();
 
     // Configure the keyboardManagerState to store the UI information.
     keyboardManagerState.ConfigureDetectShortcutUI(keyStackPanel1, keyStackPanel2);

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/ShortcutControl.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/ShortcutControl.cpp
@@ -42,6 +42,7 @@ ShortcutControl::ShortcutControl(StackPanel table, StackPanel row, const int col
     shortcutControlLayout.as<StackPanel>().Children().Append(typeShortcut.as<Button>());
     shortcutControlLayout.as<StackPanel>().Children().Append(shortcutDropDownStackPanel.as<StackPanel>());
     KeyDropDownControl::AddDropDown(table, row, shortcutDropDownStackPanel.as<StackPanel>(), colIndex, shortcutRemapBuffer, keyDropDownControlObjects, targetApp, isHybridControl, false);
+    shortcutControlLayout.as<StackPanel>().UpdateLayout();
 }
 
 // Function to set the accessible name of the target App text box
@@ -479,6 +480,7 @@ void ShortcutControl::CreateDetectShortcutWindow(winrt::Windows::Foundation::IIn
     buttonPanel.Children().Append(cancelButton);
 
     stackPanel.Children().Append(buttonPanel);
+    stackPanel.UpdateLayout();
 
     // Configure the keyboardManagerState to store the UI information.
     keyboardManagerState.ConfigureDetectShortcutUI(keyStackPanel1, keyStackPanel2);


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Some users report crashes when trying to add a shortcut in the KBM Editor. Crash dumps indicate this is caused by the detection of calling `UpdateLayout` in a cycle.

**What is include in the PR:** 
Removal of `UpdateLayout` calls from the code called when adding a shortcut.
This seems to have had no visual effect at all, so I'm not sure why the calls were there in the first place.
I've sent a test build to a user who reported this crash and it's been reported to have worked.

**How does someone test / validate:** 
Try to use the KBM editor to create and edit some shortcuts. Verify this change doesn't change the UI in any weird way.
The error replicates always on some machines and never on other machines. I've never been able to replicate it, so it may be hard for the dev team to verify locally that these changes fix the issue.

## Quality Checklist

- [x] **Linked issue:** #8693 #12575 #12770 #12656
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries
