### PR TITLE
[SvgThumbnail]Register as a picture kind

### DIFF
--- a/src/common/utils/modulesRegistry.h
+++ b/src/common/utils/modulesRegistry.h
@@ -155,7 +155,8 @@ inline registry::ChangeSet getSvgThumbnailHandlerChangeSet(const std::wstring in
                                   registry::DOTNET_COMPONENT_CATEGORY_CLSID,
                                   L"Microsoft.PowerToys.ThumbnailHandler.Svg.SvgThumbnailProvider",
                                   L"Svg Thumbnail Provider",
-                                  NonLocalizable::ExtSVG);
+                                  NonLocalizable::ExtSVG,
+                                  L"Picture");
 }
 
 inline registry::ChangeSet getPdfThumbnailHandlerChangeSet(const std::wstring installationDir, const bool perUser)

--- a/src/common/utils/registry.h
+++ b/src/common/utils/registry.h
@@ -69,9 +69,10 @@ namespace registry
         std::wstring path;
         std::optional<std::wstring> name; // none == default
         value_t value;
+        bool required = true;
 
-        ValueChange(const HKEY scope, std::wstring path, std::optional<std::wstring> name, value_t value) :
-            scope{ scope }, path{ std::move(path) }, name{ std::move(name) }, value{ std::move(value) }
+        ValueChange(const HKEY scope, std::wstring path, std::optional<std::wstring> name, value_t value, bool required = true) :
+            scope{ scope }, path{ std::move(path) }, name{ std::move(name) }, value{ std::move(value) }, required{ required }
         {
         }
 
@@ -268,7 +269,7 @@ namespace registry
         {
             for (const auto& c : changes)
             {
-                if (!c.isApplied())
+                if (c.required && !c.isApplied())
                 {
                     return false;
                 }
@@ -281,7 +282,7 @@ namespace registry
             bool ok = true;
             for (const auto& c : changes)
             {
-                ok = c.apply() && ok;
+                ok = (c.apply()||!c.required) && ok;
             }
             return ok;
         }
@@ -291,7 +292,7 @@ namespace registry
             bool ok = true;
             for (const auto& c : changes)
             {
-                ok = c.unApply() && ok;
+                ok = (c.unApply()||!c.required) && ok;
             }
             return ok;
         }
@@ -317,7 +318,8 @@ namespace registry
                                                           std::wstring handlerCategory,
                                                           std::wstring className,
                                                           std::wstring displayName,
-                                                          std::vector<std::wstring> fileTypes)
+                                                          std::vector<std::wstring> fileTypes,
+                                                          std::wstring fileKindType = L"" )
         {
             const HKEY scope = perUser ? HKEY_CURRENT_USER : HKEY_LOCAL_MACHINE;
 
@@ -369,6 +371,13 @@ namespace registry
                 fileAssociationPath += L"\\shellex\\";
                 fileAssociationPath += handlerType == PreviewHandlerType::preview ? IPREVIEW_HANDLER_CLSID : ITHUMBNAIL_PROVIDER_CLSID;
                 changes.push_back({ scope, fileAssociationPath, std::nullopt, handlerClsid });
+                if (!fileKindType.empty())
+                {
+                    // Registering a file type as a kind needs to be done at the HKEY_LOCAL_MACHINE level.
+                    // Make it optional as well so that we don't fail registering the handler if we can't write to HKEY_LOCAL_MACHINE.
+                    std::wstring kindMapPath = L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\KindMap";
+                    changes.push_back({ HKEY_LOCAL_MACHINE, kindMapPath, fileType, fileKindType, false});
+                }
             }
 
             if (handlerType == PreviewHandlerType::preview)


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Since we're treating svg files as an image when we add the "picture" kind so that the files can be found when searching / filtering for pictures. This needs to be done at the HKEY_LOCAL_MACHINE level.

**What is included in the PR:** 
- Add file kind argument to the powerpreview handlers changeset.
- Add a required field to the changes, so that some changes may not be considered vital.
- Add the Picture kind to the .svg file type.

**How does someone test / validate:** 
Disable and re-enable SVG thumbnail while running PowerToys as admin. In file explorer search in the PowerToys repo root for "kind:picture" and verify svg files appear. (Explorer restart might be needed)

## Quality Checklist

- [x] **Linked issue:** #16048 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries
