### PR TITLE
[PT Run][Folder]Full support for paths containing '/'

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder.UnitTests/InternalQueryFolderTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder.UnitTests/InternalQueryFolderTests.cs
@@ -52,6 +52,7 @@ namespace Microsoft.Plugin.Folder.UnitTests
         [DataRow(@"c:\not-exist", 2, 1, false, DisplayName = "Folder not exist, return root")]
         [DataRow(@"c:\not-exist\not-exist2", 0, 0, false, DisplayName = "Folder not exist, return root")]
         [DataRow(@"c:\bla.t", 2, 1, false, DisplayName = "Partial match file")]
+        [DataRow(@"c:/bla.t", 2, 1, false, DisplayName = "Partial match file with /")]
         public void Query_WhenCalled(string search, int folders, int files, bool truncated)
         {
             const int maxFolderSetting = 3;

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/Path/FolderHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/Path/FolderHelper.cs
@@ -84,7 +84,9 @@ namespace Microsoft.Plugin.Folder.Sources
                 throw new ArgumentNullException(nameof(search));
             }
 
-            if (search[0] == '\\' && (search.Length == 1 || search[1] != '\\'))
+            var validRoots = new char[] { '\\', '/' };
+
+            if (validRoots.Contains(search[0]) && (search.Length == 1 || !validRoots.Contains(search[1])))
             {
                 // Absolute path of system drive: \Windows\System32
                 search = Path.Combine(Path.GetPathRoot(Environment.SystemDirectory), search.Substring(1));

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/QueryInternalDirectory.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/QueryInternalDirectory.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Plugin.Folder.Sources
             {
                 // if folder doesn't exist, we want to take the last part and use it afterwards to help the user
                 // find the right folder.
-                int index = search.LastIndexOf('\\');
+                int index = search.LastIndexOfAny(new char[] { '\\', '/' });
 
                 // No slashes found, so probably not a folder
                 if (index <= 0 || index >= search.Length - 1)


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Full support for paths containing '/'.

![image](https://user-images.githubusercontent.com/25966642/170842341-1fc443d0-b793-4f31-9f14-603e23e3ca7b.png)

**What is included in the PR:** 
- Small tweak to folder plugin to support path starting with '/' as root of system drive (usually C:\).
- Fixed autocomplete and results for paths containing '/'.

**How does someone test / validate:** 
- Search for `\users` -> Results for `C:\users` directory
- Search for `/users` -> Results for `C:\users` directory
- Search for `\\network-share` -> Results for `\\network-share`

## Quality Checklist

- [x] **Linked issue:** #18519 #17107
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [x] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
