### PR TITLE
Screen reader announces role and state for Awake tray menu items

### DIFF
--- a/src/modules/awake/Awake/Core/TrayHelper.cs
+++ b/src/modules/awake/Awake/Core/TrayHelper.cs
@@ -175,7 +175,7 @@ namespace Awake.Core
             };
 
             // No keep-awake menu item.
-            ToolStripMenuItem? passiveMenuItem = new ToolStripMenuItem
+            CheckButtonToolStripMenuItem? passiveMenuItem = new CheckButtonToolStripMenuItem
             {
                 Text = "Off (Passive)",
             };
@@ -189,7 +189,7 @@ namespace Awake.Core
             };
 
             // Indefinite keep-awake menu item.
-            ToolStripMenuItem? indefiniteMenuItem = new ToolStripMenuItem
+            CheckButtonToolStripMenuItem? indefiniteMenuItem = new CheckButtonToolStripMenuItem
             {
                 Text = "Keep awake indefinitely",
             };
@@ -202,7 +202,7 @@ namespace Awake.Core
                 indefiniteKeepAwakeCallback();
             };
 
-            ToolStripMenuItem? displayOnMenuItem = new ToolStripMenuItem
+            CheckButtonToolStripMenuItem? displayOnMenuItem = new CheckButtonToolStripMenuItem
             {
                 Text = "Keep screen on",
             };
@@ -222,6 +222,7 @@ namespace Awake.Core
             };
 
             timedMenuItem.Checked = mode == AwakeMode.TIMED;
+            timedMenuItem.AccessibleName = timedMenuItem.Text + (timedMenuItem.Checked ? ". Checked. " : ". UnChecked. ");
 
             ToolStripMenuItem? halfHourMenuItem = new ToolStripMenuItem
             {
@@ -283,6 +284,39 @@ namespace Awake.Core
 
             TrayIcon.Text = text;
             TrayIcon.ContextMenuStrip = contextMenuStrip;
+        }
+
+        private class CheckButtonToolStripMenuItemAccessibleObject : ToolStripItem.ToolStripItemAccessibleObject
+        {
+            private CheckButtonToolStripMenuItem _menuItem;
+
+            public CheckButtonToolStripMenuItemAccessibleObject(CheckButtonToolStripMenuItem menuItem)
+                : base(menuItem)
+            {
+                _menuItem = menuItem;
+            }
+
+            public override AccessibleRole Role
+            {
+                get
+                {
+                    return AccessibleRole.CheckButton;
+                }
+            }
+
+            public override string Name => _menuItem.Text + ", " + Role + ", " + (_menuItem.Checked ? "Checked" : "Unchecked");
+        }
+
+        private class CheckButtonToolStripMenuItem : ToolStripMenuItem
+        {
+            public CheckButtonToolStripMenuItem()
+            {
+            }
+
+            protected override AccessibleObject CreateAccessibilityInstance()
+            {
+                return new CheckButtonToolStripMenuItemAccessibleObject(this);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request

Added custom menu item with custom accessible object that behaves as check button.
Now screen reader announces: menu_item_text + "CheckButton" + "Checked/Unchecked"

**What is this about:**

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [X] **Linked issue:** #13487
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
