### PR TITLE
Sync run on startup with actual task scheduler

### DIFF
--- a/src/runner/general_settings.cpp
+++ b/src/runner/general_settings.cpp
@@ -14,6 +14,7 @@
 
 // TODO: would be nice to get rid of these globals, since they're basically cached json settings
 static std::wstring settings_theme = L"system";
+static bool startup_disabled_manually = false;
 static bool run_as_elevated = false;
 static bool download_updates_automatically = true;
 
@@ -91,7 +92,20 @@ void apply_general_settings(const json::JsonObject& general_configs, bool save)
     if (json::has(general_configs, L"startup", json::JsonValueType::Boolean))
     {
         const bool startup = general_configs.GetNamedBoolean(L"startup");
-        if (startup)
+
+        auto settings = get_general_settings();
+        static std::once_flag once_flag;
+        std::call_once(once_flag, [settings, startup, general_configs] {
+            if (json::has(general_configs, L"startup", json::JsonValueType::Boolean))
+            {
+                if (startup == true && settings.isStartupEnabled == false)
+                {
+                    startup_disabled_manually = true;
+                }
+            }
+        });
+
+        if (startup && !startup_disabled_manually)
         {
             if (is_process_elevated())
             {
@@ -117,6 +131,7 @@ void apply_general_settings(const json::JsonObject& general_configs, bool save)
         else
         {
             delete_auto_start_task_for_this_user();
+            startup_disabled_manually = false;
         }
     }
     if (json::has(general_configs, L"enabled"))

--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -404,6 +404,10 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         result = -1;
     }
 
+    // Save settings on closing
+    auto general_settings = load_general_settings();
+    apply_general_settings(general_settings);
+
     // We need to release the mutexes to be able to restart the application
     if (msi_mutex)
     {


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
On PT startup compare run on startup value from settings file with current state of task scheduler - if startup is true and there is no task, task was deleted manually, so startup should become false.

**What is include in the PR:** 

**How does someone test / validate:** 
1) set run at startup to 'on'
2) exit powertoys
3) open task scheduler and remove powertoys startup

## Quality Checklist

- [x] **Linked issue:** #3110
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
