### PR TITLE
[PTRun]Keep selected item on top if it's the first

### DIFF
--- a/src/modules/launcher/PowerLauncher/ViewModel/ResultsViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/ResultsViewModel.cs
@@ -255,7 +255,19 @@ namespace PowerLauncher.ViewModel
 
         public void Sort()
         {
-            var sorted = Results.OrderByDescending(x => x.Result.Score).ToList();
+            var sorted = Results.OrderByDescending(
+                x =>
+                {
+                    if (_selectedItem == x && x == Results.FirstOrDefault())
+                    {
+                        // When receiving delayed results, don't displace the current first result if it's the selected one.
+                        return int.MaxValue;
+                    }
+                    else
+                    {
+                        return x.Result.Score;
+                    }
+                }).ToList();
             Clear();
             Results.AddRange(sorted);
         }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
In PowerToys Run, when items of delayed plugins are added to the list, they might be added to the currently list on top of the selected item if they get a greater score, making the experience weird when the first item was selected (user searches and sees the third item being selected by default, for example).
This PR proposes not displacing the first item if it's selected when delayed results are added to the results list.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #18845
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Keep the first item in its place if it's selected when sorting the results list.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- In PowerToys Run, open some files using the search plugin, so they get a greater score on subsquent searches.
- Search for those items again.
- Verify the items don't displace the first result(that's selected by default) when search adds its results to the list.
