### PR TITLE
fix Korean mistranslation of a word 'type'

### DIFF
--- a/src/modules/keyboardmanager/KeyboardManagerEditor/loc/ko/src/modules/keyboardmanager/KeyboardManagerEditor/Resources.resx.lcl
+++ b/src/modules/keyboardmanager/KeyboardManagerEditor/loc/ko/src/modules/keyboardmanager/KeyboardManagerEditor/Resources.resx.lcl
@@ -491,7 +491,7 @@
         <Str Cat="Text">
           <Val><![CDATA[Type]]></Val>
           <Tgt Cat="Text" Stat="Loc" Orig="New">
-            <Val><![CDATA[유형]]></Val>
+            <Val><![CDATA[입력]]></Val>
           </Tgt>
         </Str>
         <Disp Icon="Str" />


### PR DESCRIPTION
Fixed Korean Mistration of a word 'Type'.

In Key Remapping of Keyboard Manger, 'Type' is currently translated "유형" in Korean which means "category" or "Pattern".
In this page, "Type" means 'please enter the key', so it is adequate to translate to "입력" which means 'input' or 'enter' in Korean.

I think this PR may make Korean users not be confused in Key Remapping page and I hope this PR makes your project better.
Thank you.