### PR TITLE
[PTRun]Add setting to disable input delay

### DIFF
--- a/src/modules/launcher/PowerLauncher/SettingsReader.cs
+++ b/src/modules/launcher/PowerLauncher/SettingsReader.cs
@@ -105,9 +105,14 @@ namespace PowerLauncher
                         _settings.UseCentralizedKeyboardHook = overloadSettings.Properties.UseCentralizedKeyboardHook;
                     }
 
-                    if (_settings.SearchQueryResultsWithoutDelay != overloadSettings.Properties.SearchQueryResultsWithoutDelay)
+                    if (_settings.SearchQueryResultsWithDelay != overloadSettings.Properties.SearchQueryResultsWithDelay)
                     {
-                        _settings.SearchQueryResultsWithoutDelay = overloadSettings.Properties.SearchQueryResultsWithoutDelay;
+                        _settings.SearchQueryResultsWithDelay = overloadSettings.Properties.SearchQueryResultsWithDelay;
+                    }
+
+                    if (_settings.SearchInputDelay != overloadSettings.Properties.SearchInputDelay)
+                    {
+                        _settings.SearchInputDelay = overloadSettings.Properties.SearchInputDelay;
                     }
 
                     if (_settings.MaxResultsToShow != overloadSettings.Properties.MaximumNumberOfResults)

--- a/src/modules/launcher/PowerLauncher/SettingsReader.cs
+++ b/src/modules/launcher/PowerLauncher/SettingsReader.cs
@@ -105,6 +105,11 @@ namespace PowerLauncher
                         _settings.UseCentralizedKeyboardHook = overloadSettings.Properties.UseCentralizedKeyboardHook;
                     }
 
+                    if (_settings.SearchQueryResultsWithoutDelay != overloadSettings.Properties.SearchQueryResultsWithoutDelay)
+                    {
+                        _settings.SearchQueryResultsWithoutDelay = overloadSettings.Properties.SearchQueryResultsWithoutDelay;
+                    }
+
                     if (_settings.MaxResultsToShow != overloadSettings.Properties.MaximumNumberOfResults)
                     {
                         _settings.MaxResultsToShow = overloadSettings.Properties.MaximumNumberOfResults;

--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -1110,9 +1110,14 @@ namespace PowerLauncher.ViewModel
             return recordedTime;
         }
 
-        public bool GetSearchQueryResultsWithoutDelaySetting()
+        public bool GetSearchQueryResultsWithDelaySetting()
         {
-            return _settings.SearchQueryResultsWithoutDelay;
+            return _settings.SearchQueryResultsWithDelay;
+        }
+
+        public int GetSearchInputDelaySetting()
+        {
+            return _settings.SearchInputDelay;
         }
     }
 }

--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -132,6 +132,11 @@ namespace PowerLauncher.ViewModel
             // SetCustomPluginHotkey();
         }
 
+        public void RegisterSettingsChangeListener(System.ComponentModel.PropertyChangedEventHandler handler)
+        {
+            _settings.PropertyChanged += handler;
+        }
+
         private void RegisterResultsUpdatedEvent()
         {
             foreach (var pair in PluginManager.GetPluginsForInterface<IResultUpdated>())
@@ -1103,6 +1108,11 @@ namespace PowerLauncher.ViewModel
             // Reset the stopwatch and return the time elapsed
             _hotkeyTimer.Reset();
             return recordedTime;
+        }
+
+        public bool GetSearchQueryResultsWithoutDelaySetting()
+        {
+            return _settings.SearchQueryResultsWithoutDelay;
         }
     }
 }

--- a/src/modules/launcher/Wox.Infrastructure/UserSettings/PowerToysRunSettings.cs
+++ b/src/modules/launcher/Wox.Infrastructure/UserSettings/PowerToysRunSettings.cs
@@ -61,6 +61,25 @@ namespace Wox.Infrastructure.UserSettings
             }
         }
 
+        private bool _searchQueryResultsWithoutDelay;
+
+        public bool SearchQueryResultsWithoutDelay
+        {
+            get
+            {
+                return _searchQueryResultsWithoutDelay;
+            }
+
+            set
+            {
+                if (_searchQueryResultsWithoutDelay != value)
+                {
+                    _searchQueryResultsWithoutDelay = value;
+                    OnPropertyChanged(nameof(SearchQueryResultsWithoutDelay));
+                }
+            }
+        }
+
         public string Language { get; set; } = "en";
 
         public Theme Theme { get; set; } = Theme.System;

--- a/src/modules/launcher/Wox.Infrastructure/UserSettings/PowerToysRunSettings.cs
+++ b/src/modules/launcher/Wox.Infrastructure/UserSettings/PowerToysRunSettings.cs
@@ -61,21 +61,40 @@ namespace Wox.Infrastructure.UserSettings
             }
         }
 
-        private bool _searchQueryResultsWithoutDelay;
+        private bool _searchQueryResultsWithDelay = true;
 
-        public bool SearchQueryResultsWithoutDelay
+        public bool SearchQueryResultsWithDelay
         {
             get
             {
-                return _searchQueryResultsWithoutDelay;
+                return _searchQueryResultsWithDelay;
             }
 
             set
             {
-                if (_searchQueryResultsWithoutDelay != value)
+                if (_searchQueryResultsWithDelay != value)
                 {
-                    _searchQueryResultsWithoutDelay = value;
-                    OnPropertyChanged(nameof(SearchQueryResultsWithoutDelay));
+                    _searchQueryResultsWithDelay = value;
+                    OnPropertyChanged(nameof(SearchQueryResultsWithDelay));
+                }
+            }
+        }
+
+        private int _searchInputDelay = 150;
+
+        public int SearchInputDelay
+        {
+            get
+            {
+                return _searchInputDelay;
+            }
+
+            set
+            {
+                if (_searchInputDelay != value)
+                {
+                    _searchInputDelay = value;
+                    OnPropertyChanged(nameof(SearchInputDelay));
                 }
             }
         }

--- a/src/settings-ui/Settings.UI.Library/PowerLauncherProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/PowerLauncherProperties.cs
@@ -51,6 +51,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         [JsonPropertyName("use_centralized_keyboard_hook")]
         public bool UseCentralizedKeyboardHook { get; set; }
 
+        [JsonPropertyName("search_query_results_without_delay")]
+        public bool SearchQueryResultsWithoutDelay { get; set; }
+
         public PowerLauncherProperties()
         {
             OpenPowerLauncher = new HotkeySettings(false, false, true, false, 32);
@@ -65,6 +68,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             Theme = Theme.System;
             Position = StartupPosition.Cursor;
             UseCentralizedKeyboardHook = false;
+            SearchQueryResultsWithoutDelay = false;
         }
     }
 }

--- a/src/settings-ui/Settings.UI.Library/PowerLauncherProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/PowerLauncherProperties.cs
@@ -51,8 +51,11 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         [JsonPropertyName("use_centralized_keyboard_hook")]
         public bool UseCentralizedKeyboardHook { get; set; }
 
-        [JsonPropertyName("search_query_results_without_delay")]
-        public bool SearchQueryResultsWithoutDelay { get; set; }
+        [JsonPropertyName("search_query_results_with_delay")]
+        public bool SearchQueryResultsWithDelay { get; set; }
+
+        [JsonPropertyName("search_input_delay")]
+        public int SearchInputDelay { get; set; }
 
         public PowerLauncherProperties()
         {
@@ -68,7 +71,8 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             Theme = Theme.System;
             Position = StartupPosition.Cursor;
             UseCentralizedKeyboardHook = false;
-            SearchQueryResultsWithoutDelay = false;
+            SearchQueryResultsWithDelay = true;
+            SearchInputDelay = 150;
         }
     }
 }

--- a/src/settings-ui/Settings.UI.Library/ViewModels/PowerLauncherViewModel.cs
+++ b/src/settings-ui/Settings.UI.Library/ViewModels/PowerLauncherViewModel.cs
@@ -296,18 +296,35 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             }
         }
 
-        public bool SearchQueryResultsWithoutDelay
+        public bool SearchQueryResultsWithDelay
         {
             get
             {
-                return settings.Properties.SearchQueryResultsWithoutDelay;
+                return settings.Properties.SearchQueryResultsWithDelay;
             }
 
             set
             {
-                if (settings.Properties.SearchQueryResultsWithoutDelay != value)
+                if (settings.Properties.SearchQueryResultsWithDelay != value)
                 {
-                    settings.Properties.SearchQueryResultsWithoutDelay = value;
+                    settings.Properties.SearchQueryResultsWithDelay = value;
+                    UpdateSettings();
+                }
+            }
+        }
+
+        public int SearchInputDelay
+        {
+            get
+            {
+                return settings.Properties.SearchInputDelay;
+            }
+
+            set
+            {
+                if (settings.Properties.SearchInputDelay != value)
+                {
+                    settings.Properties.SearchInputDelay = value;
                     UpdateSettings();
                 }
             }

--- a/src/settings-ui/Settings.UI.Library/ViewModels/PowerLauncherViewModel.cs
+++ b/src/settings-ui/Settings.UI.Library/ViewModels/PowerLauncherViewModel.cs
@@ -296,6 +296,23 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             }
         }
 
+        public bool SearchQueryResultsWithoutDelay
+        {
+            get
+            {
+                return settings.Properties.SearchQueryResultsWithoutDelay;
+            }
+
+            set
+            {
+                if (settings.Properties.SearchQueryResultsWithoutDelay != value)
+                {
+                    settings.Properties.SearchQueryResultsWithoutDelay = value;
+                    UpdateSettings();
+                }
+            }
+        }
+
         public HotkeySettings OpenFileLocation
         {
             get

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -414,6 +414,9 @@
   <data name="PowerLauncher_ClearInputOnLaunch.Content" xml:space="preserve">
     <value>Clear the previous query on launch</value>
   </data>
+  <data name="PowerLauncher_SearchQueryResultsWithoutDelay.Content" xml:space="preserve">
+    <value>Search query results without introducing a delay to wait for more input</value>
+  </data>
   <data name="KeyboardManager_KeysMappingLayoutRightHeader.Text" xml:space="preserve">
     <value>To:</value>
     <comment>Keyboard Manager mapping keys view right header</comment>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -414,8 +414,16 @@
   <data name="PowerLauncher_ClearInputOnLaunch.Content" xml:space="preserve">
     <value>Clear the previous query on launch</value>
   </data>
-  <data name="PowerLauncher_SearchQueryResultsWithoutDelay.Content" xml:space="preserve">
-    <value>Search query results without introducing a delay to wait for more input</value>
+  <data name="PowerLauncher_SearchQueryResultsWithDelay.Header" xml:space="preserve">
+    <value>Delay search</value>
+    <comment>This is about adding a delay to wait for more input before executing a search</comment>
+  </data>
+  <data name="PowerLauncher_SearchQueryResultsWithDelay.Description" xml:space="preserve">
+    <value>Add a delay to wait for more input before executing a search</value>
+  </data>
+  <data name="PowerLauncher_SearchInputDelayMs.Header" xml:space="preserve">
+    <value>Search delay (ms)</value>
+    <comment>ms = milliseconds</comment>
   </data>
   <data name="KeyboardManager_KeysMappingLayoutRightHeader.Text" xml:space="preserve">
     <value>To:</value>

--- a/src/settings-ui/Settings.UI/Views/PowerLauncherPage.xaml
+++ b/src/settings-ui/Settings.UI/Views/PowerLauncherPage.xaml
@@ -106,7 +106,10 @@
                             </controls:Setting>
                         </controls:SettingExpander.Header>
                         <controls:SettingExpander.Content>
-                            <CheckBox x:Uid="PowerLauncher_ClearInputOnLaunch" IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.ClearInputOnLaunch}" Margin="{StaticResource ExpanderSettingMargin}" />
+                            <StackPanel>
+                                <CheckBox x:Uid="PowerLauncher_ClearInputOnLaunch" IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.ClearInputOnLaunch}" Margin="{StaticResource ExpanderSettingMargin}" />
+                                <CheckBox x:Uid="PowerLauncher_SearchQueryResultsWithoutDelay" IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.SearchQueryResultsWithoutDelay}" Margin="{StaticResource ExpanderSettingMargin}" />
+                            </StackPanel>
                         </controls:SettingExpander.Content>
                     </controls:SettingExpander>
                 </controls:SettingsGroup>

--- a/src/settings-ui/Settings.UI/Views/PowerLauncherPage.xaml
+++ b/src/settings-ui/Settings.UI/Views/PowerLauncherPage.xaml
@@ -106,10 +106,29 @@
                             </controls:Setting>
                         </controls:SettingExpander.Header>
                         <controls:SettingExpander.Content>
-                            <StackPanel>
-                                <CheckBox x:Uid="PowerLauncher_ClearInputOnLaunch" IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.ClearInputOnLaunch}" Margin="{StaticResource ExpanderSettingMargin}" />
-                                <CheckBox x:Uid="PowerLauncher_SearchQueryResultsWithoutDelay" IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.SearchQueryResultsWithoutDelay}" Margin="{StaticResource ExpanderSettingMargin}" />
-                            </StackPanel>
+                            <CheckBox x:Uid="PowerLauncher_ClearInputOnLaunch" IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.ClearInputOnLaunch}" Margin="{StaticResource ExpanderSettingMargin}" />
+                        </controls:SettingExpander.Content>
+                    </controls:SettingExpander>
+                    <controls:SettingExpander IsExpanded="True">
+                        <controls:SettingExpander.Header>
+                            <controls:Setting x:Uid="PowerLauncher_SearchQueryResultsWithDelay" Icon="&#xF182;" Style="{StaticResource ExpanderHeaderSettingStyle}" >
+                                <controls:Setting.ActionContent>
+                                    <ToggleSwitch IsOn="{x:Bind Mode=TwoWay, Path=ViewModel.SearchQueryResultsWithDelay}"/>
+                                </controls:Setting.ActionContent>
+                            </controls:Setting>
+                        </controls:SettingExpander.Header>
+                        <controls:SettingExpander.Content>
+                            <controls:Setting x:Uid="PowerLauncher_SearchInputDelayMs" IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.SearchQueryResultsWithDelay}" Style="{StaticResource ExpanderContentSettingStyle}">
+                                <controls:Setting.ActionContent>
+                                    <muxc:NumberBox Minimum="0"
+                                        Value="{x:Bind Mode=TwoWay, Path=ViewModel.SearchInputDelay}"
+                                        MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                        SpinButtonPlacementMode="Compact"
+                                        HorizontalAlignment="Left"
+                                        SmallChange="10"
+                                        LargeChange="50"/>
+                                </controls:Setting.ActionContent>
+                            </controls:Setting>
                         </controls:SettingExpander.Content>
                     </controls:SettingExpander>
                 </controls:SettingsGroup>

--- a/src/settings-ui/Settings.UI/Views/PowerLauncherPage.xaml
+++ b/src/settings-ui/Settings.UI/Views/PowerLauncherPage.xaml
@@ -96,6 +96,29 @@
                 <controls:SettingsGroup x:Uid="PowerLauncher_SearchResults" IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.EnablePowerLauncher}">
                     <controls:SettingExpander IsExpanded="True">
                         <controls:SettingExpander.Header>
+                            <controls:Setting x:Uid="PowerLauncher_SearchQueryResultsWithDelay" Icon="&#xF182;" Style="{StaticResource ExpanderHeaderSettingStyle}" >
+                                <controls:Setting.ActionContent>
+                                    <ToggleSwitch IsOn="{x:Bind Mode=TwoWay, Path=ViewModel.SearchQueryResultsWithDelay}"/>
+                                </controls:Setting.ActionContent>
+                            </controls:Setting>
+                        </controls:SettingExpander.Header>
+                        <controls:SettingExpander.Content>
+                            <controls:Setting x:Uid="PowerLauncher_SearchInputDelayMs" IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.SearchQueryResultsWithDelay}" Style="{StaticResource ExpanderContentSettingStyle}">
+                                <controls:Setting.ActionContent>
+                                    <muxc:NumberBox Minimum="0"
+                                        Maximum="1000"
+                                        Value="{x:Bind Mode=TwoWay, Path=ViewModel.SearchInputDelay}"
+                                        MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                        SpinButtonPlacementMode="Compact"
+                                        HorizontalAlignment="Left"
+                                        SmallChange="10"
+                                        LargeChange="50"/>
+                                </controls:Setting.ActionContent>
+                            </controls:Setting>
+                        </controls:SettingExpander.Content>
+                    </controls:SettingExpander>
+                    <controls:SettingExpander IsExpanded="True">
+                        <controls:SettingExpander.Header>
                             <controls:Setting x:Uid="PowerLauncher_MaximumNumberOfResults" Icon="&#xE721;" Style="{StaticResource ExpanderHeaderSettingStyle}">
                                 <controls:Setting.ActionContent>
                                     <muxc:NumberBox Value="{Binding Mode=TwoWay, Path=MaximumNumberOfResults}"
@@ -107,28 +130,6 @@
                         </controls:SettingExpander.Header>
                         <controls:SettingExpander.Content>
                             <CheckBox x:Uid="PowerLauncher_ClearInputOnLaunch" IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.ClearInputOnLaunch}" Margin="{StaticResource ExpanderSettingMargin}" />
-                        </controls:SettingExpander.Content>
-                    </controls:SettingExpander>
-                    <controls:SettingExpander IsExpanded="True">
-                        <controls:SettingExpander.Header>
-                            <controls:Setting x:Uid="PowerLauncher_SearchQueryResultsWithDelay" Icon="&#xF182;" Style="{StaticResource ExpanderHeaderSettingStyle}" >
-                                <controls:Setting.ActionContent>
-                                    <ToggleSwitch IsOn="{x:Bind Mode=TwoWay, Path=ViewModel.SearchQueryResultsWithDelay}"/>
-                                </controls:Setting.ActionContent>
-                            </controls:Setting>
-                        </controls:SettingExpander.Header>
-                        <controls:SettingExpander.Content>
-                            <controls:Setting x:Uid="PowerLauncher_SearchInputDelayMs" IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.SearchQueryResultsWithDelay}" Style="{StaticResource ExpanderContentSettingStyle}">
-                                <controls:Setting.ActionContent>
-                                    <muxc:NumberBox Minimum="0"
-                                        Value="{x:Bind Mode=TwoWay, Path=ViewModel.SearchInputDelay}"
-                                        MinWidth="{StaticResource SettingActionControlMinWidth}"
-                                        SpinButtonPlacementMode="Compact"
-                                        HorizontalAlignment="Left"
-                                        SmallChange="10"
-                                        LargeChange="50"/>
-                                </controls:Setting.ActionContent>
-                            </controls:Setting>
                         </controls:SettingExpander.Content>
                     </controls:SettingExpander>
                 </controls:SettingsGroup>


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Some users preferred the behavior of PowerToys Run before https://github.com/microsoft/PowerToys/pull/18290 was introduced.
Make it an option to remove the delay on input.

**What is included in the PR:** 
- Code to switch between using .Net Reactive or old textchanged delegate.
- Add option to the settings screen.

![image](https://user-images.githubusercontent.com/26118718/173232216-3802bb9e-f38a-4747-8612-f609205d4c0e.png)

**How does someone test / validate:** 
Switch between the option and verify the behavior is different and intended (small search delay vs no delay).


## Quality Checklist

- [x] **Linked issue:** #18696
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries
