### PR TITLE
[PT Run] Align SelectedIndex and SelectedItem

### DIFF
--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -610,7 +610,6 @@ namespace PowerLauncher.ViewModel
                                                     currentCancellationToken.ThrowIfCancellationRequested();
                                                     numResults = Results.Results.Count;
                                                     Results.Sort();
-                                                    Results.SelectedItem = Results.Results.FirstOrDefault();
                                                 }
                                             }
 

--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -615,7 +615,7 @@ namespace PowerLauncher.ViewModel
                                             }
 
                                             currentCancellationToken.ThrowIfCancellationRequested();
-                                            UpdateResultsListViewAfterQuery(queryText);
+                                            UpdateResultsListViewAfterQuery(queryText, true);
                                         }
                                     }
                                     catch (OperationCanceledException)
@@ -656,7 +656,7 @@ namespace PowerLauncher.ViewModel
             }
         }
 
-        private void UpdateResultsListViewAfterQuery(string queryText)
+        private void UpdateResultsListViewAfterQuery(string queryText, bool isDelayedInvoke = false)
         {
             Application.Current.Dispatcher.BeginInvoke(new Action(() =>
             {
@@ -669,7 +669,10 @@ namespace PowerLauncher.ViewModel
                 if (Results.Results.Count > 0)
                 {
                     Results.Visibility = Visibility.Visible;
-                    Results.SelectedIndex = 0;
+                    if (!isDelayedInvoke)
+                    {
+                        Results.SelectedIndex = 0;
+                    }
                 }
                 else
                 {

--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -615,7 +615,7 @@ namespace PowerLauncher.ViewModel
                                             }
 
                                             currentCancellationToken.ThrowIfCancellationRequested();
-                                            UpdateResultsListViewAfterQuery(queryText, true);
+                                            UpdateResultsListViewAfterQuery(queryText);
                                         }
                                     }
                                     catch (OperationCanceledException)
@@ -656,7 +656,7 @@ namespace PowerLauncher.ViewModel
             }
         }
 
-        private void UpdateResultsListViewAfterQuery(string queryText, bool isDelayedInvoke = false)
+        private void UpdateResultsListViewAfterQuery(string queryText)
         {
             Application.Current.Dispatcher.BeginInvoke(new Action(() =>
             {
@@ -669,10 +669,7 @@ namespace PowerLauncher.ViewModel
                 if (Results.Results.Count > 0)
                 {
                     Results.Visibility = Visibility.Visible;
-                    if (!isDelayedInvoke)
-                    {
-                        Results.SelectedIndex = 0;
-                    }
+                    Results.SelectedIndex = 0;
                 }
                 else
                 {


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Note: Not sure what was the initial idea by introducing this conditional setting of `SelectedIndex` to 0 only if it's not delayed execution plugin.

`SelectedItem` -> Item from the list which will receive the Action (Enter)
`SelectedIndex` -> Hovered item from the list

Anyway, for both "normal" plugins and "delayed execution" after getting the results, `SelectedItem` is set to `FirstOrDefault()` result from sorted list, but `SelectedIndex` is not updated after delayed executed plugins finished querying

This only happens with Indexer plugin as it's the only "delayed execution" plugin

**What is include in the PR:** 


**How does someone test / validate:** 
https://github.com/microsoft/PowerToys/issues/12283#issuecomment-877766337

## Quality Checklist

- [X] **Linked issue:** #12283
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
