### PR TITLE
[File Explorer] Fix restart as admin notification

### DIFF
--- a/src/modules/previewpane/powerpreview/powerpreview.cpp
+++ b/src/modules/previewpane/powerpreview/powerpreview.cpp
@@ -180,11 +180,7 @@ void PowerPreviewModule::apply_settings(const PowerToysSettings::PowerToyValues&
 {
     const bool isElevated = is_process_elevated(false);
     bool notifyShell = false;
-    if (!isElevated)
-    {
-        show_update_warning_message();
-        return;
-    }
+    bool updatesNeeded = false;
 
     for (auto& fileExplorerModule : m_fileExplorerModules)
     {
@@ -194,6 +190,11 @@ void PowerPreviewModule::apply_settings(const PowerToysSettings::PowerToyValues&
         if (!toggle.has_value() || *toggle == fileExplorerModule.registryChanges.isApplied())
         {
             continue;
+        }
+        else
+        {
+            // Mark that updates were to the registry were needed
+            updatesNeeded = true;
         }
 
         // (Un)Apply registry changes depending on the new setting value
@@ -208,6 +209,10 @@ void PowerPreviewModule::apply_settings(const PowerToysSettings::PowerToyValues&
         {
             Trace::PowerPreviewSettingsUpdateFailed(fileExplorerModule.settingName.c_str(), !*toggle, *toggle, true);
         }
+    }
+    if (!isElevated && updatesNeeded)
+    {
+        show_update_warning_message();
     }
     if (notifyShell)
     {


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
After the registry refactor, the warning that File Explorer add-ons need PowerToys run to execute as admin to change the settings is always shown.

**What is include in the PR:** 
Proper detection if the registry needs to be changed before showing the warning.

**How does someone test / validate:** 
Build the installer and run PowerToys to verify the warning doesn't appear.

## Quality Checklist

- [x] **Linked issue:** #14003
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
