### PR TITLE
[Updater]Pass flag to not restart automatically

### DIFF
--- a/src/Update/PowerToys.Update.cpp
+++ b/src/Update/PowerToys.Update.cpp
@@ -153,7 +153,7 @@ bool InstallNewVersionStage2(std::wstring installer_path, std::wstring_view inst
         sei.fMask = { SEE_MASK_FLAG_NO_UI | SEE_MASK_NOASYNC | SEE_MASK_NOCLOSEPROCESS | SEE_MASK_NO_CONSOLE };
         sei.lpFile = installer_path.c_str();
         sei.nShow = SW_SHOWNORMAL;
-        std::wstring parameters = L"/passive";
+        std::wstring parameters = L"/passive /norestart";
         sei.lpParameters = parameters.c_str();
 
         success = ShellExecuteExW(&sei) == TRUE;


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
When self-updating silently from PowerToys, don't restart the user machine automatically.

**What is included in the PR:** 
Pass the `/norestart` command line argument.

**How does someone test / validate:** 
Not quite sure since this was not reproduced. Installer arguments from running with `/help` indicate that `/norestart` avoids restarting.

## Quality Checklist

- [x] **Linked issue:** #16252
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries