### PR TITLE
[VCM] Do not unmute mics on disabling the module

### DIFF
--- a/src/modules/videoconference/VideoConferenceModule/VideoConferenceModule.cpp
+++ b/src/modules/videoconference/VideoConferenceModule/VideoConferenceModule.cpp
@@ -251,7 +251,7 @@ void VideoConferenceModule::onModuleSettingsChanged()
             {
                 toolbar.setHideToolbarWhenUnmuted(val.value());
             }
-            
+
             const auto selectedMic = values.get_string_value(L"selected_mic");
             if (selectedMic && selectedMic != settings.selectedMicrophone)
             {
@@ -508,7 +508,11 @@ void VideoConferenceModule::disable()
             }
         }
 
-        instance->unmuteAll();
+        if (getVirtualCameraMuteState())
+        {
+            reverseVirtualCameraMuteState();
+        }
+
         toolbar.hide();
 
         _enabled = false;


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
only unmute the virtual webcam when the module is disabled, since we're doing that only for our pass-through proxy cam

**What is included in the PR:** 

**How does someone test / validate:** 
- disable the module
- make sure the mic is still muted

## Quality Checklist

- [x] **Linked issue:** #15989
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
