### PR TITLE
[PT Run] Settings plugin: Update naming of remove program results

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsSettings/Properties/Resources.Designer.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsSettings/Properties/Resources.Designer.cs
@@ -160,7 +160,7 @@ namespace Microsoft.PowerToys.Run.Plugin.WindowsSettings.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Add/Remove Programs.
+        ///   Looks up a localized string similar to Add or remove programs.
         /// </summary>
         internal static string AddRemovePrograms {
             get {
@@ -295,7 +295,7 @@ namespace Microsoft.PowerToys.Run.Plugin.WindowsSettings.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Apps and Features.
+        ///   Looks up a localized string similar to Apps &amp; Features.
         /// </summary>
         internal static string AppsAndFeatures {
             get {
@@ -840,6 +840,15 @@ namespace Microsoft.PowerToys.Run.Plugin.WindowsSettings.Properties {
         internal static string CellularAndSim {
             get {
                 return ResourceManager.GetString("CellularAndSim", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Change programs.
+        /// </summary>
+        internal static string ChangePrograms {
+            get {
+                return ResourceManager.GetString("ChangePrograms", resourceCulture);
             }
         }
         
@@ -3058,6 +3067,24 @@ namespace Microsoft.PowerToys.Run.Plugin.WindowsSettings.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Remove programs.
+        /// </summary>
+        internal static string RemovePrograms {
+            get {
+                return ResourceManager.GetString("RemovePrograms", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Repair programs.
+        /// </summary>
+        internal static string RepairPrograms {
+            get {
+                return ResourceManager.GetString("RepairPrograms", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Scanners and cameras.
         /// </summary>
         internal static string ScannersAndCameras {
@@ -3630,6 +3657,15 @@ namespace Microsoft.PowerToys.Run.Plugin.WindowsSettings.Properties {
         internal static string Uninstall {
             get {
                 return ResourceManager.GetString("Uninstall", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Uninstall programs.
+        /// </summary>
+        internal static string UninstallPrograms {
+            get {
+                return ResourceManager.GetString("UninstallPrograms", resourceCulture);
             }
         }
         

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsSettings/Properties/Resources.resx
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsSettings/Properties/Resources.resx
@@ -162,7 +162,7 @@
     <comment>Area Control Panel (legacy settings)</comment>
   </data>
   <data name="AddRemovePrograms" xml:space="preserve">
-    <value>Add/Remove Programs</value>
+    <value>Add or remove programs</value>
     <comment>Area Control Panel (legacy settings)</comment>
   </data>
   <data name="AddYourPhone" xml:space="preserve">
@@ -218,7 +218,7 @@
     <comment>Short/modern name for application</comment>
   </data>
   <data name="AppsAndFeatures" xml:space="preserve">
-    <value>Apps and Features</value>
+    <value>Apps &amp; Features</value>
     <comment>Area Apps</comment>
   </data>
   <data name="AppSettingsApp" xml:space="preserve">
@@ -432,6 +432,9 @@
   <data name="CellularAndSim" xml:space="preserve">
     <value>Cellular and SIM</value>
     <comment>Area NetworkAndInternet</comment>
+  </data>
+  <data name="ChangePrograms" xml:space="preserve">
+    <value>Change programs</value>
   </data>
   <data name="ChangeUACSettings" xml:space="preserve">
     <value>Change User Account Control settings</value>
@@ -1357,6 +1360,12 @@
     <value>Remote Desktop</value>
     <comment>Area System</comment>
   </data>
+  <data name="RemovePrograms" xml:space="preserve">
+    <value>Remove programs</value>
+  </data>
+  <data name="RepairPrograms" xml:space="preserve">
+    <value>Repair programs</value>
+  </data>
   <data name="ScannersAndCameras" xml:space="preserve">
     <value>Scanners and cameras</value>
     <comment>Area Control Panel (legacy settings)</comment>
@@ -1598,6 +1607,9 @@
   <data name="Uninstall" xml:space="preserve">
     <value>Uninstall</value>
     <comment>Area MixedReality, only available if the Mixed Reality Portal app is installed.</comment>
+  </data>
+  <data name="UninstallPrograms" xml:space="preserve">
+    <value>Uninstall programs</value>
   </data>
   <data name="Usb" xml:space="preserve">
     <value>USB</value>

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsSettings/WindowsSettings.json
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsSettings/WindowsSettings.json
@@ -81,6 +81,7 @@
       "Name": "AppsAndFeatures",
       "Areas": [ "AreaApps" ],
       "Type": "AppSettingsApp",
+      "AltNames": [ "UninstallPrograms", "RemovePrograms", "ChangePrograms", "RepairPrograms" ],
       "Command": "ms-settings:appsfeatures"
     },
     {
@@ -1280,7 +1281,7 @@
       "Name": "AddRemovePrograms",
       "Areas": [ "AreaHardwareAndSound" ],
       "Type": "AppControlPanel",
-      "AltNames": [ "appwiz.cpl" ],
+      "AltNames": [ "appwiz.cpl", "UninstallPrograms", "RemovePrograms", "ChangePrograms", "RepairPrograms" ],
       "Command": "control appwiz.cpl"
     },
     {

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsSettings/WindowsSettings.json
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsSettings/WindowsSettings.json
@@ -1281,7 +1281,7 @@
       "Name": "AddRemovePrograms",
       "Areas": [ "AreaHardwareAndSound" ],
       "Type": "AppControlPanel",
-      "AltNames": [ "appwiz.cpl", "UninstallPrograms", "RemovePrograms", "ChangePrograms", "RepairPrograms" ],
+      "AltNames": [ "appwiz.cpl", "UninstallPrograms", "ChangePrograms", "RepairPrograms" ],
       "Command": "control appwiz.cpl"
     },
     {


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
The results "Apps & Features" and "Add/Remove programs" missing some alternative names.

**What is included in the PR:** 
Updated alternative names of the results and the name of Apps&Features.

![image](https://user-images.githubusercontent.com/61519853/147233277-0b3f8c16-256f-4918-bab3-258fd9646cfa.png)
![image](https://user-images.githubusercontent.com/61519853/147233565-dfcb4758-44ca-487d-bba7-b5e4d82980fd.png)


**How does someone test / validate:** 
Manually on a local build.

## Quality Checklist

- [x] **Linked issue:** #15098
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [x] **Installer:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [x] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
