### PR TITLE
[File Explorer Add-ons] Hide scrollbar when previewing svg thumbnails

### DIFF
--- a/src/modules/previewpane/SvgThumbnailProvider/SvgThumbnailProvider.cs
+++ b/src/modules/previewpane/SvgThumbnailProvider/SvgThumbnailProvider.cs
@@ -106,6 +106,9 @@ namespace Microsoft.PowerToys.ThumbnailHandler.Svg
                     await _browser.ExecuteScriptAsync($"document.getElementsByTagName('svg')[0].style = 'width:100%;height:100%';");
                 }
 
+                // Hide scrollbar - fixes #18286
+                await _browser.ExecuteScriptAsync("document.querySelector('body').style.overflow='hidden'");
+
                 MemoryStream ms = new MemoryStream();
                 await _browser.CoreWebView2.CapturePreviewAsync(CoreWebView2CapturePreviewImageFormat.Png, ms);
                 thumbnail = new Bitmap(ms);


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
In some cases SVG Thumbnail previewer was rendering scrollbar as a part of the thumbnail. This change hides the scrollbar by executing js script with WebView2 api


**What is included in the PR:** 

**How does someone test / validate:** 
https://github.com/microsoft/PowerToys/issues/18286#issuecomment-1134697098

## Quality Checklist

- [x] **Linked issue:** #18286
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
