### PR TITLE
[PT Run] Settings plugin: Settings path filter and bug fixes

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsSettings/Helper/ResultHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsSettings/Helper/ResultHelper.cs
@@ -188,5 +188,52 @@ namespace Microsoft.PowerToys.Run.Plugin.WindowsSettings.Helper
                 result.Score = lowScore--;
             }
         }
+
+        /// <summary>
+        /// Checks if a setting <see cref="WindowsSetting"/> matches the search string <see cref="Query.Search"/> to filter settings by settings path.
+        /// This method is called from the filter function <see cref="Main.Query(Query)"/> if the search string <see cref="Query.Search"/> contains the character ">".
+        /// </summary>
+        /// <param name="found">The WindowsSetting taht should be checked.</param>
+        /// <param name="searchString">The searchString entered by the user <see cref="Query.Search"/>s.</param>
+        internal static bool FilterBySettingsPath(in WindowsSetting found, in string searchString)
+        {
+            if (!searchString.Contains('>'))
+            {
+                return false;
+            }
+
+            var pathElements = searchString.Split('>');
+
+            // check app name of the WindowsSetting
+            if (!found.Type.StartsWith(pathElements[0]))
+            {
+                return false;
+            }
+
+            // Check area path of the WindowsSetting.
+            // If "pathElements.Length" is higher than one the "searchString" contains at least one area name.
+            // Because the area names in pathElements array start at index 1 sometimes <pathElements.Length - 1> or <index - 1> is used.
+            if (pathElements.Length > 1 & !(found.Areas is null))
+            {
+                if ((pathElements.Length - 1) > found.Areas.Count())
+                {
+                    // The user entered more area names (pathElements[1] -> pathElements[n]) than defined for this WindowsSetting.
+                    return false;
+                }
+
+                for (int i = 1; i <= pathElements.Length; i++)
+                {
+#pragma warning disable CS8602 // Do not catch exception "Possible null reference". The compiler thinks that Areas could be null which is not possible because of the parental if condition.
+                    if (!found.Areas[i - 1].StartsWith(pathElements[i]))
+                    {
+                        // The user has entered an area name that not matches.
+                        return false;
+                    }
+                }
+            }
+
+            // Return "true" if WindowsSetting "WindowsSetting" matches "searchString".
+            return true;
+        }
     }
 }

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsSettings/Helper/ResultHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsSettings/Helper/ResultHelper.cs
@@ -167,6 +167,12 @@ namespace Microsoft.PowerToys.Run.Plugin.WindowsSettings.Helper
                     continue;
                 }
 
+                if (windowsSetting.Areas is null)
+                {
+                    result.Score = lowScore--;
+                    continue;
+                }
+
                 if (windowsSetting.Areas.Any(x => x.StartsWith(query, StringComparison.CurrentCultureIgnoreCase)))
                 {
                     result.Score = lowScore--;

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsSettings/Helper/ResultHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsSettings/Helper/ResultHelper.cs
@@ -226,7 +226,7 @@ namespace Microsoft.PowerToys.Run.Plugin.WindowsSettings.Helper
             {
                 if (string.IsNullOrWhiteSpace(queryElements[i]))
                 {
-                    // The queryEelent is an WhiteSpace. Nothing to compare.
+                    // The queryElement is an WhiteSpace. Nothing to compare.
                     break;
                 }
 

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsSettings/Helper/ResultHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsSettings/Helper/ResultHelper.cs
@@ -154,41 +154,44 @@ namespace Microsoft.PowerToys.Run.Plugin.WindowsSettings.Helper
                     continue;
                 }
 
-                if (windowsSetting.Name.StartsWith(query, StringComparison.CurrentCultureIgnoreCase))
+                if (!string.IsNullOrWhiteSpace(query))
                 {
-                    result.Score = highScore--;
-                    continue;
-                }
+                    if (windowsSetting.Name.StartsWith(query, StringComparison.CurrentCultureIgnoreCase))
+                    {
+                        result.Score = highScore--;
+                        continue;
+                    }
 
-                // If query starts with second or next word of name, set score.
-                if (windowsSetting.Name.Contains($" {query}", StringComparison.CurrentCultureIgnoreCase))
-                {
-                    result.Score = mediumScore--;
-                    continue;
-                }
+                    // If query starts with second or next word of name, set score.
+                    if (windowsSetting.Name.Contains($" {query}", StringComparison.CurrentCultureIgnoreCase))
+                    {
+                        result.Score = mediumScore--;
+                        continue;
+                    }
 
-                if (windowsSetting.Areas is null)
-                {
-                    result.Score = lowScore--;
-                    continue;
-                }
+                    if (windowsSetting.Areas is null)
+                    {
+                        result.Score = lowScore--;
+                        continue;
+                    }
 
-                if (windowsSetting.Areas.Any(x => x.StartsWith(query, StringComparison.CurrentCultureIgnoreCase)))
-                {
-                    result.Score = lowScore--;
-                    continue;
-                }
+                    if (windowsSetting.Areas.Any(x => x.StartsWith(query, StringComparison.CurrentCultureIgnoreCase)))
+                    {
+                        result.Score = lowScore--;
+                        continue;
+                    }
 
-                if (windowsSetting.AltNames is null)
-                {
-                    result.Score = lowScore--;
-                    continue;
-                }
+                    if (windowsSetting.AltNames is null)
+                    {
+                        result.Score = lowScore--;
+                        continue;
+                    }
 
-                if (windowsSetting.AltNames.Any(x => x.StartsWith(query, StringComparison.CurrentCultureIgnoreCase)))
-                {
-                    result.Score = mediumScore--;
-                    continue;
+                    if (windowsSetting.AltNames.Any(x => x.StartsWith(query, StringComparison.CurrentCultureIgnoreCase)))
+                    {
+                        result.Score = mediumScore--;
+                        continue;
+                    }
                 }
 
                 result.Score = lowScore--;

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsSettings/Helper/ResultHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsSettings/Helper/ResultHelper.cs
@@ -199,7 +199,7 @@ namespace Microsoft.PowerToys.Run.Plugin.WindowsSettings.Helper
         /// Checks if a setting <see cref="WindowsSetting"/> matches the search string <see cref="Query.Search"/> to filter settings by settings path.
         /// This method is called from the <see cref="Predicate{T}"/> method in <see cref="Main.Query(Query)"/> if the search string <see cref="Query.Search"/> contains the character ">".
         /// </summary>
-        /// <param name="found">The WindowsSetting taht should be checked.</param>
+        /// <param name="found">The WindowsSetting's result that should be checked.</param>
         /// <param name="queryString">The searchString entered by the user <see cref="Query.Search"/>s.</param>
         internal static bool FilterBySettingsPath(in WindowsSetting found, in string queryString)
         {
@@ -217,26 +217,24 @@ namespace Microsoft.PowerToys.Run.Plugin.WindowsSettings.Helper
             }
 
             // Check area path of the WindowsSetting.
-            // If "pathElements.Length" is higher than one the "searchString" contains at least one area name.
-            // Because the area names in pathElements array start at index 1 sometimes <pathElements.Length - 1> or <index - 1> is used.
             if (!string.IsNullOrEmpty(queryElements[1]))
             {
                 if (found.Areas is null)
                 {
-                    // The user entered at least one area name (pathElements[1] -> pathElements[n]). But the WindowsSetting nas no defined areas.
+                    // The user entered at least one area name (queryElements[1]). But the WindowsSetting has no defined areas.
                     return false;
                 }
 
                 if ((queryElements.Length - 1) > found.Areas.Count())
                 {
-                    // The user entered more area names (pathElements[1] -> pathElements[n]) than defined for this WindowsSetting.
+                    // The user entered more area names (queryElements[1] -> queryElements[n]) than defined for this WindowsSetting.
                     return false;
                 }
 
                 int areaCounter = 0;
-                foreach (var qEelement in queryElements.Skip(1))
+                foreach (var qElement in queryElements.Skip(1))
                 {
-                    if (!found.Areas[areaCounter].StartsWith(qEelement, StringComparison.CurrentCultureIgnoreCase))
+                    if (!found.Areas[areaCounter].StartsWith(qElement, StringComparison.CurrentCultureIgnoreCase))
                     {
                         // The user has entered an area name that not matches.
                         return false;
@@ -246,7 +244,7 @@ namespace Microsoft.PowerToys.Run.Plugin.WindowsSettings.Helper
                 }
             }
 
-            // Return "true" if WindowsSetting "WindowsSetting" matches "searchString".
+            // Return "true" if <found> matches <queryString>.
             return true;
         }
     }

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsSettings/Helper/ResultHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsSettings/Helper/ResultHelper.cs
@@ -208,39 +208,36 @@ namespace Microsoft.PowerToys.Run.Plugin.WindowsSettings.Helper
                 return false;
             }
 
+            // Init vars
             var queryElements = queryString.Split('>');
 
-            // check app name of the WindowsSetting
-            if (!found.Type.StartsWith(queryElements[0], StringComparison.CurrentCultureIgnoreCase))
+            List<string> settingsPath = new List<string>();
+            settingsPath.Add(found.Type);
+            if (!(found.Areas is null))
             {
-                return false;
+                settingsPath.AddRange(found.Areas);
             }
 
