### PR TITLE
[FancyZones Editor] Scale canvas layout on editing

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditor.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/CanvasEditor.xaml.cs
@@ -51,6 +51,10 @@ namespace FancyZonesEditor
             if (model != null)
             {
                 _model = model;
+
+                var workArea = App.Overlay.WorkArea;
+                _model.ScaleLayout(workAreaWidth: workArea.Width, workAreaHeight: workArea.Height);
+
                 UpdateZoneRects();
 
                 _model.PropertyChanged += OnModelChanged;

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/CanvasLayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/CanvasLayoutModel.cs
@@ -93,6 +93,11 @@ namespace FancyZonesEditor.Models
 
         public void ScaleLayout(double workAreaWidth, double workAreaHeight)
         {
+            if (CanvasRect.Height == 0 || CanvasRect.Width == 0)
+            {
+                return;
+            }
+
             Int32Rect[] zones = new Int32Rect[Zones.Count];
             Zones.CopyTo(zones, 0);
             Zones.Clear();

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/CanvasLayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/CanvasLayoutModel.cs
@@ -91,6 +91,25 @@ namespace FancyZonesEditor.Models
             UpdateLayout();
         }
 
+        public void ScaleLayout(double workAreaWidth, double workAreaHeight)
+        {
+            Int32Rect[] zones = new Int32Rect[Zones.Count];
+            Zones.CopyTo(zones, 0);
+            Zones.Clear();
+
+            foreach (Int32Rect zone in zones)
+            {
+                var x = zone.X * workAreaWidth / CanvasRect.Width;
+                var y = zone.Y * workAreaHeight / CanvasRect.Height;
+                var width = zone.Width * workAreaWidth / CanvasRect.Width;
+                var height = zone.Height * workAreaHeight / CanvasRect.Height;
+
+                Zones.Add(new Int32Rect(x: (int)x, y: (int)y, width: (int)width, height: (int)height));
+            }
+
+            CanvasRect = new Rect(CanvasRect.X, CanvasRect.Y, workAreaWidth, workAreaHeight);
+        }
+
         private void AddNewZone()
         {
             if (Zones.Count == 0)


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Update `ref-width` and `ref-height` of the canvas layout on editing.

**What is included in the PR:** 

**How does someone test / validate:** 

* Create canvas layout
* Change monitor resolution/scaling 
* `Edit` canvas layout
* Verify that `ref-width` and `ref-height` weren't changed after clicking `Cancel`
* Verify that `ref-width` and `ref-height` were changed after clicking `Save and apply`

Canvas layout is stored in `\AppData\Local\Microsoft\PowerToys\FancyZones\custom-layouts.json`

## Quality Checklist

- [x] **Linked issue:** #17382
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
