### PR TITLE
Update PT Run plugins icons and author

### DIFF
--- a/src/modules/launcher/PowerLauncher/SettingsReader.cs
+++ b/src/modules/launcher/PowerLauncher/SettingsReader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation
+// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -202,7 +202,7 @@ namespace PowerLauncher
         }
 
         /// <summary>
-        /// Add new plugins and updates additional options for existing ones
+        /// Add new plugins and updates properties and additional options for existing ones
         /// </summary>
         private static void UpdateSettings(PowerLauncherSettings settings)
         {
@@ -214,6 +214,9 @@ namespace PowerLauncher
                     var additionalOptions = CombineAdditionalOptions(defaultPlugins[plugin.Id].AdditionalOptions, plugin.AdditionalOptions);
                     plugin.Name = defaultPlugins[plugin.Id].Name;
                     plugin.Description = defaultPlugins[plugin.Id].Description;
+                    plugin.Author = defaultPlugins[plugin.Id].Author;
+                    plugin.IconPathDark = defaultPlugins[plugin.Id].IconPathDark;
+                    plugin.IconPathLight = defaultPlugins[plugin.Id].IconPathLight;
                     defaultPlugins[plugin.Id] = plugin;
                     defaultPlugins[plugin.Id].AdditionalOptions = additionalOptions;
                 }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Update plugins icons and author on PT Run startup.

**What is include in the PR:** 

**How does someone test / validate:** 
- Edit `%LOCALAPPDATA%\Microsoft\PowerToys\PowerToys Run\settings.json` changing icons and author for some plugins.
- Verify that with 0.51.1 in Plugin Manager icons and author are broken
- Verify that with this build after PT Run start icons and author are properly updated

## Quality Checklist

- [x] **Linked issue:** #14826
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
