### PR TITLE
[Settings] HighContrastAdjustment fix

### DIFF
--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeShellPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/OOBE/Views/OobeShellPage.xaml
@@ -9,6 +9,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     winui:BackdropMaterial.ApplyToRootOrPageBackground="True"
     mc:Ignorable="d"
+    HighContrastAdjustment="None"
     Loaded="UserControl_Loaded">
 
     <UserControl.Resources>

--- a/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ShellPage.xaml
+++ b/src/settings-ui/Microsoft.PowerToys.Settings.UI/Views/ShellPage.xaml
@@ -9,6 +9,7 @@
     xmlns:views="using:Microsoft.PowerToys.Settings.UI.Views"
     xmlns:ic="using:Microsoft.Xaml.Interactions.Core"
     xmlns:i="using:Microsoft.Xaml.Interactivity"
+    HighContrastAdjustment="None"
     muxc:BackdropMaterial.ApplyToRootOrPageBackground="True"
     mc:Ignorable="d">
 


### PR DESCRIPTION
## Summary of the Pull Request
This PR closes two a11y issues by setting the HighContrastAdjustment = None.

Old:
![image](https://user-images.githubusercontent.com/9866362/145065197-a0357db4-22f8-4230-86b5-5d731589f886.png)

New screenshot (without black rectangle behind the text), closing #13716
![image](https://user-images.githubusercontent.com/9866362/145065278-fb3d756b-8387-4816-9776-f676e29bfe69.png)

It now also provides a roll-over color when hovering over hyperlinks, closing #10735
![A11y](https://user-images.githubusercontent.com/9866362/145065525-43c5dda3-4ea6-4567-8798-177bb1a6468d.gif)


## Quality Checklist

- [X] **Linked issue:** #13716 #10735
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
