### PR TITLE
[PTRun][WebSearch]Fix empty browser pattern crash

### DIFF
--- a/src/modules/launcher/Wox.Infrastructure/Helper.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Helper.cs
@@ -150,7 +150,11 @@ namespace Wox.Infrastructure
 
         public static bool OpenCommandInShell(string path, string pattern, string arguments, string workingDir = null, ShellRunAsType runAs = ShellRunAsType.None, bool runWithHiddenWindow = false)
         {
-            if (pattern.Contains("%1", StringComparison.Ordinal))
+            if (string.IsNullOrEmpty(pattern))
+            {
+                Log.Warn("Trying to run OpenCommandInShell with an empty pattern. The default browser definition might have issues.", typeof(Helper));
+            }
+            else if (pattern.Contains("%1", StringComparison.Ordinal))
             {
                 arguments = pattern.Replace("%1", arguments);
             }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
`OpenCommandInShell` is being called with null values on some conditions and currently crashing. Log this instead of crashing and let's investigate next time WebSearch has a weird behavior.

**What is included in the PR:** 
Check if the pattern passed to `OpenCommandInShell` is null or empty and log it.

**How does someone test / validate:** 
Not sure how to replicate. Just a code quality pass is needed.

## Quality Checklist

- [x] **Linked issue:** #18441
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
