### PR TITLE
Open PowerRename on currently active monitor

### DIFF
--- a/src/modules/powerrename/PowerRenameUIHost/PowerRenameUIHost.cpp
+++ b/src/modules/powerrename/PowerRenameUIHost/PowerRenameUIHost.cpp
@@ -116,8 +116,27 @@ void AppWindow::CreateAndShowWindow()
     LoadStringW(m_instance, IDS_APP_TITLE, title, ARRAYSIZE(title));
 
     // hardcoded width and height (1200 x 600) - with WinUI 3, it should auto-scale to the content
-    m_window = CreateWindowW(c_WindowClass, title, WS_OVERLAPPEDWINDOW, CW_USEDEFAULT, 0, 1200, 600, nullptr, nullptr, m_instance, this);
+    int windowWidth = 1200;
+    int windowHeight = 600;
+    m_window = CreateWindowW(c_WindowClass, title, WS_OVERLAPPEDWINDOW, CW_USEDEFAULT, 0, windowWidth, windowHeight, nullptr, nullptr, m_instance, this);
     THROW_LAST_ERROR_IF(!m_window);
+
+    POINT cursorPosition{};
+    if (GetCursorPos(&cursorPosition))
+    {
+        HMONITOR hMonitor = MonitorFromPoint(cursorPosition, MONITOR_DEFAULTTOPRIMARY);
+        MONITORINFOEX monitorInfo;
+        monitorInfo.cbSize = sizeof(MONITORINFOEX);
+        GetMonitorInfo(hMonitor, &monitorInfo);
+
+        SetWindowPos(m_window,
+                     HWND_TOP,
+                     monitorInfo.rcWork.left + (monitorInfo.rcWork.right - monitorInfo.rcWork.left - windowWidth) / 2,
+                     monitorInfo.rcWork.top + (monitorInfo.rcWork.bottom - monitorInfo.rcWork.top - windowHeight) / 2,
+                     0,
+                     0,
+                     SWP_NOSIZE);
+    }
 
     ShowWindow(m_window, SW_SHOWNORMAL);
     UpdateWindow(m_window);


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Previously, PowerRename was always opened on primary monitor. Now it is opened from where it was spawned (right-click->PowerRename)

**What is include in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [X] **Linked issue:** #14640
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
