### PR TITLE
[Settings][Run Plugin Manager]Fix plugins disabled error

### DIFF
--- a/src/settings-ui/Settings.UI.Library/ViewModels/PowerLauncherViewModel.cs
+++ b/src/settings-ui/Settings.UI.Library/ViewModels/PowerLauncherViewModel.cs
@@ -94,11 +94,6 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
                     break;
             }
 
-            foreach (var plugin in Plugins)
-            {
-                plugin.PropertyChanged += OnPluginInfoChange;
-            }
-
             SearchPluginsCommand = new RelayCommand(SearchPlugins);
         }
 
@@ -412,6 +407,10 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
                 if (_plugins == null)
                 {
                     _plugins = new ObservableCollection<PowerLauncherPluginViewModel>(settings.Plugins.Select(x => new PowerLauncherPluginViewModel(x, isDark)));
+                    foreach (var plugin in Plugins)
+                    {
+                        plugin.PropertyChanged += OnPluginInfoChange;
+                    }
                 }
 
                 return _plugins;
@@ -420,7 +419,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
 
         public bool ShowAllPluginsDisabledWarning
         {
-            get => EnablePowerLauncher && Plugins.Any() && Plugins.All(x => x.Disabled);
+            get => EnablePowerLauncher && settings.Plugins.Any() && settings.Plugins.All(x => x.Disabled);
         }
 
         public bool ShowPluginsLoadingMessage


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Plugins disabled error is displayed based on visible plugins.

**What is included in the PR:** 

**How does someone test / validate:** 
- Disable all plugins -> error is visible
- Enable all plugins -> error isn't visible
- Search for Calculator
- Disable Calculator -> error isn't visible

## Quality Checklist

- [x] **Linked issue:** #17748
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
