### PR TITLE
[Developer preview] Fix case sentensive issue and monaco_languages.json in use issue

### DIFF
--- a/src/modules/previewpane/MonacoPreviewHandler/FileHandler.cs
+++ b/src/modules/previewpane/MonacoPreviewHandler/FileHandler.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
@@ -18,9 +19,16 @@ namespace Microsoft.PowerToys.PreviewHandler.Monaco
         /// <returns>The monaco language id</returns>
         public static string GetLanguage(string fileExtension)
         {
+            fileExtension = fileExtension.ToLower(CultureInfo.CurrentCulture);
             try
             {
-                JsonDocument languageListDocument = JsonDocument.Parse(File.ReadAllText(Settings.AssemblyDirectory + "\\monaco_languages.json"));
+                JsonDocument languageListDocument;
+                using (StreamReader jsonFileReader = new StreamReader(new FileStream(Settings.AssemblyDirectory + "\\monaco_languages.json", FileMode.Open, FileAccess.Read, FileShare.ReadWrite)))
+                {
+                    languageListDocument = JsonDocument.Parse(jsonFileReader.ReadToEnd());
+                    jsonFileReader.Close();
+                }
+
                 JsonElement languageList = languageListDocument.RootElement.GetProperty("list");
                 foreach (JsonElement e in languageList.EnumerateArray())
                 {


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

* Opens monaco_languages.json now with streamreader like other files
* File extensions are now case-insentinsive

**How does someone test / validate:** 

* Test with a file with uppercase extension. e.g. "test.CS"

## Quality Checklist

- [x] **Linked issue:** #17692
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
