### PR TITLE
[PTRun]Add logs to check Web Browser detection

### DIFF
--- a/src/modules/launcher/Wox.Infrastructure/Helper.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Helper.cs
@@ -150,7 +150,7 @@ namespace Wox.Infrastructure
         {
             if (string.IsNullOrEmpty(pattern))
             {
-                Log.Warn("Trying to run OpenCommandInShell with an empty pattern. The default browser definition might have issues.", typeof(Helper));
+                Log.Warn($"Trying to run OpenCommandInShell with an empty pattern. The default browser definition might have issues. Path: '${path ?? string.Empty}' ; Arguments: '${arguments ?? string.Empty}' ; Working Directory: '${workingDir ?? string.Empty}'", typeof(Helper));
             }
             else if (pattern.Contains("%1", StringComparison.Ordinal))
             {

--- a/src/modules/launcher/Wox.Plugin/Common/DefaultBrowserInfo.cs
+++ b/src/modules/launcher/Wox.Plugin/Common/DefaultBrowserInfo.cs
@@ -70,7 +70,7 @@ namespace Wox.Plugin.Common
             {
                 if (!haveIRanUpdateOnce)
                 {
-                    Log.Warn("I've tried updating the chosen Web Browser info at least once", typeof(DefaultBrowserInfo));
+                    Log.Warn("I've tried updating the chosen Web Browser info at least once.", typeof(DefaultBrowserInfo));
                     haveIRanUpdateOnce = true;
                 }
 

--- a/src/modules/launcher/Wox.Plugin/Common/DefaultBrowserInfo.cs
+++ b/src/modules/launcher/Wox.Plugin/Common/DefaultBrowserInfo.cs
@@ -15,7 +15,7 @@ namespace Wox.Plugin.Common
     public static class DefaultBrowserInfo
     {
         private static readonly object _updateLock = new object();
-        private static int _lastUpdateTickCount = -1;
+        private static long _lastUpdateTickCount = -1;
 
         /// <summary>Gets the path to the MS Edge browser executable.</summary>
         public static string MSEdgePath =>
@@ -41,7 +41,9 @@ namespace Wox.Plugin.Common
 
         public static bool IsDefaultBrowserSet { get => !string.IsNullOrEmpty(Path); }
 
-        public const int UpdateTimeout = 300;
+        public const long UpdateTimeout = 300;
+
+        private static bool haveIRanUpdateOnce;
 
         /// <summary>
         /// Updates only if at least more than 300ms has passed since the last update, to avoid multiple calls to <see cref="Update"/>.
@@ -49,7 +51,7 @@ namespace Wox.Plugin.Common
         /// </summary>
         public static void UpdateIfTimePassed()
         {
-            int curTickCount = Environment.TickCount;
+            long curTickCount = Environment.TickCount64;
             if (curTickCount - _lastUpdateTickCount > UpdateTimeout)
             {
                 _lastUpdateTickCount = curTickCount;
@@ -65,6 +67,12 @@ namespace Wox.Plugin.Common
         {
             lock (_updateLock)
             {
+                if (!haveIRanUpdateOnce)
+                {
+                    Log.Warn("I've tried updating the chosen Web Browser info at least once", typeof(DefaultBrowserInfo));
+                    haveIRanUpdateOnce = true;
+                }
+
                 try
                 {
                     string progId = GetRegistryValue(

--- a/src/modules/launcher/Wox.Plugin/Common/DefaultBrowserInfo.cs
+++ b/src/modules/launcher/Wox.Plugin/Common/DefaultBrowserInfo.cs
@@ -15,7 +15,6 @@ namespace Wox.Plugin.Common
     public static class DefaultBrowserInfo
     {
         private static readonly object _updateLock = new object();
-        private static long _lastUpdateTickCount = -1;
 
         /// <summary>Gets the path to the MS Edge browser executable.</summary>
         public static string MSEdgePath =>
@@ -43,6 +42,8 @@ namespace Wox.Plugin.Common
 
         public const long UpdateTimeout = 300;
 
+        private static long _lastUpdateTickCount = -UpdateTimeout;
+
         private static bool haveIRanUpdateOnce;
 
         /// <summary>
@@ -52,7 +53,7 @@ namespace Wox.Plugin.Common
         public static void UpdateIfTimePassed()
         {
             long curTickCount = Environment.TickCount64;
-            if (curTickCount - _lastUpdateTickCount > UpdateTimeout)
+            if (curTickCount - _lastUpdateTickCount >= UpdateTimeout)
             {
                 _lastUpdateTickCount = curTickCount;
                 Update();


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

A recent trove of issues seem to indicate the default web browser is not detected correctly.

**What is included in the PR:** 
- Add logs when no pattern is detected to register the remaining values.
- Add logs to indicate it has been read at least once.
- Increase the tick we're using to see if it's an overflow issue.
- Decrease the initial value of last time it was run to check if that's the issue.

**How does someone test / validate:** 
Haven't been able to reproduce. Looking for a code quality check here.

## Quality Checklist

- [x] **Linked issue:** #18761
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries
