### PR TITLE
[FancyZones] Reset layouts after screen locking fix

### DIFF
--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesData.h
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesData.h
@@ -46,7 +46,7 @@ public:
 
     void SetVirtualDesktopCheckCallback(std::function<bool(GUID)> callback);
 
-    std::optional<FancyZonesDataTypes::DeviceInfoData> FindDeviceInfo(const FancyZonesDataTypes::DeviceIdData& zoneWindowId) const;
+    std::optional<FancyZonesDataTypes::DeviceInfoData> FindDeviceInfo(const FancyZonesDataTypes::DeviceIdData& id) const;
     std::optional<FancyZonesDataTypes::CustomZoneSetData> FindCustomZoneSet(const std::wstring& guid) const;
 
     const JSONHelpers::TDeviceInfoMap& GetDeviceInfoMap() const;

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesDataTypes.h
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesDataTypes.h
@@ -146,6 +146,11 @@ namespace FancyZonesDataTypes
         int sensitivityRadius;
     };
 
+    inline bool operator==(const ZoneSetData& lhs, const ZoneSetData& rhs)
+    {
+        return lhs.type == rhs.type && lhs.uuid == rhs.uuid;
+    }
+
     inline bool operator==(const DeviceIdData& lhs, const DeviceIdData& rhs)
     {
         return lhs.deviceName.compare(rhs.deviceName) == 0 && lhs.width == rhs.width && lhs.height == rhs.height && lhs.virtualDesktopId == rhs.virtualDesktopId && lhs.monitorId.compare(rhs.monitorId) == 0;
@@ -159,6 +164,11 @@ namespace FancyZonesDataTypes
     inline bool operator<(const DeviceIdData& lhs, const DeviceIdData& rhs)
     {
         return lhs.deviceName.compare(rhs.deviceName) < 0 || lhs.width < rhs.width || lhs.height < rhs.height || lhs.monitorId.compare(rhs.monitorId) < 0;
+    }
+
+    inline bool operator==(const DeviceInfoData& lhs, const DeviceInfoData& rhs)
+    {
+        return lhs.activeZoneSet == rhs.activeZoneSet && lhs.showSpacing == rhs.showSpacing && lhs.spacing == rhs.spacing && lhs.zoneCount == rhs.zoneCount && lhs.sensitivityRadius == rhs.sensitivityRadius;
     }
 }
 

--- a/src/modules/fancyzones/FancyZonesTests/UnitTests/JsonHelpers.Tests.cpp
+++ b/src/modules/fancyzones/FancyZonesTests/UnitTests/JsonHelpers.Tests.cpp
@@ -2042,6 +2042,258 @@ namespace FancyZonesUnitTests
 
                 Assert::IsFalse(data.RemoveAppLastZone(nullptr, deviceId, zoneSetId));
             }
+
+            TEST_METHOD (AddDevice)
+            {
+                FancyZonesDataTypes::DeviceIdData expected{
+                    .deviceName = L"Device",
+                    .width = 200,
+                    .height = 100,
+                    .virtualDesktopId = m_defaultVDId
+                };
+
+                auto result = m_fzData.AddDevice(expected);
+                Assert::IsTrue(result);
+
+                auto actualMap = m_fzData.GetDeviceInfoMap();
+
+                Assert::IsFalse(actualMap.find(expected) == actualMap.end());
+            }
+
+            TEST_METHOD (AddDeviceWithNullVirtualDesktopId)
+            {
+                FancyZonesDataTypes::DeviceIdData expected{
+                    .deviceName = L"Device",
+                    .width = 200,
+                    .height = 100,
+                    .virtualDesktopId = GUID_NULL
+                };
+
+                auto result = m_fzData.AddDevice(expected);
+                Assert::IsTrue(result);
+
+                auto actualMap = m_fzData.GetDeviceInfoMap();
+
+                Assert::IsFalse(actualMap.find(expected) == actualMap.end());
+            }
+
+            TEST_METHOD (AddDeviceDuplicate)
+            {
+                FancyZonesDataTypes::DeviceIdData expected{
+                    .deviceName = L"Device",
+                    .width = 200,
+                    .height = 100,
+                    .virtualDesktopId = m_defaultVDId
+                };
+
+                auto result = m_fzData.AddDevice(expected);
+                Assert::IsTrue(result);
+
+                auto result2 = m_fzData.AddDevice(expected);
+                Assert::IsFalse(result2);
+
+                auto actualMap = m_fzData.GetDeviceInfoMap();
+
+                Assert::IsFalse(actualMap.find(expected) == actualMap.end());
+            }
+
+            TEST_METHOD (AddDeviceWithNullVirtualDesktopIdDuplicated)
+            {
+                FancyZonesDataTypes::DeviceIdData expected{
+                    .deviceName = L"Device",
+                    .width = 200,
+                    .height = 100,
+                    .virtualDesktopId = GUID_NULL
+                };
+
+                auto result = m_fzData.AddDevice(expected);
+                Assert::IsTrue(result);
+
+                auto result2 = m_fzData.AddDevice(expected);
+                Assert::IsFalse(result2);
+
+                auto actualMap = m_fzData.GetDeviceInfoMap();
+
+                Assert::IsFalse(actualMap.find(expected) == actualMap.end());
+            }
+
+            TEST_METHOD (AddDeviceDuplicatedComparedWithNillVirtualDesktopId)
+            {
+                FancyZonesDataTypes::DeviceIdData device1{
+                    .deviceName = L"Device",
+                    .width = 200,
+                    .height = 100,
+                    .virtualDesktopId = m_defaultVDId
+                };
+
+                FancyZonesDataTypes::DeviceIdData device2{
+                    .deviceName = L"Device",
+                    .width = 200,
+                    .height = 100,
+                    .virtualDesktopId = GUID_NULL
+                };
+
+                auto result = m_fzData.AddDevice(device1);
+                Assert::IsTrue(result);
+
+                auto result2 = m_fzData.AddDevice(device2);
+                Assert::IsFalse(result2);
+
+                auto actualMap = m_fzData.GetDeviceInfoMap();
+
+                Assert::IsFalse(actualMap.find(device1) == actualMap.end());
+                Assert::IsTrue(actualMap.find(device2) == actualMap.end());
+            }
+
+            TEST_METHOD (AddDeviceDuplicatedComparedWithNillVirtualDesktopId2)
+            {
+                FancyZonesDataTypes::DeviceIdData device1{
+                    .deviceName = L"Device",
+                    .width = 200,
+                    .height = 100,
+                    .virtualDesktopId = m_defaultVDId
+                };
+
+                FancyZonesDataTypes::DeviceIdData device2{
+                    .deviceName = L"Device",
+                    .width = 200,
+                    .height = 100,
+                    .virtualDesktopId = GUID_NULL
+                };
+
+                auto result2 = m_fzData.AddDevice(device2);
+                Assert::IsTrue(result2);
+
+                auto result1 = m_fzData.AddDevice(device1);
+                Assert::IsFalse(result1);               
+
+                auto actualMap = m_fzData.GetDeviceInfoMap();
+
+                Assert::IsFalse(actualMap.find(device2) == actualMap.end());
+                Assert::IsTrue(actualMap.find(device1) == actualMap.end());
+            }
+
+            TEST_METHOD(CloneDeviceInfo)
+            {
+                FancyZonesDataTypes::DeviceIdData deviceSrc{
+                    .deviceName = L"Device1",
+                    .width = 200,
+                    .height = 100,
+                    .virtualDesktopId = m_defaultVDId
+                };
+                FancyZonesDataTypes::DeviceIdData deviceDst{
+                    .deviceName = L"Device2",
+                    .width = 300,
+                    .height = 400,
+                    .virtualDesktopId = m_defaultVDId
+                };
+
+                Assert::IsTrue(m_fzData.AddDevice(deviceSrc));
+                Assert::IsTrue(m_fzData.AddDevice(deviceDst));
+
+                m_fzData.CloneDeviceInfo(deviceSrc, deviceDst);
+
+                auto actualMap = m_fzData.GetDeviceInfoMap();
+                Assert::IsFalse(actualMap.find(deviceSrc) == actualMap.end());
+                Assert::IsFalse(actualMap.find(deviceDst) == actualMap.end());
+                
+                auto expected = m_fzData.FindDeviceInfo(deviceSrc);
+                auto actual = m_fzData.FindDeviceInfo(deviceDst);
+
+                Assert::IsTrue(expected.has_value());
+                Assert::IsTrue(actual.has_value());
+                Assert::IsTrue(expected.value() == actual.value());
+            }
+
+            TEST_METHOD (CloneDeviceInfoIntoUnknownDevice)
+            {
+                FancyZonesDataTypes::DeviceIdData deviceSrc{
+                    .deviceName = L"Device1",
+                    .width = 200,
+                    .height = 100,
+                    .virtualDesktopId = m_defaultVDId
+                };
+                FancyZonesDataTypes::DeviceIdData deviceDst{
+                    .deviceName = L"Device2",
+                    .width = 300,
+                    .height = 400,
+                    .virtualDesktopId = m_defaultVDId
+                };
+
+                Assert::IsTrue(m_fzData.AddDevice(deviceSrc));
+
+                m_fzData.CloneDeviceInfo(deviceSrc, deviceDst);
+
+                auto actualMap = m_fzData.GetDeviceInfoMap();
+                Assert::IsFalse(actualMap.find(deviceSrc) == actualMap.end());
+                Assert::IsFalse(actualMap.find(deviceDst) == actualMap.end());
+
+                auto expected = m_fzData.FindDeviceInfo(deviceSrc);
+                auto actual = m_fzData.FindDeviceInfo(deviceDst);
+
+                Assert::IsTrue(expected.has_value());
+                Assert::IsTrue(actual.has_value());
+                Assert::IsTrue(expected.value() == actual.value());
+            }
+
+            TEST_METHOD (CloneDeviceInfoFromUnknownDevice)
+            {
+                FancyZonesDataTypes::DeviceIdData deviceSrc{
+                    .deviceName = L"Device1",
+                    .width = 200,
+                    .height = 100,
+                    .virtualDesktopId = m_defaultVDId
+                };
+                FancyZonesDataTypes::DeviceIdData deviceDst{
+                    .deviceName = L"Device2",
+                    .width = 300,
+                    .height = 400,
+                    .virtualDesktopId = m_defaultVDId
+                };
+
+                Assert::IsTrue(m_fzData.AddDevice(deviceDst));
+
+                m_fzData.CloneDeviceInfo(deviceSrc, deviceDst);
+
+                auto actualMap = m_fzData.GetDeviceInfoMap();
+                Assert::IsTrue(actualMap.find(deviceSrc) == actualMap.end());
+                Assert::IsFalse(actualMap.find(deviceDst) == actualMap.end());
+
+                Assert::IsFalse(m_fzData.FindDeviceInfo(deviceSrc).has_value());
+                Assert::IsTrue(m_fzData.FindDeviceInfo(deviceDst).has_value());
+            }
+
+            TEST_METHOD(CloneDeviceInfoNullVirtualDesktopId)
+            {
+                FancyZonesDataTypes::DeviceIdData deviceSrc{
+                    .deviceName = L"Device1",
+                    .width = 200,
+                    .height = 100,
+                    .virtualDesktopId = GUID_NULL
+                };
+                FancyZonesDataTypes::DeviceIdData deviceDst{
+                    .deviceName = L"Device2",
+                    .width = 300,
+                    .height = 400,
+                    .virtualDesktopId = m_defaultVDId
+                };
+
+                Assert::IsTrue(m_fzData.AddDevice(deviceSrc));
+                Assert::IsTrue(m_fzData.AddDevice(deviceDst));
+
+                m_fzData.CloneDeviceInfo(deviceSrc, deviceDst);
+
+                auto actualMap = m_fzData.GetDeviceInfoMap();
+                Assert::IsFalse(actualMap.find(deviceSrc) == actualMap.end());
+                Assert::IsFalse(actualMap.find(deviceDst) == actualMap.end());
+
+                auto expected = m_fzData.FindDeviceInfo(deviceSrc);
+                auto actual = m_fzData.FindDeviceInfo(deviceDst);
+
+                Assert::IsTrue(expected.has_value());
+                Assert::IsTrue(actual.has_value());
+                Assert::IsTrue(expected.value() == actual.value());
+            }
     };
 
     TEST_CLASS(EditorArgsUnitTests)


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Fixed device id comparison while adding and cloning devices after monitor configuration update.
Added unit tests.

**What is include in the PR:** 

**How does someone test / validate:** 

* Remove `CurrentVirtualDesktop` from `\HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\SessionInfo\1\VirtualDesktops` and
`VirtualDesktopIDs` from `\HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\VirtualDesktops`
* Set custom layouts
* Lock screen / unplug monitor / plug monitor 
* Verify that layouts weren't reset to defaults
* Restart computer
* Verify that layouts weren't reset to defaults
* Create virtual desktop
* Verify that layouts are the same as on the first virtual desktop
* Verify the screen locking scenario again


## Quality Checklist

- [x] **Linked issue:** #13625
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
