### PR TITLE
[Settings] Always launch settings process non-elevated

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -839,6 +839,7 @@ IIO
 IItem
 IJson
 IKs
+Ijwhost
 IList
 ILogon
 IMAGEHLP
@@ -1061,6 +1062,7 @@ lhs
 lhwnd
 lia
 LIBID
+Lifecycle
 LIGHTORANGE
 LIGHTTURQUOISE
 lindex
@@ -1655,6 +1657,7 @@ regkey
 REGPINTYPES
 regsvr
 reimplementing
+REINSTALLMODE
 reloadable
 Remapper
 remappings

--- a/src/ActionRunner/actionRunner.vcxproj
+++ b/src/ActionRunner/actionRunner.vcxproj
@@ -65,6 +65,7 @@
   <Import Project="..\..\deps\spdlog.props" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.210204.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.210204.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />    
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -72,5 +73,6 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.210204.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.210204.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
   </Target>
 </Project>

--- a/src/ActionRunner/packages.config
+++ b/src/ActionRunner/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.200729.8" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.210204.1" targetFramework="native" />
 </packages>

--- a/src/Update/PowerToys.Update.vcxproj
+++ b/src/Update/PowerToys.Update.vcxproj
@@ -71,6 +71,7 @@
   <Import Project="..\..\deps\spdlog.props" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.210204.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.210204.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />        
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -78,5 +79,6 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.210204.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.210204.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />    
   </Target>
 </Project>

--- a/src/Update/packages.config
+++ b/src/Update/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.200729.8" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.210204.1" targetFramework="native" />
 </packages>

--- a/src/common/utils/elevation.h
+++ b/src/common/utils/elevation.h
@@ -15,15 +15,19 @@
 #include <winrt/Windows.Foundation.Collections.h>
 
 #include <string>
+#include <filesystem>
+
 #include <common/logger/logger.h>
 #include <common/utils/winapi_error.h>
+#include <common/utils/process_path.h>
+#include <common/utils/processApi.h>
 
-namespace 
+namespace
 {
     inline std::wstring GetErrorString(HRESULT handle)
     {
-         _com_error err(handle);
-         return err.ErrorMessage();
+        _com_error err(handle);
+        return err.ErrorMessage();
     }
 
     inline bool FindDesktopFolderView(REFIID riid, void** ppv)
@@ -51,7 +55,7 @@ namespace
 
         CComPtr<IShellBrowser> spBrowser;
         result = CComQIPtr<IServiceProvider>(spdisp)->QueryService(SID_STopLevelBrowser,
-                                                          IID_PPV_ARGS(&spBrowser));
+                                                                   IID_PPV_ARGS(&spBrowser));
         if (result != S_OK)
         {
             Logger::warn(L"Failed to query service. {}", GetErrorString(result));
@@ -104,7 +108,8 @@ namespace
 
     inline bool ShellExecuteFromExplorer(
         PCWSTR pszFile,
-        PCWSTR pszParameters = nullptr)
+        PCWSTR pszParameters = nullptr,
+        PCWSTR workingDir = L"")
     {
         CComPtr<IShellFolderViewDual> spFolderView;
         if (!GetDesktopAutomationObject(IID_PPV_ARGS(&spFolderView)))
@@ -121,11 +126,11 @@ namespace
         }
 
         CComQIPtr<IShellDispatch2>(spdispShell)
-            ->ShellExecute(CComBSTR(pszFile),
-                           CComVariant(pszParameters ? pszParameters : L""),
-                           CComVariant(L""),
-                           CComVariant(L""),
-                           CComVariant(SW_SHOWNORMAL));
+            ->ShellExecuteW(CComBSTR(pszFile),
+                            CComVariant(pszParameters ? pszParameters : L""),
+                            CComVariant(workingDir),
+                            CComVariant(L""),
+                            CComVariant(SW_SHOWNORMAL));
 
         return true;
     }
@@ -205,7 +210,7 @@ inline HANDLE run_elevated(const std::wstring& file, const std::wstring& params)
 }
 
 // Run command as non-elevated user, returns true if succeeded, puts the process id into returnPid if returnPid != NULL
-inline bool run_non_elevated(const std::wstring& file, const std::wstring& params, DWORD* returnPid)
+inline bool run_non_elevated(const std::wstring& file, const std::wstring& params, DWORD* returnPid, const wchar_t* workingDir = nullptr)
 {
     Logger::info(L"run_non_elevated with params={}", params);
     auto executable_args = L"\"" + file + L"\"";
@@ -225,7 +230,7 @@ inline bool run_non_elevated(const std::wstring& file, const std::wstring& param
         {
             Logger::error(L"GetShellWindow() failed. {}", get_last_error_or_default(GetLastError()));
         }
-        
+
         return false;
     }
     DWORD pid;
@@ -280,7 +285,7 @@ inline bool run_non_elevated(const std::wstring& file, const std::wstring& param
                                     FALSE,
                                     EXTENDED_STARTUPINFO_PRESENT,
                                     nullptr,
-                                    nullptr,
+                                    workingDir,
                                     &siex.StartupInfo,
                                     &pi);
     if (succeeded)
@@ -307,22 +312,60 @@ inline bool run_non_elevated(const std::wstring& file, const std::wstring& param
     return succeeded;
 }
 
-inline bool RunNonElevatedEx(const std::wstring& file, const std::wstring& params)
+inline bool RunNonElevatedEx(const std::wstring& file, const std::wstring& params, const std::wstring& working_dir)
 {
     try
     {
         CoInitialize(nullptr);
-        if (!ShellExecuteFromExplorer(file.c_str(), params.c_str()))
+        if (!ShellExecuteFromExplorer(file.c_str(), params.c_str(), working_dir.c_str()))
         {
             return false;
         }
     }
-    catch(...)
+    catch (...)
     {
         return false;
     }
 
     return true;
+}
+
+struct ProcessInfo
+{
+    wil::unique_process_handle processHandle;
+    DWORD processID = {};
+};
+
+inline std::optional<ProcessInfo> RunNonElevatedFailsafe(const std::wstring& file, const std::wstring& params, const std::wstring& working_dir)
+{
+    bool launched = RunNonElevatedEx(file, params, working_dir);
+    if (!launched)
+    {
+        Logger::warn(L"RunNonElevatedEx() failed. Trying fallback");
+        std::wstring action_runner_path = get_module_folderpath() + L"\\PowerToys.ActionRunner.exe";
+        std::wstring newParams = fmt::format(L"-run-non-elevated -target \"{}\" {}", file, params);
+        launched = run_non_elevated(action_runner_path, newParams, nullptr, working_dir.c_str());
+        if (launched)
+        {
+            Logger::trace(L"Started {}", file);
+        }
+        else
+        {
+            Logger::warn(L"Failed to start {}", file);
+            return std::nullopt;
+        }
+    }
+
+    auto handles = getProcessHandlesByName(std::filesystem::path{ file }.filename().wstring(), PROCESS_QUERY_INFORMATION | SYNCHRONIZE);
+
+    if (handles.empty())
+        return std::nullopt;
+
+    ProcessInfo result;
+    result.processID = GetProcessId(handles[0].get());
+    result.processHandle = std::move(handles[0]);
+
+    return result;
 }
 
 // Run command with the same elevation, returns true if succeeded

--- a/src/modules/awake/AwakeModuleInterface/AwakeModuleInterface.vcxproj
+++ b/src/modules/awake/AwakeModuleInterface/AwakeModuleInterface.vcxproj
@@ -93,6 +93,7 @@
   <Import Project="..\..\..\..\deps\spdlog.props" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="..\..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.210204.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.210204.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />    
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -100,5 +101,6 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.210204.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.210204.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
   </Target>
 </Project>

--- a/src/modules/awake/AwakeModuleInterface/packages.config
+++ b/src/modules/awake/AwakeModuleInterface/packages.config
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.200729.8" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.210204.1" targetFramework="native" />
 </packages>

--- a/src/modules/launcher/Microsoft.Launcher/Microsoft.Launcher.vcxproj
+++ b/src/modules/launcher/Microsoft.Launcher/Microsoft.Launcher.vcxproj
@@ -87,6 +87,7 @@
   <Import Project="..\..\..\..\deps\spdlog.props" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="..\..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.210204.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.210204.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />    
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -94,5 +95,6 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.210204.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.210204.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
   </Target>
 </Project>

--- a/src/modules/launcher/Microsoft.Launcher/packages.config
+++ b/src/modules/launcher/Microsoft.Launcher/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.200729.8" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.210204.1" targetFramework="native" />
 </packages>

--- a/src/modules/previewpane/powerpreview/packages.config
+++ b/src/modules/previewpane/powerpreview/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.200729.8" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.210204.1" targetFramework="native" />
 </packages>

--- a/src/modules/previewpane/powerpreview/powerpreview.vcxproj
+++ b/src/modules/previewpane/powerpreview/powerpreview.vcxproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.props')" />
+    <Import Project="..\..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.210204.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.210204.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />      
   <Target Name="GenerateResourceFiles" BeforeTargets="PrepareForBuild">
     <Exec Command="powershell -NonInteractive -executionpolicy Unrestricted $(SolutionDir)tools\build\convert-resx-to-rc.ps1 $(MSBuildThisFileDirectory) resource.base.h resource.h powerpreview.base.rc powerpreview.rc" />
   </Target>
@@ -108,5 +109,6 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.200729.8\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('..\..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.210204.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.210204.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
   </Target>
 </Project>

--- a/src/runner/tray_icon.cpp
+++ b/src/runner/tray_icon.cpp
@@ -109,7 +109,7 @@ void handle_tray_command(HWND window, const WPARAM command_id, LPARAM lparam)
 
     case ID_DOCUMENTATION_MENU_COMMAND:
     {
-        RunNonElevatedEx(L"https://aka.ms/PowerToysOverview", L"");
+        RunNonElevatedEx(L"https://aka.ms/PowerToysOverview", L"", L"");
         break;
     }
         

--- a/src/settings-ui/Settings.UI/App.xaml.cs
+++ b/src/settings-ui/Settings.UI/App.xaml.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Diagnostics;
 using System.Globalization;
+using System.Linq;
 using System.Threading.Tasks;
 using interop;
 using ManagedCommon;
@@ -90,6 +91,12 @@ namespace Microsoft.PowerToys.Settings.UI
 
             if (cmdArgs != null && cmdArgs.Length >= RequiredArgumentsQty)
             {
+                // Skip the first argument which is prepended when launched by explorer
+                if (cmdArgs[0].EndsWith(".dll", StringComparison.InvariantCultureIgnoreCase) && cmdArgs[1].EndsWith(".exe", StringComparison.InvariantCultureIgnoreCase) && (cmdArgs.Length >= RequiredArgumentsQty + 1))
+                {
+                    cmdArgs = cmdArgs.Skip(1).ToArray();
+                }
+
                 _ = int.TryParse(cmdArgs[(int)Arguments.PTPid], out int powerToysPID);
                 PowerToysPID = powerToysPID;
 
@@ -103,19 +110,19 @@ namespace Microsoft.PowerToys.Settings.UI
                     // open specific window
                     switch (cmdArgs[(int)Arguments.SettingsWindow])
                     {
-                        case "Overview": StartupPage = typeof(Microsoft.PowerToys.Settings.UI.Views.GeneralPage); break;
-                        case "AlwaysOnTop": StartupPage = typeof(Microsoft.PowerToys.Settings.UI.Views.AlwaysOnTopPage); break;
-                        case "Awake": StartupPage = typeof(Microsoft.PowerToys.Settings.UI.Views.AwakePage); break;
-                        case "ColorPicker": StartupPage = typeof(Microsoft.PowerToys.Settings.UI.Views.ColorPickerPage); break;
-                        case "FancyZones": StartupPage = typeof(Microsoft.PowerToys.Settings.UI.Views.FancyZonesPage); break;
-                        case "Run": StartupPage = typeof(Microsoft.PowerToys.Settings.UI.Views.PowerLauncherPage); break;
-                        case "ImageResizer": StartupPage = typeof(Microsoft.PowerToys.Settings.UI.Views.ImageResizerPage); break;
-                        case "KBM": StartupPage = typeof(Microsoft.PowerToys.Settings.UI.Views.KeyboardManagerPage); break;
-                        case "MouseUtils": StartupPage = typeof(Microsoft.PowerToys.Settings.UI.Views.MouseUtilsPage); break;
-                        case "PowerRename": StartupPage = typeof(Microsoft.PowerToys.Settings.UI.Views.PowerRenamePage); break;
-                        case "FileExplorer": StartupPage = typeof(Microsoft.PowerToys.Settings.UI.Views.PowerPreviewPage); break;
-                        case "ShortcutGuide": StartupPage = typeof(Microsoft.PowerToys.Settings.UI.Views.ShortcutGuidePage); break;
-                        case "VideoConference": StartupPage = typeof(Microsoft.PowerToys.Settings.UI.Views.VideoConferencePage); break;
+                        case "Overview": StartupPage = typeof(Views.GeneralPage); break;
+                        case "AlwaysOnTop": StartupPage = typeof(Views.AlwaysOnTopPage); break;
+                        case "Awake": StartupPage = typeof(Views.AwakePage); break;
+                        case "ColorPicker": StartupPage = typeof(Views.ColorPickerPage); break;
+                        case "FancyZones": StartupPage = typeof(Views.FancyZonesPage); break;
+                        case "Run": StartupPage = typeof(Views.PowerLauncherPage); break;
+                        case "ImageResizer": StartupPage = typeof(Views.ImageResizerPage); break;
+                        case "KBM": StartupPage = typeof(Views.KeyboardManagerPage); break;
+                        case "MouseUtils": StartupPage = typeof(Views.MouseUtilsPage); break;
+                        case "PowerRename": StartupPage = typeof(Views.PowerRenamePage); break;
+                        case "FileExplorer": StartupPage = typeof(Views.PowerPreviewPage); break;
+                        case "ShortcutGuide": StartupPage = typeof(Views.ShortcutGuidePage); break;
+                        case "VideoConference": StartupPage = typeof(Views.VideoConferencePage); break;
                         default: Debug.Assert(false, "Unexpected SettingsWindow argument value"); break;
                     }
                 }
@@ -178,15 +185,15 @@ namespace Microsoft.PowerToys.Settings.UI
 
         public static Task<IUICommand> ShowDialogAsync(string content, string title = null)
         {
-            var dlg = new MessageDialog(content, title ?? string.Empty);
+            var dialog = new MessageDialog(content, title ?? string.Empty);
             var handle = NativeMethods.GetActiveWindow();
             if (handle == IntPtr.Zero)
             {
                 throw new InvalidOperationException();
             }
 
-            InitializeWithWindow.Initialize(dlg, handle);
-            return dlg.ShowAsync().AsTask<IUICommand>();
+            InitializeWithWindow.Initialize(dialog, handle);
+            return dialog.ShowAsync().AsTask<IUICommand>();
         }
 
         public static TwoWayPipeMessageIPCManaged GetTwoWayIPCManager()

--- a/src/settings-ui/Settings.UI/PowerToys.Settings.csproj
+++ b/src/settings-ui/Settings.UI/PowerToys.Settings.csproj
@@ -21,7 +21,7 @@
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <WarningsNotAsErrors>CA1720</WarningsNotAsErrors>
     <OutputPath>..\..\..\$(Platform)\$(Configuration)\Settings</OutputPath>
-    <Optimize>false</Optimize>
+    <Optimize>False</Optimize>
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <DefineConstants>DEBUG;TRACE</DefineConstants>


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Attempt to launch settings process non-elevated from an elevated runner process using explorer API or non-elevated action runner as a proxy to avoid issues with WinApp SDK. I've also tried various process token manipulation techniques like changing integrity level, but it didn't produce the desired effect. Two way pipe IPC also works for non-admin user.

**What is included in the PR:** 
- add wil dependency to projects which depend on elevation.h
- refactor and unify launch api 

**How does someone test / validate:** 

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
