### PR TITLE
Fix lags for UWP application in full screen mode

### DIFF
--- a/src/common/utils/process_path.h
+++ b/src/common/utils/process_path.h
@@ -42,33 +42,27 @@ inline std::wstring get_process_path(HWND window) noexcept
         // It might take a time to connect the process. That's the reason for the retry loop here
         DWORD new_pid = pid;
 
-        const int retryAttempts = 10;
-        for (int retry = 0; retry < retryAttempts && pid == new_pid; retry++)
+        EnumChildWindows(
+            window, [](HWND hwnd, LPARAM param) -> BOOL {
+                auto new_pid_ptr = reinterpret_cast<DWORD*>(param);
+                DWORD pid;
+                GetWindowThreadProcessId(hwnd, &pid);
+                if (pid != *new_pid_ptr)
+                {
+                    *new_pid_ptr = pid;
+                    return FALSE;
+                }
+                else
+                {
+                    return TRUE;
+                }
+            },
+            reinterpret_cast<LPARAM>(&new_pid));
+
+        // If we have a new pid, get the new name.
+        if (new_pid != pid)
         {
-            EnumChildWindows(
-                window, [](HWND hwnd, LPARAM param) -> BOOL {
-                    auto new_pid_ptr = reinterpret_cast<DWORD*>(param);
-                    DWORD pid;
-                    GetWindowThreadProcessId(hwnd, &pid);
-                    if (pid != *new_pid_ptr)
-                    {
-                        *new_pid_ptr = pid;
-                        return FALSE;
-                    }
-                    else
-                    {
-                        return TRUE;
-                    }
-                },
-                reinterpret_cast<LPARAM>(&new_pid));
-
-            // If we have a new pid, get the new name.
-            if (new_pid != pid)
-            {
-                return get_process_path(new_pid);
-            }
-
-            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            return get_process_path(new_pid);
         }
     }
 


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Remove retries from `get_process_path` as this function is used in different places and should be generic. For example, when used in low-level keyboard hook it is unacceptable to block execution for 1 second(it happens for full screen UWP applications).

When `alt+tab` is pressed in full-screen UWP application we receive `WM_PRIV_WINDOWCREATED` message and `FancyZones::WndProc` is blocked for one second. Take into account, that `Move newly created windows to their last known zone` should be checked. So basically we have cases when `EnumChildWindows` doesn't find a different pid and retry doesn't make sense in this case.

**What is include in the PR:** 

**How does someone test / validate:** 
Test for KBM
- Add remapping `Ctrl(Left) + Q -> Play/Pause Media` for `video.ui.exe`(Movies & TV)
![image](https://user-images.githubusercontent.com/17161067/130631980-dd72f6f5-6547-4396-9e50-75bedbcfdb2c.png)
- Verify that remapping works when Movies & TV is in full screen mode

Test for fancy zones
- Enable Fancy zones 
- Check `Move newly created windows to their last known zone`
- Open `Movies & TV` in full-screen mode
- Press `Alt+Tab`
- Verify absence of lag

@SeraphimaZ 
Any idea how we can keep https://github.com/microsoft/PowerToys/pull/12284 changes?

## Quality Checklist

- [X] **Linked issue:** #12639, #12775
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
