### PR TITLE
[Settings] Do not try to apply profile settings if there was a timeout

### DIFF
--- a/src/settings-ui/Settings.UI.Library/ViewModels/KeyboardManagerViewModel.cs
+++ b/src/settings-ui/Settings.UI.Library/ViewModels/KeyboardManagerViewModel.cs
@@ -273,22 +273,34 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
                     }
                 });
 
-                t.Wait(1000, ts.Token);
+                var completedInTime = t.Wait(3000, ts.Token);
                 ts.Cancel();
                 ts.Dispose();
 
-                if (!readSuccessfully)
+                if (readSuccessfully)
+                {
+                    FilterRemapKeysList(_profile?.RemapKeys?.InProcessRemapKeys);
+                }
+                else
                 {
                     success = false;
                 }
 
-                FilterRemapKeysList(_profile?.RemapKeys?.InProcessRemapKeys);
+                if (!completedInTime)
+                {
+                    Logger.LogError($"Timeout encountered when loading {PowerToyName} profile");
+                }
             }
             catch (Exception e)
             {
                 // Failed to load the configuration.
                 Logger.LogError($"Exception encountered when loading {PowerToyName} profile", e);
                 success = false;
+            }
+
+            if (!success)
+            {
+                Logger.LogError($"Couldn't load {PowerToyName} profile");
             }
 
             return success;

--- a/src/settings-ui/Settings.UI/Views/KeyboardManagerPage.xaml.cs
+++ b/src/settings-ui/Settings.UI/Views/KeyboardManagerPage.xaml.cs
@@ -80,10 +80,13 @@ namespace Microsoft.PowerToys.Settings.UI.Views
 
         private int FilterRemapKeysList(List<KeysDataModel> remapKeysList)
         {
-            CombineRemappings(remapKeysList, (uint)VirtualKey.LeftControl, (uint)VirtualKey.RightControl, (uint)VirtualKey.Control);
-            CombineRemappings(remapKeysList, (uint)VirtualKey.LeftMenu, (uint)VirtualKey.RightMenu, (uint)VirtualKey.Menu);
-            CombineRemappings(remapKeysList, (uint)VirtualKey.LeftShift, (uint)VirtualKey.RightShift, (uint)VirtualKey.Shift);
-            CombineRemappings(remapKeysList, (uint)VirtualKey.LeftWindows, (uint)VirtualKey.RightWindows, Helper.VirtualKeyWindows);
+            if (remapKeysList != null)
+            {
+                CombineRemappings(remapKeysList, (uint)VirtualKey.LeftControl, (uint)VirtualKey.RightControl, (uint)VirtualKey.Control);
+                CombineRemappings(remapKeysList, (uint)VirtualKey.LeftMenu, (uint)VirtualKey.RightMenu, (uint)VirtualKey.Menu);
+                CombineRemappings(remapKeysList, (uint)VirtualKey.LeftShift, (uint)VirtualKey.RightShift, (uint)VirtualKey.Shift);
+                CombineRemappings(remapKeysList, (uint)VirtualKey.LeftWindows, (uint)VirtualKey.RightWindows, Helper.VirtualKeyWindows);
+            }
 
             return 0;
         }


### PR DESCRIPTION
## Summary of the Pull Request
- increase the timeout value to read the settings
- more logging
- more null handling
**What is this about:**

**What is included in the PR:** 

**How does someone test / validate:** 
make sure your KBM settings are still loaded and applied correctly
## Quality Checklist

- [x] **Linked issue:** #16537
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
