### PR TITLE
[VCM] Initialize out method arguments in all erroneous cases

### DIFF
--- a/src/modules/videoconference/VideoConferenceProxyFilter/VideoCaptureDevice.cpp
+++ b/src/modules/videoconference/VideoConferenceProxyFilter/VideoCaptureDevice.cpp
@@ -172,8 +172,7 @@ struct VideoCaptureReceiverPin : winrt::implements<VideoCaptureReceiverPin, IPin
             return VFW_E_NOT_CONNECTED;
         }
 
-        _captureInputPin.copy_to(pPin);
-        return S_OK;
+        return _captureInputPin.try_copy_to(pPin) ? S_OK : E_FAIL;
     }
 
     HRESULT STDMETHODCALLTYPE ConnectionMediaType(AM_MEDIA_TYPE* pmt) override
@@ -294,8 +293,7 @@ struct VideoCaptureReceiverPin : winrt::implements<VideoCaptureReceiverPin, IPin
             return VFW_E_NO_ALLOCATOR;
         }
 
-        _allocator.copy_to(allocator);
-        return S_OK;
+        return _allocator.try_copy_to(allocator) ? S_OK : E_FAIL;
     }
 
     HRESULT STDMETHODCALLTYPE NotifyAllocator(IMemAllocator* allocator, BOOL readOnly) override

--- a/src/modules/videoconference/VideoConferenceProxyFilter/VideoCaptureProxyFilter.cpp
+++ b/src/modules/videoconference/VideoConferenceProxyFilter/VideoCaptureProxyFilter.cpp
@@ -117,8 +117,7 @@ HRESULT VideoCaptureProxyPin::ConnectedTo(IPin** pPin)
         return VFW_E_NOT_CONNECTED;
     }
 
-    _connectedInputPin.try_copy_to(pPin);
-    return S_OK;
+    return _connectedInputPin.try_copy_to(pPin) ? S_OK : E_FAIL;
 }
 
 HRESULT VideoCaptureProxyPin::ConnectionMediaType(AM_MEDIA_TYPE* pmt)
@@ -194,6 +193,8 @@ HRESULT VideoCaptureProxyPin::EnumMediaTypes(IEnumMediaTypes** ppEnum)
         return E_POINTER;
     }
 
+    *ppEnum = nullptr;
+
     auto enumerator = winrt::make_self<MediaTypeEnumerator>();
     enumerator->_objects.emplace_back(CopyMediaType(_mediaFormat));
     *ppEnum = enumerator.detach();
@@ -201,8 +202,12 @@ HRESULT VideoCaptureProxyPin::EnumMediaTypes(IEnumMediaTypes** ppEnum)
     return S_OK;
 }
 
-HRESULT VideoCaptureProxyPin::QueryInternalConnections(IPin**, ULONG*)
+HRESULT VideoCaptureProxyPin::QueryInternalConnections(IPin** pins, ULONG*)
 {
+    if (pins)
+    {
+        *pins = nullptr;
+    }
     return E_NOTIMPL;
 }
 
@@ -246,7 +251,6 @@ HRESULT VideoCaptureProxyPin::GetFormat(AM_MEDIA_TYPE** ppmt)
         LOG("VideoCaptureProxyPin::GetFormat FAILED ppmt");
         return E_POINTER;
     }
-
     *ppmt = CopyMediaType(_mediaFormat).release();
     return S_OK;
 }
@@ -676,8 +680,8 @@ HRESULT VideoCaptureProxyFilter::GetSyncSource(IReferenceClock** pClock)
     {
         return E_POINTER;
     }
-    _clock.try_copy_to(pClock);
-    return S_OK;
+    *pClock = nullptr;
+    return _clock.try_copy_to(pClock) ? S_OK : E_FAIL;
 }
 
 GUID MapDShowSubtypeToMFT(const GUID& dshowSubtype)
@@ -708,6 +712,7 @@ HRESULT VideoCaptureProxyFilter::EnumPins(IEnumPins** ppEnum)
         LOG("VideoCaptureProxyFilter::EnumPins null arg provided");
         return E_POINTER;
     }
+    *ppEnum = nullptr;
 
     std::unique_lock<std::mutex> lock{ _worker_mutex };
 
@@ -802,8 +807,12 @@ HRESULT VideoCaptureProxyFilter::EnumPins(IEnumPins** ppEnum)
     return S_OK;
 }
 
-HRESULT VideoCaptureProxyFilter::FindPin(LPCWSTR, IPin**)
+HRESULT VideoCaptureProxyFilter::FindPin(LPCWSTR, IPin** pin)
 {
+    if (pin)
+    {
+        *pin = nullptr;
+    }
     return E_NOTIMPL;
 }
 


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
For some reason, it doesn't crash on my machine (probably due to heap allocation APIs providing non-reused memory chunks on my system with 64GB RAM and an empty VM), but I was able to reproduce and debug it on a remote host. The issue was that `VideoCaptureProxyFilter::EnumPins` should initialize its `ppEnum` out parameter to `nullptr` in all cases, which we didn't do. I've also inspected all other methods accepting `**`-typed values and improved error reporting.

**What is included in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #13984
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
