### PR TITLE
[Runner]remove hotkeyEx when disabling a module

### DIFF
--- a/src/runner/general_settings.cpp
+++ b/src/runner/general_settings.cpp
@@ -149,7 +149,8 @@ void apply_general_settings(const json::JsonObject& general_configs, bool save)
             {
                 continue;
             }
-            const bool module_inst_enabled = modules().at(name)->is_enabled();
+            PowertoyModule& powertoy = modules().at(name);
+            const bool module_inst_enabled = powertoy->is_enabled();
             const bool target_enabled = value.GetBoolean();
             if (module_inst_enabled == target_enabled)
             {
@@ -157,12 +158,14 @@ void apply_general_settings(const json::JsonObject& general_configs, bool save)
             }
             if (target_enabled)
             {
-                modules().at(name)->enable();
+                powertoy->enable();
             }
             else
             {
-                modules().at(name)->disable();
+                powertoy->disable();
             }
+            // Sync the hotkey state with the module state, so it can be removed for disabled modules.
+            powertoy.UpdateHotkeyEx();
         }
     }
 
@@ -221,6 +224,7 @@ void start_enabled_powertoys()
         if (!powertoys_to_disable.contains(name))
         {
             powertoy->enable();
+            powertoy.UpdateHotkeyEx();
         }
     }
 }

--- a/src/runner/powertoy_module.cpp
+++ b/src/runner/powertoy_module.cpp
@@ -74,11 +74,12 @@ void PowertoyModule::UpdateHotkeyEx()
 {
     CentralizedHotkeys::UnregisterHotkeysForModule(pt_module->get_key());
     auto container = pt_module->GetHotkeyEx();
-    if (container.has_value())
+    if (container.has_value() && pt_module->is_enabled())
     {
         auto hotkey = container.value();
         auto modulePtr = pt_module.get();
         auto action = [modulePtr](WORD modifiersMask, WORD vkCode) {
+            Logger::trace(L"{} hotkey Ex is invoked from Centralized keyboard hook", modulePtr->get_key());
             modulePtr->OnHotkeyEx();
         };
 


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
PowerToys that use the `HotkeyEx` interface for activation register a global hotkey that overrides that same hotkey on other Applications even if the PowerToy is disabled.

**What is included in the PR:** 
When updating HotKeyEx, only register it for enabled modules and deregister it for disabled modules.
Update HotKeyEx when disabling or enabling modules.
Add a log message for using HotKeyEx similar to when using the centralized keyboard hook.

**How does someone test / validate:** 
1. Verify Visual Studio shows the "Attach to Process" window when you press Ctrl+Alt+P.
2. Start PowerToys and enable the Mouse Pointer Crosshairs PowerToy with the Ctrl+Alt+P shortcut. Verify it works.
3. Disable Mouse Pointer Crosshairs, focus Visual Studio and press Ctrl+Alt+P. Verify the "Attach to Process" window appears.
4. Restart PowerToys, so it starts with Mouse Pointer Crosshairs disabled with the shortcut set to Ctrl+Alt+P. Focus Visual Studio and verify Ctrl+Alt+P invokes the "Attach to Process" window.

## Quality Checklist

- [x] **Linked issue:** #15910
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries
