### PR TITLE
[Runner] Updates dir cleanup

### DIFF
--- a/src/Update/PowerToys.Update.cpp
+++ b/src/Update/PowerToys.Update.cpp
@@ -142,22 +142,6 @@ bool InstallNewVersionStage2(std::wstring installer_path, std::wstring_view inst
 
     bool success = true;
 
-    for (const auto& entry : fs::directory_iterator(updating::get_pending_updates_path()))
-    {
-        auto entryPath = entry.path().wstring();
-        std::transform(entryPath.begin(), entryPath.end(), entryPath.begin(), ::towlower);
-
-        if ((entry.path().extension() == ".msi" || entry.path().extension() == ".exe") && installer_path.find(entryPath) == std::string::npos)
-        {
-            std::error_code err;
-            fs::remove(entry, err);
-            if (err.value())
-            {
-                Logger::warn("Failed to delete file {}. {}", entry.path().string(), err.message());
-            }
-        }
-    }
-
     if (installer_path.ends_with(L".msi"))
     {
         success = MsiInstallProductW(installer_path.data(), nullptr) == ERROR_SUCCESS;
@@ -185,13 +169,33 @@ bool InstallNewVersionStage2(std::wstring installer_path, std::wstring_view inst
         }
     }
 
+    for (const auto& entry : fs::directory_iterator(updating::get_pending_updates_path()))
+    {
+        auto entryPath = entry.path().wstring();
+        std::transform(entryPath.begin(), entryPath.end(), entryPath.begin(), ::towlower);
+
+        if ((entryPath.ends_with(L".msi") || entryPath.ends_with(L".exe")) && installer_path.find(entryPath) == std::string::npos)
+        {
+            std::error_code err;
+            fs::remove(entry, err);
+            if (err.value())
+            {
+                Logger::warn("Failed to delete file {}. {}", entry.path().string(), err.message());
+            }
+        }
+    }
+
     if (!success)
     {
         return false;
     }
 
-    std::error_code _;
-    fs::remove(installer_path, _);
+    std::error_code err;
+    fs::remove(installer_path, err);
+    if (err.value())
+    {
+        Logger::warn("Failed to delete installer. {}", err.message());
+    }
 
     UpdateState::store([&](UpdateState& state) {
         state = {};

--- a/src/Update/PowerToys.Update.cpp
+++ b/src/Update/PowerToys.Update.cpp
@@ -169,15 +169,15 @@ bool InstallNewVersionStage2(std::wstring installer_path, std::wstring_view inst
         }
     }
 
-    // Delete only .msi and .exe
-    // Skip the installer if installation failed
     for (const auto& entry : fs::directory_iterator(updating::get_pending_updates_path()))
     {
         auto entryPath = entry.path().wstring();
         std::transform(entryPath.begin(), entryPath.end(), entryPath.begin(), ::towlower);
 
+        // Delete only .msi and .exe
         if (entryPath.ends_with(L".msi") || entryPath.ends_with(L".exe"))
         {
+            // Skipping current installer in case of failed update
             if (installer_path.find(entryPath) != std::string::npos && !success)
             {
                 continue;

--- a/src/Update/PowerToys.Update.cpp
+++ b/src/Update/PowerToys.Update.cpp
@@ -142,6 +142,22 @@ bool InstallNewVersionStage2(std::wstring installer_path, std::wstring_view inst
 
     bool success = true;
 
+    for (const auto& entry : fs::directory_iterator(updating::get_pending_updates_path()))
+    {
+        auto entryPath = entry.path().wstring();
+        std::transform(entryPath.begin(), entryPath.end(), entryPath.begin(), ::towlower);
+
+        if ((entry.path().extension() == ".msi" || entry.path().extension() == ".exe") && installer_path.find(entryPath) == std::string::npos)
+        {
+            std::error_code err;
+            fs::remove(entry, err);
+            if (err.value())
+            {
+                Logger::warn("Failed to delete file {}. {}", entry.path().string(), err.message());
+            }
+        }
+    }
+
     if (installer_path.ends_with(L".msi"))
     {
         success = MsiInstallProductW(installer_path.data(), nullptr) == ERROR_SUCCESS;


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
The update file downloaded in `%LOCALAPPDATA%\Microsoft\PowerToys\Updates` is deleted only if the update succed.
If the user decide to manually update from GitHub the downloaded updated is not deleted.
Lastly several users reported that  `%LOCALAPPDATA%\Microsoft\PowerToys\Updates` isn't cleanup: maybe file in use after the update?

**What is included in the PR:**
Perform a cleanup of obsolete msi/exe if PowerToys is up-to-date during update installation.

**How does someone test / validate:** 
I have tested in debug enabling the check update button and changing PT version in `updating::get_github_version_info_async`.

- Copy some fies in  `%LOCALAPPDATA%\Microsoft\PowerToys\Updates`: exe, msi and txt
- Simulate an update from 0.56.0: every msi/exe should be deleted. `powertoyssetup-0.57.2-x64.exe` is deleted only after the installation.

## Quality Checklist

- [x] **Linked issue:** #13296
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
