### PR TITLE
[Image Resizer] Add warning for gif files

### DIFF
--- a/src/modules/imageresizer/ui/Properties/Resources.Designer.cs
+++ b/src/modules/imageresizer/ui/Properties/Resources.Designer.cs
@@ -59,7 +59,7 @@ namespace ImageResizer.Properties {
                 resourceCulture = value;
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to All Files.
         /// </summary>
@@ -77,7 +77,7 @@ namespace ImageResizer.Properties {
                 return ResourceManager.GetString("Cancel", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Height.
         /// </summary>
@@ -120,6 +120,15 @@ namespace ImageResizer.Properties {
         public static string Input_Custom {
             get {
                 return ResourceManager.GetString("Input_Custom", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Gif files with animations may not be correctly resized..
+        /// </summary>
+        public static string Input_GifWarning {
+            get {
+                return ResourceManager.GetString("Input_GifWarning", resourceCulture);
             }
         }
         

--- a/src/modules/imageresizer/ui/Properties/Resources.resx
+++ b/src/modules/imageresizer/ui/Properties/Resources.resx
@@ -142,6 +142,9 @@
   <data name="Input_IgnoreOrientation" xml:space="preserve">
     <value>Ign_ore the orientation of pictures</value>
   </data>
+  <data name="Input_GifWarning" xml:space="preserve">
+    <value>Gif files with animations may not be correctly resized.</value>
+  </data>
   <data name="Input_Replace" xml:space="preserve">
     <value>R_esize the original pictures (don't create copies)</value>
   </data>

--- a/src/modules/imageresizer/ui/ViewModels/InputViewModel.cs
+++ b/src/modules/imageresizer/ui/ViewModels/InputViewModel.cs
@@ -2,6 +2,7 @@
 // The Brice Lambson licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.  Code forked from Brice Lambson's https://github.com/bricelam/ImageResizer/
 
+using System.Linq;
 using System.Windows.Input;
 using ImageResizer.Helpers;
 using ImageResizer.Models;
@@ -41,6 +42,15 @@ namespace ImageResizer.ViewModels
         public ICommand ResizeCommand { get; }
 
         public ICommand CancelCommand { get; }
+
+        public bool TryingToResizeGifFiles
+        {
+            get
+            {
+                // Any of the files is a gif.
+                return _batch.Files.Any(filename => filename.EndsWith(".gif", System.StringComparison.InvariantCultureIgnoreCase));
+            }
+        }
 
         public void Resize()
         {

--- a/src/modules/imageresizer/ui/Views/InputPage.xaml
+++ b/src/modules/imageresizer/ui/Views/InputPage.xaml
@@ -185,7 +185,6 @@
         <CheckBox Margin="12,4,12,0"
                   Content="{x:Static p:Resources.Input_IgnoreOrientation}"
                   IsChecked="{Binding Settings.IgnoreOrientation}"/>
-        
         <Border Margin="0,24,0,0"
                 Background="{DynamicResource SecondaryBackgroundBrush}"
                 BorderBrush="{DynamicResource PrimaryBorderBrush}"
@@ -193,14 +192,24 @@
                 Padding="12">
             <Grid>
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition/>
+                    <ColumnDefinition />
                     <ColumnDefinition Width="Auto"/>
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
-
+                <TextBlock Grid.Column="0"
+                           FontWeight="Bold"
+                           Text="{x:Static p:Resources.Input_GifWarning}"
+                           TextWrapping="Wrap"
+                           MaxWidth="250"
+                           HorizontalAlignment="Left"
+                           TextAlignment="Left"
+                           Foreground="{ui:ThemeResource SystemControlErrorTextForegroundBrush}"
+                           Visibility="{Binding TryingToResizeGifFiles, Converter={StaticResource BoolValueConverter}}"
+                           />
                 <Button Grid.Column="1"
                         Style="{StaticResource AccentButtonStyle}"
                         MinWidth="76"
+                        Margin="12,0,0,0"
                         Command="{Binding ResizeCommand}"
                         AutomationProperties.Name="{x:Static p:Resources.Resize_Tooltip}"
                         Content="{x:Static p:Resources.Input_Resize}"


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
The current GIF encoder in Image Resizer doesn't support some of the GIF specification metadata, which can cause the resized animated gifs to contain artifacts / errors.

**What is include in the PR:** 
Add a warning about animated gif files when a gif file is detected in the files to resize.

![image](https://user-images.githubusercontent.com/26118718/130812225-9fb0f366-19b2-4576-b824-1ebbf85568d1.png)

**How does someone test / validate:** 
Try to use image resizer on gif files and verify the warning appears.

## Quality Checklist

- [x] **Linked issue:** #12487
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries
