### PR TITLE
#16283 VS Code Workspaces not showing up after update/first install

### DIFF
--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/VSCodeHelper/VSCodeInstances.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/VSCodeHelper/VSCodeInstances.cs
@@ -15,7 +15,7 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.VSCodeHelper
 {
     public static class VSCodeInstances
     {
-        private static string _systemPath = string.Empty;
+        private static List<string> _paths = new List<string>();
 
         private static string _userAppDataPath = Environment.GetEnvironmentVariable("AppData");
 
@@ -62,13 +62,19 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.VSCodeHelper
         // Gets the executablePath and AppData foreach instance of VSCode
         public static void LoadVSCodeInstances()
         {
-            if (_systemPath != Environment.GetEnvironmentVariable("PATH"))
+            var environmentPath = Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.User);
+            environmentPath += (environmentPath.Length > 0 && environmentPath.EndsWith(';') ? ";" : string.Empty) + Environment.GetEnvironmentVariable("PATH");
+            var paths = environmentPath.Split(";").ToList();
+            paths = paths.Distinct().ToList();
+
+            var deletedItems = paths.Except(_paths).Any();
+            var newItems = _paths.Except(paths).Any();
+
+            if (newItems || deletedItems)
             {
                 Instances = new List<VSCodeInstance>();
 
-                _systemPath = Environment.GetEnvironmentVariable("PATH");
-                var paths = _systemPath.Split(";");
-                paths = paths.Where(x => x.Contains("VS Code") || x.Contains("VSCodium")).ToArray();
+                paths = paths.Where(x => x.Contains("VS Code") || x.Contains("VSCodium")).ToList();
                 foreach (var path in paths)
                 {
                     if (Directory.Exists(path))


### PR DESCRIPTION
…lation

## Summary of the Pull Request

**What is this about:**
VS Code Workspaces not showing up after update or first install.

**What is included in the PR:** 
The issue is with the first time that powertoys is installed or after an updated for some reason the first time we get Environment.GetEnvironmentVariable("PATH") only the system environment variables are obtained and not the user environment variables.
I fixed the issue by including the user variables to.

**How does someone test / validate:** 
1. Unninstall powertoys.
2. Install lastest version of powertoys
3. Try to run powertoys  run with the query '{'. Nothing shows.
4. Uninstall powertoys again.
5. Build Powertoys Project and and exe.
6. Install the exe you created.
7. Try to run powertoys  run with the query '{'. The workspaces now show up.

## Quality Checklist

- [x] **Linked issue:** #16283
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [x] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
