### PR TITLE
[MouseUtils]Add PowerToys to window names

### DIFF
--- a/src/modules/MouseUtils/FindMyMouse/FindMyMouse.cpp
+++ b/src/modules/MouseUtils/FindMyMouse/FindMyMouse.cpp
@@ -99,8 +99,7 @@ private:
 private:
     static constexpr auto className = L"FindMyMouse";
 
-    // Use the runner name for the Window title. Otherwise, since Find My Mouse has an actual visual, its Window name will be the one shown in Task Manager after being shown.
-    static constexpr auto windowTitle = L"PowerToys Runner";
+    static constexpr auto windowTitle = L"PowerToys Find My Mouse";
 
     static LRESULT CALLBACK s_WndProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);
 

--- a/src/modules/MouseUtils/MouseHighlighter/MouseHighlighter.cpp
+++ b/src/modules/MouseUtils/MouseHighlighter/MouseHighlighter.cpp
@@ -47,7 +47,7 @@ private:
     static LRESULT CALLBACK MouseHookProc(int nCode, WPARAM wParam, LPARAM lParam) noexcept;
 
     static constexpr auto m_className = L"MouseHighlighter";
-    static constexpr auto m_windowTitle = L"MouseHighlighter";
+    static constexpr auto m_windowTitle = L"PowerToys Mouse Highlighter";
     HWND m_hwndOwner = NULL;
     HWND m_hwnd = NULL;
     HINSTANCE m_hinstance = NULL;


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
In an effort to standardize user facing strings, adding proper "PowerToys" prefix to the titles of the windows created by mouse utils.

**What is include in the PR:** 
Changes to the Windows names.

**How does someone test / validate:** 
Not sure how to make this strings user facing, but I assume they'll appear on some window inspector software.

## Quality Checklist

- [x] **Linked issue:** #2125
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries
