### PR TITLE
[PT Run] Smooth scrolling of the results list

### DIFF
--- a/src/modules/launcher/PowerLauncher/ResultList.xaml
+++ b/src/modules/launcher/PowerLauncher/ResultList.xaml
@@ -174,6 +174,7 @@
             Padding="0, 0"
             ScrollViewer.HorizontalScrollBarVisibility="Disabled"       
             ScrollViewer.VerticalScrollBarVisibility="Auto"       
+            ScrollViewer.CanContentScroll="False"
             SelectionMode="Single"
             SelectedIndex="{Binding Results.SelectedIndex, Mode=TwoWay}"
             SelectionChanged="SuggestionsListView_SelectionChanged"


### PR DESCRIPTION
This fixes scrolling when using touchpad

According to this https://social.msdn.microsoft.com/Forums/vstudio/en-US/47bd6a75-7791-4c0f-93ae-931e9a6540e7/smooth-scrolling-on-listbox?forum=wpf, downside of this is we're losing virtualization. However, I don't expect that PT Run will produce amount of results to actually affect rendering of results list. I tested this with having hundreds of folders named `test_<numbers>` and then querying for `test` in PT Run. Also, it looks like PT Run (or plugins) have some limit of how many results can be shown. So we should be safe there.

## Summary of the Pull Request

**What is this about:**

**What is included in the PR:** 

**How does someone test / validate:** 
 - Open PT v0.51.1
 - start PT Run
 - Run some query that produces a lot of results
 - Try scrolling using laptop touchpad
 - observe that scrolling is too sensitive

 - Redo the steps using this branch
 - observe that scrolling with touchpad is less sensitive and smoother

## Quality Checklist

- [X] **Linked issue:** #5383
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
