### PR TITLE
[FZ Editor] "Save" and "Cancel" buttons are hidden in the grid layout editor

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditorWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditorWindow.xaml
@@ -1,4 +1,4 @@
-<local:EditorWindow x:Class="FancyZonesEditor.GridEditorWindow"
+﻿<local:EditorWindow x:Class="FancyZonesEditor.GridEditorWindow"
                     AutomationProperties.Name="{x:Static props:Resources.Grid_Layout_Editor}"
                     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -8,19 +8,18 @@
                     xmlns:props="clr-namespace:FancyZonesEditor.Properties"
                     mc:Ignorable="d"
                     Title=""
-                    Height="300"
                     MinWidth="360"
                     BorderThickness="0"
                     xmlns:ui="http://schemas.modernwpf.com/2019"
                     ui:WindowHelper.UseModernWindowStyle="True"
                     ui:TitleBar.IsIconVisible="False"
-                    SizeToContent="Width"
+                    SizeToContent="WidthAndHeight"
                     Background="{DynamicResource PrimaryBackgroundBrush}"
                     ResizeMode="NoResize"
                     WindowStartupLocation="CenterOwner"
                     ContentRendered="EditorWindow_ContentRendered"
                     Closed="OnClosed">
-    <Grid Height="280">
+    <Grid>
         <Grid
             Height="36"
             Background="{DynamicResource SecondaryBackgroundBrush}"
@@ -62,7 +61,7 @@
                     <Run Text="{x:Static props:Resources.KeyboardControlsDescription}" />
                 </TextBlock>
             </StackPanel>
-            <Grid Margin="0,24,0,-4">
+            <Grid Margin="0,24,0,-36">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*"/>
                     <ColumnDefinition Width="8"/>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditorWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditorWindow.xaml
@@ -1,4 +1,4 @@
-﻿<local:EditorWindow x:Class="FancyZonesEditor.GridEditorWindow"
+<local:EditorWindow x:Class="FancyZonesEditor.GridEditorWindow"
                     AutomationProperties.Name="{x:Static props:Resources.Grid_Layout_Editor}"
                     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -8,7 +8,7 @@
                     xmlns:props="clr-namespace:FancyZonesEditor.Properties"
                     mc:Ignorable="d"
                     Title=""
-                    Height="176"
+                    Height="300"
                     MinWidth="360"
                     BorderThickness="0"
                     xmlns:ui="http://schemas.modernwpf.com/2019"
@@ -20,7 +20,7 @@
                     WindowStartupLocation="CenterOwner"
                     ContentRendered="EditorWindow_ContentRendered"
                     Closed="OnClosed">
-    <Grid Height="140">
+    <Grid Height="280">
         <Grid
             Height="36"
             Background="{DynamicResource SecondaryBackgroundBrush}"


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

![image](https://user-images.githubusercontent.com/8949536/134210073-d00ad5d4-7857-4d8f-96d2-248fa53a4e80.png)


**What is include in the PR:** 

Updated height of the grid editor window.

**How does someone test / validate:** 

Edit any grid layout.

## Quality Checklist

- [x] **Linked issue:** #13335
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
