### PR TITLE
[Keyboard Manager]  `Alt+Tab` navigation with arrow keys i

### DIFF
--- a/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardEventHandlers.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardEventHandlers.cpp
@@ -611,6 +611,16 @@ namespace KeyboardEventHandlers
                                     Helpers::SetKeyEvent(keyEventList, i, INPUT_KEYBOARD, (WORD)to.actionKey, 0, KeyboardManagerConstants::KEYBOARDMANAGER_SHORTCUT_FLAG);
                                     newRemapping.isShortcutInvoked = true;
                                 }
+
+                                // Remember which win key was pressed initially
+                                if (ii.GetVirtualKeyState(VK_RWIN))
+                                {
+                                    newRemapping.winKeyInvoked = ModifierKey::Right;
+                                }
+                                else if (ii.GetVirtualKeyState(VK_LWIN))
+                                {
+                                    newRemapping.winKeyInvoked = ModifierKey::Left;
+                                }
                             }
                             else
                             {

--- a/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardEventHandlers.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardEventHandlers.cpp
@@ -578,47 +578,67 @@ namespace KeyboardEventHandlers
                                 ResetIfModifierKeyForLowerLevelKeyHandlers(ii, data->lParam->vkCode, std::get<Shortcut>(it->second.targetShortcut).GetActionKey());
                             }
 
+                            Shortcut origin = it->first;
+                            origin.actionKey = data->lParam->vkCode;
+
                             size_t key_count;
-                            LPINPUT keyEventList;
+                            LPINPUT keyEventList = nullptr;
+                            if (reMap.find(origin) != reMap.end())
+                            {
+                                Shortcut from = std::get<Shortcut>(it->second.targetShortcut);
+                                Shortcut to = std::get<Shortcut>(reMap[origin].targetShortcut);
+                                key_count = from.Size() - 1 + to.Size() - 1 - from.GetCommonModifiersCount(to) + 1;
+                                keyEventList = new INPUT[key_count]();
+                                memset(keyEventList, 0, sizeof(keyEventList));
 
+                                int i = 0;
+                                Helpers::SetModifierKeyEvents(from, it->second.winKeyInvoked, keyEventList, i, false, KeyboardManagerConstants::KEYBOARDMANAGER_SHORTCUT_FLAG, to);
+                                Helpers::SetModifierKeyEvents(to, it->second.winKeyInvoked, keyEventList, i, true, KeyboardManagerConstants::KEYBOARDMANAGER_SHORTCUT_FLAG, from);
+
+                                Helpers::SetKeyEvent(keyEventList, i, INPUT_KEYBOARD, (WORD)to.actionKey, 0, KeyboardManagerConstants::KEYBOARDMANAGER_SHORTCUT_FLAG);
+                                reMap[origin].isShortcutInvoked = true;
+                            }
+                            else
+                            {
                             // Key up for all new shortcut keys, key down for original shortcut modifiers and current key press but common keys aren't repeated
-                            key_count = (dest_size) + (src_size - 1) - (2 * (size_t)commonKeys);
+                                key_count = (dest_size) + (src_size - 1) - (2 * (size_t)commonKeys);
 
-                            // If the target shortcut's action key is pressed, then it should be released and original shortcut's action key should be set
-                            bool isActionKeyPressed = false;
-                            if (ii.GetVirtualKeyState((std::get<Shortcut>(it->second.targetShortcut).GetActionKey())))
-                            {
-                                isActionKeyPressed = true;
-                                key_count += 2;
-                            }
+                                // If the target shortcut's action key is pressed, then it should be released and original shortcut's action key should be set
+                                bool isActionKeyPressed = false;
+                                if (ii.GetVirtualKeyState((std::get<Shortcut>(it->second.targetShortcut).GetActionKey())))
+                                {
+                                    isActionKeyPressed = true;
+                                    key_count += 2;
+                                }
 
-                            keyEventList = new INPUT[key_count]();
-                            memset(keyEventList, 0, sizeof(keyEventList));
+                                keyEventList = new INPUT[key_count]();
+                                memset(keyEventList, 0, sizeof(keyEventList));
 
-                            // Release new shortcut state (release in reverse order of shortcut to be accurate)
-                            int i = 0;
-                            if (isActionKeyPressed)
-                            {
-                                Helpers::SetKeyEvent(keyEventList, i, INPUT_KEYBOARD, (WORD)std::get<Shortcut>(it->second.targetShortcut).GetActionKey(), KEYEVENTF_KEYUP, KeyboardManagerConstants::KEYBOARDMANAGER_SHORTCUT_FLAG);
+                                // Release new shortcut state (release in reverse order of shortcut to be accurate)
+                                int i = 0;
+                                if (isActionKeyPressed)
+                                {
+                                    Helpers::SetKeyEvent(keyEventList, i, INPUT_KEYBOARD, (WORD)std::get<Shortcut>(it->second.targetShortcut).GetActionKey(), KEYEVENTF_KEYUP, KeyboardManagerConstants::KEYBOARDMANAGER_SHORTCUT_FLAG);
+                                    i++;
+                                }
+                                Helpers::SetModifierKeyEvents(std::get<Shortcut>(it->second.targetShortcut), it->second.winKeyInvoked, keyEventList, i, false, KeyboardManagerConstants::KEYBOARDMANAGER_SHORTCUT_FLAG, it->first);
+
+                                // Set old shortcut key down state
+                                Helpers::SetModifierKeyEvents(it->first, it->second.winKeyInvoked, keyEventList, i, true, KeyboardManagerConstants::KEYBOARDMANAGER_SHORTCUT_FLAG, std::get<Shortcut>(it->second.targetShortcut));
+
+                                // key down for original shortcut action key with shortcut flag so that we don't invoke the same shortcut remap again
+                                if (isActionKeyPressed)
+                                {
+                                    Helpers::SetKeyEvent(keyEventList, i, INPUT_KEYBOARD, (WORD)it->first.GetActionKey(), 0, KeyboardManagerConstants::KEYBOARDMANAGER_SHORTCUT_FLAG);
+                                    i++;
+                                }
+
+                                // Send current key pressed without shortcut flag so that it can be reprocessed in case the physical keys pressed are a different remapped shortcut
+                                Helpers::SetKeyEvent(keyEventList, i, INPUT_KEYBOARD, (WORD)data->lParam->vkCode, 0, 0);
                                 i++;
+
+                                // Do not send a dummy key as we want the current key press to behave as normal i.e. it can do press+release functionality if required. Required to allow a shortcut to Win key remap invoked directly after shortcut to shortcut is released to open start menu
                             }
-                            Helpers::SetModifierKeyEvents(std::get<Shortcut>(it->second.targetShortcut), it->second.winKeyInvoked, keyEventList, i, false, KeyboardManagerConstants::KEYBOARDMANAGER_SHORTCUT_FLAG, it->first);
-
-                            // Set old shortcut key down state
-                            Helpers::SetModifierKeyEvents(it->first, it->second.winKeyInvoked, keyEventList, i, true, KeyboardManagerConstants::KEYBOARDMANAGER_SHORTCUT_FLAG, std::get<Shortcut>(it->second.targetShortcut));
-
-                            // key down for original shortcut action key with shortcut flag so that we don't invoke the same shortcut remap again
-                            if (isActionKeyPressed)
-                            {
-                                Helpers::SetKeyEvent(keyEventList, i, INPUT_KEYBOARD, (WORD)it->first.GetActionKey(), 0, KeyboardManagerConstants::KEYBOARDMANAGER_SHORTCUT_FLAG);
-                                i++;
-                            }
-
-                            // Send current key pressed without shortcut flag so that it can be reprocessed in case the physical keys pressed are a different remapped shortcut
-                            Helpers::SetKeyEvent(keyEventList, i, INPUT_KEYBOARD, (WORD)data->lParam->vkCode, 0, 0);
-                            i++;
-
-                            // Do not send a dummy key as we want the current key press to behave as normal i.e. it can do press+release functionality if required. Required to allow a shortcut to Win key remap invoked directly after shortcut to shortcut is released to open start menu
 
                             // Reset the remap state
                             it->second.isShortcutInvoked = false;

--- a/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardEventHandlers.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardEventHandlers.cpp
@@ -584,10 +584,10 @@ namespace KeyboardEventHandlers
                             // Check if a new remapping should be applied
                             Shortcut currentlyPressed = it->first;
                             currentlyPressed.actionKey = data->lParam->vkCode;
-                            auto newRemapingIter = reMap.find(currentlyPressed);
-                            if (newRemapingIter != reMap.end())
+                            auto newRemappingIter = reMap.find(currentlyPressed);
+                            if (newRemappingIter != reMap.end())
                             {
-                                auto& newRemapping = newRemapingIter->second;
+                                auto& newRemapping = newRemappingIter->second;
                                 Shortcut from = std::get<Shortcut>(it->second.targetShortcut);
                                 if (newRemapping.RemapToKey())
                                 {

--- a/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardEventHandlers.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardEventHandlers.cpp
@@ -600,7 +600,7 @@ namespace KeyboardEventHandlers
                                 }else
                                 {
                                     Shortcut to = std::get<Shortcut>(newRemapping.targetShortcut);
-                                    key_count = from.Size() - 1 + to.Size() - 1 - from.GetCommonModifiersCount(to) + 1;
+                                    key_count = from.Size() - 1 + to.Size() - 1 - 2* from.GetCommonModifiersCount(to) + 1;
                                     keyEventList = new INPUT[key_count]();
                                     memset(keyEventList, 0, sizeof(keyEventList));
 

--- a/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardEventHandlers.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardEventHandlers.cpp
@@ -584,9 +584,10 @@ namespace KeyboardEventHandlers
                             // Check if a new remapping should be applied
                             Shortcut currentlyPressed = it->first;
                             currentlyPressed.actionKey = data->lParam->vkCode;
-                            if (reMap.find(currentlyPressed) != reMap.end())
+                            auto newRemapingIter = reMap.find(currentlyPressed);
+                            if (newRemapingIter != reMap.end())
                             {
-                                auto& newRemapping = reMap[currentlyPressed];
+                                auto& newRemapping = newRemapingIter->second;
                                 Shortcut from = std::get<Shortcut>(it->second.targetShortcut);
                                 if (newRemapping.RemapToKey())
                                 {
@@ -602,7 +603,6 @@ namespace KeyboardEventHandlers
                                     Shortcut to = std::get<Shortcut>(newRemapping.targetShortcut);
                                     key_count = from.Size() - 1 + to.Size() - 1 - 2* from.GetCommonModifiersCount(to) + 1;
                                     keyEventList = new INPUT[key_count]();
-                                    memset(keyEventList, 0, sizeof(keyEventList));
 
                                     int i = 0;
                                     Helpers::SetModifierKeyEvents(from, it->second.winKeyInvoked, keyEventList, i, false, KeyboardManagerConstants::KEYBOARDMANAGER_SHORTCUT_FLAG, to);

--- a/src/modules/keyboardmanager/common/RemapShortcut.h
+++ b/src/modules/keyboardmanager/common/RemapShortcut.h
@@ -26,4 +26,9 @@ public:
     {
         return targetShortcut == sc.targetShortcut && isShortcutInvoked == sc.isShortcutInvoked && winKeyInvoked == sc.winKeyInvoked;
     }
+
+    bool RemapToKey()
+    {
+        return targetShortcut.index() == 0;
+    }
 };


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
When mapping a shortcut to `Alt+Tab` navigation with arrow keys is broken. It happens because there are intermediate keys sent even if they are not needed. So in this pr we don't sent those intermediate keys

**What is include in the PR:** 

**How does someone test / validate:** 
Add the following remapping
 
![image](https://user-images.githubusercontent.com/17161067/131716236-8cefebcb-7330-440f-a217-ca807e1e798a.png)

Try to switch tabs with `Ctrl+D` and `Ctrl+Arrows`

## Quality Checklist

- [X] **Linked issue:** #12713
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
