### PR TITLE
add case insensitivity to VS Code binary detection

### DIFF
--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/VSCodeHelper/VSCodeInstances.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/VSCodeHelper/VSCodeInstances.cs
@@ -84,7 +84,10 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.VSCodeHelper
                     {
                         var files = Directory.GetFiles(path);
                         var iconPath = Path.GetDirectoryName(path);
-                        files = files.Where(x => (x.Contains("code") || x.Contains("VSCodium")) && !x.EndsWith(".cmd", StringComparison.OrdinalIgnoreCase)).ToArray();
+                        files = files.Where(x => 
+                                            (x.Contains("code", StringComparison.OrdinalIgnoreCase) ||
+                                            x.Contains("VSCodium", StringComparison.OrdinalIgnoreCase))
+                                            && !x.EndsWith(".cmd", StringComparison.OrdinalIgnoreCase)).ToArray();
 
                         if (files.Length > 0)
                         {

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/VSCodeHelper/VSCodeInstances.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/VSCodeHelper/VSCodeInstances.cs
@@ -84,7 +84,7 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.VSCodeHelper
                     {
                         var files = Directory.GetFiles(path);
                         var iconPath = Path.GetDirectoryName(path);
-                        files = files.Where(x => 
+                        files = files.Where(x =>
                                             (x.Contains("code", StringComparison.OrdinalIgnoreCase) ||
                                             x.Contains("VSCodium", StringComparison.OrdinalIgnoreCase))
                                             && !x.EndsWith(".cmd", StringComparison.OrdinalIgnoreCase)).ToArray();


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
This patch will improve discovery of non-standard (e.g. portable) installations of VS Code.

**What is included in the PR:** 
Minor change to how VS Code binaries are found (added case insensitive flag to string comparison)

**How does someone test / validate:** 
I don't know ¯\\_(ツ)_/¯

## Quality Checklist

- [x] **Linked issue:** #13362 
- [ ] **Communication:** That one does not contribute to quality of this PR 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
