### PR TITLE
[PTRun][Calculator]Always accept decimal point

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/NumberTranslator.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/NumberTranslator.cs
@@ -88,7 +88,14 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
 
         private static Regex GetSplitRegex(CultureInfo culture)
         {
-            var splitPattern = $"((?:\\d|{Regex.Escape(culture.NumberFormat.NumberDecimalSeparator)}";
+            // HACK: Specifically adding the decimal point here since some people expect that to work everywhere.
+            // This allows avoiding some unexpected errors users are getting when . is not part of the number representation.
+            // Users were getting errors where leading zeros were being removed from the decimal part of numbers like 56.0002.
+            // 56.0002 would be transformed into 56.2 due to it being translated as two different numbers and this would be accepted into the engine.
+            // Now, even if . is not part of the culture representation, users won't hit this error since the number will
+            // be passed as is to the calculator engine.
+            // This shouldn't add any regressions into accepted strings while it will have a behavior the users expect.
+            var splitPattern = $"((?:\\d|\\.|{Regex.Escape(culture.NumberFormat.NumberDecimalSeparator)}";
             if (!string.IsNullOrEmpty(culture.NumberFormat.NumberGroupSeparator))
             {
                 splitPattern += $"|{Regex.Escape(culture.NumberFormat.NumberGroupSeparator)}";


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Users expect to be able to use decimal points `.` in Calculator, even if their system is configured with another decimal separator character.
Our translation of the user current locale into Mages numbers removes leading zeroes, leading to some calculation errors as can be seen in the linked issue.

**What is included in the PR:** 
Accept `.` as part of the number before translation, so that we don't end up removing leading zeroes from the decimal point of a number the user expects to work well.

**How does someone test / validate:** 
In a locale without `.` as either the decimal serparator or number group separator, try to use numbers with `.0` in the decimal part and verify the calculation is correct.
For example, `1.449*51.06` should result in `73.98594` and not `74.7684`.

## Quality Checklist

- [x] **Linked issue:** #12375
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
