### PR TITLE
Updated FZ color UX

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -444,7 +444,7 @@
     <value>Excludes an application from snapping to zones and will only react to Windows Snap - add one application name per line</value>
   </data>
   <data name="FancyZones_HighlightOpacity.Header" xml:space="preserve">
-    <value>Zone opacity</value>
+    <value>Opacity</value>
   </data>
   <data name="FancyZones_HotkeyEditorControl.Header" xml:space="preserve">
     <value>Open layout editor</value>
@@ -518,7 +518,7 @@
     <value>Zones</value>
   </data>
   <data name="FancyZones_ZoneHighlightColor.Header" xml:space="preserve">
-    <value>Zone highlight color</value>
+    <value>Highlight color</value>
   </data>
   <data name="FancyZones_ZoneSetChangeMoveWindows.Content" xml:space="preserve">
     <value>During zone layout changes, windows assigned to a zone will match new size/positions</value>
@@ -628,10 +628,10 @@
     <value>Enable auto-complete for the search and replace fields</value>
   </data>
   <data name="FancyZones_BorderColor.Header" xml:space="preserve">
-    <value>Zone border color</value>
+    <value>Border color</value>
   </data>
   <data name="FancyZones_InActiveColor.Header" xml:space="preserve">
-    <value>Zone inactive color</value>
+    <value>Inactive color</value>
   </data>
   <data name="ShortcutGuide.ModuleDescription" xml:space="preserve">
     <value>Shows a help overlay with Windows shortcuts.</value>
@@ -998,7 +998,10 @@ Made with 💗 by Microsoft and the PowerToys community.</value>
     <value>Filename parameters</value>
   </data>
   <data name="ColorModeHeader.Header" xml:space="preserve">
-    <value>App theme</value>
+    <value>Zone appearance</value>
+  </data>
+	<data name="ColorModeHeader.Description" xml:space="preserve">
+    <value>Customize the way zones look</value>
   </data>
   <data name="Radio_Theme_Dark.Content" xml:space="preserve">
     <value>Dark</value>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/FancyZonesPage.xaml
@@ -90,6 +90,47 @@
                                     </controls:Setting.ActionContent>
                                 </controls:Setting>
 
+                               
+                            </StackPanel>
+                        </controls:SettingExpander.Content>
+                    </controls:SettingExpander>
+
+                    <controls:SettingExpander IsExpanded="True">
+                        <controls:SettingExpander.Header>
+
+                            <controls:Setting x:Uid="ColorModeHeader" Icon="&#xE790;" Style="{StaticResource ExpanderHeaderSettingStyle}" >
+                                <controls:Setting.ActionContent>
+                                    <ComboBox SelectedIndex="{x:Bind Mode=TwoWay, Path=ViewModel.SystemTheme, Converter={StaticResource BoolToComboBoxIndexConverter}}" MinWidth="{StaticResource SettingActionControlMinWidth}">
+                                        <ComboBoxItem x:Uid="FancyZones_Radio_Custom_Theme"/>
+                                        <ComboBoxItem x:Uid="FancyZones_Radio_Default_Theme"/>
+                                    </ComboBox>
+                                </controls:Setting.ActionContent>
+                            </controls:Setting>
+                        </controls:SettingExpander.Header>
+                        <controls:SettingExpander.Content>
+                            <StackPanel>
+                                <StackPanel Visibility="{x:Bind Mode=OneWay, Path=ViewModel.SystemTheme, Converter={StaticResource FalseToVisibleConverter}}" >
+                                    <controls:Setting x:Uid="FancyZones_ZoneHighlightColor" Style="{StaticResource ExpanderContentSettingStyle}">
+                                        <controls:Setting.ActionContent>
+                                            <controls:ColorPickerButton SelectedColor="{x:Bind Path=ViewModel.ZoneHighlightColor, Mode=TwoWay}" />
+                                        </controls:Setting.ActionContent>
+                                    </controls:Setting>
+                                    <Rectangle Style="{StaticResource ExpanderSeparatorStyle}" />
+
+                                    <controls:Setting x:Uid="FancyZones_InActiveColor" Style="{StaticResource ExpanderContentSettingStyle}">
+                                        <controls:Setting.ActionContent>
+                                            <controls:ColorPickerButton SelectedColor="{x:Bind Path=ViewModel.ZoneInActiveColor, Mode=TwoWay}" />
+                                        </controls:Setting.ActionContent>
+                                    </controls:Setting>
+                                    <Rectangle Style="{StaticResource ExpanderSeparatorStyle}" />
+                                    <controls:Setting x:Uid="FancyZones_BorderColor" Style="{StaticResource ExpanderContentSettingStyle}">
+                                        <controls:Setting.ActionContent>
+                                            <controls:ColorPickerButton SelectedColor="{x:Bind Path=ViewModel.ZoneBorderColor, Mode=TwoWay}" />
+                                        </controls:Setting.ActionContent>
+                                    </controls:Setting>
+                                    <Rectangle Style="{StaticResource ExpanderSeparatorStyle}" />
+
+                                </StackPanel>
                                 <controls:Setting x:Uid="FancyZones_HighlightOpacity" Style="{StaticResource ExpanderContentSettingStyle}">
                                     <controls:Setting.ActionContent>
                                         <Slider Minimum="0"
@@ -102,40 +143,6 @@
                             </StackPanel>
                         </controls:SettingExpander.Content>
                     </controls:SettingExpander>
-                    
-                    <controls:Setting x:Uid="ColorModeHeader" Icon="&#xE790;">
-                        <controls:Setting.Description>
-                            <HyperlinkButton Click="OpenColorsSettings_Click"
-                                                x:Uid="Windows_Color_Settings"/>
-                        </controls:Setting.Description>
-                        <controls:Setting.ActionContent>
-                            <ComboBox SelectedIndex="{x:Bind Mode=TwoWay, Path=ViewModel.SystemTheme, Converter={StaticResource BoolToComboBoxIndexConverter}}" MinWidth="{StaticResource SettingActionControlMinWidth}">
-                                <ComboBoxItem x:Uid="FancyZones_Radio_Custom_Theme"/>
-                                <ComboBoxItem x:Uid="FancyZones_Radio_Default_Theme"/>
-                            </ComboBox>
-                        </controls:Setting.ActionContent>
-                    </controls:Setting>
-
-                    <StackPanel>
-                        <controls:Setting x:Uid="FancyZones_ZoneHighlightColor" Visibility="{x:Bind Mode=OneWay, Path=ViewModel.SystemTheme, Converter={StaticResource FalseToVisibleConverter}}">
-                            <controls:Setting.ActionContent>
-                                <controls:ColorPickerButton SelectedColor="{x:Bind Path=ViewModel.ZoneHighlightColor, Mode=TwoWay}" />
-                            </controls:Setting.ActionContent>
-                        </controls:Setting>
-
-
-                        <controls:Setting x:Uid="FancyZones_InActiveColor" Visibility="{x:Bind Mode=OneWay, Path=ViewModel.SystemTheme, Converter={StaticResource FalseToVisibleConverter}}">
-                            <controls:Setting.ActionContent>
-                                <controls:ColorPickerButton SelectedColor="{x:Bind Path=ViewModel.ZoneInActiveColor, Mode=TwoWay}" />
-                            </controls:Setting.ActionContent>
-                        </controls:Setting>
-
-                        <controls:Setting x:Uid="FancyZones_BorderColor" Visibility="{x:Bind Mode=OneWay, Path=ViewModel.SystemTheme, Converter={StaticResource FalseToVisibleConverter}}">
-                            <controls:Setting.ActionContent>
-                                <controls:ColorPickerButton SelectedColor="{x:Bind Path=ViewModel.ZoneBorderColor, Mode=TwoWay}" />
-                            </controls:Setting.ActionContent>
-                        </controls:Setting>
-                    </StackPanel>
                 </controls:SettingsGroup>
                 
                 <controls:SettingsGroup x:Uid="FancyZones_Windows" IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsEnabled}">


### PR DESCRIPTION
## Summary of the Pull Request

Moved settings in Expander:



![FZColorUX](https://user-images.githubusercontent.com/9866362/139596045-d9088d07-2e59-4e53-893a-0235fec44e2c.gif)

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/master/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/master/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
