### PR TITLE
[Settings deep link support] Use modules relative path to PowerToys.exe

### DIFF
--- a/src/common/Microsoft.PowerToys.Common.UI/SettingsDeepLink.cs
+++ b/src/common/Microsoft.PowerToys.Common.UI/SettingsDeepLink.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.IO;
 
 namespace Microsoft.PowerToys.Common.UI
 {
@@ -61,7 +62,9 @@ namespace Microsoft.PowerToys.Common.UI
         {
             try
             {
-                Process.Start(new ProcessStartInfo(Environment.CurrentDirectory + "\\PowerToys.exe") { Arguments = "--open-settings=" + SettingsWindowNameToString(window) });
+                var assemblyPath = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
+                var fullPath = Directory.GetParent(assemblyPath).FullName;
+                Process.Start(new ProcessStartInfo(fullPath + "\\..\\PowerToys.exe") { Arguments = "--open-settings=" + SettingsWindowNameToString(window) });
             }
 #pragma warning disable CA1031 // Do not catch general exception types
             catch


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Environment.CurrentDirectory is not always reliable, as it sometimes pick up modules' current directory. This way, we look for PowerToys.exe relatively to modules path. All modules has same directory structure in install folder and I don't see something will change this structure anytime soon (i.e. won't brake this relative path)

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [X] **Linked issue:** #7408
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
