### PR TITLE
[Color Picker] Open settings

### DIFF
--- a/src/modules/colorPicker/ColorPickerUI/Helpers/AppStateHandler.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/AppStateHandler.cs
@@ -189,9 +189,17 @@ namespace ColorPicker.Helpers
 
         private void ColorEditorViewModel_OpenSettingsRequested(object sender, EventArgs e)
         {
-            var assemblyPath = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
-            var fullPath = Directory.GetParent(assemblyPath).FullName;
-            Process.Start(new ProcessStartInfo(fullPath + "\\..\\PowerToys.exe") { Arguments = "--open-settings=ColorPicker" });
+            try
+            {
+                var assemblyPath = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
+                var fullPath = Directory.GetParent(assemblyPath).FullName;
+                Process.Start(new ProcessStartInfo(fullPath + "\\..\\PowerToys.exe") { Arguments = "--open-settings=ColorPicker" });
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch
+#pragma warning restore CA1031 // Do not catch general exception types
+            {
+            }
         }
     }
 }

--- a/src/modules/colorPicker/ColorPickerUI/Helpers/AppStateHandler.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/AppStateHandler.cs
@@ -4,6 +4,8 @@
 
 using System;
 using System.ComponentModel.Composition;
+using System.Diagnostics;
+using System.IO;
 using System.Windows;
 using ColorPicker.Settings;
 using ColorPicker.ViewModelContracts;
@@ -134,6 +136,7 @@ namespace ColorPicker.Helpers
                 _colorEditorWindow = new ColorEditorWindow(this);
                 _colorEditorWindow.Content = _colorEditorViewModel;
                 _colorEditorViewModel.OpenColorPickerRequested += ColorEditorViewModel_OpenColorPickerRequested;
+                _colorEditorViewModel.OpenSettingsRequested += ColorEditorViewModel_OpenSettingsRequested;
                 _colorEditorViewModel.OpenColorPickerRequested += (object sender, EventArgs e) =>
                 {
                     SessionEventHelper.Event.EditorColorPickerOpened = true;
@@ -182,6 +185,13 @@ namespace ColorPicker.Helpers
             }
 
             _colorEditorWindow.Hide();
+        }
+
+        private void ColorEditorViewModel_OpenSettingsRequested(object sender, EventArgs e)
+        {
+            var assemblyPath = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
+            var fullPath = Directory.GetParent(assemblyPath).FullName;
+            Process.Start(new ProcessStartInfo(fullPath + "\\..\\PowerToys.exe") { Arguments = "--open-settings=ColorPicker" });
         }
     }
 }

--- a/src/modules/colorPicker/ColorPickerUI/ViewModelContracts/IColorEditorViewModel.cs
+++ b/src/modules/colorPicker/ColorPickerUI/ViewModelContracts/IColorEditorViewModel.cs
@@ -14,7 +14,11 @@ namespace ColorPicker.ViewModelContracts
     {
         event EventHandler OpenColorPickerRequested;
 
+        event EventHandler OpenSettingsRequested;
+
         ICommand OpenColorPickerCommand { get; }
+
+        ICommand OpenSettingsCommand { get; }
 
         ICommand RemoveColorCommand { get; }
 

--- a/src/modules/colorPicker/ColorPickerUI/ViewModels/ColorEditorViewModel.cs
+++ b/src/modules/colorPicker/ColorPickerUI/ViewModels/ColorEditorViewModel.cs
@@ -32,6 +32,7 @@ namespace ColorPicker.ViewModels
         public ColorEditorViewModel(IUserSettings userSettings)
         {
             OpenColorPickerCommand = new RelayCommand(() => OpenColorPickerRequested?.Invoke(this, EventArgs.Empty));
+            OpenSettingsCommand = new RelayCommand(() => OpenSettingsRequested?.Invoke(this, EventArgs.Empty));
             RemoveColorCommand = new RelayCommand(DeleteSelectedColor);
 
             SelectedColorChangedCommand = new RelayCommand((newColor) =>
@@ -47,7 +48,11 @@ namespace ColorPicker.ViewModels
 
         public event EventHandler OpenColorPickerRequested;
 
+        public event EventHandler OpenSettingsRequested;
+
         public ICommand OpenColorPickerCommand { get; }
+
+        public ICommand OpenSettingsCommand { get; }
 
         public ICommand RemoveColorCommand { get; }
 

--- a/src/modules/colorPicker/ColorPickerUI/Views/ColorEditorView.xaml
+++ b/src/modules/colorPicker/ColorPickerUI/Views/ColorEditorView.xaml
@@ -85,7 +85,7 @@
             <Button Width="46"
                     Command="{Binding OpenSettingsCommand}"
                     Height="32"
-                    Content="&#xE115;"
+                    Content="&#xE713;"
                     TabIndex="2"
                     Background="Transparent"
                     FontFamily="Segoe MDL2 Assets"

--- a/src/modules/colorPicker/ColorPickerUI/Views/ColorEditorView.xaml
+++ b/src/modules/colorPicker/ColorPickerUI/Views/ColorEditorView.xaml
@@ -82,8 +82,8 @@
                 VerticalAlignment="Center"
                 Margin="0,1,0,0" />
 
-            <!-- Enable once we have settings linking available -->
-            <!--<Button Width="46"
+            <Button Width="46"
+                    Command="{Binding OpenSettingsCommand}"
                     Height="32"
                     Content="&#xE115;"
                     TabIndex="2"
@@ -92,7 +92,7 @@
                     HorizontalAlignment="Right"
                     Margin="0,0,46,0"
                     ToolTipService.ToolTip="{x:Static p:Resources.Open_settings}"
-                    AutomationProperties.Name="{x:Static p:Resources.Open_settings}" />-->
+                    AutomationProperties.Name="{x:Static p:Resources.Open_settings}" />
 
             <Button Width="64"
                     Height="32"


### PR DESCRIPTION
## Summary of the Pull Request
This PR introduces a settings button in Color Picker to quickly open Settings: #7408

![CPSettings2](https://user-images.githubusercontent.com/9866362/136813607-75202424-5498-4b1f-95a2-71ffb492774b.gif)

**How does someone test / validate:** 
- Make sure to run the latest settings (= runner) from master branch.
- Debug Color Picker
- Click on the new settings button.

## Quality Checklist

- [X] **Linked issue:** #7408
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
