### PR TITLE
[Settings] Fix wrong labels for PowerRename

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -556,16 +556,13 @@
     <value>Settings theme</value>
   </data>
   <data name="PowerRename_Toggle_EnableOnContextMenu.Header" xml:space="preserve">
-    <value>Show in default context menu's</value>
-  </data>
-  <data name="PowerRename_Toggle_EnableOnContextMenu.Description" xml:space="preserve">
-    <value>PowerRename appears in the default context menu whenever you right-click one or multiple files</value>
+    <value>Show icon on context menu</value>
   </data>
   <data name="PowerRename_Toggle_EnableOnExtendedContextMenu.Header" xml:space="preserve">
-    <value>Show in extended context menu's</value>
+    <value>Appear only in extended context menu</value>
   </data>
   <data name="PowerRename_Toggle_EnableOnExtendedContextMenu.Description" xml:space="preserve">
-    <value>PowerRename only appears in extended context menu's (press Shift + right-click)</value>
+    <value>Press Shift + right-click on files to open the extended menu</value>
   </data>
   <data name="PowerRename_Toggle_MaxDispListNum.Header" xml:space="preserve">
     <value>Maximum number of items</value>


### PR DESCRIPTION
## Summary of the Pull Request

Solving #12925:

![image](https://user-images.githubusercontent.com/9866362/131125779-bec816e8-8076-4291-b956-0bf5bb3c45fa.png)


## Quality Checklist

- [X] **Linked issue:** #12925
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
