### PR TITLE
[FileExplorer Add-ons][SVGthumbnails] Dispose WebView resources

### DIFF
--- a/src/modules/previewpane/SvgThumbnailProvider/SvgThumbnailProvider.cs
+++ b/src/modules/previewpane/SvgThumbnailProvider/SvgThumbnailProvider.cs
@@ -164,6 +164,8 @@ namespace Microsoft.PowerToys.ThumbnailHandler.Svg
                 Application.DoEvents();
             }
 
+            _browser.Dispose();
+
             return thumbnail;
         }
 


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**
Opening folder with lot of SVG files resulted in high CPU and memory consumption. The reason is creating webview2 instance for every SVG thumbnail that needs to be shown.

After thumbnail is generated, WebView resources are no longer needed and can be released as soon as possible. This way CPU and memory usage is significantly lower.

**What is included in the PR:** 
Dispose WebView2 instance after thumbnail is generated.

**How does someone test / validate:** 

## Quality Checklist

- [x] **Linked issue:** #18865
- [x] **Communication:** I've discussed this with core contributors in the issue. 
- [] **Tests:** Added/updated and all pass
- [ ] **Installer:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
- [ ] **Binaries:** Any new files are added to WXS / YML
   - [ ] No new binaries
   - [ ] [YML for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/pipeline.user.windows.yml#L68) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries

## Contributor License Agreement (CLA)
A CLA must be signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA.
