### PR TITLE
[FindMyMouse]show on all virtual desktops

### DIFF
--- a/src/modules/MouseUtils/FindMyMouse/FindMyMouse.cpp
+++ b/src/modules/MouseUtils/FindMyMouse/FindMyMouse.cpp
@@ -141,7 +141,7 @@ bool SuperSonar<D>::Initialize(HINSTANCE hinst)
 
     m_hwndOwner = CreateWindow(L"static", nullptr, WS_POPUP, 0, 0, 0, 0, nullptr, nullptr, hinst, nullptr);
 
-    DWORD exStyle = WS_EX_TRANSPARENT | WS_EX_LAYERED | Shim()->GetExtendedStyle();
+    DWORD exStyle = WS_EX_TRANSPARENT | WS_EX_LAYERED | WS_EX_TOOLWINDOW | Shim()->GetExtendedStyle();
     return CreateWindowExW(exStyle, className, windowTitle, WS_POPUP, CW_USEDEFAULT, 0, CW_USEDEFAULT, 0, m_hwndOwner, nullptr, hinst, this) != nullptr;
 }
 


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Find My Mouse only shows on the Virtual Desktop where it's created.

**What is include in the PR:** 
Add the Tool Window extended style so that it shows on all virtual desktops.

**How does someone test / validate:** 
- Activate Find My Mouse on a Virtual Desktop and verify it works.
- Change Virtual Desktop
- Activate Find My Mouse on this other Virtual Desktop and verify it works.

## Quality Checklist

- [x] **Linked issue:** #14503
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries
