### PR TITLE
[Image Resizer] Add settings button

### DIFF
--- a/src/modules/imageresizer/ui/Properties/Resources.Designer.cs
+++ b/src/modules/imageresizer/ui/Properties/Resources.Designer.cs
@@ -205,6 +205,15 @@ namespace ImageResizer.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Open settings.
+        /// </summary>
+        public static string Open_settings {
+            get {
+                return ResourceManager.GetString("Open_settings", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Phone.
         /// </summary>
         public static string Phone {

--- a/src/modules/imageresizer/ui/Properties/Resources.resx
+++ b/src/modules/imageresizer/ui/Properties/Resources.resx
@@ -277,4 +277,7 @@
   <data name="Width" xml:space="preserve">
     <value>Width</value>
   </data>
+  <data name="Open_settings" xml:space="preserve">
+    <value>Open settings</value>
+  </data>
 </root>

--- a/src/modules/imageresizer/ui/ViewModels/InputViewModel.cs
+++ b/src/modules/imageresizer/ui/ViewModels/InputViewModel.cs
@@ -8,6 +8,7 @@ using ImageResizer.Helpers;
 using ImageResizer.Models;
 using ImageResizer.Properties;
 using ImageResizer.Views;
+using Microsoft.PowerToys.Common.UI;
 
 namespace ImageResizer.ViewModels
 {
@@ -35,6 +36,7 @@ namespace ImageResizer.ViewModels
 
             ResizeCommand = new RelayCommand(Resize);
             CancelCommand = new RelayCommand(Cancel);
+            OpenSettingsCommand = new RelayCommand(OpenSettings);
         }
 
         public Settings Settings { get; }
@@ -42,6 +44,8 @@ namespace ImageResizer.ViewModels
         public ICommand ResizeCommand { get; }
 
         public ICommand CancelCommand { get; }
+
+        public ICommand OpenSettingsCommand { get; }
 
         public bool TryingToResizeGifFiles
         {
@@ -56,6 +60,11 @@ namespace ImageResizer.ViewModels
         {
             Settings.Save();
             _mainViewModel.CurrentPage = new ProgressViewModel(_batch, _mainViewModel, _mainView);
+        }
+
+        public static void OpenSettings()
+        {
+            SettingsDeepLink.OpenSettings(SettingsDeepLink.SettingsWindow.ImageResizer);
         }
 
         public void Cancel()

--- a/src/modules/imageresizer/ui/Views/InputPage.xaml
+++ b/src/modules/imageresizer/ui/Views/InputPage.xaml
@@ -159,7 +159,7 @@
                 <Button Width="36"
                     Command="{Binding OpenSettingsCommand}"
                     Height="36"
-                    Margin="-6,0,0,0"
+                    Margin="-8,0,0,0"
                     Content="&#xE713;"
                     Background="Transparent"
                     FontFamily="Segoe MDL2 Assets"

--- a/src/modules/imageresizer/ui/Views/InputPage.xaml
+++ b/src/modules/imageresizer/ui/Views/InputPage.xaml
@@ -131,6 +131,17 @@
         <CheckBox Margin="12,4,12,0"
                   Content="{x:Static p:Resources.Input_IgnoreOrientation}"
                   IsChecked="{Binding Settings.IgnoreOrientation}"/>
+
+            <TextBlock Grid.Column="0"
+                           FontWeight="Bold"
+                           Text="{x:Static p:Resources.Input_GifWarning}"
+                           TextWrapping="Wrap"
+                       Margin="12,12,12,0"
+                           HorizontalAlignment="Right"
+                           TextAlignment="Left"
+                           Foreground="{ui:ThemeResource SystemControlErrorTextForegroundBrush}"
+                           Visibility="{Binding TryingToResizeGifFiles, Converter={StaticResource BoolValueConverter}}"
+                           />
         </StackPanel>
     
         <Border Margin="0,12,0,0"
@@ -145,16 +156,18 @@
                     <ColumnDefinition Width="Auto"/>
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
-                <TextBlock Grid.Column="0"
-                           FontWeight="Bold"
-                           Text="{x:Static p:Resources.Input_GifWarning}"
-                           TextWrapping="Wrap"
-                           MaxWidth="250"
-                           HorizontalAlignment="Left"
-                           TextAlignment="Left"
-                           Foreground="{ui:ThemeResource SystemControlErrorTextForegroundBrush}"
-                           Visibility="{Binding TryingToResizeGifFiles, Converter={StaticResource BoolValueConverter}}"
-                           />
+                <Button Width="36"
+                    Command="{Binding OpenSettingsCommand}"
+                    Height="36"
+                    Margin="-6,0,0,0"
+                    Content="&#xE713;"
+                    Background="Transparent"
+                    FontFamily="Segoe MDL2 Assets"
+                        FontSize="16"
+                    HorizontalAlignment="Left"
+                    ToolTipService.ToolTip="{x:Static p:Resources.Open_settings}"
+                    AutomationProperties.Name="{x:Static p:Resources.Open_settings}" />
+
                 <Button Grid.Column="1"
                         Style="{StaticResource AccentButtonStyle}"
                         MinWidth="76"


### PR DESCRIPTION
## Summary of the Pull Request

This PR introduces a settings button in Image Resizer to quickly open Settings: #7408

![image](https://user-images.githubusercontent.com/9866362/136941704-8657ca37-815f-4a33-91a2-5cabbdc8d06f.png)


## Quality Checklist

- [X] **Linked issue:** #7408
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
