### PR TITLE
[PTRun]Fix crash when plugins have the same name

### DIFF
--- a/src/modules/launcher/PowerLauncher.Telemetry/Events/PluginModel.cs
+++ b/src/modules/launcher/PowerLauncher.Telemetry/Events/PluginModel.cs
@@ -9,6 +9,10 @@ namespace PowerLauncher.Telemetry.Events
     [EventData]
     public class PluginModel
     {
+        public string ID { get; set; }
+
+        public string Name { get; set; }
+
         public bool Disabled { get; set; }
 
         public bool IsGlobal { get; set; }

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -52,16 +52,27 @@ namespace PowerLauncher
 
         private void SendSettingsTelemetry()
         {
-            Log.Info("Send Run settings telemetry", this.GetType());
-            var plugins = PluginManager.AllPlugins.ToDictionary(x => x.Metadata.Name, x => new PluginModel()
+            try
             {
-                Disabled = x.Metadata.Disabled,
-                ActionKeyword = x.Metadata.ActionKeyword,
-                IsGlobal = x.Metadata.IsGlobal,
-            });
+                Log.Info("Send Run settings telemetry", this.GetType());
+                var plugins = PluginManager.AllPlugins.ToDictionary(x => x.Metadata.Name + " " + x.Metadata.ID, x => new PluginModel()
+                {
+                    ID = x.Metadata.ID,
+                    Name = x.Metadata.Name,
+                    Disabled = x.Metadata.Disabled,
+                    ActionKeyword = x.Metadata.ActionKeyword,
+                    IsGlobal = x.Metadata.IsGlobal,
+                });
 
-            var telemetryEvent = new RunPluginsSettingsEvent(plugins);
-            PowerToysTelemetry.Log.WriteEvent(telemetryEvent);
+                var telemetryEvent = new RunPluginsSettingsEvent(plugins);
+                PowerToysTelemetry.Log.WriteEvent(telemetryEvent);
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception ex)
+#pragma warning restore CA1031 // Do not catch general exception types
+            {
+                Log.Exception("Unhandled exception when trying to send PowerToys Run settings telemetry.", ex, GetType());
+            }
         }
 
         protected override void OnSourceInitialized(EventArgs e)


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
When sending telemetry, PowerToys Run is crashing when it has plugins with the same name.

**What is included in the PR:** 
- Use name + id for the dictionary key instead of just the name.
- Add name and id to the data sent through telemetry.
- If something related to this telemetry call fails, log an exception instead of crashing.

**How does someone test / validate:** 
Not an easy scenario to test, this seems to happen with users that installed third party plugins with names that conflict with ours. I'm looking mostly for a code quality check here.

## Quality Checklist

- [x] **Linked issue:** #15396 #15344
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries
