### PR TITLE
[PT Run][Service] Service name with spaces

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Service/Helpers/ServiceHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Service/Helpers/ServiceHelper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation
+// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -81,16 +81,16 @@ namespace Microsoft.PowerToys.Run.Plugin.Service.Helpers
 
                 if (action == Action.Start)
                 {
-                    info.Arguments = string.Join(' ', "start", serviceResult.ServiceName);
+                    info.Arguments = $"start \"{serviceResult.ServiceName}\"";
                 }
                 else if (action == Action.Stop)
                 {
-                    info.Arguments = string.Join(' ', "stop", serviceResult.ServiceName);
+                    info.Arguments = $"stop \"{serviceResult.ServiceName}\"";
                 }
                 else if (action == Action.Restart)
                 {
                     info.FileName = "cmd";
-                    info.Arguments = string.Join(' ', "/c net stop", serviceResult.ServiceName, "&&", "net start", serviceResult.ServiceName);
+                    info.Arguments = $"/c net stop \"{serviceResult.ServiceName}\" && net start \"{serviceResult.ServiceName}\"";
                 }
 
                 var process = Process.Start(info);


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Fix for services with spaces in service name.

**What is included in the PR:** 

**How does someone test / validate:** 
Try to start/stop/restart a service with spaces in service name.
I have found only "Steam Client Service" on my machine.

![image](https://user-images.githubusercontent.com/25966642/163041028-55df78d0-5365-42a1-8cb0-0a880c31faeb.png)


## Quality Checklist

- [x] **Linked issue:** #17231
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
