### PR TITLE
[PowerRename] Set RegEx engine default flags to 0

### DIFF
--- a/src/modules/powerrename/lib/PowerRenameRegEx.h
+++ b/src/modules/powerrename/lib/PowerRenameRegEx.h
@@ -6,7 +6,7 @@
 
 #include "PowerRenameInterfaces.h"
 
-#define DEFAULT_FLAGS MatchAllOccurences
+#define DEFAULT_FLAGS 0
 
 class CPowerRenameRegEx : public IPowerRenameRegEx
 {

--- a/src/modules/powerrename/unittests/PowerRenameManagerTests.cpp
+++ b/src/modules/powerrename/unittests/PowerRenameManagerTests.cpp
@@ -8,7 +8,7 @@
 #include "TestFileHelper.h"
 #include "Helpers.h"
 
-#define DEFAULT_FLAGS MatchAllOccurences
+#define DEFAULT_FLAGS 0
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 

--- a/src/modules/powerrename/unittests/PowerRenameRegExBoostTests.cpp
+++ b/src/modules/powerrename/unittests/PowerRenameRegExBoostTests.cpp
@@ -93,7 +93,7 @@ TEST_METHOD(VerifyDefaultFlags)
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     DWORD flags = 0;
     Assert::IsTrue(renameRegEx->GetFlags(&flags) == S_OK);
-    Assert::IsTrue(flags == MatchAllOccurences);
+    Assert::IsTrue(flags == 0);
 }
 
 TEST_METHOD(VerifyCaseSensitiveSearch)

--- a/src/modules/powerrename/unittests/PowerRenameRegExTests.cpp
+++ b/src/modules/powerrename/unittests/PowerRenameRegExTests.cpp
@@ -87,7 +87,7 @@ TEST_METHOD(VerifyDefaultFlags)
     Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
     DWORD flags = 0;
     Assert::IsTrue(renameRegEx->GetFlags(&flags) == S_OK);
-    Assert::IsTrue(flags == MatchAllOccurences);
+    Assert::IsTrue(flags == 0);
 }
 
 TEST_METHOD(VerifyCaseSensitiveSearch)


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
RegEx engine had DEFAULT_FLAGS set to `MatchAllOccurrences`, opposite to 0 in PowerRenameManager. This difference in flags resulted in this bug until any of the flags were re\set manually by clicking any of the UI checkboxes. Now flags in the background matches what UI shows on PowerRename startup

**What is included in the PR:** 

**How does someone test / validate:** 
- Start PowerRename
- Confirm that Match all occurrences checkbox is UNCHECKED
- Try renaming some of the files and confirm that renaming works in accordance with checkbox (replacing only first occurrence)
- Check the Match all occurrences checkbox 
- Test renaming once again

## Quality Checklist

- [x] **Linked issue:** #15544
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [x] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
