### PR TITLE
[FancyZones Editor] Fix crash on closing after deleting a custom layout.

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -419,6 +419,11 @@ namespace FancyZonesEditor
             {
                 LayoutModel model = element.DataContext as LayoutModel;
 
+                if (model.Guid == _backup.Guid)
+                {
+                    _backup = null;
+                }
+
                 if (model == _settings.AppliedModel)
                 {
                     _settings.SetAppliedModel(_settings.BlankModel);


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Editor crashed with an exception on closing after deleting selected layout.
```
This exception was originally thrown at this call stack:
    FancyZonesEditor.MainWindowSettingsModel.RestoreSelectedModel(FancyZonesEditor.Models.LayoutModel) in MainWindowSettingsModel.cs
    FancyZonesEditor.MainWindow.CancelLayoutChanges() in MainWindow.xaml.cs
    FancyZonesEditor.MainWindow.OnClosing(object, System.EventArgs) in MainWindow.xaml.cs
    System.Windows.Window.OnClosing(System.ComponentModel.CancelEventArgs)
    System.Windows.Window.WmClose()
    System.Windows.Window.WindowFilterMessage(System.IntPtr, int, System.IntPtr, System.IntPtr, ref bool)
    System.Windows.Interop.HwndSource.PublicHooksFilterMessage(System.IntPtr, int, System.IntPtr, System.IntPtr, ref bool)
    MS.Win32.HwndWrapper.WndProc(System.IntPtr, int, System.IntPtr, System.IntPtr, ref bool)
    MS.Win32.HwndSubclass.DispatcherCallbackOperation(object)
    System.Windows.Threading.ExceptionWrapper.InternalRealCall(System.Delegate, object, int)
    ...
```

**What is include in the PR:** 

Clean up backup on a layout delete.

**How does someone test / validate:** 

* Select custom layout
* Delete selected layout
* Close editor

## Quality Checklist

- [x] **Linked issue:** #13208
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
