### PR TITLE
mage has log as ln and then has log10.

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator.UnitTest/ExtendedCalculatorParserTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator.UnitTest/ExtendedCalculatorParserTests.cs
@@ -72,7 +72,9 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.UnitTests
                 new object[] { "exp(5)", 148.413159102577M },
                 new object[] { "e^5", 148.413159102577M },
                 new object[] { "e*2", 5.43656365691809M },
-                new object[] { "log(e)", 1M },
+                new object[] { "ln(3)",  1.09861228866810M },
+                new object[] { "log(3)", 0.47712125471966M },
+                new object[] { "ln(e)", 1M },
                 new object[] { "cosh(0)", 1M },
             };
 
@@ -141,6 +143,10 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.UnitTests
         }
 
         [DataTestMethod]
+        [DataRow("log(3)", true)]
+        [DataRow("ln(3)", true)]
+        [DataRow("log", false)]
+        [DataRow("ln", false)]
         [DataRow("ceil(2 * (pi ^ 2))", true)]
         [DataRow("((1 * 2)", false)]
         [DataRow("(1 * 2)))", false)]
@@ -160,8 +166,6 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.UnitTests
         [DataRow("1+1.1e3", true)]
         public void InputValid_TestValid_WhenCalled(string input, bool valid)
         {
-            // Arrange
-
             // Act
             var result = CalculateHelper.InputValid(input);
 

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/CalculateEngine.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/CalculateEngine.cs
@@ -34,6 +34,12 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
                 return default;
             }
 
+            // mages has quirky log representation
+            // mage has log == ln vs log10
+            input = input.
+                        Replace("log(", "log10(", true, CultureInfo.CurrentCulture).
+                        Replace("ln(", "log(", true, CultureInfo.CurrentCulture);
+
             var result = _magesEngine.Interpret(input);
 
             // This could happen for some incorrect queries, like pi(2)


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Mage sees Log as LN and has Log10 representation.  Common convention is Log == log10 and LN == log base e.

This does a hard shift when we see that notation.

**What is included in the PR:** 
test and code fixes

**How does someone test / validate:** 
run tests / manual run

![image](https://user-images.githubusercontent.com/1462282/147500600-5eaa7109-07c5-4f19-8866-76ac3c89b987.png)


## Quality Checklist

- [x] **Linked issue:** #[xxx](https://github.com/microsoft/PowerToys/issues/14687)
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [x] **Tests:** Added/updated and all pass
- [x] **Installer:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
