### PR TITLE
[FancyZones] Popup behavior fix

### DIFF
--- a/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
@@ -377,7 +377,7 @@ void FancyZones::WindowCreated(HWND window) noexcept
     }
 
     auto desktopId = VirtualDesktop::instance().GetDesktopId(window);
-    if (desktopId.has_value() && *desktopId != VirtualDesktop::instance().GetCurrentVirtualDesktopId())
+    if (!desktopId.has_value() || (desktopId.has_value() && *desktopId != VirtualDesktop::instance().GetCurrentVirtualDesktopId()))
     {
         // Switch between virtual desktops results with posting same windows messages that also indicate
         // creation of new window. We need to check if window being processed is on currently active desktop.

--- a/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
@@ -17,6 +17,7 @@
 #include <FancyZonesLib/FancyZonesData/CustomLayouts.h>
 #include <FancyZonesLib/FancyZonesData/LayoutHotkeys.h>
 #include <FancyZonesLib/FancyZonesData/LayoutTemplates.h>
+#include <FancyZonesLib/FancyZonesWindowProcessing.h>
 #include <FancyZonesLib/FancyZonesWindowProperties.h>
 #include <FancyZonesLib/FancyZonesWinHookEventIDs.h>
 #include <FancyZonesLib/MonitorUtils.h>
@@ -376,28 +377,12 @@ void FancyZones::WindowCreated(HWND window) noexcept
         return;
     }
 
-    auto desktopId = VirtualDesktop::instance().GetDesktopId(window);
-    if (!desktopId.has_value() || (desktopId.has_value() && *desktopId != VirtualDesktop::instance().GetCurrentVirtualDesktopId()))
-    {
-        // Switch between virtual desktops results with posting same windows messages that also indicate
-        // creation of new window. We need to check if window being processed is on currently active desktop.
-        return;
-    }
-
-    // Avoid processing splash screens, already stamped (zoned) windows, or those windows
-    // that belong to excluded applications list.
-    const bool isSplashScreen = FancyZonesWindowUtils::IsSplashScreen(window);
-    if (isSplashScreen)
+    if (!FancyZonesWindowProcessing::IsProcessable(window))
     {
         return;
     }
 
-    const bool windowMinimized = IsIconic(window);
-    if (windowMinimized)
-    {
-        return;
-    }
-
+    // Avoid already stamped (zoned) windows
     const bool isZoned = !FancyZonesWindowProperties::RetrieveZoneIndexProperty(window).empty();
     if (isZoned)
     {

--- a/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
@@ -1230,6 +1230,12 @@ void FancyZones::UpdateZoneSets() noexcept
 bool FancyZones::ShouldProcessSnapHotkey(DWORD vkCode) noexcept
 {
     auto window = GetForegroundWindow();
+    
+    if (!FancyZonesWindowProcessing::IsProcessable(window))
+    {
+        return false;
+    }
+    
     if (FancyZonesSettings::settings().overrideSnapHotkeys && FancyZonesWindowUtils::IsCandidateForZoning(window))
     {
         HMONITOR monitor = WorkAreaKeyFromWindow(window);

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesLib.vcxproj
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesLib.vcxproj
@@ -43,6 +43,7 @@
     <ClInclude Include="FancyZonesData\Layout.h" />
     <ClInclude Include="FancyZonesData\LayoutDefaults.h" />
     <ClInclude Include="FancyZonesData\LayoutTemplates.h" />
+    <ClInclude Include="FancyZonesWindowProcessing.h" />
     <ClInclude Include="FancyZonesWinHookEventIDs.h" />
     <ClInclude Include="GenericKeyHook.h" />
     <ClInclude Include="FancyZonesData.h" />

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesLib.vcxproj.filters
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesLib.vcxproj.filters
@@ -129,6 +129,9 @@
     <ClInclude Include="LayoutConfigurator.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="FancyZonesWindowProcessing.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp">

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesWindowProcessing.h
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesWindowProcessing.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <FancyZonesLib/VirtualDesktop.h>
+#include <FancyZonesLib/WindowUtils.h>
+
+namespace FancyZonesWindowProcessing
+{
+    inline bool IsProcessable(HWND window) noexcept
+    {
+        const bool isSplashScreen = FancyZonesWindowUtils::IsSplashScreen(window);
+        if (isSplashScreen)
+        {
+            return false;
+        }
+
+        const bool windowMinimized = IsIconic(window);
+        if (windowMinimized)
+        {
+            return false;
+        }
+
+        // Switch between virtual desktops results with posting same windows messages that also indicate
+        // creation of new window. We need to check if window being processed is on currently active desktop.
+        // For windows that FancyZones shouldn't process (start menu, tray, popup menus) 
+        // VirtualDesktopManager is unable to retrieve virtual desktop id and returns an error.
+        auto desktopId = VirtualDesktop::instance().GetDesktopId(window);
+        if (!desktopId.has_value() || (desktopId.has_value() && *desktopId != VirtualDesktop::instance().GetCurrentVirtualDesktopId()))
+        {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/modules/fancyzones/FancyZonesLib/VirtualDesktop.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/VirtualDesktop.cpp
@@ -201,7 +201,7 @@ std::optional<GUID> VirtualDesktop::GetDesktopId(HWND window) const
     if (m_vdManager && m_vdManager->IsWindowOnCurrentVirtualDesktop(window, &isWindowOnCurrentDesktop) == S_OK && isWindowOnCurrentDesktop)
     {
         // Filter windows such as Windows Start Menu, Task Switcher, etc.
-        if (m_vdManager->GetWindowDesktopId(window, &id) == S_OK && id != GUID_NULL)
+        if (m_vdManager->GetWindowDesktopId(window, &id) == S_OK)
         {
             return id;
         }

--- a/src/modules/fancyzones/FancyZonesLib/WindowMoveHandler.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WindowMoveHandler.cpp
@@ -10,6 +10,7 @@
 #include "FancyZonesData/AppZoneHistory.h"
 #include "Settings.h"
 #include "WorkArea.h"
+#include <FancyZonesLib/FancyZonesWindowProcessing.h>
 #include <FancyZonesLib/WindowUtils.h>
 
 // Non-Localizable strings
@@ -60,6 +61,11 @@ WindowMoveHandler::WindowMoveHandler(const std::function<void()>& keyUpdateCallb
 
 void WindowMoveHandler::MoveSizeStart(HWND window, HMONITOR monitor, POINT const& ptScreen, const std::unordered_map<HMONITOR, winrt::com_ptr<IWorkArea>>& workAreaMap) noexcept
 {
+    if (!FancyZonesWindowProcessing::IsProcessable(window))
+    {
+        return;
+    }
+
     if (!FancyZonesWindowUtils::IsCandidateForZoning(window) || WindowMoveHandlerUtils::IsCursorTypeIndicatingSizeEvent())
     {
         return;


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

`Allow popup windows snapping` allows FancyZones to snap all popup windows including menus. 
Here is a fix for filtering those windows.

**What is included in the PR:** 

**How does someone test / validate:** 

* Snap Visual Studio Code to a zone, and open any menu. Verify that the menu is where it's supposed to be and not on the top left corner of the zone.
* Same with MS Edge, you can check this by opening https://www.parkrun.ca/richmondolympic/results/latestresults/ and opening a menu.

Expected:

![image](https://user-images.githubusercontent.com/8949536/168300142-bb190595-2d8b-42bf-9cb0-2fa455b1bd09.png)

Wrong behavior:

![image](https://user-images.githubusercontent.com/8949536/168307428-31eeed5f-35a6-4bd0-beeb-685127e8027b.png)


## Quality Checklist

- [x] **Linked issue:** #17900
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
