### PR TITLE
Add toggle for file content search in Windows Search plugin

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Main.cs
@@ -2,6 +2,8 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+// TODO Add the toggle for Windows Search file content search
+
 using System;
 using System.Collections.Generic;
 using System.Globalization;


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:** Adding a toggle for enabling file content search in the Windows Search plugin for PowerToys Run.

**What is included in the PR:** Functionality and GUI changes to the Windows Search plugin.

**How does someone test / validate:**
1. Set up Windows Search to index the contents of files.
2. Set up *.txt, *.docx, *.pptx and *.pdf files containing strings different from the files' names.
3. Enable PowerToys Run, its Windows Search plugin and turn on file content search in the plugin.
4. Search for the strings from step 2 through PowerToys Run and verify that correct corresponding files appear in the results.

## Quality Checklist

- [ ] **Linked issue:** #12940
- [ ] **Communication:** I am still discussing this with the core contributors in the issue
- [ ] **Tests:** Not tested yet
- [ ] **Installer:** Not completed yet
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Not written yet
- [ ] **Binaries:** Any new files added to WXS / YML
   - [ ] No new binaries yet
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
The CLA was signed [here](https://cla.opensource.microsoft.com/microsoft/PowerToys).