### PR TITLE
[BackgroundActivatorDLL] Unify dll/exe naming 

### DIFF
--- a/.pipelines/pipeline.user.windows.yml
+++ b/.pipelines/pipeline.user.windows.yml
@@ -73,7 +73,7 @@ build:
           include:
             - 'PowerToys.ActionRunner.exe'
             - 'PowerToys.Update.exe'
-            - 'BackgroundActivatorDLL.dll'
+            - 'PowerToys.BackgroundActivatorDLL.dll'
             - 'Notifications.dll'
             - 'os-detection.dll'
             - 'PowerToys.exe'

--- a/installer/PowerToysSetup/Product.wxs
+++ b/installer/PowerToysSetup/Product.wxs
@@ -417,7 +417,7 @@
         </RegistryKey>
       </Component>
       <Component Id="BackgroundActivator_dll" Guid="23B25EE4-BCA2-45DF-BBCD-82FBDF01C5AB" Win64="yes">
-        <File Id="BackgroundActivatorDLL.dll" KeyPath="yes" Checksum="yes" />
+        <File Id="PowerToys.BackgroundActivatorDLL.dll" KeyPath="yes" Checksum="yes" />
       </Component>
       <Component Id="PowerToys_ActionRunner_exe" Guid="626ABB17-16F0-4007-9A58-6998724A5E14" Win64="yes">
         <File Id="PowerToys.ActionRunner.exe" KeyPath="yes" Checksum="yes" />

--- a/src/common/notifications/BackgroundActivatorDLL/BackgroundActivatorDLL.vcxproj
+++ b/src/common/notifications/BackgroundActivatorDLL/BackgroundActivatorDLL.vcxproj
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.props')" />
-
   <PropertyGroup Label="Globals">
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{031AC72E-FA28-4AB7-B690-6F7B9C28AA73}</ProjectGuid>
@@ -12,7 +11,6 @@
   <PropertyGroup Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
   </PropertyGroup>
-
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
@@ -32,9 +30,8 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
-    <TargetName>BackgroundActivatorDLL</TargetName>
+    <TargetName>PowerToys.BackgroundActivatorDLL</TargetName>
   </PropertyGroup>
-
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -45,7 +42,6 @@
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
     </ClCompile>
   </ItemDefinitionGroup>
-
   <ItemDefinitionGroup>
     <ClCompile>
       <WarningLevel>Level4</WarningLevel>

--- a/src/common/notifications/BackgroundActivatorDLL/resource.h
+++ b/src/common/notifications/BackgroundActivatorDLL/resource.h
@@ -7,7 +7,7 @@
 
 #define FILE_DESCRIPTION "PowerToys Notifications"
 #define INTERNAL_NAME "Notifications"
-#define ORIGINAL_FILENAME "BackgroundActivatorDLL.dll"
+#define ORIGINAL_FILENAME "PowerToys.BackgroundActivatorDLL.dll"
 
 // Non-localizable
 //////////////////////////////

--- a/src/common/notifications/notifications.cpp
+++ b/src/common/notifications/notifications.cpp
@@ -95,7 +95,7 @@ public:
         const NOTIFICATION_USER_INPUT_DATA*,
         ULONG) override
     {
-        auto lib = LoadLibraryW(L"BackgroundActivatorDLL.dll");
+        auto lib = LoadLibraryW(L"PowerToys.BackgroundActivatorDLL.dll");
         if (!lib)
         {
             return 1;


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Rename `BackgroundActivatorDLL.dll` to `PowerToys.BackgroundActivatorDLL.dll`

**What is include in the PR:** 

**How does someone test / validate:** 
 - run PT non-elevated
 - FancyZones enabled
 - open some app as administrator
 - try to zone that app
 - confirm that "can't drag elevated app" toast notification is shown 

## Quality Checklist

- [x] **Linked issue:** #2125 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [x] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
