### PR TITLE
[Settings][FancyZones] Rounded corners settings only on Windows 11

### DIFF
--- a/src/settings-ui/Settings.UI.Library/Utilities/Helper.cs
+++ b/src/settings-ui/Settings.UI.Library/Utilities/Helper.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.IO;
 using System.IO.Abstractions;
 using System.Linq;
-using System.Runtime.InteropServices;
 using Microsoft.PowerToys.Settings.UI.Library.CustomAction;
 
 namespace Microsoft.PowerToys.Settings.UI.Library.Utilities
@@ -135,5 +134,10 @@ namespace Microsoft.PowerToys.Settings.UI.Library.Utilities
         }
 
         public const uint VirtualKeyWindows = interop.Constants.VK_WIN_BOTH;
+
+        public static bool Windows11()
+        {
+            return Environment.OSVersion.Version.Major >= 10 && Environment.OSVersion.Version.Build >= 22000;
+        }
     }
 }

--- a/src/settings-ui/Settings.UI.Library/ViewModels/FancyZonesViewModel.cs
+++ b/src/settings-ui/Settings.UI.Library/ViewModels/FancyZonesViewModel.cs
@@ -6,6 +6,7 @@ using System;
 using System.Runtime.CompilerServices;
 using Microsoft.PowerToys.Settings.UI.Library.Helpers;
 using Microsoft.PowerToys.Settings.UI.Library.Interfaces;
+using Microsoft.PowerToys.Settings.UI.Library.Utilities;
 using Microsoft.PowerToys.Settings.UI.Library.ViewModels.Commands;
 
 namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
@@ -25,6 +26,8 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
         private Func<string, int> SendConfigMSG { get; }
 
         private string settingsConfigFileFolder = string.Empty;
+
+        private bool _windows11;
 
         private enum MoveWindowBehaviour
         {
@@ -112,6 +115,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             _zoneNumberColor = !string.IsNullOrEmpty(numberColor) ? numberColor : ConfigDefaults.DefaultFancyzonesNumberColor;
 
             _isEnabled = GeneralSettingsConfig.Enabled.FancyZones;
+            _windows11 = Helper.Windows11();
         }
 
         private bool _isEnabled;
@@ -845,6 +849,8 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
                 }
             }
         }
+
+        public bool Windows11 => _windows11;
 
         private void LaunchEditor()
         {

--- a/src/settings-ui/Settings.UI.Library/ViewModels/FancyZonesViewModel.cs
+++ b/src/settings-ui/Settings.UI.Library/ViewModels/FancyZonesViewModel.cs
@@ -116,6 +116,12 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
 
             _isEnabled = GeneralSettingsConfig.Enabled.FancyZones;
             _windows11 = Helper.Windows11();
+
+            // Disable setting on windows 10
+            if (!_windows11 && DisableRoundCornersOnWindowSnap)
+            {
+                DisableRoundCornersOnWindowSnap = false;
+            }
         }
 
         private bool _isEnabled;

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -1356,7 +1356,7 @@ Made with 💗 by Microsoft and the PowerToys community.</value>
     <value>Microsoft PowerToys is a set of utilities for power users to tune and streamline their Windows experience for greater productivity.
 
 Take a moment to preview the various utilities listed or view our comprehensive documentation.</value>
-  </data>    
+  </data>
   <data name="Oobe_Overview_DescriptionLinkText.Text" xml:space="preserve">
     <value>Documentation on Microsoft Docs</value>
   </data>
@@ -1474,7 +1474,7 @@ From there, simply click on one of the supported files in the File Explorer and 
   <data name="Oobe_WhatsNew_LoadingError.Title" xml:space="preserve">
     <value>Couldn't load the release notes.</value>
   </data>
-	  <data name="Oobe_WhatsNew_LoadingError.Message" xml:space="preserve">
+  <data name="Oobe_WhatsNew_LoadingError.Message" xml:space="preserve">
     <value>Please check your internet connection.</value>
   </data>
   <data name="Oobe_WhatsNew_DetailedReleaseNotesLink.Text" xml:space="preserve">
@@ -2105,10 +2105,7 @@ From there, simply click on one of the supported files in the File Explorer and 
   <data name="Shell_WhatsNew.Content" xml:space="preserve">
     <value>What's new</value>
   </data>
-  <data name="FancyZones_DisableRoundCornersOnWindowSnap.Description" xml:space="preserve">
-    <value>Works on Windows 11 </value>
-  </data>
-  <data name="FancyZones_DisableRoundCornersOnWindowSnap.Header" xml:space="preserve">
+  <data name="FancyZones_DisableRoundCornersOnWindowSnap.Content" xml:space="preserve">
     <value>Disable round corners when window is snapped</value>
   </data>
 </root>

--- a/src/settings-ui/Settings.UI/Views/FancyZonesPage.xaml
+++ b/src/settings-ui/Settings.UI/Views/FancyZonesPage.xaml
@@ -14,6 +14,7 @@
         <converters:BoolToObjectConverter x:Key="BoolToComboBoxIndexConverter" TrueValue="1" FalseValue="0"/>
         <converters:StringFormatConverter x:Key="StringFormatConverter"/>
         <converters:BoolToVisibilityConverter x:Key="FalseToVisibleConverter" TrueValue="Collapsed" FalseValue="Visible"/>
+        <converters:BoolToVisibilityConverter x:Key="TrueToVisibleConverter" TrueValue="Visible" FalseValue="Collapsed"/>
     </Page.Resources>
 
     <controls:SettingsPageControl x:Uid="FancyZones"
@@ -189,10 +190,8 @@
                                                                  x:Uid="FancyZones_AllowPopupWindowSnap"/>
                                 <Rectangle Style="{StaticResource ExpanderSeparatorStyle}" />
                                 <CheckBox x:Uid="FancyZones_AllowChildWindowSnap" IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.AllowChildWindowSnap}" Margin="{StaticResource ExpanderSettingMargin}"/>
-                                <Rectangle Style="{StaticResource ExpanderSeparatorStyle}" />
-                                <controls:CheckBoxWithDescriptionControl IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.DisableRoundCornersOnWindowSnap}"
-                                                                 Margin="56, -2, 40, 14"
-                                                                 x:Uid="FancyZones_DisableRoundCornersOnWindowSnap"/>
+                                <Rectangle Style="{StaticResource ExpanderSeparatorStyle}" Visibility="{x:Bind Mode=OneWay, Path=ViewModel.Windows11, Converter={StaticResource TrueToVisibleConverter}}"/>
+                                <CheckBox x:Uid="FancyZones_DisableRoundCornersOnWindowSnap" IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.DisableRoundCornersOnWindowSnap}" Margin="{StaticResource ExpanderSettingMargin}" Visibility="{x:Bind Mode=OneWay, Path=ViewModel.Windows11, Converter={StaticResource TrueToVisibleConverter}}"/>
                             </StackPanel>
 
                         </controls:SettingExpander.Content>


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Show FZ settings for disable rounded corners only on Windows 11

**What is included in the PR:** 
@SeraphimaZykova does it make sense to skip ` FancyZonesWindowUtils::DisableRoundCorners(window)` if settings is enabled but OS is not Windows 11?
Another idea could be force disable of the setting if OS is not Windows 11.

**How does someone test / validate:** 
- Disable rounded corners setting for FZ should be visible only on Windows 11

## Quality Checklist

- [x] **Linked issue:** #17835
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
