### PR TITLE
[ImageResizer] Handling malformed JSON

### DIFF
--- a/src/modules/imageresizer/ui/Properties/Settings.cs
+++ b/src/modules/imageresizer/ui/Properties/Settings.cs
@@ -408,7 +408,14 @@ namespace ImageResizer.Properties
             }
 
             string jsonData = _fileSystem.File.ReadAllText(SettingsPath);
-            Settings jsonSettings = JsonSerializer.Deserialize<SettingsWrapper>(jsonData)?.Properties;
+            var jsonSettings = new Settings();
+            try
+            {
+                jsonSettings = JsonSerializer.Deserialize<SettingsWrapper>(jsonData)?.Properties;
+            }
+            catch (JsonException)
+            {
+            }
 
             // Needs to be called on the App UI thread as the properties are bound to the UI.
             App.Current.Dispatcher.Invoke(() =>


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Make ImageResizer starting with malformed settings JSON.

**What is include in the PR:** 
If `%LOCALAPPDATA%\Microsoft\PowerToys\ImageResizer\settings.json` is not properly formatted, ImageResizer UI will be started with default settings instead of crashing.

**How does someone test / validate:** 
- Add a mistake to `%LOCALAPPDATA%\Microsoft\PowerToys\ImageResizer\settings.json`
- ImageResizer UI will be started with default settings

## Quality Checklist

- [x] **Linked issue:** #2280
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
