### PR TITLE
[PT Run] Fix crash in EnvHelper if no machine path var exists

### DIFF
--- a/src/modules/launcher/PowerLauncher/Helper/EnvironmentHelper.cs
+++ b/src/modules/launcher/PowerLauncher/Helper/EnvironmentHelper.cs
@@ -185,7 +185,7 @@ namespace PowerLauncher.Helper
                     }
                     else
                     {
-                        // Checking if the list of (machine) variables contains a patrh variable
+                        // Checking if the list of (machine) variables contains a path variable
                         if (environment.ContainsKey(PathVariableName))
                         {
                             // When we merging the PATH variables we can't simply overwrite machine layer's value. The path variable must be joined by appending the user value to the machine value.
@@ -196,7 +196,7 @@ namespace PowerLauncher.Helper
                         else
                         {
                             // Log warning and only write user value into dictionary
-                            Log.Warn("List of machine variables doesn't contain a path variable! The merged list won't contain any machine values in the path variable.", typeof(PowerLauncher.Helper.EnvironmentHelper));
+                            Log.Warn("The List of machine variables doesn't contain a path variable! The merged list won't contain any machine paths in the path variable.", typeof(PowerLauncher.Helper.EnvironmentHelper));
                             environment[uVarKey] = uVarValue;
                         }
                     }

--- a/src/modules/launcher/PowerLauncher/Helper/EnvironmentHelper.cs
+++ b/src/modules/launcher/PowerLauncher/Helper/EnvironmentHelper.cs
@@ -20,7 +20,7 @@ namespace PowerLauncher.Helper
     public static class EnvironmentHelper
     {
         // The HashSet will contain the list of environment variables that will be skipped on update.
-        private const string PathVariable = "Path";
+        private const string PathVariableName = "Path";
         private static readonly HashSet<string> _protectedProcessVariables = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
@@ -179,16 +179,26 @@ namespace PowerLauncher.Helper
                     string uVarValue = (string)uVar.Value;
 
                     // The variable name of the path variable can be upper case, lower case ore mixed case. So we have to compare case insensitive.
-                    if (!uVarKey.Equals(PathVariable, StringComparison.OrdinalIgnoreCase))
+                    if (!uVarKey.Equals(PathVariableName, StringComparison.OrdinalIgnoreCase))
                     {
                         environment[uVarKey] = uVarValue;
                     }
                     else
                     {
-                        // When we merging the PATH variables we can't simply overwrite machine layer's value. The path variable must be joined by appending the user value to the machine value.
-                        // This is the official behavior and checked by trying it out on the physical machine.
-                        string newPathValue = environment[uVarKey].EndsWith(';') ? environment[uVarKey] + uVarValue : environment[uVarKey] + ';' + uVarValue;
-                        environment[uVarKey] = newPathValue;
+                        // Checking if the list of (machine) variables contains a patrh variable
+                        if (environment.ContainsKey(PathVariableName))
+                        {
+                            // When we merging the PATH variables we can't simply overwrite machine layer's value. The path variable must be joined by appending the user value to the machine value.
+                            // This is the official behavior and checked by trying it out on the physical machine.
+                            string newPathValue = environment[uVarKey].EndsWith(';') ? environment[uVarKey] + uVarValue : environment[uVarKey] + ';' + uVarValue;
+                            environment[uVarKey] = newPathValue;
+                        }
+                        else
+                        {
+                            // Log warning and only write user value into dictionary
+                            Log.Warn("List of machine variables doesn't contain a path variable! The merged list won't contain any machine values in the path variable.", typeof(PowerLauncher.Helper.EnvironmentHelper));
+                            environment[uVarKey] = uVarValue;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
If the machine variables list doesn't contain a path variable, but user variable list does we get a crash while merging both lists:

```
Version: 0.53.3.0
OS Version: Microsoft Windows NT 10.0.19044.0
IntPtr Length: 8
x64: True
Date: 13-Jan-22 12:16:15 PM
Exception:
System.Collections.Generic.KeyNotFoundException: The given key 'Path' was not present in the dictionary.
at System.Collections.Generic.Dictionary2.get_Item(TKey key)
at PowerLauncher.Helper.EnvironmentHelper.GetMergedMachineAndUserVariables(Dictionary2 environment)
at PowerLauncher.Helper.EnvironmentHelper.<>c__DisplayClass2_0.b__0()
at Wox.Infrastructure.Stopwatch.Normal(String message, Action action)
at PowerLauncher.Helper.EnvironmentHelper.GetProtectedEnvironmentVariables()
at PowerLauncher.MainWindow.OnSourceInitialized(Object sender, EventArgs e)
at System.Windows.Window.OnSourceInitialized(EventArgs e)
at PowerLauncher.MainWindow.OnSourceInitialized(EventArgs e)
at System.Windows.Window.CreateSourceWindow(Boolean duringShow)
at System.Windows.Window.CreateSourceWindowDuringShow()
at System.Windows.Window.SafeCreateWindowDuringShow()
at System.Windows.Window.ShowHelper(Object booleanBox)
at System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, Object args, Int32 numArgs)
at System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, Delegate callback, Object args, Int32 numArgs, Delegate catchHandler)
```

**What is included in the PR:** 
Adding code to handle this case.,

**How does someone test / validate:** 
Manually removing var on my system and starting PT Run.

```
[2022-01-14 10:17:50.7444] [WARN] [D:\AppDev\Github\htcfreek\PT_EnvHelperCrash\src\modules\launcher\PowerLauncher\Helper\EnvironmentHelper.cs::199]
The List of machine variables doesn't contain a path variable! The merged list won't contain any machine paths in the path variable.
```

## Quality Checklist

- [x] **Linked issue:** #15497 
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
