### PR TITLE
UnhandledExceptionHandler ARM64 support

### DIFF
--- a/PowerToys.sln
+++ b/PowerToys.sln
@@ -278,14 +278,14 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "utils", "utils", "{B39DC643
 		src\common\utils\modulesRegistry.h = src\common\utils\modulesRegistry.h
 		src\common\utils\MsiUtils.h = src\common\utils\MsiUtils.h
 		src\common\utils\os-detect.h = src\common\utils\os-detect.h
-		src\common\utils\process_path.h = src\common\utils\process_path.h
 		src\common\utils\ProcessWaiter.h = src\common\utils\ProcessWaiter.h
+		src\common\utils\process_path.h = src\common\utils\process_path.h
 		src\common\utils\registry.h = src\common\utils\registry.h
 		src\common\utils\resources.h = src\common\utils\resources.h
 		src\common\utils\string_utils.h = src\common\utils\string_utils.h
 		src\common\utils\timeutil.h = src\common\utils\timeutil.h
-		src\common\utils\UnhandledExceptionHandler_x64.h = src\common\utils\UnhandledExceptionHandler_x64.h
 		src\common\utils\winapi_error.h = src\common\utils\winapi_error.h
+		src\common\utils\UnhandledExceptionHandler.h = src\common\utils\UnhandledExceptionHandler.h
 		src\common\utils\window.h = src\common\utils\window.h
 	EndProjectSection
 EndProject
@@ -405,6 +405,7 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.PowerToys.Run.Plugin.TimeDate", "src\modules\launcher\Plugins\Microsoft.PowerToys.Run.Plugin.TimeDate\Microsoft.PowerToys.Run.Plugin.TimeDate.csproj", "{5BDBD6C9-A31F-4CEB-871A-5E9E709197EF}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests", "src\modules\launcher\Plugins\Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests\Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests.csproj", "{FD464B4C-2F68-4D06-91E7-4208146C41F5}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Plugin.WindowWalker.UnitTests", "src\modules\launcher\Plugins\Microsoft.Plugin.WindowWalker.UnitTests\Microsoft.Plugin.WindowWalker.UnitTests.csproj", "{8FE5A5EE-1B59-401C-9FB3-B04ECD3E29C1}"
 EndProject
 Global

--- a/src/common/utils/UnhandledExceptionHandler.h
+++ b/src/common/utils/UnhandledExceptionHandler.h
@@ -252,7 +252,7 @@ inline void InitSymbols()
     }
 }
 
-inline void InitUnhandledExceptionHandler_x64(void)
+inline void InitUnhandledExceptionHandler(void)
 {
     try
     {

--- a/src/common/utils/UnhandledExceptionHandler.h
+++ b/src/common/utils/UnhandledExceptionHandler.h
@@ -162,11 +162,18 @@ inline void LogStackTrace()
 
     HANDLE process = GetCurrentProcess();
     HANDLE thread = GetCurrentThread();
+
+#ifdef _M_ARM64
+    stack.AddrPC.Offset = context.Pc;
+    stack.AddrStack.Offset = context.Sp;
+    stack.AddrFrame.Offset = context.Fp;
+#else
     stack.AddrPC.Offset = context.Rip;
-    stack.AddrPC.Mode = AddrModeFlat;
     stack.AddrStack.Offset = context.Rsp;
-    stack.AddrStack.Mode = AddrModeFlat;
     stack.AddrFrame.Offset = context.Rbp;
+#endif
+    stack.AddrPC.Mode = AddrModeFlat;
+    stack.AddrStack.Mode = AddrModeFlat;
     stack.AddrFrame.Mode = AddrModeFlat;
 
     BOOL result = false;
@@ -174,7 +181,11 @@ inline void LogStackTrace()
     for (;;)
     {
         result = StackWalk64(
+#ifdef _M_ARM64
+            IMAGE_FILE_MACHINE_ARM64,
+#else
             IMAGE_FILE_MACHINE_AMD64,
+#endif
             process,
             thread,
             &stack,

--- a/src/modules/ShortcutGuide/ShortcutGuide/main.cpp
+++ b/src/modules/ShortcutGuide/ShortcutGuide/main.cpp
@@ -4,7 +4,7 @@
 #include <common/SettingsAPI/settings_helpers.h>
 #include <common/utils/ProcessWaiter.h>
 #include <common/utils/winapi_error.h>
-#include <common/utils/UnhandledExceptionHandler_x64.h>
+#include <common/utils/UnhandledExceptionHandler.h>
 #include <common/utils/logger_helper.h>
 #include <common/utils/EventWaiter.h>
 
@@ -46,7 +46,7 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, 
 {
     winrt::init_apartment();
     LoggerHelpers::init_logger(ShortcutGuideConstants::ModuleKey, L"ShortcutGuide", LogSettings::shortcutGuideLoggerName);
-    InitUnhandledExceptionHandler_x64();
+    InitUnhandledExceptionHandler();
     Logger::trace("Starting Shortcut Guide");
 
     if (!SetCurrentPath())

--- a/src/modules/alwaysontop/AlwaysOnTop/main.cpp
+++ b/src/modules/alwaysontop/AlwaysOnTop/main.cpp
@@ -2,7 +2,7 @@
 
 #include <common/utils/ProcessWaiter.h>
 #include <common/utils/window.h>
-#include <common/utils/UnhandledExceptionHandler_x64.h>
+#include <common/utils/UnhandledExceptionHandler.h>
 
 #include <common/utils/logger_helper.h>
 
@@ -18,7 +18,7 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, 
 {
     winrt::init_apartment();
     LoggerHelpers::init_logger(moduleName, internalPath, LogSettings::alwaysOnTopLoggerName);
-    InitUnhandledExceptionHandler_x64();    
+    InitUnhandledExceptionHandler();    
 
     auto mutex = CreateMutex(nullptr, true, instanceMutexName.c_str());
     if (mutex == nullptr)

--- a/src/modules/fancyzones/FancyZones/FancyZonesApp.cpp
+++ b/src/modules/fancyzones/FancyZones/FancyZonesApp.cpp
@@ -4,7 +4,7 @@
 #include <common/display/dpi_aware.h>
 #include <common/utils/logger_helper.h>
 #include <common/utils/resources.h>
-#include <common/utils/UnhandledExceptionHandler_x64.h>
+#include <common/utils/UnhandledExceptionHandler.h>
 
 #include <FancyZonesLib/Generated Files/resource.h>
 #include <FancyZonesLib/FancyZonesData.h>

--- a/src/modules/fancyzones/FancyZones/main.cpp
+++ b/src/modules/fancyzones/FancyZones/main.cpp
@@ -2,7 +2,7 @@
 
 #include <common/utils/ProcessWaiter.h>
 #include <common/utils/window.h>
-#include <common/utils/UnhandledExceptionHandler_x64.h>
+#include <common/utils/UnhandledExceptionHandler.h>
 
 #include <FancyZonesLib/trace.h>
 #include <FancyZonesLib/Generated Files/resource.h>
@@ -26,7 +26,7 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, 
 {
     winrt::init_apartment();
     LoggerHelpers::init_logger(moduleName, internalPath, LogSettings::fancyZonesLoggerName);
-    InitUnhandledExceptionHandler_x64();    
+    InitUnhandledExceptionHandler();    
 
     auto mutex = CreateMutex(nullptr, true, instanceMutexName.c_str());
     if (mutex == nullptr)

--- a/src/modules/keyboardmanager/KeyboardManagerEditor/KeyboardManagerEditor.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditor/KeyboardManagerEditor.cpp
@@ -7,7 +7,7 @@
 #include <common/utils/winapi_error.h>
 #include <common/utils/logger_helper.h>
 #include <common/utils/ProcessWaiter.h>
-#include <common/utils/UnhandledExceptionHandler_x64.h>
+#include <common/utils/UnhandledExceptionHandler.h>
 
 #include <trace.h>
 
@@ -28,7 +28,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
     UNREFERENCED_PARAMETER(hPrevInstance);
 
     LoggerHelpers::init_logger(KeyboardManagerConstants::ModuleName, L"Editor", LogSettings::keyboardManagerLoggerName);
-    InitUnhandledExceptionHandler_x64();
+    InitUnhandledExceptionHandler();
     Trace::RegisterProvider();
 
     auto mutex = CreateMutex(nullptr, true, instanceMutexName.c_str());

--- a/src/modules/keyboardmanager/KeyboardManagerEngine/main.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngine/main.cpp
@@ -3,7 +3,7 @@
 #include <common/utils/ProcessWaiter.h>
 #include <common/utils/winapi_error.h>
 #include <common/utils/logger_helper.h>
-#include <common/utils/UnhandledExceptionHandler_x64.h>
+#include <common/utils/UnhandledExceptionHandler.h>
 #include <keyboardmanager/common/KeyboardManagerConstants.h>
 #include <keyboardmanager/KeyboardManagerEngineLibrary/KeyboardManager.h>
 #include <keyboardmanager/KeyboardManagerEngineLibrary/trace.h>
@@ -15,7 +15,7 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, 
     winrt::init_apartment();
     LoggerHelpers::init_logger(KeyboardManagerConstants::ModuleName, L"Engine", LogSettings::keyboardManagerLoggerName);
     
-    InitUnhandledExceptionHandler_x64();
+    InitUnhandledExceptionHandler();
 
     auto mutex = CreateMutex(nullptr, true, instanceMutexName.c_str());
     if (mutex == nullptr)


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Currently the UnhandledExceptionHandler only targets x64 . This PR implements the specific registers needed for ARM64.
 
**What is included in the PR:** 

Rename of UnhandledExceptionHandler_x64 to UnhandledExceptionHandler, since it's no longer x64 specific. Also renamed the InitUnhandledExceptionHandler_x64 method to InitUnhandledExceptionHandler.  Conditional flags to set ARM64 stack registers and set the IMAGE_FILE_MACHINE to the proper architecture.
 
**How does someone test / validate:** 
Currently, this will have no effect on the existing build since it's using the `M_ARM64` preprocessor macro. 

Logic was checked against/adopted from https://github.com/MariaDB/server/blob/10.9/mysys/stacktrace.c#L590 

## Quality Checklist

- [X] **Linked issue:** #490
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
