### PR TITLE
[build]Fix PowerRename flaky build errors

### DIFF
--- a/src/modules/powerrename/PowerRenameUILib/PowerRenameUILib.vcxproj
+++ b/src/modules/powerrename/PowerRenameUILib/PowerRenameUILib.vcxproj
@@ -70,11 +70,11 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\modules\PowerRename\</OutDir>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\modules\$(ProjectName)\</OutDir>
     <TargetName>PowerToys.PowerRenameUILib</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\modules\PowerRename\</OutDir>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\modules\$(ProjectName)\</OutDir>
     <TargetName>PowerToys.PowerRenameUILib</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup>


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
PowerRename has some flakiness building, causing build errors for some devs.
This seems to be caused by PowerRename projects all sharing the same output folder and some of the generated files being deleted by other projects starting their build processes. `.winmd` files getting deleted seems to be the cause for these build errors.

**What is included in the PR:** 
Set PowerRenameUILib to its specific output folder, since it's the project generating `.winmd` files. These files will be copied by `PowerRenameUIHost` once it starts building.

**How does someone test / validate:** 
Verify the solution still builds, including the installer, since that means all files are in the expected place by the end of the build process.

## Quality Checklist

- [x] **Linked issue:** #15188 
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries
