### PR TITLE
[oobe] fix scoobe page threading issues

### DIFF
--- a/src/settings-ui/Settings.UI/OOBE/Views/OobeWhatsNew.xaml.cs
+++ b/src/settings-ui/Settings.UI/OOBE/Views/OobeWhatsNew.xaml.cs
@@ -85,15 +85,26 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
             TitleTxt.Text = loader.GetString("Oobe_WhatsNew");
             try
             {
-                ReleaseNotesMarkdown.Text = await GetReleaseNotesMarkdown();
-                ReleaseNotesMarkdown.Visibility = Windows.UI.Xaml.Visibility.Visible;
-                LoadingProgressRing.Visibility = Windows.UI.Xaml.Visibility.Collapsed;
+                string releaseNotesMarkdown = await GetReleaseNotesMarkdown();
+
+                // Make sure we run in the UI thread. await doesn't seem to guarantee it.
+                await Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () =>
+                {
+                    ReleaseNotesMarkdown.Text = releaseNotesMarkdown;
+                    ReleaseNotesMarkdown.Visibility = Windows.UI.Xaml.Visibility.Visible;
+                    LoadingProgressRing.Visibility = Windows.UI.Xaml.Visibility.Collapsed;
+                });
             }
             catch (Exception ex)
             {
                 Logger.LogError("Exception when loading the release notes", ex);
-                LoadingProgressRing.Visibility = Windows.UI.Xaml.Visibility.Collapsed;
-                ErrorInfoBar.Visibility = Windows.UI.Xaml.Visibility.Visible;
+
+                // Make sure we run in the UI thread. await doesn't seem to guarantee it.
+                await Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () =>
+                {
+                    LoadingProgressRing.Visibility = Windows.UI.Xaml.Visibility.Collapsed;
+                    ErrorInfoBar.Visibility = Windows.UI.Xaml.Visibility.Visible;
+                });
             }
         }
 


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
The use of `await` in the "What's New" page is not returning to the UI thread as expected, even if context should be maintained as mentioned in the `await` documentation. This happens when running `PowerToys.Settings` directly when debugging from VS. This might be a XAML islands quirk and might happen in other situations, as well, so let's make sure it runs in the right thread.

**What is included in the PR:** 
Dispatch code to the right thread after await, before doing UI element changes.

**How does someone test / validate:** 
Just looking for that Code Quality check, but running scoobe to make sure it still works is fair game as well.

## Quality Checklist

- [x] **Linked issue:** #14536
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries
