### PR TITLE
[Updating] Handle up-to-date from PowerToys.Update.exe

### DIFF
--- a/src/common/updating/updateState.cpp
+++ b/src/common/updating/updateState.cpp
@@ -69,7 +69,10 @@ UpdateState UpdateState::read()
     {
         std::error_code _;
         fs::remove(filename, _);
-        return UpdateState{};
+        UpdateState new_state;
+        json::to_file(filename, serialize(new_state));
+
+        return new_state;
     }
 }
 


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
PowerToys.Update.exe now can recover from json containing current version and UpdateState::errorDownloading state + current time.

**How does someone test / validate:** 

1. compile PT with Version.props = 0.59.0
2. Launch Settings, press "Check for Updates" to get an actual `githubUpdateLastCheckedDate` value copy it somewhere
3. Quit PT, set UpdateState.json to
```json
{"githubUpdateLastCheckedDate":"1654686636","releasePageUrl":"","state":1,"downloadedInstallerFilename":"","updateStateFileVersion":"v0.59.0"}
```
4. Substitute `githubUpdateLastCheckedDate` value with the value from step 2.
5. Launch Settings and press "Check for Updates" again, make sure that it changes to "Up to date" and not stays stuck with an error like it'd before.

## Quality Checklist

- [x] **Linked issue:** #18663
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
