### PR TITLE
[FancyZones] Open window in a zone fix

### DIFF
--- a/src/common/utils/process_path.h
+++ b/src/common/utils/process_path.h
@@ -68,6 +68,23 @@ inline std::wstring get_process_path(HWND window) noexcept
     return name;
 }
 
+inline std::wstring get_process_path_waiting_uwp(HWND window)
+{
+    const static std::wstring appFrameHost = L"ApplicationFrameHost.exe";
+
+    int attempt = 0;
+    auto processPath = get_process_path(window);
+
+    while (++attempt < 30 && processPath.length() >= appFrameHost.length() &&
+           processPath.compare(processPath.length() - appFrameHost.length(), appFrameHost.length(), appFrameHost) == 0)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        processPath = get_process_path(window);
+    }
+
+    return processPath;
+}
+
 inline std::wstring get_module_filename(HMODULE mod = nullptr)
 {
     wchar_t buffer[MAX_PATH + 1];

--- a/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
@@ -1167,8 +1167,8 @@ void FancyZones::RegisterVirtualDesktopUpdates() noexcept
         AppliedLayouts::instance().RemoveDeletedVirtualDesktops(*guids);
     }
 
-    AppZoneHistory::instance().SyncVirtualDesktops(m_currentDesktopId);
-    AppliedLayouts::instance().SyncVirtualDesktops(m_currentDesktopId);
+    AppZoneHistory::instance().SyncVirtualDesktops();
+    AppliedLayouts::instance().SyncVirtualDesktops();
 }
 
 void FancyZones::UpdateHotkey(int hotkeyId, const PowerToysSettings::HotkeyObject& hotkeyObject, bool enable) noexcept
@@ -1228,8 +1228,6 @@ void FancyZones::SettingsUpdate(SettingId id)
 void FancyZones::OnEditorExitEvent() noexcept
 {
     // Collect information about changes in zone layout after editor exited.
-    AppZoneHistory::instance().SyncVirtualDesktops(m_currentDesktopId);
-    AppliedLayouts::instance().SyncVirtualDesktops(m_currentDesktopId);
     UpdateZoneSets();
 }
 

--- a/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
@@ -267,8 +267,6 @@ FancyZones::Run() noexcept
     });
 
     PostMessage(m_window, WM_PRIV_VD_INIT, 0, 0);
-    AppliedLayouts::instance().SetVirtualDesktopCheckCallback(std::bind(&VirtualDesktop::IsVirtualDesktopIdSavedInRegistry, &m_virtualDesktop, std::placeholders::_1));
-    AppZoneHistory::instance().SetVirtualDesktopCheckCallback(std::bind(&VirtualDesktop::IsVirtualDesktopIdSavedInRegistry, &m_virtualDesktop, std::placeholders::_1));
 }
 
 // IFancyZones

--- a/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
@@ -59,12 +59,6 @@ public:
         m_hinstance(hinstance),
         m_windowMoveHandler([this]() {
             PostMessageW(m_window, WM_PRIV_LOCATIONCHANGE, NULL, NULL);
-        }),
-        m_virtualDesktop([this]() { 
-            PostMessage(m_window, WM_PRIV_VD_INIT, 0, 0); 
-        },
-        [this]() { 
-            PostMessage(m_window, WM_PRIV_VD_UPDATE, 0, 0); 
         })
     {
         this->disableModuleCallback = std::move(disableModuleCallback);
@@ -258,8 +252,6 @@ FancyZones::Run() noexcept
         }
     }
 
-    m_virtualDesktop.Init();
-
     m_dpiUnawareThread.submit(OnThreadExecutor::task_t{ [] {
                           SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT_UNAWARE);
                           SetThreadDpiHostingBehavior(DPI_HOSTING_BEHAVIOR_MIXED);
@@ -274,6 +266,7 @@ FancyZones::Run() noexcept
         }
     });
 
+    PostMessage(m_window, WM_PRIV_VD_INIT, 0, 0);
     AppliedLayouts::instance().SetVirtualDesktopCheckCallback(std::bind(&VirtualDesktop::IsVirtualDesktopIdSavedInRegistry, &m_virtualDesktop, std::placeholders::_1));
     AppZoneHistory::instance().SetVirtualDesktopCheckCallback(std::bind(&VirtualDesktop::IsVirtualDesktopIdSavedInRegistry, &m_virtualDesktop, std::placeholders::_1));
 }
@@ -289,8 +282,6 @@ FancyZones::Destroy() noexcept
         DestroyWindow(m_window);
         m_window = nullptr;
     }
-
-    m_virtualDesktop.UnInit();
 }
 
 // IFancyZonesCallback

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesData/AppZoneHistory.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesData/AppZoneHistory.cpp
@@ -282,7 +282,7 @@ bool AppZoneHistory::SetAppLastZones(HWND window, const FancyZonesDataTypes::Dev
         return false;
     }
 
-    auto processPath = get_process_path(window);
+    auto processPath = get_process_path_waiting_uwp(window);
     if (processPath.empty())
     {
         return false;
@@ -337,7 +337,7 @@ bool AppZoneHistory::RemoveAppLastZone(HWND window, const FancyZonesDataTypes::D
 {
     Logger::info(L"Add app zone history, device: {}, layout: {}", deviceId.toString(), zoneSetId);
 
-    auto processPath = get_process_path(window);
+    auto processPath = get_process_path_waiting_uwp(window);
     if (!processPath.empty())
     {
         auto history = m_history.find(processPath);
@@ -441,7 +441,7 @@ std::optional<FancyZonesDataTypes::AppZoneHistoryData> AppZoneHistory::GetZoneHi
 
 bool AppZoneHistory::IsAnotherWindowOfApplicationInstanceZoned(HWND window, const FancyZonesDataTypes::DeviceIdData& deviceId) const noexcept
 {
-    auto processPath = get_process_path(window);
+    auto processPath = get_process_path_waiting_uwp(window);
     if (!processPath.empty())
     {
         auto history = m_history.find(processPath);
@@ -475,7 +475,7 @@ bool AppZoneHistory::IsAnotherWindowOfApplicationInstanceZoned(HWND window, cons
 
 void AppZoneHistory::UpdateProcessIdToHandleMap(HWND window, const FancyZonesDataTypes::DeviceIdData& deviceId)
 {
-    auto processPath = get_process_path(window);
+    auto processPath = get_process_path_waiting_uwp(window);
     if (!processPath.empty())
     {
         auto history = m_history.find(processPath);
@@ -498,16 +498,10 @@ void AppZoneHistory::UpdateProcessIdToHandleMap(HWND window, const FancyZonesDat
 
 ZoneIndexSet AppZoneHistory::GetAppLastZoneIndexSet(HWND window, const FancyZonesDataTypes::DeviceIdData& deviceId, const std::wstring_view& zoneSetId) const
 {
-    auto processPath = get_process_path(window);
+    auto processPath = get_process_path_waiting_uwp(window);
     if (processPath.empty())
     {
         Logger::error("Process path is empty");
-        return {};
-    }
-
-    auto history = m_history.find(processPath);
-    if (history == std::end(m_history))
-    {
         return {};
     }
 
@@ -522,6 +516,12 @@ ZoneIndexSet AppZoneHistory::GetAppLastZoneIndexSet(HWND window, const FancyZone
     if (srcVirtualDesktopIDStr)
     {
         Logger::debug(L"Get {} zone history on monitor: {}, virtual desktop: {}", app, deviceId.deviceName, srcVirtualDesktopIDStr.value());
+    }
+
+    auto history = m_history.find(processPath);
+    if (history == std::end(m_history))
+    {
+        return {};
     }
 
     const auto& perDesktopData = history->second;

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesData/AppZoneHistory.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesData/AppZoneHistory.cpp
@@ -249,14 +249,13 @@ void AppZoneHistory::SaveData()
 {
     bool dirtyFlag = false;
     std::unordered_map<std::wstring, std::vector<FancyZonesDataTypes::AppZoneHistoryData>> updatedHistory;
-    VirtualDesktop virtualDesktop;
-
+    
     for (const auto& [path, dataVector] : m_history)
     {
         auto updatedVector = dataVector;
         for (auto& data : updatedVector)
         {
-            if (!virtualDesktop.IsVirtualDesktopIdSavedInRegistry(data.deviceId.virtualDesktopId))
+            if (!VirtualDesktop::instance().IsVirtualDesktopIdSavedInRegistry(data.deviceId.virtualDesktopId))
             {
                 data.deviceId.virtualDesktopId = GUID_NULL;
                 dirtyFlag = true;

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesData/AppZoneHistory.h
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesData/AppZoneHistory.h
@@ -52,7 +52,6 @@ public:
     void UpdateProcessIdToHandleMap(HWND window, const FancyZonesDataTypes::DeviceIdData& deviceId);
     ZoneIndexSet GetAppLastZoneIndexSet(HWND window, const FancyZonesDataTypes::DeviceIdData& deviceId, const std::wstring_view& zoneSetId) const;
 
-    void SetVirtualDesktopCheckCallback(std::function<bool(GUID)> callback);
     void SyncVirtualDesktops(GUID currentVirtualDesktopId);
     void RemoveDeletedVirtualDesktops(const std::vector<GUID>& activeDesktops);
 
@@ -61,5 +60,4 @@ private:
     ~AppZoneHistory() = default;
 
     TAppZoneHistoryMap m_history;
-    std::function<bool(GUID)> m_virtualDesktopCheckCallback;
 };

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesData/AppZoneHistory.h
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesData/AppZoneHistory.h
@@ -52,7 +52,7 @@ public:
     void UpdateProcessIdToHandleMap(HWND window, const FancyZonesDataTypes::DeviceIdData& deviceId);
     ZoneIndexSet GetAppLastZoneIndexSet(HWND window, const FancyZonesDataTypes::DeviceIdData& deviceId, const std::wstring_view& zoneSetId) const;
 
-    void SyncVirtualDesktops(GUID currentVirtualDesktopId);
+    void SyncVirtualDesktops();
     void RemoveDeletedVirtualDesktops(const std::vector<GUID>& activeDesktops);
 
 private:

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesData/AppliedLayouts.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesData/AppliedLayouts.cpp
@@ -245,12 +245,11 @@ void AppliedLayouts::SaveData()
 {
     bool dirtyFlag = false;
     TAppliedLayoutsMap updatedMap;
-    VirtualDesktop virtualDesktop;
-
+    
     for (const auto& [id, data] : m_layouts)
     {
         auto updatedId = id;
-        if (!virtualDesktop.IsVirtualDesktopIdSavedInRegistry(id.virtualDesktopId))
+        if (!VirtualDesktop::instance().IsVirtualDesktopIdSavedInRegistry(id.virtualDesktopId))
         {
             updatedId.virtualDesktopId = GUID_NULL;
             dirtyFlag = true;

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesData/AppliedLayouts.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesData/AppliedLayouts.cpp
@@ -268,23 +268,31 @@ void AppliedLayouts::SaveData()
     }
 }
 
-void AppliedLayouts::SyncVirtualDesktops(GUID currentVirtualDesktopId)
+void AppliedLayouts::SyncVirtualDesktops()
 {
     // Explorer persists current virtual desktop identifier to registry on a per session basis,
     // but only after first virtual desktop switch happens. If the user hasn't switched virtual
     // desktops in this session value in registry will be empty and we will use default GUID in
     // that case (00000000-0000-0000-0000-000000000000).
 
-    auto currentVirtualDesktopStr = FancyZonesUtils::GuidToString(currentVirtualDesktopId);
-    if (currentVirtualDesktopStr)
+    auto savedInRegistryVirtualDesktopID = VirtualDesktop::instance().GetCurrentVirtualDesktopIdFromRegistry();
+    if (!savedInRegistryVirtualDesktopID.has_value() || savedInRegistryVirtualDesktopID.value() == GUID_NULL)
     {
-        Logger::info(L"AppliedLayouts Sync virtual desktops: current {}", currentVirtualDesktopStr.value());
-    }    
+        return;
+    }
+
+    auto currentVirtualDesktopStr = FancyZonesUtils::GuidToString(savedInRegistryVirtualDesktopID.value());
+    if (!currentVirtualDesktopStr.has_value())
+    {
+        Logger::error(L"Failed to convert virtual desktop GUID to string");
+        return;
+    }
+
+    Logger::info(L"AppliedLayouts Sync virtual desktops: current {}", currentVirtualDesktopStr.value());
 
     bool dirtyFlag = false;
 
     std::vector<FancyZonesDataTypes::DeviceIdData> replaceWithCurrentId{};
-    std::vector<FancyZonesDataTypes::DeviceIdData> replaceWithNullId{};
 
     for (const auto& [id, data] : m_layouts)
     {
@@ -293,39 +301,18 @@ void AppliedLayouts::SyncVirtualDesktops(GUID currentVirtualDesktopId)
             replaceWithCurrentId.push_back(id);
             dirtyFlag = true;
         }
-        else
-        {
-            VirtualDesktop virtualDesktop;
-            if (!virtualDesktop.IsVirtualDesktopIdSavedInRegistry(id.virtualDesktopId))
-            {
-                replaceWithNullId.push_back(id);
-                dirtyFlag = true;
-            }
-        }
     }
 
     for (const auto& id : replaceWithCurrentId)
     {
         auto mapEntry = m_layouts.extract(id);
-        mapEntry.key().virtualDesktopId = currentVirtualDesktopId;
-        m_layouts.insert(std::move(mapEntry));
-    }
-
-    for (const auto& id : replaceWithNullId)
-    {
-        auto mapEntry = m_layouts.extract(id);
-        mapEntry.key().virtualDesktopId = GUID_NULL;
+        mapEntry.key().virtualDesktopId = savedInRegistryVirtualDesktopID.value();
         m_layouts.insert(std::move(mapEntry));
     }
 
     if (dirtyFlag)
     {
-        wil::unique_cotaskmem_string virtualDesktopIdStr;
-        if (SUCCEEDED(StringFromCLSID(currentVirtualDesktopId, &virtualDesktopIdStr)))
-        {
-            Logger::info(L"Update Virtual Desktop id to {}", virtualDesktopIdStr.get());
-        }
-
+        Logger::info(L"Update Virtual Desktop id to {}", currentVirtualDesktopStr.value());
         SaveData();
     }
 }

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesData/AppliedLayouts.h
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesData/AppliedLayouts.h
@@ -48,7 +48,7 @@ public:
     void LoadData();
     void SaveData();
 
-    void SyncVirtualDesktops(GUID currentVirtualDesktopId);
+    void SyncVirtualDesktops();
     void RemoveDeletedVirtualDesktops(const std::vector<GUID>& activeDesktops);
 
     std::optional<Layout> GetDeviceLayout(const FancyZonesDataTypes::DeviceIdData& id) const noexcept;

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesData/AppliedLayouts.h
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesData/AppliedLayouts.h
@@ -48,7 +48,6 @@ public:
     void LoadData();
     void SaveData();
 
-    void SetVirtualDesktopCheckCallback(std::function<bool(GUID)> callback);
     void SyncVirtualDesktops(GUID currentVirtualDesktopId);
     void RemoveDeletedVirtualDesktops(const std::vector<GUID>& activeDesktops);
 
@@ -67,5 +66,4 @@ private:
 
     std::unique_ptr<FileWatcher> m_fileWatcher;
     TAppliedLayoutsMap m_layouts;
-    std::function<bool(GUID)> m_virtualDesktopCheckCallback;
 };

--- a/src/modules/fancyzones/FancyZonesLib/MonitorWorkAreaHandler.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/MonitorWorkAreaHandler.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 #include "MonitorWorkAreaHandler.h"
 #include "VirtualDesktop.h"
+#include "WorkArea.h"
 #include "util.h"
 
 #include <common/logger/logger.h>

--- a/src/modules/fancyzones/FancyZonesLib/VirtualDesktop.h
+++ b/src/modules/fancyzones/FancyZonesLib/VirtualDesktop.h
@@ -3,39 +3,32 @@
 class VirtualDesktop
 {
 public:
-    VirtualDesktop();
-    ~VirtualDesktop();
+    static VirtualDesktop& instance();
 
-    inline bool IsVirtualDesktopIdSavedInRegistry(GUID id) const
-    {
-        auto ids = GetVirtualDesktopIdsFromRegistry();
-        if (!ids.has_value())
-        {
-            return false;
-        }
+    // saved values
+    GUID GetCurrentVirtualDesktopId() const noexcept;
+    GUID GetPreviousVirtualDesktopId() const noexcept;
+    void UpdateVirtualDesktopId() noexcept;
 
-        for (const auto& regId : *ids)
-        {
-            if (regId == id)
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    std::optional<GUID> GetCurrentVirtualDesktopIdFromRegistry() const;
-    std::optional<std::vector<GUID>> GetVirtualDesktopIdsFromRegistry() const;
-
+    // IVirtualDesktopManager
     bool IsWindowOnCurrentDesktop(HWND window) const;
     std::optional<GUID> GetDesktopId(HWND window) const;
     std::optional<GUID> GetDesktopIdByTopLevelWindows() const;
-
     std::vector<std::pair<HWND, GUID>> GetWindowsRelatedToDesktops() const;
 
+    // registry
+    std::optional<GUID> GetCurrentVirtualDesktopIdFromRegistry() const;
+    std::optional<std::vector<GUID>> GetVirtualDesktopIdsFromRegistry() const;
+    bool IsVirtualDesktopIdSavedInRegistry(GUID id) const;
+
 private:
-    IVirtualDesktopManager* m_vdManager;
+    VirtualDesktop();
+    ~VirtualDesktop();
+
+    IVirtualDesktopManager* m_vdManager{nullptr};
+
+    GUID m_currentVirtualDesktopId{};
+    GUID m_previousDesktopId{};
 
     std::optional<std::vector<GUID>> GetVirtualDesktopIdsFromRegistry(HKEY hKey) const;
 };

--- a/src/modules/fancyzones/FancyZonesLib/VirtualDesktop.h
+++ b/src/modules/fancyzones/FancyZonesLib/VirtualDesktop.h
@@ -1,12 +1,9 @@
 #pragma once
 
-#include "WorkArea.h"
-#include "on_thread_executor.h"
-
 class VirtualDesktop
 {
 public:
-    VirtualDesktop(const std::function<void()>& vdInitCallback, const std::function<void()>& vdUpdatedCallback);
+    VirtualDesktop();
     ~VirtualDesktop();
 
     inline bool IsVirtualDesktopIdSavedInRegistry(GUID id) const
@@ -28,9 +25,6 @@ public:
         return false;
     }
 
-    void Init();
-    void UnInit();
-
     std::optional<GUID> GetCurrentVirtualDesktopIdFromRegistry() const;
     std::optional<std::vector<GUID>> GetVirtualDesktopIdsFromRegistry() const;
 
@@ -41,14 +35,7 @@ public:
     std::vector<std::pair<HWND, GUID>> GetWindowsRelatedToDesktops() const;
 
 private:
-    std::function<void()> m_vdInitCallback;
-    std::function<void()> m_vdUpdatedCallback;
-
     IVirtualDesktopManager* m_vdManager;
 
-    OnThreadExecutor m_virtualDesktopTrackerThread;
-    wil::unique_handle m_terminateVirtualDesktopTrackerEvent;
-
     std::optional<std::vector<GUID>> GetVirtualDesktopIdsFromRegistry(HKEY hKey) const;
-    void HandleVirtualDesktopUpdates();
 };

--- a/src/modules/fancyzones/FancyZonesLib/WindowUtils.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WindowUtils.cpp
@@ -228,7 +228,7 @@ bool FancyZonesWindowUtils::IsCandidateForZoning(HWND window)
         return false;
     }
 
-    std::wstring processPath = get_process_path(window);
+    std::wstring processPath = get_process_path_waiting_uwp(window);
     CharUpperBuffW(const_cast<std::wstring&>(processPath).data(), (DWORD)processPath.length());
     if (IsExcludedByUser(processPath))
     {

--- a/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
@@ -390,7 +390,7 @@ WorkArea::GetWindowZoneIndexes(HWND window) const noexcept
         }
         else
         {
-            Logger::error(L"Failed to stringify layout id on the requested work area");
+            Logger::error(L"Failed to convert to string layout GUID on the requested work area");
         }
     }
     else

--- a/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
@@ -388,7 +388,16 @@ WorkArea::GetWindowZoneIndexes(HWND window) const noexcept
         {
             return AppZoneHistory::instance().GetAppLastZoneIndexSet(window, m_uniqueId, zoneSetId.get());
         }
+        else
+        {
+            Logger::error(L"Failed to stringify layout id on the requested work area");
+        }
     }
+    else
+    {
+        Logger::error(L"No layout initialized on the requested work area");
+    }
+
     return {};
 }
 


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

In some cases, app zone history is not found due to a virtual desktop id, so the window is not snapped to a zone after opening.
Note: this doesn't fix the problem with FileExplorer.  

**What is included in the PR:** 

* Centralized work with virtual desktops in one place.
* Changed virtual desktop comparison in the app-zone-history. In some cases, windows weren't snapped to a zone due to virtual desktop ids.  
* Added separate function for retrieving process path waiting for the uwp app to be opened to get the actual app path instead of ApplicationFrameHost.
* Added logs 

**How does someone test / validate:** 

In my case, I can reproduce a bug with a non-zoned window with Skype. 
Allow Skype to run on startup and uncheck `Settings -> General -> Launch Skype in the background`.

* Remove virtual desktops from the registry
* Snap window to a zone. 
* Restart
* Verify that the app is opened in a zone
* Create a new virtual desktop
* Restart
* Verify that the app is opened in a zone

## Quality Checklist

- [x] **Linked issue:** #https://github.com/microsoft/PowerToys/issues/17027, https://github.com/microsoft/PowerToys/issues/18035, https://github.com/microsoft/PowerToys/issues/17550, https://github.com/microsoft/PowerToys/issues/13759, https://github.com/microsoft/PowerToys/issues/17909
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
