### PR TITLE
[KBM Editor] fix crash when mapping left and right modifier to the combined key.

### DIFF
--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/BufferValidationHelpers.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/BufferValidationHelpers.cpp
@@ -3,6 +3,7 @@
 
 #include <common/interop/shared_constants.h>
 #include <keyboardmanager/common/KeyboardManagerConstants.h>
+#include <keyboardmanager/common/Helpers.h>
 
 #include "KeyboardManagerEditorStrings.h"
 #include "KeyDropDownControl.h"
@@ -23,8 +24,15 @@ namespace BufferValidationHelpers
             // Check if the value being set is the same as the other column
             if (remapBuffer[rowIndex].first[std::abs(int(colIndex) - 1)].index() == 0)
             {
-                if (std::get<DWORD>(remapBuffer[rowIndex].first[std::abs(int(colIndex) - 1)]) == selectedKeyCode)
+                DWORD otherColumnKeyCode = std::get<DWORD>(remapBuffer[rowIndex].first[std::abs(int(colIndex) - 1)]);
+                if (otherColumnKeyCode == selectedKeyCode)
                 {
+                    errorType = ShortcutErrorType::MapToSameKey;
+                } else if (
+                    (otherColumnKeyCode == Helpers::GetCombinedKey(selectedKeyCode) || selectedKeyCode == Helpers::GetCombinedKey(selectedKeyCode)) &&
+                    Helpers::GetCombinedKey(otherColumnKeyCode) == Helpers::GetCombinedKey(selectedKeyCode)
+                ) {
+                    // Check if it's mapping a left or right key and its combined code.
                     errorType = ShortcutErrorType::MapToSameKey;
                 }
             }
@@ -251,8 +259,16 @@ namespace BufferValidationHelpers
                 // If key to key
                 if (remapBuffer[rowIndex].first[std::abs(int(colIndex) - 1)].index() == 0)
                 {
-                    if (std::get<DWORD>(remapBuffer[rowIndex].first[std::abs(int(colIndex) - 1)]) == std::get<DWORD>(tempShortcut) && std::get<DWORD>(remapBuffer[rowIndex].first[std::abs(int(colIndex) - 1)]) != NULL && std::get<DWORD>(tempShortcut) != NULL)
+                    DWORD otherColumnKeyCode = std::get<DWORD>(remapBuffer[rowIndex].first[std::abs(int(colIndex) - 1)]);
+                    DWORD shortcutKeyCode = std::get<DWORD>(tempShortcut);
+                    if (otherColumnKeyCode == shortcutKeyCode && otherColumnKeyCode != NULL && shortcutKeyCode != NULL)
                     {
+                        errorType = ShortcutErrorType::MapToSameKey;
+                    } else if (
+                        (otherColumnKeyCode == Helpers::GetCombinedKey(shortcutKeyCode) || shortcutKeyCode == Helpers::GetCombinedKey(shortcutKeyCode)) &&
+                        Helpers::GetCombinedKey(otherColumnKeyCode) == Helpers::GetCombinedKey(shortcutKeyCode))
+                    {
+                        // Check if it's mapping a left or right key and its combined code.
                         errorType = ShortcutErrorType::MapToSameKey;
                     }
                 }

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/BufferValidationHelpers.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/BufferValidationHelpers.cpp
@@ -13,6 +13,13 @@
 
 namespace BufferValidationHelpers
 {
+    // Helper function to verify if a key is being remapped to/from its combined key
+    bool IsKeyRemappingToItsCombinedKey(DWORD keyCode1, DWORD keyCode2)
+    {
+        return (keyCode1 == Helpers::GetCombinedKey(keyCode1) || keyCode2 == Helpers::GetCombinedKey(keyCode2)) &&
+               Helpers::GetCombinedKey(keyCode1) == Helpers::GetCombinedKey(keyCode2);
+    }
+
     // Function to validate and update an element of the key remap buffer when the selection has changed
     ShortcutErrorType ValidateAndUpdateKeyBufferElement(int rowIndex, int colIndex, int selectedKeyCode, RemapBuffer& remapBuffer)
     {
@@ -25,14 +32,8 @@ namespace BufferValidationHelpers
             if (remapBuffer[rowIndex].first[std::abs(int(colIndex) - 1)].index() == 0)
             {
                 DWORD otherColumnKeyCode = std::get<DWORD>(remapBuffer[rowIndex].first[std::abs(int(colIndex) - 1)]);
-                if (otherColumnKeyCode == selectedKeyCode)
+                if (otherColumnKeyCode == selectedKeyCode || IsKeyRemappingToItsCombinedKey(selectedKeyCode, otherColumnKeyCode))
                 {
-                    errorType = ShortcutErrorType::MapToSameKey;
-                } else if (
-                    (otherColumnKeyCode == Helpers::GetCombinedKey(selectedKeyCode) || selectedKeyCode == Helpers::GetCombinedKey(selectedKeyCode)) &&
-                    Helpers::GetCombinedKey(otherColumnKeyCode) == Helpers::GetCombinedKey(selectedKeyCode)
-                ) {
-                    // Check if it's mapping a left or right key and its combined code.
                     errorType = ShortcutErrorType::MapToSameKey;
                 }
             }
@@ -261,14 +262,8 @@ namespace BufferValidationHelpers
                 {
                     DWORD otherColumnKeyCode = std::get<DWORD>(remapBuffer[rowIndex].first[std::abs(int(colIndex) - 1)]);
                     DWORD shortcutKeyCode = std::get<DWORD>(tempShortcut);
-                    if (otherColumnKeyCode == shortcutKeyCode && otherColumnKeyCode != NULL && shortcutKeyCode != NULL)
+                    if ((otherColumnKeyCode == shortcutKeyCode || IsKeyRemappingToItsCombinedKey(otherColumnKeyCode, shortcutKeyCode)) && otherColumnKeyCode != NULL && shortcutKeyCode != NULL)
                     {
-                        errorType = ShortcutErrorType::MapToSameKey;
-                    } else if (
-                        (otherColumnKeyCode == Helpers::GetCombinedKey(shortcutKeyCode) || shortcutKeyCode == Helpers::GetCombinedKey(shortcutKeyCode)) &&
-                        Helpers::GetCombinedKey(otherColumnKeyCode) == Helpers::GetCombinedKey(shortcutKeyCode))
-                    {
-                        // Check if it's mapping a left or right key and its combined code.
                         errorType = ShortcutErrorType::MapToSameKey;
                     }
                 }

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/BufferValidationHelpers.h
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/BufferValidationHelpers.h
@@ -14,6 +14,9 @@ namespace BufferValidationHelpers
         ClearUnusedDropDowns
     };
 
+    // Helper function to verify if a key is being remapped to/from its combined key
+    bool IsKeyRemappingToItsCombinedKey(DWORD keyCode1, DWORD keyCode2);
+
     // Function to validate and update an element of the key remap buffer when the selection has changed
     ShortcutErrorType ValidateAndUpdateKeyBufferElement(int rowIndex, int colIndex, int selectedKeyCode, RemapBuffer& remapBuffer);
 

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/KeyDropDownControl.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/KeyDropDownControl.cpp
@@ -386,6 +386,7 @@ void KeyDropDownControl::SetDropDownError(ComboBox currentDropDown, hstring mess
     catch (winrt::hresult_error const&)
     {
         // If it's loading and some remaps are invalid from previous configs, avoid crashing when flyouts can't be showed yet.
+        Logger::error(L"Failed to show dropdown error flyout: {}", message);
     }
 }
 

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/KeyDropDownControl.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/KeyDropDownControl.cpp
@@ -379,7 +379,14 @@ void KeyDropDownControl::SetDropDownError(ComboBox currentDropDown, hstring mess
 {
     currentDropDown.SelectedIndex(-1);
     warningMessage.as<TextBlock>().Text(message);
-    currentDropDown.ContextFlyout().ShowAttachedFlyout((FrameworkElement)dropDown.as<ComboBox>());
+    try
+    {
+        currentDropDown.ContextFlyout().ShowAttachedFlyout((FrameworkElement)dropDown.as<ComboBox>());
+    }
+    catch (winrt::hresult_error const&)
+    {
+        // If it's loading and some remaps are invalid from previous configs, avoid crashing when flyouts can't be showed yet.
+    }
 }
 
 // Function to add a shortcut to the UI control as combo boxes

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/LoadingAndSavingRemappingHelper.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/LoadingAndSavingRemappingHelper.cpp
@@ -2,6 +2,7 @@
 #include "LoadingAndSavingRemappingHelper.h"
 
 #include <set>
+#include <variant>
 #include <common/interop/shared_constants.h>
 #include <keyboardmanager/common/MappingConfiguration.h>
 
@@ -88,6 +89,11 @@ namespace LoadingAndSavingRemappingHelper
             // If they are mapped to the same key, delete those entries and set the common version
             if (table[leftKey] == table[rightKey])
             {
+                if (std::holds_alternative<DWORD>(table[leftKey]) && std::get<DWORD>(table[leftKey]) == combinedKey)
+                {
+                    // Avoid mapping a key to itself when the combined key is equal to the resulting mapping.
+                    return;
+                }
                 table[combinedKey] = table[leftKey];
                 table.erase(leftKey);
                 table.erase(rightKey);

--- a/src/modules/keyboardmanager/common/Helpers.cpp
+++ b/src/modules/keyboardmanager/common/Helpers.cpp
@@ -15,6 +15,27 @@ namespace Helpers
         return (GetKeyType(key) != KeyType::Action);
     }
 
+    // Function to get the combined key for modifier keys
+    DWORD GetCombinedKey(DWORD key)
+    {
+        switch (key) {
+        case VK_LWIN:
+        case VK_RWIN:
+            return CommonSharedConstants::VK_WIN_BOTH;
+        case VK_LCONTROL:
+        case VK_RCONTROL:
+            return VK_CONTROL;
+        case VK_LMENU:
+        case VK_RMENU:
+            return VK_MENU;
+        case VK_LSHIFT:
+        case VK_RSHIFT:
+            return VK_SHIFT;
+        default:
+            return key;
+        }
+    }
+
     // Function to get the type of the key
     KeyType GetKeyType(DWORD key)
     {

--- a/src/modules/keyboardmanager/common/Helpers.h
+++ b/src/modules/keyboardmanager/common/Helpers.h
@@ -18,6 +18,9 @@ namespace Helpers
     // Function to check if the key is a modifier key
     bool IsModifierKey(DWORD key);
 
+    // Function to get the combined key for modifier keys
+    DWORD GetCombinedKey(DWORD key);
+
     // Function to get the type of the key
     KeyType GetKeyType(DWORD key);
 


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
The keyboard manager editor allowed setting "Alt (Left)" -> "Alt" and "Alt (Right)" -> "Alt".
This would make it so that when these were combined when opening the Editor, they would be combined to "Alt" -> "Alt" and the editor would crash trying to present the error flyout.

**What is include in the PR:** 
Three changes related to this crash:
1 - Don't combine the modifier keys to the combined key.
2 - Catch the exception when trying to show an unavailable flyout when loading the Window.
3 - Don't allow the user to make mappings such as "Alt (Left)" -> "Alt" or "Alt" -> "Alt (Left)".

**How does someone test / validate:** 
Verify that before you could set up "Alt (Left)" -> "Alt" and "Alt (Right)" -> "Alt" and it would crash the KBM Editor if you saved and then try to reopen.
After having that configuration saved, verify that the Window no longer crashes when you try to open KBM Editor.

## Quality Checklist

- [x] **Linked issue:** #12978
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries
