### PR TITLE
[FancyZones] Restore window size fix

### DIFF
--- a/src/modules/fancyzones/FancyZonesLib/WindowUtils.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WindowUtils.cpp
@@ -402,8 +402,8 @@ void FancyZonesWindowUtils::RestoreWindowSize(HWND window) noexcept
         RECT rect;
         if (GetWindowRect(window, &rect))
         {
-            rect.right = rect.left + windowSize[0];
-            rect.bottom = rect.top + windowSize[1];
+            rect.right = rect.left + static_cast<int>(windowWidth);
+            rect.bottom = rect.top + static_cast<int>(windowHeight);
             Logger::info("Restore window size");
             SizeWindowToRect(window, rect);
         }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Fixed window size with non-100% monitor scaling.
Thanks @Jay-o-Way for the investigation :)

**What is included in the PR:** 

**How does someone test / validate:** 

* Set scaling different from 100%
* Turn the `Restore the original size of the window when unsnapping` option on
* Snap window
* Unsnap window
* Verify the size is the same as before snapping

## Quality Checklist

- [x] **Linked issue:** #17539 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
