### PR TITLE
[PT Run][Program] Search linked programs by real executable name

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32Program.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32Program.cs
@@ -44,6 +44,8 @@ namespace Microsoft.Plugin.Program.Programs
 
         public string LnkResolvedPath { get; set; }
 
+        public string LnkResolvedExecutableName { get; set; }
+
         public string ParentDirectory { get; set; }
 
         public string ExecutableName { get; set; }
@@ -97,7 +99,8 @@ namespace Microsoft.Plugin.Program.Programs
             var nameMatch = StringMatcher.FuzzySearch(query, Name);
             var descriptionMatch = StringMatcher.FuzzySearch(query, Description);
             var executableNameMatch = StringMatcher.FuzzySearch(query, ExecutableName);
-            var score = new[] { nameMatch.Score, descriptionMatch.Score / 2, executableNameMatch.Score }.Max();
+            var lnkResolvedExecutableNameMatch = StringMatcher.FuzzySearch(query, LnkResolvedExecutableName);
+            var score = new[] { nameMatch.Score, descriptionMatch.Score / 2, executableNameMatch.Score, lnkResolvedExecutableNameMatch.Score }.Max();
             return score;
         }
 
@@ -496,6 +499,7 @@ namespace Microsoft.Plugin.Program.Programs
                     }
 
                     program.LnkResolvedPath = program.FullPath;
+                    program.LnkResolvedExecutableName = Path.GetFileName(target);
 
                     // Using CurrentCulture since this is user facing
                     program.FullPath = Path.GetFullPath(target).ToLowerInvariant();


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Small fix for a regression where programs discovered by a shortcuts can't be searched with real executable name.

**What is included in the PR:** 
Be able to search programs discovered by a shortcuts with real executable name.

**How does someone test / validate:** 
- Build
- Run PT Run
- Search for `.visual studio 2022` and `.devenv`
- Both searches should display Visual Studio 2022 application in results

## Quality Checklist

- [x] **Linked issue:** #10210
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
