### PR TITLE
[OOBE] Get "What's New" behind authenticated proxy and strict firewall.

### DIFF
--- a/src/settings-ui/Settings.UI/OOBE/Views/OobeWhatsNew.xaml
+++ b/src/settings-ui/Settings.UI/OOBE/Views/OobeWhatsNew.xaml
@@ -14,6 +14,7 @@
     <Grid Margin="0,24,0,0">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
@@ -31,15 +32,7 @@
                     TextWrapping="Wrap" />
             </HyperlinkButton>
         </StackPanel>
-        <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
-            <Grid Margin="32,24,32,24">
-                <muxc:ProgressRing Grid.Row="1"
-                x:Name="LoadingProgressRing"
-                IsIndeterminate="True"
-                VerticalAlignment="Center"
-                HorizontalAlignment="Center"
-                Visibility="Visible"/>
-                <muxc:InfoBar
+        <muxc:InfoBar
                 Severity="Error"
                 x:Name="ErrorInfoBar"
                 Grid.Row="1"
@@ -49,9 +42,38 @@
                 IsClosable="False"
                 IsOpen="True"
                 IsTabStop="True" />
+        <muxc:StackPanel
+                    x:Name="ProxyStackPanel"
+                    Grid.Row="1"
+                    Visibility="Collapsed"
+                    Orientation="Vertical"
+                    VerticalAlignment="Top"
+                    IsTabStop="True">
+            <muxc:InfoBar
+                        x:Name="ProxyWarningInfoBar"
+                        Severity="Warning"
+                        Grid.Row="1"
+                        x:Uid="Oobe_WhatsNew_ProxyAuthenticationWarning"
+                        VerticalAlignment="Top"
+                        IsClosable="False"
+                        IsOpen="True"
+                        IsTabStop="True" />
+            <muxc:StackPanel Orientation="Horizontal">
+                <muxc:TextBox x:Name="UserNameBox" />
+                <muxc:PasswordBox x:Name="SecretPasswordBox" />
+                <muxc:Button x:Name="ReloadButton" Content="🗘" Click="ReloadButton_Click"/>
+            </muxc:StackPanel>
+        </muxc:StackPanel>
+        <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto">
+            <Grid Margin="32,24,32,24">
+                <muxc:ProgressRing
+                x:Name="LoadingProgressRing"
+                IsIndeterminate="True"
+                VerticalAlignment="Center"
+                HorizontalAlignment="Center"
+                Visibility="Visible"/>
                 <toolkitcontrols:MarkdownTextBlock x:Name="ReleaseNotesMarkdown"
                                                    Visibility="Collapsed"
-                                                   Grid.Row="1"
                                                    Header1FontSize="20"
                                                    Header2FontSize="17"
                                                    Header2FontWeight="SemiBold"

--- a/src/settings-ui/Settings.UI/OOBE/Views/OobeWhatsNew.xaml
+++ b/src/settings-ui/Settings.UI/OOBE/Views/OobeWhatsNew.xaml
@@ -14,7 +14,6 @@
     <Grid Margin="0,24,0,0">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
@@ -42,29 +41,17 @@
                 IsClosable="False"
                 IsOpen="True"
                 IsTabStop="True" />
-        <muxc:StackPanel
-                    x:Name="ProxyStackPanel"
-                    Grid.Row="1"
-                    Visibility="Collapsed"
-                    Orientation="Vertical"
-                    VerticalAlignment="Top"
-                    IsTabStop="True">
-            <muxc:InfoBar
-                        x:Name="ProxyWarningInfoBar"
-                        Severity="Warning"
-                        Grid.Row="1"
-                        x:Uid="Oobe_WhatsNew_ProxyAuthenticationWarning"
-                        VerticalAlignment="Top"
-                        IsClosable="False"
-                        IsOpen="True"
-                        IsTabStop="True" />
-            <muxc:StackPanel Orientation="Horizontal">
-                <muxc:TextBox x:Name="UserNameBox" />
-                <muxc:PasswordBox x:Name="SecretPasswordBox" />
-                <muxc:Button x:Name="ReloadButton" Content="🗘" Click="ReloadButton_Click"/>
-            </muxc:StackPanel>
-        </muxc:StackPanel>
-        <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto">
+        <muxc:InfoBar
+            x:Name="ProxyWarningInfoBar"
+            Severity="Warning"
+            Grid.Row="1"
+            Visibility="Collapsed"
+            x:Uid="Oobe_WhatsNew_ProxyAuthenticationWarning"
+            VerticalAlignment="Top"
+            IsClosable="False"
+            IsOpen="True"
+            IsTabStop="True" />
+        <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
             <Grid Margin="32,24,32,24">
                 <muxc:ProgressRing
                 x:Name="LoadingProgressRing"

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -1477,6 +1477,12 @@ From there, simply click on one of the supported files in the File Explorer and 
   <data name="Oobe_WhatsNew_LoadingError.Message" xml:space="preserve">
     <value>Please check your internet connection.</value>
   </data>
+  <data name="Oobe_WhatsNew_ProxyAuthenticationWarning.Title" xml:space="preserve">
+    <value>Couldn't load the release notes.</value>
+  </data>
+  <data name="Oobe_WhatsNew_ProxyAuthenticationWarning.Message" xml:space="preserve">
+    <value>Your proxy server requires authentication.</value>
+  </data>
   <data name="Oobe_WhatsNew_DetailedReleaseNotesLink.Text" xml:space="preserve">
     <value>See more detailed release notes on GitHub</value>
     <comment>Don't loc "GitHub", it's the name of a product</comment>


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

We should use system-wide proxy configuration to get "What's new?" release notes.

**What is included in the PR:** 

Added `HttpClientHandler` with default web proxy and default credentials.

**How does someone test / validate:** 

Configure environment so PowerToys have no direct Internet access.
Configure proxy server to allow access to the internet.
Configure proxy server so it will require user authentication.
Check with browser that internet is accessible after user authentication.
Open "Welcome to PowerToys" window and choose "What's New" tab.
Check release notes are loaded.
(I used virtual machine with host-only network and proxy server on the host)

## Quality Checklist

- [x] **Linked issue:** #16918
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
