### PR TITLE
[AlwaysOnTop] Inaccurate border position fix

### DIFF
--- a/src/modules/alwaysontop/AlwaysOnTop/FrameDrawer.h
+++ b/src/modules/alwaysontop/AlwaysOnTop/FrameDrawer.h
@@ -18,7 +18,7 @@ public:
 
     void Show();
     void Hide();
-    void SetBorderRect(RECT windowRect, COLORREF color, float thickness);
+    void SetBorderRect(RECT windowRect, COLORREF color, int thickness);
 
 private:
     bool CreateRenderTargets(const RECT& clientRect);
@@ -27,7 +27,7 @@ private:
     {
         D2D1_RECT_F rect;
         D2D1_COLOR_F borderColor;
-        float thickness;
+        int thickness;
     };
 
     static ID2D1Factory* GetD2DFactory();

--- a/src/modules/alwaysontop/AlwaysOnTop/Settings.cpp
+++ b/src/modules/alwaysontop/AlwaysOnTop/Settings.cpp
@@ -118,7 +118,7 @@ void AlwaysOnTopSettings::LoadSettings()
             auto val = *jsonVal;
             if (m_settings.frameThickness != val)
             {
-                m_settings.frameThickness = static_cast<float>(val);
+                m_settings.frameThickness = val;
                 NotifyObservers(SettingId::FrameThickness);
             }
         }

--- a/src/modules/alwaysontop/AlwaysOnTop/Settings.h
+++ b/src/modules/alwaysontop/AlwaysOnTop/Settings.h
@@ -19,7 +19,7 @@ struct Settings
     bool enableSound = true;
     bool blockInGameMode = true;
     bool frameAccentColor = true;
-    float frameThickness = 15.0f;
+    int frameThickness = 15;
     COLORREF frameColor = RGB(0, 173, 239);
     std::vector<std::wstring> excludedApps{};
 };

--- a/src/modules/alwaysontop/AlwaysOnTop/WindowBorder.cpp
+++ b/src/modules/alwaysontop/AlwaysOnTop/WindowBorder.cpp
@@ -2,10 +2,10 @@
 #include "WindowBorder.h"
 
 #include <dwmapi.h>
+#include "winrt/Windows.Foundation.h"
 
 #include <FrameDrawer.h>
 #include <Settings.h>
-#include "winrt/Windows.Foundation.h"
 
 // Non-Localizable strings
 namespace NonLocalizable
@@ -21,7 +21,7 @@ std::optional<RECT> GetFrameRect(HWND window)
         return std::nullopt;
     }
 
-    int border = static_cast<int>(AlwaysOnTopSettings::settings().frameThickness / 2);
+    int border = AlwaysOnTopSettings::settings().frameThickness;
     rect.top -= border;
     rect.left -= border;
     rect.right += border;
@@ -122,8 +122,8 @@ bool WindowBorder::Init(HINSTANCE hinstance)
         , m_window
         , windowRect.left
         , windowRect.top
-        , windowRect.right - windowRect.left - static_cast<int>(AlwaysOnTopSettings::settings().frameThickness)
-        , windowRect.bottom - windowRect.top - static_cast<int>(AlwaysOnTopSettings::settings().frameThickness)
+        , windowRect.right - windowRect.left
+        , windowRect.bottom - windowRect.top
         , SWP_NOMOVE | SWP_NOSIZE);
 
     m_frameDrawer = FrameDrawer::Create(m_window);


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

![ezgif com-gif-maker](https://user-images.githubusercontent.com/8949536/153273639-05a1d736-9177-4ffa-896e-4c11d0ae7d4f.gif)

**What is included in the PR:** 

**How does someone test / validate:** 

Change border thickness in settings, verify no gaps between window and border or shifted border or other inaccuracies.

## Quality Checklist

- [x] **Linked issue:** #15202
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
