### PR TITLE
Scale OOBE window

### DIFF
--- a/src/settings-ui/Settings.UI/Helpers/NativeMethods.cs
+++ b/src/settings-ui/Settings.UI/Helpers/NativeMethods.cs
@@ -42,6 +42,9 @@ namespace Microsoft.PowerToys.Settings.UI.Helpers
         public static extern bool ShowWindow(System.IntPtr hWnd, int nCmdShow);
 
         [DllImport("user32.dll")]
+        public static extern int GetDpiForWindow(System.IntPtr hWnd);
+
+        [DllImport("user32.dll")]
         public static extern bool AllowSetForegroundWindow(int dwProcessId);
 
         [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]

--- a/src/settings-ui/Settings.UI/OobeWindow.xaml.cs
+++ b/src/settings-ui/Settings.UI/OobeWindow.xaml.cs
@@ -4,6 +4,7 @@
 
 using System;
 using interop;
+using Microsoft.PowerToys.Settings.UI.Helpers;
 using Microsoft.PowerToys.Settings.UI.OOBE.Enums;
 using Microsoft.PowerToys.Settings.UI.OOBE.Views;
 using Microsoft.UI;
@@ -36,9 +37,14 @@ namespace Microsoft.PowerToys.Settings.UI
             presenter.IsMinimizable = false;
             presenter.IsMaximizable = false;
 
+            var dpi = NativeMethods.GetDpiForWindow(hWnd);
+            float scalingFactor = (float)dpi / 96;
+            int width = (int)(1100 * scalingFactor);
+            int height = (int)(700 * scalingFactor);
+
             SizeInt32 size;
-            size.Width = 1650;
-            size.Height = 1050;
+            size.Width = width;
+            size.Height = height;
             appWindow.Resize(size);
 
             this.initialModule = initialModule;


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
OOBE Window doesn't get properly sized on different scale on WinUI3, while the contents do adapt do different dpis. This makes it inconsistent across displays and resolutions.

**What is included in the PR:** 
Initial window size is set according to current DPI.
Window size reacts to dpi changes.

**How does someone test / validate:** 
Test the OOBE on different dpi settings.

## Quality Checklist

- [x] **Linked issue:** #17797
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
