### PR TITLE
[PTRun]Workaround fix tooltip crash on .net 6

### DIFF
--- a/src/modules/launcher/PowerLauncher/ResultList.xaml
+++ b/src/modules/launcher/PowerLauncher/ResultList.xaml
@@ -190,7 +190,7 @@
                         Width="642" 
                         Background="Transparent"
                         ToolTipService.BetweenShowDelay="0"
-                        ToolTipService.InitialShowDelay="1000">
+                        ToolTipService.InitialShowDelay="0">
                         <Behaviors:Interaction.Triggers>
                             <Behaviors:EventTrigger EventName="MouseEnter">
                                 <Behaviors:InvokeCommandAction Command="{Binding ActivateContextButtonsHoverCommand}"/>


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
There seems to be a racing condition in .net 6 which causes a crash when a popup disappears in the virtualized list view used by the PowerToys Run results. 
https://github.com/dotnet/wpf/issues/5730#issuecomment-1031191615
We shouldn't release with a crashing regression, so this PR hopes to provide a workaround that doesn't impact users too much.
The fix for this in .net is expected to be released on the next release so we should revisit there.

**What is included in the PR:** 
Show new tooltips right away, so that the previous tooltip isn't cleaned when the virtualized item has been removed.

**How does someone test / validate:** 
Try to replicate the linked issue and verify it no longer replicates.

## Quality Checklist

- [x] **Linked issue:** #16624 
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries
