### PR TITLE
[FancyZones] Virtual desktop switch fix

### DIFF
--- a/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
@@ -356,7 +356,8 @@ void FancyZones::WindowCreated(HWND window) noexcept
         return;
     }
 
-    if (!m_virtualDesktop.IsWindowOnCurrentDesktop(window))
+    auto desktopId = m_virtualDesktop.GetDesktopId(window);
+    if (desktopId.has_value() && *desktopId != m_currentDesktopId)
     {
         // Switch between virtual desktops results with posting same windows messages that also indicate
         // creation of new window. We need to check if window being processed is on currently active desktop.


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

A fix for the regression. 
Repro: Turn on `Move newly created windows to the current active monitor`, switch to another virtual desktop, return back, observe that all non-zoned windows moved to the active monitor.

**What is include in the PR:** 

**How does someone test / validate:** 

Verify that windows are stay where they were before switch.

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
