### PR TITLE
[PT Run] [Settings] System plugin: Move settings description

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.System/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.System/Main.cs
@@ -51,6 +51,7 @@ namespace Microsoft.PowerToys.Run.Plugin.System
             {
                 Key = "ReduceNetworkResultScore",
                 DisplayLabel = Resources.Reduce_Network_Result_Score,
+                DisplayDescription = Resources.Reduce_Network_Result_Score_Description,
                 Value = true,
             },
         };

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.System/Properties/Resources.Designer.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.System/Properties/Resources.Designer.cs
@@ -628,12 +628,20 @@ namespace Microsoft.PowerToys.Run.Plugin.System.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Reduce the priority of &apos;IP&apos; and &apos;MAC&apos; results to improve the order in the global results
-        ///(With this setting enabled, you have to type more characters to find the results.).
+        ///   Looks up a localized string similar to Reduce the priority of &apos;IP&apos; and &apos;MAC&apos; results to improve the order in the global results.
         /// </summary>
         internal static string Reduce_Network_Result_Score {
             get {
                 return ResourceManager.GetString("Reduce_Network_Result_Score", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to With this setting enabled, you have to type more characters to find the results..
+        /// </summary>
+        internal static string Reduce_Network_Result_Score_Description {
+            get {
+                return ResourceManager.GetString("Reduce_Network_Result_Score_Description", resourceCulture);
             }
         }
         

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.System/Properties/Resources.resx
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.System/Properties/Resources.resx
@@ -340,8 +340,10 @@
     <value>Wireless LAN</value>
   </data>
   <data name="Reduce_Network_Result_Score" xml:space="preserve">
-    <value>Reduce the priority of 'IP' and 'MAC' results to improve the order in the global results
-(With this setting enabled, you have to type more characters to find the results.)</value>
+    <value>Reduce the priority of 'IP' and 'MAC' results to improve the order in the global results</value>
+  </data>
+  <data name="Reduce_Network_Result_Score_Description" xml:space="preserve">
+    <value>With this setting enabled, you have to type more characters to find the results.</value>
   </data>
   <data name="Use_localized_system_commands" xml:space="preserve">
     <value>Use localized system commands instead of English ones</value>


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
This is a follow up on the PRs #17023, #17108

This PR moves the description of the new scoring setting into the secondary text element (settings description property).

**How does someone test / validate:** 
Local build.

## Quality Checklist

- [x] **Linked base PR:** #17023, #17108
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
