### PR TITLE
[Settings] Minor UI fixes

### DIFF
--- a/src/settings-ui/Settings.UI/Controls/CheckBoxWithDescriptionControl.cs
+++ b/src/settings-ui/Settings.UI/Controls/CheckBoxWithDescriptionControl.cs
@@ -40,12 +40,12 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
             // Add text box only if the description is not empty. Required for additional plugin options.
             if (!string.IsNullOrWhiteSpace(Description))
             {
-                panel.Children.Add(new TextBlock() { Margin = new Thickness(0, 10, 0, 0), Text = Header });
+                panel.Children.Add(new TextBlock() { Margin = new Thickness(0, 10, 0, 0), Text = Header, TextWrapping = TextWrapping.WrapWholeWords });
                 panel.Children.Add(new IsEnabledTextBlock() { Style = (Style)App.Current.Resources["SecondaryIsEnabledTextBlockStyle"], Text = Description });
             }
             else
             {
-                panel.Children.Add(new TextBlock() { Margin = new Thickness(0, 0, 0, 0), Text = Header });
+                panel.Children.Add(new TextBlock() { Margin = new Thickness(0, 0, 0, 0), Text = Header, TextWrapping = TextWrapping.WrapWholeWords });
             }
 
             _checkBoxSubTextControl.Content = panel;

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -2085,7 +2085,7 @@ From there, simply click on one of the supported files in the File Explorer and 
   <data name="AlwaysOnTop_Radio_Windows_Default.Content" xml:space="preserve">
     <value>Windows default</value>
   </data>
-  <data name="PowerPreviewPage.SecondaryLinksHeader" xml:space="preserve">
+  <data name="FileExplorerPreview.SecondaryLinksHeader" xml:space="preserve">
     <value>Attribution</value>
     <comment>giving credit to the projects this utility was based on</comment>
   </data>

--- a/src/settings-ui/Settings.UI/Views/MouseUtilsPage.xaml
+++ b/src/settings-ui/Settings.UI/Views/MouseUtilsPage.xaml
@@ -130,6 +130,7 @@
                                     ScrollViewer.VerticalScrollMode="Enabled"
                                     ScrollViewer.IsVerticalRailEnabled="True"
                                     TextWrapping="Wrap"
+                                    IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsFindMyMouseEnabled}"
                                     AcceptsReturn="True"
                                     MinWidth="240"
                                     MinHeight="160" />

--- a/src/settings-ui/Settings.UI/Views/PowerLauncherPage.xaml
+++ b/src/settings-ui/Settings.UI/Views/PowerLauncherPage.xaml
@@ -257,7 +257,7 @@
                                                                 <Rectangle Style="{StaticResource ExpanderSeparatorStyle}" />
                                                                 <controls:CheckBoxWithDescriptionControl Header="{x:Bind Path=DisplayLabel}" Description="{x:Bind Path=DisplayDescription}"
                                                                       IsChecked="{x:Bind Path=Value, Mode=TwoWay}"
-                                                                      Margin="{StaticResource ExpanderSettingMargin}"/>
+                                                                      Margin="56, 0, 40, 16"/>
                                                             </StackPanel>
 
                                                         </DataTemplate>

--- a/src/settings-ui/Settings.UI/Views/ShortcutGuidePage.xaml
+++ b/src/settings-ui/Settings.UI/Views/ShortcutGuidePage.xaml
@@ -66,6 +66,7 @@
                         x:Uid="ShortcutGuide_PressWinKeyWarning"
                         Severity="Warning"
                         IsTabStop="True"
+                        IsEnabled="False"
                         IsOpen="{x:Bind Mode=OneWay, Path=ViewModel.UseLegacyPressWinKeyBehavior}"
                         IsClosable="False"
                     />

--- a/src/settings-ui/Settings.UI/Views/ShortcutGuidePage.xaml
+++ b/src/settings-ui/Settings.UI/Views/ShortcutGuidePage.xaml
@@ -66,7 +66,6 @@
                         x:Uid="ShortcutGuide_PressWinKeyWarning"
                         Severity="Warning"
                         IsTabStop="True"
-                        IsEnabled="False"
                         IsOpen="{x:Bind Mode=OneWay, Path=ViewModel.UseLegacyPressWinKeyBehavior}"
                         IsClosable="False"
                     />


### PR DESCRIPTION
## Summary of the Pull Request
This PR solves a couple of minor Settings UX issues: 

#17943 - WordWrapping is now on for the Header text
#16884 - The TextBox in the Expander will now be disabled
#17110 - Fixed margins

## Quality Checklist

- [x] **Linked issue:** #17943, #16884, #17110
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
