### PR TITLE
[Settings] fix default settings window size

### DIFF
--- a/src/settings-ui/PowerToys.Settings/MainWindow.xaml.cs
+++ b/src/settings-ui/PowerToys.Settings/MainWindow.xaml.cs
@@ -32,6 +32,8 @@ namespace PowerToys.Settings
 
             this.InitializeComponent();
 
+            Utils.FitToScreen(this);
+
             ResourceLoader loader = ResourceLoader.GetForViewIndependentUse();
             Title = loader.GetString("SettingsWindow_Title");
 
@@ -61,8 +63,6 @@ namespace PowerToys.Settings
         {
             base.OnSourceInitialized(e);
 
-            Utils.FitToScreen(this);
-
             var handle = new WindowInteropHelper(this).Handle;
             NativeMethods.GetWindowPlacement(handle, out var startupPlacement);
             var placement = Utils.DeserializePlacementOrDefault(handle);
@@ -72,8 +72,8 @@ namespace PowerToys.Settings
             var screenRect = new Rectangle((int)SystemParameters.VirtualScreenLeft, (int)SystemParameters.VirtualScreenTop, (int)SystemParameters.VirtualScreenWidth, (int)SystemParameters.VirtualScreenHeight);
             var intersection = Rectangle.Intersect(windowRect, screenRect);
 
-            // Restore default position if 1/4 of width or height of the window is offscreen
-            if (intersection.Width < (Width * 0.75) || intersection.Height < (Height * 0.75))
+            // Restore default position if 5% of width or height of the window is offscreen
+            if (intersection.Width < (Width * 0.95) || intersection.Height < (Height * 0.95))
             {
                 NativeMethods.SetWindowPlacement(handle, ref startupPlacement);
             }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Fix settings window opening offscreen.
Improving offscreen detection.

**What is include in the PR:** 
In https://github.com/microsoft/PowerToys/pull/13912 `Utils.FitToScreen(this);` was moved from the constructor but is not working the same in the `OnSourceInitialized` causing issue with scaling factor.

**How does someone test / validate:** 
- Set an exceeding scaling (I can repro with 1920x1080@150%)
- Delete `%LOCALAPPDATA%\Microsoft\PowerToys\settings-placement.json`
- Open PT 0.49.x to repro the issue of the setting window opening offscreen
- Close PT
- Delete `%LOCALAPPDATA%\Microsoft\PowerToys\settings-placement.json`
- Open PT built from this branch
- Validate that settings window is not opening offscreen

## Quality Checklist

- [x] **Linked issue:** #14131
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
