### PR TITLE
[DevFilesPreview]Fix not created settings crash

### DIFF
--- a/src/modules/previewpane/MonacoPreviewHandler/Settings.cs
+++ b/src/modules/previewpane/MonacoPreviewHandler/Settings.cs
@@ -22,7 +22,19 @@ namespace Microsoft.PowerToys.PreviewHandler.Monaco
         /// </summary>
         public bool Wrap
         {
-            get => moduleSettings.GetSettings<PowerPreviewSettings>(PowerPreviewSettings.ModuleName).Properties.EnableMonacoPreviewWordWrap;
+            get
+            {
+                try
+                {
+                    return moduleSettings.GetSettings<PowerPreviewSettings>(PowerPreviewSettings.ModuleName).Properties.EnableMonacoPreviewWordWrap;
+                }
+                catch (FileNotFoundException)
+                {
+                    // Couldn't read the settings.
+                    // Assume default of true.
+                    return true;
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
 If the settings file doesn't exist, it crashes dev file preview.

**What is included in the PR:** 
Catch the exception that the settings file is not sent and assume the default value.

**How does someone test / validate:** 
Delete `%localappdata%\Microsoft\PowerToys\File Explorer\settings.json` and verify dev file preview still works.

## Quality Checklist

- [x] **Linked issue:** #17493
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries
