### PR TITLE
[Installer]Upgrade .net framework to 6.0.3

### DIFF
--- a/installer/PowerToysSetup/PowerToys.wxs
+++ b/installer/PowerToysSetup/PowerToys.wxs
@@ -21,7 +21,7 @@
         </BootstrapperApplicationRef>
 
         <util:FileSearch Variable="HasDotnet3122" Path="[ProgramFiles64Folder]dotnet\shared\Microsoft.WindowsDesktop.App\3.1.22\System.Xaml.dll" Result="exists" />
-        <util:FileSearch Variable="HasDotnet602" Path="[ProgramFiles64Folder]dotnet\shared\Microsoft.WindowsDesktop.App\6.0.2\System.Xaml.dll" Result="exists" />
+        <util:FileSearch Variable="HasDotnet603" Path="[ProgramFiles64Folder]dotnet\shared\Microsoft.WindowsDesktop.App\6.0.3\System.Xaml.dll" Result="exists" />
         <util:RegistrySearch Variable="HasWebView2PerMachine" Root="HKLM" Key="SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}" Result="exists" />
         <util:RegistrySearch Variable="HasWebView2PerUser" Root="HKCU" Key="Software\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}" Result="exists" />
 
@@ -60,11 +60,11 @@
                     Hash="08EF2F6CFDB33946061884B1CE13FA867EFBD576" />
             </ExePackage>
             <ExePackage
-                Name="windowsdesktop-runtime-6.0.2-win-x64.exe"
+                Name="windowsdesktop-runtime-6.0.3-win-x64.exe"
                 Compressed="no"
                 Id="DotnetRuntime6"
-                DetectCondition="HasDotnet602"
-                DownloadUrl="https://download.visualstudio.microsoft.com/download/pr/efa32b7a-6eec-4d97-9cdc-c7336a29a749/3df4296170397cf60884dae1be3d103b/windowsdesktop-runtime-6.0.2-win-x64.exe"
+                DetectCondition="HasDotnet603"
+                DownloadUrl="https://download.visualstudio.microsoft.com/download/pr/7f3a766e-9516-4579-aaf2-2b150caa465c/d57665f880cdcce816b278a944092965/windowsdesktop-runtime-6.0.3-win-x64.exe"
                 InstallCommand="/install /quiet /norestart"
                 RepairCommand="/repair /passive /norestart"
                 Permanent="yes"
@@ -72,11 +72,11 @@
                 UninstallCommand="/uninstall /quiet /norestart">
                 <ExitCode Value="1638" Behavior="success"/>
                 <RemotePayload
-                    Description="Microsoft Windows Desktop Runtime - 6.0.2 (x64)"
-                    ProductName="Microsoft Windows Desktop Runtime - 6.0.2 (x64)"
-                    Size="57296456"
-                    Version="6.0.2.30914"
-                    Hash="EA8DB9D01555D0EA2A3D3CD41D56A28199A064F5" />
+                    Description="Microsoft Windows Desktop Runtime - 6.0.3 (x64)"
+                    ProductName="Microsoft Windows Desktop Runtime - 6.0.3 (x64)"
+                    Size="57153808"
+                    Version="6.0.3.31024"
+                    Hash="85EB71B760EBA108348824A4928ED2BA9775BE76" />
             </ExePackage>
             <ExePackage
                 Name="MicrosoftEdgeWebview2Setup.exe"

--- a/src/modules/launcher/PowerLauncher/ResultList.xaml
+++ b/src/modules/launcher/PowerLauncher/ResultList.xaml
@@ -190,7 +190,7 @@
                         Width="642" 
                         Background="Transparent"
                         ToolTipService.BetweenShowDelay="0"
-                        ToolTipService.InitialShowDelay="0">
+                        ToolTipService.InitialShowDelay="1000">
                         <Behaviors:Interaction.Triggers>
                             <Behaviors:EventTrigger EventName="MouseEnter">
                                 <Behaviors:InvokeCommandAction Command="{Binding ActivateContextButtonsHoverCommand}"/>


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Upgrade the .net framework installed with PowerToys to 6.0.3.

**What is included in the PR:** 
Update the installer information to download .net framework 6.0.3.
Revert the workaround for the bug the 6.0.3 release fixes.

**How does someone test / validate:** 
Install .net framework 6.0.3 (can be from the installer build from this PR).
Try to replicate https://github.com/microsoft/PowerToys/issues/16624. It shouldn't replicate.

## Quality Checklist

- [x] **Linked issue:** #16646 #16624
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [x] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries
