### PR TITLE
Update VCRedist version to latest

### DIFF
--- a/installer/PowerToysSetup/PowerToys.wxs
+++ b/installer/PowerToysSetup/PowerToys.wxs
@@ -112,6 +112,7 @@
                 InstallCommand="/install /quiet /norestart"
                 RepairCommand="/repair /quiet /norestart"
                 Permanent="yes">
+                <ExitCode Value="1638" Behavior="success"/>
                 <RemotePayload
                     Description="Microsoft Visual C++ 2015-2022 Redistributable ($(var.PowerToysPlatform)) - 14.32.31332"
                     ProductName="Microsoft Visual C++ 2015-2022 Redistributable ($(var.PowerToysPlatform)) - 14.32.31332"

--- a/installer/PowerToysSetup/PowerToys.wxs
+++ b/installer/PowerToysSetup/PowerToys.wxs
@@ -10,9 +10,9 @@
     <?define Dotnet6PayloadSize="57791288"?>
     <?define Dotnet6PayloadHash="B5B1819CCA753B070181F50411375B80412860A3"?>
 
-    <?define VCRedistDownloadUrl="https://download.visualstudio.microsoft.com/download/pr/6b6923b0-3045-4379-a96f-ef5506a65d5b/426A34C6F10EA8F7DA58A8C976B586AD84DD4BAB42A0CFDBE941F1763B7755E5/VC_redist.x64.exe"?>
-    <?define VCRedistPayloadSize="25337776"?>
-    <?define VCRedistPayloadHash="47996AAB6A20DBBA69969C4B36F8FC718877751F"?>
+    <?define VCRedistDownloadUrl="https://download.visualstudio.microsoft.com/download/pr/ed95ef9e-da02-4735-9064-bd1f7f69b6ed/CE6593A1520591E7DEA2B93FD03116E3FC3B3821A0525322B0A430FAA6B3C0B4/VC_redist.x64.exe"?>
+    <?define VCRedistPayloadSize="25234792"?>
+    <?define VCRedistPayloadHash="D4F9181E70E3F1AA6C8EDFFCC15B3C3D4BABE36B"?>
 
     <?define PlatformProgramFiles="[ProgramFiles64Folder]"?>
 <?else?>
@@ -24,9 +24,9 @@
     <?define Dotnet6PayloadSize="51774400"?>
     <?define Dotnet6PayloadHash="62C15858951B123AFD4D3E14F8BE4829A7CAFF18"?>
     
-    <?define VCRedistDownloadUrl="https://download.visualstudio.microsoft.com/download/pr/6b6923b0-3045-4379-a96f-ef5506a65d5b/6114C0A7A526EA47D9ADD78C718BEA0BA32EEF0826AA5610AF76877CC5FEB7F3/VC_redist.arm64.exe"?>
-    <?define VCRedistPayloadSize="11596400"?>
-    <?define VCRedistPayloadHash="DEF8E16367DE4BDDE0399614B7E358629A959942"?>
+    <?define VCRedistDownloadUrl="https://download.visualstudio.microsoft.com/download/pr/ed95ef9e-da02-4735-9064-bd1f7f69b6ed/8E126191012691AE22A0D5A89FAC01B59BABC7B680E5D9B65828935FD366E375/VC_redist.arm64.exe"?>
+    <?define VCRedistPayloadSize="11500416"?>
+    <?define VCRedistPayloadHash="FEECAC80EF04125B058381487332872896F38477"?>
 
 <!--TODO: define to ARM64 Program files once it's available-->
     <?define PlatformProgramFiles="[ProgramFiles6432Folder]"?> 
@@ -104,7 +104,7 @@
                 UninstallCommand="/silent /uninstall">
             </ExePackage>
             <ExePackage
-                Name="VCRedist-14.32.31326.exe"
+                Name="VCRedist-14.32.31332.exe"
                 DetectCondition="DetectedVCRedistVersion >= 32"
                 Compressed="no"
                 Id="VCRedist"
@@ -113,10 +113,10 @@
                 RepairCommand="/repair /quiet /norestart"
                 Permanent="yes">
                 <RemotePayload
-                    Description="Microsoft Visual C++ 2015-2022 Redistributable ($(var.PowerToysPlatform)) - 14.32.31326"
-                    ProductName="Microsoft Visual C++ 2015-2022 Redistributable ($(var.PowerToysPlatform)) - 14.32.31326"
+                    Description="Microsoft Visual C++ 2015-2022 Redistributable ($(var.PowerToysPlatform)) - 14.32.31332"
+                    ProductName="Microsoft Visual C++ 2015-2022 Redistributable ($(var.PowerToysPlatform)) - 14.32.31332"
                     Size="$(var.VCRedistPayloadSize)"
-                    Version="14.32.31326.0"
+                    Version="14.32.31332.0"
                     Hash="$(var.VCRedistPayloadHash)" />
             </ExePackage>
             <MsiPackage


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Updates the VC++ Redist to the latest released version to fix an issue with the PowerToys Installer failing due to installing an earlier version of the package for those who already have the latest VC++ redist installed. 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [X] **Closes:** #19090 
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Built installer locally and verified it pulls in latest VC++ redist.
