### PR TITLE
[Installer]Enable Unit Converter plugin localization

### DIFF
--- a/installer/PowerToysSetup/Product.wxs
+++ b/installer/PowerToysSetup/Product.wxs
@@ -1362,6 +1362,12 @@
                 Directory="Resource$(var.IdSafeLanguage)WebSearchPluginFolder">
                 <File Id="Launcher_WebSearch_$(var.IdSafeLanguage)_File" Source="$(var.BinX64Dir)modules\launcher\Plugins\WebSearch\$(var.Language)\Community.PowerToys.Run.Plugin.WebSearch.resources.dll" />
             </Component>
+            <Component
+                Id="Launcher_UnitConverter_$(var.IdSafeLanguage)_Component"
+                Guid="$(var.CompGUIDPrefix)17"
+                Directory="Resource$(var.IdSafeLanguage)UnitConverterPluginFolder">
+                <File Id="Launcher_UnitConverter_$(var.IdSafeLanguage)_File" Source="$(var.BinX64Dir)modules\launcher\Plugins\UnitConverter\$(var.Language)\Community.PowerToys.Run.Plugin.UnitConverter.resources.dll" />
+            </Component>
             <?undef IdSafeLanguage?>
             <?undef CompGUIDPrefix?>
             <?endforeach?>


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
UniConverter plugin in PowerToys Run isn't localized on releases.

**What is included in the PR:** 
Add localization files to the installer.

**How does someone test / validate:** 
CI builds. I've verified the plugin is localized now. If you have access to the release CI pipelines, you can test the installer as well and verify the plugin is now localized.
Attention: units are not localized yet.

## Quality Checklist

- [x] **Linked issue:** #16943
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [x] **Installer:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries
