### PR TITLE
[ColorPicker] Accept lower-case HEX codes in Adjust color window

### DIFF
--- a/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml.cs
@@ -291,7 +291,7 @@ namespace ColorPicker.Controls
             var newValue = (sender as TextBox).Text;
 
             // support hex with 3 and 6 characters
-            var reg = new Regex("^#([0-9A-F]{3}){1,2}$");
+            var reg = new Regex("^#([0-9A-Fa-f]{3}){1,2}$");
 
             if (!reg.IsMatch(newValue))
             {


### PR DESCRIPTION

## Summary of the Pull Request

**What is this about:**

**What is include in the PR:** 

**How does someone test / validate:** 
 - Run PT and open color picker editor
 - Click selected color to open adjust color window
 - Edit HEX text field by entering both lowercase and uppercase hex codes
 - Observe that color is adjusted accordingly in the upper UI elements

## Quality Checklist

- [x] **Linked issue:** #14521
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
