### PR TITLE
[Settings] A11y fixes

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/OOBEPageControl/OOBEPageControl.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/OOBEPageControl/OOBEPageControl.xaml
@@ -28,7 +28,7 @@
                 
                 <TextBlock x:Name="TitleTxt"
                            Text="{x:Bind ModuleTitle}"
-                           AutomationProperties.HeadingLevel="Level2"
+                           AutomationProperties.HeadingLevel="Level1"
                            Style="{StaticResource TitleTextBlockStyle}" />
 
                 <TextBlock x:Name="DescriptionTxt"

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/SettingsGroup/SettingsGroup.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/SettingsGroup/SettingsGroup.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Automation.Peers;
 using Windows.UI.Xaml.Controls;
 
 namespace Microsoft.PowerToys.Settings.UI.Controls
@@ -54,6 +55,11 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
         private void SetEnabledState()
         {
             VisualStateManager.GoToState(this, IsEnabled ? "Normal" : "Disabled", true);
+        }
+
+        protected override AutomationPeer OnCreateAutomationPeer()
+        {
+            return new SettingsGroupAutomationPeer(this);
         }
     }
 }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/SettingsGroup/SettingsGroupAutomationPeer.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/SettingsGroup/SettingsGroupAutomationPeer.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Xaml.Automation.Peers;
+
+namespace Microsoft.PowerToys.Settings.UI.Controls.SettingsGroup
+{
+    public class SettingsGroupAutomationPeer : FrameworkElementAutomationPeer
+    {
+        public SettingsGroupAutomationPeer(SettingsGroup owner)
+            : base(owner)
+        {
+        }
+
+        protected override string GetNameCore()
+        {
+            var selectedSettingsGroup = (SettingsGroup)Owner;
+            return selectedSettingsGroup.Header;
+        }
+    }
+}

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/SettingsGroup/SettingsGroupAutomationPeer.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/SettingsGroup/SettingsGroupAutomationPeer.cs
@@ -2,14 +2,9 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Windows.UI.Xaml.Automation.Peers;
 
-namespace Microsoft.PowerToys.Settings.UI.Controls.SettingsGroup
+namespace Microsoft.PowerToys.Settings.UI.Controls
 {
     public class SettingsGroupAutomationPeer : FrameworkElementAutomationPeer
     {

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/SettingsPageControl/SettingsPageControl.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/SettingsPageControl/SettingsPageControl.xaml
@@ -21,6 +21,7 @@
         
         <TextBlock x:Name="Header"
                    Text="{x:Bind ModuleTitle}"
+                   AutomationProperties.HeadingLevel="1"
                    Style="{StaticResource TitleTextBlockStyle}"
                    Margin="0,44,0,0"
                    VerticalAlignment="Stretch"/>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/SettingsPageControl/SettingsPageControl.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/SettingsPageControl/SettingsPageControl.xaml
@@ -58,7 +58,7 @@
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                    TextWrapping="Wrap"/>
 
-                        <ItemsControl ItemsSource="{x:Bind PrimaryLinks}" Margin="0,8,0,0">
+                        <ItemsControl ItemsSource="{x:Bind PrimaryLinks}" IsTabStop="False" Margin="0,8,0,0">
                             <ItemsControl.ItemTemplate>
                                 <DataTemplate x:DataType="local:PageLink">
                                     <HyperlinkButton NavigateUri="{x:Bind Link}" Style="{StaticResource TextButtonStyle}">
@@ -94,7 +94,7 @@
                                Margin="2,8,0,0"
                                AutomationProperties.HeadingLevel="Level2"/>
 
-                    <ItemsControl x:Name="SecondaryLinksItemControl" Margin="2,0,0,0" ItemsSource="{x:Bind SecondaryLinks}">
+                    <ItemsControl x:Name="SecondaryLinksItemControl" IsTabStop="False" Margin="2,0,0,0" ItemsSource="{x:Bind SecondaryLinks}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate x:DataType="local:PageLink">
                                 <HyperlinkButton NavigateUri="{x:Bind Link}" Style="{StaticResource TextButtonStyle}">

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Microsoft.PowerToys.Settings.UI.csproj
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Microsoft.PowerToys.Settings.UI.csproj
@@ -95,6 +95,7 @@
     </Compile>
     <Compile Include="Behaviors\NavigationViewHeaderBehavior.cs" />
     <Compile Include="Behaviors\NavigationViewHeaderMode.cs" />
+    <Compile Include="Controls\SettingsGroup\SettingsGroupAutomationPeer.cs" />
     <Compile Include="Controls\ShortcutControl\ShortcutControl.xaml.cs">
       <DependentUpon>ShortcutControl.xaml</DependentUpon>
     </Compile>
@@ -105,7 +106,7 @@
     <Compile Include="Controls\ShortcutControl\ShortcutDialogContentControl.xaml.cs">
       <DependentUpon>ShortcutDialogContentControl.xaml</DependentUpon>
     </Compile>
- <Compile Include="Controls\ShortcutControl\ShortcutWithTextLabelControl.xaml.cs">
+    <Compile Include="Controls\ShortcutControl\ShortcutWithTextLabelControl.xaml.cs">
       <DependentUpon>ShortcutWithTextLabelControl.xaml</DependentUpon>
     </Compile>
     <Compile Include="Controls\SettingsPageControl\SettingsPageControl.xaml.cs">

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -1095,29 +1095,11 @@ Made with 💗 by Microsoft and the PowerToys community.</value>
     <value>Small</value>
     <comment>The size of the image</comment>
   </data>
-  <data name="FancyZones_MoveWindowBasedOnRelativePosition_Accesible.AutomationProperties.Name" xml:space="preserve">
-    <value>Windows key + Up, down, left or right arrow key to move windows based on relative position</value>
+  <data name="FancyZones_MoveWindowBasedOnRelativePosition.Content" xml:space="preserve">
+    <value>Win + Up/Down/Left/Right to move windows based on relative position</value>
   </data>
-  <data name="FancyZones_MoveWindowLeftRightBasedOnZoneIndex_Accesible.AutomationProperties.Name" xml:space="preserve">
-    <value>Windows key + Left or right arrow keys to move windows based on zone index</value>
-  </data>
-  <data name="FancyZones_MoveWindowBasedOnRelativePosition_Description.Text" xml:space="preserve">
-    <value>Windows key + &#xE010; &#xE011; &#xE012; or &#xE013;</value>
-        <comment>Do not loc the icons (hex numbers)</comment>
-  </data>
-
-  <data name="FancyZones_MoveWindowLeftRightBasedOnZoneIndex_Description.Text" xml:space="preserve">
-    <value>Windows key + &#xE00E; or &#xE00F;</value>
-        <comment>Do not loc the icons (hex numbers)</comment>
-  </data>
-  <data name="FancyZones_MoveWindowBasedOnRelativePosition.Text" xml:space="preserve">
-    <value>Based on relative position</value>
-  </data>
-  <data name="FancyZones_MoveWindow.Header" xml:space="preserve">
-    <value>Move windows</value>
-  </data>
-  <data name="FancyZones_MoveWindowLeftRightBasedOnZoneIndex.Text" xml:space="preserve">
-    <value>Based on zone index</value>
+  <data name="FancyZones_MoveWindowLeftRightBasedOnZoneIndex.Content" xml:space="preserve">
+    <value>Win + Left/Right to move windows based on zone index</value>
   </data>
   <data name="ColorPicker_Editor.Header" xml:space="preserve">
     <value>Editor</value>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -1095,11 +1095,29 @@ Made with 💗 by Microsoft and the PowerToys community.</value>
     <value>Small</value>
     <comment>The size of the image</comment>
   </data>
-  <data name="FancyZones_MoveWindowBasedOnRelativePosition.Content" xml:space="preserve">
-    <value>Win + Up/Down/Left/Right to move windows based on relative position</value>
+  <data name="FancyZones_MoveWindowBasedOnRelativePosition_Accesible.AutomationProperties.Name" xml:space="preserve">
+    <value>Windows key + Up, down, left or right arrow key to move windows based on relative position</value>
   </data>
-  <data name="FancyZones_MoveWindowLeftRightBasedOnZoneIndex.Content" xml:space="preserve">
-    <value>Win + Left/Right to move windows based on zone index</value>
+  <data name="FancyZones_MoveWindowLeftRightBasedOnZoneIndex_Accesible.AutomationProperties.Name" xml:space="preserve">
+    <value>Windows key + Left or right arrow keys to move windows based on zone index</value>
+  </data>
+  <data name="FancyZones_MoveWindowBasedOnRelativePosition_Description.Text" xml:space="preserve">
+    <value>Windows key + &#xE010; &#xE011; &#xE012; or &#xE013;</value>
+        <comment>Do not loc the icons (hex numbers)</comment>
+  </data>
+
+  <data name="FancyZones_MoveWindowLeftRightBasedOnZoneIndex_Description.Text" xml:space="preserve">
+    <value>Windows key + &#xE00E; or &#xE00F;</value>
+        <comment>Do not loc the icons (hex numbers)</comment>
+  </data>
+  <data name="FancyZones_MoveWindowBasedOnRelativePosition.Text" xml:space="preserve">
+    <value>Based on relative position</value>
+  </data>
+  <data name="FancyZones_MoveWindow.Header" xml:space="preserve">
+    <value>Move windows</value>
+  </data>
+  <data name="FancyZones_MoveWindowLeftRightBasedOnZoneIndex.Text" xml:space="preserve">
+    <value>Based on zone index</value>
   </data>
   <data name="ColorPicker_Editor.Header" xml:space="preserve">
     <value>Editor</value>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -963,6 +963,9 @@ Made with 💗 by Microsoft and the PowerToys community.</value>
   <data name="ImageResizer_FilenameFormatPlaceholder.PlaceholderText" xml:space="preserve">
     <value>Example: %1 (%2)</value>
   </data>
+  <data name="ImageResizer_FilenameParameters.AutomationProperties.Name" xml:space="preserve">
+    <value>Filename parameters</value>
+  </data>
   <data name="ColorModeHeader.Header" xml:space="preserve">
     <value>App theme</value>
   </data>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -11,6 +11,7 @@
     AutomationProperties.LandmarkType="Main">
 
     <Page.Resources>
+        <converters:BoolToObjectConverter x:Key="BoolToComboBoxIndexConverter" TrueValue="1" FalseValue="0"/>
         <converters:StringFormatConverter x:Key="StringFormatConverter"/>
     </Page.Resources>
 
@@ -226,16 +227,29 @@
 
                         <controls:SettingExpander.Content>
                             <StackPanel>
-                                <RadioButton x:Uid="FancyZones_MoveWindowLeftRightBasedOnZoneIndex"
-                                             IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.MoveWindowsBasedOnZoneIndex}"
-                                             IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.SnapHotkeysCategoryEnabled}"
-                                             GroupName="OverrideSnapGroup"
-                                             Margin="{StaticResource ExpanderSettingMargin}"/>
-                                <RadioButton x:Uid="FancyZones_MoveWindowBasedOnRelativePosition"
-                                             IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.MoveWindowsBasedOnPosition}"
-                                             IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.SnapHotkeysCategoryEnabled}"
-                                             GroupName="OverrideSnapGroup"
-                                             Margin="{StaticResource ExpanderSettingMargin}"/>
+                                <controls:Setting x:Uid="FancyZones_MoveWindow" IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.SnapHotkeysCategoryEnabled}" Style="{StaticResource ExpanderContentSettingStyle}">
+                                    <controls:Setting.ActionContent>
+                                        <ComboBox SelectedIndex="{x:Bind Mode=TwoWay, Path=ViewModel.MoveWindowsBasedOnPosition, Converter={StaticResource BoolToComboBoxIndexConverter}}" MinHeight="56" MinWidth="{StaticResource SettingActionControlMinWidth}">
+                                            <ComboBoxItem x:Uid="FancyZones_MoveWindowLeftRightBasedOnZoneIndex_Accesible">
+                                                <StackPanel Orientation="Vertical">
+                                                    <TextBlock x:Uid="FancyZones_MoveWindowLeftRightBasedOnZoneIndex"/>
+                                                    <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}" Style="{StaticResource SecondaryTextStyle}">
+                                                        <Run x:Uid="FancyZones_MoveWindowLeftRightBasedOnZoneIndex_Description" />
+                                                    </TextBlock>
+                                                </StackPanel>
+                                            </ComboBoxItem>
+                                            <ComboBoxItem x:Uid="FancyZones_MoveWindowBasedOnRelativePosition_Accesible">
+                                                <StackPanel Orientation="Vertical">
+                                                    <TextBlock x:Uid="FancyZones_MoveWindowBasedOnRelativePosition"/>
+                                                    <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}"  Style="{StaticResource SecondaryTextStyle}">
+                                                        <Run x:Uid="FancyZones_MoveWindowBasedOnRelativePosition_Description" />
+                                                    </TextBlock>
+                                                </StackPanel>
+                                            </ComboBoxItem>
+                                        </ComboBox>
+                                    </controls:Setting.ActionContent>
+                                </controls:Setting>
+
                                 <Rectangle Style="{StaticResource ExpanderSeparatorStyle}" />
                                 <CheckBox x:Uid="FancyZones_MoveWindowsAcrossAllMonitorsCheckBoxControl"
                                           Margin="56,8,16,8"

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -11,7 +11,6 @@
     AutomationProperties.LandmarkType="Main">
 
     <Page.Resources>
-        <converters:BoolToObjectConverter x:Key="BoolToComboBoxIndexConverter" TrueValue="1" FalseValue="0"/>
         <converters:StringFormatConverter x:Key="StringFormatConverter"/>
     </Page.Resources>
 
@@ -227,29 +226,16 @@
 
                         <controls:SettingExpander.Content>
                             <StackPanel>
-                                <controls:Setting x:Uid="FancyZones_MoveWindow" IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.SnapHotkeysCategoryEnabled}" Style="{StaticResource ExpanderContentSettingStyle}">
-                                    <controls:Setting.ActionContent>
-                                        <ComboBox SelectedIndex="{x:Bind Mode=TwoWay, Path=ViewModel.MoveWindowsBasedOnPosition, Converter={StaticResource BoolToComboBoxIndexConverter}}" MinHeight="56" MinWidth="{StaticResource SettingActionControlMinWidth}">
-                                            <ComboBoxItem x:Uid="FancyZones_MoveWindowLeftRightBasedOnZoneIndex_Accesible">
-                                                <StackPanel Orientation="Vertical">
-                                                    <TextBlock x:Uid="FancyZones_MoveWindowLeftRightBasedOnZoneIndex"/>
-                                                    <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}" Style="{StaticResource SecondaryTextStyle}">
-                                                        <Run x:Uid="FancyZones_MoveWindowLeftRightBasedOnZoneIndex_Description" />
-                                                    </TextBlock>
-                                                </StackPanel>
-                                            </ComboBoxItem>
-                                            <ComboBoxItem x:Uid="FancyZones_MoveWindowBasedOnRelativePosition_Accesible">
-                                                <StackPanel Orientation="Vertical">
-                                                    <TextBlock x:Uid="FancyZones_MoveWindowBasedOnRelativePosition"/>
-                                                    <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}"  Style="{StaticResource SecondaryTextStyle}">
-                                                        <Run x:Uid="FancyZones_MoveWindowBasedOnRelativePosition_Description" />
-                                                    </TextBlock>
-                                                </StackPanel>
-                                            </ComboBoxItem>
-                                        </ComboBox>
-                                    </controls:Setting.ActionContent>
-                                </controls:Setting>
-
+                                <RadioButton x:Uid="FancyZones_MoveWindowLeftRightBasedOnZoneIndex"
+                                             IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.MoveWindowsBasedOnZoneIndex}"
+                                             IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.SnapHotkeysCategoryEnabled}"
+                                             GroupName="OverrideSnapGroup"
+                                             Margin="{StaticResource ExpanderSettingMargin}"/>
+                                <RadioButton x:Uid="FancyZones_MoveWindowBasedOnRelativePosition"
+                                             IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.MoveWindowsBasedOnPosition}"
+                                             IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.SnapHotkeysCategoryEnabled}"
+                                             GroupName="OverrideSnapGroup"
+                                             Margin="{StaticResource ExpanderSettingMargin}"/>
                                 <Rectangle Style="{StaticResource ExpanderSeparatorStyle}" />
                                 <CheckBox x:Uid="FancyZones_MoveWindowsAcrossAllMonitorsCheckBoxControl"
                                           Margin="56,8,16,8"

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml
@@ -61,12 +61,14 @@
                     <muxc:InfoBar x:Uid="General_UpToDate"
                                   IsClosable="False"
                                   Severity="Success"
+                                  IsTabStop="True"
                                   IsOpen="{Binding IsNewVersionCheckedAndUpToDate, Mode=OneWay}"/>
 
                     <!-- New version available -->
                     <muxc:InfoBar x:Uid="General_NewVersionAvailable"
                                   IsClosable="False"
                                   Severity="Informational"
+                                  IsTabStop="True"
                                   IsOpen="{Binding PowerToysUpdatingState, Mode=OneWay, Converter={StaticResource UpdateStateToBoolConverter}, ConverterParameter=ReadyToDownload}"
                                   Message="{Binding PowerToysNewAvailableVersion, Mode=OneWay}">
                         <muxc:InfoBar.Content>
@@ -102,6 +104,7 @@
                     <muxc:InfoBar x:Uid="General_NewVersionReadyToInstall"
                                   IsClosable="False"
                                   Severity="Success"
+                                  IsTabStop="True"
                                   IsOpen="{Binding PowerToysUpdatingState, Mode=OneWay, Converter={StaticResource UpdateStateToBoolConverter}, ConverterParameter=ReadyToInstall}"
                                   Message="{Binding PowerToysNewAvailableVersion}">
                         <muxc:InfoBar.Content>
@@ -126,6 +129,7 @@
                     <muxc:InfoBar x:Uid="General_FailedToDownloadTheNewVersion"
                                   IsClosable="False"
                                   Severity="Error"
+                                  IsTabStop="True"
                                   IsOpen="{Binding PowerToysUpdatingState, Mode=OneWay, Converter={StaticResource UpdateStateToBoolConverter}, ConverterParameter=ErrorDownloading}"
                                   Message="{Binding PowerToysNewAvailableVersion}">
                         <muxc:InfoBar.Content>
@@ -192,6 +196,7 @@
                                 </controls:Setting>
                                 <muxc:InfoBar x:Uid="General_RunAsAdminRequired" 
                                           Severity="Warning"
+                                          IsTabStop="True"
                                           IsClosable="False"
                                           IsOpen="{Binding Mode=OneWay, Path=IsElevated, Converter={StaticResource NegationConverter}}"/>
                             </StackPanel>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
@@ -226,7 +226,7 @@
                                          HorizontalAlignment="Right"
                                          MinWidth="{StaticResource SettingActionControlMinWidth}"
                                          x:Uid="ImageResizer_FilenameFormatPlaceholder"/>
-                                <Button Content="&#xE946;" Height="32" FontFamily="{ThemeResource SymbolThemeFontFamily}">
+                                <Button Content="&#xE946;" x:Uid="ImageResizer_FilenameParameters" Height="32" FontFamily="{ThemeResource SymbolThemeFontFamily}">
                                     <Button.Flyout>
                                         <Flyout>
                                             <TextBlock x:Name="FileFormatTextBlock">

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
@@ -179,12 +179,11 @@
 
                     <controls:Setting x:Uid="ImageResizer_Encoding">
                         <controls:Setting.ActionContent>
-                            <muxc:NumberBox
+                            <Slider
                                 Minimum="0"
                                 Maximum="100"
                                 Value="{x:Bind Mode=TwoWay, Path=ViewModel.JPEGQualityLevel}"
                                 MinWidth="{StaticResource SettingActionControlMinWidth}"
-                                SpinButtonPlacementMode="Compact"
                                 HorizontalAlignment="Right"
                             />
                         </controls:Setting.ActionContent>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
@@ -179,11 +179,12 @@
 
                     <controls:Setting x:Uid="ImageResizer_Encoding">
                         <controls:Setting.ActionContent>
-                            <Slider
+                            <muxc:NumberBox
                                 Minimum="0"
                                 Maximum="100"
                                 Value="{x:Bind Mode=TwoWay, Path=ViewModel.JPEGQualityLevel}"
                                 MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                SpinButtonPlacementMode="Compact"
                                 HorizontalAlignment="Right"
                             />
                         </controls:Setting.ActionContent>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
@@ -167,7 +167,11 @@
                             </AutoSuggestBox>
                         </controls:Setting.ActionContent>
                     </controls:Setting>
-                    <muxc:InfoBar x:Uid="Run_AllPluginsDisabled" Severity="Error" IsOpen="{x:Bind ViewModel.ShowAllPluginsDisabledWarning, Mode=OneWay}" IsClosable="False" />
+                    <muxc:InfoBar x:Uid="Run_AllPluginsDisabled"
+                                  Severity="Error"
+                                  IsTabStop="True"
+                                  IsOpen="{x:Bind ViewModel.ShowAllPluginsDisabledWarning, Mode=OneWay}"
+                                  IsClosable="False" />
 
                     <StackPanel Orientation="Horizontal" Visibility="{x:Bind ViewModel.ShowPluginsLoadingMessage, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
                         <muxc:ProgressRing IsActive="True" Width="20" Height="20" Margin="18,18" />
@@ -212,10 +216,12 @@
                                                     </controls:Setting.ActionContent>
                                                 </controls:Setting>
                                                 <muxc:InfoBar Severity="Error" x:Uid="Run_NotAccessibleWarning"
+                                                              IsTabStop="True"
                                                               IsOpen="{x:Bind ShowNotAccessibleWarning}"
                                                               IsClosable="False" />
                                                 <muxc:InfoBar Severity="Error"
                                                               x:Uid="Run_NotAllowedActionKeyword"
+                                                              IsTabStop="True"
                                                               IsOpen="{x:Bind ShowNotAllowedKeywordWarning}"
                                                               IsClosable="False" />
                                                 <Rectangle Style="{StaticResource ExpanderSeparatorStyle}" />

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerPreviewPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerPreviewPage.xaml
@@ -23,12 +23,14 @@
                 <muxc:InfoBar Severity="Warning"
                                    x:Uid="FileExplorerPreview_RunAsAdminRequired"
                                    IsOpen="True"
+                                   IsTabStop="True"
                                    IsClosable="False"
                                    Visibility="{Binding Mode=OneWay, Path=IsElevated, Converter={StaticResource BoolToVisibilityConverter}}" />
 
                 <muxc:InfoBar Severity="Informational"
                                    x:Uid="FileExplorerPreview_AffectsAllUsers"
                                    IsOpen="True"
+                                   IsTabStop="True"
                                    IsClosable="False"
                                    />
 
@@ -59,6 +61,7 @@
                     <muxc:InfoBar Severity="Informational"
                                    x:Uid="FileExplorerPreview_RebootRequired"
                                    IsOpen="True"
+                                   IsTabStop="True"
                                    IsClosable="False"
                                    />
                     <controls:Setting x:Uid="FileExplorerPreview_ToggleSwitch_SVG_Thumbnail" Icon="&#xE91B;">

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ShortcutGuidePage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ShortcutGuidePage.xaml
@@ -65,7 +65,7 @@
                     <muxc:InfoBar
                         x:Uid="ShortcutGuide_PressWinKeyWarning"
                         Severity="Warning"
-                        
+                        IsTabStop="True"
                         IsOpen="{x:Bind Mode=OneWay, Path=ViewModel.UseLegacyPressWinKeyBehavior}"
                         IsClosable="False"
                     />

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ShortcutGuidePage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ShortcutGuidePage.xaml
@@ -65,6 +65,7 @@
                     <muxc:InfoBar
                         x:Uid="ShortcutGuide_PressWinKeyWarning"
                         Severity="Warning"
+                        
                         IsOpen="{x:Bind Mode=OneWay, Path=ViewModel.UseLegacyPressWinKeyBehavior}"
                         IsClosable="False"
                     />


### PR DESCRIPTION
## Summary of the Pull Request
This PR fixes a couple of outstanding accessibility issues in Settings:
#13462, #13388 - Set IsTabStop="False" on ItemControls
#13451 - SettingsGroup header now get announced (added a custom AutomationPeer)
#13386 - Set IsTabStop="True" to multiple InfoBars
#13379 - Set AutomationProperties.Name to info button
#13374 - Set HeadingLevel to headings

## Quality Checklist

- [X] **Linked issue:** #13462, #13388, #13451, #13386, #13379, #13374
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
