### PR TITLE
[Settings] Remove ModuleImageLink

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/SettingsPageControl/SettingsPageControl.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/SettingsPageControl/SettingsPageControl.xaml.cs
@@ -36,12 +36,6 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
             set => SetValue(ModuleImageSourceProperty, value);
         }
 
-        public Uri ModuleImageLink
-        {
-            get => (Uri)GetValue(ModuleImageLinkProperty);
-            set => SetValue(ModuleImageLinkProperty, value);
-        }
-
 #pragma warning disable CA2227 // Collection properties should be read only
         public ObservableCollection<PageLink> PrimaryLinks
 #pragma warning restore CA2227 // Collection properties should be read only
@@ -73,7 +67,6 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
         public static readonly DependencyProperty ModuleTitleProperty = DependencyProperty.Register("ModuleTitle", typeof(string), typeof(SettingsPageControl), new PropertyMetadata(default(string)));
         public static readonly DependencyProperty ModuleDescriptionProperty = DependencyProperty.Register("ModuleDescription", typeof(string), typeof(SettingsPageControl), new PropertyMetadata(default(string)));
         public static readonly DependencyProperty ModuleImageSourceProperty = DependencyProperty.Register("ModuleImageSource", typeof(string), typeof(SettingsPageControl), new PropertyMetadata(default(string)));
-        public static readonly DependencyProperty ModuleImageLinkProperty = DependencyProperty.Register("ModuleImageLink", typeof(string), typeof(SettingsPageControl), new PropertyMetadata(default(string)));
         public static readonly DependencyProperty PrimaryLinksProperty = DependencyProperty.Register("PrimaryLinks", typeof(ObservableCollection<PageLink>), typeof(SettingsPageControl), new PropertyMetadata(new ObservableCollection<PageLink>()));
         public static readonly DependencyProperty SecondaryLinksHeaderProperty = DependencyProperty.Register("SecondaryLinksHeader", typeof(string), typeof(SettingsPageControl), new PropertyMetadata(default(string)));
         public static readonly DependencyProperty SecondaryLinksProperty = DependencyProperty.Register("SecondaryLinks", typeof(ObservableCollection<PageLink>), typeof(SettingsPageControl), new PropertyMetadata(new ObservableCollection<PageLink>()));

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/AwakePage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/AwakePage.xaml
@@ -15,8 +15,7 @@
     </Page.Resources>
 
     <controls:SettingsPageControl x:Uid="Awake" IsTabStop="False"
-                                  ModuleImageSource="ms-appx:///Assets/Modules/Awake.png"
-                                  ModuleImageLink="https://aka.ms/PowerToysOverview_Awake">
+                                  ModuleImageSource="ms-appx:///Assets/Modules/Awake.png">
         <controls:SettingsPageControl.ModuleContent>
             <StackPanel Orientation="Vertical">
 

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
@@ -10,8 +10,7 @@
     AutomationProperties.LandmarkType="Main">
 
     <controls:SettingsPageControl x:Uid="ColorPicker"
-                                  ModuleImageSource="ms-appx:///Assets/Modules/ColorPicker.png"
-                                  ModuleImageLink="https://aka.ms/PowerToysOverview_ColorPicker">
+                                  ModuleImageSource="ms-appx:///Assets/Modules/ColorPicker.png">
         <controls:SettingsPageControl.ModuleContent>
 
         <StackPanel Orientation="Vertical"

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -15,8 +15,7 @@
     </Page.Resources>
 
     <controls:SettingsPageControl x:Uid="FancyZones"
-                                  ModuleImageSource="ms-appx:///Assets/Modules/FancyZones.png"
-                                  ModuleImageLink="https://aka.ms/PowerToysOverview_FancyZones">
+                                  ModuleImageSource="ms-appx:///Assets/Modules/FancyZones.png">
         <controls:SettingsPageControl.ModuleContent>
             <StackPanel Orientation="Vertical">
 

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml
@@ -18,8 +18,7 @@
     </Page.Resources>
 
     <controls:SettingsPageControl x:Uid="General"
-                                  ModuleImageSource="ms-appx:///Assets/Modules/PT.png"
-                                  ModuleImageLink="https://aka.ms/powertoys">
+                                  ModuleImageSource="ms-appx:///Assets/Modules/PT.png">
         <controls:SettingsPageControl.ModuleContent>
             <StackPanel Orientation="Vertical">
                 <controls:SettingsGroup x:Uid="General_Version" Margin="0,-32,0,0">

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
@@ -18,8 +18,7 @@
     </Page.Resources>
     <controls:SettingsPageControl x:Uid="ImageResizer"
                                     
-                                  ModuleImageSource="ms-appx:///Assets/Modules/ImageResizer.png"
-                                  ModuleImageLink="https://aka.ms/PowerToysOverview_ImageResizer">
+                                  ModuleImageSource="ms-appx:///Assets/Modules/ImageResizer.png">
         <controls:SettingsPageControl.ModuleContent>
             <StackPanel>
 

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/KeyboardManagerPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/KeyboardManagerPage.xaml
@@ -71,8 +71,7 @@
     </Page.Resources>
 
     <controls:SettingsPageControl x:Uid="KeyboardManager"
-                                  ModuleImageSource="ms-appx:///Assets/Modules/KBM.png"
-                                  ModuleImageLink="https://aka.ms/PowerToysOverview_KeyboardManage">
+                                  ModuleImageSource="ms-appx:///Assets/Modules/KBM.png">
         <controls:SettingsPageControl.ModuleContent>
             <StackPanel Orientation="Vertical">
 

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
@@ -19,8 +19,7 @@
     </Page.Resources>
 
     <controls:SettingsPageControl x:Uid="PowerLauncher"
-                                  ModuleImageSource="ms-appx:///Assets/Modules/PowerLauncher.png"
-                                  ModuleImageLink="https://aka.ms/PowerToysOverview_PowerToysRun">
+                                  ModuleImageSource="ms-appx:///Assets/Modules/PowerLauncher.png">
         <controls:SettingsPageControl.ModuleContent>
 
             <StackPanel Orientation="Vertical">

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerPreviewPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerPreviewPage.xaml
@@ -15,8 +15,7 @@
     </Page.Resources>
 
     <controls:SettingsPageControl x:Uid="FileExplorerPreview"
-                                  ModuleImageSource="ms-appx:///Assets/Modules/PowerPreview.png"
-                                  ModuleImageLink="https://aka.ms/PowerToysOverview_FileExplorerAddOns">
+                                  ModuleImageSource="ms-appx:///Assets/Modules/PowerPreview.png">
         <controls:SettingsPageControl.ModuleContent>
             
             

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerRenamePage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerRenamePage.xaml
@@ -10,8 +10,7 @@
     AutomationProperties.LandmarkType="Main">
 
     <controls:SettingsPageControl x:Uid="PowerRename"
-                                  ModuleImageSource="ms-appx:///Assets/Modules/PowerRename.png"
-                                  ModuleImageLink="https://aka.ms/PowerToysOverview_PowerRename">
+                                  ModuleImageSource="ms-appx:///Assets/Modules/PowerRename.png">
         <controls:SettingsPageControl.ModuleContent>
             <StackPanel Orientation="Vertical"
                     x:Name="PowerRenameView"

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ShortcutGuidePage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ShortcutGuidePage.xaml
@@ -15,8 +15,7 @@
     </Page.Resources>
 
     <controls:SettingsPageControl x:Uid="ShortcutGuide"
-                                  ModuleImageSource="ms-appx:///Assets/Modules/ShortcutGuide.png"
-                                  ModuleImageLink="https://aka.ms/PowerToysOverview_ShortcutGuide">
+                                  ModuleImageSource="ms-appx:///Assets/Modules/ShortcutGuide.png">
         <controls:SettingsPageControl.ModuleContent>
             <StackPanel Orientation="Vertical">
                 <controls:Setting x:Uid="ShortcutGuide_Enable">

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/VideoConference.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/VideoConference.xaml
@@ -8,8 +8,7 @@
     mc:Ignorable="d">
 
     <controls:SettingsPageControl x:Uid="VideoConference"
-                                  ModuleImageSource="ms-appx:///Assets/Modules/VideoConference.png"
-                                  ModuleImageLink="https://aka.ms/PowerToysOverview_VideoConference">
+                                  ModuleImageSource="ms-appx:///Assets/Modules/VideoConference.png">
         <controls:SettingsPageControl.ModuleContent>
 
             <StackPanel Orientation="Vertical">


### PR DESCRIPTION
## Summary of the Pull Request
Removing an un-used property. Keeps our XAML cleaner.

## Quality Checklist

- [X] **Linked issue:** #12872
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
