### PR TITLE
Add needs repro label to Bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -3,6 +3,7 @@ description: Report errors or unexpected behavior
 labels: 
 - Issue-Bug
 - Needs-Triage
+- Needs-Repro
 body:
 - type: markdown
   attributes:


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Add needs repro label to Bug report template to mark issues that need repros. 

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
