### PR TITLE
[Runner] Bring up maximized settings

### DIFF
--- a/src/runner/settings_window.cpp
+++ b/src/runner/settings_window.cpp
@@ -457,7 +457,17 @@ void bring_settings_to_front()
             }
             if (wcsncmp(title, windowTitle.c_str(), len) == 0)
             {
-                ShowWindow(hwnd, SW_RESTORE);
+                auto lStyles = GetWindowLong(hwnd, GWL_STYLE);
+
+                if (lStyles & WS_MAXIMIZE)
+                {
+                    ShowWindow(hwnd, SW_MAXIMIZE);
+                }
+                else
+                {
+                    ShowWindow(hwnd, SW_RESTORE);
+                }
+
                 SetForegroundWindow(hwnd);
                 return FALSE;
             }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Bring up opened settings window from the tray icon resize the window if is maximized

**What is include in the PR:** 
Handle maximized window

**How does someone test / validate:** 
1. Open settings
2. Maximize window
3. Click on tray icon with left mouse cursor
4. Settings should be brought up maximized

## Quality Checklist

- [x] **Linked issue:** #14509
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
