### PR TITLE
[Settings] Capitalize English

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.System/Properties/Resources.Designer.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.System/Properties/Resources.Designer.cs
@@ -277,7 +277,7 @@ namespace Microsoft.PowerToys.Run.Plugin.System.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Use localized system commands instead of english ones.
+        ///   Looks up a localized string similar to Use localized system commands instead of English ones.
         /// </summary>
         internal static string Use_localized_system_commands {
             get {

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.System/Properties/Resources.resx
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.System/Properties/Resources.resx
@@ -213,6 +213,6 @@
     <comment>This should align to the action in Windows of a making your computer go to sleep.</comment>
   </data>
   <data name="Use_localized_system_commands" xml:space="preserve">
-    <value>Use localized system commands instead of english ones</value>
+    <value>Use localized system commands instead of English ones</value>
   </data>
 </root>


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Capitalize English in the PT Run settings under `Windows System Commands`

**What is include in the PR:** 
Changes to resource files.

**How does someone test / validate:** 
No test is required. 
May require to send to loc-team for other languages. 

## Quality Checklist

- [x] **Linked issue:** #14058 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
