### PR TITLE
[FZ Editor] Open settings

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -101,6 +101,7 @@ AShortcut
 ASingle
 asm
 asmx
+asembly
 aspnet
 aspx
 ASSOCCHANGED
@@ -184,6 +185,7 @@ Browsable
 bsd
 bstr
 bti
+btn
 BTNFACE
 Bto
 buf

--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -101,7 +101,6 @@ AShortcut
 ASingle
 asm
 asmx
-asembly
 aspnet
 aspx
 ASSOCCHANGED

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -327,6 +327,21 @@
                                  ItemsSource="{Binding MonitorInfoForViewModel}" />
                 </Grid>
             </ScrollViewer>
+            <Button Click="SettingsBtn_Click"
+                    x:Name="settingsBtn"
+                    Margin="8"
+                    Foreground="{DynamicResource SystemControlBackgroundAccentBrush}"
+                    HorizontalAlignment="Right"
+                    VerticalAlignment="Bottom"
+                    AutomationProperties.Name="{x:Static props:Resources.OpenSettings}"
+                    ToolTip="{x:Static props:Resources.OpenSettings}"
+                    Style="{StaticResource IconOnlyButtonStyle}">
+                <Button.Content>
+                    <TextBlock Text="&#xE115;"
+                               FontFamily="Segoe MDL2 Assets"
+                               AutomationProperties.Name="{x:Static props:Resources.OpenSettings}" />
+                </Button.Content>
+            </Button>
         </Grid>
 
         <ui:ContentDialog x:Name="EditLayoutDialog"

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -337,7 +337,7 @@
                     ToolTip="{x:Static props:Resources.OpenSettings}"
                     Style="{StaticResource IconOnlyButtonStyle}">
                 <Button.Content>
-                    <TextBlock Text="&#xE115;"
+                    <TextBlock Text="&#xe713;"
                                FontFamily="Segoe MDL2 Assets"
                                AutomationProperties.Name="{x:Static props:Resources.OpenSettings}" />
                 </Button.Content>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -4,6 +4,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
 using System.Windows;
 using System.Windows.Automation;
 using System.Windows.Automation.Peers;
@@ -515,6 +517,13 @@ namespace FancyZonesEditor
             numberBox.ApplyTemplate(); // Apply template to be able to change child's property.
             var numberBoxTextBox = numberBox.Template.FindName(numberBoxTextBoxName, numberBox) as TextBox;
             numberBoxTextBox.SetValue(AutomationProperties.NameProperty, numberBox.GetValue(AutomationProperties.NameProperty));
+        }
+
+        private void SettingsBtn_Click(object sender, RoutedEventArgs e)
+        {
+            var asemblyPath = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
+            var fullPath = Directory.GetParent(asemblyPath).FullName;
+            Process.Start(new ProcessStartInfo(fullPath + "\\..\\PowerToys.exe") { Arguments = "--open-settings=FancyZones" });
         }
     }
 }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -521,8 +521,8 @@ namespace FancyZonesEditor
 
         private void SettingsBtn_Click(object sender, RoutedEventArgs e)
         {
-            var asemblyPath = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
-            var fullPath = Directory.GetParent(asemblyPath).FullName;
+            var assemblyPath = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
+            var fullPath = Directory.GetParent(assemblyPath).FullName;
             Process.Start(new ProcessStartInfo(fullPath + "\\..\\PowerToys.exe") { Arguments = "--open-settings=FancyZones" });
         }
     }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -521,9 +521,15 @@ namespace FancyZonesEditor
 
         private void SettingsBtn_Click(object sender, RoutedEventArgs e)
         {
-            var assemblyPath = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
-            var fullPath = Directory.GetParent(assemblyPath).FullName;
-            Process.Start(new ProcessStartInfo(fullPath + "\\..\\PowerToys.exe") { Arguments = "--open-settings=FancyZones" });
+            try
+            {
+                var assemblyPath = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
+                var fullPath = Directory.GetParent(assemblyPath).FullName;
+                Process.Start(new ProcessStartInfo(fullPath + "\\..\\PowerToys.exe") { Arguments = "--open-settings=FancyZones" });
+            }
+            catch
+            {
+            }
         }
     }
 }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
@@ -597,6 +597,15 @@ namespace FancyZonesEditor.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Open settings.
+        /// </summary>
+        public static string OpenSettings {
+            get {
+                return ResourceManager.GetString("OpenSettings", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to px.
         /// </summary>
         public static string Pixels {

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
@@ -338,7 +338,7 @@
   </data>
   <data name="KeyboardControlsName" xml:space="preserve">
     <value>Keyboard Navigation:</value>
-  </data>    
+  </data>
   <data name="KeyboardControlsDescription" xml:space="preserve">
     <value>
      - [Shift]+S to split currently focused zone.
@@ -346,7 +346,7 @@
      - Tab to cycle zones and resizers.
      - Delete to remove the focused resizer.
      - Arrows to move the focused resizer.</value>
-  </data>        
+  </data>
   <data name="SplitterDescription" xml:space="preserve">
     <value>Hold Shift key for vertical split.</value>
     <comment>A segmenter visual for splitting one item into two.  This would be the vertical line. Shift key is referring to key on keyboard</comment>
@@ -374,7 +374,10 @@
   <data name="Edit_Layout" xml:space="preserve">
     <value>Edit layout</value>
   </data>
-    <data name="Layout_Creation_Announce" xml:space="preserve">
+  <data name="Layout_Creation_Announce" xml:space="preserve">
     <value>custom layout was created successfully.</value>
+  </data>
+  <data name="OpenSettings" xml:space="preserve">
+    <value>Open settings</value>
   </data>
 </root>


### PR DESCRIPTION
## Summary of the Pull Request
This PR introduces a settings button in the FancyZones editor to quickly open Settings: #7408
![FZEditor](https://user-images.githubusercontent.com/9866362/136704725-e1110f29-ab2c-44e5-adf6-0e8278504633.gif)

**How does someone test / validate:** 
- Make sure to run the latest settings (= runner) from master branch.
- Debug FancyZones editor.
- Click on the new settings button.

## Quality Checklist

- [X] **Linked issue:** #7408
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
