### PR TITLE
[ColorPicker] - Decimal RGB color format

### DIFF
--- a/src/modules/colorPicker/ColorPickerUI/Helpers/ColorHelper.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/ColorHelper.cs
@@ -268,7 +268,7 @@ namespace ColorPicker.Helpers
         /// Convert a given <see cref="Color"/> to a decimal BGR value
         /// </summary>
         /// <param name="color">The <see cref="Color"/> to convert</param>
-        /// <returns>The decimal value[0..16777215]</returns>
+        /// <returns>The decimal value [0..16777215]</returns>
         internal static int ConvertDecimalBGRValue(Color color)
         {
             return (color.B * 65536) + (color.G * 256) + color.R;
@@ -278,7 +278,7 @@ namespace ColorPicker.Helpers
         /// Convert a given <see cref="Color"/> to a decimal RGB value
         /// </summary>
         /// <param name="color">The <see cref="Color"/> to convert</param>
-        /// <returns>The decimal value[0..16777215]</returns>
+        /// <returns>The decimal value [0..16777215]</returns>
         internal static int ConvertDecimalRGBValue(Color color)
         {
             return (color.R * 65536) + (color.G * 256) + color.B;

--- a/src/modules/colorPicker/ColorPickerUI/Helpers/ColorHelper.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/ColorHelper.cs
@@ -263,5 +263,25 @@ namespace ColorPicker.Helpers
 
             return $"M{Math.Round((hue - 300d) / 0.6d, 0)}";
         }
+
+        /// <summary>
+        /// Convert a given <see cref="Color"/> to a decimal BGR value
+        /// </summary>
+        /// <param name="color">The <see cref="Color"/> to convert</param>
+        /// <returns>The decimal value[0..16777215]</returns>
+        internal static int ConvertDecimalBGRValue(Color color)
+        {
+            return (color.B * 65536) + (color.G * 256) + color.R;
+        }
+
+        /// <summary>
+        /// Convert a given <see cref="Color"/> to a decimal RGB value
+        /// </summary>
+        /// <param name="color">The <see cref="Color"/> to convert</param>
+        /// <returns>The decimal value[0..16777215]</returns>
+        internal static int ConvertDecimalRGBValue(Color color)
+        {
+            return (color.R * 65536) + (color.G * 256) + color.B;
+        }
     }
 }

--- a/src/modules/colorPicker/ColorPickerUI/Helpers/ColorRepresentationHelper.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/ColorRepresentationHelper.cs
@@ -129,7 +129,7 @@ namespace ColorPicker.Helpers
         /// <returns>a string value number</returns>
         private static string ColorToDecimalBGR(Color color)
         {
-            return $"{color.R + (color.G * 256) + (color.B * 65536)}";
+            return $"{ColorHelper.ConvertDecimalBGRValue(color)}";
         }
 
         /// <summary>
@@ -139,7 +139,7 @@ namespace ColorPicker.Helpers
         /// <returns>a string value number</returns>
         private static string ColorToDecimalRGB(Color color)
         {
-            return $"{(color.R * 65536) + (color.G * 256) + color.B}";
+            return $"{ColorHelper.ConvertDecimalRGBValue(color)}";
         }
 
         /// <summary>

--- a/src/modules/colorPicker/ColorPickerUI/Helpers/ColorRepresentationHelper.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/ColorRepresentationHelper.cs
@@ -47,7 +47,8 @@ namespace ColorPicker.Helpers
                 ColorRepresentationType.CIELAB => ColorToCIELAB(color),
                 ColorRepresentationType.CIEXYZ => ColorToCIEXYZ(color),
                 ColorRepresentationType.VEC4 => ColorToFloat(color),
-                ColorRepresentationType.DecimalValue => ColorToDecimal(color),
+                ColorRepresentationType.DecimalValue => ColorToDecimalBGR(color),
+                ColorRepresentationType.DecimalRGBValue => ColorToDecimalRGB(color),
 
                 // Fall-back value, when "_userSettings.CopiedColorRepresentation.Value" is incorrect
                 _ => ColorToHex(color),
@@ -122,13 +123,23 @@ namespace ColorPicker.Helpers
         }
 
         /// <summary>
-        /// Return a <see cref="string"/> representation decimal color value
+        /// Return a <see cref="string"/> representation decimal BGR color value
         /// </summary>
         /// <param name="color">The <see cref="Color"/> to convert</param>
         /// <returns>a string value number</returns>
-        private static string ColorToDecimal(Color color)
+        private static string ColorToDecimalBGR(Color color)
         {
             return $"{color.R + (color.G * 256) + (color.B * 65536)}";
+        }
+
+        /// <summary>
+        /// Return a <see cref="string"/> representation decimal RGB color value
+        /// </summary>
+        /// <param name="color">The <see cref="Color"/> to convert</param>
+        /// <returns>a string value number</returns>
+        private static string ColorToDecimalRGB(Color color)
+        {
+            return $"{(color.R * 65536) + (color.G * 256) + color.B}";
         }
 
         /// <summary>

--- a/src/modules/colorPicker/ColorPickerUI/ViewModels/ColorEditorViewModel.cs
+++ b/src/modules/colorPicker/ColorPickerUI/ViewModels/ColorEditorViewModel.cs
@@ -324,8 +324,14 @@ namespace ColorPicker.ViewModels
             _allColorRepresentations.Add(
                 new ColorFormatModel()
                 {
-                    FormatName = "Decimal",
+                    FormatName = "Decimal BGR",
                     Convert = (Color color) => ColorRepresentationHelper.GetStringRepresentationFromMediaColor(color, ColorRepresentationType.DecimalValue),
+                });
+            _allColorRepresentations.Add(
+                new ColorFormatModel()
+                {
+                    FormatName = "Decimal RGB",
+                    Convert = (Color color) => ColorRepresentationHelper.GetStringRepresentationFromMediaColor(color, ColorRepresentationType.DecimalRGBValue),
                 });
 
             _userSettings.VisibleColorFormats.CollectionChanged += VisibleColorFormats_CollectionChanged;

--- a/src/modules/colorPicker/UnitTest-ColorPickerUI/Helpers/ColorConverterTest.cs
+++ b/src/modules/colorPicker/UnitTest-ColorPickerUI/Helpers/ColorConverterTest.cs
@@ -424,7 +424,7 @@ namespace Microsoft.ColorPicker.UnitTests
         [DataRow("FF0000", 255)] // red
         [DataRow("00FF00", 65280)] // green
         [DataRow("0000FF", 16711680)] // blue
-        public void ColorRGBToDecimalBGR(string hexValue, int decimalColorValue)
+        public void ColorRGBtoDecimalBGR(string hexValue, int decimalColorValue)
         {
             var color = HexValueToColor(hexValue);
             var result = ColorHelper.ConvertDecimalBGRValue(color);
@@ -440,7 +440,7 @@ namespace Microsoft.ColorPicker.UnitTests
         [DataRow("FF0000", 16711680)] // red
         [DataRow("00FF00", 65280)] // green
         [DataRow("0000FF", 255)] // blue
-        public void ColorRGBToDecimalRGB(string hexValue, int decimalColorValue)
+        public void ColorRGBtoDecimalRGB(string hexValue, int decimalColorValue)
         {
             var color = HexValueToColor(hexValue);
             var result = ColorHelper.ConvertDecimalRGBValue(color);

--- a/src/modules/colorPicker/UnitTest-ColorPickerUI/Helpers/ColorConverterTest.cs
+++ b/src/modules/colorPicker/UnitTest-ColorPickerUI/Helpers/ColorConverterTest.cs
@@ -16,6 +16,22 @@ namespace Microsoft.ColorPicker.UnitTests
     [TestClass]
     public class ColorConverterTest
     {
+        private Color HexValueToColor(string hexValue)
+        {
+            if (string.IsNullOrWhiteSpace(hexValue))
+            {
+                Assert.IsNotNull(hexValue);
+            }
+
+            Assert.IsTrue(hexValue.Length >= 6);
+
+            var red = int.Parse(hexValue.AsSpan(0, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+            var green = int.Parse(hexValue.AsSpan(2, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+            var blue = int.Parse(hexValue.AsSpan(4, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+
+            return Color.FromArgb(255, red, green, blue);
+        }
+
         // test values taken from https://de.wikipedia.org/wiki/HSV-Farbraum
         [TestMethod]
         [DataRow(000, 000, 000, 000, 000, 000)] // Black
@@ -184,18 +200,7 @@ namespace Microsoft.ColorPicker.UnitTests
         [DataRow("7E7EB8", 240.5, 013.5, 057.0)]
         public void ColorRGBtoHSITest(string hexValue, double hue, double saturation, double intensity)
         {
-            if (string.IsNullOrWhiteSpace(hexValue))
-            {
-                Assert.IsNotNull(hexValue);
-            }
-
-            Assert.IsTrue(hexValue.Length >= 6);
-
-            var red = int.Parse(hexValue.AsSpan(0, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
-            var green = int.Parse(hexValue.AsSpan(2, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
-            var blue = int.Parse(hexValue.AsSpan(4, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
-
-            var color = Color.FromArgb(255, red, green, blue);
+            var color = HexValueToColor(hexValue);
             var result = ColorHelper.ConvertToHSIColor(color);
 
             // hue[0°..360°]
@@ -232,18 +237,7 @@ namespace Microsoft.ColorPicker.UnitTests
         [DataRow("7E7EB8", 240, 049, 028)]
         public void ColorRGBtoHWBTest(string hexValue, double hue, double whiteness, double blackness)
         {
-            if (string.IsNullOrWhiteSpace(hexValue))
-            {
-                Assert.IsNotNull(hexValue);
-            }
-
-            Assert.IsTrue(hexValue.Length >= 6);
-
-            var red = int.Parse(hexValue.AsSpan(0, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
-            var green = int.Parse(hexValue.AsSpan(2, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
-            var blue = int.Parse(hexValue.AsSpan(4, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
-
-            var color = Color.FromArgb(255, red, green, blue);
+            var color = HexValueToColor(hexValue);
             var result = ColorHelper.ConvertToHWBColor(color);
 
             // hue[0°..360°]
@@ -280,18 +274,7 @@ namespace Microsoft.ColorPicker.UnitTests
         [DataRow("7E7EB8", "B0", 049, 028)]
         public void ColorRGBtoNColTest(string hexValue, string hue, double whiteness, double blackness)
         {
-            if (string.IsNullOrWhiteSpace(hexValue))
-            {
-                Assert.IsNotNull(hexValue);
-            }
-
-            Assert.IsTrue(hexValue.Length >= 6);
-
-            var red = int.Parse(hexValue.AsSpan(0, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
-            var green = int.Parse(hexValue.AsSpan(2, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
-            var blue = int.Parse(hexValue.AsSpan(4, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
-
-            var color = Color.FromArgb(255, red, green, blue);
+            var color = HexValueToColor(hexValue);
             var result = ColorHelper.ConvertToNaturalColor(color);
 
             // hue
@@ -336,18 +319,7 @@ namespace Microsoft.ColorPicker.UnitTests
         [DataRow("E3F988", 94.25, -23.70, 51.58)] // mindaro
         public void ColorRGBtoCIELABTest(string hexValue, double lightness, double chromaticityA, double chromaticityB)
         {
-            if (string.IsNullOrWhiteSpace(hexValue))
-            {
-                Assert.IsNotNull(hexValue);
-            }
-
-            Assert.IsTrue(hexValue.Length >= 6);
-
-            var red = int.Parse(hexValue.AsSpan(0, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
-            var green = int.Parse(hexValue.AsSpan(2, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
-            var blue = int.Parse(hexValue.AsSpan(4, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
-
-            var color = Color.FromArgb(255, red, green, blue);
+            var color = HexValueToColor(hexValue);
             var result = ColorHelper.ConvertToCIELABColor(color);
 
             // lightness[0..100]
@@ -400,18 +372,7 @@ namespace Microsoft.ColorPicker.UnitTests
         [DataRow("E3F988", 69.9955, 85.8597, 36.1785)] // mindaro
         public void ColorRGBtoCIEXYZTest(string hexValue, double x, double y, double z)
         {
-            if (string.IsNullOrWhiteSpace(hexValue))
-            {
-                Assert.IsNotNull(hexValue);
-            }
-
-            Assert.IsTrue(hexValue.Length >= 6);
-
-            var red = int.Parse(hexValue.AsSpan(0, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
-            var green = int.Parse(hexValue.AsSpan(2, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
-            var blue = int.Parse(hexValue.AsSpan(4, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
-
-            var color = Color.FromArgb(255, red, green, blue);
+            var color = HexValueToColor(hexValue);
             var result = ColorHelper.ConvertToCIEXYZColor(color);
 
             // x[0..0.95047]
@@ -454,6 +415,38 @@ namespace Microsoft.ColorPicker.UnitTests
                     }
                 }
             }
+        }
+
+        [TestMethod]
+        [DataRow("FFFFFF", 16777215)] // white
+        [DataRow("808080", 8421504)] // gray
+        [DataRow("000000", 0)] // black
+        [DataRow("FF0000", 255)] // red
+        [DataRow("00FF00", 65280)] // green
+        [DataRow("0000FF", 16711680)] // blue
+        public void ColorRGBToDecimalBGR(string hexValue, int decimalColorValue)
+        {
+            var color = HexValueToColor(hexValue);
+            var result = ColorHelper.ConvertDecimalBGRValue(color);
+
+            // decimalColor[0..16777215]
+            Assert.AreEqual(result, decimalColorValue);
+        }
+
+        [TestMethod]
+        [DataRow("FFFFFF", 16777215)] // white
+        [DataRow("808080", 8421504)] // gray
+        [DataRow("000000", 0)] // black
+        [DataRow("FF0000", 16711680)] // red
+        [DataRow("00FF00", 65280)] // green
+        [DataRow("0000FF", 255)] // blue
+        public void ColorRGBToDecimalRGB(string hexValue, int decimalColorValue)
+        {
+            var color = HexValueToColor(hexValue);
+            var result = ColorHelper.ConvertDecimalRGBValue(color);
+
+            // decimalColor[0..16777215]
+            Assert.AreEqual(result, decimalColorValue);
         }
     }
 }

--- a/src/modules/colorPicker/UnitTest-ColorPickerUI/Helpers/ColorConverterTest.cs
+++ b/src/modules/colorPicker/UnitTest-ColorPickerUI/Helpers/ColorConverterTest.cs
@@ -424,13 +424,15 @@ namespace Microsoft.ColorPicker.UnitTests
         [DataRow("FF0000", 255)] // red
         [DataRow("00FF00", 65280)] // green
         [DataRow("0000FF", 16711680)] // blue
+        [DataRow("ef68ff", 16738543)] // magenta
+        [DataRow("ffaa00", 43775)] // yellow
         public void ColorRGBtoDecimalBGR(string hexValue, int decimalColorValue)
         {
             var color = HexValueToColor(hexValue);
             var result = ColorHelper.ConvertDecimalBGRValue(color);
 
             // decimalColor[0..16777215]
-            Assert.AreEqual(result, decimalColorValue);
+            Assert.AreEqual(decimalColorValue, result);
         }
 
         [TestMethod]
@@ -440,13 +442,15 @@ namespace Microsoft.ColorPicker.UnitTests
         [DataRow("FF0000", 16711680)] // red
         [DataRow("00FF00", 65280)] // green
         [DataRow("0000FF", 255)] // blue
+        [DataRow("ef68ff", 15689983)] // magenta
+        [DataRow("ffaa00", 16755200)] // yellow
         public void ColorRGBtoDecimalRGB(string hexValue, int decimalColorValue)
         {
             var color = HexValueToColor(hexValue);
             var result = ColorHelper.ConvertDecimalRGBValue(color);
 
             // decimalColor[0..16777215]
-            Assert.AreEqual(result, decimalColorValue);
+            Assert.AreEqual(decimalColorValue, result);
         }
     }
 }

--- a/src/modules/colorPicker/UnitTest-ColorPickerUI/Helpers/ColorRepresentationHelperTest.cs
+++ b/src/modules/colorPicker/UnitTest-ColorPickerUI/Helpers/ColorRepresentationHelperTest.cs
@@ -26,6 +26,7 @@ namespace Microsoft.ColorPicker.UnitTests
         [DataRow(ColorRepresentationType.CIEXYZ, "XYZ(0, 0, 0)")]
         [DataRow(ColorRepresentationType.VEC4, "(0f, 0f, 0f, 1f)")]
         [DataRow(ColorRepresentationType.DecimalValue, "0")]
+        [DataRow(ColorRepresentationType.DecimalRGBValue, "0")]
 
         public void GetStringRepresentationTest(ColorRepresentationType type, string expected)
         {

--- a/src/settings-ui/Settings.UI.Library/Enumerations/ColorRepresentationType.cs
+++ b/src/settings-ui/Settings.UI.Library/Enumerations/ColorRepresentationType.cs
@@ -72,12 +72,12 @@ namespace Microsoft.PowerToys.Settings.UI.Library.Enumerations
         VEC4 = 11,
 
         /// <summary>
-        /// Color presentation as integer decimal BGR value 0-16777215
+        /// Color presentation as integer decimal BGR value[0..16777215]
         /// </summary>
         DecimalValue = 12,
 
         /// <summary>
-        /// Color presentation as integer decimal RGB value 0-16777215
+        /// Color presentation as integer decimal RGB value[0..16777215]
         /// </summary>
         DecimalRGBValue = 13,
     }

--- a/src/settings-ui/Settings.UI.Library/Enumerations/ColorRepresentationType.cs
+++ b/src/settings-ui/Settings.UI.Library/Enumerations/ColorRepresentationType.cs
@@ -72,8 +72,13 @@ namespace Microsoft.PowerToys.Settings.UI.Library.Enumerations
         VEC4 = 11,
 
         /// <summary>
-        /// Color presentation as integer decimal value 0-16777215
+        /// Color presentation as integer decimal BGR value 0-16777215
         /// </summary>
         DecimalValue = 12,
+
+        /// <summary>
+        /// Color presentation as integer decimal RGB value 0-16777215
+        /// </summary>
+        DecimalRGBValue = 13,
     }
 }

--- a/src/settings-ui/Settings.UI.Library/ViewModels/ColorPickerViewModel.cs
+++ b/src/settings-ui/Settings.UI.Library/ViewModels/ColorPickerViewModel.cs
@@ -56,7 +56,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
                 { ColorRepresentationType.CIELAB, "CIE LAB - CIELab(76, 21, 80)" },
                 { ColorRepresentationType.CIEXYZ, "CIE XYZ - xyz(56, 50, 7)" },
                 { ColorRepresentationType.VEC4, "VEC4 - (1.0f, 0.7f, 0f, 1f)" },
-                { ColorRepresentationType.DecimalValue, "Decimal BGR - 16755200" },
+                { ColorRepresentationType.DecimalValue, "Decimal BGR - 43775" },
                 { ColorRepresentationType.DecimalRGBValue, "Decimal RGB - 16755200" },
             };
 
@@ -217,7 +217,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             formatsUnordered.Add(new ColorFormatModel(cielabFormatName, "CIELab(66, 72, -52)", visibleFormats.ContainsKey(cielabFormatName) && visibleFormats[cielabFormatName]));
             formatsUnordered.Add(new ColorFormatModel(ciexyzFormatName, "XYZ(59, 35, 98)", visibleFormats.ContainsKey(ciexyzFormatName) && visibleFormats[ciexyzFormatName]));
             formatsUnordered.Add(new ColorFormatModel(vec4FormatName, "(0.94f, 0.41f, 1.00f, 1f)", visibleFormats.ContainsKey(vec4FormatName) && visibleFormats[vec4FormatName]));
-            formatsUnordered.Add(new ColorFormatModel(decimalFormatName, "15689983", visibleFormats.ContainsKey(decimalFormatName) && visibleFormats[decimalFormatName]));
+            formatsUnordered.Add(new ColorFormatModel(decimalFormatName, "16738543", visibleFormats.ContainsKey(decimalFormatName) && visibleFormats[decimalFormatName]));
             formatsUnordered.Add(new ColorFormatModel(decimalRGBFormatName, "15689983", visibleFormats.ContainsKey(decimalRGBFormatName) && visibleFormats[decimalRGBFormatName]));
 
             foreach (var storedColorFormat in _colorPickerSettings.Properties.VisibleColorFormats)

--- a/src/settings-ui/Settings.UI.Library/ViewModels/ColorPickerViewModel.cs
+++ b/src/settings-ui/Settings.UI.Library/ViewModels/ColorPickerViewModel.cs
@@ -56,7 +56,8 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
                 { ColorRepresentationType.CIELAB, "CIE LAB - CIELab(76, 21, 80)" },
                 { ColorRepresentationType.CIEXYZ, "CIE XYZ - xyz(56, 50, 7)" },
                 { ColorRepresentationType.VEC4, "VEC4 - (1.0f, 0.7f, 0f, 1f)" },
-                { ColorRepresentationType.DecimalValue, "Decimal - 16755200" },
+                { ColorRepresentationType.DecimalValue, "Decimal BGR - 16755200" },
+                { ColorRepresentationType.DecimalRGBValue, "Decimal RGB - 16755200" },
             };
 
             GeneralSettingsConfig = settingsRepository.SettingsConfig;
@@ -202,6 +203,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             var ciexyzFormatName = ColorRepresentationType.CIEXYZ.ToString();
             var vec4FormatName = ColorRepresentationType.VEC4.ToString();
             var decimalFormatName = "Decimal";
+            var decimalRGBFormatName = "Decimal RGB";
 
             formatsUnordered.Add(new ColorFormatModel(hexFormatName, "ef68ff", visibleFormats.ContainsKey(hexFormatName) && visibleFormats[hexFormatName]));
             formatsUnordered.Add(new ColorFormatModel(rgbFormatName, "rgb(239, 104, 255)", visibleFormats.ContainsKey(rgbFormatName) && visibleFormats[rgbFormatName]));
@@ -216,6 +218,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             formatsUnordered.Add(new ColorFormatModel(ciexyzFormatName, "XYZ(59, 35, 98)", visibleFormats.ContainsKey(ciexyzFormatName) && visibleFormats[ciexyzFormatName]));
             formatsUnordered.Add(new ColorFormatModel(vec4FormatName, "(0.94f, 0.41f, 1.00f, 1f)", visibleFormats.ContainsKey(vec4FormatName) && visibleFormats[vec4FormatName]));
             formatsUnordered.Add(new ColorFormatModel(decimalFormatName, "15689983", visibleFormats.ContainsKey(decimalFormatName) && visibleFormats[decimalFormatName]));
+            formatsUnordered.Add(new ColorFormatModel(decimalRGBFormatName, "15689983", visibleFormats.ContainsKey(decimalRGBFormatName) && visibleFormats[decimalRGBFormatName]));
 
             foreach (var storedColorFormat in _colorPickerSettings.Properties.VisibleColorFormats)
             {


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

This PR adds a new color format for **ColorPicker** and updated names and comments so users can pick between Decimal RGB and Decimal BGR. 

**What is included in the PR:** 

* new color format (Decimal RGB)
* refactoring of computation
* new tests for Decimal color formats
* small test refactoring 

**How does someone test / validate:** 

* color decimal value computation is covered with unit tests
* color picker can be selected in Settings UI
* use picker on #FF0000 and #0000FF to see a clear difference in Decimal RGB and BGR

![image](https://user-images.githubusercontent.com/15345617/168227283-0b0a4512-4c14-4714-b671-fc33a5179654.png)

## Quality Checklist

- [x] **Linked issue:** #16678
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [x] **Tests:** Added/updated and all pass
- [x] **Installer:** N/A
- [x] **Localization:** N/A
- [x] **Docs:** N/A
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
