### PR TITLE
Preview pane toggle instructions

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -1002,7 +1002,7 @@ Made with 💗 by Microsoft and the PowerToys community.</value>
   <data name="FileExplorerPreview_AffectsAllUsers.Title" xml:space="preserve">
     <value>The settings on this page affect all users on the system</value>
   </data>
-  <data name="FileExplorerPreview_TogglePreviewPane.Title" xml:space="preserve">
+  <data name="FileExplorerPreview_TogglePreviewPane.Text" xml:space="preserve">
     <value>Ensure Preview Pane is open by toggling the view with Alt + P in File Explorer</value>
   </data>
   <data name="FileExplorerPreview_RebootRequired.Title" xml:space="preserve">

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -1003,7 +1003,7 @@ Made with 💗 by Microsoft and the PowerToys community.</value>
     <value>The settings on this page affect all users on the system</value>
   </data>
   <data name="FileExplorerPreview_TogglePreviewPane.Text" xml:space="preserve">
-    <value>Ensure Preview Pane is open by toggling the view with Alt + P in File Explorer</value>
+    <value>Please ensure that Preview Pane is open by toggling the view with Alt + P in File Explorer</value>
   </data>
   <data name="FileExplorerPreview_RebootRequired.Title" xml:space="preserve">
     <value>A reboot may be required for changes to these settings to take effect</value>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -1003,7 +1003,7 @@ Made with 💗 by Microsoft and the PowerToys community.</value>
     <value>The settings on this page affect all users on the system</value>
   </data>
   <data name="FileExplorerPreview_TogglePreviewPane.Title" xml:space="preserve">
-    <value>Ensure Preview Pane is open by toggling the view with <kbd>Alt</kbd> + <kbd>P</kbd> in File Explorer</value>
+    <value>Ensure Preview Pane is open by toggling the view with Alt + P in File Explorer</value>
   </data>
   <data name="FileExplorerPreview_RebootRequired.Title" xml:space="preserve">
     <value>A reboot may be required for changes to these settings to take effect</value>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -1002,6 +1002,9 @@ Made with 💗 by Microsoft and the PowerToys community.</value>
   <data name="FileExplorerPreview_AffectsAllUsers.Title" xml:space="preserve">
     <value>The settings on this page affect all users on the system</value>
   </data>
+  <data name="FileExplorerPreview_TogglePreviewPane.Title" xml:space="preserve">
+    <value>Ensure Preview Pane is open by toggling the view with <kbd>Alt</kbd> + <kbd>P</kbd> in File Explorer</value>
+  </data>
   <data name="FileExplorerPreview_RebootRequired.Title" xml:space="preserve">
     <value>A reboot may be required for changes to these settings to take effect</value>
   </data>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerPreviewPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerPreviewPage.xaml
@@ -35,6 +35,12 @@
                                    />
 
                 <controls:SettingsGroup x:Uid="FileExplorerPreview_PreviewPane_GroupSettings">
+                <muxc:InfoBar Severity="Informational"
+                                   x:Uid="FileExplorerPreview_TogglePreviewPane"
+                                   IsOpen="True"
+                                   IsTabStop="True"
+                                   IsClosable="False"
+                                   />
                     <controls:Setting x:Uid="FileExplorerPreview_ToggleSwitch_Preview_SVG" Icon="&#xE91B;">
                         <controls:Setting.ActionContent>
                             <ToggleSwitch IsOn="{x:Bind Mode=TwoWay, Path=ViewModel.SVGRenderIsEnabled}"

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerPreviewPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerPreviewPage.xaml
@@ -35,12 +35,7 @@
                                    />
 
                 <controls:SettingsGroup x:Uid="FileExplorerPreview_PreviewPane_GroupSettings">
-                <muxc:InfoBar Severity="Informational"
-                                   x:Uid="FileExplorerPreview_TogglePreviewPane"
-                                   IsOpen="True"
-                                   IsTabStop="True"
-                                   IsClosable="False"
-                                   />
+                <TextBlock x:Uid="FileExplorerPreview_TogglePreviewPane" Margin="0,0,0,8" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                     <controls:Setting x:Uid="FileExplorerPreview_ToggleSwitch_Preview_SVG" Icon="&#xE91B;">
                         <controls:Setting.ActionContent>
                             <ToggleSwitch IsOn="{x:Bind Mode=TwoWay, Path=ViewModel.SVGRenderIsEnabled}"


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Adding text to the File Explorer settings menu explaining how to enable preview pane.

**What is include in the PR:** 
New information block in File Explorer settings menu

**How does someone test / validate:** 
Ensure localized translation is correct. Currently broken as we transition our build pipeline.

## Quality Checklist

- [X] **Linked issue:** #3858
- [X] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [X] **Binaries:** Any new files are added to WXS / YML
   - [X] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
