### PR TITLE
[Settings] Icon resizing fix

### DIFF
--- a/src/settings-ui/Settings.UI/Controls/Setting/Setting.xaml
+++ b/src/settings-ui/Settings.UI/Controls/Setting/Setting.xaml
@@ -51,6 +51,7 @@
                           Content="{TemplateBinding Icon}"
                           HorizontalAlignment="Center"
                           FontSize="20"
+                          IsTextScaleFactorEnabled="False"
                           Margin="2,0,18,0"
                           MaxWidth="20"
                           AutomationProperties.AccessibilityView="Raw"


### PR DESCRIPTION
## Summary of the Pull Request
Icon no longer gets truncated when setting the textscaling to 225%

![image](https://user-images.githubusercontent.com/9866362/146555561-362d882a-e06a-46ce-82f5-a067a529c60d.png)
 

## Quality Checklist

- [X] **Linked issue:** #14342
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
