### PR TITLE
[Settings] Upgrade WinUI to 2.7.0 to fix some issues

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Microsoft.PowerToys.Settings.UI.csproj
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Microsoft.PowerToys.Settings.UI.csproj
@@ -285,7 +285,7 @@
       <Version>6.1.3</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.UI.Xaml">
-      <Version>2.6.0-prerelease.210623001</Version>
+      <Version>2.7.0-prerelease.210913003</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Xaml.Behaviors.Uwp.Managed">
       <Version>2.0.1</Version>


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Updates WinUI to the latest pre-release (2.7.0-prerelease.210913003), which will allow fixing some issues.
This version no longer crashes Settings on Windows 10 18363.

**What is include in the PR:** 

**How does someone test / validate:** 
@niels9001, Please take a quick look into settings to verify if this breaks anything.

## Quality Checklist

- [x] **Linked issue:** #12520 #13136 #13082 #12846
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries
