### PR TITLE
[CommonUI - ColorPickerUI] Fix Fancy Zones exclusion

### DIFF
--- a/src/common/Common.UI/Common.UI.csproj
+++ b/src/common/Common.UI/Common.UI.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ControlzEx" Version="4.4.0" />
+    <PackageReference Include="ControlzEx" Version="5.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/modules/colorPicker/ColorPickerUI/ColorEditorWindow.xaml.cs
+++ b/src/modules/colorPicker/ColorPickerUI/ColorEditorWindow.xaml.cs
@@ -31,7 +31,7 @@ namespace ColorPicker
         protected override void OnSourceInitialized(EventArgs e)
         {
             base.OnSourceInitialized(e);
-            NativeMethods.SetPopupStyle(this);
+            NativeMethods.SetToolWindowStyle(this);
         }
     }
 }

--- a/src/modules/colorPicker/ColorPickerUI/ColorPickerUI.csproj
+++ b/src/modules/colorPicker/ColorPickerUI/ColorPickerUI.csproj
@@ -59,7 +59,7 @@
     <PackageReference Include="System.ComponentModel.Composition" Version="5.0.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="System.IO.Abstractions" Version="12.2.5" />
-    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.19" />
+    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.39" />
     <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/modules/colorPicker/ColorPickerUI/NativeMethods.cs
+++ b/src/modules/colorPicker/ColorPickerUI/NativeMethods.cs
@@ -15,8 +15,8 @@ namespace ColorPicker
     // will have to rename
     public static class NativeMethods
     {
-        private const int GWL_STYLE = -16;
-        private const int WS_POPUP = 1 << 31; // 0x80000000
+        private const int GWL_EX_STYLE = -20;
+        private const int WS_EX_TOOLWINDOW = 0x00000080;
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1310:Field names should not contain underscore", Justification = "Interop")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "Interop")]
@@ -180,10 +180,10 @@ namespace ColorPicker
         [DllImport("user32.dll")]
         internal static extern int SetWindowLong(IntPtr hWnd, int nIndex, int dwNewLong);
 
-        internal static void SetPopupStyle(Window win)
+        internal static void SetToolWindowStyle(Window win)
         {
             var hwnd = new WindowInteropHelper(win).Handle;
-            _ = SetWindowLong(hwnd, GWL_STYLE, GetWindowLong(hwnd, GWL_STYLE) | WS_POPUP);
+            _ = SetWindowLong(hwnd, GWL_EX_STYLE, GetWindowLong(hwnd, GWL_EX_STYLE) | WS_EX_TOOLWINDOW);
         }
     }
 }

--- a/src/modules/imageresizer/ui/ImageResizerUI.csproj
+++ b/src/modules/imageresizer/ui/ImageResizerUI.csproj
@@ -64,7 +64,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.19" />
+    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.39" />
     <PackageReference Include="ModernWpfUI" Version="0.9.4" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>

--- a/src/modules/launcher/PowerLauncher/Helper/WindowsInteropHelper.cs
+++ b/src/modules/launcher/PowerLauncher/Helper/WindowsInteropHelper.cs
@@ -14,14 +14,13 @@ using Point = System.Windows.Point;
 
 namespace PowerLauncher.Helper
 {
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1310:Field names should not contain underscore", Justification = "Matching COM")]
     public static class WindowsInteropHelper
     {
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1310:Field names should not contain underscore", Justification = "Matching COM")]
         private const int GWL_STYLE = -16; // WPF's Message code for Title Bar's Style
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1310:Field names should not contain underscore", Justification = "Matching COM")]
+        private const int GWL_EX_STYLE = -20;
         private const int WS_SYSMENU = 0x80000; // WPF's Message code for System Menu
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1310:Field names should not contain underscore", Justification = "Matching COM")]
-        private const int WS_POPUP = 1 << 31; // 0x80000000
+        private const int WS_EX_TOOLWINDOW = 0x00000080;
         private static IntPtr _hwnd_shell;
         private static IntPtr _hwnd_desktop;
 
@@ -172,12 +171,12 @@ namespace PowerLauncher.Helper
         }
 
         /// <summary>
-        /// Set WS_POPUP to make FancyZones ignoring the Window
+        /// Set WS_EX_TOOLWINDOW to make FancyZones ignoring the Window
         /// </summary>
-        public static void SetPopupStyle(Window win)
+        internal static void SetToolWindowStyle(Window win)
         {
             var hwnd = new WindowInteropHelper(win).Handle;
-            _ = NativeMethods.SetWindowLong(hwnd, GWL_STYLE, NativeMethods.GetWindowLong(hwnd, GWL_STYLE) | WS_POPUP);
+            _ = NativeMethods.SetWindowLong(hwnd, GWL_EX_STYLE, NativeMethods.GetWindowLong(hwnd, GWL_EX_STYLE) | WS_EX_TOOLWINDOW);
         }
 
         /// <summary>

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -78,7 +78,7 @@ namespace PowerLauncher
         protected override void OnSourceInitialized(EventArgs e)
         {
             base.OnSourceInitialized(e);
-            WindowsInteropHelper.SetPopupStyle(this);
+            WindowsInteropHelper.SetToolWindowStyle(this);
         }
 
         private void CheckForFirstDelete(object sender, ElapsedEventArgs e)

--- a/src/modules/launcher/PowerLauncher/PowerLauncher.csproj
+++ b/src/modules/launcher/PowerLauncher/PowerLauncher.csproj
@@ -101,7 +101,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Data.Sqlite" Version="6.0.1" />
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.2" />
-    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.19" />
+    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.39" />
     <PackageReference Include="ModernWpfUI" Version="0.9.4" />
     <PackageReference Include="System.Runtime" Version="4.3.1" />    
     <PackageReference Include="Microsoft.VCRTForwarders.140" Version="1.0.6" />

--- a/src/settings-ui/PowerToys.Settings/OobeWindow.xaml.cs
+++ b/src/settings-ui/PowerToys.Settings/OobeWindow.xaml.cs
@@ -89,7 +89,7 @@ namespace PowerToys.Settings
         {
             base.OnSourceInitialized(e);
             var hwnd = new WindowInteropHelper(this).Handle;
-            NativeMethods.SetPopupStyle(hwnd);
+            NativeMethods.SetToolWindowStyle(hwnd);
         }
     }
 }

--- a/src/settings-ui/Settings.UI/Helpers/NativeMethods.cs
+++ b/src/settings-ui/Settings.UI/Helpers/NativeMethods.cs
@@ -5,13 +5,14 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Text;
+using Windows.UI.Xaml;
 
 namespace Microsoft.PowerToys.Settings.UI.Helpers
 {
     public static class NativeMethods
     {
-        private const int GWL_STYLE = -16;
-        private const int WS_POPUP = 1 << 31; // 0x80000000
+        private const int GWL_EX_STYLE = -20;
+        private const int WS_EX_TOOLWINDOW = 0x00000080;
         internal const int SPI_GETDESKWALLPAPER = 0x0073;
 
         [DllImport("user32.dll")]
@@ -44,9 +45,9 @@ namespace Microsoft.PowerToys.Settings.UI.Helpers
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool SystemParametersInfo(int uiAction, int uiParam, StringBuilder pvParam, int fWinIni);
 
-        public static void SetPopupStyle(IntPtr hwnd)
+        public static void SetToolWindowStyle(IntPtr hwnd)
         {
-            _ = SetWindowLong(hwnd, GWL_STYLE, GetWindowLong(hwnd, GWL_STYLE) | WS_POPUP);
+            _ = SetWindowLong(hwnd, GWL_EX_STYLE, GetWindowLong(hwnd, GWL_EX_STYLE) | WS_EX_TOOLWINDOW);
         }
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Fix ColorPickerUI crash on windows theme change.

**What is included in the PR:** 
- Changed `GWL_STYLE -> GWL_STYLE` to `GWL_EXSTYLE -> WS_EX_TOOLWINDOW` in order to exclude ColorPickerUI, OOBE and Launcher in order to exclude window from Fancy Zones.
- Upgraded `ControlzEx` and `Microsoft.Xaml.Behaviors.Wpf` packages.

**How does someone test / validate:** 
- Open OOBE: validate that the window can't be snapped into FZ
- Open ColoPickerUI: validate that the window can't be snapped into FZ
- Open Launcher: validate that the window can't be snapped into FZ
- Open ColorPickerUI and change windows theme: ColorPickerUI should change theme withot freeze

## Quality Checklist

- [x] **Linked issue:** #15938
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
