### PR TITLE
[PTRun][Program]Avoid loops due to symlinks

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32Program.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32Program.cs
@@ -670,7 +670,13 @@ namespace Microsoft.Plugin.Program.Programs
                         continue;
                     }
 
-                    foreach (var childDirectory in Directory.EnumerateDirectories(currentDirectory, "*", SearchOption.TopDirectoryOnly))
+                    foreach (var childDirectory in Directory.EnumerateDirectories(currentDirectory, "*", new EnumerationOptions()
+                    {
+                        // https://docs.microsoft.com/en-us/dotnet/api/system.io.enumerationoptions?view=net-6.0
+                        // Exclude directories with the Reparse Point file attribute, to avoid loops due to symbolic links / directory junction / mount points.
+                        AttributesToSkip = FileAttributes.Hidden | FileAttributes.System | FileAttributes.ReparsePoint,
+                        RecurseSubdirectories = false,
+                    }))
                     {
                         folderQueue.Enqueue(childDirectory);
                     }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Some types of folder shortcuts cause infinite loops in the Program plugin when searching for programs.
A good example of this are the shortcuts created inside `node_modules` by npm (Node.js' default package manager).

**What is include in the PR:** 
When recursively looking for programs, don't navigate through directories with the Reparse Point attribute set. This will make it so we don't follow symbolic links, directory junctions or mount points.

**How does someone test / validate:** 
This is not easy to replicate at all. These [instructions](https://github.com/microsoft/PowerToys/issues/14483#issuecomment-970679525) can be used but still the project will be to small to cause issues before running into max_path_length and exiting. I'm mostly looking for a code check.

## Quality Checklist

- [x] **Linked issue:** #14483
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries
