### PR TITLE
[OOBE] Fix starting PowerToys Run

### DIFF
--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -84,6 +84,10 @@ namespace PowerLauncher.ViewModel
         public void RegisterHotkey(IntPtr hwnd)
         {
             Log.Info("RegisterHotkey()", GetType());
+
+            // Allow OOBE to call PowerToys Run.
+            NativeEventWaiter.WaitForEventLoop(Constants.PowerLauncherSharedEvent(), OnHotkey);
+
             _settings.PropertyChanged += (s, e) =>
             {
                 if (e.PropertyName == nameof(PowerToysRunSettings.Hotkey))


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
After changing the logic for PowerToys Run to trigger on a global shortcut, the listener for the PowerToys Run global `PowerLauncherSharedEvent` event was removed.
This event was still used in OOBE to start PowerToys Run.

**What is include in the PR:** 
Listen to the `PowerLauncherSharedEvent` event again so that OOBE can start PowerToys Run.

**How does someone test / validate:** 
With PowerToys Run enabled, go to the OOBE Page for PowerToys Run: "Settings" -> "Welcome to PowerToys" -> "PowerToys Run".
Click the "Launch PowerToys Run" and verify PowerToys Run gets activated.

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries
