### PR TITLE
[FancyZones] Use accent color and theme

### DIFF
--- a/src/modules/fancyzones/FancyZonesLib/Resources.resx
+++ b/src/modules/fancyzones/FancyZonesLib/Resources.resx
@@ -219,7 +219,7 @@
   </data>
   <data name="Cant_Drag_Elevated" xml:space="preserve">
     <value>We've detected an application running with administrator privileges. This will prevent certain interactions with these applications.</value>
-    <comment>administrator is context of user account.</comment> 
+    <comment>administrator is context of user account.</comment>
   </data>
   <data name="Cant_Drag_Elevated_Learn_More" xml:space="preserve">
     <value>Learn more</value>
@@ -262,5 +262,8 @@
   </data>
   <data name="Setting_Description_FlashZonesOnQuickSwitch" xml:space="preserve">
     <value>Flash zones when switching layout</value>
+  </data>
+  <data name="Setting_Description_SystemTheme" xml:space="preserve">
+    <value>Use system theme</value>
   </data>
 </root>

--- a/src/modules/fancyzones/FancyZonesLib/Resources.resx
+++ b/src/modules/fancyzones/FancyZonesLib/Resources.resx
@@ -263,7 +263,7 @@
   <data name="Setting_Description_FlashZonesOnQuickSwitch" xml:space="preserve">
     <value>Flash zones when switching layout</value>
   </data>
-  <data name="Setting_Description_SystemTheme" xml:space="preserve">
+  <data name="Setting_Description_System_Theme" xml:space="preserve">
     <value>Use system theme</value>
   </data>
 </root>

--- a/src/modules/fancyzones/FancyZonesLib/Settings.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/Settings.cpp
@@ -99,7 +99,7 @@ private:
         { NonLocalizable::SpanZonesAcrossMonitorsID, &m_settings.spanZonesAcrossMonitors, IDS_SETTING_DESCRIPTION_SPAN_ZONES_ACROSS_MONITORS },
         { NonLocalizable::MakeDraggedWindowTransparentID, &m_settings.makeDraggedWindowTransparent, IDS_SETTING_DESCRIPTION_MAKE_DRAGGED_WINDOW_TRANSPARENT },
         { NonLocalizable::WindowSwitchingToggleID, &m_settings.windowSwitching, IDS_SETTING_WINDOW_SWITCHING_TOGGLE_LABEL },
-        { NonLocalizable::SystemTheme, &m_settings.systemTheme, IDS_SETTING_DESCRIPTION_SYSTEMTHEME },
+        { NonLocalizable::SystemTheme, &m_settings.systemTheme, IDS_SETTING_DESCRIPTION_SYSTEM_THEME },
     };
 };
 

--- a/src/modules/fancyzones/FancyZonesLib/Settings.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/Settings.cpp
@@ -28,6 +28,7 @@ namespace NonLocalizable
     const wchar_t SpanZonesAcrossMonitorsID[] = L"fancyzones_span_zones_across_monitors";
     const wchar_t MakeDraggedWindowTransparentID[] = L"fancyzones_makeDraggedWindowTransparent";
 
+    const wchar_t SystemTheme[] = L"fancyzones_systemTheme";
     const wchar_t ZoneColorID[] = L"fancyzones_zoneColor";
     const wchar_t ZoneBorderColorID[] = L"fancyzones_zoneBorderColor";
     const wchar_t ZoneHighlightColorID[] = L"fancyzones_zoneHighlightColor";
@@ -80,7 +81,7 @@ private:
         PCWSTR name;
         bool* value;
         int resourceId;
-    } m_configBools[17] = {
+    } m_configBools[18] = {
         { NonLocalizable::ShiftDragID, &m_settings.shiftDrag, IDS_SETTING_DESCRIPTION_SHIFTDRAG },
         { NonLocalizable::MouseSwitchID, &m_settings.mouseSwitch, IDS_SETTING_DESCRIPTION_MOUSESWITCH },
         { NonLocalizable::OverrideSnapHotKeysID, &m_settings.overrideSnapHotkeys, IDS_SETTING_DESCRIPTION_OVERRIDE_SNAP_HOTKEYS },
@@ -98,6 +99,7 @@ private:
         { NonLocalizable::SpanZonesAcrossMonitorsID, &m_settings.spanZonesAcrossMonitors, IDS_SETTING_DESCRIPTION_SPAN_ZONES_ACROSS_MONITORS },
         { NonLocalizable::MakeDraggedWindowTransparentID, &m_settings.makeDraggedWindowTransparent, IDS_SETTING_DESCRIPTION_MAKE_DRAGGED_WINDOW_TRANSPARENT },
         { NonLocalizable::WindowSwitchingToggleID, &m_settings.windowSwitching, IDS_SETTING_WINDOW_SWITCHING_TOGGLE_LABEL },
+        { NonLocalizable::SystemTheme, &m_settings.systemTheme, IDS_SETTING_DESCRIPTION_SYSTEMTHEME },
     };
 };
 

--- a/src/modules/fancyzones/FancyZonesLib/Settings.h
+++ b/src/modules/fancyzones/FancyZonesLib/Settings.h
@@ -32,6 +32,7 @@ struct Settings
     bool showZonesOnAllMonitors = false;
     bool spanZonesAcrossMonitors = false;
     bool makeDraggedWindowTransparent = true;
+    bool systemTheme = true;
     std::wstring zoneColor = L"#AACDFF";
     std::wstring zoneBorderColor = L"#FFFFFF";
     std::wstring zoneHighlightColor = L"#008CFF";

--- a/src/modules/fancyzones/FancyZonesLib/ZoneColors.h
+++ b/src/modules/fancyzones/FancyZonesLib/ZoneColors.h
@@ -6,5 +6,6 @@ struct ZoneColors
     COLORREF primaryColor;
     COLORREF borderColor;
     COLORREF highlightColor;
+    COLORREF textColor;
     int highlightOpacity;
 };

--- a/src/modules/fancyzones/FancyZonesLib/ZoneWindowDrawing.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/ZoneWindowDrawing.cpp
@@ -131,10 +131,8 @@ ZoneWindowDrawing::RenderResult ZoneWindowDrawing::Render()
     // Draw backdrop
     m_renderTarget->Clear(D2D1::ColorF(0.f, 0.f, 0.f, 0.f));
 
-    ID2D1SolidColorBrush* textBrush = nullptr;
     IDWriteTextFormat* textFormat = nullptr;
 
-    m_renderTarget->CreateSolidColorBrush(D2D1::ColorF(D2D1::ColorF::Black, animationAlpha), &textBrush);
     auto writeFactory = GetWriteFactory();
 
     if (writeFactory)
@@ -144,6 +142,7 @@ ZoneWindowDrawing::RenderResult ZoneWindowDrawing::Render()
 
     for (auto drawableRect : m_sceneRects)
     {
+        ID2D1SolidColorBrush* textBrush = nullptr;
         ID2D1SolidColorBrush* borderBrush = nullptr;
         ID2D1SolidColorBrush* fillBrush = nullptr;
 
@@ -151,6 +150,7 @@ ZoneWindowDrawing::RenderResult ZoneWindowDrawing::Render()
         drawableRect.borderColor.a *= animationAlpha;
         drawableRect.fillColor.a *= animationAlpha;
 
+        m_renderTarget->CreateSolidColorBrush(drawableRect.textColor, &textBrush);
         m_renderTarget->CreateSolidColorBrush(drawableRect.borderColor, &borderBrush);
         m_renderTarget->CreateSolidColorBrush(drawableRect.fillColor, &fillBrush);
 
@@ -174,16 +174,16 @@ ZoneWindowDrawing::RenderResult ZoneWindowDrawing::Render()
             textFormat->SetParagraphAlignment(DWRITE_PARAGRAPH_ALIGNMENT_CENTER);
             m_renderTarget->DrawTextW(idStr.c_str(), (UINT32)idStr.size(), textFormat, drawableRect.rect, textBrush);
         }
+
+        if (textBrush)
+        {
+            textBrush->Release();
+        }
     }
 
     if (textFormat)
     {
         textFormat->Release();
-    }
-
-    if (textBrush)
-    {
-        textBrush->Release();
     }
 
     // The lock must be released here, as EndDraw() will wait for vertical sync
@@ -289,6 +289,7 @@ void ZoneWindowDrawing::DrawActiveZoneSet(const IZoneSet::ZonesMap& zones,
     auto borderColor = ConvertColor(colors.borderColor);
     auto inactiveColor = ConvertColor(colors.primaryColor);
     auto highlightColor = ConvertColor(colors.highlightColor);
+    auto textColor = ConvertColor(colors.textColor);
 
     inactiveColor.a = colors.highlightOpacity / 100.f;
     highlightColor.a = colors.highlightOpacity / 100.f;
@@ -313,6 +314,7 @@ void ZoneWindowDrawing::DrawActiveZoneSet(const IZoneSet::ZonesMap& zones,
                 .rect = ConvertRect(zone->GetZoneRect()),
                 .borderColor = borderColor,
                 .fillColor = inactiveColor,
+                .textColor = textColor,
                 .id = zone->Id()
             };
 
@@ -334,6 +336,7 @@ void ZoneWindowDrawing::DrawActiveZoneSet(const IZoneSet::ZonesMap& zones,
                 .rect = ConvertRect(zone->GetZoneRect()),
                 .borderColor = borderColor,
                 .fillColor = highlightColor,
+                .textColor = textColor,
                 .id = zone->Id()
             };
 

--- a/src/modules/fancyzones/FancyZonesLib/ZoneWindowDrawing.h
+++ b/src/modules/fancyzones/FancyZonesLib/ZoneWindowDrawing.h
@@ -20,6 +20,7 @@ class ZoneWindowDrawing
         D2D1_RECT_F rect;
         D2D1_COLOR_F borderColor;
         D2D1_COLOR_F fillColor;
+        D2D1_COLOR_F textColor;
         ZoneIndex id;
     };
 

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/FZConfigProperties.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/FZConfigProperties.cs
@@ -46,6 +46,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             FancyzonesExcludedApps = new StringProperty();
             FancyzonesInActiveColor = new StringProperty(ConfigDefaults.DefaultFancyZonesInActiveColor);
             FancyzonesBorderColor = new StringProperty(ConfigDefaults.DefaultFancyzonesBorderColor);
+            FancyzonesSystemTheme = new BoolProperty(true);
         }
 
         [JsonPropertyName("fancyzones_shiftDrag")]
@@ -125,6 +126,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library
 
         [JsonPropertyName("fancyzones_zoneColor")]
         public StringProperty FancyzonesInActiveColor { get; set; }
+
+        [JsonPropertyName("fancyzones_systemTheme")]
+        public BoolProperty FancyzonesSystemTheme { get; set; }
 
         // converts the current to a json string.
         public string ToJsonString()

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/FancyZonesViewModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/ViewModels/FancyZonesViewModel.cs
@@ -88,6 +88,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             _makeDraggedWindowTransparent = Settings.Properties.FancyzonesMakeDraggedWindowTransparent.Value;
             _highlightOpacity = Settings.Properties.FancyzonesHighlightOpacity.Value;
             _excludedApps = Settings.Properties.FancyzonesExcludedApps.Value;
+            _systemTheme = Settings.Properties.FancyzonesSystemTheme.Value;
             EditorHotkey = Settings.Properties.FancyzonesEditorHotkey.Value;
             _windowSwitching = Settings.Properties.FancyzonesWindowSwitching.Value;
             NextTabHotkey = Settings.Properties.FancyzonesNextTabHotkey.Value;
@@ -126,6 +127,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
         private bool _useCursorPosEditorStartupScreen;
         private bool _showOnAllMonitors;
         private bool _makeDraggedWindowTransparent;
+        private bool _systemTheme;
 
         private int _highlightOpacity;
         private string _excludedApps;
@@ -515,6 +517,24 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
                 {
                     _makeDraggedWindowTransparent = value;
                     Settings.Properties.FancyzonesMakeDraggedWindowTransparent.Value = value;
+                    NotifyPropertyChanged();
+                }
+            }
+        }
+
+        public bool SystemTheme
+        {
+            get
+            {
+                return _systemTheme;
+            }
+
+            set
+            {
+                if (value != _systemTheme)
+                {
+                    _systemTheme = value;
+                    Settings.Properties.FancyzonesSystemTheme.Value = value;
                     NotifyPropertyChanged();
                 }
             }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -450,7 +450,7 @@
     <value>Open layout editor</value>
     <comment>Shortcut to launch the FancyZones layout editor application</comment>
   </data>
-	<data name="FancyZones_WindowSwitching_GroupSettings.Header" xml:space="preserve">
+  <data name="FancyZones_WindowSwitching_GroupSettings.Header" xml:space="preserve">
     <value>Window switching</value>
   </data>
   <data name="FancyZones_WindowSwitching_GroupSettings.Description" xml:space="preserve">
@@ -1721,8 +1721,8 @@ From there, simply click on a Markdown file, PDF file or SVG icon in the File Ex
     <value>Do not activate when Game Mode is on</value>
     <comment>"Game mode" is the Windows feature to prevent notification when playing a game.</comment>
   </data>
-  <data name="FancyZones_Radio_Custom_Theme.Content" xml:space="preserve">
-    <value>Custom</value>
+  <data name="FancyZones_Radio_Custom_Colors.Content" xml:space="preserve">
+    <value>Custom colors</value>
   </data>
   <data name="FancyZones_Radio_Default_Theme.Content" xml:space="preserve">
     <value>Windows default</value>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -444,7 +444,7 @@
     <value>Excludes an application from snapping to zones and will only react to Windows Snap - add one application name per line</value>
   </data>
   <data name="FancyZones_HighlightOpacity.Header" xml:space="preserve">
-    <value>Zone opacity</value>
+    <value>Opacity</value>
   </data>
   <data name="FancyZones_HotkeyEditorControl.Header" xml:space="preserve">
     <value>Open layout editor</value>
@@ -536,7 +536,7 @@
     <value>Zones</value>
   </data>
   <data name="FancyZones_ZoneHighlightColor.Header" xml:space="preserve">
-    <value>Zone highlight color</value>
+    <value>Highlight color</value>
   </data>
   <data name="FancyZones_ZoneSetChangeMoveWindows.Content" xml:space="preserve">
     <value>During zone layout changes, windows assigned to a zone will match new size/positions</value>
@@ -646,10 +646,10 @@
     <value>Enable auto-complete for the search and replace fields</value>
   </data>
   <data name="FancyZones_BorderColor.Header" xml:space="preserve">
-    <value>Zone border color</value>
+    <value>Border color</value>
   </data>
   <data name="FancyZones_InActiveColor.Header" xml:space="preserve">
-    <value>Zone inactive color</value>
+    <value>Inactive color</value>
   </data>
   <data name="ShortcutGuide.ModuleDescription" xml:space="preserve">
     <value>Shows a help overlay with Windows shortcuts.</value>
@@ -1016,7 +1016,10 @@ Made with 💗 by Microsoft and the PowerToys community.</value>
     <value>Filename parameters</value>
   </data>
   <data name="ColorModeHeader.Header" xml:space="preserve">
-    <value>App theme</value>
+    <value>Zone appearance</value>
+  </data>
+	<data name="ColorModeHeader.Description" xml:space="preserve">
+    <value>Customize the way zones look</value>
   </data>
   <data name="Radio_Theme_Dark.Content" xml:space="preserve">
     <value>Dark</value>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -408,7 +408,7 @@
   <data name="PowerLauncher_UseCentralizedKeyboardHook.Header" xml:space="preserve">
     <value>Use centralized keyboard hook</value>
   </data>
-	<data name="PowerLauncher_UseCentralizedKeyboardHook.Description" xml:space="preserve">
+  <data name="PowerLauncher_UseCentralizedKeyboardHook.Description" xml:space="preserve">
     <value>Try this if there are issues with the shortcut</value>
   </data>
   <data name="PowerLauncher_ClearInputOnLaunch.Content" xml:space="preserve">
@@ -520,10 +520,10 @@
   <data name="FancyZones_UseCursorPosEditorStartupScreen.Description" xml:space="preserve">
     <value>When using multiple displays</value>
   </data>
-	<data name="FancyZones_LaunchPositionMouse.Content" xml:space="preserve">
+  <data name="FancyZones_LaunchPositionMouse.Content" xml:space="preserve">
     <value>Where the mouse pointer is</value>
   </data>
-	<data name="FancyZones_LaunchPositionScreen.Content" xml:space="preserve">
+  <data name="FancyZones_LaunchPositionScreen.Content" xml:space="preserve">
     <value>With active focus</value>
   </data>
   <data name="FancyZones_ZoneBehavior_GroupSettings.Header" xml:space="preserve">
@@ -595,13 +595,13 @@
   <data name="PowerRename_Toggle_ContextMenu.Header" xml:space="preserve">
     <value>Show PowerRename in</value>
   </data>
-	<data name="PowerRename_Toggle_ContextMenu.Description" xml:space="preserve">
+  <data name="PowerRename_Toggle_ContextMenu.Description" xml:space="preserve">
     <value>Press shift + right-click on files to open the extended menu</value>
   </data>
-	<data name="PowerRename_Toggle_StandardContextMenu.Content" xml:space="preserve">
+  <data name="PowerRename_Toggle_StandardContextMenu.Content" xml:space="preserve">
     <value>Default and extended context menu</value>
   </data>
-	<data name="PowerRename_Toggle_ExtendedContextMenu.Content" xml:space="preserve">
+  <data name="PowerRename_Toggle_ExtendedContextMenu.Content" xml:space="preserve">
     <value>Extended context menu only</value>
   </data>
   <data name="PowerRename_Toggle_EnableOnExtendedContextMenu.Description" xml:space="preserve">
@@ -939,10 +939,10 @@
   <data name="ImageResizer_FileModifiedDate.Description" xml:space="preserve">
     <value>Used as the 'modified timestamp' in the file properties</value>
   </data>
-	<data name="ImageResizer_UseOriginalDate.Content" xml:space="preserve">
+  <data name="ImageResizer_UseOriginalDate.Content" xml:space="preserve">
     <value>Original file timestamp</value>
   </data>
-	<data name="ImageResizer_UseResizeDate.Content" xml:space="preserve">
+  <data name="ImageResizer_UseResizeDate.Content" xml:space="preserve">
     <value>Timestamp of resize action</value>
   </data>
   <data name="Encoding.Header" xml:space="preserve">
@@ -1723,5 +1723,11 @@ From there, simply click on a Markdown file, PDF file or SVG icon in the File Ex
   <data name="MouseUtils_Prevent_Activation_On_Game_Mode.Content" xml:space="preserve">
     <value>Do not activate when Game Mode is on</value>
     <comment>"Game mode" is the Windows feature to prevent notification when playing a game.</comment>
+  </data>
+  <data name="FancyZones_Radio_Custom_Theme.Content" xml:space="preserve">
+    <value>Custom</value>
+  </data>
+  <data name="FancyZones_Radio_Default_Theme.Content" xml:space="preserve">
+    <value>Windows default</value>
   </data>
 </root>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -1015,12 +1015,6 @@ Made with 💗 by Microsoft and the PowerToys community.</value>
   <data name="ImageResizer_FilenameParameters.AutomationProperties.Name" xml:space="preserve">
     <value>Filename parameters</value>
   </data>
-  <data name="ColorModeHeader.Header" xml:space="preserve">
-    <value>Zone appearance</value>
-  </data>
-	<data name="ColorModeHeader.Description" xml:space="preserve">
-    <value>Customize the way zones look</value>
-  </data>
   <data name="Radio_Theme_Dark.Content" xml:space="preserve">
     <value>Dark</value>
     <comment>Dark refers to color, not weight</comment>
@@ -1732,5 +1726,14 @@ From there, simply click on a Markdown file, PDF file or SVG icon in the File Ex
   </data>
   <data name="FancyZones_Radio_Default_Theme.Content" xml:space="preserve">
     <value>Windows default</value>
+  </data>
+  <data name="ColorModeHeader.Header" xml:space="preserve">
+    <value>App theme</value>
+  </data>
+  <data name="FancyZones_Zone_Appearance.Description" xml:space="preserve">
+    <value>Customize the way zones look</value>
+  </data>
+  <data name="FancyZones_Zone_Appearance.Header" xml:space="preserve">
+    <value>Zone appearance</value>
   </data>
 </root>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -90,6 +90,47 @@
                                     </controls:Setting.ActionContent>
                                 </controls:Setting>
 
+                               
+                            </StackPanel>
+                        </controls:SettingExpander.Content>
+                    </controls:SettingExpander>
+
+                    <controls:SettingExpander IsExpanded="True">
+                        <controls:SettingExpander.Header>
+
+                            <controls:Setting x:Uid="ColorModeHeader" Icon="&#xE790;" Style="{StaticResource ExpanderHeaderSettingStyle}" >
+                                <controls:Setting.ActionContent>
+                                    <ComboBox SelectedIndex="{x:Bind Mode=TwoWay, Path=ViewModel.SystemTheme, Converter={StaticResource BoolToComboBoxIndexConverter}}" MinWidth="{StaticResource SettingActionControlMinWidth}">
+                                        <ComboBoxItem x:Uid="FancyZones_Radio_Custom_Theme"/>
+                                        <ComboBoxItem x:Uid="FancyZones_Radio_Default_Theme"/>
+                                    </ComboBox>
+                                </controls:Setting.ActionContent>
+                            </controls:Setting>
+                        </controls:SettingExpander.Header>
+                        <controls:SettingExpander.Content>
+                            <StackPanel>
+                                <StackPanel Visibility="{x:Bind Mode=OneWay, Path=ViewModel.SystemTheme, Converter={StaticResource FalseToVisibleConverter}}" >
+                                    <controls:Setting x:Uid="FancyZones_ZoneHighlightColor" Style="{StaticResource ExpanderContentSettingStyle}">
+                                        <controls:Setting.ActionContent>
+                                            <controls:ColorPickerButton SelectedColor="{x:Bind Path=ViewModel.ZoneHighlightColor, Mode=TwoWay}" />
+                                        </controls:Setting.ActionContent>
+                                    </controls:Setting>
+                                    <Rectangle Style="{StaticResource ExpanderSeparatorStyle}" />
+
+                                    <controls:Setting x:Uid="FancyZones_InActiveColor" Style="{StaticResource ExpanderContentSettingStyle}">
+                                        <controls:Setting.ActionContent>
+                                            <controls:ColorPickerButton SelectedColor="{x:Bind Path=ViewModel.ZoneInActiveColor, Mode=TwoWay}" />
+                                        </controls:Setting.ActionContent>
+                                    </controls:Setting>
+                                    <Rectangle Style="{StaticResource ExpanderSeparatorStyle}" />
+                                    <controls:Setting x:Uid="FancyZones_BorderColor" Style="{StaticResource ExpanderContentSettingStyle}">
+                                        <controls:Setting.ActionContent>
+                                            <controls:ColorPickerButton SelectedColor="{x:Bind Path=ViewModel.ZoneBorderColor, Mode=TwoWay}" />
+                                        </controls:Setting.ActionContent>
+                                    </controls:Setting>
+                                    <Rectangle Style="{StaticResource ExpanderSeparatorStyle}" />
+
+                                </StackPanel>
                                 <controls:Setting x:Uid="FancyZones_HighlightOpacity" Style="{StaticResource ExpanderContentSettingStyle}">
                                     <controls:Setting.ActionContent>
                                         <Slider Minimum="0"
@@ -102,40 +143,6 @@
                             </StackPanel>
                         </controls:SettingExpander.Content>
                     </controls:SettingExpander>
-                    
-                    <controls:Setting x:Uid="ColorModeHeader" Icon="&#xE790;">
-                        <controls:Setting.Description>
-                            <HyperlinkButton Click="OpenColorsSettings_Click"
-                                                x:Uid="Windows_Color_Settings"/>
-                        </controls:Setting.Description>
-                        <controls:Setting.ActionContent>
-                            <ComboBox SelectedIndex="{x:Bind Mode=TwoWay, Path=ViewModel.SystemTheme, Converter={StaticResource BoolToComboBoxIndexConverter}}" MinWidth="{StaticResource SettingActionControlMinWidth}">
-                                <ComboBoxItem x:Uid="FancyZones_Radio_Custom_Theme"/>
-                                <ComboBoxItem x:Uid="FancyZones_Radio_Default_Theme"/>
-                            </ComboBox>
-                        </controls:Setting.ActionContent>
-                    </controls:Setting>
-
-                    <StackPanel>
-                        <controls:Setting x:Uid="FancyZones_ZoneHighlightColor" Visibility="{x:Bind Mode=OneWay, Path=ViewModel.SystemTheme, Converter={StaticResource FalseToVisibleConverter}}">
-                            <controls:Setting.ActionContent>
-                                <controls:ColorPickerButton SelectedColor="{x:Bind Path=ViewModel.ZoneHighlightColor, Mode=TwoWay}" />
-                            </controls:Setting.ActionContent>
-                        </controls:Setting>
-
-
-                        <controls:Setting x:Uid="FancyZones_InActiveColor" Visibility="{x:Bind Mode=OneWay, Path=ViewModel.SystemTheme, Converter={StaticResource FalseToVisibleConverter}}">
-                            <controls:Setting.ActionContent>
-                                <controls:ColorPickerButton SelectedColor="{x:Bind Path=ViewModel.ZoneInActiveColor, Mode=TwoWay}" />
-                            </controls:Setting.ActionContent>
-                        </controls:Setting>
-
-                        <controls:Setting x:Uid="FancyZones_BorderColor" Visibility="{x:Bind Mode=OneWay, Path=ViewModel.SystemTheme, Converter={StaticResource FalseToVisibleConverter}}">
-                            <controls:Setting.ActionContent>
-                                <controls:ColorPickerButton SelectedColor="{x:Bind Path=ViewModel.ZoneBorderColor, Mode=TwoWay}" />
-                            </controls:Setting.ActionContent>
-                        </controls:Setting>
-                    </StackPanel>
                 </controls:SettingsGroup>
                 
                 <controls:SettingsGroup x:Uid="FancyZones_Windows" IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}">

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -98,7 +98,7 @@
                     <controls:SettingExpander IsExpanded="True">
                         <controls:SettingExpander.Header>
 
-                            <controls:Setting x:Uid="ColorModeHeader" Icon="&#xE790;" Style="{StaticResource ExpanderHeaderSettingStyle}" >
+                            <controls:Setting x:Uid="FancyZones_Zone_Appearance" Icon="&#xE790;" Style="{StaticResource ExpanderHeaderSettingStyle}" >
                                 <controls:Setting.ActionContent>
                                     <ComboBox SelectedIndex="{x:Bind Mode=TwoWay, Path=ViewModel.SystemTheme, Converter={StaticResource BoolToComboBoxIndexConverter}}" MinWidth="{StaticResource SettingActionControlMinWidth}">
                                         <ComboBoxItem x:Uid="FancyZones_Radio_Custom_Theme"/>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -101,7 +101,7 @@
                             <controls:Setting x:Uid="FancyZones_Zone_Appearance" Icon="&#xE790;" Style="{StaticResource ExpanderHeaderSettingStyle}" >
                                 <controls:Setting.ActionContent>
                                     <ComboBox SelectedIndex="{x:Bind Mode=TwoWay, Path=ViewModel.SystemTheme, Converter={StaticResource BoolToComboBoxIndexConverter}}" MinWidth="{StaticResource SettingActionControlMinWidth}">
-                                        <ComboBoxItem x:Uid="FancyZones_Radio_Custom_Theme"/>
+                                        <ComboBoxItem x:Uid="FancyZones_Radio_Custom_Colors"/>
                                         <ComboBoxItem x:Uid="FancyZones_Radio_Default_Theme"/>
                                     </ComboBox>
                                 </controls:Setting.ActionContent>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -13,6 +13,7 @@
     <Page.Resources>
         <converters:BoolToObjectConverter x:Key="BoolToComboBoxIndexConverter" TrueValue="1" FalseValue="0"/>
         <converters:StringFormatConverter x:Key="StringFormatConverter"/>
+        <converters:BoolToVisibilityConverter x:Key="FalseToVisibleConverter" TrueValue="Collapsed" FalseValue="Visible"/>
     </Page.Resources>
 
     <controls:SettingsPageControl x:Uid="FancyZones"
@@ -98,31 +99,44 @@
                                             HorizontalAlignment="Right"/>
                                     </controls:Setting.ActionContent>
                                 </controls:Setting>
-
-                                <controls:Setting  x:Uid="FancyZones_ZoneHighlightColor" Style="{StaticResource ExpanderContentSettingStyle}">
-                                    <controls:Setting.ActionContent>
-                                        <controls:ColorPickerButton SelectedColor="{x:Bind Path=ViewModel.ZoneHighlightColor, Mode=TwoWay}" />
-                                    </controls:Setting.ActionContent>
-                                </controls:Setting>
-
-
-                                <controls:Setting  x:Uid="FancyZones_InActiveColor" Style="{StaticResource ExpanderContentSettingStyle}">
-                                    <controls:Setting.ActionContent>
-                                        <controls:ColorPickerButton SelectedColor="{x:Bind Path=ViewModel.ZoneInActiveColor, Mode=TwoWay}" />
-                                    </controls:Setting.ActionContent>
-                                </controls:Setting>
-
-                                <controls:Setting  x:Uid="FancyZones_BorderColor" Style="{StaticResource ExpanderContentSettingStyle}">
-                                    <controls:Setting.ActionContent>
-                                        <controls:ColorPickerButton SelectedColor="{x:Bind Path=ViewModel.ZoneBorderColor, Mode=TwoWay}" />
-                                    </controls:Setting.ActionContent>
-                                </controls:Setting>
-
                             </StackPanel>
                         </controls:SettingExpander.Content>
                     </controls:SettingExpander>
-                </controls:SettingsGroup>
+                    
+                    <controls:Setting x:Uid="ColorModeHeader" Icon="&#xE790;">
+                        <controls:Setting.Description>
+                            <HyperlinkButton Click="OpenColorsSettings_Click"
+                                                x:Uid="Windows_Color_Settings"/>
+                        </controls:Setting.Description>
+                        <controls:Setting.ActionContent>
+                            <ComboBox SelectedIndex="{x:Bind Mode=TwoWay, Path=ViewModel.SystemTheme, Converter={StaticResource BoolToComboBoxIndexConverter}}" MinWidth="{StaticResource SettingActionControlMinWidth}">
+                                <ComboBoxItem x:Uid="FancyZones_Radio_Custom_Theme"/>
+                                <ComboBoxItem x:Uid="FancyZones_Radio_Default_Theme"/>
+                            </ComboBox>
+                        </controls:Setting.ActionContent>
+                    </controls:Setting>
 
+                    <StackPanel>
+                        <controls:Setting x:Uid="FancyZones_ZoneHighlightColor" Visibility="{x:Bind Mode=OneWay, Path=ViewModel.SystemTheme, Converter={StaticResource FalseToVisibleConverter}}">
+                            <controls:Setting.ActionContent>
+                                <controls:ColorPickerButton SelectedColor="{x:Bind Path=ViewModel.ZoneHighlightColor, Mode=TwoWay}" />
+                            </controls:Setting.ActionContent>
+                        </controls:Setting>
+
+
+                        <controls:Setting x:Uid="FancyZones_InActiveColor" Visibility="{x:Bind Mode=OneWay, Path=ViewModel.SystemTheme, Converter={StaticResource FalseToVisibleConverter}}">
+                            <controls:Setting.ActionContent>
+                                <controls:ColorPickerButton SelectedColor="{x:Bind Path=ViewModel.ZoneInActiveColor, Mode=TwoWay}" />
+                            </controls:Setting.ActionContent>
+                        </controls:Setting>
+
+                        <controls:Setting x:Uid="FancyZones_BorderColor" Visibility="{x:Bind Mode=OneWay, Path=ViewModel.SystemTheme, Converter={StaticResource FalseToVisibleConverter}}">
+                            <controls:Setting.ActionContent>
+                                <controls:ColorPickerButton SelectedColor="{x:Bind Path=ViewModel.ZoneBorderColor, Mode=TwoWay}" />
+                            </controls:Setting.ActionContent>
+                        </controls:Setting>
+                    </StackPanel>
+                </controls:SettingsGroup>
                 
                 <controls:SettingsGroup x:Uid="FancyZones_Windows" IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}">
 
@@ -234,11 +248,6 @@
                         </controls:SettingExpander.Content>
                     </controls:SettingExpander>
                 </controls:SettingsGroup>
-
-
-
-
-
 
                 <controls:SettingsGroup x:Uid="ExcludedApps" IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}">
                     <controls:SettingExpander IsExpanded="True">

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml.cs
@@ -19,5 +19,10 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             ViewModel = new FancyZonesViewModel(settingsUtils, SettingsRepository<GeneralSettings>.GetInstance(settingsUtils), SettingsRepository<FancyZonesSettings>.GetInstance(settingsUtils), ShellPage.SendDefaultIPCMessage);
             DataContext = ViewModel;
         }
+
+        private void OpenColorsSettings_Click(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        {
+            Helpers.StartProcessHelper.Start(Helpers.StartProcessHelper.ColorsSettings);
+        }
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Use accent color and theme for zones

**What is include in the PR:** 

More screenshots including light theme here: https://github.com/microsoft/PowerToys/issues/4098#issuecomment-955576892

![FZ3](https://user-images.githubusercontent.com/25966642/139593720-78e26363-33aa-40c6-ba30-9b6ef3da9a9b.gif)

![image](https://user-images.githubusercontent.com/25966642/140185592-5852ec06-f49d-4f74-9f93-99e16803a92c.png)

![image](https://user-images.githubusercontent.com/25966642/140185626-cc537a8c-fb8d-4735-ba2b-adc5b1b59a9f.png)

**How does someone test / validate:** 
- Activate FZ
- Play with the settings toggle "Use custom colors"
- When enabled FZ should use colors configured in the settings (old behaviour)
- When disabled FZ should use Windows accent color and theme
- Change theme and accent color from Windows settings: FZ should use current Windows settings

## Quality Checklist

- [x] **Linked issue:** #4098
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
