### PR TITLE
Put UpdateResultsListViewAfterQuery calls inside addResultLock blocks

### DIFF
--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -574,11 +574,10 @@ namespace PowerLauncher.ViewModel
                                     Results.Sort();
                                     Results.SelectedItem = Results.Results.FirstOrDefault();
                                 }
+
+                                currentCancellationToken.ThrowIfCancellationRequested();
+                                UpdateResultsListViewAfterQuery(queryText);
                             }
-
-                            currentCancellationToken.ThrowIfCancellationRequested();
-
-                            UpdateResultsListViewAfterQuery(queryText);
 
                             // Run the slower query of the DelayedExecution plugins
                             currentCancellationToken.ThrowIfCancellationRequested();
@@ -611,10 +610,10 @@ namespace PowerLauncher.ViewModel
                                                     numResults = Results.Results.Count;
                                                     Results.Sort();
                                                 }
-                                            }
 
-                                            currentCancellationToken.ThrowIfCancellationRequested();
-                                            UpdateResultsListViewAfterQuery(queryText, true);
+                                                currentCancellationToken.ThrowIfCancellationRequested();
+                                                UpdateResultsListViewAfterQuery(queryText, true);
+                                            }
                                         }
                                     }
                                     catch (OperationCanceledException)


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Stack trace shows that PT Run crashed in `UpdateResultsListViewAfterQuery` function, line `Results.Results.NotifyChanges(). For some reason array is being copied (`at System.Array.Copy(Array sourceArray, Int32 sourceIndex, Array destinationArray, Int32 destinationIndex, Int32 length, Boolean reliable)`) there...

My assumption is that this crash happens because `Results.Results` can be changed in parallel both from `Parallel.ForEach(plugins, (plugin) =>` block while executing delayed plugins (e.g. `Results.Results.RemoveAll(r => r.Result.PluginID == plugin.Metadata.ID);` line) and `UpdateResultsListViewAfterQuery` which is invoked after processing non-delayed plugins (`System.Array.Copy` mentioned above).

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [X] **Linked issue:** #8921
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
