### PR TITLE
[ColorPicker][OOBE] Fix FancyZones snap

### DIFF
--- a/src/modules/colorPicker/ColorPickerUI/ColorEditorWindow.xaml.cs
+++ b/src/modules/colorPicker/ColorPickerUI/ColorEditorWindow.xaml.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Windows;
 using ColorPicker.Helpers;
 
@@ -25,6 +26,12 @@ namespace ColorPicker
         {
             e.Cancel = true;
             _appStateHandler.EndUserSession();
+        }
+
+        protected override void OnSourceInitialized(EventArgs e)
+        {
+            base.OnSourceInitialized(e);
+            NativeMethods.SetPopupStyle(this);
         }
     }
 }

--- a/src/modules/colorPicker/ColorPickerUI/NativeMethods.cs
+++ b/src/modules/colorPicker/ColorPickerUI/NativeMethods.cs
@@ -6,6 +6,8 @@ using System;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Text;
+using System.Windows;
+using System.Windows.Interop;
 
 namespace ColorPicker
 {
@@ -13,6 +15,9 @@ namespace ColorPicker
     // will have to rename
     public static class NativeMethods
     {
+        private const int GWL_STYLE = -16;
+        private const int WS_POPUP = 1 << 31; // 0x80000000
+
         [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1310:Field names should not contain underscore", Justification = "Interop")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "Interop")]
         public const int WH_KEYBOARD_LL = 13;
@@ -168,5 +173,17 @@ namespace ColorPicker
 
         [DllImport("user32.dll", CharSet = CharSet.Unicode)]
         internal static extern int GetWindowText(int hwnd, StringBuilder text, int count);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        internal static extern int GetWindowLong(IntPtr hWnd, int nIndex);
+
+        [DllImport("user32.dll")]
+        internal static extern int SetWindowLong(IntPtr hWnd, int nIndex, int dwNewLong);
+
+        internal static void SetPopupStyle(Window win)
+        {
+            var hwnd = new WindowInteropHelper(win).Handle;
+            _ = SetWindowLong(hwnd, GWL_STYLE, GetWindowLong(hwnd, GWL_STYLE) | WS_POPUP);
+        }
     }
 }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Helpers/NativeMethods.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Helpers/NativeMethods.cs
@@ -9,11 +9,20 @@ namespace Microsoft.PowerToys.Settings.UI.Helpers
 {
     public static class NativeMethods
     {
+        private const int GWL_STYLE = -16;
+        private const int WS_POPUP = 1 << 31; // 0x80000000
+
         [DllImport("user32.dll")]
         internal static extern uint SendInput(uint nInputs, NativeKeyboardHelper.INPUT[] pInputs, int cbSize);
 
         [DllImport("user32.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.StdCall, SetLastError = true)]
         internal static extern short GetAsyncKeyState(int vKey);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        internal static extern int GetWindowLong(IntPtr hWnd, int nIndex);
+
+        [DllImport("user32.dll")]
+        internal static extern int SetWindowLong(IntPtr hWnd, int nIndex, int dwNewLong);
 
 #pragma warning disable CA1401 // P/Invokes should not be visible
         [DllImport("user32.dll")]
@@ -28,5 +37,10 @@ namespace Microsoft.PowerToys.Settings.UI.Helpers
         [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
         public static extern bool FreeLibrary(IntPtr hModule);
 #pragma warning restore CA1401 // P/Invokes should not be visible
+
+        public static void SetPopupStyle(IntPtr hwnd)
+        {
+            _ = SetWindowLong(hwnd, GWL_STYLE, GetWindowLong(hwnd, GWL_STYLE) | WS_POPUP);
+        }
     }
 }

--- a/src/settings-ui/PowerToys.Settings/OobeWindow.xaml.cs
+++ b/src/settings-ui/PowerToys.Settings/OobeWindow.xaml.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Windows;
+using System.Windows.Interop;
 using interop;
 using Microsoft.PowerToys.Settings.UI.Helpers;
 using Microsoft.PowerToys.Settings.UI.OOBE.Views;
@@ -82,6 +83,13 @@ namespace PowerToys.Settings
             {
                 ((App)Application.Current).OpenSettingsWindow(type);
             });
+        }
+
+        protected override void OnSourceInitialized(EventArgs e)
+        {
+            base.OnSourceInitialized(e);
+            var hwnd = new WindowInteropHelper(this).Handle;
+            NativeMethods.SetPopupStyle(hwnd);
         }
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request
ColorPicker Editor and OOBE window can be snapped intoFanzyZones.
Once snapped both can't be resized.

**What is this about:**
Setting WS_POPUP style to prevent snap into zones.
This is the same solution adopted for PT Run (actually hardcoded) https://github.com/microsoft/PowerToys/pull/9071

**What is include in the PR:** 

**How does someone test / validate:** 
- Build PT
- Open Open ColorPicker Editor
- Validate that the window can't be snapped into zones (drag and win+arrows)
- Open Welcome to PT
- Validate that the window can't be snapped into zones (drag and win+arrows)

## Quality Checklist

- [x] **Linked issue:** https://github.com/microsoft/PowerToys/issues/10360 https://github.com/microsoft/PowerToys/issues/10015
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
