### PR TITLE
Added Arm64 support on the store submission task.

### DIFF
--- a/.github/workflows/msstore-submissions.yml
+++ b/.github/workflows/msstore-submissions.yml
@@ -18,6 +18,7 @@ jobs:
           assets=$(jq -n "$release" | jq '.assets')
           powerToysSetup=$(jq -n "$assets" | jq '[.[]|select(.name | contains("PowerToysSetup"))]')
           echo ::set-output name=powerToysInstallerX64Url::$(jq -n "$powerToysSetup" | jq -r '[.[]|select(.name | contains("x64"))][0].browser_download_url')
+          echo ::set-output name=powerToysInstallerArm64Url::$(jq -n "$powerToysSetup" | jq -r '[.[]|select(.name | contains("arm64"))][0].browser_download_url')
 
       - name: Configure Store Credentials
         uses: microsoft/store-submission@v1
@@ -40,6 +41,13 @@ jobs:
                     "packageUrl":"${{ steps.releaseVars.outputs.powerToysInstallerX64Url }}",
                     "languages":["zh-hans", "zh-hant", "en", "cs", "nl", "fr", "pt", "pt-br", "de", "hu", "it", "ja", "ko", "pl", "ru", "es", "tr"],
                     "architectures":["X64"],
+                    "installerParameters":"-passive",
+                    "isSilentInstall":true
+                  },
+                  {
+                    "packageUrl":"${{ steps.releaseVars.outputs.powerToysInstallerArm64Url }}",
+                    "languages":["zh-hans", "zh-hant", "en", "cs", "nl", "fr", "pt", "pt-br", "de", "hu", "it", "ja", "ko", "pl", "ru", "es", "tr"],
+                    "architectures":["Arm64"],
                     "installerParameters":"-passive",
                     "isSilentInstall":true
                   }

--- a/.github/workflows/msstore-submissions.yml
+++ b/.github/workflows/msstore-submissions.yml
@@ -41,14 +41,14 @@ jobs:
                     "packageUrl":"${{ steps.releaseVars.outputs.powerToysInstallerX64Url }}",
                     "languages":["zh-hans", "zh-hant", "en", "cs", "nl", "fr", "pt", "pt-br", "de", "hu", "it", "ja", "ko", "pl", "ru", "es", "tr"],
                     "architectures":["X64"],
-                    "installerParameters":"-passive",
+                    "installerParameters":"/passive /norestart",
                     "isSilentInstall":true
                   },
                   {
                     "packageUrl":"${{ steps.releaseVars.outputs.powerToysInstallerArm64Url }}",
                     "languages":["zh-hans", "zh-hant", "en", "cs", "nl", "fr", "pt", "pt-br", "de", "hu", "it", "ja", "ko", "pl", "ru", "es", "tr"],
                     "architectures":["Arm64"],
-                    "installerParameters":"-passive",
+                    "installerParameters":"/passive /norestart",
                     "isSilentInstall":true
                   }
               ]


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
`msstore-submissions.yml` was not sending the new Arm64 binaries to the Microsoft Store.

**What is included in the PR:** 
It now sends the new Arm64 URL to the Microsoft Store.

**How does someone test / validate:** 
Run the task.

## Quality Checklist

- [ ] **Linked issue:** #xxx
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
