### PR TITLE
[Chore] Removed FxCop

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeZone/Helper/JsonHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeZone/Helper/JsonHelper.cs
@@ -38,7 +38,8 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeZone.Helper
                 using var stream = assembly.GetManifestResourceStream(resourceName);
                 if (stream is null)
                 {
-                    throw new Exception("stream is null");
+                    Log.Error("Stream is null", typeof(JsonHelper));
+                    return new TimeZoneList();
                 }
 
                 using var reader = new StreamReader(stream);

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeZone/Microsoft.PowerToys.Run.Plugin.TimeZone.csproj
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeZone/Microsoft.PowerToys.Run.Plugin.TimeZone.csproj
@@ -53,11 +53,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Removed FxCop from TimeZone plugin and replaced with Microsoft.CodeAnalysis.NetAnalyzers
FxCop has been removed with #8375

**What is included in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #8375
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
