### PR TITLE
[PT Run][VSCode Workspaces Plugin]  Add DevContainer workspaces to search results 

### DIFF
--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/Main.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/Main.cs
@@ -44,13 +44,9 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces
                     var title = $"{a.FolderName}";
 
                     var typeWorkspace = a.WorkspaceTypeToString();
-                    if (a.TypeWorkspace == TypeWorkspace.Codespaces)
+                    if (a.TypeWorkspace != TypeWorkspace.Local)
                     {
-                        title += $" - {typeWorkspace}";
-                    }
-                    else if (a.TypeWorkspace != TypeWorkspace.Local)
-                    {
-                        title += $" - {(a.ExtraInfo != null ? $"{a.ExtraInfo} ({typeWorkspace})" : typeWorkspace)}";
+                        title = $"{title}{(a.ExtraInfo != null ? $" - {a.ExtraInfo}" : string.Empty)} ({typeWorkspace})";
                     }
 
                     var tooltip = new ToolTipData(title, $"{Resources.Workspace}{(a.TypeWorkspace != TypeWorkspace.Local ? $" {Resources.In} {typeWorkspace}" : string.Empty)}: {SystemPath.RealPath(a.RelativePath)}");

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/Properties/Resources.Designer.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/Properties/Resources.Designer.cs
@@ -106,6 +106,15 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Dev Container.
+        /// </summary>
+        internal static string TypeWorkspaceDevContainer {
+            get {
+                return ResourceManager.GetString("TypeWorkspaceDevContainer", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Local.
         /// </summary>
         internal static string TypeWorkspaceLocal {

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/Properties/Resources.resx
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/Properties/Resources.resx
@@ -142,4 +142,8 @@
     <value>Workspace</value>
     <comment>It refers to the "Visual Studio Code  workspace"</comment>
   </data>
+  <data name="TypeWorkspaceDevContainer" xml:space="preserve">
+    <value>Dev Container</value>
+    <comment>As in "Visual Studio Code Dev Container workspace "</comment>
+  </data>
 </root>

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/WorkspacesHelper/ParseVSCodeUri.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/WorkspacesHelper/ParseVSCodeUri.cs
@@ -16,6 +16,8 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.WorkspacesHelper
 
         private static readonly Regex CodespacesWorkspace = new Regex(@"^vscode-remote://vsonline\+(.+?(?=\/))(.+)$", RegexOptions.Compiled);
 
+        private static readonly Regex DevContainerWorkspace = new Regex(@"^vscode-remote://dev-container\+(.+?(?=\/))(.+)$", RegexOptions.Compiled);
+
         public static (TypeWorkspace? TypeWorkspace, string MachineName, string Path) GetTypeWorkspace(string uri)
         {
             if (LocalWorkspace.IsMatch(uri))
@@ -52,6 +54,15 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.WorkspacesHelper
                 if (match.Groups.Count > 1)
                 {
                     return (TypeWorkspace.Codespaces, string.Empty, match.Groups[2].Value);
+                }
+            }
+            else if (DevContainerWorkspace.IsMatch(uri))
+            {
+                var match = DevContainerWorkspace.Match(uri);
+
+                if (match.Groups.Count > 1)
+                {
+                    return (TypeWorkspace.DevContainer, string.Empty, match.Groups[2].Value);
                 }
             }
 

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/WorkspacesHelper/ParseVSCodeUri.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/WorkspacesHelper/ParseVSCodeUri.cs
@@ -53,7 +53,7 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.WorkspacesHelper
 
                 if (match.Groups.Count > 1)
                 {
-                    return (TypeWorkspace.Codespaces, string.Empty, match.Groups[2].Value);
+                    return (TypeWorkspace.Codespaces, null, match.Groups[2].Value);
                 }
             }
             else if (DevContainerWorkspace.IsMatch(uri))
@@ -62,7 +62,7 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.WorkspacesHelper
 
                 if (match.Groups.Count > 1)
                 {
-                    return (TypeWorkspace.DevContainer, string.Empty, match.Groups[2].Value);
+                    return (TypeWorkspace.DevContainer, null, match.Groups[2].Value);
                 }
             }
 

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/WorkspacesHelper/VSCodeWorkspace.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/WorkspacesHelper/VSCodeWorkspace.cs
@@ -30,6 +30,7 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.WorkspacesHelper
                 case TypeWorkspace.RemoteContainers: return Resources.TypeWorkspaceContainer;
                 case TypeWorkspace.RemoteSSH: return "SSH";
                 case TypeWorkspace.RemoteWSL: return "WSL";
+                case TypeWorkspace.DevContainer: return "Dev Container";
             }
 
             return string.Empty;
@@ -43,5 +44,6 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.WorkspacesHelper
         RemoteWSL = 3,
         RemoteSSH = 4,
         RemoteContainers = 5,
+        DevContainer = 6,
     }
 }

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/WorkspacesHelper/VSCodeWorkspace.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/WorkspacesHelper/VSCodeWorkspace.cs
@@ -30,7 +30,7 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.WorkspacesHelper
                 case TypeWorkspace.RemoteContainers: return Resources.TypeWorkspaceContainer;
                 case TypeWorkspace.RemoteSSH: return "SSH";
                 case TypeWorkspace.RemoteWSL: return "WSL";
-                case TypeWorkspace.DevContainer: return "Dev Container";
+                case TypeWorkspace.DevContainer: return Resources.TypeWorkspaceDevContainer;
             }
 
             return string.Empty;


### PR DESCRIPTION
## Summary of the Pull Request



**What is this about:**
Adds DevContainer workspaces to the search results of the VSCode Workspaces Plugin.

Currently the PT Run Plugin for VSCode workspaces only searches for the local, wsl, codespaces and ssh workspaces. When working with DevContainer workspaces it will be much more convenient to open the DevContainer workspace directly via PT Run instead of opening the local workspace first and then reopening it as a DevContainer workspace.

**What is include in the PR:** 
Code extending the current plugin to include DevContainers in the search results. 


**How does someone test / validate:** 

1. Create local workspace
2. Open PT Run
3. Activate VSCode Workspaces Plugin and search for the local Workspace
=> local workspace should appear as search result
4. Create DevContainer with the Remote - Containers Extension
5. Add devcontainer configuration with the Remote - Containers Extension Commands
6 Open workspace as DevContainer workspace
7. Open PT Run
8. Activate VSCode Workspaces Plugin and search for the local Workspace
=> local and DevContainer workspace should appear in the search results
9. Select DevContainer search result
=> VSCode should launch and open the DevContainer workspace

## Quality Checklist

- [x] **Linked issue:** #14310 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
