### PR TITLE
[Settings] a11y fixes

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/App.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/App.xaml
@@ -24,6 +24,7 @@
                 <Setter Property="Margin" Value="0,0,0,2" />
                 <Setter Property="Padding" Value="0,0,0,0" />
                 <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                <Setter Property="IsTabStop" Value="False"/>
             </Style>
 
             <Style TargetType="controls:CheckBoxWithDescriptionControl" BasedOn="{StaticResource DefaultCheckBoxStyle}" />

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/FancyZonesPreviewControl.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/FancyZonesPreviewControl.xaml
@@ -39,7 +39,7 @@
             <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
         <Border Opacity="0.8" Grid.ColumnSpan="2" Grid.RowSpan="3" CornerRadius="2" >
-            <Image Source="{x:Bind WallpaperPath, Mode=OneWay}" Stretch="UniformToFill"/>
+            <Image Source="{x:Bind WallpaperPath, Mode=OneWay}" Stretch="UniformToFill" AutomationProperties.AccessibilityView="Raw"/>
         </Border>
      
         <Grid Background="{ThemeResource SystemControlAcrylicElementBrush}" Grid.Row="2"  Grid.ColumnSpan="2"/>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/SettingsPageControl/SettingsPageControl.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/SettingsPageControl/SettingsPageControl.xaml
@@ -5,6 +5,7 @@
     xmlns:local="using:Microsoft.PowerToys.Settings.UI.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Loaded="UserControl_Loaded"
     xmlns:converters="using:Microsoft.Toolkit.Uwp.UI.Converters" xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls"
     mc:Ignorable="d">
 
@@ -59,7 +60,7 @@
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                    TextWrapping="Wrap"/>
 
-                        <ItemsControl ItemsSource="{x:Bind PrimaryLinks}" IsTabStop="False" Margin="0,8,0,0">
+                        <ItemsControl x:Name="PrimaryLinksControl" ItemsSource="{x:Bind PrimaryLinks}" IsTabStop="False" Margin="0,8,0,0">
                             <ItemsControl.ItemTemplate>
                                 <DataTemplate x:DataType="local:PageLink">
                                     <HyperlinkButton NavigateUri="{x:Bind Link}" Style="{StaticResource TextButtonStyle}">

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/SettingsPageControl/SettingsPageControl.xaml.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Controls/SettingsPageControl/SettingsPageControl.xaml.cs
@@ -71,5 +71,10 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
         public static readonly DependencyProperty SecondaryLinksHeaderProperty = DependencyProperty.Register("SecondaryLinksHeader", typeof(string), typeof(SettingsPageControl), new PropertyMetadata(default(string)));
         public static readonly DependencyProperty SecondaryLinksProperty = DependencyProperty.Register("SecondaryLinks", typeof(ObservableCollection<PageLink>), typeof(SettingsPageControl), new PropertyMetadata(new ObservableCollection<PageLink>()));
         public static readonly DependencyProperty ModuleContentProperty = DependencyProperty.Register("ModuleContent", typeof(object), typeof(SettingsPageControl), new PropertyMetadata(new Grid()));
+
+        private void UserControl_Loaded(object sender, RoutedEventArgs e)
+        {
+            PrimaryLinksControl.Focus(FocusState.Programmatic);
+        }
     }
 }

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -1540,6 +1540,9 @@ From there, simply click on a Markdown file, PDF file or SVG icon in the File Ex
   <data name="EditButton.AutomationProperties.Name" xml:space="preserve">
     <value>Edit</value>
   </data>
+	<data name="ImageResizer_EditSize.AutomationProperties.Name" xml:space="preserve">
+    <value>Edit size</value>
+  </data>
   <data name="No" xml:space="preserve">
     <value>No</value>
     <comment>Label of a cancel button</comment>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/GeneralPage.xaml
@@ -162,9 +162,11 @@
 
                     <controls:Setting x:Uid="GeneralPage_ToggleSwitch_AutoDownloadUpdates"
                                       Margin="0,-6,0,0"
+                                      IsEnabled="{Binding AutoUpdatesEnabled}" 
                                       Visibility="{Binding Mode=OneWay, Path=IsAdmin, Converter={StaticResource VisibleIfTrueConverter}}">
-                        <ToggleSwitch  IsOn="{Binding Mode=TwoWay, Path=AutoDownloadUpdates}"
-                                       IsEnabled="{Binding AutoUpdatesEnabled}" />
+                        <controls:Setting.ActionContent>
+                            <ToggleSwitch  IsOn="{Binding Mode=TwoWay, Path=AutoDownloadUpdates}" />
+                        </controls:Setting.ActionContent>
                     </controls:Setting>
                     </controls:SettingsGroup>
 

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
@@ -86,7 +86,7 @@
                                             <TextBlock x:Uid="EditTooltip"/>
                                         </ToolTipService.ToolTip>
                                         <Button.Flyout>
-                                            <Flyout>
+                                            <Flyout x:Uid="EditButton">
                                                 <StackPanel Spacing="16" Margin="0,12,0,0">
                                                     <TextBox
                                                         x:Uid="ImageResizer_Name"

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ImageResizerPage.xaml
@@ -86,8 +86,8 @@
                                             <TextBlock x:Uid="EditTooltip"/>
                                         </ToolTipService.ToolTip>
                                         <Button.Flyout>
-                                            <Flyout x:Uid="EditButton">
-                                                <StackPanel Spacing="16" Margin="0,12,0,0">
+                                                <Flyout x:Uid="ImageResizer_EditSize">
+                                                    <StackPanel Spacing="16" Margin="0,12,0,0">
                                                     <TextBox
                                                         x:Uid="ImageResizer_Name"
                                                         Text="{x:Bind Path=Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/PowerLauncherPage.xaml
@@ -222,12 +222,12 @@
                                                     </controls:Setting.ActionContent>
                                                 </controls:Setting>
                                                 <muxc:InfoBar Severity="Error" x:Uid="Run_NotAccessibleWarning"
-                                                              IsTabStop="True"
+                                                              IsTabStop="{x:Bind ShowNotAccessibleWarning}"
                                                               IsOpen="{x:Bind ShowNotAccessibleWarning}"
                                                               IsClosable="False" />
                                                 <muxc:InfoBar Severity="Error"
                                                               x:Uid="Run_NotAllowedActionKeyword"
-                                                              IsTabStop="True"
+                                                              IsTabStop="{x:Bind ShowNotAllowedKeywordWarning}"
                                                               IsOpen="{x:Bind ShowNotAllowedKeywordWarning}"
                                                               IsClosable="False" />
                                                 <Rectangle Style="{StaticResource ExpanderSeparatorStyle}" />


### PR DESCRIPTION
## Summary of the Pull Request
#13353 - Added AutomationProperties.Name to Flyout
#13375 - Moved ToggleSwitch to ActionContent so it gets a AutomationProperties.Name
#13471 - Set IsTabStop on ItemTemplate, so double focus is removed.
#13483 - Focus is now set on the page content

## Quality Checklist

- [X] **Linked issue:** #13353, #13375, #13471, #13483
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
