### PR TITLE
[FancyZones Editor] Fix an editor crash

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -419,7 +419,7 @@ namespace FancyZonesEditor
             {
                 LayoutModel model = element.DataContext as LayoutModel;
 
-                if (model.Guid == _backup.Guid)
+                if (_backup != null && model.Guid == _backup.Guid)
                 {
                     _backup = null;
                 }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Deleting the layout using the context menu causes a crash. 

**What is include in the PR:** 

Added check for null.

**How does someone test / validate:** 

Click `Delete` in the context menu.
 
![image](https://user-images.githubusercontent.com/8949536/134908038-c429f7e4-5194-4e99-9ae2-4a91de55d294.png)

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
