### PR TITLE
[Image Resizer] Try to recover metadata even when the metadata data structure is invalid (#14913)

### DIFF
--- a/src/modules/imageresizer/tests/Models/ResizeOperationTests.cs
+++ b/src/modules/imageresizer/tests/Models/ResizeOperationTests.cs
@@ -33,7 +33,7 @@ namespace ImageResizer.Models
         }
 
         [TestMethod]
-        public void ExecuteCopiesFrameMetadataExceptWhenMetadataCannotBeCloned()
+        public void ExecuteCopiesFrameMetadataEvenWhenMetadataCannotBeCloned()
         {
             var operation = new ResizeOperation("TestMetadataIssue2447.jpg", _directory, Settings());
 
@@ -41,7 +41,7 @@ namespace ImageResizer.Models
 
             AssertEx.Image(
                 _directory.File(),
-                image => Assert.IsNull(((BitmapMetadata)image.Frames[0].Metadata).CameraModel));
+                image => Assert.IsNotNull(((BitmapMetadata)image.Frames[0].Metadata).CameraModel));
         }
 
         [TestMethod]

--- a/src/modules/imageresizer/ui/Extensions/BitmapMetadataExtension.cs
+++ b/src/modules/imageresizer/ui/Extensions/BitmapMetadataExtension.cs
@@ -112,7 +112,16 @@ namespace ImageResizer.Extensions
         {
             var listOfAllMetadata = new List<(string metadataPath, object value)>();
 
-            GetMetadataRecursively(metadata, string.Empty);
+            try
+            {
+                GetMetadataRecursively(metadata, string.Empty);
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception ex)
+#pragma warning restore CA1031 // Do not catch general exception types
+            {
+                Debug.WriteLine(ex);
+            }
 
             return listOfAllMetadata;
 
@@ -202,7 +211,16 @@ namespace ImageResizer.Extensions
         {
             var listOfAllMetadata = new List<(string metadataPath, object value)>();
 
-            GetMetadataRecursively(metadata, string.Empty);
+            try
+            {
+                GetMetadataRecursively(metadata, string.Empty);
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception ex)
+#pragma warning restore CA1031 // Do not catch general exception types
+            {
+                Debug.WriteLine(ex);
+            }
 
             return listOfAllMetadata;
 

--- a/src/modules/imageresizer/ui/Extensions/BitmapMetadataExtension.cs
+++ b/src/modules/imageresizer/ui/Extensions/BitmapMetadataExtension.cs
@@ -105,9 +105,16 @@ namespace ImageResizer.Extensions
         }
 
         /// <summary>
-        /// Gets all metadata
-        /// Iterates recursively through all metadata
+        /// Gets all metadata.
+        /// Iterates recursively through metadata and adds valid items to a list while skipping invalid data items.
         /// </summary>
+        /// <remarks>
+        /// Invalid data items are items which throw an exception when reading the data with metadata.GetQuery(...).
+        /// Sometimes Metadata collections are improper closed and cause an exception on IEnumerator.MoveNext(). In this case, we return all data items which were successfully collected so far.
+        /// </remarks>
+        /// <returns>
+        /// metadata path and metadata value of all successfully read data items.
+        /// </returns>
         public static List<(string metadataPath, object value)> GetListOfMetadata(this BitmapMetadata metadata)
         {
             var listOfAllMetadata = new List<(string metadataPath, object value)>();

--- a/src/modules/imageresizer/ui/Extensions/BitmapMetadataExtension.cs
+++ b/src/modules/imageresizer/ui/Extensions/BitmapMetadataExtension.cs
@@ -120,6 +120,7 @@ namespace ImageResizer.Extensions
             catch (Exception ex)
 #pragma warning restore CA1031 // Do not catch general exception types
             {
+                Debug.WriteLine($"Exception while trying to iterate recursively over metadata. We were able to read {listOfAllMetadata.Count} metadata entries.");
                 Debug.WriteLine(ex);
             }
 
@@ -219,6 +220,7 @@ namespace ImageResizer.Extensions
             catch (Exception ex)
 #pragma warning restore CA1031 // Do not catch general exception types
             {
+                Debug.WriteLine($"Exception while trying to iterate recursively over metadata. We were able to read {listOfAllMetadata.Count} metadata entries.");
                 Debug.WriteLine(ex);
             }
 

--- a/src/modules/imageresizer/ui/Models/ResizeOperation.cs
+++ b/src/modules/imageresizer/ui/Models/ResizeOperation.cs
@@ -83,17 +83,14 @@ namespace ImageResizer.Models
                     {
                         try
                         {
-                            // Detect whether metadata can copied successfully
-                            var modifiableMetadata = metadata.Clone();
-
 #if DEBUG
                             Debug.WriteLine($"### Processing metadata of file {_file}");
-                            modifiableMetadata.PrintsAllMetadataToDebugOutput();
+                            metadata.PrintsAllMetadataToDebugOutput();
 #endif
 
                             // read all metadata and build up metadata object from the scratch. Discard invalid (unreadable/unwritable) metadata.
                             var newMetadata = new BitmapMetadata(metadata.Format);
-                            var listOfMetadata = modifiableMetadata.GetListOfMetadata();
+                            var listOfMetadata = metadata.GetListOfMetadata();
                             foreach (var (metadataPath, value) in listOfMetadata)
                             {
                                 if (value is BitmapMetadata bitmapMetadata)


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
see #14913

**What is include in the PR:** 
a fix for #14913

**How does someone test / validate:** 
1. download image in found in issue https://github.com/microsoft/PowerToys/issues/2447#issuecomment-628058477
2. Resize the image
3. Check if all the metadata is there

*Before this fix:*
![image](https://user-images.githubusercontent.com/16760760/145279510-89a195d8-6058-4d38-8502-68496d8d3cdb.png)
*After this fix:*
![image](https://user-images.githubusercontent.com/16760760/145279812-d7bf15e4-2831-4924-9b1d-6512c635c8ca.png)


## Quality Checklist

- [x] **Linked issue:** #14913
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [x] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
