### PR TITLE
Add XSD and WSDL files for Monaco preview handler

### DIFF
--- a/src/modules/previewpane/MonacoPreviewHandler/languages.json
+++ b/src/modules/previewpane/MonacoPreviewHandler/languages.json
@@ -927,7 +927,9 @@
         ".svg",
         ".svgz",
         ".opf",
-        ".xsl"
+        ".xsl",
+        ".xsd",
+        ".wsdl"
       ],
       "firstLine": "(\\<\\?xml.*)|(\\<svg)|(\\<\\!doctype\\s+svg)",
       "aliases": [


### PR DESCRIPTION
## Summary of the Pull Request
Include XSD and WSDL file extensions for previewing like they are XML files.

**What is this about:**

**What is included in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [X] **Linked issue:** #15966
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
