### PR TITLE
[PowerRename] Fixing "Learn more about RegEx" link

### DIFF
--- a/src/modules/powerrename/PowerRenameUILib/MainWindow.xaml
+++ b/src/modules/powerrename/PowerRenameUILib/MainWindow.xaml
@@ -173,7 +173,7 @@
                                                 </DataTemplate>
                                             </ListView.ItemTemplate>
                                         </ListView>
-                                        <HyperlinkButton Grid.Row="2" VerticalAlignment="Bottom">
+                                        <HyperlinkButton Grid.Row="2" VerticalAlignment="Bottom" NavigateUri="https://aka.ms/powertoysRegExHelp">
                                             <TextBlock x:Uid="RegExCheatSheet_LearnMore" />
                                         </HyperlinkButton>
                                     </Grid>


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Fixing broken RegEx link in PowerRename.

**What is include in the PR:** 

**How does someone test / validate:** 
Check that link works in PowerRename RegEx cheat sheet menu

## Quality Checklist

- [x] **Linked issue:** #14704 
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
