### PR TITLE
[Settings] Minor UI tweaks for VCM

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/VideoConference.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/VideoConference.xaml
@@ -5,8 +5,13 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:controls="using:Microsoft.PowerToys.Settings.UI.Controls"
+    xmlns:converters="using:Microsoft.Toolkit.Uwp.UI.Converters"
     mc:Ignorable="d">
 
+    <Page.Resources>
+        <converters:StringVisibilityConverter x:Name="EmptyToCollapsedConverter" EmptyValue="Collapsed" NotEmptyValue="Visible"/>
+    </Page.Resources>
+    
     <controls:SettingsPageControl x:Uid="VideoConference"
                                   ModuleImageSource="ms-appx:///Assets/Modules/VideoConference.png">
         <controls:SettingsPageControl.ModuleContent>
@@ -15,7 +20,7 @@
 
                 <controls:Setting x:Uid="VideoConference_Enable" IsEnabled="{ Binding Mode=OneWay, Path=IsElevated }">
                     <controls:Setting.Icon>
-                        <BitmapIcon UriSource="ms-appx:///Assets/FluentIcons/FluentIconsVideoConference.png" ShowAsMonochrome="False" />
+                        <BitmapIcon UriSource="ms-appx:///Assets/FluentIcons/FluentIconsVideoConferenceMute.png" ShowAsMonochrome="False" />
                     </controls:Setting.Icon>
                     <controls:Setting.ActionContent>
                         <ToggleSwitch IsOn="{Binding Mode=TwoWay, Path=IsEnabled}" />
@@ -33,14 +38,14 @@
                     <controls:Setting x:Uid="VideoConference_MicrophoneMuteHotkeyControl_Header">
                         <controls:Setting.ActionContent>
                             <controls:ShortcutControl HotkeySettings="{x:Bind Path=ViewModel.MicrophoneMuteHotkey, Mode=TwoWay}"
-                                                            MinWidth="{StaticResource SettingActionControlMinWidth}"/>
+                                                      MinWidth="{StaticResource SettingActionControlMinWidth}"/>
                         </controls:Setting.ActionContent>
                     </controls:Setting>
 
                     <controls:Setting x:Uid="VideoConference_CameraMuteHotkeyControl_Header">
                         <controls:Setting.ActionContent>
                             <controls:ShortcutControl HotkeySettings="{x:Bind Path=ViewModel.CameraMuteHotkey, Mode=TwoWay}"
-                                                            MinWidth="{StaticResource SettingActionControlMinWidth}"/>
+                                                      MinWidth="{StaticResource SettingActionControlMinWidth}"/>
                         </controls:Setting.ActionContent>
                     </controls:Setting>
 
@@ -75,18 +80,23 @@
                             <StackPanel Orientation="Vertical">
                                 <controls:Setting x:Uid="VideoConference_CameraOverlayImagePathHeader" Style="{StaticResource ExpanderContentSettingStyle}">
                                     <controls:Setting.ActionContent>
-                                        <StackPanel Orientation="Horizontal" Spacing="8">
-                                            <Button x:Uid="VideoConference_CameraOverlayImageBrowse"
-                                                    Command="{Binding Mode=OneWay, Path=SelectOverlayImage}" />
+                                        <StackPanel Orientation="Vertical">
+                                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                                                <Button x:Uid="VideoConference_CameraOverlayImageBrowse"
+                                                        Command="{Binding Mode=OneWay, Path=SelectOverlayImage}" />
 
-                                            <Button x:Uid="VideoConference_CameraOverlayImageClear"
-                                                    Command="{Binding Mode=OneWay, Path=ClearOverlayImage}"/>
+                                                <Button x:Uid="VideoConference_CameraOverlayImageClear"
+                                                        Margin="8,0,0,0"
+                                                        Visibility="{Binding Path=CameraImageOverlayPath, Mode=OneWay, Converter={StaticResource EmptyToCollapsedConverter}}"
+                                                        Command="{Binding Mode=OneWay, Path=ClearOverlayImage}"/>
+                                                                    
+                                            </StackPanel>
+                                          
                                         </StackPanel>
                                     </controls:Setting.ActionContent>
                                 </controls:Setting>
-                                <Border CornerRadius="4">
-                                    <Image Width="240"
-                                           x:Uid="VideoConference_CameraOverlayImageAlt"
+                                <Border CornerRadius="4" Visibility="{Binding Path=CameraImageOverlayPath, Mode=OneWay, Converter={StaticResource EmptyToCollapsedConverter}}" Margin="56, 8, 40, 20" HorizontalAlignment="Right" MaxHeight="100">
+                                    <Image x:Uid="VideoConference_CameraOverlayImageAlt"
                                            ToolTipService.ToolTip="{Binding Mode=OneWay, Path=CameraImageOverlayPath}"
                                            Source="{Binding Mode=OneWay, Path=CameraImageOverlayPath}"/>
                                 </Border>


### PR DESCRIPTION
## Summary of the Pull Request
This PR addresses the following changes:
- The icon wasn't enabled for the VCM page, and now it is
![image](https://user-images.githubusercontent.com/9866362/142261094-520817da-8f2b-42d7-bf0e-77035bfce09e.png)

- Clear button is now hidden when there's no image selected, because there's nothing to clear :)
![Browsebutton](https://user-images.githubusercontent.com/9866362/142261265-c201e5fa-29e0-47f0-b512-9e039ba1f084.png)

- Tweaked the UI when an image is selected, addressing: #14248
![Withimage](https://user-images.githubusercontent.com/9866362/142261278-ba15cbfb-d138-432e-8862-59f5f4ecd3bf.png)

## Quality Checklist

- [X] **Linked issue:** #14248
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
