### PR TITLE
[MouseCrosshairs] Fix wrong initial position

### DIFF
--- a/src/modules/MouseUtils/MousePointerCrosshairs/InclusiveCrosshairs.cpp
+++ b/src/modules/MouseUtils/MousePointerCrosshairs/InclusiveCrosshairs.cpp
@@ -247,10 +247,10 @@ void InclusiveCrosshairs::StartDrawing()
 {
     Logger::info("Start drawing crosshairs.");
     Trace::StartDrawingCrosshairs();
-    UpdateCrosshairsPosition();
-    m_visible = true;
     SetWindowPos(m_hwnd, HWND_TOPMOST, GetSystemMetrics(SM_XVIRTUALSCREEN), GetSystemMetrics(SM_YVIRTUALSCREEN), GetSystemMetrics(SM_CXVIRTUALSCREEN), GetSystemMetrics(SM_CYVIRTUALSCREEN), 0);
+    UpdateCrosshairsPosition();
     ShowWindow(m_hwnd, SW_SHOWNOACTIVATE);
+    m_visible = true;
     m_mouseHook = SetWindowsHookEx(WH_MOUSE_LL, MouseHookProc, m_hinstance, 0);
 }
 


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
After https://github.com/microsoft/PowerToys/pull/16077 there is a edge case where if a monitor has negative coordinates, the first time the crosshairs is activated, it will appear in the wrong place, due to the fact the windows still hasn't expanded to the right coordinates.

**What is included in the PR:** 
Resize window before updating crosshairs position.

**How does someone test / validate:** 
Real edge case, you have to have a monitor with negative coordinates to test this. Code quality check is what is intended here.

## Quality Checklist

- [x] **Linked issue:** #16050
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries
