### PR TITLE
[File Explorer] Thumbnail handlers reload

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -103,6 +103,7 @@ asm
 asmx
 aspnet
 aspx
+ASSOCCHANGED
 ASYNCWINDOWPLACEMENT
 ASYNCWINDOWPOS
 atl
@@ -842,6 +843,7 @@ IDirectory
 IDispatch
 IDisposable
 idl
+IDLIST
 IDOK
 IDOn
 IDR
@@ -1851,6 +1853,8 @@ sfgao
 SFGAOF
 SHAREIMAGELISTS
 sharpkeys
+SHCNE
+SHCNF
 shcore
 shellapi
 SHELLDLL

--- a/src/modules/previewpane/powerpreview/settings.cpp
+++ b/src/modules/previewpane/powerpreview/settings.cpp
@@ -3,6 +3,8 @@
 #include "trace.h"
 #include <iostream>
 #include <atlstr.h>
+#include <powerpreview/thumbnail_provider.h>
+#include <ShlObj_core.h>
 
 using namespace std;
 
@@ -97,6 +99,11 @@ namespace PowerPreviewSettings
                             else
                             {
                                 Trace::PowerPreviewSettingsUpdateFailed(this->GetToggleSettingName().c_str(), lastState, newState, enabled);
+                            }
+
+                            if (dynamic_cast<ThumbnailProviderSettings*>(this))
+                            {
+                                SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_IDLIST, NULL, NULL);
                             }
                         }
                         // If process is not elevated, return false as it is not possible to update the registry


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Invoking [SHChangeNotify SHCNE_ASSOCCHANGED](https://docs.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-shchangenotify#remarks) when thumbnail providers are turned on/off.

**What is include in the PR:** 
Reload thumbnail handlers providers are turned on/off.
Reboot should't be required anymore.

_Note: calling SHChangeNotify don't clear generated thumbnails. I have looked into this and I haven't found an offical way to clear thumbnails cache for a specific extension._

**How does someone test / validate:** 
- Build and install PT
- Create a new svg file (copy/paste an existing file)
- Thumbnail should be generated
- Disable svg thumbnails
- Create a new svg file (copy/paste an existing file)
- Thumbnail should not be generated
- Enable svg thumbnails
- Create a new svg file (copy/paste an existing file)
- Thumbnail should be generated

## Quality Checklist

- [x] **Linked issue:** Partial #7213
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
