### PR TITLE
[AlwaysOnTop] Non-selectable border 

### DIFF
--- a/src/modules/alwaysontop/AlwaysOnTop/WindowBorder.cpp
+++ b/src/modules/alwaysontop/AlwaysOnTop/WindowBorder.cpp
@@ -96,7 +96,7 @@ bool WindowBorder::Init(HINSTANCE hinstance)
     m_window = CreateWindowExW(WS_EX_LAYERED | WS_EX_TOPMOST | WS_EX_TOOLWINDOW
         , NonLocalizable::ToolWindowClassName
         , L""
-        , WS_POPUP
+        , WS_POPUP | WS_DISABLED
         , windowRect.left
         , windowRect.top
         , windowRect.right - windowRect.left
@@ -216,6 +216,10 @@ LRESULT WindowBorder::WndProc(UINT message, WPARAM wparam, LPARAM lparam) noexce
     break;
 
     case WM_ERASEBKGND:
+        return TRUE;
+
+    // prevent from beeping if the border was clicked
+    case WM_SETCURSOR:
         return TRUE;
 
     default:


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Make border non-selectable to prevent from closing via Alt+F4.

**What is included in the PR:** 

**How does someone test / validate:** 

* Pin window
* Try to close the border window 

## Quality Checklist

- [x] **Linked issue:** #15287
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
