### PR TITLE
[Color Picker] CIEXYZ values should be labeled in upper case "XYZ" instead of "xyz"

### DIFF
--- a/src/modules/colorPicker/ColorPickerUI/Helpers/ColorRepresentationHelper.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/ColorRepresentationHelper.cs
@@ -262,7 +262,7 @@ namespace ColorPicker.Helpers
             y = Math.Round(y * 100, 4);
             z = Math.Round(z * 100, 4);
 
-            return $"xyz({x.ToString(CultureInfo.InvariantCulture)}" +
+            return $"XYZ({x.ToString(CultureInfo.InvariantCulture)}" +
                    $", {y.ToString(CultureInfo.InvariantCulture)}" +
                    $", {z.ToString(CultureInfo.InvariantCulture)})";
         }

--- a/src/modules/colorPicker/UnitTest-ColorPickerUI/Helpers/ColorRepresentationHelperTest.cs
+++ b/src/modules/colorPicker/UnitTest-ColorPickerUI/Helpers/ColorRepresentationHelperTest.cs
@@ -23,7 +23,7 @@ namespace Microsoft.ColorPicker.UnitTests
         [DataRow(ColorRepresentationType.HWB, "hwb(0, 0%, 100%)")]
         [DataRow(ColorRepresentationType.RGB, "rgb(0, 0, 0)")]
         [DataRow(ColorRepresentationType.CIELAB, "CIELab(0, 0, 0)")]
-        [DataRow(ColorRepresentationType.CIEXYZ, "xyz(0, 0, 0)")]
+        [DataRow(ColorRepresentationType.CIEXYZ, "XYZ(0, 0, 0)")]
         [DataRow(ColorRepresentationType.VEC4, "(0f, 0f, 0f, 1f)")]
         [DataRow(ColorRepresentationType.DecimalValue, "0")]
 

--- a/src/settings-ui/Settings.UI.Library/ViewModels/ColorPickerViewModel.cs
+++ b/src/settings-ui/Settings.UI.Library/ViewModels/ColorPickerViewModel.cs
@@ -213,7 +213,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             formatsUnordered.Add(new ColorFormatModel(hwbFormatName, "hwb(100, 50%, 75%)", visibleFormats.ContainsKey(hwbFormatName) && visibleFormats[hwbFormatName]));
             formatsUnordered.Add(new ColorFormatModel(ncolFormatName, "R10, 50%, 75%", visibleFormats.ContainsKey(ncolFormatName) && visibleFormats[ncolFormatName]));
             formatsUnordered.Add(new ColorFormatModel(cielabFormatName, "CIELab(66, 72, -52)", visibleFormats.ContainsKey(cielabFormatName) && visibleFormats[cielabFormatName]));
-            formatsUnordered.Add(new ColorFormatModel(ciexyzFormatName, "xyz(59, 35, 98)", visibleFormats.ContainsKey(ciexyzFormatName) && visibleFormats[ciexyzFormatName]));
+            formatsUnordered.Add(new ColorFormatModel(ciexyzFormatName, "XYZ(59, 35, 98)", visibleFormats.ContainsKey(ciexyzFormatName) && visibleFormats[ciexyzFormatName]));
             formatsUnordered.Add(new ColorFormatModel(vec4FormatName, "(0.94f, 0.41f, 1.00f, 1f)", visibleFormats.ContainsKey(vec4FormatName) && visibleFormats[vec4FormatName]));
             formatsUnordered.Add(new ColorFormatModel(decimalFormatName, "15689983", visibleFormats.ContainsKey(decimalFormatName) && visibleFormats[decimalFormatName]));
 


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
According to comments `xyz` meaning different color space. We should use `XYZ`.

**What is included in the PR:** 
Changed `ColorToCIEXYZ` string pattern

**How does someone test / validate:**
1. Run Power Toys with Color Picker enabled
2. Enable CIEXYZ in Color Picker
3. Check example for CIEXYZ looks like `XYZ(59, 35, 98)`
4. Use Color Picker
5. Check the pane in Color Picker contains CIEXYZ entry with `XYZ(xx.xxx, yy.yyy, zz.zzz)` - numbers depend on chosen color
6. Push Copy to clipboard button
7. Check clipboard contains the same `XYZ(xx.xxx, yy.yyy, zz.zzz)` values

## Quality Checklist

- [x] **Linked issue:** #17037
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [x] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
