### PR TITLE
[ColorPicker Editor] Adjust color menu: Hex input improvements

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -662,6 +662,7 @@ HARDWAREINPUT
 hashcode
 Hashset
 Hashtable
+hashtag
 HASHVAL
 hbitmap
 hbmp

--- a/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml
+++ b/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml
@@ -437,7 +437,8 @@
                                              GotKeyboardFocus="HexCode_GotKeyboardFocus"
                                              TextChanged="HexCode_TextChanged"
                                              TextWrapping="Wrap"
-                                             MaxLength="7" />
+                                             MaxLength="7"
+                                             CharacterCasing="Upper" />
                                 </StackPanel>
 
                                 <Button Margin="0,32,0,0"

--- a/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml
+++ b/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml
@@ -438,7 +438,7 @@
                                              TextChanged="HexCode_TextChanged"
                                              TextWrapping="Wrap"
                                              MaxLength="7"
-                                             CharacterCasing="Upper" />
+                                             CharacterCasing="Lower" />
                                 </StackPanel>
 
                                 <Button Margin="0,32,0,0"

--- a/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml
+++ b/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml
@@ -436,7 +436,8 @@
                                              AutomationProperties.Name="{x:Static p:Resources.Hex_value}"
                                              GotKeyboardFocus="HexCode_GotKeyboardFocus"
                                              TextChanged="HexCode_TextChanged"
-                                             TextWrapping="Wrap" />
+                                             TextWrapping="Wrap"
+                                             MaxLength="7" />
                                 </StackPanel>
 
                                 <Button Margin="0,32,0,0"

--- a/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml.cs
@@ -332,6 +332,10 @@ namespace ColorPicker.Controls
         {
             string newHexString = BitConverter.ToString(new byte[] { color.R, color.G, color.B }).Replace("-", string.Empty, StringComparison.InvariantCulture);
 
+#pragma warning disable CA1308 // Normalize strings to uppercase - Supressed because we want to show hex value in lower case on all places
+            newHexString = newHexString.ToLowerInvariant();
+#pragma warning restore CA1308 // Normalize strings to uppercase
+
             // Return only with hashtag if user typed it before
             bool addHashtag = oldValue.StartsWith("#", StringComparison.InvariantCulture);
             return addHashtag ? "#" + newHexString : newHexString;
@@ -344,7 +348,7 @@ namespace ColorPicker.Controls
         /// <returns>Formatted string with hashtag and six characters of hex code.</returns>
         private static string FormatHexColorString(string hexCodeText)
         {
-            if (hexCodeText.Length == 3 | hexCodeText.Length == 4)
+            if (hexCodeText.Length == 3 || hexCodeText.Length == 4)
             {
                 // Hex with or without hashtag and three characters
                 return Regex.Replace(hexCodeText, "^#?([0-9a-fA-F])([0-9a-fA-F])([0-9a-fA-F])$", "#$1$1$2$2$3$3");

--- a/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml.cs
@@ -72,7 +72,7 @@ namespace ColorPicker.Controls
             control._ignoreHexChanges = true;
             control._ignoreRGBChanges = true;
 
-            control.HexCode.Text = ColorToHex(newColor);
+            control.HexCode.Text = ColorToHex(newColor, control.HexCode.Text);
             control.RNumberBox.Text = newColor.R.ToString(CultureInfo.InvariantCulture);
             control.GNumberBox.Text = newColor.G.ToString(CultureInfo.InvariantCulture);
             control.BNumberBox.Text = newColor.B.ToString(CultureInfo.InvariantCulture);
@@ -166,7 +166,7 @@ namespace ColorPicker.Controls
         {
             if (!_ignoreHexChanges)
             {
-                HexCode.Text = ColorToHex(currentColor);
+                HexCode.Text = ColorToHex(currentColor, HexCode.Text);
             }
 
             if (!_ignoreRGBChanges)
@@ -243,7 +243,7 @@ namespace ColorPicker.Controls
             var originalColorBackground = new SolidColorBrush(_originalColor);
             CurrentColorButton.Background = originalColorBackground;
 
-            HexCode.Text = ColorToHex(_originalColor);
+            HexCode.Text = ColorToHex(_originalColor, HexCode.Text);
         }
 
 #pragma warning disable CA1822 // Mark members as static
@@ -326,9 +326,13 @@ namespace ColorPicker.Controls
             UpdateTextBoxesAndCurrentColor(Color.FromRgb(color.R, color.G, color.B));
         }
 
-        private static string ColorToHex(Color color)
+        private static string ColorToHex(Color color, string oldValue = "")
         {
-            return "#" + BitConverter.ToString(new byte[] { color.R, color.G, color.B }).Replace("-", string.Empty, StringComparison.InvariantCulture);
+            string newHexString = BitConverter.ToString(new byte[] { color.R, color.G, color.B }).Replace("-", string.Empty, StringComparison.InvariantCulture);
+
+            // Return only with hashtag if user typed it before
+            bool addHashtag = oldValue.StartsWith("#", StringComparison.InvariantCulture);
+            return addHashtag ? "#" + newHexString : newHexString;
         }
 
         /// <summary>

--- a/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml.cs
@@ -290,8 +290,8 @@ namespace ColorPicker.Controls
         {
             var newValue = (sender as TextBox).Text;
 
-            // support hex with 3 and 6 characters
-            var reg = new Regex("^#([0-9A-Fa-f]{3}){1,2}$");
+            // support hex with 3 and 6 characters and optional with hashtag
+            var reg = new Regex("^#?([0-9A-Fa-f]{3}){1,2}$");
 
             if (!reg.IsMatch(newValue))
             {

--- a/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml.cs
@@ -72,7 +72,7 @@ namespace ColorPicker.Controls
             control._ignoreHexChanges = true;
             control._ignoreRGBChanges = true;
 
-            control.HexCode.Text = ColorToHex(newColor, control.HexCode.Text);
+            control.HexCode.Text = ColorToHex(newColor);
             control.RNumberBox.Text = newColor.R.ToString(CultureInfo.InvariantCulture);
             control.GNumberBox.Text = newColor.G.ToString(CultureInfo.InvariantCulture);
             control.BNumberBox.Text = newColor.B.ToString(CultureInfo.InvariantCulture);
@@ -166,6 +166,7 @@ namespace ColorPicker.Controls
         {
             if (!_ignoreHexChanges)
             {
+                // Second parameter is set to keep the hashtag if typed by the user before
                 HexCode.Text = ColorToHex(currentColor, HexCode.Text);
             }
 
@@ -243,7 +244,7 @@ namespace ColorPicker.Controls
             var originalColorBackground = new SolidColorBrush(_originalColor);
             CurrentColorButton.Background = originalColorBackground;
 
-            HexCode.Text = ColorToHex(_originalColor, HexCode.Text);
+            HexCode.Text = ColorToHex(_originalColor);
         }
 
 #pragma warning disable CA1822 // Mark members as static

--- a/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml.cs
@@ -302,7 +302,7 @@ namespace ColorPicker.Controls
             {
                 var converter = new System.Drawing.ColorConverter();
 
-                var color = (System.Drawing.Color)converter.ConvertFromString(HexCode.Text);
+                var color = (System.Drawing.Color)converter.ConvertFromString(FormatHexColorString(HexCode.Text));
                 _ignoreHexChanges = true;
                 SetColorFromTextBoxes(color);
                 _ignoreHexChanges = false;
@@ -329,6 +329,25 @@ namespace ColorPicker.Controls
         private static string ColorToHex(Color color)
         {
             return "#" + BitConverter.ToString(new byte[] { color.R, color.G, color.B }).Replace("-", string.Empty, StringComparison.InvariantCulture);
+        }
+
+        /// <summary>
+        /// Formats the hex code string to be accepted by <see cref="ConvertFromString()"/> of <see cref="ColorConverter.ColorConverter"/>. We are adding hashtag at the beginning if neede and convert from three characters to six characters code.
+        /// </summary>
+        /// <param name="hexCodeText">The string we read from the hex text box.</param>
+        /// <returns>Formatted string with hashtag and six characters of hex code.</returns>
+        private static string FormatHexColorString(string hexCodeText)
+        {
+            if (hexCodeText.Length == 3 | hexCodeText.Length == 4)
+            {
+                // Hex with or without hashtag and three characters
+                return Regex.Replace(hexCodeText, "^#?([0-9a-fA-F])([0-9a-fA-F])([0-9a-fA-F])$", "#$1$1$2$2$3$3");
+            }
+            else
+            {
+                // Hex with or without hashtag and six characters
+                return Regex.Match(hexCodeText, "^#.*$").Success ? hexCodeText : "#" + hexCodeText;
+            }
         }
 
         private void HexCode_GotKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)

--- a/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml.cs
@@ -350,7 +350,7 @@ namespace ColorPicker.Controls
             else
             {
                 // Hex with or without hashtag and six characters
-                return Regex.Match(hexCodeText, "^#.*$").Success ? hexCodeText : "#" + hexCodeText;
+                return hexCodeText.StartsWith("#", StringComparison.InvariantCulture) ? hexCodeText : "#" + hexCodeText;
             }
         }
 

--- a/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml.cs
@@ -303,6 +303,7 @@ namespace ColorPicker.Controls
             {
                 var converter = new System.Drawing.ColorConverter();
 
+                // "FormatHexColorString()" is needed to add hashtag if missing and convert to convert the hex code from three characters to six charaters. Without this we get format exceptions and incorrect color values.
                 var color = (System.Drawing.Color)converter.ConvertFromString(FormatHexColorString(HexCode.Text));
                 _ignoreHexChanges = true;
                 SetColorFromTextBoxes(color);
@@ -337,7 +338,7 @@ namespace ColorPicker.Controls
         }
 
         /// <summary>
-        /// Formats the hex code string to be accepted by <see cref="ConvertFromString()"/> of <see cref="ColorConverter.ColorConverter"/>. We are adding hashtag at the beginning if neede and convert from three characters to six characters code.
+        /// Formats the hex code string to be accepted by <see cref="ConvertFromString()"/> of <see cref="ColorConverter.ColorConverter"/>. We are adding hashtag at the beginning if needed and convert from three characters to six characters code.
         /// </summary>
         /// <param name="hexCodeText">The string we read from the hex text box.</param>
         /// <returns>Formatted string with hashtag and six characters of hex code.</returns>

--- a/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Controls/ColorPickerControl.xaml.cs
@@ -303,7 +303,7 @@ namespace ColorPicker.Controls
             {
                 var converter = new System.Drawing.ColorConverter();
 
-                // "FormatHexColorString()" is needed to add hashtag if missing and convert to convert the hex code from three characters to six charaters. Without this we get format exceptions and incorrect color values.
+                // "FormatHexColorString()" is needed to add hashtag if missing and to convert the hex code from three to six characters. Without this we get format exceptions and incorrect color values.
                 var color = (System.Drawing.Color)converter.ConvertFromString(FormatHexColorString(HexCode.Text));
                 _ignoreHexChanges = true;
                 SetColorFromTextBoxes(color);


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
The UX we have at the moment has several problems/unexpected behaviors:
1. Hex input box allows more characters than possible.
2. The input in hex text box switches from lower case (typed by user) to upper case on changing the slider or RGB value.
3. Hex  color code requires # when typed into hex text box. (This prevents users from copying hex code without hashtag into the text box. They have to type the hashtag manually.)
4. We allow the input of hex color codes with only three characters. But we can't interpret/convert it correctly. 

![img](https://user-images.githubusercontent.com/61519853/145715785-8bd5eebb-0eb1-423b-894f-1ae1413f7d0d.png)

**What is included in the PR:** 
The following fixes are included:
1. Hex input box is limited to 7 characters.
2. Hex input box's casing is set to lower to be aligned with format representation of picked color.
![image](https://user-images.githubusercontent.com/61519853/147226839-778c0294-c343-4e10-a554-588329a70169.png)
3. Regex for hex text box is updated to not enforce hashtag anymore.
4. A new method `FormatHexColorString()` is added to format the text for the `ConvertFromString()` method and to handle hex code with three characters correctly.
5. The existing method `ColorToHex()` is updated to add hashtag only if it was there before. (If the user types a hashtag it is kept as long as the dialog is open and the user doesn't removes it.)

![pt-cp-hex3](https://user-images.githubusercontent.com/61519853/146680541-0e528c8b-a919-4b8d-b24a-ae9357ba8d46.gif)
![pt-cp-hexhashtag](https://user-images.githubusercontent.com/61519853/146680538-6dbe11af-0724-4430-b5a3-1a975c653ac6.gif)

**How does someone test / validate:** 
Testing code on local build.

## Quality Checklist

- [x] **Linked issue:** #14971,#14969,#14160
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
