### PR TITLE
[FancyZones] Cleanup

### DIFF
--- a/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
@@ -480,7 +480,7 @@ FancyZones::OnKeyDown(PKBDLLHOOKSTRUCT info) noexcept
             digitPressed = info->vkCode - VK_NUMPAD0;
         }
 
-        bool dragging = m_windowMoveHandler.InMoveSize();
+        bool dragging = m_windowMoveHandler.InDragging();
         bool changeLayoutWhileNotDragging = !dragging && !shift && win && ctrl && alt && digitPressed != -1;
         bool changeLayoutWhileDragging = dragging && digitPressed != -1;
 
@@ -749,7 +749,7 @@ LRESULT FancyZones::WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lpa
         }
         else if (message == WM_PRIV_LOCATIONCHANGE)
         {
-            if (m_windowMoveHandler.InMoveSize())
+            if (m_windowMoveHandler.InDragging())
             {
                 if (auto monitor = MonitorFromPoint(ptScreen, MONITOR_DEFAULTTONULL))
                 {

--- a/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
@@ -1294,11 +1294,11 @@ bool FancyZones::ShouldProcessSnapHotkey(DWORD vkCode) noexcept
 void FancyZones::ApplyQuickLayout(int key) noexcept
 {
     std::wstring uuid;
-    for (auto [zoneUuid, hotkey] : FancyZonesDataInstance().GetLayoutQuickKeys())
+    for (auto [layoutUuid, hotkey] : FancyZonesDataInstance().GetLayoutQuickKeys())
     {
         if (hotkey == key)
         {
-            uuid = zoneUuid;
+            uuid = layoutUuid;
         }
     }
 

--- a/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
@@ -332,7 +332,7 @@ void FancyZones::MoveWindowIntoZone(HWND window, winrt::com_ptr<IWorkArea> workA
     {
         if (workArea)
         {
-            Trace::FancyZones::SnapNewWindowIntoZone(workArea->ActiveZoneSet());
+            Trace::FancyZones::SnapNewWindowIntoZone(workArea->ZoneSet());
         }
         m_windowMoveHandler.MoveWindowIntoZoneByIndexSet(window, zoneIndexSet, workArea);
         fancyZonesData.UpdateProcessIdToHandleMap(window, workArea->UniqueId());
@@ -972,7 +972,7 @@ bool FancyZones::OnSnapHotkeyBasedOnZoneNumber(HWND window, DWORD vkCode) noexce
             auto workArea = m_workAreaHandler.GetWorkArea(m_currentDesktopId, *currMonitorInfo);
             if (m_windowMoveHandler.MoveWindowIntoZoneByDirectionAndIndex(window, vkCode, false /* cycle through zones */, workArea))
             {
-                Trace::FancyZones::KeyboardSnapWindowToZone(workArea->ActiveZoneSet());
+                Trace::FancyZones::KeyboardSnapWindowToZone(workArea->ZoneSet());
                 return true;
             }
             // We iterated through all zones in current monitor zone layout, move on to next one (or previous depending on direction).
@@ -1008,7 +1008,7 @@ bool FancyZones::OnSnapHotkeyBasedOnZoneNumber(HWND window, DWORD vkCode) noexce
             }
             else
             {
-                Trace::FancyZones::KeyboardSnapWindowToZone(workArea->ActiveZoneSet());
+                Trace::FancyZones::KeyboardSnapWindowToZone(workArea->ZoneSet());
             }
             return moved;
         }
@@ -1017,7 +1017,7 @@ bool FancyZones::OnSnapHotkeyBasedOnZoneNumber(HWND window, DWORD vkCode) noexce
             bool moved = m_windowMoveHandler.MoveWindowIntoZoneByDirectionAndIndex(window, vkCode, true /* cycle through zones */, workArea);
             if (moved)
             {
-                Trace::FancyZones::KeyboardSnapWindowToZone(workArea->ActiveZoneSet());
+                Trace::FancyZones::KeyboardSnapWindowToZone(workArea->ZoneSet());
             }
             return moved;
         }
@@ -1058,7 +1058,7 @@ bool FancyZones::OnSnapHotkeyBasedOnPosition(HWND window, DWORD vkCode) noexcept
                 auto workArea = m_workAreaHandler.GetWorkArea(m_currentDesktopId, monitor);
                 if (workArea)
                 {
-                    auto zoneSet = workArea->ActiveZoneSet();
+                    auto zoneSet = workArea->ZoneSet();
                     if (zoneSet)
                     {
                         const auto zones = zoneSet->GetZones();
@@ -1093,7 +1093,7 @@ bool FancyZones::OnSnapHotkeyBasedOnPosition(HWND window, DWORD vkCode) noexcept
             // Moving to another monitor succeeded
             const auto& [trueZoneIdx, workArea] = zoneRectsInfo[chosenIdx];
             m_windowMoveHandler.MoveWindowIntoZoneByIndexSet(window, { trueZoneIdx }, workArea);
-            Trace::FancyZones::KeyboardSnapWindowToZone(workArea->ActiveZoneSet());
+            Trace::FancyZones::KeyboardSnapWindowToZone(workArea->ZoneSet());
             return true;
         }
 
@@ -1106,7 +1106,7 @@ bool FancyZones::OnSnapHotkeyBasedOnPosition(HWND window, DWORD vkCode) noexcept
             auto workArea = m_workAreaHandler.GetWorkArea(m_currentDesktopId, current);
             if (workArea)
             {
-                auto zoneSet = workArea->ActiveZoneSet();
+                auto zoneSet = workArea->ZoneSet();
                 if (zoneSet)
                 {
                     const auto zones = zoneSet->GetZones();
@@ -1138,7 +1138,7 @@ bool FancyZones::OnSnapHotkeyBasedOnPosition(HWND window, DWORD vkCode) noexcept
             // Moving to another monitor succeeded
             const auto& [trueZoneIdx, workArea] = zoneRectsInfo[chosenIdx];
             m_windowMoveHandler.MoveWindowIntoZoneByIndexSet(window, { trueZoneIdx }, workArea);
-            Trace::FancyZones::KeyboardSnapWindowToZone(workArea->ActiveZoneSet());
+            Trace::FancyZones::KeyboardSnapWindowToZone(workArea->ZoneSet());
             return true;
         }
         else
@@ -1177,7 +1177,7 @@ bool FancyZones::ProcessDirectedSnapHotkey(HWND window, DWORD vkCode, bool cycle
         bool result = m_windowMoveHandler.ExtendWindowByDirectionAndPosition(window, vkCode, workArea);
         if (result) 
         {
-            Trace::FancyZones::KeyboardSnapWindowToZone(workArea->ActiveZoneSet());
+            Trace::FancyZones::KeyboardSnapWindowToZone(workArea->ZoneSet());
         }
         return result;
     }
@@ -1186,7 +1186,7 @@ bool FancyZones::ProcessDirectedSnapHotkey(HWND window, DWORD vkCode, bool cycle
         bool result = m_windowMoveHandler.MoveWindowIntoZoneByDirectionAndPosition(window, vkCode, cycle, workArea);
         if (result)
         {
-            Trace::FancyZones::KeyboardSnapWindowToZone(workArea->ActiveZoneSet());
+            Trace::FancyZones::KeyboardSnapWindowToZone(workArea->ZoneSet());
         }
         return result;
     }
@@ -1276,7 +1276,7 @@ bool FancyZones::ShouldProcessSnapHotkey(DWORD vkCode) noexcept
         HMONITOR monitor = WorkAreaKeyFromWindow(window);
 
         auto workArea = m_workAreaHandler.GetWorkArea(m_currentDesktopId, monitor);
-        if (workArea && workArea->ActiveZoneSet() && workArea->ActiveZoneSet()->LayoutType() != FancyZonesDataTypes::ZoneSetLayoutType::Blank)
+        if (workArea && workArea->ZoneSet() && workArea->ZoneSet()->LayoutType() != FancyZonesDataTypes::ZoneSetLayoutType::Blank)
         {
             if (vkCode == VK_UP || vkCode == VK_DOWN)
             {
@@ -1347,7 +1347,7 @@ std::vector<std::pair<HMONITOR, RECT>> FancyZones::GetRawMonitorData() noexcept
     const auto& activeWorkAreaMap = m_workAreaHandler.GetWorkAreasByDesktopId(m_currentDesktopId);
     for (const auto& [monitor, workArea] : activeWorkAreaMap)
     {
-        if (workArea->ActiveZoneSet() != nullptr)
+        if (workArea->ZoneSet() != nullptr)
         {
             MONITORINFOEX mi;
             mi.cbSize = sizeof(mi);

--- a/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
@@ -148,19 +148,19 @@ public:
 
     LRESULT WndProc(HWND, UINT, WPARAM, LPARAM) noexcept;
     void OnDisplayChange(DisplayChangeType changeType) noexcept;
-    void AddZoneWindow(HMONITOR monitor, const std::wstring& deviceId) noexcept;
+    void AddWorkArea(HMONITOR monitor, const std::wstring& deviceId) noexcept;
 
 protected:
     static LRESULT CALLBACK s_WndProc(HWND, UINT, WPARAM, LPARAM) noexcept;
 
 private:
-    void UpdateZoneWindows() noexcept;
+    void UpdateWorkAreas() noexcept;
     void UpdateWindowsPositions(bool suppressMove = false) noexcept;
     void CycleTabs(bool reverse) noexcept;
     bool OnSnapHotkeyBasedOnZoneNumber(HWND window, DWORD vkCode) noexcept;
     bool OnSnapHotkeyBasedOnPosition(HWND window, DWORD vkCode) noexcept;
     bool OnSnapHotkey(DWORD vkCode) noexcept;
-    bool ProcessDirectedSnapHotkey(HWND window, DWORD vkCode, bool cycle, winrt::com_ptr<IWorkArea> zoneWindow) noexcept;
+    bool ProcessDirectedSnapHotkey(HWND window, DWORD vkCode, bool cycle, winrt::com_ptr<IWorkArea> workArea) noexcept;
 
     void RegisterVirtualDesktopUpdates() noexcept;
 
@@ -168,7 +168,7 @@ private:
     void OnSettingsChanged() noexcept;
 
     std::pair<winrt::com_ptr<IWorkArea>, ZoneIndexSet> GetAppZoneHistoryInfo(HWND window, HMONITOR monitor, const std::unordered_map<HMONITOR, winrt::com_ptr<IWorkArea>>& workAreaMap) noexcept;
-    void MoveWindowIntoZone(HWND window, winrt::com_ptr<IWorkArea> zoneWindow, const ZoneIndexSet& zoneIndexSet) noexcept;
+    void MoveWindowIntoZone(HWND window, winrt::com_ptr<IWorkArea> workArea, const ZoneIndexSet& zoneIndexSet) noexcept;
     bool MoveToAppLastZone(HWND window, HMONITOR active, HMONITOR primary) noexcept;
 
     void OnEditorExitEvent() noexcept;
@@ -324,18 +324,18 @@ std::pair<winrt::com_ptr<IWorkArea>, ZoneIndexSet> FancyZones::GetAppZoneHistory
     return std::pair<winrt::com_ptr<IWorkArea>, ZoneIndexSet>{ nullptr, {} };
 }
 
-void FancyZones::MoveWindowIntoZone(HWND window, winrt::com_ptr<IWorkArea> zoneWindow, const ZoneIndexSet& zoneIndexSet) noexcept
+void FancyZones::MoveWindowIntoZone(HWND window, winrt::com_ptr<IWorkArea> workArea, const ZoneIndexSet& zoneIndexSet) noexcept
 {
     _TRACER_;
     auto& fancyZonesData = FancyZonesDataInstance();
-    if (!fancyZonesData.IsAnotherWindowOfApplicationInstanceZoned(window, zoneWindow->UniqueId()))
+    if (!fancyZonesData.IsAnotherWindowOfApplicationInstanceZoned(window, workArea->UniqueId()))
     {
-        if (zoneWindow)
+        if (workArea)
         {
-            Trace::FancyZones::SnapNewWindowIntoZone(zoneWindow->ActiveZoneSet());
+            Trace::FancyZones::SnapNewWindowIntoZone(workArea->ActiveZoneSet());
         }
-        m_windowMoveHandler.MoveWindowIntoZoneByIndexSet(window, zoneIndexSet, zoneWindow);
-        fancyZonesData.UpdateProcessIdToHandleMap(window, zoneWindow->UniqueId());
+        m_windowMoveHandler.MoveWindowIntoZoneByIndexSet(window, zoneIndexSet, workArea);
+        fancyZonesData.UpdateProcessIdToHandleMap(window, workArea->UniqueId());
     }
 }
 
@@ -820,8 +820,7 @@ void FancyZones::OnDisplayChange(DisplayChangeType changeType) noexcept
         }
     }
 
-    UpdateZoneWindows();
-
+    UpdateWorkAreas();
 
     if ((changeType == DisplayChangeType::WorkArea) || (changeType == DisplayChangeType::DisplayChange))
     {
@@ -832,7 +831,7 @@ void FancyZones::OnDisplayChange(DisplayChangeType changeType) noexcept
     }
 }
 
-void FancyZones::AddZoneWindow(HMONITOR monitor, const std::wstring& deviceId) noexcept
+void FancyZones::AddWorkArea(HMONITOR monitor, const std::wstring& deviceId) noexcept
 {
     _TRACER_;
     if (m_workAreaHandler.IsNewWorkArea(m_currentDesktopId, monitor))
@@ -898,11 +897,11 @@ LRESULT CALLBACK FancyZones::s_WndProc(HWND window, UINT message, WPARAM wparam,
                      DefWindowProc(window, message, wparam, lparam);
 }
 
-void FancyZones::UpdateZoneWindows() noexcept
+void FancyZones::UpdateWorkAreas() noexcept
 {
     if (m_settings->GetSettings()->spanZonesAcrossMonitors)
     {
-        AddZoneWindow(nullptr, {});
+        AddWorkArea(nullptr, {});
     }
     else
     {
@@ -923,7 +922,7 @@ void FancyZones::UpdateZoneWindows() noexcept
                 FancyZones* fancyZones = params->fancyZones;
 
                 std::wstring deviceId = FancyZonesUtils::GetDisplayDeviceId(mi.szDevice, displayDeviceIdxMap);
-                fancyZones->AddZoneWindow(monitor, deviceId);
+                fancyZones->AddWorkArea(monitor, deviceId);
             }
             return TRUE;
         };
@@ -938,10 +937,10 @@ void FancyZones::UpdateWindowsPositions(bool suppressMove) noexcept
     for (const auto [window, desktopId] : m_virtualDesktop.GetWindowsRelatedToDesktops())
     {
         auto zoneIndexSet = GetZoneIndexSet(window);
-        auto zoneWindow = m_workAreaHandler.GetWorkArea(window, desktopId);
-        if (zoneWindow)
+        auto workArea = m_workAreaHandler.GetWorkArea(window, desktopId);
+        if (workArea)
         {
-            m_windowMoveHandler.MoveWindowIntoZoneByIndexSet(window, zoneIndexSet, zoneWindow, suppressMove);
+            m_windowMoveHandler.MoveWindowIntoZoneByIndexSet(window, zoneIndexSet, workArea, suppressMove);
         }
     }
 }
@@ -970,10 +969,10 @@ bool FancyZones::OnSnapHotkeyBasedOnZoneNumber(HWND window, DWORD vkCode) noexce
         auto currMonitorInfo = std::find(std::begin(monitorInfo), std::end(monitorInfo), current);
         do
         {
-            auto zoneWindow = m_workAreaHandler.GetWorkArea(m_currentDesktopId, *currMonitorInfo);
-            if (m_windowMoveHandler.MoveWindowIntoZoneByDirectionAndIndex(window, vkCode, false /* cycle through zones */, zoneWindow))
+            auto workArea = m_workAreaHandler.GetWorkArea(m_currentDesktopId, *currMonitorInfo);
+            if (m_windowMoveHandler.MoveWindowIntoZoneByDirectionAndIndex(window, vkCode, false /* cycle through zones */, workArea))
             {
-                Trace::FancyZones::KeyboardSnapWindowToZone(zoneWindow->ActiveZoneSet());
+                Trace::FancyZones::KeyboardSnapWindowToZone(workArea->ActiveZoneSet());
                 return true;
             }
             // We iterated through all zones in current monitor zone layout, move on to next one (or previous depending on direction).
@@ -997,11 +996,11 @@ bool FancyZones::OnSnapHotkeyBasedOnZoneNumber(HWND window, DWORD vkCode) noexce
     }
     else
     {
-        auto zoneWindow = m_workAreaHandler.GetWorkArea(m_currentDesktopId, current);
+        auto workArea = m_workAreaHandler.GetWorkArea(m_currentDesktopId, current);
         // Single monitor environment, or combined multi-monitor environment.
         if (m_settings->GetSettings()->restoreSize)
         {
-            bool moved = m_windowMoveHandler.MoveWindowIntoZoneByDirectionAndIndex(window, vkCode, false /* cycle through zones */, zoneWindow);
+            bool moved = m_windowMoveHandler.MoveWindowIntoZoneByDirectionAndIndex(window, vkCode, false /* cycle through zones */, workArea);
             if (!moved)
             {
                 FancyZonesUtils::RestoreWindowOrigin(window);
@@ -1009,16 +1008,16 @@ bool FancyZones::OnSnapHotkeyBasedOnZoneNumber(HWND window, DWORD vkCode) noexce
             }
             else
             {
-                Trace::FancyZones::KeyboardSnapWindowToZone(zoneWindow->ActiveZoneSet());
+                Trace::FancyZones::KeyboardSnapWindowToZone(workArea->ActiveZoneSet());
             }
             return moved;
         }
         else
         {
-            bool moved = m_windowMoveHandler.MoveWindowIntoZoneByDirectionAndIndex(window, vkCode, true /* cycle through zones */, zoneWindow);
+            bool moved = m_windowMoveHandler.MoveWindowIntoZoneByDirectionAndIndex(window, vkCode, true /* cycle through zones */, workArea);
             if (moved)
             {
-                Trace::FancyZones::KeyboardSnapWindowToZone(zoneWindow->ActiveZoneSet());
+                Trace::FancyZones::KeyboardSnapWindowToZone(workArea->ActiveZoneSet());
             }
             return moved;
         }
@@ -1092,9 +1091,9 @@ bool FancyZones::OnSnapHotkeyBasedOnPosition(HWND window, DWORD vkCode) noexcept
         if (chosenIdx < zoneRects.size())
         {
             // Moving to another monitor succeeded
-            const auto& [trueZoneIdx, zoneWindow] = zoneRectsInfo[chosenIdx];
-            m_windowMoveHandler.MoveWindowIntoZoneByIndexSet(window, { trueZoneIdx }, zoneWindow);
-            Trace::FancyZones::KeyboardSnapWindowToZone(zoneWindow->ActiveZoneSet());
+            const auto& [trueZoneIdx, workArea] = zoneRectsInfo[chosenIdx];
+            m_windowMoveHandler.MoveWindowIntoZoneByIndexSet(window, { trueZoneIdx }, workArea);
+            Trace::FancyZones::KeyboardSnapWindowToZone(workArea->ActiveZoneSet());
             return true;
         }
 
@@ -1137,9 +1136,9 @@ bool FancyZones::OnSnapHotkeyBasedOnPosition(HWND window, DWORD vkCode) noexcept
         if (chosenIdx < zoneRects.size())
         {
             // Moving to another monitor succeeded
-            const auto& [trueZoneIdx, zoneWindow] = zoneRectsInfo[chosenIdx];
-            m_windowMoveHandler.MoveWindowIntoZoneByIndexSet(window, { trueZoneIdx }, zoneWindow);
-            Trace::FancyZones::KeyboardSnapWindowToZone(zoneWindow->ActiveZoneSet());
+            const auto& [trueZoneIdx, workArea] = zoneRectsInfo[chosenIdx];
+            m_windowMoveHandler.MoveWindowIntoZoneByIndexSet(window, { trueZoneIdx }, workArea);
+            Trace::FancyZones::KeyboardSnapWindowToZone(workArea->ActiveZoneSet());
             return true;
         }
         else
@@ -1170,24 +1169,24 @@ bool FancyZones::OnSnapHotkey(DWORD vkCode) noexcept
     return false;
 }
 
-bool FancyZones::ProcessDirectedSnapHotkey(HWND window, DWORD vkCode, bool cycle, winrt::com_ptr<IWorkArea> zoneWindow) noexcept
+bool FancyZones::ProcessDirectedSnapHotkey(HWND window, DWORD vkCode, bool cycle, winrt::com_ptr<IWorkArea> workArea) noexcept
 {
     // Check whether Alt is used in the shortcut key combination
     if (GetAsyncKeyState(VK_MENU) & 0x8000)
     {
-        bool result = m_windowMoveHandler.ExtendWindowByDirectionAndPosition(window, vkCode, zoneWindow);
+        bool result = m_windowMoveHandler.ExtendWindowByDirectionAndPosition(window, vkCode, workArea);
         if (result) 
         {
-            Trace::FancyZones::KeyboardSnapWindowToZone(zoneWindow->ActiveZoneSet());
+            Trace::FancyZones::KeyboardSnapWindowToZone(workArea->ActiveZoneSet());
         }
         return result;
     }
     else
     {
-        bool result = m_windowMoveHandler.MoveWindowIntoZoneByDirectionAndPosition(window, vkCode, cycle, zoneWindow);
+        bool result = m_windowMoveHandler.MoveWindowIntoZoneByDirectionAndPosition(window, vkCode, cycle, workArea);
         if (result)
         {
-            Trace::FancyZones::KeyboardSnapWindowToZone(zoneWindow->ActiveZoneSet());
+            Trace::FancyZones::KeyboardSnapWindowToZone(workArea->ActiveZoneSet());
         }
         return result;
     }
@@ -1276,8 +1275,8 @@ bool FancyZones::ShouldProcessSnapHotkey(DWORD vkCode) noexcept
     {
         HMONITOR monitor = WorkAreaKeyFromWindow(window);
 
-        auto zoneWindow = m_workAreaHandler.GetWorkArea(m_currentDesktopId, monitor);
-        if (zoneWindow && zoneWindow->ActiveZoneSet() && zoneWindow->ActiveZoneSet()->LayoutType() != FancyZonesDataTypes::ZoneSetLayoutType::Blank)
+        auto workArea = m_workAreaHandler.GetWorkArea(m_currentDesktopId, monitor);
+        if (workArea && workArea->ActiveZoneSet() && workArea->ActiveZoneSet()->LayoutType() != FancyZonesDataTypes::ZoneSetLayoutType::Blank)
         {
             if (vkCode == VK_UP || vkCode == VK_DOWN)
             {

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesDataTypes.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesDataTypes.cpp
@@ -178,7 +178,7 @@ namespace FancyZonesDataTypes
         }
 
         /*
-        Refer to ZoneWindowUtils::GenerateUniqueId parts contain:
+        Refer to FancyZonesUtils::GenerateUniqueId parts contain:
         1. monitor id [string]
         2. width of device [int]
         3. height of device [int]
@@ -258,7 +258,7 @@ namespace FancyZonesDataTypes
         }
 
         /*
-        Refer to ZoneWindowUtils::GenerateUniqueId parts contain:
+        Refer to FancyZonesUtils::GenerateUniqueId parts contain:
         1. monitor id [string]
         2. width of device [int]
         3. height of device [int]

--- a/src/modules/fancyzones/FancyZonesLib/MonitorWorkAreaHandler.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/MonitorWorkAreaHandler.cpp
@@ -134,9 +134,9 @@ void MonitorWorkAreaHandler::UpdateZoneColors(const ZoneColors& colors)
 {
     for (const auto& workArea : workAreaMap)
     {
-        for (const auto& zoneWindow : workArea.second)
+        for (const auto& workAreaPtr : workArea.second)
         {
-            zoneWindow.second->SetZoneColors(colors);
+            workAreaPtr.second->SetZoneColors(colors);
         }
     }
 }
@@ -145,9 +145,9 @@ void MonitorWorkAreaHandler::UpdateOverlappingAlgorithm(OverlappingZonesAlgorith
 {
     for (const auto& workArea : workAreaMap)
     {
-        for (const auto& zoneWindow : workArea.second)
+        for (const auto& workAreaPtr : workArea.second)
         {
-            zoneWindow.second->SetOverlappingZonesAlgorithm(overlappingAlgorithm);
+            workAreaPtr.second->SetOverlappingZonesAlgorithm(overlappingAlgorithm);
         }
     }
 }

--- a/src/modules/fancyzones/FancyZonesLib/WindowMoveHandler.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WindowMoveHandler.cpp
@@ -59,7 +59,7 @@ WindowMoveHandler::WindowMoveHandler(const winrt::com_ptr<IFancyZonesSettings>& 
 {
 }
 
-void WindowMoveHandler::MoveSizeStart(HWND window, HMONITOR monitor, POINT const& ptScreen, const std::unordered_map<HMONITOR, winrt::com_ptr<IWorkArea>>& zoneWindowMap) noexcept
+void WindowMoveHandler::MoveSizeStart(HWND window, HMONITOR monitor, POINT const& ptScreen, const std::unordered_map<HMONITOR, winrt::com_ptr<IWorkArea>>& workAreaMap) noexcept
 {
     if (!FancyZonesUtils::IsCandidateForZoning(window, m_settings->GetSettings()->excludedAppsArray) || WindowMoveHandlerUtils::IsCursorTypeIndicatingSizeEvent())
     {
@@ -70,8 +70,8 @@ void WindowMoveHandler::MoveSizeStart(HWND window, HMONITOR monitor, POINT const
     m_moveSizeWindowInfo.isStandardWindow = FancyZonesUtils::IsStandardWindow(window);
     m_inMoveSize = true;
 
-    auto iter = zoneWindowMap.find(monitor);
-    if (iter == end(zoneWindowMap))
+    auto iter = workAreaMap.find(monitor);
+    if (iter == end(workAreaMap))
     {
         return;
     }
@@ -94,41 +94,41 @@ void WindowMoveHandler::MoveSizeStart(HWND window, HMONITOR monitor, POINT const
 
     if (m_dragEnabled)
     {
-        m_zoneWindowMoveSize = iter->second;
+        m_workAreaMoveSize = iter->second;
         SetWindowTransparency(m_windowMoveSize);
-        m_zoneWindowMoveSize->MoveSizeEnter(m_windowMoveSize);
+        m_workAreaMoveSize->MoveSizeEnter(m_windowMoveSize);
         if (m_settings->GetSettings()->showZonesOnAllMonitors)
         {
-            for (auto [keyMonitor, zoneWindow] : zoneWindowMap)
+            for (auto [keyMonitor, workArea] : workAreaMap)
             {
-                // Skip calling ShowZoneWindow for iter->second (m_zoneWindowMoveSize) since it
+                // Skip calling ShowZoneWindow for iter->second (m_workAreaMoveSize) since it
                 // was already called in MoveSizeEnter
-                const bool moveSizeEnterCalled = zoneWindow == m_zoneWindowMoveSize;
-                if (zoneWindow && !moveSizeEnterCalled)
+                const bool moveSizeEnterCalled = workArea == m_workAreaMoveSize;
+                if (workArea && !moveSizeEnterCalled)
                 {
-                    zoneWindow->ShowZoneWindow();
+                    workArea->ShowZoneWindow();
                 }
             }
         }
     }
-    else if (m_zoneWindowMoveSize)
+    else if (m_workAreaMoveSize)
     {
         ResetWindowTransparency();
-        m_zoneWindowMoveSize = nullptr;
-        for (auto [keyMonitor, zoneWindow] : zoneWindowMap)
+        m_workAreaMoveSize = nullptr;
+        for (auto [keyMonitor, workArea] : workAreaMap)
         {
-            if (zoneWindow)
+            if (workArea)
             {
-                zoneWindow->HideZoneWindow();
+                workArea->HideZoneWindow();
             }
         }
     }
 
-    auto zoneWindow = zoneWindowMap.find(monitor);
-    if (zoneWindow != zoneWindowMap.end())
+    auto workArea = workAreaMap.find(monitor);
+    if (workArea != workAreaMap.end())
     {
-        const auto zoneWindowPtr = zoneWindow->second;
-        const auto activeZoneSet = zoneWindowPtr->ActiveZoneSet();
+        const auto workAreaPtr = workArea->second;
+        const auto activeZoneSet = workAreaPtr->ActiveZoneSet();
         if (activeZoneSet)
         {
             activeZoneSet->DismissWindow(window);
@@ -136,7 +136,7 @@ void WindowMoveHandler::MoveSizeStart(HWND window, HMONITOR monitor, POINT const
     }
 }
 
-void WindowMoveHandler::MoveSizeUpdate(HMONITOR monitor, POINT const& ptScreen, const std::unordered_map<HMONITOR, winrt::com_ptr<IWorkArea>>& zoneWindowMap) noexcept
+void WindowMoveHandler::MoveSizeUpdate(HMONITOR monitor, POINT const& ptScreen, const std::unordered_map<HMONITOR, winrt::com_ptr<IWorkArea>>& workAreaMap) noexcept
 {
     if (!m_inMoveSize)
     {
@@ -146,44 +146,44 @@ void WindowMoveHandler::MoveSizeUpdate(HMONITOR monitor, POINT const& ptScreen, 
     // This updates m_dragEnabled depending on if the shift key is being held down.
     UpdateDragState();
 
-    if (m_zoneWindowMoveSize)
+    if (m_workAreaMoveSize)
     {
         // Update the WorkArea already handling move/size
         if (!m_dragEnabled)
         {
             // Drag got disabled, tell it to cancel and hide all windows
-            m_zoneWindowMoveSize = nullptr;
+            m_workAreaMoveSize = nullptr;
             ResetWindowTransparency();
 
-            for (auto [keyMonitor, zoneWindow] : zoneWindowMap)
+            for (auto [keyMonitor, workArea] : workAreaMap)
             {
-                if (zoneWindow)
+                if (workArea)
                 {
-                    zoneWindow->HideZoneWindow();
+                    workArea->HideZoneWindow();
                 }
             }
         }
         else
         {
-            auto iter = zoneWindowMap.find(monitor);
-            if (iter != zoneWindowMap.end())
+            auto iter = workAreaMap.find(monitor);
+            if (iter != workAreaMap.end())
             {
-                if (iter->second != m_zoneWindowMoveSize)
+                if (iter->second != m_workAreaMoveSize)
                 {
                     // The drag has moved to a different monitor.
-                    m_zoneWindowMoveSize->ClearSelectedZones();
+                    m_workAreaMoveSize->ClearSelectedZones();
                     if (!m_settings->GetSettings()->showZonesOnAllMonitors)
                     {
-                        m_zoneWindowMoveSize->HideZoneWindow();
+                        m_workAreaMoveSize->HideZoneWindow();
                     }
 
-                    m_zoneWindowMoveSize = iter->second;
-                    m_zoneWindowMoveSize->MoveSizeEnter(m_windowMoveSize);
+                    m_workAreaMoveSize = iter->second;
+                    m_workAreaMoveSize->MoveSizeEnter(m_windowMoveSize);
                 }
 
-                for (auto [keyMonitor, zoneWindow] : zoneWindowMap)
+                for (auto [keyMonitor, workArea] : workAreaMap)
                 {
-                    zoneWindow->MoveSizeUpdate(ptScreen, m_dragEnabled, m_ctrlKeyState.state());
+                    workArea->MoveSizeUpdate(ptScreen, m_dragEnabled, m_ctrlKeyState.state());
                 }
             }
         }
@@ -192,18 +192,18 @@ void WindowMoveHandler::MoveSizeUpdate(HMONITOR monitor, POINT const& ptScreen, 
     {
         // We'll get here if the user presses/releases shift while dragging.
         // Restart the drag on the WorkArea that m_windowMoveSize is on
-        MoveSizeStart(m_windowMoveSize, monitor, ptScreen, zoneWindowMap);
+        MoveSizeStart(m_windowMoveSize, monitor, ptScreen, workAreaMap);
 
         // m_dragEnabled could get set to false if we're moving an elevated window.
         // In that case do not proceed.
         if (m_dragEnabled)
         {
-            MoveSizeUpdate(monitor, ptScreen, zoneWindowMap);
+            MoveSizeUpdate(monitor, ptScreen, workAreaMap);
         }
     }
 }
 
-void WindowMoveHandler::MoveSizeEnd(HWND window, POINT const& ptScreen, const std::unordered_map<HMONITOR, winrt::com_ptr<IWorkArea>>& zoneWindowMap) noexcept
+void WindowMoveHandler::MoveSizeEnd(HWND window, POINT const& ptScreen, const std::unordered_map<HMONITOR, winrt::com_ptr<IWorkArea>>& workAreaMap) noexcept
 {
     if (window != m_windowMoveSize)
     {
@@ -214,9 +214,9 @@ void WindowMoveHandler::MoveSizeEnd(HWND window, POINT const& ptScreen, const st
     m_shiftKeyState.disable();
     m_ctrlKeyState.disable();
 
-    if (m_zoneWindowMoveSize)
+    if (m_workAreaMoveSize)
     {
-        auto zoneWindow = std::move(m_zoneWindowMoveSize);
+        auto workArea = std::move(m_workAreaMoveSize);
         ResetWindowTransparency();
 
         bool hasNoVisibleOwner = FancyZonesUtils::HasNoVisibleOwner(window);
@@ -231,7 +231,7 @@ void WindowMoveHandler::MoveSizeEnd(HWND window, POINT const& ptScreen, const st
         }
         else
         {
-            zoneWindow->MoveSizeEnd(m_windowMoveSize, ptScreen);
+            workArea->MoveSizeEnd(m_windowMoveSize, ptScreen);
         }
     }
     else
@@ -251,17 +251,17 @@ void WindowMoveHandler::MoveSizeEnd(HWND window, POINT const& ptScreen, const st
         auto monitor = MonitorFromWindow(window, MONITOR_DEFAULTTONULL);
         if (monitor)
         {
-            auto zoneWindow = zoneWindowMap.find(monitor);
-            if (zoneWindow != zoneWindowMap.end())
+            auto workArea = workAreaMap.find(monitor);
+            if (workArea != workAreaMap.end())
             {
-                const auto zoneWindowPtr = zoneWindow->second;
-                const auto activeZoneSet = zoneWindowPtr->ActiveZoneSet();
+                const auto workAreaPtr = workArea->second;
+                const auto activeZoneSet = workAreaPtr->ActiveZoneSet();
                 if (activeZoneSet)
                 {
                     wil::unique_cotaskmem_string guidString;
                     if (SUCCEEDED_LOG(StringFromCLSID(activeZoneSet->Id(), &guidString)))
                     {
-                        FancyZonesDataInstance().RemoveAppLastZone(window, zoneWindowPtr->UniqueId(), guidString.get());
+                        FancyZonesDataInstance().RemoveAppLastZone(window, workAreaPtr->UniqueId(), guidString.get());
                     }
                 }
             }
@@ -275,36 +275,36 @@ void WindowMoveHandler::MoveSizeEnd(HWND window, POINT const& ptScreen, const st
     m_windowMoveSize = nullptr;
 
     // Also, hide all windows (regardless of settings)
-    for (auto [keyMonitor, zoneWindow] : zoneWindowMap)
+    for (auto [keyMonitor, workArea] : workAreaMap)
     {
-        if (zoneWindow)
+        if (workArea)
         {
-            zoneWindow->HideZoneWindow();
+            workArea->HideZoneWindow();
         }
     }
 }
 
-void WindowMoveHandler::MoveWindowIntoZoneByIndexSet(HWND window, const ZoneIndexSet& indexSet, winrt::com_ptr<IWorkArea> zoneWindow, bool suppressMove) noexcept
+void WindowMoveHandler::MoveWindowIntoZoneByIndexSet(HWND window, const ZoneIndexSet& indexSet, winrt::com_ptr<IWorkArea> workArea, bool suppressMove) noexcept
 {
     if (window != m_windowMoveSize)
     {
-        zoneWindow->MoveWindowIntoZoneByIndexSet(window, indexSet, suppressMove);
+        workArea->MoveWindowIntoZoneByIndexSet(window, indexSet, suppressMove);
     }
 }
 
-bool WindowMoveHandler::MoveWindowIntoZoneByDirectionAndIndex(HWND window, DWORD vkCode, bool cycle, winrt::com_ptr<IWorkArea> zoneWindow) noexcept
+bool WindowMoveHandler::MoveWindowIntoZoneByDirectionAndIndex(HWND window, DWORD vkCode, bool cycle, winrt::com_ptr<IWorkArea> workArea) noexcept
 {
-    return zoneWindow && zoneWindow->MoveWindowIntoZoneByDirectionAndIndex(window, vkCode, cycle);
+    return workArea && workArea->MoveWindowIntoZoneByDirectionAndIndex(window, vkCode, cycle);
 }
 
-bool WindowMoveHandler::MoveWindowIntoZoneByDirectionAndPosition(HWND window, DWORD vkCode, bool cycle, winrt::com_ptr<IWorkArea> zoneWindow) noexcept
+bool WindowMoveHandler::MoveWindowIntoZoneByDirectionAndPosition(HWND window, DWORD vkCode, bool cycle, winrt::com_ptr<IWorkArea> workArea) noexcept
 {
-    return zoneWindow && zoneWindow->MoveWindowIntoZoneByDirectionAndPosition(window, vkCode, cycle);
+    return workArea && workArea->MoveWindowIntoZoneByDirectionAndPosition(window, vkCode, cycle);
 }
 
-bool WindowMoveHandler::ExtendWindowByDirectionAndPosition(HWND window, DWORD vkCode, winrt::com_ptr<IWorkArea> zoneWindow) noexcept
+bool WindowMoveHandler::ExtendWindowByDirectionAndPosition(HWND window, DWORD vkCode, winrt::com_ptr<IWorkArea> workArea) noexcept
 {
-    return zoneWindow && zoneWindow->ExtendWindowByDirectionAndPosition(window, vkCode);
+    return workArea && workArea->ExtendWindowByDirectionAndPosition(window, vkCode);
 }
 
 void WindowMoveHandler::WarnIfElevationIsRequired(HWND window) noexcept

--- a/src/modules/fancyzones/FancyZonesLib/WindowMoveHandler.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WindowMoveHandler.cpp
@@ -128,10 +128,10 @@ void WindowMoveHandler::MoveSizeStart(HWND window, HMONITOR monitor, POINT const
     if (workArea != workAreaMap.end())
     {
         const auto workAreaPtr = workArea->second;
-        const auto activeZoneSet = workAreaPtr->ActiveZoneSet();
-        if (activeZoneSet)
+        const auto zoneSet = workAreaPtr->ZoneSet();
+        if (zoneSet)
         {
-            activeZoneSet->DismissWindow(window);
+            zoneSet->DismissWindow(window);
         }
     }
 }
@@ -255,11 +255,11 @@ void WindowMoveHandler::MoveSizeEnd(HWND window, POINT const& ptScreen, const st
             if (workArea != workAreaMap.end())
             {
                 const auto workAreaPtr = workArea->second;
-                const auto activeZoneSet = workAreaPtr->ActiveZoneSet();
-                if (activeZoneSet)
+                const auto zoneSet = workAreaPtr->ZoneSet();
+                if (zoneSet)
                 {
                     wil::unique_cotaskmem_string guidString;
-                    if (SUCCEEDED_LOG(StringFromCLSID(activeZoneSet->Id(), &guidString)))
+                    if (SUCCEEDED_LOG(StringFromCLSID(zoneSet->Id(), &guidString)))
                     {
                         FancyZonesDataInstance().RemoveAppLastZone(window, workAreaPtr->UniqueId(), guidString.get());
                     }

--- a/src/modules/fancyzones/FancyZonesLib/WindowMoveHandler.h
+++ b/src/modules/fancyzones/FancyZonesLib/WindowMoveHandler.h
@@ -14,14 +14,14 @@ class WindowMoveHandler
 public:
     WindowMoveHandler(const winrt::com_ptr<IFancyZonesSettings>& settings, const std::function<void()>& keyUpdateCallback);
 
-    void MoveSizeStart(HWND window, HMONITOR monitor, POINT const& ptScreen, const std::unordered_map<HMONITOR, winrt::com_ptr<IWorkArea>>& zoneWindowMap) noexcept;
-    void MoveSizeUpdate(HMONITOR monitor, POINT const& ptScreen, const std::unordered_map<HMONITOR, winrt::com_ptr<IWorkArea>>& zoneWindowMap) noexcept;
-    void MoveSizeEnd(HWND window, POINT const& ptScreen, const std::unordered_map<HMONITOR, winrt::com_ptr<IWorkArea>>& zoneWindowMap) noexcept;
+    void MoveSizeStart(HWND window, HMONITOR monitor, POINT const& ptScreen, const std::unordered_map<HMONITOR, winrt::com_ptr<IWorkArea>>& workAreaMap) noexcept;
+    void MoveSizeUpdate(HMONITOR monitor, POINT const& ptScreen, const std::unordered_map<HMONITOR, winrt::com_ptr<IWorkArea>>& workAreaMap) noexcept;
+    void MoveSizeEnd(HWND window, POINT const& ptScreen, const std::unordered_map<HMONITOR, winrt::com_ptr<IWorkArea>>& workAreaMap) noexcept;
 
-    void MoveWindowIntoZoneByIndexSet(HWND window, const ZoneIndexSet& indexSet, winrt::com_ptr<IWorkArea> zoneWindow, bool suppressMove = false) noexcept;
-    bool MoveWindowIntoZoneByDirectionAndIndex(HWND window, DWORD vkCode, bool cycle, winrt::com_ptr<IWorkArea> zoneWindow) noexcept;
-    bool MoveWindowIntoZoneByDirectionAndPosition(HWND window, DWORD vkCode, bool cycle, winrt::com_ptr<IWorkArea> zoneWindow) noexcept;
-    bool ExtendWindowByDirectionAndPosition(HWND window, DWORD vkCode, winrt::com_ptr<IWorkArea> zoneWindow) noexcept;
+    void MoveWindowIntoZoneByIndexSet(HWND window, const ZoneIndexSet& indexSet, winrt::com_ptr<IWorkArea> workArea, bool suppressMove = false) noexcept;
+    bool MoveWindowIntoZoneByDirectionAndIndex(HWND window, DWORD vkCode, bool cycle, winrt::com_ptr<IWorkArea> workArea) noexcept;
+    bool MoveWindowIntoZoneByDirectionAndPosition(HWND window, DWORD vkCode, bool cycle, winrt::com_ptr<IWorkArea> workArea) noexcept;
+    bool ExtendWindowByDirectionAndPosition(HWND window, DWORD vkCode, winrt::com_ptr<IWorkArea> workArea) noexcept;
 
     inline void OnMouseDown() noexcept
     {
@@ -69,7 +69,7 @@ private:
     HWND m_windowMoveSize{}; // The window that is being moved/sized
     bool m_inMoveSize{}; // Whether or not a move/size operation is currently active
     MoveSizeWindowInfo m_moveSizeWindowInfo; // MoveSizeWindowInfo of the window at the moment when dragging started
-    winrt::com_ptr<IWorkArea> m_zoneWindowMoveSize; // "Active" WorkArea, where the move/size is happening. Will update as drag moves between monitors.
+    winrt::com_ptr<IWorkArea> m_workAreaMoveSize; // "Active" WorkArea, where the move/size is happening. Will update as drag moves between monitors.
     bool m_dragEnabled{}; // True if we should be showing zone hints while dragging
 
     WindowTransparencyProperties m_windowTransparencyProperties;

--- a/src/modules/fancyzones/FancyZonesLib/WindowMoveHandler.h
+++ b/src/modules/fancyzones/FancyZonesLib/WindowMoveHandler.h
@@ -34,9 +34,9 @@ public:
         return m_dragEnabled;
     }
 
-    inline bool InMoveSize() const noexcept
+    inline bool InDragging() const noexcept
     {
-        return m_inMoveSize;
+        return m_inDragging;
     }
 
 private:
@@ -66,10 +66,10 @@ private:
 
     winrt::com_ptr<IFancyZonesSettings> m_settings{};
 
-    HWND m_windowMoveSize{}; // The window that is being moved/sized
-    bool m_inMoveSize{}; // Whether or not a move/size operation is currently active
-    MoveSizeWindowInfo m_moveSizeWindowInfo; // MoveSizeWindowInfo of the window at the moment when dragging started
-    winrt::com_ptr<IWorkArea> m_workAreaMoveSize; // "Active" WorkArea, where the move/size is happening. Will update as drag moves between monitors.
+    bool m_inDragging{}; // Whether or not a move/size operation is currently active
+    HWND m_draggedWindow{}; // The window that is being moved/sized
+    MoveSizeWindowInfo m_draggedWindowInfo; // MoveSizeWindowInfo of the window at the moment when dragging started
+    winrt::com_ptr<IWorkArea> m_draggedWindowWorkArea; // "Active" WorkArea, where the move/size is happening. Will update as drag moves between monitors.
     bool m_dragEnabled{}; // True if we should be showing zone hints while dragging
 
     WindowTransparencyProperties m_windowTransparencyProperties;

--- a/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
@@ -129,7 +129,7 @@ public:
     IFACEMETHODIMP_(void)
     SaveWindowProcessToZoneIndex(HWND window) noexcept;
     IFACEMETHODIMP_(IZoneSet*)
-    ActiveZoneSet() const noexcept { return m_activeZoneSet.get(); }
+    ZoneSet() const noexcept { return m_zoneSet.get(); }
     IFACEMETHODIMP_(ZoneIndexSet)
     GetWindowZoneIndexes(HWND window) const noexcept;
     IFACEMETHODIMP_(void)
@@ -164,7 +164,7 @@ private:
     FancyZonesDataTypes::DeviceIdData m_uniqueId;
     HWND m_window{}; // Hidden tool window used to represent current monitor desktop work area.
     HWND m_windowMoveSize{};
-    winrt::com_ptr<IZoneSet> m_activeZoneSet;
+    winrt::com_ptr<IZoneSet> m_zoneSet;
     ZoneIndexSet m_initialHighlightZone;
     ZoneIndexSet m_highlightZone;
     WPARAM m_keyLast{};
@@ -233,7 +233,7 @@ IFACEMETHODIMP WorkArea::MoveSizeEnter(HWND window) noexcept
     m_highlightZone = {};
     m_initialHighlightZone = {};
     ShowZoneWindow();
-    Trace::WorkArea::MoveOrResizeStarted(m_activeZoneSet);
+    Trace::WorkArea::MoveOrResizeStarted(m_zoneSet);
     return S_OK;
 }
 
@@ -256,7 +256,7 @@ IFACEMETHODIMP WorkArea::MoveSizeUpdate(POINT const& ptScreen, bool dragEnabled,
             }
             else
             {
-                highlightZone = m_activeZoneSet->GetCombinedZoneRange(m_initialHighlightZone, highlightZone);
+                highlightZone = m_zoneSet->GetCombinedZoneRange(m_initialHighlightZone, highlightZone);
             }
         }
         else
@@ -275,7 +275,7 @@ IFACEMETHODIMP WorkArea::MoveSizeUpdate(POINT const& ptScreen, bool dragEnabled,
 
     if (redraw)
     {
-        m_zoneWindowDrawing->DrawActiveZoneSet(m_activeZoneSet->GetZones(), m_highlightZone, m_zoneColors);
+        m_zoneWindowDrawing->DrawActiveZoneSet(m_zoneSet->GetZones(), m_highlightZone, m_zoneColors);
     }
 
     return S_OK;
@@ -288,18 +288,18 @@ IFACEMETHODIMP WorkArea::MoveSizeEnd(HWND window, POINT const& ptScreen) noexcep
         return E_INVALIDARG;
     }
 
-    if (m_activeZoneSet)
+    if (m_zoneSet)
     {
         POINT ptClient = ptScreen;
         MapWindowPoints(nullptr, m_window, &ptClient, 1);
-        m_activeZoneSet->MoveWindowIntoZoneByIndexSet(window, m_window, m_highlightZone);
+        m_zoneSet->MoveWindowIntoZoneByIndexSet(window, m_window, m_highlightZone);
 
         if (FancyZonesUtils::HasNoVisibleOwner(window))
         {
             SaveWindowProcessToZoneIndex(window);
         }
     }
-    Trace::WorkArea::MoveOrResizeEnd(m_activeZoneSet);
+    Trace::WorkArea::MoveOrResizeEnd(m_zoneSet);
 
     HideZoneWindow();
     m_windowMoveSize = nullptr;
@@ -315,18 +315,18 @@ WorkArea::MoveWindowIntoZoneByIndex(HWND window, ZoneIndex index) noexcept
 IFACEMETHODIMP_(void)
 WorkArea::MoveWindowIntoZoneByIndexSet(HWND window, const ZoneIndexSet& indexSet, bool suppressMove) noexcept
 {
-    if (m_activeZoneSet)
+    if (m_zoneSet)
     {
-        m_activeZoneSet->MoveWindowIntoZoneByIndexSet(window, m_window, indexSet, suppressMove);
+        m_zoneSet->MoveWindowIntoZoneByIndexSet(window, m_window, indexSet, suppressMove);
     }
 }
 
 IFACEMETHODIMP_(bool)
 WorkArea::MoveWindowIntoZoneByDirectionAndIndex(HWND window, DWORD vkCode, bool cycle) noexcept
 {
-    if (m_activeZoneSet)
+    if (m_zoneSet)
     {
-        if (m_activeZoneSet->MoveWindowIntoZoneByDirectionAndIndex(window, m_window, vkCode, cycle))
+        if (m_zoneSet->MoveWindowIntoZoneByDirectionAndIndex(window, m_window, vkCode, cycle))
         {
             if (FancyZonesUtils::HasNoVisibleOwner(window))
             {
@@ -341,9 +341,9 @@ WorkArea::MoveWindowIntoZoneByDirectionAndIndex(HWND window, DWORD vkCode, bool 
 IFACEMETHODIMP_(bool)
 WorkArea::MoveWindowIntoZoneByDirectionAndPosition(HWND window, DWORD vkCode, bool cycle) noexcept
 {
-    if (m_activeZoneSet)
+    if (m_zoneSet)
     {
-        if (m_activeZoneSet->MoveWindowIntoZoneByDirectionAndPosition(window, m_window, vkCode, cycle))
+        if (m_zoneSet->MoveWindowIntoZoneByDirectionAndPosition(window, m_window, vkCode, cycle))
         {
             SaveWindowProcessToZoneIndex(window);
             return true;
@@ -355,9 +355,9 @@ WorkArea::MoveWindowIntoZoneByDirectionAndPosition(HWND window, DWORD vkCode, bo
 IFACEMETHODIMP_(bool)
 WorkArea::ExtendWindowByDirectionAndPosition(HWND window, DWORD vkCode) noexcept
 {
-    if (m_activeZoneSet)
+    if (m_zoneSet)
     {
-        if (m_activeZoneSet->ExtendWindowByDirectionAndPosition(window, m_window, vkCode))
+        if (m_zoneSet->ExtendWindowByDirectionAndPosition(window, m_window, vkCode))
         {
             SaveWindowProcessToZoneIndex(window);
             return true;
@@ -369,13 +369,13 @@ WorkArea::ExtendWindowByDirectionAndPosition(HWND window, DWORD vkCode) noexcept
 IFACEMETHODIMP_(void)
 WorkArea::SaveWindowProcessToZoneIndex(HWND window) noexcept
 {
-    if (m_activeZoneSet)
+    if (m_zoneSet)
     {
-        auto zoneIndexSet = m_activeZoneSet->GetZoneIndexSetFromWindow(window);
+        auto zoneIndexSet = m_zoneSet->GetZoneIndexSetFromWindow(window);
         if (zoneIndexSet.size())
         {
             OLECHAR* guidString;
-            if (StringFromCLSID(m_activeZoneSet->Id(), &guidString) == S_OK)
+            if (StringFromCLSID(m_zoneSet->Id(), &guidString) == S_OK)
             {
                 FancyZonesDataInstance().SetAppLastZones(window, m_uniqueId, guidString, zoneIndexSet);
             }
@@ -388,10 +388,10 @@ WorkArea::SaveWindowProcessToZoneIndex(HWND window) noexcept
 IFACEMETHODIMP_(ZoneIndexSet)
 WorkArea::GetWindowZoneIndexes(HWND window) const noexcept
 {
-    if (m_activeZoneSet)
+    if (m_zoneSet)
     {
         wil::unique_cotaskmem_string zoneSetId;
-        if (SUCCEEDED(StringFromCLSID(m_activeZoneSet->Id(), &zoneSetId)))
+        if (SUCCEEDED(StringFromCLSID(m_zoneSet->Id(), &zoneSetId)))
         {
             return FancyZonesDataInstance().GetAppLastZoneIndexSet(window, m_uniqueId, zoneSetId.get());
         }
@@ -405,7 +405,7 @@ WorkArea::ShowZoneWindow() noexcept
     if (m_window)
     {
         SetAsTopmostWindow();
-        m_zoneWindowDrawing->DrawActiveZoneSet(m_activeZoneSet->GetZones(), m_highlightZone, m_zoneColors);
+        m_zoneWindowDrawing->DrawActiveZoneSet(m_zoneSet->GetZones(), m_highlightZone, m_zoneColors);
         m_zoneWindowDrawing->Show();
     }
 }
@@ -429,16 +429,16 @@ WorkArea::UpdateActiveZoneSet() noexcept
     if (m_window)
     {
         m_highlightZone.clear();
-        m_zoneWindowDrawing->DrawActiveZoneSet(m_activeZoneSet->GetZones(), m_highlightZone, m_zoneColors);
+        m_zoneWindowDrawing->DrawActiveZoneSet(m_zoneSet->GetZones(), m_highlightZone, m_zoneColors);
     }
 }
 
 IFACEMETHODIMP_(void)
 WorkArea::CycleTabs(HWND window, bool reverse) noexcept
 {
-    if (m_activeZoneSet)
+    if (m_zoneSet)
     {
-        m_activeZoneSet->CycleTabs(window, reverse);
+        m_zoneSet->CycleTabs(window, reverse);
     }
 }
 
@@ -448,7 +448,7 @@ WorkArea::ClearSelectedZones() noexcept
     if (m_highlightZone.size())
     {
         m_highlightZone.clear();
-        m_zoneWindowDrawing->DrawActiveZoneSet(m_activeZoneSet->GetZones(), m_highlightZone, m_zoneColors);
+        m_zoneWindowDrawing->DrawActiveZoneSet(m_zoneSet->GetZones(), m_highlightZone, m_zoneColors);
     }
 }
 
@@ -458,7 +458,7 @@ WorkArea::FlashZones() noexcept
     if (m_window)
     {
         SetAsTopmostWindow();
-        m_zoneWindowDrawing->DrawActiveZoneSet(m_activeZoneSet->GetZones(), {}, m_zoneColors);
+        m_zoneWindowDrawing->DrawActiveZoneSet(m_zoneSet->GetZones(), {}, m_zoneColors);
         m_zoneWindowDrawing->Flash();
     }
 }
@@ -554,16 +554,16 @@ void WorkArea::CalculateZoneSet(OverlappingZonesAlgorithm overlappingAlgorithm) 
 
 void WorkArea::UpdateActiveZoneSet(_In_opt_ IZoneSet* zoneSet) noexcept
 {
-    m_activeZoneSet.copy_from(zoneSet);
+    m_zoneSet.copy_from(zoneSet);
 
-    if (m_activeZoneSet)
+    if (m_zoneSet)
     {
         wil::unique_cotaskmem_string zoneSetId;
-        if (SUCCEEDED_LOG(StringFromCLSID(m_activeZoneSet->Id(), &zoneSetId)))
+        if (SUCCEEDED_LOG(StringFromCLSID(m_zoneSet->Id(), &zoneSetId)))
         {
             FancyZonesDataTypes::ZoneSetData data{
                 .uuid = zoneSetId.get(),
-                .type = m_activeZoneSet->LayoutType()
+                .type = m_zoneSet->LayoutType()
             };
             FancyZonesDataInstance().SetActiveZoneSet(m_uniqueId, data);
         }
@@ -594,9 +594,9 @@ LRESULT WorkArea::WndProc(UINT message, WPARAM wparam, LPARAM lparam) noexcept
 
 ZoneIndexSet WorkArea::ZonesFromPoint(POINT pt) noexcept
 {
-    if (m_activeZoneSet)
+    if (m_zoneSet)
     {
-        return m_activeZoneSet->ZonesFromPoint(pt);
+        return m_zoneSet->ZonesFromPoint(pt);
     }
     return {};
 }

--- a/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
@@ -165,7 +165,6 @@ private:
     HWND m_window{}; // Hidden tool window used to represent current monitor desktop work area.
     HWND m_windowMoveSize{};
     winrt::com_ptr<IZoneSet> m_activeZoneSet;
-    std::vector<winrt::com_ptr<IZoneSet>> m_zoneSets;
     ZoneIndexSet m_initialHighlightZone;
     ZoneIndexSet m_highlightZone;
     WPARAM m_keyLast{};

--- a/src/modules/fancyzones/FancyZonesLib/WorkArea.h
+++ b/src/modules/fancyzones/FancyZonesLib/WorkArea.h
@@ -103,7 +103,7 @@ interface __declspec(uuid("{7F017528-8110-4FB3-BE41-F472969C2560}")) IWorkArea :
     /**
      * @returns Active zone layout for this work area.
      */
-    IFACEMETHOD_(IZoneSet*, ActiveZoneSet)() const = 0;
+    IFACEMETHOD_(IZoneSet*, ZoneSet)() const = 0;
     /*
     * @returns Zone index of the window
     */

--- a/src/modules/fancyzones/FancyZonesLib/Zone.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/Zone.cpp
@@ -35,44 +35,11 @@ public:
     IFACEMETHODIMP_(RECT) GetZoneRect() const noexcept { return m_zoneRect; }
     IFACEMETHODIMP_(long) GetZoneArea() const noexcept { return max(m_zoneRect.bottom - m_zoneRect.top, 0) * max(m_zoneRect.right - m_zoneRect.left, 0); }
     IFACEMETHODIMP_(ZoneIndex) Id() const noexcept { return m_id; }
-    IFACEMETHODIMP_(RECT) ComputeActualZoneRect(HWND window, HWND zoneWindow) const noexcept;
 
 private:
     RECT m_zoneRect{};
     const ZoneIndex m_id{};
 };
-
-RECT Zone::ComputeActualZoneRect(HWND window, HWND zoneWindow) const noexcept
-{
-    // Take care of 1px border
-    RECT newWindowRect = m_zoneRect;
-
-    RECT windowRect{};
-    ::GetWindowRect(window, &windowRect);
-
-    RECT frameRect{};
-
-    if (SUCCEEDED(DwmGetWindowAttribute(window, DWMWA_EXTENDED_FRAME_BOUNDS, &frameRect, sizeof(frameRect))))
-    {
-        LONG leftMargin = frameRect.left - windowRect.left;
-        LONG rightMargin = frameRect.right - windowRect.right;
-        LONG bottomMargin = frameRect.bottom - windowRect.bottom;
-        newWindowRect.left -= leftMargin;
-        newWindowRect.right -= rightMargin;
-        newWindowRect.bottom -= bottomMargin;
-    }
-
-    // Map to screen coords
-    MapWindowRect(zoneWindow, nullptr, &newWindowRect);
-
-    if ((::GetWindowLong(window, GWL_STYLE) & WS_SIZEBOX) == 0)
-    {
-        newWindowRect.right = newWindowRect.left + (windowRect.right - windowRect.left);
-        newWindowRect.bottom = newWindowRect.top + (windowRect.bottom - windowRect.top);
-    }
-
-    return newWindowRect;
-}
 
 winrt::com_ptr<IZone> MakeZone(const RECT& zoneRect, const ZoneIndex zoneId) noexcept
 {

--- a/src/modules/fancyzones/FancyZonesLib/Zone.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/Zone.cpp
@@ -40,7 +40,6 @@ public:
 private:
     RECT m_zoneRect{};
     const ZoneIndex m_id{};
-    std::map<HWND, RECT> m_windows{};
 };
 
 RECT Zone::ComputeActualZoneRect(HWND window, HWND zoneWindow) const noexcept

--- a/src/modules/fancyzones/FancyZonesLib/Zone.h
+++ b/src/modules/fancyzones/FancyZonesLib/Zone.h
@@ -26,16 +26,6 @@ interface __declspec(uuid("{8228E934-B6EF-402A-9892-15A1441BF8B0}")) IZone : pub
      * @returns Zone identifier.
      */
     IFACEMETHOD_(ZoneIndex, Id)() const = 0;
-    /**
-     * Compute the coordinates of the rectangle to which a window should be resized.
-     *
-     * @param   window     Handle of window which should be assigned to zone.
-     * @param   zoneWindow The m_window of a WorkArea, it's a hidden window representing the
-     *                     current monitor desktop work area.
-     * @returns a RECT structure, describing global coordinates to which a window should be resized
-     */
-    IFACEMETHOD_(RECT, ComputeActualZoneRect)(HWND window, HWND zoneWindow) const = 0;
-
 };
 
 winrt::com_ptr<IZone> MakeZone(const RECT& zoneRect, const ZoneIndex zoneId) noexcept;

--- a/src/modules/fancyzones/FancyZonesLib/ZoneSet.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/ZoneSet.cpp
@@ -323,7 +323,7 @@ ZoneSet::MoveWindowIntoZoneByIndexSet(HWND window, HWND workAreaWindow, const Zo
         if (m_zones.contains(id))
         {
             const auto& zone = m_zones.at(id);
-            const RECT newSize = zone->ComputeActualZoneRect(window, workAreaWindow);
+            const RECT newSize = zone->GetZoneRect();
             if (!sizeEmpty)
             {
                 size.left = min(size.left, newSize.left);
@@ -351,7 +351,9 @@ ZoneSet::MoveWindowIntoZoneByIndexSet(HWND window, HWND workAreaWindow, const Zo
         if (!suppressMove)
         {
             SaveWindowSizeAndOrigin(window);
-            SizeWindowToRect(window, size);
+
+            auto rect = AdjustRectForSizeWindowToRect(window, size, workAreaWindow);
+            SizeWindowToRect(window, rect);
         }
 
         StampWindow(window, bitmask);

--- a/src/modules/fancyzones/FancyZonesLib/ZoneSet.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/ZoneSet.cpp
@@ -434,14 +434,14 @@ ZoneSet::MoveWindowIntoZoneByDirectionAndPosition(HWND window, HWND workAreaWind
         }
     }
 
-    RECT windowRect, windowZoneRect;
-    if (GetWindowRect(window, &windowRect) && GetWindowRect(workAreaWindow, &windowZoneRect))
+    RECT windowRect, workAreaRect;
+    if (GetWindowRect(window, &windowRect) && GetWindowRect(workAreaWindow, &workAreaRect))
     {
         // Move to coordinates relative to windowZone
-        windowRect.top -= windowZoneRect.top;
-        windowRect.bottom -= windowZoneRect.top;
-        windowRect.left -= windowZoneRect.left;
-        windowRect.right -= windowZoneRect.left;
+        windowRect.top -= workAreaRect.top;
+        windowRect.bottom -= workAreaRect.top;
+        windowRect.left -= workAreaRect.left;
+        windowRect.right -= workAreaRect.left;
 
         auto result = FancyZonesUtils::ChooseNextZoneByPosition(vkCode, windowRect, zoneRects);
         if (result < zoneRects.size())
@@ -455,7 +455,7 @@ ZoneSet::MoveWindowIntoZoneByDirectionAndPosition(HWND window, HWND workAreaWind
             // Consider all zones as available
             zoneRects.resize(m_zones.size());
             std::transform(m_zones.begin(), m_zones.end(), zoneRects.begin(), [](auto zone) { return zone.second->GetZoneRect(); });
-            windowRect = FancyZonesUtils::PrepareRectForCycling(windowRect, windowZoneRect, vkCode);
+            windowRect = FancyZonesUtils::PrepareRectForCycling(windowRect, workAreaRect, vkCode);
             result = FancyZonesUtils::ChooseNextZoneByPosition(vkCode, windowRect, zoneRects);
 
             if (result < zoneRects.size())

--- a/src/modules/fancyzones/FancyZonesLib/trace.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/trace.cpp
@@ -14,7 +14,7 @@
 #define EventEditorLaunchKey "FancyZones_EditorLaunch"
 #define EventSettingsKey "FancyZones_Settings"
 #define EventDesktopChangedKey "FancyZones_VirtualDesktopChanged"
-#define EventZoneWindowKeyUpKey "FancyZones_ZoneWindowKeyUp"
+#define EventWorkAreaKeyUpKey "FancyZones_ZoneWindowKeyUp"
 #define EventSnapNewWindowIntoZone "FancyZones_SnapNewWindowIntoZone"
 #define EventKeyboardSnapWindowToZone "FancyZones_KeyboardSnapWindowToZone"
 #define EventMoveOrResizeStartedKey "FancyZones_MoveOrResizeStarted"
@@ -345,7 +345,7 @@ void Trace::WorkArea::KeyUp(WPARAM wParam) noexcept
 {
     TraceLoggingWrite(
         g_hProvider,
-        EventZoneWindowKeyUpKey,
+        EventWorkAreaKeyUpKey,
         ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
         TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE),
         TraceLoggingValue(wParam, KeyboardValueKey));

--- a/src/modules/fancyzones/FancyZonesLib/util.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/util.cpp
@@ -300,6 +300,38 @@ namespace FancyZonesUtils
         }
     }
 
+    RECT AdjustRectForSizeWindowToRect(HWND window, RECT rect, HWND windowOfRect) noexcept
+    {
+        RECT newWindowRect = rect;
+
+        RECT windowRect{};
+        ::GetWindowRect(window, &windowRect);
+
+        // Take care of borders
+        RECT frameRect{};
+        if (SUCCEEDED(DwmGetWindowAttribute(window, DWMWA_EXTENDED_FRAME_BOUNDS, &frameRect, sizeof(frameRect))))
+        {
+            LONG leftMargin = frameRect.left - windowRect.left;
+            LONG rightMargin = frameRect.right - windowRect.right;
+            LONG bottomMargin = frameRect.bottom - windowRect.bottom;
+            newWindowRect.left -= leftMargin;
+            newWindowRect.right -= rightMargin;
+            newWindowRect.bottom -= bottomMargin;
+        }
+
+        // Take care of windows that cannot be resized
+        if ((::GetWindowLong(window, GWL_STYLE) & WS_SIZEBOX) == 0)
+        {
+            newWindowRect.right = newWindowRect.left + (windowRect.right - windowRect.left);
+            newWindowRect.bottom = newWindowRect.top + (windowRect.bottom - windowRect.top);
+        }
+
+        // Convert to screen coordinates
+        MapWindowRect(windowOfRect, nullptr, &newWindowRect);
+
+        return newWindowRect;
+    }
+
     void SizeWindowToRect(HWND window, RECT rect) noexcept
     {
         WINDOWPLACEMENT placement{};

--- a/src/modules/fancyzones/FancyZonesLib/util.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/util.cpp
@@ -692,22 +692,22 @@ namespace FancyZonesUtils
         return closestIdx;
     }
 
-    RECT PrepareRectForCycling(RECT windowRect, RECT zoneWindowRect, DWORD vkCode) noexcept
+    RECT PrepareRectForCycling(RECT windowRect, RECT workAreaRect, DWORD vkCode) noexcept
     {
         LONG deltaX = 0, deltaY = 0;
         switch (vkCode)
         {
         case VK_UP:
-            deltaY = zoneWindowRect.bottom - zoneWindowRect.top;
+            deltaY = workAreaRect.bottom - workAreaRect.top;
             break;
         case VK_DOWN:
-            deltaY = zoneWindowRect.top - zoneWindowRect.bottom;
+            deltaY = workAreaRect.top - workAreaRect.bottom;
             break;
         case VK_LEFT:
-            deltaX = zoneWindowRect.right - zoneWindowRect.left;
+            deltaX = workAreaRect.right - workAreaRect.left;
             break;
         case VK_RIGHT:
-            deltaX = zoneWindowRect.left - zoneWindowRect.right;
+            deltaX = workAreaRect.left - workAreaRect.right;
         }
 
         windowRect.left += deltaX;

--- a/src/modules/fancyzones/FancyZonesLib/util.h
+++ b/src/modules/fancyzones/FancyZonesLib/util.h
@@ -189,6 +189,9 @@ namespace FancyZonesUtils
     UINT GetDpiForMonitor(HMONITOR monitor) noexcept;
     void OrderMonitors(std::vector<std::pair<HMONITOR, RECT>>& monitorInfo);
 
+    // Parameter rect is in windowOfRect coordinates
+    RECT AdjustRectForSizeWindowToRect(HWND window, RECT rect, HWND windowOfRect) noexcept;
+
     // Parameter rect must be in screen coordinates (e.g. obtained from GetWindowRect)
     void SizeWindowToRect(HWND window, RECT rect) noexcept;
 

--- a/src/modules/fancyzones/FancyZonesLib/util.h
+++ b/src/modules/fancyzones/FancyZonesLib/util.h
@@ -212,7 +212,7 @@ namespace FancyZonesUtils
     std::wstring GenerateUniqueIdAllMonitorsArea(const std::wstring& virtualDesktopId);
     std::wstring TrimDeviceId(const std::wstring& deviceId);
 
-    RECT PrepareRectForCycling(RECT windowRect, RECT zoneWindowRect, DWORD vkCode) noexcept;
+    RECT PrepareRectForCycling(RECT windowRect, RECT workAreaRect, DWORD vkCode) noexcept;
     size_t ChooseNextZoneByPosition(DWORD vkCode, RECT windowRect, const std::vector<RECT>& zoneRects) noexcept;
 
     // If HWND is already dead, we assume it wasn't elevated

--- a/src/modules/fancyzones/FancyZonesTests/UnitTests/WorkArea.Spec.cpp
+++ b/src/modules/fancyzones/FancyZonesTests/UnitTests/WorkArea.Spec.cpp
@@ -81,10 +81,10 @@ namespace FancyZonesUnitTests
                 auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, {}, m_zoneColors, m_overlappingAlgorithm);
                 testWorkArea(workArea);
 
-                auto* activeZoneSet{ workArea->ActiveZoneSet() };
-                Assert::IsNotNull(activeZoneSet);
-                Assert::AreEqual(static_cast<int>(activeZoneSet->LayoutType()), static_cast<int>(FancyZonesDataTypes::ZoneSetLayoutType::PriorityGrid));
-                Assert::AreEqual(activeZoneSet->GetZones().size(), static_cast<size_t>(3));
+                auto* zoneSet{ workArea->ZoneSet() };
+                Assert::IsNotNull(zoneSet);
+                Assert::AreEqual(static_cast<int>(zoneSet->LayoutType()), static_cast<int>(FancyZonesDataTypes::ZoneSetLayoutType::PriorityGrid));
+                Assert::AreEqual(zoneSet->GetZones().size(), static_cast<size_t>(3));
             }
 
             TEST_METHOD (CreateWorkAreaNoHinst)
@@ -92,10 +92,10 @@ namespace FancyZonesUnitTests
                 auto workArea = MakeWorkArea({}, m_monitor, m_uniqueId, {}, m_zoneColors, m_overlappingAlgorithm);
                 testWorkArea(workArea);
 
-                auto* activeZoneSet{ workArea->ActiveZoneSet() };
-                Assert::IsNotNull(activeZoneSet);
-                Assert::AreEqual(static_cast<int>(activeZoneSet->LayoutType()), static_cast<int>(FancyZonesDataTypes::ZoneSetLayoutType::PriorityGrid));
-                Assert::AreEqual(activeZoneSet->GetZones().size(), static_cast<size_t>(3));
+                auto* zoneSet{ workArea->ZoneSet() };
+                Assert::IsNotNull(zoneSet);
+                Assert::AreEqual(static_cast<int>(zoneSet->LayoutType()), static_cast<int>(FancyZonesDataTypes::ZoneSetLayoutType::PriorityGrid));
+                Assert::AreEqual(zoneSet->GetZones().size(), static_cast<size_t>(3));
             }
 
             TEST_METHOD (CreateWorkAreaNoHinstFlashZones)
@@ -103,10 +103,10 @@ namespace FancyZonesUnitTests
                 auto workArea = MakeWorkArea({}, m_monitor, m_uniqueId, {}, m_zoneColors, m_overlappingAlgorithm);
                 testWorkArea(workArea);
 
-                auto* activeZoneSet{ workArea->ActiveZoneSet() };
-                Assert::IsNotNull(activeZoneSet);
-                Assert::AreEqual(static_cast<int>(activeZoneSet->LayoutType()), static_cast<int>(FancyZonesDataTypes::ZoneSetLayoutType::PriorityGrid));
-                Assert::AreEqual(activeZoneSet->GetZones().size(), static_cast<size_t>(3));
+                auto* zoneSet{ workArea->ZoneSet() };
+                Assert::IsNotNull(zoneSet);
+                Assert::AreEqual(static_cast<int>(zoneSet->LayoutType()), static_cast<int>(FancyZonesDataTypes::ZoneSetLayoutType::PriorityGrid));
+                Assert::AreEqual(zoneSet->GetZones().size(), static_cast<size_t>(3));
             }
 
             TEST_METHOD (CreateWorkAreaNoMonitor)
@@ -138,10 +138,10 @@ namespace FancyZonesUnitTests
                 Assert::IsNotNull(workArea.get());
                 Assert::IsTrue(expectedUniqueId == workArea->UniqueId());
 
-                auto* activeZoneSet{ workArea->ActiveZoneSet() };
-                Assert::IsNotNull(activeZoneSet);
-                Assert::AreEqual(static_cast<int>(activeZoneSet->LayoutType()), static_cast<int>(FancyZonesDataTypes::ZoneSetLayoutType::PriorityGrid));
-                Assert::AreEqual(activeZoneSet->GetZones().size(), static_cast<size_t>(3));
+                auto* zoneSet{ workArea->ZoneSet() };
+                Assert::IsNotNull(zoneSet);
+                Assert::AreEqual(static_cast<int>(zoneSet->LayoutType()), static_cast<int>(FancyZonesDataTypes::ZoneSetLayoutType::PriorityGrid));
+                Assert::AreEqual(zoneSet->GetZones().size(), static_cast<size_t>(3));
             }
 
             TEST_METHOD (CreateWorkAreaNoDesktopId)
@@ -164,10 +164,10 @@ namespace FancyZonesUnitTests
                 const std::wstring expectedWorkArea = std::to_wstring(m_monitorInfo.rcMonitor.right) + L"_" + std::to_wstring(m_monitorInfo.rcMonitor.bottom);
                 Assert::IsNotNull(workArea.get());
 
-                auto* activeZoneSet{ workArea->ActiveZoneSet() };
-                Assert::IsNotNull(activeZoneSet);
-                Assert::AreEqual(static_cast<int>(activeZoneSet->LayoutType()), static_cast<int>(FancyZonesDataTypes::ZoneSetLayoutType::PriorityGrid));
-                Assert::AreEqual(activeZoneSet->GetZones().size(), static_cast<size_t>(3));
+                auto* zoneSet{ workArea->ZoneSet() };
+                Assert::IsNotNull(zoneSet);
+                Assert::AreEqual(static_cast<int>(zoneSet->LayoutType()), static_cast<int>(FancyZonesDataTypes::ZoneSetLayoutType::PriorityGrid));
+                Assert::AreEqual(zoneSet->GetZones().size(), static_cast<size_t>(3));
             }
 
         TEST_METHOD (CreateWorkAreaClonedFromParent)
@@ -187,7 +187,7 @@ namespace FancyZonesUnitTests
                 // newWorkArea = false - workArea won't be cloned from parent
                 auto actualWorkArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, {}, m_zoneColors, m_overlappingAlgorithm);
 
-                Assert::IsNotNull(actualWorkArea->ActiveZoneSet());
+                Assert::IsNotNull(actualWorkArea->ZoneSet());
 
                 Assert::IsTrue(m_fancyZonesData.GetDeviceInfoMap().contains(m_uniqueId));
                 auto currentDeviceInfo = m_fancyZonesData.GetDeviceInfoMap().at(m_uniqueId);
@@ -299,7 +299,7 @@ namespace FancyZonesUnitTests
                 const auto actual = workArea->MoveSizeEnd(window, POINT{ 0, 0 });
                 Assert::AreEqual(expected, actual);
 
-                const auto zoneSet = workArea->ActiveZoneSet();
+                const auto zoneSet = workArea->ZoneSet();
                 zoneSet->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0);
                 const auto actualZoneIndexSet = zoneSet->GetZoneIndexSetFromWindow(window);
                 Assert::IsFalse(std::vector<ZoneIndex>{} == actualZoneIndexSet);
@@ -316,7 +316,7 @@ namespace FancyZonesUnitTests
                 const auto actual = workArea->MoveSizeEnd(window, POINT{ -100, -100 });
                 Assert::AreEqual(expected, actual);
 
-                const auto zoneSet = workArea->ActiveZoneSet();
+                const auto zoneSet = workArea->ZoneSet();
                 const auto actualZoneIndexSet = zoneSet->GetZoneIndexSetFromWindow(window);
                 Assert::IsTrue(std::vector<ZoneIndex>{} == actualZoneIndexSet);
             }
@@ -355,7 +355,7 @@ namespace FancyZonesUnitTests
                 const auto actual = workArea->MoveSizeEnd(window, POINT{ -1, -1 });
                 Assert::AreEqual(expected, actual);
 
-                const auto zoneSet = workArea->ActiveZoneSet();
+                const auto zoneSet = workArea->ZoneSet();
                 zoneSet->MoveWindowIntoZoneByIndex(window, Mocks::Window(), 0);
                 const auto actualZoneIndex = zoneSet->GetZoneIndexSetFromWindow(window);
                 Assert::IsFalse(std::vector<ZoneIndex>{} == actualZoneIndex); // with invalid point zone remains the same
@@ -364,17 +364,17 @@ namespace FancyZonesUnitTests
             TEST_METHOD (MoveWindowIntoZoneByIndex)
             {
                 auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, {}, m_zoneColors, m_overlappingAlgorithm);
-                Assert::IsNotNull(workArea->ActiveZoneSet());
+                Assert::IsNotNull(workArea->ZoneSet());
 
                 workArea->MoveWindowIntoZoneByIndex(Mocks::Window(), 0);
 
-                const auto actual = workArea->ActiveZoneSet();
+                const auto actual = workArea->ZoneSet();
             }
 
             TEST_METHOD (MoveWindowIntoZoneByDirectionAndIndex)
             {
                 auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, {}, m_zoneColors, m_overlappingAlgorithm);
-                Assert::IsNotNull(workArea->ActiveZoneSet());
+                Assert::IsNotNull(workArea->ZoneSet());
 
                 const auto window = Mocks::WindowCreate(m_hInst);
                 workArea->MoveWindowIntoZoneByDirectionAndIndex(window, VK_RIGHT, true);
@@ -389,7 +389,7 @@ namespace FancyZonesUnitTests
             TEST_METHOD (MoveWindowIntoZoneByDirectionManyTimes)
             {
                 auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, {}, m_zoneColors, m_overlappingAlgorithm);
-                Assert::IsNotNull(workArea->ActiveZoneSet());
+                Assert::IsNotNull(workArea->ZoneSet());
 
                 const auto window = Mocks::WindowCreate(m_hInst);
                 workArea->MoveWindowIntoZoneByDirectionAndIndex(window, VK_RIGHT, true);
@@ -406,7 +406,7 @@ namespace FancyZonesUnitTests
             TEST_METHOD (SaveWindowProcessToZoneIndexNullptrWindow)
             {
                 auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, {}, m_zoneColors, m_overlappingAlgorithm);
-                Assert::IsNotNull(workArea->ActiveZoneSet());
+                Assert::IsNotNull(workArea->ZoneSet());
 
                 workArea->SaveWindowProcessToZoneIndex(nullptr);
 
@@ -417,11 +417,11 @@ namespace FancyZonesUnitTests
             TEST_METHOD (SaveWindowProcessToZoneIndexNoWindowAdded)
             {
                 auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, {}, m_zoneColors, m_overlappingAlgorithm);
-                Assert::IsNotNull(workArea->ActiveZoneSet());
+                Assert::IsNotNull(workArea->ZoneSet());
 
                 auto window = Mocks::WindowCreate(m_hInst);
                 auto zone = MakeZone(RECT{ 0, 0, 100, 100 }, 1);
-                workArea->ActiveZoneSet()->AddZone(zone);
+                workArea->ZoneSet()->AddZone(zone);
 
                 workArea->SaveWindowProcessToZoneIndex(window);
 
@@ -432,12 +432,12 @@ namespace FancyZonesUnitTests
             TEST_METHOD (SaveWindowProcessToZoneIndexNoWindowAddedWithFilledAppZoneHistory)
             {
                 auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, {}, m_zoneColors, m_overlappingAlgorithm);
-                Assert::IsNotNull(workArea->ActiveZoneSet());
+                Assert::IsNotNull(workArea->ZoneSet());
 
                 const auto window = Mocks::WindowCreate(m_hInst);
                 const auto processPath = get_process_path(window);
                 const auto deviceId = workArea->UniqueId();
-                const auto zoneSetId = workArea->ActiveZoneSet()->Id();
+                const auto zoneSetId = workArea->ZoneSet()->Id();
 
                 // fill app zone history map
                 Assert::IsTrue(m_fancyZonesData.SetAppLastZones(window, deviceId, Helpers::GuidToString(zoneSetId), { 0 }));
@@ -448,7 +448,7 @@ namespace FancyZonesUnitTests
 
                 // add zone without window
                 const auto zone = MakeZone(RECT{ 0, 0, 100, 100 }, 1);
-                workArea->ActiveZoneSet()->AddZone(zone);
+                workArea->ZoneSet()->AddZone(zone);
 
                 workArea->SaveWindowProcessToZoneIndex(window);
                 Assert::AreEqual((size_t)1, m_fancyZonesData.GetAppZoneHistoryMap().size());
@@ -460,15 +460,15 @@ namespace FancyZonesUnitTests
             TEST_METHOD (SaveWindowProcessToZoneIndexWindowAdded)
             {
                 auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, {}, m_zoneColors, m_overlappingAlgorithm);
-                Assert::IsNotNull(workArea->ActiveZoneSet());
+                Assert::IsNotNull(workArea->ZoneSet());
 
                 auto window = Mocks::WindowCreate(m_hInst);
                 const auto processPath = get_process_path(window);
                 const auto deviceId = workArea->UniqueId();
-                const auto zoneSetId = workArea->ActiveZoneSet()->Id();
+                const auto zoneSetId = workArea->ZoneSet()->Id();
 
                 auto zone = MakeZone(RECT{ 0, 0, 100, 100 }, 1);
-                workArea->ActiveZoneSet()->AddZone(zone);
+                workArea->ZoneSet()->AddZone(zone);
                 workArea->MoveWindowIntoZoneByIndex(window, 0);
 
                 //fill app zone history map
@@ -482,7 +482,7 @@ namespace FancyZonesUnitTests
 
                 const auto& actualAppZoneHistory = m_fancyZonesData.GetAppZoneHistoryMap();
                 Assert::AreEqual((size_t)1, actualAppZoneHistory.size());
-                const auto& expected = workArea->ActiveZoneSet()->GetZoneIndexSetFromWindow(window);
+                const auto& expected = workArea->ZoneSet()->GetZoneIndexSetFromWindow(window);
                 const auto& actual = appHistoryArray[0].zoneIndexSet;
                 Assert::IsTrue(expected == actual);
             }
@@ -490,7 +490,7 @@ namespace FancyZonesUnitTests
             TEST_METHOD (WhenWindowIsNotResizablePlacingItIntoTheZoneShouldNotResizeIt)
             {
                 auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, {}, m_zoneColors, m_overlappingAlgorithm);
-                Assert::IsNotNull(workArea->ActiveZoneSet());
+                Assert::IsNotNull(workArea->ZoneSet());
 
                 auto window = Mocks::WindowCreate(m_hInst);
 
@@ -501,7 +501,7 @@ namespace FancyZonesUnitTests
                 SetWindowLong(window, GWL_STYLE, GetWindowLong(window, GWL_STYLE) & ~WS_SIZEBOX);
 
                 auto zone = MakeZone(RECT{ 50, 50, 300, 300 }, 1);
-                workArea->ActiveZoneSet()->AddZone(zone);
+                workArea->ZoneSet()->AddZone(zone);
 
                 workArea->MoveWindowIntoZoneByDirectionAndIndex(window, VK_LEFT, true);
 

--- a/src/modules/fancyzones/FancyZonesTests/UnitTests/ZoneSet.Spec.cpp
+++ b/src/modules/fancyzones/FancyZonesTests/UnitTests/ZoneSet.Spec.cpp
@@ -297,9 +297,9 @@ namespace FancyZonesUnitTests
             {
                 winrt::com_ptr<IZone> zone = MakeZone({ 0, 0, 100, 100 }, 1);
                 HWND window = Mocks::Window();
-                HWND zoneWindow = Mocks::Window();
+                HWND workArea = Mocks::Window();
                 m_set->AddZone(zone);
-                m_set->MoveWindowIntoZoneByIndexSet(window, zoneWindow, { 0 });
+                m_set->MoveWindowIntoZoneByIndexSet(window, workArea, { 0 });
 
                 auto actual = m_set->GetZoneIndexSetFromWindow(Mocks::Window());
                 Assert::IsTrue(std::vector<ZoneIndex>{} == actual);
@@ -309,9 +309,9 @@ namespace FancyZonesUnitTests
             {
                 winrt::com_ptr<IZone> zone = MakeZone({ 0, 0, 100, 100 }, 1);
                 HWND window = Mocks::Window();
-                HWND zoneWindow = Mocks::Window();
+                HWND workArea = Mocks::Window();
                 m_set->AddZone(zone);
-                m_set->MoveWindowIntoZoneByIndexSet(window, zoneWindow, { 0 });
+                m_set->MoveWindowIntoZoneByIndexSet(window, workArea, { 0 });
 
                 auto actual = m_set->GetZoneIndexSetFromWindow(nullptr);
                 Assert::IsTrue(std::vector<ZoneIndex>{} == actual);
@@ -432,7 +432,7 @@ namespace FancyZonesUnitTests
             TEST_METHOD (MoveWindowIntoZoneByPointDropAddWindow)
             {
                 const auto window = Mocks::Window();
-                const auto zoneWindow = Mocks::Window();
+                const auto workArea = Mocks::Window();
 
                 winrt::com_ptr<IZone> zone1 = MakeZone({ 0, 0, 100, 100 }, 0);
                 winrt::com_ptr<IZone> zone2 = MakeZone({ 10, 10, 90, 90 }, 1);
@@ -450,7 +450,7 @@ namespace FancyZonesUnitTests
             TEST_METHOD (MoveWindowIntoZoneByPointDropAddWindowToSameZone)
             {
                 const auto window = Mocks::Window();
-                const auto zoneWindow = Mocks::Window();
+                const auto workArea = Mocks::Window();
 
                 winrt::com_ptr<IZone> zone1 = MakeZone({ 0, 0, 100, 100 }, 0);
                 winrt::com_ptr<IZone> zone2 = MakeZone({ 10, 10, 90, 90 }, 1);
@@ -468,7 +468,7 @@ namespace FancyZonesUnitTests
             TEST_METHOD (MoveWindowIntoZoneByPointSeveralZonesWithSameWindow)
             {
                 const auto window = Mocks::Window();
-                const auto zoneWindow = Mocks::Window();
+                const auto workArea = Mocks::Window();
 
                 winrt::com_ptr<IZone> zone1 = MakeZone({ 0, 0, 100, 100 }, 0);
                 winrt::com_ptr<IZone> zone2 = MakeZone({ 10, 10, 90, 90 }, 1);


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Some cleanup I think would be beneficial.

**What is include in the PR:** 
 * Rename `zoneUuid` -> `zoneLayoutUuid`: The variable holds the UUID of the layout (not of a zone).
 * Rename `m_activeZoneSet` -> `m_zoneSet`: There is only one zone set used by a work area.
 * Refer to the current move/size action as active
 * Complete renaming `ZoneWindow` to `WorkArea`: Fix leftovers from "[FancyZones] Rename ZoneWindow -> WorkArea (#12223)"
 * Move adjustment of RECT to utils.cpp: By doing so, also fix a bug where a non-`WS_SIZEBOX` window (a window that should not be resized) was resized (and not properly resized) if it was zoned into more than one zone.
 * Remove obsolete code: The field `m_windows` is unused, and may be removed.
 * Remove obsolete code: The field `m_zoneSets` is unused, and may be removed.

**How does someone test / validate:** 

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
