### PR TITLE
[Runner] Do not sync settings with scheduler state, since it might ca…

### DIFF
--- a/src/runner/general_settings.cpp
+++ b/src/runner/general_settings.cpp
@@ -14,7 +14,6 @@
 
 // TODO: would be nice to get rid of these globals, since they're basically cached json settings
 static std::wstring settings_theme = L"system";
-static bool startup_disabled_manually = false;
 static bool run_as_elevated = false;
 static bool download_updates_automatically = true;
 
@@ -94,20 +93,7 @@ void apply_general_settings(const json::JsonObject& general_configs, bool save)
     {
         const bool startup = general_configs.GetNamedBoolean(L"startup");
 
-        auto settings = get_general_settings();
-        static std::once_flag once_flag;
-        std::call_once(once_flag, [settings, startup, general_configs] {
-            if (json::has(general_configs, L"startup", json::JsonValueType::Boolean))
-            {
-                if (startup == true && settings.isStartupEnabled == false)
-                {
-                    Logger::info("PowerToys run at startup disabled manually");
-                    startup_disabled_manually = true;
-                }
-            }
-        });
-
-        if (startup && !startup_disabled_manually)
+        if (startup)
         {
             if (is_process_elevated())
             {
@@ -133,7 +119,6 @@ void apply_general_settings(const json::JsonObject& general_configs, bool save)
         else
         {
             delete_auto_start_task_for_this_user();
-            startup_disabled_manually = false;
         }
     }
     if (json::has(general_configs, L"enabled"))

--- a/src/runner/restart_elevated.cpp
+++ b/src/runner/restart_elevated.cpp
@@ -52,5 +52,5 @@ bool restart_same_elevation()
     constexpr DWORD exe_path_size = 0xFFFF;
     auto exe_path = std::make_unique<wchar_t[]>(exe_path_size);
     GetModuleFileNameW(nullptr, exe_path.get(), exe_path_size);
-    return run_same_elevation(exe_path.get(), L"", nullptr);
+    return run_same_elevation(exe_path.get(), L"--dont-elevate", nullptr);
 }


### PR DESCRIPTION
…use issues with elevation

## Summary of the Pull Request

**What is this about:**

**What is included in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #16961
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
