### PR TITLE
[PTRun][Program]List special empty shortcuts

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32Program.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32Program.cs
@@ -487,8 +487,14 @@ namespace Microsoft.Plugin.Program.Programs
                 var program = CreateWin32Program(path);
                 string target = ShellLinkHelper.RetrieveTargetPath(path);
 
-                if (!string.IsNullOrEmpty(target) && (File.Exists(target) || Directory.Exists(target)))
+                if (!string.IsNullOrEmpty(target))
                 {
+                    if (!(File.Exists(target) || Directory.Exists(target)))
+                    {
+                        // If the link points nowhere, consider it invalid.
+                        return InvalidProgram;
+                    }
+
                     program.LnkResolvedPath = program.FullPath;
 
                     // Using CurrentCulture since this is user facing
@@ -514,11 +520,6 @@ namespace Microsoft.Plugin.Program.Programs
                             program.Description = info.FileDescription;
                         }
                     }
-                }
-                else
-                {
-                    // If the link points nowhere, consider it invalid.
-                    return InvalidProgram;
                 }
 
                 return program;


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
https://github.com/microsoft/PowerToys/pull/17184 made it so we didn't list invalid shortcuts.
Some empty shortcuts are still valid, however, such as the classic shortcuts to File Explorer or Control Panel.

**What is included in the PR:** 
Still list shortcuts with empty targets.

**How does someone test / validate:** 
Verify File Explorer appears again in PowerToys Run.

## Quality Checklist

- [x] **Linked issue:** #17513
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries
