### PR TITLE
Fix typo

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeVideoConference.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeVideoConference.xaml
@@ -20,7 +20,7 @@
 
                 <controls:ShortcutWithTextLabelControl x:Name="HotkeyMicVidControl" x:Uid="Oobe_VideoConference_ToggleMicVid" />
                 <controls:ShortcutWithTextLabelControl x:Name="HotkeyMicControl" x:Uid="Oobe_VideoConference_ToggleMic" />
-                <controls:ShortcutWithTextLabelControl x:Name="HotkeyVidControl" x:Uid="Oobe_VideoConference_ToggleMic" />
+                <controls:ShortcutWithTextLabelControl x:Name="HotkeyVidControl" x:Uid="Oobe_VideoConference_ToggleVid" />
                 
                 <toolkitcontrols:MarkdownTextBlock Background="Transparent" x:Uid="Oobe_VideoConference_HowToLaunch" />
 


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Fix typo raised in #14236 

**What is include in the PR:** 
Change  `<controls:ShortcutWithTextLabelControl x:Name="HotkeyVidControl" x:Uid="Oobe_VideoConference_ToggleMic" />` to ` <controls:ShortcutWithTextLabelControl x:Name="HotkeyVidControl" x:Uid="Oobe_VideoConference_ToggleVid" />`

**How does someone test / validate:** 
No test is required. 

## Quality Checklist

- [x] **Linked issue:** #14236
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
