### PR TITLE
[runner] Save settings on closing only when PT was actually running

### DIFF
--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -391,6 +391,10 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
              cmdLine.find("--dont-elevate") != std::string::npos))
         {
             result = runner(elevated, open_settings, settings_window, openOobe);
+
+            // Save settings on closing
+            auto general_settings = get_general_settings();
+            PTSettingsHelper::save_general_settings(general_settings.to_json());
         }
         else
         {
@@ -404,10 +408,6 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
         MessageBoxW(nullptr, std::wstring(err_what.begin(), err_what.end()).c_str(), GET_RESOURCE_STRING(IDS_ERROR).c_str(), MB_OK | MB_ICONERROR);
         result = -1;
     }
-
-    // Save settings on closing
-    auto general_settings = get_general_settings();
-    PTSettingsHelper::save_general_settings(general_settings.to_json());
 
     // We need to release the mutexes to be able to restart the application
     if (msi_mutex)


### PR DESCRIPTION
i.e. Don't save if PT was only scheduling a restart

## Summary of the Pull Request

**What is this about:**

**What is included in the PR:** 

**How does someone test / validate:** 
 - Run PT 0.55
 - If not, enable 'always run as admin' option
 - If needed restart PT so it's running as admin
 - Disable any module
 - Close PT
 - Open PT
 - Observe that disabled modules are ENABLED

Using this version of PT, repeat the steps and confirm that disabled modules are still disabled after restart.

## Quality Checklist

- [x] **Linked issue:** #15450 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
