### PR TITLE
[Code refactoring] Make code comment and NullOrEmpty check more clear

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/ImageResizerViewModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/ImageResizerViewModel.cs
@@ -252,12 +252,14 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
 
         public void AddRow(string sizeNamePrefix)
         {
-            // Without validation we get warning CA1062 when unsing the parameter variable sizeNamePrefix
-            string prefixString = string.IsNullOrEmpty(sizeNamePrefix) ? "New Size" : sizeNamePrefix;
+            /// This is a fallback validation to eliminate the warning "CA1062:Validate arguments of public methods" when using the parameter (variable) "sizeNamePrefix" in the code.
+            /// (Normally the parameter "sizeNamePrefix" can't be null or empty because it is filled with a localized string when we call this method from <see cref="UI.Views.ImageResizerPage.AddSizeButton_Click"/>.
+            /// If the parameter is unexpectedly empty or null we fill the parameter with a non-localized string.
+            sizeNamePrefix = string.IsNullOrEmpty(sizeNamePrefix) ? "New Size" : sizeNamePrefix;
 
             ObservableCollection<ImageSize> imageSizes = Sizes;
             int maxId = imageSizes.Count > 0 ? imageSizes.OrderBy(x => x.Id).Last().Id : -1;
-            string sizeName = GenerateNameForNewSize(imageSizes, prefixString);
+            string sizeName = GenerateNameForNewSize(imageSizes, sizeNamePrefix);
 
             ImageSize newSize = new ImageSize(maxId + 1, sizeName, ResizeFit.Fit, 854, 480, ResizeUnit.Pixel);
             newSize.PropertyChanged += SizePropertyChanged;

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/ImageResizerViewModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/ImageResizerViewModel.cs
@@ -253,8 +253,8 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
         public void AddRow(string sizeNamePrefix)
         {
             /// This is a fallback validation to eliminate the warning "CA1062:Validate arguments of public methods" when using the parameter (variable) "sizeNamePrefix" in the code.
-            /// (Normally the parameter "sizeNamePrefix" can't be null or empty because it is filled with a localized string when we call this method from <see cref="UI.Views.ImageResizerPage.AddSizeButton_Click"/>.
-            /// If the parameter is unexpectedly empty or null we fill the parameter with a non-localized string.
+            /// If the parameter is unexpectedly empty or null, we fill the parameter with a non-localized string.
+            /// (Normally the parameter "sizeNamePrefix" can't be null or empty because it is filled with a localized string when we call this method from <see cref="UI.Views.ImageResizerPage.AddSizeButton_Click"/>.)
             sizeNamePrefix = string.IsNullOrEmpty(sizeNamePrefix) ? "New Size" : sizeNamePrefix;
 
             ObservableCollection<ImageSize> imageSizes = Sizes;

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/ImageResizerViewModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/ImageResizerViewModel.cs
@@ -254,7 +254,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
         {
             /// This is a fallback validation to eliminate the warning "CA1062:Validate arguments of public methods" when using the parameter (variable) "sizeNamePrefix" in the code.
             /// If the parameter is unexpectedly empty or null, we fill the parameter with a non-localized string.
-            /// (Normally the parameter "sizeNamePrefix" can't be null or empty because it is filled with a localized string when we call this method from <see cref="UI.Views.ImageResizerPage.AddSizeButton_Click"/>.)
+            /// Normally the parameter "sizeNamePrefix" can't be null or empty because it is filled with a localized string when we call this method from <see cref="UI.Views.ImageResizerPage.AddSizeButton_Click"/>.
             sizeNamePrefix = string.IsNullOrEmpty(sizeNamePrefix) ? "New Size" : sizeNamePrefix;
 
             ObservableCollection<ImageSize> imageSizes = Sizes;


### PR DESCRIPTION
## Summary of the Pull Request

Improvements on `.NullOrEmpty` check and the comment before to make the use case more clear.

See also this discussion: https://github.com/microsoft/PowerToys/pull/13285#discussion_r713135369

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [x] **Tests:** ~Added/updated and~ all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
