### PR TITLE
spelling: Ignore .pipelines/ESRPSigning_core.json

### DIFF
--- a/.github/actions/spell-check/excludes.txt
+++ b/.github/actions/spell-check/excludes.txt
@@ -51,3 +51,4 @@ ignore$
 ^\.gitmodules$
 (?:^|/)WindowsSettings\.json$
 (?:^|/)timezones\.json$
+^\Q.pipelines/ESRPSigning_core.json\E$


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Fixes #15753

**What is included in the PR:** 

* Adds excludes entry for `.pipelines/ESRPSigning_core.json`

**How does someone test / validate:** 

* Look for a ✅ . 
* The log should show check-spelling is checking one fewer file than it was previously checked:
    ```diff
    -Checking 2143 files
    +Checking 2142 files
    ```

## Quality Checklist

- [x] **Linked issue:** #15753
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [x] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
