### PR TITLE
[Settings] Fixing ColorPickerButton a11y bugs

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/ColorPickerButton.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/ColorPickerButton.xaml
@@ -5,11 +5,34 @@
     xmlns:local="using:Microsoft.PowerToys.Settings.UI.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     mc:Ignorable="d"
     d:DesignHeight="300"
     d:DesignWidth="400">
 
     <Grid>
-
+        <muxc:DropDownButton Padding="4,4,8,4">
+            <Border x:Name="ColorPreviewBorder"
+                    Width="48"
+                    CornerRadius="2"
+                    Height="24"
+                    BorderBrush="{ThemeResource CardBorderBrush}"
+                    BorderThickness="{ThemeResource CardBorderThickness}">
+                <Border.Background>
+                    <SolidColorBrush Color="{x:Bind SelectedColor, Mode=OneWay}"/>
+                </Border.Background>
+            </Border>
+            <muxc:DropDownButton.Flyout>
+                <Flyout>
+                    <muxc:ColorPicker IsColorSliderVisible="True"
+                                      IsColorChannelTextInputVisible="True"
+                                      IsHexInputVisible="True"
+                                      IsAlphaEnabled="False"
+                                      IsAlphaSliderVisible="False"
+                                      IsAlphaTextInputVisible="False"
+                                      Color="{x:Bind SelectedColor, Mode=TwoWay}" />
+                </Flyout>
+            </muxc:DropDownButton.Flyout>
+        </muxc:DropDownButton>
     </Grid>
 </UserControl>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/ColorPickerButton.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/ColorPickerButton.xaml
@@ -6,12 +6,14 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+    xmlns:clr="using:Windows.UI"
     mc:Ignorable="d"
+    
     d:DesignHeight="300"
     d:DesignWidth="400">
 
     <Grid>
-        <muxc:DropDownButton Padding="4,4,8,4">
+        <muxc:DropDownButton Padding="4,4,8,4" AutomationProperties.FullDescription="{x:Bind clr:ColorHelper.ToDisplayName(SelectedColor), Mode=OneWay }">
             <Border x:Name="ColorPreviewBorder"
                     Width="48"
                     CornerRadius="2"

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/ColorPickerButton.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/ColorPickerButton.xaml
@@ -1,0 +1,15 @@
+﻿<UserControl
+    x:Class="Microsoft.PowerToys.Settings.UI.Controls.ColorPickerButton"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Microsoft.PowerToys.Settings.UI.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+    <Grid>
+
+    </Grid>
+</UserControl>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/ColorPickerButton.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/ColorPickerButton.xaml.cs
@@ -1,10 +1,15 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
+using Windows.UI;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Controls.Primitives;
@@ -13,15 +18,54 @@ using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 
-// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
-
 namespace Microsoft.PowerToys.Settings.UI.Controls
 {
     public sealed partial class ColorPickerButton : UserControl
     {
+        private Color _selectedColor;
+
+        public Color SelectedColor
+        {
+            get
+            {
+                return _selectedColor;
+            }
+
+            set
+            {
+                if (_selectedColor != value)
+                {
+                    _selectedColor = value;
+                    SetValue(SelectedColorProperty, value);
+                }
+            }
+        }
+
+        public static readonly DependencyProperty SelectedColorProperty = DependencyProperty.Register("SelectedColor", typeof(Color), typeof(ColorPickerButton), new PropertyMetadata(null));
+
         public ColorPickerButton()
         {
             this.InitializeComponent();
+            IsEnabledChanged -= ColorPickerButton_IsEnabledChanged;
+            SetEnabledState();
+            IsEnabledChanged += ColorPickerButton_IsEnabledChanged;
+        }
+
+        private void ColorPickerButton_IsEnabledChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            SetEnabledState();
+        }
+
+        private void SetEnabledState()
+        {
+            if (this.IsEnabled)
+            {
+                ColorPreviewBorder.Opacity = 1;
+            }
+            else
+            {
+                ColorPreviewBorder.Opacity = 0.2;
+            }
         }
     }
 }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/ColorPickerButton.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/ColorPickerButton.xaml.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace Microsoft.PowerToys.Settings.UI.Controls
+{
+    public sealed partial class ColorPickerButton : UserControl
+    {
+        public ColorPickerButton()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/IsEnabledTextBlock/IsEnabledTextBlock.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/IsEnabledTextBlock/IsEnabledTextBlock.xaml
@@ -5,6 +5,7 @@
 
     <Style TargetType="local:IsEnabledTextBlock">
         <Setter Property="Foreground" Value="{ThemeResource DefaultTextForegroundThemeBrush}" />
+        <Setter Property="IsTabStop" Value="False" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="local:IsEnabledTextBlock">

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Microsoft.PowerToys.Settings.UI.csproj
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Microsoft.PowerToys.Settings.UI.csproj
@@ -96,6 +96,9 @@
     <Compile Include="Behaviors\NavigationViewHeaderBehavior.cs" />
     <Compile Include="Behaviors\NavigationViewHeaderMode.cs" />
     <Compile Include="Controls\CheckBoxWithDescriptionControl.cs" />
+    <Compile Include="Controls\ColorPickerButton.xaml.cs">
+      <DependentUpon>ColorPickerButton.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Controls\IsEnabledTextBlock\IsEnabledTextBlock.cs" />
     <Compile Include="Controls\SettingsGroup\SettingsGroupAutomationPeer.cs" />
     <Compile Include="Controls\ShortcutControl\ShortcutControl.xaml.cs">
@@ -305,6 +308,10 @@
     <PRIResource Include="Strings\en-us\Resources.resw" />
   </ItemGroup>
   <ItemGroup>
+    <Page Include="Controls\ColorPickerButton.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="Controls\IsEnabledTextBlock\IsEnabledTextBlock.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -101,71 +101,20 @@
 
                                 <controls:Setting  x:Uid="FancyZones_ZoneHighlightColor" Style="{StaticResource ExpanderContentSettingStyle}">
                                     <controls:Setting.ActionContent>
-                                        <muxc:DropDownButton Padding="4,4,8,4">
-                                            <Border Width="48" CornerRadius="2" Height="24">
-                                                <Border.Background>
-                                                    <SolidColorBrush Color="{x:Bind Path=ViewModel.ZoneHighlightColor, Mode=TwoWay}"/>
-                                                </Border.Background>
-                                            </Border>
-                                            <muxc:DropDownButton.Flyout>
-                                                <Flyout>
-                                                    <muxc:ColorPicker IsColorSliderVisible="True"
-                                                                      IsColorChannelTextInputVisible="True"
-                                                                      IsHexInputVisible="True"
-                                                                      IsAlphaEnabled="False"
-                                                                      IsAlphaSliderVisible="False"
-                                                                      IsAlphaTextInputVisible="False"
-                                                                      Color="{x:Bind Path=ViewModel.ZoneHighlightColor, Mode=TwoWay}" />
-                                                </Flyout>
-                                            </muxc:DropDownButton.Flyout>
-                                        </muxc:DropDownButton>
+                                        <controls:ColorPickerButton SelectedColor="{x:Bind Path=ViewModel.ZoneHighlightColor, Mode=TwoWay}" />
                                     </controls:Setting.ActionContent>
                                 </controls:Setting>
 
 
                                 <controls:Setting  x:Uid="FancyZones_InActiveColor" Style="{StaticResource ExpanderContentSettingStyle}">
                                     <controls:Setting.ActionContent>
-                                        <muxc:DropDownButton Padding="4,4,8,4">
-                                            <Border Width="48" CornerRadius="2" Height="24">
-                                                <Border.Background>
-                                                    <SolidColorBrush Color="{x:Bind Path=ViewModel.ZoneInActiveColor, Mode=TwoWay}"/>
-                                                </Border.Background>
-                                            </Border>
-                                            <muxc:DropDownButton.Flyout>
-                                                <Flyout>
-                                                    <muxc:ColorPicker IsColorSliderVisible="True"
-                                                                      IsColorChannelTextInputVisible="True"
-                                                                      IsHexInputVisible="True"
-                                                                      IsAlphaEnabled="False"
-                                                                      IsAlphaSliderVisible="False"
-                                                                      IsAlphaTextInputVisible="False"
-                                                                      Color="{x:Bind Path=ViewModel.ZoneInActiveColor, Mode=TwoWay}" />
-                                                </Flyout>
-                                            </muxc:DropDownButton.Flyout>
-                                        </muxc:DropDownButton>
+                                        <controls:ColorPickerButton SelectedColor="{x:Bind Path=ViewModel.ZoneInActiveColor, Mode=TwoWay}" />
                                     </controls:Setting.ActionContent>
                                 </controls:Setting>
 
                                 <controls:Setting  x:Uid="FancyZones_BorderColor" Style="{StaticResource ExpanderContentSettingStyle}">
                                     <controls:Setting.ActionContent>
-                                        <muxc:DropDownButton Padding="4,4,8,4">
-                                            <Border Width="48" CornerRadius="2" Height="24">
-                                                <Border.Background>
-                                                    <SolidColorBrush Color="{x:Bind Path=ViewModel.ZoneBorderColor, Mode=TwoWay}"/>
-                                                </Border.Background>
-                                            </Border>
-                                            <muxc:DropDownButton.Flyout>
-                                                <Flyout>
-                                                    <muxc:ColorPicker IsColorSliderVisible="True"
-                                                                      IsColorChannelTextInputVisible="True"
-                                                                      IsHexInputVisible="True"
-                                                                      IsAlphaEnabled="False"
-                                                                      IsAlphaSliderVisible="False"
-                                                                      IsAlphaTextInputVisible="False"
-                                                                      Color="{x:Bind Path=ViewModel.ZoneBorderColor, Mode=TwoWay}" />
-                                                </Flyout>
-                                            </muxc:DropDownButton.Flyout>
-                                        </muxc:DropDownButton>
+                                        <controls:ColorPickerButton SelectedColor="{x:Bind Path=ViewModel.ZoneBorderColor, Mode=TwoWay}" />
                                     </controls:Setting.ActionContent>
                                 </controls:Setting>
 


### PR DESCRIPTION
## Summary of the Pull Request
Created a new ColorPickerButton control that reduces the amount of XAML we need to write for each instance.

It also solves the following bugs:
#13410 - Narrator now announces the selected color.
#13396 - A border has been added so the color is now distinguishable when matching the button background: 
![image](https://user-images.githubusercontent.com/9866362/138451383-891c923b-5cbf-4a4b-93ad-82250da9f302.png)
- Resolved a minor bug that adds an additional tab focus in the recently created CheckBoxWithDescriptionControl.

## Quality Checklist

- [X] **Linked issue:** #13410 #13396
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
