### PR TITLE
[PT Run] Add scheme verfication for application URI

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Uri.UnitTests/UriHelper/ExtendedUriParserTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Uri.UnitTests/UriHelper/ExtendedUriParserTests.cs
@@ -78,6 +78,7 @@ namespace Microsoft.Plugin.Uri.UnitTests.UriHelper
         [DataRow("ftp://user:password@google.com:2121", true, "ftp://user:password@google.com:2121/", false)]
         [DataRow("ftp://user:password@1.1.1.1", true, "ftp://user:password@1.1.1.1/", false)]
         [DataRow("ftp://user:password@1.1.1.1:2121", true, "ftp://user:password@1.1.1.1:2121/", false)]
+        [DataRow("^:", false, null, false)]
 
         public void TryParseCanParseHostName(string query, bool expectedSuccess, string expectedResult, bool expectedIsWebUri)
         {

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Uri/UriHelper/ExtendedUriParser.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Uri/UriHelper/ExtendedUriParser.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Microsoft.Plugin.Uri.Interfaces;
 
 namespace Microsoft.Plugin.Uri.UriHelper
@@ -21,10 +22,13 @@ namespace Microsoft.Plugin.Uri.UriHelper
 
             // Handling URL with only scheme, typically mailto or application uri.
             // Do nothing, return the result without urlBuilder
+            // And check if scheme match REC3986 (issue #15035)
+            const string schemeRegex = @"^([a-z][a-z0-9+\-.]*):";
             if (input.EndsWith(":", StringComparison.OrdinalIgnoreCase)
                 && !input.StartsWith("http", StringComparison.OrdinalIgnoreCase)
                 && !input.Contains("/", StringComparison.OrdinalIgnoreCase)
-                && !input.All(char.IsDigit))
+                && !input.All(char.IsDigit)
+                && Regex.IsMatch(input, schemeRegex))
             {
                 result = new System.Uri(input);
                 isWebUri = false;


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Add RFC3986 scheme verification for application URI. Resolves #15305 

**What is included in the PR:** 
Add scheme verification

**How does someone test / validate:** 
Enter `^:` in PT Run and see the logs. 

## Quality Checklist

- [x] **Linked issue:** #15305 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [x] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
