### PR TITLE
Make sure the final WiX bundle contains a *signed* MSI

### DIFF
--- a/.pipelines/ci/templates/build-powertoys-steps.yml
+++ b/.pipelines/ci/templates/build-powertoys-steps.yml
@@ -92,13 +92,24 @@ steps:
     restoreDirectory: '$(Build.SourcesDirectory)\installer\packages'
 
 - task: VSBuild@1
-  displayName: 'Build PowerToysSetup.sln'
+  displayName: 'Build PowerToys MSI'
   inputs:
     solution: '**\installer\PowerToysSetup.sln'
     vsVersion: 17.0
     platform: '$(BuildPlatform)'
     configuration: '$(BuildConfiguration)'
-    msbuildArgs: ${{ parameters.additionalBuildArguments }}
+    msbuildArgs: /t:PowerToysInstaller ${{ parameters.additionalBuildArguments }}
+    maximumCpuCount: true
+
+- task: VSBuild@1
+  displayName: 'Build PowerToys Bootstrapper'
+  inputs:
+    solution: '**\installer\PowerToysSetup.sln'
+    vsVersion: 17.0
+    platform: '$(BuildPlatform)'
+    configuration: '$(BuildConfiguration)'
+    msbuildArgs: /t:PowerToysBootstrapper ${{ parameters.additionalBuildArguments }}
+    clean: false
     maximumCpuCount: true
 
 # directly not doing WinAppDriver testing

--- a/.pipelines/release.yml
+++ b/.pipelines/release.yml
@@ -263,7 +263,7 @@ jobs:
     inputs:
       solution: '**/installer/PowerToysSetup.sln'
       vsVersion: 17.0
-      msbuildArgs: /p:CIBuild=true /bl:$(Build.SourcesDirectory)\msbuild.binlog /t:PowerToysBootstrapper
+      msbuildArgs: /p:CIBuild=true /bl:$(Build.SourcesDirectory)\msbuild.binlog /t:PowerToysBootstrapper /p:BuildProjectReferences=false
       platform: $(BuildPlatform)
       configuration: $(BuildConfiguration)
       clean: false # don't undo our hard work above by deleting the MSI

--- a/.pipelines/release.yml
+++ b/.pipelines/release.yml
@@ -263,10 +263,10 @@ jobs:
     inputs:
       solution: '**/installer/PowerToysSetup.sln'
       vsVersion: 17.0
-      msbuildArgs: /p:CIBuild=true /bl:$(Build.SourcesDirectory)\msbuild.binlog
+      msbuildArgs: /p:CIBuild=true /bl:$(Build.SourcesDirectory)\msbuild.binlog /t:PowerToysBootstrapper
       platform: $(BuildPlatform)
       configuration: $(BuildConfiguration)
-      clean: true
+      clean: false # don't undo our hard work above by deleting the MSI
       maximumCpuCount: true
 
   - task: CmdLine@2

--- a/.pipelines/release.yml
+++ b/.pipelines/release.yml
@@ -263,7 +263,7 @@ jobs:
     inputs:
       solution: '**/installer/PowerToysSetup.sln'
       vsVersion: 17.0
-      msbuildArgs: /p:CIBuild=true /bl:$(Build.SourcesDirectory)\msbuild.binlog /t:PowerToysBootstrapper /p:BuildProjectReferences=false
+      msbuildArgs: /p:CIBuild=true /bl:$(Build.SourcesDirectory)\msbuild.binlog /t:PowerToysBootstrapper
       platform: $(BuildPlatform)
       configuration: $(BuildConfiguration)
       clean: false # don't undo our hard work above by deleting the MSI

--- a/installer/PowerToysSetup.sln
+++ b/installer/PowerToysSetup.sln
@@ -12,9 +12,6 @@ EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "logger", "..\src\common\logger\logger.vcxproj", "{D9B8FC84-322A-4F9F-BBB9-20915C47DDFD}"
 EndProject
 Project("{930C7802-8A8C-48F9-8165-68863BCCD9DD}") = "PowerToysBootstrapper", "PowerToysSetup\PowerToysBootstrapper.wixproj", "{31D72625-43C1-41B1-B784-BCE4A8DC5543}"
-	ProjectSection(ProjectDependencies) = postProject
-		{022A9D30-7C4F-416D-A9DF-5FF2661CC0AD} = {022A9D30-7C4F-416D-A9DF-5FF2661CC0AD}
-	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/installer/PowerToysSetup.sln
+++ b/installer/PowerToysSetup.sln
@@ -12,6 +12,9 @@ EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "logger", "..\src\common\logger\logger.vcxproj", "{D9B8FC84-322A-4F9F-BBB9-20915C47DDFD}"
 EndProject
 Project("{930C7802-8A8C-48F9-8165-68863BCCD9DD}") = "PowerToysBootstrapper", "PowerToysSetup\PowerToysBootstrapper.wixproj", "{31D72625-43C1-41B1-B784-BCE4A8DC5543}"
+	ProjectSection(ProjectDependencies) = postProject
+		{022A9D30-7C4F-416D-A9DF-5FF2661CC0AD} = {022A9D30-7C4F-416D-A9DF-5FF2661CC0AD}
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
**What is this about:**

The Release build pipeline was (1) cleaning the PowerToysSetup solution,
which deleted the recently-signed PowerToys MSI and (2) rebuilding the
PowerToys MSI regardless of cleaning (thanks to WiX.)

This resulted in the final bundle _still_ containing an unsigned MSI
despite all our attempts to sign it.

**What is included in the PR:** 

I've turned off build cleaning and broken the dependency between
PowerToysBootstrapper and PowerToysSetup. This results in msbuild not
running the PowerToysSetup project's build steps at all, and therefore
not overwriting the signed msi with a newly-linked unsigned one.

> **NOTE**: This will impact your ability to <kbd>F5</kbd>-run the
bootstrapper from within Visual Studio. Going forward, you'll need to
build the MSI separately before building the bootstrapper.

**How does someone test / validate:** 

See screenshots posted in followup comment.

## Quality Checklist

- [x] **Linked issue:** #17410
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [x] **Tests:** Added/updated and all pass
- [x] **Installer:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [x] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries