### PR TITLE
[FancyZones] Fix reapplying the default layout

### DIFF
--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesData/AppliedLayouts.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesData/AppliedLayouts.cpp
@@ -420,8 +420,9 @@ bool AppliedLayouts::ApplyDefaultLayout(const FancyZonesDataTypes::DeviceIdData&
 
     m_layouts[deviceId] = std::move(layout);
     
-    SaveData();
-
+    // Saving default layout data doesn't make sense, since it's ignored on parsing.
+    // Given that default layouts are ignored when parsing, 
+    // saving default data can cause an infinite loop of reading, reapplying default layout and saving the same file.
     return true;
 }
 


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Ignoring default layouts while reading caused a loop of reapplying the same default layout. 

**What is included in the PR:** 

**How does someone test / validate:** 

* Delete `applied-layouts.json`
* Run FancyZones
* Verify you don't have a lot of `Set default layout ...` messages in logs.  

## Quality Checklist

- [x] **Linked issue:** #18057 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
