### PR TITLE
[FancyZones] Do not snap child windows via the "Win+Arrow" shortcut

### DIFF
--- a/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
@@ -416,7 +416,7 @@ void FancyZones::WindowCreated(HWND window) noexcept
         return;
     }
 
-    const bool isCandidateForLastKnownZone = FancyZonesUtils::IsCandidateForLastKnownZone(window, m_settings->GetSettings()->excludedAppsArray);
+    const bool isCandidateForLastKnownZone = FancyZonesUtils::IsCandidateForZoning(window, m_settings->GetSettings()->excludedAppsArray);
     if (!isCandidateForLastKnownZone)
     {
         return;

--- a/src/modules/fancyzones/FancyZonesLib/util.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/util.cpp
@@ -441,20 +441,10 @@ namespace FancyZonesUtils
         return true;
     }
 
-    bool IsCandidateForLastKnownZone(HWND window, const std::vector<std::wstring>& excludedApps) noexcept
+    bool IsCandidateForZoning(HWND window, const std::vector<std::wstring>& excludedApps) noexcept
     {
         auto zonable = IsStandardWindow(window) && HasNoVisibleOwner(window);
         if (!zonable)
-        {
-            return false;
-        }
-
-        return IsZonableByProcessPath(get_process_path(window), excludedApps);
-    }
-
-    bool IsCandidateForZoning(HWND window, const std::vector<std::wstring>& excludedApps) noexcept
-    {
-        if (!IsStandardWindow(window))
         {
             return false;
         }

--- a/src/modules/fancyzones/FancyZonesLib/util.h
+++ b/src/modules/fancyzones/FancyZonesLib/util.h
@@ -199,7 +199,6 @@ namespace FancyZonesUtils
 
     bool HasNoVisibleOwner(HWND window) noexcept;
     bool IsStandardWindow(HWND window);
-    bool IsCandidateForLastKnownZone(HWND window, const std::vector<std::wstring>& excludedApps) noexcept;
     bool IsCandidateForZoning(HWND window, const std::vector<std::wstring>& excludedApps) noexcept;
 
     bool IsWindowMaximized(HWND window) noexcept;


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

* Check visible owner in `IsCandidateForZoning` (called on snapping window with `Win+Arrow` shortcut)
* Removed fully duplicated `IsCandidateForLastKnownZone`

**What is included in the PR:** 

**How does someone test / validate:** 

* Open the search window in Notepad++ (ctrl+f)
* Click `Win+Arrow` 
* Verify that the search window isn't zoned

## Quality Checklist

- [x] **Linked issue:** #14222
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
