### PR TITLE
Fix typo in logging 

### DIFF
--- a/installer/PowerToysSetupCustomActions/CustomAction.cpp
+++ b/installer/PowerToysSetupCustomActions/CustomAction.cpp
@@ -51,7 +51,7 @@ UINT __stdcall ApplyModulesRegistryChangeSetsCA(MSIHANDLE hInstall)
     hr = WcaInitialize(hInstall, "ApplyModulesRegistryChangeSets");
     ExitOnFailure(hr, "Failed to initialize");
     hr = getInstallFolder(hInstall, installationFolder);
-    ExitOnFailure(hr, "Failed to get installfolder.");
+    ExitOnFailure(hr, "Failed to get installFolder.");
     for (const auto& changeSet : getAllModulesChangeSets(installationFolder, false))
     {
         if (!changeSet.apply())
@@ -76,7 +76,7 @@ UINT __stdcall UnApplyModulesRegistryChangeSetsCA(MSIHANDLE hInstall)
     hr = WcaInitialize(hInstall, "UndoModulesRegistryChangeSets"); // original func name is too long
     ExitOnFailure(hr, "Failed to initialize");
     hr = getInstallFolder(hInstall, installationFolder);
-    ExitOnFailure(hr, "Failed to get installfolder.");
+    ExitOnFailure(hr, "Failed to get installFolder.");
     for (const auto& changeSet : getAllModulesChangeSets(installationFolder, false))
     {
         changeSet.unApply();


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Fix typo identified by the bot in https://github.com/microsoft/PowerToys/pull/14004/files#diff-c502a81cdf8afa7a38f0f462709abcdbdfcc44beaa6227a1e64a26566c7e8876 

**What is include in the PR:** 
Change `installfolder` to `installFolder`

**How does someone test / validate:** 
No need. 

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
