### PR TITLE
[FancyZones Editor] Don't return error on empty files.

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
@@ -630,7 +630,7 @@ namespace FancyZonesEditor.Utils
                 }
             }
 
-            return new ParsingResult(false, FancyZonesEditor.Properties.Resources.Error_Parsing_Layout_Templates_Message);
+            return new ParsingResult(true);
         }
 
         public ParsingResult ParseCustomLayouts()
@@ -670,7 +670,7 @@ namespace FancyZonesEditor.Utils
                 }
             }
 
-            return new ParsingResult(false, FancyZonesEditor.Properties.Resources.Error_Parsing_Custom_Layouts_Message);
+            return new ParsingResult(true);
         }
 
         public void SerializeAppliedLayouts()


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

`custom-layouts.json` and `layout-templates.json` can actually be empty, so there shouldn't be an error message.

**What is included in the PR:** 

**How does someone test / validate:** 

Delete those files from `AppData\Local\Microsoft\PowerToys\FancyZones`, open the editor, verify there is no error message.

## Quality Checklist

- [x] **Linked issue:** #14782 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
