### PR TITLE
[PT Run - Calculator plugin] Normalize input before processing

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/Main.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Text;
 using ManagedCommon;
 using Wox.Plugin;
 using Wox.Plugin.Logger;
@@ -33,7 +34,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
             }
 
             NumberTranslator translator = NumberTranslator.Create(CultureInfo.CurrentCulture, new CultureInfo("en-US"));
-            var input = translator.Translate(query.Search);
+            var input = translator.Translate(query.Search.Normalize(NormalizationForm.FormKC));
 
             if (!CalculateHelper.InputValid(input))
             {


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
FormKC normalization docs:
```
        //
        // Summary:
        //     Indicates that a Unicode string is normalized using full compatibility decomposition,
        //     followed by the replacement of sequences with their primary composites, if possible.
```
E.g. Full-width parentheses are normalized and accepted as valid input for Calculator plugin.

**What is included in the PR:** 

**How does someone test / validate:** 
- confirm that Calculator plugin works with full-width parentheses
- e.g. `（22+33） * 2`

## Quality Checklist

- [x] **Linked issue:** #12664
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
