### PR TITLE
[Settings] A11y fixes (2)

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -128,6 +128,7 @@ AUTOSIZECOLUMNS
 AUTOUPDATE
 available
 AValid
+awakeness
 awakeversion
 AWAYMODE
 AYUV

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/ColorPickerViewModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/ColorPickerViewModel.cs
@@ -148,43 +148,19 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             }
         }
 
-        public bool ActivationOpensEditor
+        public int ActivationBehavior
         {
-            get => _colorPickerSettings.Properties.ActivationAction == ColorPickerActivationAction.OpenEditor;
-            set
+            get
             {
-                if (value && _colorPickerSettings.Properties.ActivationAction != ColorPickerActivationAction.OpenEditor)
-                {
-                    _colorPickerSettings.Properties.ActivationAction = ColorPickerActivationAction.OpenEditor;
-                    OnPropertyChanged(nameof(ActivationOpensEditor));
-                    NotifySettingsChanged();
-                }
+                return (int)_colorPickerSettings.Properties.ActivationAction;
             }
-        }
 
-        public bool ActivationOpensColorPickerOnly
-        {
-            get => _colorPickerSettings.Properties.ActivationAction == ColorPickerActivationAction.OpenOnlyColorPicker;
             set
             {
-                if (value && _colorPickerSettings.Properties.ActivationAction != ColorPickerActivationAction.OpenOnlyColorPicker)
+                if (value != (int)_colorPickerSettings.Properties.ActivationAction)
                 {
-                    _colorPickerSettings.Properties.ActivationAction = ColorPickerActivationAction.OpenOnlyColorPicker;
-                    OnPropertyChanged(nameof(ActivationOpensColorPickerOnly));
-                    NotifySettingsChanged();
-                }
-            }
-        }
-
-        public bool ActivationOpensColorPickerAndEditor
-        {
-            get => _colorPickerSettings.Properties.ActivationAction == ColorPickerActivationAction.OpenColorPickerAndThenEditor;
-            set
-            {
-                if (value && _colorPickerSettings.Properties.ActivationAction != ColorPickerActivationAction.OpenColorPickerAndThenEditor)
-                {
-                    _colorPickerSettings.Properties.ActivationAction = ColorPickerActivationAction.OpenColorPickerAndThenEditor;
-                    OnPropertyChanged(nameof(ActivationOpensEditor));
+                    _colorPickerSettings.Properties.ActivationAction = (ColorPickerActivationAction)value;
+                    OnPropertyChanged(nameof(ActivationBehavior));
                     NotifySettingsChanged();
                 }
             }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Converters/AwakeModeToBoolConverter.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Converters/AwakeModeToBoolConverter.cs
@@ -12,30 +12,13 @@ namespace Microsoft.PowerToys.Settings.UI.Converters
     {
         public object Convert(object value, Type targetType, object parameter, string language)
         {
-            if (targetType != typeof(bool?))
-            {
-                throw new InvalidOperationException("The target type needs to be a boolean.");
-            }
-
-            if (parameter == null)
-            {
-                throw new NullReferenceException("Parameter cannot be null for the PowerToys Awake mode to bool converter.");
-            }
-
-            var expectedMode = (AwakeMode)Enum.Parse(typeof(AwakeMode), parameter.ToString());
-            var currentMode = (AwakeMode)value;
-
-            return currentMode.Equals(expectedMode);
+            var mode = (AwakeMode)value;
+            return (int)mode;
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, string language)
         {
-            if (parameter == null)
-            {
-                throw new NullReferenceException("Parameter cannot be null for the PowerToys Awake mode to bool converter.");
-            }
-
-            return (AwakeMode)Enum.Parse(typeof(AwakeMode), parameter.ToString());
+            return (AwakeMode)Enum.ToObject(typeof(AwakeMode), (int)value);
         }
     }
 }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Converters/AwakeModeToIntConverter.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Converters/AwakeModeToIntConverter.cs
@@ -8,7 +8,7 @@ using Windows.UI.Xaml.Data;
 
 namespace Microsoft.PowerToys.Settings.UI.Converters
 {
-    public sealed class AwakeModeToBoolConverter : IValueConverter
+    public sealed class AwakeModeToIntConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, string language)
         {

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Microsoft.PowerToys.Settings.UI.csproj
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Microsoft.PowerToys.Settings.UI.csproj
@@ -105,7 +105,7 @@
     <Compile Include="Controls\ShortcutControl\ShortcutDialogContentControl.xaml.cs">
       <DependentUpon>ShortcutDialogContentControl.xaml</DependentUpon>
     </Compile>
- <Compile Include="Controls\ShortcutControl\ShortcutWithTextLabelControl.xaml.cs">
+    <Compile Include="Controls\ShortcutControl\ShortcutWithTextLabelControl.xaml.cs">
       <DependentUpon>ShortcutWithTextLabelControl.xaml</DependentUpon>
     </Compile>
     <Compile Include="Controls\SettingsPageControl\SettingsPageControl.xaml.cs">
@@ -118,7 +118,7 @@
     <Compile Include="Controls\TextBlockControl.xaml.cs">
       <DependentUpon>TextBlockControl.xaml</DependentUpon>
     </Compile>
-    <Compile Include="Converters\AwakeModeToBoolConverter.cs" />
+    <Compile Include="Converters\AwakeModeToIntConverter.cs" />
     <Compile Include="Converters\ImageResizerFitToStringConverter.cs" />
     <Compile Include="Converters\ImageResizerUnitToStringConverter.cs" />
     <Compile Include="Converters\UpdateStateToBoolConverter.cs" />

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -1099,22 +1099,21 @@ Made with 💗 by Microsoft and the PowerToys community.</value>
     <value>Windows key + Left or right arrow keys to move windows based on zone index</value>
   </data>
   <data name="FancyZones_MoveWindowBasedOnRelativePosition_Description.Text" xml:space="preserve">
-    <value>Windows key + &#xE010; &#xE011; &#xE012; or &#xE013;</value>
-        <comment>Do not loc the icons (hex numbers)</comment>
+    <value>Windows key +    or </value>
+    <comment>Do not loc the icons (hex numbers)</comment>
   </data>
-
   <data name="FancyZones_MoveWindowLeftRightBasedOnZoneIndex_Description.Text" xml:space="preserve">
-    <value>Windows key + &#xE00E; or &#xE00F;</value>
-        <comment>Do not loc the icons (hex numbers)</comment>
+    <value>Windows key +  or </value>
+    <comment>Do not loc the icons (hex numbers)</comment>
   </data>
   <data name="FancyZones_MoveWindowBasedOnRelativePosition.Text" xml:space="preserve">
-    <value>Based on relative position</value>
+    <value>Relative position</value>
   </data>
   <data name="FancyZones_MoveWindow.Header" xml:space="preserve">
-    <value>Move windows</value>
+    <value>Move windows based on</value>
   </data>
   <data name="FancyZones_MoveWindowLeftRightBasedOnZoneIndex.Text" xml:space="preserve">
-    <value>Based on zone index</value>
+    <value>Zone index</value>
   </data>
   <data name="ColorPicker_Editor.Header" xml:space="preserve">
     <value>Editor</value>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -1391,7 +1391,7 @@ From there, simply click on a Markdown file, PDF file or SVG icon in the File Ex
   </data>
   <data name="Awake_EnableAwake.Header" xml:space="preserve">
     <value>Enable Awake</value>
-    <comment>Awake is a produce name, do not loc</comment>
+    <comment>Awake is a product name, do not loc</comment>
   </data>
   <data name="Awake_NoKeepAwake.Content" xml:space="preserve">
     <value>Keep using the selected power plan</value>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -1092,11 +1092,29 @@ Made with 💗 by Microsoft and the PowerToys community.</value>
     <value>Small</value>
     <comment>The size of the image</comment>
   </data>
-  <data name="FancyZones_MoveWindowBasedOnRelativePosition.Content" xml:space="preserve">
-    <value>Win + Up/Down/Left/Right to move windows based on relative position</value>
+  <data name="FancyZones_MoveWindowBasedOnRelativePosition_Accesible.AutomationProperties.Name" xml:space="preserve">
+    <value>Windows key + Up, down, left or right arrow key to move windows based on relative position</value>
   </data>
-  <data name="FancyZones_MoveWindowLeftRightBasedOnZoneIndex.Content" xml:space="preserve">
-    <value>Win + Left/Right to move windows based on zone index</value>
+  <data name="FancyZones_MoveWindowLeftRightBasedOnZoneIndex_Accesible.AutomationProperties.Name" xml:space="preserve">
+    <value>Windows key + Left or right arrow keys to move windows based on zone index</value>
+  </data>
+  <data name="FancyZones_MoveWindowBasedOnRelativePosition_Description.Text" xml:space="preserve">
+    <value>Windows key + &#xE010; &#xE011; &#xE012; or &#xE013;</value>
+        <comment>Do not loc the icons (hex numbers)</comment>
+  </data>
+
+  <data name="FancyZones_MoveWindowLeftRightBasedOnZoneIndex_Description.Text" xml:space="preserve">
+    <value>Windows key + &#xE00E; or &#xE00F;</value>
+        <comment>Do not loc the icons (hex numbers)</comment>
+  </data>
+  <data name="FancyZones_MoveWindowBasedOnRelativePosition.Text" xml:space="preserve">
+    <value>Based on relative position</value>
+  </data>
+  <data name="FancyZones_MoveWindow.Header" xml:space="preserve">
+    <value>Move windows</value>
+  </data>
+  <data name="FancyZones_MoveWindowLeftRightBasedOnZoneIndex.Text" xml:space="preserve">
+    <value>Based on zone index</value>
   </data>
   <data name="ColorPicker_Editor.Header" xml:space="preserve">
     <value>Editor</value>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -1391,24 +1391,16 @@ From there, simply click on a Markdown file, PDF file or SVG icon in the File Ex
   </data>
   <data name="Awake_EnableAwake.Header" xml:space="preserve">
     <value>Enable Awake</value>
+    <comment>Awake is a produce name, do not loc</comment>
   </data>
-  <data name="Awake_NoKeepAwakeContent.Text" xml:space="preserve">
-    <value>Inactive</value>
+  <data name="Awake_NoKeepAwake.Content" xml:space="preserve">
+    <value>Keep using the selected power plan</value>
   </data>
-  <data name="Awake_IndefiniteKeepAwakeContent.Text" xml:space="preserve">
+  <data name="Awake_IndefiniteKeepAwake.Content" xml:space="preserve">
     <value>Keep awake indefinitely</value>
   </data>
-  <data name="Awake_TemporaryKeepAwakeContent.Text" xml:space="preserve">
+  <data name="Awake_TemporaryKeepAwake.Content" xml:space="preserve">
     <value>Keep awake temporarily</value>
-  </data>
-  <data name="Awake_NoKeepAwakeDescription.Text" xml:space="preserve">
-    <value>Your PC operates according to its current power plan</value>
-  </data>
-  <data name="Awake_IndefiniteKeepAwakeDescription.Text" xml:space="preserve">
-    <value>Keeps your PC awake until the setting is disabled</value>
-  </data>
-  <data name="Awake_TemporaryKeepAwakeDescription.Text" xml:space="preserve">
-    <value>Keeps your PC awake until the set time elapses</value>
   </data>
   <data name="Awake_EnableDisplayKeepAwake.Header" xml:space="preserve">
     <value>Keep screen on</value>
@@ -1507,7 +1499,7 @@ From there, simply click on a Markdown file, PDF file or SVG icon in the File Ex
     <value>See what's new</value>
   </data>
   <data name="Awake_Mode.Description" xml:space="preserve">
-    <value>Set the preferred behaviour of Awake</value>
+    <value>Manage the state of your device when Awake is active</value>
   </data>
   <data name="ExcludedApps.Header" xml:space="preserve">
     <value>Excluded apps</value>
@@ -1635,5 +1627,8 @@ From there, simply click on a Markdown file, PDF file or SVG icon in the File Ex
   <data name="ImageResizer_DefaultSize_NewSizePrefix" xml:space="preserve">
     <value>New size</value>
     <comment>First part of the default name of new sizes that can be added in PT's settings ui.</comment>
+  </data>
+  <data name="Awake_TimeBeforeAwake.Header" xml:space="preserve">
+    <value>Time before returning to the previous awakeness state</value>
   </data>
 </root>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -985,23 +985,14 @@ Made with 💗 by Microsoft and the PowerToys community.</value>
   <data name="ColorPicker_CopiedColorRepresentation.Header" xml:space="preserve">
     <value>Default color format</value>
   </data>
-  <data name="ColorPickerFirst.Text" xml:space="preserve">
-    <value>Color Picker with editor mode enabled</value>
-    <comment>do not loc the product name</comment>
+  <data name="ColorPickerFirst.Content" xml:space="preserve">
+    <value>Pick a color and open editor</value>
   </data>
-  <data name="ColorPickerFirst_Accessible.AutomationProperties.Name" xml:space="preserve">
-    <value>Color Picker with editor mode enabled</value>
-    <comment>do not loc the product name</comment>
+  <data name="EditorFirst.Content" xml:space="preserve">
+    <value>Open editor</value>
   </data>
-  <data name="ColorPickerFirst_Description.Text" xml:space="preserve">
-    <value>Pick a color from the screen, copy formatted value to clipboard, then to the editor</value>
-    <comment>do not loc the product name</comment>
-  </data>
-  <data name="EditorFirst.Text" xml:space="preserve">
-    <value>Editor</value>
-  </data>
-  <data name="EditorFirst_Accessible.AutomationProperties.Name" xml:space="preserve">
-    <value>Editor</value>
+  <data name="ColorPickerOnly.Content" xml:space="preserve">
+    <value>Only pick a color</value>
   </data>
   <data name="ColorPicker_ActivationAction.Header" xml:space="preserve">
     <value>Activation behavior</value>
@@ -1044,20 +1035,6 @@ Made with 💗 by Microsoft and the PowerToys community.</value>
   <data name="MadeWithOssLove.Text" xml:space="preserve">
     <value>Made with 💗 by Microsoft and the PowerToys community.</value>
   </data>
-  <data name="ColorPickerOnly.Text" xml:space="preserve">
-    <value>Color Picker only</value>
-    <comment>do not loc the product name</comment>
-  </data>
-  <data name="ColorPickerOnly_Accessible.AutomationProperties.Name" xml:space="preserve">
-    <value>Color Picker only</value>
-    <comment>do not loc the product name</comment>
-  </data>
-  <data name="ColorPickerOnly_Description.Text" xml:space="preserve">
-    <value>Pick a color from the screen and copy formatted value to clipboard</value>
-  </data>
-  <data name="EditorFirst_Description.Text" xml:space="preserve">
-    <value>Open directly into the editor mode</value>
-  </data>
   <data name="ColorPicker_ColorFormats.Header" xml:space="preserve">
     <value>Color formats</value>
   </data>
@@ -1092,10 +1069,10 @@ Made with 💗 by Microsoft and the PowerToys community.</value>
     <value>Small</value>
     <comment>The size of the image</comment>
   </data>
-  <data name="FancyZones_MoveWindowBasedOnRelativePosition_Accesible.AutomationProperties.Name" xml:space="preserve">
+  <data name="FancyZones_MoveWindowBasedOnRelativePosition_Accessible.AutomationProperties.Name" xml:space="preserve">
     <value>Windows key + Up, down, left or right arrow key to move windows based on relative position</value>
   </data>
-  <data name="FancyZones_MoveWindowLeftRightBasedOnZoneIndex_Accesible.AutomationProperties.Name" xml:space="preserve">
+  <data name="FancyZones_MoveWindowLeftRightBasedOnZoneIndex_Accessible.AutomationProperties.Name" xml:space="preserve">
     <value>Windows key + Left or right arrow keys to move windows based on zone index</value>
   </data>
   <data name="FancyZones_MoveWindowBasedOnRelativePosition_Description.Text" xml:space="preserve">

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/AwakePage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/AwakePage.xaml
@@ -4,14 +4,14 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:c="using:Microsoft.PowerToys.Settings.UI.Converters"
+    xmlns:converters="using:Microsoft.PowerToys.Settings.UI.Converters"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     xmlns:controls="using:Microsoft.PowerToys.Settings.UI.Controls"
     mc:Ignorable="d"
     AutomationProperties.LandmarkType="Main">
 
     <Page.Resources>
-        <c:AwakeModeToBoolConverter x:Key="AwakeModeToBoolConverter" />
+        <converters:AwakeModeToIntConverter x:Key="AwakeModeToIntConverter" />
     </Page.Resources>
 
     <controls:SettingsPageControl x:Uid="Awake" IsTabStop="False"
@@ -33,7 +33,7 @@
                     <controls:Setting x:Uid="Awake_Mode" Icon="&#xEC4E;" >
                         <controls:Setting.ActionContent>
                             <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}"
-                                      SelectedIndex="{x:Bind Path=ViewModel.Mode, Mode=TwoWay, Converter={StaticResource AwakeModeToBoolConverter}}">
+                                      SelectedIndex="{x:Bind Path=ViewModel.Mode, Mode=TwoWay, Converter={StaticResource AwakeModeToIntConverter}}">
                                 <ComboBoxItem x:Uid="Awake_NoKeepAwake"/>
                                 <ComboBoxItem x:Uid="Awake_IndefiniteKeepAwake"/>
                                 <ComboBoxItem x:Uid="Awake_TemporaryKeepAwake"/>
@@ -41,7 +41,7 @@
                         </controls:Setting.ActionContent>
                     </controls:Setting>
 
-                    <controls:Setting x:Uid="Awake_TimeBeforeAwake" Icon="&#xE121;" Visibility="{x:Bind ViewModel.IsTimeConfigurationEnabled, Mode=OneWay}">
+                    <controls:Setting x:Uid="Awake_TimeBeforeAwake" Icon="&#xE916;" Visibility="{x:Bind ViewModel.IsTimeConfigurationEnabled, Mode=OneWay}">
                         <controls:Setting.ActionContent>
                             <StackPanel
                                                 Orientation="Horizontal">

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/AwakePage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/AwakePage.xaml
@@ -29,86 +29,50 @@
                 </controls:Setting>
 
                 <controls:SettingsGroup x:Uid="Awake_Behavior_GroupSettings" IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}">
+                 
+                    <controls:Setting x:Uid="Awake_Mode" Icon="&#xEC4E;" >
+                        <controls:Setting.ActionContent>
+                            <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                      SelectedIndex="{x:Bind Path=ViewModel.Mode, Mode=TwoWay, Converter={StaticResource AwakeModeToBoolConverter}}">
+                                <ComboBoxItem x:Uid="Awake_NoKeepAwake"/>
+                                <ComboBoxItem x:Uid="Awake_IndefiniteKeepAwake"/>
+                                <ComboBoxItem x:Uid="Awake_TemporaryKeepAwake"/>
+                            </ComboBox>
+                        </controls:Setting.ActionContent>
+                    </controls:Setting>
+
+                    <controls:Setting x:Uid="Awake_TimeBeforeAwake" Icon="&#xE121;" Visibility="{x:Bind ViewModel.IsTimeConfigurationEnabled, Mode=OneWay}">
+                        <controls:Setting.ActionContent>
+                            <StackPanel
+                                                Orientation="Horizontal">
+                                <muxc:NumberBox x:Uid="Awake_TemporaryKeepAwake_Hours"
+                                                Value="{x:Bind ViewModel.Hours, Mode=TwoWay}"
+                                                Minimum="0"
+                                                SpinButtonPlacementMode="Compact"
+                                                HorizontalAlignment="Left"
+                                                Width="96"
+                                                SmallChange="1" 
+                                                LargeChange="5"/>
+                                <muxc:NumberBox x:Uid="Awake_TemporaryKeepAwake_Minutes"
+                                                Value="{x:Bind ViewModel.Minutes, Mode=TwoWay}"
+                                                Minimum="0"
+                                                SpinButtonPlacementMode="Compact"
+                                                Margin="8,0,0,0"
+                                                HorizontalAlignment="Left"
+                                                Width="96"
+                                                Maximum="60"
+                                                SmallChange="1" 
+                                                LargeChange="5"/>
+                            </StackPanel>
+                        </controls:Setting.ActionContent>
+                    </controls:Setting>
+
                     <controls:Setting x:Uid="Awake_EnableDisplayKeepAwake" Icon="&#xE7FB;">
                         <controls:Setting.ActionContent>
                             <ToggleSwitch IsOn="{x:Bind ViewModel.KeepDisplayOn, Mode=TwoWay}" />
                         </controls:Setting.ActionContent>
                     </controls:Setting>
 
-                    <controls:SettingExpander IsExpanded="True">
-                        <controls:SettingExpander.Header>
-                            <controls:Setting x:Uid="Awake_Mode"
-                                              Icon="&#xEC4E;"
-                                              Style="{StaticResource ExpanderHeaderSettingStyle}" />
-                        </controls:SettingExpander.Header>
-                        <controls:SettingExpander.Content>
-                            <StackPanel Padding="56,16,16,24"
-                                        Spacing="12">
-                                <RadioButton x:Uid="Awake_NoKeepAwake"
-                                             IsChecked="{x:Bind Path=ViewModel.Mode, Mode=TwoWay, Converter={StaticResource AwakeModeToBoolConverter}, ConverterParameter=0}">
-                                    <RadioButton.Content>
-                                        <TextBlock TextWrapping="WrapWholeWords"
-                                                   LineHeight="20">
-                                            <Run x:Uid="Awake_NoKeepAwakeContent"/>
-                                            <LineBreak/>
-                                            <Run Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                                x:Uid="Awake_NoKeepAwakeDescription"/>
-                                        </TextBlock>
-                                    </RadioButton.Content>
-                                </RadioButton>
-                                <RadioButton x:Uid="Awake_IndefiniteKeepAwake"
-                                             IsChecked="{x:Bind Path=ViewModel.Mode, Mode=TwoWay, Converter={StaticResource AwakeModeToBoolConverter}, ConverterParameter=1}">
-                                    <RadioButton.Content>
-                                        <TextBlock TextWrapping="WrapWholeWords"
-                                                   LineHeight="20">
-                                            <Run x:Uid="Awake_IndefiniteKeepAwakeContent"/>
-                                            <LineBreak/>
-                                            <Run Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                                 x:Uid="Awake_IndefiniteKeepAwakeDescription"/>
-                                        </TextBlock>
-                                    </RadioButton.Content>
-                                </RadioButton>
-                                <RadioButton x:Uid="Awake_TemporaryKeepAwake"
-                                            IsChecked="{x:Bind Path=ViewModel.Mode, Mode=TwoWay, Converter={StaticResource AwakeModeToBoolConverter}, ConverterParameter=2}">
-                                    <RadioButton.Content>
-                                        <TextBlock TextWrapping="WrapWholeWords"
-                                                   LineHeight="20">
-                                            <Run x:Uid="Awake_TemporaryKeepAwakeContent"/>
-                                            <LineBreak/>
-                                            <Run Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                                 x:Uid="Awake_TemporaryKeepAwakeDescription"/>
-                                        </TextBlock>
-                                    </RadioButton.Content>
-                                </RadioButton>
-                                <StackPanel AutomationProperties.LabeledBy="{Binding ElementName=ModeTitleLabel}"
-                                            Margin="0,-8,0,0">
-
-                                    <StackPanel Margin="28,8,0,0"
-                                                Orientation="Horizontal">
-                                        <muxc:NumberBox x:Uid="Awake_TemporaryKeepAwake_Hours"
-                                                        Value="{x:Bind ViewModel.Hours, Mode=TwoWay}"
-                                                        IsEnabled="{x:Bind ViewModel.IsTimeConfigurationEnabled, Mode=OneWay}"
-                                                        Minimum="0"
-                                                        SpinButtonPlacementMode="Compact"
-                                                        HorizontalAlignment="Left"
-                                                        MinWidth="90"
-                                                        SmallChange="1" 
-                                                        LargeChange="5"/>
-                                        <muxc:NumberBox x:Uid="Awake_TemporaryKeepAwake_Minutes"
-                                                        Value="{x:Bind ViewModel.Minutes, Mode=TwoWay}"
-                                                        IsEnabled="{x:Bind ViewModel.IsTimeConfigurationEnabled, Mode=OneWay}"
-                                                        Minimum="0"
-                                                        SpinButtonPlacementMode="Compact"
-                                                        Margin="8,0,0,0"
-                                                        HorizontalAlignment="Left"
-                                                        MinWidth="90"
-                                                        SmallChange="1" 
-                                                        LargeChange="5"/>
-                                    </StackPanel>
-                                </StackPanel>
-                            </StackPanel>
-                        </controls:SettingExpander.Content>
-                    </controls:SettingExpander>
                 </controls:SettingsGroup>
             </StackPanel>
         </controls:SettingsPageControl.ModuleContent>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
@@ -36,7 +36,8 @@
 
                             <controls:Setting x:Uid="ColorPicker_ActivationAction" Icon="&#xEC4E;" >
                                 <controls:Setting.ActionContent>
-                                    <ComboBox SelectedIndex="{Binding ActivationBehavior, Mode=TwoWay}" >
+                            <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                      SelectedIndex="{Binding ActivationBehavior, Mode=TwoWay}" >
                                         <ComboBoxItem x:Uid="EditorFirst"/>
                                         <ComboBoxItem x:Uid="ColorPickerFirst"/>
                                         <ComboBoxItem x:Uid="ColorPickerOnly"/>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
@@ -37,7 +37,7 @@
                             <controls:Setting x:Uid="ColorPicker_ActivationAction" Icon="&#xEC4E;" >
                                 <controls:Setting.ActionContent>
                             <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}"
-                                      SelectedIndex="{Binding ActivationBehavior, Mode=TwoWay}" >
+                                      SelectedIndex="{x:Bind Path=ViewModel.ActivationBehavior, Mode=TwoWay}" >
                                         <ComboBoxItem x:Uid="EditorFirst"/>
                                         <ComboBoxItem x:Uid="ColorPickerFirst"/>
                                         <ComboBoxItem x:Uid="ColorPickerOnly"/>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ColorPickerPage.xaml
@@ -34,50 +34,15 @@
                         </controls:Setting.ActionContent>
                     </controls:Setting>
 
-                <controls:SettingExpander IsExpanded="True" IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}">
-                    <controls:SettingExpander.Header>
-                        <controls:Setting x:Uid="ColorPicker_ActivationAction" Icon="&#xEC4E;" Style="{StaticResource ExpanderHeaderSettingStyle}" />
-                    </controls:SettingExpander.Header>
-                    <controls:SettingExpander.Content>
-                        <StackPanel Padding="56,16,16,24" Spacing="12">
-                            <RadioButton x:Uid="ColorPickerFirst_Accessible" IsChecked="{Binding ActivationOpensColorPickerAndEditor, Mode=TwoWay}" GroupName="ColorPickerActivationAction">
-                                <RadioButton.Content>
-                                    <StackPanel>
-                                        <TextBlock x:Uid="ColorPickerFirst"/>
-                                            <controls:TextBlockControl x:Uid="ColorPickerFirst_Description" 
-                                                                       FontSize="{StaticResource SecondaryTextFontSize}"
-                                                                       EnabledForeground="{ThemeResource TextFillColorSecondaryBrush}"
-                                                                       DisabledForeground="{ThemeResource TextFillColorDisabledBrush}"/>
-                                        </StackPanel>
-                                </RadioButton.Content>
-                            </RadioButton>
-
-                            <RadioButton x:Uid="EditorFirst_Accessible" IsChecked="{Binding ActivationOpensEditor, Mode=TwoWay}" GroupName="ColorPickerActivationAction">
-                                <RadioButton.Content>
-                                    <StackPanel>
-                                        <TextBlock x:Uid="EditorFirst"/>
-                                            <controls:TextBlockControl x:Uid="EditorFirst_Description" 
-                                                                       FontSize="{StaticResource SecondaryTextFontSize}"
-                                                                       EnabledForeground="{ThemeResource TextFillColorSecondaryBrush}"
-                                                                       DisabledForeground="{ThemeResource TextFillColorDisabledBrush}"/>
-                                    </StackPanel>
-                                </RadioButton.Content>
-                            </RadioButton>
-
-                            <RadioButton x:Uid="ColorPickerOnly_Accessible" IsChecked="{Binding ActivationOpensColorPickerOnly, Mode=TwoWay}" GroupName="ColorPickerActivationAction">
-                                <RadioButton.Content>
-                                    <StackPanel>
-                                            <TextBlock x:Uid="ColorPickerOnly"/>
-                                            <controls:TextBlockControl x:Uid="ColorPickerOnly_Description" 
-                                                                       FontSize="{StaticResource SecondaryTextFontSize}"
-                                                                       EnabledForeground="{ThemeResource TextFillColorSecondaryBrush}"
-                                                                       DisabledForeground="{ThemeResource TextFillColorDisabledBrush}"/>
-                                        </StackPanel>
-                                </RadioButton.Content>
-                            </RadioButton>
-                        </StackPanel>
-                    </controls:SettingExpander.Content>
-                </controls:SettingExpander>
+                            <controls:Setting x:Uid="ColorPicker_ActivationAction" Icon="&#xEC4E;" >
+                                <controls:Setting.ActionContent>
+                                    <ComboBox SelectedIndex="{Binding ActivationBehavior, Mode=TwoWay}" >
+                                        <ComboBoxItem x:Uid="EditorFirst"/>
+                                        <ComboBoxItem x:Uid="ColorPickerFirst"/>
+                                        <ComboBoxItem x:Uid="ColorPickerOnly"/>
+                                    </ComboBox>
+                                </controls:Setting.ActionContent>
+                            </controls:Setting>
                 </controls:SettingsGroup>
 
                 <controls:SettingsGroup x:Uid="ColorFormats" IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}">

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -11,6 +11,7 @@
     AutomationProperties.LandmarkType="Main">
 
     <Page.Resources>
+        <converters:BoolToObjectConverter x:Key="BoolToComboBoxIndexConverter" TrueValue="1" FalseValue="0"/>
         <converters:StringFormatConverter x:Key="StringFormatConverter"/>
     </Page.Resources>
 
@@ -226,16 +227,29 @@
 
                         <controls:SettingExpander.Content>
                             <StackPanel>
-                                <RadioButton x:Uid="FancyZones_MoveWindowLeftRightBasedOnZoneIndex"
-                                             IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.MoveWindowsBasedOnZoneIndex}"
-                                             IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.SnapHotkeysCategoryEnabled}"
-                                             GroupName="OverrideSnapGroup"
-                                             Margin="{StaticResource ExpanderSettingMargin}"/>
-                                <RadioButton x:Uid="FancyZones_MoveWindowBasedOnRelativePosition"
-                                             IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.MoveWindowsBasedOnPosition}"
-                                             IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.SnapHotkeysCategoryEnabled}"
-                                             GroupName="OverrideSnapGroup"
-                                             Margin="{StaticResource ExpanderSettingMargin}"/>
+                                <controls:Setting x:Uid="FancyZones_MoveWindow" IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.SnapHotkeysCategoryEnabled}" Style="{StaticResource ExpanderContentSettingStyle}">
+                                    <controls:Setting.ActionContent>
+                                        <ComboBox SelectedIndex="{x:Bind Mode=TwoWay, Path=ViewModel.MoveWindowsBasedOnPosition, Converter={StaticResource BoolToComboBoxIndexConverter}}" MinHeight="56" MinWidth="{StaticResource SettingActionControlMinWidth}">
+                                            <ComboBoxItem x:Uid="FancyZones_MoveWindowLeftRightBasedOnZoneIndex_Accesible">
+                                                <StackPanel Orientation="Vertical">
+                                                    <TextBlock x:Uid="FancyZones_MoveWindowLeftRightBasedOnZoneIndex"/>
+                                                    <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}" Style="{StaticResource SecondaryTextStyle}">
+                                                        <Run x:Uid="FancyZones_MoveWindowLeftRightBasedOnZoneIndex_Description" />
+                                                    </TextBlock>
+                                                </StackPanel>
+                                            </ComboBoxItem>
+                                            <ComboBoxItem x:Uid="FancyZones_MoveWindowBasedOnRelativePosition_Accesible">
+                                                <StackPanel Orientation="Vertical">
+                                                    <TextBlock x:Uid="FancyZones_MoveWindowBasedOnRelativePosition"/>
+                                                    <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}"  Style="{StaticResource SecondaryTextStyle}">
+                                                        <Run x:Uid="FancyZones_MoveWindowBasedOnRelativePosition_Description" />
+                                                    </TextBlock>
+                                                </StackPanel>
+                                            </ComboBoxItem>
+                                        </ComboBox>
+                                    </controls:Setting.ActionContent>
+                                </controls:Setting>
+
                                 <Rectangle Style="{StaticResource ExpanderSeparatorStyle}" />
                                 <CheckBox x:Uid="FancyZones_MoveWindowsAcrossAllMonitorsCheckBoxControl"
                                           Margin="56,8,16,8"

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -230,7 +230,7 @@
                                 <controls:Setting x:Uid="FancyZones_MoveWindow" IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.SnapHotkeysCategoryEnabled}" Style="{StaticResource ExpanderContentSettingStyle}">
                                     <controls:Setting.ActionContent>
                                         <ComboBox SelectedIndex="{x:Bind Mode=TwoWay, Path=ViewModel.MoveWindowsBasedOnPosition, Converter={StaticResource BoolToComboBoxIndexConverter}}" MinHeight="56" MinWidth="{StaticResource SettingActionControlMinWidth}">
-                                            <ComboBoxItem x:Uid="FancyZones_MoveWindowLeftRightBasedOnZoneIndex_Accesible">
+                                            <ComboBoxItem x:Uid="FancyZones_MoveWindowLeftRightBasedOnZoneIndex_Accessible">
                                                 <StackPanel Orientation="Vertical">
                                                     <TextBlock x:Uid="FancyZones_MoveWindowLeftRightBasedOnZoneIndex"/>
                                                     <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}" Style="{StaticResource SecondaryTextStyle}">
@@ -238,7 +238,7 @@
                                                     </TextBlock>
                                                 </StackPanel>
                                             </ComboBoxItem>
-                                            <ComboBoxItem x:Uid="FancyZones_MoveWindowBasedOnRelativePosition_Accesible">
+                                            <ComboBoxItem x:Uid="FancyZones_MoveWindowBasedOnRelativePosition_Accessible">
                                                 <StackPanel Orientation="Vertical">
                                                     <TextBlock x:Uid="FancyZones_MoveWindowBasedOnRelativePosition"/>
                                                     <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}"  Style="{StaticResource SecondaryTextStyle}">

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -231,7 +231,7 @@
                                     <controls:Setting.ActionContent>
                                         <ComboBox SelectedIndex="{x:Bind Mode=TwoWay, Path=ViewModel.MoveWindowsBasedOnPosition, Converter={StaticResource BoolToComboBoxIndexConverter}}" MinHeight="56" MinWidth="{StaticResource SettingActionControlMinWidth}">
                                             <ComboBoxItem x:Uid="FancyZones_MoveWindowLeftRightBasedOnZoneIndex_Accessible">
-                                                <StackPanel Orientation="Vertical">
+                                                <StackPanel Orientation="Vertical" Spacing="4">
                                                     <TextBlock x:Uid="FancyZones_MoveWindowLeftRightBasedOnZoneIndex"/>
                                                     <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}" Style="{StaticResource SecondaryTextStyle}">
                                                         <Run x:Uid="FancyZones_MoveWindowLeftRightBasedOnZoneIndex_Description" />
@@ -239,7 +239,7 @@
                                                 </StackPanel>
                                             </ComboBoxItem>
                                             <ComboBoxItem x:Uid="FancyZones_MoveWindowBasedOnRelativePosition_Accessible">
-                                                <StackPanel Orientation="Vertical">
+                                                <StackPanel Orientation="Vertical" Spacing="4">
                                                     <TextBlock x:Uid="FancyZones_MoveWindowBasedOnRelativePosition"/>
                                                     <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}"  Style="{StaticResource SecondaryTextStyle}">
                                                         <Run x:Uid="FancyZones_MoveWindowBasedOnRelativePosition_Description" />

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
@@ -179,12 +179,11 @@
 
                     <controls:Setting x:Uid="ImageResizer_Encoding">
                         <controls:Setting.ActionContent>
-                            <muxc:NumberBox
+                            <Slider
                                 Minimum="0"
                                 Maximum="100"
                                 Value="{x:Bind Mode=TwoWay, Path=ViewModel.JPEGQualityLevel}"
                                 MinWidth="{StaticResource SettingActionControlMinWidth}"
-                                SpinButtonPlacementMode="Compact"
                                 HorizontalAlignment="Right"
                             />
                         </controls:Setting.ActionContent>


### PR DESCRIPTION
## Summary of the Pull Request

#13482 - Replaced RadioButtons with ComboBox since these are more appropriate, reduces space and resolves this issue:
FancyZones
![image](https://user-images.githubusercontent.com/9866362/135486216-208d28a0-e0f8-4f10-a989-bc660bcfb6dc.png)

Color Picker
![image](https://user-images.githubusercontent.com/9866362/135490142-564f8b6a-41b0-4c28-bae9-7ce33a31e616.png)

Awake
![image](https://user-images.githubusercontent.com/9866362/135633716-bb8e7861-2ee0-41bd-b616-73353304e10e.png)


## Quality Checklist

- [X] **Linked issue:** #13482 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
