### PR TITLE
Fix disabling module as admin

### DIFF
--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -406,8 +406,8 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     }
 
     // Save settings on closing
-    auto general_settings = load_general_settings();
-    apply_general_settings(general_settings);
+    auto general_settings = get_general_settings();
+    PTSettingsHelper::save_general_settings(general_settings.to_json());
 
     // We need to release the mutexes to be able to restart the application
     if (msi_mutex)


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Instead of loading settings from file when saving on closing , take runtime settings.

**What is included in the PR:** 

**How does someone test / validate:** 
 - Restart PT as admin
 - Turn on Always run as administrator
 - Turn off any module
 - Exit PT
 - Start PT

Confirm that disabled module is still disabled

## Quality Checklist

- [x] **Linked issue:** #15450
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
