### PR TITLE
[WindowWalker] PowerLauncher removed from results

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.WindowWalker/Components/OpenWindows.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.WindowWalker/Components/OpenWindows.cs
@@ -5,6 +5,8 @@
 // Code forked from Betsegaw Tadele's https://github.com/betsegaw/windowwalker/
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
 
 namespace Microsoft.Plugin.WindowWalker.Components
 {
@@ -13,6 +15,11 @@ namespace Microsoft.Plugin.WindowWalker.Components
     /// </summary>
     internal class OpenWindows
     {
+        /// <summary>
+        /// PowerLauncher main executable
+        /// </summary>
+        private static readonly string _powerLauncherExe = Path.GetFileName(Process.GetCurrentProcess().MainModule.FileName);
+
         /// <summary>
         /// Delegate handler for open windows updates
         /// </summary>
@@ -86,7 +93,7 @@ namespace Microsoft.Plugin.WindowWalker.Components
 
             if (newWindow.IsWindow && newWindow.Visible && newWindow.IsOwner &&
                 (!newWindow.IsToolWindow || newWindow.IsAppWindow) && !newWindow.TaskListDeleted &&
-                newWindow.ClassName != "Windows.UI.Core.CoreWindow")
+                newWindow.ClassName != "Windows.UI.Core.CoreWindow" && newWindow.ProcessName != _powerLauncherExe)
             {
                 windows.Add(newWindow);
             }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Removing PowerLauncher.exe from WindowWalker results.

**What is include in the PR:** 

**How does someone test / validate:** 
- Open Launcher
- Type `<pow`
- PowerLauncher.exe shouldn't be displayed

## Quality Checklist

- [x] **Linked issue:** #14281
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
