### PR TITLE
Keep Gcode thumbnails transparency as is

### DIFF
--- a/src/modules/previewpane/GcodePreviewHandler/GcodePreviewHandlerControl.cs
+++ b/src/modules/previewpane/GcodePreviewHandler/GcodePreviewHandlerControl.cs
@@ -106,10 +106,7 @@ namespace Microsoft.PowerToys.PreviewHandler.Gcode
             {
                 var bitmapBytes = Convert.FromBase64String(bitmapBase64);
 
-                using (var bitmapStream = new MemoryStream(bitmapBytes))
-                {
-                    thumbnail = new Bitmap(bitmapStream);
-                }
+                thumbnail = new Bitmap(new MemoryStream(bitmapBytes));
             }
 
             return thumbnail;

--- a/src/modules/previewpane/GcodeThumbnailProvider/GcodeThumbnailProvider.cs
+++ b/src/modules/previewpane/GcodeThumbnailProvider/GcodeThumbnailProvider.cs
@@ -137,7 +137,6 @@ namespace Microsoft.PowerToys.ThumbnailHandler.Gcode
                 graphics.SmoothingMode = SmoothingMode.HighQuality;
                 graphics.PixelOffsetMode = PixelOffsetMode.HighQuality;
 
-                graphics.Clear(Color.White);
                 graphics.DrawImage(image, 0, 0, width, height);
             }
 
@@ -170,8 +169,8 @@ namespace Microsoft.PowerToys.ThumbnailHandler.Gcode
                     {
                         if (thumbnail != null && thumbnail.Size.Width > 0 && thumbnail.Size.Height > 0)
                         {
-                            phbmp = thumbnail.GetHbitmap();
-                            pdwAlpha = WTS_ALPHATYPE.WTSAT_RGB;
+                            phbmp = thumbnail.GetHbitmap(Color.Transparent);
+                            pdwAlpha = WTS_ALPHATYPE.WTSAT_ARGB;
                         }
                     }
                 }

--- a/src/modules/previewpane/GcodeThumbnailProvider/GcodeThumbnailProvider.cs
+++ b/src/modules/previewpane/GcodeThumbnailProvider/GcodeThumbnailProvider.cs
@@ -56,10 +56,7 @@ namespace Microsoft.PowerToys.ThumbnailHandler.Gcode
             {
                 var bitmapBytes = Convert.FromBase64String(bitmapBase64);
 
-                using (var bitmapStream = new MemoryStream(bitmapBytes))
-                {
-                    thumbnail = new Bitmap(bitmapStream);
-                }
+                thumbnail = new Bitmap(new MemoryStream(bitmapBytes));
 
                 if (thumbnail.Width != cx && thumbnail.Height != cx)
                 {

--- a/src/modules/previewpane/UnitTests-GcodeThumbnailProvider/GcodeThumbnailProviderTests.cs
+++ b/src/modules/previewpane/UnitTests-GcodeThumbnailProvider/GcodeThumbnailProviderTests.cs
@@ -31,7 +31,7 @@ namespace GcodeThumbnailProviderUnitTests
             provider.GetThumbnail(256, out IntPtr bitmap, out WTS_ALPHATYPE alphaType);
 
             Assert.IsTrue(bitmap != IntPtr.Zero);
-            Assert.IsTrue(alphaType == WTS_ALPHATYPE.WTSAT_RGB);
+            Assert.IsTrue(alphaType == WTS_ALPHATYPE.WTSAT_ARGB);
         }
 
         [TestMethod]


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Makes the G-code thumbnails transparent.

![image](https://user-images.githubusercontent.com/85504/149659598-dfac8926-0a4f-4ef1-bd2c-175c9923f588.png)

Dark mode:

![image](https://user-images.githubusercontent.com/85504/149659616-8f751e6e-986b-4c16-8883-ffc8076b3964.png)

**What is included in the PR:** 

Just a change to the output bitmap to include the unaltered alpha channel.

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #15653
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [x] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
