### PR TITLE
[ColorPicker] Accessibility: announce color format for "Copy to clipboard"

### DIFF
--- a/src/modules/colorPicker/ColorPickerUI/Controls/ColorFormatControl.xaml
+++ b/src/modules/colorPicker/ColorPickerUI/Controls/ColorFormatControl.xaml
@@ -1,4 +1,5 @@
 ﻿<UserControl x:Class="ColorPicker.Controls.ColorFormatControl"
+             xmlns:local="clr-namespace:ColorPicker"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -50,7 +51,8 @@
                     Width="36"
                     Grid.Column="2"
                     AutomationProperties.Name="{x:Static p:Resources.Copy_to_clipboard}"
-                    AutomationProperties.HelpText="{Binding ElementName=ColorTextRepresentationTextBlock, Path=Text}"
+                    AutomationProperties.HelpText="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type local:Controls.ColorFormatControl}}, Path=SelectedColorCopyHelperText}"
+
                     FontSize="12"
                     Style="{StaticResource DefaultButtonStyle}"
                     FontFamily="Segoe MDL2 Assets">

--- a/src/modules/colorPicker/ColorPickerUI/Controls/ColorFormatControl.xaml.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Controls/ColorFormatControl.xaml.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Globalization;
 using System.Windows;
 using System.Windows.Automation.Peers;
 using System.Windows.Controls;
@@ -22,6 +23,8 @@ namespace ColorPicker.Controls
         public static readonly DependencyProperty ColorFormatModelProperty = DependencyProperty.Register("ColorFormatModel", typeof(ColorFormatModel), typeof(ColorFormatControl), new PropertyMetadata(ColorFormatModelPropertyChanged));
 
         public static readonly DependencyProperty SelectedColorProperty = DependencyProperty.Register("SelectedColor", typeof(Color), typeof(ColorFormatControl), new PropertyMetadata(SelectedColorPropertyChanged));
+
+        public static readonly DependencyProperty SelectedColorCopyHelperTextProperty = DependencyProperty.Register("SelectedColorCopyHelperText", typeof(string), typeof(ColorFormatControl));
 
         public static readonly DependencyProperty ColorCopiedNotificationBorderProperty = DependencyProperty.Register("ColorCopiedNotificationBorder", typeof(FrameworkElement), typeof(ColorFormatControl), new PropertyMetadata(ColorCopiedBorderPropertyChanged));
 
@@ -47,6 +50,12 @@ namespace ColorPicker.Controls
             set { SetValue(ColorCopiedNotificationBorderProperty, value); }
         }
 
+        public string SelectedColorCopyHelperText
+        {
+            get { return (string)GetValue(SelectedColorCopyHelperTextProperty); }
+            set { SetValue(SelectedColorCopyHelperTextProperty, value); }
+        }
+
         public ColorFormatControl()
         {
             InitializeComponent();
@@ -68,7 +77,10 @@ namespace ColorPicker.Controls
 
         private static void SelectedColorPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-            ((ColorFormatControl)d).ColorTextRepresentationTextBlock.Text = ((ColorFormatControl)d).ColorFormatModel.Convert((Color)e.NewValue);
+            var self = (ColorFormatControl)d;
+            var colorText = self.ColorFormatModel.Convert((Color)e.NewValue);
+            self.ColorTextRepresentationTextBlock.Text = colorText;
+            self.SelectedColorCopyHelperText = string.Format(CultureInfo.InvariantCulture, "{0} {1}", self.ColorFormatModel.FormatName, colorText);
         }
 
         private static void ColorFormatModelPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Now we prepend helper text with a color format name.

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #13361
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
