### PR TITLE
[Bootstrapper] Preserve original MSI name

### DIFF
--- a/installer/PowerToysBootstrapper/bootstrapper/bootstrapper.cpp
+++ b/installer/PowerToysBootstrapper/bootstrapper/bootstrapper.cpp
@@ -42,7 +42,9 @@ std::optional<fs::path> ExtractEmbeddedInstaller(const fs::path extractPath)
         return std::nullopt;
     }
 
-    auto installerPath = extractPath / L"PowerToysBootstrappedInstaller-" PRODUCT_VERSION_STRING L".msi";
+    std::wstring msiName(L"PowerToysSetup-" STRINGIZE(VERSION_MAJOR) "." STRINGIZE(VERSION_MINOR) "." STRINGIZE(VERSION_REVISION) L"-");
+    msiName += get_architecture_string(get_current_architecture()) + std::wstring(L".msi");
+    auto installerPath = extractPath / msiName;
     return executableRes->saveAsFile(installerPath) ? std::make_optional(std::move(installerPath)) : std::nullopt;
 }
 


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Preserve the original file name for the MSI included in the bootstrapper

**What is include in the PR:** 

**How does someone test / validate:** 
- Build the bootstrapper
- Validate that PowerToys can be installed
- Validate that the MSI extracted from the bootstrapper (launch with `--extract_msi`) preserve the original file name that include the architecture

## Quality Checklist

- [x] **Linked issue:** #9642
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
