### PR TITLE
[PowerRename] Don't treat extensions for folders

### DIFF
--- a/src/modules/powerrename/lib/Helpers.cpp
+++ b/src/modules/powerrename/lib/Helpers.cpp
@@ -42,7 +42,7 @@ HRESULT GetTrimmedFileName(_Out_ PWSTR result, UINT cchMax, _In_ PCWSTR source)
     return hr;
 }
 
-HRESULT GetTransformedFileName(_Out_ PWSTR result, UINT cchMax, _In_ PCWSTR source, DWORD flags)
+HRESULT GetTransformedFileName(_Out_ PWSTR result, UINT cchMax, _In_ PCWSTR source, DWORD flags, bool isFolder)
 {
     std::locale::global(std::locale(""));
     HRESULT hr = E_INVALIDARG;
@@ -50,19 +50,47 @@ HRESULT GetTransformedFileName(_Out_ PWSTR result, UINT cchMax, _In_ PCWSTR sour
     {
         if (flags & Uppercase)
         {
-            if (flags & NameOnly)
+            if (isFolder)
             {
-                std::wstring stem = fs::path(source).stem().wstring();
-                std::transform(stem.begin(), stem.end(), stem.begin(), ::towupper);
-                hr = StringCchPrintf(result, cchMax, L"%s%s", stem.c_str(), fs::path(source).extension().c_str());
-            }
-            else if (flags & ExtensionOnly)
-            {
-                std::wstring extension = fs::path(source).extension().wstring();
-                if (!extension.empty())
+                if (!(flags & ExtensionOnly))
                 {
-                    std::transform(extension.begin(), extension.end(), extension.begin(), ::towupper);
-                    hr = StringCchPrintf(result, cchMax, L"%s%s", fs::path(source).stem().c_str(), extension.c_str());
+                    hr = StringCchCopy(result, cchMax, source);
+                    if (SUCCEEDED(hr))
+                    {
+                        std::transform(result, result + wcslen(result), result, ::towupper);
+                    }
+                }
+                else
+                {
+                    // Nothing to do, but valid case.
+                    hr = S_OK;
+                }
+
+            }
+            else
+            {
+                if (flags & NameOnly)
+                {
+                    std::wstring stem = fs::path(source).stem().wstring();
+                    std::transform(stem.begin(), stem.end(), stem.begin(), ::towupper);
+                    hr = StringCchPrintf(result, cchMax, L"%s%s", stem.c_str(), fs::path(source).extension().c_str());
+                }
+                else if (flags & ExtensionOnly)
+                {
+                    std::wstring extension = fs::path(source).extension().wstring();
+                    if (!extension.empty())
+                    {
+                        std::transform(extension.begin(), extension.end(), extension.begin(), ::towupper);
+                        hr = StringCchPrintf(result, cchMax, L"%s%s", fs::path(source).stem().c_str(), extension.c_str());
+                    }
+                    else
+                    {
+                        hr = StringCchCopy(result, cchMax, source);
+                        if (SUCCEEDED(hr))
+                        {
+                            std::transform(result, result + wcslen(result), result, ::towupper);
+                        }
+                    }
                 }
                 else
                 {
@@ -73,30 +101,49 @@ HRESULT GetTransformedFileName(_Out_ PWSTR result, UINT cchMax, _In_ PCWSTR sour
                     }
                 }
             }
-            else
-            {
-                hr = StringCchCopy(result, cchMax, source);
-                if (SUCCEEDED(hr))
-                {
-                    std::transform(result, result + wcslen(result), result, ::towupper);
-                }
-            }
         }
         else if (flags & Lowercase)
         {
-            if (flags & NameOnly)
+            if (isFolder)
             {
-                std::wstring stem = fs::path(source).stem().wstring();
-                std::transform(stem.begin(), stem.end(), stem.begin(), ::towlower);
-                hr = StringCchPrintf(result, cchMax, L"%s%s", stem.c_str(), fs::path(source).extension().c_str());
-            }
-            else if (flags & ExtensionOnly)
-            {
-                std::wstring extension = fs::path(source).extension().wstring();
-                if (!extension.empty())
+                if (!(flags & ExtensionOnly))
                 {
-                    std::transform(extension.begin(), extension.end(), extension.begin(), ::towlower);
-                    hr = StringCchPrintf(result, cchMax, L"%s%s", fs::path(source).stem().c_str(), extension.c_str());
+                    hr = StringCchCopy(result, cchMax, source);
+                    if (SUCCEEDED(hr))
+                    {
+                        std::transform(result, result + wcslen(result), result, ::towlower);
+                    }
+                }
+                else
+                {
+                    // Nothing to do, but valid case.
+                    hr = S_OK;
+                }
+            }
+            else
+            {
+                if (flags & NameOnly)
+                {
+                    std::wstring stem = fs::path(source).stem().wstring();
+                    std::transform(stem.begin(), stem.end(), stem.begin(), ::towlower);
+                    hr = StringCchPrintf(result, cchMax, L"%s%s", stem.c_str(), fs::path(source).extension().c_str());
+                }
+                else if (flags & ExtensionOnly)
+                {
+                    std::wstring extension = fs::path(source).extension().wstring();
+                    if (!extension.empty())
+                    {
+                        std::transform(extension.begin(), extension.end(), extension.begin(), ::towlower);
+                        hr = StringCchPrintf(result, cchMax, L"%s%s", fs::path(source).stem().c_str(), extension.c_str());
+                    }
+                    else
+                    {
+                        hr = StringCchCopy(result, cchMax, source);
+                        if (SUCCEEDED(hr))
+                        {
+                            std::transform(result, result + wcslen(result), result, ::towlower);
+                        }
+                    }
                 }
                 else
                 {
@@ -107,22 +154,14 @@ HRESULT GetTransformedFileName(_Out_ PWSTR result, UINT cchMax, _In_ PCWSTR sour
                     }
                 }
             }
-            else
-            {
-                hr = StringCchCopy(result, cchMax, source);
-                if (SUCCEEDED(hr))
-                {
-                    std::transform(result, result + wcslen(result), result, ::towlower);
-                }
-            }
         }
         else if (flags & Titlecase)
         {
             if (!(flags & ExtensionOnly))
             {
                 std::vector<std::wstring> exceptions = { L"a", L"an", L"to", L"the", L"at", L"by", L"for", L"in", L"of", L"on", L"up", L"and", L"as", L"but", L"or", L"nor" };
-                std::wstring stem = fs::path(source).stem().wstring();
-                std::wstring extension = fs::path(source).extension().wstring();
+                std::wstring stem = isFolder ? source : fs::path(source).stem().wstring();
+                std::wstring extension = isFolder ? L"" : fs::path(source).extension().wstring();
 
                 size_t stemLength = stem.length();
                 bool isFirstWord = true;
@@ -171,8 +210,8 @@ HRESULT GetTransformedFileName(_Out_ PWSTR result, UINT cchMax, _In_ PCWSTR sour
         {
             if (!(flags & ExtensionOnly))
             {
-                std::wstring stem = fs::path(source).stem().wstring();
-                std::wstring extension = fs::path(source).extension().wstring();
+                std::wstring stem = isFolder ? source : fs::path(source).stem().wstring();
+                std::wstring extension = isFolder ? L"" : fs::path(source).extension().wstring();
 
                 size_t stemLength = stem.length();
 

--- a/src/modules/powerrename/lib/Helpers.cpp
+++ b/src/modules/powerrename/lib/Helpers.cpp
@@ -52,20 +52,11 @@ HRESULT GetTransformedFileName(_Out_ PWSTR result, UINT cchMax, _In_ PCWSTR sour
         {
             if (isFolder)
             {
-                if (!(flags & ExtensionOnly))
+                hr = StringCchCopy(result, cchMax, source);
+                if (SUCCEEDED(hr))
                 {
-                    hr = StringCchCopy(result, cchMax, source);
-                    if (SUCCEEDED(hr))
-                    {
-                        std::transform(result, result + wcslen(result), result, ::towupper);
-                    }
+                    std::transform(result, result + wcslen(result), result, ::towupper);
                 }
-                else
-                {
-                    // Nothing to do, but valid case.
-                    hr = S_OK;
-                }
-
             }
             else
             {
@@ -106,18 +97,10 @@ HRESULT GetTransformedFileName(_Out_ PWSTR result, UINT cchMax, _In_ PCWSTR sour
         {
             if (isFolder)
             {
-                if (!(flags & ExtensionOnly))
+                hr = StringCchCopy(result, cchMax, source);
+                if (SUCCEEDED(hr))
                 {
-                    hr = StringCchCopy(result, cchMax, source);
-                    if (SUCCEEDED(hr))
-                    {
-                        std::transform(result, result + wcslen(result), result, ::towlower);
-                    }
-                }
-                else
-                {
-                    // Nothing to do, but valid case.
-                    hr = S_OK;
+                    std::transform(result, result + wcslen(result), result, ::towlower);
                 }
             }
             else

--- a/src/modules/powerrename/lib/Helpers.h
+++ b/src/modules/powerrename/lib/Helpers.h
@@ -5,7 +5,7 @@
 #include <string>
 
 HRESULT GetTrimmedFileName(_Out_ PWSTR result, UINT cchMax, _In_ PCWSTR source);
-HRESULT GetTransformedFileName(_Out_ PWSTR result, UINT cchMax, _In_ PCWSTR source, DWORD flags);
+HRESULT GetTransformedFileName(_Out_ PWSTR result, UINT cchMax, _In_ PCWSTR source, DWORD flags, bool isFolder);
 HRESULT GetDatedFileName(_Out_ PWSTR result, UINT cchMax, _In_ PCWSTR source, SYSTEMTIME fileTime);
 bool isFileTimeUsed(_In_ PCWSTR source);
 bool DataObjectContainsRenamableItem(_In_ IUnknown* dataSource);

--- a/src/modules/powerrename/lib/PowerRenameManager.cpp
+++ b/src/modules/powerrename/lib/PowerRenameManager.cpp
@@ -984,22 +984,35 @@ DWORD WINAPI CPowerRenameManager::s_regexWorkerThread(_In_ void* pv)
                     winrt::check_hresult(spItem->GetNewName(&currentNewName));
 
                     wchar_t sourceName[MAX_PATH] = { 0 };
-                    if (flags & NameOnly)
+
+                    if (isFolder)
                     {
-                        StringCchCopy(sourceName, ARRAYSIZE(sourceName), fs::path(originalName).stem().c_str());
-                    }
-                    else if (flags & ExtensionOnly)
-                    {
-                        std::wstring extension = fs::path(originalName).extension().wstring();
-                        if (!extension.empty() && extension.front() == '.')
+                        // Folders don't have extensions - nothing to rename, leaving sourceName empty
+                        if (!(flags & ExtensionOnly))
                         {
-                            extension = extension.erase(0, 1);
+                            StringCchCopy(sourceName, ARRAYSIZE(sourceName), originalName);
                         }
-                        StringCchCopy(sourceName, ARRAYSIZE(sourceName), extension.c_str());
+                    
                     }
                     else
                     {
-                        StringCchCopy(sourceName, ARRAYSIZE(sourceName), originalName);
+                        if (flags & NameOnly)
+                        {
+                            StringCchCopy(sourceName, ARRAYSIZE(sourceName), fs::path(originalName).stem().c_str());
+                        }
+                        else if (flags & ExtensionOnly)
+                        {
+                            std::wstring extension = fs::path(originalName).extension().wstring();
+                            if (!extension.empty() && extension.front() == '.')
+                            {
+                                extension = extension.erase(0, 1);
+                            }
+                            StringCchCopy(sourceName, ARRAYSIZE(sourceName), extension.c_str());
+                        }
+                        else
+                        {
+                            StringCchCopy(sourceName, ARRAYSIZE(sourceName), originalName);
+                        }
                     }
 
                     SYSTEMTIME fileTime = { 0 };
@@ -1037,25 +1050,36 @@ DWORD WINAPI CPowerRenameManager::s_regexWorkerThread(_In_ void* pv)
                     if (newName != nullptr)
                     {
                         newNameToUse = resultName;
-                        if (flags & NameOnly)
+
+                        if (isFolder)
                         {
-                            StringCchPrintf(resultName, ARRAYSIZE(resultName), L"%s%s", newName, fs::path(originalName).extension().c_str());
-                        }
-                        else if (flags & ExtensionOnly)
-                        {
-                            std::wstring extension = fs::path(originalName).extension().wstring();
-                            if (!extension.empty())
+                            if (!(flags & ExtensionOnly))
                             {
-                                StringCchPrintf(resultName, ARRAYSIZE(resultName), L"%s.%s", fs::path(originalName).stem().c_str(), newName);
-                            }
-                            else
-                            {
-                                StringCchCopy(resultName, ARRAYSIZE(resultName), originalName);
+                                StringCchCopy(resultName, ARRAYSIZE(resultName), newName);
                             }
                         }
                         else
                         {
-                            StringCchCopy(resultName, ARRAYSIZE(resultName), newName);
+                            if (flags & NameOnly)
+                            {
+                                StringCchPrintf(resultName, ARRAYSIZE(resultName), L"%s%s", newName, fs::path(originalName).extension().c_str());
+                            }
+                            else if (flags & ExtensionOnly)
+                            {
+                                std::wstring extension = fs::path(originalName).extension().wstring();
+                                if (!extension.empty())
+                                {
+                                    StringCchPrintf(resultName, ARRAYSIZE(resultName), L"%s.%s", fs::path(originalName).stem().c_str(), newName);
+                                }
+                                else
+                                {
+                                    StringCchCopy(resultName, ARRAYSIZE(resultName), originalName);
+                                }
+                            }
+                            else
+                            {
+                                StringCchCopy(resultName, ARRAYSIZE(resultName), newName);
+                            }
                         }
                     }
 
@@ -1069,7 +1093,7 @@ DWORD WINAPI CPowerRenameManager::s_regexWorkerThread(_In_ void* pv)
                     wchar_t transformedName[MAX_PATH] = { 0 };
                     if (newNameToUse != nullptr && (flags & Uppercase || flags & Lowercase || flags & Titlecase || flags & Capitalized))
                     {
-                        winrt::check_hresult(GetTransformedFileName(transformedName, ARRAYSIZE(transformedName), newNameToUse, flags));
+                        winrt::check_hresult(GetTransformedFileName(transformedName, ARRAYSIZE(transformedName), newNameToUse, flags, isFolder));
                         newNameToUse = transformedName;
                     }
 

--- a/src/modules/powerrename/lib/PowerRenameManager.cpp
+++ b/src/modules/powerrename/lib/PowerRenameManager.cpp
@@ -965,7 +965,8 @@ DWORD WINAPI CPowerRenameManager::s_regexWorkerThread(_In_ void* pv)
                     winrt::check_hresult(spItem->GetIsSubFolderContent(&isSubFolderContent));
                     if ((isFolder && (flags & PowerRenameFlags::ExcludeFolders)) ||
                         (!isFolder && (flags & PowerRenameFlags::ExcludeFiles)) ||
-                        (isSubFolderContent && (flags & PowerRenameFlags::ExcludeSubfolders)))
+                        (isSubFolderContent && (flags & PowerRenameFlags::ExcludeSubfolders)) ||
+                        (isFolder && (flags & PowerRenameFlags::ExtensionOnly)))
                     {
                         // Exclude this item from renaming.  Ensure new name is cleared.
                         winrt::check_hresult(spItem->PutNewName(nullptr));
@@ -987,11 +988,7 @@ DWORD WINAPI CPowerRenameManager::s_regexWorkerThread(_In_ void* pv)
 
                     if (isFolder)
                     {
-                        // Folders don't have extensions - nothing to rename, leaving sourceName empty
-                        if (!(flags & ExtensionOnly))
-                        {
-                            StringCchCopy(sourceName, ARRAYSIZE(sourceName), originalName);
-                        }
+                        StringCchCopy(sourceName, ARRAYSIZE(sourceName), originalName);
                     
                     }
                     else
@@ -1053,10 +1050,7 @@ DWORD WINAPI CPowerRenameManager::s_regexWorkerThread(_In_ void* pv)
 
                         if (isFolder)
                         {
-                            if (!(flags & ExtensionOnly))
-                            {
-                                StringCchCopy(resultName, ARRAYSIZE(resultName), newName);
-                            }
+                            StringCchCopy(resultName, ARRAYSIZE(resultName), newName);
                         }
                         else
                         {

--- a/src/modules/powerrename/lib/PowerRenameManager.cpp
+++ b/src/modules/powerrename/lib/PowerRenameManager.cpp
@@ -1087,7 +1087,13 @@ DWORD WINAPI CPowerRenameManager::s_regexWorkerThread(_In_ void* pv)
                     wchar_t transformedName[MAX_PATH] = { 0 };
                     if (newNameToUse != nullptr && (flags & Uppercase || flags & Lowercase || flags & Titlecase || flags & Capitalized))
                     {
-                        winrt::check_hresult(GetTransformedFileName(transformedName, ARRAYSIZE(transformedName), newNameToUse, flags, isFolder));
+                        try
+                        {
+                            winrt::check_hresult(GetTransformedFileName(transformedName, ARRAYSIZE(transformedName), newNameToUse, flags, isFolder));
+                        }
+                        catch (...)
+                        {
+                        }
                         newNameToUse = transformedName;
                     }
 

--- a/src/modules/powerrename/unittests/PowerRenameManagerTests.cpp
+++ b/src/modules/powerrename/unittests/PowerRenameManagerTests.cpp
@@ -293,8 +293,9 @@ namespace PowerRenameManagerTests
         TEST_METHOD (VerifyExtensionOnlyTransform)
         {
             rename_pairs renamePairs[] = {
-                { L"foo.FOO", L"foo.bar", false, true, 0 },
-                { L"foo.bar", L"foo.bar_norename", false, false, 0 }
+                { L"foo.FOO", L"foo.bar", true, true, 0 },
+                { L"foo.FOOO", L"foo.FOOO_norename", false, false, 0 },
+                { L"foo.bar", L"foo.bar_norename", true, false, 0 }
             };
 
             RenameHelper(renamePairs, ARRAYSIZE(renamePairs), L"foo", L"bar", SYSTEMTIME{ 2020, 7, 3, 22, 15, 6, 42, 453 }, DEFAULT_FLAGS | Lowercase | ExtensionOnly);

--- a/src/modules/powerrename/unittests/PowerRenameManagerTests.cpp
+++ b/src/modules/powerrename/unittests/PowerRenameManagerTests.cpp
@@ -294,7 +294,7 @@ namespace PowerRenameManagerTests
         {
             rename_pairs renamePairs[] = {
                 { L"foo.FOO", L"foo.bar", true, true, 0 },
-                { L"foo.FOOO", L"foo.FOOO_norename", false, false, 0 },
+                { L"bar.FOO", L"bar.FOO_norename", false, false, 0 },
                 { L"foo.bar", L"foo.bar_norename", true, false, 0 }
             };
 


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Folder were treated same as files - `<filename>.<extension>`, so `FilenameOnly` and `ExtensionOnly` weren't working properly for folders with dot (.) in name. This PR fixes this. Now folder renaming behavior is:
 - Options `FilenameAndExtension` and `FilenameOnly` should produce same results. As folders only have filename.
 - Option `ExtensionOnly` should not rename folders in any way. So, if ExtensionOnly is selected, whatever you type or select as renaming option Renamed column will remain empty for folders.


**What is include in the PR:** 

**How does someone test / validate:** 
 - Try this example https://github.com/microsoft/PowerToys/issues/14680#issuecomment-987045830.
 - Check if other options, like uppercase, lowercase, titlecase, etc... produce correct results for folders that have dot in name.

## Quality Checklist

- [x] **Linked issue:** #14680 #10377
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
