### PR TITLE
[FancyZones] Removed check if window already snapped.

### DIFF
--- a/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
@@ -333,19 +333,12 @@ std::pair<winrt::com_ptr<IWorkArea>, ZoneIndexSet> FancyZones::GetAppZoneHistory
 
 void FancyZones::MoveWindowIntoZone(HWND window, winrt::com_ptr<IWorkArea> workArea, const ZoneIndexSet& zoneIndexSet) noexcept
 {
-    if (!AppZoneHistory::instance().IsAnotherWindowOfApplicationInstanceZoned(window, workArea->UniqueId()))
+    if (workArea)
     {
-        if (workArea)
-        {
-            Trace::FancyZones::SnapNewWindowIntoZone(workArea->ZoneSet());
-        }
-        m_windowMoveHandler.MoveWindowIntoZoneByIndexSet(window, zoneIndexSet, workArea);
-        AppZoneHistory::instance().UpdateProcessIdToHandleMap(window, workArea->UniqueId());
+        Trace::FancyZones::SnapNewWindowIntoZone(workArea->ZoneSet());
     }
-    else
-    {
-        Logger::info(L"Window was already zoned");
-    }
+    m_windowMoveHandler.MoveWindowIntoZoneByIndexSet(window, zoneIndexSet, workArea);
+    AppZoneHistory::instance().UpdateProcessIdToHandleMap(window, workArea->UniqueId());
 }
 
 bool FancyZones::MoveToAppLastZone(HWND window, HMONITOR active, HMONITOR primary) noexcept


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Removed check if the window was already snapped.
In this case, the `DesktopWindowXamlSource` is processed prior to the Terminal window itself, so when the Terminal window is opened, FZ ignores it as already snapped.

**What is included in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #17027 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
