### PR TITLE
[PowerToys Run] Windows Terminal plugin: Improve query speed

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsTerminal/Helpers/TerminalQuery.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsTerminal/Helpers/TerminalQuery.cs
@@ -25,7 +25,7 @@ namespace Microsoft.PowerToys.Run.Plugin.WindowsTerminal.Helpers
             "Microsoft.WindowsTerminalPreview",
         }.AsReadOnly();
 
-        // Cache for the AUMID that we don't have to query the AUMID every time.
+        // Cache for the package AUMID that we don't have to query the AUMID every time. (On slow systems, each query costs up to 50 ms.)
         private static readonly Dictionary<string, string> _PackageAumidCache = new Dictionary<string, string>();
 
         private IEnumerable<TerminalPackage> Terminals => GetTerminals();
@@ -62,7 +62,7 @@ namespace Microsoft.PowerToys.Run.Plugin.WindowsTerminal.Helpers
             {
                 if (!_PackageAumidCache.ContainsKey(p.Id.Name))
                 {
-                    // When changing the target release to 19041 in the future, we can use  <GetAppListEntries()> instead of <GetAppListEntriesAsync()>!
+                    // When changing the target release to 19041 in the future, we can use <GetAppListEntries()> instead of <GetAppListEntriesAsync()>!
                     var appListEntries = p.GetAppListEntriesAsync();
                     while (appListEntries.Status != AsyncStatus.Completed)
                     {

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsTerminal/Helpers/TerminalQuery.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsTerminal/Helpers/TerminalQuery.cs
@@ -16,12 +16,11 @@ namespace Microsoft.PowerToys.Run.Plugin.WindowsTerminal.Helpers
         /// Static list of all Windows Terminal packages. As key we use the app name and in the value we save the AUMID of each package.
         /// AUMID = ApplicationUserModelId: This is an identifier id for the app. The syntax is '<PackageFamilyName>!App'.
         /// The AUMID of an AppX package will never change. (https://github.com/microsoft/PowerToys/pull/15836#issuecomment-1025204301)
-        private static readonly IReadOnlyDictionary<string, string> Packages =
-            new Dictionary<string, string>()
-            {
-                { "Microsoft.WindowsTerminal", "Microsoft.WindowsTerminal_8wekyb3d8bbwe!App" },
-                { "Microsoft.WindowsTerminalPreview", "Microsoft.WindowsTerminalPreview_8wekyb3d8bbwe!App" },
-            };
+        private static readonly IReadOnlyDictionary<string, string> Packages = new Dictionary<string, string>()
+        {
+            { "Microsoft.WindowsTerminal", "Microsoft.WindowsTerminal_8wekyb3d8bbwe!App" },
+            { "Microsoft.WindowsTerminalPreview", "Microsoft.WindowsTerminalPreview_8wekyb3d8bbwe!App" },
+        };
 
         private readonly PackageManager _packageManager;
 

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsTerminal/Helpers/TerminalQuery.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsTerminal/Helpers/TerminalQuery.cs
@@ -93,6 +93,6 @@ namespace Microsoft.PowerToys.Run.Plugin.WindowsTerminal.Helpers
                 var settingsPath = Path.Combine(localAppDataPath, "Packages", p.Id.FamilyName, "LocalState", "settings.json");
                 yield return new TerminalPackage(aumid, version, p.DisplayName, settingsPath, p.Logo.LocalPath);
             }
-      }
+        }
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Before this change we query the AppUserModellID (AUMID) for every installed terminal app on every query. Because the method we used is async we sleeped 100 ms in a loop while waiting for the result. This leads to high query times: On each query up to 250 ms when wt and wt prev are installed.

I have changed the code and now we have query times up to 15 ms on fast machines and up to 35 ms on slow machines.

**What is included in the PR:** 
Now that we [know](https://github.com/microsoft/PowerToys/pull/15836#issuecomment-1025204301) that the AUMID didn't change in the future we can write it fixed in the code. Then we don't have to query it and the plugin queries become faster.

I have changed the package list into a dictionary and it now contains the packages names and the corresponding AUMIDs.

**How does someone test / validate:** 
Run local dev build to test the plugin function and checked the log for errors and query times.

## Quality Checklist

- [x] **Linked issue:** #15778
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [x] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
