### PR TITLE
[Installer]Include PTRun WindowsTerminal loc

### DIFF
--- a/installer/PowerToysSetup/Product.wxs
+++ b/installer/PowerToysSetup/Product.wxs
@@ -475,6 +475,7 @@
                                 </Directory>
                                 <Directory Id="WindowsTerminalPluginFolder" Name="WindowsTerminal">
                                     <Directory Id="WindowsTerminalImagesFolder" Name="Images" />
+                                    <Directory Id="WindowsTerminalLanguagesFolder" Name="Languages" />
                                 </Directory>
                                 <Directory Id="SystemPluginFolder" Name="System">
                                     <Directory Id="SystemImagesFolder" Name="Images" />

--- a/installer/PowerToysSetup/Product.wxs
+++ b/installer/PowerToysSetup/Product.wxs
@@ -1347,14 +1347,12 @@
                 Directory="Resource$(var.IdSafeLanguage)TimeZonePluginFolder">
                 <File Id="Launcher_TimeZone_$(var.IdSafeLanguage)_File" Source="$(var.BinX64Dir)modules\launcher\Plugins\TimeZone\$(var.Language)\Microsoft.PowerToys.Run.Plugin.TimeZone.resources.dll" />
             </Component>
-            <!-- Uncomment after Plugin receives the localization files.
-                <Component 
-                    Id="Launcher_WindowsTerminal_$(var.IdSafeLanguage)_Component" 
-                    Guid="$(var.CompGUIDPrefix)15"                
-                    Directory="Resource$(var.IdSafeLanguage)WindowsTerminalFolder">
-                    <File Id="Launcher_WindowsTerminal_$(var.IdSafeLanguage)_File" Source="$(var.BinX64Dir)modules\launcher\Plugins\WindowsTerminal\$(var.Language)\Microsoft.PowerToys.Run.Plugin.WindowsTerminal.resources.dll" />
-                </Component>
-                -->
+            <Component
+                Id="Launcher_WindowsTerminal_$(var.IdSafeLanguage)_Component"
+                Guid="$(var.CompGUIDPrefix)15"
+                Directory="Resource$(var.IdSafeLanguage)WindowsTerminalFolder">
+                <File Id="Launcher_WindowsTerminal_$(var.IdSafeLanguage)_File" Source="$(var.BinX64Dir)modules\launcher\Plugins\WindowsTerminal\$(var.Language)\Microsoft.PowerToys.Run.Plugin.WindowsTerminal.resources.dll" />
+            </Component>
             <?undef IdSafeLanguage?>
             <?undef CompGUIDPrefix?>
             <?endforeach?>


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Installer is not including localization resources for the Windows Terminal plugin.

**What is included in the PR:** 
Uncomment the installer instructions that will include localization for the plugin.

**How does someone test / validate:** 
Let's wait for a CI Build and see if it localizes the plugin.

## Quality Checklist

- [x] **Linked issue:** #16712
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [x] **Installer:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [x] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
