### PR TITLE
[FancyZones] Bypass restriction on SetForegroundWindow

### DIFF
--- a/src/modules/fancyzones/FancyZonesLib/ZoneSet.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/ZoneSet.cpp
@@ -592,18 +592,16 @@ ZoneSet::CycleTabs(HWND window, bool reverse) noexcept
     for (;;)
     {
         auto next = GetNextTab(indexSet, window, reverse);
-        if (next == NULL)
-        {
-            break;
-        }
 
-        auto success = SetForegroundWindow(next);
-        if (!success && GetLastError() == ERROR_INVALID_WINDOW_HANDLE)
+        // Determine whether the window still exists
+        if (!IsWindow(next))
         {
             // Dismiss the encountered window since it was probably closed
             DismissWindow(next);
             continue;
         }
+
+        SwitchToWindow(next);
 
         break;
     }

--- a/src/modules/fancyzones/FancyZonesLib/util.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/util.cpp
@@ -337,6 +337,22 @@ namespace FancyZonesUtils
         ::SetWindowPlacement(window, &placement);
     }
 
+    void SwitchToWindow(HWND window) noexcept
+    {
+        // Check if the window is minimized
+        if (IsIconic(window))
+        {
+            // Show the window since SetForegroundWindow fails on minimized windows
+            ShowWindow(window, SW_RESTORE);
+        }
+
+        // This is a hack to bypass the restriction on setting the foreground window
+        INPUT inputs[1] = { { .type = INPUT_MOUSE } };
+        SendInput(ARRAYSIZE(inputs), inputs, sizeof(INPUT));
+
+        SetForegroundWindow(window);
+    }
+
     bool HasNoVisibleOwner(HWND window) noexcept
     {
         auto owner = GetWindow(window, GW_OWNER);

--- a/src/modules/fancyzones/FancyZonesLib/util.h
+++ b/src/modules/fancyzones/FancyZonesLib/util.h
@@ -192,6 +192,8 @@ namespace FancyZonesUtils
     // Parameter rect must be in screen coordinates (e.g. obtained from GetWindowRect)
     void SizeWindowToRect(HWND window, RECT rect) noexcept;
 
+    void SwitchToWindow(HWND window) noexcept;
+
     bool HasNoVisibleOwner(HWND window) noexcept;
     bool IsStandardWindow(HWND window);
     bool IsCandidateForLastKnownZone(HWND window, const std::vector<std::wstring>& excludedApps) noexcept;


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
When using the window switching shortcuts, if FancyZones is not allowed to set the foreground window, Windows flashes the taskbar button of the window as a form of notification to the user that the window requested to be shown (more accurately, set to be the foreground window).

**What is include in the PR:** 
Use a hack to bypass the restriction and switch the foreground window even if another window locked it. This PR would make switching windows behave like `ALT`+`TAB`.

**How does someone test / validate:** 
 * Run program A: A program that disables calls to `SetForegroundWindow` (I created a small program that calls `LockSetForegroundWindow(LSFW_LOCK)` on `message == WM_ACTIVATE && LOWORD(wparam) != WA_INACTIVE`).
 * Run program B: Any other program.
 * Zone window A to a zone.
 * Zone window B to the same zone.
 * Switch from window A to window B (quickly, before the lock timeouts) using the shortcut.
Before the fix, the taskbar button of window B would flash, but window A stays the foreground window. Now it should switch correctly.

## Quality Checklist

- [ ] **Linked issue:** #XXX
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
