### PR TITLE
[PT Run] [Program] FileSystemWatcher Crash

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Storage/Win32ProgramFileSystemWatchers.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Storage/Win32ProgramFileSystemWatchers.cs
@@ -44,14 +44,11 @@ namespace Microsoft.Plugin.Program.Storage
                 {
                     Directory.GetFiles(path);
                 }
-                catch (DirectoryNotFoundException)
+#pragma warning disable CA1031 // Do not catch general exception types
+                catch (Exception ex)
+#pragma warning restore CA1031 // Do not catch general exception types
                 {
-                    Log.Warn($"Directory {path} cannot be found", typeof(Win32ProgramFileSystemWatchers));
-                    invalidPaths.Add(path);
-                }
-                catch (UnauthorizedAccessException)
-                {
-                    Log.Warn($"Access denied to directory {path}", typeof(Win32ProgramFileSystemWatchers));
+                    Log.Exception($"Failed to get files in {path}", ex, typeof(Win32ProgramFileSystemWatchers));
                     invalidPaths.Add(path);
                 }
             }

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Storage/Win32ProgramFileSystemWatchers.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Storage/Win32ProgramFileSystemWatchers.cs
@@ -40,9 +40,18 @@ namespace Microsoft.Plugin.Program.Storage
             var invalidPaths = new List<string>();
             foreach (var path in paths)
             {
-                if (!Directory.Exists(path))
+                try
                 {
-                    Log.Warn($"Directory {path} does not exist and will be ignored", typeof(Win32ProgramFileSystemWatchers));
+                    Directory.GetFiles(path);
+                }
+                catch (DirectoryNotFoundException)
+                {
+                    Log.Warn($"Directory {path} cannot be found", typeof(Win32ProgramFileSystemWatchers));
+                    invalidPaths.Add(path);
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    Log.Warn($"Access denied to directory {path}", typeof(Win32ProgramFileSystemWatchers));
                     invalidPaths.Add(path);
                 }
             }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Program plugin fail to load if a FileSystemWatcher is initialized for a directory that does not exist or isn't accessible.
Unfortunately the previous PR didn't fully fix the issue: https://github.com/microsoft/PowerToys/pull/14649

**What is included in the PR:** 
- Initialize FileSystemWatcher only for valid directories.
- Log as warning invalid directories.

**How does someone test / validate:** 
- Validate the code
- Already tested with an anofficial build: https://github.com/microsoft/PowerToys/issues/11511#issuecomment-1009275679

## Quality Checklist

- [x] **Linked issue:** #11511
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
