### PR TITLE
[ci][test]Disable tests that depend on WebView2

### DIFF
--- a/.pipelines/ci/templates/build-powertoys-steps.yml
+++ b/.pipelines/ci/templates/build-powertoys-steps.yml
@@ -165,7 +165,7 @@ steps:
       !**\ref\**
 
 # TODO: Enable these tests after figuring out what caused the tests that depend on WebView2 to start timing out in CI.
-#  **\PreviewPaneUnitTests.dll # UnitTests-MarkdownPreviewHandler
+#  **\PreviewPaneUnitTests.dll # It's UnitTests-MarkdownPreviewHandler
 #  **\UnitTests-SvgThumbnailProvider.dll
 #  **\UnitTests-SvgPreviewHandler.dll
 

--- a/.pipelines/ci/templates/build-powertoys-steps.yml
+++ b/.pipelines/ci/templates/build-powertoys-steps.yml
@@ -147,7 +147,6 @@ steps:
       **\UnitTests-GcodePreviewHandler.dll
       **\UnitTests-PdfPreviewHandler.dll
       **\UnitTests-PreviewHandlerCommon.dll
-      **\PreviewPaneUnitTests.dll
       **\Microsoft.PowerToys.Run.Plugin.Registry.UnitTests.dll
       **\UnitTest-ColorPickerUI.dll
       **\Microsoft.Interop.Tests.dll
@@ -166,8 +165,8 @@ steps:
       !**\ref\**
 
 # TODO: Enable these tests after figuring out what caused the tests that depend on WebView2 to start timing out in CI.
+#  **\PreviewPaneUnitTests.dll # UnitTests-MarkdownPreviewHandler
 #  **\UnitTests-SvgThumbnailProvider.dll
-#  **\UnitTests-MarkdownPreviewHandler.dll
 #  **\UnitTests-SvgPreviewHandler.dll
 
 # Native dlls

--- a/.pipelines/ci/templates/build-powertoys-steps.yml
+++ b/.pipelines/ci/templates/build-powertoys-steps.yml
@@ -141,14 +141,11 @@ steps:
     testSelector: 'testAssemblies'
     testAssemblyVer2: |
       **\UnitTests-GcodeThumbnailProvider.dll
-      **\UnitTests-SvgThumbnailProvider.dll
       **\UnitTests-StlThumbnailProvider.dll
       **\UnitTests-PdfThumbnailProvider.dll
       **\Settings.UI.UnitTests.dll
-      **\UnitTests-MarkdownPreviewHandler.dll
       **\UnitTests-GcodePreviewHandler.dll
       **\UnitTests-PdfPreviewHandler.dll
-      **\UnitTests-SvgPreviewHandler.dll
       **\UnitTests-PreviewHandlerCommon.dll
       **\PreviewPaneUnitTests.dll
       **\Microsoft.PowerToys.Run.Plugin.Registry.UnitTests.dll
@@ -167,6 +164,11 @@ steps:
       **\Microsoft.Plugin.WindowWalker.UnitTests.dll
       !**\obj\**
       !**\ref\**
+
+# TODO: Enable these tests after figuring out what caused the tests that depend on WebView2 to start timing out in CI.
+#  **\UnitTests-SvgThumbnailProvider.dll
+#  **\UnitTests-MarkdownPreviewHandler.dll
+#  **\UnitTests-SvgPreviewHandler.dll
 
 # Native dlls
 - task: VSTest@2


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
CI tests are timing out in CI. Prime suspect is that something changed with the WebView2 runtimes in the test machines. Let's try it out with this PR.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #19076
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Disable tests that depend on WebView2.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
CI is able to pass again.
