### PR TITLE
[OOBE]Not showing Welcome page after install

### DIFF
--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -195,6 +195,7 @@ int runner(bool isProcessElevated, bool openSettings, std::string settingsWindow
 
         if (openOobe)
         {
+            PTSettingsHelper::save_oobe_opened_state();
             open_oobe_window();
         }
         else if (openScoobe)
@@ -370,10 +371,6 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     try
     {
         openOobe = !PTSettingsHelper::get_oobe_opened_state();
-        if (openOobe)
-        {
-            PTSettingsHelper::save_oobe_opened_state();
-        }
     }
     catch (const std::exception& e)
     {


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
After https://github.com/microsoft/PowerToys/pull/15920, PowerToys is not showing OOBE Welcome page after install. The reason for this is that it saves that it called OOBE before actually restarting as not elevated.

**What is included in the PR:** 
Only save that oobe was called if the call to open oobe is called inside runner.

**How does someone test / validate:** 
Uninstall Powertoys, delete %localappdata%\Microsoft\PowerToys, install PowerToys built from this branch and verify the OOBE opens in the Welcome page.

## Quality Checklist

- [x] **Linked issue:** #16560 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries
