### PR TITLE
Feature/lab color representation

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -1951,6 +1951,7 @@ SRCCOPY
 sre
 sregex
 SResize
+SRGB
 srme
 srre
 srw

--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -12,10 +12,10 @@ Acceleratorkeys
 ACCEPTFILES
 accessibile
 accessibilityinsights
+Accessible
 Acl
 aclapi
 AColumn
-Accessible
 acos
 acrt
 Actioncenter
@@ -229,10 +229,13 @@ CHILDACTIVATE
 CHILDWINDOW
 chrdavis
 chrisharris
+chromaticities
 chrono
 Chrzan
 chrzan
 CHT
+cielab
+CIEXYZ
 CImage
 cinttypes
 cla
@@ -288,6 +291,7 @@ comhost
 cominterop
 commandline
 commctrl
+companding
 Compat
 COMPOSITIONFULL
 comsupp
@@ -402,6 +406,7 @@ ddd
 ddee
 ddf
 Deact
+debian
 DECLAR
 declspec
 decltype
@@ -1258,6 +1263,7 @@ mii
 MIIM
 millis
 mimetype
+mindaro
 Minimizeallwindows
 MINIMIZEBOX
 miniz

--- a/src/modules/colorPicker/ColorPickerUI/Helpers/ColorHelper.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/ColorHelper.cs
@@ -154,6 +154,8 @@ namespace ColorPicker.Helpers
 
         /// <summary>
         /// Convert a given <see cref="Color"/> to a CIE XYZ color (XYZ)
+        /// The constants of the formula used come from this wikipedia page:
+        /// https://en.wikipedia.org/wiki/SRGB#The_reverse_transformation_(sRGB_to_CIE_XYZ)
         /// </summary>
         /// <param name="color">The <see cref="Color"/> to convert</param>
         /// <returns>The X [0..1], Y [0..1] and Z [0..1]</returns>
@@ -177,6 +179,8 @@ namespace ColorPicker.Helpers
 
         /// <summary>
         /// Convert a CIE XYZ color <see cref="double"/> to a CIE LAB color (LAB)
+        /// The constants of the formula used come from this wikipedia page:
+        /// https://en.wikipedia.org/wiki/CIELAB_color_space#Converting_between_CIELAB_and_CIEXYZ_coordinates
         /// </summary>
         /// <param name="x">The <see cref="x"/> represents a mix of the three CIE RGB curves</param>
         /// <param name="y">The <see cref="y"/> represents the luminance</param>

--- a/src/modules/colorPicker/ColorPickerUI/Helpers/ColorHelper.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/ColorHelper.cs
@@ -194,7 +194,7 @@ namespace ColorPicker.Helpers
             y = y * 100 / 100.0;
             z = z * 100 / 108.8840;
 
-            // XYZ to L*a*b* transformation
+            // XYZ to CIELab transformation
             double fx = (x > .008856) ? Math.Pow(x, 1.0 / 3.0) : (x * 7.787) + (16.0 / 116.0);
             double fy = (y > .008856) ? Math.Pow(y, 1.0 / 3.0) : (y * 7.787) + (16.0 / 116.0);
             double fz = (z > .008856) ? Math.Pow(z, 1.0 / 3.0) : (z * 7.787) + (16.0 / 116.0);

--- a/src/modules/colorPicker/ColorPickerUI/Helpers/ColorHelper.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/ColorHelper.cs
@@ -195,9 +195,13 @@ namespace ColorPicker.Helpers
             z = z * 100 / 108.8840;
 
             // XYZ to CIELab transformation
-            double fx = (x > .008856) ? Math.Pow(x, 1.0 / 3.0) : (x * 7.787) + (16.0 / 116.0);
-            double fy = (y > .008856) ? Math.Pow(y, 1.0 / 3.0) : (y * 7.787) + (16.0 / 116.0);
-            double fz = (z > .008856) ? Math.Pow(z, 1.0 / 3.0) : (z * 7.787) + (16.0 / 116.0);
+            double delta = 6d / 29;
+            double m = (1d / 3) * Math.Pow(delta, -2);
+            double t = Math.Pow(delta, 3);
+
+            double fx = (x > t) ? Math.Pow(x, 1.0 / 3.0) : (x * m) + (16.0 / 116.0);
+            double fy = (y > t) ? Math.Pow(y, 1.0 / 3.0) : (y * m) + (16.0 / 116.0);
+            double fz = (z > t) ? Math.Pow(z, 1.0 / 3.0) : (z * m) + (16.0 / 116.0);
 
             double l = (116 * fy) - 16;
             double a = 500 * (fx - fy);

--- a/src/modules/colorPicker/ColorPickerUI/Helpers/ColorHelper.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/ColorHelper.cs
@@ -192,8 +192,8 @@ namespace ColorPicker.Helpers
 
             // XYZ to L*a*b* transformation
             double fx = (x > .008856) ? Math.Pow(x, 1.0 / 3.0) : (x * 7.787) + (16.0 / 116.0);
-            double fy = (x > .008856) ? Math.Pow(y, 1.0 / 3.0) : (y * 7.787) + (16.0 / 116.0);
-            double fz = (x > .008856) ? Math.Pow(z, 1.0 / 3.0) : (z * 7.787) + (16.0 / 116.0);
+            double fy = (y > .008856) ? Math.Pow(y, 1.0 / 3.0) : (y * 7.787) + (16.0 / 116.0);
+            double fz = (z > .008856) ? Math.Pow(z, 1.0 / 3.0) : (z * 7.787) + (16.0 / 116.0);
 
             double l = (116 * fy) - 16;
             double a = 500 * (fx - fy);

--- a/src/modules/colorPicker/ColorPickerUI/Helpers/ColorHelper.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/ColorHelper.cs
@@ -159,20 +159,19 @@ namespace ColorPicker.Helpers
         /// <returns>The X [0..1], Y [0..1] and Z [0..1]</returns>
         internal static (double x, double y, double z) ConvertToCIEXYZColor(Color color)
         {
-            // normalize red, green, blue values
-            double rLinear = color.R / 255d;
-            double gLinear = color.G / 255d;
-            double bLinear = color.B / 255d;
+            double r = color.R / 255d;
+            double g = color.G / 255d;
+            double b = color.B / 255d;
 
-            // convert to a sRGB form
-            double r = (rLinear > 0.04045) ? Math.Pow((rLinear + 0.055) / 1.055, 2.4) : (rLinear / 12.92);
-            double g = (gLinear > 0.04045) ? Math.Pow((gLinear + 0.055) / 1.055, 2.4) : (gLinear / 12.92);
-            double b = (bLinear > 0.04045) ? Math.Pow((bLinear + 0.055) / 1.055, 2.4) : (bLinear / 12.92);
+            // inverse companding, gamma correction must be undone
+            double rLinear = (r > 0.04045) ? Math.Pow((r + 0.055) / 1.055, 2.4) : (r / 12.92);
+            double gLinear = (g > 0.04045) ? Math.Pow((g + 0.055) / 1.055, 2.4) : (g / 12.92);
+            double bLinear = (b > 0.04045) ? Math.Pow((b + 0.055) / 1.055, 2.4) : (b / 12.92);
 
             return (
-                (r * 0.4124) + (g * 0.3576) + (b * 0.1805),
-                (r * 0.2126) + (g * 0.7152) + (b * 0.0722),
-                (r * 0.0193) + (g * 0.1192) + (b * 0.9505)
+                (rLinear * 0.4124) + (gLinear * 0.3576) + (bLinear * 0.1805),
+                (rLinear * 0.2126) + (gLinear * 0.7152) + (bLinear * 0.0722),
+                (rLinear * 0.0193) + (gLinear * 0.1192) + (bLinear * 0.9505)
             );
         }
 

--- a/src/modules/colorPicker/ColorPickerUI/Helpers/ColorHelper.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/ColorHelper.cs
@@ -190,9 +190,9 @@ namespace ColorPicker.Helpers
             GetCIELABColorFromCIEXYZ(double x, double y, double z)
         {
             // These values are based on the D65 Illuminant
-            x = x * 100 / 95.0470;
+            x = x * 100 / 95.0489;
             y = y * 100 / 100.0;
-            z = z * 100 / 108.883;
+            z = z * 100 / 108.8840;
 
             // XYZ to L*a*b* transformation
             double fx = (x > .008856) ? Math.Pow(x, 1.0 / 3.0) : (x * 7.787) + (16.0 / 116.0);

--- a/src/modules/colorPicker/ColorPickerUI/Helpers/ColorRepresentationHelper.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/ColorRepresentationHelper.cs
@@ -44,6 +44,7 @@ namespace ColorPicker.Helpers
                 ColorRepresentationType.HWB => ColorToHWB(color),
                 ColorRepresentationType.NCol => ColorToNCol(color),
                 ColorRepresentationType.RGB => ColorToRGB(color),
+                ColorRepresentationType.CIELAB => ColorToCIELAB(color),
 
                 // Fall-back value, when "_userSettings.CopiedColorRepresentation.Value" is incorrect
                 _ => ColorToHex(color),
@@ -191,11 +192,28 @@ namespace ColorPicker.Helpers
         /// <summary>
         /// Return a <see cref="string"/> representation of a RGB color
         /// </summary>
-        /// <param name="color">The see cref="Color"/> for the RGB color presentation</param>
+        /// <param name="color">The <see cref="Color"/> for the RGB color presentation</param>
         /// <returns>A <see cref="string"/> representation of a RGB color</returns>
         private static string ColorToRGB(Color color)
             => $"rgb({color.R.ToString(CultureInfo.InvariantCulture)}"
              + $", {color.G.ToString(CultureInfo.InvariantCulture)}"
              + $", {color.B.ToString(CultureInfo.InvariantCulture)})";
+
+        /// <summary>
+        /// Returns a <see cref="string"/> representation of a CIE LAB color
+        /// </summary>
+        /// <param name="color">The <see cref="Color"/> for the CIE LAB color presentation</param>
+        /// <returns>A <see cref="string"/> representation of a CIE LAB color</returns>
+        private static string ColorToCIELAB(Color color)
+        {
+            var (lightness, chromaticityA, chromaticityB) = ColorHelper.ConvertToCIELABColor(color);
+            lightness = Math.Round(lightness);
+            chromaticityA = Math.Round(chromaticityA);
+            chromaticityB = Math.Round(chromaticityB);
+
+            return $"L*a*b*({lightness.ToString(CultureInfo.InvariantCulture)}" +
+                   $", {chromaticityA.ToString(CultureInfo.InvariantCulture)}" +
+                   $", {chromaticityB.ToString(CultureInfo.InvariantCulture)})";
+        }
     }
 }

--- a/src/modules/colorPicker/ColorPickerUI/Helpers/ColorRepresentationHelper.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/ColorRepresentationHelper.cs
@@ -212,7 +212,7 @@ namespace ColorPicker.Helpers
             chromaticityA = Math.Round(chromaticityA);
             chromaticityB = Math.Round(chromaticityB);
 
-            return $"L*a*b*({lightness.ToString(CultureInfo.InvariantCulture)}" +
+            return $"CIELab({lightness.ToString(CultureInfo.InvariantCulture)}" +
                    $", {chromaticityA.ToString(CultureInfo.InvariantCulture)}" +
                    $", {chromaticityB.ToString(CultureInfo.InvariantCulture)})";
         }

--- a/src/modules/colorPicker/ColorPickerUI/Helpers/ColorRepresentationHelper.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/ColorRepresentationHelper.cs
@@ -208,9 +208,9 @@ namespace ColorPicker.Helpers
         private static string ColorToCIELAB(Color color)
         {
             var (lightness, chromaticityA, chromaticityB) = ColorHelper.ConvertToCIELABColor(color);
-            lightness = Math.Round(lightness);
-            chromaticityA = Math.Round(chromaticityA);
-            chromaticityB = Math.Round(chromaticityB);
+            lightness = Math.Round(lightness, 2);
+            chromaticityA = Math.Round(chromaticityA, 2);
+            chromaticityB = Math.Round(chromaticityB, 2);
 
             return $"CIELab({lightness.ToString(CultureInfo.InvariantCulture)}" +
                    $", {chromaticityA.ToString(CultureInfo.InvariantCulture)}" +
@@ -226,9 +226,9 @@ namespace ColorPicker.Helpers
         {
             var (x, y, z) = ColorHelper.ConvertToCIEXYZColor(color);
 
-            x = Math.Round(x * 100);
-            y = Math.Round(y * 100);
-            z = Math.Round(z * 100);
+            x = Math.Round(x * 100, 4);
+            y = Math.Round(y * 100, 4);
+            z = Math.Round(z * 100, 4);
 
             return $"xyz({x.ToString(CultureInfo.InvariantCulture)}" +
                    $", {y.ToString(CultureInfo.InvariantCulture)}" +

--- a/src/modules/colorPicker/ColorPickerUI/Helpers/ColorRepresentationHelper.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/ColorRepresentationHelper.cs
@@ -45,6 +45,7 @@ namespace ColorPicker.Helpers
                 ColorRepresentationType.NCol => ColorToNCol(color),
                 ColorRepresentationType.RGB => ColorToRGB(color),
                 ColorRepresentationType.CIELAB => ColorToCIELAB(color),
+                ColorRepresentationType.CIEXYZ => ColorToCIEXYZ(color),
 
                 // Fall-back value, when "_userSettings.CopiedColorRepresentation.Value" is incorrect
                 _ => ColorToHex(color),
@@ -214,6 +215,24 @@ namespace ColorPicker.Helpers
             return $"L*a*b*({lightness.ToString(CultureInfo.InvariantCulture)}" +
                    $", {chromaticityA.ToString(CultureInfo.InvariantCulture)}" +
                    $", {chromaticityB.ToString(CultureInfo.InvariantCulture)})";
+        }
+
+        /// <summary>
+        /// Returns a <see cref="string"/> representation of a CIE XYZ color
+        /// </summary>
+        /// <param name="color">The <see cref="Color"/> for the CIE XYZ color presentation</param>
+        /// <returns>A <see cref="string"/> representation of a CIE XYZ color</returns>
+        private static string ColorToCIEXYZ(Color color)
+        {
+            var (x, y, z) = ColorHelper.ConvertToCIEXYZColor(color);
+
+            x = Math.Round(x * 100);
+            y = Math.Round(y * 100);
+            z = Math.Round(z * 100);
+
+            return $"xyz({x.ToString(CultureInfo.InvariantCulture)}" +
+                   $", {y.ToString(CultureInfo.InvariantCulture)}" +
+                   $", {z.ToString(CultureInfo.InvariantCulture)})";
         }
     }
 }

--- a/src/modules/colorPicker/ColorPickerUI/ViewModels/ColorEditorViewModel.cs
+++ b/src/modules/colorPicker/ColorPickerUI/ViewModels/ColorEditorViewModel.cs
@@ -203,6 +203,12 @@ namespace ColorPicker.ViewModels
                     FormatName = ColorRepresentationType.CIELAB.ToString(),
                     Convert = (Color color) => { return ColorRepresentationHelper.GetStringRepresentationFromMediaColor(color, ColorRepresentationType.CIELAB); },
                 });
+            _allColorRepresentations.Add(
+                new ColorFormatModel()
+                {
+                    FormatName = ColorRepresentationType.CIEXYZ.ToString(),
+                    Convert = (Color color) => { return ColorRepresentationHelper.GetStringRepresentationFromMediaColor(color, ColorRepresentationType.CIEXYZ); },
+                });
 
             _userSettings.VisibleColorFormats.CollectionChanged += VisibleColorFormats_CollectionChanged;
 

--- a/src/modules/colorPicker/ColorPickerUI/ViewModels/ColorEditorViewModel.cs
+++ b/src/modules/colorPicker/ColorPickerUI/ViewModels/ColorEditorViewModel.cs
@@ -197,6 +197,12 @@ namespace ColorPicker.ViewModels
                     FormatName = ColorRepresentationType.NCol.ToString(),
                     Convert = (Color color) => { return ColorRepresentationHelper.GetStringRepresentationFromMediaColor(color, ColorRepresentationType.NCol); },
                 });
+            _allColorRepresentations.Add(
+                new ColorFormatModel()
+                {
+                    FormatName = ColorRepresentationType.CIELAB.ToString(),
+                    Convert = (Color color) => { return ColorRepresentationHelper.GetStringRepresentationFromMediaColor(color, ColorRepresentationType.CIELAB); },
+                });
 
             _userSettings.VisibleColorFormats.CollectionChanged += VisibleColorFormats_CollectionChanged;
 

--- a/src/modules/colorPicker/UnitTest-ColorPickerUI/Helpers/ColorConverterTest.cs
+++ b/src/modules/colorPicker/UnitTest-ColorPickerUI/Helpers/ColorConverterTest.cs
@@ -305,23 +305,22 @@ namespace Microsoft.ColorPicker.UnitTests
         }
 
         [TestMethod]
-        [DataRow("FFFFFF", 100.00, 0.01, -0.01)] // white
+        [DataRow("FFFFFF", 100.00, 0.00, -0.01)] // white
         [DataRow("808080", 53.59, 0.00, -0.01)] // gray
         [DataRow("000000", 0.00, 0.00, 0.00)] // black
         [DataRow("FF0000", 53.23, 80.11, 67.22)] // red
         [DataRow("008000", 46.23, -51.70, 49.90)] // green
-        [DataRow("80FFFF", 93.16, -35.22, -10.88)] // cyan
+        [DataRow("80FFFF", 93.16, -35.23, -10.87)] // cyan
         [DataRow("8080FF", 59.20, 33.1, -63.47)] // blue
         [DataRow("BF40BF", 50.10, 65.51, -41.49)] // magenta
         [DataRow("BFBF00", 75.04, -17.35, 76.03)] // yellow
         [DataRow("008000", 46.23, -51.70, 49.90)] // green
-        [DataRow("80FFFF", 93.16, -35.22, -10.88)] // cyan
         [DataRow("8080FF", 59.20, 33.1, -63.47)] // blue
         [DataRow("BF40BF", 50.10, 65.51, -41.49)] // magenta
         [DataRow("0048BA", 34.35, 27.94, -64.81)] // absolute zero
-        [DataRow("B0BF1A", 73.91, -23.38, 71.15)] // acid green
+        [DataRow("B0BF1A", 73.91, -23.39, 71.15)] // acid green
         [DataRow("D0FF14", 93.87, -40.21, 88.97)] // arctic lime
-        [DataRow("1B4D3E", 29.13, -20.96, 3.95)] // brunswick green
+        [DataRow("1B4D3E", 29.13, -20.97, 3.95)] // brunswick green
         [DataRow("FFEF00", 93.01, -13.86, 91.48)] // canary yellow
         [DataRow("FFA600", 75.16, 23.41, 79.11)] // cheese
         [DataRow("1A2421", 13.18, -5.23, 0.56)] // dark jungle green
@@ -332,8 +331,8 @@ namespace Microsoft.ColorPicker.UnitTests
         [DataRow("5218FA", 36.65, 75.63, -97.71)] // han purple
         [DataRow("FF496C", 59.07, 69.90, 21.79)] // infra red
         [DataRow("545AA7", 41.20, 19.32, -42.35)] // liberty
-        [DataRow("E6A8D7", 75.91, 30.14, -14.80)] // light orchid
-        [DataRow("ADDFAD", 84.32, -25.66, 19.36)] // light moss green
+        [DataRow("E6A8D7", 75.91, 30.13, -14.80)] // light orchid
+        [DataRow("ADDFAD", 84.32, -25.67, 19.36)] // light moss green
         [DataRow("E3F988", 94.25, -23.70, 51.57)] // mindaro
         public void ColorRGBtoCIELABTest(string hexValue, double lightness, double chromaticityA, double chromaticityB)
         {

--- a/src/modules/colorPicker/UnitTest-ColorPickerUI/Helpers/ColorConverterTest.cs
+++ b/src/modules/colorPicker/UnitTest-ColorPickerUI/Helpers/ColorConverterTest.cs
@@ -304,6 +304,122 @@ namespace Microsoft.ColorPicker.UnitTests
             Assert.AreEqual(result.blackness * 100d, blackness, 0.5d);
         }
 
+        // values taken from https://convertingcolors.com/named-colors.html
+        // and manual convert via https://convertingcolors.com/
+        [TestMethod]
+        [DataRow("FFFFFF", 100.00, 0.01, -0.01)] // white
+        [DataRow("808080", 53.59, 0.00, -0.01)] // gray
+        [DataRow("000000", 0.00, 0.00, 0.00)] // black
+        [DataRow("FF0000", 53.23, 80.11, 67.22)] // red
+        [DataRow("008000", 46.23, -51.70, 49.90)] // green
+        [DataRow("80FFFF", 93.16, -35.22, -10.88)] // cyan
+        [DataRow("8080FF", 59.20, 33.11, -63.47)] // blue
+        [DataRow("BF40BF", 50.10, 65.51, -41.49)] // magenta
+        [DataRow("BFBF00", 75.04, -17.35, 76.03)] // yellow
+        [DataRow("008000", 46.23, -51.70, 49.90)] // green
+        [DataRow("80FFFF", 93.16, -35.22, -10.88)] // cyan
+        [DataRow("8080FF", 59.20, 33.11, -63.47)] // blue
+        [DataRow("BF40BF", 50.10, 65.51, -41.49)] // magenta
+        [DataRow("0048BA", 34.35, 27.94, -64.81)] // absolute zero
+        [DataRow("B0BF1A", 73.91, -23.38, 71.15)] // acid green
+        [DataRow("D0FF14", 93.87, -40.20, 88.97)] // arctic lime
+        [DataRow("1B4D3E", 29.13, -20.96, 3.95)] // brunswick green
+        [DataRow("FFEF00", 93.01, -13.86, 91.48)] // canary yellow
+        [DataRow("FFA600", 75.16, 23.41, 79.10)] // cheese
+        [DataRow("1A2421", 13.18, -5.23, 0.56)] // dark jungle green
+        [DataRow("003399", 25.77, 28.89, -59.10)] // dark powder blue
+        [DataRow("D70A53", 46.03, 71.91, 18.02)] // debian red
+        [DataRow("80FFD5", 92.09, -45.08, 9.28)] // fathom secret green
+        [DataRow("EFDFBB", 89.26, -0.13, 19.64)] // dutch white
+        [DataRow("5218FA", 36.65, 75.63, -97.71)] // han purple
+        [DataRow("FF496C", 59.07, 69.90, 21.79)] // infra red
+        [DataRow("545AA7", 41.20, 19.32, -42.35)] // liberty
+        [DataRow("E6A8D7", 75.91, 30.14, -14.80)] // light orchid
+        [DataRow("ADDFAD", 84.32, -25.66, 19.36)] // light moss green
+        [DataRow("E3F988", 94.25, -23.70, 51.57)] // mindaro
+        public void ColorRGBtoCIELABTest(string hexValue, double lightness, double chromaticityA, double chromaticityB)
+        {
+            if (string.IsNullOrWhiteSpace(hexValue))
+            {
+                Assert.IsNotNull(hexValue);
+            }
+
+            Assert.IsTrue(hexValue.Length >= 6);
+
+            var red = int.Parse(hexValue.Substring(0, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+            var green = int.Parse(hexValue.Substring(2, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+            var blue = int.Parse(hexValue.Substring(4, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+
+            var color = Color.FromArgb(255, red, green, blue);
+            var result = ColorHelper.ConvertToCIELABColor(color);
+
+            // lightness[0..100]
+            Assert.AreEqual(Math.Round(result.lightness, 2), lightness);
+
+            // chromaticityA[-128..127]
+            Assert.AreEqual(Math.Round(result.chromaticityA, 2), chromaticityA);
+
+            // chromaticityB[-128..127]
+            Assert.AreEqual(Math.Round(result.chromaticityB, 2), chromaticityB);
+        }
+
+        [TestMethod]
+        [DataRow("FFFFFF", 95.0500, 100.0000, 108.9000)] // white
+        [DataRow("808080", 20.5175, 21.5861, 23.5072)] // gray
+        [DataRow("000000", 0.0000, 0.0000, 0.0000)] // black
+        [DataRow("FF0000", 41.2400, 21.2600, 1.9300)] // red
+        [DataRow("008000", 7.7192, 15.4383, 2.5731)] // green
+        [DataRow("80FFFF", 62.7121, 83.3292, 107.3866)] // cyan
+        [DataRow("8080FF", 34.6713, 27.2475, 98.0397)] // blue
+        [DataRow("BF40BF", 32.7232, 18.5047, 51.1373)] // magenta
+        [DataRow("BFBF00", 40.1167, 48.3380, 7.2158)] // yellow
+        [DataRow("008000", 7.7192, 15.4383, 2.5731)] // green
+        [DataRow("80FFFF", 62.7121, 83.3292, 107.3866)] // cyan
+        [DataRow("8080FF", 34.6713, 27.2475, 98.0397)] // blue
+        [DataRow("BF40BF", 32.7232, 18.5047, 51.1373)] // magenta
+        [DataRow("0048BA", 11.1803, 8.1799, 47.4440)] // absolute zero
+        [DataRow("B0BF1A", 36.7218, 46.5663, 8.0300)] // acid green
+        [DataRow("D0FF14", 61.8987, 84.9804, 13.8023)] // arctic lime
+        [DataRow("1B4D3E", 3.9754, 5.8886, 5.4845)] // brunswick green
+        [DataRow("FFEF00", 72.1065, 82.9930, 12.2188)] // canary yellow
+        [DataRow("FFA600", 54.8762, 48.5324, 6.4754)] // cheese
+        [DataRow("1A2421", 1.3314, 1.5912, 1.6758)] // dark jungle green
+        [DataRow("003399", 6.9336, 4.6676, 30.6725)] // dark powder blue
+        [DataRow("D70A53", 29.6942, 15.2887, 9.5696)] // debian red
+        [DataRow("80FFD5", 56.6723, 80.9133, 75.5817)] // fathom secret green
+        [DataRow("EFDFBB", 70.9539, 74.7139, 57.6953)] // dutch white
+        [DataRow("5218FA", 21.0616, 9.3492, 91.1370)] // han purple
+        [DataRow("FF496C", 46.3293, 27.1078, 16.9779)] // infra red
+        [DataRow("545AA7", 14.2874, 11.9872, 38.1199)] // liberty
+        [DataRow("E6A8D7", 58.9015, 49.7346, 70.7853)] // light orchid
+        [DataRow("ADDFAD", 51.1641, 64.6767, 49.3224)] // light moss green
+        [DataRow("E3F988", 69.9982, 85.8598, 36.1759)] // mindaro
+        public void ColorRGBtoCIEXYZTest(string hexValue, double x, double y, double z)
+        {
+            if (string.IsNullOrWhiteSpace(hexValue))
+            {
+                Assert.IsNotNull(hexValue);
+            }
+
+            Assert.IsTrue(hexValue.Length >= 6);
+
+            var red = int.Parse(hexValue.Substring(0, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+            var green = int.Parse(hexValue.Substring(2, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+            var blue = int.Parse(hexValue.Substring(4, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+
+            var color = Color.FromArgb(255, red, green, blue);
+            var result = ColorHelper.ConvertToCIEXYZColor(color);
+
+            // x[0..1]
+            Assert.AreEqual(Math.Round(result.x * 100, 4), x);
+
+            // y[0..1]
+            Assert.AreEqual(Math.Round(result.y * 100, 4), y);
+
+            // z[0..1]
+            Assert.AreEqual(Math.Round(result.z * 100, 4), z);
+        }
+
         [TestMethod]
         public void ColorRGBtoCMYKZeroDivTest()
         {

--- a/src/modules/colorPicker/UnitTest-ColorPickerUI/Helpers/ColorConverterTest.cs
+++ b/src/modules/colorPicker/UnitTest-ColorPickerUI/Helpers/ColorConverterTest.cs
@@ -304,8 +304,6 @@ namespace Microsoft.ColorPicker.UnitTests
             Assert.AreEqual(result.blackness * 100d, blackness, 0.5d);
         }
 
-        // values taken from https://convertingcolors.com/named-colors.html
-        // and manual convert via https://convertingcolors.com/
         [TestMethod]
         [DataRow("FFFFFF", 100.00, 0.01, -0.01)] // white
         [DataRow("808080", 53.59, 0.00, -0.01)] // gray

--- a/src/modules/colorPicker/UnitTest-ColorPickerUI/Helpers/ColorConverterTest.cs
+++ b/src/modules/colorPicker/UnitTest-ColorPickerUI/Helpers/ColorConverterTest.cs
@@ -408,13 +408,13 @@ namespace Microsoft.ColorPicker.UnitTests
             var color = Color.FromArgb(255, red, green, blue);
             var result = ColorHelper.ConvertToCIEXYZColor(color);
 
-            // x[0..1]
+            // x[0..0.95047]
             Assert.AreEqual(Math.Round(result.x * 100, 4), x);
 
             // y[0..1]
             Assert.AreEqual(Math.Round(result.y * 100, 4), y);
 
-            // z[0..1]
+            // z[0..1.08883]
             Assert.AreEqual(Math.Round(result.z * 100, 4), z);
         }
 

--- a/src/modules/colorPicker/UnitTest-ColorPickerUI/Helpers/ColorConverterTest.cs
+++ b/src/modules/colorPicker/UnitTest-ColorPickerUI/Helpers/ColorConverterTest.cs
@@ -311,19 +311,19 @@ namespace Microsoft.ColorPicker.UnitTests
         [DataRow("FF0000", 53.23, 80.11, 67.22)] // red
         [DataRow("008000", 46.23, -51.70, 49.90)] // green
         [DataRow("80FFFF", 93.16, -35.22, -10.88)] // cyan
-        [DataRow("8080FF", 59.20, 33.11, -63.47)] // blue
+        [DataRow("8080FF", 59.20, 33.1, -63.47)] // blue
         [DataRow("BF40BF", 50.10, 65.51, -41.49)] // magenta
         [DataRow("BFBF00", 75.04, -17.35, 76.03)] // yellow
         [DataRow("008000", 46.23, -51.70, 49.90)] // green
         [DataRow("80FFFF", 93.16, -35.22, -10.88)] // cyan
-        [DataRow("8080FF", 59.20, 33.11, -63.47)] // blue
+        [DataRow("8080FF", 59.20, 33.1, -63.47)] // blue
         [DataRow("BF40BF", 50.10, 65.51, -41.49)] // magenta
         [DataRow("0048BA", 34.35, 27.94, -64.81)] // absolute zero
         [DataRow("B0BF1A", 73.91, -23.38, 71.15)] // acid green
-        [DataRow("D0FF14", 93.87, -40.20, 88.97)] // arctic lime
+        [DataRow("D0FF14", 93.87, -40.21, 88.97)] // arctic lime
         [DataRow("1B4D3E", 29.13, -20.96, 3.95)] // brunswick green
         [DataRow("FFEF00", 93.01, -13.86, 91.48)] // canary yellow
-        [DataRow("FFA600", 75.16, 23.41, 79.10)] // cheese
+        [DataRow("FFA600", 75.16, 23.41, 79.11)] // cheese
         [DataRow("1A2421", 13.18, -5.23, 0.56)] // dark jungle green
         [DataRow("003399", 25.77, 28.89, -59.10)] // dark powder blue
         [DataRow("D70A53", 46.03, 71.91, 18.02)] // debian red

--- a/src/modules/colorPicker/UnitTest-ColorPickerUI/Helpers/ColorRepresentationHelperTest.cs
+++ b/src/modules/colorPicker/UnitTest-ColorPickerUI/Helpers/ColorRepresentationHelperTest.cs
@@ -23,6 +23,7 @@ namespace Microsoft.ColorPicker.UnitTests
         [DataRow(ColorRepresentationType.HWB, "hwb(0, 0%, 100%)")]
         [DataRow(ColorRepresentationType.RGB, "rgb(0, 0, 0)")]
         [DataRow(ColorRepresentationType.CIELAB, "L*a*b*(0, 0, 0)")]
+        [DataRow(ColorRepresentationType.CIEXYZ, "xyz(0, 0, 0)")]
 
         public void GetStringRepresentationTest(ColorRepresentationType type, string expected)
         {

--- a/src/modules/colorPicker/UnitTest-ColorPickerUI/Helpers/ColorRepresentationHelperTest.cs
+++ b/src/modules/colorPicker/UnitTest-ColorPickerUI/Helpers/ColorRepresentationHelperTest.cs
@@ -22,7 +22,7 @@ namespace Microsoft.ColorPicker.UnitTests
         [DataRow(ColorRepresentationType.HSV, "hsv(0, 0%, 0%)")]
         [DataRow(ColorRepresentationType.HWB, "hwb(0, 0%, 100%)")]
         [DataRow(ColorRepresentationType.RGB, "rgb(0, 0, 0)")]
-        [DataRow(ColorRepresentationType.CIELAB, "L*a*b*(0, 0, 0)")]
+        [DataRow(ColorRepresentationType.CIELAB, "CIELab(0, 0, 0)")]
         [DataRow(ColorRepresentationType.CIEXYZ, "xyz(0, 0, 0)")]
 
         public void GetStringRepresentationTest(ColorRepresentationType type, string expected)

--- a/src/modules/colorPicker/UnitTest-ColorPickerUI/Helpers/ColorRepresentationHelperTest.cs
+++ b/src/modules/colorPicker/UnitTest-ColorPickerUI/Helpers/ColorRepresentationHelperTest.cs
@@ -22,6 +22,7 @@ namespace Microsoft.ColorPicker.UnitTests
         [DataRow(ColorRepresentationType.HSV, "hsv(0, 0%, 0%)")]
         [DataRow(ColorRepresentationType.HWB, "hwb(0, 0%, 100%)")]
         [DataRow(ColorRepresentationType.RGB, "rgb(0, 0, 0)")]
+        [DataRow(ColorRepresentationType.CIELAB, "L*a*b*(0, 0, 0)")]
 
         public void GetStringRepresentationTest(ColorRepresentationType type, string expected)
         {

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/Enumerations/ColorRepresentationType.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/Enumerations/ColorRepresentationType.cs
@@ -60,5 +60,10 @@ namespace Microsoft.PowerToys.Settings.UI.Library.Enumerations
         /// Color presentation as CIELAB color space, also referred to as L*a*b* (L[0..100], A[-128..127], B[-128..127])
         /// </summary>
         CIELAB = 9,
+
+        /// <summary>
+        /// Color presentation as CIEXYZ color space (X[0..100], Y[0..100], Z[0..100]
+        /// </summary>
+        CIEXYZ = 10,
     }
 }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/Enumerations/ColorRepresentationType.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/Enumerations/ColorRepresentationType.cs
@@ -55,5 +55,10 @@ namespace Microsoft.PowerToys.Settings.UI.Library.Enumerations
         /// Color presentation as natural color (hue, whiteness[0%..100%], blackness[0%..100%])
         /// </summary>
         NCol = 8,
+
+        /// <summary>
+        /// Color presentation as CIELAB color space, also referred to as L*a*b* (L[0..100], A[-128..127], B[-128..127])
+        /// </summary>
+        CIELAB = 9,
     }
 }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/Enumerations/ColorRepresentationType.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/Enumerations/ColorRepresentationType.cs
@@ -57,7 +57,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.Enumerations
         NCol = 8,
 
         /// <summary>
-        /// Color presentation as CIELAB color space, also referred to as L*a*b* (L[0..100], A[-128..127], B[-128..127])
+        /// Color presentation as CIELAB color space, also referred to as CIELAB(L[0..100], A[-128..127], B[-128..127])
         /// </summary>
         CIELAB = 9,
 

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/Enumerations/ColorRepresentationType.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/Enumerations/ColorRepresentationType.cs
@@ -62,7 +62,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.Enumerations
         CIELAB = 9,
 
         /// <summary>
-        /// Color presentation as CIEXYZ color space (X[0..100], Y[0..100], Z[0..100]
+        /// Color presentation as CIEXYZ color space (X[0..95], Y[0..100], Z[0..109]
         /// </summary>
         CIEXYZ = 10,
     }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/ColorPickerViewModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/ColorPickerViewModel.cs
@@ -53,6 +53,8 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
                 { ColorRepresentationType.HWB,  "HWB - hwb(100, 50%, 75%)" },
                 { ColorRepresentationType.NCol, "NCol - R10, 50%, 75%" },
                 { ColorRepresentationType.RGB,  "RGB - rgb(100, 50, 75)" },
+                { ColorRepresentationType.CIELAB, "CIE LAB - L*a*b*(76, 21, 80)" },
+                { ColorRepresentationType.CIEXYZ, "CIE XYZ - xyz(56, 50, 7)" },
             };
 
             GeneralSettingsConfig = settingsRepository.SettingsConfig;
@@ -219,6 +221,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             var hwbFormatName = ColorRepresentationType.HWB.ToString();
             var ncolFormatName = ColorRepresentationType.NCol.ToString();
             var cielabFormatName = ColorRepresentationType.CIELAB.ToString();
+            var ciexyzFormatName = ColorRepresentationType.CIEXYZ.ToString();
 
             formatsUnordered.Add(new ColorFormatModel(hexFormatName, "#EF68FF", visibleFormats.ContainsKey(hexFormatName) && visibleFormats[hexFormatName]));
             formatsUnordered.Add(new ColorFormatModel(rgbFormatName, "rgb(239, 104, 255)", visibleFormats.ContainsKey(rgbFormatName) && visibleFormats[rgbFormatName]));
@@ -230,6 +233,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             formatsUnordered.Add(new ColorFormatModel(hwbFormatName, "hwb(100, 50%, 75%)", visibleFormats.ContainsKey(hwbFormatName) && visibleFormats[hwbFormatName]));
             formatsUnordered.Add(new ColorFormatModel(ncolFormatName, "R10, 50%, 75%", visibleFormats.ContainsKey(ncolFormatName) && visibleFormats[ncolFormatName]));
             formatsUnordered.Add(new ColorFormatModel(cielabFormatName, "L*a*b*(66, 72, -52)", visibleFormats.ContainsKey(cielabFormatName) && visibleFormats[cielabFormatName]));
+            formatsUnordered.Add(new ColorFormatModel(ciexyzFormatName, "xyz(59, 35, 98)", visibleFormats.ContainsKey(ciexyzFormatName) && visibleFormats[ciexyzFormatName]));
 
             foreach (var storedColorFormat in _colorPickerSettings.Properties.VisibleColorFormats)
             {

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/ColorPickerViewModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/ColorPickerViewModel.cs
@@ -218,6 +218,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             var hsiFormatName = ColorRepresentationType.HSI.ToString();
             var hwbFormatName = ColorRepresentationType.HWB.ToString();
             var ncolFormatName = ColorRepresentationType.NCol.ToString();
+            var cielabFormatName = ColorRepresentationType.CIELAB.ToString();
 
             formatsUnordered.Add(new ColorFormatModel(hexFormatName, "#EF68FF", visibleFormats.ContainsKey(hexFormatName) && visibleFormats[hexFormatName]));
             formatsUnordered.Add(new ColorFormatModel(rgbFormatName, "rgb(239, 104, 255)", visibleFormats.ContainsKey(rgbFormatName) && visibleFormats[rgbFormatName]));
@@ -228,6 +229,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             formatsUnordered.Add(new ColorFormatModel(hsiFormatName, "hsi(100, 50%, 75%)", visibleFormats.ContainsKey(hsiFormatName) && visibleFormats[hsiFormatName]));
             formatsUnordered.Add(new ColorFormatModel(hwbFormatName, "hwb(100, 50%, 75%)", visibleFormats.ContainsKey(hwbFormatName) && visibleFormats[hwbFormatName]));
             formatsUnordered.Add(new ColorFormatModel(ncolFormatName, "R10, 50%, 75%", visibleFormats.ContainsKey(ncolFormatName) && visibleFormats[ncolFormatName]));
+            formatsUnordered.Add(new ColorFormatModel(cielabFormatName, "66, 72, -52", visibleFormats.ContainsKey(cielabFormatName) && visibleFormats[cielabFormatName]));
 
             foreach (var storedColorFormat in _colorPickerSettings.Properties.VisibleColorFormats)
             {

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/ColorPickerViewModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/ColorPickerViewModel.cs
@@ -229,7 +229,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             formatsUnordered.Add(new ColorFormatModel(hsiFormatName, "hsi(100, 50%, 75%)", visibleFormats.ContainsKey(hsiFormatName) && visibleFormats[hsiFormatName]));
             formatsUnordered.Add(new ColorFormatModel(hwbFormatName, "hwb(100, 50%, 75%)", visibleFormats.ContainsKey(hwbFormatName) && visibleFormats[hwbFormatName]));
             formatsUnordered.Add(new ColorFormatModel(ncolFormatName, "R10, 50%, 75%", visibleFormats.ContainsKey(ncolFormatName) && visibleFormats[ncolFormatName]));
-            formatsUnordered.Add(new ColorFormatModel(cielabFormatName, "66, 72, -52", visibleFormats.ContainsKey(cielabFormatName) && visibleFormats[cielabFormatName]));
+            formatsUnordered.Add(new ColorFormatModel(cielabFormatName, "L*a*b*(66, 72, -52)", visibleFormats.ContainsKey(cielabFormatName) && visibleFormats[cielabFormatName]));
 
             foreach (var storedColorFormat in _colorPickerSettings.Properties.VisibleColorFormats)
             {

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/ColorPickerViewModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/ColorPickerViewModel.cs
@@ -53,7 +53,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
                 { ColorRepresentationType.HWB,  "HWB - hwb(100, 50%, 75%)" },
                 { ColorRepresentationType.NCol, "NCol - R10, 50%, 75%" },
                 { ColorRepresentationType.RGB,  "RGB - rgb(100, 50, 75)" },
-                { ColorRepresentationType.CIELAB, "CIE LAB - L*a*b*(76, 21, 80)" },
+                { ColorRepresentationType.CIELAB, "CIE LAB - CIELab(76, 21, 80)" },
                 { ColorRepresentationType.CIEXYZ, "CIE XYZ - xyz(56, 50, 7)" },
             };
 
@@ -232,7 +232,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             formatsUnordered.Add(new ColorFormatModel(hsiFormatName, "hsi(100, 50%, 75%)", visibleFormats.ContainsKey(hsiFormatName) && visibleFormats[hsiFormatName]));
             formatsUnordered.Add(new ColorFormatModel(hwbFormatName, "hwb(100, 50%, 75%)", visibleFormats.ContainsKey(hwbFormatName) && visibleFormats[hwbFormatName]));
             formatsUnordered.Add(new ColorFormatModel(ncolFormatName, "R10, 50%, 75%", visibleFormats.ContainsKey(ncolFormatName) && visibleFormats[ncolFormatName]));
-            formatsUnordered.Add(new ColorFormatModel(cielabFormatName, "L*a*b*(66, 72, -52)", visibleFormats.ContainsKey(cielabFormatName) && visibleFormats[cielabFormatName]));
+            formatsUnordered.Add(new ColorFormatModel(cielabFormatName, "CIELab(66, 72, -52)", visibleFormats.ContainsKey(cielabFormatName) && visibleFormats[cielabFormatName]));
             formatsUnordered.Add(new ColorFormatModel(ciexyzFormatName, "xyz(59, 35, 98)", visibleFormats.ContainsKey(ciexyzFormatName) && visibleFormats[ciexyzFormatName]));
 
             foreach (var storedColorFormat in _colorPickerSettings.Properties.VisibleColorFormats)


### PR DESCRIPTION
## Summary of the Pull Request

Added CIE LAB and CIE XYZ color space to the Color Picker.

**What is include in the PR:** 

This pull request adds the CIE LAB color space, also referred to as L* a* b* and the CIE XYZ color space to the Color Picker.  To calculate the CIELAB space from RGB, a conversion from RGB to CIEXYZ had to be made, this conversion is also included in this pull request.

**How does someone test / validate:** 

Open Color Picker, and validate that the CIE LAB and CIE XYZ color space are visible, if these color spaces are enabled via the settings.
![afbeelding](https://user-images.githubusercontent.com/55654104/131226692-f87d825f-a218-4ea5-959c-be5af1a6876e.png)
![afbeelding](https://user-images.githubusercontent.com/55654104/131173169-a8ce049a-4e0b-4b4b-8306-341c31377b08.png)

Validate that the output of the color is correct (use online available color conversion websites if you don't have any tool available)

## Quality Checklist

- [x] **Linked issue:** #11536 #12937
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [x] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA. ✅ 