-            // Check area path of the WindowsSetting.
-            if (!string.IsNullOrEmpty(queryElements[1]))
+            // Compare query and settings path
+            for (int i = 0; i < queryElements.Length; i++)
             {
-                if (found.Areas is null)
+                if (string.IsNullOrWhiteSpace(queryElements[i]))
                 {
-                    // The user entered at least one area name (queryElements[1]). But the WindowsSetting has no defined areas.
-                    return false;
+                    // The queryEelent is an WhiteSpace. Nothing to compare.
+                    break;
                 }
 
-                if ((queryElements.Length - 1) > found.Areas.Count())
+                if (i < settingsPath.Count)
                 {
-                    // The user entered more area names (queryElements[1] -> queryElements[n]) than defined for this WindowsSetting.
-                    return false;
-                }
-
-                int areaCounter = 0;
-                foreach (var qElement in queryElements.Skip(1))
-                {
-                    if (!found.Areas[areaCounter].StartsWith(qElement, StringComparison.CurrentCultureIgnoreCase))
+                    if (!settingsPath[i].StartsWith(queryElements[i], StringComparison.CurrentCultureIgnoreCase))
                     {
-                        // The user has entered an area name that not matches.
                         return false;
                     }
-
-                    areaCounter++;
+                }
+                else
+                {
+                    // The user has entered more query parts than existing elements in settings path.
+                    return false;
                 }
             }
 

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsSettings/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsSettings/Main.cs
@@ -110,6 +110,12 @@ namespace Microsoft.PowerToys.Run.Plugin.WindowsSettings
 
             bool Predicate(WindowsSetting found)
             {
+                if (string.IsNullOrWhiteSpace(query.Search))
+                {
+                    // If no search string is entered skip query comparsion.
+                    return true;
+                }
+
                 if (found.Name.Contains(query.Search, StringComparison.CurrentCultureIgnoreCase))
                 {
                     return true;

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsSettings/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsSettings/Main.cs
@@ -112,7 +112,7 @@ namespace Microsoft.PowerToys.Run.Plugin.WindowsSettings
             {
                 if (string.IsNullOrWhiteSpace(query.Search))
                 {
-                    // If no search string is entered skip query comparsion.
+                    // If no search string is entered skip query comparison.
                     return true;
                 }
 

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsSettings/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsSettings/Main.cs
@@ -145,6 +145,12 @@ namespace Microsoft.PowerToys.Run.Plugin.WindowsSettings
                     }
                 }
 
+                // Search by key char '>' for app name and settings path
+                if (query.Search.Contains('>'))
+                {
+                    return ResultHelper.FilterBySettingsPath(found, query.Search);
+                }
+
                 return false;
             }
         }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

This PR implements filtering/searching by settings path. This works a bit like navigating through the settings: `app > area1 > area2`
Additional this PR fixes a "System.ArgumentNullException" in `ResultHelper.SetScores` and improves query duration on empty queries.

![image](https://user-images.githubusercontent.com/61519853/132986746-3c741d4f-f3ca-447f-888a-3eb65bc56218.png)
![image](https://user-images.githubusercontent.com/61519853/132986750-00964a9e-d2e8-4c35-b9fd-b24ba7899086.png)
![image](https://user-images.githubusercontent.com/61519853/132986752-c51fa976-42cb-490e-b2dd-36cc64bac7b1.png)

![PT_SettingsPlugin_Navigation](https://user-images.githubusercontent.com/61519853/132986764-b58b37cb-bad7-4171-bee7-05921d67ee9f.gif)

**What is include in the PR:** 
- Adding a new method to filter by settings path.
- Adding an if statement to prevent "System.ArgumentNullException" in `ResultHelper.SetScores` if the setting has no defined areas.
- Improve query time on empty queries like `$` ($ = activation command) by skipping filtering and setting score on every setting to the same value without checking setting`s properties.

**How does someone test / validate:** 
Building locally for testing functionality and checking log file for errors.

## ToDo-Checklist
- [x] PR description
- [x] Fix bug why it doesn't work
- [x] Use `not is null` instead of `.Any()`
- [x] Adding culture property
- [x] Fixing typos
- [x] Maybe solve #13150
- [x] Improve behavior to have a smoother search and easier code: https://www.delftstack.com/howto/csharp/add-list-to-list-in-csharp/#:~:text=Add%20a%20List%20to%20Another%20List%20With%20the,elements%20of%20the%20collection%20x%20in%20the%20list.
- [ ] Adding me as author (see [this comment](https://github.com/microsoft/PowerToys/pull/13151#issuecomment-918116059))

## Quality Checklist

- [x] **Linked issue:** #12203, #12204, #13150
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
