### PR TITLE
 [FancyZones Editor] Crash fix

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/App.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/App.xaml.cs
@@ -125,6 +125,8 @@ namespace FancyZonesEditor
 
         private void OnExit(object sender, ExitEventArgs e)
         {
+            Dispose();
+
             if (_eventHandle != null)
             {
                 _eventHandle.Set();

--- a/src/modules/fancyzones/editor/FancyZonesEditor/App.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/App.xaml.cs
@@ -37,6 +37,8 @@ namespace FancyZonesEditor
 
         private EventWaitHandle _eventHandle;
 
+        private Thread _exitWaitThread;
+
         public static bool DebugMode
         {
             get
@@ -61,7 +63,8 @@ namespace FancyZonesEditor
             Overlay = new Overlay();
             MainWindowSettings = new MainWindowSettingsModel();
 
-            new Thread(App_WaitExit).Start();
+            _exitWaitThread = new Thread(App_WaitExit);
+            _exitWaitThread.Start();
         }
 
         private void OnStartup(object sender, StartupEventArgs e)
@@ -126,6 +129,8 @@ namespace FancyZonesEditor
             {
                 _eventHandle.Set();
             }
+
+            _exitWaitThread.Join();
 
             Logger.LogInfo("FancyZones Editor exited");
         }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/App.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/App.xaml.cs
@@ -61,17 +61,7 @@ namespace FancyZonesEditor
             Overlay = new Overlay();
             MainWindowSettings = new MainWindowSettingsModel();
 
-            new Thread(() =>
-            {
-                _eventHandle = new EventWaitHandle(false, EventResetMode.AutoReset, interop.Constants.FZEExitEvent());
-                if (_eventHandle.WaitOne())
-                {
-                    Logger.LogInfo("FancyZones disabled, exit");
-                    Environment.Exit(0);
-                }
-            }).Start();
-
-            Logger.LogInfo("FancyZones Editor started");
+            new Thread(App_WaitExit).Start();
         }
 
         private void OnStartup(object sender, StartupEventArgs e)
@@ -138,6 +128,15 @@ namespace FancyZonesEditor
             }
 
             Logger.LogInfo("FancyZones Editor exited");
+        }
+
+        private void App_WaitExit()
+        {
+            _eventHandle = new EventWaitHandle(false, EventResetMode.AutoReset, interop.Constants.FZEExitEvent());
+            if (_eventHandle.WaitOne())
+            {
+                Environment.Exit(0);
+            }
         }
 
         public void App_KeyUp(object sender, System.Windows.Input.KeyEventArgs e)

--- a/src/modules/fancyzones/editor/FancyZonesEditor/App.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/App.xaml.cs
@@ -142,6 +142,7 @@ namespace FancyZonesEditor
             _eventHandle = new EventWaitHandle(false, EventResetMode.AutoReset, interop.Constants.FZEExitEvent());
             if (_eventHandle.WaitOne())
             {
+                Logger.LogInfo("Exit event triggered");
                 Environment.Exit(0);
             }
         }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Logs/Logger.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Logs/Logger.cs
@@ -95,7 +95,7 @@ namespace FancyZonesEditor.Logs
 
             var methodName = stackTrace.GetFrame(3)?.GetMethod();
             var className = methodName?.DeclaringType.Name;
-            return className + " :: " + methodName?.Name;
+            return className + "::" + methodName?.Name;
         }
     }
 }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -41,20 +41,7 @@ namespace FancyZonesEditor
             DataContext = _settings;
 
             KeyUp += MainWindow_KeyUp;
-
-            // Prevent closing the dialog with enter
-            PreviewKeyDown += (object sender, KeyEventArgs e) =>
-            {
-                if (e.Key == Key.Enter && _openedDialog != null && _openedDialog.IsVisible)
-                {
-                    var source = e.OriginalSource as RadioButton;
-                    if (source != null && source.IsChecked != true)
-                    {
-                        source.IsChecked = true;
-                        e.Handled = true;
-                    }
-                }
-            };
+            PreviewKeyDown += MainWindow_PreviewKeyDown;
 
             if (spanZonesAcrossMonitors)
             {
@@ -81,6 +68,20 @@ namespace FancyZonesEditor
             if (e.Key == Key.Escape)
             {
                 CloseDialog(sender);
+            }
+        }
+
+        // Prevent closing the dialog with enter
+        private void MainWindow_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Enter && _openedDialog != null && _openedDialog.IsVisible)
+            {
+                var source = e.OriginalSource as RadioButton;
+                if (source != null && source.IsChecked != true)
+                {
+                    source.IsChecked = true;
+                    e.Handled = true;
+                }
             }
         }
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -4,8 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
 using System.Windows;
 using System.Windows.Automation;
 using System.Windows.Automation.Peers;
@@ -256,7 +254,7 @@ namespace FancyZonesEditor
 
         private void Announce(string name, string message)
         {
-            if (AutomationPeer.ListenerExists(AutomationEvents.MenuOpened))
+            if (AutomationPeer.ListenerExists(AutomationEvents.MenuOpened) && _createLayoutAnnounce != null)
             {
                 var peer = UIElementAutomationPeer.FromElement(_createLayoutAnnounce);
                 AutomationProperties.SetName(_createLayoutAnnounce, name + " " + message);
@@ -516,7 +514,10 @@ namespace FancyZonesEditor
         private void TextBox_GotKeyboardFocus(object sender, RoutedEventArgs e)
         {
             TextBox tb = sender as TextBox;
-            tb.SelectionStart = tb.Text.Length;
+            if (tb != null)
+            {
+                tb.SelectionStart = tb.Text.Length;
+            }
         }
 
         private void CancelLayoutChanges()


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

The crash always happens at `System.AppContext.OnProcessExit()`. It could be caused by not properly closing windows or disposing of controls. 
In case of a crash happens on the editor start, there could be another reason for closing the editor, such as incorrect settings, and after closing, the crash happened. We only have the last error message saved. So for this type of problem [logger](https://github.com/microsoft/PowerToys/pull/13928) could help to investigate.

**What is include in the PR:** 

* Replaced anonymous methods capturing class members.
* Called `Dispose` of App.
* Stopped thread.

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #13105
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
