### PR TITLE
[Image Resizer] Fix image resizer unexpected property type or value (#9885, #14266)

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -892,7 +892,6 @@ Iface
 IFACEMETHOD
 IFACEMETHODIMP
 IFancy
-ifd
 ifdef
 IFeatures
 IFile

--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -892,6 +892,7 @@ Iface
 IFACEMETHOD
 IFACEMETHODIMP
 IFancy
+ifd
 ifdef
 IFeatures
 IFile

--- a/src/modules/imageresizer/ui/Extensions/BitmapMetadataExtension.cs
+++ b/src/modules/imageresizer/ui/Extensions/BitmapMetadataExtension.cs
@@ -58,5 +58,27 @@ namespace ImageResizer.Extensions
                 return null;
             }
         }
+
+        public static BitmapMetadata RemoveMetadataIfInvalid(this BitmapMetadata metadata, string query)
+        {
+            if (metadata == null || string.IsNullOrWhiteSpace(query))
+            {
+                return metadata;
+            }
+
+            try
+            {
+                _ = metadata.GetQuerySafe(query);
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception)
+#pragma warning restore CA1031 // Do not catch general exception types
+            {
+                // Reading invalid metadata causes an exception. We remove the given metadata in this case.
+                metadata.RemoveQuery(query);
+            }
+
+            return metadata;
+        }
     }
 }

--- a/src/modules/imageresizer/ui/Extensions/BitmapMetadataExtension.cs
+++ b/src/modules/imageresizer/ui/Extensions/BitmapMetadataExtension.cs
@@ -43,7 +43,14 @@ namespace ImageResizer.Extensions
 
             try
             {
-                return metadata.GetQuery(query);
+                if (metadata.ContainsQuery(query))
+                {
+                    return metadata.GetQuery(query);
+                }
+                else
+                {
+                    return null;
+                }
             }
             catch (NotSupportedException)
             {

--- a/src/modules/imageresizer/ui/Extensions/BitmapMetadataExtension.cs
+++ b/src/modules/imageresizer/ui/Extensions/BitmapMetadataExtension.cs
@@ -140,6 +140,68 @@ namespace ImageResizer.Extensions
             }
         }
 
+        /// <summary>
+        /// Prints all metadata to debug console
+        /// </summary>
+        /// <remarks>
+        /// Intented for debug!!!
+        /// </remarks>
+        public static void PrintsAllMetadataToDebugOutput(this BitmapMetadata metadata)
+        {
+            if (metadata == null)
+            {
+                Debug.WriteLine($"Metadata was null.");
+            }
+
+            var listOfMetadata = metadata.GetListOfMetadata();
+            foreach (var metadataItem in listOfMetadata)
+            {
+                Debug.WriteLine($"{metadataItem.metadataPath} | {metadataItem.value}");
+            }
+        }
+
+        /// <summary>
+        /// Gets all metadata
+        /// Iterates recursively through all metadata
+        /// </summary>
+        /// <remarks>
+        /// Intented for debug!!!
+        /// </remarks>
+        public static List<(string metadataPath, object value)> GetListOfMetadata(this BitmapMetadata metadata)
+        {
+            var listOfAllMetadata = new List<(string metadataPath, object value)>();
+
+            GetMetadataRecursively(metadata, string.Empty);
+
+            return listOfAllMetadata;
+
+            void GetMetadataRecursively(BitmapMetadata metadata, string query)
+            {
+                foreach (string relativeQuery in metadata)
+                {
+                    string absolutePath = query + relativeQuery;
+
+                    object metadataQueryReader = null;
+
+                    try
+                    {
+                        metadataQueryReader = metadata.GetQuerySafe(relativeQuery);
+                        listOfAllMetadata.Add((absolutePath, metadataQueryReader));
+                    }
+#pragma warning disable CA1031 // Do not catch general exception types
+                    catch (Exception ex)
+#pragma warning restore CA1031 // Do not catch general exception types
+                    {
+                        listOfAllMetadata.Add((absolutePath, $"######## INVALID METADATA: {ex.Message}"));
+                        Debug.WriteLine(ex);
+                    }
+
+                    if (metadataQueryReader is BitmapMetadata innerMetadata)
+                    {
+                        GetMetadataRecursively(innerMetadata, absolutePath);
+                    }
+                }
+            }
         }
     }
 }

--- a/src/modules/imageresizer/ui/Extensions/BitmapMetadataExtension.cs
+++ b/src/modules/imageresizer/ui/Extensions/BitmapMetadataExtension.cs
@@ -79,7 +79,7 @@ namespace ImageResizer.Extensions
             catch (Exception ex)
 #pragma warning restore CA1031 // Do not catch general exception types
             {
-                Debug.WriteLine($"Exception while trying to remove {query} from metadata.");
+                Debug.WriteLine($"Exception while trying to remove metadata entry at position: {query}");
                 Debug.WriteLine(ex);
             }
         }
@@ -99,7 +99,7 @@ namespace ImageResizer.Extensions
             catch (Exception ex)
 #pragma warning restore CA1031 // Do not catch general exception types
             {
-                Debug.WriteLine($"Exception while trying to set value {value} to query {query}");
+                Debug.WriteLine($"Exception while trying to set metadata {value} at position: {query}");
                 Debug.WriteLine(ex);
             }
         }
@@ -132,13 +132,17 @@ namespace ImageResizer.Extensions
                     catch (Exception ex)
 #pragma warning restore CA1031 // Do not catch general exception types
                     {
-                        Debug.WriteLine((absolutePath, $"Invalid metadata found at query path {absolutePath}. Skipping metadata entry | {ex.Message}"));
+                        Debug.WriteLine($"Removing corrupt metadata property {absolutePath}. Skipping metadata entry | {ex.Message}");
                         Debug.WriteLine(ex);
                     }
 
                     if (metadataQueryReader != null)
                     {
                         listOfAllMetadata.Add((absolutePath, metadataQueryReader));
+                    }
+                    else
+                    {
+                        Debug.WriteLine($"No metadata found for query {absolutePath}. Skipping empty null entry because its invalid.");
                     }
 
                     if (metadataQueryReader is BitmapMetadata innerMetadata)

--- a/src/modules/imageresizer/ui/Models/ResizeOperation.cs
+++ b/src/modules/imageresizer/ui/Models/ResizeOperation.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.  Code forked from Brice Lambson's https://github.com/bricelam/ImageResizer/
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
@@ -90,14 +89,24 @@ namespace ImageResizer.Models
 #if DEBUG
                             modifiableMetadata.PrintsAllMetadataToDebugOutput();
 #endif
-                            var metadataList = modifiableMetadata.GetListOfInvalidMetadata();
-                            foreach (var (metadataPath, value) in metadataList)
+
+                            // transfer all readable metadata into a new metadata object. Discards invalid/unreadable tags.
+                            var newMetadata = new BitmapMetadata(metadata.Format);
+                            var listOfMetadata = modifiableMetadata.GetListOfMetadata();
+                            foreach (var (metadataPath, value) in listOfMetadata)
                             {
-                                Debug.WriteLine($"Trying to remove invalid metadata found at {metadataPath}.");
-                                modifiableMetadata.RemoveQuerySafe(metadataPath);
+                                if (value is BitmapMetadata bitmapMetadata)
+                                {
+                                    var newBitmapMetadata = new BitmapMetadata(bitmapMetadata.Format);
+                                    newMetadata.SetQuerySafe(metadataPath, newBitmapMetadata);
+                                }
+                                else
+                                {
+                                    newMetadata.SetQuerySafe(metadataPath, value);
+                                }
                             }
 
-                            metadata = modifiableMetadata;
+                            metadata = newMetadata;
                         }
                         catch (ArgumentException ex)
                         {

--- a/src/modules/imageresizer/ui/Models/ResizeOperation.cs
+++ b/src/modules/imageresizer/ui/Models/ResizeOperation.cs
@@ -83,11 +83,11 @@ namespace ImageResizer.Models
                         try
                         {
                             // Detect whether metadata can copied successfully
-                            var newMetadata = metadata.Clone();
+                            var modifiableMetadata = metadata.Clone();
 
-                            newMetadata.RemoveQuery("/app1/ifd/exif:{uint=330}"); // this fixes the issue #9885, image 2 and 3
+                            modifiableMetadata.RemoveMetadataIfInvalid("/app1/ifd/exif:{uint=330}"); // this fixes the issue #9885, image 2 and 3
 
-                            metadata = newMetadata;
+                            metadata = modifiableMetadata;
                         }
                         catch (ArgumentException)
                         {

--- a/src/modules/imageresizer/ui/Models/ResizeOperation.cs
+++ b/src/modules/imageresizer/ui/Models/ResizeOperation.cs
@@ -87,18 +87,19 @@ namespace ImageResizer.Models
                             var modifiableMetadata = metadata.Clone();
 
 #if DEBUG
+                            Debug.WriteLine($"### Processing metadata of file {_file}");
                             modifiableMetadata.PrintsAllMetadataToDebugOutput();
 #endif
 
-                            // transfer all readable metadata into a new metadata object. Discards invalid/unreadable tags.
+                            // read all metadata and build up metadata object from the scratch. Discard invalid (unreadable/unwritable) metadata.
                             var newMetadata = new BitmapMetadata(metadata.Format);
                             var listOfMetadata = modifiableMetadata.GetListOfMetadata();
                             foreach (var (metadataPath, value) in listOfMetadata)
                             {
                                 if (value is BitmapMetadata bitmapMetadata)
                                 {
-                                    var newBitmapMetadata = new BitmapMetadata(bitmapMetadata.Format);
-                                    newMetadata.SetQuerySafe(metadataPath, newBitmapMetadata);
+                                    var innerMetadata = new BitmapMetadata(bitmapMetadata.Format);
+                                    newMetadata.SetQuerySafe(metadataPath, innerMetadata);
                                 }
                                 else
                                 {

--- a/src/modules/imageresizer/ui/Models/ResizeOperation.cs
+++ b/src/modules/imageresizer/ui/Models/ResizeOperation.cs
@@ -87,6 +87,9 @@ namespace ImageResizer.Models
                             // Detect whether metadata can copied successfully
                             var modifiableMetadata = metadata.Clone();
 
+#if DEBUG
+                            modifiableMetadata.PrintsAllMetadataToDebugOutput();
+#endif
                             var metadataList = modifiableMetadata.GetListOfInvalidMetadata();
                             foreach (var (metadataPath, value) in metadataList)
                             {

--- a/src/modules/imageresizer/ui/Models/ResizeOperation.cs
+++ b/src/modules/imageresizer/ui/Models/ResizeOperation.cs
@@ -109,9 +109,9 @@ namespace ImageResizer.Models
                     encoder.Frames.Add(
                         BitmapFrame.Create(
                             Transform(originalFrame),
-                            thumbnail: null,
+                            originalFrame.Thumbnail,
                             metadata,
-                            colorContexts: null));
+                            originalFrame.ColorContexts));
                 }
 
                 path = GetDestinationPath(encoder);

--- a/src/modules/imageresizer/ui/Models/ResizeOperation.cs
+++ b/src/modules/imageresizer/ui/Models/ResizeOperation.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.  Code forked from Brice Lambson's https://github.com/bricelam/ImageResizer/
 
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.IO.Abstractions;
@@ -85,13 +87,20 @@ namespace ImageResizer.Models
                             // Detect whether metadata can copied successfully
                             var modifiableMetadata = metadata.Clone();
 
-                            modifiableMetadata.RemoveMetadataIfInvalid("/app1/ifd/exif:{uint=330}"); // this fixes the issue #9885, image 2 and 3
+                            var metadataList = modifiableMetadata.GetListOfInvalidMetadata();
+                            foreach (var (metadataPath, value) in metadataList)
+                            {
+                                Debug.WriteLine($"Trying to remove invalid metadata found at {metadataPath}.");
+                                modifiableMetadata.RemoveQuerySafe(metadataPath);
+                            }
 
                             metadata = modifiableMetadata;
                         }
-                        catch (ArgumentException)
+                        catch (ArgumentException ex)
                         {
                             metadata = null;
+
+                            Debug.WriteLine(ex);
                         }
                     }
 

--- a/src/modules/imageresizer/ui/Models/ResizeOperation.cs
+++ b/src/modules/imageresizer/ui/Models/ResizeOperation.cs
@@ -83,7 +83,11 @@ namespace ImageResizer.Models
                         try
                         {
                             // Detect whether metadata can copied successfully
-                            _ = metadata.Clone();
+                            var newMetadata = metadata.Clone();
+
+                            newMetadata.RemoveQuery("/app1/ifd/exif:{uint=330}"); // this fixes the issue #9885, image 2 and 3
+
+                            metadata = newMetadata;
                         }
                         catch (ArgumentException)
                         {


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Improves resilience of the image resize implementation.

This PR fixes different categories of bugs in described in #9885 and #14266.

Bug category 1:
- Image contains partially invalid metadata which throws an exception on:
  - reading a given metadata field
  - writing metadata to a given field or persisting the image containing the metadata to disk. 

Bug category 2:
- Some metadata depends on the availability of a thumbnail image. The encoder crashes if the thumbnail image is not found.

**What is include in the PR:** 
- Loop over all metadata and try to read the actual value. Remove metadata item if exception is thrown while reading the value. Build up the metadata object from the scratch by adding all valid values. This resolves Bug category 1
- copy thumbnail image from input to output image to resolve Bug category 2
- Adds two metadata debug methods to simplify the debugging of metadata related bugs 

**How does someone test / validate:** 
test with images provided in linked issue.

Images: Bug category 1:
[#9885 (comment)](https://github.com/microsoft/PowerToys/issues/9885#issuecomment-958967927)
[#9885 (comment)](https://github.com/microsoft/PowerToys/issues/9885#issuecomment-891829849)
[#14266 (comment)](https://github.com/microsoft/PowerToys/issues/14266#issue-1044400800)

Images: Bug category 2:
[#9885 (comment)](https://github.com/microsoft/PowerToys/issues/9885#issue-815762941)

## Quality Checklist

- [x] **Linked issue:** #9885, #14266
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
