### PR TITLE
[PT Run]Align subtitles for web search plugin

### DIFF
--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.WebSearch/Main.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.WebSearch/Main.cs
@@ -74,7 +74,7 @@ namespace Community.PowerToys.Run.Plugin.WebSearch
                 results.Add(new Result
                 {
                     Title = Properties.Resources.plugin_description.Remove(Description.Length - 1, 1),
-                    SubTitle = Properties.Resources.plugin_in_browser,
+                    SubTitle = string.Format(System.Globalization.CultureInfo.CurrentCulture, Properties.Resources.plugin_open, _browserName),
                     QueryTextDisplay = string.Empty,
                     IcoPath = _defaultIconPath,
                     ProgramArguments = arguments,

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.WebSearch/Main.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.WebSearch/Main.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO.Abstractions;
 using System.Linq;
 using System.Text;
@@ -74,7 +75,7 @@ namespace Community.PowerToys.Run.Plugin.WebSearch
                 results.Add(new Result
                 {
                     Title = Properties.Resources.plugin_description.Remove(Description.Length - 1, 1),
-                    SubTitle = string.Format(System.Globalization.CultureInfo.CurrentCulture, Properties.Resources.plugin_open, _browserName),
+                    SubTitle = string.Format(CultureInfo.CurrentCulture, Properties.Resources.plugin_in_browser_name, _browserName),
                     QueryTextDisplay = string.Empty,
                     IcoPath = _defaultIconPath,
                     ProgramArguments = arguments,
@@ -109,7 +110,7 @@ namespace Community.PowerToys.Run.Plugin.WebSearch
                 var result = new Result
                 {
                     Title = searchTerm,
-                    SubTitle = string.Format(System.Globalization.CultureInfo.CurrentCulture, Properties.Resources.plugin_open, _browserName),
+                    SubTitle = string.Format(CultureInfo.CurrentCulture, Properties.Resources.plugin_open, _browserName),
                     QueryTextDisplay = searchTerm,
                     IcoPath = _defaultIconPath,
                 };
@@ -134,7 +135,7 @@ namespace Community.PowerToys.Run.Plugin.WebSearch
                 }
                 else
                 {
-                    string url = string.Format(System.Globalization.CultureInfo.InvariantCulture, _searchEngineUrl, searchTerm);
+                    string url = string.Format(CultureInfo.InvariantCulture, _searchEngineUrl, searchTerm);
 
                     result.Action = action =>
                     {

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.WebSearch/Properties/Resources.Designer.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.WebSearch/Properties/Resources.Designer.cs
@@ -97,6 +97,15 @@ namespace Community.PowerToys.Run.Plugin.WebSearch.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to In {0}.
+        /// </summary>
+        public static string plugin_in_browser_name {
+            get {
+                return ResourceManager.GetString("plugin_in_browser_name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Web Search.
         /// </summary>
         public static string plugin_name {

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.WebSearch/Properties/Resources.Designer.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.WebSearch/Properties/Resources.Designer.cs
@@ -88,15 +88,6 @@ namespace Community.PowerToys.Run.Plugin.WebSearch.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to In the default browser.
-        /// </summary>
-        public static string plugin_in_browser {
-            get {
-                return ResourceManager.GetString("plugin_in_browser", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to In {0}.
         /// </summary>
         public static string plugin_in_browser_name {

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.WebSearch/Properties/Resources.resx
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.WebSearch/Properties/Resources.resx
@@ -131,6 +131,7 @@
   </data>
   <data name="plugin_in_browser_name" xml:space="preserve">
     <value>In {0}</value>
+    <comment>Like "Search the web in {the browser name}"</comment>
   </data>
   <data name="plugin_name" xml:space="preserve">
     <value>Web Search</value>

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.WebSearch/Properties/Resources.resx
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.WebSearch/Properties/Resources.resx
@@ -129,6 +129,9 @@
   <data name="plugin_in_browser" xml:space="preserve">
     <value>In the default browser</value>
   </data>
+  <data name="plugin_in_browser_name" xml:space="preserve">
+    <value>In {0}</value>
+  </data>
   <data name="plugin_name" xml:space="preserve">
     <value>Web Search</value>
   </data>


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Align subtitles for web search plugin

**What is included in the PR:** 
Change subtitle. 

**How does someone test / validate:** 
Launch PT run and input the active command only to see if the result aligned with the result after keywords were entered. 

## Quality Checklist

- [x] **Linked issue:** #15126
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
