### PR TITLE
[Settings] UX bugfixes

### DIFF
--- a/src/settings-ui/Settings.UI/Views/AlwaysOnTopPage.xaml
+++ b/src/settings-ui/Settings.UI/Views/AlwaysOnTopPage.xaml
@@ -106,7 +106,7 @@
                             <controls:Setting x:Uid="AlwaysOnTop_ExcludedApps" Icon="&#xECE4;" Style="{StaticResource ExpanderHeaderSettingStyle}"/>
                         </controls:SettingExpander.Header>
                         <controls:SettingExpander.Content>
-                            <TextBox x:Uid="FancyZones_ExcludedApps_TextBoxControl"
+                            <TextBox x:Uid="AlwaysOnTop_ExcludedApps_TextBoxControl"
                                  Margin="{StaticResource ExpanderSettingMargin}"
                                          Text="{x:Bind Mode=TwoWay, Path=ViewModel.ExcludedApps, UpdateSourceTrigger=PropertyChanged}"
                                          ScrollViewer.VerticalScrollBarVisibility ="Visible"

--- a/src/settings-ui/Settings.UI/Views/VideoConference.xaml
+++ b/src/settings-ui/Settings.UI/Views/VideoConference.xaml
@@ -19,13 +19,7 @@
         <controls:SettingsPageControl.ModuleContent>
 
             <StackPanel Orientation="Vertical">
-                <muxc:InfoBar
-                    Severity="Warning"
-                    x:Uid="VideoConference_RunAsAdminRequired"
-                    IsOpen="True"
-                    IsTabStop="True"
-                    IsClosable="False"
-                    Visibility="{Binding Mode=OneWay, Path=IsElevated, Converter={StaticResource BoolToVisibilityConverter}}" />
+            
                 <controls:Setting x:Uid="VideoConference_Enable" IsEnabled="{ Binding Mode=OneWay, Path=IsElevated }">
                     <controls:Setting.Icon>
                         <BitmapIcon UriSource="ms-appx:///Assets/FluentIcons/FluentIconsVideoConferenceMute.png" ShowAsMonochrome="False" />
@@ -34,7 +28,14 @@
                         <ToggleSwitch IsOn="{Binding Mode=TwoWay, Path=IsEnabled}" x:Uid="ToggleSwitch"/>
                     </controls:Setting.ActionContent>
                 </controls:Setting>
-
+                <muxc:InfoBar
+                    Severity="Warning"
+                    x:Uid="VideoConference_RunAsAdminRequired"
+                    IsOpen="True"
+                    IsTabStop="True"
+                    IsClosable="False"
+                    Visibility="{Binding Mode=OneWay, Path=IsElevated, Converter={StaticResource BoolToVisibilityConverter}}" />
+                
                 <controls:SettingsGroup x:Uid="VideoConference_Shortcuts" IsEnabled="{Binding Mode=OneWay, Path=IsEnabled}">
                     <controls:Setting x:Uid="VideoConference_CameraAndMicrophoneMuteHotkeyControl_Header">
                         <controls:Setting.ActionContent>


### PR DESCRIPTION
## Summary of the Pull Request

- Always On Top placeholder text now uses the correct x:Uid, resolving: #15348
![image](https://user-images.githubusercontent.com/9866362/151703849-fe67ccc4-023a-4183-a2a0-3de9d5827f55.png)

- Put the admin warning under the enable setting, resolving: #15488

## Quality Checklist

- [X] **Linked issue:** #15348, #15488
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
