### PR TITLE
Make launcher detect portable installations of VS Code in system PATH

### DIFF
--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/VSCodeHelper/VSCodeInstances.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/VSCodeHelper/VSCodeInstances.cs
@@ -74,7 +74,11 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.VSCodeHelper
             {
                 Instances = new List<VSCodeInstance>();
 
-                paths = paths.Where(x => x.Contains("VS Code") || x.Contains("VSCodium")).ToList();
+                paths = paths.Where(x => 
+                                    x.Contains("VS Code",  StringComparison.OrdinalIgnoreCase) || 
+                                    x.Contains("VSCodium", StringComparison.OrdinalIgnoreCase) ||
+                                    x.Contains("vscode", StringComparison.OrdinalIgnoreCase)
+                                   ).ToList();
                 foreach (var path in paths)
                 {
                     if (Directory.Exists(path))

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/VSCodeHelper/VSCodeInstances.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/VSCodeHelper/VSCodeInstances.cs
@@ -77,8 +77,7 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.VSCodeHelper
                 paths = paths.Where(x => 
                                     x.Contains("VS Code",  StringComparison.OrdinalIgnoreCase) || 
                                     x.Contains("VSCodium", StringComparison.OrdinalIgnoreCase) ||
-                                    x.Contains("vscode", StringComparison.OrdinalIgnoreCase)
-                                   ).ToList();
+                                    x.Contains("vscode", StringComparison.OrdinalIgnoreCase)).ToList();
                 foreach (var path in paths)
                 {
                     if (Directory.Exists(path))

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/VSCodeHelper/VSCodeInstances.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/VSCodeHelper/VSCodeInstances.cs
@@ -74,8 +74,8 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.VSCodeHelper
             {
                 Instances = new List<VSCodeInstance>();
 
-                paths = paths.Where(x => 
-                                    x.Contains("VS Code",  StringComparison.OrdinalIgnoreCase) || 
+                paths = paths.Where(x =>
+                                    x.Contains("VS Code",  StringComparison.OrdinalIgnoreCase) ||
                                     x.Contains("VSCodium", StringComparison.OrdinalIgnoreCase) ||
                                     x.Contains("vscode", StringComparison.OrdinalIgnoreCase)).ToList();
                 foreach (var path in paths)


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Added a string to be searched for in PATH so that portable installations (e.g. installed with Scoop) of VS Code will also be found
**What is included in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [ ] **Linked issue:** #13362
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
