### PR TITLE
fix regression #14715 by adding an additional check for the newly build metadata object

### DIFF
--- a/src/modules/imageresizer/ui/Extensions/BitmapMetadataExtension.cs
+++ b/src/modules/imageresizer/ui/Extensions/BitmapMetadataExtension.cs
@@ -188,6 +188,31 @@ namespace ImageResizer.Extensions
         }
 
         /// <summary>
+        /// Detect whether the metadata object is valid and can be copied successfully
+        /// </summary>
+        /// <remarks>
+        /// ImageMetadata.Clone() causes an exception if there is something wrong with the metadata object.
+        /// Operation is rather expensive.
+        /// </remarks>
+        /// <param name="metadata">Metadata object to be checked</param>
+        /// <returns>true if valid, false if invalid</returns>
+        public static bool IsMetadataObjectValid(this BitmapMetadata metadata)
+        {
+            try
+            {
+                _ = metadata.Clone();
+
+                return true;
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception)
+#pragma warning restore CA1031 // Do not catch general exception types
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
         /// Prints all metadata to debug console
         /// </summary>
         /// <remarks>

--- a/src/modules/imageresizer/ui/Models/ResizeOperation.cs
+++ b/src/modules/imageresizer/ui/Models/ResizeOperation.cs
@@ -104,7 +104,15 @@ namespace ImageResizer.Models
                                 }
                             }
 
-                            metadata = newMetadata;
+                            if (newMetadata.IsMetadataObjectValid())
+                            {
+                                metadata = newMetadata;
+                            }
+                            else
+                            {
+                                // Seems like we build an invalid metadata object. ImageResizer will fail when trying to write the image to disk. We discard all metadata to be able to save the image.
+                                metadata = null;
+                            }
                         }
                         catch (ArgumentException ex)
                         {


### PR DESCRIPTION
fixes regression #14715 

## Summary of the Pull Request
Resizing the [image](https://github.com/microsoft/PowerToys/issues/14715#issuecomment-989331525) was possible with version 0.49.1 and earlier. This fixes a regression introduced by me with PR #14914.

**What is this about:**

**What is included in the PR:** 

**How does someone test / validate:** 
resizing image https://github.com/microsoft/PowerToys/issues/14715#issuecomment-989331525 works after this PR

## Quality Checklist

- [x] **Linked issue:** #14715
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
