### PR TITLE
[ci] Fix pdf thumbnail unit tests flakiness

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -39,6 +39,8 @@ body:
       - Image Resizer
       - Keyboard Manager
       - MD Preview
+      - PDF Preview
+      - PDF Thumbnail
       - PowerRename
       - PowerToys Run
       - Shortcut Guide

--- a/.pipelines/ci/templates/build-powertoys-steps.yml
+++ b/.pipelines/ci/templates/build-powertoys-steps.yml
@@ -121,6 +121,7 @@ steps:
     testSelector: 'testAssemblies'
     testAssemblyVer2: |
       **\UnitTests-SvgThumbnailProvider.dll
+      **\UnitTests-PdfThumbnailProvider.dll
       **\Microsoft.PowerToys.Settings.UI.UnitTests.dll
       **\UnitTests-MarkdownPreviewHandler.dll
       **\UnitTests-PdfPreviewHandler.dll

--- a/src/modules/previewpane/UnitTests-PdfPreviewHandler/PdfPreviewHandlerTest.cs
+++ b/src/modules/previewpane/UnitTests-PdfPreviewHandler/PdfPreviewHandlerTest.cs
@@ -66,16 +66,18 @@ namespace PdfPreviewHandlerUnitTests
         private static IStream GetMockStream(byte[] sourceArray)
         {
             var streamMock = new Mock<IStream>();
-            var firstCall = true;
+            int bytesRead = 0;
+
             streamMock
                 .Setup(x => x.Read(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<IntPtr>()))
                 .Callback<byte[], int, IntPtr>((buffer, countToRead, bytesReadPtr) =>
                 {
-                    if (firstCall)
+                    int actualCountToRead = Math.Min(sourceArray.Length - bytesRead, countToRead);
+                    if (actualCountToRead > 0)
                     {
-                        Array.Copy(sourceArray, 0, buffer, 0, sourceArray.Length);
-                        Marshal.WriteInt32(bytesReadPtr, sourceArray.Length);
-                        firstCall = false;
+                        Array.Copy(sourceArray, bytesRead, buffer, 0, actualCountToRead);
+                        Marshal.WriteInt32(bytesReadPtr, actualCountToRead);
+                        bytesRead += actualCountToRead;
                     }
                     else
                     {

--- a/src/modules/previewpane/UnitTests-PdfThumbnailProvider/PdfThumbnailProviderTests.cs
+++ b/src/modules/previewpane/UnitTests-PdfThumbnailProvider/PdfThumbnailProviderTests.cs
@@ -70,16 +70,18 @@ namespace PdfThumbnailProviderUnitTests
         private static IStream GetMockStream(byte[] sourceArray)
         {
             var streamMock = new Mock<IStream>();
-            var firstCall = true;
+            int bytesRead = 0;
+
             streamMock
                 .Setup(x => x.Read(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<IntPtr>()))
                 .Callback<byte[], int, IntPtr>((buffer, countToRead, bytesReadPtr) =>
                 {
-                    if (firstCall)
+                    int actualCountToRead = Math.Min(sourceArray.Length - bytesRead, countToRead);
+                    if (actualCountToRead > 0)
                     {
-                        Array.Copy(sourceArray, 0, buffer, 0, sourceArray.Length);
-                        Marshal.WriteInt32(bytesReadPtr, sourceArray.Length);
-                        firstCall = false;
+                        Array.Copy(sourceArray, bytesRead, buffer, 0, actualCountToRead);
+                        Marshal.WriteInt32(bytesReadPtr, actualCountToRead);
+                        bytesRead += actualCountToRead;
                     }
                     else
                     {


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
The pdf unit tests use a mock of the IStream interface which fails if it can't copy the contents of the stream in a single pass.

**What is include in the PR:** 
Fixes for the mock to run correctly even when it receives a smaller buffer side.
Also run Pdf Thumbnail tests as part of the automated tests.
Took the chance to also add PDF modules to the bug report template.

**How does someone test / validate:** 
Tests run successfully.

## Quality Checklist

- [x] **Linked issue:** #13247
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries
