### PR TITLE
[FileExplorer-Add-ons][SVG Thumbnail] Preprocess svg thumbnail before previewing

### DIFF
--- a/src/modules/previewpane/SvgPreviewHandler/SvgPreviewControl.cs
+++ b/src/modules/previewpane/SvgPreviewHandler/SvgPreviewControl.cs
@@ -12,7 +12,6 @@ using System.Windows.Forms;
 using Common;
 using Common.Utilities;
 using Microsoft.PowerToys.PreviewHandler.Svg.Telemetry.Events;
-using Microsoft.PowerToys.PreviewHandler.Svg.Utilities;
 using Microsoft.PowerToys.Telemetry;
 using Microsoft.Web.WebView2.Core;
 using Microsoft.Web.WebView2.WinForms;

--- a/src/modules/previewpane/SvgThumbnailProvider/SvgThumbnailProvider.cs
+++ b/src/modules/previewpane/SvgThumbnailProvider/SvgThumbnailProvider.cs
@@ -252,6 +252,13 @@ namespace Microsoft.PowerToys.ThumbnailHandler.Svg
                 using (var reader = new StreamReader(stream))
                 {
                     svgData = reader.ReadToEnd();
+                    try
+                    {
+                        svgData = SvgPreviewHandlerHelper.AddStyleSVG(svgData);
+                    }
+                    catch (Exception)
+                    {
+                    }
                 }
             }
 

--- a/src/modules/previewpane/UnitTests-SvgPreviewHandler/SvgPreviewHandlerHelperTests.cs
+++ b/src/modules/previewpane/UnitTests-SvgPreviewHandler/SvgPreviewHandlerHelperTests.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Text;
-using Microsoft.PowerToys.PreviewHandler.Svg.Utilities;
+using Common.Utilities;
 using Microsoft.PowerToys.STATestExtension;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/src/modules/previewpane/common/Utilities/SvgPreviewHandlerHelper.cs
+++ b/src/modules/previewpane/common/Utilities/SvgPreviewHandlerHelper.cs
@@ -4,11 +4,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Xml.Linq;
 
-namespace Microsoft.PowerToys.PreviewHandler.Svg.Utilities
+namespace Common.Utilities
 {
     /// <summary>
     /// Helper utilities for Svg Preview Handler.


### PR DESCRIPTION

same logic is usedas for preview handler

## Summary of the Pull Request

**What is this about:**

**What is included in the PR:** 

**How does someone test / validate:** 
Take svgs from following comment and observe that both thumbnails are previewed correctly:
https://github.com/microsoft/PowerToys/issues/18107#issuecomment-1149380080

## Quality Checklist

- [x] **Linked issue:** #18107
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
