### PR TITLE
CA1031 Suppressions Cleanup

### DIFF
--- a/src/common/Common.UI/SettingsDeepLink.cs
+++ b/src/common/Common.UI/SettingsDeepLink.cs
@@ -68,9 +68,7 @@ namespace Common.UI
                 var fullPath = Directory.GetParent(assemblyPath).FullName;
                 Process.Start(new ProcessStartInfo(fullPath + "\\..\\PowerToys.exe") { Arguments = "--open-settings=" + SettingsWindowNameToString(window) });
             }
-#pragma warning disable CA1031 // Do not catch general exception types
             catch
-#pragma warning restore CA1031 // Do not catch general exception types
             {
                 // TODO(stefan): Log exception once unified logging is implemented
             }

--- a/src/modules/colorPicker/ColorPickerUI/Mouse/CursorManager.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Mouse/CursorManager.cs
@@ -59,9 +59,7 @@ namespace ColorPicker.Mouse
                     Logger.LogInfo("Cursor file path was null");
                 }
             }
-#pragma warning disable CA1031 // Do not catch general exception types
             catch (Exception ex)
-#pragma warning restore CA1031 // Do not catch general exception types
             {
                 Logger.LogError("Failed to change cursor", ex);
             }

--- a/src/modules/colorPicker/ColorPickerUI/Program.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Program.cs
@@ -28,9 +28,7 @@ namespace ColorPicker
                     application.Run();
                 }
             }
-#pragma warning disable CA1031 // Do not catch general exception types
             catch (Exception ex)
-#pragma warning restore CA1031 // Do not catch general exception types
             {
                 Logger.LogError("Unhandled exception", ex);
                 CursorManager.RestoreOriginalCursors();

--- a/src/modules/colorPicker/ColorPickerUI/Settings/UserSettings.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Settings/UserSettings.cs
@@ -145,9 +145,7 @@ namespace ColorPicker.Settings
                             Logger.LogError("Failed to read changed settings", ex);
                             Thread.Sleep(500);
                         }
-#pragma warning disable CA1031 // Do not catch general exception types
                         catch (Exception ex)
-#pragma warning restore CA1031 // Do not catch general exception types
                         {
                             if (retryCount > MaxNumberOfRetry)
                             {

--- a/src/modules/colorPicker/UnitTest-ColorPickerUI/Helpers/ColorConverterTest.cs
+++ b/src/modules/colorPicker/UnitTest-ColorPickerUI/Helpers/ColorConverterTest.cs
@@ -441,11 +441,9 @@ namespace Microsoft.ColorPicker.UnitTests
                         {
                             _ = ColorHelper.ConvertToCMYKColor(color);
                         }
-#pragma warning disable CA1031 // Do not catch general exception types
 
                         // intentionally trying to catch
                         catch (Exception ex)
-#pragma warning restore CA1031 // Do not catch general exception types
                         {
                             exception = ex;
                         }

--- a/src/modules/imageresizer/tests/Test/TestDirectory.cs
+++ b/src/modules/imageresizer/tests/Test/TestDirectory.cs
@@ -57,9 +57,7 @@ namespace ImageResizer
                             Directory.Delete(_path, recursive: true);
                             break;
                         }
-#pragma warning disable CA1031 // Do not catch general exception types
                         catch
-#pragma warning restore CA1031 // Do not catch general exception types
                         {
                             Thread.Sleep(150);
                         }

--- a/src/modules/imageresizer/ui/Extensions/BitmapMetadataExtension.cs
+++ b/src/modules/imageresizer/ui/Extensions/BitmapMetadataExtension.cs
@@ -75,9 +75,7 @@ namespace ImageResizer.Extensions
                     metadata.RemoveQuery(query);
                 }
             }
-#pragma warning disable CA1031 // Do not catch general exception types
             catch (Exception ex)
-#pragma warning restore CA1031 // Do not catch general exception types
             {
                 Debug.WriteLine($"Exception while trying to remove metadata entry at position: {query}");
                 Debug.WriteLine(ex);
@@ -95,9 +93,7 @@ namespace ImageResizer.Extensions
             {
                 metadata.SetQuery(query, value);
             }
-#pragma warning disable CA1031 // Do not catch general exception types
             catch (Exception ex)
-#pragma warning restore CA1031 // Do not catch general exception types
             {
                 Debug.WriteLine($"Exception while trying to set metadata {value} at position: {query}");
                 Debug.WriteLine(ex);
@@ -123,9 +119,7 @@ namespace ImageResizer.Extensions
             {
                 GetMetadataRecursively(metadata, string.Empty);
             }
-#pragma warning disable CA1031 // Do not catch general exception types
             catch (Exception ex)
-#pragma warning restore CA1031 // Do not catch general exception types
             {
                 Debug.WriteLine($"Exception while trying to iterate recursively over metadata. We were able to read {listOfAllMetadata.Count} metadata entries.");
                 Debug.WriteLine(ex);
@@ -145,9 +139,7 @@ namespace ImageResizer.Extensions
                     {
                         metadataQueryReader = GetQueryWithPreCheck(metadata, relativeQuery);
                     }
-#pragma warning disable CA1031 // Do not catch general exception types
                     catch (Exception ex)
-#pragma warning restore CA1031 // Do not catch general exception types
                     {
                         Debug.WriteLine($"Removing corrupt metadata property {absolutePath}. Skipping metadata entry | {ex.Message}");
                         Debug.WriteLine(ex);
@@ -223,9 +215,7 @@ namespace ImageResizer.Extensions
             {
                 GetMetadataRecursively(metadata, string.Empty);
             }
-#pragma warning disable CA1031 // Do not catch general exception types
             catch (Exception ex)
-#pragma warning restore CA1031 // Do not catch general exception types
             {
                 Debug.WriteLine($"Exception while trying to iterate recursively over metadata. We were able to read {listOfAllMetadata.Count} metadata entries.");
                 Debug.WriteLine(ex);
@@ -251,9 +241,7 @@ namespace ImageResizer.Extensions
                         metadataQueryReader = metadata.GetQuerySafe(relativeQuery);
                         listOfAllMetadata.Add((absolutePath, metadataQueryReader));
                     }
-#pragma warning disable CA1031 // Do not catch general exception types
                     catch (Exception ex)
-#pragma warning restore CA1031 // Do not catch general exception types
                     {
                         listOfAllMetadata.Add((absolutePath, $"######## INVALID METADATA: {ex.Message}"));
                         Debug.WriteLine(ex);

--- a/src/modules/imageresizer/ui/Models/ResizeBatch.cs
+++ b/src/modules/imageresizer/ui/Models/ResizeBatch.cs
@@ -70,9 +70,7 @@ namespace ImageResizer.Models
                     {
                         Execute(file);
                     }
-#pragma warning disable CA1031 // Do not catch general exception types
                     catch (Exception ex)
-#pragma warning restore CA1031 // Do not catch general exception types
                     {
                         errors.Add(new ResizeError { File = _fileSystem.Path.GetFileName(file), Error = ex.Message });
                     }

--- a/src/modules/imageresizer/ui/Models/ResizeOperation.cs
+++ b/src/modules/imageresizer/ui/Models/ResizeOperation.cs
@@ -258,9 +258,7 @@ namespace ImageResizer.Models
 
                     return true;
                 }
-#pragma warning disable CA1031 // Do not catch general exception types
                 catch (Exception)
-#pragma warning restore CA1031 // Do not catch general exception types
                 {
                     return false;
                 }

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/ContextMenuLoader.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/ContextMenuLoader.cs
@@ -24,7 +24,6 @@ namespace Microsoft.Plugin.Folder
             _context = context;
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "We want to keep the process alive, and instead log the exception")]
         public List<ContextMenuResult> LoadContextMenus(Result selectedResult)
         {
             var contextMenus = new List<ContextMenuResult>();
@@ -98,7 +97,6 @@ namespace Microsoft.Plugin.Folder
             return contextMenus;
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "We want to keep the process alive, and instead log the exception")]
         private ContextMenuResult CreateOpenContainingFolderResult(SearchResult record)
         {
             return new ContextMenuResult

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/ContextMenuLoader.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/ContextMenuLoader.cs
@@ -36,7 +36,6 @@ namespace Microsoft.Plugin.Indexer
             _context = context;
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "We want to keep the process alive, and instead log and show an error message")]
         public List<ContextMenuResult> LoadContextMenus(Result selectedResult)
         {
             var contextMenus = new List<ContextMenuResult>();
@@ -119,7 +118,6 @@ namespace Microsoft.Plugin.Indexer
         }
 
         // Function to add the context menu item to run as admin
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "We want to keep the process alive, and instead log the exception message")]
         private static ContextMenuResult CreateRunAsAdminContextMenu(SearchResult record)
         {
             return new ContextMenuResult
@@ -147,7 +145,6 @@ namespace Microsoft.Plugin.Indexer
         }
 
         // Function to add the context menu item to run as admin
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "We want to keep the process alive, and instead log the exception message")]
         private static ContextMenuResult CreateRunAsUserContextMenu(SearchResult record)
         {
             return new ContextMenuResult
@@ -190,7 +187,6 @@ namespace Microsoft.Plugin.Indexer
             return false;
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "We want to keep the process alive, and instead log and show an error message")]
         private ContextMenuResult CreateOpenContainingFolderResult(SearchResult record)
         {
             return new ContextMenuResult

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Main.cs
@@ -71,7 +71,6 @@ namespace Microsoft.Plugin.Indexer
         }
 
         // This function uses the Windows indexer and returns the list of results obtained
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "We want to keep the process alive but will log the exception")]
         public List<Result> Query(Query query, bool isFullQuery)
         {
             var results = new List<Result>();

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Main.cs
@@ -168,7 +168,6 @@ namespace Microsoft.Plugin.Program
             return menuOptions;
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "We want to keep the process alive and show the user a warning message")]
         public static void StartProcess(Func<ProcessStartInfo, Process> runProcess, ProcessStartInfo info)
         {
             try

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/PackagemanagerWrapper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/PackagemanagerWrapper.cs
@@ -30,7 +30,6 @@ namespace Microsoft.Plugin.Program.Programs
                 : Enumerable.Empty<IPackage>();
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "We want to catch all exception to prevent error in a program from affecting loading of program plugin.")]
         private static PackageWrapper TryGetWrapperFromPackage(Package package)
         {
             try

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/ShellLinkHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/ShellLinkHelper.cs
@@ -132,7 +132,6 @@ namespace Microsoft.Plugin.Program.Programs
         public bool HasArguments { get; set; }
 
         // Retrieve the target path using Shell Link
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "HRESULT E_FAIL is thrown while fetching description and E_FAIL does not relate to any specific exception.")]
         public string RetrieveTargetPath(string path)
         {
             var link = new ShellLink();

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/UWP.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/UWP.cs
@@ -127,7 +127,6 @@ namespace Microsoft.Plugin.Program.Programs
             Version = PackageVersion.Unknown;
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Intentionally keeping the process alive.")]
         public static UWPApplication[] All()
         {
             var windows10 = new Version(10, 0);
@@ -164,7 +163,6 @@ namespace Microsoft.Plugin.Program.Programs
             }
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Intentionally keeping the process alive.")]
         private static IEnumerable<IPackage> CurrentUserPackages()
         {
             return PackageManagerWrapper.FindPackagesForCurrentUser().Where(p =>

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/UWPApplication.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/UWPApplication.cs
@@ -125,7 +125,6 @@ namespace Microsoft.Plugin.Program.Programs
             return result;
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Intentionally keeping the process alive.")]
         public List<ContextMenuResult> ContextMenus(string queryArguments, IPublicAPI api)
         {
             if (api == null)
@@ -205,7 +204,6 @@ namespace Microsoft.Plugin.Program.Programs
             return contextMenus;
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Intentionally keeping the process alive, and showing the user an error message")]
         private async void Launch(IPublicAPI api, string queryArguments)
         {
             var appManager = new ApplicationActivationHelper.ApplicationActivationManager();
@@ -288,9 +286,7 @@ namespace Microsoft.Plugin.Program.Programs
                             return true;
                         }
                     }
-#pragma warning disable CA1031 // Do not catch general exception types
                     catch (Exception e)
-#pragma warning restore CA1031 // Do not catch general exception types
                     {
                         ProgramLogger.Exception($"Unable to parse manifest file for {DisplayName}", e, MethodBase.GetCurrentMethod().DeclaringType, manifest);
                     }

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32Program.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/Win32Program.cs
@@ -244,7 +244,6 @@ namespace Microsoft.Plugin.Program.Programs
             return result;
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Intentionally keeping the process alive.")]
         public List<ContextMenuResult> ContextMenus(string queryArguments, IPublicAPI api)
         {
             if (api == null)
@@ -358,8 +357,6 @@ namespace Microsoft.Plugin.Program.Programs
             return ExecutableName;
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Any error in CreateWin32Program should not prevent other programs from loading.")]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1308:Normalize strings to uppercase", Justification = "User facing path needs to be shown in lowercase.")]
         private static Win32Program CreateWin32Program(string path)
         {
             try
@@ -397,8 +394,6 @@ namespace Microsoft.Plugin.Program.Programs
         private static readonly Regex InternetShortcutURLPrefixes = new Regex(@"^steam:\/\/(rungameid|run)\/|^com\.epicgames\.launcher:\/\/apps\/", RegexOptions.Compiled);
 
         // This function filters Internet Shortcut programs
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Any error in InternetShortcutProgram should not prevent other programs from loading.")]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1308:Normalize strings to uppercase", Justification = "User facing path needs to be shown in lowercase.")]
         private static Win32Program InternetShortcutProgram(string path)
         {
             try
@@ -478,8 +473,6 @@ namespace Microsoft.Plugin.Program.Programs
             }
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Unsure of what exceptions are caught here while enabling static analysis")]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1308:Normalize strings to uppercase", Justification = "User facing path needs to be shown in lowercase.")]
         private static Win32Program LnkProgram(string path)
         {
             try
@@ -540,7 +533,6 @@ namespace Microsoft.Plugin.Program.Programs
             }
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Any error in ExeProgram should not prevent other programs from loading.")]
         private static Win32Program ExeProgram(string path)
         {
             try
@@ -648,7 +640,6 @@ namespace Microsoft.Plugin.Program.Programs
                 : null;
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Minimise the effect of error on other programs")]
         private static IEnumerable<string> ProgramPaths(string directory, IList<string> suffixes, bool recursiveSearch = true)
         {
             if (!Directory.Exists(directory))
@@ -921,7 +912,6 @@ namespace Microsoft.Plugin.Program.Programs
             return program;
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Keeping the process alive but logging the exception")]
         public static IList<Win32Program> All(ProgramPluginSettings settings)
         {
             if (settings == null)

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Storage/Win32ProgramFileSystemWatchers.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Storage/Win32ProgramFileSystemWatchers.cs
@@ -44,9 +44,7 @@ namespace Microsoft.Plugin.Program.Storage
                 {
                     Directory.GetFiles(path);
                 }
-#pragma warning disable CA1031 // Do not catch general exception types
                 catch (Exception ex)
-#pragma warning restore CA1031 // Do not catch general exception types
                 {
                     Log.Exception($"Failed to get files in {path}", ex, typeof(Win32ProgramFileSystemWatchers));
                     invalidPaths.Add(path);

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Storage/Win32ProgramRepository.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Storage/Win32ProgramRepository.cs
@@ -92,7 +92,6 @@ namespace Microsoft.Plugin.Program.Storage
             }
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Intentionally keeping the process alive>")]
         private void OnAppRenamed(object sender, RenamedEventArgs e)
         {
             string oldPath = e.OldFullPath;
@@ -142,7 +141,6 @@ namespace Microsoft.Plugin.Program.Storage
             }
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Intentionally keeping the process alive")]
         private void OnAppDeleted(object sender, FileSystemEventArgs e)
         {
             string path = e.FullPath;

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Shell/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Shell/Main.cs
@@ -50,7 +50,6 @@ namespace Microsoft.Plugin.Shell
             _storage.Save();
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Keeping the process alive, but logging the exception")]
         public List<Result> Query(Query query)
         {
             if (query == null)

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/Main.cs
@@ -102,9 +102,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
                 // Result to big to convert to decimal
                 return ErrorHandler.OnError(IconPath, isGlobalQuery, query.RawQuery, Properties.Resources.wox_plugin_calculator_not_covert_to_decimal);
             }
-#pragma warning disable CA1031 // Do not catch general exception types
             catch (Exception e)
-#pragma warning restore CA1031 // Do not catch general exception types
             {
                 // Any other crash occurred
                 // We want to keep the process alive if any the mages library throws any exceptions.

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Registry/Helper/ContextMenuHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Registry/Helper/ContextMenuHelper.cs
@@ -86,8 +86,6 @@ namespace Microsoft.PowerToys.Run.Plugin.Registry.Helper
             return list;
         }
 
-        #pragma warning disable CA1031 // Do not catch general exception types
-
         /// <summary>
         /// Open the Windows registry editor and jump to registry key inside the given key (inside the <see cref="RegistryEntry"/>
         /// </summary>
@@ -135,7 +133,5 @@ namespace Microsoft.PowerToys.Run.Plugin.Registry.Helper
                 return false;
             }
         }
-
-        #pragma warning restore CA1031 // Do not catch general exception types
     }
 }

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Registry/Helper/RegistryHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Registry/Helper/RegistryHelper.cs
@@ -13,8 +13,6 @@ using Microsoft.Win32;
 
 namespace Microsoft.PowerToys.Run.Plugin.Registry.Helper
 {
-#pragma warning disable CA1031 // Do not catch general exception types
-
     /// <summary>
     /// Helper class to easier work with the registry
     /// </summary>
@@ -230,6 +228,4 @@ namespace Microsoft.PowerToys.Run.Plugin.Registry.Helper
             return list;
         }
     }
-
-    #pragma warning restore CA1031 // Do not catch general exception types
 }

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Registry/Helper/ResultHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Registry/Helper/ResultHelper.cs
@@ -19,8 +19,6 @@ namespace Microsoft.PowerToys.Run.Plugin.Registry.Helper
     /// </summary>
     internal static class ResultHelper
     {
-        #pragma warning disable CA1031 // Do not catch general exception types
-
         /// <summary>
         /// Return a list with <see cref="Result"/>s, based on the given list
         /// </summary>
@@ -167,8 +165,6 @@ namespace Microsoft.PowerToys.Run.Plugin.Registry.Helper
 
             return resultList;
         }
-
-#pragma warning restore CA1031 // Do not catch general exception types
 
         /// <summary>
         /// Return a truncated name

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeZone/Helper/ContextMenuHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeZone/Helper/ContextMenuHelper.cs
@@ -6,8 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Input;
-using System.Windows.Media.Animation;
-using Microsoft.PowerToys.Run.Plugin.TimeZone.Classes;
 using Microsoft.PowerToys.Run.Plugin.TimeZone.Properties;
 using Wox.Plugin;
 using Wox.Plugin.Logger;
@@ -50,8 +48,6 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeZone.Helper
             return list;
         }
 
-#pragma warning disable CA1031 // Do not catch general exception types
-
         /// <summary>
         /// Copy the given text to the clipboard
         /// </summary>
@@ -71,7 +67,5 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeZone.Helper
                 return false;
             }
         }
-
-        #pragma warning restore CA1031 // Do not catch general exception types
     }
 }

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsTerminal/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsTerminal/Main.cs
@@ -137,9 +137,7 @@ namespace Microsoft.PowerToys.Run.Plugin.WindowsTerminal
             {
                 appManager.ActivateApplication(id, queryArguments, noFlags, out var unusedPid);
             }
-#pragma warning disable CA1031 // Do not catch general exception types
             catch (Exception ex)
-#pragma warning restore CA1031 // Do not catch general exception types
             {
                 var name = "Plugin: " + Resources.plugin_name;
                 var message = Resources.run_terminal_failed;
@@ -155,9 +153,7 @@ namespace Microsoft.PowerToys.Run.Plugin.WindowsTerminal
                 string path = "shell:AppsFolder\\" + id;
                 Helper.OpenInShell(path, TerminalHelper.GetArguments(profile, _openNewTab), runAs: Helper.ShellRunAsType.Administrator);
             }
-#pragma warning disable CA1031 // Do not catch general exception types
             catch (Exception ex)
-#pragma warning restore CA1031 // Do not catch general exception types
             {
                 var name = "Plugin: " + Resources.plugin_name;
                 var message = Resources.run_terminal_failed;

--- a/src/modules/launcher/PowerLauncher/Helper/EnvironmentHelper.cs
+++ b/src/modules/launcher/PowerLauncher/Helper/EnvironmentHelper.cs
@@ -139,9 +139,7 @@ namespace PowerLauncher.Helper
                                 }
                             }
                         }
