### PR TITLE
[PT RUN] [VSCodeWorkspaces] no remote ssh machines are appearing in the result

### DIFF
--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/RemoteMachinesHelper/VSCodeRemoteMachinesApi.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/RemoteMachinesHelper/VSCodeRemoteMachinesApi.cs
@@ -35,7 +35,7 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.RemoteMachinesHelper
 
                         try
                         {
-                            JsonElement vscodeSettingsFile = JsonSerializer.Deserialize<JsonElement>(fileContent);
+                            JsonElement vscodeSettingsFile = JsonSerializer.Deserialize<JsonElement>(fileContent, new JsonSerializerOptions() { AllowTrailingCommas = true, ReadCommentHandling = JsonCommentHandling.Skip });
                             if (vscodeSettingsFile.TryGetProperty("remote.SSH.configFile", out var pathElement))
                             {
                                 var path = pathElement.GetString();

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/SshConfigParser/SshConfig.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/SshConfigParser/SshConfig.cs
@@ -21,7 +21,7 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.SshConfigParser
 
         public static IEnumerable<SshHost> Parse(string str)
         {
-            str = str.Replace('\r', '\0');
+            str = str.Replace("\r", string.Empty);
             var list = new List<SshHost>();
             foreach (Match match in _sshConfig.Matches(str))
             {


### PR DESCRIPTION
Fix issue #15106

## Summary of the Pull Request

**What is this about:**
Remote ssh machines for VSCodeWorkspaces plugin not showing.

**What is included in the PR:** 
- Fix for deserializing vscode settings.json
- Fix for only one remote ssh machine appearing

**How does someone test / validate:** 
1. Open Powertoys run
2. Type "{"
3. If you have remote ssh machines configured they should appear on the result list
![image](https://user-images.githubusercontent.com/20097801/146986387-eeb29227-0731-4729-ac28-efaa1615db62.png)


## Quality Checklist

- [x] **Linked issue:** #15106
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
