### PR TITLE
[OOBE] [What's New] Modified regular expression to hide "x64 ARM64 Installer Hash" lines.

### DIFF
--- a/src/settings-ui/Settings.UI/OOBE/Views/OobeWhatsNew.xaml.cs
+++ b/src/settings-ui/Settings.UI/OOBE/Views/OobeWhatsNew.xaml.cs
@@ -52,6 +52,12 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
             DataContext = ViewModel;
         }
 
+        /// <summary>
+        /// Regex to remove installer hash sections from the release notes.
+        /// </summary>
+        private const string RemoveInstallerHashesRegex = @"((\r\n)+#+ installer hashes)?((\r\n)+#+( x64)?( arm64)? installer( SHA256)? hash(\r\n)+[0-9A-F]{64})+";
+        private const RegexOptions RemoveInstallerHashesRegexOptions = RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant;
+
         private static async Task<string> GetReleaseNotesMarkdown()
         {
             string releaseNotesJSON = string.Empty;
@@ -71,12 +77,13 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
             StringBuilder releaseNotesHtmlBuilder = new StringBuilder(string.Empty);
 
             // Regex to remove installer hash sections from the release notes.
-            Regex removeHashRegex = new Regex(@"(\r\n)+#+ installer( SHA256)? hash(\r\n)+[0-9A-F]{64}", RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+            Regex removeHashRegex = new Regex(RemoveInstallerHashesRegex, RemoveInstallerHashesRegexOptions);
 
             foreach (var release in latestReleases)
             {
                 releaseNotesHtmlBuilder.AppendLine("# " + release.Name);
-                releaseNotesHtmlBuilder.AppendLine(removeHashRegex.Replace(release.ReleaseNotes, string.Empty));
+                var notes = removeHashRegex.Replace(release.ReleaseNotes, string.Empty);
+                releaseNotesHtmlBuilder.AppendLine(notes);
                 releaseNotesHtmlBuilder.AppendLine("&nbsp;");
             }
 


### PR DESCRIPTION

## Summary of the Pull Request

**What is this about:**

We added ARM64 architecture to our installer build. GitHub now provides two installer hashes for both architectures. 

**What is included in the PR:** 

Changed regular expression to eat new installer hash lines.

**How does someone test / validate:** 

1. Start PowerToys
2. Open Welcome to PowerToys window
3. Hit What's New button.
4. Check there are no lines with installer hashes

## Quality Checklist

- [x] **Linked issue:** #18788
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [ ] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
