### PR TITLE
[AlwaysOnTop] Border after window closing fix

### DIFF
--- a/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.cpp
+++ b/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.cpp
@@ -262,12 +262,11 @@ void AlwaysOnTop::RegisterHotkey() const
 void AlwaysOnTop::SubscribeToEvents()
 {
     // subscribe to windows events
-    std::array<DWORD, 6> events_to_subscribe = {
+    std::array<DWORD, 5> events_to_subscribe = {
         EVENT_OBJECT_LOCATIONCHANGE,
         EVENT_SYSTEM_MINIMIZESTART,
         EVENT_SYSTEM_MINIMIZEEND,
         EVENT_SYSTEM_MOVESIZEEND,
-        EVENT_OBJECT_DESTROY,
         EVENT_OBJECT_NAMECHANGE
     };
 
@@ -345,9 +344,27 @@ bool AlwaysOnTop::IsTracked(HWND window) const noexcept
 
 void AlwaysOnTop::HandleWinHookEvent(WinHookEvent* data) noexcept
 {
-    if (!AlwaysOnTopSettings::settings().enableFrame)
+    if (!AlwaysOnTopSettings::settings().enableFrame || !data->hwnd)
     {
         return;
+    }
+
+    // fix for the https://github.com/microsoft/PowerToys/issues/15300
+    // check if the window was closed, since for some EVENT_OBJECT_DESTROY doesn't work 
+    std::vector<HWND> toErase{};
+    for (const auto& [window, border] : m_topmostWindows)
+    {
+        bool visible = IsWindowVisible(window);
+        if (!visible)
+        {
+            UnpinTopmostWindow(window);
+            toErase.push_back(window);
+        }
+    }
+
+    for (const auto window : toErase)
+    {
+        m_topmostWindows.erase(window);
     }
 
     switch (data->event)
@@ -393,15 +410,6 @@ void AlwaysOnTop::HandleWinHookEvent(WinHookEvent* data) noexcept
             {
                 border->UpdateBorderPosition();
             }
-        }
-    }
-    break;
-    case EVENT_OBJECT_DESTROY:
-    {
-        auto iter = m_topmostWindows.find(data->hwnd);
-        if (iter != m_topmostWindows.end())
-        {
-            m_topmostWindows.erase(iter);
         }
     }
     break;


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

The border could remain on screen after closing a pinned window for some apps. 

![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/8949536/153606361-b307dae3-19de-4487-ba4b-3f97be02037f.gif)

![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/8949536/153607788-2170272b-542a-4b28-bde2-ac20567c18e8.gif)

**What is included in the PR:** 

**How does someone test / validate:** 

* Pin ColorPicker/Outlook/Stick Notes/Windows Explorer dialog
* Close pinned window
* Verify the border is closed too

## Quality Checklist

- [x] **Linked issue:** #15300
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
