### PR TITLE
[FindMyMouse]Minimum delay and left ctrl exit

### DIFF
--- a/src/modules/MouseUtils/FindMyMouse/FindMyMouse.cpp
+++ b/src/modules/MouseUtils/FindMyMouse/FindMyMouse.cpp
@@ -323,6 +323,10 @@ void SuperSonar<D>::OnSonarKeyboardInput(RAWINPUT const& input)
             else
             {
                 m_sonarState = SonarState::ControlDown1;
+                m_lastKeyTime = GetTickCount();
+                m_lastKeyPos = {};
+                GetCursorPos(&m_lastKeyPos);
+                UpdateMouseSnooping();
             }
             Logger::info("Detecting double left control click with {} ms interval.", doubleClickInterval);
             m_lastKeyTime = now;

--- a/src/modules/MouseUtils/FindMyMouse/FindMyMouse.cpp
+++ b/src/modules/MouseUtils/FindMyMouse/FindMyMouse.cpp
@@ -54,6 +54,9 @@ protected:
     HWND m_hwnd;
     POINT m_sonarPos = ptNowhere;
 
+    // Only consider double left control click if at least 100ms passed between the clicks, to avoid keyboards that might be sending rapid clicks.
+    static const int MIN_DOUBLE_CLICK_TIME = 100;
+
     static constexpr int SonarRadius = 100;
     static constexpr int SonarZoomFactor = 9;
     static constexpr DWORD FadeDuration = 500;
@@ -304,23 +307,35 @@ void SuperSonar<D>::OnSonarKeyboardInput(RAWINPUT const& input)
         break;
 
     case SonarState::ControlUp1:
-    case SonarState::ControlUp2:
         if (pressed)
         {
-            m_sonarState = SonarState::ControlDown2;
             auto now = GetTickCount();
+            auto doubleClickInterval = now - m_lastKeyTime;
             POINT ptCursor{};
             if (GetCursorPos(&ptCursor) &&
-                now - m_lastKeyTime <= GetDoubleClickTime() &&
+                doubleClickInterval >= MIN_DOUBLE_CLICK_TIME &&
+                doubleClickInterval <= GetDoubleClickTime() &&
                 IsEqual(m_lastKeyPos, ptCursor))
             {
+                m_sonarState = SonarState::ControlDown2;
                 StartSonar();
             }
+            else
+            {
+                m_sonarState = SonarState::ControlDown1;
+            }
+            Logger::info("Detecting double left control click with {} ms interval.", doubleClickInterval);
             m_lastKeyTime = now;
             m_lastKeyPos = ptCursor;
         }
         break;
-
+    case SonarState::ControlUp2:
+        // Also deactivate sonar with left control.
+        if (pressed)
+        {
+            StopSonar();
+        }
+        break;
     case SonarState::ControlDown2:
         if (!pressed)
         {


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Addresses issues talked about internally by the dev team:
- Random activation of FindMyMouse, making it seem like a single control click has registered as a double click.
- Expectation of having FindMyMouse go away by pressing Left Control again.

**What is include in the PR:** 
- Introduce minimum of 100ms between clicks to register a double click.
- Log time between detected double clicks.
- Make FindMyMouse go away by pressing Left Control again.

**How does someone test / validate:** 
Not sure about the random activation issue, since I couldn't replicate it.
After activating FindMyMouse, press Left Control again to make it go away.

## Quality Checklist

- [x] **Linked issue:** #14044 #14043
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries
