### PR TITLE
[Updater]Use sensible default time between checks

### DIFF
--- a/src/runner/UpdateUtils.cpp
+++ b/src/runner/UpdateUtils.cpp
@@ -154,7 +154,7 @@ void PeriodicUpdateWorker()
     for (;;)
     {
         auto state = UpdateState::read();
-        int64_t sleep_minutes_till_next_update = 0;
+        int64_t sleep_minutes_till_next_update = UPDATE_CHECK_AFTER_FAILED_INTERVAL_MINUTES;
         if (state.githubUpdateLastCheckedDate.has_value())
         {
             int64_t last_checked_minutes_ago = timeutil::diff::in_minutes(timeutil::now(), *state.githubUpdateLastCheckedDate);


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
In https://github.com/microsoft/PowerToys/issues/17057#issuecomment-1075082130, the user logs were polluted with messages of trying to check for updates in a loop.

**What is included in the PR:** 
Use a sensible default for minutes before re-checking for an update to try to avoid infinite loops.

**How does someone test / validate:** 
Code quality check is what I'm looking for here, since it's not clear how the user got this to happen, but this should help prevent it.

## Quality Checklist

- [x] **Linked issue:** https://github.com/microsoft/PowerToys/issues/17057#issuecomment-1075082130
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries
