### PR TITLE
[FancyZones] Apply default on switching virtual desktop

### DIFF
--- a/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
@@ -418,8 +418,14 @@ WorkArea::HideZonesOverlay() noexcept
 IFACEMETHODIMP_(void)
 WorkArea::UpdateActiveZoneSet() noexcept
 {
+    bool isLayoutAlreadyApplied = AppliedLayouts::instance().IsLayoutApplied(m_uniqueId);
+    if (!isLayoutAlreadyApplied)
+    {
+        AppliedLayouts::instance().ApplyDefaultLayout(m_uniqueId);
+    }
+
     CalculateZoneSet(FancyZonesSettings::settings().overlappingZonesAlgorithm);
-    if (m_window)
+    if (m_window && m_zoneSet)
     {
         m_highlightZone.clear();
         m_zonesOverlay->DrawActiveZoneSet(m_zoneSet->GetZones(), m_highlightZone, Colors::GetZoneColors(), FancyZonesSettings::settings().showZoneNumber);


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

During triaging issues noticed a possible regression caused by https://github.com/microsoft/PowerToys/pull/17412. 

**What is included in the PR:** 

**How does someone test / validate:** 

* Remove virtual desktops from registry
* Reset layout to default
* Switch virtual desktop
* Verify default layout was applied

## Quality Checklist

- [x] **Linked issue:** #14261 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
