### PR TITLE
[PT Run] [Program] FileSystemWatcher Crash

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Storage/Win32ProgramFileSystemWatchers.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Storage/Win32ProgramFileSystemWatchers.cs
@@ -1,10 +1,13 @@
-﻿// Copyright (c) Microsoft Corporation
+// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using Wox.Infrastructure.Storage;
+using Wox.Plugin.Logger;
 
 namespace Microsoft.Plugin.Program.Storage
 {
@@ -33,7 +36,18 @@ namespace Microsoft.Plugin.Program.Storage
                                Environment.GetFolderPath(Environment.SpecialFolder.Desktop),
                                Environment.GetFolderPath(Environment.SpecialFolder.CommonDesktopDirectory),
                             };
-            return paths;
+
+            var invalidPaths = new List<string>();
+            foreach (var path in paths)
+            {
+                if (!Directory.Exists(path))
+                {
+                    Log.Warn($"Directory {path} does not exist and will be ignored", typeof(Win32ProgramFileSystemWatchers));
+                    invalidPaths.Add(path);
+                }
+            }
+
+            return paths.Except(invalidPaths).ToArray();
         }
 
         // Initializes the FileSystemWatchers


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Program plugin fail to load if a FileSystemWatcher is initialized for a directory that does not exist or isn't accessible.

**What is include in the PR:** 

- Initialize FileSystemWatcher only for valid directories.
- Log as warning invalid directories.

**How does someone test / validate:** 

- I have been able to repro this only in debug adding an invalid directory to the paths array.
- Validate that the directory is logged and skipped.

## Quality Checklist

- [x] **Linked issue:** #11511
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
