### PR TITLE
[Shortcut Guide] Suppress Windows Menu appearing

### DIFF
--- a/src/modules/ShortcutGuide/ShortcutGuide/ShortcutGuideSettings.h
+++ b/src/modules/ShortcutGuide/ShortcutGuide/ShortcutGuideSettings.h
@@ -7,4 +7,6 @@ struct ShortcutGuideSettings
     int overlayOpacity = 90;
     std::wstring theme = L"system";
     std::wstring disabledApps = L"";
+    bool shouldReactToPressedWinKey = false;
+    int windowsKeyPressTime = 900;
 };

--- a/src/modules/ShortcutGuide/ShortcutGuide/shortcut_guide.cpp
+++ b/src/modules/ShortcutGuide/ShortcutGuide/shortcut_guide.cpp
@@ -221,12 +221,15 @@ void OverlayWindow::CloseWindow(HideWindowType type, int mainThreadId)
 
     if (this->winkey_popup)
     {
-        INPUT dummyEvent[1] = {};
-        dummyEvent[0].type = INPUT_KEYBOARD;
-        dummyEvent[0].ki.wVk = 0x99;
-        dummyEvent[0].ki.dwFlags = KEYEVENTF_KEYUP;
-        SendInput(1, dummyEvent, sizeof(INPUT));
-        
+        if (shouldReactToPressedWinKey.value)
+        {
+            // Send a dummy key to prevent Start Menu from activating
+            INPUT dummyEvent[1] = {};
+            dummyEvent[0].type = INPUT_KEYBOARD;
+            dummyEvent[0].ki.wVk = 0xFF;
+            dummyEvent[0].ki.dwFlags = KEYEVENTF_KEYUP;
+            SendInput(1, dummyEvent, sizeof(INPUT));
+        }
         this->winkey_popup->SetWindowCloseType(ToWstring(type));
         Logger::trace(L"Terminating process");
         PostThreadMessage(mainThreadId, WM_QUIT, 0, 0);

--- a/src/modules/ShortcutGuide/ShortcutGuide/shortcut_guide.cpp
+++ b/src/modules/ShortcutGuide/ShortcutGuide/shortcut_guide.cpp
@@ -411,7 +411,7 @@ ShortcutGuideSettings OverlayWindow::GetSettings() noexcept
 
     try
     {
-        settings.shouldReactToPressedWinKey = (int)properties.GetNamedObject(ShouldReactToPressedWinKey::name).GetNamedBoolean(L"value");
+        settings.shouldReactToPressedWinKey = properties.GetNamedObject(ShouldReactToPressedWinKey::name).GetNamedBoolean(L"value");
     }
     catch (...)
     {

--- a/src/modules/ShortcutGuide/ShortcutGuide/shortcut_guide.cpp
+++ b/src/modules/ShortcutGuide/ShortcutGuide/shortcut_guide.cpp
@@ -221,6 +221,12 @@ void OverlayWindow::CloseWindow(HideWindowType type, int mainThreadId)
 
     if (this->winkey_popup)
     {
+        INPUT dummyEvent[1] = {};
+        dummyEvent[0].type = INPUT_KEYBOARD;
+        dummyEvent[0].ki.wVk = 0x99;
+        dummyEvent[0].ki.dwFlags = KEYEVENTF_KEYUP;
+        SendInput(1, dummyEvent, sizeof(INPUT));
+        
         this->winkey_popup->SetWindowCloseType(ToWstring(type));
         Logger::trace(L"Terminating process");
         PostThreadMessage(mainThreadId, WM_QUIT, 0, 0);
@@ -300,6 +306,7 @@ void OverlayWindow::init_settings()
     overlayOpacity.value = settings.overlayOpacity;
     theme.value = settings.theme;
     disabledApps.value = settings.disabledApps;
+    shouldReactToPressedWinKey.value = settings.shouldReactToPressedWinKey;
     update_disabled_apps();
 }
 
@@ -394,6 +401,22 @@ ShortcutGuideSettings OverlayWindow::GetSettings() noexcept
     try
     {
         settings.overlayOpacity = (int)properties.GetNamedObject(OverlayOpacity::name).GetNamedNumber(L"value");
+    }
+    catch (...)
+    {
+    }
+
+    try
+    {
+        settings.shouldReactToPressedWinKey = (int)properties.GetNamedObject(ShouldReactToPressedWinKey::name).GetNamedBoolean(L"value");
+    }
+    catch (...)
+    {
+    }
+
+    try
+    {
+        settings.windowsKeyPressTime = (int)properties.GetNamedObject(WindowsKeyPressTime::name).GetNamedNumber(L"value");
     }
     catch (...)
     {

--- a/src/modules/ShortcutGuide/ShortcutGuide/shortcut_guide.h
+++ b/src/modules/ShortcutGuide/ShortcutGuide/shortcut_guide.h
@@ -78,6 +78,17 @@ private:
         std::wstring value;
     } disabledApps;
 
+    struct ShouldReactToPressedWinKey
+    {
+        static inline PCWSTR name = L"use_legacy_press_win_key_behavior";
+        bool value;
+    } shouldReactToPressedWinKey;
+
+    struct WindowsKeyPressTime
+    {
+        static inline PCWSTR name = L"press_time";
+    } windowsKeyPressTime;
+
     struct OpenShortcut
     {
         static inline PCWSTR name = L"open_shortcutguide";

--- a/src/modules/ShortcutGuide/ShortcutGuide/trace.cpp
+++ b/src/modules/ShortcutGuide/ShortcutGuide/trace.cpp
@@ -39,6 +39,8 @@ void Trace::SendSettings(ShortcutGuideSettings settings) noexcept
         TraceLoggingInt32(settings.overlayOpacity, "OverlayOpacity"),
         TraceLoggingWideString(settings.theme.c_str(), "Theme"),
         TraceLoggingWideString(settings.disabledApps.c_str(), "DisabledApps"),
+        TraceLoggingBoolean(settings.shouldReactToPressedWinKey, "ShouldReactToPressedWinKey"),
+        TraceLoggingInt32(settings.windowsKeyPressTime, "WindowsKeyPressTime"),
         ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
         TraceLoggingBoolean(TRUE, "UTCReplace_AppSessionGuid"),
         TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
After the changes in Shortcut Guide to bring back the long Windows press activation method, the Windows menu is appearing after releasing the Windows key.

**What is include in the PR:** 
Fixes the Windows menu appearing.
Uses the new settings in the shortcut guide process.
Sends telemetry for the new settings.

**How does someone test / validate:** 
With the Windows key press activation method, verify the start menu no longer appears.

## Quality Checklist

- [x] **Linked issue:** #13516
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
