### PR TITLE
[PowerRename] Open PowerRename on current monitor

### DIFF
--- a/src/modules/powerrename/PowerRenameUILib/MainWindow.xaml.cpp
+++ b/src/modules/powerrename/PowerRenameUILib/MainWindow.xaml.cpp
@@ -47,6 +47,29 @@ namespace winrt::PowerRenameUI::implementation
         Microsoft::UI::WindowId windowId =
             Microsoft::UI::GetWindowIdFromWindow(m_window);
 
+        POINT cursorPosition{};
+        if (GetCursorPos(&cursorPosition))
+        {
+            HMONITOR hMonitor = MonitorFromPoint(cursorPosition, MONITOR_DEFAULTTOPRIMARY);
+            MONITORINFOEX monitorInfo;
+            monitorInfo.cbSize = sizeof(MONITORINFOEX);
+            GetMonitorInfo(hMonitor, &monitorInfo);
+            RECT rect;
+            if (GetWindowRect(m_window, &rect))
+            {
+                int width = rect.right - rect.left;
+                int height = rect.bottom - rect.top;
+
+                MoveWindow(m_window,
+                             monitorInfo.rcWork.left + (monitorInfo.rcWork.right - monitorInfo.rcWork.left - width) / 2,
+                             monitorInfo.rcWork.top + (monitorInfo.rcWork.bottom - monitorInfo.rcWork.top - height) / 2,
+                             width,
+                             height,
+                             true);
+            }
+        }
+
+
         Microsoft::UI::Windowing::AppWindow appWindow =
             Microsoft::UI::Windowing::AppWindow::GetFromWindowId(windowId);
         appWindow.SetIcon(PowerRenameUIIco);
@@ -107,7 +130,7 @@ namespace winrt::PowerRenameUI::implementation
                         CComPtr<IShellItemArray> shellItemArray;
                         // To test PowerRename uncomment this line and update the path to
                         // your local (absolute or relative) path which you want to see in PowerRename
-                        // files.push_back(<path>);
+                        // g_files.push_back(<path>);
 
                         if (!g_files.empty())
                         {

--- a/src/modules/powerrename/PowerRenameUILib/PowerRenameUI.vcxproj
+++ b/src/modules/powerrename/PowerRenameUILib/PowerRenameUI.vcxproj
@@ -150,16 +150,18 @@
     <Image Include="Assets\file.png" />
     <Image Include="Assets\folder.png" />
     <Image Include="PowerRenameUI.ico">
-          <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Image>
   </ItemGroup>
-
   <ItemGroup>
     <_WildCardPRIResource Include="Strings\*\Resources.resw" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\common\logger\logger.vcxproj">
       <Project>{d9b8fc84-322a-4f9f-bbb9-20915c47ddfd}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\common\version\version.vcxproj">
+      <Project>{cc6e41ac-8174-4e8a-8d22-85dd7f4851df}</Project>
     </ProjectReference>
     <ProjectReference Include="..\lib\PowerRenameLib.vcxproj">
       <Project>{51920f1f-c28c-4adf-8660-4238766796c2}</Project>

--- a/src/modules/powerrename/PowerRenameUILib/PowerRenameUI.vcxproj.filters
+++ b/src/modules/powerrename/PowerRenameUILib/PowerRenameUI.vcxproj.filters
@@ -44,7 +44,4 @@
     </Image>
     <Image Include="PowerRenameUI.ico" />
   </ItemGroup>
-  <ItemGroup>
-    <PRIResource Include="Resources.resw" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
Fix regression - Open PowerRename on current monitor
Add missing reference to Version proj
Minor cleanup

## Summary of the Pull Request

**What is this about:**

**What is included in the PR:** 

**How does someone test / validate:** 
- build and install PowerToys
- test if PowerRename is opened on correct monitor where it was spawned
## Quality Checklist

- [x] **Linked issue:** #18171
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
