### PR TITLE
[FZEditor] Improve narrator support on Grid Editor

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditorWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditorWindow.xaml
@@ -37,7 +37,8 @@
         </Grid>
         <StackPanel Margin="16">
             <StackPanel Margin="0,8,0,0">
-                <TextBlock 
+                <TextBlock
+                    Focusable="True"
                     TextWrapping="Wrap">
                     <Run 
                         FontWeight="Bold" 
@@ -46,6 +47,7 @@
                 </TextBlock>
                 <TextBlock 
                     Margin="0,8,0,0"
+                    Focusable="True"
                     TextWrapping="Wrap">
                     <Run 
                         FontWeight="Bold" 
@@ -54,6 +56,7 @@
                 </TextBlock>
                 <TextBlock 
                     Margin="0,8,0,0"
+                    Focusable="True"
                     TextWrapping="Wrap">
                     <Run 
                         FontWeight="Bold" 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridResizer.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridResizer.xaml
@@ -4,9 +4,10 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:FancyZonesEditor"
+             xmlns:props="clr-namespace:FancyZonesEditor.Properties"
              mc:Ignorable="d" 
              Focusable="True"
-             Initialized="ThumbInitialized"
+             AutomationProperties.Name="{x:Static props:Resources.Resizer_Thumb_Announce}"
              d:DesignHeight="300" d:DesignWidth="300">
     <Thumb.Template>
         <ControlTemplate>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridResizer.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridResizer.xaml
@@ -6,6 +6,7 @@
              xmlns:local="clr-namespace:FancyZonesEditor"
              mc:Ignorable="d" 
              Focusable="True"
+             Initialized="ThumbInitialized"
              d:DesignHeight="300" d:DesignWidth="300">
     <Thumb.Template>
         <ControlTemplate>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridResizer.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridResizer.xaml.cs
@@ -58,10 +58,5 @@ namespace FancyZonesEditor
                 }
             }
         }
-
-        private void ThumbInitialized(object sender, System.EventArgs e)
-        {
-            System.Windows.Automation.AutomationProperties.SetName(this, FancyZonesEditor.Properties.Resources.Resizer_Thumb_Announce);
-        }
     }
 }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridResizer.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridResizer.xaml.cs
@@ -58,5 +58,10 @@ namespace FancyZonesEditor
                 }
             }
         }
+
+        private void ThumbInitialized(object sender, System.EventArgs e)
+        {
+            System.Windows.Automation.AutomationProperties.SetName(this, FancyZonesEditor.Properties.Resources.Resizer_Thumb_Announce);
+        }
     }
 }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridZone.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridZone.xaml.cs
@@ -112,6 +112,7 @@ namespace FancyZonesEditor
             // using current culture as this is end user facing
             WidthLabel.Text = Math.Round(ActualWidth).ToString(CultureInfo.CurrentCulture);
             HeightLabel.Text = Math.Round(ActualHeight).ToString(CultureInfo.CurrentCulture);
+            System.Windows.Automation.AutomationProperties.SetName(this, FancyZonesEditor.Properties.Resources.Zone_Name + " " + (_zone.Index + 1).ToString(CultureInfo.CurrentCulture) + ". " + WidthLabel.Text + " x " + HeightLabel.Text);
         }
 
         public void UpdateShiftState(bool shiftState)

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridZone.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridZone.xaml.cs
@@ -112,7 +112,13 @@ namespace FancyZonesEditor
             // using current culture as this is end user facing
             WidthLabel.Text = Math.Round(ActualWidth).ToString(CultureInfo.CurrentCulture);
             HeightLabel.Text = Math.Round(ActualHeight).ToString(CultureInfo.CurrentCulture);
-            System.Windows.Automation.AutomationProperties.SetName(this, FancyZonesEditor.Properties.Resources.Zone_Name + " " + (_zone.Index + 1).ToString(CultureInfo.CurrentCulture) + ". " + WidthLabel.Text + " x " + HeightLabel.Text);
+            System.Windows.Automation.AutomationProperties.SetName(
+                this,
+#pragma warning disable SA1118 // Parameter should not span multiple lines
+                Properties.Resources.Zone_Name + " " + (_zone.Index + 1).ToString(CultureInfo.CurrentCulture) + ". " +
+                Properties.Resources.Width_Name + ": " + WidthLabel.Text + ", " +
+                Properties.Resources.Height_Name + ": " + HeightLabel.Text);
+#pragma warning restore SA1118 // Parameter should not span multiple lines
         }
 
         public void UpdateShiftState(bool shiftState)

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
@@ -251,6 +251,26 @@ namespace FancyZonesEditor.Properties {
         }
 
         /// <summary>
+        ///   Looks up a localized string for representing the name of the width dimension.
+        /// </summary>
+        public static string Width_Name {
+            get
+            {
+                return ResourceManager.GetString("Width_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string for representing the name of the height dimension.
+        /// </summary>
+        public static string Height_Name {
+            get
+            {
+                return ResourceManager.GetString("Height_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string for explaining how to use the thumbs to resize zone.
         /// </summary>
         public static string Resizer_Thumb_Announce {

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
@@ -241,10 +241,19 @@ namespace FancyZonesEditor.Properties {
         }
 
         /// <summary>
+        ///   Looks up a localized string for representing the names of a single zone.
+        /// </summary>
+        public static string Zone_Name {
+            get
+            {
+                return ResourceManager.GetString("Zone_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string for explaining how to use the thumbs to resize zone.
         /// </summary>
-        public static string Resizer_Thumb_Announce
-        {
+        public static string Resizer_Thumb_Announce {
             get
             {
                 return ResourceManager.GetString("Resizer_Thumb_Announce", resourceCulture);

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.Designer.cs
@@ -239,7 +239,18 @@ namespace FancyZonesEditor.Properties {
                 return ResourceManager.GetString("Delete_Layout_Dialog_Announce", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string for explaining how to use the thumbs to resize zone.
+        /// </summary>
+        public static string Resizer_Thumb_Announce
+        {
+            get
+            {
+                return ResourceManager.GetString("Resizer_Thumb_Announce", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Delete zone.
         /// </summary>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
@@ -292,6 +292,14 @@
     <value>Zone</value>
     <comment>The name of the zones.</comment>
   </data>
+  <data name="Width_Name" xml:space="preserve">
+    <value>Width</value>
+    <comment>The name of dimension called width.</comment>
+  </data>
+  <data name="Height_Name" xml:space="preserve">
+    <value>Height</value>
+    <comment>The name of dimension called height.</comment>
+  </data>
   <data name="Resizer_Thumb_Announce" xml:space="preserve">
     <value>Use the arrow keys to resize, delete key to remove.</value>
     <comment>Keys and key means the keyboard keys.</comment>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
@@ -288,6 +288,10 @@
   <data name="Delete_Layout_Dialog_Announce" xml:space="preserve">
     <value>Delete layout dialog.</value>
   </data>
+  <data name="Zone_Name" xml:space="preserve">
+    <value>Zone</value>
+    <comment>The name of the zones.</comment>
+  </data>
   <data name="Resizer_Thumb_Announce" xml:space="preserve">
     <value>Use the arrow keys to resize, delete key to remove.</value>
     <comment>Keys and key means the keyboard keys.</comment>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Properties/Resources.resx
@@ -288,6 +288,10 @@
   <data name="Delete_Layout_Dialog_Announce" xml:space="preserve">
     <value>Delete layout dialog.</value>
   </data>
+  <data name="Resizer_Thumb_Announce" xml:space="preserve">
+    <value>Use the arrow keys to resize, delete key to remove.</value>
+    <comment>Keys and key means the keyboard keys.</comment>
+  </data>
   <data name="Are_You_Sure" xml:space="preserve">
     <value>Are you sure?</value>
   </data>


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Screen readers weren't giving enough information while navigating through the grid editor in FancyZones Editor.

**What is included in the PR:** 
- Announce zone id and dimensions for zones as they're selected.
- Announce to use arrow keys to move while the thumb buttons are selected.
- Allow the helper information to be focused so that the narrator can announce it.

**How does someone test / validate:** 
With narrator on, navigate through the screen and verify the issue is addressed.

## Quality Checklist

- [x] **Linked issue:** #16552
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
