### PR TITLE
Revert "[PT Run] Smooth scrolling of the results list (#15033)"

### DIFF
--- a/src/modules/launcher/PowerLauncher/ResultList.xaml
+++ b/src/modules/launcher/PowerLauncher/ResultList.xaml
@@ -174,7 +174,6 @@
             Padding="0, 0"
             ScrollViewer.HorizontalScrollBarVisibility="Disabled"       
             ScrollViewer.VerticalScrollBarVisibility="Auto"       
-            ScrollViewer.CanContentScroll="False"
             SelectionMode="Single"
             SelectedIndex="{Binding Results.SelectedIndex, Mode=TwoWay}"
             SelectionChanged="SuggestionsListView_SelectionChanged"


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
https://github.com/microsoft/PowerToys/pull/15033 added some smoothness to scrolling but created input delays when typing in PowerToys Run (likely due to the side effect of disabling list virtualization. This makes for a worse experience than the issue the change fixed initially.

**What is included in the PR:** 
This reverts commit 3ada3c20a204d7905164b5811237099630a3ef29. (PR https://github.com/microsoft/PowerToys/pull/15033 )

**How does someone test / validate:** 
PowerToys Run keeps working, removing the input delay. This has been confirmed by users across these issues:
https://github.com/microsoft/PowerToys/issues/15364
https://github.com/microsoft/PowerToys/issues/15317

## Quality Checklist

- [x] **Linked issue:** #15364 #15317 #15299
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries
