### PR TITLE
[PTRun] [UnitConverter] Unit Converter should recognize metre

### DIFF
--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/InputInterpreter.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/InputInterpreter.cs
@@ -169,6 +169,22 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
         }
 
         /// <summary>
+        /// Converts spelling "metre" to "meter"
+        /// </summary>
+        public static void MetreToMeter(ref string[] split)
+        {
+            if (split[1].ToLower() == "metre")
+            {
+                split[1] = "meter";
+            }
+
+            if (split[3].ToLower() == "metre")
+            {
+                split[3] = "meter";
+            }
+        }
+
+        /// <summary>
         /// Choose "UsGallon" or "ImperialGallon" according to current culture when the input contains "gal" or "gallon".
         /// </summary>
         public static void GallonHandler(ref string[] split, CultureInfo culture)
@@ -215,6 +231,7 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
             }
 
             InputInterpreter.DegreePrefixer(ref split);
+            InputInterpreter.MetreToMeter(ref split);
             InputInterpreter.FeetToFt(ref split);
             InputInterpreter.GallonHandler(ref split, CultureInfo.CurrentCulture);
             if (!double.TryParse(split[0], out double value))


### PR DESCRIPTION
## Summary of the Pull Request
**What is this about:** Users expect to be able to use both meter and metre spelling as can be seen in the linked issue.

**What is included in the PR:** Unit `metre` will be automatically converted to `meter`.

**How does someone test / validate:**
1. run PowerToys with enabled PT Run
2. open PT Run dialog
3. type` %% 1 metre to inch`
4. check result showing `39,3701 inch`
5. change input to `%% 1 meter to inch`
6. check result showing the same `39,3701 inch`

## Quality Checklist
* [x]  **Linked issue:** [PTRun] [UnitConverter] Unit Converter should recognise metre #16693
* [ ]  **Communication:** I've discussed this with core contributors in the issue.
* [ ]  **Tests:** Added/updated and all pass
* [ ]  **Installer:** Added/updated and all pass
* [ ]  **Localization:** All end user facing strings can be localized
* [ ]  **Docs:** Added/ updated
* [ ] * [x]  **Binaries:** Any new files are added to WXS / YML
  
  * [x]  No new binaries
  * [ ]  [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
  * [ ]  [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.