### PR TITLE
[FindMyMouse]setting for minimum shake distance

### DIFF
--- a/src/modules/MouseUtils/FindMyMouse/FindMyMouse.cpp
+++ b/src/modules/MouseUtils/FindMyMouse/FindMyMouse.cpp
@@ -69,6 +69,7 @@ protected:
     DWORD m_fadeDuration = FIND_MY_MOUSE_DEFAULT_ANIMATION_DURATION_MS;
     int m_finalAlphaNumerator = FIND_MY_MOUSE_DEFAULT_OVERLAY_OPACITY;
     std::vector<std::wstring> m_excludedApps;
+    int m_shakeMinimumDistance = FIND_MY_MOUSE_DEFAULT_SHAKE_MINIMUM_DISTANCE;
     static constexpr int FinalAlphaDenominator = 100;
     winrt::DispatcherQueueController m_dispatcherQueueController{ nullptr };
 
@@ -403,6 +404,11 @@ void SuperSonar<D>::DetectShake()
         maxY = max(currentY, maxY);
     }
     
+    if (distanceTravelled < m_shakeMinimumDistance)
+    {
+        return;
+    }
+
     // Size of the rectangle the pointer moved in.
     double rectangleWidth = (double)maxX - minX;
     double rectangleHeight = (double)maxY - minY;
@@ -423,7 +429,7 @@ void SuperSonar<D>::OnSonarMouseInput(RAWINPUT const& input)
     {
         LONG relativeX = 0;
         LONG relativeY = 0;
-        if ((input.data.mouse.usFlags & MOUSE_MOVE_ABSOLUTE) == MOUSE_MOVE_ABSOLUTE)
+        if ((input.data.mouse.usFlags & MOUSE_MOVE_ABSOLUTE) == MOUSE_MOVE_ABSOLUTE && (input.data.mouse.lLastX!=0 || input.data.mouse.lLastY!=0))
         {
             // Getting absolute mouse coordinates. Likely inside a VM / RDP session.
             if (m_seenAnAbsoluteMousePosition)
@@ -736,6 +742,7 @@ public:
             m_finalAlphaNumerator = settings.overlayOpacity;
             m_sonarZoomFactor = settings.spotlightInitialZoom;
             m_excludedApps = settings.excludedApps;
+            m_shakeMinimumDistance = settings.shakeMinimumDistance;
         }
         else
         {
@@ -762,6 +769,7 @@ public:
                     m_finalAlphaNumerator = localSettings.overlayOpacity;
                     m_sonarZoomFactor = localSettings.spotlightInitialZoom;
                     m_excludedApps = localSettings.excludedApps;
+                    m_shakeMinimumDistance = localSettings.shakeMinimumDistance;
                     UpdateMouseSnooping(); // For the shake mouse activation method
 
                     // Apply new settings to runtime composition objects.

--- a/src/modules/MouseUtils/FindMyMouse/FindMyMouse.h
+++ b/src/modules/MouseUtils/FindMyMouse/FindMyMouse.h
@@ -16,6 +16,7 @@ constexpr int FIND_MY_MOUSE_DEFAULT_SPOTLIGHT_RADIUS = 100;
 constexpr int FIND_MY_MOUSE_DEFAULT_ANIMATION_DURATION_MS = 500;
 constexpr int FIND_MY_MOUSE_DEFAULT_SPOTLIGHT_INITIAL_ZOOM = 9;
 constexpr FindMyMouseActivationMethod FIND_MY_MOUSE_DEFAULT_ACTIVATION_METHOD = FindMyMouseActivationMethod::DoubleControlKey;
+constexpr int FIND_MY_MOUSE_DEFAULT_SHAKE_MINIMUM_DISTANCE = 1000;
 
 struct FindMyMouseSettings
 {
@@ -27,6 +28,7 @@ struct FindMyMouseSettings
     int spotlightRadius = FIND_MY_MOUSE_DEFAULT_SPOTLIGHT_RADIUS;
     int animationDurationMs = FIND_MY_MOUSE_DEFAULT_ANIMATION_DURATION_MS;
     int spotlightInitialZoom = FIND_MY_MOUSE_DEFAULT_SPOTLIGHT_INITIAL_ZOOM;
+    int shakeMinimumDistance = FIND_MY_MOUSE_DEFAULT_SHAKE_MINIMUM_DISTANCE;
     std::vector<std::wstring> excludedApps;
 };
 

--- a/src/modules/MouseUtils/FindMyMouse/dllmain.cpp
+++ b/src/modules/MouseUtils/FindMyMouse/dllmain.cpp
@@ -21,6 +21,7 @@ namespace
     const wchar_t JSON_KEY_ANIMATION_DURATION_MS[] = L"animation_duration_ms";
     const wchar_t JSON_KEY_SPOTLIGHT_INITIAL_ZOOM[] = L"spotlight_initial_zoom";
     const wchar_t JSON_KEY_EXCLUDED_APPS[] = L"excluded_apps";
+    const wchar_t JSON_KEY_SHAKING_MINIMUM_DISTANCE[] = L"shaking_minimum_distance";
 }
 
 extern "C" IMAGE_DOS_HEADER __ImageBase;
@@ -299,6 +300,16 @@ void FindMyMouse::parse_settings(PowerToysSettings::PowerToyValues& settings)
         catch (...)
         {
             Logger::warn("Failed to initialize Excluded Apps from settings. Will use default value");
+        }
+        try
+        {
+            // Parse Shaking Minimum Distance
+            auto jsonPropertiesObject = settingsObject.GetNamedObject(JSON_KEY_PROPERTIES).GetNamedObject(JSON_KEY_SHAKING_MINIMUM_DISTANCE);
+            findMyMouseSettings.shakeMinimumDistance = (UINT)jsonPropertiesObject.GetNamedNumber(JSON_KEY_VALUE);
+        }
+        catch (...)
+        {
+            Logger::warn("Failed to initialize Shaking Minimum Distance from settings. Will use default value");
         }
     }
     else

--- a/src/settings-ui/Settings.UI.Library/FindMyMouseProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/FindMyMouseProperties.cs
@@ -35,6 +35,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         [JsonPropertyName("excluded_apps")]
         public StringProperty ExcludedApps { get; set; }
 
+        [JsonPropertyName("shaking_minimum_distance")]
+        public IntProperty ShakingMinimumDistance { get; set; }
+
         public FindMyMouseProperties()
         {
             ActivationMethod = new IntProperty(0);
@@ -46,6 +49,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             AnimationDurationMs = new IntProperty(500);
             SpotlightInitialZoom = new IntProperty(9);
             ExcludedApps = new StringProperty();
+            ShakingMinimumDistance = new IntProperty(1000);
         }
     }
 }

--- a/src/settings-ui/Settings.UI.Library/ViewModels/MouseUtilsViewModel.cs
+++ b/src/settings-ui/Settings.UI.Library/ViewModels/MouseUtilsViewModel.cs
@@ -61,6 +61,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             _findMyMouseAnimationDurationMs = FindMyMouseSettingsConfig.Properties.AnimationDurationMs.Value;
             _findMyMouseSpotlightInitialZoom = FindMyMouseSettingsConfig.Properties.SpotlightInitialZoom.Value;
             _findMyMouseExcludedApps = FindMyMouseSettingsConfig.Properties.ExcludedApps.Value;
+            _findMyMouseShakingMinimumDistance = FindMyMouseSettingsConfig.Properties.ShakingMinimumDistance.Value;
 
             if (mouseHighlighterSettingsRepository == null)
             {
@@ -280,6 +281,24 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
                 {
                     _findMyMouseExcludedApps = value;
                     FindMyMouseSettingsConfig.Properties.ExcludedApps.Value = value;
+                    NotifyFindMyMousePropertyChanged();
+                }
+            }
+        }
+
+        public int FindMyMouseShakingMinimumDistance
+        {
+            get
+            {
+                return _findMyMouseShakingMinimumDistance;
+            }
+
+            set
+            {
+                if (value != _findMyMouseShakingMinimumDistance)
+                {
+                    _findMyMouseShakingMinimumDistance = value;
+                    FindMyMouseSettingsConfig.Properties.ShakingMinimumDistance.Value = value;
                     NotifyFindMyMousePropertyChanged();
                 }
             }
@@ -633,6 +652,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
         private int _findMyMouseAnimationDurationMs;
         private int _findMyMouseSpotlightInitialZoom;
         private string _findMyMouseExcludedApps;
+        private int _findMyMouseShakingMinimumDistance;
 
         private bool _isMouseHighlighterEnabled;
         private string _highlighterLeftButtonClickColor;

--- a/src/settings-ui/Settings.UI/Converters/FindMyMouseActivationShakeMouseIntToVisibilityConverter.cs
+++ b/src/settings-ui/Settings.UI/Converters/FindMyMouseActivationShakeMouseIntToVisibilityConverter.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Data;
+
+namespace Microsoft.PowerToys.Settings.UI.Converters
+{
+    public sealed class FindMyMouseActivationShakeMouseIntToVisibilityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, string language)
+        {
+            var activationShake = (int)value;
+
+            // Assumes 1 is the index for the shake mouse option in the activation method combo box
+            if (activationShake == 1)
+            {
+                return Visibility.Visible;
+            }
+            else
+            {
+                return Visibility.Collapsed;
+            }
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, string language)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/settings-ui/Settings.UI/Settings.UI.csproj
+++ b/src/settings-ui/Settings.UI/Settings.UI.csproj
@@ -125,6 +125,7 @@
     </Compile>
     <Compile Include="Controls\SettingsPageControl\PageLink.cs" />
     <Compile Include="Converters\AwakeModeToIntConverter.cs" />
+    <Compile Include="Converters\FindMyMouseActivationShakeMouseIntToVisibilityConverter.cs" />
     <Compile Include="Converters\ImageResizerFitToStringConverter.cs" />
     <Compile Include="Converters\ImageResizerUnitToStringConverter.cs" />
     <Compile Include="Converters\UpdateStateToBoolConverter.cs" />

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -1825,6 +1825,12 @@ From there, simply click on one of the supported files in the File Explorer and 
     <value>Time before the spotlight appears (ms)</value>
     <comment>ms = milliseconds</comment>
   </data>
+  <data name="MouseUtils_FindMyMouse_ShakingMinimumDistance.Header" xml:space="preserve">
+    <value>Shake minimum distance</value>
+  </data>
+  <data name="MouseUtils_FindMyMouse_ShakingMinimumDistance.Description" xml:space="preserve">
+    <value>The minimum distance for mouse shaking activation, for adjusting sensitivity</value>
+  </data>
   <data name="MouseUtils_MouseHighlighter.Header" xml:space="preserve">
     <value>Mouse Highlighter</value>
     <comment>Refers to the utility name</comment>

--- a/src/settings-ui/Settings.UI/Views/MouseUtilsPage.xaml
+++ b/src/settings-ui/Settings.UI/Views/MouseUtilsPage.xaml
@@ -25,38 +25,46 @@
                             <ToggleSwitch IsOn="{x:Bind ViewModel.IsFindMyMouseEnabled, Mode=TwoWay}" x:Uid="ToggleSwitch"/>
                         </controls:Setting.ActionContent>
                     </controls:Setting>
-                    <controls:Setting x:Uid="MouseUtils_FindMyMouse_ActivationMethod" IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsFindMyMouseEnabled}">
-                        <controls:Setting.ActionContent>
-                            <ComboBox SelectedIndex="{x:Bind Path=ViewModel.FindMyMouseActivationMethod, Mode=TwoWay}" MinWidth="{StaticResource SettingActionControlMinWidth}">
-                                <ComboBoxItem x:Uid="MouseUtils_FindMyMouse_ActivationDoubleControlPress" />
-                                <ComboBoxItem x:Uid="MouseUtils_FindMyMouse_ActivationShakeMouse" />
-                            </ComboBox>
-                        </controls:Setting.ActionContent>
-                    </controls:Setting>
-                    <controls:Setting x:Uid="MouseUtils_FindMyMouse_ShakingMinimumDistance" Icon="&#xE847;" Visibility="{x:Bind Mode=OneWay, Path=ViewModel.FindMyMouseActivationMethod, Converter={StaticResource FindMyMouseActivationShakeMouseIntToVisibilityConverter}}">
-                        <controls:Setting.ActionContent>
-                            <muxc:NumberBox
-                                Minimum="0"
-                                Maximum="1000000"
-                                Value="{x:Bind Mode=TwoWay, Path=ViewModel.FindMyMouseShakingMinimumDistance}"
-                                MinWidth="{StaticResource SettingActionControlMinWidth}"
-                                SpinButtonPlacementMode="Compact"
-                                HorizontalAlignment="Left"
-                                SmallChange="100"
-                                LargeChange="1000"
-                            />
-                        </controls:Setting.ActionContent>
-                    </controls:Setting>
+                    <controls:SettingExpander IsEnabled="{x:Bind ViewModel.IsFindMyMouseEnabled, Mode=OneWay}" IsExpanded="True" >
+                        <controls:SettingExpander.Header>
+                            <controls:Setting x:Uid="MouseUtils_FindMyMouse_ActivationMethod"  Icon="&#xE961;" IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsFindMyMouseEnabled}">
+                                <controls:Setting.ActionContent>
+                                    <ComboBox SelectedIndex="{x:Bind Path=ViewModel.FindMyMouseActivationMethod, Mode=TwoWay}" MinWidth="{StaticResource SettingActionControlMinWidth}">
+                                        <ComboBoxItem x:Uid="MouseUtils_FindMyMouse_ActivationDoubleControlPress" />
+                                        <ComboBoxItem x:Uid="MouseUtils_FindMyMouse_ActivationShakeMouse" />
+                                    </ComboBox>
+                                </controls:Setting.ActionContent>
+                            </controls:Setting>
+                        </controls:SettingExpander.Header>
+                        <controls:SettingExpander.Content>
+                            <StackPanel>
+                                <controls:Setting x:Uid="MouseUtils_FindMyMouse_ShakingMinimumDistance"  Style="{StaticResource ExpanderContentSettingStyle}" Visibility="{x:Bind Mode=OneWay, Path=ViewModel.FindMyMouseActivationMethod, Converter={StaticResource FindMyMouseActivationShakeMouseIntToVisibilityConverter}}">
+                                    <controls:Setting.ActionContent>
+                                        <muxc:NumberBox
+                                            Minimum="0"
+                                            Maximum="1000000"
+                                            Value="{x:Bind Mode=TwoWay, Path=ViewModel.FindMyMouseShakingMinimumDistance}"
+                                            MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                            SpinButtonPlacementMode="Compact"
+                                            HorizontalAlignment="Left"
+                                            SmallChange="100"
+                                            LargeChange="1000"
+                                        />
+                                    </controls:Setting.ActionContent>
+                                </controls:Setting>
+                                <CheckBox x:Uid="MouseUtils_Prevent_Activation_On_Game_Mode"
+                                          IsChecked="{x:Bind ViewModel.FindMyMouseDoNotActivateOnGameMode, Mode=TwoWay}"
+                                          Margin="{StaticResource ExpanderSettingMargin}"
+                                          IsEnabled="{x:Bind ViewModel.IsFindMyMouseEnabled, Mode=OneWay}" />
+                            </StackPanel>
+                        </controls:SettingExpander.Content>
+                    </controls:SettingExpander>
                     <controls:SettingExpander IsEnabled="{x:Bind ViewModel.IsFindMyMouseEnabled, Mode=OneWay}" IsExpanded="False" >
                         <controls:SettingExpander.Header>
                             <controls:Setting x:Uid="ShortcutGuide_Appearance_Behavior" Icon="&#xE790;" />
                         </controls:SettingExpander.Header>
                         <controls:SettingExpander.Content>
                             <StackPanel>
-                                <CheckBox x:Uid="MouseUtils_Prevent_Activation_On_Game_Mode"
-                                          IsChecked="{x:Bind ViewModel.FindMyMouseDoNotActivateOnGameMode, Mode=TwoWay}"
-                                          Margin="{StaticResource ExpanderSettingMargin}"
-                                          IsEnabled="{x:Bind ViewModel.IsFindMyMouseEnabled, Mode=OneWay}" />
                                 <controls:Setting x:Uid="MouseUtils_FindMyMouse_OverlayOpacity" IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsFindMyMouseEnabled}" Style="{StaticResource ExpanderContentSettingStyle}">
                                     <controls:Setting.ActionContent>
                                         <Slider Minimum="1"

--- a/src/settings-ui/Settings.UI/Views/MouseUtilsPage.xaml
+++ b/src/settings-ui/Settings.UI/Views/MouseUtilsPage.xaml
@@ -7,8 +7,11 @@
     mc:Ignorable="d"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     xmlns:controls="using:Microsoft.PowerToys.Settings.UI.Controls"
+    xmlns:localConverters="using:Microsoft.PowerToys.Settings.UI.Converters"
     AutomationProperties.LandmarkType="Main">
-
+    <Page.Resources>
+        <localConverters:FindMyMouseActivationShakeMouseIntToVisibilityConverter x:Key="FindMyMouseActivationShakeMouseIntToVisibilityConverter"/>
+    </Page.Resources>
     <controls:SettingsPageControl x:Uid="MouseUtils"
                                   ModuleImageSource="ms-appx:///Assets/Modules/MouseUtils.png">
         <controls:SettingsPageControl.ModuleContent>
@@ -28,6 +31,20 @@
                                 <ComboBoxItem x:Uid="MouseUtils_FindMyMouse_ActivationDoubleControlPress" />
                                 <ComboBoxItem x:Uid="MouseUtils_FindMyMouse_ActivationShakeMouse" />
                             </ComboBox>
+                        </controls:Setting.ActionContent>
+                    </controls:Setting>
+                    <controls:Setting x:Uid="MouseUtils_FindMyMouse_ShakingMinimumDistance" Icon="&#xE847;" Visibility="{x:Bind Mode=OneWay, Path=ViewModel.FindMyMouseActivationMethod, Converter={StaticResource FindMyMouseActivationShakeMouseIntToVisibilityConverter}}">
+                        <controls:Setting.ActionContent>
+                            <muxc:NumberBox
+                                Minimum="0"
+                                Maximum="1000000"
+                                Value="{x:Bind Mode=TwoWay, Path=ViewModel.FindMyMouseShakingMinimumDistance}"
+                                MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                SpinButtonPlacementMode="Compact"
+                                HorizontalAlignment="Left"
+                                SmallChange="100"
+                                LargeChange="1000"
+                            />
                         </controls:Setting.ActionContent>
                     </controls:Setting>
                     <controls:SettingExpander IsEnabled="{x:Bind ViewModel.IsFindMyMouseEnabled, Mode=OneWay}" IsExpanded="False" >


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Some users report find my mouse shaking activation being too sensitive.
This adds a setting so that there's a configurable minimum distance travelled for activation.

**What is included in the PR:** 
Logic for only activating Find My Mouse if the distance considering for detecting the shake is greater than a configurable distance.
Setting that only appears in settings if the activation method is "Shake mouse".
![image](https://user-images.githubusercontent.com/26118718/156614322-9dfea112-a230-4569-84a5-18633e9d3c1a.png)

**How does someone test / validate:** 
Play with the setting and see if it's applying. Higher values should make it harder to activate Find My Mouse.

## Quality Checklist

- [x] **Linked issue:** #16669 
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries
