### PR TITLE
[settings] Fix OOBE size and make it non-resizable & Bring back Settings window placement preserve logic

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -1157,6 +1157,7 @@ Marquesas
 martinchrzan
 martinmoene
 Mato
+Maximizable
 MAXIMIZEBOX
 MAXSHORTCUTSIZE
 maxversiontested
@@ -1203,6 +1204,7 @@ millis
 mimetype
 mindaro
 Minimatch
+Minimizable
 MINIMIZEBOX
 MINIMIZEEND
 MINIMIZESTART

--- a/src/settings-ui/Settings.UI/Helpers/Utils.cs
+++ b/src/settings-ui/Settings.UI/Helpers/Utils.cs
@@ -22,7 +22,7 @@ namespace Microsoft.PowerToys.Settings.UI.Helpers
 
                 placement.Length = Marshal.SizeOf(typeof(WINDOWPLACEMENT));
                 placement.Flags = 0;
-                placement.ShowCmd = placement.ShowCmd == NativeMethods.SW_SHOWMAXIMIZED ? NativeMethods.SW_SHOWMAXIMIZED : NativeMethods.SW_SHOWNORMAL;
+                placement.ShowCmd = (placement.ShowCmd == NativeMethods.SW_SHOWMAXIMIZED) ? NativeMethods.SW_SHOWMAXIMIZED : NativeMethods.SW_SHOWNORMAL;
                 return placement;
             }
             catch (Exception)

--- a/src/settings-ui/Settings.UI/Helpers/Utils.cs
+++ b/src/settings-ui/Settings.UI/Helpers/Utils.cs
@@ -15,21 +15,18 @@ namespace Microsoft.PowerToys.Settings.UI.Helpers
 
         public static WINDOWPLACEMENT DeserializePlacementOrDefault(IntPtr handle)
         {
-            if (File.Exists(_placementPath))
+            try
             {
-                try
-                {
-                    var json = File.ReadAllText(_placementPath);
-                    var placement = JsonSerializer.Deserialize<WINDOWPLACEMENT>(json);
+                var json = File.ReadAllText(_placementPath);
+                var placement = JsonSerializer.Deserialize<WINDOWPLACEMENT>(json);
 
-                    placement.Length = Marshal.SizeOf(typeof(WINDOWPLACEMENT));
-                    placement.Flags = 0;
-                    placement.ShowCmd = placement.ShowCmd == NativeMethods.SW_SHOWMAXIMIZED ? NativeMethods.SW_SHOWMAXIMIZED : NativeMethods.SW_SHOWNORMAL;
-                    return placement;
-                }
-                catch (Exception)
-                {
-                }
+                placement.Length = Marshal.SizeOf(typeof(WINDOWPLACEMENT));
+                placement.Flags = 0;
+                placement.ShowCmd = placement.ShowCmd == NativeMethods.SW_SHOWMAXIMIZED ? NativeMethods.SW_SHOWMAXIMIZED : NativeMethods.SW_SHOWNORMAL;
+                return placement;
+            }
+            catch (Exception)
+            {
             }
 
             _ = NativeMethods.GetWindowPlacement(handle, out var defaultPlacement);

--- a/src/settings-ui/Settings.UI/Helpers/Utils.cs
+++ b/src/settings-ui/Settings.UI/Helpers/Utils.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+
+namespace Microsoft.PowerToys.Settings.UI.Helpers
+{
+    internal class Utils
+    {
+        private static string _placementPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), @"Microsoft\PowerToys\settings-placement.json");
+
+        public static WINDOWPLACEMENT DeserializePlacementOrDefault(IntPtr handle)
+        {
+            if (File.Exists(_placementPath))
+            {
+                try
+                {
+                    var json = File.ReadAllText(_placementPath);
+                    var placement = JsonSerializer.Deserialize<WINDOWPLACEMENT>(json);
+
+                    placement.Length = Marshal.SizeOf(typeof(WINDOWPLACEMENT));
+                    placement.Flags = 0;
+                    placement.ShowCmd = placement.ShowCmd == NativeMethods.SW_SHOWMAXIMIZED ? NativeMethods.SW_SHOWMAXIMIZED : NativeMethods.SW_SHOWNORMAL;
+                    return placement;
+                }
+                catch (Exception)
+                {
+                }
+            }
+
+            _ = NativeMethods.GetWindowPlacement(handle, out var defaultPlacement);
+            return defaultPlacement;
+        }
+
+        public static void SerializePlacement(IntPtr handle)
+        {
+            _ = NativeMethods.GetWindowPlacement(handle, out var placement);
+            try
+            {
+                var json = JsonSerializer.Serialize(placement);
+                File.WriteAllText(_placementPath, json);
+            }
+            catch (Exception)
+            {
+            }
+        }
+    }
+}

--- a/src/settings-ui/Settings.UI/MainWindow.xaml.cs
+++ b/src/settings-ui/Settings.UI/MainWindow.xaml.cs
@@ -3,7 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Drawing;
 using Microsoft.PowerLauncher.Telemetry;
+using Microsoft.PowerToys.Settings.UI.Helpers;
 using Microsoft.PowerToys.Settings.UI.Library.Utilities;
 using Microsoft.PowerToys.Settings.UI.Views;
 using Microsoft.PowerToys.Telemetry;
@@ -33,6 +35,10 @@ namespace Microsoft.PowerToys.Settings.UI
             WindowId windowId = Win32Interop.GetWindowIdFromWindow(hWnd);
             AppWindow appWindow = AppWindow.GetFromWindowId(windowId);
             appWindow.SetIcon("icon.ico");
+
+            NativeMethods.GetWindowPlacement(hWnd, out var startupPlacement);
+            var placement = Utils.DeserializePlacementOrDefault(hWnd);
+            NativeMethods.SetWindowPlacement(hWnd, ref placement);
 
             ResourceLoader loader = ResourceLoader.GetForViewIndependentUse();
             Title = loader.GetString("SettingsWindow_Title");
@@ -103,6 +109,9 @@ namespace Microsoft.PowerToys.Settings.UI
         private void Window_Closed(object sender, WindowEventArgs args)
         {
             App.ClearSettingsWindow();
+
+            var hWnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
+            Utils.SerializePlacement(hWnd);
         }
     }
 }

--- a/src/settings-ui/Settings.UI/MainWindow.xaml.cs
+++ b/src/settings-ui/Settings.UI/MainWindow.xaml.cs
@@ -36,7 +36,6 @@ namespace Microsoft.PowerToys.Settings.UI
             AppWindow appWindow = AppWindow.GetFromWindowId(windowId);
             appWindow.SetIcon("icon.ico");
 
-            NativeMethods.GetWindowPlacement(hWnd, out var startupPlacement);
             var placement = Utils.DeserializePlacementOrDefault(hWnd);
             NativeMethods.SetWindowPlacement(hWnd, ref placement);
 

--- a/src/settings-ui/Settings.UI/OobeWindow.xaml.cs
+++ b/src/settings-ui/Settings.UI/OobeWindow.xaml.cs
@@ -33,6 +33,8 @@ namespace Microsoft.PowerToys.Settings.UI
 
             OverlappedPresenter presenter = appWindow.Presenter as OverlappedPresenter;
             presenter.IsResizable = false;
+            presenter.IsMinimizable = false;
+            presenter.IsMaximizable = false;
 
             SizeInt32 size;
             size.Width = 1650;

--- a/src/settings-ui/Settings.UI/OobeWindow.xaml.cs
+++ b/src/settings-ui/Settings.UI/OobeWindow.xaml.cs
@@ -10,6 +10,7 @@ using Microsoft.UI;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Windows.ApplicationModel.Resources;
+using Windows.Graphics;
 
 namespace Microsoft.PowerToys.Settings.UI
 {
@@ -29,6 +30,14 @@ namespace Microsoft.PowerToys.Settings.UI
             WindowId windowId = Win32Interop.GetWindowIdFromWindow(hWnd);
             AppWindow appWindow = AppWindow.GetFromWindowId(windowId);
             appWindow.SetIcon("icon.ico");
+
+            OverlappedPresenter presenter = appWindow.Presenter as OverlappedPresenter;
+            presenter.IsResizable = false;
+
+            SizeInt32 size;
+            size.Width = 1650;
+            size.Height = 1050;
+            appWindow.Resize(size);
 
             this.initialModule = initialModule;
 


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
![image](https://user-images.githubusercontent.com/57057282/164213186-19d3a0eb-494a-4438-8351-ccb977a7d029.png)

**What is included in the PR:** 

**How does someone test / validate:** 
- Open OOBE and confirm it's non-resizable and that size is ok on different resolutions and scaling
- Resize settings window, close, open it again. Confirm that window size and placement is preserved.

## Quality Checklist

- [x] **Linked issue:** #17812 #17811
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
