### PR TITLE
[Settings] Do not try to launch non-elevated settings process when it…

### DIFF
--- a/src/common/utils/elevation.h
+++ b/src/common/utils/elevation.h
@@ -83,7 +83,7 @@ namespace
     inline bool GetDesktopAutomationObject(REFIID riid, void** ppv)
     {
         CComPtr<IShellView> spsv;
-        
+
         // Desktop may not be available on startup
         auto attempts = 5;
         for (auto i = 1; i <= attempts; i++)
@@ -491,5 +491,32 @@ inline bool check_user_is_admin()
     }
 
     freeMemory(pSID, pGroupInfo);
+    return false;
+}
+
+inline bool is_process_of_window_elevated(HWND window)
+{
+    DWORD pid = 0;
+    GetWindowThreadProcessId(window, &pid);
+    if (!pid)
+    {
+        return false;
+    }
+
+    wil::unique_handle hProcess{ OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION,
+                                             FALSE,
+                                             pid) };
+
+    wil::unique_handle token;
+
+    if (OpenProcessToken(hProcess.get(), TOKEN_QUERY, &token))
+    {
+        TOKEN_ELEVATION elevation;
+        DWORD size;
+        if (GetTokenInformation(token.get(), TokenElevation, &elevation, sizeof(elevation), &size))
+        {
+            return elevation.TokenIsElevated != 0;
+        }
+    }
     return false;
 }

--- a/src/modules/fancyzones/FancyZonesLib/WindowUtils.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WindowUtils.cpp
@@ -3,10 +3,11 @@
 
 #include <common/display/dpi_aware.h>
 #include <common/logger/logger.h>
+#include <common/utils/elevation.h>
+#include <common/utils/excluded_apps.h>
 #include <common/utils/process_path.h>
 #include <common/utils/winapi_error.h>
 #include <common/utils/window.h>
-#include <common/utils/excluded_apps.h>
 
 #include <FancyZonesLib/FancyZonesWindowProperties.h>
 #include <FancyZonesLib/Settings.h>
@@ -245,30 +246,7 @@ bool FancyZonesWindowUtils::IsCandidateForZoning(HWND window)
 
 bool FancyZonesWindowUtils::IsProcessOfWindowElevated(HWND window)
 {
-    DWORD pid = 0;
-    GetWindowThreadProcessId(window, &pid);
-    if (!pid)
-    {
-        return false;
-    }
-
-    wil::unique_handle hProcess{ OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION,
-                                             FALSE,
-                                             pid) };
-
-    wil::unique_handle token;
-    bool elevated = false;
-
-    if (OpenProcessToken(hProcess.get(), TOKEN_QUERY, &token))
-    {
-        TOKEN_ELEVATION elevation;
-        DWORD size;
-        if (GetTokenInformation(token.get(), TokenElevation, &elevation, sizeof(elevation), &size))
-        {
-            return elevation.TokenIsElevated != 0;
-        }
-    }
-    return false;
+    return is_process_of_window_elevated(window);
 }
 
 bool FancyZonesWindowUtils::IsExcludedByUser(const std::wstring& processPath) noexcept

--- a/src/runner/Resources.resx
+++ b/src/runner/Resources.resx
@@ -122,4 +122,7 @@
   <data name="BUGREPORT_SUCCESS" xml:space="preserve">
     <value>Bug report .zip file has been created on your Desktop.</value>
   </data>
+  <data name="CANNOT_LAUNCH_SETTINGS_NONELEVATED" xml:space="preserve">
+    <value>Cannot start PowerToys.Settings process non-elevated, because explorer.exe process is elevated. Consider enabling UAC.</value>
+  </data>  
 </root>

--- a/src/runner/settings_window.cpp
+++ b/src/runner/settings_window.cpp
@@ -11,6 +11,7 @@
 #include "restart_elevated.h"
 #include "UpdateUtils.h"
 #include "centralized_kb_hook.h"
+#include "Generated Files/resource.h"
 
 #include <common/utils/json.h>
 #include <common/SettingsAPI/settings_helpers.cpp>
@@ -20,6 +21,7 @@
 #include <common/utils/elevation.h>
 #include <common/utils/process_path.h>
 #include <common/utils/timeutil.h>
+#include <common/utils/resources.h>
 #include <common/utils/winapi_error.h>
 #include <common/updating/updateState.h>
 #include <common/themes/windows_colors.h>
@@ -197,67 +199,6 @@ void receive_json_send_to_main_thread(const std::wstring& msg)
     dispatch_run_on_main_ui_thread(dispatch_received_json_callback, copy);
 }
 
-// Try to run the Settings process with non-elevated privileges.
-BOOL run_settings_non_elevated(LPCWSTR executable_path, LPWSTR executable_args, PROCESS_INFORMATION* process_info)
-{
-    HWND hwnd = GetShellWindow();
-    if (!hwnd)
-    {
-        return false;
-    }
-
-    DWORD pid;
-    GetWindowThreadProcessId(hwnd, &pid);
-
-    winrt::handle process{ OpenProcess(PROCESS_CREATE_PROCESS, FALSE, pid) };
-    if (!process)
-    {
-        return false;
-    }
-
-    SIZE_T size = 0;
-    InitializeProcThreadAttributeList(nullptr, 1, 0, &size);
-    auto pproc_buffer = std::unique_ptr<char[]>{ new (std::nothrow) char[size] };
-    auto pptal = reinterpret_cast<PPROC_THREAD_ATTRIBUTE_LIST>(pproc_buffer.get());
-    if (!pptal)
-    {
-        return false;
-    }
-
-    if (!InitializeProcThreadAttributeList(pptal, 1, 0, &size))
-    {
-        return false;
-    }
-
-    if (!UpdateProcThreadAttribute(pptal,
-                                   0,
-                                   PROC_THREAD_ATTRIBUTE_PARENT_PROCESS,
-                                   &process,
-                                   sizeof(process),
-                                   nullptr,
-                                   nullptr))
-    {
-        return false;
-    }
-
-    STARTUPINFOEX siex = { 0 };
-    siex.lpAttributeList = pptal;
-    siex.StartupInfo.cb = sizeof(siex);
-
-    BOOL process_created = CreateProcessW(executable_path,
-                                          executable_args,
-                                          nullptr,
-                                          nullptr,
-                                          FALSE,
-                                          EXTENDED_STARTUPINFO_PRESENT,
-                                          nullptr,
-                                          nullptr,
-                                          &siex.StartupInfo,
-                                          process_info);
-    g_isLaunchInProgress = false;
-    return process_created;
-}
-
 DWORD g_settings_process_id = 0;
 
 void run_settings_window(bool show_oobe_window, bool show_scoobe_window, std::optional<std::wstring> settings_window)
@@ -355,13 +296,24 @@ void run_settings_window(bool show_oobe_window, bool show_scoobe_window, std::op
 
     if (is_process_elevated())
     {
-        auto res = RunNonElevatedFailsafe(executable_path, executable_args, get_module_folderpath());
-        process_created = res.has_value();
-        if (process_created)
+        const bool explorer_is_elevated = is_process_of_window_elevated(GetShellWindow());
+        if (explorer_is_elevated)
         {
-            process_info.dwProcessId = res->processID;
-            process_info.hProcess = res->processHandle.release();
-            g_isLaunchInProgress = false;
+            MessageBoxW(nullptr,
+                        GET_RESOURCE_STRING(IDS_CANNOT_LAUNCH_SETTINGS_NONELEVATED).c_str(),
+                        L"PowerToys",
+                        MB_OK | MB_ICONERROR);
+        }
+        else
+        {
+            auto res = RunNonElevatedFailsafe(executable_path, executable_args, get_module_folderpath());
+            process_created = res.has_value();
+            if (process_created)
+            {
+                process_info.dwProcessId = res->processID;
+                process_info.hProcess = res->processHandle.release();
+                g_isLaunchInProgress = false;
+            }
         }
     }
 


### PR DESCRIPTION

## Summary of the Pull Request
…'s impossible, since elevated WinAppSDK 1.0 apps crash

**What is this about:**
- For v0.58, we've ported Settings app to Win UI 3.0 which is a part of Windows App SDK.
- SDK v1.0 [doesn't support running elevated applications](https://github.com/dotnet/maui/issues/6208).
- When we launch Settings app from an elevated runner, we try to launch it non-elevated using a [common technique involving shell/explorer.exe process](https://devblogs.microsoft.com/oldnewthing/20190425-00/?p=102443).
- however, that method (as well as all others) [will fail](https://devblogs.microsoft.com/oldnewthing/20150618-00/?p=45351) if UAC is completely disabled via [a local policy](https://manuals.gfi.com/en/esm2013administrator/content/acm/topics/config/disabling_user_account_control__uac_.htm).
- unless UAC is disabled, explorer.exe will detect that it was launched elevated and restart itself without elevation, so that shouldn't be a common scenario.

We will change the current code to a warning once WinAppSDK 1.1 is released, which should support running from an elevated context.

**What is included in the PR:** 
Instead of crashing Settings on start, we display a message box explaining the situation.

**How does someone test / validate:** 
- launch `explorer.exe /nouaccheck` elevated to prevent it drop elevated status. the effect is the same as disabling UAC but doesn't require reboots

## Quality Checklist

- [x] **Linked issue:** #18021
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
