### PR TITLE
[ImageResizer] fixed regression: Too much Metadata (#15413)

### DIFF
--- a/src/modules/imageresizer/ui/Models/ResizeOperation.cs
+++ b/src/modules/imageresizer/ui/Models/ResizeOperation.cs
@@ -136,9 +136,9 @@ namespace ImageResizer.Models
                     encoder.Frames.Add(
                         BitmapFrame.Create(
                             Transform(originalFrame),
-                            originalFrame.Thumbnail,
+                            thumbnail: null, /* should be null, see #15413 */
                             metadata,
-                            null));
+                            colorContexts: null /* should be null, see #14866 */ ));
                 }
 
                 path = GetDestinationPath(encoder);


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
set thumbnail image null as it was before v0.51.1.

**What is included in the PR:** 
fix for a regression described in #15413,

**How does someone test / validate:** 
You can use this image to validate the problem: https://github.com/microsoft/PowerToys/issues/15413#issuecomment-1011133032

## Quality Checklist

- [x] **Linked issue:** #15413
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
