### PR TITLE
[PT Run > TimeDate plugin] Setting to ignore number only input on global queries

### DIFF
--- a/doc/devdocs/modules/launcher/plugins/timedate.md
+++ b/doc/devdocs/modules/launcher/plugins/timedate.md
@@ -72,6 +72,7 @@ The following formats are currently available:
 	| Key | Default value | Name/Description |
 	|--------------|-----------|------------|
 	| `OnlyDateTimeNowGlobal` | `true` | Show only 'Time', 'Date', and 'Now' result on global queries |
+	| `GlobalQueryIgnoreNumberInput` | `false` | Ignore number only input on global queries |
 	| `TimeWithSeconds` | `false` | Show time with seconds (Applies to 'Time' and 'Now' result) |
 	| `DateWithWeekday` | `false` | Show date with weekday and name of month (Applies to 'Date' and 'Now' result) |
 	| `HideNumberMessageOnGlobalQuery` | `false` | Hide 'Invalid number input' error message on global queries |

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests/PluginSettingsTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests/PluginSettingsTests.cs
@@ -22,11 +22,12 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests
             var result = settings?.Length;
 
             // Assert
-            Assert.AreEqual(4, result);
+            Assert.AreEqual(5, result);
         }
 
         [DataTestMethod]
         [DataRow("OnlyDateTimeNowGlobal")]
+        [DataRow("GlobalQueryIgnoreNumberInput")]
         [DataRow("TimeWithSeconds")]
         [DataRow("DateWithWeekday")]
         [DataRow("HideNumberMessageOnGlobalQuery")]
@@ -44,6 +45,7 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests
 
         [DataTestMethod]
         [DataRow("OnlyDateTimeNowGlobal", true)]
+        [DataRow("GlobalQueryIgnoreNumberInput", false)]
         [DataRow("TimeWithSeconds", false)]
         [DataRow("DateWithWeekday", false)]
         [DataRow("HideNumberMessageOnGlobalQuery", false)]

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate/Components/SearchController.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate/Components/SearchController.cs
@@ -55,6 +55,12 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.Components
                 return results;
             }
 
+            // Ignore number only input on global queries if setting is true
+            if (!isKeywordSearch && TimeDateSettings.Instance.GlobalQueryIgnoreNumberInput && searchTerm.Any(char.IsLetter))
+            {
+                return results;
+            }
+
             // Switch search type
             if (isEmptySearchInput)
             {

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate/Components/TimeDateSettings.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate/Components/TimeDateSettings.cs
@@ -34,6 +34,11 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.Components
         internal bool OnlyDateTimeNowGlobal { get; private set; }
 
         /// <summary>
+        /// Gets a value indicating whether we shouold ignore number only input on global queries
+        /// </summary>
+        internal bool GlobalQueryIgnoreNumberInput { get; private set; }
+
+        /// <summary>
         /// Gets a value indicating whether to show the time with seconds or not
         /// </summary>
         internal bool TimeWithSeconds { get; private set; }
@@ -96,6 +101,12 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.Components
                 },
                 new PluginAdditionalOption()
                 {
+                    Key = nameof(GlobalQueryIgnoreNumberInput),
+                    DisplayLabel = Resources.Microsoft_plugin_timedate_SettingGlobalQueryIgnoreNumberInput,
+                    Value = false,
+                },
+                new PluginAdditionalOption()
+                {
                     Key = nameof(TimeWithSeconds),
                     DisplayLabel = Resources.Microsoft_plugin_timedate_SettingTimeWithSeconds,
                     DisplayDescription = Resources.Microsoft_plugin_timedate_SettingTimeWithSeconds_Description,
@@ -131,6 +142,7 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.Components
             }
 
             OnlyDateTimeNowGlobal = GetSettingOrDefault(settings, nameof(OnlyDateTimeNowGlobal));
+            GlobalQueryIgnoreNumberInput = GetSettingOrDefault(settings, nameof(GlobalQueryIgnoreNumberInput));
             TimeWithSeconds = GetSettingOrDefault(settings, nameof(TimeWithSeconds));
             DateWithWeekday = GetSettingOrDefault(settings, nameof(DateWithWeekday));
             HideNumberMessageOnGlobalQuery = GetSettingOrDefault(settings, nameof(HideNumberMessageOnGlobalQuery));

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate/Properties/Resources.Designer.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate/Properties/Resources.Designer.cs
@@ -421,6 +421,15 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Ignore number only input on global queries.
+        /// </summary>
+        internal static string Microsoft_plugin_timedate_SettingGlobalQueryIgnoreNumberInput {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_timedate_SettingGlobalQueryIgnoreNumberInput", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Hide &apos;Invalid number input&apos; error message on global queries.
         /// </summary>
         internal static string Microsoft_plugin_timedate_SettingHideNumberMessageOnGlobalQuery {

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate/Properties/Resources.resx
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate/Properties/Resources.resx
@@ -252,6 +252,9 @@
   <data name="Microsoft_plugin_timedate_SettingDateWithWeekday_Description" xml:space="preserve">
     <value>This setting applies to the 'Date' and 'Now' result.</value>
   </data>
+  <data name="Microsoft_plugin_timedate_SettingGlobalQueryIgnoreNumberInput" xml:space="preserve">
+    <value>Ignore number only input on global queries</value>
+  </data>
   <data name="Microsoft_plugin_timedate_SettingHideNumberMessageOnGlobalQuery" xml:space="preserve">
     <value>Hide 'Invalid number input' error message on global queries</value>
   </data>


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Adds a settings that the user can disable plugin for number only input on global queries like `2 25`.

**How does someone test / validate:** 

Update and run tests. Test functionality on local build.

## Quality Checklist

- [x] **Linked issue:** #18038
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [x] **Tests:** Added/updated and all pass
- [x] **Installer:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [x] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
