### PR TITLE
[FileExplorer]Add warnings for incompatibilities

### DIFF
--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -1017,6 +1017,14 @@ Made with 💗 by Microsoft and the PowerToys community.</value>
   <data name="FileExplorerPreview_RebootRequired.Title" xml:space="preserve">
     <value>A reboot may be required for changes to these settings to take effect</value>
   </data>
+  <data name="FileExplorerPreview_PreviewHandlerOutlookIncompatibility.Title" xml:space="preserve">
+    <value>Enabling the preview handlers will override other preview handlers already installed - there have been reports of incompatibility between Outlook and the PDF Preview Handler</value>
+    <comment>Outlook is the name of a Microsoft product</comment>
+  </data>
+  <data name="FileExplorerPreview_ThumbnailsMightNotAppearOnRemoteFolders.Title" xml:space="preserve">
+    <value>Thumbnails might not appear on paths managed by cloud storage solutions like OneDrive, since these solutions may get their thumbnails from the cloud instead of generating them locally</value>
+    <comment>OneDrive is the name of a Microsoft product</comment>
+  </data>
   <data name="FancyZones_ExcludeApps_TextBoxControl.PlaceholderText" xml:space="preserve">
     <value>Example: outlook.exe</value>
     <comment>Don't translate outlook.exe</comment>

--- a/src/settings-ui/Settings.UI/Views/PowerPreviewPage.xaml
+++ b/src/settings-ui/Settings.UI/Views/PowerPreviewPage.xaml
@@ -21,6 +21,12 @@
             <StackPanel Orientation="Vertical">
 
                 <controls:SettingsGroup x:Uid="FileExplorerPreview_PreviewPane">
+                    <muxc:InfoBar Severity="Warning"
+                                   x:Uid="FileExplorerPreview_PreviewHandlerOutlookIncompatibility"
+                                   IsOpen="True"
+                                   IsTabStop="True"
+                                   IsClosable="False"
+                                   />
                     <controls:Setting x:Uid="FileExplorerPreview_ToggleSwitch_Preview_SVG" Icon="&#xE91B;">
                         <controls:Setting.ActionContent>
                             <ToggleSwitch IsOn="{x:Bind Mode=TwoWay, Path=ViewModel.SVGRenderIsEnabled}"
@@ -60,6 +66,12 @@
                 <controls:SettingsGroup x:Uid="FileExplorerPreview_IconThumbnail_GroupSettings">
                     <muxc:InfoBar Severity="Informational"
                                    x:Uid="FileExplorerPreview_RebootRequired"
+                                   IsOpen="True"
+                                   IsTabStop="True"
+                                   IsClosable="False"
+                                   />
+                    <muxc:InfoBar Severity="Warning"
+                                   x:Uid="FileExplorerPreview_ThumbnailsMightNotAppearOnRemoteFolders"
                                    IsOpen="True"
                                    IsTabStop="True"
                                    IsClosable="False"


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Some incompatibilities in preview handlers and thumbnails catch the users by surprise. Adding warnings for these should reduce dissatisfaction:

![image](https://user-images.githubusercontent.com/26118718/160172065-61dd7959-0b53-42a7-a6b0-e559150a048a.png)

![image](https://user-images.githubusercontent.com/26118718/160172029-5e8b6bf7-e70b-47e8-939f-f12388ad38f8.png)

We're still investigating https://github.com/microsoft/PowerToys/issues/14283, but we should add a warning in the meanwhile.

**What is included in the PR:** 
Add warnings.

**How does someone test / validate:** 
Verify these appear in Settings.

## Quality Checklist

- [x] **Linked issue:** #12949 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
