### PR TITLE
[Color Picker] Increase width of editor window

### DIFF
--- a/src/modules/colorPicker/ColorPickerUI/ColorEditorWindow.xaml
+++ b/src/modules/colorPicker/ColorPickerUI/ColorEditorWindow.xaml
@@ -17,7 +17,7 @@
         BorderThickness="1"
         Title="Color Picker"
         Height="380"
-        Width="400"
+        Width="440"
         ResizeMode="NoResize"
         Topmost="True"
         WindowStartupLocation="CenterScreen">

--- a/src/modules/colorPicker/ColorPickerUI/Controls/ColorFormatControl.xaml
+++ b/src/modules/colorPicker/ColorPickerUI/Controls/ColorFormatControl.xaml
@@ -8,7 +8,7 @@
 
     <Border x:Name="MainBorder"
             Margin="12,16,12,0"
-            Width="308"
+            Width="348"
             Height="36"
             CornerRadius="2"
             HorizontalAlignment="Stretch"

--- a/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml
+++ b/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml
@@ -239,11 +239,11 @@
                                   ShadowDepth="2" />
             </Grid.Effect>
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="36" />
-                <ColumnDefinition Width="36" />
+                <ColumnDefinition Width="46" />
+                <ColumnDefinition Width="46" />
                 <ColumnDefinition Width="165" />
-                <ColumnDefinition Width="36" />
-                <ColumnDefinition Width="36" />
+                <ColumnDefinition Width="46" />
+                <ColumnDefinition Width="46" />
             </Grid.ColumnDefinitions>
 
             <Button x:Name="colorVariation1Button"
@@ -288,7 +288,7 @@
                     Background="Red"
                     Width="165"
                     Height="48"
-                    Margin="72,0,0,0"
+                    Margin="92,0,0,0"
                     AutomationProperties.Name="{x:Static p:Resources.Selected_color}"
                     AutomationProperties.HelpText="{x:Static p:Resources.Selected_color_helptext}"
                     ToolTipService.ToolTip="{x:Static p:Resources.Selected_color_tooltip}"

--- a/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml.cs
@@ -191,13 +191,7 @@ namespace ColorPicker.Controls
             {
                 _isCollapsed = false;
 
-                var opacityAppear = new DoubleAnimation(1.0, new Duration(TimeSpan.FromMilliseconds(300)));
-                opacityAppear.EasingFunction = new QuadraticEase() { EasingMode = EasingMode.EaseInOut };
-
-                var resize = new DoubleAnimation(400, new Duration(TimeSpan.FromMilliseconds(300)));
-                resize.EasingFunction = new ExponentialEase() { EasingMode = EasingMode.EaseInOut };
-
-                var resizeColor = new DoubleAnimation(309, new Duration(TimeSpan.FromMilliseconds(250)));
+                var resizeColor = new DoubleAnimation(349, new Duration(TimeSpan.FromMilliseconds(250)));
                 resizeColor.EasingFunction = new ExponentialEase() { EasingMode = EasingMode.EaseInOut };
 
                 var moveColor = new ThicknessAnimation(new Thickness(0), new Duration(TimeSpan.FromMilliseconds(250)));
@@ -217,16 +211,10 @@ namespace ColorPicker.Controls
             {
                 _isCollapsed = true;
 
-                var opacityAppear = new DoubleAnimation(0, new Duration(TimeSpan.FromMilliseconds(150)));
-                opacityAppear.EasingFunction = new QuadraticEase() { EasingMode = EasingMode.EaseInOut };
-
-                var resize = new DoubleAnimation(0, new Duration(TimeSpan.FromMilliseconds(150)));
-                resize.EasingFunction = new ExponentialEase() { EasingMode = EasingMode.EaseInOut };
-
                 var resizeColor = new DoubleAnimation(165, new Duration(TimeSpan.FromMilliseconds(150)));
                 resizeColor.EasingFunction = new ExponentialEase() { EasingMode = EasingMode.EaseInOut };
 
-                var moveColor = new ThicknessAnimation(new Thickness(72, 0, 0, 0), new Duration(TimeSpan.FromMilliseconds(150)));
+                var moveColor = new ThicknessAnimation(new Thickness(92, 0, 0, 0), new Duration(TimeSpan.FromMilliseconds(150)));
                 moveColor.EasingFunction = new ExponentialEase() { EasingMode = EasingMode.EaseInOut };
 
                 ControlHelper.SetCornerRadius(CurrentColorButton, new CornerRadius(0));


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Some color formats that we're trying to add might have longer formats which won't appear correctly with the current color picker editor window width.
This is needed if https://github.com/microsoft/PowerToys/pull/12935 ends up having decimal formats for the CIELAB and CIEXYZ color formats.

![image](https://user-images.githubusercontent.com/26118718/134666434-68a67f28-cf4b-4283-9fa4-c3678ce2697d.png)

**What is include in the PR:** 
Increases width to the color picker editor window.
Cleans some animations which were not being used.

**How does someone test / validate:** 
Just looking for that visual quality check.

## Quality Checklist

- [x] **Linked issue:** #11536 #12937
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries
