### PR TITLE
[FancyZones] Update windows positions after changing the layout fix

### DIFF
--- a/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
@@ -157,14 +157,14 @@ private:
     bool OnSnapHotkeyBasedOnZoneNumber(HWND window, DWORD vkCode) noexcept;
     bool OnSnapHotkeyBasedOnPosition(HWND window, DWORD vkCode) noexcept;
     bool OnSnapHotkey(DWORD vkCode) noexcept;
-    bool ProcessDirectedSnapHotkey(HWND window, DWORD vkCode, bool cycle, winrt::com_ptr<IWorkArea> workArea) noexcept;
+    bool ProcessDirectedSnapHotkey(HWND window, DWORD vkCode, bool cycle, std::shared_ptr<WorkArea> workArea) noexcept;
 
     void RegisterVirtualDesktopUpdates() noexcept;
 
     void UpdateHotkey(int hotkeyId, const PowerToysSettings::HotkeyObject& hotkeyObject, bool enable) noexcept;
     
-    std::pair<winrt::com_ptr<IWorkArea>, ZoneIndexSet> GetAppZoneHistoryInfo(HWND window, HMONITOR monitor, const std::unordered_map<HMONITOR, winrt::com_ptr<IWorkArea>>& workAreaMap) noexcept;
-    void MoveWindowIntoZone(HWND window, winrt::com_ptr<IWorkArea> workArea, const ZoneIndexSet& zoneIndexSet) noexcept;
+    std::pair<std::shared_ptr<WorkArea>, ZoneIndexSet> GetAppZoneHistoryInfo(HWND window, HMONITOR monitor, const std::unordered_map<HMONITOR, std::shared_ptr<WorkArea>>& workAreaMap) noexcept;
+    void MoveWindowIntoZone(HWND window, std::shared_ptr<WorkArea> workArea, const ZoneIndexSet& zoneIndexSet) noexcept;
     bool MoveToAppLastZone(HWND window, HMONITOR active, HMONITOR primary) noexcept;
 
     void OnEditorExitEvent() noexcept;
@@ -289,14 +289,14 @@ FancyZones::VirtualDesktopChanged() noexcept
     PostMessage(m_window, WM_PRIV_VD_SWITCH, 0, 0);
 }
 
-std::pair<winrt::com_ptr<IWorkArea>, ZoneIndexSet> FancyZones::GetAppZoneHistoryInfo(HWND window, HMONITOR monitor, const std::unordered_map<HMONITOR, winrt::com_ptr<IWorkArea>>& workAreaMap) noexcept
+std::pair<std::shared_ptr<WorkArea>, ZoneIndexSet> FancyZones::GetAppZoneHistoryInfo(HWND window, HMONITOR monitor, const std::unordered_map<HMONITOR, std::shared_ptr<WorkArea>>& workAreaMap) noexcept
 {
     if (monitor)
     {
         if (workAreaMap.contains(monitor))
         {
             auto workArea = workAreaMap.at(monitor);
-            return std::pair<winrt::com_ptr<IWorkArea>, ZoneIndexSet>{ workArea, workArea->GetWindowZoneIndexes(window) };
+            return std::pair<std::shared_ptr<WorkArea>, ZoneIndexSet>{ workArea, workArea->GetWindowZoneIndexes(window) };
         }
         else
         {
@@ -310,15 +310,15 @@ std::pair<winrt::com_ptr<IWorkArea>, ZoneIndexSet> FancyZones::GetAppZoneHistory
             auto zoneIndexSet = workArea->GetWindowZoneIndexes(window);
             if (!zoneIndexSet.empty())
             {
-                return std::pair<winrt::com_ptr<IWorkArea>, ZoneIndexSet>{ workArea, zoneIndexSet };
+                return std::pair<std::shared_ptr<WorkArea>, ZoneIndexSet>{ workArea, zoneIndexSet };
             }
         }
     }
     
-    return std::pair<winrt::com_ptr<IWorkArea>, ZoneIndexSet>{ nullptr, {} };
+    return std::pair<std::shared_ptr<WorkArea>, ZoneIndexSet>{ nullptr, {} };
 }
 
-void FancyZones::MoveWindowIntoZone(HWND window, winrt::com_ptr<IWorkArea> workArea, const ZoneIndexSet& zoneIndexSet) noexcept
+void FancyZones::MoveWindowIntoZone(HWND window, std::shared_ptr<WorkArea> workArea, const ZoneIndexSet& zoneIndexSet) noexcept
 {
     if (workArea)
     {
@@ -338,7 +338,7 @@ bool FancyZones::MoveToAppLastZone(HWND window, HMONITOR active, HMONITOR primar
     }
 
     // Search application history on currently active monitor.
-    std::pair<winrt::com_ptr<IWorkArea>, ZoneIndexSet> appZoneHistoryInfo = GetAppZoneHistoryInfo(window, active, workAreaMap);
+    std::pair<std::shared_ptr<WorkArea>, ZoneIndexSet> appZoneHistoryInfo = GetAppZoneHistoryInfo(window, active, workAreaMap);
 
     // No application history on currently active monitor
     if (appZoneHistoryInfo.second.empty())
@@ -994,7 +994,7 @@ bool FancyZones::OnSnapHotkeyBasedOnPosition(HWND window, DWORD vkCode) noexcept
 
         // If that didn't work, extract zones from all other monitors and target one of them
         std::vector<RECT> zoneRects;
-        std::vector<std::pair<ZoneIndex, winrt::com_ptr<IWorkArea>>> zoneRectsInfo;
+        std::vector<std::pair<ZoneIndex, std::shared_ptr<WorkArea>>> zoneRectsInfo;
         RECT currentMonitorRect{ .top = 0, .bottom = -1 };
 
         for (const auto& [monitor, monitorRect] : allMonitors)
@@ -1119,7 +1119,7 @@ bool FancyZones::OnSnapHotkey(DWORD vkCode) noexcept
     return false;
 }
 
-bool FancyZones::ProcessDirectedSnapHotkey(HWND window, DWORD vkCode, bool cycle, winrt::com_ptr<IWorkArea> workArea) noexcept
+bool FancyZones::ProcessDirectedSnapHotkey(HWND window, DWORD vkCode, bool cycle, std::shared_ptr<WorkArea> workArea) noexcept
 {
     // Check whether Alt is used in the shortcut key combination
     if (GetAsyncKeyState(VK_MENU) & 0x8000)

--- a/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
@@ -885,13 +885,17 @@ void FancyZones::UpdateWorkAreas() noexcept
 
 void FancyZones::UpdateWindowsPositions(bool suppressMove) noexcept
 {
-    for (const auto [window, desktopId] : VirtualDesktop::instance().GetWindowsRelatedToDesktops())
+    auto activeWorkAreas = m_workAreaHandler.GetWorkAreasByDesktopId(VirtualDesktop::instance().GetCurrentVirtualDesktopId());
+    
+    for (const auto& window : VirtualDesktop::instance().GetWindowsFromCurrentDesktop())
     {
         auto zoneIndexSet = FancyZonesWindowProperties::RetrieveZoneIndexProperty(window);
-        auto workArea = m_workAreaHandler.GetWorkArea(window, desktopId);
-        if (workArea)
+        if (zoneIndexSet.size() > 0)
         {
-            m_windowMoveHandler.MoveWindowIntoZoneByIndexSet(window, zoneIndexSet, workArea, suppressMove);
+            for (const auto& [monitor, workArea] : activeWorkAreas)
+            {
+                m_windowMoveHandler.MoveWindowIntoZoneByIndexSet(window, zoneIndexSet, workArea, suppressMove);
+            }
         }
     }
 }

--- a/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
@@ -791,10 +791,7 @@ void FancyZones::OnDisplayChange(DisplayChangeType changeType) noexcept
         if (FancyZonesSettings::settings().displayChange_moveWindows)
         {
             auto activeWorkAreas = m_workAreaHandler.GetWorkAreasByDesktopId(VirtualDesktop::instance().GetCurrentVirtualDesktopId());
-            for (const auto& [monitor, workArea] : activeWorkAreas)
-            {
-                workArea->UpdateWindowsPositions();
-            }
+            m_windowMoveHandler.UpdateWindowsPositions(activeWorkAreas);
         }
     }
 }
@@ -1216,10 +1213,7 @@ void FancyZones::UpdateZoneSets() noexcept
     if (FancyZonesSettings::settings().zoneSetChange_moveWindows)
     {
         auto activeWorkAreas = m_workAreaHandler.GetWorkAreasByDesktopId(VirtualDesktop::instance().GetCurrentVirtualDesktopId());
-        for (const auto& [monitor, workArea] : activeWorkAreas)
-        {
-            workArea->UpdateWindowsPositions();
-        }
+        m_windowMoveHandler.UpdateWindowsPositions(activeWorkAreas);
     }
 }
 

--- a/src/modules/fancyzones/FancyZonesLib/FancyZones.h
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZones.h
@@ -4,10 +4,6 @@
 
 #include <functional>
 
-interface IWorkArea;
-interface IFancyZonesSettings;
-interface IZoneSet;
-
 struct WinHookEvent;
 
 interface __declspec(uuid("{50D3F0F5-736E-4186-BDF4-3D6BEE150C3A}")) IFancyZones : public IUnknown

--- a/src/modules/fancyzones/FancyZonesLib/MonitorWorkAreaHandler.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/MonitorWorkAreaHandler.cpp
@@ -6,10 +6,10 @@
 
 #include <common/logger/logger.h>
 
-winrt::com_ptr<IWorkArea> MonitorWorkAreaHandler::GetWorkArea(const GUID& desktopId, HMONITOR monitor)
+std::shared_ptr<WorkArea> MonitorWorkAreaHandler::GetWorkArea(const GUID& desktopId, HMONITOR monitor)
 {
     auto desktopIt = workAreaMap.find(desktopId);
-    if (desktopIt != std::end(workAreaMap))
+    if (desktopIt != workAreaMap.end())
     {
         auto& perDesktopData = desktopIt->second;
         auto monitorIt = perDesktopData.find(monitor);
@@ -21,7 +21,7 @@ winrt::com_ptr<IWorkArea> MonitorWorkAreaHandler::GetWorkArea(const GUID& deskto
     return nullptr;
 }
 
-winrt::com_ptr<IWorkArea> MonitorWorkAreaHandler::GetWorkAreaFromCursor(const GUID& desktopId)
+std::shared_ptr<WorkArea> MonitorWorkAreaHandler::GetWorkAreaFromCursor(const GUID& desktopId)
 {
     auto allMonitorsWorkArea = GetWorkArea(desktopId, NULL);
     if (allMonitorsWorkArea)
@@ -42,7 +42,7 @@ winrt::com_ptr<IWorkArea> MonitorWorkAreaHandler::GetWorkAreaFromCursor(const GU
     }
 }
 
-winrt::com_ptr<IWorkArea> MonitorWorkAreaHandler::GetWorkArea(HWND window, const GUID& desktopId)
+std::shared_ptr<WorkArea> MonitorWorkAreaHandler::GetWorkArea(HWND window, const GUID& desktopId)
 {
     auto allMonitorsWorkArea = GetWorkArea(desktopId, NULL);
     if (allMonitorsWorkArea)
@@ -58,19 +58,20 @@ winrt::com_ptr<IWorkArea> MonitorWorkAreaHandler::GetWorkArea(HWND window, const
     }
 }
 
-const std::unordered_map<HMONITOR, winrt::com_ptr<IWorkArea>>& MonitorWorkAreaHandler::GetWorkAreasByDesktopId(const GUID& desktopId)
+const std::unordered_map<HMONITOR, std::shared_ptr<WorkArea>>& MonitorWorkAreaHandler::GetWorkAreasByDesktopId(const GUID& desktopId)
 {
     if (workAreaMap.contains(desktopId))
     {
         return workAreaMap[desktopId];
     }
-    static const std::unordered_map<HMONITOR, winrt::com_ptr<IWorkArea>> empty;
+
+    static const std::unordered_map<HMONITOR, std::shared_ptr<WorkArea>> empty{};
     return empty;
 }
 
-std::vector<winrt::com_ptr<IWorkArea>> MonitorWorkAreaHandler::GetAllWorkAreas()
+std::vector<std::shared_ptr<WorkArea>> MonitorWorkAreaHandler::GetAllWorkAreas()
 {
-    std::vector<winrt::com_ptr<IWorkArea>> workAreas{};
+    std::vector<std::shared_ptr<WorkArea>> workAreas{};
     for (const auto& [desktopId, perDesktopData] : workAreaMap)
     {
         std::transform(std::begin(perDesktopData),
@@ -81,7 +82,7 @@ std::vector<winrt::com_ptr<IWorkArea>> MonitorWorkAreaHandler::GetAllWorkAreas()
     return workAreas;
 }
 
-void MonitorWorkAreaHandler::AddWorkArea(const GUID& desktopId, HMONITOR monitor, winrt::com_ptr<IWorkArea>& workArea)
+void MonitorWorkAreaHandler::AddWorkArea(const GUID& desktopId, HMONITOR monitor, std::shared_ptr<WorkArea>& workArea)
 {
     if (!workAreaMap.contains(desktopId))
     {

--- a/src/modules/fancyzones/FancyZonesLib/MonitorWorkAreaHandler.h
+++ b/src/modules/fancyzones/FancyZonesLib/MonitorWorkAreaHandler.h
@@ -2,7 +2,7 @@
 
 #include "GuidUtils.h"
 
-interface IWorkArea;
+class WorkArea;
 struct ZoneColors;
 enum struct OverlappingZonesAlgorithm;
 
@@ -18,7 +18,7 @@ public:
      * @returns    Object representing single work area, interface to all actions available on work area
      *             (e.g. moving windows through zone layout specified for that work area).
      */
-    winrt::com_ptr<IWorkArea> GetWorkArea(const GUID& desktopId, HMONITOR monitor);
+    std::shared_ptr<WorkArea> GetWorkArea(const GUID& desktopId, HMONITOR monitor);
 
     /**
      * Get work area based on virtual desktop id and the current cursor position.
@@ -28,7 +28,7 @@ public:
      * @returns    Object representing single work area, interface to all actions available on work area
      *             (e.g. moving windows through zone layout specified for that work area).
      */
-    winrt::com_ptr<IWorkArea> GetWorkAreaFromCursor(const GUID& desktopId);
+    std::shared_ptr<WorkArea> GetWorkAreaFromCursor(const GUID& desktopId);
 
     /**
      * Get work area on which specified window is located.
@@ -39,7 +39,7 @@ public:
      * @returns    Object representing single work area, interface to all actions available on work area
      *             (e.g. moving windows through zone layout specified for that work area).
      */
-    winrt::com_ptr<IWorkArea> GetWorkArea(HWND window, const GUID& desktopId);
+    std::shared_ptr<WorkArea> GetWorkArea(HWND window, const GUID& desktopId);
 
     /**
      * Get map of all work areas on single virtual desktop. Key in the map is monitor handle, while value
@@ -49,12 +49,12 @@ public:
      *
      * @returns    Map containing pairs of monitor and work area for that monitor (within same virtual desktop).
      */
-    const std::unordered_map<HMONITOR, winrt::com_ptr<IWorkArea>>& GetWorkAreasByDesktopId(const GUID& desktopId);
+    const std::unordered_map<HMONITOR, std::shared_ptr<WorkArea>>& GetWorkAreasByDesktopId(const GUID& desktopId);
 
     /**
      * @returns    All registered work areas.
      */
-    std::vector<winrt::com_ptr<IWorkArea>> GetAllWorkAreas();
+    std::vector<std::shared_ptr<WorkArea>> GetAllWorkAreas();
 
     /**
      * Register new work area.
@@ -63,7 +63,7 @@ public:
      * @param[in]  monitor   Monitor handle.
      * @param[in]  workAra   Object representing single work area.
      */
-    void AddWorkArea(const GUID& desktopId, HMONITOR monitor, winrt::com_ptr<IWorkArea>& workArea);
+    void AddWorkArea(const GUID& desktopId, HMONITOR monitor, std::shared_ptr<WorkArea>& workArea);
 
     /**
      * Check if work area is already registered.
@@ -89,5 +89,5 @@ public:
     
 private:
     // Work area is uniquely defined by monitor and virtual desktop id.
-    std::unordered_map<GUID, std::unordered_map<HMONITOR, winrt::com_ptr<IWorkArea>>> workAreaMap;
+    std::unordered_map<GUID, std::unordered_map<HMONITOR, std::shared_ptr<WorkArea>>> workAreaMap;
 };

--- a/src/modules/fancyzones/FancyZonesLib/VirtualDesktop.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/VirtualDesktop.cpp
@@ -240,6 +240,31 @@ std::vector<std::pair<HWND, GUID>> VirtualDesktop::GetWindowsRelatedToDesktops()
     return result;
 }
 
+std::vector<HWND> VirtualDesktop::GetWindowsFromCurrentDesktop() const
+{
+    using result_t = std::vector<HWND>;
+    result_t windows;
+
+    auto callback = [](HWND window, LPARAM data) -> BOOL {
+        result_t& result = *reinterpret_cast<result_t*>(data);
+        result.push_back(window);
+        return TRUE;
+    };
+    EnumWindows(callback, reinterpret_cast<LPARAM>(&windows));
+
+    std::vector<HWND> result;
+    for (auto window : windows)
+    {
+        BOOL isOnCurrentVD{};
+        if (m_vdManager->IsWindowOnCurrentVirtualDesktop(window, &isOnCurrentVD) == S_OK && isOnCurrentVD)
+        {
+            result.push_back(window);
+        }
+    }
+
+    return result;
+}
+
 GUID VirtualDesktop::GetCurrentVirtualDesktopId() const noexcept
 {
     return m_currentVirtualDesktopId;

--- a/src/modules/fancyzones/FancyZonesLib/VirtualDesktop.h
+++ b/src/modules/fancyzones/FancyZonesLib/VirtualDesktop.h
@@ -15,6 +15,7 @@ public:
     std::optional<GUID> GetDesktopId(HWND window) const;
     std::optional<GUID> GetDesktopIdByTopLevelWindows() const;
     std::vector<std::pair<HWND, GUID>> GetWindowsRelatedToDesktops() const;
+    std::vector<HWND> GetWindowsFromCurrentDesktop() const;
 
     // registry
     std::optional<GUID> GetCurrentVirtualDesktopIdFromRegistry() const;

--- a/src/modules/fancyzones/FancyZonesLib/WindowMoveHandler.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WindowMoveHandler.cpp
@@ -59,7 +59,7 @@ WindowMoveHandler::WindowMoveHandler(const std::function<void()>& keyUpdateCallb
 {
 }
 
-void WindowMoveHandler::MoveSizeStart(HWND window, HMONITOR monitor, POINT const& ptScreen, const std::unordered_map<HMONITOR, winrt::com_ptr<IWorkArea>>& workAreaMap) noexcept
+void WindowMoveHandler::MoveSizeStart(HWND window, HMONITOR monitor, POINT const& ptScreen, const std::unordered_map<HMONITOR, std::shared_ptr<WorkArea>>& workAreaMap) noexcept
 {
     if (!FancyZonesWindowProcessing::IsProcessable(window))
     {
@@ -104,7 +104,7 @@ void WindowMoveHandler::MoveSizeStart(HWND window, HMONITOR monitor, POINT const
         m_draggedWindowWorkArea->MoveSizeEnter(m_draggedWindow);
         if (FancyZonesSettings::settings().showZonesOnAllMonitors)
         {
-            for (auto [keyMonitor, workArea] : workAreaMap)
+            for (const auto& [keyMonitor, workArea] : workAreaMap)
             {
                 // Skip calling ShowZonesOverlay for iter->second (m_draggedWindowWorkArea) since it
                 // was already called in MoveSizeEnter
@@ -120,7 +120,7 @@ void WindowMoveHandler::MoveSizeStart(HWND window, HMONITOR monitor, POINT const
     {
         ResetWindowTransparency();
         m_draggedWindowWorkArea = nullptr;
-        for (auto [keyMonitor, workArea] : workAreaMap)
+        for (const auto& [keyMonitor, workArea] : workAreaMap)
         {
             if (workArea)
             {
@@ -132,8 +132,7 @@ void WindowMoveHandler::MoveSizeStart(HWND window, HMONITOR monitor, POINT const
     auto workArea = workAreaMap.find(monitor);
     if (workArea != workAreaMap.end())
     {
-        const auto workAreaPtr = workArea->second;
-        const auto zoneSet = workAreaPtr->ZoneSet();
+        const auto zoneSet = workArea->second->ZoneSet();
         if (zoneSet)
         {
             zoneSet->DismissWindow(window);
@@ -141,7 +140,7 @@ void WindowMoveHandler::MoveSizeStart(HWND window, HMONITOR monitor, POINT const
     }
 }
 
-void WindowMoveHandler::MoveSizeUpdate(HMONITOR monitor, POINT const& ptScreen, const std::unordered_map<HMONITOR, winrt::com_ptr<IWorkArea>>& workAreaMap) noexcept
+void WindowMoveHandler::MoveSizeUpdate(HMONITOR monitor, POINT const& ptScreen, const std::unordered_map<HMONITOR, std::shared_ptr<WorkArea>>& workAreaMap) noexcept
 {
     if (!m_inDragging)
     {
@@ -208,7 +207,7 @@ void WindowMoveHandler::MoveSizeUpdate(HMONITOR monitor, POINT const& ptScreen, 
     }
 }
 
-void WindowMoveHandler::MoveSizeEnd(HWND window, POINT const& ptScreen, const std::unordered_map<HMONITOR, winrt::com_ptr<IWorkArea>>& workAreaMap) noexcept
+void WindowMoveHandler::MoveSizeEnd(HWND window, POINT const& ptScreen, const std::unordered_map<HMONITOR, std::shared_ptr<WorkArea>>& workAreaMap) noexcept
 {
     if (window != m_draggedWindow)
     {
@@ -292,7 +291,7 @@ void WindowMoveHandler::MoveSizeEnd(HWND window, POINT const& ptScreen, const st
     }
 }
 
-void WindowMoveHandler::MoveWindowIntoZoneByIndexSet(HWND window, const ZoneIndexSet& indexSet, winrt::com_ptr<IWorkArea> workArea, bool suppressMove) noexcept
+void WindowMoveHandler::MoveWindowIntoZoneByIndexSet(HWND window, const ZoneIndexSet& indexSet, std::shared_ptr<WorkArea> workArea, bool suppressMove) noexcept
 {
     if (window != m_draggedWindow)
     {
@@ -300,17 +299,17 @@ void WindowMoveHandler::MoveWindowIntoZoneByIndexSet(HWND window, const ZoneInde
     }
 }
 
-bool WindowMoveHandler::MoveWindowIntoZoneByDirectionAndIndex(HWND window, DWORD vkCode, bool cycle, winrt::com_ptr<IWorkArea> workArea) noexcept
+bool WindowMoveHandler::MoveWindowIntoZoneByDirectionAndIndex(HWND window, DWORD vkCode, bool cycle, std::shared_ptr<WorkArea> workArea) noexcept
 {
     return workArea && workArea->MoveWindowIntoZoneByDirectionAndIndex(window, vkCode, cycle);
 }
 
-bool WindowMoveHandler::MoveWindowIntoZoneByDirectionAndPosition(HWND window, DWORD vkCode, bool cycle, winrt::com_ptr<IWorkArea> workArea) noexcept
+bool WindowMoveHandler::MoveWindowIntoZoneByDirectionAndPosition(HWND window, DWORD vkCode, bool cycle, std::shared_ptr<WorkArea> workArea) noexcept
 {
     return workArea && workArea->MoveWindowIntoZoneByDirectionAndPosition(window, vkCode, cycle);
 }
 
-bool WindowMoveHandler::ExtendWindowByDirectionAndPosition(HWND window, DWORD vkCode, winrt::com_ptr<IWorkArea> workArea) noexcept
+bool WindowMoveHandler::ExtendWindowByDirectionAndPosition(HWND window, DWORD vkCode, std::shared_ptr<WorkArea> workArea) noexcept
 {
     return workArea && workArea->ExtendWindowByDirectionAndPosition(window, vkCode);
 }

--- a/src/modules/fancyzones/FancyZonesLib/WindowMoveHandler.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WindowMoveHandler.cpp
@@ -291,11 +291,11 @@ void WindowMoveHandler::MoveSizeEnd(HWND window, POINT const& ptScreen, const st
     }
 }
 
-void WindowMoveHandler::MoveWindowIntoZoneByIndexSet(HWND window, const ZoneIndexSet& indexSet, std::shared_ptr<WorkArea> workArea, bool suppressMove) noexcept
+void WindowMoveHandler::MoveWindowIntoZoneByIndexSet(HWND window, const ZoneIndexSet& indexSet, std::shared_ptr<WorkArea> workArea) noexcept
 {
     if (window != m_draggedWindow)
     {
-        workArea->MoveWindowIntoZoneByIndexSet(window, indexSet, suppressMove);
+        workArea->MoveWindowIntoZoneByIndexSet(window, indexSet);
     }
 }
 

--- a/src/modules/fancyzones/FancyZonesLib/WindowMoveHandler.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WindowMoveHandler.cpp
@@ -314,6 +314,26 @@ bool WindowMoveHandler::ExtendWindowByDirectionAndPosition(HWND window, DWORD vk
     return workArea && workArea->ExtendWindowByDirectionAndPosition(window, vkCode);
 }
 
+void WindowMoveHandler::UpdateWindowsPositions(const std::unordered_map<HMONITOR, std::shared_ptr<WorkArea>>& activeWorkAreas) noexcept
+{
+    for (const auto& window : VirtualDesktop::instance().GetWindowsFromCurrentDesktop())
+    {
+        auto zoneIndexSet = FancyZonesWindowProperties::RetrieveZoneIndexProperty(window);
+        if (zoneIndexSet.size() == 0)
+        {
+            continue;
+        }
+
+        for (const auto& [monitor, workArea] : activeWorkAreas)
+        {
+            if (MonitorFromWindow(window, MONITOR_DEFAULTTONULL) == monitor)
+            {
+                workArea->MoveWindowIntoZoneByIndexSet(window, zoneIndexSet);
+            }
+        }
+    }
+}
+
 void WindowMoveHandler::WarnIfElevationIsRequired(HWND window) noexcept
 {
     using namespace notifications;

--- a/src/modules/fancyzones/FancyZonesLib/WindowMoveHandler.h
+++ b/src/modules/fancyzones/FancyZonesLib/WindowMoveHandler.h
@@ -23,6 +23,8 @@ public:
     bool MoveWindowIntoZoneByDirectionAndPosition(HWND window, DWORD vkCode, bool cycle, std::shared_ptr<WorkArea> workArea) noexcept;
     bool ExtendWindowByDirectionAndPosition(HWND window, DWORD vkCode, std::shared_ptr<WorkArea> workArea) noexcept;
 
+    void UpdateWindowsPositions(const std::unordered_map<HMONITOR, std::shared_ptr<WorkArea>>& activeWorkAreas) noexcept;
+    
     inline void OnMouseDown() noexcept
     {
         m_mouseState = !m_mouseState;

--- a/src/modules/fancyzones/FancyZonesLib/WindowMoveHandler.h
+++ b/src/modules/fancyzones/FancyZonesLib/WindowMoveHandler.h
@@ -7,21 +7,21 @@
 #include <functional>
 
 interface IFancyZonesSettings;
-interface IWorkArea;
+class WorkArea;
 
 class WindowMoveHandler
 {
 public:
     WindowMoveHandler(const std::function<void()>& keyUpdateCallback);
 
-    void MoveSizeStart(HWND window, HMONITOR monitor, POINT const& ptScreen, const std::unordered_map<HMONITOR, winrt::com_ptr<IWorkArea>>& workAreaMap) noexcept;
-    void MoveSizeUpdate(HMONITOR monitor, POINT const& ptScreen, const std::unordered_map<HMONITOR, winrt::com_ptr<IWorkArea>>& workAreaMap) noexcept;
-    void MoveSizeEnd(HWND window, POINT const& ptScreen, const std::unordered_map<HMONITOR, winrt::com_ptr<IWorkArea>>& workAreaMap) noexcept;
+    void MoveSizeStart(HWND window, HMONITOR monitor, POINT const& ptScreen, const std::unordered_map<HMONITOR, std::shared_ptr<WorkArea>>& workAreaMap) noexcept;
+    void MoveSizeUpdate(HMONITOR monitor, POINT const& ptScreen, const std::unordered_map<HMONITOR, std::shared_ptr<WorkArea>>& workAreaMap) noexcept;
+    void MoveSizeEnd(HWND window, POINT const& ptScreen, const std::unordered_map<HMONITOR, std::shared_ptr<WorkArea>>& workAreaMap) noexcept;
 
-    void MoveWindowIntoZoneByIndexSet(HWND window, const ZoneIndexSet& indexSet, winrt::com_ptr<IWorkArea> workArea, bool suppressMove = false) noexcept;
-    bool MoveWindowIntoZoneByDirectionAndIndex(HWND window, DWORD vkCode, bool cycle, winrt::com_ptr<IWorkArea> workArea) noexcept;
-    bool MoveWindowIntoZoneByDirectionAndPosition(HWND window, DWORD vkCode, bool cycle, winrt::com_ptr<IWorkArea> workArea) noexcept;
-    bool ExtendWindowByDirectionAndPosition(HWND window, DWORD vkCode, winrt::com_ptr<IWorkArea> workArea) noexcept;
+    void MoveWindowIntoZoneByIndexSet(HWND window, const ZoneIndexSet& indexSet, std::shared_ptr<WorkArea> workArea, bool suppressMove = false) noexcept;
+    bool MoveWindowIntoZoneByDirectionAndIndex(HWND window, DWORD vkCode, bool cycle, std::shared_ptr<WorkArea> workArea) noexcept;
+    bool MoveWindowIntoZoneByDirectionAndPosition(HWND window, DWORD vkCode, bool cycle, std::shared_ptr<WorkArea> workArea) noexcept;
+    bool ExtendWindowByDirectionAndPosition(HWND window, DWORD vkCode, std::shared_ptr<WorkArea> workArea) noexcept;
 
     inline void OnMouseDown() noexcept
     {
@@ -67,7 +67,7 @@ private:
     bool m_inDragging{}; // Whether or not a move/size operation is currently active
     HWND m_draggedWindow{}; // The window that is being moved/sized
     MoveSizeWindowInfo m_draggedWindowInfo; // MoveSizeWindowInfo of the window at the moment when dragging started
-    winrt::com_ptr<IWorkArea> m_draggedWindowWorkArea; // "Active" WorkArea, where the move/size is happening. Will update as drag moves between monitors.
+    std::shared_ptr<WorkArea> m_draggedWindowWorkArea; // "Active" WorkArea, where the move/size is happening. Will update as drag moves between monitors.
     bool m_dragEnabled{}; // True if we should be showing zone hints while dragging
 
     WindowTransparencyProperties m_windowTransparencyProperties;

--- a/src/modules/fancyzones/FancyZonesLib/WindowMoveHandler.h
+++ b/src/modules/fancyzones/FancyZonesLib/WindowMoveHandler.h
@@ -18,7 +18,7 @@ public:
     void MoveSizeUpdate(HMONITOR monitor, POINT const& ptScreen, const std::unordered_map<HMONITOR, std::shared_ptr<WorkArea>>& workAreaMap) noexcept;
     void MoveSizeEnd(HWND window, POINT const& ptScreen, const std::unordered_map<HMONITOR, std::shared_ptr<WorkArea>>& workAreaMap) noexcept;
 
-    void MoveWindowIntoZoneByIndexSet(HWND window, const ZoneIndexSet& indexSet, std::shared_ptr<WorkArea> workArea, bool suppressMove = false) noexcept;
+    void MoveWindowIntoZoneByIndexSet(HWND window, const ZoneIndexSet& indexSet, std::shared_ptr<WorkArea> workArea) noexcept;
     bool MoveWindowIntoZoneByDirectionAndIndex(HWND window, DWORD vkCode, bool cycle, std::shared_ptr<WorkArea> workArea) noexcept;
     bool MoveWindowIntoZoneByDirectionAndPosition(HWND window, DWORD vkCode, bool cycle, std::shared_ptr<WorkArea> workArea) noexcept;
     bool ExtendWindowByDirectionAndPosition(HWND window, DWORD vkCode, std::shared_ptr<WorkArea> workArea) noexcept;

--- a/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
@@ -13,6 +13,8 @@
 #include "trace.h"
 #include "on_thread_executor.h"
 #include "Settings.h"
+#include <FancyZonesLib/FancyZonesWindowProperties.h>
+#include <FancyZonesLib/VirtualDesktop.h>
 #include <FancyZonesLib/WindowUtils.h>
 
 #include <ShellScalingApi.h>
@@ -344,6 +346,18 @@ void WorkArea::UpdateActiveZoneSet() noexcept
     {
         m_highlightZone.clear();
         m_zonesOverlay->DrawActiveZoneSet(m_zoneSet->GetZones(), m_highlightZone, Colors::GetZoneColors(), FancyZonesSettings::settings().showZoneNumber);
+    }
+}
+
+void WorkArea::UpdateWindowsPositions() noexcept
+{
+    for (const auto& window : VirtualDesktop::instance().GetWindowsFromCurrentDesktop())
+    {
+        auto zoneIndexSet = FancyZonesWindowProperties::RetrieveZoneIndexProperty(window);
+        if (zoneIndexSet.size() > 0)
+        {
+            MoveWindowIntoZoneByIndexSet(window, zoneIndexSet);
+        }
     }
 }
 

--- a/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
@@ -351,13 +351,25 @@ void WorkArea::UpdateActiveZoneSet() noexcept
 
 void WorkArea::UpdateWindowsPositions() noexcept
 {
+    if (!m_zoneSet)
+    {
+        return;
+    }
+
     for (const auto& window : VirtualDesktop::instance().GetWindowsFromCurrentDesktop())
     {
         auto zoneIndexSet = FancyZonesWindowProperties::RetrieveZoneIndexProperty(window);
-        if (zoneIndexSet.size() > 0)
+        if (zoneIndexSet.size() == 0)
         {
-            MoveWindowIntoZoneByIndexSet(window, zoneIndexSet);
+            continue;
         }
+
+        if (MonitorFromWindow(window, MONITOR_DEFAULTTONULL) != m_monitor)
+        {
+            continue;
+        }
+
+        m_zoneSet->MoveWindowIntoZoneByIndexSet(window, m_window, zoneIndexSet);
     }
 }
 

--- a/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
@@ -349,30 +349,6 @@ void WorkArea::UpdateActiveZoneSet() noexcept
     }
 }
 
-void WorkArea::UpdateWindowsPositions() noexcept
-{
-    if (!m_zoneSet)
-    {
-        return;
-    }
-
-    for (const auto& window : VirtualDesktop::instance().GetWindowsFromCurrentDesktop())
-    {
-        auto zoneIndexSet = FancyZonesWindowProperties::RetrieveZoneIndexProperty(window);
-        if (zoneIndexSet.size() == 0)
-        {
-            continue;
-        }
-
-        if (MonitorFromWindow(window, MONITOR_DEFAULTTONULL) != m_monitor)
-        {
-            continue;
-        }
-
-        m_zoneSet->MoveWindowIntoZoneByIndexSet(window, m_window, zoneIndexSet);
-    }
-}
-
 void WorkArea::CycleTabs(HWND window, bool reverse) noexcept
 {
     if (m_zoneSet)

--- a/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
@@ -220,11 +220,11 @@ void WorkArea::MoveWindowIntoZoneByIndex(HWND window, ZoneIndex index) noexcept
     MoveWindowIntoZoneByIndexSet(window, { index });
 }
 
-void WorkArea::MoveWindowIntoZoneByIndexSet(HWND window, const ZoneIndexSet& indexSet, bool suppressMove) noexcept
+void WorkArea::MoveWindowIntoZoneByIndexSet(HWND window, const ZoneIndexSet& indexSet) noexcept
 {
     if (m_zoneSet)
     {
-        m_zoneSet->MoveWindowIntoZoneByIndexSet(window, m_window, indexSet, suppressMove);
+        m_zoneSet->MoveWindowIntoZoneByIndexSet(window, m_window, indexSet);
     }
 }
 

--- a/src/modules/fancyzones/FancyZonesLib/WorkArea.h
+++ b/src/modules/fancyzones/FancyZonesLib/WorkArea.h
@@ -46,7 +46,7 @@ public:
     HRESULT MoveSizeUpdate(POINT const& ptScreen, bool dragEnabled, bool selectManyZones) noexcept;
     HRESULT MoveSizeEnd(HWND window, POINT const& ptScreen) noexcept;
     void MoveWindowIntoZoneByIndex(HWND window, ZoneIndex index) noexcept;
-    void MoveWindowIntoZoneByIndexSet(HWND window, const ZoneIndexSet& indexSet, bool suppressMove = false) noexcept;
+    void MoveWindowIntoZoneByIndexSet(HWND window, const ZoneIndexSet& indexSet) noexcept;
     bool MoveWindowIntoZoneByDirectionAndIndex(HWND window, DWORD vkCode, bool cycle) noexcept;
     bool MoveWindowIntoZoneByDirectionAndPosition(HWND window, DWORD vkCode, bool cycle) noexcept;
     bool ExtendWindowByDirectionAndPosition(HWND window, DWORD vkCode) noexcept;

--- a/src/modules/fancyzones/FancyZonesLib/WorkArea.h
+++ b/src/modules/fancyzones/FancyZonesLib/WorkArea.h
@@ -58,7 +58,6 @@ public:
     void SaveWindowProcessToZoneIndex(HWND window) noexcept;
     
     void UpdateActiveZoneSet() noexcept;
-    void UpdateWindowsPositions() noexcept;
 
     void ShowZonesOverlay() noexcept;
     void HideZonesOverlay() noexcept;

--- a/src/modules/fancyzones/FancyZonesLib/WorkArea.h
+++ b/src/modules/fancyzones/FancyZonesLib/WorkArea.h
@@ -3,137 +3,57 @@
 #include "FancyZonesLib/ZoneSet.h"
 #include "FancyZonesLib/FancyZonesDataTypes.h"
 
-/**
- * Class representing single work area, which is defined by monitor and virtual desktop.
- */
-interface __declspec(uuid("{7F017528-8110-4FB3-BE41-F472969C2560}")) IWorkArea : public IUnknown
-{
-    /**
-     * A window is being moved or resized. Track down window position and give zone layout
-     * hints if dragging functionality is enabled.
-     *
-     * @param   window      Handle of window being moved or resized.
-     */
-    IFACEMETHOD(MoveSizeEnter)(HWND window) = 0;
+class ZonesOverlay;
 
-    /**
-     * A window has changed location, shape, or size. Track down window position and give zone layout
-     * hints if dragging functionality is enabled.
-     *
-     * @param   ptScreen        Cursor coordinates.
-     * @param   dragEnabled     Boolean indicating is giving hints about active zone layout enabled.
-     *                          Hints are given while dragging window while holding SHIFT key.
-     * @param   selectManyZones When this parameter is true, the set of highlighted zones is computed
-     *                          by finding the minimum bounding rectangle of the zone(s) from which the
-     *                          user started dragging and the zone(s) above which the user is hovering
-     *                          at the moment this function is called. Otherwise, highlight only the zone(s)
-     *                          above which the user is currently hovering.
-     */
-    IFACEMETHOD(MoveSizeUpdate)(POINT const& ptScreen, bool dragEnabled, bool selectManyZones) = 0;
-    /**
-     * The movement or resizing of a window has finished. Assign window to the zone of it
-     * is dropped within zone borders.
-     *
-     * @param window   Handle of window being moved or resized.
-     * @param ptScreen Cursor coordinates where window is dropped.
-     */
-    IFACEMETHOD(MoveSizeEnd)(HWND window, POINT const& ptScreen) = 0;
-    /**
-     * Assign window to the zone based on zone index inside zone layout.
-     *
-     * @param   window Handle of window which should be assigned to zone.
-     * @param   index  Zone index within zone layout.
-     */
-    IFACEMETHOD_(void, MoveWindowIntoZoneByIndex)(HWND window, ZoneIndex index) = 0;
-    /**
-     * Assign window to the zones based on the set of zone indices inside zone layout.
-     *
-     * @param   window   Handle of window which should be assigned to zone.
-     * @param   indexSet The set of zone indices within zone layout.
-     * @param   suppressMove Whether we should just update the records or move window to the zone.
-     */
-    IFACEMETHOD_(void, MoveWindowIntoZoneByIndexSet)(HWND window, const ZoneIndexSet& indexSet, bool suppressMove = false) = 0;
-    /**
-     * Assign window to the zone based on direction (using WIN + LEFT/RIGHT arrow), based on zone index numbers,
-     * not their on-screen position.
-     *
-     * @param   window Handle of window which should be assigned to zone.
-     * @param   vkCode Pressed arrow key.
-     * @param   cycle  Whether we should move window to the first zone if we reached last zone in layout.
-     *
-     * @returns Boolean which is always true if cycle argument is set, otherwise indicating if there is more
-     *          zones left in the zone layout in which window can move.
-     */
-    IFACEMETHOD_(bool, MoveWindowIntoZoneByDirectionAndIndex)(HWND window, DWORD vkCode, bool cycle) = 0;
-    /**
-     * Assign window to the zone based on direction (using WIN + LEFT/RIGHT/UP/DOWN arrow), based on
-     * their on-screen position.
-     *
-     * @param   window Handle of window which should be assigned to zone.
-     * @param   vkCode Pressed arrow key.
-     * @param   cycle  Whether we should move window to the first zone if we reached last zone in layout.
-     *
-     * @returns Boolean which is always true if cycle argument is set, otherwise indicating if there is more
-     *          zones left in the zone layout in which window can move.
-     */
-    IFACEMETHOD_(bool, MoveWindowIntoZoneByDirectionAndPosition)(HWND window, DWORD vkCode, bool cycle) = 0;
-    /**
-     * Extend or shrink the window to an adjacent zone based on direction (using CTRL+WIN+ALT + LEFT/RIGHT/UP/DOWN arrow), based on
-     * their on-screen position.
-     *
-     * @param   window Handle of window which should be assigned to zone.
-     * @param   vkCode Pressed arrow key.
-     *
-     * @returns Boolean indicating whether the window was rezoned. False could be returned when there are no more
-     *          zones available in the given direction.
-     */
-    IFACEMETHOD_(bool, ExtendWindowByDirectionAndPosition)(HWND window, DWORD vkCode) = 0;
-    /**
-     * Save information about zone in which window was assigned, when closing the window.
-     * Used once we open same window again to assign it to its previous zone.
-     *
-     * @param   window Window handle.
-     */
-    IFACEMETHOD_(void, SaveWindowProcessToZoneIndex)(HWND window) = 0;
-    /**
-     * @returns Unique work area identifier. Format: <device-id>_<resolution>_<virtual-desktop-id>
-     */
-    IFACEMETHOD_(FancyZonesDataTypes::DeviceIdData, UniqueId)() const = 0;
-    /**
-     * @returns Active zone layout for this work area.
-     */
-    IFACEMETHOD_(IZoneSet*, ZoneSet)() const = 0;
-    /*
-    * @returns Zone index of the window
-    */
-    IFACEMETHOD_(ZoneIndexSet, GetWindowZoneIndexes)(HWND window) const = 0;
-    /**
-     * Show a drawing of the zones in the work area.
-     */
-    IFACEMETHOD_(void, ShowZonesOverlay)() = 0;
-    /**
-     * Hide the drawing of the zones in the work area.
-     */
-    IFACEMETHOD_(void, HideZonesOverlay)() = 0;
-    /**
-     * Update currently active zone layout for this work area.
-     */
-    IFACEMETHOD_(void, UpdateActiveZoneSet)() = 0;
-    /**
-     * Cycle through tabs in the zone that the window is in.
-     *
-     * @param   window Handle of window which is cycled from (the current tab).
-     * @param   reverse Whether to cycle in reverse order (to the previous tab) or to move to the next tab.
-     */
-    IFACEMETHOD_(void, CycleTabs)(HWND window, bool reverse) = 0;
-    /**
-     * Clear the selected zones when this WorkArea loses focus.
-     */
-    IFACEMETHOD_(void, ClearSelectedZones)() = 0;
-    /*
-     * Display the layout on the screen and then hide it.
-     */
-    IFACEMETHOD_(void, FlashZones)() = 0;
+class WorkArea
+{
+public:
+    WorkArea(HINSTANCE hinstance);
+    ~WorkArea();
+
+public:
+    bool Init(HINSTANCE hinstance, HMONITOR monitor, const FancyZonesDataTypes::DeviceIdData& uniqueId, const FancyZonesDataTypes::DeviceIdData& parentUniqueId);
+
+    HRESULT MoveSizeEnter(HWND window) noexcept;
+    HRESULT MoveSizeUpdate(POINT const& ptScreen, bool dragEnabled, bool selectManyZones) noexcept;
+    HRESULT MoveSizeEnd(HWND window, POINT const& ptScreen) noexcept;
+    void MoveWindowIntoZoneByIndex(HWND window, ZoneIndex index) noexcept;
+    void MoveWindowIntoZoneByIndexSet(HWND window, const ZoneIndexSet& indexSet, bool suppressMove = false) noexcept;
+    bool MoveWindowIntoZoneByDirectionAndIndex(HWND window, DWORD vkCode, bool cycle) noexcept;
+    bool MoveWindowIntoZoneByDirectionAndPosition(HWND window, DWORD vkCode, bool cycle) noexcept;
+    bool ExtendWindowByDirectionAndPosition(HWND window, DWORD vkCode) noexcept;
+    FancyZonesDataTypes::DeviceIdData UniqueId() const noexcept { return { m_uniqueId }; }
+    void SaveWindowProcessToZoneIndex(HWND window) noexcept;
+    IZoneSet* ZoneSet() const noexcept { return m_zoneSet.get(); }
+    ZoneIndexSet GetWindowZoneIndexes(HWND window) const noexcept;
+    void ShowZonesOverlay() noexcept;
+    void HideZonesOverlay() noexcept;
+    void UpdateActiveZoneSet() noexcept;
+    void CycleTabs(HWND window, bool reverse) noexcept;
+    void ClearSelectedZones() noexcept;
+    void FlashZones() noexcept;
+
+protected:
+    static LRESULT CALLBACK s_WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lparam) noexcept;
+
+private:
+    void InitializeZoneSets(const FancyZonesDataTypes::DeviceIdData& parentUniqueId) noexcept;
+    void CalculateZoneSet(OverlappingZonesAlgorithm overlappingAlgorithm) noexcept;
+    void UpdateActiveZoneSet(_In_opt_ IZoneSet* zoneSet) noexcept;
+    LRESULT WndProc(UINT message, WPARAM wparam, LPARAM lparam) noexcept;
+    ZoneIndexSet ZonesFromPoint(POINT pt) noexcept;
+    void SetAsTopmostWindow() noexcept;
+
+    HMONITOR m_monitor{};
+    FancyZonesDataTypes::DeviceIdData m_uniqueId;
+    HWND m_window{}; // Hidden tool window used to represent current monitor desktop work area.
+    HWND m_windowMoveSize{};
+    winrt::com_ptr<IZoneSet> m_zoneSet;
+    ZoneIndexSet m_initialHighlightZone;
+    ZoneIndexSet m_highlightZone;
+    WPARAM m_keyLast{};
+    size_t m_keyCycle{};
+    std::unique_ptr<ZonesOverlay> m_zonesOverlay;
 };
 
-winrt::com_ptr<IWorkArea> MakeWorkArea(HINSTANCE hinstance, HMONITOR monitor, const FancyZonesDataTypes::DeviceIdData& uniqueId, const FancyZonesDataTypes::DeviceIdData& parentUniqueId) noexcept;
+std::shared_ptr<WorkArea> MakeWorkArea(HINSTANCE hinstance, HMONITOR monitor, const FancyZonesDataTypes::DeviceIdData& uniqueId, const FancyZonesDataTypes::DeviceIdData& parentUniqueId) noexcept;

--- a/src/modules/fancyzones/FancyZonesLib/WorkArea.h
+++ b/src/modules/fancyzones/FancyZonesLib/WorkArea.h
@@ -42,6 +42,11 @@ public:
         return true;
     }
 
+    FancyZonesDataTypes::DeviceIdData UniqueId() const noexcept { return { m_uniqueId }; }
+    IZoneSet* ZoneSet() const noexcept { return m_zoneSet.get(); }
+    
+    ZoneIndexSet GetWindowZoneIndexes(HWND window) const noexcept;
+    
     HRESULT MoveSizeEnter(HWND window) noexcept;
     HRESULT MoveSizeUpdate(POINT const& ptScreen, bool dragEnabled, bool selectManyZones) noexcept;
     HRESULT MoveSizeEnd(HWND window, POINT const& ptScreen) noexcept;
@@ -50,17 +55,18 @@ public:
     bool MoveWindowIntoZoneByDirectionAndIndex(HWND window, DWORD vkCode, bool cycle) noexcept;
     bool MoveWindowIntoZoneByDirectionAndPosition(HWND window, DWORD vkCode, bool cycle) noexcept;
     bool ExtendWindowByDirectionAndPosition(HWND window, DWORD vkCode) noexcept;
-    FancyZonesDataTypes::DeviceIdData UniqueId() const noexcept { return { m_uniqueId }; }
     void SaveWindowProcessToZoneIndex(HWND window) noexcept;
-    IZoneSet* ZoneSet() const noexcept { return m_zoneSet.get(); }
-    ZoneIndexSet GetWindowZoneIndexes(HWND window) const noexcept;
+    
+    void UpdateActiveZoneSet() noexcept;
+    void UpdateWindowsPositions() noexcept;
+
     void ShowZonesOverlay() noexcept;
     void HideZonesOverlay() noexcept;
-    void UpdateActiveZoneSet() noexcept;
-    void CycleTabs(HWND window, bool reverse) noexcept;
-    void ClearSelectedZones() noexcept;
     void FlashZones() noexcept;
-
+    void ClearSelectedZones() noexcept;
+    
+    void CycleTabs(HWND window, bool reverse) noexcept;
+    
     void LogInitializationError();
 
 protected:

--- a/src/modules/fancyzones/FancyZonesLib/ZoneSet.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/ZoneSet.cpp
@@ -54,7 +54,7 @@ public:
     IFACEMETHODIMP_(void)
     CycleTabs(HWND window, bool reverse) noexcept;
     IFACEMETHODIMP_(bool)
-    CalculateZones(RECT workArea, int zoneCount, int spacing) noexcept;
+    CalculateZones(FancyZonesUtils::Rect workArea, int zoneCount, int spacing) noexcept;
     IFACEMETHODIMP_(bool) IsZoneEmpty(ZoneIndex zoneIndex) const noexcept;
     IFACEMETHODIMP_(ZoneIndexSet) GetCombinedZoneRange(const ZoneIndexSet& initialZones, const ZoneIndexSet& finalZones) const noexcept;
 
@@ -569,7 +569,7 @@ void ZoneSet::InsertTabIntoZone(HWND window, std::optional<size_t> tabSortKeyWit
 }
 
 IFACEMETHODIMP_(bool)
-ZoneSet::CalculateZones(RECT workAreaRect, int zoneCount, int spacing) noexcept
+ZoneSet::CalculateZones(FancyZonesUtils::Rect workAreaRect, int zoneCount, int spacing) noexcept
 {
     Rect workArea(workAreaRect);
     //invalid work area

--- a/src/modules/fancyzones/FancyZonesLib/ZoneSet.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/ZoneSet.cpp
@@ -40,7 +40,7 @@ public:
     IFACEMETHODIMP_(void)
     MoveWindowIntoZoneByIndex(HWND window, HWND workAreaWindow, ZoneIndex index) noexcept;
     IFACEMETHODIMP_(void)
-    MoveWindowIntoZoneByIndexSet(HWND window, HWND workAreaWindow, const ZoneIndexSet& indexSet, bool suppressMove = false) noexcept;
+    MoveWindowIntoZoneByIndexSet(HWND window, HWND workAreaWindow, const ZoneIndexSet& indexSet) noexcept;
     IFACEMETHODIMP_(bool)
     MoveWindowIntoZoneByDirectionAndIndex(HWND window, HWND workAreaWindow, DWORD vkCode, bool cycle) noexcept;
     IFACEMETHODIMP_(bool)
@@ -188,7 +188,7 @@ ZoneSet::MoveWindowIntoZoneByIndex(HWND window, HWND workAreaWindow, ZoneIndex i
 }
 
 IFACEMETHODIMP_(void)
-ZoneSet::MoveWindowIntoZoneByIndexSet(HWND window, HWND workAreaWindow, const ZoneIndexSet& zoneIds, bool suppressMove) noexcept
+ZoneSet::MoveWindowIntoZoneByIndexSet(HWND window, HWND workAreaWindow, const ZoneIndexSet& zoneIds) noexcept
 {
     if (m_zones.empty())
     {
@@ -239,17 +239,14 @@ ZoneSet::MoveWindowIntoZoneByIndexSet(HWND window, HWND workAreaWindow, const Zo
 
     if (!sizeEmpty)
     {
-        if (!suppressMove)
+        FancyZonesWindowUtils::SaveWindowSizeAndOrigin(window);
+
+        auto rect = FancyZonesWindowUtils::AdjustRectForSizeWindowToRect(window, size, workAreaWindow);
+        FancyZonesWindowUtils::SizeWindowToRect(window, rect);
+
+        if (FancyZonesSettings::settings().disableRoundCorners)
         {
-            FancyZonesWindowUtils::SaveWindowSizeAndOrigin(window);
-
-            auto rect = FancyZonesWindowUtils::AdjustRectForSizeWindowToRect(window, size, workAreaWindow);
-            FancyZonesWindowUtils::SizeWindowToRect(window, rect);
-
-            if (FancyZonesSettings::settings().disableRoundCorners)
-            {
-                FancyZonesWindowUtils::DisableRoundCorners(window);
-            }
+            FancyZonesWindowUtils::DisableRoundCorners(window);
         }
 
         FancyZonesWindowProperties::StampZoneIndexProperty(window, indexSet);

--- a/src/modules/fancyzones/FancyZonesLib/ZoneSet.h
+++ b/src/modules/fancyzones/FancyZonesLib/ZoneSet.h
@@ -56,9 +56,8 @@ interface __declspec(uuid("{E4839EB7-669D-49CF-84A9-71A2DFD851A3}")) IZoneSet : 
      * @param   workAreaWindow The m_window of a WorkArea, it's a hidden window representing the
      *                         current monitor desktop work area.
      * @param   indexSet       The set of zone indices within zone layout.
-     * @param   suppressMove   Whether we should just update the records or move window to the zone.
      */
-    IFACEMETHOD_(void, MoveWindowIntoZoneByIndexSet)(HWND window, HWND workAreaWindow, const ZoneIndexSet& indexSet, bool suppressMove = false) = 0;
+    IFACEMETHOD_(void, MoveWindowIntoZoneByIndexSet)(HWND window, HWND workAreaWindow, const ZoneIndexSet& indexSet) = 0;
     /**
      * Assign window to the zone based on direction (using WIN + LEFT/RIGHT arrow), based on zone index numbers,
      * not their on-screen position.

--- a/src/modules/fancyzones/FancyZonesLib/ZoneSet.h
+++ b/src/modules/fancyzones/FancyZonesLib/ZoneSet.h
@@ -2,6 +2,7 @@
 
 #include <FancyZonesLib/LayoutConfigurator.h>
 #include "Settings.h"
+#include "util.h"
 
 namespace FancyZonesDataTypes
 {
@@ -135,7 +136,7 @@ interface __declspec(uuid("{E4839EB7-669D-49CF-84A9-71A2DFD851A3}")) IZoneSet : 
      *
      * @returns Boolean indicating if calculation was successful.
      */
-    IFACEMETHOD_(bool, CalculateZones)(RECT workAreaRect, int zoneCount, int spacing) = 0;
+    IFACEMETHOD_(bool, CalculateZones)(FancyZonesUtils::Rect workAreaRect, int zoneCount, int spacing) = 0;
     /**
      * Check if the zone with the specified index is empty. Returns true if the zone with passed zoneIndex does not exist.
      * 

--- a/src/modules/fancyzones/FancyZonesTests/UnitTests/WorkArea.Spec.cpp
+++ b/src/modules/fancyzones/FancyZonesTests/UnitTests/WorkArea.Spec.cpp
@@ -23,39 +23,14 @@ namespace FancyZonesUnitTests
 
     TEST_CLASS (WorkAreaCreationUnitTests)
     {
-        FancyZonesDataTypes::DeviceIdData m_parentUniqueId;
         FancyZonesDataTypes::DeviceIdData m_uniqueId;
-
-        HINSTANCE m_hInst{};
-        HMONITOR m_monitor{};
-        MONITORINFOEX m_monitorInfo{};
-        GUID m_virtualDesktopGuid{};
-
-        void testWorkArea(winrt::com_ptr<IWorkArea> workArea)
-        {
-            const std::wstring expectedWorkArea = std::to_wstring(m_monitorInfo.rcMonitor.right) + L"_" + std::to_wstring(m_monitorInfo.rcMonitor.bottom);
-
-            Assert::IsNotNull(workArea.get());
-            Assert::IsTrue(m_uniqueId == workArea->UniqueId());
-        }
+        FancyZonesDataTypes::DeviceIdData m_emptyUniqueId;
 
         TEST_METHOD_INITIALIZE(Init)
         {
-            m_hInst = (HINSTANCE)GetModuleHandleW(nullptr);
-
-            m_monitor = MonitorFromPoint(POINT{ 0, 0 }, MONITOR_DEFAULTTOPRIMARY);
-            m_monitorInfo.cbSize = sizeof(m_monitorInfo);
-            Assert::AreNotEqual(0, GetMonitorInfoW(m_monitor, &m_monitorInfo));
-
-            m_parentUniqueId.deviceName = L"DELA026#5&10a58c63&0&UID16777488";
-            CLSIDFromString(L"{61FA9FC0-26A6-4B37-A834-491C148DFC57}", &m_parentUniqueId.virtualDesktopId);
-                
             m_uniqueId.deviceName = L"DELA026#5&10a58c63&0&UID16777488";
-            CLSIDFromString(L"{39B25DD2-130D-4B5D-8851-4791D66B1539}", &m_uniqueId.virtualDesktopId);
-                                
-            auto guid = Helpers::StringToGuid(L"{39B25DD2-130D-4B5D-8851-4791D66B1539}");
-            Assert::IsTrue(guid.has_value());
-            m_virtualDesktopGuid = *guid;
+            auto res = CLSIDFromString(L"{39B25DD2-130D-4B5D-8851-4791D66B1539}", &m_uniqueId.virtualDesktopId);
+            Assert::IsTrue(SUCCEEDED(res));
 
             AppZoneHistory::instance().LoadData();
             AppliedLayouts::instance().LoadData();
@@ -67,124 +42,76 @@ namespace FancyZonesUnitTests
             std::filesystem::remove(AppZoneHistory::AppZoneHistoryFileName());
         }
 
-            TEST_METHOD (CreateWorkArea)
-            {
-                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, {});
-                testWorkArea(workArea);
+        TEST_METHOD (CreateWorkArea)
+        {
+            auto workArea = MakeWorkArea({}, Mocks::Monitor(), m_uniqueId, m_emptyUniqueId);
+            Assert::IsFalse(workArea == nullptr);
+            Assert::IsTrue(m_uniqueId == workArea->UniqueId());
 
-                auto* zoneSet{ workArea->ZoneSet() };
-                Assert::IsNotNull(zoneSet);
-                Assert::AreEqual(static_cast<int>(zoneSet->LayoutType()), static_cast<int>(FancyZonesDataTypes::ZoneSetLayoutType::PriorityGrid));
-                Assert::AreEqual(zoneSet->GetZones().size(), static_cast<size_t>(3));
-            }
+            auto* zoneSet{ workArea->ZoneSet() };
+            Assert::IsNotNull(zoneSet);
+            Assert::AreEqual(static_cast<int>(zoneSet->LayoutType()), static_cast<int>(FancyZonesDataTypes::ZoneSetLayoutType::PriorityGrid));
+            Assert::AreEqual(zoneSet->GetZones().size(), static_cast<size_t>(3));
+        }
 
-            TEST_METHOD (CreateWorkAreaNoHinst)
-            {
-                auto workArea = MakeWorkArea({}, m_monitor, m_uniqueId, {});
-                testWorkArea(workArea);
+        TEST_METHOD (CreateCombinedWorkArea)
+        {
+            auto workArea = MakeWorkArea({}, {}, m_uniqueId, m_emptyUniqueId);
+            Assert::IsFalse(workArea == nullptr);
+            Assert::IsTrue(m_uniqueId == workArea->UniqueId());
 
-                auto* zoneSet{ workArea->ZoneSet() };
-                Assert::IsNotNull(zoneSet);
-                Assert::AreEqual(static_cast<int>(zoneSet->LayoutType()), static_cast<int>(FancyZonesDataTypes::ZoneSetLayoutType::PriorityGrid));
-                Assert::AreEqual(zoneSet->GetZones().size(), static_cast<size_t>(3));
-            }
-
-            TEST_METHOD (CreateWorkAreaNoHinstFlashZones)
-            {
-                auto workArea = MakeWorkArea({}, m_monitor, m_uniqueId, {});
-                testWorkArea(workArea);
-
-                auto* zoneSet{ workArea->ZoneSet() };
-                Assert::IsNotNull(zoneSet);
-                Assert::AreEqual(static_cast<int>(zoneSet->LayoutType()), static_cast<int>(FancyZonesDataTypes::ZoneSetLayoutType::PriorityGrid));
-                Assert::AreEqual(zoneSet->GetZones().size(), static_cast<size_t>(3));
-            }
-
-            TEST_METHOD (CreateWorkAreaNoMonitor)
-            {
-                auto workArea = MakeWorkArea(m_hInst, {}, m_uniqueId, {});
-                testWorkArea(workArea);
-            }
-
-            TEST_METHOD (CreateWorkAreaNoDeviceId)
-            {
-                // Generate unique id without device id
-                FancyZonesDataTypes::DeviceIdData uniqueIdData;
-                uniqueIdData.virtualDesktopId = m_virtualDesktopGuid;
-
-                auto workArea = MakeWorkArea(m_hInst, m_monitor, uniqueIdData, {});
-
-                const std::wstring expectedWorkArea = std::to_wstring(m_monitorInfo.rcMonitor.right) + L"_" + std::to_wstring(m_monitorInfo.rcMonitor.bottom);
-                const FancyZonesDataTypes::DeviceIdData expectedUniqueId{ L"FallbackDevice", m_virtualDesktopGuid };
-
-                Assert::IsNotNull(workArea.get());
-                Assert::IsTrue(expectedUniqueId == workArea->UniqueId());
-
-                auto* zoneSet{ workArea->ZoneSet() };
-                Assert::IsNotNull(zoneSet);
-                Assert::AreEqual(static_cast<int>(zoneSet->LayoutType()), static_cast<int>(FancyZonesDataTypes::ZoneSetLayoutType::PriorityGrid));
-                Assert::AreEqual(zoneSet->GetZones().size(), static_cast<size_t>(3));
-            }
-
-            TEST_METHOD (CreateWorkAreaNoDesktopId)
-            {
-                // Generate unique id without virtual desktop id
-                FancyZonesDataTypes::DeviceIdData uniqueId;
-                uniqueId.deviceName = FancyZonesUtils::TrimDeviceId(m_deviceId);
-
-                auto workArea = MakeWorkArea(m_hInst, m_monitor, uniqueId, {});
-
-                const std::wstring expectedWorkArea = std::to_wstring(m_monitorInfo.rcMonitor.right) + L"_" + std::to_wstring(m_monitorInfo.rcMonitor.bottom);
-                Assert::IsNotNull(workArea.get());
-
-                auto* zoneSet{ workArea->ZoneSet() };
-                Assert::IsNotNull(zoneSet);
-                Assert::AreEqual(static_cast<int>(zoneSet->LayoutType()), static_cast<int>(FancyZonesDataTypes::ZoneSetLayoutType::PriorityGrid));
-                Assert::AreEqual(zoneSet->GetZones().size(), static_cast<size_t>(3));
-            }
+            auto* zoneSet{ workArea->ZoneSet() };
+            Assert::IsNotNull(zoneSet);
+            Assert::AreEqual(static_cast<int>(zoneSet->LayoutType()), static_cast<int>(FancyZonesDataTypes::ZoneSetLayoutType::PriorityGrid));
+            Assert::AreEqual(zoneSet->GetZones().size(), static_cast<size_t>(3));
+        }
 
         TEST_METHOD (CreateWorkAreaClonedFromParent)
         {
             using namespace FancyZonesDataTypes;
 
-            const ZoneSetLayoutType type = ZoneSetLayoutType::PriorityGrid;
-            const int spacing = 10;
-            const int zoneCount = 5;
-            const auto customSetGuid = Helpers::CreateGuidString();
+            FancyZonesDataTypes::DeviceIdData parentUniqueId;
+            parentUniqueId.deviceName = L"DELA026#5&10a58c63&0&UID16777488";
+            parentUniqueId.virtualDesktopId = FancyZonesUtils::GuidFromString(L"{61FA9FC0-26A6-4B37-A834-491C148DFC57}").value();
 
-            auto parentWorkArea = MakeWorkArea(m_hInst, m_monitor, m_parentUniqueId, {});
-                
-            // newWorkArea = false - workArea won't be cloned from parent
-            auto actualWorkArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, {});
+            Layout layout{
+                .uuid = FancyZonesUtils::GuidFromString(L"{61FA9FC0-26A6-4B37-A834-491C148DFC58}").value(),
+                .type = ZoneSetLayoutType::Rows,
+                .showSpacing = true,
+                .spacing = 10,
+                .zoneCount = 10,
+                .sensitivityRadius = 20,
+            };
+
+            auto parentWorkArea = MakeWorkArea({}, Mocks::Monitor(), parentUniqueId, m_emptyUniqueId);
+            AppliedLayouts::instance().ApplyLayout(parentUniqueId, layout);
+
+            auto actualWorkArea = MakeWorkArea({}, Mocks::Monitor(), m_uniqueId, parentUniqueId);
 
             Assert::IsNotNull(actualWorkArea->ZoneSet());
 
             Assert::IsTrue(AppliedLayouts::instance().GetAppliedLayoutMap().contains(m_uniqueId));
-            auto currentDeviceInfo = AppliedLayouts::instance().GetAppliedLayoutMap().at(m_uniqueId);
-            // default values
-            Assert::AreEqual(true, currentDeviceInfo.showSpacing);
-            Assert::AreEqual(3, currentDeviceInfo.zoneCount);
-            Assert::AreEqual(16, currentDeviceInfo.spacing);
-            Assert::AreEqual(static_cast<int>(ZoneSetLayoutType::PriorityGrid), static_cast<int>(currentDeviceInfo.type));
+            auto actualLayout = AppliedLayouts::instance().GetAppliedLayoutMap().at(m_uniqueId);
+
+            Assert::AreEqual(static_cast<int>(layout.type), static_cast<int>(actualLayout.type));
+            Assert::AreEqual(FancyZonesUtils::GuidToString(layout.uuid).value(), FancyZonesUtils::GuidToString(actualLayout.uuid).value());
+            Assert::AreEqual(layout.sensitivityRadius, actualLayout.sensitivityRadius);
+            Assert::AreEqual(layout.showSpacing, actualLayout.showSpacing);
+            Assert::AreEqual(layout.spacing, actualLayout.spacing);
+            Assert::AreEqual(layout.zoneCount, actualLayout.zoneCount);
         }
     };
 
     TEST_CLASS (WorkAreaUnitTests)
     {
         FancyZonesDataTypes::DeviceIdData m_uniqueId;
+        FancyZonesDataTypes::DeviceIdData m_parentUniqueId; // default empty
 
         HINSTANCE m_hInst{};
         HMONITOR m_monitor{};
-        MONITORINFO m_monitorInfo{};
 
         TEST_METHOD_INITIALIZE(Init)
         {
-            m_hInst = (HINSTANCE)GetModuleHandleW(nullptr);
-            
-            m_monitor = MonitorFromPoint(POINT{ 0, 0 }, MONITOR_DEFAULTTOPRIMARY);
-            m_monitorInfo.cbSize = sizeof(m_monitorInfo);
-            Assert::AreNotEqual(0, GetMonitorInfoW(m_monitor, &m_monitorInfo));
-
             m_uniqueId.deviceName = L"DELA026#5&10a58c63&0&UID16777488";
             CLSIDFromString(L"{39B25DD2-130D-4B5D-8851-4791D66B1539}", &m_uniqueId.virtualDesktopId);
 
@@ -198,10 +125,10 @@ namespace FancyZonesUnitTests
             std::filesystem::remove(AppliedLayouts::AppliedLayoutsFileName());
         }
 
-        public:
+    public:
             TEST_METHOD (MoveSizeEnter)
             {
-                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, {});
+                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, m_parentUniqueId);
 
                 const auto expected = S_OK;
                 const auto actual = workArea->MoveSizeEnter(Mocks::Window());
@@ -211,7 +138,7 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (MoveSizeEnterTwice)
             {
-                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, {});
+                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, m_parentUniqueId);
 
                 const auto expected = S_OK;
 
@@ -223,7 +150,7 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (MoveSizeUpdate)
             {
-                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, {});
+                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, m_parentUniqueId);
 
                 const auto expected = S_OK;
                 const auto actual = workArea->MoveSizeUpdate(POINT{ 0, 0 }, true, false);
@@ -233,7 +160,7 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (MoveSizeUpdatePointNegativeCoordinates)
             {
-                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, {});
+                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, m_parentUniqueId);
 
                 const auto expected = S_OK;
                 const auto actual = workArea->MoveSizeUpdate(POINT{ -10, -10 }, true, false);
@@ -243,17 +170,17 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (MoveSizeUpdatePointBigCoordinates)
             {
-                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, {});
+                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, m_parentUniqueId);
 
                 const auto expected = S_OK;
-                const auto actual = workArea->MoveSizeUpdate(POINT{ m_monitorInfo.rcMonitor.right + 1, m_monitorInfo.rcMonitor.bottom + 1 }, true, false);
+                const auto actual = workArea->MoveSizeUpdate(POINT{ LONG_MAX, LONG_MAX }, true, false);
 
                 Assert::AreEqual(expected, actual);
             }
 
             TEST_METHOD (MoveSizeEnd)
             {
-                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, {});
+                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, m_parentUniqueId);
 
                 const auto window = Mocks::Window();
                 workArea->MoveSizeEnter(window);
@@ -270,7 +197,7 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (MoveSizeEndWindowNotAdded)
             {
-                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, {});
+                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, m_parentUniqueId);
 
                 const auto window = Mocks::Window();
                 workArea->MoveSizeEnter(window);
@@ -286,7 +213,7 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (MoveSizeEndDifferentWindows)
             {
-                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, {});
+                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, m_parentUniqueId);
 
                 const auto window = Mocks::Window();
                 workArea->MoveSizeEnter(window);
@@ -299,7 +226,7 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (MoveSizeEndWindowNotSet)
             {
-                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, {});
+                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, m_parentUniqueId);
 
                 const auto expected = E_INVALIDARG;
                 const auto actual = workArea->MoveSizeEnd(Mocks::Window(), POINT{ 0, 0 });
@@ -309,7 +236,7 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (MoveSizeEndInvalidPoint)
             {
-                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, {});
+                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, m_parentUniqueId);
 
                 const auto window = Mocks::Window();
                 workArea->MoveSizeEnter(window);
@@ -326,7 +253,7 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (MoveWindowIntoZoneByIndex)
             {
-                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, {});
+                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, m_parentUniqueId);
                 Assert::IsNotNull(workArea->ZoneSet());
 
                 workArea->MoveWindowIntoZoneByIndex(Mocks::Window(), 0);
@@ -336,7 +263,7 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (MoveWindowIntoZoneByDirectionAndIndex)
             {
-                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, {});
+                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, m_parentUniqueId);
                 Assert::IsNotNull(workArea->ZoneSet());
 
                 const auto window = Mocks::WindowCreate(m_hInst);
@@ -351,7 +278,7 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (MoveWindowIntoZoneByDirectionManyTimes)
             {
-                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, {});
+                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, m_parentUniqueId);
                 Assert::IsNotNull(workArea->ZoneSet());
 
                 const auto window = Mocks::WindowCreate(m_hInst);
@@ -368,7 +295,7 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (SaveWindowProcessToZoneIndexNullptrWindow)
             {
-                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, {});
+                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, m_parentUniqueId);
                 Assert::IsNotNull(workArea->ZoneSet());
 
                 workArea->SaveWindowProcessToZoneIndex(nullptr);
@@ -379,7 +306,7 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (SaveWindowProcessToZoneIndexNoWindowAdded)
             {
-                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, {});
+                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, m_parentUniqueId);
                 Assert::IsNotNull(workArea->ZoneSet());
 
                 auto window = Mocks::WindowCreate(m_hInst);
@@ -393,7 +320,7 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (SaveWindowProcessToZoneIndexNoWindowAddedWithFilledAppZoneHistory)
             {
-                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, {});
+                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, m_parentUniqueId);
                 Assert::IsNotNull(workArea->ZoneSet());
 
                 const auto window = Mocks::WindowCreate(m_hInst);
@@ -420,7 +347,7 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (SaveWindowProcessToZoneIndexWindowAdded)
             {
-                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, {});
+                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, m_parentUniqueId);
                 Assert::IsNotNull(workArea->ZoneSet());
 
                 auto window = Mocks::WindowCreate(m_hInst);
@@ -449,7 +376,7 @@ namespace FancyZonesUnitTests
 
             TEST_METHOD (WhenWindowIsNotResizablePlacingItIntoTheZoneShouldNotResizeIt)
             {
-                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, {});
+                auto workArea = MakeWorkArea(m_hInst, m_monitor, m_uniqueId, m_parentUniqueId);
                 Assert::IsNotNull(workArea->ZoneSet());
 
                 auto window = Mocks::WindowCreate(m_hInst);


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

Fix window size and position update after changing a layout. 

**What is included in the PR:** 

**How does someone test / validate:** 

* Make sure the `During zone layout changes, windows assigned to a zone will match new size/position` option is on
* Snap window to a zone
* Change layout
* Verify window position and size were updated 

## Quality Checklist

- [x] **Linked issue:** #18679
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
