### PR TITLE
Reset color history to top after choosing new color

### DIFF
--- a/src/modules/colorPicker/ColorPickerUI/ViewModels/ColorEditorViewModel.cs
+++ b/src/modules/colorPicker/ColorPickerUI/ViewModels/ColorEditorViewModel.cs
@@ -131,6 +131,8 @@ namespace ColorPicker.ViewModels
 
                 _userSettings.ColorHistory.ReleaseNotification();
             }
+
+            // Reset list view to top here, maybe
         }
 
         private void DeleteSelectedColor()

--- a/src/modules/colorPicker/ColorPickerUI/ViewModels/ColorEditorViewModel.cs
+++ b/src/modules/colorPicker/ColorPickerUI/ViewModels/ColorEditorViewModel.cs
@@ -34,7 +34,6 @@ namespace ColorPicker.ViewModels
             OpenColorPickerCommand = new RelayCommand(() => OpenColorPickerRequested?.Invoke(this, EventArgs.Empty));
             OpenSettingsCommand = new RelayCommand(() => OpenSettingsRequested?.Invoke(this, EventArgs.Empty));
             RemoveColorCommand = new RelayCommand(DeleteSelectedColor);
-
             SelectedColorChangedCommand = new RelayCommand((newColor) =>
             {
                 ColorsHistory.Insert(0, (Color)newColor);
@@ -131,8 +130,6 @@ namespace ColorPicker.ViewModels
 
                 _userSettings.ColorHistory.ReleaseNotification();
             }
-
-            // Reset list view to top here, maybe
         }
 
         private void DeleteSelectedColor()

--- a/src/modules/colorPicker/ColorPickerUI/Views/ColorEditorView.xaml.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Views/ColorEditorView.xaml.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Specialized;
 using System.Windows.Controls;
 using ColorPicker.Helpers;
 
@@ -12,14 +13,30 @@ namespace ColorPicker.Views
     /// </summary>
     public partial class ColorEditorView : UserControl
     {
-        public ColorEditorView() =>
+        public ColorEditorView()
+        {
             InitializeComponent();
+            ((INotifyCollectionChanged)HistoryColors.ItemsSource).CollectionChanged += new NotifyCollectionChangedEventHandler(HandleItemAdded);
+        }
 
         private void HistoryColors_ItemClick(object sender, ModernWpf.Controls.ItemClickEventArgs e)
         {
             // Note: it does not handle clicking on the same color.
             // More appropriate event would be SelectionChanged but we can not distinguish between user action and program action inside of it.
             SessionEventHelper.Event.EditorHistoryColorPicked = true;
+        }
+
+        private void HandleItemAdded(object sender, NotifyCollectionChangedEventArgs e)
+        {
+            if (e.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Add)
+            {
+                ScrollHistoryToTop();
+            }
+        }
+
+        private void ScrollHistoryToTop()
+        {
+            HistoryColors.ScrollIntoView(HistoryColors.Items[0]);
         }
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Issue #15073 History position not updated on adjusting color

**What is included in the PR:** 
Commented where I think a fix should go.

**How does someone test / validate:** 
1) Scroll color history down
2) Select new color or edit color in history
3) History list view should scroll to top

## Quality Checklist

- [x] **Linked issue:** #15073 
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
