### PR TITLE
[FancyZones] Fix not shown layout on window dragging

### DIFF
--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesWindowProcessing.h
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesWindowProcessing.h
@@ -24,7 +24,13 @@ namespace FancyZonesWindowProcessing
         // For windows that FancyZones shouldn't process (start menu, tray, popup menus) 
         // VirtualDesktopManager is unable to retrieve virtual desktop id and returns an error.
         auto desktopId = VirtualDesktop::instance().GetDesktopId(window);
-        if (!desktopId.has_value() || (desktopId.has_value() && *desktopId != VirtualDesktop::instance().GetCurrentVirtualDesktopId()))
+        auto currentDesktopId = VirtualDesktop::instance().GetCurrentVirtualDesktopId();
+        if (!desktopId.has_value())
+        {
+            return false;
+        }
+
+        if (currentDesktopId != GUID_NULL && desktopId.value() != currentDesktopId)
         {
             return false;
         }

--- a/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
@@ -502,6 +502,7 @@ void WorkArea::CalculateZoneSet(OverlappingZonesAlgorithm overlappingAlgorithm) 
     const auto appliedLayout = AppliedLayouts::instance().GetDeviceLayout(m_uniqueId);
     if (!appliedLayout.has_value())
     {
+        Logger::error(L"Layout wasn't applied. Can't init zone set");
         return;
     }
 


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

**What is included in the PR:** 

**How does someone test / validate:** 

* Clear virtual desktops in the registry
* Start FZ
* Drag window
* Verify layout is shown

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
