### PR TITLE
[ColorPicker] Fix hex input without # in adjust color ui

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -741,6 +741,7 @@ hashcode
 Hashset
 Hashtable
 HASHVAL
+Hashtag
 hbitmap
 hbmp
 hbr

--- a/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml
+++ b/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml
@@ -436,7 +436,8 @@
                                              AutomationProperties.Name="{x:Static p:Resources.Hex_value}"
                                              GotKeyboardFocus="HexCode_GotKeyboardFocus"
                                              TextChanged="HexCode_TextChanged"
-                                             TextWrapping="Wrap" />
+                                             TextWrapping="Wrap"
+                                             MaxLength="7"/>
                                 </StackPanel>
 
                                 <Button Margin="0,32,0,0"

--- a/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml.cs
@@ -300,7 +300,7 @@ namespace ColorPicker.Controls
             }
 
             // Add # if not typed by user. Prevents us form crash in converter.ConvertFromString()
-            if (newValue.StartsWith("#", StringComparison.CurrentCulture))
+            if (!newValue.StartsWith("#", StringComparison.CurrentCulture))
             {
                 newValue = "#" + newValue;
                 insertHexTextHashtag = true;

--- a/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml.cs
@@ -290,8 +290,11 @@ namespace ColorPicker.Controls
         {
             var newValue = (sender as TextBox).Text;
 
-            // support hex with 3 and 6 characters
+            // support hex with 3 or 6 characters and with or without #
             var reg = new Regex("^#?([0-9A-Fa-f]{3}){1,2}$");
+
+            // Add # if not typed by user. Prevents us form crash in converter.ConvertFromString()
+            newValue = newValue.StartsWith("#", StringComparison.CurrentCulture) ? newValue : "#" + newValue;
 
             if (!reg.IsMatch(newValue))
             {
@@ -302,7 +305,7 @@ namespace ColorPicker.Controls
             {
                 var converter = new System.Drawing.ColorConverter();
 
-                var color = (System.Drawing.Color)converter.ConvertFromString(HexCode.Text);
+                var color = (System.Drawing.Color)converter.ConvertFromString(newValue);
                 _ignoreHexChanges = true;
                 SetColorFromTextBoxes(color);
                 _ignoreHexChanges = false;

--- a/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml.cs
@@ -288,25 +288,40 @@ namespace ColorPicker.Controls
 
         private void HexCode_TextChanged(object sender, TextChangedEventArgs e)
         {
+            bool insertHexTextHashtag = false;
             var newValue = (sender as TextBox).Text;
 
             // support hex with 3 or 6 characters and with or without #
             var reg = new Regex("^#?([0-9A-Fa-f]{3}){1,2}$");
-
-            // Add # if not typed by user. Prevents us form crash in converter.ConvertFromString()
-            newValue = newValue.StartsWith("#", StringComparison.CurrentCulture) ? newValue : "#" + newValue;
 
             if (!reg.IsMatch(newValue))
             {
                 return;
             }
 
+            // Add # if not typed by user. Prevents us form crash in converter.ConvertFromString()
+            if (newValue.StartsWith("#", StringComparison.CurrentCulture))
+            {
+                newValue = "#" + newValue;
+                insertHexTextHashtag = true;
+            }
+
             if (!_ignoreHexChanges)
             {
+                _ignoreHexChanges = true;
+
+                // Update hex text box to show code with # and fix cursor position
+                if (insertHexTextHashtag)
+                {
+                    HexCode.Text = newValue;
+                    HexCode.Select(HexCode.Text.Length, 0);
+                    insertHexTextHashtag = false;
+                }
+
+                // Update other controls
                 var converter = new System.Drawing.ColorConverter();
 
                 var color = (System.Drawing.Color)converter.ConvertFromString(newValue);
-                _ignoreHexChanges = true;
                 SetColorFromTextBoxes(color);
                 _ignoreHexChanges = false;
             }

--- a/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml.cs
@@ -291,7 +291,7 @@ namespace ColorPicker.Controls
             var newValue = (sender as TextBox).Text;
 
             // support hex with 3 and 6 characters
-            var reg = new Regex("^#([0-9A-Fa-f]{3}){1,2}$");
+            var reg = new Regex("^#?([0-9A-Fa-f]{3}){1,2}$");
 
             if (!reg.IsMatch(newValue))
             {


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
In the color edit dialog we currently only accept hex values with `#`. This is not user friendly as we removed the `#` on the picked color code. When users copy the color code into the edit dialog hex field they have to add the `#` manually.

This PR updates UX to add the `#` automatically and to limit value length. The changes works with 3 and 6 value hex code.
![pt-cp-hexfix](https://user-images.githubusercontent.com/61519853/145714404-0180f4e9-a185-493b-820b-9a0f55a59da2.gif)
_Note: The gif doesn't shows in real time (Don't know why.)_

**What is included in the PR:** 
* Updating the regex to accept hex color code with and without `#`.
* Update code to add `#` in text box if color code is valid.
* Add max length property to the text box.

**How does someone test / validate:** 
Build and tried manually with typing the code and inserting the code form clipboard with and without `#`.

## Quality Checklist

- [x] **Linked issue:** #14160 
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
