### PR TITLE
[PT Run] Run as user feature

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Properties/Resources.Designer.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Plugin.Indexer.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -61,7 +61,7 @@ namespace Microsoft.Plugin.Indexer.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Disable drive detection warning.
+        ///   Looks up a localized string similar to Disable non-indexed files warning.
         /// </summary>
         public static string disable_drive_detection_warning {
             get {
@@ -183,6 +183,15 @@ namespace Microsoft.Plugin.Indexer.Properties {
         public static string Microsoft_plugin_indexer_run_as_administrator {
             get {
                 return ResourceManager.GetString("Microsoft_plugin_indexer_run_as_administrator", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Run as different user (Ctrl+Shift+U).
+        /// </summary>
+        public static string Microsoft_plugin_indexer_run_as_user {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_indexer_run_as_user", resourceCulture);
             }
         }
         

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Properties/Resources.resx
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Properties/Resources.resx
@@ -162,4 +162,7 @@
   <data name="disable_drive_detection_warning" xml:space="preserve">
     <value>Disable non-indexed files warning</value>
   </data>
+  <data name="Microsoft_plugin_indexer_run_as_user" xml:space="preserve">
+    <value>Run as different user (Ctrl+Shift+U)</value>
+  </data>
 </root>

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program.UnitTests/Programs/Win32Tests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program.UnitTests/Programs/Win32Tests.cs
@@ -466,10 +466,11 @@ namespace Microsoft.Plugin.Program.UnitTests.Programs
             List<ContextMenuResult> contextMenuResults = _pinnedWebpage.ContextMenus(string.Empty, mock.Object);
 
             // Assert
-            Assert.AreEqual(3, contextMenuResults.Count);
+            Assert.AreEqual(4, contextMenuResults.Count);
             Assert.AreEqual(Properties.Resources.wox_plugin_program_run_as_administrator, contextMenuResults[0].Title);
-            Assert.AreEqual(Properties.Resources.wox_plugin_program_open_containing_folder, contextMenuResults[1].Title);
-            Assert.AreEqual(Properties.Resources.wox_plugin_program_open_in_console, contextMenuResults[2].Title);
+            Assert.AreEqual(Properties.Resources.wox_plugin_program_run_as_user, contextMenuResults[1].Title);
+            Assert.AreEqual(Properties.Resources.wox_plugin_program_open_containing_folder, contextMenuResults[2].Title);
+            Assert.AreEqual(Properties.Resources.wox_plugin_program_open_in_console, contextMenuResults[3].Title);
         }
 
         [TestMethod]
@@ -497,10 +498,11 @@ namespace Microsoft.Plugin.Program.UnitTests.Programs
             List<ContextMenuResult> contextMenuResults = _chrome.ContextMenus(string.Empty, mock.Object);
 
             // Assert
-            Assert.AreEqual(3, contextMenuResults.Count);
+            Assert.AreEqual(4, contextMenuResults.Count);
             Assert.AreEqual(Properties.Resources.wox_plugin_program_run_as_administrator, contextMenuResults[0].Title);
-            Assert.AreEqual(Properties.Resources.wox_plugin_program_open_containing_folder, contextMenuResults[1].Title);
-            Assert.AreEqual(Properties.Resources.wox_plugin_program_open_in_console, contextMenuResults[2].Title);
+            Assert.AreEqual(Properties.Resources.wox_plugin_program_run_as_user, contextMenuResults[1].Title);
+            Assert.AreEqual(Properties.Resources.wox_plugin_program_open_containing_folder, contextMenuResults[2].Title);
+            Assert.AreEqual(Properties.Resources.wox_plugin_program_open_in_console, contextMenuResults[3].Title);
         }
 
         [TestMethod]
@@ -513,10 +515,11 @@ namespace Microsoft.Plugin.Program.UnitTests.Programs
             List<ContextMenuResult> contextMenuResults = _cmdRunCommand.ContextMenus(string.Empty, mock.Object);
 
             // Assert
-            Assert.AreEqual(3, contextMenuResults.Count);
+            Assert.AreEqual(4, contextMenuResults.Count);
             Assert.AreEqual(Properties.Resources.wox_plugin_program_run_as_administrator, contextMenuResults[0].Title);
-            Assert.AreEqual(Properties.Resources.wox_plugin_program_open_containing_folder, contextMenuResults[1].Title);
-            Assert.AreEqual(Properties.Resources.wox_plugin_program_open_in_console, contextMenuResults[2].Title);
+            Assert.AreEqual(Properties.Resources.wox_plugin_program_run_as_user, contextMenuResults[1].Title);
+            Assert.AreEqual(Properties.Resources.wox_plugin_program_open_containing_folder, contextMenuResults[2].Title);
+            Assert.AreEqual(Properties.Resources.wox_plugin_program_open_in_console, contextMenuResults[3].Title);
         }
 
         [TestMethod]
@@ -529,10 +532,11 @@ namespace Microsoft.Plugin.Program.UnitTests.Programs
             List<ContextMenuResult> contextMenuResults = _dummyAppRefApp.ContextMenus(string.Empty, mock.Object);
 
             // Assert
-            Assert.AreEqual(3, contextMenuResults.Count);
+            Assert.AreEqual(4, contextMenuResults.Count);
             Assert.AreEqual(Properties.Resources.wox_plugin_program_run_as_administrator, contextMenuResults[0].Title);
-            Assert.AreEqual(Properties.Resources.wox_plugin_program_open_containing_folder, contextMenuResults[1].Title);
-            Assert.AreEqual(Properties.Resources.wox_plugin_program_open_in_console, contextMenuResults[2].Title);
+            Assert.AreEqual(Properties.Resources.wox_plugin_program_run_as_user, contextMenuResults[1].Title);
+            Assert.AreEqual(Properties.Resources.wox_plugin_program_open_containing_folder, contextMenuResults[2].Title);
+            Assert.AreEqual(Properties.Resources.wox_plugin_program_open_in_console, contextMenuResults[3].Title);
         }
 
         [TestMethod]
@@ -545,10 +549,11 @@ namespace Microsoft.Plugin.Program.UnitTests.Programs
             List<ContextMenuResult> contextMenuResults = _dummyShortcutApp.ContextMenus(string.Empty, mock.Object);
 
             // Assert
-            Assert.AreEqual(3, contextMenuResults.Count);
+            Assert.AreEqual(4, contextMenuResults.Count);
             Assert.AreEqual(Properties.Resources.wox_plugin_program_run_as_administrator, contextMenuResults[0].Title);
-            Assert.AreEqual(Properties.Resources.wox_plugin_program_open_containing_folder, contextMenuResults[1].Title);
-            Assert.AreEqual(Properties.Resources.wox_plugin_program_open_in_console, contextMenuResults[2].Title);
+            Assert.AreEqual(Properties.Resources.wox_plugin_program_run_as_user, contextMenuResults[1].Title);
+            Assert.AreEqual(Properties.Resources.wox_plugin_program_open_containing_folder, contextMenuResults[2].Title);
+            Assert.AreEqual(Properties.Resources.wox_plugin_program_open_in_console, contextMenuResults[3].Title);
         }
 
         [TestMethod]

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/UWPApplication.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/UWPApplication.cs
@@ -158,6 +158,8 @@ namespace Microsoft.Plugin.Program.Programs
                                 return true;
                             },
                         });
+
+                // We don't add contex menu to 'run as different user', because UWP applications normally installed per user and not for all users.
             }
 
             contextMenus.Add(

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/UWPApplication.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/UWPApplication.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Plugin.Program.Programs
                             },
                         });
 
-                // We don't add contex menu to 'run as different user', because UWP applications normally installed per user and not for all users.
+                // We don't add context menu to 'run as different user', because UWP applications normally installed per user and not for all users.
             }
 
             contextMenus.Add(

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32Program.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32Program.cs
@@ -266,7 +266,24 @@ namespace Microsoft.Plugin.Program.Programs
                     AcceleratorModifiers = ModifierKeys.Control | ModifierKeys.Shift,
                     Action = _ =>
                     {
-                        var info = GetProcessStartInfo(queryArguments, true);
+                        var info = GetProcessStartInfo(queryArguments, RunAsType.Administrator);
+                        Task.Run(() => Main.StartProcess(Process.Start, info));
+
+                        return true;
+                    },
+                });
+
+                contextMenus.Add(new ContextMenuResult
+                {
+                    PluginName = Assembly.GetExecutingAssembly().GetName().Name,
+                    Title = Properties.Resources.wox_plugin_program_run_as_user,
+                    Glyph = "\xE7EE",
+                    FontFamily = "Segoe MDL2 Assets",
+                    AcceleratorKey = Key.U,
+                    AcceleratorModifiers = ModifierKeys.Control | ModifierKeys.Shift,
+                    Action = _ =>
+                    {
+                        var info = GetProcessStartInfo(queryArguments, RunAsType.OtherUser);
                         Task.Run(() => Main.StartProcess(Process.Start, info));
 
                         return true;
@@ -317,7 +334,7 @@ namespace Microsoft.Plugin.Program.Programs
             return contextMenus;
         }
 
-        private ProcessStartInfo GetProcessStartInfo(string programArguments, bool runAsAdmin = false)
+        private ProcessStartInfo GetProcessStartInfo(string programArguments, RunAsType runAs = RunAsType.None)
         {
             return new ProcessStartInfo
             {
@@ -325,8 +342,15 @@ namespace Microsoft.Plugin.Program.Programs
                 WorkingDirectory = ParentDirectory,
                 UseShellExecute = true,
                 Arguments = programArguments,
-                Verb = runAsAdmin ? "runas" : string.Empty,
+                Verb = runAs == RunAsType.Administrator ? "runAs" : runAs == RunAsType.OtherUser ? "runAsUser" : string.Empty,
             };
+        }
+
+        private enum RunAsType
+        {
+            None,
+            Administrator,
+            OtherUser,
         }
 
         public override string ToString()

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Properties/Resources.Designer.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Plugin.Program.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -201,6 +201,15 @@ namespace Microsoft.Plugin.Program.Properties {
         public static string wox_plugin_program_run_as_administrator {
             get {
                 return ResourceManager.GetString("wox_plugin_program_run_as_administrator", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Run as different user (Ctrl+Shift+U).
+        /// </summary>
+        public static string wox_plugin_program_run_as_user {
+            get {
+                return ResourceManager.GetString("wox_plugin_program_run_as_user", resourceCulture);
             }
         }
     }

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Properties/Resources.resx
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Properties/Resources.resx
@@ -165,4 +165,7 @@
   <data name="powertoys_run_plugin_program_uwp_failed" xml:space="preserve">
     <value>Can't start UWP</value>
   </data>
+  <data name="wox_plugin_program_run_as_user" xml:space="preserve">
+    <value>Run as different user (Ctrl+Shift+U)</value>
+  </data>
 </root>

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Shell/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Shell/Main.cs
@@ -165,7 +165,7 @@ namespace Microsoft.Plugin.Shell
             {
                 runAsVerbArg = "runAsUser";
             }
-            else if (runAs == RunAsType.Administrator || !_settings.RunAsAdministrator)
+            else if (runAs == RunAsType.Administrator || _settings.RunAsAdministrator)
             {
                 runAsVerbArg = "runAs";
             }

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Shell/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Shell/Main.cs
@@ -153,19 +153,29 @@ namespace Microsoft.Plugin.Shell
             return history.ToList();
         }
 
-        private ProcessStartInfo PrepareProcessStartInfo(string command, bool runAsAdministrator = false)
+        private ProcessStartInfo PrepareProcessStartInfo(string command, RunAsType runAs = RunAsType.None)
         {
             string trimmedCommand = command.Trim();
             command = Environment.ExpandEnvironmentVariables(trimmedCommand);
             var workingDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-            var runAsAdministratorArg = !runAsAdministrator && !_settings.RunAsAdministrator ? string.Empty : "runas";
+
+            // Set runAsArg
+            string runAsVerbArg = string.Empty;
+            if (runAs == RunAsType.OtherUser)
+            {
+                runAsVerbArg = "runAsUser";
+            }
+            else if (runAs == RunAsType.Administrator || !_settings.RunAsAdministrator)
+            {
+                runAsVerbArg = "runAs";
+            }
 
             ProcessStartInfo info;
             if (_settings.Shell == ExecutionShell.Cmd)
             {
                 var arguments = _settings.LeaveShellOpen ? $"/k \"{command}\"" : $"/c \"{command}\" & pause";
 
-                info = ShellCommand.SetProcessStartInfo("cmd.exe", workingDirectory, arguments, runAsAdministratorArg);
+                info = ShellCommand.SetProcessStartInfo("cmd.exe", workingDirectory, arguments, runAsVerbArg);
             }
             else if (_settings.Shell == ExecutionShell.Powershell)
             {
@@ -179,14 +189,14 @@ namespace Microsoft.Plugin.Shell
                     arguments = $"\"{command} ; Read-Host -Prompt \\\"Press Enter to continue\\\"\"";
                 }
 
-                info = ShellCommand.SetProcessStartInfo("powershell.exe", workingDirectory, arguments, runAsAdministratorArg);
+                info = ShellCommand.SetProcessStartInfo("powershell.exe", workingDirectory, arguments, runAsVerbArg);
             }
             else if (_settings.Shell == ExecutionShell.RunCommand)
             {
                 // Open explorer if the path is a file or directory
                 if (Directory.Exists(command) || File.Exists(command))
                 {
-                    info = ShellCommand.SetProcessStartInfo("explorer.exe", arguments: command, verb: runAsAdministratorArg);
+                    info = ShellCommand.SetProcessStartInfo("explorer.exe", arguments: command, verb: runAsVerbArg);
                 }
                 else
                 {
@@ -197,16 +207,16 @@ namespace Microsoft.Plugin.Shell
                         if (ExistInPath(filename))
                         {
                             var arguments = parts[1];
-                            info = ShellCommand.SetProcessStartInfo(filename, workingDirectory, arguments, runAsAdministratorArg);
+                            info = ShellCommand.SetProcessStartInfo(filename, workingDirectory, arguments, runAsVerbArg);
                         }
                         else
                         {
-                            info = ShellCommand.SetProcessStartInfo(command, verb: runAsAdministratorArg);
+                            info = ShellCommand.SetProcessStartInfo(command, verb: runAsVerbArg);
                         }
                     }
                     else
                     {
-                        info = ShellCommand.SetProcessStartInfo(command, verb: runAsAdministratorArg);
+                        info = ShellCommand.SetProcessStartInfo(command, verb: runAsVerbArg);
                     }
                 }
             }
@@ -220,6 +230,13 @@ namespace Microsoft.Plugin.Shell
             _settings.AddCmdHistory(trimmedCommand);
 
             return info;
+        }
+
+        private enum RunAsType
+        {
+            None,
+            Administrator,
+            OtherUser,
         }
 
         private void Execute(Func<ProcessStartInfo, Process> startProcess, ProcessStartInfo info)
@@ -326,7 +343,21 @@ namespace Microsoft.Plugin.Shell
                     AcceleratorModifiers = ModifierKeys.Control | ModifierKeys.Shift,
                     Action = c =>
                     {
-                        Execute(Process.Start, PrepareProcessStartInfo(selectedResult.Title, true));
+                        Execute(Process.Start, PrepareProcessStartInfo(selectedResult.Title, RunAsType.Administrator));
+                        return true;
+                    },
+                },
+                new ContextMenuResult
+                {
+                    PluginName = Assembly.GetExecutingAssembly().GetName().Name,
+                    Title = Properties.Resources.wox_plugin_cmd_run_as_user,
+                    Glyph = "\xE7EE",
+                    FontFamily = "Segoe MDL2 Assets",
+                    AcceleratorKey = Key.U,
+                    AcceleratorModifiers = ModifierKeys.Control | ModifierKeys.Shift,
+                    Action = _ =>
+                    {
+                        Execute(Process.Start, PrepareProcessStartInfo(selectedResult.Title, RunAsType.OtherUser));
                         return true;
                     },
                 },

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Shell/Properties/Resources.Designer.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Shell/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Plugin.Shell.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -120,6 +120,15 @@ namespace Microsoft.Plugin.Shell.Properties {
         public static string wox_plugin_cmd_run_as_administrator {
             get {
                 return ResourceManager.GetString("wox_plugin_cmd_run_as_administrator", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Run as different user (Ctrl+Shift+U).
+        /// </summary>
+        public static string wox_plugin_cmd_run_as_user {
+            get {
+                return ResourceManager.GetString("wox_plugin_cmd_run_as_user", resourceCulture);
             }
         }
     }

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Shell/Properties/Resources.resx
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Shell/Properties/Resources.resx
@@ -138,4 +138,7 @@
   <data name="wox_plugin_cmd_command_not_found" xml:space="preserve">
     <value>Command not found</value>
   </data>
+  <data name="wox_plugin_cmd_run_as_user" xml:space="preserve">
+    <value>Run as different user (Ctrl+Shift+U)</value>
+  </data>
 </root>

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.WindowWalker/Components/WindowProcess.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.WindowWalker/Components/WindowProcess.cs
@@ -186,7 +186,7 @@ namespace Microsoft.Plugin.WindowWalker.Components
             if (IsFullAccessDenied)
             {
                 string killTree = killProcessTree ? " /t" : string.Empty;
-                Helper.OpenInShell("taskkill.exe", $"/pid {(int)ProcessID} /f{killTree}", null, true, true);
+                Helper.OpenInShell("taskkill.exe", $"/pid {(int)ProcessID} /f{killTree}", null, Helper.ShellRunAsType.Administrator, true);
             }
             else
             {

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Registry/Helper/RegistryHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Registry/Helper/RegistryHelper.cs
@@ -145,7 +145,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Registry.Helper
             Win32.Registry.SetValue(@"HKEY_Current_User\Software\Microsoft\Windows\CurrentVersion\Applets\Regedit", "LastKey", fullKey);
 
             // -m => allow multi-instance (hidden start option)
-            Wox.Infrastructure.Helper.OpenInShell("regedit.exe", "-m", null, true);
+            Wox.Infrastructure.Helper.OpenInShell("regedit.exe", "-m", null, Wox.Infrastructure.Helper.ShellRunAsType.Administrator);
         }
 
         /// <summary>

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.System/Components/Commands.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.System/Components/Commands.cs
@@ -136,7 +136,7 @@ namespace Microsoft.PowerToys.Run.Plugin.System.Components
                     IcoPath = $"Images\\firmwareSettings.{iconTheme}.png",
                     Action = c =>
                     {
-                        return ResultHelper.ExecuteCommand(confirmCommands, Resources.Microsoft_plugin_sys_uefi_confirmation, () => Helper.OpenInShell("shutdown", "/r /fw /t 0", null, true));
+                        return ResultHelper.ExecuteCommand(confirmCommands, Resources.Microsoft_plugin_sys_uefi_confirmation, () => Helper.OpenInShell("shutdown", "/r /fw /t 0", null, Helper.ShellRunAsType.Administrator));
                     },
                 });
             }

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsTerminal/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsTerminal/Main.cs
@@ -153,7 +153,7 @@ namespace Microsoft.PowerToys.Run.Plugin.WindowsTerminal
             try
             {
                 string path = "shell:AppsFolder\\" + id;
-                Helper.OpenInShell(path, TerminalHelper.GetArguments(profile, _openNewTab), runAsAdmin: true);
+                Helper.OpenInShell(path, TerminalHelper.GetArguments(profile, _openNewTab), runAs: Helper.ShellRunAsType.Administrator);
             }
 #pragma warning disable CA1031 // Do not catch general exception types
             catch (Exception ex)

--- a/src/modules/launcher/Wox.Test/Plugins/WindowsIndexerTest.cs
+++ b/src/modules/launcher/Wox.Test/Plugins/WindowsIndexerTest.cs
@@ -291,11 +291,12 @@ namespace Wox.Test.Plugins
             List<ContextMenuResult> contextMenuItems = contextMenuLoader.LoadContextMenus(result);
 
             // Assert
-            Assert.AreEqual(4, contextMenuItems.Count);
+            Assert.AreEqual(5, contextMenuItems.Count);
             Assert.AreEqual(Microsoft.Plugin.Indexer.Properties.Resources.Microsoft_plugin_indexer_open_containing_folder, contextMenuItems[0].Title);
             Assert.AreEqual(Microsoft.Plugin.Indexer.Properties.Resources.Microsoft_plugin_indexer_run_as_administrator, contextMenuItems[1].Title);
-            Assert.AreEqual(Microsoft.Plugin.Indexer.Properties.Resources.Microsoft_plugin_indexer_copy_path, contextMenuItems[2].Title);
-            Assert.AreEqual(Microsoft.Plugin.Indexer.Properties.Resources.Microsoft_plugin_indexer_open_in_console, contextMenuItems[3].Title);
+            Assert.AreEqual(Microsoft.Plugin.Indexer.Properties.Resources.Microsoft_plugin_indexer_run_as_user, contextMenuItems[2].Title);
+            Assert.AreEqual(Microsoft.Plugin.Indexer.Properties.Resources.Microsoft_plugin_indexer_copy_path, contextMenuItems[3].Title);
+            Assert.AreEqual(Microsoft.Plugin.Indexer.Properties.Resources.Microsoft_plugin_indexer_open_in_console, contextMenuItems[4].Title);
         }
 
         [DataTestMethod]


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Before this PR users can start app in PT Run as admin but not as other user.

**What is included in the PR:** 
This PR extends the class `Wox.Infrastructure.Helper`:
- Add "run as user" feature to `OpenInShell`.
- New `RunAsUser` method.

And this PR adds a `Run as different user (Ctrl+Shift+U)` context menu to the following plugins on result that shows a "run as admin" context menu:
- Program plugin (except uwp apps *)
- Shell plugin
- Search plugin

_*) UWP apps normally installed per user. There this menu makes no sense._

![image](https://user-images.githubusercontent.com/61519853/160250338-2724724d-48d7-4d3b-82f7-8c2c30c5ab68.png)

![image](https://user-images.githubusercontent.com/61519853/160250344-caa30fcd-9fc2-4b19-8c91-4104c6290b17.png)


**How does someone test / validate:** 
Build locally and test if user input mask is shown and build succeeds.

## Quality Checklist

- [x] **Linked issue:** #1605
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [x] **Tests:** Added/updated and all pass
- [x] **Installer:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [x] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
