### PR TITLE
[ColorPicker] Adjust window positioning in bottom & right corners of …

### DIFF
--- a/src/modules/colorPicker/ColorPickerUI/Behaviors/ChangeWindowPositionBehavior.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Behaviors/ChangeWindowPositionBehavior.cs
@@ -12,9 +12,9 @@ namespace ColorPicker.Behaviors
     public class ChangeWindowPositionBehavior : Behavior<Window>
     {
         // color window should not get into these zones, only mouse to avoid window getting outsize of monitor
-        private const int MonitorRightSideDeadZone = 275;
+        private const int MonitorRightSideDeadZone = 285;
         private const int MonitorBottomSideDeadZone = 90;
-        private const int WindowTopOffsetWhenInBottomSideDeadZone = 10;
+        private const int WindowOffsetWhenInDeadZone = 10;
 
         private const int YOffset = 10;
         private const int XOffset = 5;
@@ -61,12 +61,12 @@ namespace ColorPicker.Behaviors
 
             if ((windowLeft + MonitorRightSideDeadZone) > monitorBounds.Right / dpi.DpiScaleX)
             {
-                windowLeft -= MonitorRightSideDeadZone - (((int)monitorBounds.Right / dpi.DpiScaleX) - windowLeft);
+                windowLeft -= AssociatedObject.Width + WindowOffsetWhenInDeadZone;
             }
 
             if ((windowTop + MonitorBottomSideDeadZone) > monitorBounds.Bottom / dpi.DpiScaleX)
             {
-                windowTop -= AssociatedObject.Height + WindowTopOffsetWhenInBottomSideDeadZone;
+                windowTop -= AssociatedObject.Height + WindowOffsetWhenInDeadZone;
             }
 
             AssociatedObject.Left = windowLeft;

--- a/src/modules/colorPicker/ColorPickerUI/Behaviors/ChangeWindowPositionBehavior.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Behaviors/ChangeWindowPositionBehavior.cs
@@ -12,8 +12,8 @@ namespace ColorPicker.Behaviors
     public class ChangeWindowPositionBehavior : Behavior<Window>
     {
         // color window should not get into these zones, only mouse to avoid window getting outsize of monitor
-        private const int MonitorRightSideDeadZone = 200;
-        private const int MonitorBottomSideDeadZone = 80;
+        private const int MonitorRightSideDeadZone = 275;
+        private const int MonitorBottomSideDeadZone = 70;
 
         private const int YOffset = 10;
         private const int XOffset = 5;
@@ -65,7 +65,7 @@ namespace ColorPicker.Behaviors
 
             if ((windowTop + MonitorBottomSideDeadZone) > monitorBounds.Bottom / dpi.DpiScaleX)
             {
-                windowTop -= MonitorBottomSideDeadZone - (((int)monitorBounds.Bottom / dpi.DpiScaleX) - windowTop);
+                windowTop -= MonitorBottomSideDeadZone;
             }
 
             AssociatedObject.Left = windowLeft;

--- a/src/modules/colorPicker/ColorPickerUI/Behaviors/ChangeWindowPositionBehavior.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Behaviors/ChangeWindowPositionBehavior.cs
@@ -13,7 +13,8 @@ namespace ColorPicker.Behaviors
     {
         // color window should not get into these zones, only mouse to avoid window getting outsize of monitor
         private const int MonitorRightSideDeadZone = 275;
-        private const int MonitorBottomSideDeadZone = 70;
+        private const int MonitorBottomSideDeadZone = 90;
+        private const int WindowTopOffsetWhenInBottomSideDeadZone = 10;
 
         private const int YOffset = 10;
         private const int XOffset = 5;
@@ -65,7 +66,7 @@ namespace ColorPicker.Behaviors
 
             if ((windowTop + MonitorBottomSideDeadZone) > monitorBounds.Bottom / dpi.DpiScaleX)
             {
-                windowTop -= MonitorBottomSideDeadZone;
+                windowTop -= AssociatedObject.Height + WindowTopOffsetWhenInBottomSideDeadZone;
             }
 
             AssociatedObject.Left = windowLeft;


### PR DESCRIPTION
…the screens

## Summary of the Pull Request

**What is this about:**
Issue #13642:
 ~- Increased offset for the right screen edge so longer color representations (like CIELab) can fit the screen~
 - On the right side of the screen, move colorpicker to the left of the cursor


Issue #5936:
 - In the bottom of the screen, move colorpicker on top of the cursor so there are no inaccessible areas

UPDATED LATEST FIX GIF:
![cp3](https://user-images.githubusercontent.com/57057282/147071581-5aa259a2-1d8a-43e5-be78-7eaf2592b169.gif)

**NOTE: Visual Studio is maximized. Blue area on the right is part of second monitor.**

**What is included in the PR:** 

**How does someone test / validate:** 
 - Run colorpicker
 - Use CIELab color representation
 - Move cursor to the right edge of the screen
 - Observe that colorpicker fits the screen
 - Move cursor to the bottom-right corner of the screen
 - Confirm that there are no inaccessible areas/cursor does not go over colorpicker window

## Quality Checklist

- [X] **Linked issue:** #13642 #5936
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
