### PR TITLE
Fix check-spelling

### DIFF
--- a/.github/workflows/spelling2.yml
+++ b/.github/workflows/spelling2.yml
@@ -36,6 +36,7 @@ jobs:
         config: .github/actions/spell-check
         suppress_push_for_open_pull_request: 1
         post_comment: 0
+        dictionary_source_prefixes: '{"cspell": "https://raw.githubusercontent.com/check-spelling/cspell-dicts/master/dictionaries/"}'
         extra_dictionaries:
           cspell:filetypes/filetypes.txt
           cspell:html/html.txt


### PR DESCRIPTION
GitHub apparently changed the behavior of raw.githubusercontent.com.

Previously, https://raw.githubusercontent.com/:org/:repo/HEAD/:path worked.
It no longer works.

Instead, we will use the master branch.

## Summary of the Pull Request

**What is this about:**

https://github.com/microsoft/PowerToys/pull/17936#issuecomment-1111119529

**What is included in the PR:** 

This overrides the `cspell` mapping to use a path that currently works.

**How does someone test / validate:** 

Here's a current run showing it works: https://github.com/jsoref/PowerToys/actions/runs/2233958230

If you want to test, you can pull the branch into your own repository.

Unfortunately, changes to the workflow file aren't tested as part of a PR.

I'll eventually move this config into the action metadata folder (but not for the coming release).

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
