### PR TITLE
Fixing the issue with HEX textbox not being updated with the correct RGB values

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -1445,6 +1445,7 @@ nuget
 null
 nullopt
 nullptr
+numberbox
 NUMLOCK
 NUMPAD
 nunit

--- a/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml
+++ b/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml
@@ -398,7 +398,7 @@
                                                   Width="72"
                                                   ui:ControlHelper.CornerRadius="2,0,0,2"
                                                   AutomationProperties.Name="{x:Static p:Resources.Red_value}"
-                                                  ValueChanged="RGBNumberBox_ValueChanged"
+                                                  TextBoxBase.TextChanged="RGBNumberBox_TextChanged"
                                                   Minimum="0"
                                                   Maximum="255" />
 
@@ -408,7 +408,7 @@
                                                   Width="72"
                                                   ui:ControlHelper.CornerRadius="0"
                                                   AutomationProperties.Name="{x:Static p:Resources.Green_value}"
-                                                  ValueChanged="RGBNumberBox_ValueChanged"
+                                                  TextBoxBase.TextChanged="RGBNumberBox_TextChanged"
                                                   Minimum="0"
                                                   Maximum="255" />
 
@@ -418,7 +418,7 @@
                                                   Margin="-1,0,0,0"
                                                   ui:ControlHelper.CornerRadius="0,2,2,0"
                                                   AutomationProperties.Name="{x:Static p:Resources.Blue_value}"
-                                                  ValueChanged="RGBNumberBox_ValueChanged"
+                                                  TextBoxBase.TextChanged="RGBNumberBox_TextChanged"
                                                   Minimum="0"
                                                   Maximum="255" />
                                 </StackPanel>

--- a/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml.cs
@@ -297,22 +297,6 @@ namespace ColorPicker.Controls
             _ignoreGradientsChanges = false;
         }
 
-        private static Point GetMousePositionWithinGrid(Border border)
-        {
-            var pos = System.Windows.Input.Mouse.GetPosition(border);
-            if (pos.X < 0)
-            {
-                pos.X = 0;
-            }
-
-            if (pos.X > border.Width)
-            {
-                pos.X = border.Width;
-            }
-
-            return pos;
-        }
-
         private void HexCode_TextChanged(object sender, TextChangedEventArgs e)
         {
             var newValue = (sender as TextBox).Text;
@@ -342,9 +326,9 @@ namespace ColorPicker.Controls
         {
             if (!_ignoreRGBChanges)
             {
-                var r = byte.Parse(RNumberBox.Text, CultureInfo.InvariantCulture);
-                var g = byte.Parse(GNumberBox.Text, CultureInfo.InvariantCulture);
-                var b = byte.Parse(BNumberBox.Text, CultureInfo.InvariantCulture);
+                var r = (byte)RNumberBox.Value;
+                var g = (byte)GNumberBox.Value;
+                var b = (byte)BNumberBox.Value;
                 _ignoreRGBChanges = true;
                 SetColorFromTextBoxes(System.Drawing.Color.FromArgb(r, g, b));
                 _ignoreRGBChanges = false;


### PR DESCRIPTION
 ## Summary of the Pull Request

**What is this about:**
When changing values in the RGB boxes, previous value was being used to calculate HEX color (and other representations), not the current one
Also fixing the issue when current color was changed only when pressed enter of textbox lost focus.

ModernWPF numberBox is not exposing events immediately when a value changes, I have added some code that goes into its internals and grab the actual value (with validating it properly)  

**What is include in the PR:** 
See above

**How does someone test / validate:** 
Manual check
![RGBTextBoxesFixes](https://user-images.githubusercontent.com/11967522/131223992-05d2133c-fc2b-490e-bc62-e8a54b28094b.gif)


## Quality Checklist

- [x] **Linked issue:** #12931 #11108
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
