### PR TITLE
[PT Run][Registry] show no results on query fail

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Registry/Helper/RegistryHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Registry/Helper/RegistryHelper.cs
@@ -104,7 +104,8 @@ namespace Microsoft.PowerToys.Run.Plugin.Registry.Helper
 
                 if (result.Count == 0)
                 {
-                    return FindSubKey(subKey, string.Empty);
+                    // If a subKey can't be found, show no results.
+                    break;
                 }
 
                 if (result.Count == 1 && index < subKeysNames.Length)


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
When searching for a key, PowerToys Run Registry plugin shows results from the "parent" registry key when the search for a subkey fails. The expected behavior is that no results are shown if a query fails.

**What is include in the PR:** 
Show no results when the search for a subkey fails.

**How does someone test / validate:** 
Search for `:HKCU\Apppppppppp` in PowerToys Run. It should show no results.

## Quality Checklist

- [x] **Linked issue:** #13164
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries
