### PR TITLE
Added automatic Microsoft Store integration

### DIFF
--- a/.github/workflows/msstore-submissions.yml
+++ b/.github/workflows/msstore-submissions.yml
@@ -1,0 +1,52 @@
+name: Submit Microsoft.PowerToys package to Windows Store
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+
+  microsoft_store:
+    name: Publish Microsoft Store
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get latest URL from public releases
+        id: releaseVars
+        run: |
+          release=$(curl https://api.github.com/repos/Microsoft/PowerToys/releases | jq '[.[]|select(.name | contains("Release"))][0]')
+          assets=$(jq -n "$release" | jq '.assets')
+          powerToysSetup=$(jq -n "$assets" | jq '[.[]|select(.name | contains("PowerToysSetup"))]')
+          echo ::set-output name=powerToysInstallerX64Url::$(jq -n "$powerToysSetup" | jq -r '[.[]|select(.name | contains("x64"))][0].browser_download_url')
+
+      - name: Configure Store Credentials
+        uses: microsoft/store-submission@v1
+        with:
+          command: configure
+          type: win32
+          seller-id: ${{ secrets.SELLER_ID }}
+          product-id: ${{ secrets.PRODUCT_ID }}
+          tenant-id: ${{ secrets.TENANT_ID }}
+          client-id: ${{ secrets.CLIENT_ID }}
+          client-secret: ${{ secrets.CLIENT_SECRET }}
+
+      - name: Update draft submission
+        uses: microsoft/store-submission@v1
+        with:
+          command: update
+          product-update: '{
+              "packages":[
+                  {
+                    "packageUrl":"${{ steps.releaseVars.outputs.powerToysInstallerX64Url }}",
+                    "languages":["zh-hans", "zh-hant", "en", "cs", "nl", "fr", "pt", "pt-br", "de", "hu", "it", "ja", "ko", "pl", "ru", "es", "tr"],
+                    "architectures":["X64"],
+                    "installerParameters":"-passive",
+                    "isSilentInstall":true
+                  }
+              ]
+            }'
+
+      - name: Publish Submission
+        uses: microsoft/store-submission@v1
+        with: 
+          command: publish


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Adds Microsoft Store Submission automation.

**What is included in the PR:** 
A YAML file that sends a new version of PowerToys to the Microsoft Store.

**How does someone test / validate:** 
Manually running the yaml file. This will actually publish to the store, so be careful.

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
