### PR TITLE
[PT Run, Image Resizer] Fix for WPF DPI issue on .net core 3.1.19

### DIFF
--- a/src/modules/imageresizer/ui/App.xaml.cs
+++ b/src/modules/imageresizer/ui/App.xaml.cs
@@ -26,6 +26,8 @@ namespace ImageResizer
 
         protected override void OnStartup(StartupEventArgs e)
         {
+            // Fix for .net 3.1.19 making Image Resizer not adapt to DPI changes.
+            NativeMethods.SetProcessDPIAware();
             var batch = ResizeBatch.FromCommandLine(Console.In, e?.Args);
 
             // TODO: Add command-line parameters that can be used in lieu of the input page (issue #14)

--- a/src/modules/imageresizer/ui/Utilities/NativeMethods.cs
+++ b/src/modules/imageresizer/ui/Utilities/NativeMethods.cs
@@ -19,6 +19,9 @@ namespace ImageResizer.Utilities
         [DllImport("user32.dll")]
         internal static extern uint SendInput(uint nInputs, INPUT[] pInputs, int cbSize);
 
+        [DllImport("user32.dll", SetLastError = true)]
+        internal static extern bool SetProcessDPIAware();
+
         [StructLayout(LayoutKind.Sequential)]
         public struct INPUT
         {

--- a/src/modules/launcher/PowerLauncher/App.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/App.xaml.cs
@@ -93,6 +93,9 @@ namespace PowerLauncher
         private void OnStartup(object sender, StartupEventArgs e)
         {
             Log.Info("On Startup.", GetType());
+
+            // Fix for .net 3.1.19 making PowerToys Run not adapt to DPI changes.
+            PowerLauncher.Helper.NativeMethods.SetProcessDPIAware();
             var bootTime = new System.Diagnostics.Stopwatch();
             bootTime.Start();
             Stopwatch.Normal("App.OnStartup - Startup cost", () =>

--- a/src/modules/launcher/PowerLauncher/Helper/NativeMethods.cs
+++ b/src/modules/launcher/PowerLauncher/Helper/NativeMethods.cs
@@ -40,6 +40,9 @@ namespace PowerLauncher.Helper
         [DllImport("user32.dll")]
         internal static extern IntPtr SetForegroundWindow(IntPtr hWnd);
 
+        [DllImport("user32.dll", SetLastError = true)]
+        internal static extern bool SetProcessDPIAware();
+
         [DllImport("user32.dll")]
         internal static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
 


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
With the release of .net core 3.1.19, PowerToys Run and Image Resizer stopped adapting correctly to the zoom level set up on Windows Display settings.

**What is include in the PR:** 
Adopts the workaround suggested in the corresponding WPF issue: https://github.com/dotnet/wpf/issues/5375#issuecomment-931451210

**How does someone test / validate:** 
Users have validated the fix in the linked issue with a test build.

## Quality Checklist

- [x] **Linked issue:** #13221
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries
