### PR TITLE
[ColorPicker]Use Hotkey when started from runner

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -1938,6 +1938,7 @@ Subdir
 subfolder
 subkey
 SUBLANG
+submenu
 subquery
 substr
 Sul

--- a/src/modules/colorPicker/ColorPickerUI/Helpers/AppStateHandler.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/AppStateHandler.cs
@@ -5,6 +5,7 @@
 using System;
 using System.ComponentModel.Composition;
 using System.Windows;
+using System.Windows.Interop;
 using ColorPicker.Settings;
 using ColorPicker.ViewModelContracts;
 using Common.UI;
@@ -20,6 +21,9 @@ namespace ColorPicker.Helpers
         private ColorEditorWindow _colorEditorWindow;
         private bool _colorPickerShown;
         private object _colorPickerVisibilityLock = new object();
+
+        private HwndSource _hwndSource;
+        private const int _globalHotKeyId = 0x0001;
 
         // Blocks using the escape key to close the color picker editor when the adjust color flyout is open.
         public static bool BlockEscapeKeyClosingColorPickerEditor { get; set; }
@@ -56,6 +60,12 @@ namespace ColorPicker.Helpers
                 {
                     ShowColorPicker();
                 }
+
+                // Handle the escape key to close Color Picker locally when being spawn from PowerToys, since Keyboard Hooks from the KeyboardMonitor are heavy.
+                if (!(System.Windows.Application.Current as ColorPickerUI.App).IsRunningDetachedFromPowerToys())
+                {
+                    SetupEscapeGlobalKeyShortcut();
+                }
             }
         }
 
@@ -72,6 +82,12 @@ namespace ColorPicker.Helpers
                     else
                     {
                         HideColorPicker();
+                    }
+
+                    // Handle the escape key to close Color Picker locally when being spawn from PowerToys, since Keyboard Hooks from the KeyboardMonitor are heavy.
+                    if (!(System.Windows.Application.Current as ColorPickerUI.App).IsRunningDetachedFromPowerToys())
+                    {
+                        ClearEscapeGlobalKeyShortcut();
                     }
 
                     SessionEventHelper.End();
@@ -189,6 +205,68 @@ namespace ColorPicker.Helpers
         private void ColorEditorViewModel_OpenSettingsRequested(object sender, EventArgs e)
         {
             SettingsDeepLink.OpenSettings(SettingsDeepLink.SettingsWindow.ColorPicker);
+        }
+
+        internal void RegisterWindowHandle(System.Windows.Interop.HwndSource hwndSource)
+        {
+            _hwndSource = hwndSource;
+        }
+
+#pragma warning disable CA1801 // Review unused parameters
+        public IntPtr ProcessWindowMessages(IntPtr hwnd, int msg, IntPtr wparam, IntPtr lparam, ref bool handled)
+#pragma warning restore CA1801 // Review unused parameters
+        {
+            switch (msg)
+            {
+                case NativeMethods.WM_HOTKEY:
+                    if (!BlockEscapeKeyClosingColorPickerEditor)
+                    {
+                        handled = EndUserSession();
+                    }
+                    else
+                    {
+                        // If escape key is blocked it means a submenu is open.
+                        // Send the escape key to the Window to close that submenu.
+                        // Description for LPARAM in https://docs.microsoft.com/en-us/windows/win32/inputdev/wm-keyup#parameters
+                        // It's basically some modifiers + scancode for escape (1) + number of repititions (1)
+                        handled = true;
+                        handled &= NativeMethods.PostMessage(_hwndSource.Handle, NativeMethods.WM_KEYDOWN, (IntPtr)NativeMethods.VK_ESCAPE, (IntPtr)0x00010001);
+                        handled &= NativeMethods.PostMessage(_hwndSource.Handle, NativeMethods.WM_KEYUP, (IntPtr)NativeMethods.VK_ESCAPE, (IntPtr)0xC0010001);
+                    }
+
+                    break;
+            }
+
+            return IntPtr.Zero;
+        }
+
+        public void SetupEscapeGlobalKeyShortcut()
+        {
+            if (_hwndSource == null)
+            {
+                return;
+            }
+
+            _hwndSource.AddHook(ProcessWindowMessages);
+            if (!NativeMethods.RegisterHotKey(_hwndSource.Handle, _globalHotKeyId, NativeMethods.MOD_NOREPEAT, NativeMethods.VK_ESCAPE))
+            {
+                Logger.LogWarning("Couldn't register the hotkey for Esc.");
+            }
+        }
+
+        public void ClearEscapeGlobalKeyShortcut()
+        {
+            if (_hwndSource == null)
+            {
+                return;
+            }
+
+            if (!NativeMethods.UnregisterHotKey(_hwndSource.Handle, _globalHotKeyId))
+            {
+                Logger.LogWarning("Couldn't unregister the hotkey for Esc.");
+            }
+
+            _hwndSource.RemoveHook(ProcessWindowMessages);
         }
     }
 }

--- a/src/modules/colorPicker/ColorPickerUI/Helpers/AppStateHandler.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/AppStateHandler.cs
@@ -228,7 +228,7 @@ namespace ColorPicker.Helpers
                         // If escape key is blocked it means a submenu is open.
                         // Send the escape key to the Window to close that submenu.
                         // Description for LPARAM in https://docs.microsoft.com/en-us/windows/win32/inputdev/wm-keyup#parameters
-                        // It's basically some modifiers + scancode for escape (1) + number of repititions (1)
+                        // It's basically some modifiers + scancode for escape (1) + number of repetitions (1)
                         handled = true;
                         handled &= NativeMethods.PostMessage(_hwndSource.Handle, NativeMethods.WM_KEYDOWN, (IntPtr)NativeMethods.VK_ESCAPE, (IntPtr)0x00010001);
                         handled &= NativeMethods.PostMessage(_hwndSource.Handle, NativeMethods.WM_KEYUP, (IntPtr)NativeMethods.VK_ESCAPE, (IntPtr)0xC0010001);

--- a/src/modules/colorPicker/ColorPickerUI/MainWindow.xaml
+++ b/src/modules/colorPicker/ColorPickerUI/MainWindow.xaml
@@ -14,6 +14,7 @@
         Background="Transparent"
         SizeToContent="WidthAndHeight"
         AllowsTransparency="True"
+        SourceInitialized="MainWindowSourceInitialized"
         AutomationProperties.Name="Color Picker">
     <e:Interaction.Behaviors>
         <behaviors:ChangeWindowPositionBehavior/>

--- a/src/modules/colorPicker/ColorPickerUI/MainWindow.xaml.cs
+++ b/src/modules/colorPicker/ColorPickerUI/MainWindow.xaml.cs
@@ -4,6 +4,7 @@
 
 using System.ComponentModel.Composition;
 using System.Windows;
+using System.Windows.Interop;
 using ColorPicker.ViewModelContracts;
 
 namespace ColorPicker
@@ -19,6 +20,7 @@ namespace ColorPicker
             Bootstrapper.InitializeContainer(this);
             InitializeComponent();
             DataContext = this;
+            Show(); // Call show just to make sure source is initialized at startup.
             Hide();
         }
 
@@ -29,6 +31,11 @@ namespace ColorPicker
         {
             Closing -= MainWindow_Closing;
             Bootstrapper.Dispose();
+        }
+
+        private void MainWindowSourceInitialized(object sender, System.EventArgs e)
+        {
+            this.MainViewModel.RegisterWindowHandle(HwndSource.FromHwnd(new WindowInteropHelper(this).Handle));
         }
     }
 }

--- a/src/modules/colorPicker/ColorPickerUI/NativeMethods.cs
+++ b/src/modules/colorPicker/ColorPickerUI/NativeMethods.cs
@@ -46,6 +46,26 @@ namespace ColorPicker
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "Interop")]
         public const int VK_RWIN = 0x5C;
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1310:Field names should not contain underscore", Justification = "Interop")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "Interop")]
+        public const int VK_ESCAPE = 0x1B;
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1310:Field names should not contain underscore", Justification = "Interop")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "Interop")]
+        public const int WM_HOTKEY = 0x0312;
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1310:Field names should not contain underscore", Justification = "Interop")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "Interop")]
+        public const int WM_KEYDOWN = 0x0100;
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1310:Field names should not contain underscore", Justification = "Interop")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "Interop")]
+        public const int WM_KEYUP = 0x0101;
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1310:Field names should not contain underscore", Justification = "Interop")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "Interop")]
+        public const uint MOD_NOREPEAT = 0x4000;
+
         public delegate bool MonitorEnumProc(
             IntPtr monitor, IntPtr hdc, IntPtr lprcMonitor, IntPtr lParam);
 
@@ -87,6 +107,15 @@ namespace ColorPicker
 
         [DllImport("user32.dll", EntryPoint = "SystemParametersInfo")]
         internal static extern bool SystemParametersInfo(int uiAction, int uiParam, IntPtr pvParam, int fWinIni);
+
+        [DllImport("user32.dll")]
+        internal static extern bool RegisterHotKey(IntPtr hWnd, int id, uint fsModifiers, uint vk);
+
+        [DllImport("user32.dll")]
+        internal static extern bool UnregisterHotKey(IntPtr hWnd, int id);
+
+        [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+        internal static extern bool PostMessage(IntPtr hWnd, uint Msg, IntPtr wParam, IntPtr lParam);
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1307:Accessible fields should begin with upper-case letter", Justification = "Interop object")]
         [StructLayout(LayoutKind.Sequential)]

--- a/src/modules/colorPicker/ColorPickerUI/ViewModelContracts/IMainViewModel.cs
+++ b/src/modules/colorPicker/ColorPickerUI/ViewModelContracts/IMainViewModel.cs
@@ -27,5 +27,7 @@ namespace ColorPicker.ViewModelContracts
         /// Gets a value indicating whether gets the show color name
         /// </summary>
         bool ShowColorName { get; }
+
+        void RegisterWindowHandle(System.Windows.Interop.HwndSource hwndSource);
     }
 }

--- a/src/modules/colorPicker/ColorPickerUI/ViewModels/MainViewModel.cs
+++ b/src/modules/colorPicker/ColorPickerUI/ViewModels/MainViewModel.cs
@@ -65,7 +65,15 @@ namespace ColorPicker.ViewModels
             }
 
             _userSettings.ShowColorName.PropertyChanged += (s, e) => { OnPropertyChanged(nameof(ShowColorName)); };
-            keyboardMonitor?.Start();
+
+            // Only start a local keyboard low level hook if running as a standalone.
+            // Otherwise, the global keyboard hook from runner will be used to activate Color Picker through ShowColorPickerSharedEvent
+            // and the Escape key will be registered as a shortcut by appStateHandler when ColorPicker is being used.
+            // This is much lighter than using a local low level keyboard hook.
+            if ((System.Windows.Application.Current as ColorPickerUI.App).IsRunningDetachedFromPowerToys())
+            {
+                keyboardMonitor?.Start();
+            }
         }
 
         /// <summary>
@@ -163,5 +171,10 @@ namespace ColorPicker.ViewModels
         /// <param name="e">The new values for the zoom</param>
         private void MouseInfoProvider_OnMouseWheel(object sender, Tuple<Point, bool> e)
             => _zoomWindowHelper.Zoom(e.Item1, e.Item2);
+
+        public void RegisterWindowHandle(System.Windows.Interop.HwndSource hwndSource)
+        {
+            _appStateHandler.RegisterWindowHandle(hwndSource);
+        }
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Keyboard hooks are heavy. They're called on every key stroke and in the case of C# this has the initial overhead of marshalling data.
When started from the runner, ColorPicker already uses the centralized keyboard hook and maintains a local keyboard hook just to receive the Escape key to close.
A different method, like a registered HotKey should be used for this instead.

**What is included in the PR:** 
When starting from the runner, use a registered HotKey and don't use local low-level keyboard hooks at all.
Simulate sending the escape key to the Window when it should close submenus instead of closing the window.
Ensure the window source is initialized at startup.

**How does someone test / validate:** 
Observe normal operation of ColorPicker when started from the runner and that the Escape key still closes it.

## Quality Checklist

- [x] **Linked issue:** #17264
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries
