### PR TITLE
[MouseUtils]check queue dispatcher initialization

### DIFF
--- a/src/modules/MouseUtils/FindMyMouse/FindMyMouse.cpp
+++ b/src/modules/MouseUtils/FindMyMouse/FindMyMouse.cpp
@@ -598,6 +598,12 @@ public:
         else
         {
             // Runtime objects already created. Should update in the owner thread.
+            if (m_dispatcherQueueController == nullptr)
+            {
+                Logger::warn("Tried accessing the dispatch queue controller before it was initialized.");
+                // No dispatcher Queue Controller? Means initialization still hasn't run, so settings will be applied then.
+                return;
+            }
             auto dispatcherQueue = m_dispatcherQueueController.DispatcherQueue();
             FindMyMouseSettings localSettings = settings;
             bool enqueueSucceeded = dispatcherQueue.TryEnqueue([=]() {

--- a/src/modules/MouseUtils/MousePointerCrosshairs/InclusiveCrosshairs.cpp
+++ b/src/modules/MouseUtils/MousePointerCrosshairs/InclusiveCrosshairs.cpp
@@ -277,6 +277,12 @@ void InclusiveCrosshairs::ApplySettings(InclusiveCrosshairsSettings& settings, b
     if (applyToRunTimeObjects)
     {
         // Runtime objects already created. Should update in the owner thread.
+        if (m_dispatcherQueueController == nullptr)
+        {
+            Logger::warn("Tried accessing the dispatch queue controller before it was initialized.");
+            // No dispatcher Queue Controller? Means initialization still hasn't run, so settings will be applied then.
+            return;
+        }
         auto dispatcherQueue = m_dispatcherQueueController.DispatcherQueue();
         InclusiveCrosshairsSettings localSettings = settings;
         bool enqueueSucceeded = dispatcherQueue.TryEnqueue([=]() {


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Some users report a crash when enabling Mouse Pointer Crosshairs

**What is included in the PR:** 
Check for queue dispatcher initialization in case the settings are updated before the PowerToy has had a chance to initialize its queue dispatcher.

**How does someone test / validate:** 
This is not easy to replicate consistently. Seems to depend on the user machines. I've been able to replicate it only twice by disabling/enabling the PowerToy quickly in a row. Looking for that Code Quality check here only.

## Quality Checklist

- [x] **Linked issue:** #15885
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
