### PR TITLE
[PowerRename] Add row highlighting

### DIFF
--- a/src/modules/powerrename/PowerRenameUILib/ExplorerItem.cpp
+++ b/src/modules/powerrename/PowerRenameUILib/ExplorerItem.cpp
@@ -50,6 +50,7 @@ namespace winrt::PowerRenameUILib::implementation
         {
             m_renamed = value;
             m_propertyChanged(*this, Windows::UI::Xaml::Data::PropertyChangedEventArgs{ L"Renamed" });
+            m_propertyChanged(*this, Windows::UI::Xaml::Data::PropertyChangedEventArgs{ L"Highlight" });
         }
     }
 
@@ -87,7 +88,13 @@ namespace winrt::PowerRenameUILib::implementation
         {
             m_checked = value;
             m_propertyChanged(*this, Windows::UI::Xaml::Data::PropertyChangedEventArgs{ L"Checked" });
+            m_propertyChanged(*this, Windows::UI::Xaml::Data::PropertyChangedEventArgs{ L"Highlight" });
         }
+    }
+
+    bool ExplorerItem::Highlight()
+    {
+        return m_checked && !m_renamed.empty();
     }
 
     winrt::event_token ExplorerItem::PropertyChanged(winrt::Windows::UI::Xaml::Data::PropertyChangedEventHandler const& handler)

--- a/src/modules/powerrename/PowerRenameUILib/ExplorerItem.cpp
+++ b/src/modules/powerrename/PowerRenameUILib/ExplorerItem.cpp
@@ -50,7 +50,13 @@ namespace winrt::PowerRenameUILib::implementation
         {
             m_renamed = value;
             m_propertyChanged(*this, Windows::UI::Xaml::Data::PropertyChangedEventArgs{ L"Renamed" });
-            m_propertyChanged(*this, Windows::UI::Xaml::Data::PropertyChangedEventArgs{ L"Highlight" });
+
+            auto visibility = m_checked && !m_renamed.empty() ? Windows::UI::Xaml::Visibility::Visible : Windows::UI::Xaml::Visibility::Collapsed;
+            if (m_highlight != visibility)
+            {
+                m_highlight = visibility;
+                m_propertyChanged(*this, Windows::UI::Xaml::Data::PropertyChangedEventArgs{ L"Highlight" });
+            }
         }
     }
 
@@ -88,13 +94,19 @@ namespace winrt::PowerRenameUILib::implementation
         {
             m_checked = value;
             m_propertyChanged(*this, Windows::UI::Xaml::Data::PropertyChangedEventArgs{ L"Checked" });
-            m_propertyChanged(*this, Windows::UI::Xaml::Data::PropertyChangedEventArgs{ L"Highlight" });
+
+            auto visibility = m_checked && !m_renamed.empty() ? Windows::UI::Xaml::Visibility::Visible : Windows::UI::Xaml::Visibility::Collapsed;
+            if (m_highlight != visibility)
+            {
+                m_highlight = visibility;
+                m_propertyChanged(*this, Windows::UI::Xaml::Data::PropertyChangedEventArgs{ L"Highlight" });
+            }
         }
     }
 
-    bool ExplorerItem::Highlight()
+    winrt::Windows::UI::Xaml::Visibility ExplorerItem::Highlight()
     {
-        return m_checked && !m_renamed.empty();
+        return m_highlight;
     }
 
     winrt::event_token ExplorerItem::PropertyChanged(winrt::Windows::UI::Xaml::Data::PropertyChangedEventHandler const& handler)

--- a/src/modules/powerrename/PowerRenameUILib/ExplorerItem.cpp
+++ b/src/modules/powerrename/PowerRenameUILib/ExplorerItem.cpp
@@ -13,6 +13,7 @@ namespace winrt::PowerRenameUILib::implementation
         m_id{ id }, m_idStr{ std::to_wstring(id) }, m_original{ original }, m_renamed{ renamed }, m_type{ type }, m_depth{ depth }, m_checked{ checked }
     {
         m_imagePath = (m_type == static_cast<UINT>(ExplorerItemType::Folder)) ? folderImagePath : fileImagePath;
+        m_highlight = m_checked && !m_renamed.empty() ? Windows::UI::Xaml::Visibility::Visible : Windows::UI::Xaml::Visibility::Collapsed;
     }
 
     int32_t ExplorerItem::Id()

--- a/src/modules/powerrename/PowerRenameUILib/ExplorerItem.h
+++ b/src/modules/powerrename/PowerRenameUILib/ExplorerItem.h
@@ -26,7 +26,7 @@ namespace winrt::PowerRenameUILib::implementation
         void Type(int32_t value);
         bool Checked();
         void Checked(bool value);
-        bool Highlight();
+        winrt::Windows::UI::Xaml::Visibility Highlight();
         Windows::Foundation::Collections::IObservableVector<PowerRenameUILib::ExplorerItem> Children();
         void Children(Windows::Foundation::Collections::IObservableVector<PowerRenameUILib::ExplorerItem> const& value);
         winrt::event_token PropertyChanged(Windows::UI::Xaml::Data::PropertyChangedEventHandler const& handler);
@@ -42,6 +42,7 @@ namespace winrt::PowerRenameUILib::implementation
         winrt::Windows::Foundation::Collections::IObservableVector<PowerRenameUILib::ExplorerItem> m_children;
         int32_t m_type;
         bool m_checked;
+        winrt::Windows::UI::Xaml::Visibility m_highlight;
         winrt::event<Windows::UI::Xaml::Data::PropertyChangedEventHandler> m_propertyChanged;
     };
 }

--- a/src/modules/powerrename/PowerRenameUILib/ExplorerItem.h
+++ b/src/modules/powerrename/PowerRenameUILib/ExplorerItem.h
@@ -26,6 +26,7 @@ namespace winrt::PowerRenameUILib::implementation
         void Type(int32_t value);
         bool Checked();
         void Checked(bool value);
+        bool Highlight();
         Windows::Foundation::Collections::IObservableVector<PowerRenameUILib::ExplorerItem> Children();
         void Children(Windows::Foundation::Collections::IObservableVector<PowerRenameUILib::ExplorerItem> const& value);
         winrt::event_token PropertyChanged(Windows::UI::Xaml::Data::PropertyChangedEventHandler const& handler);

--- a/src/modules/powerrename/PowerRenameUILib/ExplorerItem.idl
+++ b/src/modules/powerrename/PowerRenameUILib/ExplorerItem.idl
@@ -12,6 +12,6 @@ namespace PowerRenameUILib
         String ImagePath { get; };
         Int32 Type;
         Boolean Checked;
-        Boolean Highlight { get; };
+        Windows.UI.Xaml.Visibility Highlight { get; };
     }
 }

--- a/src/modules/powerrename/PowerRenameUILib/ExplorerItem.idl
+++ b/src/modules/powerrename/PowerRenameUILib/ExplorerItem.idl
@@ -12,5 +12,6 @@ namespace PowerRenameUILib
         String ImagePath { get; };
         Int32 Type;
         Boolean Checked;
+        Boolean Highlight { get; };
     }
 }

--- a/src/modules/powerrename/PowerRenameUILib/MainWindow.xaml
+++ b/src/modules/powerrename/PowerRenameUILib/MainWindow.xaml
@@ -92,6 +92,7 @@
                                 <ColumnDefinition Width="*" />
                                 <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
+                            <CheckBox Visibility="{x:Bind Highlight, Mode=OneWay}"></CheckBox>
 
                             <StackPanel Orientation="Horizontal" Grid.Column="0">
                                 <StackPanel MinWidth="{x:Bind Indentation}"/>

--- a/src/modules/powerrename/PowerRenameUILib/MainWindow.xaml
+++ b/src/modules/powerrename/PowerRenameUILib/MainWindow.xaml
@@ -92,6 +92,7 @@
                                 <ColumnDefinition Width="*" />
                                 <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
+                            <CheckBox IsChecked="{x:Bind Highlight, Mode=OneWay}"></CheckBox>
 
                             <StackPanel Orientation="Horizontal" Grid.Column="0">
                                 <StackPanel MinWidth="{x:Bind Indentation}"/>

--- a/src/modules/powerrename/PowerRenameUILib/MainWindow.xaml
+++ b/src/modules/powerrename/PowerRenameUILib/MainWindow.xaml
@@ -92,7 +92,6 @@
                                 <ColumnDefinition Width="*" />
                                 <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
-                            <CheckBox IsChecked="{x:Bind Highlight, Mode=OneWay}"></CheckBox>
 
                             <StackPanel Orientation="Horizontal" Grid.Column="0">
                                 <StackPanel MinWidth="{x:Bind Indentation}"/>

--- a/src/modules/powerrename/PowerRenameUILib/MainWindow.xaml
+++ b/src/modules/powerrename/PowerRenameUILib/MainWindow.xaml
@@ -93,7 +93,7 @@
                                 <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
 
-                            <Border HorizontalAlignment="Stretch" Grid.ColumnSpan="2" BorderThickness="0,0,0,1" Margin="0,0,0,-1" BorderBrush="{ThemeResource SystemAccentColor}" VerticalAlignment="Stretch" Background="{ThemeResource SystemAccentColorLight1}" Opacity="0.1" Visibility="{x:Bind Highlight, Mode=OneWay}" />
+                            <Border HorizontalAlignment="Stretch" Grid.ColumnSpan="2" BorderThickness="0,0,0,1" Margin="0,0,0,-1" BorderBrush="{ThemeResource SystemAccentColor}" VerticalAlignment="Stretch" Background="{ThemeResource AccentTextFillColorPrimaryBrush}" Opacity="0.1" Visibility="{x:Bind Highlight, Mode=OneWay}" />
 
                             <Grid Grid.Column="0" HorizontalAlignment="Left" Margin="10,4,0,4">
                                     <Grid.ColumnDefinitions>

--- a/src/modules/powerrename/PowerRenameUILib/MainWindow.xaml
+++ b/src/modules/powerrename/PowerRenameUILib/MainWindow.xaml
@@ -87,13 +87,13 @@
                 </ListView.ItemContainerStyle>
                 <ListView.ItemTemplate>
                     <DataTemplate x:Name="ExplorerItemTemplate" x:DataType="local:ExplorerItem">
-                        <Grid Height="28">
+                        <Grid Height="28" Padding="0,0,0,0">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*" />
                                 <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
 
-                            <Grid HorizontalAlignment="Stretch" Grid.ColumnSpan="2" VerticalAlignment="Stretch" Background="Red" Visibility="{x:Bind Highlight, Mode=OneWay}" />
+                            <Border HorizontalAlignment="Stretch" Grid.ColumnSpan="2" BorderThickness="0,0,0,1" Margin="0,0,0,-1" BorderBrush="{ThemeResource SystemAccentColor}" VerticalAlignment="Stretch" Background="{ThemeResource SystemAccentColorLight1}" Opacity="0.1" Visibility="{x:Bind Highlight, Mode=OneWay}" />
 
                             <Grid Grid.Column="0" HorizontalAlignment="Left" Margin="10,4,0,4">
                                     <Grid.ColumnDefinitions>
@@ -106,6 +106,8 @@
                              
                                     <CheckBox TabIndex="0"
                                           MinWidth="0"
+                                              Width="28"
+                                              Height="28"
                                           Grid.Column="1"
                                           XYFocusKeyboardNavigation="Enabled"
                                           Checked="Checked_ids"
@@ -128,8 +130,8 @@
                                            VerticalAlignment="Center"
                                            FontSize="12" />
                                 </Grid>
-                                <TextBlock Text="{x:Bind Renamed, Mode=OneWay}" Grid.Column="1" FontWeight="Bold" VerticalAlignment="Center" FontSize="12" />
-                            </Grid>
+                            <TextBlock Text="{x:Bind Renamed, Mode=OneWay}" Grid.Column="1" FontWeight="Bold" Foreground="{ThemeResource SystemAccentColor}" VerticalAlignment="Center" FontSize="12" />
+                        </Grid>
                     </DataTemplate>
                 </ListView.ItemTemplate>
             </ListView>

--- a/src/modules/powerrename/PowerRenameUILib/MainWindow.xaml
+++ b/src/modules/powerrename/PowerRenameUILib/MainWindow.xaml
@@ -130,7 +130,12 @@
                                            VerticalAlignment="Center"
                                            FontSize="12" />
                                 </Grid>
-                            <TextBlock Text="{x:Bind Renamed, Mode=OneWay}" Grid.Column="1" FontWeight="Bold" Foreground="{ThemeResource SystemAccentColor}" VerticalAlignment="Center" FontSize="12" />
+                            <TextBlock Text="{x:Bind Renamed, Mode=OneWay}"
+                                       Grid.Column="1"
+                                       FontWeight="Bold"
+                                       Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}"
+                                       VerticalAlignment="Center"
+                                       FontSize="12" />
                         </Grid>
                     </DataTemplate>
                 </ListView.ItemTemplate>

--- a/src/modules/powerrename/PowerRenameUILib/MainWindow.xaml
+++ b/src/modules/powerrename/PowerRenameUILib/MainWindow.xaml
@@ -77,7 +77,7 @@
                                 <ControlTemplate TargetType="ListViewItem">
                                     <StackPanel Orientation="Vertical">
                                         <ContentPresenter />
-                                        <Rectangle Height="1" Margin="0,4,0,0" Opacity="0.8" Grid.ColumnSpan="5" Fill="{ThemeResource CardStrokeColorDefaultBrush}" HorizontalAlignment="Stretch" VerticalAlignment="Bottom" />
+                                        <Rectangle Height="1" Margin="0,0,0,0" Opacity="0.8" Grid.ColumnSpan="5" Fill="{ThemeResource CardStrokeColorDefaultBrush}" HorizontalAlignment="Stretch" VerticalAlignment="Bottom" />
 
                                     </StackPanel>
                                 </ControlTemplate>
@@ -87,34 +87,49 @@
                 </ListView.ItemContainerStyle>
                 <ListView.ItemTemplate>
                     <DataTemplate x:Name="ExplorerItemTemplate" x:DataType="local:ExplorerItem">
-                        <Grid Height="20" Margin="10,4,0,0">
+                        <Grid Height="28">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*" />
                                 <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
+                            <Grid HorizontalAlignment="Stretch" Grid.ColumnSpan="2" VerticalAlignment="Stretch" Background="Red" Visibility="{x:Bind Highlight, Mode=OneWay}" />
 
-                            <StackPanel Orientation="Horizontal" Grid.Column="0">
-                                <StackPanel MinWidth="{x:Bind Indentation}"/>
-                                <CheckBox TabIndex="0"
-                             MinWidth="0"
-                              XYFocusKeyboardNavigation="Enabled"
-                              Checked="Checked_ids"
-                              IsTabStop="True"
-                              Unchecked="Checked_ids"
-                              Content=""
-                              Name="{x:Bind IdStr}"
-                              AutomationProperties.Name="{x:Bind Original}"
-                              AutomationProperties.HelpText="{x:Bind Renamed}"
-                              IsChecked="{x:Bind Checked, Mode=TwoWay}" />
-                                <Image Width="16" Margin="4,0,0,0" Source="{x:Bind ImagePath}" HorizontalAlignment="Left" />
-                                <TextBlock Margin="6,0,0,0"
-                               Text="{x:Bind Original, Mode=OneWay}"
-                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                               VerticalAlignment="Center"
-                               FontSize="12" />
-                            </StackPanel>
-                            <TextBlock Text="{x:Bind Renamed, Mode=OneWay}" Grid.Column="1" FontWeight="Bold" VerticalAlignment="Center" FontSize="12" />
-                        </Grid>
+                            <Grid Grid.Column="0" HorizontalAlignment="Left" Margin="10,4,0,4">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition MinWidth="{x:Bind Indentation}"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                        <ColumnDefinition Width="Auto"/>
+                                    </Grid.ColumnDefinitions>
+                                 
+                             
+                                    <CheckBox TabIndex="0"
+                                          MinWidth="0"
+                                          Grid.Column="1"
+                                          XYFocusKeyboardNavigation="Enabled"
+                                          Checked="Checked_ids"
+                                          IsTabStop="True"
+                                          Unchecked="Checked_ids"
+                                          Content=""
+                                          Name="{x:Bind IdStr}"
+                                          AutomationProperties.Name="{x:Bind Original}"
+                                          AutomationProperties.HelpText="{x:Bind Renamed}"
+                                          IsChecked="{x:Bind Checked, Mode=TwoWay}" />
+                                    <Image Width="16"
+                                            Grid.Column="2"
+                                           Margin="4,0,0,0"
+                                           Source="{x:Bind ImagePath}"
+                                           HorizontalAlignment="Left" />
+                                    <TextBlock Margin="6,0,0,0"
+                                           Grid.Column="3"
+                                           Text="{x:Bind Original, Mode=OneWay}"
+                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                           VerticalAlignment="Center"
+                                           FontSize="12" />
+                                </Grid>
+                                <TextBlock Text="{x:Bind Renamed, Mode=OneWay}" Grid.Column="1" FontWeight="Bold" VerticalAlignment="Center" FontSize="12" />
+                            </Grid>
+                    
                     </DataTemplate>
                 </ListView.ItemTemplate>
             </ListView>


### PR DESCRIPTION
## Summary of the Pull Request
Currently, it's quite difficult to see what items in the preview list are in scope of getting their names changed. @stefansjfw made it possible to highlight items that will be renamed.

![PowerRename hightlight2](https://user-images.githubusercontent.com/9866362/144286826-9a197e22-c432-47fd-aec8-fa5b2d8690ff.gif)

Dark mode:

![image](https://user-images.githubusercontent.com/9866362/144287152-eacc64b8-9005-4aea-b20c-94903c8fe178.png)


## Quality Checklist

- [X] **Linked issue:** #14724, #608
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
