### PR TITLE
[FancyZones] Align max negative spacing with limit in FZ Editor

### DIFF
--- a/src/modules/fancyzones/FancyZonesLib/Zone.h
+++ b/src/modules/fancyzones/FancyZonesLib/Zone.h
@@ -2,7 +2,7 @@
 
 namespace ZoneConstants
 {
-    constexpr int MAX_NEGATIVE_SPACING = -10;
+    constexpr int MAX_NEGATIVE_SPACING = -20;
 }
 
 using ZoneIndex = int64_t;


### PR DESCRIPTION
## Summary of the Pull Request
In FZ Editor, minimum value for spacing around zones number box while editing Grid layouts is set to -20. The same limit in FancyZones engine was -10. The result of that was if you try to apply layout with -20 =< space around zones  < -10, layout wouldn't be created and FZ would result in no layout applied.

**What is this about:**

**What is included in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [X] **Linked issue:** #10565
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
