### PR TITLE
[Oobe]Fix close button style

### DIFF
--- a/src/settings-ui/PowerToys.Settings/OobeWindow.xaml.cs
+++ b/src/settings-ui/PowerToys.Settings/OobeWindow.xaml.cs
@@ -96,7 +96,7 @@ namespace PowerToys.Settings
         {
             base.OnSourceInitialized(e);
             var hwnd = new WindowInteropHelper(this).Handle;
-            NativeMethods.SetToolWindowStyle(hwnd);
+            NativeMethods.SetPopupStyle(hwnd);
         }
     }
 }

--- a/src/settings-ui/Settings.UI/Helpers/NativeMethods.cs
+++ b/src/settings-ui/Settings.UI/Helpers/NativeMethods.cs
@@ -11,8 +11,8 @@ namespace Microsoft.PowerToys.Settings.UI.Helpers
 {
     public static class NativeMethods
     {
-        private const int GWL_EX_STYLE = -20;
-        private const int WS_EX_TOOLWINDOW = 0x00000080;
+        private const int GWL_STYLE = -16;
+        private const int WS_POPUP = 1 << 31; // 0x80000000
         internal const int SPI_GETDESKWALLPAPER = 0x0073;
 
         [DllImport("user32.dll")]
@@ -45,9 +45,9 @@ namespace Microsoft.PowerToys.Settings.UI.Helpers
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool SystemParametersInfo(int uiAction, int uiParam, StringBuilder pvParam, int fWinIni);
 
-        public static void SetToolWindowStyle(IntPtr hwnd)
+        public static void SetPopupStyle(IntPtr hwnd)
         {
-            _ = SetWindowLong(hwnd, GWL_EX_STYLE, GetWindowLong(hwnd, GWL_EX_STYLE) | WS_EX_TOOLWINDOW);
+            _ = SetWindowLong(hwnd, GWL_STYLE, GetWindowLong(hwnd, GWL_STYLE) | WS_POPUP);
         }
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Close button in the OOBE window had its style changed to a different style than the settings window.
This was done in https://github.com/microsoft/PowerToys/pull/16041 to make it not draggable by FancyZones, but FancyZones no longer drags popup windows by default, so this change can be reverted.

**What is included in the PR:** 
Revert the changes that changed the Window style.

**How does someone test / validate:** 
Open Oobe window and verify the style of the closed button looks good now.

## Quality Checklist

- [x] **Linked issue:** #16529
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries
