### PR TITLE
[Installer]Add version to the winappsdk filename

### DIFF
--- a/installer/PowerToysSetup/PowerToys.wxs
+++ b/installer/PowerToysSetup/PowerToys.wxs
@@ -110,7 +110,7 @@
                 UninstallCommand="/silent /uninstall">
             </ExePackage>
             <ExePackage
-                Name="WindowsAppRuntimeInstall.exe"
+                Name="WindowsAppRuntimeInstall-1.0.3.exe"
                 Compressed="no"
                 Id="WinAppSDK101"
                 DownloadUrl="https://aka.ms/windowsappsdk/1.0/1.0.3/windowsappruntimeinstall-1.0.3-$(var.PowerToysPlatform).exe"


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Add the version to WindowsAppRuntimeInstall.exe so that it doesn't collide with other installers the user might've downloaded for windappsdk, since all the installers are named WindowsAppRuntimeInstall.exe regardless of version.
The Wix bootstrapper will prefer to use a local installer if one is found and it will have the wrong hash if it's not the same version.

**What is included in the PR:** 
Add the version to WindowsAppRuntimeInstall.exe file name.

**How does someone test / validate:** 
Download a different version installer for windowsappsdk to the same path as the PowerToys installer and verify PowerToys is still able to install windowsappsdk without receiving a wrong hash error.

## Quality Checklist

- [x] **Linked issue:** #490
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [x] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries
