### PR TITLE
Announce opening Edit Layout dialog

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -217,7 +217,7 @@ namespace FancyZonesEditor
                 name = name.TrimEnd();
             }
 
-            AnnounceSuccessfulLayoutCreation(name);
+            Announce(name, FancyZonesEditor.Properties.Resources.Layout_Creation_Announce);
             int maxCustomIndex = 0;
             foreach (LayoutModel customModel in MainWindowSettingsModel.CustomModels)
             {
@@ -249,12 +249,12 @@ namespace FancyZonesEditor
             App.FancyZonesEditorIO.SerializeZoneSettings();
         }
 
-        private void AnnounceSuccessfulLayoutCreation(string name)
+        private void Announce(string name, string message)
         {
             if (AutomationPeer.ListenerExists(AutomationEvents.MenuOpened))
             {
                 var peer = UIElementAutomationPeer.FromElement(_createLayoutAnnounce);
-                AutomationProperties.SetName(_createLayoutAnnounce, name + " " + FancyZonesEditor.Properties.Resources.Layout_Creation_Announce);
+                AutomationProperties.SetName(_createLayoutAnnounce, name + " " + message);
                 peer?.RaiseAutomationEvent(AutomationEvents.MenuOpened);
             }
         }
@@ -454,6 +454,7 @@ namespace FancyZonesEditor
 
         private void Dialog_Opened(ContentDialog sender, ContentDialogOpenedEventArgs args)
         {
+            Announce(sender.Name, FancyZonesEditor.Properties.Resources.Edit_Layout_Open_Announce);
             _openedDialog = sender;
         }
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
@@ -284,6 +284,15 @@ namespace FancyZonesEditor.Properties {
                 return ResourceManager.GetString("Edit_Layout", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to opened.
+        /// </summary>
+        public static string Edit_Layout_Open_Announce {
+            get {
+                return ResourceManager.GetString("Edit_Layout_Open_Announce", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Edit zones.

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
@@ -374,6 +374,9 @@
   <data name="Edit_Layout" xml:space="preserve">
     <value>Edit layout</value>
   </data>
+  <data name="Edit_Layout_Open_Announce" xml:space="preserve">
+    <value>opened</value>
+  </data>
   <data name="Layout_Creation_Announce" xml:space="preserve">
     <value>custom layout was created successfully.</value>
   </data>


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

**What is include in the PR:** 

**How does someone test / validate:** 
 - start PT
 - open FZ Editor
 - Turn on Narrator
 - Using keyboard focus to edit button of any layout and press enter
 - Observe that "Edit layout dialog opened" is announced by Narrator


## Quality Checklist

- [X] **Linked issue:** #10805
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
