### PR TITLE
[FZ Editor] Fix SizeToContent

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditorWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditorWindow.xaml
@@ -13,7 +13,7 @@
                     xmlns:ui="http://schemas.modernwpf.com/2019"
                     ui:WindowHelper.UseModernWindowStyle="True"
                     ui:TitleBar.IsIconVisible="False"
-                    SizeToContent="Width"
+                    SizeToContent="WidthAndHeight"
                     Background="{DynamicResource PrimaryBackgroundBrush}"
                     ResizeMode="NoResize"
                     WindowStartupLocation="CenterOwner"

--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditorWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditorWindow.xaml
@@ -8,17 +8,19 @@
                     xmlns:props="clr-namespace:FancyZonesEditor.Properties"
                     mc:Ignorable="d"
                     Title=""
+                    Height="196"
                     MinWidth="360"
                     BorderThickness="0"
                     xmlns:ui="http://schemas.modernwpf.com/2019"
                     ui:WindowHelper.UseModernWindowStyle="True"
                     ui:TitleBar.IsIconVisible="False"
-                    SizeToContent="WidthAndHeight"
+                    SizeToContent="Width"
                     Background="{DynamicResource PrimaryBackgroundBrush}"
                     ResizeMode="NoResize"
                     WindowStartupLocation="CenterOwner"
+                    ContentRendered="EditorWindow_ContentRendered"
                     Closed="OnClosed">
-    <Grid>
+    <Grid Height="160">
         <Grid Height="36"
               Background="{DynamicResource SecondaryBackgroundBrush}"
               Margin="0,-36,0,0"
@@ -31,7 +33,7 @@
                     VerticalAlignment="Center"
                     Margin="0,4,0,0" />
         </Grid>
-        <StackPanel Margin="16"
+        <StackPanel Margin="16" VerticalAlignment="Bottom"
                     FocusManager.FocusedElement="{Binding ElementName=newZoneButton}">
 
             <local:ClickAutomationEventButton x:Name="newZoneButton"
@@ -51,7 +53,7 @@
                     Click="OnAddZone"
                     OnClickAutomationValue="{x:Static props:Resources.New_zone_added}" />
 
-            <Grid Margin="0,24,0,0">
+            <Grid Margin="0,24,0,-4">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="8" />

--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditorWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditorWindow.xaml.cs
@@ -59,5 +59,11 @@ namespace FancyZonesEditor
                 App.Overlay.FocusEditor();
             }
         }
+
+        // This is required to fix a WPF rendering bug when using custom chrome
+        private void EditorWindow_ContentRendered(object sender, System.EventArgs e)
+        {
+            InvalidateVisual();
+        }
     }
 }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditorWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditorWindow.xaml
@@ -8,17 +8,19 @@
                     xmlns:props="clr-namespace:FancyZonesEditor.Properties"
                     mc:Ignorable="d"
                     Title=""
+                    Height="176"
                     MinWidth="360"
                     BorderThickness="0"
                     xmlns:ui="http://schemas.modernwpf.com/2019"
                     ui:WindowHelper.UseModernWindowStyle="True"
                     ui:TitleBar.IsIconVisible="False"
-                    SizeToContent="WidthAndHeight"
+                    SizeToContent="Width"
                     Background="{DynamicResource PrimaryBackgroundBrush}"
                     ResizeMode="NoResize"
                     WindowStartupLocation="CenterOwner"
+                    ContentRendered="EditorWindow_ContentRendered"
                     Closed="OnClosed">
-    <Grid>
+    <Grid Height="140">
         <Grid
             Height="36"
             Background="{DynamicResource SecondaryBackgroundBrush}"
@@ -52,7 +54,7 @@
                     <Run Text="{x:Static props:Resources.MergeDescription}" />
                 </TextBlock>
             </StackPanel>
-            <Grid Margin="0,24,0,0">
+            <Grid Margin="0,24,0,-4">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*"/>
                     <ColumnDefinition Width="8"/>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditorWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditorWindow.xaml
@@ -13,7 +13,7 @@
                     xmlns:ui="http://schemas.modernwpf.com/2019"
                     ui:WindowHelper.UseModernWindowStyle="True"
                     ui:TitleBar.IsIconVisible="False"
-                    SizeToContent="Width"
+                    SizeToContent="WidthAndHeight"
                     Background="{DynamicResource PrimaryBackgroundBrush}"
                     ResizeMode="NoResize"
                     WindowStartupLocation="CenterOwner"

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditorWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditorWindow.xaml.cs
@@ -38,5 +38,11 @@ namespace FancyZonesEditor
         }
 
         private GridLayoutModel _stashedModel;
+
+        // This is required to fix a WPF rendering bug when using custom chrome
+        private void EditorWindow_ContentRendered(object sender, System.EventArgs e)
+        {
+            InvalidateVisual();
+        }
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request

Fixes #12887

Long button labels still work:
![Capture](https://user-images.githubusercontent.com/9866362/130790855-9ec73ca4-f062-4799-84d5-6a0694cbba42.PNG)

 

## Quality Checklist

- [X] **Linked issue:** #12887
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
