### PR TITLE
[PT Run] [VSCodeWorkspaces]  Show previous opened VSCode workspaces #14931

### DIFF
--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/Properties/Resources.Designer.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -84,6 +84,15 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.Properties {
         internal static string PluginTitle {
             get {
                 return ResourceManager.GetString("PluginTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Project Folder.
+        /// </summary>
+        internal static string ProjectFolder {
+            get {
+                return ResourceManager.GetString("ProjectFolder", resourceCulture);
             }
         }
         

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/Properties/Resources.resx
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/Properties/Resources.resx
@@ -140,10 +140,14 @@
   </data>
   <data name="Workspace" xml:space="preserve">
     <value>Workspace</value>
-    <comment>It refers to the "Visual Studio Code  workspace"</comment>
+    <comment>It refers to the Visual Studio Code .code-workspace</comment>
   </data>
   <data name="TypeWorkspaceDevContainer" xml:space="preserve">
     <value>Dev Container</value>
     <comment>As in "Visual Studio Code Dev Container workspace "</comment>
+  </data>
+  <data name="ProjectFolder" xml:space="preserve">
+    <value>Project Folder</value>
+    <comment>It refers to the Visual Studio Code Project Folders</comment>
   </data>
 </root>

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/WorkspacesHelper/ParseVSCodeUri.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/WorkspacesHelper/ParseVSCodeUri.cs
@@ -18,7 +18,7 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.WorkspacesHelper
 
         private static readonly Regex DevContainerWorkspace = new Regex(@"^vscode-remote://dev-container\+(.+?(?=\/))(.+)$", RegexOptions.Compiled);
 
-        public static (TypeWorkspace? TypeWorkspace, string MachineName, string Path) GetTypeWorkspace(string uri)
+        public static (WorkspaceEnvironment? WorkspaceEnvironment, string MachineName, string Path) GetWorkspaceEnvironment(string uri)
         {
             if (LocalWorkspace.IsMatch(uri))
             {
@@ -26,7 +26,7 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.WorkspacesHelper
 
                 if (match.Groups.Count > 1)
                 {
-                    return (TypeWorkspace.Local, null, match.Groups[1].Value);
+                    return (WorkspaceEnvironment.Local, null, match.Groups[1].Value);
                 }
             }
             else if (RemoteSSHWorkspace.IsMatch(uri))
@@ -35,7 +35,7 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.WorkspacesHelper
 
                 if (match.Groups.Count > 1)
                 {
-                    return (TypeWorkspace.RemoteSSH, match.Groups[1].Value, match.Groups[2].Value);
+                    return (WorkspaceEnvironment.RemoteSSH, match.Groups[1].Value, match.Groups[2].Value);
                 }
             }
             else if (RemoteWSLWorkspace.IsMatch(uri))
@@ -44,7 +44,7 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.WorkspacesHelper
 
                 if (match.Groups.Count > 1)
                 {
-                    return (TypeWorkspace.RemoteWSL, match.Groups[1].Value, match.Groups[2].Value);
+                    return (WorkspaceEnvironment.RemoteWSL, match.Groups[1].Value, match.Groups[2].Value);
                 }
             }
             else if (CodespacesWorkspace.IsMatch(uri))
@@ -53,7 +53,7 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.WorkspacesHelper
 
                 if (match.Groups.Count > 1)
                 {
-                    return (TypeWorkspace.Codespaces, null, match.Groups[2].Value);
+                    return (WorkspaceEnvironment.Codespaces, null, match.Groups[2].Value);
                 }
             }
             else if (DevContainerWorkspace.IsMatch(uri))
@@ -62,7 +62,7 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.WorkspacesHelper
 
                 if (match.Groups.Count > 1)
                 {
-                    return (TypeWorkspace.DevContainer, null, match.Groups[2].Value);
+                    return (WorkspaceEnvironment.DevContainer, null, match.Groups[2].Value);
                 }
             }
 

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/WorkspacesHelper/VSCodeWorkspace.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/WorkspacesHelper/VSCodeWorkspace.cs
@@ -17,27 +17,29 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.WorkspacesHelper
 
         public string ExtraInfo { get; set; }
 
-        public TypeWorkspace TypeWorkspace { get; set; }
+        public WorkspaceEnvironment WorkspaceEnvironment { get; set; }
+
+        public WorkspaceType WorkspaceType { get; set; }
 
         public VSCodeInstance VSCodeInstance { get; set; }
 
-        public string WorkspaceTypeToString()
+        public string WorkspaceEnvironmentToString()
         {
-            switch (TypeWorkspace)
+            switch (WorkspaceEnvironment)
             {
-                case TypeWorkspace.Local: return Resources.TypeWorkspaceLocal;
-                case TypeWorkspace.Codespaces: return "Codespaces";
-                case TypeWorkspace.RemoteContainers: return Resources.TypeWorkspaceContainer;
-                case TypeWorkspace.RemoteSSH: return "SSH";
-                case TypeWorkspace.RemoteWSL: return "WSL";
-                case TypeWorkspace.DevContainer: return Resources.TypeWorkspaceDevContainer;
+                case WorkspaceEnvironment.Local: return Resources.TypeWorkspaceLocal;
+                case WorkspaceEnvironment.Codespaces: return "Codespaces";
+                case WorkspaceEnvironment.RemoteContainers: return Resources.TypeWorkspaceContainer;
+                case WorkspaceEnvironment.RemoteSSH: return "SSH";
+                case WorkspaceEnvironment.RemoteWSL: return "WSL";
+                case WorkspaceEnvironment.DevContainer: return Resources.TypeWorkspaceDevContainer;
             }
 
             return string.Empty;
         }
     }
 
-    public enum TypeWorkspace
+    public enum WorkspaceEnvironment
     {
         Local = 1,
         Codespaces = 2,
@@ -45,5 +47,11 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.WorkspacesHelper
         RemoteSSH = 4,
         RemoteContainers = 5,
         DevContainer = 6,
+    }
+
+    public enum WorkspaceType
+    {
+        ProjectFolder = 1,
+        WorkspaceFile = 2,
     }
 }

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/WorkspacesHelper/VSCodeWorkspaceProperty.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/WorkspacesHelper/VSCodeWorkspaceProperty.cs
@@ -6,15 +6,12 @@ using System.Text.Json.Serialization;
 
 namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.WorkspacesHelper
 {
-    public class VSCodeWorkspaceEntry
+    public class VSCodeWorkspaceProperty
     {
-        [JsonPropertyName("folderUri")]
-        public string FolderUri { get; set; }
+        [JsonPropertyName("id")]
+        public string Id { get; set; }
 
-        [JsonPropertyName("label")]
-        public string Label { get; set; }
-
-        [JsonPropertyName("workspace")]
-        public VSCodeWorkspaceProperty Workspace { get; set; }
+        [JsonPropertyName("configPath")]
+        public string ConfigPath { get; set; }
     }
 }

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/plugin.json
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/plugin.json
@@ -4,7 +4,7 @@
   "ActionKeyword": "{",
   "Name": "VS Code Workspaces",
   "Author": "ricardosantos9521",
-  "Version": "1.0.0",
+  "Version": "1.1.0",
   "Language": "csharp",
   "Website": "https://github.com/ricardosantos9521/PowerToys/",
   "ExecuteFileName": "Community.PowerToys.Run.Plugin.VSCodeWorkspaces.dll",


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
- Showing previous opened workspaces that are configured in a file with extension ".code-workspace"

**What is included in the PR:** 
- Support to search and open previous opened workspaces ".code-workspace"
- Rename Workspace to Project Folder

**How does someone test / validate:** 
1. Open PT Run
2. Type '{'
3. Search for projects/remote ssh machines/workspace (including .code-workspace)
4. Enter to open the "result"

![image](https://user-images.githubusercontent.com/20097801/147001759-a35263db-1757-48e7-bdf1-7a3330ddb31a.png)
![image](https://user-images.githubusercontent.com/20097801/147001774-02282959-de4e-4537-a370-35d6f175f680.png)


## Quality Checklist

- [x] **Linked issue:** #14931
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
