### PR TITLE
[FancyZones] Split zones-settings: app zone history

### DIFF
--- a/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
@@ -12,6 +12,7 @@
 #include <common/SettingsAPI/FileWatcher.h>
 
 #include <FancyZonesLib/FancyZonesData.h>
+#include <FancyZonesLib/FancyZonesData/AppZoneHistory.h>
 #include <FancyZonesLib/FancyZonesData/CustomLayouts.h>
 #include <FancyZonesLib/FancyZonesData/LayoutHotkeys.h>
 #include <FancyZonesLib/FancyZonesWindowProperties.h>
@@ -74,6 +75,7 @@ public:
         FancyZonesDataInstance().ReplaceZoneSettingsFileFromOlderVersions();
         LayoutHotkeys::instance().LoadData();
         CustomLayouts::instance().LoadData();
+        AppZoneHistory::instance().LoadData();
     }
 
     // IFancyZones
@@ -275,6 +277,7 @@ FancyZones::Run() noexcept
     });
 
     FancyZonesDataInstance().SetVirtualDesktopCheckCallback(std::bind(&VirtualDesktop::IsVirtualDesktopIdSavedInRegistry, &m_virtualDesktop, std::placeholders::_1));
+    AppZoneHistory::instance().SetVirtualDesktopCheckCallback(std::bind(&VirtualDesktop::IsVirtualDesktopIdSavedInRegistry, &m_virtualDesktop, std::placeholders::_1));
 }
 
 // IFancyZones
@@ -334,14 +337,14 @@ void FancyZones::MoveWindowIntoZone(HWND window, winrt::com_ptr<IWorkArea> workA
 {
     _TRACER_;
     auto& fancyZonesData = FancyZonesDataInstance();
-    if (!fancyZonesData.IsAnotherWindowOfApplicationInstanceZoned(window, workArea->UniqueId()))
+    if (!AppZoneHistory::instance().IsAnotherWindowOfApplicationInstanceZoned(window, workArea->UniqueId()))
     {
         if (workArea)
         {
             Trace::FancyZones::SnapNewWindowIntoZone(workArea->ZoneSet());
         }
         m_windowMoveHandler.MoveWindowIntoZoneByIndexSet(window, zoneIndexSet, workArea);
-        fancyZonesData.UpdateProcessIdToHandleMap(window, workArea->UniqueId());
+        AppZoneHistory::instance().UpdateProcessIdToHandleMap(window, workArea->UniqueId());
     }
 }
 

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesData.h
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesData.h
@@ -48,7 +48,6 @@ public:
     std::optional<FancyZonesDataTypes::DeviceInfoData> FindDeviceInfo(const FancyZonesDataTypes::DeviceIdData& id) const;
 
     const JSONHelpers::TDeviceInfoMap& GetDeviceInfoMap() const;
-    const std::unordered_map<std::wstring, std::vector<FancyZonesDataTypes::AppZoneHistoryData>>& GetAppZoneHistoryMap() const;
 
     inline const std::wstring& GetZonesSettingsFileName() const 
     {
@@ -65,20 +64,12 @@ public:
     void SyncVirtualDesktops(GUID desktopId);
     void RemoveDeletedDesktops(const std::vector<GUID>& activeDesktops);
 
-    bool IsAnotherWindowOfApplicationInstanceZoned(HWND window, const FancyZonesDataTypes::DeviceIdData& deviceId) const;
-    void UpdateProcessIdToHandleMap(HWND window, const FancyZonesDataTypes::DeviceIdData& deviceId);
-    ZoneIndexSet GetAppLastZoneIndexSet(HWND window, const FancyZonesDataTypes::DeviceIdData& deviceId, const std::wstring_view& zoneSetId) const;
-    bool RemoveAppLastZone(HWND window, const FancyZonesDataTypes::DeviceIdData& deviceId, const std::wstring_view& zoneSetId);
-    bool SetAppLastZones(HWND window, const FancyZonesDataTypes::DeviceIdData& deviceId, const std::wstring& zoneSetId, const ZoneIndexSet& zoneIndexSet);
-
     void SetActiveZoneSet(const FancyZonesDataTypes::DeviceIdData& deviceId, const FancyZonesDataTypes::ZoneSetData& zoneSet);
 
     json::JsonObject GetPersistFancyZonesJSON();
 
     void LoadFancyZonesData();
-    void SaveAppZoneHistoryAndZoneSettings() const;
     void SaveZoneSettings() const;
-    void SaveAppZoneHistory() const;
 
     void SaveFancyZonesEditorParameters(bool spanZonesAcrossMonitors, const std::wstring& virtualDesktopId, const HMONITOR& targetMonitor, const std::vector<std::pair<HMONITOR, MONITORINFOEX>>& allMonitors) const;
 
@@ -123,8 +114,6 @@ private:
         return result + L"\\" + std::wstring(L"zones-settings.json");
     }
 #endif
-    void RemoveDesktopAppZoneHistory(GUID desktopId);
-
     // Maps app path to app's zone history data
     std::unordered_map<std::wstring, std::vector<FancyZonesDataTypes::AppZoneHistoryData>> appZoneHistoryMap{};
     // Maps device unique ID to device data

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesData/AppZoneHistory.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesData/AppZoneHistory.cpp
@@ -1,0 +1,327 @@
+#include "../pch.h"
+#include "AppZoneHistory.h"
+
+#include <common/logger/call_tracer.h>
+#include <common/logger/logger.h>
+#include <common/utils/process_path.h>
+
+#include <FancyZonesLib/FancyZonesWindowProperties.h>
+#include <FancyZonesLib/JsonHelpers.h>
+
+AppZoneHistory::AppZoneHistory()
+{
+}
+
+AppZoneHistory& AppZoneHistory::instance()
+{
+    static AppZoneHistory self;
+    return self;
+}
+
+void AppZoneHistory::SetVirtualDesktopCheckCallback(std::function<bool(GUID)> callback)
+{
+    m_virtualDesktopCheckCallback = callback;
+}
+
+void AppZoneHistory::LoadData()
+{
+    auto file = AppZoneHistoryFileName();
+    auto data = json::from_file(file);
+
+    try
+    {
+        if (data)
+        {
+            m_history = JSONHelpers::ParseAppZoneHistory(data.value());
+        }
+        else
+        {
+            m_history.clear();
+            Logger::error(L"app-zone-history.json file is missing or malformed");
+        }
+    }
+    catch (const winrt::hresult_error& e)
+    {
+        Logger::error(L"Parsing app-zone-history error: {}", e.message());
+    }
+}
+
+void AppZoneHistory::SaveData()
+{
+    _TRACER_;
+
+    bool dirtyFlag = false;
+    std::unordered_map<std::wstring, std::vector<FancyZonesDataTypes::AppZoneHistoryData>> updatedHistory;
+    if (m_virtualDesktopCheckCallback)
+    {
+        for (const auto& [path, dataVector] : m_history)
+        {
+            auto updatedVector = dataVector;
+            for (auto& data : updatedVector)
+            {
+                if (!m_virtualDesktopCheckCallback(data.deviceId.virtualDesktopId))
+                {
+                    data.deviceId.virtualDesktopId = GUID_NULL;
+                    dirtyFlag = true;
+                }
+            }
+
+            updatedHistory.insert(std::make_pair(path, updatedVector));
+        }
+    }
+
+    if (dirtyFlag)
+    {
+        JSONHelpers::SaveAppZoneHistory(AppZoneHistoryFileName(), updatedHistory);
+    }
+    else
+    {
+        JSONHelpers::SaveAppZoneHistory(AppZoneHistoryFileName(), m_history);
+    }
+}
+
+bool AppZoneHistory::SetAppLastZones(HWND window, const FancyZonesDataTypes::DeviceIdData& deviceId, const std::wstring& zoneSetId, const ZoneIndexSet& zoneIndexSet)
+{
+    _TRACER_;
+
+    if (IsAnotherWindowOfApplicationInstanceZoned(window, deviceId))
+    {
+        return false;
+    }
+
+    auto processPath = get_process_path(window);
+    if (processPath.empty())
+    {
+        return false;
+    }
+
+    DWORD processId = 0;
+    GetWindowThreadProcessId(window, &processId);
+
+    auto history = m_history.find(processPath);
+    if (history != std::end(m_history))
+    {
+        auto& perDesktopData = history->second;
+        for (auto& data : perDesktopData)
+        {
+            if (data.deviceId.isEqualWithNullVirtualDesktopId(deviceId))
+            {
+                // application already has history on this work area, update it with new window position
+                data.processIdToHandleMap[processId] = window;
+                data.zoneSetUuid = zoneSetId;
+                data.zoneIndexSet = zoneIndexSet;
+                SaveData();
+                return true;
+            }
+        }
+    }
+
+    std::unordered_map<DWORD, HWND> processIdToHandleMap{};
+    processIdToHandleMap[processId] = window;
+    FancyZonesDataTypes::AppZoneHistoryData data{ .processIdToHandleMap = processIdToHandleMap,
+                                                  .zoneSetUuid = zoneSetId,
+                                                  .deviceId = deviceId,
+                                                  .zoneIndexSet = zoneIndexSet };
+
+    if (m_history.contains(processPath))
+    {
+        // application already has history but on other desktop, add with new desktop info
+        m_history[processPath].push_back(data);
+    }
+    else
+    {
+        // new application, create entry in app zone history map
+        m_history[processPath] = std::vector<FancyZonesDataTypes::AppZoneHistoryData>{ data };
+    }
+
+    SaveData();
+    return true;
+}
+
+bool AppZoneHistory::RemoveAppLastZone(HWND window, const FancyZonesDataTypes::DeviceIdData& deviceId, const std::wstring_view& zoneSetId)
+{
+    _TRACER_;
+
+    auto processPath = get_process_path(window);
+    if (!processPath.empty())
+    {
+        auto history = m_history.find(processPath);
+        if (history != std::end(m_history))
+        {
+            auto& perDesktopData = history->second;
+            for (auto data = std::begin(perDesktopData); data != std::end(perDesktopData);)
+            {
+                if (data->deviceId.isEqualWithNullVirtualDesktopId(deviceId) && data->zoneSetUuid == zoneSetId)
+                {
+                    if (!IsAnotherWindowOfApplicationInstanceZoned(window, deviceId))
+                    {
+                        DWORD processId = 0;
+                        GetWindowThreadProcessId(window, &processId);
+
+                        data->processIdToHandleMap.erase(processId);
+                    }
+
+                    // if there is another instance of same application placed in the same zone don't erase history
+                    ZoneIndex windowZoneStamp = reinterpret_cast<ZoneIndex>(::GetProp(window, ZonedWindowProperties::PropertyMultipleZoneID));
+                    for (auto placedWindow : data->processIdToHandleMap)
+                    {
+                        ZoneIndex placedWindowZoneStamp = reinterpret_cast<ZoneIndex>(::GetProp(placedWindow.second, ZonedWindowProperties::PropertyMultipleZoneID));
+                        if (IsWindow(placedWindow.second) && (windowZoneStamp == placedWindowZoneStamp))
+                        {
+                            return false;
+                        }
+                    }
+
+                    data = perDesktopData.erase(data);
+                    if (perDesktopData.empty())
+                    {
+                        m_history.erase(processPath);
+                    }
+                    SaveData();
+                    return true;
+                }
+                else
+                {
+                    ++data;
+                }
+            }
+        }
+    }
+
+    return false;
+}
+
+void AppZoneHistory::RemoveApp(const std::wstring& appPath)
+{
+    m_history.erase(appPath);
+}
+
+const AppZoneHistory::TAppZoneHistoryMap& AppZoneHistory::GetFullAppZoneHistory() const noexcept
+{
+    return m_history;
+}
+
+std::optional<FancyZonesDataTypes::AppZoneHistoryData> AppZoneHistory::GetZoneHistory(const std::wstring& appPath, const FancyZonesDataTypes::DeviceIdData& deviceId) const noexcept
+{
+    auto iter = m_history.find(appPath);
+    if (iter != m_history.end())
+    {
+        auto historyVector = iter->second;
+        for (const auto& history : historyVector)
+        {
+            if (history.deviceId.isEqualWithNullVirtualDesktopId(deviceId))
+            {
+                return history;
+            }
+        }
+    }
+    
+    return std::nullopt;
+}
+
+bool AppZoneHistory::IsAnotherWindowOfApplicationInstanceZoned(HWND window, const FancyZonesDataTypes::DeviceIdData& deviceId) const noexcept
+{
+    auto processPath = get_process_path(window);
+    if (!processPath.empty())
+    {
+        auto history = m_history.find(processPath);
+        if (history != std::end(m_history))
+        {
+            auto& perDesktopData = history->second;
+            for (auto& data : perDesktopData)
+            {
+                if (data.deviceId.isEqualWithNullVirtualDesktopId(deviceId))
+                {
+                    DWORD processId = 0;
+                    GetWindowThreadProcessId(window, &processId);
+
+                    auto processIdIt = data.processIdToHandleMap.find(processId);
+
+                    if (processIdIt == std::end(data.processIdToHandleMap))
+                    {
+                        return false;
+                    }
+                    else if (processIdIt->second != window && IsWindow(processIdIt->second))
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+
+    return false;
+}
+
+void AppZoneHistory::UpdateProcessIdToHandleMap(HWND window, const FancyZonesDataTypes::DeviceIdData& deviceId)
+{
+    auto processPath = get_process_path(window);
+    if (!processPath.empty())
+    {
+        auto history = m_history.find(processPath);
+        if (history != std::end(m_history))
+        {
+            auto& perDesktopData = history->second;
+            for (auto& data : perDesktopData)
+            {
+                if (data.deviceId.isEqualWithNullVirtualDesktopId(deviceId))
+                {
+                    DWORD processId = 0;
+                    GetWindowThreadProcessId(window, &processId);
+                    data.processIdToHandleMap[processId] = window;
+                    break;
+                }
+            }
+        }
+    }
+}
+
+ZoneIndexSet AppZoneHistory::GetAppLastZoneIndexSet(HWND window, const FancyZonesDataTypes::DeviceIdData& deviceId, const std::wstring_view& zoneSetId) const
+{
+    auto processPath = get_process_path(window);
+    if (!processPath.empty())
+    {
+        auto history = m_history.find(processPath);
+        if (history != std::end(m_history))
+        {
+            const auto& perDesktopData = history->second;
+            for (const auto& data : perDesktopData)
+            {
+                if (data.zoneSetUuid == zoneSetId && data.deviceId.isEqualWithNullVirtualDesktopId(deviceId))
+                {
+                    return data.zoneIndexSet;
+                }
+            }
+        }
+    }
+
+    return {};
+}
+
+void AppZoneHistory::RemoveDesktopAppZoneHistory(GUID desktopId)
+{
+    for (auto it = std::begin(m_history); it != std::end(m_history);)
+    {
+        auto& perDesktopData = it->second;
+        for (auto desktopIt = std::begin(perDesktopData); desktopIt != std::end(perDesktopData);)
+        {
+            if (desktopIt->deviceId.virtualDesktopId == desktopId)
+            {
+                desktopIt = perDesktopData.erase(desktopIt);
+            }
+            else
+            {
+                ++desktopIt;
+            }
+        }
+
+        if (perDesktopData.empty())
+        {
+            it = m_history.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+}

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesData/AppZoneHistory.h
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesData/AppZoneHistory.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <FancyZonesLib/FancyZonesDataTypes.h>
+#include <FancyZonesLib/ModuleConstants.h>
+
+#include <common/SettingsAPI/settings_helpers.h>
+
+class AppZoneHistory
+{
+public:
+    using TAppZoneHistoryMap = std::unordered_map<std::wstring, std::vector<FancyZonesDataTypes::AppZoneHistoryData>>;
+
+    static AppZoneHistory& instance();
+
+    inline static std::wstring AppZoneHistoryFileName()
+    {
+        std::wstring saveFolderPath = PTSettingsHelper::get_module_save_folder_location(NonLocalizable::ModuleKey);
+#if defined(UNIT_TESTS)
+        return saveFolderPath + L"\\test-app-zone-history.json";
+#endif
+        return saveFolderPath + L"\\app-zone-history.json";
+    }
+
+    void SetVirtualDesktopCheckCallback(std::function<bool(GUID)> callback);
+
+    void LoadData();
+    void SaveData();
+
+    bool SetAppLastZones(HWND window, const FancyZonesDataTypes::DeviceIdData& deviceId, const std::wstring& zoneSetId, const ZoneIndexSet& zoneIndexSet);
+    bool RemoveAppLastZone(HWND window, const FancyZonesDataTypes::DeviceIdData& deviceId, const std::wstring_view& zoneSetId);
+
+    void RemoveApp(const std::wstring& appPath);
+
+    const TAppZoneHistoryMap& GetFullAppZoneHistory() const noexcept;
+    std::optional<FancyZonesDataTypes::AppZoneHistoryData> GetZoneHistory(const std::wstring& appPath, const FancyZonesDataTypes::DeviceIdData& deviceId) const noexcept;
+
+    bool IsAnotherWindowOfApplicationInstanceZoned(HWND window, const FancyZonesDataTypes::DeviceIdData& deviceId) const noexcept;
+    void UpdateProcessIdToHandleMap(HWND window, const FancyZonesDataTypes::DeviceIdData& deviceId);
+    ZoneIndexSet GetAppLastZoneIndexSet(HWND window, const FancyZonesDataTypes::DeviceIdData& deviceId, const std::wstring_view& zoneSetId) const;
+
+    void RemoveDesktopAppZoneHistory(GUID desktopId);
+
+private:
+    AppZoneHistory();
+    ~AppZoneHistory() = default;
+
+    TAppZoneHistoryMap m_history;
+    std::function<bool(GUID)> m_virtualDesktopCheckCallback;
+};

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesLib.vcxproj
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesLib.vcxproj
@@ -38,6 +38,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="FancyZonesData\CustomLayouts.h" />
+    <ClInclude Include="FancyZonesData\AppZoneHistory.h" />
     <ClInclude Include="FancyZones.h" />
     <ClInclude Include="FancyZonesDataTypes.h" />
     <ClInclude Include="FancyZonesData\LayoutTemplates.h" />
@@ -68,6 +69,10 @@
     <ClInclude Include="ZonesOverlay.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="FancyZonesData\AppZoneHistory.cpp">
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">../pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|x64'">../pch.h</PrecompiledHeaderFile>
+    </ClCompile>
     <ClCompile Include="FancyZonesData\CustomLayouts.cpp">
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">../pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderFile Condition="'$(Configuration)|$(Platform)'=='Release|x64'">../pch.h</PrecompiledHeaderFile>

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesLib.vcxproj.filters
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesLib.vcxproj.filters
@@ -90,6 +90,9 @@
     <ClInclude Include="GuidUtils.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="FancyZonesData\AppZoneHistory.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="FancyZonesData\CustomLayouts.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -165,6 +168,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="FancyZonesData\LayoutHotkeys.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="FancyZonesData\AppZoneHistory.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/modules/fancyzones/FancyZonesLib/WindowMoveHandler.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WindowMoveHandler.cpp
@@ -7,7 +7,7 @@
 #include <common/utils/elevation.h>
 #include <common/utils/resources.h>
 
-#include "FancyZonesData.h"
+#include "FancyZonesData/AppZoneHistory.h"
 #include "Settings.h"
 #include "WorkArea.h"
 #include "util.h"
@@ -261,7 +261,7 @@ void WindowMoveHandler::MoveSizeEnd(HWND window, POINT const& ptScreen, const st
                     wil::unique_cotaskmem_string guidString;
                     if (SUCCEEDED_LOG(StringFromCLSID(zoneSet->Id(), &guidString)))
                     {
-                        FancyZonesDataInstance().RemoveAppLastZone(window, workAreaPtr->UniqueId(), guidString.get());
+                        AppZoneHistory::instance().RemoveAppLastZone(window, workAreaPtr->UniqueId(), guidString.get());
                     }
                 }
             }

--- a/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
@@ -5,6 +5,7 @@
 #include <common/logger/logger.h>
 
 #include "FancyZonesData.h"
+#include "FancyZonesData/AppZoneHistory.h"
 #include "FancyZonesDataTypes.h"
 #include "ZonesOverlay.h"
 #include "trace.h"
@@ -379,7 +380,7 @@ WorkArea::SaveWindowProcessToZoneIndex(HWND window) noexcept
             OLECHAR* guidString;
             if (StringFromCLSID(m_zoneSet->Id(), &guidString) == S_OK)
             {
-                FancyZonesDataInstance().SetAppLastZones(window, m_uniqueId, guidString, zoneIndexSet);
+                AppZoneHistory::instance().SetAppLastZones(window, m_uniqueId, guidString, zoneIndexSet);
             }
 
             CoTaskMemFree(guidString);
@@ -395,7 +396,7 @@ WorkArea::GetWindowZoneIndexes(HWND window) const noexcept
         wil::unique_cotaskmem_string zoneSetId;
         if (SUCCEEDED(StringFromCLSID(m_zoneSet->Id(), &zoneSetId)))
         {
-            return FancyZonesDataInstance().GetAppLastZoneIndexSet(window, m_uniqueId, zoneSetId.get());
+            return AppZoneHistory::instance().GetAppLastZoneIndexSet(window, m_uniqueId, zoneSetId.get());
         }
     }
     return {};

--- a/src/modules/fancyzones/FancyZonesLib/trace.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/trace.cpp
@@ -3,6 +3,7 @@
 #include "FancyZonesLib/ZoneSet.h"
 #include "FancyZonesLib/Settings.h"
 #include "FancyZonesLib/FancyZonesData.h"
+#include "FancyZonesData/AppZoneHistory.h"
 #include "FancyZonesLib/FancyZonesData/CustomLayouts.h"
 #include "FancyZonesLib/FancyZonesData/LayoutHotkeys.h"
 #include "FancyZonesLib/FancyZonesDataTypes.h"
@@ -145,7 +146,7 @@ void Trace::FancyZones::OnKeyDown(DWORD vkCode, bool win, bool control, bool inM
 void Trace::FancyZones::DataChanged() noexcept
 {
     const FancyZonesData& data = FancyZonesDataInstance();
-    int appsHistorySize = static_cast<int>(data.GetAppZoneHistoryMap().size());
+    int appsHistorySize = static_cast<int>(AppZoneHistory::instance().GetFullAppZoneHistory().size());
     const auto& customZones = CustomLayouts::instance().GetAllLayouts();
     const auto& devices = data.GetDeviceInfoMap();
     auto quickKeysCount = LayoutHotkeys::instance().GetHotkeysCount();

--- a/src/modules/fancyzones/FancyZonesTests/UnitTests/AppZoneHistoryTests.Spec.cpp
+++ b/src/modules/fancyzones/FancyZonesTests/UnitTests/AppZoneHistoryTests.Spec.cpp
@@ -1,0 +1,129 @@
+#include "pch.h"
+#include <filesystem>
+
+#include <FancyZonesLib/FancyZonesData/AppZoneHistory.h>
+
+#include "util.h"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace FancyZonesUnitTests
+{
+    TEST_CLASS (AppZoneHistoryUnitTests)
+    {
+        HINSTANCE m_hInst{};
+
+        TEST_METHOD_INITIALIZE(Init)
+        {
+            m_hInst = (HINSTANCE)GetModuleHandleW(nullptr);
+            AppZoneHistory::instance().LoadData();
+        }
+
+        TEST_METHOD_CLEANUP(CleanUp)
+        {
+            std::filesystem::remove(AppZoneHistory::instance().AppZoneHistoryFileName());
+        }
+
+        TEST_METHOD (AppLastZoneInvalidWindow)
+        {
+            const std::wstring zoneSetId = L"{2FEC41DA-3A0B-4E31-9CE1-9473C65D99F2}";
+            const FancyZonesDataTypes::DeviceIdData deviceId{ L"DELA026#5&10a58c63&0&UID16777488_2194_1234_{39B25DD2-130D-4B5D-8851-4791D66B1539}" };
+            const auto window = Mocks::Window();
+
+            Assert::IsTrue(std::vector<ZoneIndex>{} == AppZoneHistory::instance().GetAppLastZoneIndexSet(window, deviceId, zoneSetId));
+
+            const int expectedZoneIndex = 1;
+            Assert::IsFalse(AppZoneHistory::instance().SetAppLastZones(window, deviceId, zoneSetId, { expectedZoneIndex }));
+        }
+
+        TEST_METHOD (AppLastZoneNullWindow)
+        {
+            const std::wstring zoneSetId = L"{2FEC41DA-3A0B-4E31-9CE1-9473C65D99F2}";
+            const FancyZonesDataTypes::DeviceIdData deviceId{ L"DELA026#5&10a58c63&0&UID16777488_2194_1234_{39B25DD2-130D-4B5D-8851-4791D66B1539}" };
+            const auto window = nullptr;
+
+            const int expectedZoneIndex = 1;
+            Assert::IsFalse(AppZoneHistory::instance().SetAppLastZones(window, deviceId, zoneSetId, { expectedZoneIndex }));
+        }
+
+        TEST_METHOD (AppLastdeviceIdTest)
+        {
+            const std::wstring zoneSetId = L"{2FEC41DA-3A0B-4E31-9CE1-9473C65D99F2}";
+            const FancyZonesDataTypes::DeviceIdData deviceId1{ L"DELA026#5&10a58c63&0&UID16777488_2194_1234_{39B25DD2-130D-4B5D-8851-4791D66B1539}" };
+            const FancyZonesDataTypes::DeviceIdData deviceId2{ L"DELA026#5&10a58c63&0&UID16777489_2194_1234_{39B25DD2-130D-4B5D-8851-4791D66B1539}" };
+            const auto window = Mocks::WindowCreate(m_hInst);
+
+            const int expectedZoneIndex = 10;
+            Assert::IsTrue(AppZoneHistory::instance().SetAppLastZones(window, deviceId1, zoneSetId, { expectedZoneIndex }));
+            Assert::IsTrue(std::vector<ZoneIndex>{ expectedZoneIndex } == AppZoneHistory::instance().GetAppLastZoneIndexSet(window, deviceId1, zoneSetId));
+            Assert::IsTrue(std::vector<ZoneIndex>{} == AppZoneHistory::instance().GetAppLastZoneIndexSet(window, deviceId2, zoneSetId));
+        }
+
+        TEST_METHOD (AppLastZoneSetIdTest)
+        {
+            const std::wstring zoneSetId1 = L"{B7A1F5A9-9DC2-4505-84AB-993253839093}";
+            const std::wstring zoneSetId2 = L"{B7A1F5A9-9DC2-4505-84AB-993253839094}";
+            const FancyZonesDataTypes::DeviceIdData deviceId{ L"DELA026#5&10a58c63&0&UID16777488_2194_1234_{39B25DD2-130D-4B5D-8851-4791D66B1539}" };
+            const auto window = Mocks::WindowCreate(m_hInst);
+
+            const int expectedZoneIndex = 10;
+            Assert::IsTrue(AppZoneHistory::instance().SetAppLastZones(window, deviceId, zoneSetId1, { expectedZoneIndex }));
+            Assert::IsTrue(std::vector<ZoneIndex>{ expectedZoneIndex } == AppZoneHistory::instance().GetAppLastZoneIndexSet(window, deviceId, zoneSetId1));
+            Assert::IsTrue(std::vector<ZoneIndex>{} == AppZoneHistory::instance().GetAppLastZoneIndexSet(window, deviceId, zoneSetId2));
+        }
+
+        TEST_METHOD (AppLastZoneRemoveWindow)
+        {
+            const std::wstring zoneSetId = L"{B7A1F5A9-9DC2-4505-84AB-993253839093}";
+            const FancyZonesDataTypes::DeviceIdData deviceId{ L"DELA026#5&10a58c63&0&UID16777488_2194_1234_{39B25DD2-130D-4B5D-8851-4791D66B1539}" };
+            const auto window = Mocks::WindowCreate(m_hInst);
+
+            Assert::IsTrue(AppZoneHistory::instance().SetAppLastZones(window, deviceId, zoneSetId, { 1 }));
+            Assert::IsTrue(AppZoneHistory::instance().RemoveAppLastZone(window, deviceId, zoneSetId));
+            Assert::IsTrue(std::vector<ZoneIndex>{} == AppZoneHistory::instance().GetAppLastZoneIndexSet(window, deviceId, zoneSetId));
+        }
+
+        TEST_METHOD (AppLastZoneRemoveUnknownWindow)
+        {
+            const std::wstring zoneSetId = L"{2FEC41DA-3A0B-4E31-9CE1-9473C65D99F2}";
+            const FancyZonesDataTypes::DeviceIdData deviceId{ L"DELA026#5&10a58c63&0&UID16777488_2194_1234_{39B25DD2-130D-4B5D-8851-4791D66B1539}" };
+            const auto window = Mocks::WindowCreate(m_hInst);
+
+            Assert::IsFalse(AppZoneHistory::instance().RemoveAppLastZone(window, deviceId, zoneSetId));
+            Assert::IsTrue(std::vector<ZoneIndex>{} == AppZoneHistory::instance().GetAppLastZoneIndexSet(window, deviceId, zoneSetId));
+        }
+
+        TEST_METHOD (AppLastZoneRemoveUnknownZoneSetId)
+        {
+            const std::wstring zoneSetIdToInsert = L"{2FEC41DA-3A0B-4E31-9CE1-9473C65D99F2}";
+            const std::wstring zoneSetIdToRemove = L"{2FEC41DA-3A0B-4E31-9CE1-9473C65D99F1}";
+            const FancyZonesDataTypes::DeviceIdData deviceId{ L"DELA026#5&10a58c63&0&UID16777488_2194_1234_{39B25DD2-130D-4B5D-8851-4791D66B1539}" };
+            const auto window = Mocks::WindowCreate(m_hInst);
+
+            Assert::IsTrue(AppZoneHistory::instance().SetAppLastZones(window, deviceId, zoneSetIdToInsert, { 1 }));
+            Assert::IsFalse(AppZoneHistory::instance().RemoveAppLastZone(window, deviceId, zoneSetIdToRemove));
+            Assert::IsTrue(std::vector<ZoneIndex>{ 1 } == AppZoneHistory::instance().GetAppLastZoneIndexSet(window, deviceId, zoneSetIdToInsert));
+        }
+
+        TEST_METHOD (AppLastZoneRemoveUnknownWindowId)
+        {
+            const std::wstring zoneSetId = L"{2FEC41DA-3A0B-4E31-9CE1-9473C65D99F2}";
+            const FancyZonesDataTypes::DeviceIdData deviceIdToInsert{ L"DELA026#5&10a58c63&0&UID16777488_2194_1234_{39B25DD2-130D-4B5D-8851-4791D66B1539}" };
+            const FancyZonesDataTypes::DeviceIdData deviceIdToRemove{ L"DELA026#5&10a58c63&0&UID16777489_2194_1234_{39B25DD2-130D-4B5D-8851-4791D66B1539}" };
+            const auto window = Mocks::WindowCreate(m_hInst);
+
+            Assert::IsTrue(AppZoneHistory::instance().SetAppLastZones(window, deviceIdToInsert, zoneSetId, { 1 }));
+            Assert::IsFalse(AppZoneHistory::instance().RemoveAppLastZone(window, deviceIdToRemove, zoneSetId));
+            Assert::IsTrue(std::vector<ZoneIndex>{ 1 } == AppZoneHistory::instance().GetAppLastZoneIndexSet(window, deviceIdToInsert, zoneSetId));
+        }
+
+        TEST_METHOD (AppLastZoneRemoveNullWindow)
+        {
+            const std::wstring zoneSetId = L"{2FEC41DA-3A0B-4E31-9CE1-9473C65D99F2}";
+            const FancyZonesDataTypes::DeviceIdData deviceId{ L"DELA026#5&10a58c63&0&UID16777488_2194_1234_{39B25DD2-130D-4B5D-8851-4791D66B1539}" };
+            const auto window = Mocks::WindowCreate(m_hInst);
+
+            Assert::IsFalse(AppZoneHistory::instance().RemoveAppLastZone(nullptr, deviceId, zoneSetId));
+        }
+    };
+}

--- a/src/modules/fancyzones/FancyZonesTests/UnitTests/UnitTests.vcxproj
+++ b/src/modules/fancyzones/FancyZonesTests/UnitTests/UnitTests.vcxproj
@@ -41,6 +41,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="AppZoneHistoryTests.Spec.cpp" />
     <ClCompile Include="CustomLayoutsTests.Spec.cpp" />
     <ClCompile Include="FancyZones.Spec.cpp" />
     <ClCompile Include="FancyZonesSettings.Spec.cpp" />

--- a/src/modules/fancyzones/FancyZonesTests/UnitTests/UnitTests.vcxproj.filters
+++ b/src/modules/fancyzones/FancyZonesTests/UnitTests/UnitTests.vcxproj.filters
@@ -51,6 +51,9 @@
     <ClCompile Include="CustomLayoutsTests.Spec.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="AppZoneHistoryTests.Spec.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h">


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Moved `AppZoneHistory` without any change from `FancyZonesData` to keep it uniform with `LayoutHotkeys`, `LayoutTemplates`, and `CustomLayouts`.

**What is included in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #14782
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [x] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
