### PR TITLE
[PT Run] Settings plugin: Update sharing settings

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsSettings/Properties/Resources.Designer.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsSettings/Properties/Resources.Designer.cs
@@ -2149,6 +2149,15 @@ namespace Microsoft.PowerToys.Run.Plugin.WindowsSettings.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Nearby share settings.
+        /// </summary>
+        internal static string NearbyShareSettings {
+            get {
+                return ResourceManager.GetString("NearbyShareSettings", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to netcpl.cpl.
         /// </summary>
         internal static string netcpl_cpl {
@@ -3283,7 +3292,16 @@ namespace Microsoft.PowerToys.Run.Plugin.WindowsSettings.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Shared experiences.
+        ///   Looks up a localized string similar to Share across devices.
+        /// </summary>
+        internal static string ShareAcrossDevices {
+            get {
+                return ResourceManager.GetString("ShareAcrossDevices", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Shared experience settings.
         /// </summary>
         internal static string SharedExperiences {
             get {

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsSettings/Properties/Resources.resx
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsSettings/Properties/Resources.resx
@@ -981,6 +981,10 @@
     <value>Navigation bar</value>
     <comment>Area Personalization</comment>
   </data>
+  <data name="NearbyShareSettings" xml:space="preserve">
+    <value>Nearby share settings</value>
+    <comment>Area System</comment>
+  </data>
   <data name="netcpl.cpl" xml:space="preserve">
     <value>netcpl.cpl</value>
     <comment>File name, Should not translated</comment>
@@ -1443,8 +1447,12 @@
     <value>Set up a kiosk</value>
     <comment>Area UserAccounts</comment>
   </data>
+  <data name="ShareAcrossDevices" xml:space="preserve">
+    <value>Share across devices</value>
+    <comment>Area System</comment>
+  </data>
   <data name="SharedExperiences" xml:space="preserve">
-    <value>Shared experiences</value>
+    <value>Shared experience settings</value>
     <comment>Area System</comment>
   </data>
   <data name="Shortcuts" xml:space="preserve">

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsSettings/Properties/Resources.resx
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsSettings/Properties/Resources.resx
@@ -982,7 +982,7 @@
     <comment>Area Personalization</comment>
   </data>
   <data name="NearbyShareSettings" xml:space="preserve">
-    <value>Nearby share settings</value>
+    <value>Nearby sharing settings</value>
     <comment>Area System</comment>
   </data>
   <data name="netcpl.cpl" xml:space="preserve">

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsSettings/WindowsSettings.json
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsSettings/WindowsSettings.json
@@ -988,7 +988,21 @@
       "Name": "SharedExperiences",
       "Areas": [ "AreaSystem" ],
       "Type": "AppSettingsApp",
-      "AltNames": [ "Crossdevice" ],
+      "AltNames": [ "Crossdevice", "NearbyShareSettings", "ShareAcrossDevices" ],
+      "Command": "ms-settings:crossdevice"
+    },
+	{
+      "Name": "NearbyShareSettings",
+      "Areas": [ "AreaSystem" ],
+      "Type": "AppSettingsApp",
+      "AltNames": [ "Crossdevice", "ShareAcrossDevices", "SharedExperiences" ],
+      "Command": "ms-settings:crossdevice"
+    },
+	{
+      "Name": "ShareAcrossDevices",
+      "Areas": [ "AreaSystem" ],
+      "Type": "AppSettingsApp",
+      "AltNames": [ "Crossdevice", "NearbyShareSettings", "SharedExperiences" ],
       "Command": "ms-settings:crossdevice"
     },
     {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This PR updates the sharing settings results in Windows setting plugin.

![image](https://user-images.githubusercontent.com/61519853/175811334-2a1b0e01-6d07-41f3-aef6-2a95c7082498.png)
_Note: After creating the screenshot I fixed name of nearby result._


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #18618
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

Two new settings results are added and ones is updated with additional alt names.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Test results on local build.

