### PR TITLE
Update Product.wxs - Remove '(Preview)' from the start menu folder and application shortcut.

### DIFF
--- a/installer/PowerToysSetup/Product.wxs
+++ b/installer/PowerToysSetup/Product.wxs
@@ -19,7 +19,7 @@
   <?define ShortcutGuideModuleInterface=$(var.BinX64Dir)\modules\ShortcutGuide\ShortcutGuideModuleInterface?>
   
     <Product Id="*"
-       Name="PowerToys (Preview)"
+       Name="PowerToys"
        Language="1033"
        Version="$(var.Version)"
        Manufacturer="Microsoft Corporation"
@@ -392,7 +392,7 @@
         </Directory>
       </Directory>
       <Directory Id="ProgramMenuFolder">
-        <Directory Id="ApplicationProgramsFolder" Name="PowerToys (Preview)"/>
+        <Directory Id="ApplicationProgramsFolder" Name="PowerToys"/>
       </Directory>
       <Directory Id="DesktopFolder" Name="Desktop" />        
    </Directory>
@@ -449,7 +449,7 @@
     <DirectoryRef Id="ApplicationProgramsFolder">
       <Component Id="PowerToysStartMenuShortcut" Guid="336AB4F9-078C-4DCA-B69F-3808A9FFD758">
         <Shortcut Id="ApplicationStartMenuShortcut"
-          Name="PowerToys (Preview)"
+          Name="PowerToys"
           Description="PowerToys - Windows system utilities to maximize productivity"
           Icon="powertoys.exe"
           IconIndex="0"
@@ -943,7 +943,7 @@
                         Value="1"
                         KeyPath="yes"/>
         <Shortcut Id="DesktopShortcutId"
-                  Name="PowerToys (Preview)"
+                  Name="PowerToys"
                   Description="PowerToys - Windows system utilities to maximize productivity"
                   Target="[!PowerToys.exe]"
                   WorkingDirectory="INSTALLFOLDER"


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:** Remove '(Preview)' from the start menu folder and application shortcut. There is no need for such a clarification and it is often annoying.

**What is included in the PR:** Remove '(Preview)' from the start menu folder and application shortcut.

**How does someone test / validate:** Install it! 😁

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
