### PR TITLE
[ImageResizer]Sanitize target file name

### DIFF
--- a/src/modules/imageresizer/tests/Models/ResizeOperationTests.cs
+++ b/src/modules/imageresizer/tests/Models/ResizeOperationTests.cs
@@ -486,6 +486,24 @@ namespace ImageResizer.Models
                 image => Assert.IsNull(((BitmapMetadata)image.Frames[0].Metadata).GetQuerySafe("System.Photo.Orientation")));
         }
 
+        [TestMethod]
+        public void VerifyFileNameIsSanitized()
+        {
+            var operation = new ResizeOperation(
+                "Test.png",
+                _directory,
+                Settings(
+                    s =>
+                    {
+                        s.FileName = @"Directory\%1:*?""<>|(%2)";
+                        s.SelectedSize.Name = "Test\\/";
+                    }));
+
+            operation.Execute();
+
+            Assert.IsTrue(File.Exists(_directory + @"\Directory\Test_______(Test__).png"));
+        }
+
         private static Settings Settings(Action<Settings> action = null)
         {
             var settings = new Settings()

--- a/src/modules/imageresizer/tests/Models/ResizeOperationTests.cs
+++ b/src/modules/imageresizer/tests/Models/ResizeOperationTests.cs
@@ -504,6 +504,23 @@ namespace ImageResizer.Models
             Assert.IsTrue(File.Exists(_directory + @"\Directory\Test_______(Test__).png"));
         }
 
+        [TestMethod]
+        public void VerifyNotRecommendedNameIsChanged()
+        {
+            var operation = new ResizeOperation(
+                "Test.png",
+                _directory,
+                Settings(
+                    s =>
+                    {
+                        s.FileName = @"nul";
+                    }));
+
+            operation.Execute();
+
+            Assert.IsTrue(File.Exists(_directory + @"\nul_.png"));
+        }
+
         private static Settings Settings(Action<Settings> action = null)
         {
             var settings = new Settings()

--- a/src/modules/imageresizer/ui/Models/ResizeOperation.cs
+++ b/src/modules/imageresizer/ui/Models/ResizeOperation.cs
@@ -205,16 +205,33 @@ namespace ImageResizer.Models
                 extension = supportedExtensions.FirstOrDefault();
             }
 
+            // Remove directory characters from the size's name.
+            string sizeNameSanitized = _settings.SelectedSize.Name;
+            sizeNameSanitized = sizeNameSanitized
+                .Replace('\\', '_')
+                .Replace('/', '_');
+
             // Using CurrentCulture since this is user facing
             var fileName = string.Format(
                 CultureInfo.CurrentCulture,
                 _settings.FileNameFormat,
                 originalFileName,
-                _settings.SelectedSize.Name,
+                sizeNameSanitized,
                 _settings.SelectedSize.Width,
                 _settings.SelectedSize.Height,
                 encoder.Frames[0].PixelWidth,
                 encoder.Frames[0].PixelHeight);
+
+            // Remove invalid characters from the final file name.
+            fileName = fileName
+                .Replace(':', '_')
+                .Replace('*', '_')
+                .Replace('?', '_')
+                .Replace('"', '_')
+                .Replace('<', '_')
+                .Replace('>', '_')
+                .Replace('|', '_');
+
             var path = _fileSystem.Path.Combine(directory, fileName + extension);
             var uniquifier = 1;
             while (_fileSystem.File.Exists(path))

--- a/src/modules/imageresizer/ui/Models/ResizeOperation.cs
+++ b/src/modules/imageresizer/ui/Models/ResizeOperation.cs
@@ -26,6 +26,14 @@ namespace ImageResizer.Models
         private readonly string _destinationDirectory;
         private readonly Settings _settings;
 
+        // Filenames to avoid according to https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#file-and-directory-names
+        private static readonly string[] _avoidFilenames =
+            {
+                "CON", "PRN", "AUX", "NUL",
+                "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
+                "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
+            };
+
         public ResizeOperation(string file, string destinationDirectory, Settings settings)
         {
             _file = file;
@@ -231,6 +239,12 @@ namespace ImageResizer.Models
                 .Replace('<', '_')
                 .Replace('>', '_')
                 .Replace('|', '_');
+
+            // Avoid creating not recommended filenames
+            if (_avoidFilenames.Contains(fileName.ToUpperInvariant()))
+            {
+                fileName = fileName + "_";
+            }
 
             var path = _fileSystem.Path.Combine(directory, fileName + extension);
             var uniquifier = 1;


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Image Resizer allows setting invalid filename characters in the file name and size name, causing weird results like creating directories.

**What is include in the PR:** 
Sanitize the filename by converting invalid characters to underscores.
Add a test.

**How does someone test / validate:** 
Add a custom size with something like "1/2" in the name, like in the issue, and verify it gets replaced with underscore in the filename instead of creating a directory.
For testing without installing, run the ImageResizerUI project directly.
Or just look at the code and trust the test that is added ;)

## Quality Checklist

- [x] **Linked issue:** #11363
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [x] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries
