### PR TITLE
[ci] restore bootstrapper nuget packages

### DIFF
--- a/.pipelines/pipeline.user.windows.yml
+++ b/.pipelines/pipeline.user.windows.yml
@@ -33,6 +33,9 @@ restore:
       name: 'Restore Installer'
       command: '.pipelines\restore-installer.cmd'
     - !!defaultcommand
+      name: 'Restore Installer BootStrapper'
+      command: '.pipelines\restore-bootstrapper.cmd'
+    - !!defaultcommand
       name: 'Restore Localization packages'
       command: '.pipelines\restore-localization.cmd'
     - !!defaultcommand

--- a/.pipelines/restore-bootstrapper.cmd
+++ b/.pipelines/restore-bootstrapper.cmd
@@ -1,0 +1,3 @@
+cd /D "%~dp0"
+
+nuget restore ../installer/PowerToysBootstrapper/PowerToysBootstrapper.sln || exit /b 1


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Pipelines are failing to build current master after https://github.com/microsoft/PowerToys/commit/1f2f247c1d1155a4574a21cf86ff71c01e7cb798 with this error:

```
error : This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is ..\packages\Microsoft.Windows.ImplementationLibrary.1.0.210204.1\build\native\Microsoft.Windows.ImplementationLibrary.targets.
```

**What is include in the PR:** 
Instructions to restore bootstrapper package before building.

**How does someone test / validate:** 
Get it merged into master and see if it builds properly afterwards.

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries
