### PR TITLE
[FancyZones] Split zones-settings: layout templates

### DIFF
--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesData.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesData.cpp
@@ -170,6 +170,12 @@ void FancyZonesData::ReplaceZoneSettingsFileFromOlderVersions()
         //deviceInfoMap = JSONHelpers::ParseDeviceInfos(fancyZonesDataJSON);
         //customZoneSetsMap = JSONHelpers::ParseCustomZoneSets(fancyZonesDataJSON);
 
+        auto templates = JSONHelpers::ParseLayoutTemplates(fancyZonesDataJSON);
+        if (templates)
+        {
+            JSONHelpers::SaveLayoutTemplates(templates.value());
+        }
+        
         auto quickKeysMap = JSONHelpers::ParseQuickKeys(fancyZonesDataJSON);
         if (quickKeysMap)
         {

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesData.h
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesData.h
@@ -31,6 +31,7 @@ namespace FancyZonesUnitTests
     class WorkAreaUnitTests;
     class WorkAreaCreationUnitTests;
     class LayoutHotkeysUnitTests;
+    class LayoutTemplatesUnitTests;
 }
 #endif
 
@@ -90,6 +91,7 @@ private:
     friend class FancyZonesUnitTests::WorkAreaCreationUnitTests;
     friend class FancyZonesUnitTests::ZoneSetCalculateZonesUnitTests;
     friend class FancyZonesUnitTests::LayoutHotkeysUnitTests;
+    friend class FancyZonesUnitTests::LayoutTemplatesUnitTests;
 
     inline void SetDeviceInfo(const FancyZonesDataTypes::DeviceIdData& deviceId, FancyZonesDataTypes::DeviceInfoData data)
     {

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesData/LayoutTemplates.h
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesData/LayoutTemplates.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <FancyZonesLib/ModuleConstants.h>
+
+#include <common/SettingsAPI/settings_helpers.h>
+
+namespace NonLocalizable
+{
+    namespace LayoutTemplatesIds
+    {
+        const static wchar_t* LayoutTemplatesArrayID = L"layout-templates";
+    }
+}
+
+class LayoutTemplates
+{
+public:
+    inline static std::wstring LayoutTemplatesFileName()
+    {
+        std::wstring saveFolderPath = PTSettingsHelper::get_module_save_folder_location(NonLocalizable::ModuleKey);
+#if defined(UNIT_TESTS)
+        return saveFolderPath + L"\\test-layout-templates.json";
+#endif
+        return saveFolderPath + L"\\layout-templates.json";
+    }
+};

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesLib.vcxproj
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesLib.vcxproj
@@ -39,6 +39,7 @@
   <ItemGroup>
     <ClInclude Include="FancyZones.h" />
     <ClInclude Include="FancyZonesDataTypes.h" />
+    <ClInclude Include="FancyZonesData\LayoutTemplates.h" />
     <ClInclude Include="FancyZonesWinHookEventIDs.h" />
     <ClInclude Include="GenericKeyHook.h" />
     <ClInclude Include="FancyZonesData.h" />

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesLib.vcxproj.filters
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesLib.vcxproj.filters
@@ -96,6 +96,9 @@
     <ClInclude Include="ModuleConstants.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="FancyZonesData\LayoutTemplates.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp">

--- a/src/modules/fancyzones/FancyZonesLib/JsonHelpers.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/JsonHelpers.cpp
@@ -7,6 +7,7 @@
 #include "util.h"
 
 #include <FancyZonesLib/FancyZonesData/LayoutHotkeys.h>
+#include <FancyZonesLib/FancyZonesData/LayoutTemplates.h>
 
 #include <common/logger/logger.h>
 
@@ -583,23 +584,9 @@ namespace JSONHelpers
         auto before = json::from_file(zonesSettingsFileName);
 
         json::JsonObject root{};
-        json::JsonArray templates{};
-
-        try
-        {
-            if (before.has_value() && before->HasKey(NonLocalizable::Templates))
-            {
-                templates = before->GetNamedArray(NonLocalizable::Templates);
-            }
-        }
-        catch (const winrt::hresult_error&)
-        {
-        
-        }
                
         root.SetNamedValue(NonLocalizable::DevicesStr, JSONHelpers::SerializeDeviceInfos(deviceInfoMap));
         root.SetNamedValue(NonLocalizable::CustomZoneSetsStr, JSONHelpers::SerializeCustomZoneSets(customZoneSetsMap));
-        root.SetNamedValue(NonLocalizable::Templates, templates);
         
         if (!before.has_value() || before.value().Stringify() != root.Stringify())
         {
@@ -768,5 +755,26 @@ namespace JSONHelpers
 
         root.SetNamedValue(NonLocalizable::LayoutHotkeysIds::LayoutHotkeysArrayID, keysArray);
         json::to_file(LayoutHotkeys::LayoutHotkeysFileName(), root);
+    }
+
+    std::optional<json::JsonArray> ParseLayoutTemplates(const json::JsonObject& fancyZonesDataJSON)
+    {
+        try
+        {
+            return fancyZonesDataJSON.GetNamedArray(NonLocalizable::Templates);
+        }
+        catch (const winrt::hresult_error& e)
+        {
+            Logger::error(L"Parsing layout templates error: {}", e.message());
+        }
+
+        return std::nullopt;
+    }
+
+    void SaveLayoutTemplates(const json::JsonArray& templates)
+    {
+        json::JsonObject root{};
+        root.SetNamedValue(NonLocalizable::LayoutTemplatesIds::LayoutTemplatesArrayID, templates);
+        json::to_file(LayoutTemplates::LayoutTemplatesFileName(), root);
     }
 }

--- a/src/modules/fancyzones/FancyZonesLib/JsonHelpers.h
+++ b/src/modules/fancyzones/FancyZonesLib/JsonHelpers.h
@@ -105,7 +105,11 @@ namespace JSONHelpers
     TCustomZoneSetsMap ParseCustomZoneSets(const json::JsonObject& fancyZonesDataJSON);
     json::JsonArray SerializeCustomZoneSets(const TCustomZoneSetsMap& customZoneSetsMap);
 
-    // replace zone-settings: layout hotkeys
+    // replace zones-settings: layout hotkeys
     std::optional<TLayoutQuickKeysMap> ParseQuickKeys(const json::JsonObject& fancyZonesDataJSON);
     void SaveLayoutHotkeys(const TLayoutQuickKeysMap& quickKeysMap);
+
+    // replace zones-settings: layout templates
+    std::optional<json::JsonArray> ParseLayoutTemplates(const json::JsonObject& fancyZonesDataJSON);
+    void SaveLayoutTemplates(const json::JsonArray& templates);
 }

--- a/src/modules/fancyzones/FancyZonesTests/UnitTests/JsonHelpers.Tests.cpp
+++ b/src/modules/fancyzones/FancyZonesTests/UnitTests/JsonHelpers.Tests.cpp
@@ -1723,36 +1723,6 @@ namespace FancyZonesUnitTests
                 Assert::IsTrue(actual);
             }
 
-            TEST_METHOD (SaveFancyZonesDataWithTemplates)
-            {
-                FancyZonesData data;
-                data.SetSettingsModulePath(m_moduleName);
-                const auto& jsonPath = data.zonesSettingsFileName;
-
-                // json with templates
-                json::JsonObject expectedJsonObj;
-                json::JsonObject templateObj = json::JsonObject::Parse(L"{\"type\": \"focus\", \"show-spacing\": false, \"spacing\": 15, \"zone-count\": 7, \"sensitivity-radius\": 25}");
-                json::JsonArray templatesArray{};
-                templatesArray.Append(templateObj);
-                expectedJsonObj.SetNamedValue(L"devices", json::JsonArray{});
-                expectedJsonObj.SetNamedValue(L"custom-zone-sets", json::JsonArray{});
-                expectedJsonObj.SetNamedValue(L"templates", templatesArray);
-
-                // write json with templates to file
-                json::to_file(jsonPath, expectedJsonObj);
-
-                data.SaveAppZoneHistoryAndZoneSettings();
-
-                // verify that file was written successfully
-                Assert::IsTrue(std::filesystem::exists(jsonPath));
-
-                // verify that templates were not changed after calling SaveFancyZonesData()
-                std::wstring str;
-                std::wifstream { jsonPath, std::ios::binary } >> str;
-                json::JsonObject actualJson = json::JsonObject::Parse(str);
-                compareJsonObjects(expectedJsonObj, actualJson);
-            }
-
             TEST_METHOD (AppLastZoneIndex)
             {
                 const FancyZonesDataTypes::DeviceIdData deviceId{ L"device-id" };

--- a/src/modules/fancyzones/FancyZonesTests/UnitTests/LayoutTemplatesTests.Spec.cpp
+++ b/src/modules/fancyzones/FancyZonesTests/UnitTests/LayoutTemplatesTests.Spec.cpp
@@ -1,0 +1,95 @@
+#include "pch.h"
+#include <filesystem>
+
+#include <FancyZonesLib/FancyZonesData.h>
+#include <FancyZonesLib/FancyZonesData/LayoutTemplates.h>
+
+#include "util.h"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace FancyZonesUnitTests
+{
+    TEST_CLASS (LayoutTemplatesUnitTests)
+    {
+        FancyZonesData& m_fzData = FancyZonesDataInstance();
+        std::wstring m_testFolder = L"FancyZonesUnitTests";
+
+        TEST_METHOD_INITIALIZE(Init)
+        {
+            m_fzData.clear_data();
+            m_fzData.SetSettingsModulePath(L"FancyZonesUnitTests");
+        }
+
+        TEST_METHOD_CLEANUP(CleanUp)
+        {
+            std::filesystem::remove_all(LayoutTemplates::LayoutTemplatesFileName());
+            std::filesystem::remove_all(PTSettingsHelper::get_module_save_folder_location(m_testFolder));
+        }
+
+        TEST_METHOD (MoveLayoutHotkeysFromZonesSettings)
+        {
+            // prepare
+            json::JsonObject root{};
+            json::JsonArray devicesArray{}, customLayoutsArray{}, templateLayoutsArray{}, quickLayoutKeysArray{};
+            root.SetNamedValue(L"devices", devicesArray);
+            root.SetNamedValue(L"custom-zone-sets", customLayoutsArray);
+            root.SetNamedValue(L"quick-layout-keys", quickLayoutKeysArray);
+            
+            {
+                json::JsonObject layout{};
+                layout.SetNamedValue(L"type", json::value(L"blank"));
+                layout.SetNamedValue(L"show-spacing", json::value(false));
+                layout.SetNamedValue(L"spacing", json::value(0));
+                layout.SetNamedValue(L"zone-count", json::value(0));
+                layout.SetNamedValue(L"sensitivity-radius", json::value(0));
+                templateLayoutsArray.Append(layout);
+            }
+            {
+                json::JsonObject layout{};
+                layout.SetNamedValue(L"type", json::value(L"grid"));
+                layout.SetNamedValue(L"show-spacing", json::value(true));
+                layout.SetNamedValue(L"spacing", json::value(-10));
+                layout.SetNamedValue(L"zone-count", json::value(4));
+                layout.SetNamedValue(L"sensitivity-radius", json::value(30));
+                templateLayoutsArray.Append(layout);
+            }
+
+            root.SetNamedValue(L"templates", templateLayoutsArray);
+            json::to_file(m_fzData.GetZoneSettingsPath(m_testFolder), root);
+
+            // test
+            m_fzData.ReplaceZoneSettingsFileFromOlderVersions();
+            
+            auto result = json::from_file(LayoutTemplates::LayoutTemplatesFileName());
+            Assert::IsTrue(result.has_value());
+            Assert::IsTrue(result.value().HasKey(NonLocalizable::LayoutTemplatesIds::LayoutTemplatesArrayID));
+            auto res = CustomAssert::CompareJsonArrays(templateLayoutsArray, result.value().GetNamedArray(NonLocalizable::LayoutTemplatesIds::LayoutTemplatesArrayID));
+            Assert::IsTrue(res.first, res.second.c_str());
+        }
+
+        TEST_METHOD (MoveLayoutHotkeysFromZonesSettingsNoTemplates)
+        {
+            // prepare
+            json::JsonObject root{};
+            json::JsonArray devicesArray{}, customLayoutsArray{}, quickLayoutKeysArray{};
+            root.SetNamedValue(L"devices", devicesArray);
+            root.SetNamedValue(L"custom-zone-sets", customLayoutsArray);
+            root.SetNamedValue(L"quick-layout-keys", quickLayoutKeysArray);
+            json::to_file(m_fzData.GetZoneSettingsPath(m_testFolder), root);
+
+            // test
+            m_fzData.ReplaceZoneSettingsFileFromOlderVersions();
+            auto result = json::from_file(LayoutTemplates::LayoutTemplatesFileName());
+            Assert::IsFalse(result.has_value());
+        }
+
+        TEST_METHOD (MoveLayoutHotkeysFromZonesSettingsNoFile)
+        {
+            // test
+            m_fzData.ReplaceZoneSettingsFileFromOlderVersions();
+            auto result = json::from_file(LayoutTemplates::LayoutTemplatesFileName());
+            Assert::IsFalse(result.has_value());
+        }
+    };
+}

--- a/src/modules/fancyzones/FancyZonesTests/UnitTests/UnitTests.vcxproj
+++ b/src/modules/fancyzones/FancyZonesTests/UnitTests/UnitTests.vcxproj
@@ -45,6 +45,7 @@
     <ClCompile Include="FancyZonesSettings.Spec.cpp" />
     <ClCompile Include="JsonHelpers.Tests.cpp" />
     <ClCompile Include="LayoutHotkeysTests.Spec.cpp" />
+    <ClCompile Include="LayoutTemplatesTests.Spec.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(CIBuild)'!='true'">Create</PrecompiledHeader>
     </ClCompile>

--- a/src/modules/fancyzones/FancyZonesTests/UnitTests/UnitTests.vcxproj.filters
+++ b/src/modules/fancyzones/FancyZonesTests/UnitTests/UnitTests.vcxproj.filters
@@ -45,6 +45,9 @@
     <ClCompile Include="LayoutHotkeysTests.Spec.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="LayoutTemplatesTests.Spec.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h">

--- a/src/modules/fancyzones/editor/FancyZonesEditor/EditorWindow.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/EditorWindow.cs
@@ -31,7 +31,7 @@ namespace FancyZonesEditor
                 App.Overlay.SetLayoutSettings(App.Overlay.Monitors[App.Overlay.CurrentDesktop], model);
             }
 
-            App.FancyZonesEditorIO.SerializeZoneSettings();
+            App.FancyZonesEditorIO.SerializeLayoutTemplates();
 
             Close();
         }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -281,6 +281,8 @@ namespace FancyZonesEditor
             CancelLayoutChanges();
 
             App.FancyZonesEditorIO.SerializeZoneSettings();
+            App.FancyZonesEditorIO.SerializeLayoutHotkeys();
+            App.FancyZonesEditorIO.SerializeLayoutTemplates();
             App.Overlay.CloseLayoutWindow();
             App.Current.Shutdown();
         }
@@ -424,6 +426,8 @@ namespace FancyZonesEditor
             }
 
             App.FancyZonesEditorIO.SerializeZoneSettings();
+            App.FancyZonesEditorIO.SerializeLayoutTemplates();
+            App.FancyZonesEditorIO.SerializeLayoutHotkeys();
 
             // reset selected model
             Select(_settings.AppliedModel);

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
@@ -394,6 +394,15 @@ namespace FancyZonesEditor.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to An error occurred while parsing template layouts..
+        /// </summary>
+        public static string Error_Parsing_Layout_Templates_Message {
+            get {
+                return ResourceManager.GetString("Error_Parsing_Layout_Templates_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A layout that contained invalid data has been removed..
         /// </summary>
         public static string Error_Parsing_Zones_Settings_Message {

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
@@ -386,4 +386,7 @@
   <data name="Error_Parsing_Layout_Hotkeys_Message" xml:space="preserve">
     <value>An error occurred while parsing layout hotkeys.</value>
   </data>
+  <data name="Error_Parsing_Layout_Templates_Message" xml:space="preserve">
+    <value>An error occurred while parsing template layouts.</value>
+  </data>
 </root>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
@@ -30,6 +30,7 @@ namespace FancyZonesEditor.Utils
         // Non-localizable strings: Files
         private const string ZonesSettingsFile = "\\Microsoft\\PowerToys\\FancyZones\\zones-settings.json";
         private const string LayoutHotkeysFile = "\\Microsoft\\PowerToys\\FancyZones\\layout-hotkeys.json";
+        private const string LayoutTemplatesFile = "\\Microsoft\\PowerToys\\FancyZones\\layout-templates.json";
         private const string ParamsFile = "\\Microsoft\\PowerToys\\FancyZones\\editor-parameters.json";
 
         // Non-localizable string: Multi-monitor id
@@ -51,6 +52,8 @@ namespace FancyZonesEditor.Utils
         public string FancyZonesSettingsFile { get; private set; }
 
         public string FancyZonesLayoutHotkeysFile { get; private set; }
+
+        public string FancyZonesLayoutTemplatesFile { get; private set; }
 
         public string FancyZonesEditorParamsFile { get; private set; }
 
@@ -182,7 +185,7 @@ namespace FancyZonesEditor.Utils
             public JsonElement Info { get; set; } // CanvasInfoWrapper or GridInfoWrapper
         }
 
-        // zones-settings: templates
+        // layout-templates: templates
         private struct TemplateLayoutWrapper
         {
             public string Type { get; set; }
@@ -194,6 +197,12 @@ namespace FancyZonesEditor.Utils
             public int ZoneCount { get; set; }
 
             public int SensitivityRadius { get; set; }
+        }
+
+        // layout-templates: layout-templates-wrapper
+        private struct TemplateLayoutsListWrapper
+        {
+            public List<TemplateLayoutWrapper> TemplatesList { get; set; }
         }
 
         // layout-hotkeys: layout-hotkeys-wrapper
@@ -216,8 +225,6 @@ namespace FancyZonesEditor.Utils
             public List<DeviceWrapper> Devices { get; set; }
 
             public List<CustomLayoutWrapper> CustomZoneSets { get; set; }
-
-            public List<TemplateLayoutWrapper> Templates { get; set; }
         }
 
         private struct EditorParams
@@ -250,6 +257,7 @@ namespace FancyZonesEditor.Utils
             var localAppDataDir = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
             FancyZonesSettingsFile = localAppDataDir + ZonesSettingsFile;
             FancyZonesLayoutHotkeysFile = localAppDataDir + LayoutHotkeysFile;
+            FancyZonesLayoutTemplatesFile = localAppDataDir + LayoutTemplatesFile;
             FancyZonesEditorParamsFile = localAppDataDir + ParamsFile;
         }
 
@@ -523,8 +531,6 @@ namespace FancyZonesEditor.Utils
                 {
                     bool devicesParsingResult = SetDevices(zoneSettings.Devices);
                     bool customZonesParsingResult = SetCustomLayouts(zoneSettings.CustomZoneSets);
-                    bool templatesParsingResult = SetTemplateLayouts(zoneSettings.Templates);
-
                     if (!devicesParsingResult || !customZonesParsingResult)
                     {
                         return new ParsingResult(false, FancyZonesEditor.Properties.Resources.Error_Parsing_Zones_Settings_Message, settingsString);
@@ -541,6 +547,12 @@ namespace FancyZonesEditor.Utils
             if (!parsingHotkeysResult.Result)
             {
                 return parsingHotkeysResult;
+            }
+
+            var parsingTemplatesResult = ParseLayoutTemplates();
+            if (!parsingTemplatesResult.Result)
+            {
+                return parsingTemplatesResult;
             }
 
             return new ParsingResult(true);
@@ -585,6 +597,46 @@ namespace FancyZonesEditor.Utils
             return new ParsingResult(true);
         }
 
+        public ParsingResult ParseLayoutTemplates()
+        {
+            Logger.LogTrace();
+
+            if (_fileSystem.File.Exists(FancyZonesLayoutTemplatesFile))
+            {
+                TemplateLayoutsListWrapper templates;
+                string dataString = string.Empty;
+
+                try
+                {
+                    dataString = ReadFile(FancyZonesLayoutTemplatesFile);
+                    templates = JsonSerializer.Deserialize<TemplateLayoutsListWrapper>(dataString, _options);
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogError("Layout templates parsing error", ex);
+                    return new ParsingResult(false, ex.Message, dataString);
+                }
+
+                try
+                {
+                    bool parsingResult = SetTemplateLayouts(templates.TemplatesList);
+                    if (parsingResult)
+                    {
+                        return new ParsingResult(true);
+                    }
+
+                    return new ParsingResult(false, FancyZonesEditor.Properties.Resources.Error_Parsing_Layout_Templates_Message, dataString);
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogError("Layout templates parsing error", ex);
+                    return new ParsingResult(false, ex.Message, dataString);
+                }
+            }
+
+            return new ParsingResult(false, FancyZonesEditor.Properties.Resources.Error_Parsing_Layout_Templates_Message);
+        }
+
         public void SerializeZoneSettings()
         {
             Logger.LogTrace();
@@ -592,7 +644,6 @@ namespace FancyZonesEditor.Utils
             ZoneSettingsWrapper zoneSettings = new ZoneSettingsWrapper { };
             zoneSettings.Devices = new List<DeviceWrapper>();
             zoneSettings.CustomZoneSets = new List<CustomLayoutWrapper>();
-            zoneSettings.Templates = new List<TemplateLayoutWrapper>();
 
             // Serialize used devices
             foreach (var monitor in App.Overlay.Monitors)
@@ -710,25 +761,6 @@ namespace FancyZonesEditor.Utils
                 zoneSettings.CustomZoneSets.Add(customLayout);
             }
 
-            // Serialize template layouts
-            foreach (LayoutModel layout in MainWindowSettingsModel.DefaultModels)
-            {
-                TemplateLayoutWrapper wrapper = new TemplateLayoutWrapper
-                {
-                    Type = LayoutTypeToJsonTag(layout.Type),
-                    SensitivityRadius = layout.SensitivityRadius,
-                    ZoneCount = layout.TemplateZoneCount,
-                };
-
-                if (layout is GridLayoutModel grid)
-                {
-                    wrapper.ShowSpacing = grid.ShowSpacing;
-                    wrapper.Spacing = grid.Spacing;
-                }
-
-                zoneSettings.Templates.Add(wrapper);
-            }
-
             try
             {
                 string jsonString = JsonSerializer.Serialize(zoneSettings, _options);
@@ -777,6 +809,41 @@ namespace FancyZonesEditor.Utils
             catch (Exception ex)
             {
                 Logger.LogError("Serialize layout hotkeys error", ex);
+                App.ShowExceptionMessageBox(Properties.Resources.Error_Applying_Layout, ex);
+            }
+        }
+
+        public void SerializeLayoutTemplates()
+        {
+            TemplateLayoutsListWrapper templates = new TemplateLayoutsListWrapper { };
+            templates.TemplatesList = new List<TemplateLayoutWrapper>();
+
+            foreach (LayoutModel layout in MainWindowSettingsModel.DefaultModels)
+            {
+                TemplateLayoutWrapper wrapper = new TemplateLayoutWrapper
+                {
+                    Type = LayoutTypeToJsonTag(layout.Type),
+                    SensitivityRadius = layout.SensitivityRadius,
+                    ZoneCount = layout.TemplateZoneCount,
+                };
+
+                if (layout is GridLayoutModel grid)
+                {
+                    wrapper.ShowSpacing = grid.ShowSpacing;
+                    wrapper.Spacing = grid.Spacing;
+                }
+
+                templates.TemplatesList.Add(wrapper);
+            }
+
+            try
+            {
+                string jsonString = JsonSerializer.Serialize(templates, _options);
+                _fileSystem.File.WriteAllText(FancyZonesLayoutTemplatesFile, jsonString);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError("Serialize layout templates error", ex);
                 App.ShowExceptionMessageBox(Properties.Resources.Error_Applying_Layout, ex);
             }
         }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
@@ -771,11 +771,9 @@ namespace FancyZonesEditor.Utils
                 Logger.LogError("Serialize zone settings error", ex);
                 App.ShowExceptionMessageBox(Properties.Resources.Error_Applying_Layout, ex);
             }
-
-            SerializeLayoutHotkeys();
         }
 
-        private void SerializeLayoutHotkeys()
+        public void SerializeLayoutHotkeys()
         {
             LayoutHotkeysWrapper hotkeys = new LayoutHotkeysWrapper { };
             hotkeys.LayoutHotkeys = new List<LayoutHotkeyWrapper>();


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

* Keep layout templates in a separate file.
* Create `layout-templates.json` from `zones-settings` on FZ start
* Save templates in the `layout-templates.json` in Editor.
* Unit tests

**What is included in the PR:** 

**How does someone test / validate:** 

* Run PT, verify `layout-templates.json` created
* Run tests
* Open editor, edit any template, verify it was saved properly

## Quality Checklist

- [x] **Linked issue:** #14782 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [x] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
