### PR TITLE
[AlwaysOnTop] Window border stays after Win+D fix

### DIFF
--- a/src/modules/alwaysontop/AlwaysOnTop/WindowBorder.cpp
+++ b/src/modules/alwaysontop/AlwaysOnTop/WindowBorder.cpp
@@ -49,7 +49,7 @@ WindowBorder::~WindowBorder()
     if (m_window)
     {
         SetWindowLongPtrW(m_window, GWLP_USERDATA, 0);
-        ShowWindow(m_window, SW_HIDE);
+        DestroyWindow(m_window);
     }
 }
 


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Destroy the border window instead of hiding it. 

**What is included in the PR:** 

**How does someone test / validate:** 

* Pin any window
* Press `Win+D` twice
* Move or close pinned window
* Verify the border doesn't stay where it was.

## Quality Checklist

- [x] **Linked issue:** #18266 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
