### PR TITLE
VCM as admin fixes

### DIFF
--- a/src/modules/interface/powertoy_module_interface.h
+++ b/src/modules/interface/powertoy_module_interface.h
@@ -47,7 +47,7 @@ public:
 
         std::strong_ordering operator<=>(const Hotkey&) const = default;
     };
-    
+
     struct HotkeyEx
     {
         WORD modifiersMask = 0;
@@ -98,7 +98,7 @@ public:
      */
     virtual bool on_hotkey(size_t hotkeyId) { return false; }
 
-     /* These are for enabling the legacy behavior of showing the shortcut guide after pressing the win key.
+    /* These are for enabling the legacy behavior of showing the shortcut guide after pressing the win key.
      * keep_track_of_pressed_win_key returns true if the module wants to keep track of the win key being pressed.
      * milliseconds_win_key_must_be_pressed returns the number of milliseconds the win key should be pressed before triggering the module.
      * Don't use these for new modules.
@@ -109,6 +109,8 @@ public:
     virtual void send_settings_telemetry()
     {
     }
+
+    virtual bool is_enabled_by_default() const { return true; }
 
 protected:
     HANDLE CreateDefaultEvent(const wchar_t* eventName)

--- a/src/modules/videoconference/VideoConferenceModule/VideoConferenceModule.cpp
+++ b/src/modules/videoconference/VideoConferenceModule/VideoConferenceModule.cpp
@@ -527,6 +527,11 @@ void VideoConferenceModule::destroy()
     instance = nullptr;
 }
 
+bool VideoConferenceModule::is_enabled_by_default() const
+{
+    return false;
+}
+
 void VideoConferenceModule::sendSourceCameraNameUpdate()
 {
     if (!_settingsUpdateChannel.has_value() || settings.selectedCamera.empty())

--- a/src/modules/videoconference/VideoConferenceModule/VideoConferenceModule.h
+++ b/src/modules/videoconference/VideoConferenceModule/VideoConferenceModule.h
@@ -45,6 +45,7 @@ public:
     virtual void disable() override;
     virtual bool is_enabled() override;
     virtual void destroy() override;
+    virtual bool is_enabled_by_default() const override;
 
     virtual const wchar_t * get_key() override;
 

--- a/src/runner/general_settings.cpp
+++ b/src/runner/general_settings.cpp
@@ -164,9 +164,15 @@ void apply_general_settings(const json::JsonObject& general_configs, bool save)
     }
 }
 
-void start_initial_powertoys()
+void start_enabled_powertoys()
 {
     std::unordered_set<std::wstring> powertoys_to_disable;
+    // Take into account default values supplied by modules themselves
+    for (auto& [name, powertoy] : modules())
+    {
+        if (!powertoy->is_enabled_by_default())
+            powertoys_to_disable.emplace(name);
+    }
 
     json::JsonObject general_settings;
     try
@@ -177,9 +183,16 @@ void start_initial_powertoys()
             json::JsonObject enabled = general_settings.GetNamedObject(L"enabled");
             for (const auto& disabled_element : enabled)
             {
+                std::wstring disable_module_name{ static_cast<std::wstring_view>(disabled_element.Key()) };
+                // Disable explicitly disabled modules
                 if (!disabled_element.Value().GetBoolean())
                 {
-                    powertoys_to_disable.emplace(disabled_element.Key());
+                    powertoys_to_disable.emplace(std::move(disable_module_name));
+                }
+                // If module was scheduled for disable, but it's enabled in the settings - override default value
+                else if (auto it = powertoys_to_disable.find(disable_module_name); it != end(powertoys_to_disable))
+                {
+                    powertoys_to_disable.erase(it);
                 }
             }
         }
@@ -188,21 +201,11 @@ void start_initial_powertoys()
     {
     }
 
-    if (powertoys_to_disable.empty())
+    for (auto& [name, powertoy] : modules())
     {
-        for (auto& [name, powertoy] : modules())
+        if (!powertoys_to_disable.contains(name))
         {
             powertoy->enable();
-        }
-    }
-    else
-    {
-        for (auto& [name, powertoy] : modules())
-        {
-            if (powertoys_to_disable.find(name) == powertoys_to_disable.end())
-            {
-                powertoy->enable();
-            }
         }
     }
 }

--- a/src/runner/general_settings.h
+++ b/src/runner/general_settings.h
@@ -21,4 +21,4 @@ struct GeneralSettings
 json::JsonObject load_general_settings();
 GeneralSettings get_general_settings();
 void apply_general_settings(const json::JsonObject& general_configs, bool save = true);
-void start_initial_powertoys();
+void start_enabled_powertoys();

--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -177,7 +177,7 @@ int runner(bool isProcessElevated, bool openSettings, std::string settingsWindow
             }
         }
         // Start initial powertoys
-        start_initial_powertoys();
+        start_enabled_powertoys();
 
         Trace::EventLaunch(get_product_version(), isProcessElevated);
 

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/EnabledModules.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI.Library/EnabledModules.cs
@@ -80,7 +80,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             }
         }
 
-        private bool videoConference = true;
+        private bool videoConference; // defaulting to off https://github.com/microsoft/PowerToys/issues/14507
 
         [JsonPropertyName("Video Conference")]
         public bool VideoConference

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -1728,7 +1728,7 @@ From there, simply click on a Markdown file, PDF file or SVG icon in the File Ex
     <value>Enable Find My Mouse</value>
     <comment>"Find My Mouse" is the name of the utility.</comment>
   </data>
-	<data name="MouseUtils_FindMyMouse_Description.Text" xml:space="preserve">
+  <data name="MouseUtils_FindMyMouse_Description.Text" xml:space="preserve">
     <value>Find My Mouse highlights the position of the cursor when pressing the left Ctrl key twice.</value>
     <comment>"Ctrl" is a keyboard key. "Find My Mouse" is the name of the utility</comment>
   </data>
@@ -1772,14 +1772,14 @@ From there, simply click on a Markdown file, PDF file or SVG icon in the File Ex
     <value>Mouse Highlighter mode will highlight mouse clicks.</value>
     <comment>"Mouse Highlighter" is the name of the utility. Mouse is the hardware mouse.</comment>
   </data>
-	<data name="MouseUtils_MouseHighlighter_ActivationShortcut.Header" xml:space="preserve">
+  <data name="MouseUtils_MouseHighlighter_ActivationShortcut.Header" xml:space="preserve">
     <value>Activation shortcut</value>
   </data>
-	<data name="MouseUtils_MouseHighlighter_ActivationShortcut.Description" xml:space="preserve">
+  <data name="MouseUtils_MouseHighlighter_ActivationShortcut.Description" xml:space="preserve">
     <value>Customize the shortcut to turn on or off this mode</value>
     <comment>"Mouse Highlighter" is the name of the utility. Mouse is the hardware mouse.</comment>
   </data>
-	<data name="MouseUtils_MouseHighlighter_LeftButtonClickColor.Header" xml:space="preserve">
+  <data name="MouseUtils_MouseHighlighter_LeftButtonClickColor.Header" xml:space="preserve">
     <value>Left button highlight color</value>
   </data>
   <data name="MouseUtils_MouseHighlighter_RightButtonClickColor.Header" xml:space="preserve">
@@ -1817,5 +1817,8 @@ From there, simply click on a Markdown file, PDF file or SVG icon in the File Ex
   </data>
   <data name="FancyZones_Zone_Appearance.Header" xml:space="preserve">
     <value>Zone appearance</value>
+  </data>
+  <data name="VideoConference_RunAsAdminRequired.Title" xml:space="preserve">
+    <value>You need to run as administrator to modify these settings.</value>
   </data>
 </root>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -1728,7 +1728,7 @@ From there, simply click on a Markdown file, PDF file or SVG icon in the File Ex
     <value>Enable Find My Mouse</value>
     <comment>"Find My Mouse" is the name of the utility.</comment>
   </data>
-  <data name="MouseUtils_FindMyMouse_Description.Text" xml:space="preserve">
+	<data name="MouseUtils_FindMyMouse_Description.Text" xml:space="preserve">
     <value>Find My Mouse highlights the position of the cursor when pressing the left Ctrl key twice.</value>
     <comment>"Ctrl" is a keyboard key. "Find My Mouse" is the name of the utility</comment>
   </data>
@@ -1772,14 +1772,14 @@ From there, simply click on a Markdown file, PDF file or SVG icon in the File Ex
     <value>Mouse Highlighter mode will highlight mouse clicks.</value>
     <comment>"Mouse Highlighter" is the name of the utility. Mouse is the hardware mouse.</comment>
   </data>
-  <data name="MouseUtils_MouseHighlighter_ActivationShortcut.Header" xml:space="preserve">
+	<data name="MouseUtils_MouseHighlighter_ActivationShortcut.Header" xml:space="preserve">
     <value>Activation shortcut</value>
   </data>
-  <data name="MouseUtils_MouseHighlighter_ActivationShortcut.Description" xml:space="preserve">
+	<data name="MouseUtils_MouseHighlighter_ActivationShortcut.Description" xml:space="preserve">
     <value>Customize the shortcut to turn on or off this mode</value>
     <comment>"Mouse Highlighter" is the name of the utility. Mouse is the hardware mouse.</comment>
   </data>
-  <data name="MouseUtils_MouseHighlighter_LeftButtonClickColor.Header" xml:space="preserve">
+	<data name="MouseUtils_MouseHighlighter_LeftButtonClickColor.Header" xml:space="preserve">
     <value>Left button highlight color</value>
   </data>
   <data name="MouseUtils_MouseHighlighter_RightButtonClickColor.Header" xml:space="preserve">

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/ViewModels/ShellViewModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/ViewModels/ShellViewModel.cs
@@ -38,7 +38,9 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             set { Set(ref isBackEnabled, value); }
         }
 
+#pragma warning disable CA1822 // Mark members as static
         public bool IsVideoConferenceBuild
+#pragma warning restore CA1822 // Mark members as static
         {
             get
             {
@@ -49,7 +51,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                     NativeMethods.FreeLibrary(mfHandle);
                 }
 
-                return this != null && File.Exists("modules/VideoConference/VideoConferenceModule.dll") && mfAvailable;
+                return true; // this != null && File.Exists("modules/VideoConference/VideoConferenceModule.dll") && mfAvailable;
             }
         }
 

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/ViewModels/ShellViewModel.cs
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/ViewModels/ShellViewModel.cs
@@ -38,9 +38,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             set { Set(ref isBackEnabled, value); }
         }
 
-#pragma warning disable CA1822 // Mark members as static
         public bool IsVideoConferenceBuild
-#pragma warning restore CA1822 // Mark members as static
         {
             get
             {
@@ -51,7 +49,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                     NativeMethods.FreeLibrary(mfHandle);
                 }
 
-                return true; // this != null && File.Exists("modules/VideoConference/VideoConferenceModule.dll") && mfAvailable;
+                return this != null && File.Exists("modules/VideoConference/VideoConferenceModule.dll") && mfAvailable;
             }
         }
 

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/VideoConference.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/VideoConference.xaml
@@ -5,7 +5,8 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:controls="using:Microsoft.PowerToys.Settings.UI.Controls"
-    xmlns:converters="using:Microsoft.Toolkit.Uwp.UI.Converters" xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+    xmlns:converters="using:Microsoft.Toolkit.Uwp.UI.Converters" 
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     mc:Ignorable="d">
 
     <Page.Resources>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/VideoConference.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/VideoConference.xaml
@@ -5,11 +5,12 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:controls="using:Microsoft.PowerToys.Settings.UI.Controls"
-    xmlns:converters="using:Microsoft.Toolkit.Uwp.UI.Converters"
+    xmlns:converters="using:Microsoft.Toolkit.Uwp.UI.Converters" xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     mc:Ignorable="d">
 
     <Page.Resources>
         <converters:StringVisibilityConverter x:Name="EmptyToCollapsedConverter" EmptyValue="Collapsed" NotEmptyValue="Visible"/>
+        <converters:BoolToObjectConverter x:Key="BoolToVisibilityConverter" TrueValue="Collapsed" FalseValue="Visible"/>
     </Page.Resources>
     
     <controls:SettingsPageControl x:Uid="VideoConference"
@@ -17,7 +18,13 @@
         <controls:SettingsPageControl.ModuleContent>
 
             <StackPanel Orientation="Vertical">
-
+                <muxc:InfoBar
+                    Severity="Warning"
+                    x:Uid="VideoConference_RunAsAdminRequired"
+                    IsOpen="True"
+                    IsTabStop="True"
+                    IsClosable="False"
+                    Visibility="{Binding Mode=OneWay, Path=IsElevated, Converter={StaticResource BoolToVisibilityConverter}}" />
                 <controls:Setting x:Uid="VideoConference_Enable" IsEnabled="{ Binding Mode=OneWay, Path=IsElevated }">
                     <controls:Setting.Icon>
                         <BitmapIcon UriSource="ms-appx:///Assets/FluentIcons/FluentIconsVideoConferenceMute.png" ShowAsMonochrome="False" />


### PR DESCRIPTION
## Summary of the Pull Request

VCM needs UAC access to turn itself off and since during install you need UAC, it is on by default magically.  We shouldn't enable this style of behavior since we're shifting toward a UAC free install.

**What is this about:**
1. Shift VCM to off by default
2. adding info bar for telling you must be admin to enable

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #14507 and #14089
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
