### PR TITLE
[FZ Editor] Include template name in edit template dialog title + don't resize dialog when typing to long name

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -352,10 +352,14 @@
                           PrimaryButtonClick="EditLayoutDialog_PrimaryButtonClick"
                           SecondaryButtonClick="EditLayoutDialog_SecondaryButtonClick"
                           ScrollViewer.VerticalScrollBarVisibility="Auto"
+                          MaxWidth="320"
                           Opened="Dialog_Opened"
                           Closed="Dialog_Closed">
+            <ui:ContentDialog.Title>
+                <TextBlock x:Name="EditLayoutDialogTitle" TextTrimming="CharacterEllipsis" TextWrapping="NoWrap" MaxWidth="320" Margin="0,0,96,0" />
+            </ui:ContentDialog.Title>
             <Grid DataContext="{Binding SelectedModel}"
-                  MinWidth="320" Margin="4,4,24,32">
+                 Margin="4,4,24,32">
 
                 <StackPanel Margin="0,-37,0,0"
                             HorizontalAlignment="Right"

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -351,7 +351,6 @@
                           PrimaryButtonText="{x:Static props:Resources.Save}"
                           PrimaryButtonClick="EditLayoutDialog_PrimaryButtonClick"
                           SecondaryButtonClick="EditLayoutDialog_SecondaryButtonClick"
-                          Title="{x:Static props:Resources.Edit_Layout}"
                           ScrollViewer.VerticalScrollBarVisibility="Auto"
                           Opened="Dialog_Opened"
                           Closed="Dialog_Closed">

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -356,7 +356,7 @@
                           Opened="Dialog_Opened"
                           Closed="Dialog_Closed">
             <ui:ContentDialog.Title>
-                <TextBlock x:Name="EditLayoutDialogTitle" TextTrimming="CharacterEllipsis" TextWrapping="NoWrap" MaxWidth="320" Margin="0,0,96,0" />
+                <TextBlock x:Name="EditLayoutDialogTitle" MaxWidth="320" Margin="0,0,96,0" Loaded="EditLayoutDialogTitle_Loaded"/>
             </ui:ContentDialog.Title>
             <Grid DataContext="{Binding SelectedModel}"
                  Margin="4,4,24,32">

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -426,6 +426,7 @@
                                  Margin="12,0,0,0"
                                  ui:ControlHelper.Header="{x:Static props:Resources.Name}"
                                  MinWidth="286"
+                                 MaxWidth="286"
                                  HorizontalAlignment="Stretch"
                                  GotKeyboardFocus="TextBox_GotKeyboardFocus" />
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -315,7 +315,7 @@ namespace FancyZonesEditor
             }
 
             Keyboard.ClearFocus();
-            EditLayoutDialog.Title = string.Format(Properties.Resources.Edit_Template, ((LayoutModel)dataContext).Name);
+            EditLayoutDialogTitle.Text = string.Format(Properties.Resources.Edit_Template, ((LayoutModel)dataContext).Name);
             await EditLayoutDialog.ShowAsync();
         }
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -548,5 +548,11 @@ namespace FancyZonesEditor
         {
             SettingsDeepLink.OpenSettings(SettingsDeepLink.SettingsWindow.FancyZones);
         }
+
+        private void EditLayoutDialogTitle_Loaded(object sender, EventArgs e)
+        {
+            EditLayoutDialogTitle.TextTrimming = TextTrimming.CharacterEllipsis;
+            EditLayoutDialogTitle.TextWrapping = TextWrapping.NoWrap;
+        }
     }
 }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -315,6 +315,7 @@ namespace FancyZonesEditor
             }
 
             Keyboard.ClearFocus();
+            EditLayoutDialog.Title = string.Format(Properties.Resources.Edit_Template, ((LayoutModel)dataContext).Name);
             await EditLayoutDialog.ShowAsync();
         }
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
@@ -286,7 +286,7 @@ namespace FancyZonesEditor.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Edit &apos;{0}&apos; template.
+        ///   Looks up a localized string similar to Edit &apos;{0}&apos;.
         /// </summary>
         public static string Edit_Template {
             get {

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
@@ -277,20 +277,20 @@ namespace FancyZonesEditor.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Edit layout.
-        /// </summary>
-        public static string Edit_Layout {
-            get {
-                return ResourceManager.GetString("Edit_Layout", resourceCulture);
-            }
-        }
-
-        /// <summary>
         ///   Looks up a localized string similar to opened.
         /// </summary>
         public static string Edit_Layout_Open_Announce {
             get {
                 return ResourceManager.GetString("Edit_Layout_Open_Announce", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Edit &apos;{0}&apos; template.
+        /// </summary>
+        public static string Edit_Template {
+            get {
+                return ResourceManager.GetString("Edit_Template", resourceCulture);
             }
         }
         

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
@@ -371,8 +371,8 @@
   <data name="QuickKey_Title" xml:space="preserve">
     <value>Layout shortcut</value>
   </data>
-  <data name="Edit_Layout" xml:space="preserve">
-    <value>Edit layout</value>
+  <data name="Edit_Template" xml:space="preserve">
+    <value>Edit '{0}' template</value>
   </data>
   <data name="Edit_Layout_Open_Announce" xml:space="preserve">
     <value>opened</value>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
@@ -372,7 +372,7 @@
     <value>Layout shortcut</value>
   </data>
   <data name="Edit_Template" xml:space="preserve">
-    <value>Edit '{0}' template</value>
+    <value>Edit '{0}'</value>
   </data>
   <data name="Edit_Layout_Open_Announce" xml:space="preserve">
     <value>opened</value>


### PR DESCRIPTION
## Summary of the Pull Request

Co-author: @niels9001 

**What is this about:**
1) Edit template dialog title
 - Include template name in Edit template dialog title
![image](https://user-images.githubusercontent.com/57057282/147581671-3cae3847-c287-4fa7-a647-7655843005ee.png)
 - When template name is too long, title is being trimmed
![image](https://user-images.githubusercontent.com/57057282/147581739-dbce3b60-2b21-4aee-8ec0-55178410e71e.png)

2) Do not resize edit dialog title while typing too long template name
 - Before
 ![before](https://user-images.githubusercontent.com/57057282/147582092-ae0eca19-8256-40fb-8dae-a8688e90ccd2.gif)

 - After
![after](https://user-images.githubusercontent.com/57057282/147582102-096b5313-2ac8-4c95-9a98-cae98ff19681.gif)


**What is included in the PR:** 

**How does someone test / validate:** 
Check the attached gifs for testing 

## Quality Checklist

- [x] **Linked issue:** #10847
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
