### PR TITLE
[ColorPicker] Unify hex color code to lowercase

### DIFF
--- a/src/modules/colorPicker/ColorPickerUI/Helpers/ColorRepresentationHelper.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/ColorRepresentationHelper.cs
@@ -79,9 +79,9 @@ namespace ColorPicker.Helpers
         /// <param name="color">The see cref="Color"/> for the hexadecimal presentation</param>
         /// <returns>A hexadecimal <see cref="string"/> representation of a RGB color</returns>
         private static string ColorToHex(Color color)
-            => $"{color.R.ToString("X2", CultureInfo.InvariantCulture)}"
-             + $"{color.G.ToString("X2", CultureInfo.InvariantCulture)}"
-             + $"{color.B.ToString("X2", CultureInfo.InvariantCulture)}";
+            => $"{color.R.ToString("x2", CultureInfo.InvariantCulture)}"
+             + $"{color.G.ToString("x2", CultureInfo.InvariantCulture)}"
+             + $"{color.B.ToString("x2", CultureInfo.InvariantCulture)}";
 
         /// <summary>
         /// Return a <see cref="string"/> representation of a HSB color


### PR DESCRIPTION
## Summary of the Pull Request
When using ColorPicker HEX color format in `Pick a color and open editor` mode, editor shows color code in lowercase. However, when using ColorPicker in `Only pick a color` mode, HEX format is shown and copied to clipboard in uppercase.

**What is this about:**
Unify HEX color code to lower case in all ColorPicker modes.

**What is included in the PR:** 

**How does someone test / validate:** 
 - Open ColorPicker page in Settings, set Activation behavior to `Pick a color and open editor`. Set Default color format to HEX
 - Open ColorPicker using hotkey, observe that color code in mouse tooltip is now lowercase (it was uppercase  before this change). Pick a color. Observe that HEX color format is lowercase in editor.
 - Set Activation behavior to 'Only pick a color`
 - Open ColorPicker using hotkey, pick a color to copy color code to clipboard, paste color code to some text editor and observe that it is lowercase (it was uppercase before this change)


## Quality Checklist

- [x] **Linked issue:** #16488
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
