### PR TITLE
[AlwaysOnTop] Release/recreate borders instead of hiding/showing

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -1169,6 +1169,8 @@ mimetype
 mindaro
 Minimatch
 MINIMIZEBOX
+MINIMIZEEND
+MINIMIZESTART
 miniz
 minlevel
 Miracast

--- a/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.h
+++ b/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.h
@@ -67,7 +67,7 @@ private:
 
     bool PinTopmostWindow(HWND window) const noexcept;
     bool UnpinTopmostWindow(HWND window) const noexcept;
-    bool AssignBorderTracker(HWND window);
+    bool AssignBorder(HWND window);
 
     virtual void SettingsUpdate(SettingId type) override;
 

--- a/src/modules/alwaysontop/AlwaysOnTop/WindowBorder.h
+++ b/src/modules/alwaysontop/AlwaysOnTop/WindowBorder.h
@@ -6,15 +6,12 @@ class FrameDrawer;
 
 class WindowBorder : public SettingsObserver
 {
-public:
     WindowBorder(HWND window);
     WindowBorder(WindowBorder&& other);
+    
+public:
+    static std::unique_ptr<WindowBorder> Create(HWND window, HINSTANCE hinstance);
     ~WindowBorder();
-
-    bool Init(HINSTANCE hinstance);
-
-    void Show() const;
-    void Hide() const;
 
     void UpdateBorderPosition() const;
     void UpdateBorderProperties() const;
@@ -41,5 +38,6 @@ private:
 
     LRESULT WndProc(UINT message, WPARAM wparam, LPARAM lparam) noexcept;
 
+    bool Init(HINSTANCE hinstance);
     virtual void SettingsUpdate(SettingId id) override;
 };


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Completely release window border resources to reduce CPU/GPU consumption instead of hiding the border. 
It's expected now that the border will be shown with some delay when switching the virtual desktop.

**What is included in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #15362 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
