### PR TITLE
[PT Run] WindowWalker: Temporary remove IsCloaked check

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.WindowWalker/Components/OpenWindows.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.WindowWalker/Components/OpenWindows.cs
@@ -92,10 +92,12 @@ namespace Microsoft.Plugin.WindowWalker.Components
             {
                 // To hide (not add) preloaded uwp app windows that are invisible to the user we check the cloak state in DWM to be "none". (Issue #13637.)
                 // (If user asking to see these windows again we can add an optional plugin setting in the future.)
-                if (!newWindow.IsCloaked)
-                {
-                    windows.Add(newWindow);
-                }
+                // [@htcfreek, 2022-02-01: Removed the IsCloaked check to list windows from virtual desktops other than the current one again (#15887). In a second PR I will fix it re-implement it with improved code again.]
+                // if (!newWindow.IsCloaked)
+                // {
+                windows.Add(newWindow);
+
+                // }
             }
 
             return true;


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

With #15441 I have implemented a check for the DWM property `IsCloaked` to hide invisible uwp app windows (#13637). After the change, all windows assigned to a virtual desktop that is not the current visible one aren't listed in the results anymore.

**What is included in the PR:** 

This PR removes the check for `IsCloaked` property temporary until I have implement an improved version of the check.

**How does someone test / validate:** 

Tested the behavior.

## Quality Checklist

- [x] **Linked issue:** #15887
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
