### PR TITLE
[PTRun]Fix focus glitch on first time run

### DIFF
--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -205,6 +205,10 @@ namespace PowerLauncher
                     UpdatePosition();
                     BringProcessToForeground();
 
+                    // HACK: Setting focus here again fixes some focus issues, like on first run or after showing a message box.
+                    SearchBox.QueryTextBox.Focus();
+                    Keyboard.Focus(SearchBox.QueryTextBox);
+
                     if (!_viewModel.LastQuerySelected)
                     {
                         _viewModel.LastQuerySelected = true;


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
On some occasions, PowerToys Run still doesn't focus correctly. This fixes some of these.

**What is included in the PR:** 
Set focus to the query text box after sending the process to the foreground.
This fixes:
- Not focusing the first time PT Run runs on login.
- Not focusing after having just shown a message box.

**How does someone test / validate:** 
It's hard to replicate this. The most reliable way to replicate this has been:
1- Use the default key combination (Alt+Space) so that you're using a global hotkey.
2- In the PowerToys Run Windows System Commands plugin enable the option to "Show a dialog to confirm system commands".
3- Alt-Space to bring up PowerToys Run
4 - Type "sleep" and select the option to sleep.
5 - Select No in the confirmation dialog.
6 - Alt-Space to bring up PowerToys Run.
7 - Try to type something to confirm PowerToys Run has focus. Without this fix, it won't have focus. With this fix, it will have focus.

Another way I've been able to replicate some times is setting PowerToys to run as admin at system startup and pressing Alt-Space after logging in. Without this fix, it won't have focus. With this fix, it will have focus.

## Quality Checklist

- [x] **Linked issue:** #13643 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
