### PR TITLE
[FancyZones][Hotfix] Fix VirtualDesktopManager init 

### DIFF
--- a/src/modules/fancyzones/FancyZonesLib/VirtualDesktop.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/VirtualDesktop.cpp
@@ -12,31 +12,6 @@ namespace NonLocalizable
     const wchar_t RegKeyVirtualDesktopsFromSession[] = L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\SessionInfo\\%d\\VirtualDesktops";
 }
 
-const CLSID CLSID_ImmersiveShell = { 0xC2F03A33, 0x21F5, 0x47FA, 0xB4, 0xBB, 0x15, 0x63, 0x62, 0xA2, 0xF2, 0x39 };
-
-IServiceProvider* GetServiceProvider()
-{
-    IServiceProvider* provider{ nullptr };
-    if (FAILED(CoCreateInstance(CLSID_ImmersiveShell, nullptr, CLSCTX_LOCAL_SERVER, __uuidof(provider), (PVOID*)&provider)))
-    {
-        Logger::error("Failed to get ServiceProvider for VirtualDesktopManager");
-        return nullptr;
-    }
-    return provider;
-}
-
-IVirtualDesktopManager* GetVirtualDesktopManager()
-{
-    IVirtualDesktopManager* manager{ nullptr };
-    IServiceProvider* serviceProvider = GetServiceProvider();
-    if (serviceProvider == nullptr || FAILED(serviceProvider->QueryService(__uuidof(manager), &manager)))
-    {
-        Logger::error("Failed to get VirtualDesktopManager");
-        return nullptr;
-    }
-    return manager;
-}
-
 std::optional<GUID> NewGetCurrentDesktopId()
 {
     wil::unique_hkey key{};
@@ -99,9 +74,21 @@ HKEY GetVirtualDesktopsRegKey()
 
 VirtualDesktop::VirtualDesktop(const std::function<void()>& vdInitCallback, const std::function<void()>& vdUpdatedCallback) :
     m_vdInitCallback(vdInitCallback),
-    m_vdUpdatedCallback(vdUpdatedCallback),
-    m_vdManager(GetVirtualDesktopManager())
+    m_vdUpdatedCallback(vdUpdatedCallback)
 {
+    auto res = CoCreateInstance(CLSID_VirtualDesktopManager, nullptr, CLSCTX_ALL, IID_PPV_ARGS(&m_vdManager));
+    if (FAILED(res))
+    {
+        Logger::error("Failed to create VirtualDesktopManager instance");
+    }
+}
+
+VirtualDesktop::~VirtualDesktop()
+{
+    if (m_vdManager)
+    {
+        m_vdManager->Release();
+    }
 }
 
 void VirtualDesktop::Init()

--- a/src/modules/fancyzones/FancyZonesLib/VirtualDesktop.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/VirtualDesktop.cpp
@@ -203,7 +203,7 @@ std::optional<GUID> VirtualDesktop::GetDesktopId(HWND window) const
 {
     GUID id;
     BOOL isWindowOnCurrentDesktop = false;
-    if (m_vdManager->IsWindowOnCurrentVirtualDesktop(window, &isWindowOnCurrentDesktop) == S_OK && isWindowOnCurrentDesktop)
+    if (m_vdManager && m_vdManager->IsWindowOnCurrentVirtualDesktop(window, &isWindowOnCurrentDesktop) == S_OK && isWindowOnCurrentDesktop)
     {
         // Filter windows such as Windows Start Menu, Task Switcher, etc.
         if (m_vdManager->GetWindowDesktopId(window, &id) == S_OK && id != GUID_NULL)

--- a/src/modules/fancyzones/FancyZonesLib/VirtualDesktop.h
+++ b/src/modules/fancyzones/FancyZonesLib/VirtualDesktop.h
@@ -7,7 +7,7 @@ class VirtualDesktop
 {
 public:
     VirtualDesktop(const std::function<void()>& vdInitCallback, const std::function<void()>& vdUpdatedCallback);
-    ~VirtualDesktop() = default;
+    ~VirtualDesktop();
 
     inline bool IsVirtualDesktopIdSavedInRegistry(GUID id) const
     {


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

* Changed `IVirtualDesktopManager` initialization
* Added missed nullptr check 

**What is include in the PR:** 

**How does someone test / validate:** 

* Launch PT, verify that FZ works.
* Verify that no `[error] Failed to create VirtualDesktopManager instance`  in the logs.

## Quality Checklist

- [x] **Linked issue:** #13214 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
