### PR TITLE
[Settings] Fix brush for CheckBox description

### DIFF
--- a/src/settings-ui/Settings.UI/Controls/CheckBoxWithDescriptionControl.cs
+++ b/src/settings-ui/Settings.UI/Controls/CheckBoxWithDescriptionControl.cs
@@ -39,7 +39,7 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
         {
             StackPanel panel = new StackPanel() { Orientation = Orientation.Vertical };
             panel.Children.Add(new TextBlock() { Margin = new Thickness(0, 10, 0, 0), Text = Header });
-            panel.Children.Add(new IsEnabledTextBlock() { FontSize = (double)App.Current.Resources["SecondaryTextFontSize"], Foreground = (SolidColorBrush)App.Current.Resources["TextFillColorSecondaryBrush"], Text = Description });
+            panel.Children.Add(new IsEnabledTextBlock() { Style = (Style)App.Current.Resources["SecondaryIsEnabledTextBlockStyle"], Text = Description });
             _checkBoxSubTextControl.Content = panel;
         }
 

--- a/src/settings-ui/Settings.UI/Controls/IsEnabledTextBlock/IsEnabledTextBlock.xaml
+++ b/src/settings-ui/Settings.UI/Controls/IsEnabledTextBlock/IsEnabledTextBlock.xaml
@@ -32,4 +32,8 @@
             </Setter.Value>
         </Setter>
     </Style>
+    <Style TargetType="local:IsEnabledTextBlock" x:Key="SecondaryIsEnabledTextBlockStyle">
+        <Setter Property="Foreground" Value="{ThemeResource TextFillColorSecondaryBrush}" />
+        <Setter Property="FontSize" Value="{StaticResource SecondaryTextFontSize}"/>
+    </Style>
 </ResourceDictionary>


### PR DESCRIPTION
## Summary of the Pull Request

Solves: #15140 

Switching between brushes in PowerToys Settings should render the correct color now.

## Quality Checklist

- [X] **Linked issue:** #15140 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
