### PR TITLE
[Settings] Add SettingsGroup Description property and VCM message

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/SettingsGroup/SettingsGroup.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/SettingsGroup/SettingsGroup.cs
@@ -19,11 +19,23 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
     /// </summary>
     [TemplateVisualState(Name = "Normal", GroupName = "CommonStates")]
     [TemplateVisualState(Name = "Disabled", GroupName = "CommonStates")]
+    [TemplatePart(Name = PartDescriptionPresenter, Type = typeof(ContentPresenter))]
     public partial class SettingsGroup : ItemsControl
     {
+        private const string PartDescriptionPresenter = "DescriptionPresenter";
+        private ContentPresenter _descriptionPresenter;
+        private SettingsGroup _settingsGroup;
+
         public SettingsGroup()
         {
             DefaultStyleKey = typeof(SettingsGroup);
+        }
+
+        [Localizable(true)]
+        public string Header
+        {
+            get => (string)GetValue(HeaderProperty);
+            set => SetValue(HeaderProperty, value);
         }
 
         public static readonly DependencyProperty HeaderProperty = DependencyProperty.Register(
@@ -33,18 +45,31 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
             new PropertyMetadata(default(string)));
 
         [Localizable(true)]
-        public string Header
+        public object Description
         {
-            get => (string)GetValue(HeaderProperty);
-            set => SetValue(HeaderProperty, value);
+            get => (object)GetValue(DescriptionProperty);
+            set => SetValue(DescriptionProperty, value);
         }
+
+        public static readonly DependencyProperty DescriptionProperty = DependencyProperty.Register(
+            "Description",
+            typeof(object),
+            typeof(SettingsGroup),
+            new PropertyMetadata(null, OnDescriptionChanged));
 
         protected override void OnApplyTemplate()
         {
             IsEnabledChanged -= SettingsGroup_IsEnabledChanged;
+            _settingsGroup = (SettingsGroup)this;
+            _descriptionPresenter = (ContentPresenter)_settingsGroup.GetTemplateChild(PartDescriptionPresenter);
             SetEnabledState();
             IsEnabledChanged += SettingsGroup_IsEnabledChanged;
             base.OnApplyTemplate();
+        }
+
+        private static void OnDescriptionChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            ((SettingsGroup)d).Update();
         }
 
         private void SettingsGroup_IsEnabledChanged(object sender, DependencyPropertyChangedEventArgs e)
@@ -55,6 +80,23 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
         private void SetEnabledState()
         {
             VisualStateManager.GoToState(this, IsEnabled ? "Normal" : "Disabled", true);
+        }
+
+        private void Update()
+        {
+            if (_settingsGroup == null)
+            {
+                return;
+            }
+
+            if (_settingsGroup.Description == null)
+            {
+                _settingsGroup._descriptionPresenter.Visibility = Visibility.Collapsed;
+            }
+            else
+            {
+                _settingsGroup._descriptionPresenter.Visibility = Visibility.Visible;
+            }
         }
 
         protected override AutomationPeer OnCreateAutomationPeer()

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/SettingsGroup/SettingsGroup.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/SettingsGroup/SettingsGroup.xaml
@@ -25,6 +25,7 @@
                                 <VisualState x:Name="Disabled">
                                     <VisualState.Setters>
                                         <Setter Target="HeaderPresenter.Foreground" Value="{ThemeResource TextFillColorDisabledBrush}" />
+                                        <Setter Target="DescriptionPresenter.Foreground" Value="{ThemeResource TextFillColorDisabledBrush}" />
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>
@@ -32,14 +33,36 @@
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
                         </Grid.RowDefinitions>
                         <TextBlock x:Name="HeaderPresenter"
                                    Text="{TemplateBinding Header}"
                                    Grid.Row="0"
                                    Style="{ThemeResource BodyStrongTextBlockStyle}"
-                                   Margin="1,32,0,8"
+                                   Margin="1,32,0,0"
                                    AutomationProperties.HeadingLevel="Level2"/>
-                        <ItemsPresenter Grid.Row="1"/>
+
+                        <ContentPresenter
+                                x:Name="DescriptionPresenter"
+                                Content="{TemplateBinding Description}"
+                                TextWrapping="WrapWholeWords"
+                                Margin="1,4,0,0"
+                                Grid.Row="1"
+                                Foreground="{ThemeResource TextFillColorSecondaryBrush}">
+                            <ContentPresenter.Resources>
+                                <Style TargetType="TextBlock" BasedOn="{StaticResource CaptionTextBlockStyle}">
+                                    <Style.Setters>
+                                        <Setter Property="TextWrapping" Value="WrapWholeWords"/>
+                                    </Style.Setters>
+                                </Style>
+                                <Style TargetType="HyperlinkButton" BasedOn="{StaticResource TextButtonStyle}">
+                                    <Style.Setters>
+                                        <Setter Property="Padding" Value="0,0,0,0"/>
+                                    </Style.Setters>
+                                </Style>
+                            </ContentPresenter.Resources>
+                        </ContentPresenter>
+                        <ItemsPresenter Grid.Row="2" Margin="0,8,0,0"/>
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -190,7 +190,7 @@
   <data name="VideoConference_Camera.Header" xml:space="preserve">
     <value>Camera</value>
   </data>
-	<data name="VideoConference_Camera.Description" xml:space="preserve">
+  <data name="VideoConference_Camera.Description" xml:space="preserve">
     <value>To use this feature, make sure to select PowerToys VideoConference Mute as your camera source in your apps.</value>
   </data>
   <data name="VideoConference_Microphone.Header" xml:space="preserve">
@@ -999,9 +999,9 @@ Made with 💗 by Microsoft and the PowerToys community.</value>
   <data name="FileExplorerPreview_PreviewPane.Header" xml:space="preserve">
     <value>Preview Pane</value>
   </data>
-	<data name="FileExplorerPreview_PreviewPane.Description" xml:space="preserve">
+  <data name="FileExplorerPreview_PreviewPane.Description" xml:space="preserve">
     <value>Ensure that Preview Pane is open by toggling the view with Alt + P in File Explorer.</value>
-	   <comment>Preview Pane and File Explorer are app/feature names in Windows. 'Alt + P' is a shortcut</comment>
+    <comment>Preview Pane and File Explorer are app/feature names in Windows. 'Alt + P' is a shortcut</comment>
   </data>
   <data name="FileExplorerPreview_RunAsAdminRequired.Title" xml:space="preserve">
     <value>You need to run as administrator to modify these settings.</value>
@@ -1009,7 +1009,6 @@ Made with 💗 by Microsoft and the PowerToys community.</value>
   <data name="FileExplorerPreview_AffectsAllUsers.Title" xml:space="preserve">
     <value>The settings on this page affect all users on the system</value>
   </data>
-
   <data name="FileExplorerPreview_RebootRequired.Title" xml:space="preserve">
     <value>A reboot may be required for changes to these settings to take effect</value>
   </data>
@@ -1729,9 +1728,9 @@ From there, simply click on a Markdown file, PDF file or SVG icon in the File Ex
     <value>Find My Mouse</value>
     <comment>Refers to the utility name</comment>
   </data>
-	<data name="MouseUtils_FindMyMouse.Description" xml:space="preserve">
+  <data name="MouseUtils_FindMyMouse.Description" xml:space="preserve">
     <value>Find My Mouse highlights the position of the cursor when pressing the left Ctrl key twice.</value>
-    <comment>Ctrl" is a keyboard key. "Find My Mouse" is the name of the utility</comment>
+    <comment>"Ctrl" is a keyboard key. "Find My Mouse" is the name of the utility</comment>
   </data>
   <data name="MouseUtils_Enable_FindMyMouse.Header" xml:space="preserve">
     <value>Enable Find My Mouse</value>
@@ -1769,7 +1768,7 @@ From there, simply click on a Markdown file, PDF file or SVG icon in the File Ex
     <value>Mouse Highlighter</value>
     <comment>Refers to the utility name</comment>
   </data>
-	<data name="MouseUtils_MouseHighlighter.Description" xml:space="preserve">
+  <data name="MouseUtils_MouseHighlighter.Description" xml:space="preserve">
     <value>Mouse Highlighter mode will highlight mouse clicks.</value>
     <comment>"Mouse Highlighter" is the name of the utility. Mouse is the hardware mouse.</comment>
   </data>
@@ -1777,14 +1776,14 @@ From there, simply click on a Markdown file, PDF file or SVG icon in the File Ex
     <value>Enable Mouse Highlighter</value>
     <comment>"Find My Mouse" is the name of the utility.</comment>
   </data>
-	<data name="MouseUtils_MouseHighlighter_ActivationShortcut.Header" xml:space="preserve">
+  <data name="MouseUtils_MouseHighlighter_ActivationShortcut.Header" xml:space="preserve">
     <value>Activation shortcut</value>
   </data>
-	<data name="MouseUtils_MouseHighlighter_ActivationShortcut.Description" xml:space="preserve">
+  <data name="MouseUtils_MouseHighlighter_ActivationShortcut.Description" xml:space="preserve">
     <value>Customize the shortcut to turn on or off this mode</value>
     <comment>"Mouse Highlighter" is the name of the utility. Mouse is the hardware mouse.</comment>
   </data>
-	<data name="MouseUtils_MouseHighlighter_LeftButtonClickColor.Header" xml:space="preserve">
+  <data name="MouseUtils_MouseHighlighter_LeftButtonClickColor.Header" xml:space="preserve">
     <value>Left button highlight color</value>
   </data>
   <data name="MouseUtils_MouseHighlighter_RightButtonClickColor.Header" xml:space="preserve">

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -993,8 +993,12 @@ Made with 💗 by Microsoft and the PowerToys community.</value>
   <data name="FileExplorerPreview_IconThumbnail_GroupSettings.Header" xml:space="preserve">
     <value>Icon Preview</value>
   </data>
-  <data name="FileExplorerPreview_PreviewPane_GroupSettings.Header" xml:space="preserve">
+  <data name="FileExplorerPreview_PreviewPane.Header" xml:space="preserve">
     <value>Preview Pane</value>
+  </data>
+	<data name="FileExplorerPreview_PreviewPane.Description" xml:space="preserve">
+    <value>Ensure that Preview Pane is open by toggling the view with Alt + P in File Explorer.</value>
+	   <comment>Preview Pane and File Explorer are app/feature names in Windows. 'Alt + P' is a shortcut</comment>
   </data>
   <data name="FileExplorerPreview_RunAsAdminRequired.Title" xml:space="preserve">
     <value>You need to run as administrator to modify these settings.</value>
@@ -1002,9 +1006,7 @@ Made with 💗 by Microsoft and the PowerToys community.</value>
   <data name="FileExplorerPreview_AffectsAllUsers.Title" xml:space="preserve">
     <value>The settings on this page affect all users on the system</value>
   </data>
-  <data name="FileExplorerPreview_TogglePreviewPane.Text" xml:space="preserve">
-    <value>Please ensure that Preview Pane is open by toggling the view with Alt + P in File Explorer</value>
-  </data>
+
   <data name="FileExplorerPreview_RebootRequired.Title" xml:space="preserve">
     <value>A reboot may be required for changes to these settings to take effect</value>
   </data>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -1721,13 +1721,13 @@ From there, simply click on a Markdown file, PDF file or SVG icon in the File Ex
     <value>Find My Mouse</value>
     <comment>Refers to the utility name</comment>
   </data>
+	<data name="MouseUtils_FindMyMouse.Description" xml:space="preserve">
+    <value>Find My Mouse highlights the position of the cursor when pressing the left Ctrl key twice.</value>
+    <comment>Ctrl" is a keyboard key. "Find My Mouse" is the name of the utility</comment>
+  </data>
   <data name="MouseUtils_Enable_FindMyMouse.Header" xml:space="preserve">
     <value>Enable Find My Mouse</value>
     <comment>"Find My Mouse" is the name of the utility.</comment>
-  </data>
-	<data name="MouseUtils_FindMyMouse_Description.Text" xml:space="preserve">
-    <value>Find My Mouse highlights the position of the cursor when pressing the left Ctrl key twice.</value>
-    <comment>"Ctrl" is a keyboard key. "Find My Mouse" is the name of the utility</comment>
   </data>
   <data name="MouseUtils_Prevent_Activation_On_Game_Mode.Content" xml:space="preserve">
     <value>Do not activate when Game Mode is on</value>
@@ -1761,13 +1761,13 @@ From there, simply click on a Markdown file, PDF file or SVG icon in the File Ex
     <value>Mouse Highlighter</value>
     <comment>Refers to the utility name</comment>
   </data>
+	<data name="MouseUtils_MouseHighlighter.Description" xml:space="preserve">
+    <value>Mouse Highlighter mode will highlight mouse clicks.</value>
+    <comment>"Mouse Highlighter" is the name of the utility. Mouse is the hardware mouse.</comment>
+  </data>
   <data name="MouseUtils_Enable_MouseHighlighter.Header" xml:space="preserve">
     <value>Enable Mouse Highlighter</value>
     <comment>"Find My Mouse" is the name of the utility.</comment>
-  </data>
-  <data name="MouseUtils_MouseHighlighter_Description.Text" xml:space="preserve">
-    <value>Mouse Highlighter mode will highlight mouse clicks.</value>
-    <comment>"Mouse Highlighter" is the name of the utility. Mouse is the hardware mouse.</comment>
   </data>
 	<data name="MouseUtils_MouseHighlighter_ActivationShortcut.Header" xml:space="preserve">
     <value>Activation shortcut</value>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -190,6 +190,9 @@
   <data name="VideoConference_Camera.Header" xml:space="preserve">
     <value>Camera</value>
   </data>
+	<data name="VideoConference_Camera.Description" xml:space="preserve">
+    <value>To use this feature, make sure to select PowerToys VideoConference Mute as your camera source in your apps.</value>
+  </data>
   <data name="VideoConference_Microphone.Header" xml:space="preserve">
     <value>Microphone</value>
   </data>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/MouseUtilsPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/MouseUtilsPage.xaml
@@ -14,7 +14,6 @@
         <controls:SettingsPageControl.ModuleContent>
             <StackPanel Orientation="Vertical">
                 <controls:SettingsGroup x:Uid="MouseUtils_FindMyMouse">
-                    <TextBlock x:Uid="MouseUtils_FindMyMouse_Description" Margin="0,0,0,8" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                     <controls:Setting x:Uid="MouseUtils_Enable_FindMyMouse">
                         <controls:Setting.Icon>
                             <BitmapIcon UriSource="ms-appx:///Assets/FluentIcons/FluentIconsFindMyMouse.png" ShowAsMonochrome="False" />
@@ -89,7 +88,6 @@
                 </controls:SettingsGroup>
 
                 <controls:SettingsGroup x:Uid="MouseUtils_MouseHighlighter">
-                    <TextBlock x:Uid="MouseUtils_MouseHighlighter_Description" Margin="0,0,0,8" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                     <controls:Setting x:Uid="MouseUtils_Enable_MouseHighlighter">
                         <controls:Setting.Icon>
                             <BitmapIcon UriSource="ms-appx:///Assets/FluentIcons/FluentIconsMouseHighlighter.png" ShowAsMonochrome="False" />

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerPreviewPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerPreviewPage.xaml
@@ -34,8 +34,7 @@
                                    IsClosable="False"
                                    />
 
-                <controls:SettingsGroup x:Uid="FileExplorerPreview_PreviewPane_GroupSettings">
-                <TextBlock x:Uid="FileExplorerPreview_TogglePreviewPane" Margin="0,0,0,8" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                <controls:SettingsGroup x:Uid="FileExplorerPreview_PreviewPane">
                     <controls:Setting x:Uid="FileExplorerPreview_ToggleSwitch_Preview_SVG" Icon="&#xE91B;">
                         <controls:Setting.ActionContent>
                             <ToggleSwitch IsOn="{x:Bind Mode=TwoWay, Path=ViewModel.SVGRenderIsEnabled}"

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ShellPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ShellPage.xaml
@@ -128,7 +128,8 @@
                 </muxc:NavigationViewItem>
 
                 <muxc:NavigationViewItem x:Uid="Shell_VideoConference"
-                                         helpers:NavHelper.NavigateTo="views:VideoConferencePage">
+                                         helpers:NavHelper.NavigateTo="views:VideoConferencePage"
+                                         IsEnabled="{x:Bind ViewModel.IsVideoConferenceBuild, Mode=OneWay}">
                     <muxc:NavigationViewItem.Icon>
                         <BitmapIcon UriSource="ms-appx:///Assets/FluentIcons/FluentIconsVideoConferenceMute.png"
                                     ShowAsMonochrome="False" />

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ShellPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ShellPage.xaml
@@ -128,8 +128,7 @@
                 </muxc:NavigationViewItem>
 
                 <muxc:NavigationViewItem x:Uid="Shell_VideoConference"
-                                         helpers:NavHelper.NavigateTo="views:VideoConferencePage"
-                                         IsEnabled="{x:Bind ViewModel.IsVideoConferenceBuild, Mode=OneWay}">
+                                         helpers:NavHelper.NavigateTo="views:VideoConferencePage">
                     <muxc:NavigationViewItem.Icon>
                         <BitmapIcon UriSource="ms-appx:///Assets/FluentIcons/FluentIconsVideoConferenceMute.png"
                                     ShowAsMonochrome="False" />


### PR DESCRIPTION
## Summary of the Pull Request
This PR introduces a Description property to SettingsGroup. This makes it easier for us to add a description to a group of settings (which we had to do the last week for Power Preview and Mouse Utilities.

It also closes #6444 by adding a description to the camera section of VCM:
![image](https://user-images.githubusercontent.com/9866362/143608755-20e3807b-708c-45cb-b07b-360f82ce3c8b.png)


## Quality Checklist

- [X] **Linked issue:** #6444
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
