### PR TITLE
[PowerRename] Fix . instead of \. regex info

### DIFF
--- a/src/modules/powerrename/PowerRenameUILib/MainWindow.cpp
+++ b/src/modules/powerrename/PowerRenameUILib/MainWindow.cpp
@@ -20,7 +20,7 @@ namespace winrt::PowerRenameUILib::implementation
         m_searchRegExShortcuts = winrt::single_threaded_observable_vector<PowerRenameUILib::PatternSnippet>();
         auto resourceLoader{ Windows::ApplicationModel::Resources::ResourceLoader::GetForCurrentView() };
 
-        m_searchRegExShortcuts.Append(winrt::make<PowerRenameUILib::implementation::PatternSnippet>(L"\\.", resourceLoader.GetString(L"RegExCheatSheet_MatchAny")));
+        m_searchRegExShortcuts.Append(winrt::make<PowerRenameUILib::implementation::PatternSnippet>(L".", resourceLoader.GetString(L"RegExCheatSheet_MatchAny")));
         m_searchRegExShortcuts.Append(winrt::make<PowerRenameUILib::implementation::PatternSnippet>(L"\\d", resourceLoader.GetString(L"RegExCheatSheet_MatchDigit")));
         m_searchRegExShortcuts.Append(winrt::make<PowerRenameUILib::implementation::PatternSnippet>(L"\\D", resourceLoader.GetString(L"RegExCheatSheet_MatchNonDigit")));
         m_searchRegExShortcuts.Append(winrt::make<PowerRenameUILib::implementation::PatternSnippet>(L"\\w", resourceLoader.GetString(L"RegExCheatSheet_MatchNonWS")));

--- a/src/modules/powerrename/PowerRenameUILib/MainWindow.cpp
+++ b/src/modules/powerrename/PowerRenameUILib/MainWindow.cpp
@@ -25,7 +25,7 @@ namespace winrt::PowerRenameUILib::implementation
         m_searchRegExShortcuts.Append(winrt::make<PowerRenameUILib::implementation::PatternSnippet>(L"\\D", resourceLoader.GetString(L"RegExCheatSheet_MatchNonDigit")));
         m_searchRegExShortcuts.Append(winrt::make<PowerRenameUILib::implementation::PatternSnippet>(L"\\w", resourceLoader.GetString(L"RegExCheatSheet_MatchNonWS")));
         m_searchRegExShortcuts.Append(winrt::make<PowerRenameUILib::implementation::PatternSnippet>(L"\\S", resourceLoader.GetString(L"RegExCheatSheet_MatchWordChar")));
-        m_searchRegExShortcuts.Append(winrt::make<PowerRenameUILib::implementation::PatternSnippet>(L"\\S+", resourceLoader.GetString(L"RegExCheatSheet_MatchSeveralWS")));
+        m_searchRegExShortcuts.Append(winrt::make<PowerRenameUILib::implementation::PatternSnippet>(L"\\S+", resourceLoader.GetString(L"RegExCheatSheet_MatchOneOrMoreWS")));
         m_searchRegExShortcuts.Append(winrt::make<PowerRenameUILib::implementation::PatternSnippet>(L"\\b", resourceLoader.GetString(L"RegExCheatSheet_MatchWordBoundary")));
 
         m_dateTimeShortcuts = winrt::single_threaded_observable_vector<PowerRenameUILib::PatternSnippet>();

--- a/src/modules/powerrename/PowerRenameUILib/Strings/en-us/Resources.resw
+++ b/src/modules/powerrename/PowerRenameUILib/Strings/en-us/Resources.resw
@@ -138,8 +138,8 @@
   <data name="RegExCheatSheet_MatchWordChar" xml:space="preserve">
     <value>A word character, short for [a-zA-Z_0-9]</value>
   </data>
-  <data name="RegExCheatSheet_MatchSeveralWS" xml:space="preserve">
-    <value>Several non-whitespace characters</value>
+  <data name="RegExCheatSheet_MatchOneOrMoreWS" xml:space="preserve">
+    <value>One or more non-whitespace characters</value>
   </data>
   <data name="RegExCheatSheet_MatchWordBoundary" xml:space="preserve">
     <value>Matches a word boundary where a word character is [a-zA-Z0-9_].</value>


### PR DESCRIPTION
## Summary of the Pull Request
Regex help was wrong.
Before:
![image](https://user-images.githubusercontent.com/57057282/152802951-05103c32-87b4-4c7a-810c-9e6006d1ccef.png)

Now:
![image](https://user-images.githubusercontent.com/57057282/152802825-fa25d230-ab2c-4b33-8d17-25b86bbda60b.png)

`.` matches any character
`\.` matches the dot (.)
**What is this about:**

**What is included in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #15664
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
