### PR TITLE
[PT Run] Check for invalid plugin additional option

### DIFF
--- a/src/modules/launcher/PowerLauncher/SettingsReader.cs
+++ b/src/modules/launcher/PowerLauncher/SettingsReader.cs
@@ -227,9 +227,12 @@ namespace PowerLauncher
             var defaultOptions = defaultAdditionalOptions.ToDictionary(x => x.Key);
             foreach (var option in additionalOptions)
             {
-                if (defaultOptions.ContainsKey(option.Key))
+                if (option.Key != null)
                 {
-                    defaultOptions[option.Key].Value = option.Value;
+                    if (defaultOptions.ContainsKey(option.Key))
+                    {
+                        defaultOptions[option.Key].Value = option.Value;
+                    }
                 }
             }
 

--- a/src/modules/launcher/PowerLauncher/SettingsReader.cs
+++ b/src/modules/launcher/PowerLauncher/SettingsReader.cs
@@ -227,12 +227,9 @@ namespace PowerLauncher
             var defaultOptions = defaultAdditionalOptions.ToDictionary(x => x.Key);
             foreach (var option in additionalOptions)
             {
-                if (option.Key != null)
+                if (option.Key != null && defaultOptions.ContainsKey(option.Key))
                 {
-                    if (defaultOptions.ContainsKey(option.Key))
-                    {
-                        defaultOptions[option.Key].Value = option.Value;
-                    }
+                    defaultOptions[option.Key].Value = option.Value;
                 }
             }
 


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Dictionary.ContainsKey(TKey key) throws when key=null. So, if plugin has `AdditionalOptions` like this:
```
            "AdditionalOptions": [
                {
                    "Key": null,
                    "DisplayLabel": null,
                    "Value": false
                }
            ]
```
JSON will be parsed correctly but inside `SetingsReader::CombineAdditionalOptions` exception will be thrown as key is `null`. With this change, on PT Run startup, this invalid Additional option will be ignored, and removed from settings.json.

Note: Couldn't reproduce and find out where from was this invalid additional option added to settings.json. But, as already said, it with this change it'll be automatically removed from settings.json on PTRun startup

**What is include in the PR:** 

**How does someone test / validate:** 
 - Close PT if running
 - Open PT Run settings.json file
 - pick any Plugin and add additional option to it
 ```
            "AdditionalOptions": [
                {
                    "Key": null,
                    "DisplayLabel": null,
                    "Value": false
                }
            ]
```
 - Start PT
 - Ensure that PT Run is running and it is shown on hotkey (Alt + Space)
 - Check Event logger and ensure there is no `System.ArgumentNullException` thrown by PowerLauncher.exe

## Quality Checklist

- [X] **Linked issue:** #13546 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
