### PR TITLE
Add common csproj/vcxproj settings to Directory.Build.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,18 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project>
+
+  <PropertyGroup>
+    <Copyright>Copyright (C) 2022 Microsoft Corporation</Copyright>
+    <AssemblyCompany>Microsoft Corp.</AssemblyCompany>
+    <AssemblyCopyright>Copyright (C) 2022 Microsoft Corporation</AssemblyCopyright>
+    <AssemblyProduct>PowerToys</AssemblyProduct>
+    <Company>Microsoft Corp.</Company>
+    <Product>PowerToys</Product>
+    <NeutralLanguage>en-US</NeutralLanguage>
+    <!--<Version>$(Version).0</Version>-->
+    <Platforms>x64</Platforms>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisMode>Recommended</AnalysisMode>
+  </PropertyGroup>
 
   <PropertyGroup>
     <_PropertySheetDisplayName>PowerToys.Root.Props</_PropertySheetDisplayName>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,10 +5,8 @@
     <AssemblyCompany>Microsoft Corp.</AssemblyCompany>
     <AssemblyCopyright>Copyright (C) 2022 Microsoft Corporation</AssemblyCopyright>
     <AssemblyProduct>PowerToys</AssemblyProduct>
-    <Company>Microsoft Corp.</Company>
-    <Product>PowerToys</Product>
+    <Company>Microsoft Corporation</Company>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <!--<Version>$(Version).0</Version>-->
     <Platforms>x64</Platforms>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisMode>Recommended</AnalysisMode>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,8 +14,13 @@
     <AnalysisMode>Recommended</AnalysisMode>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(MSBuildProjectExtension)' == '.csproj'">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
   <PropertyGroup>
     <_PropertySheetDisplayName>PowerToys.Root.Props</_PropertySheetDisplayName>
     <ForceImportBeforeCppProps>$(MsbuildThisFileDirectory)\Cpp.Build.props</ForceImportBeforeCppProps>
   </PropertyGroup>
+
 </Project>

--- a/PowerToys.sln
+++ b/PowerToys.sln
@@ -175,6 +175,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		src\.editorconfig = src\.editorconfig
 		.vsconfig = .vsconfig
+		Directory.Build.props = Directory.Build.props
 		Solution.props = Solution.props
 	EndProjectSection
 EndProject

--- a/src/modules/imageresizer/tests/ImageResizerUITest.csproj
+++ b/src/modules/imageresizer/tests/ImageResizerUITest.csproj
@@ -8,28 +8,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ImageResizer</RootNamespace>
     <AssemblyName>ImageResizer.Test</AssemblyName>
-    <AssemblyCompany>Microsoft Corp.</AssemblyCompany>
-    <AssemblyCopyright>Copyright (C) 2022 Microsoft Corp.</AssemblyCopyright>
     <Version>$(Version).0</Version>
     <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\modules\ImageResizer\$(AssemblyName)\</OutputPath>
-    <CodeAnalysisRuleSet>..\..\..\codeAnalysis\Rules.ruleset</CodeAnalysisRuleSet>
-    <Platforms>x64</Platforms>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <Platform Condition="'$(Platform)'==''">x64</Platform>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IntermediateOutputPath>$(SolutionDir)$(Platform)\$(Configuration)\obj\$(AssemblyName)\</IntermediateOutputPath>
-    <EnableNETAnalyzers>true</EnableNETAnalyzers>
-    <AnalysisMode>Recommended</AnalysisMode>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup>
   <ItemGroup>
     <None Remove="TestMetadataIssue1928.jpg" />
     <None Remove="TestMetadataIssue1928_NoMetadata.jpg" />

--- a/src/modules/imageresizer/ui/ImageResizerUI.csproj
+++ b/src/modules/imageresizer/ui/ImageResizerUI.csproj
@@ -3,44 +3,31 @@
   
   <PropertyGroup>
     <AssemblyTitle>PowerToys.ImageResizer</AssemblyTitle>
-    <AssemblyCompany>Microsoft Corp.</AssemblyCompany>
-    <AssemblyCopyright>Copyright (C) 2022 Microsoft Corp.</AssemblyCopyright>
-    <CodeAnalysisRuleSet>..\..\..\codeAnalysis\Rules.ruleset</CodeAnalysisRuleSet>
     <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\modules\ImageResizer</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <UseWPF>true</UseWPF>
-    <Platforms>x64</Platforms>
   </PropertyGroup>
   
   <PropertyGroup>
-    <Platform Condition="'$(Platform)'==''">x64</Platform>
     <ProjectGuid>{2BE46397-4DFA-414C-9BD4-41E4BBF8CB34}</ProjectGuid>
     <OutputType>WinExe</OutputType>
     <RootNamespace>ImageResizer</RootNamespace>
     <AssemblyName>PowerToys.ImageResizer</AssemblyName>
     <TargetFramework>net6.0-windows10.0.18362.0</TargetFramework>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IntermediateOutputPath>$(SolutionDir)$(Platform)\$(Configuration)\obj\$(AssemblyName)\</IntermediateOutputPath>
-    <EnableNETAnalyzers>true</EnableNETAnalyzers>
-    <AnalysisMode>Recommended</AnalysisMode>
   </PropertyGroup>
   
   <PropertyGroup>
     <ApplicationIcon>Resources\ImageResizer.ico</ApplicationIcon>
-    <NeutralLanguage>en-US</NeutralLanguage>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Optimize>true</Optimize>
-    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Optimize>false</Optimize>
-    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder.UnitTests/DriveOrSharedFolderTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder.UnitTests/DriveOrSharedFolderTests.cs
@@ -93,11 +93,11 @@ namespace Microsoft.Plugin.Folder.UnitTests
             // Assert
             if (hasValues)
             {
-                Assert.IsTrue(results.Count() > 0);
+                Assert.IsTrue(results.Any());
             }
             else
             {
-                Assert.IsTrue(results.Count() == 0);
+                Assert.IsFalse(results.Any());
             }
         }
     }

--- a/src/modules/previewpane/UnitTests-GcodePreviewHandler/GcodePreviewHandlerTest.cs
+++ b/src/modules/previewpane/UnitTests-GcodePreviewHandler/GcodePreviewHandlerTest.cs
@@ -16,6 +16,7 @@ using Moq;
 namespace GcodePreviewHandlerUnitTests
 {
     [STATestClass]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2201:Do not raise reserved exception types", Justification = "new Exception() is fine in test projects.")]
     public class GcodePreviewHandlerTest
     {
         [TestMethod]

--- a/src/modules/previewpane/UnitTests-PdfPreviewHandler/PdfPreviewHandlerTest.cs
+++ b/src/modules/previewpane/UnitTests-PdfPreviewHandler/PdfPreviewHandlerTest.cs
@@ -16,6 +16,7 @@ using Moq;
 namespace PdfPreviewHandlerUnitTests
 {
     [STATestClass]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2201:Do not raise reserved exception types", Justification = "new Exception() is fine in test projects.")]
     public class PdfPreviewHandlerTest
     {
         [TestMethod]

--- a/src/modules/previewpane/UnitTests-SvgPreviewHandler/SvgPreviewControlTests.cs
+++ b/src/modules/previewpane/UnitTests-SvgPreviewHandler/SvgPreviewControlTests.cs
@@ -17,6 +17,7 @@ using PreviewHandlerCommon;
 namespace SvgPreviewHandlerUnitTests
 {
     [STATestClass]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2201:Do not raise reserved exception types", Justification = "new Exception() is fine in test projects.")]
     public class SvgPreviewControlTests
     {
         [TestMethod]


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
- Add common csproj/vcxproj settings to `Directory.Build.props`
  - Contains Copyright, Company, Product name, NeutralLanguage
  - Enable NET Analyzers (This will enable it for by default for all modules, no need for a hint in the PR Template)
    - I expect that this will make some warnings in vcxproj projects visible. Not a problem since `TreatWarningsAsErrors` is usually turn off there
    - Enable `TreatWarningsAsErrors` for csproj files
  - Those settings in `Directory.Build.props` can be removed from the csproj/vcxproj.
    - I can do this, just want to know what you think about this
  - Settings a value (e.g. Copyright) in the csproj/vcxproj will override the value from `Directory.Build.props`
- Changed `ImageResizerUI.csproj` and `ImageResizerUITest.csproj` as proof of concept

**How does someone test / validate:** 
Left: current main branch (original) | Right: branch CleanCodeDeveloper:Add-global-csproj-settings (this PR)
![image](https://user-images.githubusercontent.com/16760760/158887335-b5d3c39a-b25b-4ba4-894e-f7774cfdecf2.png)

## Quality Checklist

- [x] **Linked issue:** #16423
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
