### PR TITLE
[FindMyMouse]Fix duplicated settings path

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/FindMyMouseSettings.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/FindMyMouseSettings.cs
@@ -9,7 +9,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
 {
     public class FindMyMouseSettings : BasePTModuleSettings, ISettingsConfig
     {
-        public const string ModuleName = "Find My Mouse";
+        public const string ModuleName = "FindMyMouse";
 
         [JsonPropertyName("properties")]
         public FindMyMouseProperties Properties { get; set; }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/MouseUtilsPage.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/MouseUtilsPage.xaml.cs
@@ -14,6 +14,24 @@ namespace Microsoft.PowerToys.Settings.UI.Views
 
         public MouseUtilsPage()
         {
+            try
+            {
+                // By mistake, the first release of Find My Mouse was saving settings in two places at the same time.
+                // Delete the wrong path for Find My Mouse settings.
+                var tempSettingsUtils = new SettingsUtils();
+                if (tempSettingsUtils.SettingsExists("Find My Mouse"))
+                {
+                    var settingsFilePath = tempSettingsUtils.GetSettingsFilePath("Find My Mouse");
+                    System.IO.File.Delete(settingsFilePath);
+                    tempSettingsUtils.DeleteSettings("Find My Mouse");
+                }
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (System.Exception)
+#pragma warning restore CA1031 // Do not catch general exception types
+            {
+            }
+
             var settingsUtils = new SettingsUtils();
             ViewModel = new MouseUtilsViewModel(settingsUtils, SettingsRepository<GeneralSettings>.GetInstance(settingsUtils), SettingsRepository<FindMyMouseSettings>.GetInstance(settingsUtils), ShellPage.SendDefaultIPCMessage);
             DataContext = ViewModel;


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Find My Mouse is saving settings to two different directories. Fix the issue by saving in only one directory and deleting the wrong one.

**What is include in the PR:** 
Fix the error which caused the settings to be saved in two different directories.
Delete the wrong folder.

**How does someone test / validate:** 
Run it, enter the settings page for Mouse Utils, and see the wrong directory disappear, while still having your settings load correctly. The wrong settings folder shouldn't be created again after changing settings.

## Quality Checklist

- [x] **Linked issue:** #14130
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
