### PR TITLE
[AlwaysOnTop] Show borders only for AOT-pinned windows

### DIFF
--- a/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.cpp
+++ b/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.cpp
@@ -12,6 +12,7 @@
 namespace NonLocalizable
 {
     const static wchar_t* TOOL_WINDOW_CLASS_NAME = L"AlwaysOnTopWindow";
+    const static wchar_t* WINDOW_PROP = L"AlwaysOnTop_Pinned";
 }
 
 // TODO: move to common utils
@@ -227,7 +228,7 @@ void AlwaysOnTop::StartTrackingTopmostWindows()
 
     for (HWND window : result)
     {
-        if (IsTopmost(window))
+        if (IsPinned(window))
         {
             AssignBorder(window);
         }
@@ -315,13 +316,21 @@ bool AlwaysOnTop::IsTopmost(HWND window) const noexcept
     return (exStyle & WS_EX_TOPMOST) == WS_EX_TOPMOST;
 }
 
+bool AlwaysOnTop::IsPinned(HWND window) const noexcept
+{
+    auto handle = GetProp(window, NonLocalizable::WINDOW_PROP);
+    return (handle != NULL);
+}
+
 bool AlwaysOnTop::PinTopmostWindow(HWND window) const noexcept
 {
+    SetProp(window, NonLocalizable::WINDOW_PROP, (HANDLE)1);
     return SetWindowPos(window, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
 }
 
 bool AlwaysOnTop::UnpinTopmostWindow(HWND window) const noexcept
 {
+    RemoveProp(window, NonLocalizable::WINDOW_PROP);
     return SetWindowPos(window, HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
 }
 

--- a/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.cpp
+++ b/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.cpp
@@ -12,7 +12,7 @@
 namespace NonLocalizable
 {
     const static wchar_t* TOOL_WINDOW_CLASS_NAME = L"AlwaysOnTopWindow";
-    const static wchar_t* WINDOW_PROP = L"AlwaysOnTop_Pinned";
+    const static wchar_t* WINDOW_IS_PINNED_PROP = L"AlwaysOnTop_Pinned";
 }
 
 // TODO: move to common utils
@@ -318,19 +318,22 @@ bool AlwaysOnTop::IsTopmost(HWND window) const noexcept
 
 bool AlwaysOnTop::IsPinned(HWND window) const noexcept
 {
-    auto handle = GetProp(window, NonLocalizable::WINDOW_PROP);
+    auto handle = GetProp(window, NonLocalizable::WINDOW_IS_PINNED_PROP);
     return (handle != NULL);
 }
 
 bool AlwaysOnTop::PinTopmostWindow(HWND window) const noexcept
 {
-    SetProp(window, NonLocalizable::WINDOW_PROP, (HANDLE)1);
+    if (!SetProp(window, NonLocalizable::WINDOW_IS_PINNED_PROP, (HANDLE)1))
+    {
+        Logger::error(L"SetProp failed");
+    }
     return SetWindowPos(window, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
 }
 
 bool AlwaysOnTop::UnpinTopmostWindow(HWND window) const noexcept
 {
-    RemoveProp(window, NonLocalizable::WINDOW_PROP);
+    RemoveProp(window, NonLocalizable::WINDOW_IS_PINNED_PROP);
     return SetWindowPos(window, HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
 }
 

--- a/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.h
+++ b/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.h
@@ -64,6 +64,7 @@ private:
 
     bool IsTracked(HWND window) const noexcept;
     bool IsTopmost(HWND window) const noexcept;
+    bool IsPinned(HWND window) const noexcept;
 
     bool PinTopmostWindow(HWND window) const noexcept;
     bool UnpinTopmostWindow(HWND window) const noexcept;


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Set prop when pinning window to distinguish it from non-AOT topmost windows.

**What is included in the PR:** 

**How does someone test / validate:** 

1)
* Pin window with older AOT version.
* Run new AOT
* Verify that no border is shown.

2)
* Pin window with new AOT version
* Restart AOT
* Verify that the border is shown

## Quality Checklist

- [x] **Linked issue:** #15453
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
