### PR TITLE
[ci][powerpreview]Add include to fix build error

### DIFF
--- a/src/common/utils/registry.h
+++ b/src/common/utils/registry.h
@@ -8,6 +8,7 @@
 #include <vector>
 #include <optional>
 #include <cassert>
+#include <sstream>
 
 #include "../logger/logger.h"
 #include "../utils/winapi_error.h"


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
CI is currently failing on `undefined class 'std::basic_ostringstream<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t>>'` when building the `powerpreview.vcxproj` project.

**What is include in the PR:** 
Include `sstream` to resolve this name in CI.