### PR TITLE
[ci][binskim]skip cppwinrt.exe binary checks

### DIFF
--- a/.pipelines/pipeline.user.windows.yml
+++ b/.pipelines/pipeline.user.windows.yml
@@ -255,6 +255,7 @@ static_analysis_options:
         exclude:
           - 'WiX.*/**/*.dll'
           - 'Wix.*/**/*.exe'
+          - 'Microsoft.Windows.CppWinRT.*/**/*.exe'
   moderncop_options:
     files_to_scan:
       - from: 'src'


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
CI is currently failing on postbuild static analysis of winrtcpp.exe inside Microsoft.Windows.CppWinRT packages. This makes little sense, since it's an official Microsoft release.

**What is include in the PR:** 
Skip the binary check for those files.
