### PR TITLE
[Settings] Restore window size and position

### DIFF
--- a/src/settings-ui/PowerToys.Settings/Helpers/NativeMethods.cs
+++ b/src/settings-ui/PowerToys.Settings/Helpers/NativeMethods.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace PowerToys.Settings.Helpers
+{
+    public static class NativeMethods
+    {
+        internal const int SW_SHOWNORMAL = 1;
+        internal const int SW_SHOWMAXIMIZED = 3;
+
+        [DllImport("user32.dll")]
+        internal static extern bool SetWindowPlacement(IntPtr hWnd, ref WINDOWPLACEMENT lpwndpl);
+
+        [DllImport("user32.dll")]
+        internal static extern bool GetWindowPlacement(IntPtr hWnd, out WINDOWPLACEMENT lpwndpl);
+    }
+}

--- a/src/settings-ui/PowerToys.Settings/Helpers/POINT.cs
+++ b/src/settings-ui/PowerToys.Settings/Helpers/POINT.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace PowerToys.Settings.Helpers
+{
+    [Serializable]
+    [StructLayout(LayoutKind.Sequential)]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1815:Override equals and operator equals on value types", Justification = "Interop")]
+    public struct POINT
+    {
+        public int X { get; set; }
+
+        public int Y { get; set; }
+
+        public POINT(int x, int y)
+        {
+            X = x;
+            Y = y;
+        }
+    }
+}

--- a/src/settings-ui/PowerToys.Settings/Helpers/RECT.cs
+++ b/src/settings-ui/PowerToys.Settings/Helpers/RECT.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace PowerToys.Settings.Helpers
+{
+    [Serializable]
+    [StructLayout(LayoutKind.Sequential)]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1815:Override equals and operator equals on value types", Justification = "Interop")]
+    public struct RECT
+    {
+        public int Left { get; set; }
+
+        public int Top { get; set; }
+
+        public int Right { get; set; }
+
+        public int Bottom { get; set; }
+
+        public RECT(int left, int top, int right, int bottom)
+        {
+            Left = left;
+            Top = top;
+            Right = right;
+            Bottom = bottom;
+        }
+    }
+}

--- a/src/settings-ui/PowerToys.Settings/Helpers/WINDOWPLACEMENT.cs
+++ b/src/settings-ui/PowerToys.Settings/Helpers/WINDOWPLACEMENT.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace PowerToys.Settings.Helpers
+{
+    [Serializable]
+    [StructLayout(LayoutKind.Sequential)]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1815:Override equals and operator equals on value types", Justification = "Interop")]
+    public struct WINDOWPLACEMENT
+    {
+        public int Length { get; set; }
+
+        public int Flags { get; set; }
+
+        public int ShowCmd { get; set; }
+
+        public POINT MinPosition { get; set; }
+
+        public POINT MaxPosition { get; set; }
+
+        public RECT NormalPosition { get; set; }
+    }
+}

--- a/src/settings-ui/PowerToys.Settings/Utils.cs
+++ b/src/settings-ui/PowerToys.Settings/Utils.cs
@@ -2,12 +2,19 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text.Json;
 using System.Windows;
+using PowerToys.Settings.Helpers;
 
 namespace PowerToys.Settings
 {
     internal class Utils
     {
+        private static string _placementPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), @"Microsoft\PowerToys\settings-placement.json");
+
         public static void FitToScreen(Window window)
         {
             if (SystemParameters.WorkArea.Width < window.Width)
@@ -65,6 +72,46 @@ namespace PowerToys.Settings
             window.MinHeight = originalMinHeight;
             window.MinWidth = originalMinWidth;
             window.ShowInTaskbar = true;
+        }
+
+        public static WINDOWPLACEMENT DeserializePlacementOrDefault(IntPtr handle)
+        {
+            if (File.Exists(_placementPath))
+            {
+                try
+                {
+                    var json = File.ReadAllText(_placementPath);
+                    var placement = JsonSerializer.Deserialize<WINDOWPLACEMENT>(json);
+
+                    placement.Length = Marshal.SizeOf(typeof(WINDOWPLACEMENT));
+                    placement.Flags = 0;
+                    placement.ShowCmd = placement.ShowCmd == NativeMethods.SW_SHOWMAXIMIZED ? NativeMethods.SW_SHOWMAXIMIZED : NativeMethods.SW_SHOWNORMAL;
+                    return placement;
+                }
+#pragma warning disable CA1031 // Do not catch general exception types
+                catch (Exception)
+#pragma warning restore CA1031 // Do not catch general exception types
+                {
+                }
+            }
+
+            _ = NativeMethods.GetWindowPlacement(handle, out var defaultPlacement);
+            return defaultPlacement;
+        }
+
+        public static void SerializePlacement(IntPtr handle)
+        {
+            _ = NativeMethods.GetWindowPlacement(handle, out var placement);
+            try
+            {
+                var json = JsonSerializer.Serialize(placement);
+                File.WriteAllText(_placementPath, json);
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception)
+#pragma warning restore CA1031 // Do not catch general exception types
+            {
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Restore settings window size and position

**What is include in the PR:** 
- Using GetWindowPlacement and SetWindowPlacement to restore settings window size and position
- Also checking if the restored windows is offscreen and rollback to default
- Aware of multiple monitors and scaling

Let's discuss about this solution. Should I add try-catch to be more safe?

**How does someone test / validate:** 
- Validate that settings window is always restored and visibile

## Quality Checklist

- [x] **Linked issue:** #3685
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
