### PR TITLE
[PT Run] Fix some keyboard issues on plugin

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Registry/Helper/ContextMenuHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Registry/Helper/ContextMenuHelper.cs
@@ -75,11 +75,12 @@ namespace Microsoft.PowerToys.Run.Plugin.Registry.Helper
             list.Add(new ContextMenuResult
             {
                 AcceleratorKey = Key.Enter,
+                AcceleratorModifiers = ModifierKeys.Control,
                 Action = _ => TryToOpenInRegistryEditor(entry),
                 FontFamily = "Segoe MDL2 Assets",
                 Glyph = "\xE8A7",                           // E8A7 => Symbol: OpenInNewWindow
                 PluginName = assemblyName,
-                Title = $"{Resources.OpenKeyInRegistryEditor} (Enter)",
+                Title = $"{Resources.OpenKeyInRegistryEditor} (Ctrl+Enter)",
             });
 
             return list;

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Service/Helpers/ServiceHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Service/Helpers/ServiceHelper.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.ServiceProcess;
+using System.Threading.Tasks;
 using Microsoft.PowerToys.Run.Plugin.Service.Properties;
 using Wox.Infrastructure;
 using Wox.Plugin;
@@ -18,18 +19,41 @@ namespace Microsoft.PowerToys.Run.Plugin.Service.Helpers
 {
     public static class ServiceHelper
     {
-        public static IEnumerable<Result> Search(string search, string icoPath)
+        public static IEnumerable<Result> Search(string search, string icoPath, PluginInitContext context)
         {
             var services = ServiceController.GetServices();
 
             return services
                 .Where(s => s.DisplayName.StartsWith(search, StringComparison.OrdinalIgnoreCase) || s.ServiceName.StartsWith(search, StringComparison.OrdinalIgnoreCase))
-                .Select(s => new Result
+                .Select(s =>
                 {
-                    Title = GetResultTitle(s),
-                    SubTitle = GetResultSubTitle(s),
-                    IcoPath = icoPath,
-                    ContextData = new ServiceResult(s),
+                    ServiceResult serviceResult = new ServiceResult(s);
+                    Func<ActionContext, bool> serviceAction;
+                    if (serviceResult.IsRunning)
+                    {
+                        serviceAction = _ =>
+                        {
+                            Task.Run(() => ServiceHelper.ChangeStatus(serviceResult, Action.Stop, context.API));
+                            return true;
+                        };
+                    }
+                    else
+                    {
+                        serviceAction = _ =>
+                        {
+                            Task.Run(() => ServiceHelper.ChangeStatus(serviceResult, Action.Start, context.API));
+                            return true;
+                        };
+                    }
+
+                    return new Result
+                    {
+                        Title = ServiceHelper.GetResultTitle(s),
+                        SubTitle = ServiceHelper.GetResultSubTitle(s),
+                        IcoPath = icoPath,
+                        ContextData = serviceResult,
+                        Action = serviceAction,
+                    };
                 });
         }
 

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Service/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Service/Main.cs
@@ -51,6 +51,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Service
                     Glyph = "\xE71A",
                     FontFamily = "Segoe MDL2 Assets",
                     AcceleratorKey = Key.Enter,
+                    AcceleratorModifiers = ModifierKeys.Control,
                     Action = _ =>
                     {
                         Task.Run(() => ServiceHelper.ChangeStatus(serviceResult, Action.Stop, _context.API));
@@ -84,6 +85,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Service
                     Glyph = "\xEDB5",
                     FontFamily = "Segoe MDL2 Assets",
                     AcceleratorKey = Key.Enter,
+                    AcceleratorModifiers = ModifierKeys.Control,
                     Action = _ =>
                     {
                         Task.Run(() => ServiceHelper.ChangeStatus(serviceResult, Action.Start, _context.API));

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Service/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Service/Main.cs
@@ -116,7 +116,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Service
         public List<Result> Query(Query query)
         {
             var search = query?.Search ?? string.Empty;
-            return ServiceHelper.Search(search, _icoPath).ToList();
+            return ServiceHelper.Search(search, _icoPath, _context).ToList();
         }
 
         public string GetTranslatedPluginTitle()

--- a/src/modules/launcher/PowerLauncher/ResultList.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/ResultList.xaml.cs
@@ -58,14 +58,17 @@ namespace PowerLauncher
             if (listView.SelectedItem != null)
             {
                 ListBoxItem listBoxItem = (ListBoxItem)listView.ItemContainerGenerator.ContainerFromItem(listView.SelectedItem);
-                ContentPresenter contentPresenter = FindVisualChild<ContentPresenter>(listBoxItem);
-                DataTemplate dataTemplate = contentPresenter.ContentTemplate;
-                Button button = (Button)dataTemplate.FindName("commandButton", contentPresenter);
-                ToolTip tooltip = button.ToolTip as ToolTip;
-                tooltip.PlacementTarget = button;
-                tooltip.Placement = System.Windows.Controls.Primitives.PlacementMode.Right;
-                tooltip.PlacementRectangle = new Rect(0, button.Height, 0, 0);
-                tooltip.IsOpen = true;
+                if (listBoxItem != null)
+                {
+                    ContentPresenter contentPresenter = FindVisualChild<ContentPresenter>(listBoxItem);
+                    DataTemplate dataTemplate = contentPresenter.ContentTemplate;
+                    Button button = (Button)dataTemplate.FindName("commandButton", contentPresenter);
+                    ToolTip tooltip = button.ToolTip as ToolTip;
+                    tooltip.PlacementTarget = button;
+                    tooltip.Placement = System.Windows.Controls.Primitives.PlacementMode.Right;
+                    tooltip.PlacementRectangle = new Rect(0, button.Height, 0, 0);
+                    tooltip.IsOpen = true;
+                }
             }
         }
 

--- a/src/modules/launcher/PowerLauncher/ResultList.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/ResultList.xaml.cs
@@ -69,6 +69,14 @@ namespace PowerLauncher
                     tooltip.PlacementRectangle = new Rect(0, button.Height, 0, 0);
                     tooltip.IsOpen = true;
                 }
+                else
+                {
+                    HideCurrentToolTip();
+                }
+            }
+            else
+            {
+                HideCurrentToolTip();
             }
         }
 


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Fixes some issues while using the keyboard with PowerToys Run.

**What is include in the PR:** 
- Fix for the issue that Enter is used as a Accelerator Key on Registry and Service plugins, disallowing selecting specific context menu actions with Enter.
- Improve the tooltip logic when navigating with the keyboard.

**How does someone test / validate:** 
Use the Registry plugin with the keyboard and use the Enter key to try and copy a key to the clipboard.

## Quality Checklist

- [x] **Linked issue:** #13458
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries
