### PR TITLE
[File Explorer Add-ons] Add viewBox attribute to svgs that don't have one

### DIFF
--- a/src/modules/previewpane/SvgPreviewHandler/Utilities/SvgPreviewHandlerHelper.cs
+++ b/src/modules/previewpane/SvgPreviewHandler/Utilities/SvgPreviewHandlerHelper.cs
@@ -84,6 +84,7 @@ namespace Microsoft.PowerToys.PreviewHandler.Svg.Utilities
             string widthR = string.Empty;
             string heightR = string.Empty;
             string oldStyle = string.Empty;
+            bool hasViewBox = false;
 
             // Get width and height of element and remove it afterwards because it will be added inside style attribute
             for (int i = 0; i < attributes.Count(); i++)
@@ -106,6 +107,10 @@ namespace Microsoft.PowerToys.PreviewHandler.Svg.Utilities
                     attributes.ElementAt(i).Remove();
                     i--;
                 }
+                else if (attributes.ElementAt(i).Name == "viewBox")
+                {
+                    hasViewBox = true;
+                }
             }
 
             svgData.ReplaceAttributes(attributes);
@@ -122,6 +127,14 @@ namespace Microsoft.PowerToys.PreviewHandler.Svg.Utilities
             scaling += $"  _height:expression(this.scrollHeight > {heightR} ? \" {height}\" : \"auto\"); _width:expression(this.scrollWidth > {widthR} ? \"{width}\" : \"auto\");";
 
             svgData.Add(new XAttribute("style", scaling + centering + oldStyle));
+
+            if (!hasViewBox)
+            {
+                // Fixes https://github.com/microsoft/PowerToys/issues/18107
+                string viewBox = $"0 0 {widthR} {heightR}";
+                svgData.Add(new XAttribute("viewBox", viewBox));
+            }
+
             return svgData.ToString();
         }
 


### PR DESCRIPTION
This alows svg previewer to show full svg, not just a part of it

## Summary of the Pull Request

**What is this about:**

**What is included in the PR:** 

**How does someone test / validate:** 
- Take the svg files linked in the issue
- Try to preview files with PT v0.58 and observe that only part of the image is shown
- Try to preview files with this version and observe that full image is previewed

## Quality Checklist

- [x] **Linked issue:** #18107
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
