### PR TITLE
Fix broken link

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -3,6 +3,6 @@
 ## Code organization
 The PowerToys are split into DLLs for each PowerToy module ([`modules`](/src/modules) folder), and an executable ([`runner`](/src/runner) folder) that loads and manages those DLLs.
 
-The settings window is a separate executable, contained in [`settings`](/src/settings) folder. It utilizes a WebView to display an HTML-based settings window (contained in [`settings-web`](/src/settings-web) folder).
+The settings window is a separate executable, contained in [`settings-ui`](/src/settings-ui) folder. It utilizes a WebView to display an HTML-based settings window.
 
 The [`common`](/src/common) contains code for a static library with helper functions, used by both the runner and the PowerToys modules.


### PR DESCRIPTION
## src/README.md had some outdated links.  

I updated the settings-ui link, and removed the settings-web one

**How does someone test / validate:** 
I tried the links and they worked in my repo

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [X] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [X] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.

I've signed this.