### PR TITLE
[PowerToys Run] Fix Previous query not erased when closing

### DIFF
--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -885,7 +885,7 @@ namespace PowerLauncher.ViewModel
             }
             else
             {
-                if (_settings.ClearInputOnLaunch && Results.Visibility == Visibility.Visible)
+                if (_settings.ClearInputOnLaunch)
                 {
                     ClearQueryCommand.Execute(null);
                     Task.Run(() =>


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
The previous query was not erased when closing if there are no results. It happens because there is a condition checking if there are results before erasing the query

**What is included in the PR:** 
Fixing the issue by removing the condition

**How does someone test / validate:** 
Check that the previous query is erased after closing (if the query has no results)

## Quality Checklist

- [x] **Linked issue:** #[10407](https://github.com/microsoft/PowerToys/issues/14317)
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
