### PR TITLE
[MouseCrosshairs]Change default shortcut

### DIFF
--- a/src/modules/MouseUtils/MousePointerCrosshairs/dllmain.cpp
+++ b/src/modules/MouseUtils/MousePointerCrosshairs/dllmain.cpp
@@ -298,7 +298,7 @@ public:
         if (!m_hotkey.modifiersMask)
         {
             Logger::info("Mouse Pointer Crosshairs  is going to use default shortcut");
-            m_hotkey.modifiersMask = MOD_CONTROL | MOD_ALT;
+            m_hotkey.modifiersMask = MOD_WIN | MOD_ALT;
             m_hotkey.vkCode = 0x50; // P key
         }
         m_inclusiveCrosshairsSettings = inclusiveCrosshairsSettings;

--- a/src/settings-ui/Settings.UI.Library/MousePointerCrosshairsProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/MousePointerCrosshairsProperties.cs
@@ -31,7 +31,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
 
         public MousePointerCrosshairsProperties()
         {
-            ActivationShortcut = new HotkeySettings(false, true, true, false, 0x50); // Ctrl + Alt + P
+            ActivationShortcut = new HotkeySettings(true, false, true, false, 0x50); // Win + Alt + P
             CrosshairsColor = new StringProperty("#FF0000");
             CrosshairsOpacity = new IntProperty(75);
             CrosshairsRadius = new IntProperty(20);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Mouse pointer crosshairs default shortcut will have collision with special modified characters from Alt Gr+P on some keyboards.
Change the default activation key to Win+Alt+P instead of Control+Alt+P.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #16021
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Change the default activation key to Win+Alt+P instead of Control+Alt+P.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Delete %localappdata%/Microsoft/PowerToys , run PowerToys, enable Mouse Pointer Crosshairs (disabled by default) and verify the default shortcut is Win+Alt+P