### PR TITLE
[Always On Top] Accent Color for Frame Borders

### DIFF
--- a/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.cpp
+++ b/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.cpp
@@ -38,7 +38,7 @@ bool isExcluded(HWND window)
 }
 
 AlwaysOnTop::AlwaysOnTop() :
-    SettingsObserver({SettingId::FrameEnabled, SettingId::Hotkey, SettingId::ExcludeApps}),
+    SettingsObserver({SettingId::FrameEnabled, SettingId::Hotkey, SettingId::ExcludeApps, SettingId::FrameAccentColor}),
     m_hinstance(reinterpret_cast<HINSTANCE>(&__ImageBase))
 {
     s_instance = this;

--- a/src/modules/alwaysontop/AlwaysOnTop/Settings.cpp
+++ b/src/modules/alwaysontop/AlwaysOnTop/Settings.cpp
@@ -19,6 +19,7 @@ namespace NonLocalizable
     const static wchar_t* FrameColorID = L"frame-color";
     const static wchar_t* BlockInGameModeID = L"do-not-activate-on-game-mode";
     const static wchar_t* ExcludedAppsID = L"excluded-apps";
+    const static wchar_t* FrameAccentColor = L"frame-accent-color";
 }
 
 // TODO: move to common utils
@@ -42,6 +43,14 @@ inline COLORREF HexToRGB(std::wstring_view hex, const COLORREF fallbackColor = R
 
 AlwaysOnTopSettings::AlwaysOnTopSettings()
 {
+    m_uiSettings.ColorValuesChanged([&](winrt::Windows::UI::ViewManagement::UISettings const& settings,
+                                        winrt::Windows::Foundation::IInspectable const& args)
+    {
+        if (m_settings.frameAccentColor)
+        {
+            NotifyObservers(SettingId::FrameAccentColor);
+        }
+    });
 }
 
 AlwaysOnTopSettings& AlwaysOnTopSettings::instance()
@@ -165,6 +174,16 @@ void AlwaysOnTopSettings::LoadSettings()
             {
                 m_settings.excludedApps = excludedApps;
                 NotifyObservers(SettingId::ExcludeApps);
+            }
+        }
+
+        if (const auto jsonVal = values.get_bool_value(NonLocalizable::FrameAccentColor))
+        {
+            auto val = *jsonVal;
+            if (m_settings.frameAccentColor != val)
+            {
+                m_settings.frameAccentColor = val;
+                NotifyObservers(SettingId::FrameAccentColor);
             }
         }
     }

--- a/src/modules/alwaysontop/AlwaysOnTop/Settings.h
+++ b/src/modules/alwaysontop/AlwaysOnTop/Settings.h
@@ -7,6 +7,8 @@
 
 #include <SettingsConstants.h>
 
+#include <winrt/Windows.UI.ViewManagement.h>
+
 class SettingsObserver;
 
 // Needs to be kept in sync with src\settings-ui\Settings.UI.Library\AlwaysOnTopProperties.cs
@@ -16,6 +18,7 @@ struct Settings
     bool enableFrame = true;
     bool enableSound = true;
     bool blockInGameMode = true;
+    bool frameAccentColor = true;
     float frameThickness = 15.0f;
     COLORREF frameColor = RGB(0, 173, 239);
     std::vector<std::wstring> excludedApps{};
@@ -42,6 +45,7 @@ private:
     AlwaysOnTopSettings();
     ~AlwaysOnTopSettings() = default;
 
+    winrt::Windows::UI::ViewManagement::UISettings m_uiSettings;
     Settings m_settings;
     std::unique_ptr<FileWatcher> m_settingsFileWatcher;
     std::unordered_set<SettingsObserver*> m_observers;

--- a/src/modules/alwaysontop/AlwaysOnTop/SettingsConstants.h
+++ b/src/modules/alwaysontop/AlwaysOnTop/SettingsConstants.h
@@ -8,5 +8,6 @@ enum class SettingId
     FrameThickness,
     FrameColor,
     BlockInGameMode,
-    ExcludeApps
+    ExcludeApps,
+    FrameAccentColor
 };

--- a/src/settings-ui/Settings.UI.Library/AlwaysOnTopProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/AlwaysOnTopProperties.cs
@@ -16,6 +16,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         public const string DefaultFrameColor = "#0099cc";
         public const bool DefaultSoundEnabled = true;
         public const bool DefaultDoNotActivateOnGameMode = true;
+        public const bool DefaultFrameAccentColor = true;
 
         public AlwaysOnTopProperties()
         {
@@ -26,6 +27,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             SoundEnabled = new BoolProperty(DefaultSoundEnabled);
             DoNotActivateOnGameMode = new BoolProperty(DefaultDoNotActivateOnGameMode);
             ExcludedApps = new StringProperty();
+            FrameAccentColor = new BoolProperty(DefaultFrameAccentColor);
         }
 
         [JsonPropertyName("hotkey")]
@@ -48,6 +50,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library
 
         [JsonPropertyName("excluded-apps")]
         public StringProperty ExcludedApps { get; set; }
+
+        [JsonPropertyName("frame-accent-color")]
+        public BoolProperty FrameAccentColor { get; set; }
 
         public string ToJsonString()
         {

--- a/src/settings-ui/Settings.UI.Library/ViewModels/AlwaysOnTopViewModel.cs
+++ b/src/settings-ui/Settings.UI.Library/ViewModels/AlwaysOnTopViewModel.cs
@@ -52,6 +52,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             _soundEnabled = Settings.Properties.SoundEnabled.Value;
             _doNotActivateOnGameMode = Settings.Properties.DoNotActivateOnGameMode.Value;
             _excludedApps = Settings.Properties.ExcludedApps.Value;
+            _frameAccentColor = Settings.Properties.FrameAccentColor.Value;
 
             // set the callback functions value to hangle outgoing IPC message.
             SendConfigMSG = ipcMSGCallBackFunc;
@@ -190,6 +191,21 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             }
         }
 
+        public bool FrameAccentColor
+        {
+            get => _frameAccentColor;
+
+            set
+            {
+                if (value != _frameAccentColor)
+                {
+                    _frameAccentColor = value;
+                    Settings.Properties.FrameAccentColor.Value = value;
+                    NotifyPropertyChanged();
+                }
+            }
+        }
+
         public void NotifyPropertyChanged([CallerMemberName] string propertyName = null)
         {
             OnPropertyChanged(propertyName);
@@ -204,5 +220,6 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
         private bool _soundEnabled;
         private bool _doNotActivateOnGameMode;
         private string _excludedApps;
+        private bool _frameAccentColor;
     }
 }

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -1757,7 +1757,7 @@ From there, simply click on a Markdown file, PDF file or SVG icon in the File Ex
   </data>
   <data name="MouseUtils_FindMyMouse_SpotlightRadius.Header" xml:space="preserve">
     <value>Spotlight radius (px)</value>
-	<comment>px = pixels</comment>
+    <comment>px = pixels</comment>
   </data>
   <data name="MouseUtils_FindMyMouse_SpotlightInitialZoom.Header" xml:space="preserve">
     <value>Spotlight initial zoom</value>
@@ -1767,11 +1767,11 @@ From there, simply click on a Markdown file, PDF file or SVG icon in the File Ex
   </data>
   <data name="MouseUtils_FindMyMouse_AnimationDurationMs.Header" xml:space="preserve">
     <value>Animation duration (ms)</value>
-	<comment>ms = milliseconds</comment>
+    <comment>ms = milliseconds</comment>
   </data>
   <data name="MouseUtils_FindMyMouse_AnimationDurationMs.Description" xml:space="preserve">
     <value>Time before the spotlight appears (ms)</value>
-	<comment>ms = milliseconds</comment>
+    <comment>ms = milliseconds</comment>
   </data>
   <data name="MouseUtils_MouseHighlighter.Header" xml:space="preserve">
     <value>Mouse Highlighter</value>
@@ -1803,23 +1803,23 @@ From there, simply click on a Markdown file, PDF file or SVG icon in the File Ex
   </data>
   <data name="MouseUtils_MouseHighlighter_HighlightRadius.Header" xml:space="preserve">
     <value>Radius (px)</value>
-	<comment>px = pixels</comment>  
+    <comment>px = pixels</comment>
   </data>
   <data name="MouseUtils_MouseHighlighter_FadeDelayMs.Header" xml:space="preserve">
     <value>Fade delay (ms)</value>
-	<comment>ms = milliseconds</comment>
+    <comment>ms = milliseconds</comment>
   </data>
   <data name="MouseUtils_MouseHighlighter_FadeDelayMs.Description" xml:space="preserve">
     <value>Time before a highlight appears (ms)</value>
-	<comment>ms = milliseconds</comment>
+    <comment>ms = milliseconds</comment>
   </data>
   <data name="MouseUtils_MouseHighlighter_FadeDurationMs.Header" xml:space="preserve">
     <value>Fade duration (ms)</value>
-	<comment>ms = milliseconds</comment>
+    <comment>ms = milliseconds</comment>
   </data>
   <data name="MouseUtils_MouseHighlighter_FadeDurationMs.Description" xml:space="preserve">
     <value>Duration of the disappear animation (ms)</value>
-	<comment>ms = milliseconds</comment>
+    <comment>ms = milliseconds</comment>
   </data>
   <data name="FancyZones_Radio_Custom_Colors.Content" xml:space="preserve">
     <value>Custom colors</value>
@@ -1869,11 +1869,11 @@ From there, simply click on a Markdown file, PDF file or SVG icon in the File Ex
   </data>
   <data name="AlwaysOnTop.ModuleDescription" xml:space="preserve">
     <value>Always On Top is a quick and easy way to pin windows on top.</value>
-      <comment>"Always On Top" is the name of the utility</comment>
+    <comment>"Always On Top" is the name of the utility</comment>
   </data>
   <data name="AlwaysOnTop.ModuleTitle" xml:space="preserve">
     <value>Always On Top </value>
-      <comment>"Always On Top" is the name of the utility</comment>
+    <comment>"Always On Top" is the name of the utility</comment>
   </data>
   <data name="AlwaysOnTop_Activation_GroupSettings.Header" xml:space="preserve">
     <value>Activation</value>
@@ -1902,48 +1902,57 @@ From there, simply click on a Markdown file, PDF file or SVG icon in the File Ex
     <comment>px = pixels</comment>
   </data>
   <data name="AlwaysOnTop_Behavior_GroupSettings.Header" xml:space="preserve">
-   <value>Appearance &amp; behavior</value>
+    <value>Appearance &amp; behavior</value>
   </data>
   <data name="Shell_AlwaysOnTop.Content" xml:space="preserve">
     <value>Always On Top</value>
-      <comment>"Always On Top" is the name of the utility</comment>
+    <comment>"Always On Top" is the name of the utility</comment>
   </data>
   <data name="AlwaysOnTop_GameMode.Content" xml:space="preserve">
     <value>Do not activate when Game Mode is on</value>
-	  <comment>Game Mode is a Windows feature</comment>
+    <comment>Game Mode is a Windows feature</comment>
   </data>
-	  <data name="AlwaysOnTop_SoundTitle.Header" xml:space="preserve">
+  <data name="AlwaysOnTop_SoundTitle.Header" xml:space="preserve">
     <value>Sound</value>
   </data>
   <data name="AlwaysOnTop_Sound.Content" xml:space="preserve">
     <value>Play a sound when pinning a window</value>
   </data>
-	<data name="AlwaysOnTop_Behavior.Header" xml:space="preserve">
+  <data name="AlwaysOnTop_Behavior.Header" xml:space="preserve">
     <value>Behavior</value>
   </data>
-	<data name="LearnMore_AlwaysOnTop.Text" xml:space="preserve">
+  <data name="LearnMore_AlwaysOnTop.Text" xml:space="preserve">
     <value>Learn more about Always On Top</value>
-	    <comment>"Always On Top" is the name of the utility</comment>
+    <comment>"Always On Top" is the name of the utility</comment>
   </data>
-	<data name="AlwaysOnTop_ActivationShortcut.Header" xml:space="preserve">
+  <data name="AlwaysOnTop_ActivationShortcut.Header" xml:space="preserve">
     <value>Activation shortcut</value>
   </data>
-	<data name="AlwaysOnTop_ActivationShortcut.Description" xml:space="preserve">
+  <data name="AlwaysOnTop_ActivationShortcut.Description" xml:space="preserve">
     <value>Customize the shortcut to pin or unpin an app window</value>
     <comment>"Always On Top" is the name of the utility</comment>
   </data>
   <data name="Oobe_AlwaysOnTop" xml:space="preserve">
     <value>Always On Top</value>
-      <comment>"Always On Top" is the name of the utility</comment>
+    <comment>"Always On Top" is the name of the utility</comment>
   </data>
   <data name="Oobe_AlwaysOnTop_Description" xml:space="preserve">
     <value>Always On Top improves your multitasking workflow by pinning an application window so it's always in front - even when focus changes to another window after that.</value>
-      <comment>"Always On Top" is the name of the utility</comment>
+    <comment>"Always On Top" is the name of the utility</comment>
   </data>
   <data name="Oobe_AlwaysOnTop_HowToUse.Text" xml:space="preserve">
     <value>to pin or unpin the selected window so it's always on top of all other windows.</value>
   </data>
   <data name="Oobe_AlwaysOnTop_TipsAndTricks.Text" xml:space="preserve">
     <value>You can tweak the visual outline of the pinned windows in PowerToys settings.</value>
+  </data>
+  <data name="AlwaysOnTop_FrameColor_Mode.Header" xml:space="preserve">
+    <value>Color mode</value>
+  </data>
+  <data name="AlwaysOnTop_Radio_Custom_Color.Content" xml:space="preserve">
+    <value>Custom color</value>
+  </data>
+  <data name="AlwaysOnTop_Radio_Windows_Default.Content" xml:space="preserve">
+    <value>Window default</value>
   </data>
 </root>

--- a/src/settings-ui/Settings.UI/Views/AlwaysOnTopPage.xaml
+++ b/src/settings-ui/Settings.UI/Views/AlwaysOnTopPage.xaml
@@ -5,8 +5,15 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:controls="using:Microsoft.PowerToys.Settings.UI.Controls"
+    xmlns:converters="using:Microsoft.Toolkit.Uwp.UI.Converters"     
     mc:Ignorable="d"
     AutomationProperties.LandmarkType="Main">
+
+    <Page.Resources>
+        <converters:BoolToObjectConverter x:Key="BoolToComboBoxIndexConverter" TrueValue="1" FalseValue="0"/>
+        <converters:BoolToVisibilityConverter x:Key="FalseToVisibleConverter" TrueValue="Collapsed" FalseValue="Visible"/>
+    </Page.Resources>
+
     <controls:SettingsPageControl x:Uid="AlwaysOnTop" IsTabStop="False"
                                   ModuleImageSource="ms-appx:///Assets/Modules/AlwaysOnTop.png">
         <controls:SettingsPageControl.ModuleContent>
@@ -50,7 +57,17 @@
                         </controls:SettingExpander.Header>
                         <controls:SettingExpander.Content>
                             <StackPanel>
-                                <controls:Setting x:Uid="AlwaysOnTop_FrameColor" Style="{StaticResource ExpanderContentSettingStyle}" IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.FrameEnabled}">
+
+                                <controls:Setting x:Uid="AlwaysOnTop_FrameColor_Mode" Style="{StaticResource ExpanderContentSettingStyle}" IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.FrameEnabled}">
+                                    <controls:Setting.ActionContent>
+                                        <ComboBox SelectedIndex="{x:Bind Mode=TwoWay, Path=ViewModel.FrameAccentColor, Converter={StaticResource BoolToComboBoxIndexConverter}}" MinWidth="{StaticResource SettingActionControlMinWidth}">
+                                            <ComboBoxItem x:Uid="AlwaysOnTop_Radio_Custom_Color"/>
+                                            <ComboBoxItem x:Uid="AlwaysOnTop_Radio_Windows_Default"/>
+                                        </ComboBox>
+                                    </controls:Setting.ActionContent>
+                                </controls:Setting>
+
+                                <controls:Setting x:Uid="AlwaysOnTop_FrameColor" Style="{StaticResource ExpanderContentSettingStyle}" IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.FrameEnabled}" Visibility="{x:Bind Mode=OneWay, Path=ViewModel.FrameAccentColor, Converter={StaticResource FalseToVisibleConverter}}">
                                     <controls:Setting.ActionContent>
                                         <controls:ColorPickerButton SelectedColor="{x:Bind Path=ViewModel.FrameColor, Mode=TwoWay}" />
                                     </controls:Setting.ActionContent>


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Added settings for use accent color for frame borders.

**What is included in the PR:** 
- Accent color enabled by default
- Detect/Update frame on accent color changed

![Screenshot 2022-01-22 181746](https://user-images.githubusercontent.com/25966642/150649041-6130cf97-2dab-4aa0-bf6d-82e0f7bc4b6b.png)

![Screenshot 2022-01-22 181816](https://user-images.githubusercontent.com/25966642/150649044-c2547184-6496-4629-bdee-dab13e89d8b1.png)

**How does someone test / validate:** 
- Settings > AOT > Custom color
  - Pin a window: custom color should be used for borders
  - Change color: borders color should be updated
- Settings > AOT > Windows default: accent color should be used
  - Pin a window: accent color should be used
  - Change accent color from Windows setting: borders color should be updated

## Quality Checklist

- [x] **Linked issue:** #15347
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
