### PR TITLE
[PT Run: Registry] Handle Invalid Base Keys

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Registry/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Registry/Main.cs
@@ -86,23 +86,27 @@ namespace Microsoft.PowerToys.Run.Plugin.Registry
                 // no base key found
                 return ResultHelper.GetResultList(RegistryHelper.GetAllBaseKeys(), _defaultIconPath);
             }
+            else if (baseKeyList.Count() == 1)
+            {
+                // only one base key was found -> start search for the sub-key
+                var list = RegistryHelper.SearchForSubKey(baseKeyList.First(), subKey);
+
+                // when only one sub-key was found and a user search for values ("\\")
+                // show the filtered list of values of one sub-key
+                if (searchForValueName && list.Count == 1)
+                {
+                    return ResultHelper.GetValuesFromKey(list.First().Key, _defaultIconPath, queryValueName);
+                }
+
+                return ResultHelper.GetResultList(list, _defaultIconPath);
+            }
             else if (baseKeyList.Count() > 1)
             {
                 // more than one base key was found -> show results
                 return ResultHelper.GetResultList(baseKeyList.Select(found => new RegistryEntry(found)), _defaultIconPath);
             }
 
-            // only one base key was found -> start search for the sub-key
-            var list = RegistryHelper.SearchForSubKey(baseKeyList.First(), subKey);
-
-            // when only one sub-key was found and a user search for values ("\\")
-            // show the filtered list of values of one sub-key
-            if (searchForValueName && list.Count == 1)
-            {
-                return ResultHelper.GetValuesFromKey(list.First().Key, _defaultIconPath, queryValueName);
-            }
-
-            return ResultHelper.GetResultList(list, _defaultIconPath);
+            return new List<Result>();
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Handle invalid base keys for PT Run Registry plugin.

**What is include in the PR:** 
No `System.InvalidOperationException` in log file with invalid base keys as input.

**How does someone test / validate:** 
- Test the following queries:
  - `:qwerty`
  - `:hkcuuuu`
  - `:hkcu>`
- `System.InvalidOperationException` not logged in log file.

## Quality Checklist

- [x] **Linked issue:** #13173
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
