### PR TITLE
[FancyZones][Settings] Flyout with "Allow zones to span across monitors" prerequisites.

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/TextBlockControl.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/TextBlockControl.xaml
@@ -1,0 +1,15 @@
+﻿<UserControl
+    x:Class="Microsoft.PowerToys.Settings.UI.Controls.TextBlockControl"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+    <TextBlock x:Name="textBlock"
+               Text="{Binding Text}"
+               TextWrapping="WrapWholeWords" 
+               Loaded="TextBlock_Loaded"/>
+</UserControl>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/TextBlockControl.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/TextBlockControl.xaml.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+
+namespace Microsoft.PowerToys.Settings.UI.Controls
+{
+    public sealed partial class TextBlockControl : UserControl
+    {
+        public static readonly DependencyProperty TextProperty = DependencyProperty.Register(
+           "Text",
+           typeof(string),
+           typeof(TextBlockControl),
+           null);
+
+        [Localizable(true)]
+        public string Text
+        {
+            get => (string)GetValue(TextProperty);
+            set => SetValue(TextProperty, value);
+        }
+
+        public static readonly DependencyProperty EnabledForegroundProperty = DependencyProperty.Register(
+           "EnabledForeground",
+           typeof(Brush),
+           typeof(TextBlockControl),
+           null);
+
+        public Brush EnabledForeground
+        {
+            get => (Brush)GetValue(EnabledForegroundProperty);
+            set => SetValue(EnabledForegroundProperty, value);
+        }
+
+        public static readonly DependencyProperty DisabledForegroundProperty = DependencyProperty.Register(
+           "DisabledForeground",
+           typeof(Brush),
+           typeof(TextBlockControl),
+           null);
+
+        public Brush DisabledForeground
+        {
+            get => (Brush)GetValue(DisabledForegroundProperty);
+            set => SetValue(DisabledForegroundProperty, value);
+        }
+
+        public TextBlockControl()
+        {
+            this.InitializeComponent();
+            DataContext = this;
+
+            IsEnabledChanged += TextBlockControl_IsEnabledChanged;
+        }
+
+        private void TextBlockControl_IsEnabledChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            if ((bool)e.NewValue)
+            {
+                textBlock.Foreground = EnabledForeground;
+            }
+            else
+            {
+                textBlock.Foreground = DisabledForeground;
+            }
+        }
+
+        private void TextBlock_Loaded(object sender, RoutedEventArgs e)
+        {
+            textBlock.Foreground = IsEnabled ? EnabledForeground : DisabledForeground;
+        }
+    }
+}

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Microsoft.PowerToys.Settings.UI.csproj
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Microsoft.PowerToys.Settings.UI.csproj
@@ -115,6 +115,9 @@
       <DependentUpon>OOBEPageControl.xaml</DependentUpon>
     </Compile>
     <Compile Include="Controls\SettingsPageControl\PageLink.cs" />
+    <Compile Include="Controls\TextBlockControl.xaml.cs">
+      <DependentUpon>TextBlockControl.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Converters\AwakeModeToBoolConverter.cs" />
     <Compile Include="Converters\ImageResizerFitToStringConverter.cs" />
     <Compile Include="Converters\ImageResizerUnitToStringConverter.cs" />
@@ -331,6 +334,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Controls\OOBEPageControl\OOBEPageControl.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Controls\TextBlockControl.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -879,7 +879,7 @@
 Made with 💗 by Microsoft and the PowerToys community.</value>
     <comment>Windows refers to the OS</comment>
   </data>
-  <data name="FancyZones_SpanZonesAcrossMonitorsCheckBoxControl.Content" xml:space="preserve">
+  <data name="FancyZones_SpanZonesAcrossMonitorsCheckBoxControl.Text" xml:space="preserve">
     <value>Allow zones to span across monitors</value>
   </data>
   <data name="ImageResizer_Formatting_ActualHeight.Text" xml:space="preserve">
@@ -1574,12 +1574,6 @@ From there, simply click on a Markdown file or SVG icon in the File Explorer and
     <value>Remove</value>
   </data>
   <data name="FancyZones_SpanZonesAcrossMonitorsPrerequisites.Text" xml:space="preserve">
-    <value>Prerequisites:</value>
-  </data>
-  <data name="FancyZones_SpanZonesAcrossMonitorsPrerequisites_dpi.Text" xml:space="preserve">
-    <value>All monitors should have the same DPI scaling.</value>
-  </data>
-  <data name="FancyZones_SpanZonesAcrossMonitorsPrerequisites_orientation.Text" xml:space="preserve">
-    <value>Consider that all connected monitors would be treated as one large combined rectangle.</value>
+    <value>All monitors must have the same DPI scaling and will be treated as one large combined rectangle which contains all monitors.</value>
   </data>
 </root>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -880,7 +880,7 @@ Made with 💗 by Microsoft and the PowerToys community.</value>
     <comment>Windows refers to the OS</comment>
   </data>
   <data name="FancyZones_SpanZonesAcrossMonitorsCheckBoxControl.Content" xml:space="preserve">
-    <value>Allow zones to span across monitors (all monitors must have the same DPI scaling)</value>
+    <value>Allow zones to span across monitors</value>
   </data>
   <data name="ImageResizer_Formatting_ActualHeight.Text" xml:space="preserve">
     <value>Actual height</value>
@@ -1572,5 +1572,14 @@ From there, simply click on a Markdown file or SVG icon in the File Explorer and
   </data>
   <data name="RemoveTooltip.Text" xml:space="preserve">
     <value>Remove</value>
+  </data>
+  <data name="FancyZones_SpanZonesAcrossMonitorsPrerequisites.Text" xml:space="preserve">
+    <value>Prerequisites:</value>
+  </data>
+  <data name="FancyZones_SpanZonesAcrossMonitorsPrerequisites_dpi.Text" xml:space="preserve">
+    <value>All monitors should have the same DPI scaling.</value>
+  </data>
+  <data name="FancyZones_SpanZonesAcrossMonitorsPrerequisites_orientation.Text" xml:space="preserve">
+    <value>Consider that all connected monitors would be treated as one large combined rectangle.</value>
   </data>
 </root>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -87,36 +87,15 @@
                                 <Rectangle Style="{StaticResource ExpanderSeparatorStyle}" />
                                 <CheckBox x:Uid="FancyZones_ShowZonesOnAllMonitorsCheckBoxControl" IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.ShowOnAllMonitors}" Margin="{StaticResource ExpanderSettingMargin}"  />
                                 <Rectangle Style="{StaticResource ExpanderSeparatorStyle}" />
-                                <Grid Margin="{StaticResource ExpanderSettingMargin}">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="*"/>
-                                        <ColumnDefinition Width="Auto"/>
-                                    </Grid.ColumnDefinitions>
-
-                                    <CheckBox x:Uid="FancyZones_SpanZonesAcrossMonitorsCheckBoxControl" IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.SpanZonesAcrossMonitors}" />
-                                    <Button Content="&#xE946;" FontFamily="{ThemeResource SymbolThemeFontFamily}" HorizontalAlignment="Right">
-                                        <Button.Flyout>
-                                            <Flyout x:Name="SpanZonesAcrossMonitorsFlyout">
-                                                <Flyout.FlyoutPresenterStyle>
-                                                    <Style TargetType="FlyoutPresenter">
-                                                        <Setter Property="ScrollViewer.HorizontalScrollMode" Value="Disabled"/>
-                                                        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled"/>
-                                                    </Style> 
-                                                </Flyout.FlyoutPresenterStyle>
-                                                <TextBlock x:Name="PrerequisitesTextBlock" TextWrapping="WrapWholeWords">
-                                                    <Run x:Uid="FancyZones_SpanZonesAcrossMonitorsPrerequisites" FontWeight="SemiBold" />
-                                                    <LineBreak/>
-                                                    <LineBreak/>
-                                                    <Run Text="&#xF13E;" FontWeight="SemiBold" FontFamily="Segoe MDL2 Assets"/>
-                                                    <Run x:Uid="FancyZones_SpanZonesAcrossMonitorsPrerequisites_dpi" />
-                                                    <LineBreak/>
-                                                    <Run Text="&#xF13E;" FontWeight="SemiBold" FontFamily="Segoe MDL2 Assets"/>
-                                                    <Run x:Uid="FancyZones_SpanZonesAcrossMonitorsPrerequisites_orientation"/>
-                                                </TextBlock>
-                                            </Flyout>
-                                        </Button.Flyout>
-                                    </Button>
-                                </Grid>
+                                <CheckBox IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.SpanZonesAcrossMonitors}" Margin="{StaticResource ExpanderSettingMargin}" >
+                                    <StackPanel Orientation="Vertical">
+                                        <TextBlock x:Uid="FancyZones_SpanZonesAcrossMonitorsCheckBoxControl" />
+                                        <TextBlock x:Uid="FancyZones_SpanZonesAcrossMonitorsPrerequisites" 
+                                               FontSize="{StaticResource SecondaryTextFontSize}"
+                                               TextWrapping="WrapWholeWords"
+                                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                                    </StackPanel>
+                                </CheckBox>
                             
                                 <controls:Setting  x:Uid="FancyZones_OverlappingZones" Style="{StaticResource ExpanderContentSettingStyle}">
                                     <controls:Setting.ActionContent>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -1,4 +1,4 @@
-﻿<Page
+<Page
     x:Class="Microsoft.PowerToys.Settings.UI.Views.FancyZonesPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -73,7 +73,7 @@
                 </controls:SettingsGroup>
 
 
-                <controls:SettingsGroup x:Uid="FancyZones_Zones" IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}">
+                <controls:SettingsGroup x:Uid="FancyZones_Zones" x:Name="ZonesSettingsGroup" IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}">
                     <controls:SettingExpander IsExpanded="True">
                         <controls:SettingExpander.Header>
                             <controls:Setting x:Uid="FancyZones_ZoneBehavior_GroupSettings" Icon="&#xE620;" Style="{StaticResource ExpanderHeaderSettingStyle}" />
@@ -90,10 +90,11 @@
                                 <CheckBox IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.SpanZonesAcrossMonitors}" Margin="{StaticResource ExpanderSettingMargin}" >
                                     <StackPanel Orientation="Vertical">
                                         <TextBlock x:Uid="FancyZones_SpanZonesAcrossMonitorsCheckBoxControl" />
-                                        <TextBlock x:Uid="FancyZones_SpanZonesAcrossMonitorsPrerequisites" 
-                                               FontSize="{StaticResource SecondaryTextFontSize}"
-                                               TextWrapping="WrapWholeWords"
-                                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
+                                        <controls:TextBlockControl x:Uid="FancyZones_SpanZonesAcrossMonitorsPrerequisites"
+                                                FontSize="{StaticResource SecondaryTextFontSize}"
+                                                EnabledForeground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                DisabledForeground="{ThemeResource TextFillColorDisabledBrush}"
+                                                IsEnabled="{Binding ElementName=ZonesSettingsGroup, Path=IsEnabled, Mode=OneWay}"/>
                                     </StackPanel>
                                 </CheckBox>
                             

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -87,14 +87,16 @@
                                 <Rectangle Style="{StaticResource ExpanderSeparatorStyle}" />
                                 <CheckBox x:Uid="FancyZones_ShowZonesOnAllMonitorsCheckBoxControl" IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.ShowOnAllMonitors}" Margin="{StaticResource ExpanderSettingMargin}"  />
                                 <Rectangle Style="{StaticResource ExpanderSeparatorStyle}" />
-                                <CheckBox IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.SpanZonesAcrossMonitors}" Margin="{StaticResource ExpanderSettingMargin}" >
+                                <CheckBox IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.SpanZonesAcrossMonitors}" 
+                                          Margin="{StaticResource ExpanderSettingMargin}"
+                                          AutomationProperties.Name="{Binding ElementName=SpanZonesAcrossMonitorsPrerequisitesTitle, Path=Text}">
                                     <StackPanel Orientation="Vertical">
-                                        <TextBlock x:Uid="FancyZones_SpanZonesAcrossMonitorsCheckBoxControl" />
+                                        <TextBlock x:Name="SpanZonesAcrossMonitorsPrerequisitesTitle" x:Uid="FancyZones_SpanZonesAcrossMonitorsCheckBoxControl" />
                                         <controls:TextBlockControl x:Uid="FancyZones_SpanZonesAcrossMonitorsPrerequisites"
-                                                FontSize="{StaticResource SecondaryTextFontSize}"
-                                                EnabledForeground="{ThemeResource TextFillColorSecondaryBrush}"
-                                                DisabledForeground="{ThemeResource TextFillColorDisabledBrush}"
-                                                IsEnabled="{Binding ElementName=ZonesSettingsGroup, Path=IsEnabled, Mode=OneWay}"/>
+                                            FontSize="{StaticResource SecondaryTextFontSize}"
+                                            EnabledForeground="{ThemeResource TextFillColorSecondaryBrush}"
+                                            DisabledForeground="{ThemeResource TextFillColorDisabledBrush}"
+                                            IsEnabled="{Binding ElementName=ZonesSettingsGroup, Path=IsEnabled, Mode=OneWay}"/>
                                     </StackPanel>
                                 </CheckBox>
                             

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -87,8 +87,37 @@
                                 <Rectangle Style="{StaticResource ExpanderSeparatorStyle}" />
                                 <CheckBox x:Uid="FancyZones_ShowZonesOnAllMonitorsCheckBoxControl" IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.ShowOnAllMonitors}" Margin="{StaticResource ExpanderSettingMargin}"  />
                                 <Rectangle Style="{StaticResource ExpanderSeparatorStyle}" />
-                                <CheckBox x:Uid="FancyZones_SpanZonesAcrossMonitorsCheckBoxControl" IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.SpanZonesAcrossMonitors}" Margin="{StaticResource ExpanderSettingMargin}"  />
-                               
+                                <Grid Margin="{StaticResource ExpanderSettingMargin}">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+
+                                    <CheckBox x:Uid="FancyZones_SpanZonesAcrossMonitorsCheckBoxControl" IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.SpanZonesAcrossMonitors}" />
+                                    <Button Content="&#xE946;" FontFamily="{ThemeResource SymbolThemeFontFamily}" HorizontalAlignment="Right">
+                                        <Button.Flyout>
+                                            <Flyout x:Name="SpanZonesAcrossMonitorsFlyout">
+                                                <Flyout.FlyoutPresenterStyle>
+                                                    <Style TargetType="FlyoutPresenter">
+                                                        <Setter Property="ScrollViewer.HorizontalScrollMode" Value="Disabled"/>
+                                                        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled"/>
+                                                    </Style> 
+                                                </Flyout.FlyoutPresenterStyle>
+                                                <TextBlock x:Name="PrerequisitesTextBlock" TextWrapping="WrapWholeWords">
+                                                    <Run x:Uid="FancyZones_SpanZonesAcrossMonitorsPrerequisites" FontWeight="SemiBold" />
+                                                    <LineBreak/>
+                                                    <LineBreak/>
+                                                    <Run Text="&#xF13E;" FontWeight="SemiBold" FontFamily="Segoe MDL2 Assets"/>
+                                                    <Run x:Uid="FancyZones_SpanZonesAcrossMonitorsPrerequisites_dpi" />
+                                                    <LineBreak/>
+                                                    <Run Text="&#xF13E;" FontWeight="SemiBold" FontFamily="Segoe MDL2 Assets"/>
+                                                    <Run x:Uid="FancyZones_SpanZonesAcrossMonitorsPrerequisites_orientation"/>
+                                                </TextBlock>
+                                            </Flyout>
+                                        </Button.Flyout>
+                                    </Button>
+                                </Grid>
+                            
                                 <controls:Setting  x:Uid="FancyZones_OverlappingZones" Style="{StaticResource ExpanderContentSettingStyle}">
                                     <controls:Setting.ActionContent>
                                         <ComboBox SelectedIndex="{x:Bind Path=ViewModel.OverlappingZonesAlgorithmIndex, Mode=TwoWay}" MinWidth="{StaticResource SettingActionControlMinWidth}">


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Added a flyout with `Allow zones to span across monitors` prerequisites. Any suggestions about better wording or style are welcome.

![image](https://user-images.githubusercontent.com/8949536/130994439-d26631a5-b893-49f0-a1e0-dbb90e9a603b.png)

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #12885
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
