### PR TITLE
Fix check-spelling comments

### DIFF
--- a/.github/workflows/spelling2.yml
+++ b/.github/workflows/spelling2.yml
@@ -72,5 +72,6 @@ jobs:
     - name: comment
       uses: check-spelling/check-spelling@v0.0.20-alpha3
       with:
+        config: .github/actions/spell-check
         custom_task: comment
         internal_state_directory: /tmp/data


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Fixes the comment references made by check-spelling

**What is included in the PR:** 

Minimal changes to make sure that the comment stage uses the same configuration as the check pass

**How does someone test / validate:** 

Create a PR in a repository against main, and then a PR in a repository against a branch with this fix

Baseline (main) https://github.com/check-spelling/PowerToys/pull/3#issuecomment-1019425721 has incorrect references to:
```
my @expect_files=qw('".github/actions/spelling/whitelist.txt"');
...
my $new_expect_file=".github/actions/spelling/expect.txt";
```

With this change (spell-check), https://github.com/check-spelling/PowerToys/pull/4#issuecomment-1019425784 has proper references to:
```
my @expect_files=qw('".github/actions/spell-check/expect.txt"');
...
my $new_expect_file=".github/actions/spell-check/expect.txt";
```

The paths are supposed to match the paths in the repository so that check-spelling will update its config files.

When I applied the changes to split the workflow, I missed copying over the config flag to this other job.

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
