### PR TITLE
[PowerRename] Added KeyboardAccelerator + set default width/height

### DIFF
--- a/src/modules/powerrename/PowerRenameUIHost/PowerRenameUIHost.cpp
+++ b/src/modules/powerrename/PowerRenameUIHost/PowerRenameUIHost.cpp
@@ -52,7 +52,7 @@ AppWindow::AppWindow(HINSTANCE hInstance, std::vector<std::wstring> files) noexc
         CComPtr<IShellItemArray> shellItemArray;
         // To test PowerRenameUIHost uncomment this line and update the path to
         // your local (absolute or relative) path which you want to see in PowerRename
-        //files.push_back(L"<path>");
+        files.push_back(L"C:\\Test_Dir");
 
         if (!files.empty())
         {
@@ -88,7 +88,8 @@ void AppWindow::CreateAndShowWindow()
     wchar_t title[64];
     LoadStringW(m_instance, IDS_APP_TITLE, title, ARRAYSIZE(title));
 
-    m_window = CreateWindowW(c_WindowClass, title, WS_OVERLAPPEDWINDOW, CW_USEDEFAULT, 0, CW_USEDEFAULT, CW_USEDEFAULT, nullptr, nullptr, m_instance, this);
+    // hardcoded width and height (1200 x 600) - with WinUI 3, it should auto-scale to the content
+    m_window = CreateWindowW(c_WindowClass, title, WS_OVERLAPPEDWINDOW, CW_USEDEFAULT, 0, 1200, 600, nullptr, nullptr, m_instance, this);
     THROW_LAST_ERROR_IF(!m_window);
 
     ShowWindow(m_window, SW_SHOWNORMAL);

--- a/src/modules/powerrename/PowerRenameUIHost/PowerRenameUIHost.cpp
+++ b/src/modules/powerrename/PowerRenameUIHost/PowerRenameUIHost.cpp
@@ -52,7 +52,7 @@ AppWindow::AppWindow(HINSTANCE hInstance, std::vector<std::wstring> files) noexc
         CComPtr<IShellItemArray> shellItemArray;
         // To test PowerRenameUIHost uncomment this line and update the path to
         // your local (absolute or relative) path which you want to see in PowerRename
-        files.push_back(L"C:\\Test_Dir");
+        // files.push_back(L"path");
 
         if (!files.empty())
         {

--- a/src/modules/powerrename/PowerRenameUILib/App.xaml
+++ b/src/modules/powerrename/PowerRenameUILib/App.xaml
@@ -625,6 +625,7 @@
                 <Setter Property="BorderThickness" Value="{ThemeResource TextControlBorderThemeThickness}" />
                 <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
                 <Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}" />
+                <Setter Property="AcceptsReturn" Value="False" />
                 <Setter Property="ScrollViewer.HorizontalScrollMode" Value="Auto" />
                 <Setter Property="ScrollViewer.VerticalScrollMode" Value="Auto" />
                 <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Hidden" />

--- a/src/modules/powerrename/PowerRenameUILib/MainWindow.xaml
+++ b/src/modules/powerrename/PowerRenameUILib/MainWindow.xaml
@@ -258,7 +258,6 @@
                         <ToggleButton x:Name="toggleButton_enumItems" Content="&#xEA40;" FontFamily="{ThemeResource SymbolThemeFontFamily}" MinHeight="32" x:Uid="ToggleButton_EnumItems" Style="{StaticResource CustomToggleButtonStyle}" />
                     </StackPanel>
                 </StackPanel>
-
             </ScrollViewer>
 
             <Rectangle Height="1" Fill="{ThemeResource CardStrokeColorDefaultBrush}" HorizontalAlignment="Stretch" Margin="0,0,20,0" VerticalAlignment="Top" Grid.Row="1" />
@@ -306,6 +305,7 @@
             <muxc:SplitButton Grid.Row="1" Style="{StaticResource SplitAccentButtonStyle}" x:Name="button_rename" Margin="0,0,20,0" x:Uid="ButtonApply" Click="button_rename_Click" HorizontalAlignment="Right" VerticalAlignment="Bottom" IsEnabled="{x:Bind UIUpdatesItem.ButtonRenameEnabled, Mode=OneWay}">
                 <muxc:SplitButton.KeyboardAccelerators>
                     <KeyboardAccelerator Key="Enter" />
+                    <KeyboardAccelerator Key="Enter" Modifiers="Control" />
                 </muxc:SplitButton.KeyboardAccelerators>
                 <muxc:SplitButton.Content>
                     <StackPanel Orientation="Horizontal">

--- a/src/modules/powerrename/PowerRenameUILib/MainWindow.xaml
+++ b/src/modules/powerrename/PowerRenameUILib/MainWindow.xaml
@@ -304,6 +304,9 @@
             </StackPanel>
 
             <muxc:SplitButton Grid.Row="1" Style="{StaticResource SplitAccentButtonStyle}" x:Name="button_rename" Margin="0,0,20,0" x:Uid="ButtonApply" Click="button_rename_Click" HorizontalAlignment="Right" VerticalAlignment="Bottom" IsEnabled="{x:Bind UIUpdatesItem.ButtonRenameEnabled, Mode=OneWay}">
+                <muxc:SplitButton.KeyboardAccelerators>
+                    <KeyboardAccelerator Key="Enter" />
+                </muxc:SplitButton.KeyboardAccelerators>
                 <muxc:SplitButton.Content>
                     <StackPanel Orientation="Horizontal">
                         <FontIcon Glyph="&#xE13E;" FontSize="14" VerticalAlignment="Center" Margin="0,2,10,0" />


### PR DESCRIPTION
## Summary of the Pull Request
- #14085 Default width / height is now 1200x600 solving: 
- #14153 Added Enter and Ctrl+Enter as KeyboardAccelerator. However, whenever a TextBox or Button has a focus this will not work. Enter only works whenever the focus is outside of the input panel's scrollviewer. 

## Quality Checklist

- [X] **Linked issue:** #14153, #14085 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
