### PR TITLE
[PTRun][Program]Fix bug when renaming url shortcut

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program.UnitTests/Storage/Win32ProgramRepositoryTest.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program.UnitTests/Storage/Win32ProgramRepositoryTest.cs
@@ -352,10 +352,11 @@ namespace Microsoft.Plugin.Program.UnitTests.Storage
 
             string oldFullPath = directory + "\\" + oldpath;
             string fullPath = directory + "\\" + path;
+            string linkingTo = Directory.GetCurrentDirectory();
 
             // ShellLinkHelper must be mocked for lnk applications
             var mockShellLink = new Mock<IShellLinkHelper>();
-            mockShellLink.Setup(m => m.RetrieveTargetPath(It.IsAny<string>())).Returns(string.Empty);
+            mockShellLink.Setup(m => m.RetrieveTargetPath(It.IsAny<string>())).Returns(linkingTo);
             Win32Program.ShellLinkHelper = mockShellLink.Object;
 
             // old item and new item are the actual items when they are in existence
@@ -363,14 +364,14 @@ namespace Microsoft.Plugin.Program.UnitTests.Storage
             {
                 Name = "oldpath",
                 ExecutableName = oldpath,
-                FullPath = fullPath,
+                FullPath = linkingTo,
             };
 
             Win32Program newitem = new Win32Program
             {
                 Name = "path",
                 ExecutableName = path,
-                FullPath = fullPath,
+                FullPath = linkingTo,
             };
 
             win32ProgramRepository.Add(olditem);

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32Program.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32Program.cs
@@ -491,8 +491,18 @@ namespace Microsoft.Plugin.Program.Programs
                         }
                     }
                 }
+                else
+                {
+                    // If the link points nowhere, consider it invalid.
+                    return InvalidProgram;
+                }
 
                 return program;
+            }
+            catch (System.IO.FileLoadException e)
+            {
+                ProgramLogger.Warn($"|Couldn't load the link file at {path}. This might be caused by a new link being created and locked by the OS.", e, MethodBase.GetCurrentMethod().DeclaringType, path);
+                return InvalidProgram;
             }
 
             // Only do a catch all in production. This is so make developer aware of any unhandled exception and add the exception handling in.

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32Program.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32Program.cs
@@ -501,7 +501,7 @@ namespace Microsoft.Plugin.Program.Programs
             }
             catch (System.IO.FileLoadException e)
             {
-                ProgramLogger.Warn($"|Couldn't load the link file at {path}. This might be caused by a new link being created and locked by the OS.", e, MethodBase.GetCurrentMethod().DeclaringType, path);
+                ProgramLogger.Warn($"Couldn't load the link file at {path}. This might be caused by a new link being created and locked by the OS.", e, MethodBase.GetCurrentMethod().DeclaringType, path);
                 return InvalidProgram;
             }
 

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Storage/Win32ProgramRepository.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Storage/Win32ProgramRepository.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Plugin.Program.Storage
                 }
                 else if (appType == Win32Program.ApplicationType.InternetShortcutApplication)
                 {
-                    oldApp = new Win32Program() { Name = Path.GetFileNameWithoutExtension(e.OldName), ExecutableName = Path.GetFileName(e.OldName), FullPath = newApp?.FullPath };
+                    oldApp = new Win32Program() { Name = Path.GetFileNameWithoutExtension(e.OldName), ExecutableName = Path.GetFileName(e.OldName), FullPath = newApp?.FullPath ?? oldPath };
                 }
                 else
                 {

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Storage/Win32ProgramRepository.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Storage/Win32ProgramRepository.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Plugin.Program.Storage
             string newPath = e.FullPath;
 
             string extension = Path.GetExtension(newPath);
-            Win32Program.ApplicationType appType = Win32Program.GetAppTypeFromPath(newPath);
+            Win32Program.ApplicationType oldAppType = Win32Program.GetAppTypeFromPath(oldPath);
             Programs.Win32Program newApp = Win32Program.GetAppFromPath(newPath);
             Programs.Win32Program oldApp = null;
 
@@ -109,11 +109,7 @@ namespace Microsoft.Plugin.Program.Storage
             // This situation is not encountered for other application types because the fullPath is the path itself, instead of being computed by using the path to the app.
             try
             {
-                if (appType == Win32Program.ApplicationType.ShortcutApplication)
-                {
-                    oldApp = new Win32Program() { Name = Path.GetFileNameWithoutExtension(e.OldName), ExecutableName = Path.GetFileName(e.OldName), FullPath = newApp.FullPath };
-                }
-                else if (appType == Win32Program.ApplicationType.InternetShortcutApplication)
+                if (oldAppType == Win32Program.ApplicationType.ShortcutApplication || oldAppType == Win32Program.ApplicationType.InternetShortcutApplication)
                 {
                     oldApp = new Win32Program() { Name = Path.GetFileNameWithoutExtension(e.OldName), ExecutableName = Path.GetFileName(e.OldName), FullPath = newApp?.FullPath ?? oldPath };
                 }
@@ -160,6 +156,11 @@ namespace Microsoft.Plugin.Program.Storage
                 if (extension.Equals(LnkExtension, StringComparison.OrdinalIgnoreCase))
                 {
                     app = GetAppWithSameLnkResolvedPath(path);
+                    if (app == null)
+                    {
+                        // Cancelled links won't be have a resolved path.
+                        app = GetAppWithSameNameAndExecutable(Path.GetFileNameWithoutExtension(path), Path.GetFileName(path));
+                    }
                 }
                 else if (extension.Equals(UrlExtension, StringComparison.OrdinalIgnoreCase))
                 {

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Storage/Win32ProgramRepository.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Storage/Win32ProgramRepository.cs
@@ -158,7 +158,7 @@ namespace Microsoft.Plugin.Program.Storage
                     app = GetAppWithSameLnkResolvedPath(path);
                     if (app == null)
                     {
-                        // Cancelled links won't be have a resolved path.
+                        // Cancelled links won't have a resolved path.
                         app = GetAppWithSameNameAndExecutable(Path.GetFileNameWithoutExtension(path), Path.GetFileName(path));
                     }
                 }

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Storage/Win32ProgramRepository.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Storage/Win32ProgramRepository.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Plugin.Program.Storage
                 }
                 else if (appType == Win32Program.ApplicationType.InternetShortcutApplication)
                 {
-                    oldApp = new Win32Program() { Name = Path.GetFileNameWithoutExtension(e.OldName), ExecutableName = Path.GetFileName(e.OldName), FullPath = newApp.FullPath };
+                    oldApp = new Win32Program() { Name = Path.GetFileNameWithoutExtension(e.OldName), ExecutableName = Path.GetFileName(e.OldName), FullPath = newApp?.FullPath };
                 }
                 else
                 {
@@ -132,7 +132,7 @@ namespace Microsoft.Plugin.Program.Storage
             {
                 if (string.IsNullOrWhiteSpace(oldApp.Name) || string.IsNullOrWhiteSpace(oldApp.ExecutableName) || string.IsNullOrWhiteSpace(oldApp.FullPath))
                 {
-                    Log.Error($"Old app was not initialized properly. OldFullPath: {e.OldFullPath}; OldName: {e.OldName}; FullPath: {e.FullPath}", GetType());
+                    Log.Warn($"Old app data was not initialized properly for removal after file renaming. This likely means it was not a valid app to begin with and removal is not needed. OldFullPath: {e.OldFullPath}; OldName: {e.OldName}; FullPath: {e.FullPath}", GetType());
                 }
                 else
                 {


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
When creating or renaming an URL shortcut, PowerToys Run is listening to the event and throws a null reference exception, since it's not a valid shortcut we want to treat as an app.

**What is included in the PR:** 
Don't raise the null reference exception and treat it as a warning instead of an error in the logs.

**How does someone test / validate:** 
Create a new URL shortcut in the Desktop (point it to `http://github.com` for example.
Verify that you get a warning in PowerToys Run logs instead of an error.

## Quality Checklist

- [x] **Linked issue:** #17136
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries
