### PR TITLE
[AOT] Low level keyboard hook

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -35,6 +35,7 @@ ALarger
 alekhyareddy
 alignas
 ALLAPPS
+ALLINPUT
 Alloc
 ALLOWUNDO
 ALPHATYPE

--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -1095,6 +1095,7 @@ LINQTo
 Linux
 listview
 lld
+LLKH
 llkhf
 Llvm
 lmcons

--- a/src/common/interop/shared_constants.h
+++ b/src/common/interop/shared_constants.h
@@ -34,6 +34,9 @@ namespace CommonSharedConstants
 
     // Path to the event used by Awake
     const wchar_t AWAKE_EXIT_EVENT[] = L"Local\\PowerToysAwakeExitEvent-c0d5e305-35fc-4fb5-83ec-f6070cfaf7fe";
+    
+    // Path to the event used by AlwaysOnTop
+    const wchar_t ALWAYS_ON_TOP_PIN_EVENT[] = L"Local\\AlwaysOnTopPinEvent-892e0aa2-cfa8-4cc4-b196-ddeb32314ce8";
 
     // Max DWORD for key code to disable keys.
     const DWORD VK_DISABLED = 0x100;

--- a/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.cpp
+++ b/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.cpp
@@ -48,14 +48,27 @@ AlwaysOnTop::AlwaysOnTop(bool powerToysPid) :
             if (m_hPinEvent)
             {
                 m_thread = std::thread([this]() {
-                    while (1)
+                    MSG msg;
+					while (1)
                     {
-                        if (WaitForSingleObject(m_hPinEvent, INFINITE) == WAIT_OBJECT_0)
+                        DWORD dwEvt = MsgWaitForMultipleObjects(1, &m_hPinEvent, false, INFINITE, QS_ALLINPUT);
+                        switch (dwEvt)
                         {
+                        case WAIT_OBJECT_0:
                             if (HWND fw{ GetForegroundWindow() })
                             {
                                 ProcessCommand(fw);
                             }
+                            break;
+                        case WAIT_OBJECT_0 + 1:
+                            if (PeekMessageW(&msg, nullptr, 0, 0, PM_REMOVE))
+                            {
+                                TranslateMessage(&msg);
+                                DispatchMessageW(&msg);
+                            }
+                            break;
+                        default:
+                            return false;
                         }
                     }
                 });

--- a/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.h
+++ b/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.h
@@ -13,7 +13,7 @@
 class AlwaysOnTop : public SettingsObserver
 {
 public:
-    AlwaysOnTop();
+    AlwaysOnTop(bool powerToysPid);
     ~AlwaysOnTop();
 
 protected:
@@ -47,6 +47,9 @@ private:
     HWND m_window{ nullptr };
     HINSTANCE m_hinstance;
     std::map<HWND, std::unique_ptr<WindowBorder>> m_topmostWindows{};
+    HANDLE m_hPinEvent;
+    std::thread m_thread;
+    bool m_powerToysPid;
 
     LRESULT WndProc(HWND, UINT, WPARAM, LPARAM) noexcept;
     void HandleWinHookEvent(WinHookEvent* data) noexcept;

--- a/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.h
+++ b/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.h
@@ -13,7 +13,7 @@
 class AlwaysOnTop : public SettingsObserver
 {
 public:
-    AlwaysOnTop(bool powerToysPid);
+    AlwaysOnTop(bool useLLKH);
     ~AlwaysOnTop();
 
 protected:
@@ -49,13 +49,14 @@ private:
     std::map<HWND, std::unique_ptr<WindowBorder>> m_topmostWindows{};
     HANDLE m_hPinEvent;
     std::thread m_thread;
-    bool m_powerToysPid;
+    const bool m_useCentralizedLLKH;
 
     LRESULT WndProc(HWND, UINT, WPARAM, LPARAM) noexcept;
     void HandleWinHookEvent(WinHookEvent* data) noexcept;
     
     bool InitMainWindow();
     void RegisterHotkey() const;
+    void RegisterLLKH();
     void SubscribeToEvents();
 
     void ProcessCommand(HWND window);

--- a/src/modules/alwaysontop/AlwaysOnTop/main.cpp
+++ b/src/modules/alwaysontop/AlwaysOnTop/main.cpp
@@ -52,7 +52,7 @@ int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, 
 
     Trace::RegisterProvider();
 
-    AlwaysOnTop app;
+    AlwaysOnTop app(!pid.empty());
 
     run_message_loop();
 

--- a/src/settings-ui/Settings.UI.Library/ViewModels/AlwaysOnTopViewModel.cs
+++ b/src/settings-ui/Settings.UI.Library/ViewModels/AlwaysOnTopViewModel.cs
@@ -3,7 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Globalization;
 using System.Runtime.CompilerServices;
+using System.Text.Json;
 using Microsoft.PowerToys.Settings.UI.Library.Helpers;
 using Microsoft.PowerToys.Settings.UI.Library.Interfaces;
 
@@ -97,6 +99,14 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
 
                     Settings.Properties.Hotkey.Value = _hotkey;
                     NotifyPropertyChanged();
+
+                    // Using InvariantCulture as this is an IPC message
+                    SendConfigMSG(
+                        string.Format(
+                            CultureInfo.InvariantCulture,
+                            "{{ \"powertoys\": {{ \"{0}\": {1} }} }}",
+                            AlwaysOnTopSettings.ModuleName,
+                            JsonSerializer.Serialize(Settings)));
                 }
             }
         }


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Use a low level keyboard hook for trigger AOT

**What is included in the PR:** 
- Use low level keyboard hook when AOT is executed from PT Runner
- Use hotkey when AOT is executed as stand-alone executable (VS debug)

**How does someone test / validate:** 
* Build and test with PT Running elevated and non elevated
  * Set WIN + Shift + T as AOT shortcut
  * Pin a window using the shortcut
  * Unpin a window using the shortcut
  * Change shortcut
  * Pin a window using the new shortcut
  * Unpin a window using the new shortcut
  * Check that WIN + Shift + T is released (Windows shortcut for focus the windows taskbar)
  * Set WIN + Shift + T as AOT shortcut
  * Disable AOT
  * Check that WIN + Shift + T is released (Windows shortcut for focus the windows taskbar)
* Run AlwaysOnTop in debug in VS
  * AOT should work using hotkey (note that some shortcuts won't work)

## Quality Checklist

- [x] **Linked issue:** #17312 #16972 #15962 #15621
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
