### PR TITLE
[Setup] Cleanup target dir before installation

### DIFF
--- a/installer/PowerToysSetup/Product.wxs
+++ b/installer/PowerToysSetup/Product.wxs
@@ -85,6 +85,12 @@
       <Custom Action="SetRegisterPowerToysSchTaskParam" Before="RegisterPowerToysSchTask" />
       <Custom Action="SetApplyModulesRegistryChangeSetsParam" Before="ApplyModulesRegistryChangeSets" />
       <Custom Action="SetUnApplyModulesRegistryChangeSetsParam" Before="UnApplyModulesRegistryChangeSets" />
+
+      <Custom Action="SetCleanupTargetFolderParam" Before="CleanupTargetFolder" />
+      <Custom Action="CleanupTargetFolder" Before="InstallFiles" >
+          NOT Installed
+      </Custom>
+        
       <Custom Action="RegisterPowerToysSchTask" After="InstallFiles">
         NOT Installed and CREATESCHEDULEDTASK = 1
       </Custom>
@@ -134,6 +140,10 @@
                     Property="UnApplyModulesRegistryChangeSets"
                     Value="[INSTALLFOLDER]" />
 
+    <CustomAction Id="SetCleanupTargetFolderParam"
+                    Property="CleanupTargetFolder"
+                    Value="[INSTALLFOLDER]" />
+
         <!-- Needs to Impersonate="no" and Execute="deferred" in order to run elevated. -->
     <CustomAction Id="RegisterPowerToysSchTask"
                   Return="ignore"
@@ -165,12 +175,12 @@
                   DllEntry="UninstallEmbeddedMSIXCA"
                    />
 
-        <CustomAction Id="TelemetryLogInstallSuccess"
-                  Return="ignore"
-                  Impersonate="yes"
-                  BinaryKey="PTCustomActions"
-                  DllEntry="TelemetryLogInstallSuccessCA"
-                   />
+    <CustomAction Id="TelemetryLogInstallSuccess"
+                Return="ignore"
+                Impersonate="yes"
+                BinaryKey="PTCustomActions"
+                DllEntry="TelemetryLogInstallSuccessCA"
+                />
 
     <CustomAction Id="TelemetryLogInstallCancel"
                   Return="ignore"
@@ -242,6 +252,14 @@
                   Execute="deferred"
                   BinaryKey="PTCustomActions"
                   DllEntry="UnApplyModulesRegistryChangeSetsCA"
+                  />
+        
+    <CustomAction Id="CleanupTargetFolder"
+                    Return="check"
+                    Impersonate="no"
+                    Execute="deferred"
+                    BinaryKey="PTCustomActions"
+                    DllEntry="CleanupTargetFolderCA"
                   />
 
 

--- a/installer/PowerToysSetupCustomActions/CustomAction.cpp
+++ b/installer/PowerToysSetupCustomActions/CustomAction.cpp
@@ -63,6 +63,42 @@ HRESULT getInstallFolder(MSIHANDLE hInstall, std::wstring& installationDir)
 LExit:
     return hr;
 }
+
+UINT __stdcall CleanupTargetFolderCA(MSIHANDLE hInstall)
+{
+    initSystemLogger();
+    HRESULT hr = S_OK;
+    std::wstring installationFolder;
+    std::error_code ec;
+    fs::path installPath;
+
+    hr = WcaInitialize(hInstall, "CleanupTargetFolder");
+    ExitOnFailure(hr, "Failed to initialize");
+    hr = getInstallFolder(hInstall, installationFolder);
+    ExitOnFailure(hr, "Failed to get installFolder.");
+    installPath = installationFolder;
+    try
+    {
+        if (fs::exists(installPath, ec) && fs::is_directory(installPath, ec) && !fs::is_empty(installPath, ec))
+        {
+            for (auto entry : fs::directory_iterator{ installPath, ec })
+            {
+                fs::remove_all(entry.path(), ec);
+                if (ec)
+                {
+                    Logger::warn("CleanupTargetFolderCA error: {}", ec.message());
+                }
+            }
+        }
+    }
+    catch (std::exception& ex)
+    {
+        Logger::warn("CleanupTargetFolderCA error: {}", ex.what());
+    }
+LExit:
+    return hr;
+}
+
 UINT __stdcall ApplyModulesRegistryChangeSetsCA(MSIHANDLE hInstall)
 {
     initSystemLogger();

--- a/installer/PowerToysSetupCustomActions/CustomAction.def
+++ b/installer/PowerToysSetupCustomActions/CustomAction.def
@@ -2,6 +2,7 @@ LIBRARY "PowerToysSetupCustomActions"
 
 EXPORTS
 	ApplyModulesRegistryChangeSetsCA
+	CleanupTargetFolderCA
 	CreateScheduledTaskCA
 	DetectPrevInstallPathCA
 	RemoveScheduledTasksCA


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
- cleanup installation folder via custom action
- **note that it'll remove everything in the installation folder w/o warning, so user data might be lost** 

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #14701
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
