### PR TITLE
[ImageResizer] Add support for blanks in height/width fields (#15306)

### DIFF
--- a/src/modules/imageresizer/ui/Properties/Settings.cs
+++ b/src/modules/imageresizer/ui/Properties/Settings.cs
@@ -21,6 +21,11 @@ namespace ImageResizer.Properties
     public sealed partial class Settings : IDataErrorInfo, INotifyPropertyChanged
     {
         private static readonly IFileSystem _fileSystem = new FileSystem();
+        private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions
+        {
+            NumberHandling = JsonNumberHandling.AllowNamedFloatingPointLiterals,
+            WriteIndented = true,
+        };
 
         // Used to synchronize access to the settings.json file
         private static Mutex _jsonMutex = new Mutex();
@@ -409,7 +414,7 @@ namespace ImageResizer.Properties
         public void Save()
         {
             _jsonMutex.WaitOne();
-            string jsonData = JsonSerializer.Serialize(new SettingsWrapper() { Properties = this });
+            string jsonData = JsonSerializer.Serialize(new SettingsWrapper() { Properties = this }, _jsonSerializerOptions);
 
             // Create directory if it doesn't exist
             IFileInfo file = _fileSystem.FileInfo.FromFileName(SettingsPath);
@@ -442,7 +447,7 @@ namespace ImageResizer.Properties
             var jsonSettings = new Settings();
             try
             {
-                jsonSettings = JsonSerializer.Deserialize<SettingsWrapper>(jsonData)?.Properties;
+                jsonSettings = JsonSerializer.Deserialize<SettingsWrapper>(jsonData, _jsonSerializerOptions)?.Properties;
             }
             catch (JsonException)
             {


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Fix auto width/height feature that it works again as described:
> Auto width/height
> You can leave the height or width empty. This will honor the specified dimension and "lock" the other dimension to a value proportional to the original image aspect ratio.
[Image Resizer, Microsoft Docs](https://docs.microsoft.com/en-us/windows/powertoys/image-resizer#auto-widthheight)

Using a blank in the width/height field causes the image resizer to crash as described in #15306.

My guess is that this was a regression from the `Newtonsoft.Json` to `System.Json.Text` migration for JSON Settings serialization (if that ever happened, just guessing). Unfortunately, `System.Json.Text` handles cases like `NaN` differently than `Newtonsoft.Json`. Support for native support for "Named Floating Point Literals" where added with version 5 of `System.Text.Json`. [See Microsoft Docs for further details]( https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-migrate-from-newtonsoft-how-to?pivots=dotnet-6-0#nan-infinity--infinity).

I first thought that we need to wait for the .NET 6 migration to fix this due to the need for v5 `System.Text.Json`. Turns out that we already using `System.Text.Json` v5.0.2 in ImageResizer so here’s the fix.

**What is included in the PR:** 
Added JsonSerializerOptions in the settings serialization class of image resizer.

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #15306
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [x] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
