### PR TITLE
[PT Run] If only delayed results available, select first

### DIFF
--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -579,6 +579,8 @@ namespace PowerLauncher.ViewModel
                                 UpdateResultsListViewAfterQuery(queryText);
                             }
 
+                            bool noInitialResults = numResults == 0;
+
                             // Run the slower query of the DelayedExecution plugins
                             currentCancellationToken.ThrowIfCancellationRequested();
                             Parallel.ForEach(plugins, (plugin) =>
@@ -612,7 +614,7 @@ namespace PowerLauncher.ViewModel
                                                 }
 
                                                 currentCancellationToken.ThrowIfCancellationRequested();
-                                                UpdateResultsListViewAfterQuery(queryText, true);
+                                                UpdateResultsListViewAfterQuery(queryText, noInitialResults, true);
                                             }
                                         }
                                     }
@@ -654,7 +656,7 @@ namespace PowerLauncher.ViewModel
             }
         }
 
-        private void UpdateResultsListViewAfterQuery(string queryText, bool isDelayedInvoke = false)
+        private void UpdateResultsListViewAfterQuery(string queryText, bool noInitialResults = false, bool isDelayedInvoke = false)
         {
             Application.Current.Dispatcher.BeginInvoke(new Action(() =>
             {
@@ -667,9 +669,13 @@ namespace PowerLauncher.ViewModel
                 if (Results.Results.Count > 0)
                 {
                     Results.Visibility = Visibility.Visible;
-                    if (!isDelayedInvoke)
+                    if (!isDelayedInvoke || noInitialResults)
                     {
                         Results.SelectedIndex = 0;
+                        if (noInitialResults)
+                        {
+                            Results.SelectedItem = Results.Results.FirstOrDefault();
+                        }
                     }
                 }
                 else


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
So far, if query results were produced only by delayed executed plugins (Search plugin is the only delayed plugin atm), none of the results were auto-selected. With this change, in this case, first result in the list is selected.

Tested with custom build and confirmed by the user that reported the issue. Check the discussion there.

**What is include in the PR:** 

**How does someone test / validate:** 
 - Create New Folder on Desktop
 - open PT Run
 - Type New Folder
 - Confirm that all of the results are produced by Search plugin (path starts with search:)
 - Observe that first result is hovered and hitting enter opens the New Folder in Explorer

## Quality Checklist

- [X] **Linked issue:** #14093
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
