### PR TITLE
[installer]update installed .net to 6.0.2

### DIFF
--- a/installer/PowerToysSetup/PowerToys.wxs
+++ b/installer/PowerToysSetup/PowerToys.wxs
@@ -21,7 +21,7 @@
         </BootstrapperApplicationRef>
 
         <util:FileSearch Variable="HasDotnet3122" Path="[ProgramFiles64Folder]dotnet\shared\Microsoft.WindowsDesktop.App\3.1.22\System.Xaml.dll" Result="exists" />
-        <util:FileSearch Variable="HasDotnet601" Path="[ProgramFiles64Folder]dotnet\shared\Microsoft.WindowsDesktop.App\6.0.1\System.Xaml.dll" Result="exists" />
+        <util:FileSearch Variable="HasDotnet602" Path="[ProgramFiles64Folder]dotnet\shared\Microsoft.WindowsDesktop.App\6.0.2\System.Xaml.dll" Result="exists" />
         <util:RegistrySearch Variable="HasWebView2PerMachine" Root="HKLM" Key="SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}" Result="exists" />
         <util:RegistrySearch Variable="HasWebView2PerUser" Root="HKCU" Key="Software\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}" Result="exists" />
 
@@ -60,11 +60,11 @@
                     Hash="08EF2F6CFDB33946061884B1CE13FA867EFBD576" />
             </ExePackage>
             <ExePackage
-                Name="windowsdesktop-runtime-6.0.1-win-x64.exe"
+                Name="windowsdesktop-runtime-6.0.2-win-x64.exe"
                 Compressed="no"
                 Id="DotnetRuntime6"
-                DetectCondition="HasDotnet601"
-                DownloadUrl="https://download.visualstudio.microsoft.com/download/pr/bf058765-6f71-4971-aee1-15229d8bfb3e/c3366e6b74bec066487cd643f915274d/windowsdesktop-runtime-6.0.1-win-x64.exe"
+                DetectCondition="HasDotnet602"
+                DownloadUrl="https://download.visualstudio.microsoft.com/download/pr/efa32b7a-6eec-4d97-9cdc-c7336a29a749/3df4296170397cf60884dae1be3d103b/windowsdesktop-runtime-6.0.2-win-x64.exe"
                 InstallCommand="/install /quiet"
                 RepairCommand="/repair /passive"
                 Permanent="yes"
@@ -72,11 +72,11 @@
                 UninstallCommand="/uninstall /quiet">
                 <ExitCode Value="1638" Behavior="success"/>
                 <RemotePayload
-                    Description="Microsoft Windows Desktop Runtime - 6.0.1 (x64)"
-                    ProductName="Microsoft Windows Desktop Runtime - 6.0.1 (x64)"
-                    Size="57508696"
-                    Version="6.0.1.30718"
-                    Hash="1DC44C31438725846F59071C868736112398329B" />
+                    Description="Microsoft Windows Desktop Runtime - 6.0.2 (x64)"
+                    ProductName="Microsoft Windows Desktop Runtime - 6.0.2 (x64)"
+                    Size="57296456"
+                    Version="6.0.2.30914"
+                    Hash="EA8DB9D01555D0EA2A3D3CD41D56A28199A064F5" />
             </ExePackage>
             <ExePackage
                 Name="MicrosoftEdgeWebview2Setup.exe"


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Updates the installer for .net framework 6.0.2.

**What is included in the PR:** 
New data to download .net framework 6.0.2 instead of .net framework 6.0.1.

**How does someone test / validate:** 
.net framework 6.0.2 installs and PowerToys runs successfully.

## Quality Checklist

- [x] **Linked issue:** #16088
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [x] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries
