### PR TITLE
[FancyZones] Template layout settings reset fix

### DIFF
--- a/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
@@ -1338,16 +1338,8 @@ void FancyZones::ApplyQuickLayout(int key) noexcept
         return;
     }
 
-    auto uuidStr = FancyZonesUtils::GuidToString(layoutId.value());
-    if (!uuidStr)
-    {
-        return;
-    }
-
-    FancyZonesDataTypes::ZoneSetData data{ .uuid = uuidStr.value(), .type = FancyZonesDataTypes::ZoneSetLayoutType::Custom };
-    
     auto workArea = m_workAreaHandler.GetWorkAreaFromCursor(m_currentDesktopId);
-    AppliedLayouts::instance().ApplyLayout(workArea->UniqueId(), data);
+    AppliedLayouts::instance().ApplyLayout(workArea->UniqueId(), layout.value());
     AppliedLayouts::instance().SaveData();
     UpdateZoneSets();
     FlashZones();

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesData/AppliedLayouts.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesData/AppliedLayouts.cpp
@@ -7,7 +7,6 @@
 #include <FancyZonesLib/GuidUtils.h>
 #include <FancyZonesLib/FancyZonesData/CustomLayouts.h>
 #include <FancyZonesLib/FancyZonesData/LayoutDefaults.h>
-#include <FancyZonesLib/FancyZonesData/LayoutTemplates.h>
 #include <FancyZonesLib/FancyZonesWinHookEventIDs.h>
 #include <FancyZonesLib/JsonHelpers.h>
 #include <FancyZonesLib/util.h>
@@ -320,59 +319,9 @@ bool AppliedLayouts::IsLayoutApplied(const FancyZonesDataTypes::DeviceIdData& id
     return iter != m_layouts.end();
 }
 
-bool AppliedLayouts::ApplyLayout(const FancyZonesDataTypes::DeviceIdData& deviceId, const FancyZonesDataTypes::ZoneSetData& layout)
+bool AppliedLayouts::ApplyLayout(const FancyZonesDataTypes::DeviceIdData& deviceId, Layout layout)
 {
-    auto uuid = FancyZonesUtils::GuidFromString(layout.uuid);
-    if (!uuid)
-    {
-        return false;
-    }
-
-    Layout layoutToApply {
-        .uuid = uuid.value(),
-        .type = layout.type,
-        .showSpacing = DefaultValues::ShowSpacing,
-        .spacing = DefaultValues::Spacing,
-        .zoneCount = DefaultValues::ZoneCount,
-        .sensitivityRadius = DefaultValues::SensitivityRadius,
-    };
-
-    // copy layouts properties to the applied-layout
-    auto customLayout = CustomLayouts::instance().GetLayout(layoutToApply.uuid);
-    if (customLayout)
-    {
-        if (customLayout.value().type == FancyZonesDataTypes::CustomLayoutType::Grid)
-        {
-            auto layoutInfo = std::get<FancyZonesDataTypes::GridLayoutInfo>(customLayout.value().info);
-            layoutToApply.sensitivityRadius = layoutInfo.sensitivityRadius();
-            layoutToApply.showSpacing = layoutInfo.showSpacing();
-            layoutToApply.spacing = layoutInfo.spacing();
-            layoutToApply.zoneCount = layoutInfo.zoneCount();
-        }
-        else if (customLayout.value().type == FancyZonesDataTypes::CustomLayoutType::Canvas)
-        {
-            auto layoutInfo = std::get<FancyZonesDataTypes::CanvasLayoutInfo>(customLayout.value().info);
-            layoutToApply.sensitivityRadius = layoutInfo.sensitivityRadius;
-            layoutToApply.zoneCount = (int)layoutInfo.zones.size();
-        }
-    }
-    else
-    {
-        // check templates only if it wasn't a custom layout, since templates don't have ids yet
-        auto templateLayout = LayoutTemplates::instance().GetLayout(layout.type);
-        if (templateLayout)
-        {
-            auto layoutInfo = templateLayout.value();
-            layoutToApply.sensitivityRadius = layoutInfo.sensitivityRadius;
-            layoutToApply.showSpacing = layoutInfo.showSpacing;
-            layoutToApply.spacing = layoutInfo.spacing;
-            layoutToApply.zoneCount = layoutInfo.zoneCount;
-        }
-    
-    }
-    
-    m_layouts[deviceId] = std::move(layoutToApply);
-
+    m_layouts[deviceId] = std::move(layout);
     return true;
 }
 

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesData/AppliedLayouts.h
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesData/AppliedLayouts.h
@@ -54,7 +54,7 @@ public:
 
     bool IsLayoutApplied(const FancyZonesDataTypes::DeviceIdData& id) const noexcept;
 
-    bool ApplyLayout(const FancyZonesDataTypes::DeviceIdData& deviceId, const FancyZonesDataTypes::ZoneSetData& layout);
+    bool ApplyLayout(const FancyZonesDataTypes::DeviceIdData& deviceId, Layout layout);
     bool ApplyDefaultLayout(const FancyZonesDataTypes::DeviceIdData& deviceId);
     bool CloneLayout(const FancyZonesDataTypes::DeviceIdData& srcId, const FancyZonesDataTypes::DeviceIdData& dstId);
 

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesData/CustomLayouts.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesData/CustomLayouts.cpp
@@ -216,7 +216,43 @@ void CustomLayouts::LoadData()
     }
 }
 
-std::optional<FancyZonesDataTypes::CustomLayoutData> CustomLayouts::GetLayout(const GUID& id) const noexcept
+std::optional<Layout> CustomLayouts::GetLayout(const GUID& id) const noexcept
+{
+    auto iter = m_layouts.find(id);
+    if (iter == m_layouts.end())
+    {
+        return std::nullopt;
+    }
+    
+    FancyZonesDataTypes::CustomLayoutData customLayout = iter->second;
+    Layout layout{
+        .uuid = id,
+        .type = FancyZonesDataTypes::ZoneSetLayoutType::Custom,
+        .showSpacing = DefaultValues::ShowSpacing,
+        .spacing = DefaultValues::Spacing,
+        .zoneCount = DefaultValues::ZoneCount,
+        .sensitivityRadius = DefaultValues::SensitivityRadius
+    };
+
+    if (customLayout.type == FancyZonesDataTypes::CustomLayoutType::Grid)
+    {
+        auto layoutInfo = std::get<FancyZonesDataTypes::GridLayoutInfo>(customLayout.info);
+        layout.sensitivityRadius = layoutInfo.sensitivityRadius();
+        layout.showSpacing = layoutInfo.showSpacing();
+        layout.spacing = layoutInfo.spacing();
+        layout.zoneCount = layoutInfo.zoneCount();
+    }
+    else if (customLayout.type == FancyZonesDataTypes::CustomLayoutType::Canvas)
+    {
+        auto layoutInfo = std::get<FancyZonesDataTypes::CanvasLayoutInfo>(customLayout.info);
+        layout.sensitivityRadius = layoutInfo.sensitivityRadius;
+        layout.zoneCount = (int)layoutInfo.zones.size();
+    }
+
+    return layout;
+}
+
+std::optional<FancyZonesDataTypes::CustomLayoutData> CustomLayouts::GetCustomLayoutData(const GUID& id) const noexcept
 {
     auto iter = m_layouts.find(id);
     if (iter != m_layouts.end())

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesData/CustomLayouts.h
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesData/CustomLayouts.h
@@ -5,6 +5,7 @@
 #include <memory>
 #include <optional>
 
+#include <FancyZonesLib/FancyZonesData/Layout.h>
 #include <FancyZonesLib/FancyZonesDataTypes.h>
 #include <FancyZonesLib/GuidUtils.h>
 #include <FancyZonesLib/ModuleConstants.h>
@@ -63,7 +64,8 @@ public:
 
     void LoadData();
 
-    std::optional<FancyZonesDataTypes::CustomLayoutData> GetLayout(const GUID& id) const noexcept;
+    std::optional<Layout> GetLayout(const GUID& id) const noexcept;
+    std::optional<FancyZonesDataTypes::CustomLayoutData> GetCustomLayoutData(const GUID& id) const noexcept;
     const TCustomLayoutMap& GetAllLayouts() const noexcept;
 
 private:

--- a/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
@@ -527,20 +527,6 @@ void WorkArea::CalculateZoneSet(OverlappingZonesAlgorithm overlappingAlgorithm) 
 void WorkArea::UpdateActiveZoneSet(_In_opt_ IZoneSet* zoneSet) noexcept
 {
     m_zoneSet.copy_from(zoneSet);
-
-    if (m_zoneSet)
-    {
-        wil::unique_cotaskmem_string zoneSetId;
-        if (SUCCEEDED_LOG(StringFromCLSID(m_zoneSet->Id(), &zoneSetId)))
-        {
-            FancyZonesDataTypes::ZoneSetData data{
-                .uuid = zoneSetId.get(),
-                .type = m_zoneSet->LayoutType()
-            };
-
-            AppliedLayouts::instance().ApplyLayout(m_uniqueId, data);
-        }
-    }
 }
 
 LRESULT WorkArea::WndProc(UINT message, WPARAM wparam, LPARAM lparam) noexcept

--- a/src/modules/fancyzones/FancyZonesLib/ZoneSet.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/ZoneSet.cpp
@@ -875,7 +875,7 @@ bool ZoneSet::CalculateUniquePriorityGridLayout(Rect workArea, int zoneCount, in
 
 bool ZoneSet::CalculateCustomLayout(Rect workArea, int spacing) noexcept
 {
-    const auto zoneSetSearchResult = CustomLayouts::instance().GetLayout(m_config.Id);
+    const auto zoneSetSearchResult = CustomLayouts::instance().GetCustomLayoutData(m_config.Id);
     if (!zoneSetSearchResult.has_value())
     {
         return false;

--- a/src/modules/fancyzones/FancyZonesTests/UnitTests/AppliedLayoutsTests.Spec.cpp
+++ b/src/modules/fancyzones/FancyZonesTests/UnitTests/AppliedLayoutsTests.Spec.cpp
@@ -279,15 +279,26 @@ namespace FancyZonesUnitTests
             };
 
             // test
-            FancyZonesDataTypes::ZoneSetData expectedZoneSetData {
-                .uuid = L"{33A2B101-06E0-437B-A61E-CDBECF502906}",
-                .type = FancyZonesDataTypes::ZoneSetLayoutType::Focus
+            Layout expectedLayout {
+                .uuid = FancyZonesUtils::GuidFromString(L"{33A2B101-06E0-437B-A61E-CDBECF502906}").value(),
+                .type = FancyZonesDataTypes::ZoneSetLayoutType::Focus,
+                .showSpacing = true,
+                .spacing = 10,
+                .zoneCount = 15,
+                .sensitivityRadius = 30
             };
 
-            AppliedLayouts::instance().ApplyLayout(deviceId, expectedZoneSetData);
+            AppliedLayouts::instance().ApplyLayout(deviceId, expectedLayout);
 
             Assert::IsFalse(AppliedLayouts::instance().GetAppliedLayoutMap().empty());
             Assert::IsTrue(AppliedLayouts::instance().GetDeviceLayout(deviceId).has_value());
+
+            auto actual = AppliedLayouts::instance().GetAppliedLayoutMap().find(deviceId)->second;
+            Assert::IsTrue(expectedLayout.type == actual.type);
+            Assert::AreEqual(expectedLayout.showSpacing, actual.showSpacing);
+            Assert::AreEqual(expectedLayout.spacing, actual.spacing);
+            Assert::AreEqual(expectedLayout.zoneCount, actual.zoneCount);
+            Assert::AreEqual(expectedLayout.sensitivityRadius, actual.sensitivityRadius);
         }
 
         TEST_METHOD (ApplyLayoutReplace)
@@ -322,19 +333,27 @@ namespace FancyZonesUnitTests
             AppliedLayouts::instance().LoadData();
 
             // test
-            FancyZonesDataTypes::ZoneSetData expectedZoneSetData {
-                .uuid = L"{33A2B101-06E0-437B-A61E-CDBECF502906}",
-                .type = FancyZonesDataTypes::ZoneSetLayoutType::Focus
+            Layout expectedLayout{
+                .uuid = FancyZonesUtils::GuidFromString(L"{33A2B101-06E0-437B-A61E-CDBECF502906}").value(),
+                .type = FancyZonesDataTypes::ZoneSetLayoutType::Focus,
+                .showSpacing = true,
+                .spacing = 10,
+                .zoneCount = 15,
+                .sensitivityRadius = 30
             };
 
-            AppliedLayouts::instance().ApplyLayout(deviceId, expectedZoneSetData);
+            AppliedLayouts::instance().ApplyLayout(deviceId, expectedLayout);
 
             Assert::AreEqual((size_t)1, AppliedLayouts::instance().GetAppliedLayoutMap().size());
             Assert::IsTrue(AppliedLayouts::instance().GetDeviceLayout(deviceId).has_value());
 
             auto actual = AppliedLayouts::instance().GetAppliedLayoutMap().find(deviceId)->second;
-            Assert::AreEqual(expectedZoneSetData.uuid.c_str(), FancyZonesUtils::GuidToString(actual.uuid).value().c_str());
-            Assert::IsTrue(expectedZoneSetData.type == actual.type);
+            Assert::AreEqual(FancyZonesUtils::GuidToString(expectedLayout.uuid).value().c_str(), FancyZonesUtils::GuidToString(actual.uuid).value().c_str());
+            Assert::IsTrue(expectedLayout.type == actual.type);
+            Assert::AreEqual(expectedLayout.showSpacing, actual.showSpacing);
+            Assert::AreEqual(expectedLayout.spacing, actual.spacing);
+            Assert::AreEqual(expectedLayout.zoneCount, actual.zoneCount);
+            Assert::AreEqual(expectedLayout.sensitivityRadius, actual.sensitivityRadius);
         }
 
         TEST_METHOD (ApplyDefaultLayout)


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

**What is included in the PR:** 

**How does someone test / validate:** 

* Apply the same template layout with some differences to the different monitors, e.g. set `Grid` with 3 and 4 zones.
* Restart PT
* Verify settings (zone count in this case) is applied properly

## Quality Checklist

- [x] **Linked issue:** #16155
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
