### PR TITLE
[KBM Editor] Catch UpdateLayout exceptions

### DIFF
--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/EditKeyboardWindow.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/EditKeyboardWindow.cpp
@@ -354,7 +354,14 @@ inline void CreateEditKeyboardWindowImpl(HINSTANCE hInst, KBMEditor::KeyboardMan
     xamlContainer.Children().Append(header);
     xamlContainer.Children().Append(helperText);
     xamlContainer.Children().Append(scrollViewer);
-    xamlContainer.UpdateLayout();
+    try
+    {
+        // If a layout update has been triggered by other methods (e.g.: adapting to zoom level), this may throw an exception.
+        xamlContainer.UpdateLayout();
+    }
+    catch (...)
+    {
+    }
 
     desktopSource.Content(xamlContainer);
     ////End XAML Island section

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/EditShortcutsWindow.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/EditShortcutsWindow.cpp
@@ -325,7 +325,14 @@ inline void CreateEditShortcutsWindowImpl(HINSTANCE hInst, KBMEditor::KeyboardMa
     xamlContainer.Children().Append(header);
     xamlContainer.Children().Append(helperText);
     xamlContainer.Children().Append(scrollViewer);
-    xamlContainer.UpdateLayout();
+    try
+    {
+        // If a layout update has been triggered by other methods (e.g.: adapting to zoom level), this may throw an exception.
+        xamlContainer.UpdateLayout();
+    }
+    catch (...)
+    {
+    }
 
     desktopSource.Content(xamlContainer);
 

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/KeyboardManagerState.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/KeyboardManagerState.cpp
@@ -171,8 +171,22 @@ void KeyboardManagerState::UpdateDetectShortcutUI()
                 AddKeyToLayout(currentShortcutUI2.as<StackPanel>(), shortcut[i]);
             }
         }
-        currentShortcutUI1.as<StackPanel>().UpdateLayout();
-        currentShortcutUI2.as<StackPanel>().UpdateLayout();
+        try
+        {
+            // If a layout update has been triggered by other methods (e.g.: adapting to zoom level), this may throw an exception.
+            currentShortcutUI1.as<StackPanel>().UpdateLayout();
+        }
+        catch (...)
+        {
+        }
+        try
+        {
+            // If a layout update has been triggered by other methods (e.g.: adapting to zoom level), this may throw an exception.
+            currentShortcutUI2.as<StackPanel>().UpdateLayout();
+        }
+        catch (...)
+        {
+        }
     });
 }
 
@@ -189,7 +203,14 @@ void KeyboardManagerState::UpdateDetectSingleKeyRemapUI()
         currentSingleKeyUI.as<StackPanel>().Children().Clear();
         hstring key = winrt::to_hstring(keyboardMap.GetKeyName(detectedRemapKey).c_str());
         AddKeyToLayout(currentSingleKeyUI.as<StackPanel>(), key);
-        currentSingleKeyUI.as<StackPanel>().UpdateLayout();
+        try
+        {
+            // If a layout update has been triggered by other methods (e.g.: adapting to zoom level), this may throw an exception.
+            currentSingleKeyUI.as<StackPanel>().UpdateLayout();
+        }
+        catch (...)
+        {
+        }
     });
 }
 

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/ShortcutControl.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/ShortcutControl.cpp
@@ -42,7 +42,14 @@ ShortcutControl::ShortcutControl(StackPanel table, StackPanel row, const int col
     shortcutControlLayout.as<StackPanel>().Children().Append(typeShortcut.as<Button>());
     shortcutControlLayout.as<StackPanel>().Children().Append(shortcutDropDownStackPanel.as<StackPanel>());
     KeyDropDownControl::AddDropDown(table, row, shortcutDropDownStackPanel.as<StackPanel>(), colIndex, shortcutRemapBuffer, keyDropDownControlObjects, targetApp, isHybridControl, false);
-    shortcutControlLayout.as<StackPanel>().UpdateLayout();
+    try
+    {
+        // If a layout update has been triggered by other methods (e.g.: adapting to zoom level), this may throw an exception.
+        shortcutControlLayout.as<StackPanel>().UpdateLayout();
+    }
+    catch (...)
+    {
+    }
 }
 
 // Function to set the accessible name of the target App text box
@@ -480,7 +487,14 @@ void ShortcutControl::CreateDetectShortcutWindow(winrt::Windows::Foundation::IIn
     buttonPanel.Children().Append(cancelButton);
 
     stackPanel.Children().Append(buttonPanel);
-    stackPanel.UpdateLayout();
+    try
+    {
+        // If a layout update has been triggered by other methods (e.g.: adapting to zoom level), this may throw an exception.
+        stackPanel.UpdateLayout();
+    }
+    catch (...)
+    {
+    }
 
     // Configure the keyboardManagerState to store the UI information.
     keyboardManagerState.ConfigureDetectShortcutUI(keyStackPanel1, keyStackPanel2);

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/SingleKeyRemapControl.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/SingleKeyRemapControl.cpp
@@ -56,7 +56,14 @@ SingleKeyRemapControl::SingleKeyRemapControl(StackPanel table, StackPanel row, c
         }
     });
 
-    singleKeyRemapControlLayout.as<StackPanel>().UpdateLayout();
+    try
+    {
+        // If a layout update has been triggered by other methods (e.g.: adapting to zoom level), this may throw an exception.
+        singleKeyRemapControlLayout.as<StackPanel>().UpdateLayout();
+    }
+    catch (...)
+    {
+    }
 }
 
 // Function to set the accessible names for all the controls in a row
@@ -168,7 +175,14 @@ void SingleKeyRemapControl::AddNewControlKeyRemapRow(StackPanel& parent, std::ve
         }
 
         children.RemoveAt(rowIndex);
-        parent.UpdateLayout();
+        try
+        {
+            // If a layout update has been triggered by other methods (e.g.: adapting to zoom level), this may throw an exception.
+            parent.UpdateLayout();
+        }
+        catch (...)
+        {
+        }
         singleKeyRemapBuffer.erase(singleKeyRemapBuffer.begin() + rowIndex);
     
         // delete the SingleKeyRemapControl objects so that they get destructed
@@ -183,7 +197,14 @@ void SingleKeyRemapControl::AddNewControlKeyRemapRow(StackPanel& parent, std::ve
     deleteRemapKeystoolTip.Content(box_value(GET_RESOURCE_STRING(IDS_DELETE_REMAPPING_BUTTON)));
     ToolTipService::SetToolTip(deleteRemapKeys, deleteRemapKeystoolTip);
     row.Children().Append(deleteRemapKeys);
-    parent.UpdateLayout();
+    try
+    {
+        // If a layout update has been triggered by other methods (e.g.: adapting to zoom level), this may throw an exception.
+        parent.UpdateLayout();
+    }
+    catch (...)
+    {
+    }
 
     // Set accessible names
     UpdateAccessibleNames(keyboardRemapControlObjects.back()[0]->getSingleKeyRemapControl(), keyboardRemapControlObjects.back()[1]->getSingleKeyRemapControl(), deleteRemapKeys, (int)keyboardRemapControlObjects.size());
@@ -362,7 +383,14 @@ void SingleKeyRemapControl::createDetectKeyWindow(winrt::Windows::Foundation::II
     buttonPanel.Children().Append(cancelButton);
 
     stackPanel.Children().Append(buttonPanel);
-    stackPanel.UpdateLayout();
+    try
+    {
+        // If a layout update has been triggered by other methods (e.g.: adapting to zoom level), this may throw an exception.
+        stackPanel.UpdateLayout();
+    }
+    catch (...)
+    {
+    }
 
     // Configure the keyboardManagerState to store the UI information.
     keyboardManagerState.ConfigureDetectSingleKeyRemapUI(keyStackPanel);


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Some users report crashes from the Keyboard Manager Editor.
I've been able to reproduce it on a 4K monitor with 225% zoom.
It's caused by the detection of an update layout cycle, in case there's a layout update already triggered (which seems to be the case for 225% zoom when adding elements).

**What is include in the PR:** 
Catch the UpdateLayout exception to not crash.

**How does someone test / validate:** 
On a 4K monitor with 225% zoom, start without any shortcuts when you press the "Remap a shortcut" button and then press the "+" button. Verify this crashes in 0.47.0 but not in this PR. (Running from VS will still break on the exception, but it should be caught if you press "Continue")

## Quality Checklist

- [x] **Linked issue:** #13634 #12978
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries
