### PR TITLE
[PTRun]Avoid starting two instances from runner

### DIFF
--- a/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
+++ b/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
@@ -226,9 +226,6 @@ public:
             processStartingMutex.unlock();
         }
 
-
-
-        m_enabled = true;
         ResetEvent(m_hCentralizedKeyboardHookEvent);
         ResetEvent(send_telemetry_event);
 
@@ -288,6 +285,7 @@ public:
             }
         }
         processStarting = false;
+        m_enabled = true;
         Logger::info("Microsoft_Launcher::enable() end");
     }
 

--- a/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
+++ b/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
@@ -14,6 +14,7 @@
 #include <common/utils/winapi_error.h>
 
 #include <filesystem>
+#include <mutex>
 
 namespace
 {
@@ -60,6 +61,8 @@ private:
     // Load initial settings from the persisted values.
     void init_settings();
 
+    bool processStarting = false;
+    std::mutex processStartingMutex;
     bool processStarted = false;
 
     //contains the name of the powerToys
@@ -204,7 +207,27 @@ public:
     // Enable the powertoy
     virtual void enable()
     {
-        Logger::info("Microsoft_Launcher::enable()");
+        Logger::info("Microsoft_Launcher::enable() begin");
+
+        // This synchronization code is here since we've seen logs of this function being entered twice in the same process/thread pair.
+        // The theory here is that the call to ShellExecuteExW might be enabling some context switching that allows the low level keyboard hook to be run.
+        // Ref: https://github.com/microsoft/PowerToys/issues/12908#issuecomment-986995633
+        // We want only one instance to be started at the same time.
+        processStartingMutex.lock();
+        if (processStarting)
+        {
+            processStartingMutex.unlock();
+            Logger::warn(L"Two PowerToys Run processes were trying to get started at the same time.");
+            return;
+        }
+        else
+        {
+            processStarting = true;
+            processStartingMutex.unlock();
+        }
+
+
+
         m_enabled = true;
         ResetEvent(m_hCentralizedKeyboardHookEvent);
         ResetEvent(send_telemetry_event);
@@ -264,6 +287,8 @@ public:
                 }
             }
         }
+        processStarting = false;
+        Logger::info("Microsoft_Launcher::enable() end");
     }
 
     // Disable the powertoy


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Some of the errors about PowerToys Run files being in use by another process seem to be caused by the runner trying two start two PowerToys Run executable instances concurrently.
Some of the logs we've received show a log order which shouldn't happen in theory in the same thread:
https://github.com/microsoft/PowerToys/issues/12908#issuecomment-986995633
My theory is that the call to to `ShellExecuteExW` might be enabling some context switching that allows the low level keyboard hook to be run and try to start another instance.

**What is include in the PR:** 
Add some synchronization logic to avoid starting two instances at the same time.

**How does someone test / validate:** 
Not quite sure, I've never been able to replicate this myself. A code review is what I'm looking for in here.

## Quality Checklist

- [x] **Linked issue:** #12908
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries
