### PR TITLE
[VCM] Restore microphone muted states to their original state on exit

### DIFF
--- a/src/modules/videoconference/VideoConferenceModule/VideoConferenceModule.cpp
+++ b/src/modules/videoconference/VideoConferenceModule/VideoConferenceModule.cpp
@@ -289,7 +289,6 @@ VideoConferenceModule::VideoConferenceModule() :
 
 inline VideoConferenceModule::~VideoConferenceModule()
 {
-    instance->unmuteAll();
     toolbar.hide();
 }
 


### PR DESCRIPTION
## Summary of the Pull Request
Do not unmute devices on exit due to privacy issues.

**What is this about:**
Possible concerns: need to start PT again or change camera device in the app if you want to unmute it again.

**What is included in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #15310
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
