### PR TITLE
Shows the assigned QuickKey in the layout overview.

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -125,7 +125,8 @@
                       Margin="16,12,16,16">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="24" />
-                        <RowDefinition Height="124" />
+                        <RowDefinition Height="104" />
+                        <RowDefinition Height="12" />
                         <RowDefinition Height="0" />
                     </Grid.RowDefinitions>
                     <TextBlock Name="layoutName"
@@ -140,6 +141,48 @@
                                          Margin="0,8,0,8"
                                          VerticalAlignment="Stretch"
                                          HorizontalAlignment="Stretch" />
+                    <Grid Grid.Row="2"
+                          Opacity="0.5"
+                          ToolTip="{x:Static props:Resources.QuickKey_Title}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <Grid.Style>
+                            <Style TargetType="Grid">
+                                <Setter Property="Visibility" Value="Visible" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding QuickKey}" Value="{x:Static props:Resources.Quick_Key_None}">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Grid.Style>
+                        <TextBlock
+                            x:Name="QuickKeyTitle"
+                            FontSize="10"
+                            Text="{x:Static props:Resources.QuickKey_Title}" />
+                        <TextBlock Grid.Column="1"
+                            Margin="4,1,0,0"
+                            AutomationProperties.Name="{x:Static props:Resources.QuickKey_Description}"
+                            FontFamily="Segoe MDL2 Assets"
+                            FontSize="10"
+                            VerticalAlignment="Center"
+                            Foreground="{DynamicResource SystemControlBackgroundAccentBrush}"
+                            Text="&#xE946;"
+                            ToolTip="{x:Static props:Resources.QuickKey_Description}" />
+                        <TextBlock Margin="10,0,0,0"
+                            Grid.Column="2"
+                            HorizontalAlignment="Right"
+                            VerticalAlignment="Center"
+                            AutomationProperties.HelpText="{x:Static props:Resources.QuickKey_Description}"
+                            AutomationProperties.LabeledBy="{Binding ElementName=QuickKeyTitle}"
+                            AutomationProperties.Name="{x:Static props:Resources.QuickKey_Title}"
+                            FontSize="14"
+                            FontWeight="Bold"
+                            Text="{Binding QuickKey}" />
+                    </Grid>
                 </Grid>
                 <Button x:Name="EditLayoutButton"
                         HorizontalAlignment="Right"


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Adding an overview to each layout with the custom key assigned to it.

Now it look like this:

![image](https://user-images.githubusercontent.com/929932/154547198-6253893d-b293-477a-b130-f20ce0bfb23e.png)

![image](https://user-images.githubusercontent.com/929932/154547335-63b7ed3a-841b-4315-a377-537c3d7dc575.png)


**What is included in the PR:** Code changes

**How does someone test / validate:** 
Open the FancyZones editor and see the changes in the layouts overview.

## Quality Checklist

- [ ] **Linked issue:** #16260
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
