### PR TITLE
[MouseUtils]fix dll file info

### DIFF
--- a/src/modules/MouseUtils/FindMyMouse/Directory.Build.targets
+++ b/src/modules/MouseUtils/FindMyMouse/Directory.Build.targets
@@ -1,5 +1,0 @@
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Target Name="GenerateResourceFiles" BeforeTargets="PrepareForBuild">
-    <Exec Command="powershell -NonInteractive -executionpolicy Unrestricted $(SolutionDir)tools\build\convert-resx-to-rc.ps1 .\ resource.base.h resource.h FindMyMouse.base.rc FindMyMouse.rc" />
-  </Target>
-</Project>

--- a/src/modules/MouseUtils/FindMyMouse/FindMyMouse.rc
+++ b/src/modules/MouseUtils/FindMyMouse/FindMyMouse.rc
@@ -1,6 +1,6 @@
 #include <windows.h>
 #include "resource.h"
-#include "../../../../common/version/version.h"
+#include "../../../common/version/version.h"
 
 #define APSTUDIO_READONLY_SYMBOLS
 #include "winres.h"

--- a/src/modules/MouseUtils/FindMyMouse/FindMyMouse.vcxproj
+++ b/src/modules/MouseUtils/FindMyMouse/FindMyMouse.vcxproj
@@ -106,8 +106,7 @@
   <ItemGroup>
     <ClInclude Include="FindMyMouse.h" />
     <ClInclude Include="pch.h" />
-    <ClInclude Include="Generated Files\resource.h" />
-    <None Include="resource.base.h" />
+    <ClInclude Include="resource.h" />
     <ClInclude Include="trace.h" />
   </ItemGroup>
   <ItemGroup>
@@ -117,7 +116,6 @@
       <PrecompiledHeader Condition="'$(CIBuild)'!='true'">Create</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="trace.cpp" />
-    <None Include="FindMyMouse.base.rc" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\common\logger\logger.vcxproj">
@@ -128,7 +126,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <ResourceCompile Include="Generated Files\FindMyMouse.rc" />
+    <ResourceCompile Include="FindMyMouse.rc" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/modules/MouseUtils/FindMyMouse/FindMyMouse.vcxproj.filters
+++ b/src/modules/MouseUtils/FindMyMouse/FindMyMouse.vcxproj.filters
@@ -41,22 +41,16 @@
     <ClInclude Include="FindMyMouse.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="Generated Files\resource.h">
-      <Filter>Generated Files</Filter>
+    <ClInclude Include="resource.h">
+      <Filter>Resource Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-    <None Include="resource.base.h">
-      <Filter>Resource Files</Filter>
-    </None>
-    <None Include="FindMyMouse.base.rc">
-      <Filter>Resource Files</Filter>
-    </None>
   </ItemGroup>
   <ItemGroup>
-    <ResourceCompile Include="Generated Files\FindMyMouse.rc">
-      <Filter>Generated Files</Filter>
+    <ResourceCompile Include="FindMyMouse.rc">
+      <Filter>Resource Files</Filter>
     </ResourceCompile>
   </ItemGroup>
 </Project>

--- a/src/modules/MouseUtils/FindMyMouse/resource.h
+++ b/src/modules/MouseUtils/FindMyMouse/resource.h
@@ -8,7 +8,6 @@
 #define FILE_DESCRIPTION "PowerToys FindMyMouse"
 #define INTERNAL_NAME "PowerToys.FindMyMouse"
 #define ORIGINAL_FILENAME "PowerToys.FindMyMouse.dll"
-#define IDS_KEYBOARDMANAGER_ICON 1001
 
 // Non-localizable
 //////////////////////////////

--- a/src/modules/MouseUtils/MouseHighlighter/Directory.Build.targets
+++ b/src/modules/MouseUtils/MouseHighlighter/Directory.Build.targets
@@ -1,5 +1,0 @@
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Target Name="GenerateResourceFiles" BeforeTargets="PrepareForBuild">
-    <Exec Command="powershell -NonInteractive -executionpolicy Unrestricted $(SolutionDir)tools\build\convert-resx-to-rc.ps1 .\ resource.base.h resource.h MouseHighlighter.base.rc MouseHighlighter.rc" />
-  </Target>
-</Project>

--- a/src/modules/MouseUtils/MouseHighlighter/MouseHighlighter.rc
+++ b/src/modules/MouseUtils/MouseHighlighter/MouseHighlighter.rc
@@ -1,6 +1,6 @@
 #include <windows.h>
 #include "resource.h"
-#include "../../../../common/version/version.h"
+#include "../../../common/version/version.h"
 
 #define APSTUDIO_READONLY_SYMBOLS
 #include "winres.h"

--- a/src/modules/MouseUtils/MouseHighlighter/MouseHighlighter.vcxproj
+++ b/src/modules/MouseUtils/MouseHighlighter/MouseHighlighter.vcxproj
@@ -106,8 +106,7 @@
     <ClInclude Include="MouseHighlighter.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="trace.h" />
-    <ClInclude Include="Generated Files\resource.h" />
-    <None Include="resource.base.h" />
+    <ClInclude Include="resource.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp" />
@@ -116,13 +115,12 @@
       <PrecompiledHeader Condition="'$(CIBuild)'!='true'">Create</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="trace.cpp" />
-    <None Include="MouseHighlighter.base.rc" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <ResourceCompile Include="Generated Files\MouseHighlighter.rc" />
+    <ResourceCompile Include="MouseHighlighter.rc" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\common\logger\logger.vcxproj">

--- a/src/modules/MouseUtils/MouseHighlighter/MouseHighlighter.vcxproj.filters
+++ b/src/modules/MouseUtils/MouseHighlighter/MouseHighlighter.vcxproj.filters
@@ -21,8 +21,8 @@
     <ClInclude Include="trace.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="Generated Files\resource.h">
-      <Filter>Generated Files</Filter>
+    <ClInclude Include="resource.h">
+      <Filter>Resource Files</Filter>
     </ClInclude>
     <ClInclude Include="MouseHighlighter.h">
       <Filter>Header Files</Filter>
@@ -30,12 +30,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-    <None Include="MouseHighlighter.base.rc">
-      <Filter>Resource Files</Filter>
-    </None>
-    <None Include="resource.base.h">
-      <Filter>Resource Files</Filter>
-    </None>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Source Files">
@@ -55,8 +49,8 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ResourceCompile Include="Generated Files\MouseHighlighter.rc">
-      <Filter>Generated Files</Filter>
+    <ResourceCompile Include="MouseHighlighter.rc">
+      <Filter>Resource Files</Filter>
     </ResourceCompile>
   </ItemGroup>
 </Project>

--- a/src/modules/MouseUtils/MouseHighlighter/resource.h
+++ b/src/modules/MouseUtils/MouseHighlighter/resource.h
@@ -8,7 +8,6 @@
 #define FILE_DESCRIPTION "PowerToys MouseHighlighter"
 #define INTERNAL_NAME "PowerToys.MouseHighlighter"
 #define ORIGINAL_FILENAME "PowerToys.MouseHighlighter.dll"
-#define IDS_KEYBOARDMANAGER_ICON 1001
 
 // Non-localizable
 //////////////////////////////


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Info is missing in the dll files for FindMyMouse and MousHighlighter.
This seems to have been caused by trying to do usual resource file generation, but without any real localizable resource files, since there are no localizable strings.

**What is included in the PR:** 
Use static resource files instead of trying to generate resource files.

**How does someone test / validate:** 
Build and verify `modules\MouseUtils\PowerToys.FindMyMouse.dll` and `modules\MouseUtils\PowerToys.MouseHighlighter.dll` have version applied in Properties > Details tab.


## Quality Checklist

- [x] **Linked issue:** #15672 15672
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries
