### PR TITLE
[PT Run] Add setting to use centralized keyboard hook

### DIFF
--- a/src/common/interop/interop.cpp
+++ b/src/common/interop/interop.cpp
@@ -171,6 +171,10 @@ public
             return gcnew String(CommonSharedConstants::POWER_LAUNCHER_SHARED_EVENT);
         }
 
+        static String ^ PowerLauncherCentralizedHookSharedEvent() {
+            return gcnew String(CommonSharedConstants::POWER_LAUNCHER_CENTRALIZED_HOOK_SHARED_EVENT);
+        }
+
         static String ^ RunSendSettingsTelemetryEvent() {
             return gcnew String(CommonSharedConstants::RUN_SEND_SETTINGS_TELEMETRY_EVENT);
         }

--- a/src/common/interop/shared_constants.h
+++ b/src/common/interop/shared_constants.h
@@ -15,6 +15,8 @@ namespace CommonSharedConstants
     // Path to the event used by PowerLauncher
     const wchar_t POWER_LAUNCHER_SHARED_EVENT[] = L"Local\\PowerToysRunInvokeEvent-30f26ad7-d36d-4c0e-ab02-68bb5ff3c4ab";
 
+    const wchar_t POWER_LAUNCHER_CENTRALIZED_HOOK_SHARED_EVENT[] = L"Local\\PowerToysRunCentralizedHookInvokeEvent-30f26ad7-d36d-4c0e-ab02-68bb5ff3c4ab";
+
     const wchar_t RUN_SEND_SETTINGS_TELEMETRY_EVENT[] = L"Local\\PowerToysRunInvokeEvent-638ec522-0018-4b96-837d-6bd88e06f0d6";
 
     const wchar_t RUN_EXIT_EVENT[] = L"Local\\PowerToysRunExitEvent-3e38e49d-a762-4ef1-88f2-fd4bc7481516";

--- a/src/modules/launcher/PowerLauncher/App.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/App.xaml.cs
@@ -109,7 +109,7 @@ namespace PowerLauncher
 
                 _settingsVM = new SettingWindowViewModel();
                 _settings = _settingsVM.Settings;
-                _settings.UsePowerToysRunnerKeyboardHook = e.Args.Contains("--centralized-kb-hook");
+                _settings.StartedFromPowerToysRunner = e.Args.Contains("--started-from-runner");
 
                 _stringMatcher = new StringMatcher();
                 StringMatcher.Instance = _stringMatcher;

--- a/src/modules/launcher/PowerLauncher/SettingsReader.cs
+++ b/src/modules/launcher/PowerLauncher/SettingsReader.cs
@@ -100,6 +100,11 @@ namespace PowerLauncher
                         _settings.Hotkey = openPowerlauncher;
                     }
 
+                    if (_settings.UseCentralizedKeyboardHook != overloadSettings.Properties.UseCentralizedKeyboardHook)
+                    {
+                        _settings.UseCentralizedKeyboardHook = overloadSettings.Properties.UseCentralizedKeyboardHook;
+                    }
+
                     if (_settings.MaxResultsToShow != overloadSettings.Properties.MaximumNumberOfResults)
                     {
                         _settings.MaxResultsToShow = overloadSettings.Properties.MaximumNumberOfResults;

--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -88,9 +88,15 @@ namespace PowerLauncher.ViewModel
             // Allow OOBE to call PowerToys Run.
             NativeEventWaiter.WaitForEventLoop(Constants.PowerLauncherSharedEvent(), OnHotkey);
 
+            if (_settings.StartedFromPowerToysRunner)
+            {
+                // Allow runner to call PowerToys Run from the centralized keyboard hook.
+                NativeEventWaiter.WaitForEventLoop(Constants.PowerLauncherCentralizedHookSharedEvent(), OnCentralizedKeyboardHookHotKey);
+            }
+
             _settings.PropertyChanged += (s, e) =>
             {
-                if (e.PropertyName == nameof(PowerToysRunSettings.Hotkey))
+                if (e.PropertyName == nameof(PowerToysRunSettings.Hotkey) || e.PropertyName == nameof(PowerToysRunSettings.UseCentralizedKeyboardHook))
                 {
                     Application.Current.Dispatcher.Invoke(() =>
                     {
@@ -741,26 +747,33 @@ namespace PowerLauncher.ViewModel
                     Log.Info("Unregistering previous low level key handler", GetType());
                 }
 
-                _globalHotKeyVK = hotkey.Key;
-                _globalHotKeyFSModifiers = VKModifiersFromHotKey(hotkey);
-                if (NativeMethods.RegisterHotKey(hwnd, _globalHotKeyId, _globalHotKeyFSModifiers, _globalHotKeyVK))
+                if (_settings.StartedFromPowerToysRunner && _settings.UseCentralizedKeyboardHook)
                 {
-                    // Using global hotkey registered through the native RegisterHotKey method.
-                    _globalHotKeyHwnd = hwnd;
-                    _usingGlobalHotKey = true;
-                    Log.Info("Registered global hotkey", GetType());
-                    return;
+                    Log.Info("Using the Centralized Keyboard Hook for the HotKey.", GetType());
                 }
-
-                Log.Warn("Registering global shortcut failed. Will use low-level keyboard hook instead.", GetType());
-
-                // Using fallback low-level keyboard hook through HotkeyManager.
-                if (HotkeyManager == null)
+                else
                 {
-                    HotkeyManager = new HotkeyManager();
-                }
+                    _globalHotKeyVK = hotkey.Key;
+                    _globalHotKeyFSModifiers = VKModifiersFromHotKey(hotkey);
+                    if (NativeMethods.RegisterHotKey(hwnd, _globalHotKeyId, _globalHotKeyFSModifiers, _globalHotKeyVK))
+                    {
+                        // Using global hotkey registered through the native RegisterHotKey method.
+                        _globalHotKeyHwnd = hwnd;
+                        _usingGlobalHotKey = true;
+                        Log.Info("Registered global hotkey", GetType());
+                        return;
+                    }
 
-                _hotkeyHandle = HotkeyManager.RegisterHotkey(hotkey, action);
+                    Log.Warn("Registering global shortcut failed. Will use low-level keyboard hook instead.", GetType());
+
+                    // Using fallback low-level keyboard hook through HotkeyManager.
+                    if (HotkeyManager == null)
+                    {
+                        HotkeyManager = new HotkeyManager();
+                    }
+
+                    _hotkeyHandle = HotkeyManager.RegisterHotkey(hotkey, action);
+                }
             }
 #pragma warning disable CA1031 // Do not catch general exception types
             catch (Exception)
@@ -816,6 +829,14 @@ namespace PowerLauncher.ViewModel
             }
         }
         */
+
+        private void OnCentralizedKeyboardHookHotKey()
+        {
+            if (_settings.StartedFromPowerToysRunner && _settings.UseCentralizedKeyboardHook)
+            {
+                OnHotkey();
+            }
+        }
 
         private void OnHotkey()
         {

--- a/src/modules/launcher/Wox.Infrastructure/UserSettings/PowerToysRunSettings.cs
+++ b/src/modules/launcher/Wox.Infrastructure/UserSettings/PowerToysRunSettings.cs
@@ -42,6 +42,25 @@ namespace Wox.Infrastructure.UserSettings
             }
         }
 
+        private bool _useCentralizedKeyboardHook;
+
+        public bool UseCentralizedKeyboardHook
+        {
+            get
+            {
+                return _useCentralizedKeyboardHook;
+            }
+
+            set
+            {
+                if (_useCentralizedKeyboardHook != value)
+                {
+                    _useCentralizedKeyboardHook = value;
+                    OnPropertyChanged(nameof(UseCentralizedKeyboardHook));
+                }
+            }
+        }
+
         public string Language { get; set; } = "en";
 
         public Theme Theme { get; set; } = Theme.System;
@@ -172,7 +191,7 @@ namespace Wox.Infrastructure.UserSettings
 
         public bool IgnoreHotkeysOnFullscreen { get; set; }
 
-        public bool UsePowerToysRunnerKeyboardHook { get; set; }
+        public bool StartedFromPowerToysRunner { get; set; }
 
         public HttpProxy Proxy { get; set; } = new HttpProxy();
 

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/PowerLauncherProperties.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/PowerLauncherProperties.cs
@@ -48,6 +48,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         [JsonPropertyName("startupPosition")]
         public StartupPosition Position { get; set; }
 
+        [JsonPropertyName("use_centralized_keyboard_hook")]
+        public bool UseCentralizedKeyboardHook { get; set; }
+
         public PowerLauncherProperties()
         {
             OpenPowerLauncher = new HotkeySettings(false, false, true, false, 32);
@@ -61,6 +64,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             MaximumNumberOfResults = 4;
             Theme = Theme.System;
             Position = StartupPosition.Cursor;
+            UseCentralizedKeyboardHook = false;
         }
     }
 }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/PowerLauncherViewModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/PowerLauncherViewModel.cs
@@ -275,6 +275,23 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             }
         }
 
+        public bool UseCentralizedKeyboardHook
+        {
+            get
+            {
+                return settings.Properties.UseCentralizedKeyboardHook;
+            }
+
+            set
+            {
+                if (settings.Properties.UseCentralizedKeyboardHook != value)
+                {
+                    settings.Properties.UseCentralizedKeyboardHook = value;
+                    UpdateSettings();
+                }
+            }
+        }
+
         public HotkeySettings OpenFileLocation
         {
             get

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -401,6 +401,9 @@
   <data name="PowerLauncher_IgnoreHotkeysInFullScreen.Content" xml:space="preserve">
     <value>Ignore shortcuts in fullscreen mode</value>
   </data>
+  <data name="PowerLauncher_UseCentralizedKeyboardHook.Content" xml:space="preserve">
+    <value>Use centralized keyboard hook (try it if there are issues with the shortcut)</value>
+  </data>
   <data name="PowerLauncher_ClearInputOnLaunch.Content" xml:space="preserve">
     <value>Clear the previous query on launch</value>
   </data>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
@@ -45,6 +45,7 @@
                         </controls:SettingExpander.Header>
                         <controls:SettingExpander.Content>
                             <StackPanel>
+                                <CheckBox x:Uid="PowerLauncher_UseCentralizedKeyboardHook" IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.UseCentralizedKeyboardHook}" Margin="{StaticResource ExpanderSettingMargin}" />
                                 <CheckBox x:Uid="PowerLauncher_IgnoreHotkeysInFullScreen" IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.IgnoreHotkeysInFullScreen}" Margin="{StaticResource ExpanderSettingMargin}" />
                             </StackPanel>
                         </controls:SettingExpander.Content>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
@@ -46,6 +46,7 @@
                         <controls:SettingExpander.Content>
                             <StackPanel>
                                 <CheckBox x:Uid="PowerLauncher_UseCentralizedKeyboardHook" IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.UseCentralizedKeyboardHook}" Margin="{StaticResource ExpanderSettingMargin}" />
+                                <Rectangle Style="{StaticResource ExpanderSeparatorStyle}" />
                                 <CheckBox x:Uid="PowerLauncher_IgnoreHotkeysInFullScreen" IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.IgnoreHotkeysInFullScreen}" Margin="{StaticResource ExpanderSettingMargin}" />
                             </StackPanel>
                         </controls:SettingExpander.Content>


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
After changing PowerToys Run to use a global shortcut instead of the centralized keyboard hook, this created issues for some users on some shortcuts, like "Shift+Caps Lock" turning Caps Lock on and off and "Win+Space" not working on elevated windows when PowerToys is elevated.

**What is include in the PR:** 
Add a setting for scenarios where users prefer to use the centralized keyboard hook:

![image](https://user-images.githubusercontent.com/26118718/135622059-c16b0bde-3bd2-490d-bfe8-129dc5f12746.png)


**How does someone test / validate:** 
Turn on the setting and test that the "Shift+Caps Lock" shortcut no longer turns Caps Lock on/off.

## Quality Checklist

- [x] **Linked issue:** #13536 #13517
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries
