### PR TITLE
[FancyZones]Fix rounded corners optimized bug

### DIFF
--- a/src/modules/fancyzones/FancyZonesLib/WindowUtils.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WindowUtils.cpp
@@ -478,15 +478,23 @@ RECT FancyZonesWindowUtils::AdjustRectForSizeWindowToRect(HWND window, RECT rect
 
 void FancyZonesWindowUtils::DisableRoundCorners(HWND window) noexcept
 {
-    HANDLE handle = GetPropW(window, ZonedWindowProperties::PropertyCornerPreference);
+    HANDLE handle = GetProp(window, ZonedWindowProperties::PropertyCornerPreference);
     if (!handle)
     {
         int cornerPreference = DWMWCP_DEFAULT;
         // save corner preference if it wasn't set already
         DwmGetWindowAttribute(window, DWMWA_WINDOW_CORNER_PREFERENCE, &cornerPreference, sizeof(cornerPreference));
 
-        HANDLE preferenceHandle;
-        memcpy(&preferenceHandle, &cornerPreference, sizeof(int));
+        static_assert(sizeof(int) == 4);
+        static_assert(sizeof(HANDLE) == 8);
+        static_assert(sizeof(HANDLE) == sizeof(uint64_t));
+
+        // 0 is a valid value, so use a high bit to distinguish between 0 and a GetProp fail
+        uint64_t cornerPreference64 = static_cast<uint64_t>(cornerPreference);
+        cornerPreference64 = cornerPreference64 & 0xFFFF | 0x10000;
+
+        HANDLE preferenceHandle = {};
+        memcpy(&preferenceHandle, &cornerPreference64, sizeof(HANDLE));
 
         if (!SetProp(window, ZonedWindowProperties::PropertyCornerPreference, preferenceHandle))
         {
@@ -504,11 +512,18 @@ void FancyZonesWindowUtils::DisableRoundCorners(HWND window) noexcept
 
 void FancyZonesWindowUtils::ResetRoundCornersPreference(HWND window) noexcept
 {
-    HANDLE handle = GetPropW(window, ZonedWindowProperties::PropertyCornerPreference);
+    HANDLE handle = GetProp(window, ZonedWindowProperties::PropertyCornerPreference);
     if (handle)
     {
-        int cornerPreference;
-        memcpy(&cornerPreference, &handle, sizeof(int));
+        static_assert(sizeof(int) == 4);
+        static_assert(sizeof(HANDLE) == 8);
+        static_assert(sizeof(HANDLE) == sizeof(uint64_t));
+
+        uint64_t cornerPreference64 = {};
+        memcpy(&cornerPreference64, &handle, sizeof(uint64_t));
+        cornerPreference64 = cornerPreference64 & 0xFFFF;
+
+        int cornerPreference = static_cast<int>(cornerPreference64);
 
         if (!SUCCEEDED(DwmSetWindowAttribute(window, DWMWA_WINDOW_CORNER_PREFERENCE, &cornerPreference, sizeof(cornerPreference))))
         {


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

There's a bug in the way we are storing and verifying the corner rounds preference. 0 is a valid value for this value so it's indistinguishable whether the preference is found with GetProp or the value is just 0.
This makes the logic fail when the values are properly initialized to 0, such as when the code is built with /O2.

**What is included in the PR:** 

Use the handle upper bits to differentiate between no value found and 0.

**How does someone test / validate:** 

Test it works in release in Windows 11.

## Quality Checklist

- [x] **Linked issue:** #17406 #17367
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries
