### PR TITLE
[FindMyMouse] Add setting to activate by shaking mouse

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -1126,6 +1126,7 @@ logon
 LOGPIXELSX
 LOn
 longdate
+LONGLONG
 lookbehind
 lowlevel
 LOWORD

--- a/src/modules/MouseUtils/FindMyMouse/FindMyMouse.cpp
+++ b/src/modules/MouseUtils/FindMyMouse/FindMyMouse.cpp
@@ -44,6 +44,7 @@ protected:
     void BeforeMoveSonar() {}
     void AfterMoveSonar() {}
     void SetSonarVisibility(bool visible) = delete;
+    void UpdateMouseSnooping();
 
 protected:
     // Base class members you can access.
@@ -140,8 +141,6 @@ private:
 
     void StartSonar();
     void StopSonar();
-
-    void UpdateMouseSnooping();
 };
 
 template<typename D>
@@ -733,7 +732,8 @@ public:
                     m_fadeDuration = localSettings.animationDurationMs > 0 ? localSettings.animationDurationMs : 1;
                     m_finalAlphaNumerator = localSettings.overlayOpacity;
                     m_sonarZoomFactor = localSettings.spotlightInitialZoom;
-        
+                    UpdateMouseSnooping(); // For the shake mouse activation method
+
                     // Apply new settings to runtime composition objects.
                     m_backdrop.Brush().as<winrt::CompositionColorBrush>().Color(m_backgroundColor);
                     m_circleShape.FillBrush().as<winrt::CompositionColorBrush>().Color(m_spotlightColor);

--- a/src/modules/MouseUtils/FindMyMouse/FindMyMouse.h
+++ b/src/modules/MouseUtils/FindMyMouse/FindMyMouse.h
@@ -1,6 +1,13 @@
 #pragma once
 #include "pch.h"
 
+enum struct FindMyMouseActivationMethod : int
+{
+    DoubleControlKey = 0,
+    ShakeMouse = 1,
+    EnumElements = 2, // number of elements in the enum, not counting this
+};
+
 constexpr bool FIND_MY_MOUSE_DEFAULT_DO_NOT_ACTIVATE_ON_GAME_MODE = true;
 const winrt::Windows::UI::Color FIND_MY_MOUSE_DEFAULT_BACKGROUND_COLOR = winrt::Windows::UI::ColorHelper::FromArgb(255, 0, 0, 0);
 const winrt::Windows::UI::Color FIND_MY_MOUSE_DEFAULT_SPOTLIGHT_COLOR = winrt::Windows::UI::ColorHelper::FromArgb(255, 255, 255, 255);
@@ -8,9 +15,11 @@ constexpr int FIND_MY_MOUSE_DEFAULT_OVERLAY_OPACITY = 50;
 constexpr int FIND_MY_MOUSE_DEFAULT_SPOTLIGHT_RADIUS = 100;
 constexpr int FIND_MY_MOUSE_DEFAULT_ANIMATION_DURATION_MS = 500;
 constexpr int FIND_MY_MOUSE_DEFAULT_SPOTLIGHT_INITIAL_ZOOM = 9;
+constexpr FindMyMouseActivationMethod FIND_MY_MOUSE_DEFAULT_ACTIVATION_METHOD = FindMyMouseActivationMethod::DoubleControlKey;
 
 struct FindMyMouseSettings
 {
+    FindMyMouseActivationMethod activationMethod = FIND_MY_MOUSE_DEFAULT_ACTIVATION_METHOD;
     bool doNotActivateOnGameMode = FIND_MY_MOUSE_DEFAULT_DO_NOT_ACTIVATE_ON_GAME_MODE;
     winrt::Windows::UI::Color backgroundColor = FIND_MY_MOUSE_DEFAULT_BACKGROUND_COLOR;
     winrt::Windows::UI::Color spotlightColor = FIND_MY_MOUSE_DEFAULT_SPOTLIGHT_COLOR;

--- a/src/modules/MouseUtils/FindMyMouse/dllmain.cpp
+++ b/src/modules/MouseUtils/FindMyMouse/dllmain.cpp
@@ -11,6 +11,7 @@ namespace
 {
     const wchar_t JSON_KEY_PROPERTIES[] = L"properties";
     const wchar_t JSON_KEY_VALUE[] = L"value";
+    const wchar_t JSON_KEY_ACTIVATION_METHOD[] = L"activation_method";
     const wchar_t JSON_KEY_DO_NOT_ACTIVATE_ON_GAME_MODE[] = L"do_not_activate_on_game_mode";
     const wchar_t JSON_KEY_BACKGROUND_COLOR[] = L"background_color";
     const wchar_t JSON_KEY_SPOTLIGHT_COLOR[] = L"spotlight_color";
@@ -171,6 +172,20 @@ void FindMyMouse::parse_settings(PowerToysSettings::PowerToyValues& settings)
     FindMyMouseSettings findMyMouseSettings;
     if (settingsObject.GetView().Size())
     {
+        try
+        {
+            // Parse Activation Method
+            auto jsonPropertiesObject = settingsObject.GetNamedObject(JSON_KEY_PROPERTIES).GetNamedObject(JSON_KEY_ACTIVATION_METHOD);
+            UINT value = (UINT)jsonPropertiesObject.GetNamedNumber(JSON_KEY_VALUE);
+            if (value < (int)FindMyMouseActivationMethod::EnumElements)
+            {
+                findMyMouseSettings.activationMethod = (FindMyMouseActivationMethod)value;
+            }
+        }
+        catch (...)
+        {
+            Logger::warn("Failed to initialize Activation Method from settings. Will use default value");
+        }
         try
         {
             auto jsonPropertiesObject = settingsObject.GetNamedObject(JSON_KEY_PROPERTIES).GetNamedObject(JSON_KEY_DO_NOT_ACTIVATE_ON_GAME_MODE);

--- a/src/settings-ui/Settings.UI.Library/FindMyMouseProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/FindMyMouseProperties.cs
@@ -8,6 +8,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library
 {
     public class FindMyMouseProperties
     {
+        [JsonPropertyName("activation_method")]
+        public IntProperty ActivationMethod { get; set; }
+
         [JsonPropertyName("do_not_activate_on_game_mode")]
         public BoolProperty DoNotActivateOnGameMode { get; set; }
 
@@ -31,6 +34,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
 
         public FindMyMouseProperties()
         {
+            ActivationMethod = new IntProperty(0);
             DoNotActivateOnGameMode = new BoolProperty(true);
             BackgroundColor = new StringProperty("#000000");
             SpotlightColor = new StringProperty("#FFFFFF");

--- a/src/settings-ui/Settings.UI.Library/ViewModels/MouseUtilsViewModel.cs
+++ b/src/settings-ui/Settings.UI.Library/ViewModels/MouseUtilsViewModel.cs
@@ -47,6 +47,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             }
 
             FindMyMouseSettingsConfig = findMyMouseSettingsRepository.SettingsConfig;
+            _findMyMouseActivationMethod = FindMyMouseSettingsConfig.Properties.ActivationMethod.Value;
             _findMyMouseDoNotActivateOnGameMode = FindMyMouseSettingsConfig.Properties.DoNotActivateOnGameMode.Value;
 
             string backgroundColor = FindMyMouseSettingsConfig.Properties.BackgroundColor.Value;
@@ -114,6 +115,24 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
                     OutGoingGeneralSettings outgoing = new OutGoingGeneralSettings(GeneralSettingsConfig);
                     SendConfigMSG(outgoing.ToString());
 
+                    NotifyFindMyMousePropertyChanged();
+                }
+            }
+        }
+
+        public int FindMyMouseActivationMethod
+        {
+            get
+            {
+                return _findMyMouseActivationMethod;
+            }
+
+            set
+            {
+                if (value != _findMyMouseActivationMethod)
+                {
+                    _findMyMouseActivationMethod = value;
+                    FindMyMouseSettingsConfig.Properties.ActivationMethod.Value = value;
                     NotifyFindMyMousePropertyChanged();
                 }
             }
@@ -586,6 +605,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
         private Func<string, int> SendConfigMSG { get; }
 
         private bool _isFindMyMouseEnabled;
+        private int _findMyMouseActivationMethod;
         private bool _findMyMouseDoNotActivateOnGameMode;
         private string _findMyMouseBackgroundColor;
         private string _findMyMouseSpotlightColor;

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -1764,6 +1764,17 @@ From there, simply click on a Markdown file, PDF file or SVG icon in the File Ex
     <value>Enable Find My Mouse</value>
     <comment>"Find My Mouse" is the name of the utility.</comment>
   </data>
+  <data name="MouseUtils_FindMyMouse_ActivationMethod.Header" xml:space="preserve">
+    <value>Activation Method</value>
+  </data>
+  <data name="MouseUtils_FindMyMouse_ActivationDoubleControlPress.Content" xml:space="preserve">
+    <value>Press Left Control twice</value>
+    <comment>Left control is the physical key on the keyboard.</comment>
+  </data>
+  <data name="MouseUtils_FindMyMouse_ActivationShakeMouse.Content" xml:space="preserve">
+    <value>Shake mouse</value>
+    <comment>Mouse is the hardware peripheral.</comment>
+  </data>
   <data name="MouseUtils_Prevent_Activation_On_Game_Mode.Content" xml:space="preserve">
     <value>Do not activate when Game Mode is on</value>
     <comment>"Game mode" is the Windows feature to prevent notification when playing a game.</comment>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -1648,7 +1648,7 @@ From there, simply click on a Markdown file, PDF file or SVG icon in the File Ex
     <comment>Mouse as in the hardware peripheral</comment>
   </data>
   <data name="Oobe_MouseUtils_FindMyMouse_Description.Text" xml:space="preserve">
-    <value>Press the left Ctrl key twice to focus the mouse pointer.</value>
+    <value>Shake the mouse or press the left Ctrl key twice to focus the mouse pointer.</value>
     <comment>Mouse as in the hardware peripheral. Key as in a keyboard key</comment>
   </data>
   <data name="Oobe_MouseUtils_MouseHighlighter.Text" xml:space="preserve">
@@ -1757,7 +1757,7 @@ From there, simply click on a Markdown file, PDF file or SVG icon in the File Ex
     <comment>Refers to the utility name</comment>
   </data>
   <data name="MouseUtils_FindMyMouse.Description" xml:space="preserve">
-    <value>Find My Mouse highlights the position of the cursor when pressing the left Ctrl key twice.</value>
+    <value>Find My Mouse highlights the position of the cursor when shaking the mouse or pressing the left Ctrl key twice.</value>
     <comment>"Ctrl" is a keyboard key. "Find My Mouse" is the name of the utility</comment>
   </data>
   <data name="MouseUtils_Enable_FindMyMouse.Header" xml:space="preserve">
@@ -1765,7 +1765,7 @@ From there, simply click on a Markdown file, PDF file or SVG icon in the File Ex
     <comment>"Find My Mouse" is the name of the utility.</comment>
   </data>
   <data name="MouseUtils_FindMyMouse_ActivationMethod.Header" xml:space="preserve">
-    <value>Activation Method</value>
+    <value>Activation method</value>
   </data>
   <data name="MouseUtils_FindMyMouse_ActivationDoubleControlPress.Content" xml:space="preserve">
     <value>Press Left Control twice</value>

--- a/src/settings-ui/Settings.UI/Views/MouseUtilsPage.xaml
+++ b/src/settings-ui/Settings.UI/Views/MouseUtilsPage.xaml
@@ -28,6 +28,14 @@
                         </controls:SettingExpander.Header>
                         <controls:SettingExpander.Content>
                             <StackPanel>
+                                <controls:Setting x:Uid="MouseUtils_FindMyMouse_ActivationMethod" IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsFindMyMouseEnabled}" Style="{StaticResource ExpanderContentSettingStyle}">
+                                    <controls:Setting.ActionContent>
+                                        <ComboBox SelectedIndex="{x:Bind Path=ViewModel.FindMyMouseActivationMethod, Mode=TwoWay}" MinWidth="{StaticResource SettingActionControlMinWidth}">
+                                            <ComboBoxItem x:Uid="MouseUtils_FindMyMouse_ActivationDoubleControlPress" />
+                                            <ComboBoxItem x:Uid="MouseUtils_FindMyMouse_ActivationShakeMouse" />
+                                        </ComboBox>
+                                    </controls:Setting.ActionContent>
+                                </controls:Setting>
                                 <CheckBox x:Uid="MouseUtils_Prevent_Activation_On_Game_Mode"
                                           IsChecked="{x:Bind ViewModel.FindMyMouseDoNotActivateOnGameMode, Mode=TwoWay}"
                                           Margin="{StaticResource ExpanderSettingMargin}"

--- a/src/settings-ui/Settings.UI/Views/MouseUtilsPage.xaml
+++ b/src/settings-ui/Settings.UI/Views/MouseUtilsPage.xaml
@@ -22,20 +22,20 @@
                             <ToggleSwitch IsOn="{x:Bind ViewModel.IsFindMyMouseEnabled, Mode=TwoWay}" x:Uid="ToggleSwitch"/>
                         </controls:Setting.ActionContent>
                     </controls:Setting>
+                    <controls:Setting x:Uid="MouseUtils_FindMyMouse_ActivationMethod" IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsFindMyMouseEnabled}">
+                        <controls:Setting.ActionContent>
+                            <ComboBox SelectedIndex="{x:Bind Path=ViewModel.FindMyMouseActivationMethod, Mode=TwoWay}" MinWidth="{StaticResource SettingActionControlMinWidth}">
+                                <ComboBoxItem x:Uid="MouseUtils_FindMyMouse_ActivationDoubleControlPress" />
+                                <ComboBoxItem x:Uid="MouseUtils_FindMyMouse_ActivationShakeMouse" />
+                            </ComboBox>
+                        </controls:Setting.ActionContent>
+                    </controls:Setting>
                     <controls:SettingExpander IsEnabled="{x:Bind ViewModel.IsFindMyMouseEnabled, Mode=OneWay}" IsExpanded="False" >
                         <controls:SettingExpander.Header>
                             <controls:Setting x:Uid="ShortcutGuide_Appearance_Behavior" Icon="&#xE790;" />
                         </controls:SettingExpander.Header>
                         <controls:SettingExpander.Content>
                             <StackPanel>
-                                <controls:Setting x:Uid="MouseUtils_FindMyMouse_ActivationMethod" IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsFindMyMouseEnabled}" Style="{StaticResource ExpanderContentSettingStyle}">
-                                    <controls:Setting.ActionContent>
-                                        <ComboBox SelectedIndex="{x:Bind Path=ViewModel.FindMyMouseActivationMethod, Mode=TwoWay}" MinWidth="{StaticResource SettingActionControlMinWidth}">
-                                            <ComboBoxItem x:Uid="MouseUtils_FindMyMouse_ActivationDoubleControlPress" />
-                                            <ComboBoxItem x:Uid="MouseUtils_FindMyMouse_ActivationShakeMouse" />
-                                        </ComboBox>
-                                    </controls:Setting.ActionContent>
-                                </controls:Setting>
                                 <CheckBox x:Uid="MouseUtils_Prevent_Activation_On_Game_Mode"
                                           IsChecked="{x:Bind ViewModel.FindMyMouseDoNotActivateOnGameMode, Mode=TwoWay}"
                                           Margin="{StaticResource ExpanderSettingMargin}"


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Adds a setting to activate Find My Mouse by shaking the mouse pointer.

**What is included in the PR:** 
Adds the activation method of shaking the mouse. The algorithm is more or less like this: "If in the last second the distance travelled by the mouse pointer is 4 times greater than the diagonal of the rectangle containing that movement, it's a mouse shake.
Adds a setting to control activation method as well.

![image](https://user-images.githubusercontent.com/26118718/153509687-e99cc9ce-28bf-481b-b27b-39715cb3d82a.png)

**How does someone test / validate:** 
Go to settings and change the activation method to "shake mouse". Then try shaking your mouse.


## Quality Checklist

- [x] **Linked issue:** #14638
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries
