### PR TITLE
[Window Walker] Path for elevated process

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.WindowWalker/Components/NativeMethods.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.WindowWalker/Components/NativeMethods.cs
@@ -645,8 +645,18 @@ namespace Microsoft.Plugin.WindowWalker.Components
         /// <summary>
         /// GetWindowLong index to retrieves the extended window styles.
         /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1310:Field names should not contain underscore", Justification = "Matching interop var")]
         public const int GWL_EXSTYLE = -20;
+
+        /// <summary>
+        /// A window receives this message when the user chooses a command from the Window menu (formerly known as the system or control menu)
+        /// or when the user chooses the maximize button, minimize button, restore button, or close button.
+        /// </summary>
+        public const int WM_SYSCOMMAND = 0x0112;
+
+        /// <summary>
+        /// Restores the window to its normal position and size.
+        /// </summary>
+        public const int SC_RESTORE = 0xf120;
 
         /// <summary>
         /// The following are the extended window styles
@@ -877,5 +887,8 @@ namespace Microsoft.Plugin.WindowWalker.Components
         [DllImport("user32.dll", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool GetWindowPlacement(IntPtr hWnd, out WINDOWPLACEMENT lpwndpl);
+
+        [DllImport("user32.dll")]
+        public static extern int SendMessage(IntPtr hWnd, int msg, int wParam);
     }
 }

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.WindowWalker/Components/Window.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.WindowWalker/Components/Window.cs
@@ -254,7 +254,11 @@ namespace Microsoft.Plugin.WindowWalker.Components
             }
             else
             {
-                NativeMethods.ShowWindow(Hwnd, NativeMethods.ShowWindowCommands.Restore);
+                if (!NativeMethods.ShowWindow(Hwnd, NativeMethods.ShowWindowCommands.Restore))
+                {
+                    // ShowWindow doesn't work if the process is running elevated: fallback to SendMessage
+                    _ = NativeMethods.SendMessage(Hwnd, NativeMethods.WM_SYSCOMMAND, NativeMethods.SC_RESTORE);
+                }
             }
 
             NativeMethods.FlashWindow(Hwnd, true);

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.WindowWalker/Components/Window.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.WindowWalker/Components/Window.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation
+// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -6,15 +6,10 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Drawing;
 using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using System.Windows;
-using System.Windows.Interop;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
 
 namespace Microsoft.Plugin.WindowWalker.Components
 {
@@ -318,7 +313,7 @@ namespace Microsoft.Plugin.WindowWalker.Components
         {
             uint processId = GetProcessIDFromWindowHandle(hwnd);
             ProcessID = processId;
-            IntPtr processHandle = NativeMethods.OpenProcess(NativeMethods.ProcessAccessFlags.AllAccess, true, (int)processId);
+            IntPtr processHandle = NativeMethods.OpenProcess(NativeMethods.ProcessAccessFlags.QueryLimitedInformation, true, (int)processId);
             StringBuilder processName = new StringBuilder(MaximumFileNameLength);
 
             if (NativeMethods.GetProcessImageFileName(processHandle, processName, MaximumFileNameLength) != 0)


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Fix path not displayed for elevated process and task manager

![image](https://user-images.githubusercontent.com/25966642/147580482-86e7fb3e-d089-4fb8-a42d-dcf66471c380.png)

**What is included in the PR:** 
Call `OpenProcess` with `PROCESS_QUERY_LIMITED_INFORMATION` instead of `PROCESS_ALL_ACCESS`.

**How does someone test / validate:** 
- Open task manager and some apps as administrator
- Search opened window in PT Run
- Task manager and opened apps should display path as expected
- New changes: PT Run should be able to restore minimized task manager and elevated windows

## Quality Checklist

- [x] **Linked issue:** #1885
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
