### PR TITLE
[PTRun][Program]Add logs on launch failure

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Main.cs
@@ -185,8 +185,9 @@ namespace Microsoft.Plugin.Program
 
                 runProcess(info);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                Logger.ProgramLogger.Exception($"Unable to start ", ex, System.Reflection.MethodBase.GetCurrentMethod().DeclaringType, info?.FileName);
                 var name = "Plugin: " + Properties.Resources.wox_plugin_program_plugin_name;
                 var message = $"{Properties.Resources.powertoys_run_plugin_program_start_failed}: {info?.FileName}";
                 _context.API.ShowMsg(name, message, string.Empty);

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/UWPApplication.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/UWPApplication.cs
@@ -214,8 +214,9 @@ namespace Microsoft.Plugin.Program.Programs
                 {
                     appManager.ActivateApplication(UserModelId, queryArguments, noFlags, out var unusedPid);
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
+                    ProgramLogger.Exception($"Unable to launch UWP {DisplayName}", ex, MethodBase.GetCurrentMethod().DeclaringType, queryArguments);
                     var name = "Plugin: " + Properties.Resources.wox_plugin_program_plugin_name;
                     var message = $"{Properties.Resources.powertoys_run_plugin_program_uwp_failed}: {DisplayName}";
                     api.ShowMsg(name, message, string.Empty);


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Add additional logs when not being able to start a program. This will help debug issues like https://github.com/microsoft/PowerToys/issues/16912

**What is included in the PR:** 
Additional logs.

**How does someone test / validate:** 
Hard to replicate, just looking for a quick code review.

## Quality Checklist

- [x] **Linked issue:** #16912
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries