### PR TITLE
[PT Run] Web search should use user's default browser #16549

### DIFF
--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.WebSearch/Main.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.WebSearch/Main.cs
@@ -63,7 +63,7 @@ namespace Community.PowerToys.Run.Plugin.WebSearch
             // empty non-global query:
             if (!AreResultsGlobal() && query.ActionKeyword == query.RawQuery)
             {
-                string arguments = "\"? \"";
+                string arguments = "? ";
                 results.Add(new Result
                 {
                     Title = Properties.Resources.plugin_description.Remove(Description.Length - 1, 1),
@@ -73,7 +73,7 @@ namespace Community.PowerToys.Run.Plugin.WebSearch
                     ProgramArguments = arguments,
                     Action = action =>
                     {
-                        if (!Helper.OpenInShell(BrowserInfo.Path ?? BrowserInfo.MSEdgePath, arguments))
+                        if (!Helper.OpenCommandInShell(BrowserInfo.Path, BrowserInfo.ArgumentsPattern, arguments))
                         {
                             onPluginError();
                             return false;
@@ -105,37 +105,19 @@ namespace Community.PowerToys.Run.Plugin.WebSearch
                     IcoPath = _iconPath,
                 };
 
-                if (BrowserInfo.SupportsWebSearchByCmdLineArgument)
+                string arguments = $"? {searchTerm}";
+
+                result.ProgramArguments = arguments;
+                result.Action = action =>
                 {
-                    string arguments = $"\"? {searchTerm}\"";
-
-                    result.ProgramArguments = arguments;
-                    result.Action = action =>
+                    if (!Helper.OpenCommandInShell(BrowserInfo.Path, BrowserInfo.ArgumentsPattern, arguments))
                     {
-                        if (!Helper.OpenInShell(BrowserInfo.Path ?? BrowserInfo.MSEdgePath, arguments))
-                        {
-                            onPluginError();
-                            return false;
-                        }
+                        onPluginError();
+                        return false;
+                    }
 
-                        return true;
-                    };
-                }
-                else
-                {
-                    string url = string.Format(CultureInfo.InvariantCulture, BrowserInfo.SearchEngineUrl, searchTerm);
-
-                    result.Action = action =>
-                    {
-                        if (!Helper.OpenInShell(url))
-                        {
-                            onPluginError();
-                            return false;
-                        }
-
-                        return true;
-                    };
-                }
+                    return true;
+                };
 
                 results.Add(result);
             }

--- a/src/modules/launcher/Wox.Infrastructure/Helper.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Helper.cs
@@ -148,6 +148,16 @@ namespace Wox.Infrastructure
             return Process.Start(processStartInfo);
         }
 
+        public static bool OpenCommandInShell(string path, string pattern, string arguments, string workingDir = null, ShellRunAsType runAs = ShellRunAsType.None, bool runWithHiddenWindow = false)
+        {
+            if (pattern.Contains("%1", StringComparison.Ordinal))
+            {
+                arguments = pattern.Replace("%1", arguments);
+            }
+
+            return OpenInShell(path, arguments, workingDir, runAs, runWithHiddenWindow);
+        }
+
         public static bool OpenInShell(string path, string arguments = null, string workingDir = null, ShellRunAsType runAs = ShellRunAsType.None, bool runWithHiddenWindow = false)
         {
             using (var process = new Process())

--- a/src/modules/launcher/Wox.Plugin/Common/DefaultBrowserInfo.cs
+++ b/src/modules/launcher/Wox.Plugin/Common/DefaultBrowserInfo.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.IO.Abstractions;
 using System.Text;
 using Wox.Plugin.Common.Win32;
 using Wox.Plugin.Logger;
@@ -18,40 +17,40 @@ namespace Wox.Plugin.Common
         private static readonly object _updateLock = new object();
         private static int _lastUpdateTickCount = -1;
 
-        public static readonly string MSEdgePath = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86) + @"\Microsoft\Edge\Application\msedge.exe";
-        public const string MSEdgeName = "Microsoft Edge";
+        /// <summary>Gets the path to the MS Edge browser executable.</summary>
+        public static string MSEdgePath =>
+            Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86) +
+            @"\Microsoft\Edge\Application\msedge.exe";
 
-        private static readonly IPath FilePath = new FileSystem().Path;
+        /// <summary>Gets the command line pattern of the MS Edge.</summary>
+        public static string MSEdgeArgumentsPattern => "--single-argument %1";
+
+        public const string MSEdgeName = "Microsoft Edge";
 
         /// <summary>Gets the path to default browser's executable.</summary>
         public static string Path { get; private set; }
 
-        /// <summary>Gets <see cref="Path" /> since the icon is embedded in the executable.</summary>
-        public static string IconPath { get => Path; }
+        /// <summary>Gets <see cref="Path"/> since the icon is embedded in the executable.</summary>
+        public static string IconPath => Path;
 
+        /// <summary>Gets the user-friendly name of the default browser.</summary>
         public static string Name { get; private set; }
 
-        /// <summary>Gets a value indicating whether the browser supports querying a web search via command line argument (`? <term>`).</summary>
-        public static bool SupportsWebSearchByCmdLineArgument { get => SearchEngineUrl is null; }
+        /// <summary>Gets the command line pattern for MS Edge.</summary>
+        public static string ArgumentsPattern { get; private set; }
 
         public static bool IsDefaultBrowserSet { get => !string.IsNullOrEmpty(Path); }
 
-        /// <summary>
-        /// Gets the browser's default search engine's url ready to be formatted with a single value (like `https://www.bing.com/search?q={0}`)
-        /// </summary>
-#pragma warning disable CA1056 // URI-like properties should not be strings
-        public static string SearchEngineUrl { get; private set; }
-#pragma warning restore CA1056 // URI-like properties should not be strings
+        public const int UpdateTimeout = 300;
 
         /// <summary>
         /// Updates only if at least more than 300ms has passed since the last update, to avoid multiple calls to <see cref="Update"/>.
         /// (because of multiple plugins calling update at the same time.)
         /// </summary>
-        /// <param name="defaultToEdgeOnFail">If true, If <see cref="Update"/> fails, for any reason, the browser will be set to Microsoft Edge.</param>
         public static void UpdateIfTimePassed()
         {
             int curTickCount = Environment.TickCount;
-            if (curTickCount - _lastUpdateTickCount > 300)
+            if (curTickCount - _lastUpdateTickCount > UpdateTimeout)
             {
                 _lastUpdateTickCount = curTickCount;
                 Update();
@@ -72,140 +71,74 @@ namespace Wox.Plugin.Common
                     string progId = GetRegistryValue(
                         @"HKEY_CURRENT_USER\Software\Microsoft\Windows\Shell\Associations\UrlAssociations\http\UserChoice",
                         "ProgId");
+                    string appName = GetRegistryValue($@"HKEY_CLASSES_ROOT\{progId}\Application", "ApplicationName")
+                        ?? GetRegistryValue($@"HKEY_CLASSES_ROOT\{progId}", "FriendlyTypeName");
 
-                    // The `?` argument doesn't work on opera, so we get the user's default search engine:
-                    if (progId.StartsWith("Opera", StringComparison.OrdinalIgnoreCase))
+                    if (appName != null)
                     {
-                        // Opera user preferences file:
-                        string prefFile;
-
-                        if (progId.Contains("GX", StringComparison.OrdinalIgnoreCase))
+                        // Handle indirect strings:
+                        if (appName.StartsWith("@", StringComparison.Ordinal))
                         {
-                            Name = "Opera GX";
-                            prefFile = System.IO.File.ReadAllText($"{Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)}\\Opera Software\\Opera GX Stable\\Preferences");
-                        }
-                        else
-                        {
-                            Name = "Opera";
-                            prefFile = System.IO.File.ReadAllText($"{Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)}\\Opera Software\\Opera Stable\\Preferences");
+                            appName = GetIndirectString(appName);
                         }
 
-                        // "default_search_provider_data" doesn't exist if the user hasn't searched for the first time,
-                        // therefore we set `url` to opera's default search engine:
-                        string url = "https://www.google.com/search?client=opera&q={0}&sourceid=opera";
-
-                        using (System.Text.Json.JsonDocument doc = System.Text.Json.JsonDocument.Parse(prefFile))
-                        {
-                            if (doc.RootElement.TryGetProperty("default_search_provider_data", out var element))
-                            {
-                                if (element.TryGetProperty("template_url_data", out element))
-                                {
-                                    if (element.TryGetProperty("url", out element))
-                                    {
-                                        url = element.GetString();
-                                    }
-                                }
-                            }
-                        }
-
-                        url = url
-                            .Replace("{searchTerms}", "{0}", StringComparison.Ordinal)
-                            .Replace("{inputEncoding}", "UTF-8", StringComparison.Ordinal)
-                            .Replace("{outputEncoding}", "UTF-8", StringComparison.Ordinal);
-
-                        int startIndex = url.IndexOf('}', StringComparison.Ordinal) + 1;
-
-                        // In case there are other url parameters (e.g. `&foo={bar}`), remove them:
-                        for (int i = url.IndexOf("}", startIndex, StringComparison.Ordinal);
-                                i != -1;
-                                i = url.IndexOf("}", startIndex, StringComparison.Ordinal))
-                        {
-                            for (int j = i - 1; j > 0; --j)
-                            {
-                                if (url[j] == '&')
-                                {
-                                    url = url.Remove(j, i - j + 1);
-                                    break;
-                                }
-                            }
-                        }
-
-                        SearchEngineUrl = url;
-                    }
-                    else
-                    {
-                        string appName = GetRegistryValue($@"HKEY_CLASSES_ROOT\{progId}\Application", "ApplicationName")
-                            ?? GetRegistryValue($@"HKEY_CLASSES_ROOT\{progId}", "FriendlyTypeName");
-
-                        if (appName != null)
-                        {
-                            // Handle indirect strings:
-                            if (appName.StartsWith("@", StringComparison.Ordinal))
-                            {
-                                appName = GetIndirectString(appName);
-                            }
-
-                            appName = appName
-                                .Replace("URL", null, StringComparison.OrdinalIgnoreCase)
-                                .Replace("HTML", null, StringComparison.OrdinalIgnoreCase)
-                                .Replace("Document", null, StringComparison.OrdinalIgnoreCase)
-                                .TrimEnd();
-                        }
-
-                        Name = appName;
-
-                        SearchEngineUrl = null;
+                        appName = appName
+                            .Replace("URL", null, StringComparison.OrdinalIgnoreCase)
+                            .Replace("HTML", null, StringComparison.OrdinalIgnoreCase)
+                            .Replace("Document", null, StringComparison.OrdinalIgnoreCase)
+                            .Replace("Web", null, StringComparison.OrdinalIgnoreCase)
+                            .TrimEnd();
                     }
 
-                    // Get the path to the browser's executable:
-                    // for example "C:\Program Files\SomeCompany\SomeBrowser\Application\launcher.exe" --single-argument %1
-                    string programLocation = GetRegistryValue($@"HKEY_CLASSES_ROOT\{progId}\shell\open\command", null);
-                    if (string.IsNullOrEmpty(programLocation))
+                    Name = appName;
+
+                    string commandPattern = GetRegistryValue($@"HKEY_CLASSES_ROOT\{progId}\shell\open\command", null);
+
+                    if (string.IsNullOrEmpty(commandPattern))
                     {
                         throw new ArgumentOutOfRangeException(
-                            nameof(programLocation),
-                            "Default browser program location is not specified.");
+                            nameof(commandPattern),
+                            "Default browser program command is not specified.");
                     }
 
-                    if (programLocation.StartsWith('\"'))
+                    if (commandPattern.StartsWith('@'))
                     {
-                        var endQuoteIndex = programLocation.IndexOf('\"', 1);
+                        commandPattern = GetIndirectString(commandPattern);
+                    }
+
+                    if (commandPattern.StartsWith('\"'))
+                    {
+                        var endQuoteIndex = commandPattern.IndexOf('\"', 1);
                         if (endQuoteIndex != -1)
                         {
-                            programLocation = programLocation.Substring(1, endQuoteIndex - 1);
+                            Path = commandPattern.Substring(1, endQuoteIndex - 1);
+                            ArgumentsPattern = commandPattern.Substring(endQuoteIndex + 1).Trim();
                         }
-                    }
-
-                    if (programLocation.StartsWith('@'))
-                    {
-                        string directProgramLocation = GetIndirectString(programLocation);
-                        Path = string.Equals(FilePath.GetExtension(directProgramLocation), ".exe", StringComparison.Ordinal)
-                            ? directProgramLocation
-                            : throw new ArgumentOutOfRangeException(
-                            nameof(programLocation),
-                            programLocation,
-                            "Unexpected default browser program location.");
                     }
                     else
                     {
-                        // Using Ordinal since this is internal and used with a symbol
-                        var indexOfComma = programLocation.IndexOf(',', StringComparison.Ordinal);
-                        Path = indexOfComma == -1
-                            ? programLocation
-                            : programLocation.Substring(0, indexOfComma);
+                        var spaceIndex = commandPattern.IndexOf(' ');
+                        if (spaceIndex != -1)
+                        {
+                            Path = commandPattern.Substring(0, spaceIndex);
+                            ArgumentsPattern = commandPattern.Substring(spaceIndex + 1).Trim();
+                        }
                     }
 
                     if (string.IsNullOrEmpty(Path))
                     {
-                        throw new ArgumentOutOfRangeException(nameof(Path), "Browser path is null or empty.");
+                        throw new ArgumentOutOfRangeException(
+                            nameof(Path),
+                            "Default browser program path could not be determined.");
                     }
                 }
                 catch (Exception e)
                 {
-                    Path = null;
-                    Name = null;
-                    SearchEngineUrl = null;
-                    Log.Exception("Exception when retrieving browser path/name. Path and Name are null.", e, typeof(DefaultBrowserInfo));
+                    // fallback to MS Edge
+                    Path = MSEdgePath;
+                    Name = MSEdgeName;
+                    ArgumentsPattern = MSEdgeArgumentsPattern;
+                    Log.Exception("Exception when retrieving browser path/name. Path and Name are set to use Microsoft Edge.", e, typeof(DefaultBrowserInfo));
                 }
 
                 string GetRegistryValue(string registryLocation, string valueName)
@@ -226,7 +159,7 @@ namespace Wox.Plugin.Common
                         return stringBuilder.ToString();
                     }
 
-                    throw new ArgumentNullException(nameof(Path), "Could not load indirect string.");
+                    throw new ArgumentNullException(nameof(str), "Could not load indirect string.");
                 }
             }
         }

--- a/src/modules/launcher/Wox.Plugin/Common/DefaultBrowserInfo.cs
+++ b/src/modules/launcher/Wox.Plugin/Common/DefaultBrowserInfo.cs
@@ -36,7 +36,7 @@ namespace Wox.Plugin.Common
         /// <summary>Gets the user-friendly name of the default browser.</summary>
         public static string Name { get; private set; }
 
-        /// <summary>Gets the command line pattern for MS Edge.</summary>
+        /// <summary>Gets the command line pattern of the default browser.</summary>
         public static string ArgumentsPattern { get; private set; }
 
         public static bool IsDefaultBrowserSet { get => !string.IsNullOrEmpty(Path); }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Before this PR PT Run used Application or Default Icon location specified in the registry to find default browser program location. If PT Run was unable to detect program location it used Microsoft Edge.
Also for Opera browser implementation checked internal Opera settings and started a search engine specified with constructed address.

**What is included in the PR:** 
Default Browser Info detection logic updated to use shell command for default browser.
Parameters specified in command are used and search terms are working for Chrome, Firefox, Microsoft Edge and Opera.
If we're unable to find default browser we're using Microsoft Edge.

**How does someone test / validate:** 
Start Power Toys
Go to Power Toys Run
Type ?? to start Web Search plugin
Check your default browser is mentioned in the suggestion area
Close Power Toys
Change your default browser
Repeat previous steps and check that a new default browser shown in the suggestion area

## Quality Checklist

- [x] **Linked issue:** #16549 
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
