### PR TITLE
[PT Run]  UnitConverter float number precision is not enough #17610

### DIFF
--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter.UnitTest/UnitHandlerTests.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter.UnitTest/UnitHandlerTests.cs
@@ -27,6 +27,14 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter.UnitTest
         }
 
         [TestMethod]
+        public void HandleSmall()
+        {
+            var convertModel = new ConvertModel(1, "nanometer", "kilometer");
+            double result = UnitHandler.ConvertInput(convertModel, UnitsNet.QuantityType.Length);
+            Assert.AreEqual(1E-12, result);
+        }
+
+        [TestMethod]
         public void HandlesByteCapitals()
         {
             var convertModel = new ConvertModel(1, "kB", "kb");
@@ -35,11 +43,73 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter.UnitTest
         }
 
         [TestMethod]
+        public void HandlesParsecToNanometer()
+        {
+            var convertModel = new ConvertModel(1, "parsec", "nanometer");
+            var result = UnitHandler.Convert(convertModel).Single();
+            var str = result.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            Assert.AreEqual(3.0857000000000004E+25, result.ConvertedValue);
+            Assert.AreEqual("3.0857e+25 nanometer", str);
+        }
+
+        [TestMethod]
+        public void HandlesNanometerToParsec()
+        {
+            var convertModel = new ConvertModel(1, "nanometer", "parsec");
+            var result = UnitHandler.Convert(convertModel).Single();
+            var str = result.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            Assert.AreEqual(3.2408000000000005E-26, result.ConvertedValue);
+            Assert.AreEqual("3.2408e-26 parsec", str);
+        }
+
+        [TestMethod]
         public void HandleInvalidModel()
         {
             var convertModel = new ConvertModel(1, "aa", "bb");
             var results = UnitHandler.Convert(convertModel);
             Assert.AreEqual(0, results.Count());
+        }
+
+        [TestMethod]
+        public void RoundZero()
+        {
+            double result = UnitHandler.Round(0.0);
+            Assert.AreEqual(0, result);
+        }
+
+        [TestMethod]
+        public void RoundNormalValue()
+        {
+            double result = UnitHandler.Round(3.141592653589793);
+            Assert.AreEqual(3.1416, result);
+        }
+
+        [TestMethod]
+        public void RoundSmallValue()
+        {
+            double result = UnitHandler.Round(1.23456789012345E-16);
+            Assert.AreEqual(1.2346E-16, result);
+        }
+
+        [TestMethod]
+        public void RoundBigValue()
+        {
+            double result = UnitHandler.Round(1234567890123456.0);
+            Assert.AreEqual(1234600000000000.0, result);
+        }
+
+        [TestMethod]
+        public void RoundNegativeValue()
+        {
+            double result = UnitHandler.Round(-3.141592653589793);
+            Assert.AreEqual(-3.1416, result);
+        }
+
+        [TestMethod]
+        public void RoundNinesValue()
+        {
+            double result = UnitHandler.Round(999999999999.9998);
+            Assert.AreEqual(1000000000000.0, result);
         }
     }
 }

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter.UnitTest/UnitHandlerTests.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter.UnitTest/UnitHandlerTests.cs
@@ -27,7 +27,7 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter.UnitTest
         }
 
         [TestMethod]
-        public void HandleSmall()
+        public void HandleNanometerToKilometer()
         {
             var convertModel = new ConvertModel(1, "nanometer", "kilometer");
             double result = UnitHandler.ConvertInput(convertModel, UnitsNet.QuantityType.Length);

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/Main.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/Main.cs
@@ -73,7 +73,7 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
                     {
                         try
                         {
-                            Clipboard.SetText(result.ToString());
+                            Clipboard.SetText(result.ConvertedValue.ToString(UnitConversionResult.Format, CultureInfo.CurrentCulture));
                             ret = true;
                         }
                         catch (ExternalException)
@@ -105,7 +105,7 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
                     {
                         try
                         {
-                            Clipboard.SetText(result.ToString());
+                            Clipboard.SetText(result.ConvertedValue.ToString(UnitConversionResult.Format, CultureInfo.CurrentCulture));
                             ret = true;
                         }
                         catch (ExternalException)

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/Main.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/Main.cs
@@ -62,7 +62,7 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
             return new Result
             {
                 ContextData = result,
-                Title = $"{result.ConvertedValue} {result.UnitName}",
+                Title = result.ToString(),
                 IcoPath = _icon_path,
                 Score = 300,
                 SubTitle = string.Format(CultureInfo.CurrentCulture, Properties.Resources.copy_to_clipboard, result.QuantityType),
@@ -73,7 +73,7 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
                     {
                         try
                         {
-                            Clipboard.SetText(result.ConvertedValue.ToString(CultureInfo.CurrentCulture));
+                            Clipboard.SetText(result.ToString());
                             ret = true;
                         }
                         catch (ExternalException)
@@ -105,7 +105,7 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
                     {
                         try
                         {
-                            Clipboard.SetText(result.ConvertedValue.ToString(CultureInfo.CurrentCulture));
+                            Clipboard.SetText(result.ToString());
                             ret = true;
                         }
                         catch (ExternalException)

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/UnitConversionResult.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/UnitConversionResult.cs
@@ -8,7 +8,7 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
 {
     public class UnitConversionResult
     {
-        public static string Format { get; set; } = "{0:g14} {1}";
+        public static string Format { get; set; } = "g14";
 
         public double ConvertedValue { get; }
 
@@ -30,7 +30,7 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
                 provider = System.Globalization.CultureInfo.CurrentCulture;
             }
 
-            return string.Format(provider, Format, ConvertedValue, UnitName);
+            return ConvertedValue.ToString(Format, provider) + " " + UnitName;
         }
     }
 }

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/UnitConversionResult.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/UnitConversionResult.cs
@@ -8,6 +8,8 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
 {
     public class UnitConversionResult
     {
+        public static string Format { get; set; } = "{0:g14} {1}";
+
         public double ConvertedValue { get; }
 
         public string UnitName { get; }
@@ -19,6 +21,16 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
             ConvertedValue = convertedValue;
             UnitName = unitName;
             QuantityType = quantityType;
+        }
+
+        public string ToString(System.IFormatProvider provider = null)
+        {
+            if (provider == null)
+            {
+                provider = System.Globalization.CultureInfo.CurrentCulture;
+            }
+
+            return string.Format(provider, Format, ConvertedValue, UnitName);
         }
     }
 }

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/UnitHandler.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/UnitHandler.cs
@@ -54,7 +54,7 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
         /// <summary>
         /// Rounds the value to the predefined number of significant digits.
         /// </summary>
-        /// <param name="value">Value to b runded</param>
+        /// <param name="value">Value to be rounded</param>
         public static double Round(double value)
         {
             if (value == 0.0D)

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/UnitHandler.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/UnitHandler.cs
@@ -52,6 +52,23 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
         }
 
         /// <summary>
+        /// Rounds the value to the predefined number of significant digits.
+        /// </summary>
+        /// <param name="value">Value to b runded</param>
+        public static double Round(double value)
+        {
+            if (value == 0.0D)
+            {
+                return 0;
+            }
+
+            var power = Math.Floor(Math.Log10(Math.Abs(value)));
+            var exponent = Math.Pow(10, power);
+            var rounded = Math.Round(value / exponent, _roundingFractionalDigits) * exponent;
+            return rounded;
+        }
+
+        /// <summary>
         /// Given parsed ConvertModel, computes result. (E.g "1 foot in cm").
         /// </summary>
         /// <returns>The converted value as a double.</returns>
@@ -83,7 +100,7 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
 
                 if (!double.IsNaN(convertedValue))
                 {
-                    UnitConversionResult result = new UnitConversionResult(Math.Round(convertedValue, _roundingFractionalDigits), convertModel.ToUnit, quantityType);
+                    UnitConversionResult result = new UnitConversionResult(Round(convertedValue), convertModel.ToUnit, quantityType);
                     results.Add(result);
                 }
             }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
In Power Toys Run Unit Converter plugin we have a rounding method which rounds 1 nm to 0 m
Although that's almost true we should provide more precise results

**What is included in the PR:** 
Introduced rounding to significant digits, not to digits after decimal separator
Added test methods to verify we have a reasonable rounding in extreme cases
Also added conversion to string to fix last digit errors in worst case scenarios

**How does someone test / validate:** 

1. Start Power Toys with enabled Power Toys Run and enabled Power Toys Run Unit Converter
2. Open Power Toys Run window (Alt+Space by default)
3. Type `%% 1 nanometer to parsec` in input field
4. Check the answer in drop-down list is `3.2408e-26 parsec`. The result is affected by your current localization settings
5. Hit Enter key on keyboard
6. Check the string copied into clipboard is the number from point 4, `3.2408e-26`
7. Enable Include in global results for Power Toys Run Unit Converter
8. Open Power Toys Run window 
9. Type `1 parsec to nanometer` in input field
10. Check the answer in drop-down list is `3.0857e+25 nanometer`
11. Hit Copy to Clipboard button on the left
12. Check the string copied into clipboard is the number as in point 10, `3.0857e+25`.

## Quality Checklist

- [x] **Linked issue:** #17610
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [x] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
