### PR TITLE
[VCM] Fix crash with NVIDIA broadcaster

### DIFF
--- a/src/modules/videoconference/VideoConferenceProxyFilter/VideoCaptureProxyFilter.cpp
+++ b/src/modules/videoconference/VideoConferenceProxyFilter/VideoCaptureProxyFilter.cpp
@@ -713,6 +713,9 @@ HRESULT VideoCaptureProxyFilter::EnumPins(IEnumPins** ppEnum)
         return E_POINTER;
     }
     *ppEnum = nullptr;
+    auto enumerator = winrt::make_self<ObjectEnumerator<IPin, IEnumPins>>();
+    auto detached_enumerator = enumerator.detach();
+    *ppEnum = detached_enumerator;
 
     std::unique_lock<std::mutex> lock{ _worker_mutex };
 
@@ -801,9 +804,8 @@ HRESULT VideoCaptureProxyFilter::EnumPins(IEnumPins** ppEnum)
         }
     }
 
-    auto enumerator = winrt::make_self<ObjectEnumerator<IPin, IEnumPins>>();
-    enumerator->_objects.emplace_back(_outPin);
-    *ppEnum = enumerator.detach();
+    detached_enumerator->_objects.emplace_back(_outPin);
+
     return S_OK;
 }
 


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Turns out NVIDIA broadcaster always expects `IPin` enumerator to be not null. We provide it with zero pins when no cameras are present.

**What is included in the PR:** 

**How does someone test / validate:** 


## Quality Checklist

- [x] **Linked issue:** #14312
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
