### PR TITLE
Update ResizeOperation.cs

### DIFF
--- a/src/modules/imageresizer/ui/Models/ResizeOperation.cs
+++ b/src/modules/imageresizer/ui/Models/ResizeOperation.cs
@@ -56,6 +56,8 @@ namespace ImageResizer.Models
 
                 var encoder = CreateEncoder(containerFormat);
 
+                var skipImage = false;
+
                 if (decoder.Metadata != null)
                 {
                     try
@@ -75,6 +77,12 @@ namespace ImageResizer.Models
                 foreach (var originalFrame in decoder.Frames)
                 {
                     var transformedBitmap = Transform(originalFrame);
+
+                    if (transformedBitmap == originalFrame)
+                    {
+                        skipImage = true;
+                    }
+
                     BitmapMetadata originalMetadata = (BitmapMetadata)originalFrame.Metadata;
 
 #if DEBUG
@@ -96,6 +104,12 @@ namespace ImageResizer.Models
                     }
 
                     var frame = CreateBitmapFrame(transformedBitmap, metadata);
+
+                    // if the frame was not modified, we should not replace the metadata
+                    if (skipImage)
+                    {
+                        frame = CreateBitmapFrame(originalFrame, originalMetadata);
+                    }
 
                     encoder.Frames.Add(frame);
                 }


### PR DESCRIPTION
Add a new boolean to check if the image was resized, skip modifying the metadata if the image was not modified.

## Summary of the Pull Request

**What is this about:**
This is a possible solution with minimal code change to address the bug: https://github.com/microsoft/PowerToys/issues/7986

Because the Transform() function returns the source image if it should not be resized based on the user configuration, we can check if the source frame and transformed frame are the same. If so, we can skip modifying any image metadata.

While this approach is not optimal in terms of performance, since we throw away any work done generating new metadata, it does minimize new code introduced. All of the logic which decides if an image should be resized has not been modified or duplicated elsewhere.

**What is included in the PR:** 

a minor modification to src/modules/imageresizer/ui/Models/ResizeOperation.cs, which includes two additional checks. One to see if the source and generated image frame are identical, and another which checks the new boolean to skip updating the image metadata.

**How does someone test / validate:** 

For testing I would recommend following the original request in issue #7986.  

1. resize a folder of images, with some images being smaller than the target size. 
2. check the smaller images, which should have been skipped, to make sure the file size has not changed.

## Quality Checklist

- [x] **Linked issue:** #7986
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
