### PR TITLE
[Setup] Use custom prefix for WiX bootstrapper logs and collect them …

### DIFF
--- a/installer/PowerToysSetup/PowerToys.wxs
+++ b/installer/PowerToysSetup/PowerToys.wxs
@@ -27,6 +27,8 @@
 
         <Variable Name="InstallFolder" Type="string" Value="[ProgramFiles64Folder]PowerToys" bal:Overridable="yes"/>
 
+        <Variable Name="MsiLogFolder" Type="string" Value="[LocalAppDataFolder]\Microsoft\PowerToys\" /> 
+        <Log Disable="no" Prefix='powertoys-bootstrapper-msi-$(var.Version)' Extension=".log" />
 
       <!-- Only install/upgrade if the version is greater or equal than the currently installed version of PowerToys, to handle the case in which PowerToys was installed from old MSI (before WiX bootstrapper was used) -->
       <!-- If the previous installation is a bundle installation, just let WiX run its logic. -->


### PR DESCRIPTION
…via BugReportTool

## Summary of the Pull Request

**What is this about:**
- Using [`LogPathVariable`](https://wixtoolset.org/documentation/manual/v3/xsd/wix/msipackage.html) doesn't change the actual log location, since it's being overridden by WiX bootstrapper. And it [doesn't provide](https://stackoverflow.com/questions/37850149/how-to-change-the-logs-path-in-wix-extended-bootstrapper-application) [a way](https://stackoverflow.com/questions/38249881/wix-toolset-default-logging-file-location) to change default logging location. Setting `Disable="yes"` also didn't have any effect.
- Therefore, to collect both MSI and WiX installer logs, we collect them using BugReportTool

**How does someone test / validate:** 
- build the installer
- run the bugreport tool
- make sure the logs are in the report .zip file
## Quality Checklist

- [x] **Linked issue:** #16862
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
