### PR TITLE
[PowerToys Run] Fix crash when shutting Windows down

### DIFF
--- a/src/modules/launcher/PowerLauncher/App.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/App.xaml.cs
@@ -40,6 +40,9 @@ namespace PowerLauncher
         private StringMatcher _stringMatcher;
         private SettingsReader _settingsReader;
 
+        // To prevent two disposals running at the same time.
+        private static readonly object _disposingLock = new object();
+
         [STAThread]
         public static void Main()
         {
@@ -238,33 +241,44 @@ namespace PowerLauncher
 
         protected virtual void Dispose(bool disposing)
         {
-            if (!_disposed)
+            // Prevent two disposes at the same time.
+            lock (_disposingLock)
             {
-                Stopwatch.Normal("App.OnExit - Exit cost", () =>
+                if (!disposing)
                 {
-                    Log.Info("Start PowerToys Run Exit----------------------------------------------------  ", GetType());
-                    if (disposing)
-                    {
-                        if (_themeManager != null)
-                        {
-                            _themeManager.ThemeChanged -= OnThemeChanged;
-                        }
+                    return;
+                }
 
-                        API?.SaveAppAllSettings();
-                        PluginManager.Dispose();
-                        _mainWindow?.Dispose();
-                        API?.Dispose();
-                        _mainVM?.Dispose();
-                        _themeManager?.Dispose();
-                        _disposed = true;
+                if (_disposed)
+                {
+                    return;
+                }
+
+                _disposed = true;
+            }
+
+            Stopwatch.Normal("App.OnExit - Exit cost", () =>
+            {
+                Log.Info("Start PowerToys Run Exit----------------------------------------------------  ", GetType());
+                if (disposing)
+                {
+                    if (_themeManager != null)
+                    {
+                        _themeManager.ThemeChanged -= OnThemeChanged;
                     }
 
-                    // TODO: free unmanaged resources (unmanaged objects) and override finalizer
-                    // TODO: set large fields to null
-                    _disposed = true;
-                    Log.Info("End PowerToys Run Exit ----------------------------------------------------  ", GetType());
-                });
-            }
+                    API?.SaveAppAllSettings();
+                    PluginManager.Dispose();
+                    _mainWindow?.Dispose();
+                    API?.Dispose();
+                    _mainVM?.Dispose();
+                    _themeManager?.Dispose();
+                }
+
+                // TODO: free unmanaged resources (unmanaged objects) and override finalizer
+                // TODO: set large fields to null
+                Log.Info("End PowerToys Run Exit ----------------------------------------------------  ", GetType());
+            });
         }
 
         // // TODO: override finalizer only if 'Dispose(bool disposing)' has code to free unmanaged resources


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
PowerToys Run sometimes crashes when shutting Windows down.
Doesn't replicate every time.
The main reason is that when Windows is shutting down, it signals PowerToys Run to exit, so it runs its dispose logic to save the cache and settings. It also tells the runner to exit, which also signals PowerToys Run to exit, meaning the dispose logic will be called twice and have race conditions.

**What is include in the PR:** 
A lock so that the dispose logic doesn't run twice concurrently.

**How does someone test / validate:** 
Not easy to replicate. I'm looking just to see if the code looks good.

## Quality Checklist

- [x] **Linked issue:** #13094
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries
