### PR TITLE
Add error message when dotnet failed to download

### DIFF
--- a/installer/PowerToysBootstrapper/bootstrapper/bootstrapper.cpp
+++ b/installer/PowerToysBootstrapper/bootstrapper/bootstrapper.cpp
@@ -437,6 +437,7 @@ int Bootstrapper(HINSTANCE hInstance)
                 else
                 {
                     spdlog::error("Couldn't download dotnet");
+                    ShowMessageBoxError(IDS_DOTNET_CORE_DOWNLOAD_FAILURE);
                 }
 
                 if (!installedSuccessfully)


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Add an error message when dotnet failed to download.

**What is included in the PR:** 
Add an error message.

**How does someone test / validate:** 
Run the installer in a clean VM with a firewall configured to block the `https://download.visualstudio.microsoft.com/` (the dotnet source we used) and see if the error message was prompted.

## Quality Checklist

- [x] **Linked issue:** #14901
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [x] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.

Note: branch name was a typo, ignore it. :D 