### PR TITLE
[FindMyMouse]Account for low double click settings

### DIFF
--- a/src/modules/MouseUtils/FindMyMouse/FindMyMouse.cpp
+++ b/src/modules/MouseUtils/FindMyMouse/FindMyMouse.cpp
@@ -55,6 +55,7 @@ protected:
     POINT m_sonarPos = ptNowhere;
 
     // Only consider double left control click if at least 100ms passed between the clicks, to avoid keyboards that might be sending rapid clicks.
+    // At actual check, time a fifth of the current double click setting might be used instead to take into account users who might have low values.
     static const int MIN_DOUBLE_CLICK_TIME = 100;
 
     static constexpr int SonarRadius = 100;
@@ -312,9 +313,10 @@ void SuperSonar<D>::OnSonarKeyboardInput(RAWINPUT const& input)
             auto now = GetTickCount();
             auto doubleClickInterval = now - m_lastKeyTime;
             POINT ptCursor{};
+            auto doubleClickTimeSetting = GetDoubleClickTime();
             if (GetCursorPos(&ptCursor) &&
-                doubleClickInterval >= MIN_DOUBLE_CLICK_TIME &&
-                doubleClickInterval <= GetDoubleClickTime() &&
+                doubleClickInterval >= min(MIN_DOUBLE_CLICK_TIME, doubleClickTimeSetting / 5) &&
+                doubleClickInterval <= doubleClickTimeSetting &&
                 IsEqual(m_lastKeyPos, ptCursor))
             {
                 m_sonarState = SonarState::ControlDown2;


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
After https://github.com/microsoft/PowerToys/pull/14045 it's possible that users who have double click time set up to work with < 100ms will no longer be able to activate FindMyMouse.
So, we should take into account this and not force an absolute minimum for recognizing a double control click.

Requested in:
https://github.com/microsoft/PowerToys/pull/14045#pullrequestreview-796029158

**What is include in the PR:** 
Code to use minimum double click time as  the minimum between 100ms and 1/5 of the configured double click time.

**How does someone test / validate:** 
Just check if it still works correctly and general code check.
Double clicking under < 100ms can be hard.

## Quality Checklist

- [x] **Linked issue:** #14043
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries
