### PR TITLE
Make sure we run CG component detection on main

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -192,6 +192,7 @@ buf
 BUFSIZE
 bugreport
 BUILDARCH
+buildtask
 buildtransitive
 Burkina
 Buryatia

--- a/.pipelines/ci/templates/build-powertoys-ci.yml
+++ b/.pipelines/ci/templates/build-powertoys-ci.yml
@@ -22,3 +22,9 @@ jobs:
   - template: build-powertoys-steps.yml
     parameters:
       additionalBuildArguments: ${{ parameters.additionalBuildArguments }}
+
+  # It appears that the Component Governance build task that gets automatically injected stopped working
+  # when we renamed our main branch.
+  - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+    displayName: 'Component Detection'
+    condition: and(succeededOrFailed(), not(eq(variables['Build.Reason'], 'PullRequest')))


### PR DESCRIPTION
I believe that there is a hidden "default branch" setting in Azure
DevOps, and ours is set to "master". CG only attempts to automatically
inject to builds off the default branch... and because we're a GitHub
repo running builds in AzDO we _can't change what the default branch
is_. Oops.

Copied from microsoft/terminal@e0bd76b30