### PR TITLE
[KBM]Fix concurrent shortcut remap locking key

### DIFF
--- a/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardEventHandlers.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardEventHandlers.cpp
@@ -586,22 +586,36 @@ namespace KeyboardEventHandlers
                                 if (newRemapping.RemapToKey())
                                 {
                                     DWORD to = std::get<0>(newRemapping.targetShortcut);
-                                    key_count = from.Size() - 1 + 1;
+                                    bool isLastKeyStillPressed = ii.GetVirtualKeyState((WORD)from.actionKey);
+                                    key_count = from.Size() - 1 + 1 + (isLastKeyStillPressed ? 1 : 0);
                                     keyEventList = new INPUT[key_count]();
                                     memset(keyEventList, 0, sizeof(keyEventList));
                                     int i = 0;
                                     Helpers::SetModifierKeyEvents(from, it->second.winKeyInvoked, keyEventList, i, false, KeyboardManagerConstants::KEYBOARDMANAGER_SHORTCUT_FLAG);
+                                    if (ii.GetVirtualKeyState((WORD)from.actionKey))
+                                    {
+                                        // If the action key from the last shortcut is still being pressed, release it.
+                                        Helpers::SetKeyEvent(keyEventList, i, INPUT_KEYBOARD, (WORD)from.actionKey, KEYEVENTF_KEYUP, KeyboardManagerConstants::KEYBOARDMANAGER_SHORTCUT_FLAG);
+                                        i++;
+                                    }
                                     Helpers::SetKeyEvent(keyEventList, i, INPUT_KEYBOARD, (WORD)to, 0, KeyboardManagerConstants::KEYBOARDMANAGER_SHORTCUT_FLAG);
                                 }else
                                 {
                                     Shortcut to = std::get<Shortcut>(newRemapping.targetShortcut);
-                                    key_count = from.Size() - 1 + to.Size() - 1 - 2* from.GetCommonModifiersCount(to) + 1;
+                                    bool isLastKeyStillPressed = ii.GetVirtualKeyState((WORD)from.actionKey);
+
+                                    key_count = from.Size() - 1 + to.Size() - 1 - 2* from.GetCommonModifiersCount(to) + 1 + (isLastKeyStillPressed ? 1 : 0);
                                     keyEventList = new INPUT[key_count]();
 
                                     int i = 0;
                                     Helpers::SetModifierKeyEvents(from, it->second.winKeyInvoked, keyEventList, i, false, KeyboardManagerConstants::KEYBOARDMANAGER_SHORTCUT_FLAG, to);
+                                    if (ii.GetVirtualKeyState((WORD)from.actionKey))
+                                    {
+                                        // If the action key from the last shortcut is still being pressed, release it.
+                                        Helpers::SetKeyEvent(keyEventList, i, INPUT_KEYBOARD, (WORD)from.actionKey, KEYEVENTF_KEYUP, KeyboardManagerConstants::KEYBOARDMANAGER_SHORTCUT_FLAG);
+                                        i++;
+                                    }
                                     Helpers::SetModifierKeyEvents(to, it->second.winKeyInvoked, keyEventList, i, true, KeyboardManagerConstants::KEYBOARDMANAGER_SHORTCUT_FLAG, from);
-
                                     Helpers::SetKeyEvent(keyEventList, i, INPUT_KEYBOARD, (WORD)to.actionKey, 0, KeyboardManagerConstants::KEYBOARDMANAGER_SHORTCUT_FLAG);
                                     newRemapping.isShortcutInvoked = true;
                                 }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
When triggering two shortcut remappings at the same time, the original remap was not being correctly released.
For example, when mapping "Shift(Left)+A" to "Shift(Left)+Q" and "Shift(Left)+S" to "Shift(Left)+W":
![image](https://user-images.githubusercontent.com/26118718/170516452-61ca33a4-24a7-4c35-9023-130920471503.png)
Then when you do the following sequence:
1. Press Shift
2. Press A
3. Press S
4. Unpress A
5. Unpress S
6. Press A

The output will be "QWA" instead of "QWQ" and further tries to use the remapping will fail until you press and unpress Q. The reason for this is that Q was not released at step 3 when the code is considering the new mapping.

**What is included in the PR:** 
When a new mapping is detected as the current one and the previous one is still active, release the action key triggered by the previous remapping as well.

**How does someone test / validate:** 
Follow the steps described above in https://keyboardchecker.com/ and verify Q doesn't get stuck, while it will get stuck if tried in the current PowerToys release.
![image](https://user-images.githubusercontent.com/26118718/170517485-91ebc21d-2377-43bb-a0c4-c5050ad829da.png)

## Quality Checklist

- [x] **Linked issue:** #17303
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries
