### PR TITLE
[PT Run][Windows Terminal] Logging missing profiles

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsTerminal/Helpers/TerminalQuery.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsTerminal/Helpers/TerminalQuery.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Security.Principal;
 using Windows.Management.Deployment;
+using Wox.Plugin.Logger;
 
 namespace Microsoft.PowerToys.Run.Plugin.WindowsTerminal.Helpers
 {
@@ -35,10 +36,16 @@ namespace Microsoft.PowerToys.Run.Plugin.WindowsTerminal.Helpers
         {
             var profiles = new List<TerminalProfile>();
 
+            if (!Terminals.Any())
+            {
+                Log.Warn($"No Windows Terminal packages installed", typeof(TerminalQuery));
+            }
+
             foreach (var terminal in Terminals)
             {
                 if (!File.Exists(terminal.SettingsPath))
                 {
+                    Log.Warn($"Failed to find settings file {terminal.SettingsPath}", typeof(TerminalQuery));
                     continue;
                 }
 


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Several users are reporting windows terminal plugin doesn't show results.

**What is included in the PR:** 
Added logging that could help to understand the issue.

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #15810
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
