### PR TITLE
[FancyZones] Restore original corners

### DIFF
--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesWindowProperties.h
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesWindowProperties.h
@@ -9,6 +9,7 @@ namespace ZonedWindowProperties
 {
     const wchar_t PropertyRestoreSizeID[] = L"FancyZones_RestoreSize";
     const wchar_t PropertyRestoreOriginID[] = L"FancyZones_RestoreOrigin";
+    const wchar_t PropertyCornerPreference[] = L"FancyZones_CornerPreference";
 
     const wchar_t MultiMonitorDeviceID[] = L"FancyZones#MultiMonitorDevice";
 }

--- a/src/modules/fancyzones/FancyZonesLib/Settings.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/Settings.cpp
@@ -34,7 +34,7 @@ namespace NonLocalizable
     const wchar_t MakeDraggedWindowTransparentID[] = L"fancyzones_makeDraggedWindowTransparent";
     const wchar_t AllowPopupWindowSnapID[] = L"fancyzones_allowPopupWindowSnap";
     const wchar_t AllowChildWindowSnapID[] = L"fancyzones_allowChildWindowSnap";
-    const wchar_t DisableRoundCornersOnSnapping[] = L"fancyzones_disableRoundCornersOnSnapping";
+    const wchar_t DisableRoundCornersOnSnapping[] = L"fancyzones_disableRoundCornersOnSnap";
 
     const wchar_t SystemThemeID[] = L"fancyzones_systemTheme";
     const wchar_t ZoneColorID[] = L"fancyzones_zoneColor";

--- a/src/modules/fancyzones/FancyZonesLib/Settings.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/Settings.cpp
@@ -34,6 +34,7 @@ namespace NonLocalizable
     const wchar_t MakeDraggedWindowTransparentID[] = L"fancyzones_makeDraggedWindowTransparent";
     const wchar_t AllowPopupWindowSnapID[] = L"fancyzones_allowPopupWindowSnap";
     const wchar_t AllowChildWindowSnapID[] = L"fancyzones_allowChildWindowSnap";
+    const wchar_t DisableRoundCornersOnSnapping[] = L"fancyzones_disableRoundCornersOnSnapping";
 
     const wchar_t SystemThemeID[] = L"fancyzones_systemTheme";
     const wchar_t ZoneColorID[] = L"fancyzones_zoneColor";
@@ -126,6 +127,7 @@ void FancyZonesSettings::LoadSettings()
         SetBoolFlag(values, NonLocalizable::ShowZoneNumberID, SettingId::ShowZoneNumber, m_settings.showZoneNumber);
         SetBoolFlag(values, NonLocalizable::AllowPopupWindowSnapID, SettingId::AllowSnapPopupWindows, m_settings.allowSnapPopupWindows);
         SetBoolFlag(values, NonLocalizable::AllowChildWindowSnapID, SettingId::AllowSnapChildWindows, m_settings.allowSnapChildWindows);
+        SetBoolFlag(values, NonLocalizable::DisableRoundCornersOnSnapping, SettingId::DisableRoundCornersOnSnapping, m_settings.disableRoundCorners);
 
         // colors
         if (auto val = values.get_string_value(NonLocalizable::ZoneColorID))

--- a/src/modules/fancyzones/FancyZonesLib/Settings.h
+++ b/src/modules/fancyzones/FancyZonesLib/Settings.h
@@ -45,6 +45,7 @@ struct Settings
     bool showZoneNumber = true;
     bool allowSnapPopupWindows = false;
     bool allowSnapChildWindows = false;
+    bool disableRoundCorners = false;
     std::wstring zoneColor = L"#AACDFF";
     std::wstring zoneBorderColor = L"#FFFFFF";
     std::wstring zoneHighlightColor = L"#008CFF";

--- a/src/modules/fancyzones/FancyZonesLib/SettingsConstants.h
+++ b/src/modules/fancyzones/FancyZonesLib/SettingsConstants.h
@@ -33,4 +33,5 @@ enum class SettingId
     ExcludedApps,
     AllowSnapPopupWindows,
     AllowSnapChildWindows,
+    DisableRoundCornersOnSnapping,
 };

--- a/src/modules/fancyzones/FancyZonesLib/WindowMoveHandler.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WindowMoveHandler.cpp
@@ -247,10 +247,7 @@ void WindowMoveHandler::MoveSizeEnd(HWND window, POINT const& ptScreen, const st
             }
         }
 
-        if (FancyZonesSettings::settings().disableRoundCorners)
-        {
-            FancyZonesWindowUtils::ResetRoundCornersPreference(window);
-        }
+        FancyZonesWindowUtils::ResetRoundCornersPreference(window);
 
         auto monitor = MonitorFromWindow(window, MONITOR_DEFAULTTONULL);
         if (monitor)

--- a/src/modules/fancyzones/FancyZonesLib/WindowMoveHandler.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WindowMoveHandler.cpp
@@ -247,7 +247,10 @@ void WindowMoveHandler::MoveSizeEnd(HWND window, POINT const& ptScreen, const st
             }
         }
 
-        FancyZonesWindowUtils::ResetRoundCornersPreference(window);
+        if (FancyZonesSettings::settings().disableRoundCorners)
+        {
+            FancyZonesWindowUtils::ResetRoundCornersPreference(window);
+        }
 
         auto monitor = MonitorFromWindow(window, MONITOR_DEFAULTTONULL);
         if (monitor)

--- a/src/modules/fancyzones/FancyZonesLib/WindowMoveHandler.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WindowMoveHandler.cpp
@@ -247,6 +247,8 @@ void WindowMoveHandler::MoveSizeEnd(HWND window, POINT const& ptScreen, const st
             }
         }
 
+        FancyZonesWindowUtils::ResetRoundCornersPreference(window);
+
         auto monitor = MonitorFromWindow(window, MONITOR_DEFAULTTONULL);
         if (monitor)
         {

--- a/src/modules/fancyzones/FancyZonesLib/WindowUtils.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WindowUtils.cpp
@@ -339,11 +339,6 @@ void FancyZonesWindowUtils::SizeWindowToRect(HWND window, RECT rect) noexcept
     ScreenToWorkAreaCoords(window, rect);
 
     placement.rcNormalPosition = rect;
-
-    // Set window corner preference on Windows 11 to "Do not round"
-    int corner_preference = DWMWCP_DONOTROUND;
-    DwmSetWindowAttribute(window, DWMWA_WINDOW_CORNER_PREFERENCE, &corner_preference, sizeof(corner_preference));
-
     placement.flags |= WPF_ASYNCWINDOWPLACEMENT;
 
     auto result = ::SetWindowPlacement(window, &placement);
@@ -413,11 +408,6 @@ void FancyZonesWindowUtils::RestoreWindowSize(HWND window) noexcept
             SizeWindowToRect(window, rect);
         }
 
-        // Set window corner preference on Windows 11 to "Default"
-        // TODO: Should probably store preference from before snap
-        int corner_preference = DWMWCP_DEFAULT;
-        DwmSetWindowAttribute(window, DWMWA_WINDOW_CORNER_PREFERENCE, &corner_preference, sizeof(corner_preference));
-
         ::RemoveProp(window, ZonedWindowProperties::PropertyRestoreSizeID);
     }
 }
@@ -484,6 +474,21 @@ RECT FancyZonesWindowUtils::AdjustRectForSizeWindowToRect(HWND window, RECT rect
     MapWindowRect(windowOfRect, nullptr, &newWindowRect);
 
     return newWindowRect;
+}
+
+void FancyZonesWindowUtils::DisableRoundCorners(HWND window) noexcept
+{
+    // Set window corner preference on Windows 11 to "Do not round"
+    int corner_preference = DWMWCP_DONOTROUND;
+    DwmSetWindowAttribute(window, DWMWA_WINDOW_CORNER_PREFERENCE, &corner_preference, sizeof(corner_preference));
+}
+
+void FancyZonesWindowUtils::ResetRoundCornersPreference(HWND window) noexcept
+{
+    // Set window corner preference on Windows 11 to "Default"
+    // TODO: Should probably store preference from before snap
+    int corner_preference = DWMWCP_DEFAULT;
+    DwmSetWindowAttribute(window, DWMWA_WINDOW_CORNER_PREFERENCE, &corner_preference, sizeof(corner_preference));
 }
 
 void FancyZonesWindowUtils::MakeWindowTransparent(HWND window)

--- a/src/modules/fancyzones/FancyZonesLib/WindowUtils.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WindowUtils.cpp
@@ -478,17 +478,54 @@ RECT FancyZonesWindowUtils::AdjustRectForSizeWindowToRect(HWND window, RECT rect
 
 void FancyZonesWindowUtils::DisableRoundCorners(HWND window) noexcept
 {
+    HANDLE handle = GetPropW(window, ZonedWindowProperties::PropertyCornerPreference);
+    if (!handle)
+    {
+        int cornerPreference = DWMWCP_DEFAULT;
+        // save corner preference if it wasn't set already
+        DwmGetWindowAttribute(window, DWMWA_WINDOW_CORNER_PREFERENCE, &cornerPreference, sizeof(cornerPreference));
+
+        HANDLE preferenceHandle;
+        memcpy(&preferenceHandle, &cornerPreference, sizeof(int));
+
+        if (!SetProp(window, ZonedWindowProperties::PropertyCornerPreference, preferenceHandle))
+        {
+            Logger::error(L"Failed to save corner preference, {}", get_last_error_or_default(GetLastError()));
+        }
+    }
+
     // Set window corner preference on Windows 11 to "Do not round"
-    int corner_preference = DWMWCP_DONOTROUND;
-    DwmSetWindowAttribute(window, DWMWA_WINDOW_CORNER_PREFERENCE, &corner_preference, sizeof(corner_preference));
+    int cornerPreference = DWMWCP_DONOTROUND;
+    if (!SUCCEEDED(DwmSetWindowAttribute(window, DWMWA_WINDOW_CORNER_PREFERENCE, &cornerPreference, sizeof(cornerPreference))))
+    {
+        Logger::error(L"Failed to set DWMWCP_DONOTROUND corner preference");
+    }
 }
 
 void FancyZonesWindowUtils::ResetRoundCornersPreference(HWND window) noexcept
 {
-    // Set window corner preference on Windows 11 to "Default"
-    // TODO: Should probably store preference from before snap
-    int corner_preference = DWMWCP_DEFAULT;
-    DwmSetWindowAttribute(window, DWMWA_WINDOW_CORNER_PREFERENCE, &corner_preference, sizeof(corner_preference));
+    HANDLE handle = GetPropW(window, ZonedWindowProperties::PropertyCornerPreference);
+    if (handle)
+    {
+        int cornerPreference;
+        memcpy(&cornerPreference, &handle, sizeof(int));
+
+        if (!SUCCEEDED(DwmSetWindowAttribute(window, DWMWA_WINDOW_CORNER_PREFERENCE, &cornerPreference, sizeof(cornerPreference))))
+        {
+            Logger::error(L"Failed to set saved corner preference");
+        }
+
+        RemoveProp(window, ZonedWindowProperties::PropertyCornerPreference);
+    }
+    else
+    {
+        // Set window corner preference on Windows 11 to "Default"
+        int cornerPreference = DWMWCP_DEFAULT;
+        if (!SUCCEEDED(DwmSetWindowAttribute(window, DWMWA_WINDOW_CORNER_PREFERENCE, &cornerPreference, sizeof(cornerPreference))))
+        {
+            Logger::error(L"Failed to set DWMWCP_DEFAULT corner preference");
+        }
+    }
 }
 
 void FancyZonesWindowUtils::MakeWindowTransparent(HWND window)

--- a/src/modules/fancyzones/FancyZonesLib/WindowUtils.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WindowUtils.cpp
@@ -517,15 +517,6 @@ void FancyZonesWindowUtils::ResetRoundCornersPreference(HWND window) noexcept
 
         RemoveProp(window, ZonedWindowProperties::PropertyCornerPreference);
     }
-    else
-    {
-        // Set window corner preference on Windows 11 to "Default"
-        int cornerPreference = DWMWCP_DEFAULT;
-        if (!SUCCEEDED(DwmSetWindowAttribute(window, DWMWA_WINDOW_CORNER_PREFERENCE, &cornerPreference, sizeof(cornerPreference))))
-        {
-            Logger::error(L"Failed to set DWMWCP_DEFAULT corner preference");
-        }
-    }
 }
 
 void FancyZonesWindowUtils::MakeWindowTransparent(HWND window)

--- a/src/modules/fancyzones/FancyZonesLib/WindowUtils.h
+++ b/src/modules/fancyzones/FancyZonesLib/WindowUtils.h
@@ -27,4 +27,7 @@ namespace FancyZonesWindowUtils
     void RestoreWindowOrigin(HWND window) noexcept;
     void MakeWindowTransparent(HWND window);
     RECT AdjustRectForSizeWindowToRect(HWND window, RECT rect, HWND windowOfRect) noexcept; // Parameter rect is in windowOfRect coordinates
+
+    void DisableRoundCorners(HWND window) noexcept;
+    void ResetRoundCornersPreference(HWND window) noexcept;
 }

--- a/src/modules/fancyzones/FancyZonesLib/ZoneSet.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/ZoneSet.cpp
@@ -245,6 +245,8 @@ ZoneSet::MoveWindowIntoZoneByIndexSet(HWND window, HWND workAreaWindow, const Zo
 
             auto rect = FancyZonesWindowUtils::AdjustRectForSizeWindowToRect(window, size, workAreaWindow);
             FancyZonesWindowUtils::SizeWindowToRect(window, rect);
+
+            FancyZonesWindowUtils::DisableRoundCorners(window);
         }
 
         FancyZonesWindowProperties::StampZoneIndexProperty(window, indexSet);

--- a/src/modules/fancyzones/FancyZonesLib/ZoneSet.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/ZoneSet.cpp
@@ -246,7 +246,10 @@ ZoneSet::MoveWindowIntoZoneByIndexSet(HWND window, HWND workAreaWindow, const Zo
             auto rect = FancyZonesWindowUtils::AdjustRectForSizeWindowToRect(window, size, workAreaWindow);
             FancyZonesWindowUtils::SizeWindowToRect(window, rect);
 
-            FancyZonesWindowUtils::DisableRoundCorners(window);
+            if (FancyZonesSettings::settings().disableRoundCorners)
+            {
+                FancyZonesWindowUtils::DisableRoundCorners(window);
+            }
         }
 
         FancyZonesWindowProperties::StampZoneIndexProperty(window, indexSet);

--- a/src/modules/fancyzones/FancyZonesLib/trace.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/trace.cpp
@@ -55,6 +55,9 @@
 #define ShowZonesOnAllMonitorsKey "ShowZonesOnAllMonitors"
 #define SpanZonesAcrossMonitorsKey "SpanZonesAcrossMonitors"
 #define MakeDraggedWindowTransparentKey "MakeDraggedWindowTransparent"
+#define AllowSnapChildWindows "AllowSnapChildWindows"
+#define AllowSnapPopupWindows "AllowSnapPopupWindows"
+#define DisableRoundCornersOnSnapping "DisableRoundCornersOnSnapping"
 #define ZoneColorKey "ZoneColor"
 #define ZoneBorderColorKey "ZoneBorderColor"
 #define ZoneHighlightColorKey "ZoneHighlightColor"
@@ -324,6 +327,9 @@ void Trace::SettingsTelemetry(const Settings& settings) noexcept
         TraceLoggingBoolean(settings.showZonesOnAllMonitors, ShowZonesOnAllMonitorsKey),
         TraceLoggingBoolean(settings.spanZonesAcrossMonitors, SpanZonesAcrossMonitorsKey),
         TraceLoggingBoolean(settings.makeDraggedWindowTransparent, MakeDraggedWindowTransparentKey),
+        TraceLoggingBoolean(settings.allowSnapChildWindows, AllowSnapChildWindows),
+        TraceLoggingBoolean(settings.allowSnapPopupWindows, AllowSnapPopupWindows),
+        TraceLoggingBoolean(settings.disableRoundCorners, DisableRoundCornersOnSnapping),
         TraceLoggingWideString(settings.zoneColor.c_str(), ZoneColorKey),
         TraceLoggingWideString(settings.zoneBorderColor.c_str(), ZoneBorderColorKey),
         TraceLoggingWideString(settings.zoneHighlightColor.c_str(), ZoneHighlightColorKey),

--- a/src/settings-ui/Settings.UI.Library/FZConfigProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/FZConfigProperties.cs
@@ -45,6 +45,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             FancyzonesMakeDraggedWindowTransparent = new BoolProperty();
             FancyzonesAllowPopupWindowSnap = new BoolProperty();
             FancyzonesAllowChildWindowSnap = new BoolProperty();
+            FancyzonesDisableRoundCornersOnSnap = new BoolProperty();
             FancyzonesExcludedApps = new StringProperty();
             FancyzonesInActiveColor = new StringProperty(ConfigDefaults.DefaultFancyZonesInActiveColor);
             FancyzonesBorderColor = new StringProperty(ConfigDefaults.DefaultFancyzonesBorderColor);
@@ -109,6 +110,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library
 
         [JsonPropertyName("fancyzones_allowChildWindowSnap")]
         public BoolProperty FancyzonesAllowChildWindowSnap { get; set; }
+
+        [JsonPropertyName("fancyzones_disableRoundCornersOnSnap")]
+        public BoolProperty FancyzonesDisableRoundCornersOnSnap { get; set; }
 
         [JsonPropertyName("fancyzones_zoneHighlightColor")]
         public StringProperty FancyzonesZoneHighlightColor { get; set; }

--- a/src/settings-ui/Settings.UI.Library/ViewModels/FancyZonesViewModel.cs
+++ b/src/settings-ui/Settings.UI.Library/ViewModels/FancyZonesViewModel.cs
@@ -86,6 +86,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             _makeDraggedWindowTransparent = Settings.Properties.FancyzonesMakeDraggedWindowTransparent.Value;
             _allowPopupWindowSnap = Settings.Properties.FancyzonesAllowPopupWindowSnap.Value;
             _allowChildWindowSnap = Settings.Properties.FancyzonesAllowChildWindowSnap.Value;
+            _disableRoundCornersOnSnap = Settings.Properties.FancyzonesDisableRoundCornersOnSnap.Value;
             _highlightOpacity = Settings.Properties.FancyzonesHighlightOpacity.Value;
             _excludedApps = Settings.Properties.FancyzonesExcludedApps.Value;
             _systemTheme = Settings.Properties.FancyzonesSystemTheme.Value;
@@ -135,6 +136,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
         private bool _showZoneNumber;
         private bool _allowPopupWindowSnap;
         private bool _allowChildWindowSnap;
+        private bool _disableRoundCornersOnSnap;
 
         private int _highlightOpacity;
         private string _excludedApps;
@@ -597,6 +599,24 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
                 {
                     _allowChildWindowSnap = value;
                     Settings.Properties.FancyzonesAllowChildWindowSnap.Value = value;
+                    NotifyPropertyChanged();
+                }
+            }
+        }
+
+        public bool DisableRoundCornersOnWindowSnap
+        {
+            get
+            {
+                return _disableRoundCornersOnSnap;
+            }
+
+            set
+            {
+                if (_disableRoundCornersOnSnap != value)
+                {
+                    _disableRoundCornersOnSnap = value;
+                    Settings.Properties.FancyzonesDisableRoundCornersOnSnap.Value = value;
                     NotifyPropertyChanged();
                 }
             }

--- a/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/FancyZones.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/FancyZones.cs
@@ -70,6 +70,9 @@ namespace ViewModelTests
             Assert.AreEqual(originalSettings.Properties.FancyzonesZoneHighlightColor.Value, viewModel.ZoneHighlightColor);
             Assert.AreEqual(originalSettings.Properties.FancyzonesZoneSetChangeMoveWindows.Value, viewModel.ZoneSetChangeMoveWindows);
             Assert.AreEqual(originalSettings.Properties.UseCursorposEditorStartupscreen.Value, viewModel.UseCursorPosEditorStartupScreen);
+            Assert.AreEqual(originalSettings.Properties.FancyzonesAllowPopupWindowSnap.Value, viewModel.AllowPopupWindowSnap);
+            Assert.AreEqual(originalSettings.Properties.FancyzonesAllowChildWindowSnap.Value, viewModel.AllowChildWindowSnap);
+            Assert.AreEqual(originalSettings.Properties.FancyzonesDisableRoundCornersOnSnap.Value, viewModel.DisableRoundCornersOnWindowSnap);
 
             // Verify that the stub file was used
             var expectedCallCount = 2;  // once via the view model, and once by the test (GetSettings<T>)
@@ -425,6 +428,60 @@ namespace ViewModelTests
             // assert
             var expected = viewModel.OverlappingZonesAlgorithmIndex;
             var actual = SettingsRepository<FancyZonesSettings>.GetInstance(mockFancyZonesSettingsUtils.Object).SettingsConfig.Properties.FancyzonesOverlappingZonesAlgorithm.Value;
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void AllowChildWindowsToSnapShouldSetValue2TrueWhenSuccessful()
+        {
+            Mock<SettingsUtils> mockSettingsUtils = new Mock<SettingsUtils>();
+
+            // arrange
+            FancyZonesViewModel viewModel = new FancyZonesViewModel(mockSettingsUtils.Object, SettingsRepository<GeneralSettings>.GetInstance(mockGeneralSettingsUtils.Object), SettingsRepository<FancyZonesSettings>.GetInstance(mockFancyZonesSettingsUtils.Object), sendMockIPCConfigMSG, FancyZonesTestFolderName);
+            Assert.IsFalse(viewModel.AllowChildWindowSnap); // check if value was initialized to false.
+
+            // act
+            viewModel.AllowChildWindowSnap = true;
+
+            // assert
+            var expected = viewModel.AllowChildWindowSnap;
+            var actual = SettingsRepository<FancyZonesSettings>.GetInstance(mockFancyZonesSettingsUtils.Object).SettingsConfig.Properties.FancyzonesAllowChildWindowSnap.Value;
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void AllowPopupWindowsToSnapShouldSetValue2TrueWhenSuccessful()
+        {
+            Mock<SettingsUtils> mockSettingsUtils = new Mock<SettingsUtils>();
+
+            // arrange
+            FancyZonesViewModel viewModel = new FancyZonesViewModel(mockSettingsUtils.Object, SettingsRepository<GeneralSettings>.GetInstance(mockGeneralSettingsUtils.Object), SettingsRepository<FancyZonesSettings>.GetInstance(mockFancyZonesSettingsUtils.Object), sendMockIPCConfigMSG, FancyZonesTestFolderName);
+            Assert.IsFalse(viewModel.AllowPopupWindowSnap); // check if value was initialized to false.
+
+            // act
+            viewModel.AllowPopupWindowSnap = true;
+
+            // assert
+            var expected = viewModel.AllowPopupWindowSnap;
+            var actual = SettingsRepository<FancyZonesSettings>.GetInstance(mockFancyZonesSettingsUtils.Object).SettingsConfig.Properties.FancyzonesAllowPopupWindowSnap.Value;
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void DisableRoundCornersOnSnapShouldSetValue2TrueWhenSuccessful()
+        {
+            Mock<SettingsUtils> mockSettingsUtils = new Mock<SettingsUtils>();
+
+            // arrange
+            FancyZonesViewModel viewModel = new FancyZonesViewModel(mockSettingsUtils.Object, SettingsRepository<GeneralSettings>.GetInstance(mockGeneralSettingsUtils.Object), SettingsRepository<FancyZonesSettings>.GetInstance(mockFancyZonesSettingsUtils.Object), sendMockIPCConfigMSG, FancyZonesTestFolderName);
+            Assert.IsFalse(viewModel.DisableRoundCornersOnWindowSnap); // check if value was initialized to false.
+
+            // act
+            viewModel.DisableRoundCornersOnWindowSnap = true;
+
+            // assert
+            var expected = viewModel.DisableRoundCornersOnWindowSnap;
+            var actual = SettingsRepository<FancyZonesSettings>.GetInstance(mockFancyZonesSettingsUtils.Object).SettingsConfig.Properties.FancyzonesDisableRoundCornersOnSnap.Value;
             Assert.AreEqual(expected, actual);
         }
 

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -2077,4 +2077,10 @@ From there, simply click on one of the supported files in the File Explorer and 
   <data name="Shell_WhatsNew.Content" xml:space="preserve">
     <value>What's new</value>
   </data>
+  <data name="FancyZones_DisableRoundCornersOnWindowSnap.Description" xml:space="preserve">
+    <value>Works on Windows 11 </value>
+  </data>
+  <data name="FancyZones_DisableRoundCornersOnWindowSnap.Header" xml:space="preserve">
+    <value>Disable round corners when window is snapped</value>
+  </data>
 </root>

--- a/src/settings-ui/Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/settings-ui/Settings.UI/Views/FancyZonesPage.xaml
@@ -189,6 +189,10 @@
                                                                  x:Uid="FancyZones_AllowPopupWindowSnap"/>
                                 <Rectangle Style="{StaticResource ExpanderSeparatorStyle}" />
                                 <CheckBox x:Uid="FancyZones_AllowChildWindowSnap" IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.AllowChildWindowSnap}" Margin="{StaticResource ExpanderSettingMargin}"/>
+                                <Rectangle Style="{StaticResource ExpanderSeparatorStyle}" />
+                                <controls:CheckBoxWithDescriptionControl IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.DisableRoundCornersOnWindowSnap}"
+                                                                 Margin="56, -2, 40, 14"
+                                                                 x:Uid="FancyZones_DisableRoundCornersOnWindowSnap"/>
                             </StackPanel>
 
                         </controls:SettingExpander.Content>


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Restore original corners on the window unsnapping from the zone.

**What is included in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #17406, https://github.com/microsoft/PowerToys/issues/17367
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
