### PR TITLE
[meta]git ignore monaco generated installer file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -344,3 +344,6 @@ src/common/Telemetry/*.etl
 /src/modules/previewpane/SvgThumbnailProvider/$(SolutionDir)$(Platform)/$(Configuration)/modules/FileExplorerPreview/SvgThumbnailProvider.xml
 /src/modules/powerrename/ui/RCa24464
 /src/modules/powerrename/ui/RCb24464
+
+# Generated installer file for Monaco source files.
+/installer/PowerToysSetup/MonacoSRC.wxs


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

After https://github.com/microsoft/PowerToys/pull/15138 , building the installer creates `installer/PowerToysSetup/MonacoSRC.wxs`, which gets recognized as a new file by git.

**What is included in the PR:** 
Add the generated file to `.gitignore` so it doesn't get included in any future PRs by mistake.

**How does someone test / validate:** 
Build the installer, verify `installer/PowerToysSetup/MonacoSRC.wxs` isn't listed with `git status` as an untracked file to add.

## Quality Checklist

- [x] **Linked issue:** #1527
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries
