### PR TITLE
[Test]Fix flaky markdown preview test

### DIFF
--- a/src/modules/previewpane/UnitTests-MarkdownPreviewHandler/MarkdownPreviewHandlerTest.cs
+++ b/src/modules/previewpane/UnitTests-MarkdownPreviewHandler/MarkdownPreviewHandlerTest.cs
@@ -16,7 +16,8 @@ namespace MarkdownPreviewHandlerUnitTests
     [STATestClass]
     public class MarkdownPreviewHandlerTest
     {
-        private static readonly int TenSecondsInMilliseconds = 10000;
+        // A long timeout is needed. WebView2 can take a long time to load the first time in some CI systems.
+        private static readonly int HardTimeoutInMilliseconds = 30000;
         private static readonly int SleepTimeInMilliseconds = 200;
 
         [TestMethod]
@@ -30,7 +31,7 @@ namespace MarkdownPreviewHandlerUnitTests
 
                 int beforeTick = Environment.TickCount;
 
-                while (markdownPreviewHandlerControl.Controls.Count == 0 && Environment.TickCount < beforeTick + TenSecondsInMilliseconds)
+                while (markdownPreviewHandlerControl.Controls.Count == 0 && Environment.TickCount < beforeTick + HardTimeoutInMilliseconds)
                 {
                     Application.DoEvents();
                     Thread.Sleep(SleepTimeInMilliseconds);
@@ -53,7 +54,7 @@ namespace MarkdownPreviewHandlerUnitTests
 
                 int beforeTick = Environment.TickCount;
 
-                while (markdownPreviewHandlerControl.Controls.Count == 0 && Environment.TickCount < beforeTick + TenSecondsInMilliseconds)
+                while (markdownPreviewHandlerControl.Controls.Count == 0 && Environment.TickCount < beforeTick + HardTimeoutInMilliseconds)
                 {
                     Application.DoEvents();
                     Thread.Sleep(SleepTimeInMilliseconds);
@@ -76,7 +77,7 @@ namespace MarkdownPreviewHandlerUnitTests
 
                 int beforeTick = Environment.TickCount;
 
-                while (markdownPreviewHandlerControl.Controls.Count < 2 && Environment.TickCount < beforeTick + TenSecondsInMilliseconds)
+                while (markdownPreviewHandlerControl.Controls.Count < 2 && Environment.TickCount < beforeTick + HardTimeoutInMilliseconds)
                 {
                     Application.DoEvents();
                     Thread.Sleep(SleepTimeInMilliseconds);
@@ -99,7 +100,7 @@ namespace MarkdownPreviewHandlerUnitTests
 
                 int beforeTick = Environment.TickCount;
 
-                while (markdownPreviewHandlerControl.Controls.Count == 0 && Environment.TickCount < beforeTick + TenSecondsInMilliseconds)
+                while (markdownPreviewHandlerControl.Controls.Count == 0 && Environment.TickCount < beforeTick + HardTimeoutInMilliseconds)
                 {
                     Application.DoEvents();
                     Thread.Sleep(SleepTimeInMilliseconds);
@@ -122,7 +123,7 @@ namespace MarkdownPreviewHandlerUnitTests
 
                 int beforeTick = Environment.TickCount;
 
-                while (markdownPreviewHandlerControl.Controls.Count < 2 && Environment.TickCount < beforeTick + TenSecondsInMilliseconds)
+                while (markdownPreviewHandlerControl.Controls.Count < 2 && Environment.TickCount < beforeTick + HardTimeoutInMilliseconds)
                 {
                     Application.DoEvents();
                     Thread.Sleep(SleepTimeInMilliseconds);
@@ -145,7 +146,7 @@ namespace MarkdownPreviewHandlerUnitTests
 
                 int beforeTick = Environment.TickCount;
 
-                while (markdownPreviewHandlerControl.Controls.Count == 0 && Environment.TickCount < beforeTick + TenSecondsInMilliseconds)
+                while (markdownPreviewHandlerControl.Controls.Count == 0 && Environment.TickCount < beforeTick + HardTimeoutInMilliseconds)
                 {
                     Application.DoEvents();
                     Thread.Sleep(SleepTimeInMilliseconds);

--- a/src/modules/previewpane/UnitTests-SvgPreviewHandler/SvgPreviewControlTests.cs
+++ b/src/modules/previewpane/UnitTests-SvgPreviewHandler/SvgPreviewControlTests.cs
@@ -21,7 +21,8 @@ namespace SvgPreviewHandlerUnitTests
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2201:Do not raise reserved exception types", Justification = "new Exception() is fine in test projects.")]
     public class SvgPreviewControlTests
     {
-        private static readonly int ThreeSecondsInMilliseconds = 3000;
+        // A long timeout is needed. WebView2 can take a long time to load the first time in some CI systems.
+        private static readonly int HardTimeoutInMilliseconds = 30000;
         private static readonly int SleepTimeInMilliseconds = 200;
 
         [TestMethod]
@@ -35,7 +36,7 @@ namespace SvgPreviewHandlerUnitTests
 
                 int beforeTick = Environment.TickCount;
 
-                while (svgPreviewControl.Controls.Count == 0 && Environment.TickCount < beforeTick + ThreeSecondsInMilliseconds)
+                while (svgPreviewControl.Controls.Count == 0 && Environment.TickCount < beforeTick + HardTimeoutInMilliseconds)
                 {
                     Application.DoEvents();
                     Thread.Sleep(SleepTimeInMilliseconds);
@@ -58,7 +59,7 @@ namespace SvgPreviewHandlerUnitTests
 
                 int beforeTick = Environment.TickCount;
 
-                while (svgPreviewControl.Controls.Count == 0 && Environment.TickCount < beforeTick + ThreeSecondsInMilliseconds)
+                while (svgPreviewControl.Controls.Count == 0 && Environment.TickCount < beforeTick + HardTimeoutInMilliseconds)
                 {
                     Application.DoEvents();
                     Thread.Sleep(SleepTimeInMilliseconds);
@@ -85,7 +86,7 @@ namespace SvgPreviewHandlerUnitTests
 
                 int beforeTick = Environment.TickCount;
 
-                while (svgPreviewControl.Controls.Count == 0 && Environment.TickCount < beforeTick + ThreeSecondsInMilliseconds)
+                while (svgPreviewControl.Controls.Count == 0 && Environment.TickCount < beforeTick + HardTimeoutInMilliseconds)
                 {
                     Application.DoEvents();
                     Thread.Sleep(SleepTimeInMilliseconds);
@@ -119,7 +120,7 @@ namespace SvgPreviewHandlerUnitTests
 
                 int beforeTick = Environment.TickCount;
 
-                while (svgPreviewControl.Controls.Count == 0 && Environment.TickCount < beforeTick + ThreeSecondsInMilliseconds)
+                while (svgPreviewControl.Controls.Count == 0 && Environment.TickCount < beforeTick + HardTimeoutInMilliseconds)
                 {
                     Application.DoEvents();
                     Thread.Sleep(SleepTimeInMilliseconds);
@@ -156,7 +157,7 @@ namespace SvgPreviewHandlerUnitTests
 
                 int beforeTick = Environment.TickCount;
 
-                while (svgPreviewControl.Controls.Count < 2 && Environment.TickCount < beforeTick + ThreeSecondsInMilliseconds)
+                while (svgPreviewControl.Controls.Count < 2 && Environment.TickCount < beforeTick + HardTimeoutInMilliseconds)
                 {
                     Application.DoEvents();
                     Thread.Sleep(SleepTimeInMilliseconds);
@@ -186,7 +187,7 @@ namespace SvgPreviewHandlerUnitTests
 
                 int beforeTick = Environment.TickCount;
 
-                while (svgPreviewControl.Controls.Count == 0 && Environment.TickCount < beforeTick + ThreeSecondsInMilliseconds)
+                while (svgPreviewControl.Controls.Count == 0 && Environment.TickCount < beforeTick + HardTimeoutInMilliseconds)
                 {
                     Application.DoEvents();
                     Thread.Sleep(SleepTimeInMilliseconds);
@@ -212,7 +213,7 @@ namespace SvgPreviewHandlerUnitTests
 
                 int beforeTick = Environment.TickCount;
 
-                while (svgPreviewControl.Controls.Count == 0 && Environment.TickCount < beforeTick + ThreeSecondsInMilliseconds)
+                while (svgPreviewControl.Controls.Count == 0 && Environment.TickCount < beforeTick + HardTimeoutInMilliseconds)
                 {
                     Application.DoEvents();
                     Thread.Sleep(SleepTimeInMilliseconds);


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
CI runs are failing a lot on the MarkdownPreviewHandler Tests.

**What is included in the PR:** 
- Increase the timeout to wait for WebView2 to get initialized, as that might be what's taking longer on CI.

**How does someone test / validate:** 
- CI test runs pass more reliably.

## Quality Checklist

- [x] **Linked issue:** #18839
- [ ] **Communication:** I've discussed this with core contributors in the issue. 
- [x] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [x] **Binaries:** Any new files are added to WXS / YML
   - [x] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries
