### PR TITLE
Fix ColorPickerEditor keyboard navigation

### DIFF
--- a/src/modules/colorPicker/ColorPickerUI/Views/ColorEditorView.xaml
+++ b/src/modules/colorPicker/ColorPickerUI/Views/ColorEditorView.xaml
@@ -24,6 +24,7 @@
                          Grid.Row="1"
                          Padding="0"
                          TabIndex="2"
+                         KeyboardNavigation.DirectionalNavigation="Contained"
                          Width="64"
                          AutomationProperties.Name="{x:Static p:Resources.Color_History}"
                          HorizontalAlignment="Center"
@@ -68,6 +69,7 @@
               Height="32"
               Background="Transparent"
               VerticalAlignment="Top"
+              KeyboardNavigation.DirectionalNavigation="Contained"
               IsHitTestVisible="True">
             <e:Interaction.Behaviors>
                 <behaviors:DragWindowBehavior/>
@@ -118,8 +120,9 @@
                 <StackPanel>
                     <ItemsControl IsTabStop="False"
                                   TabIndex="4"
+                                  KeyboardNavigation.DirectionalNavigation="Contained"
                                   FocusManager.IsFocusScope="True"
-                                  KeyboardNavigation.TabNavigation="Continue"
+                                  KeyboardNavigation.TabNavigation="Once"
                                   ItemsSource="{Binding ColorRepresentations}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
@@ -145,6 +148,7 @@
                                          Visibility="{Binding ColorsHistory.Count, Converter={StaticResource numberToVisibilityConverter}}"
                                          IsTabStop="True"
                                          TabIndex="2"
+                                         KeyboardNavigation.DirectionalNavigation="Contained"
                                          SelectedColor="{Binding SelectedColor}"
                                          SelectedColorChangedCommand="{Binding SelectedColorChangedCommand}"
                                          Grid.Column="1"


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Work items from the issue:

- [x] Keyboard focus should not move to 'Copy to clipboard' button using down arrow keys from the darkest shade control. It should only navigate when user pressed tab key to navigate further.

- [x] Focus should either navigate to Color history buttons form 'Pick a color from screen' button using tab and Shift+ tab key and not with arrow keys or it should move both ways up and down using arrow keys.


- [ ] ~Keyboard focus should navigate to Close dialogue button.~
Although it looks like it's custom (as it's in line with pick color and next to Settings button), Close button is default window's close button. Therefore it can't be navigated by keyboard from within the window.

- [x] On pressing left/ right arrow keys from lightest and darkest color shade pallet controls focus should either move to the lightest or darkest color or it should remain on the same control itself(recommended).


**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [X] **Linked issue:** #13348
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
