### PR TITLE
Add support for hex/binary numbers to calculator

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/CalculateHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/CalculateHelper.cs
@@ -18,7 +18,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
             @"sinh\s*\(|cosh\s*\(|tanh\s*\(|arsinh\s*\(|arcosh\s*\(|artanh\s*\(|" +
             @"pi|" +
             @"==|~=|&&|\|\||" +
-            @"e|[0-9]|[\+\-\*\/\^\., ""]|[\(\)\|\!\[\]]" +
+            @"e|[0-9]|0x[0-9a-fA-F]+|0b[01]+|[\+\-\*\/\^\., ""]|[\(\)\|\!\[\]]" +
             @")+$", RegexOptions.Compiled);
 
         public static bool InputValid(string input)


### PR DESCRIPTION
**What is this about:**
This is a minor change that allows hexadecimal and binary numbers to be interpreted by the calculator plugin. The underlying Mages library supports parsing these numbers, so the validation regex here is the only barrier to them being used.

**What is include in the PR:** 
A modification to the expression validation regex that allows hex/binary numbers to be passed in calculations.

**How does someone test / validate:** 
Type a calculation expression with a hex number (e.g. 0x12AB) or binary number (e.g. 0b1010) and the calculator will show the calculated result.

## Quality Checklist

- [x] **Linked issue:** #14947
- [ ] **Communication:** I've discussed this with core contributors in the issue. (N/A - minor change)
- [x] **Tests:** Added/updated and all pass
- [x] **Installer:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/updated (N/A - no updates needed)
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
CLA has been signed.