### PR TITLE
[FancyZones] Process windows with "Show windows from this app on all desktops" option fix

### DIFF
--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesWindowProcessing.h
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesWindowProcessing.h
@@ -2,7 +2,6 @@
 
 #include <FancyZonesLib/VirtualDesktop.h>
 #include <FancyZonesLib/WindowUtils.h>
-#include <FancyZonesLib/util.h>
 
 namespace FancyZonesWindowProcessing
 {

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesWindowProcessing.h
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesWindowProcessing.h
@@ -2,6 +2,7 @@
 
 #include <FancyZonesLib/VirtualDesktop.h>
 #include <FancyZonesLib/WindowUtils.h>
+#include <FancyZonesLib/util.h>
 
 namespace FancyZonesWindowProcessing
 {
@@ -19,18 +20,17 @@ namespace FancyZonesWindowProcessing
             return false;
         }
 
-        // Switch between virtual desktops results with posting same windows messages that also indicate
-        // creation of new window. We need to check if window being processed is on currently active desktop.
         // For windows that FancyZones shouldn't process (start menu, tray, popup menus) 
         // VirtualDesktopManager is unable to retrieve virtual desktop id and returns an error.
         auto desktopId = VirtualDesktop::instance().GetDesktopId(window);
-        auto currentDesktopId = VirtualDesktop::instance().GetCurrentVirtualDesktopId();
         if (!desktopId.has_value())
         {
             return false;
         }
 
-        if (currentDesktopId != GUID_NULL && desktopId.value() != currentDesktopId)
+        // Switch between virtual desktops results with posting same windows messages that also indicate
+        // creation of new window. We need to check if window being processed is on currently active desktop.
+        if (!VirtualDesktop::instance().IsWindowOnCurrentDesktop(window))
         {
             return false;
         }

--- a/src/modules/fancyzones/FancyZonesLib/VirtualDesktop.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/VirtualDesktop.cpp
@@ -190,8 +190,13 @@ bool VirtualDesktop::IsVirtualDesktopIdSavedInRegistry(GUID id) const
 
 bool VirtualDesktop::IsWindowOnCurrentDesktop(HWND window) const
 {
-    std::optional<GUID> id = GetDesktopId(window);
-    return id.has_value();
+    BOOL isWindowOnCurrentDesktop = false;
+    if (m_vdManager)
+    {
+        m_vdManager->IsWindowOnCurrentVirtualDesktop(window, &isWindowOnCurrentDesktop);
+    }
+
+    return isWindowOnCurrentDesktop;
 }
 
 std::optional<GUID> VirtualDesktop::GetDesktopId(HWND window) const


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

We were checking if the window was on the current virtual desktop with a simple comparison between the current VD id and the VD id from the window. 
With the "Show windows from this app on all desktops" option, `IVirtualDesktopManager` returns an id different from all presented virtual desktops, so that comparison doesn't work. Changed it to the `IsWindowOnCurrentVirtualDesktop` check, which fixed the problem.

**What is included in the PR:** 

**How does someone test / validate:** 

## Quality Checklist

- [ ] **Linked issue:** #18657 
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
