### PR TITLE
[FileExplorer Add-ons] If SVG file is bigger than 2MB save it as html page and preview the page 

### DIFF
--- a/src/modules/previewpane/SvgPreviewHandler/SvgPreviewControl.cs
+++ b/src/modules/previewpane/SvgPreviewHandler/SvgPreviewControl.cs
@@ -186,7 +186,8 @@ namespace Microsoft.PowerToys.PreviewHandler.Svg
 
                         // WebView2.NavigateToString() limitation
                         // See https://docs.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2.navigatetostring?view=webview2-dotnet-1.0.864.35#remarks
-                        if (svgData.Length > 2 * 1024 * 1024)
+                        // While testing the limit, it turned out it is ~1.5MB, so to be on a safe side we go for 1.5m bytes
+                        if (svgData.Length > 1_500_000)
                         {
                             string filename = _webView2UserDataFolder + "\\" + Guid.NewGuid().ToString() + ".html";
                             File.WriteAllText(filename, svgData);

--- a/src/modules/previewpane/SvgPreviewHandler/SvgPreviewControl.cs
+++ b/src/modules/previewpane/SvgPreviewHandler/SvgPreviewControl.cs
@@ -95,9 +95,7 @@ namespace Microsoft.PowerToys.PreviewHandler.Svg
 
                 blocked = SvgPreviewHandlerHelper.CheckBlockedElements(svgData);
             }
-#pragma warning disable CA1031 // Do not catch general exception types
             catch (Exception ex)
-#pragma warning restore CA1031 // Do not catch general exception types
             {
                 PreviewError(ex, dataSource);
                 return;
@@ -107,9 +105,7 @@ namespace Microsoft.PowerToys.PreviewHandler.Svg
             {
                 svgData = SvgPreviewHandlerHelper.AddStyleSVG(svgData);
             }
-#pragma warning disable CA1031 // Do not catch general exception types
             catch (Exception ex)
-#pragma warning restore CA1031 // Do not catch general exception types
             {
                 PowerToysTelemetry.Log.WriteEvent(new SvgFilePreviewError { Message = ex.Message });
             }
@@ -132,9 +128,7 @@ namespace Microsoft.PowerToys.PreviewHandler.Svg
                     base.DoPreview(dataSource);
                     PowerToysTelemetry.Log.WriteEvent(new SvgFilePreviewed());
                 }
-#pragma warning disable CA1031 // Do not catch general exception types
                 catch (Exception ex)
-#pragma warning restore CA1031 // Do not catch general exception types
                 {
                     PreviewError(ex, dataSource);
                 }
@@ -190,7 +184,8 @@ namespace Microsoft.PowerToys.PreviewHandler.Svg
                         _browser.CoreWebView2.SetVirtualHostNameToFolderMapping(VirtualHostName, AssemblyDirectory, CoreWebView2HostResourceAccessKind.Allow);
                         _browser.CoreWebView2.Settings.AreDefaultScriptDialogsEnabled = false;
 
-                        // WebView2.NavigateToString() limitation. See docs.
+                        // WebView2.NavigateToString() limitation
+                        // See https://docs.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2.navigatetostring?view=webview2-dotnet-1.0.864.35#remarks
                         if (svgData.Length > 2 * 1024 * 1024)
                         {
                             string filename = _webView2UserDataFolder + "\\" + Guid.NewGuid().ToString() + ".html";

--- a/src/modules/previewpane/SvgThumbnailProvider/SvgThumbnailProvider.cs
+++ b/src/modules/previewpane/SvgThumbnailProvider/SvgThumbnailProvider.cs
@@ -49,7 +49,7 @@ namespace Microsoft.PowerToys.ThumbnailHandler.Svg
         /// <summary>
         /// Name of the virtual host
         /// </summary>
-        public const string VirtualHostName = "PowerToysLocalSvgThumbnail";
+        private const string VirtualHostName = "PowerToysLocalSvgThumbnail";
 
         /// <summary>
         /// Gets the path of the current assembly.
@@ -57,7 +57,7 @@ namespace Microsoft.PowerToys.ThumbnailHandler.Svg
         /// <remarks>
         /// Source: https://stackoverflow.com/a/283917/14774889
         /// </remarks>
-        public static string AssemblyDirectory
+        private static string AssemblyDirectory
         {
             get
             {
@@ -69,6 +69,12 @@ namespace Microsoft.PowerToys.ThumbnailHandler.Svg
         }
 
         /// <summary>
+        /// Represent WebView2 user data folder path.
+        /// </summary>
+        private string _webView2UserDataFolder = System.Environment.GetEnvironmentVariable("USERPROFILE") +
+                                    "\\AppData\\LocalLow\\Microsoft\\PowerToys\\SvgThumbnailPreview-Temp";
+
+        /// <summary>
         /// Render SVG using WebView2 control, capture the WebView2
         /// preview and create Bitmap out of it.
         /// </summary>
@@ -76,6 +82,8 @@ namespace Microsoft.PowerToys.ThumbnailHandler.Svg
         /// <param name="cx">The maximum thumbnail size, in pixels.</param>
         public Bitmap GetThumbnail(string content, uint cx)
         {
+            CleanupWebView2UserDataFolder();
+
             if (cx == 0 || cx > MaxThumbnailSize || string.IsNullOrEmpty(content) || !content.Contains("svg"))
             {
                 return null;
@@ -117,8 +125,7 @@ namespace Microsoft.PowerToys.ThumbnailHandler.Svg
 
             ConfiguredTaskAwaitable<CoreWebView2Environment>.ConfiguredTaskAwaiter
                webView2EnvironmentAwaiter = CoreWebView2Environment
-                   .CreateAsync(userDataFolder: System.Environment.GetEnvironmentVariable("USERPROFILE") +
-                                                "\\AppData\\LocalLow\\Microsoft\\PowerToys\\SvgThumbnailPreview-Temp")
+                   .CreateAsync(userDataFolder: _webView2UserDataFolder)
                    .ConfigureAwait(true).GetAwaiter();
             webView2EnvironmentAwaiter.OnCompleted(async () =>
             {
@@ -129,9 +136,20 @@ namespace Microsoft.PowerToys.ThumbnailHandler.Svg
                     await _browser.CoreWebView2.AddScriptToExecuteOnDocumentCreatedAsync("window.addEventListener('contextmenu', window => {window.preventDefault();});");
                     _browser.CoreWebView2.SetVirtualHostNameToFolderMapping(VirtualHostName, AssemblyDirectory, CoreWebView2HostResourceAccessKind.Allow);
                     _browser.CoreWebView2.Settings.AreDefaultScriptDialogsEnabled = false;
-                    _browser.NavigateToString(wrappedContent);
+
+                    // WebView2.NavigateToString() limitation. See docs.
+                    if (wrappedContent.Length > 2 * 1024 * 1024)
+                    {
+                        string filename = _webView2UserDataFolder + "\\" + Guid.NewGuid().ToString() + ".html";
+                        File.WriteAllText(filename, wrappedContent);
+                        _browser.Source = new Uri(filename);
+                    }
+                    else
+                    {
+                        _browser.NavigateToString(wrappedContent);
+                    }
                 }
-                catch (NullReferenceException)
+                catch (Exception)
                 {
                 }
             });
@@ -248,6 +266,26 @@ namespace Microsoft.PowerToys.ThumbnailHandler.Svg
         public void Dispose()
         {
             GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Cleanup the previously created tmp html files from svg files bigger than 2MB.
+        /// </summary>
+        private void CleanupWebView2UserDataFolder()
+        {
+            try
+            {
+                // Cleanup temp dir
+                var dir = new DirectoryInfo(_webView2UserDataFolder);
+
+                foreach (var file in dir.EnumerateFiles("*.html"))
+                {
+                    file.Delete();
+                }
+            }
+            catch (Exception)
+            {
+            }
         }
     }
 }

--- a/src/modules/previewpane/SvgThumbnailProvider/SvgThumbnailProvider.cs
+++ b/src/modules/previewpane/SvgThumbnailProvider/SvgThumbnailProvider.cs
@@ -139,7 +139,8 @@ namespace Microsoft.PowerToys.ThumbnailHandler.Svg
 
                     // WebView2.NavigateToString() limitation
                     // See https://docs.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2.navigatetostring?view=webview2-dotnet-1.0.864.35#remarks
-                    if (wrappedContent.Length > 2 * 1024 * 1024)
+                    // While testing the limit, it turned out it is ~1.5MB, so to be on a safe side we go for 1.5m bytes
+                    if (wrappedContent.Length > 1_500_000)
                     {
                         string filename = _webView2UserDataFolder + "\\" + Guid.NewGuid().ToString() + ".html";
                         File.WriteAllText(filename, wrappedContent);

--- a/src/modules/previewpane/SvgThumbnailProvider/SvgThumbnailProvider.cs
+++ b/src/modules/previewpane/SvgThumbnailProvider/SvgThumbnailProvider.cs
@@ -137,7 +137,8 @@ namespace Microsoft.PowerToys.ThumbnailHandler.Svg
                     _browser.CoreWebView2.SetVirtualHostNameToFolderMapping(VirtualHostName, AssemblyDirectory, CoreWebView2HostResourceAccessKind.Allow);
                     _browser.CoreWebView2.Settings.AreDefaultScriptDialogsEnabled = false;
 
-                    // WebView2.NavigateToString() limitation. See docs.
+                    // WebView2.NavigateToString() limitation
+                    // See https://docs.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2.navigatetostring?view=webview2-dotnet-1.0.864.35#remarks
                     if (wrappedContent.Length > 2 * 1024 * 1024)
                     {
                         string filename = _webView2UserDataFolder + "\\" + Guid.NewGuid().ToString() + ".html";


### PR DESCRIPTION
Reason: WebView2.NavigateToString() has 2MB string limitation

## Summary of the Pull Request

**What is this about:**

**What is included in the PR:** 

**How does someone test / validate:** 
Download big svg files attached here https://github.com/microsoft/PowerToys/issues/18031#issuecomment-1118131817 and try to preview it

## Quality Checklist

- [x] **Linked issue:** #18031 #18125
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
