### PR TITLE
[AlwaysOnTop] Fix for topmost resetting.

### DIFF
--- a/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.cpp
+++ b/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.cpp
@@ -394,6 +394,8 @@ void AlwaysOnTop::HandleWinHookEvent(WinHookEvent* data) noexcept
         auto iter = m_topmostWindows.find(data->hwnd);
         if (iter != m_topmostWindows.end())
         {
+            // pin border again, in some cases topmost flag stops working: https://github.com/microsoft/PowerToys/issues/17332
+            PinTopmostWindow(data->hwnd); 
             AssignBorder(data->hwnd);
         }
     }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

In some cases, the topmost flag stops working. It's still present, but windows behave as regular, not topmost. 
Pinning it again fixes the problem.

**What is included in the PR:** 

**How does someone test / validate:** 

* Pin Excel
* Pin OneNote
* Alt-tab between those windows (2-5 times)
* Verify both windows are still topmost.

## Quality Checklist

- [x] **Linked issue:** #17332
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
