### PR TITLE
Community.PowerToys.Run.Plugin.VSCodeWorkspaces - provide support for…

### DIFF
--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/VSCodeHelper/VSCodeInstances.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/VSCodeHelper/VSCodeInstances.cs
@@ -68,14 +68,14 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.VSCodeHelper
 
                 _systemPath = Environment.GetEnvironmentVariable("PATH");
                 var paths = _systemPath.Split(";");
-                paths = paths.Where(x => x.Contains("VS Code")).ToArray();
+                paths = paths.Where(x => x.Contains("VS Code") || x.Contains("VSCodium")).ToArray();
                 foreach (var path in paths)
                 {
                     if (Directory.Exists(path))
                     {
                         var files = Directory.GetFiles(path);
                         var iconPath = Path.GetDirectoryName(path);
-                        files = files.Where(x => x.Contains("code") && !x.EndsWith(".cmd")).ToArray();
+                        files = files.Where(x => (x.Contains("code") || x.Contains("VSCodium")) && !x.EndsWith(".cmd")).ToArray();
 
                         if (files.Length > 0)
                         {
@@ -101,6 +101,11 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.VSCodeHelper
                             {
                                 version = "Code - Exploration";
                                 instance.VSCodeVersion = VSCodeVersion.Exploration;
+                            }
+                            else if (file.EndsWith("VSCodium"))
+                            {
+                                version = "VSCodium";
+                                instance.VSCodeVersion = VSCodeVersion.Stable; // ?
                             }
 
                             if (version != string.Empty)


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Very small changes to add support for [VSCodium](https://github.com/VSCodium/vscodium)
to the Community.PowerToys.Run.Plugin.VSCodeWorkspaces plugin

**How does someone test / validate:** 
1.  Compile `PowerToys.sln`
2.  Compile the installer
  [/doc/devdocs/readme.md](https://github.com/microsoft/PowerToys/blob/main/doc/devdocs/readme.md) says:
  > You can run `x64\Release\PowerToys.exe` directly without installing PowerToys, **but some modules** (i.e. PowerRename, ImageResizer, File Explorer extension etc.) **will not be available unless you also build the installer and install PowerToys**
3.  Install PowerToys on computer with [VSCodium](https://github.com/VSCodium/vscodium)
4.  Enable **VS Code Workspace** in **PowerToys Run**
4.  Create/Open workspace with VSCodium then close it
5.  Press hotkey for **PowerToys Run** ( __alt + space__ by default ). Start typing the name of your workspace from step 5 ( start with `{` symbol )
Check that your workspace appears in the results

## Quality Checklist

- [x] **Linked issue:**
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
- [x] A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
