### PR TITLE
Fix typo #13117

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -375,7 +375,6 @@ CXSMICON
 CXVIRTUALSCREEN
 cxx
 cxxopts
-CYMK
 CYSMICON
 cziplib
 Dac

--- a/src/modules/colorPicker/ColorPickerUI/Helpers/ColorHelper.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/ColorHelper.cs
@@ -13,7 +13,7 @@ namespace ColorPicker.Helpers
     internal static class ColorHelper
     {
         /// <summary>
-        /// Convert a given <see cref="Color"/> to a CYMK color (cyan, magenta, yellow, black key)
+        /// Convert a given <see cref="Color"/> to a CMYK color (cyan, magenta, yellow, black key)
         /// </summary>
         /// <param name="color">The <see cref="Color"/> to convert</param>
         /// <returns>The cyan[0..1], magenta[0..1], yellow[0..1] and black key[0..1] of the converted color</returns>

--- a/src/modules/colorPicker/ColorPickerUI/Helpers/ColorRepresentationHelper.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/ColorRepresentationHelper.cs
@@ -35,7 +35,7 @@ namespace ColorPicker.Helpers
         internal static string GetStringRepresentation(Color color, ColorRepresentationType colorRepresentationType)
             => colorRepresentationType switch
             {
-                ColorRepresentationType.CMYK => ColorToCYMK(color),
+                ColorRepresentationType.CMYK => ColorToCMYK(color),
                 ColorRepresentationType.HEX => ColorToHex(color),
                 ColorRepresentationType.HSB => ColorToHSB(color),
                 ColorRepresentationType.HSI => ColorToHSI(color),
@@ -54,7 +54,7 @@ namespace ColorPicker.Helpers
         /// </summary>
         /// <param name="color">The <see cref="Color"/> for the CYMK color presentation</param>
         /// <returns>A <see cref="string"/> representation of a CYMK color</returns>
-        private static string ColorToCYMK(Color color)
+        private static string ColorToCMYK(Color color)
         {
             var (cyan, magenta, yellow, blackKey) = ColorHelper.ConvertToCMYKColor(color);
 

--- a/src/modules/colorPicker/ColorPickerUI/Helpers/ColorRepresentationHelper.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/ColorRepresentationHelper.cs
@@ -50,10 +50,10 @@ namespace ColorPicker.Helpers
             };
 
         /// <summary>
-        /// Return a <see cref="string"/> representation of a CYMK color
+        /// Return a <see cref="string"/> representation of a CMYK color
         /// </summary>
-        /// <param name="color">The <see cref="Color"/> for the CYMK color presentation</param>
-        /// <returns>A <see cref="string"/> representation of a CYMK color</returns>
+        /// <param name="color">The <see cref="Color"/> for the CMYK color presentation</param>
+        /// <returns>A <see cref="string"/> representation of a CMYK color</returns>
         private static string ColorToCMYK(Color color)
         {
             var (cyan, magenta, yellow, blackKey) = ColorHelper.ConvertToCMYKColor(color);


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Fix the typo mentioned in #13117

**What is include in the PR:** 
Change "CYMK" to "CMYK" in `src/modules/colorPicker/ColorPickerUI/Helpers/ColorRepresentationHelper.cs` and `.github/actions/spell-check/expect.txt`

**How does someone test / validate:** 
Solution build

## Quality Checklist

- [x] **Linked issue:** #13117 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
