### PR TITLE
[PTRun][Services] Search for result full title

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Service/Helpers/ServiceHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Service/Helpers/ServiceHelper.cs
@@ -24,7 +24,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Service.Helpers
             var services = ServiceController.GetServices();
 
             return services
-                .Where(s => s.DisplayName.StartsWith(search, StringComparison.OrdinalIgnoreCase) || s.ServiceName.StartsWith(search, StringComparison.OrdinalIgnoreCase))
+                .Where(s => s.DisplayName.StartsWith(search, StringComparison.OrdinalIgnoreCase) || s.ServiceName.StartsWith(search, StringComparison.OrdinalIgnoreCase) || GetResultTitle(s).StartsWith(search, StringComparison.OrdinalIgnoreCase))
                 .Select(s =>
                 {
                     ServiceResult serviceResult = new ServiceResult(s);


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
When searching for the title presented for a service by PowerToys Run, no results appear.

**What is include in the PR:** 
Also query the presented title so that results appear when searching for the title presented in the results list.

**How does someone test / validate:** 
Search for "!Windows Audio (Audiosrv)" and verify the result appears. (Windows Audio is the english localized string for the Audiosrv service).

## Quality Checklist

- [x] **Linked issue:** #13491
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries