### PR TITLE
[PTRun] Sort order for previously selected not always working

### DIFF
--- a/src/modules/launcher/PowerLauncher/Storage/UserSelectedRecord.cs
+++ b/src/modules/launcher/PowerLauncher/Storage/UserSelectedRecord.cs
@@ -11,8 +11,15 @@ namespace PowerLauncher.Storage
 {
     public class UserSelectedRecord
     {
+        public class UserSelectedRecordItem
+        {
+            public int SelectedCount { get; set; }
+
+            public DateTime LastSelected { get; set; }
+        }
+
         [JsonInclude]
-        public Dictionary<string, int> Records { get; private set; } = new Dictionary<string, int>();
+        public Dictionary<string, UserSelectedRecordItem> Records { get; private set; } = new Dictionary<string, UserSelectedRecordItem>();
 
         public void Add(Result result)
         {
@@ -22,13 +29,14 @@ namespace PowerLauncher.Storage
             }
 
             var key = result.ToString();
-            if (Records.TryGetValue(key, out int value))
+            if (Records.TryGetValue(key, out var value))
             {
-                Records[key] = value + 1;
+                Records[key].SelectedCount = value.SelectedCount + 1;
+                Records[key].LastSelected = DateTime.UtcNow;
             }
             else
             {
-                Records.Add(key, 1);
+                Records.Add(key, new UserSelectedRecordItem { SelectedCount = 0, LastSelected = DateTime.UtcNow });
             }
         }
 
@@ -39,9 +47,9 @@ namespace PowerLauncher.Storage
                 throw new ArgumentNullException(nameof(result));
             }
 
-            if (result != null && Records.TryGetValue(result.ToString(), out int value))
+            if (result != null && Records.TryGetValue(result.ToString(), out var value))
             {
-                return value;
+                return value.SelectedCount;
             }
 
             return 0;

--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -945,6 +945,7 @@ namespace PowerLauncher.ViewModel
             foreach (var result in list)
             {
                 result.Score += _userSelectedRecord.GetSelectedCount(result) * 5;
+                result.SelectedCount = _userSelectedRecord.GetSelectedCount(result);
             }
 
             // Using CurrentCultureIgnoreCase since this is user facing

--- a/src/modules/launcher/PowerLauncher/ViewModel/ResultsViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/ResultsViewModel.cs
@@ -255,7 +255,7 @@ namespace PowerLauncher.ViewModel
 
         public void Sort()
         {
-            var sorted = Results.OrderByDescending(x => x.Result.Score).ToList();
+            var sorted = Results.OrderByDescending(x => x.Result.SelectedCount).ThenByDescending(x => x.Result.Score).ToList();
             Clear();
             Results.AddRange(sorted);
         }

--- a/src/modules/launcher/Wox.Plugin/Result.cs
+++ b/src/modules/launcher/Wox.Plugin/Result.cs
@@ -100,6 +100,8 @@ namespace Wox.Plugin
 
         public int Score { get; set; }
 
+        public int SelectedCount { get; set; }
+
         public Result(IList<int> titleHighlightData = null, IList<int> subTitleHighlightData = null)
         {
             TitleHighlightData = titleHighlightData;


### PR DESCRIPTION
## Summary of the Pull Request
Some items in the list will appear before previously selected/clicked items. Previously selected items should always be before never-selected items. We need to do this because the "Score" is not uniform (across plugins) and thus it might require a lot more clicks to put something at the top of the list.

We might want to also put a time box on the amount of time it can be considered "clicked". For instance, if it's last click was a long time ago, use the current "Score * 5" system, else use the new system.

E.g.:
Search results have this makeup.

Item 1: Score 900
Item 2: Score 200
Item 3: Score 100
Item 4: Score 3

Here, "Item 4" has to be clicked "a lot" and it's an unknown (to the user) why it's not at the top. Because we're using (Score + (ClickedCount * 5)). We need to click "Item 4" 182 times to get it to the top.


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [X] **Closes:** #18958
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

To fix this we can store the number of times clicked separately and order by number of times clicked and then by "Score". We can also age out clicked items if wanted. We can ignore clicked items, if we clicked them "a long time ago".

Unless there is some unified score model, what else can be done?

Also, I don't know if this will affect PT Run "utilities" like calculator and such, and we might want to omit them from "clicked count if they are not already?"



## Validation Steps Performed