-#pragma warning disable CA1031 // Do not catch general exception types
                         catch (Exception ex)
-#pragma warning restore CA1031 // Do not catch general exception types
                         {
                             // The dotnet method "System.Environment.SetEnvironmentVariable" has it's own internal method to check the input parameters. Here we catch the exceptions that we don't check before updating the environment variable and log it to avoid crashes of PT Run.
                             Log.Exception($"Unhandled exception while updating the environment variable [{kv.Key}] for the PT Run process. (The variable value has a length of [{varValueLength}].)", ex, typeof(PowerLauncher.Helper.EnvironmentHelper));
@@ -215,9 +213,7 @@ namespace PowerLauncher.Helper
             {
                 return Environment.GetEnvironmentVariables(target);
             }
-#pragma warning disable CA1031 // Do not catch general exception types
             catch (Exception ex)
-#pragma warning restore CA1031 // Do not catch general exception types
             {
                 Log.Exception($"Unhandled exception while getting the environment variables for target '{target}'.", ex, typeof(PowerLauncher.Helper.EnvironmentHelper));
                 return new Hashtable();

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -68,9 +68,7 @@ namespace PowerLauncher
                 var telemetryEvent = new RunPluginsSettingsEvent(plugins);
                 PowerToysTelemetry.Log.WriteEvent(telemetryEvent);
             }
-#pragma warning disable CA1031 // Do not catch general exception types
             catch (Exception ex)
-#pragma warning restore CA1031 // Do not catch general exception types
             {
                 Log.Exception("Unhandled exception when trying to send PowerToys Run settings telemetry.", ex, GetType());
             }

--- a/src/modules/launcher/PowerLauncher/Plugin/PluginConfig.cs
+++ b/src/modules/launcher/PowerLauncher/Plugin/PluginConfig.cs
@@ -37,7 +37,6 @@ namespace PowerLauncher.Plugin
             return PluginMetadatas;
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Suppressing this to enable FxCop. We are logging the exception, and going forward general exceptions should not be caught")]
         private static void ParsePluginConfigs(IEnumerable<string> directories)
         {
             // todo use linq when diable plugin is implemented since parallel.foreach + list is not thread saft
@@ -65,7 +64,6 @@ namespace PowerLauncher.Plugin
             }
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Suppressing this to enable FxCop. We are logging the exception, and going forward general exceptions should not be caught")]
         private static PluginMetadata GetPluginMetadata(string pluginDirectory)
         {
             string configPath = Path.Combine(pluginDirectory, PluginConfigName);

--- a/src/modules/launcher/PowerLauncher/Plugin/PluginManager.cs
+++ b/src/modules/launcher/PowerLauncher/Plugin/PluginManager.cs
@@ -12,7 +12,6 @@ using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using PowerLauncher.Properties;
-using Wox.Infrastructure;
 using Wox.Infrastructure.Storage;
 using Wox.Plugin;
 using Wox.Plugin.Logger;
@@ -135,7 +134,6 @@ namespace PowerLauncher.Plugin
         /// <summary>
         /// Call initialize for all plugins
         /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Suppressing this to enable FxCop. We are logging the exception, and going forward general exceptions should not be caught")]
         public static void InitializePlugins(IPublicAPI api)
         {
             API = api ?? throw new ArgumentNullException(nameof(api));
@@ -165,7 +163,6 @@ namespace PowerLauncher.Plugin
             }
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Suppressing this to enable FxCop. We are logging the exception, and going forward general exceptions should not be caught")]
         public static List<Result> QueryForPlugin(PluginPair pair, Query query, bool delayedExecution = false)
         {
             if (pair == null)
@@ -272,7 +269,6 @@ namespace PowerLauncher.Plugin
             return AllPlugins.Where(p => p.Plugin is T);
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Suppressing this to enable FxCop. We are logging the exception, and going forward general exceptions should not be caught")]
         public static List<ContextMenuResult> GetContextMenusForPlugin(Result result)
         {
             var pluginPair = _contextMenuPlugins.FirstOrDefault(o => o.Metadata.ID == result.PluginID);

--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -780,9 +780,7 @@ namespace PowerLauncher.ViewModel
                     _hotkeyHandle = HotkeyManager.RegisterHotkey(hotkey, action);
                 }
             }
-#pragma warning disable CA1031 // Do not catch general exception types
             catch (Exception)
-#pragma warning restore CA1031 // Do not catch general exception types
             {
                 string errorMsg = string.Format(CultureInfo.InvariantCulture, Properties.Resources.registerHotkeyFailed, hotkeyStr);
                 MessageBox.Show(errorMsg);

--- a/src/modules/launcher/PowerLauncher/ViewModel/ResultViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/ResultViewModel.cs
@@ -193,9 +193,7 @@ namespace PowerLauncher.ViewModel
                     {
                         return Result.Icon();
                     }
-#pragma warning disable CA1031 // Do not catch general exception types
                     catch (Exception e)
-#pragma warning restore CA1031 // Do not catch general exception types
                     {
                         Log.Exception($"IcoPath is empty and exception when calling Icon() for result <{Result.Title}> of plugin <{Result.PluginDirectory}>", e, GetType());
                         imagePath = ImageLoader.ErrorIconPath;

--- a/src/modules/launcher/Wox.Infrastructure/Exception/ExceptionFormatter.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Exception/ExceptionFormatter.cs
@@ -117,7 +117,6 @@ namespace Wox.Infrastructure.Exception
         }
 
         // http://msdn.microsoft.com/en-us/library/hh925568%28v=vs.110%29.aspx
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Suppressing this to enable FxCop. We are logging the exception, and going forward general exceptions should not be caught")]
         private static List<string> GetFrameworkVersionFromRegistry()
         {
             try

--- a/src/modules/launcher/Wox.Infrastructure/Helper.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Helper.cs
@@ -94,7 +94,6 @@ namespace Wox.Infrastructure
         }
 
         // Function to run as admin for context menu items
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Suppressing this to enable FxCop. We are logging the exception, and going forward general exceptions should not be caught")]
         public static void RunAsAdmin(string path)
         {
             var info = new ProcessStartInfo
@@ -116,7 +115,6 @@ namespace Wox.Infrastructure
         }
 
         // Function to run as other user for context menu items
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Suppressing this to enable FxCop. We are logging the exception, and going forward general exceptions should not be caught")]
         public static void RunAsUser(string path)
         {
             var info = new ProcessStartInfo

--- a/src/modules/launcher/Wox.Infrastructure/Image/ImageHashGenerator.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Image/ImageHashGenerator.cs
@@ -14,7 +14,6 @@ namespace Wox.Infrastructure.Image
 {
     public class ImageHashGenerator : IImageHashGenerator
     {
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Suppressing this to enable FxCop. We are logging the exception, and going forward general exceptions should not be caught")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Security", "CA5350:Do Not Use Weak Cryptographic Algorithms", Justification = "Level of protection needed for the image data does not require a security guarantee")]
         public string GetHashFromImage(ImageSource image)
         {

--- a/src/modules/launcher/Wox.Infrastructure/Image/ImageLoader.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Image/ImageLoader.cs
@@ -119,7 +119,6 @@ namespace Wox.Infrastructure.Image
             Cache,
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Suppressing this to enable FxCop. We are logging the exception, and going forward general exceptions should not be caught")]
         private static ImageResult LoadInternal(string path, bool loadFullImage = false)
         {
             ImageSource image;

--- a/src/modules/launcher/Wox.Infrastructure/Storage/BinaryStorage`1.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Storage/BinaryStorage`1.cs
@@ -86,7 +86,6 @@ namespace Wox.Infrastructure.Storage
             }
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Suppressing this to enable FxCop. We are logging the exception, and going forward general exceptions should not be caught")]
         private T Deserialize(Stream stream, T defaultData)
         {
             // http://stackoverflow.com/questions/2120055/binaryformatter-deserialize-gives-serializationexception

--- a/src/modules/launcher/Wox.Plugin/Common/DefaultBrowserInfo.cs
+++ b/src/modules/launcher/Wox.Plugin/Common/DefaultBrowserInfo.cs
@@ -61,7 +61,6 @@ namespace Wox.Plugin.Common
         /// Consider using <see cref="UpdateIfTimePassed"/> to avoid updating multiple times.
         /// (because of multiple plugins calling update at the same time.)
         /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "We want to keep the process alive but will log the exception")]
         public static void Update()
         {
             lock (_updateLock)

--- a/src/modules/launcher/Wox.Plugin/PluginPair.cs
+++ b/src/modules/launcher/Wox.Plugin/PluginPair.cs
@@ -136,9 +136,7 @@ namespace Wox.Plugin
             {
                 _assembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(Metadata.ExecuteFilePath);
             }
-#pragma warning disable CA1031 // Do not catch general exception types
             catch (Exception e)
-#pragma warning restore CA1031 // Do not catch general exception types
             {
                 Log.Exception($"Couldn't load assembly for {Metadata.Name} in {Metadata.ExecuteFilePath}", e, MethodBase.GetCurrentMethod().DeclaringType);
                 return false;
@@ -170,9 +168,7 @@ namespace Wox.Plugin
             {
                 Plugin = (IPlugin)Activator.CreateInstance(type);
             }
-#pragma warning disable CA1031 // Do not catch general exception types
             catch (Exception e)
-#pragma warning restore CA1031 // Do not catch general exception types
             {
                 Log.Exception($"Can't create instance for <{Metadata.Name}> in {Metadata.ExecuteFilePath}", e, MethodBase.GetCurrentMethod().DeclaringType);
                 return false;
@@ -197,9 +193,7 @@ namespace Wox.Plugin
                     API = api,
                 });
             }
-#pragma warning disable CA1031 // Do not catch general exception types
             catch (Exception e)
-#pragma warning restore CA1031 // Do not catch general exception types
             {
                 Log.Exception($"Fail to Init plugin: {Metadata.Name}", e, GetType());
                 return false;

--- a/src/modules/previewpane/GcodePreviewHandler/GcodePreviewHandlerControl.cs
+++ b/src/modules/previewpane/GcodePreviewHandler/GcodePreviewHandlerControl.cs
@@ -75,9 +75,7 @@ namespace Microsoft.PowerToys.PreviewHandler.Gcode
                     base.DoPreview(dataSource);
                     PowerToysTelemetry.Log.WriteEvent(new GcodeFilePreviewed());
                 }
-#pragma warning disable CA1031 // Do not catch general exception types
                 catch (Exception ex)
-#pragma warning restore CA1031 // Do not catch general exception types
                 {
                     PreviewError(ex, dataSource);
                 }

--- a/src/modules/previewpane/PdfPreviewHandler/PdfPreviewHandlerControl.cs
+++ b/src/modules/previewpane/PdfPreviewHandler/PdfPreviewHandlerControl.cs
@@ -130,9 +130,7 @@ namespace Microsoft.PowerToys.PreviewHandler.Pdf
                             });
                         }
                     }
-#pragma warning disable CA1031 // Password protected files throws an generic Exception
                     catch (Exception ex)
-#pragma warning restore CA1031
                     {
                         if (ex.Message.Contains("Unable to update the password. The value provided as the current password is incorrect.", StringComparison.Ordinal))
                         {
@@ -156,9 +154,7 @@ namespace Microsoft.PowerToys.PreviewHandler.Pdf
 
                 PowerToysTelemetry.Log.WriteEvent(new PdfFilePreviewed());
             }
-#pragma warning disable CA1031 // Do not catch general exception types
             catch (Exception ex)
-#pragma warning restore CA1031 // Do not catch general exception types
             {
                 PowerToysTelemetry.Log.WriteEvent(new PdfFilePreviewError { Message = ex.Message });
 

--- a/src/modules/previewpane/SvgPreviewHandler/Utilities/SvgPreviewHandlerHelper.cs
+++ b/src/modules/previewpane/SvgPreviewHandler/Utilities/SvgPreviewHandlerHelper.cs
@@ -60,9 +60,7 @@ namespace Microsoft.PowerToys.PreviewHandler.Svg.Utilities
                     }
                 }
             }
-#pragma warning disable CA1031 // Do not catch general exception types
             catch (Exception)
-#pragma warning restore CA1031 // Do not catch general exception types
             {
             }
 

--- a/src/settings-ui/Settings.UI.Library/GeneralSettings.cs
+++ b/src/settings-ui/Settings.UI.Library/GeneralSettings.cs
@@ -50,7 +50,6 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         [JsonPropertyName("download_updates_automatically")]
         public bool AutoDownloadUpdates { get; set; }
 
-        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Any error from calling interop code should not prevent the program from loading.")]
         public GeneralSettings()
         {
             Startup = false;

--- a/src/settings-ui/Settings.UI.Library/SettingsUtils.cs
+++ b/src/settings-ui/Settings.UI.Library/SettingsUtils.cs
@@ -109,7 +109,6 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         }
 
         // Save settings to a json file.
-        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "General exceptions will be logged until we can better understand runtime exception scenarios")]
         public void SaveSettings(string jsonSettings, string powertoy = DefaultModuleName, string fileName = DefaultFileName)
         {
             try

--- a/src/settings-ui/Settings.UI.Library/UpdatingSettings.cs
+++ b/src/settings-ui/Settings.UI.Library/UpdatingSettings.cs
@@ -55,9 +55,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
                     string version = ReleasePageLink.Substring(ReleasePageLink.LastIndexOf('/') + 1);
                     return version.Trim();
                 }
-#pragma warning disable CA1031 // Do not catch general exception types
                 catch (Exception)
-#pragma warning restore CA1031 // Do not catch general exception types
                 {
                 }
 
@@ -75,9 +73,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
                     var date = DateTimeOffset.FromUnixTimeSeconds(seconds).UtcDateTime;
                     return date.ToLocalTime().ToString(CultureInfo.CurrentCulture);
                 }
-#pragma warning disable CA1031 // Do not catch general exception types
                 catch (Exception)
-#pragma warning restore CA1031 // Do not catch general exception types
                 {
                 }
 
@@ -108,9 +104,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
 
                     return JsonSerializer.Deserialize<UpdatingSettings>(data);
                 }
-#pragma warning disable CA1031 // Do not catch general exception types
                 catch (Exception)
-#pragma warning restore CA1031 // Do not catch general exception types
                 {
                 }
             }

--- a/src/settings-ui/Settings.UI.Library/ViewModels/GeneralViewModel.cs
+++ b/src/settings-ui/Settings.UI.Library/ViewModels/GeneralViewModel.cs
@@ -278,9 +278,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
                     {
                         UpdateUIThemeCallBack(GeneralSettingsConfig.Theme);
                     }
-#pragma warning disable CA1031 // Do not catch general exception types
                     catch (Exception e)
-#pragma warning restore CA1031 // Do not catch general exception types
                     {
                         Logger.LogError("Exception encountered when changing Settings theme", e);
                     }

--- a/src/settings-ui/Settings.UI.Library/ViewModels/ImageResizerViewModel.cs
+++ b/src/settings-ui/Settings.UI.Library/ViewModels/ImageResizerViewModel.cs
@@ -26,7 +26,6 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
 
         private Func<string, int> SendConfigMSG { get; }
 
-        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Exceptions should not crash the program but will be logged until we can understand common exception scenarios")]
         public ImageResizerViewModel(ISettingsUtils settingsUtils, ISettingsRepository<GeneralSettings> settingsRepository, Func<string, int> ipcMSGCallBackFunc, Func<string, string> resourceLoader)
         {
             _settingsUtils = settingsUtils ?? throw new ArgumentNullException(nameof(settingsUtils));

--- a/src/settings-ui/Settings.UI.Library/ViewModels/KeyboardManagerViewModel.cs
+++ b/src/settings-ui/Settings.UI.Library/ViewModels/KeyboardManagerViewModel.cs
@@ -47,7 +47,6 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
 
         private Func<List<KeysDataModel>, int> FilterRemapKeysList { get; }
 
-        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Exceptions should not crash the program but will be logged until we can understand common exception scenarios")]
         public KeyboardManagerViewModel(ISettingsUtils settingsUtils, ISettingsRepository<GeneralSettings> settingsRepository, Func<string, int> ipcMSGCallBackFunc, Func<List<KeysDataModel>, int> filterRemapKeysList)
         {
             if (settingsRepository == null)
@@ -200,7 +199,6 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             NativeMethods.SetForegroundWindow(handle);
         }
 
-        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Exceptions here (especially mutex errors) should not halt app execution, but they will be logged.")]
         private void OpenEditor(int type)
         {
             try
@@ -236,7 +234,6 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             OnPropertyChanged(nameof(RemapShortcuts));
         }
 
-        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Exceptions here (especially mutex errors) should not halt app execution, but they will be logged.")]
         public bool LoadProfile()
         {
             var success = true;

--- a/src/settings-ui/Settings.UI.Library/ViewModels/PowerRenameViewModel.cs
+++ b/src/settings-ui/Settings.UI.Library/ViewModels/PowerRenameViewModel.cs
@@ -26,7 +26,6 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
 
         private Func<string, int> SendConfigMSG { get; }
 
-        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Exceptions should not crash the program but will be logged until we can understand common exception scenarios")]
         public PowerRenameViewModel(ISettingsUtils settingsUtils, ISettingsRepository<GeneralSettings> settingsRepository, Func<string, int> ipcMSGCallBackFunc, string configFileSubfolder = "")
         {
             // Update Settings file folder:

--- a/src/settings-ui/Settings.UI.Library/ViewModels/VideoConferenceViewModel.cs
+++ b/src/settings-ui/Settings.UI.Library/ViewModels/VideoConferenceViewModel.cs
@@ -53,9 +53,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             {
                 Settings = _settingsUtils.GetSettings<VideoConferenceSettings>(GetSettingsSubPath());
             }
-#pragma warning disable CA1031 // Do not catch general exception types
             catch
-#pragma warning restore CA1031 // Do not catch general exception types
             {
                 Settings = new VideoConferenceSettings();
                 _settingsUtils.SaveSettings(Settings.ToJsonString(), GetSettingsSubPath());
@@ -177,9 +175,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                     RaisePropertyChanged(nameof(CameraImageOverlayPath));
                 }
             }
-#pragma warning disable CA1031 // Do not catch general exception types
             catch
-#pragma warning restore CA1031 // Do not catch general exception types
             {
             }
         }

--- a/src/settings-ui/Settings.UI/Views/GeneralPage.xaml.cs
+++ b/src/settings-ui/Settings.UI/Views/GeneralPage.xaml.cs
@@ -28,7 +28,6 @@ namespace Microsoft.PowerToys.Settings.UI.Views
         /// Initializes a new instance of the <see cref="GeneralPage"/> class.
         /// General Settings page constructor.
         /// </summary>
-        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Exceptions from the IPC response handler should be caught and logged.")]
         public GeneralPage()
         {
             InitializeComponent();

--- a/src/settings-ui/Settings.UI/Views/ImageResizerPage.xaml.cs
+++ b/src/settings-ui/Settings.UI/Views/ImageResizerPage.xaml.cs
@@ -65,7 +65,6 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             }
         }
 
-        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "JSON exceptions from saving new settings should be caught and logged.")]
         private void AddSizeButton_Click(object sender, RoutedEventArgs e)
         {
             try

--- a/src/settings-ui/Settings.UI/Views/MouseUtilsPage.xaml.cs
+++ b/src/settings-ui/Settings.UI/Views/MouseUtilsPage.xaml.cs
@@ -26,9 +26,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
                     tempSettingsUtils.DeleteSettings("Find My Mouse");
                 }
             }
-#pragma warning disable CA1031 // Do not catch general exception types
             catch (System.Exception)
-#pragma warning restore CA1031 // Do not catch general exception types
             {
             }
 


### PR DESCRIPTION
## Summary of the Pull Request

Cleaned up all the boring CA1031 suppressions.
CA1031 has been removed migrating FxCop to .NET Analyzers.

## Quality Checklist

- [x] **Linked issue:** #9560
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
