### PR TITLE
[runner]Fix non-elevated restart loop

### DIFF
--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -443,10 +443,9 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     if (is_restart_scheduled())
     {
         if (!restart_if_scheduled())
-
         {
-            Logger::warn("Scheduled restart failed. Trying restart as admin as fallback...");
-            restart_same_elevation();
+            // If it's not possible to restart non-elevated due to some condition in the user's configuration, user should start PowerToys manually.
+            Logger::warn("Scheduled restart failed. Couldn't restart non-elevated. PowerToys exits here because retrying it would just mean failing in a loop.");
         }
     }
     stop_tray_icon();

--- a/src/runner/restart_elevated.cpp
+++ b/src/runner/restart_elevated.cpp
@@ -41,7 +41,7 @@ bool restart_if_scheduled()
     case RestartAsElevatedOpenSettings:
         return run_elevated(exe_path.get(), L"--open-settings");
     case RestartAsNonElevated:
-        return run_non_elevated(exe_path.get(), L"--dont-elevate", NULL);
+        return run_non_elevated(exe_path.get(), L"", NULL);
     default:
         return false;
     }
@@ -52,5 +52,5 @@ bool restart_same_elevation()
     constexpr DWORD exe_path_size = 0xFFFF;
     auto exe_path = std::make_unique<wchar_t[]>(exe_path_size);
     GetModuleFileNameW(nullptr, exe_path.get(), exe_path_size);
-    return run_same_elevation(exe_path.get(), L"--dont-elevate", nullptr);
+    return run_same_elevation(exe_path.get(), L"", nullptr);
 }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
When trying to run PowerToys non-elevated, we're passing the `--dont-elevate` argument again, meaning the new process will just fail and try it again in a loop of creating new processes.

**What is included in the PR:** 
- Don't call new processes with `--dont-elevate` in a loop. If runner receives this argument, it should try to start non-elevated but shouldn't request the new process to try it as well.
- If the runner can't restart non-elevated, just fail, don't try to keep running elevated. There's likely a good reason for not being able to run non-elevated like using another admin user to install PowerToys. The process shouldn't try running as other user elevated when it fails to run non-elevated, as that new process would use another user's settings.

**How does someone test / validate:** 
Never managed to really replicate this issue.
Check if you think this will bring new issues.

## Quality Checklist

- [x] **Linked issue:** #17720
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries
