### PR TITLE
[Bug Report Tool] Zip folder can not be created

### DIFF
--- a/tools/BugReportTool/BugReportTool/Main.cpp
+++ b/tools/BugReportTool/BugReportTool/Main.cpp
@@ -299,7 +299,9 @@ int wmain(int argc, wchar_t* argv[], wchar_t*)
         return 1;
     }
 
+#ifndef _DEBUG
     InstallationFolder::ReportStructure(reportDir);
+#endif
 
     // Hide sensitive information
     HideUserPrivateInfo(reportDir);
@@ -329,10 +331,6 @@ int wmain(int argc, wchar_t* argv[], wchar_t*)
 
     // Zip folder
     auto zipPath = path::path(saveZipPath);
-    std::string reportFilename{"PowerToysReport_"};
-    reportFilename += timeutil::format_as_local("%F-%H-%M-%S", timeutil::now());
-    reportFilename += ".zip";
-    zipPath /= reportFilename;
 
     try
     {

--- a/tools/BugReportTool/BugReportTool/ZipTools/zipfolder.cpp
+++ b/tools/BugReportTool/BugReportTool/ZipTools/zipfolder.cpp
@@ -1,9 +1,17 @@
 #include "ZipFolder.h"
 #include "..\..\..\..\deps\cziplib\src\zip.h"
+#include <common/utils/timeutil.h>
 
 void ZipFolder(std::filesystem::path zipPath, std::filesystem::path folderPath)
 {
-    struct zip_t* zip = zip_open(zipPath.string().c_str(), ZIP_DEFAULT_COMPRESSION_LEVEL, 'w');
+    std::string reportFilename{ "PowerToysReport_" };
+    reportFilename += timeutil::format_as_local("%F-%H-%M-%S", timeutil::now());
+    reportFilename += ".zip";
+
+    auto tmpZipPath = std::filesystem::temp_directory_path();
+    tmpZipPath /= reportFilename;
+
+    struct zip_t* zip = zip_open(tmpZipPath.string().c_str(), ZIP_DEFAULT_COMPRESSION_LEVEL, 'w');
     if (!zip)
     {
         printf("Can not open zip.");
@@ -25,4 +33,11 @@ void ZipFolder(std::filesystem::path zipPath, std::filesystem::path folderPath)
     }
 
     zip_close(zip);
+    std::filesystem::copy(tmpZipPath, zipPath);
+    std::error_code err;
+    std::filesystem::remove_all(tmpZipPath, err);
+    if (err.value() != 0)
+    {
+        wprintf_s(L"Failed to delete %s. Error code: %d\n", tmpZipPath.c_str(), err.value());
+    }
 }

--- a/tools/BugReportTool/BugReportTool/ZipTools/zipfolder.cpp
+++ b/tools/BugReportTool/BugReportTool/ZipTools/zipfolder.cpp
@@ -14,6 +14,8 @@ void ZipFolder(std::filesystem::path zipPath, std::filesystem::path folderPath)
     struct zip_t* zip = zip_open(tmpZipPath.string().c_str(), ZIP_DEFAULT_COMPRESSION_LEVEL, 'w');
     if (!zip)
     {
+        printf(tmpZipPath.string().c_str());
+        printf("\n");
         printf("Can not open zip.");
         throw -1;
     }

--- a/tools/BugReportTool/BugReportTool/ZipTools/zipfolder.cpp
+++ b/tools/BugReportTool/BugReportTool/ZipTools/zipfolder.cpp
@@ -33,8 +33,15 @@ void ZipFolder(std::filesystem::path zipPath, std::filesystem::path folderPath)
     }
 
     zip_close(zip);
-    std::filesystem::copy(tmpZipPath, zipPath);
+
     std::error_code err;
+    std::filesystem::copy(tmpZipPath, zipPath, err);
+    if (err.value() != 0)
+    {
+        wprintf_s(L"Failed to copy %s. Error code: %d\n", tmpZipPath.c_str(), err.value());
+    }
+
+    err = {};
     std::filesystem::remove_all(tmpZipPath, err);
     if (err.value() != 0)
     {

--- a/tools/BugReportTool/BugReportTool/ZipTools/zipfolder.cpp
+++ b/tools/BugReportTool/BugReportTool/ZipTools/zipfolder.cpp
@@ -14,8 +14,6 @@ void ZipFolder(std::filesystem::path zipPath, std::filesystem::path folderPath)
     struct zip_t* zip = zip_open(tmpZipPath.string().c_str(), ZIP_DEFAULT_COMPRESSION_LEVEL, 'w');
     if (!zip)
     {
-        printf(tmpZipPath.string().c_str());
-        printf("\n");
         printf("Can not open zip.");
         throw -1;
     }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
For some users desktop path can not be represented as `char*`. On the other hand, https://github.com/kuba--/zip requires `char*` as a path for zip folder. 

To solve the issue we zip a folder into the temp folder and then copy it to the desktop.

Don't call `InstallationFolder::ReportStructure(reportDir);` in the debug mode because it takes a lot of time and makes testing in debug mode impossible. Also, updated the cziplib submodule.

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [X] **Linked issue:** #12707
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
