### PR TITLE
[Image Resizer] Fix regression: Metadata Tag "ColorSpace" is lost on resize (#14866)

### DIFF
--- a/src/modules/imageresizer/ui/Models/ResizeOperation.cs
+++ b/src/modules/imageresizer/ui/Models/ResizeOperation.cs
@@ -133,7 +133,7 @@ namespace ImageResizer.Models
                             Transform(originalFrame),
                             originalFrame.Thumbnail,
                             metadata,
-                            originalFrame.ColorContexts));
+                            null));
                 }
 
                 path = GetDestinationPath(encoder);


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
fixes a regression where the color space is lost on resizing images.

**What is include in the PR:** 
a fix for #14866

**How does someone test / validate:** 
see #14866

## Quality Checklist

- [x] **Linked issue:** #14866
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
