### PR TITLE
[FancyZones Editor] Prevent opening content dialog twice.

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -161,6 +161,12 @@ namespace FancyZonesEditor
 
         private async void NewLayoutButton_Click(object sender, RoutedEventArgs e)
         {
+            if (_openedDialog != null)
+            {
+                // another dialog already opened
+                return;
+            }
+
             string defaultNamePrefix = FancyZonesEditor.Properties.Resources.Default_Custom_Layout_Name;
             int maxCustomIndex = 0;
             foreach (LayoutModel customModel in MainWindowSettingsModel.CustomModels)


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Check if dialog was opened

**What is include in the PR:** 

**How does someone test / validate:** 

Open Editor, double-click on the `Create new layout` button. Verify that it wasn't crashed.

## Quality Checklist

- [x] **Linked issue:** #13578
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
