### PR TITLE
[Settings] Settings UX enhancements

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Styles/Button.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Styles/Button.xaml
@@ -29,7 +29,7 @@
         <Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}" />
         <Setter Property="ManipulationMode" Value="System,TranslateX" />
         <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
-        <Setter Property="MinWidth" Value="{StaticResource ToggleSwitchThemeMinWidth}"/>
+       
         <Setter Property="FocusVisualMargin" Value="-7,-3,-7,-3" />
 
         <Setter Property="Template">

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Themes/Colors.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Themes/Colors.xaml
@@ -7,6 +7,8 @@
             <StaticResource x:Key="CardBackgroundBrush" ResourceKey="CardBackgroundFillColorDefaultBrush" />
             <StaticResource x:Key="CardBorderBrush" ResourceKey="CardStrokeColorDefaultBrush" />
             <StaticResource x:Key="CardPrimaryForegroundBrush" ResourceKey="TextFillColorPrimaryBrush" />
+            <SolidColorBrush x:Key="InfoBarInformationalSeverityBackgroundBrush" Color="#FF34424d"/>
+            <Color x:Key="InfoBarInformationalSeverityIconBackground">#FF5fb2f2</Color>
             <Thickness x:Key="CardBorderThickness">1</Thickness>
         </ResourceDictionary>
 
@@ -14,6 +16,8 @@
             <StaticResource x:Key="CardBackgroundBrush" ResourceKey="CardBackgroundFillColorDefaultBrush" />
             <StaticResource x:Key="CardBorderBrush" ResourceKey="CardStrokeColorDefaultBrush" />
             <StaticResource x:Key="CardPrimaryForegroundBrush" ResourceKey="TextFillColorPrimaryBrush" />
+            <SolidColorBrush x:Key="InfoBarInformationalSeverityBackgroundBrush" Color="#FFd3e7f7"/>
+            <Color x:Key="InfoBarInformationalSeverityIconBackground">#FF0063b1</Color>
             <Thickness x:Key="CardBorderThickness">1</Thickness>
         </ResourceDictionary>
 
@@ -21,6 +25,8 @@
             <StaticResource x:Key="CardBackgroundBrush" ResourceKey="SystemColorButtonFaceColorBrush" />
             <StaticResource x:Key="CardBorderBrush" ResourceKey="SystemColorButtonTextColorBrush" />
             <StaticResource x:Key="CardPrimaryForegroundBrush" ResourceKey="SystemColorButtonTextColorBrush" />
+            <SolidColorBrush x:Key="InfoBarInformationalSeverityBackgroundBrush" Color="#FF34424d"/>
+            <Color x:Key="InfoBarInformationalSeverityIconBackground">#FF5fb2f2</Color>
             <Thickness x:Key="CardBorderThickness">2</Thickness>
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml
@@ -66,7 +66,7 @@
                     <!-- New version available -->
                     <muxc:InfoBar x:Uid="General_NewVersionAvailable"
                                   IsClosable="False"
-                                  Severity="Success"
+                                  Severity="Informational"
                                   IsOpen="{Binding PowerToysUpdatingState, Mode=OneWay, Converter={StaticResource UpdateStateToBoolConverter}, ConverterParameter=ReadyToDownload}"
                                   Message="{Binding PowerToysNewAvailableVersion, Mode=OneWay}">
                         <muxc:InfoBar.Content>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/KeyboardManagerPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/KeyboardManagerPage.xaml
@@ -6,12 +6,14 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:controls="using:Microsoft.PowerToys.Settings.UI.Controls"
+     xmlns:toolkitconverters="using:Microsoft.Toolkit.Uwp.UI.Converters"
     xmlns:Lib="using:Microsoft.PowerToys.Settings.UI.Library"
     mc:Ignorable="d"
     AutomationProperties.LandmarkType="Main">
 
     <Page.Resources>
         <local:VisibleIfNotEmpty x:Key="visibleIfNotEmptyConverter" />
+        <toolkitconverters:StringVisibilityConverter x:Key="collapsedIfStringIsEmptyConverter" EmptyValue="Collapsed" NotEmptyValue="Visible" />
         <Style TargetType="ListViewItem" x:Name="KeysListViewContainerStyle">
             <Setter Property="IsTabStop" Value="False"/>
         </Style>
@@ -122,7 +124,7 @@
                                                   IsTabStop="False">
                                         <ItemsControl.ItemsPanel>
                                             <ItemsPanelTemplate>
-                                                <StackPanel Orientation="Horizontal"/>
+                                                <StackPanel Orientation="Horizontal" Spacing="4"/>
                                             </ItemsPanelTemplate>
                                         </ItemsControl.ItemsPanel>
                                     </ItemsControl>
@@ -138,7 +140,7 @@
                                                   IsTabStop="False">
                                         <ItemsControl.ItemsPanel>
                                             <ItemsPanelTemplate>
-                                                <StackPanel Orientation="Horizontal"/>
+                                                <StackPanel Orientation="Horizontal" Spacing="4"/>
                                             </ItemsPanelTemplate>
                                         </ItemsControl.ItemsPanel>
                                     </ItemsControl>
@@ -201,9 +203,23 @@
                                         </ItemsControl.ItemsPanel>
                                     </ItemsControl>
 
-                                    <TextBlock Margin="8,0,0,0" Style="{StaticResource SecondaryTextStyle}" VerticalAlignment="Center">
-                                        <Run Text="{x:Bind TargetApp}" FontWeight="SemiBold"/>
-                                    </TextBlock>
+                                    <StackPanel Orientation="Horizontal" Visibility="{x:Bind TargetApp, Converter={StaticResource collapsedIfStringIsEmptyConverter}}">
+
+                                        <Border VerticalAlignment="Center"
+                                                Padding="12,4,12,6"
+                                                Margin="16,0,0,0"
+                                                CornerRadius="12">
+                                            <Border.Background>
+                                                <SolidColorBrush Color="{ThemeResource SystemAccentColorLight3}" Opacity="0.3"/>
+                                            </Border.Background>
+                                            <TextBlock Text="{x:Bind TargetApp}"
+                                                       Foreground="{ThemeResource SystemAccentColorDark1}" FontWeight="SemiBold" FontSize="12" />
+                                        </Border>
+
+                                    </StackPanel>
+                                  
+                                  
+
                                 </StackPanel>
                             </DataTemplate>
                         </ListView.ItemTemplate>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/KeyboardManagerPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/KeyboardManagerPage.xaml
@@ -6,14 +6,13 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:controls="using:Microsoft.PowerToys.Settings.UI.Controls"
-     xmlns:toolkitconverters="using:Microsoft.Toolkit.Uwp.UI.Converters"
     xmlns:Lib="using:Microsoft.PowerToys.Settings.UI.Library"
     mc:Ignorable="d"
     AutomationProperties.LandmarkType="Main">
 
     <Page.Resources>
         <local:VisibleIfNotEmpty x:Key="visibleIfNotEmptyConverter" />
-        <toolkitconverters:StringVisibilityConverter x:Key="collapsedIfStringIsEmptyConverter" EmptyValue="Collapsed" NotEmptyValue="Visible" />
+      
         <Style TargetType="ListViewItem" x:Name="KeysListViewContainerStyle">
             <Setter Property="IsTabStop" Value="False"/>
         </Style>
@@ -203,23 +202,21 @@
                                         </ItemsControl.ItemsPanel>
                                     </ItemsControl>
 
-                                    <StackPanel Orientation="Horizontal" Visibility="{x:Bind TargetApp, Converter={StaticResource collapsedIfStringIsEmptyConverter}}">
-
+                                    <StackPanel Orientation="Horizontal">
                                         <Border VerticalAlignment="Center"
                                                 Padding="12,4,12,6"
                                                 Margin="16,0,0,0"
                                                 CornerRadius="12">
                                             <Border.Background>
-                                                <SolidColorBrush Color="{ThemeResource SystemAccentColorLight3}" Opacity="0.3"/>
+                                                <SolidColorBrush Color="{ThemeResource SystemAccentColorLight3}"
+                                                                 Opacity="0.3"/>
                                             </Border.Background>
                                             <TextBlock Text="{x:Bind TargetApp}"
-                                                       Foreground="{ThemeResource SystemAccentColorDark1}" FontWeight="SemiBold" FontSize="12" />
+                                                       Foreground="{ThemeResource SystemAccentColorDark1}"
+                                                       FontWeight="SemiBold"
+                                                       FontSize="12" />
                                         </Border>
-
                                     </StackPanel>
-                                  
-                                  
-
                                 </StackPanel>
                             </DataTemplate>
                         </ListView.ItemTemplate>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
@@ -197,23 +197,23 @@
                                                         Height="20" />
                                                 </controls:Setting.Icon>
                                                 <controls:Setting.ActionContent>
-                                                    <StackPanel Orientation="Horizontal">
+                                                    <StackPanel Orientation="Horizontal" Spacing="16">
                                                         <!-- To do: replace with InfoBadge once we move towards WinUI 2.7 -->
-                                                        <Grid x:Name="IconArea" Visibility="{x:Bind ShowNotAccessibleWarning}">
+                                                        <Grid VerticalAlignment="Center"
+                                                              AutomationProperties.AccessibilityView="Raw"
+                                                              Visibility="{x:Bind ShowNotAccessibleWarning}">
                                                             <TextBlock x:Name="IconBackground"
-                                                                       VerticalAlignment="Top"
-                                                                       Margin="{StaticResource InfoBarIconMargin}"
+                                                                        VerticalAlignment="Center"
                                                                        FontSize="{StaticResource InfoBarIconFontSize}"
                                                                        Text="{StaticResource InfoBarIconBackgroundGlyph}"
-                                                                       Foreground="{ThemeResource InfoBarWarningSeverityIconBackground}"
+                                                                       Foreground="{ThemeResource InfoBarErrorSeverityIconBackground}"
                                                                        FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                                                        AutomationProperties.AccessibilityView="Raw" />
                                                             
                                                             <TextBlock x:Name="StandardIcon"
-                                                                       Margin="{StaticResource InfoBarIconMargin}"
                                                                        FontSize="{StaticResource InfoBarIconFontSize}"
-                                                                       Text="{StaticResource InfoBarWarningIconGlyph}"
-                                                                       Foreground="{ThemeResource InfoBarWarningSeverityIconForeground}"
+                                                                       Text="{StaticResource InfoBarErrorIconGlyph}"
+                                                                       Foreground="{ThemeResource InfoBarErrorSeverityIconForeground}"
                                                                        FontFamily="{ThemeResource SymbolThemeFontFamily}"/>
                                                         </Grid>
 
@@ -232,7 +232,7 @@
                                                                  MinWidth="{StaticResource SettingActionControlMinWidth}" />
                                                     </controls:Setting.ActionContent>
                                                 </controls:Setting>
-                                                <muxc:InfoBar Severity="Warning" x:Uid="Run_NotAccessibleWarning"
+                                                <muxc:InfoBar Severity="Error" x:Uid="Run_NotAccessibleWarning"
                                                               IsOpen="{x:Bind ShowNotAccessibleWarning}"
                                                               IsClosable="False" />
                                                 <muxc:InfoBar Severity="Error"

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
@@ -197,8 +197,30 @@
                                                         Height="20" />
                                                 </controls:Setting.Icon>
                                                 <controls:Setting.ActionContent>
-                                                    <ToggleSwitch x:Uid="PowerLauncher_EnablePluginToggle"
-                                                                  IsOn="{x:Bind Path=Disabled, Converter={StaticResource BoolNegationConverter}, Mode=TwoWay}"/>
+                                                    <StackPanel Orientation="Horizontal">
+                                                        <!-- To do: replace with InfoBadge once we move towards WinUI 2.7 -->
+                                                        <Grid x:Name="IconArea" Visibility="{x:Bind ShowNotAccessibleWarning}">
+                                                            <TextBlock x:Name="IconBackground"
+                                                                       VerticalAlignment="Top"
+                                                                       Margin="{StaticResource InfoBarIconMargin}"
+                                                                       FontSize="{StaticResource InfoBarIconFontSize}"
+                                                                       Text="{StaticResource InfoBarIconBackgroundGlyph}"
+                                                                       Foreground="{ThemeResource InfoBarWarningSeverityIconBackground}"
+                                                                       FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                                                       AutomationProperties.AccessibilityView="Raw" />
+                                                            
+                                                            <TextBlock x:Name="StandardIcon"
+                                                                       Margin="{StaticResource InfoBarIconMargin}"
+                                                                       FontSize="{StaticResource InfoBarIconFontSize}"
+                                                                       Text="{StaticResource InfoBarWarningIconGlyph}"
+                                                                       Foreground="{ThemeResource InfoBarWarningSeverityIconForeground}"
+                                                                       FontFamily="{ThemeResource SymbolThemeFontFamily}"/>
+                                                        </Grid>
+
+                                                        <ToggleSwitch x:Uid="PowerLauncher_EnablePluginToggle"
+                                                                      IsOn="{x:Bind Path=Disabled, Converter={StaticResource BoolNegationConverter}, Mode=TwoWay}"/>
+                                                    </StackPanel>
+                                                
                                                 </controls:Setting.ActionContent>
                                             </controls:Setting>
                                         </controls:SettingExpander.Header>
@@ -206,12 +228,17 @@
                                             <StackPanel>
                                                 <controls:Setting x:Uid="PowerLauncher_ActionKeyword" Style="{StaticResource ExpanderContentSettingStyle}" IsEnabled="{x:Bind Enabled, Mode=OneWay}">
                                                     <controls:Setting.ActionContent>
-                                                        <TextBox Text="{x:Bind Path=ActionKeyword, Mode=TwoWay}"
+                                                        <TextBox Text="{x:Bind Path=ActionKeyword, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                                                  MinWidth="{StaticResource SettingActionControlMinWidth}" />
                                                     </controls:Setting.ActionContent>
                                                 </controls:Setting>
-                                                <muxc:InfoBar Severity="Warning" x:Uid="Run_NotAccessibleWarning" IsOpen="{x:Bind ShowNotAccessibleWarning}" IsClosable="False" />
-                                                <muxc:InfoBar Severity="Error" x:Uid="Run_NotAllowedActionKeyword" IsOpen="{x:Bind ShowNotAllowedKeywordWarning}" IsClosable="False" />
+                                                <muxc:InfoBar Severity="Warning" x:Uid="Run_NotAccessibleWarning"
+                                                              IsOpen="{x:Bind ShowNotAccessibleWarning}"
+                                                              IsClosable="False" />
+                                                <muxc:InfoBar Severity="Error"
+                                                              x:Uid="Run_NotAllowedActionKeyword"
+                                                              IsOpen="{x:Bind ShowNotAllowedKeywordWarning}"
+                                                              IsClosable="False" />
                                                 <Rectangle Style="{StaticResource ExpanderSeparatorStyle}" />
                                                 <CheckBox x:Uid="PowerLauncher_IncludeInGlobalResult"
                                                           IsChecked="{x:Bind Path=IsGlobal, Mode=TwoWay}"


### PR DESCRIPTION
## Summary of the Pull Request

#12867 - Changed Severity to Normal, but added blue highlight color so it stands out better.

Before:
![Before](https://user-images.githubusercontent.com/9866362/130985612-eb2e23e7-46fb-4efd-b97d-6ea494e463d5.PNG)

After:
![After](https://user-images.githubusercontent.com/9866362/130985553-abf4d712-03e3-48df-8268-6b64c6f5c901.PNG)
![After2](https://user-images.githubusercontent.com/9866362/130985653-05f064a2-487f-42ef-9bf9-0affb85e1878.PNG)

#12865 - Added an icon that shows that there's an error without expanding the plug-in settings. We can replace this later on with a InfoBadge whenever we upgrade to WinUI 2.7.
![ErrorWarningSIgnPlugins](https://user-images.githubusercontent.com/9866362/130986273-55dcd756-d0a4-4266-bbfa-6f2aecd5b680.gif)

#12874 - Added a border around the app name
![image](https://user-images.githubusercontent.com/9866362/130990987-1e74acb6-8820-4ff0-a857-e65cce3e3088.png)

## Quality Checklist

- [X] **Linked issue:** #12867, #12865, #12874
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
