### PR TITLE
[PTRun][VsCode] fix no results showing for latest insider build

### DIFF
--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/WorkspacesHelper/VSCodeWorkspacesApi.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/WorkspacesHelper/VSCodeWorkspacesApi.cs
@@ -142,9 +142,10 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.WorkspacesHelper
         private List<VSCodeWorkspace> GetWorkspacesInVscdb(VSCodeInstance vscodeInstance, string filePath)
         {
             var dbFileResults = new List<VSCodeWorkspace>();
+            SqliteConnection sqliteConnection = null;
             try
             {
-                var sqliteConnection = new SqliteConnection($"Data Source={filePath};Mode=ReadOnly;");
+                sqliteConnection = new SqliteConnection($"Data Source={filePath};Mode=ReadOnly;");
                 sqliteConnection.Open();
 
                 if (sqliteConnection.State == System.Data.ConnectionState.Open)
@@ -183,13 +184,15 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.WorkspacesHelper
                         }
                     }
                 }
-
-                sqliteConnection.Close();
             }
             catch (Exception e)
             {
                 var message = $"Failed to retrieve workspaces from db: {filePath}";
                 Log.Exception(message, e, GetType());
+            }
+            finally
+            {
+                sqliteConnection?.Close();
             }
 
             return dbFileResults;

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/WorkspacesHelper/VSCodeWorkspacesApi.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/WorkspacesHelper/VSCodeWorkspacesApi.cs
@@ -68,103 +68,131 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.WorkspacesHelper
 
                     if (File.Exists(vscode_storage))
                     {
-                        var fileContent = File.ReadAllText(vscode_storage);
+                        var storageResults = GetWorkspacesInJson(vscodeInstance, vscode_storage);
+                        results.AddRange(storageResults);
+                    }
 
-                        try
-                        {
-                            VSCodeStorageFile vscodeStorageFile = JsonSerializer.Deserialize<VSCodeStorageFile>(fileContent);
-
-                            if (vscodeStorageFile != null && vscodeStorageFile.OpenedPathsList != null)
-                            {
-                                // for previous versions of vscode
-                                if (vscodeStorageFile.OpenedPathsList.Workspaces3 != null)
-                                {
-                                    foreach (var workspaceUri in vscodeStorageFile.OpenedPathsList.Workspaces3)
-                                    {
-                                        var workspace = ParseVSCodeUri(workspaceUri, vscodeInstance);
-                                        if (workspace != null)
-                                        {
-                                            results.Add(workspace);
-                                        }
-                                    }
-                                }
-
-                                // vscode v1.55.0 or later
-                                if (vscodeStorageFile.OpenedPathsList.Entries != null)
-                                {
-                                    foreach (var entry in vscodeStorageFile.OpenedPathsList.Entries)
-                                    {
-                                        bool isWorkspaceFile = false;
-                                        var uri = entry.FolderUri;
-                                        if (entry.Workspace != null && entry.Workspace.ConfigPath != null)
-                                        {
-                                            isWorkspaceFile = true;
-                                            uri = entry.Workspace.ConfigPath;
-                                        }
-
-                                        var workspace = ParseVSCodeUri(uri, vscodeInstance, isWorkspaceFile);
-                                        if (workspace != null)
-                                        {
-                                            results.Add(workspace);
-                                        }
-                                    }
-                                }
-                            }
-                            else if (File.Exists(vscode_storage_db))
-                            {
-                                var sqliteConnection = new SqliteConnection($"Data Source={vscode_storage_db};Mode=ReadOnly;");
-                                sqliteConnection.Open();
-
-                                if (sqliteConnection.State == System.Data.ConnectionState.Open)
-                                {
-                                    var sqlite_cmd = sqliteConnection.CreateCommand();
-                                    sqlite_cmd.CommandText = "SELECT value FROM ItemTable WHERE key LIKE 'history.recentlyOpenedPathsList'";
-
-                                    var sqlite_datareader = sqlite_cmd.ExecuteReader();
-
-                                    if (sqlite_datareader.Read())
-                                    {
-                                        string entries = sqlite_datareader.GetString(0);
-                                        if (!string.IsNullOrEmpty(entries))
-                                        {
-                                            VSCodeStorageEntries vscodeStorageEntries = JsonSerializer.Deserialize<VSCodeStorageEntries>(entries);
-                                            if (vscodeStorageEntries.Entries != null)
-                                            {
-                                                vscodeStorageEntries.Entries = vscodeStorageEntries.Entries.Where(x => x != null).ToList();
-                                                foreach (var entry in vscodeStorageEntries.Entries)
-                                                {
-                                                    bool isWorkspaceFile = false;
-                                                    var uri = entry.FolderUri;
-                                                    if (entry.Workspace != null && entry.Workspace.ConfigPath != null)
-                                                    {
-                                                        isWorkspaceFile = true;
-                                                        uri = entry.Workspace.ConfigPath;
-                                                    }
-
-                                                    var workspace = ParseVSCodeUri(uri, vscodeInstance, isWorkspaceFile);
-                                                    if (workspace != null)
-                                                    {
-                                                        results.Add(workspace);
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-
-                                sqliteConnection.Close();
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            var message = $"Failed to deserialize ${vscode_storage}";
-                            Log.Exception(message, ex, GetType());
-                        }
+                    if (File.Exists(vscode_storage_db))
+                    {
+                        var storageDbResults = GetWorkspacesInVscdb(vscodeInstance, vscode_storage_db);
+                        results.AddRange(storageDbResults);
                     }
                 }
 
                 return results;
             }
+        }
+
+        private List<VSCodeWorkspace> GetWorkspacesInJson(VSCodeInstance vscodeInstance, string filePath)
+        {
+            var storageFileResults = new List<VSCodeWorkspace>();
+
+            var fileContent = File.ReadAllText(filePath);
+
+            try
+            {
+                VSCodeStorageFile vscodeStorageFile = JsonSerializer.Deserialize<VSCodeStorageFile>(fileContent);
+
+                if (vscodeStorageFile != null && vscodeStorageFile.OpenedPathsList != null)
+                {
+                    // for previous versions of vscode
+                    if (vscodeStorageFile.OpenedPathsList.Workspaces3 != null)
+                    {
+                        foreach (var workspaceUri in vscodeStorageFile.OpenedPathsList.Workspaces3)
+                        {
+                            var workspace = ParseVSCodeUri(workspaceUri, vscodeInstance);
+                            if (workspace != null)
+                            {
+                                storageFileResults.Add(workspace);
+                            }
+                        }
+                    }
+
+                    // vscode v1.55.0 or later
+                    if (vscodeStorageFile.OpenedPathsList.Entries != null)
+                    {
+                        foreach (var entry in vscodeStorageFile.OpenedPathsList.Entries)
+                        {
+                            bool isWorkspaceFile = false;
+                            var uri = entry.FolderUri;
+                            if (entry.Workspace != null && entry.Workspace.ConfigPath != null)
+                            {
+                                isWorkspaceFile = true;
+                                uri = entry.Workspace.ConfigPath;
+                            }
+
+                            var workspace = ParseVSCodeUri(uri, vscodeInstance, isWorkspaceFile);
+                            if (workspace != null)
+                            {
+                                storageFileResults.Add(workspace);
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                var message = $"Failed to deserialize {filePath}";
+                Log.Exception(message, ex, GetType());
+            }
+
+            return storageFileResults;
+        }
+
+        private List<VSCodeWorkspace> GetWorkspacesInVscdb(VSCodeInstance vscodeInstance, string filePath)
+        {
+            var dbFileResults = new List<VSCodeWorkspace>();
+            try
+            {
+                var sqliteConnection = new SqliteConnection($"Data Source={filePath};Mode=ReadOnly;");
+                sqliteConnection.Open();
+
+                if (sqliteConnection.State == System.Data.ConnectionState.Open)
+                {
+                    var sqlite_cmd = sqliteConnection.CreateCommand();
+                    sqlite_cmd.CommandText = "SELECT value FROM ItemTable WHERE key LIKE 'history.recentlyOpenedPathsList'";
+
+                    var sqlite_datareader = sqlite_cmd.ExecuteReader();
+
+                    if (sqlite_datareader.Read())
+                    {
+                        string entries = sqlite_datareader.GetString(0);
+                        if (!string.IsNullOrEmpty(entries))
+                        {
+                            VSCodeStorageEntries vscodeStorageEntries = JsonSerializer.Deserialize<VSCodeStorageEntries>(entries);
+                            if (vscodeStorageEntries.Entries != null)
+                            {
+                                vscodeStorageEntries.Entries = vscodeStorageEntries.Entries.Where(x => x != null).ToList();
+                                foreach (var entry in vscodeStorageEntries.Entries)
+                                {
+                                    bool isWorkspaceFile = false;
+                                    var uri = entry.FolderUri;
+                                    if (entry.Workspace != null && entry.Workspace.ConfigPath != null)
+                                    {
+                                        isWorkspaceFile = true;
+                                        uri = entry.Workspace.ConfigPath;
+                                    }
+
+                                    var workspace = ParseVSCodeUri(uri, vscodeInstance, isWorkspaceFile);
+                                    if (workspace != null)
+                                    {
+                                        dbFileResults.Add(workspace);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                sqliteConnection.Close();
+            }
+            catch (Exception e)
+            {
+                var message = $"Failed to retrieve workspaces from db: {filePath}";
+                Log.Exception(message, e, GetType());
+            }
+
+            return dbFileResults;
         }
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request
Fixes the vscode Workspaces Plugin for the latest vscode insider builds. 

**What is this about:**
The vscode team decided to relocate the storage.json file from _appData/storage.json_ to _appData/user/globalStorage/storage.json_ . The workspace plugin checks if the file exists on the old location and returns empty results as the file is no longer located at the checked position. With the more recent versions (v1.64+) vscode stores the workspaces in a .vscdb file instead of the storage.json so for the recent versions we don't need the storage.json and can skip the check.

**What is included in the PR:** 
I split the code into 2 seperate functions to query the storage.json and the .vscdb files independently. With this change it does not matter for the new versions of vscode where the storage.json is placed as we only need to query the .vscdb file for our results.

**How does someone test / validate:**
1. Install latest vscode insiders
2.  Open workspace/folder
3. Try to find it with PT Run

## Quality Checklist

- [x] **Linked issue:** #17496 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
