### PR TITLE
[Installer]Enable Web Search plugin localization

### DIFF
--- a/installer/PowerToysSetup/Product.wxs
+++ b/installer/PowerToysSetup/Product.wxs
@@ -1356,6 +1356,12 @@
                 Directory="Resource$(var.IdSafeLanguage)WindowsTerminalPluginFolder">
                 <File Id="Launcher_WindowsTerminal_$(var.IdSafeLanguage)_File" Source="$(var.BinX64Dir)modules\launcher\Plugins\WindowsTerminal\$(var.Language)\Microsoft.PowerToys.Run.Plugin.WindowsTerminal.resources.dll" />
             </Component>
+            <Component
+                Id="Launcher_WebSearch_$(var.IdSafeLanguage)_Component"
+                Guid="$(var.CompGUIDPrefix)16"
+                Directory="Resource$(var.IdSafeLanguage)WebSearchPluginFolder">
+                <File Id="Launcher_WebSearch_$(var.IdSafeLanguage)_File" Source="$(var.BinX64Dir)modules\launcher\Plugins\WebSearch\$(var.Language)\Community.PowerToys.Run.Plugin.WebSearch.resources.dll" />
+            </Component>
             <?undef IdSafeLanguage?>
             <?undef CompGUIDPrefix?>
             <?endforeach?>


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
WebSearch plugin in PowerToys Run isn't localized on releases.

**What is included in the PR:** 
Add localization files to the installer.

**How does someone test / validate:** 
CI builds. I've verified the plugin is localized now. If you have access to the release CI pipelines, you can test the installer as well and verify the plugin is now localized.

## Quality Checklist

- [x] **Linked issue:** #16675
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [x] **Installer:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [x] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
