### PR TITLE
[PowerToys Run] Fix register notifications crash

### DIFF
--- a/src/modules/launcher/PowerLauncher/PublicAPIInstance.cs
+++ b/src/modules/launcher/PowerLauncher/PublicAPIInstance.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Reflection;
 using System.Windows;
 using ManagedCommon;
 using Microsoft.PowerToys.Common.UI;
@@ -16,6 +17,7 @@ using PowerLauncher.ViewModel;
 using Windows.UI.Notifications;
 using Wox.Infrastructure.Image;
 using Wox.Plugin;
+using Wox.Plugin.Logger;
 
 namespace Wox
 {
@@ -37,7 +39,14 @@ namespace Wox
             WebRequest.RegisterPrefix("data", new DataWebRequestFactory());
 
             DesktopNotificationManagerCompat.RegisterActivator<LauncherNotificationActivator>();
-            DesktopNotificationManagerCompat.RegisterAumidAndComServer<LauncherNotificationActivator>("PowerToysRun");
+            try
+            {
+                DesktopNotificationManagerCompat.RegisterAumidAndComServer<LauncherNotificationActivator>("PowerToysRun");
+            }
+            catch (System.UnauthorizedAccessException ex)
+            {
+                Log.Exception("Exception calling RegisterAumidAndComServer. Notifications not available.", ex, MethodBase.GetCurrentMethod().DeclaringType);
+            }
         }
 
         public void ChangeQuery(string query, bool requery = false)


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
PowerToys Run crashes at startup when it's unable to register for notifications, which are only used by the Services plugin.

**What is include in the PR:** 
Catch the exception, log it, but don't crash.

**How does someone test / validate:** 
It's hard to replicate, but you can replace the call to `DesktopNotificationManagerCompat.RegisterAumidAndComServer<LauncherNotificationActivator>("PowerToysRun");` with a `throw new System.UnauthorizedAccessException();` call and check for behavior.

## Quality Checklist

- [x] **Linked issue:** #11216 #12890
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries
