### PR TITLE
[ci]fix windows terminal loc build

### DIFF
--- a/installer/PowerToysSetup/Product.wxs
+++ b/installer/PowerToysSetup/Product.wxs
@@ -1351,7 +1351,7 @@
             <Component
                 Id="Launcher_WindowsTerminal_$(var.IdSafeLanguage)_Component"
                 Guid="$(var.CompGUIDPrefix)15"
-                Directory="Resource$(var.IdSafeLanguage)WindowsTerminalFolder">
+                Directory="Resource$(var.IdSafeLanguage)WindowsTerminalPluginFolder">
                 <File Id="Launcher_WindowsTerminal_$(var.IdSafeLanguage)_File" Source="$(var.BinX64Dir)modules\launcher\Plugins\WindowsTerminal\$(var.Language)\Microsoft.PowerToys.Run.Plugin.WindowsTerminal.resources.dll" />
             </Component>
             <?undef IdSafeLanguage?>


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
https://github.com/microsoft/PowerToys/pull/16777 was missing a folder reference for localization, which broke release ci on main.

**What is included in the PR:** 
Fix the folder reference.

**How does someone test / validate:** 
No way here really, release CI succeeds.

## Quality Checklist

- [x] **Linked issue:** #16712 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [x] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
