### PR TITLE
[PTRun][Calculator]Fix trailing zeroes on hexadecimal numbers

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator.UnitTest/NumberTranslatorTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator.UnitTest/NumberTranslatorTests.cs
@@ -130,5 +130,21 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.UnitTests
             Assert.IsNotNull(result);
             Assert.AreEqual(expectedResult, result);
         }
+
+        [DataTestMethod]
+        [DataRow("12.0004", "12.0004")]
+        [DataRow("0xF000", "0xF000")]
+        public void Translate_NoRemovalOfLeadingZeroesOnEdgeCases(string input, string expectedResult)
+        {
+            // Arrange
+            var translator = NumberTranslator.Create(new CultureInfo("pt-PT"), new CultureInfo("en-US"));
+
+            // Act
+            var result = translator.Translate(input);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(expectedResult, result);
+        }
     }
 }

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/NumberTranslator.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/NumberTranslator.cs
@@ -95,7 +95,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
             // Now, even if . is not part of the culture representation, users won't hit this error since the number will
             // be passed as is to the calculator engine.
             // This shouldn't add any regressions into accepted strings while it will have a behavior the users expect.
-            var splitPattern = $"((?:\\d|\\.|{Regex.Escape(culture.NumberFormat.NumberDecimalSeparator)}";
+            var splitPattern = $"((?:\\d|[a-fA-F]|\\.|{Regex.Escape(culture.NumberFormat.NumberDecimalSeparator)}";
             if (!string.IsNullOrEmpty(culture.NumberFormat.NumberGroupSeparator))
             {
                 splitPattern += $"|{Regex.Escape(culture.NumberFormat.NumberGroupSeparator)}";


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
The number translator we use to pre-process queries in calculator to accept localized numbers is parsing zeros after 'A'-'F' characters in hexadecimal numbers as if they were a single zero.
Example: Given the query '0xF00000' it tokenizes the query as '0', 'xF' and '00000'. It then removes leading zeroes from '00000' and the final query is translated as '0xF0'.

**What is included in the PR:** 
Accept hexadecimal characters into the token containing numbers.

**How does someone test / validate:** 
Test the query 0xF00, should show 3840 instead of 240.

## Quality Checklist

- [x] **Linked issue:** #17237
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [x] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries
