### PR TITLE
[PTRun][Program] Avoid looping on folder cycles

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32Program.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32Program.cs
@@ -625,9 +625,20 @@ namespace Microsoft.Plugin.Program.Programs
             var folderQueue = new Queue<string>();
             folderQueue.Enqueue(directory);
 
+            // Keep track of already visited directories to avoid cycles.
+            var alreadyVisited = new HashSet<string>();
+
             do
             {
                 var currentDirectory = folderQueue.Dequeue();
+
+                if (alreadyVisited.Contains(currentDirectory))
+                {
+                    continue;
+                }
+
+                alreadyVisited.Add(currentDirectory);
+
                 try
                 {
                     foreach (var suffix in suffixes)


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
The program plugin tries to recursively look for programs in some paths.
This can cause infinite loops if there are loops in the folder structure (not sure how people manage this on Windows, might be WSL).

**What is include in the PR:** 
Keep track of folders we've already visited and don't visit those again.

**How does someone test / validate:** 
I've not been able to replicate this locally, so just looking for that good old code quality check that I'm not doing anything wrong on that function, since it's pretty self contained.

## Quality Checklist

- [x] **Linked issue:** #13532
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries
