### PR TITLE
[PTRun][Settings][Program] Fix 100% CPU load issue

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Main.cs
@@ -19,7 +19,7 @@ using Stopwatch = Wox.Infrastructure.Stopwatch;
 
 namespace Microsoft.Plugin.Program
 {
-    public class Main : IPlugin, IPluginI18n, IContextMenu, ISavable, IReloadable, IDisposable
+    public class Main : IPlugin, IPluginI18n, IContextMenu, ISavable, IDisposable
     {
         // The order of this array is important! The Parsers will be checked in order (index 0 to index Length-1) and the first parser which is able to parse the Query will be used
         // NoArgumentsArgumentParser does always succeed and therefor should always be last/fallback
@@ -192,11 +192,6 @@ namespace Microsoft.Plugin.Program
                 var message = $"{Properties.Resources.powertoys_run_plugin_program_start_failed}: {info?.FileName}";
                 _context.API.ShowMsg(name, message, string.Empty);
             }
-        }
-
-        public void ReloadData()
-        {
-            IndexPrograms();
         }
 
         public void Dispose()

--- a/src/settings-ui/Settings.UI.Library/ViewModels/PowerLauncherViewModel.cs
+++ b/src/settings-ui/Settings.UI.Library/ViewModels/PowerLauncherViewModel.cs
@@ -439,6 +439,10 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             {
                 var plugins = settings.Plugins.Where(p => p.Name.StartsWith(SearchText, StringComparison.OrdinalIgnoreCase) || p.Name.IndexOf($" {SearchText}", StringComparison.OrdinalIgnoreCase) > 0);
                 _plugins = new ObservableCollection<PowerLauncherPluginViewModel>(plugins.Select(x => new PowerLauncherPluginViewModel(x, isDark)));
+                foreach (var plugin in _plugins)
+                {
+                    plugin.PropertyChanged += OnPluginInfoChange;
+                }
             }
             else
             {

--- a/src/settings-ui/Settings.UI.Library/ViewModels/PowerLauncherViewModel.cs
+++ b/src/settings-ui/Settings.UI.Library/ViewModels/PowerLauncherViewModel.cs
@@ -104,6 +104,15 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
 
         private void OnPluginInfoChange(object sender, PropertyChangedEventArgs e)
         {
+            if (
+                e.PropertyName == nameof(PowerLauncherPluginViewModel.ShowNotAccessibleWarning)
+                || e.PropertyName == nameof(PowerLauncherPluginViewModel.ShowNotAllowedKeywordWarning)
+                )
+            {
+                // Don't trigger a settings update if the changed property is for visual notification.
+                return;
+            }
+
             OnPropertyChanged(nameof(ShowAllPluginsDisabledWarning));
             UpdateSettings();
         }

--- a/src/settings-ui/Settings.UI/Views/PowerLauncherPage.xaml.cs
+++ b/src/settings-ui/Settings.UI/Views/PowerLauncherPage.xaml.cs
@@ -19,15 +19,31 @@ namespace Microsoft.PowerToys.Settings.UI.Views
         private readonly ObservableCollection<Tuple<string, string>> searchResultPreferencesOptions;
         private readonly ObservableCollection<Tuple<string, string>> searchTypePreferencesOptions;
 
+        private int _lastIPCMessageSentTick;
+
+        // Keep track of the last IPC Message that was sent.
+        private int SendDefaultIPCMessageTimed(string msg)
+        {
+            _lastIPCMessageSentTick = Environment.TickCount;
+            return ShellPage.SendDefaultIPCMessage(msg);
+        }
+
         public PowerLauncherPage()
         {
             InitializeComponent();
             var settingsUtils = new SettingsUtils();
+            _lastIPCMessageSentTick = Environment.TickCount;
             PowerLauncherSettings settings = settingsUtils.GetSettingsOrDefault<PowerLauncherSettings>(PowerLauncherSettings.ModuleName);
-            ViewModel = new PowerLauncherViewModel(settings, SettingsRepository<GeneralSettings>.GetInstance(settingsUtils), ShellPage.SendDefaultIPCMessage, App.IsDarkTheme);
+            ViewModel = new PowerLauncherViewModel(settings, SettingsRepository<GeneralSettings>.GetInstance(settingsUtils), SendDefaultIPCMessageTimed, App.IsDarkTheme);
             DataContext = ViewModel;
             _ = Helper.GetFileWatcher(PowerLauncherSettings.ModuleName, "settings.json", () =>
             {
+                if (Environment.TickCount < _lastIPCMessageSentTick + 500)
+                {
+                    // Don't try to update data from the file if we tried to write to it through IPC int the last 500 milliseconds.
+                    return;
+                }
+
                 PowerLauncherSettings powerLauncherSettings = null;
                 try
                 {

--- a/src/settings-ui/Settings.UI/Views/PowerLauncherPage.xaml.cs
+++ b/src/settings-ui/Settings.UI/Views/PowerLauncherPage.xaml.cs
@@ -40,7 +40,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             {
                 if (Environment.TickCount < _lastIPCMessageSentTick + 500)
                 {
-                    // Don't try to update data from the file if we tried to write to it through IPC int the last 500 milliseconds.
+                    // Don't try to update data from the file if we tried to write to it through IPC in the last 500 milliseconds.
                     return;
                 }
 


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Each change in PowerToys Run settings triggers a plugin reload for plugins with the IReload interface. Program plugin has this interface and takes a long time to load, despite having no setting that would necessitate a reload.

**What is included in the PR:** 
- Don't reload the Program plugin on every setting change.
- Don't save the settings 3 times for each change. Only once is needed.
- To fix a UI glitch while reloading settings due to frequent saves, only reload the PTRun Settings if we didn't trigger a save in the last 500 milliseconds.
- After searching for a Plugin in Settings, a bug causes it to not trigger saves anymore, fix this.

**How does someone test / validate:** 
Try to trigger the 100% CPU and UI glitch described in the issue and verify it no longer happens, while the settings still propagate.


## Quality Checklist

- [x] **Linked issue:** #17390
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries
