### PR TITLE
PT Run activation shortcut, replace Window Search

### DIFF
--- a/src/modules/interface/powertoy_module_interface.h
+++ b/src/modules/interface/powertoy_module_interface.h
@@ -106,6 +106,11 @@ public:
     virtual bool keep_track_of_pressed_win_key() { return false; }
     virtual UINT milliseconds_win_key_must_be_pressed() { return 0; }
 
+    /* Even more special case, danger, look away. is_windows_search_replacement_mode allows using Win key by itself to open PTRun, but also allow Win+[other-key] to do whatever it does.
+     * Don't use these for new modules.
+     */
+    virtual bool is_windows_search_replacement_mode() { return false; }
+
     virtual void send_settings_telemetry()
     {
     }

--- a/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
+++ b/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
@@ -242,7 +242,7 @@ public:
             std::wstring runExecutablePath = modulePath;
             std::wstring params;
             params += L" -powerToysPid " + std::to_wstring(powertoys_pid) + L" ";
-            params += L"--started-from-runner ";
+            params += L"--started-from-runner  --is-elevated-true";
             runExecutablePath += L"\\modules\\launcher\\PowerToys.PowerLauncher.exe";
             processStarted = RunNonElevatedFailsafe(runExecutablePath, params, modulePath).has_value();
         }
@@ -252,7 +252,7 @@ public:
             std::wstring executable_args;
             executable_args += L" -powerToysPid ";
             executable_args += std::to_wstring(powertoys_pid);
-            executable_args += L" --started-from-runner";
+            executable_args += L" --started-from-runner --is-elevated-false";
 
             SHELLEXECUTEINFOW sei{ sizeof(sei) };
             sei.fMask = { SEE_MASK_NOCLOSEPROCESS | SEE_MASK_FLAG_NO_UI };

--- a/src/modules/launcher/PowerLauncher/App.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/App.xaml.cs
@@ -135,6 +135,16 @@ namespace PowerLauncher
                 _mainVM.MainWindowVisibility = Visibility.Visible;
                 _mainVM.ColdStartFix();
                 _themeManager.ThemeChanged += OnThemeChanged;
+
+                var ptIsElevated = e.Args.Contains("--is-elevated-true");
+                if (_settings.IsWindowsSearchReplacementMode && !ptIsElevated)
+                {
+                    textToLog.AppendLine("Bad combo, IsWindowsSearchReplacementMode AND non elevated PT");
+
+                    // _settings.IsWindowsSearchReplacementMode = false;
+                    MessageBox.Show("Current PowerToys Run settings requires elevated permission to work properly. PowerToys Run will not activate if an elevated program is the foreground application. \r\n\r\nYou should change PowerToys to run as Administrator to correct this.", "PowerToys Run");
+                }
+
                 textToLog.AppendLine("End PowerToys Run startup ----------------------------------------------------  ");
 
                 bootTime.Stop();

--- a/src/modules/launcher/PowerLauncher/SettingsReader.cs
+++ b/src/modules/launcher/PowerLauncher/SettingsReader.cs
@@ -105,6 +105,11 @@ namespace PowerLauncher
                         _settings.UseCentralizedKeyboardHook = overloadSettings.Properties.UseCentralizedKeyboardHook;
                     }
 
+                    if (_settings.IsWindowsSearchReplacementMode != overloadSettings.Properties.IsWindowsSearchReplacementMode)
+                    {
+                        _settings.IsWindowsSearchReplacementMode = overloadSettings.Properties.IsWindowsSearchReplacementMode;
+                    }
+
                     if (_settings.SearchQueryResultsWithDelay != overloadSettings.Properties.SearchQueryResultsWithDelay)
                     {
                         _settings.SearchQueryResultsWithDelay = overloadSettings.Properties.SearchQueryResultsWithDelay;

--- a/src/modules/launcher/Wox.Infrastructure/UserSettings/PowerToysRunSettings.cs
+++ b/src/modules/launcher/Wox.Infrastructure/UserSettings/PowerToysRunSettings.cs
@@ -61,6 +61,25 @@ namespace Wox.Infrastructure.UserSettings
             }
         }
 
+        private bool _isWindowsSearchReplacementMode;
+
+        public bool IsWindowsSearchReplacementMode
+        {
+            get
+            {
+                return _isWindowsSearchReplacementMode;
+            }
+
+            set
+            {
+                if (_isWindowsSearchReplacementMode != value)
+                {
+                    _isWindowsSearchReplacementMode = value;
+                    OnPropertyChanged(nameof(IsWindowsSearchReplacementMode));
+                }
+            }
+        }
+
         private bool _searchQueryResultsWithDelay = true;
 
         public bool SearchQueryResultsWithDelay

--- a/src/runner/centralized_kb_hook.cpp
+++ b/src/runner/centralized_kb_hook.cpp
@@ -91,7 +91,6 @@ namespace CentralizedKeyboardHook
 
         const auto& keyPressInfo = *reinterpret_cast<KBDLLHOOKSTRUCT*>(lParam);
 
-        bool fileWindowsSearchReplacement = false;
         // Check if the keys are pressed.
         if (!pressedKeyDescriptors.empty())
         {
@@ -100,31 +99,18 @@ namespace CentralizedKeyboardHook
             {
                 if (keyPressInfo.vkCode == VK_LWIN)
                 {
-                    // if a fresh Win key comes in, we restart tracking
-                    //keysPressed.clear();
                     dirtyKeysStack = false;
                 }
                 else
                 {
-                    // if a non Win key comes in, we're dirty
                     dirtyKeysStack = true;
                 }
-
-                //if (keysPressed.contains(VK_LWIN))
-                //{
-                //    // if a non Win key comes in, we're dirty
-                //    dirtyKeysStack = true;
-                //}
-
-                // save these keys
-                // keysPressed.insert(keyPressInfo.vkCode);
             }
 
             if ((wParam == WM_KEYUP || wParam == WM_SYSKEYUP))
             {
                 if (keyPressInfo.vkCode == VK_LWIN)
-                {
-                    //if (keysPressed.size() == 1 && !dirtyKeysStack)
+                {                    
                     if (!dirtyKeysStack)
                     {
                         // win-up, escape to kill old win-down
@@ -151,13 +137,6 @@ namespace CentralizedKeyboardHook
                         }
                         return CallNextHookEx(hHook, nCode, wParam, lParam);
                     }
-                }
-                else
-                {
-                    /*if (keysPressed.contains(keyPressInfo.vkCode))
-                    {
-                        keysPressed.erase(keysPressed.find(keyPressInfo.vkCode));
-                    }*/
                 }
             }
 

--- a/src/runner/centralized_kb_hook.h
+++ b/src/runner/centralized_kb_hook.h
@@ -14,4 +14,5 @@ namespace CentralizedKeyboardHook
     void AddPressedKeyActionForWindowsSearchReplacement(const std::wstring& moduleName, std::function<bool()>&& action) noexcept;
     void ClearModuleHotkeys(const std::wstring& moduleName) noexcept;
     void RegisterWindow(HWND hwnd) noexcept;
+    void UpdateHasAnyWindowsSearchReplacement() noexcept;
 };

--- a/src/runner/centralized_kb_hook.h
+++ b/src/runner/centralized_kb_hook.h
@@ -9,7 +9,9 @@ namespace CentralizedKeyboardHook
     void Start() noexcept;
     void Stop() noexcept;
     void SetHotkeyAction(const std::wstring& moduleName, const Hotkey& hotkey, std::function<bool()>&& action) noexcept;
+    void SendKeyUp();
     void AddPressedKeyAction(const std::wstring& moduleName, const DWORD vk, const UINT milliseconds, std::function<bool()>&& action) noexcept;
+    void AddPressedKeyActionForWindowsSearchReplacement(const std::wstring& moduleName, std::function<bool()>&& action) noexcept;
     void ClearModuleHotkeys(const std::wstring& moduleName) noexcept;
     void RegisterWindow(HWND hwnd) noexcept;
 };

--- a/src/runner/powertoy_module.cpp
+++ b/src/runner/powertoy_module.cpp
@@ -86,6 +86,8 @@ void PowertoyModule::update_hotkeys()
             });
         }
     }
+
+    CentralizedKeyboardHook::UpdateHasAnyWindowsSearchReplacement();
 }
 
 void PowertoyModule::UpdateHotkeyEx()
@@ -135,4 +137,6 @@ void PowertoyModule::UpdateHotkeyEx()
         CentralizedKeyboardHook::AddPressedKeyAction(pt_module->get_key(), VK_LWIN, pt_module->milliseconds_win_key_must_be_pressed(), action);
         CentralizedKeyboardHook::AddPressedKeyAction(pt_module->get_key(), VK_RWIN, pt_module->milliseconds_win_key_must_be_pressed(), action);
     }
+
+    CentralizedKeyboardHook::UpdateHasAnyWindowsSearchReplacement();
 }

--- a/src/runner/powertoy_module.cpp
+++ b/src/runner/powertoy_module.cpp
@@ -2,6 +2,7 @@
 #include "powertoy_module.h"
 #include "centralized_kb_hook.h"
 #include "centralized_hotkeys.h"
+#include "common/utils/elevation.h"
 #include <common/logger/logger.h>
 #include <common/utils/winapi_error.h>
 
@@ -60,6 +61,8 @@ void PowertoyModule::update_hotkeys()
     pt_module->get_hotkeys(hotkeys.data(), hotkeyCount);
 
     auto modulePtr = pt_module.get();
+
+    // auto isElevated = is_process_elevated();
 
     std::wstring name = modulePtr->get_name();
 

--- a/src/settings-ui/Settings.UI.Library/PowerLauncherProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/PowerLauncherProperties.cs
@@ -51,6 +51,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         [JsonPropertyName("use_centralized_keyboard_hook")]
         public bool UseCentralizedKeyboardHook { get; set; }
 
+        [JsonPropertyName("is_windows_search_replacement_mode")]
+        public bool IsWindowsSearchReplacementMode { get; set; }
+
         [JsonPropertyName("search_query_results_with_delay")]
         public bool SearchQueryResultsWithDelay { get; set; }
 

--- a/src/settings-ui/Settings.UI.Library/ViewModels/PowerLauncherViewModel.cs
+++ b/src/settings-ui/Settings.UI.Library/ViewModels/PowerLauncherViewModel.cs
@@ -296,6 +296,23 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             }
         }
 
+        public bool IsWindowsSearchReplacementMode
+        {
+            get
+            {
+                return settings.Properties.IsWindowsSearchReplacementMode;
+            }
+
+            set
+            {
+                if (settings.Properties.IsWindowsSearchReplacementMode != value)
+                {
+                    settings.Properties.IsWindowsSearchReplacementMode = value;
+                    UpdateSettings();
+                }
+            }
+        }
+
         public bool SearchQueryResultsWithDelay
         {
             get

--- a/src/settings-ui/Settings.UI.Library/ViewModels/PowerLauncherViewModel.cs
+++ b/src/settings-ui/Settings.UI.Library/ViewModels/PowerLauncherViewModel.cs
@@ -24,6 +24,8 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
 
         private string _searchText;
 
+        private bool _isElevated;
+
         private GeneralSettings GeneralSettingsConfig { get; set; }
 
         private PowerLauncherSettings settings;
@@ -36,7 +38,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
 
         private Func<string, int> SendConfigMSG { get; }
 
-        public PowerLauncherViewModel(PowerLauncherSettings settings, ISettingsRepository<GeneralSettings> settingsRepository, Func<string, int> ipcMSGCallBackFunc, Func<bool> isDark)
+        public PowerLauncherViewModel(PowerLauncherSettings settings, ISettingsRepository<GeneralSettings> settingsRepository, Func<string, int> ipcMSGCallBackFunc, Func<bool> isDark, bool isElevated)
         {
             if (settings == null)
             {
@@ -45,6 +47,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
 
             this.settings = settings;
             this.isDark = isDark;
+            this._isElevated = isElevated;
 
             // To obtain the general Settings configurations of PowerToys
             if (settingsRepository == null)
@@ -293,6 +296,14 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
                     settings.Properties.UseCentralizedKeyboardHook = value;
                     UpdateSettings();
                 }
+            }
+        }
+
+        public bool IsPTElevated
+        {
+            get
+            {
+                return _isElevated;
             }
         }
 

--- a/src/settings-ui/Settings.UI.Library/ViewModels/PowerLauncherViewModel.cs
+++ b/src/settings-ui/Settings.UI.Library/ViewModels/PowerLauncherViewModel.cs
@@ -313,6 +313,23 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             }
         }
 
+        public bool IsNotWindowsSearchReplacementMode
+        {
+            get
+            {
+                return !settings.Properties.IsWindowsSearchReplacementMode;
+            }
+
+            set
+            {
+                if (settings.Properties.IsWindowsSearchReplacementMode != !value)
+                {
+                    settings.Properties.IsWindowsSearchReplacementMode = !value;
+                    UpdateSettings();
+                }
+            }
+        }
+
         public bool SearchQueryResultsWithDelay
         {
             get

--- a/src/settings-ui/Settings.UI.Library/ViewModels/PowerLauncherViewModel.cs
+++ b/src/settings-ui/Settings.UI.Library/ViewModels/PowerLauncherViewModel.cs
@@ -313,23 +313,6 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             }
         }
 
-        public bool IsNotWindowsSearchReplacementMode
-        {
-            get
-            {
-                return !settings.Properties.IsWindowsSearchReplacementMode;
-            }
-
-            set
-            {
-                if (settings.Properties.IsWindowsSearchReplacementMode != !value)
-                {
-                    settings.Properties.IsWindowsSearchReplacementMode = !value;
-                    UpdateSettings();
-                }
-            }
-        }
-
         public bool SearchQueryResultsWithDelay
         {
             get

--- a/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/PowerLauncherViewModelTest.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/PowerLauncherViewModelTest.cs
@@ -66,7 +66,7 @@ namespace ViewModelTests
 
             // Initialise View Model with test Config files
             Func<string, int> sendMockIPCConfigMSG = msg => { return 0; };
-            PowerLauncherViewModel viewModel = new PowerLauncherViewModel(originalSettings, generalSettingsRepository, sendMockIPCConfigMSG, () => true);
+            PowerLauncherViewModel viewModel = new PowerLauncherViewModel(originalSettings, generalSettingsRepository, sendMockIPCConfigMSG, () => true, true);
 
             // Verify that the old settings persisted
             Assert.AreEqual(originalGeneralSettings.Enabled.PowerLauncher, viewModel.EnablePowerLauncher);

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -418,7 +418,7 @@
     <value>You can activate PowerToys Run by either picking an Activation shortcut or by using the Windows key. Using the Windows key replaces 'Windows Search'. If you replace Windows Search, you can still access it with the normal Win+S shortcut.</value>
   </data>
   <data name="PowerLauncher_WindowsSearchReplacementModeEnabled.Title" xml:space="preserve">
-    <value>For PowerToys Run to work in all cases with any activation shortcut, PowerToys needs to be running as Administrator.</value>
+    <value>For PowerToys Run to work in all cases PowerToys needs to be running as Administrator.</value>
   </data>	
   <data name="PowerLauncher_ClearInputOnLaunch.Content" xml:space="preserve">
     <value>Clear the previous query on launch</value>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -411,6 +411,12 @@
   <data name="PowerLauncher_UseCentralizedKeyboardHook.Description" xml:space="preserve">
     <value>Try this if there are issues with the shortcut</value>
   </data>
+  <data name="PowerLauncher_IsWindowsSearchReplacementMode.Header" xml:space="preserve">
+    <value>PowerToys Run activation mode</value>
+  </data>
+  <data name="PowerLauncher_IsWindowsSearchReplacementMode.Description" xml:space="preserve">
+    <value>You can use PowerToys Run by picking a keyboard shortcut below or just by using the Windows key, replacing the Windows Search. If you do replace Windows Search, you can still access it with the normal Win+S shortcut.</value>
+  </data>	
   <data name="PowerLauncher_ClearInputOnLaunch.Content" xml:space="preserve">
     <value>Clear the previous query on launch</value>
   </data>
@@ -1284,7 +1290,13 @@ Made with 💗 by Microsoft and the PowerToys community.</value>
   <data name="Run_Radio_Position_Primary_Monitor.Content" xml:space="preserve">
     <value>Primary monitor</value>
   </data>
-  <data name="Run_PluginsLoading.Text" xml:space="preserve">
+	<data name="Run_Radio_WindowsSearchAddOnMode.Content" xml:space="preserve">
+    <value>Use custom shortcut</value>
+  </data>
+	<data name="Run_Radio_WindowsSearchReplacementMode.Content" xml:space="preserve">
+    <value>Replace Windows Search</value>
+  </data>
+	<data name="Run_PluginsLoading.Text" xml:space="preserve">
     <value>Plugins are loading...</value>
   </data>
   <data name="ColorPicker_ButtonDown.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -415,7 +415,10 @@
     <value>PowerToys Run activation mode</value>
   </data>
   <data name="PowerLauncher_IsWindowsSearchReplacementMode.Description" xml:space="preserve">
-    <value>You can use PowerToys Run by picking a keyboard shortcut below or just by using the Windows key, replacing the Windows Search. If you do replace Windows Search, you can still access it with the normal Win+S shortcut.</value>
+    <value>You can activate PowerToys Run by either picking an Activation shortcut or by using the Windows key. Using the Windows key replaces 'Windows Search'. If you replace Windows Search, you can still access it with the normal Win+S shortcut.</value>
+  </data>
+  <data name="PowerLauncher_WindowsSearchReplacementModeEnabled.Title" xml:space="preserve">
+    <value>For PowerToys Run to work in all cases with any activation shortcut, PowerToys needs to be running as Administrator.</value>
   </data>	
   <data name="PowerLauncher_ClearInputOnLaunch.Content" xml:space="preserve">
     <value>Clear the previous query on launch</value>
@@ -1291,7 +1294,7 @@ Made with 💗 by Microsoft and the PowerToys community.</value>
     <value>Primary monitor</value>
   </data>
 	<data name="Run_Radio_WindowsSearchAddOnMode.Content" xml:space="preserve">
-    <value>Use custom shortcut</value>
+    <value>Activation shortcut</value>
   </data>
 	<data name="Run_Radio_WindowsSearchReplacementMode.Content" xml:space="preserve">
     <value>Replace Windows Search</value>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -420,6 +420,9 @@
   <data name="PowerLauncher_WindowsSearchReplacementModeEnabled.Title" xml:space="preserve">
     <value>For PowerToys Run to work in all cases PowerToys needs to be running as Administrator.</value>
   </data>	
+  <data name="PowerLauncher_WindowsSearchReplacementModeEnabledWarning.Title" xml:space="preserve">
+    <value>For PowerToys Run to work in all cases PowerToys needs to be running as Administrator.  Enable this under General settings.</value>
+  </data>	
   <data name="PowerLauncher_ClearInputOnLaunch.Content" xml:space="preserve">
     <value>Clear the previous query on launch</value>
   </data>

--- a/src/settings-ui/Settings.UI/Views/PowerLauncherPage.xaml
+++ b/src/settings-ui/Settings.UI/Views/PowerLauncherPage.xaml
@@ -77,7 +77,18 @@
                                           Severity="Informational"
                                           IsTabStop="True"
                                           IsClosable="False"
-                                          IsOpen="True">
+                                          IsOpen="{x:Bind Mode=OneWay, Path=ViewModel.IsPTElevated}">
+                        <muxc:InfoBar.ActionButton>
+                            <HyperlinkButton NavigateUri="https://aka.ms/powertoysDetectedElevatedHelp"
+                                                         x:Uid="GeneralPage_ToggleSwitch_AlwaysRunElevated_Link"/>
+                        </muxc:InfoBar.ActionButton>
+                    </muxc:InfoBar>
+
+                    <muxc:InfoBar x:Uid="PowerLauncher_WindowsSearchReplacementModeEnabledWarning" 
+                                          Severity="Warning"
+                                          IsTabStop="True"
+                                          IsClosable="False"
+                                          IsOpen="{x:Bind Mode=OneWay, Path=ViewModel.IsPTElevated, Converter={StaticResource BoolNegationConverter}}">
                         <muxc:InfoBar.ActionButton>
                             <HyperlinkButton NavigateUri="https://aka.ms/powertoysDetectedElevatedHelp"
                                                          x:Uid="GeneralPage_ToggleSwitch_AlwaysRunElevated_Link"/>

--- a/src/settings-ui/Settings.UI/Views/PowerLauncherPage.xaml
+++ b/src/settings-ui/Settings.UI/Views/PowerLauncherPage.xaml
@@ -12,8 +12,9 @@
     xmlns:converters="using:CommunityToolkit.WinUI.UI.Converters"
     mc:Ignorable="d"
     AutomationProperties.LandmarkType="Main">
-    
+
     <Page.Resources>
+        <converters:BoolToObjectConverter x:Key="BoolToComboBoxIndexConverter" TrueValue="1" FalseValue="0"/>
         <converters:BoolToObjectConverter x:Key="BoolToVisibilityConverter" TrueValue="Visible" FalseValue="Collapsed"/>
         <converters:BoolNegationConverter x:Key="BoolNegationConverter"/>
     </Page.Resources>
@@ -34,7 +35,19 @@
 
 
                 <controls:SettingsGroup x:Uid="Shortcut" IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.EnablePowerLauncher}">
-                    <controls:SettingExpander IsExpanded="True">
+
+
+                    <controls:Setting x:Uid="PowerLauncher_IsWindowsSearchReplacementMode">
+                        <controls:Setting.ActionContent>
+                            <ComboBox SelectedIndex="{x:Bind Mode=TwoWay, Path=ViewModel.IsWindowsSearchReplacementMode, Converter={StaticResource BoolToComboBoxIndexConverter}}" MinWidth="{StaticResource SettingActionControlMinWidth}">
+                                <ComboBoxItem x:Uid="Run_Radio_WindowsSearchAddOnMode"/>
+                                <ComboBoxItem x:Uid="Run_Radio_WindowsSearchReplacementMode"/>
+                            </ComboBox>
+                        </controls:Setting.ActionContent>
+                    </controls:Setting>
+
+
+                    <controls:SettingExpander IsExpanded="True" IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsWindowsSearchReplacementMode, Converter={StaticResource BoolNegationConverter}}">
                         <controls:SettingExpander.Header>
                             <controls:Setting x:Uid="Activation_Shortcut" Icon="&#xEDA7;" Style="{StaticResource ExpanderHeaderSettingStyle}">
                                 <controls:Setting.ActionContent>

--- a/src/settings-ui/Settings.UI/Views/PowerLauncherPage.xaml
+++ b/src/settings-ui/Settings.UI/Views/PowerLauncherPage.xaml
@@ -17,6 +17,8 @@
         <converters:BoolToObjectConverter x:Key="BoolToComboBoxIndexConverter" TrueValue="1" FalseValue="0"/>
         <converters:BoolToObjectConverter x:Key="BoolToVisibilityConverter" TrueValue="Visible" FalseValue="Collapsed"/>
         <converters:BoolNegationConverter x:Key="BoolNegationConverter"/>
+        <converters:BoolToVisibilityConverter x:Key="FalseToVisibleConverter" TrueValue="Collapsed" FalseValue="Visible"/>
+        <converters:BoolToVisibilityConverter x:Key="TrueToVisibleConverter" TrueValue="Visible" FalseValue="Collapsed"/>
     </Page.Resources>
 
     <controls:SettingsPageControl x:Uid="PowerLauncher"
@@ -47,7 +49,9 @@
                     </controls:Setting>
 
 
-                    <controls:SettingExpander IsExpanded="True" IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsWindowsSearchReplacementMode, Converter={StaticResource BoolNegationConverter}}">
+                    <controls:SettingExpander 
+                                            IsExpanded="True"
+                                            Visibility="{x:Bind Mode=OneWay, Path=ViewModel.IsWindowsSearchReplacementMode, Converter={StaticResource FalseToVisibleConverter}}">
                         <controls:SettingExpander.Header>
                             <controls:Setting x:Uid="Activation_Shortcut" Icon="&#xEDA7;" Style="{StaticResource ExpanderHeaderSettingStyle}">
                                 <controls:Setting.ActionContent>
@@ -70,7 +74,7 @@
                     </controls:SettingExpander>
 
                     <muxc:InfoBar x:Uid="PowerLauncher_WindowsSearchReplacementModeEnabled" 
-                                          Severity="Warning"
+                                          Severity="Informational"
                                           IsTabStop="True"
                                           IsClosable="False"
                                           IsOpen="True">

--- a/src/settings-ui/Settings.UI/Views/PowerLauncherPage.xaml
+++ b/src/settings-ui/Settings.UI/Views/PowerLauncherPage.xaml
@@ -68,6 +68,18 @@
                             </StackPanel>
                         </controls:SettingExpander.Content>
                     </controls:SettingExpander>
+
+                    <muxc:InfoBar x:Uid="PowerLauncher_WindowsSearchReplacementModeEnabled" 
+                                          Severity="Warning"
+                                          IsTabStop="True"
+                                          IsClosable="False"
+                                          IsOpen="True">
+                        <muxc:InfoBar.ActionButton>
+                            <HyperlinkButton NavigateUri="https://aka.ms/powertoysDetectedElevatedHelp"
+                                                         x:Uid="GeneralPage_ToggleSwitch_AlwaysRunElevated_Link"/>
+                        </muxc:InfoBar.ActionButton>
+                    </muxc:InfoBar>
+
                 </controls:SettingsGroup>
 
 

--- a/src/settings-ui/Settings.UI/Views/PowerLauncherPage.xaml.cs
+++ b/src/settings-ui/Settings.UI/Views/PowerLauncherPage.xaml.cs
@@ -36,7 +36,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             var settingsUtils = new SettingsUtils();
             _lastIPCMessageSentTick = Environment.TickCount;
             PowerLauncherSettings settings = settingsUtils.GetSettingsOrDefault<PowerLauncherSettings>(PowerLauncherSettings.ModuleName);
-            ViewModel = new PowerLauncherViewModel(settings, SettingsRepository<GeneralSettings>.GetInstance(settingsUtils), SendDefaultIPCMessageTimed, App.IsDarkTheme);
+            ViewModel = new PowerLauncherViewModel(settings, SettingsRepository<GeneralSettings>.GetInstance(settingsUtils), SendDefaultIPCMessageTimed, App.IsDarkTheme, App.IsElevated);
             DataContext = ViewModel;
             _ = Helper.GetFileWatcher(PowerLauncherSettings.ModuleName, "settings.json", () =>
             {
@@ -60,7 +60,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
                 {
                     this.DispatcherQueue.TryEnqueue(() =>
                     {
-                        DataContext = ViewModel = new PowerLauncherViewModel(powerLauncherSettings, SettingsRepository<GeneralSettings>.GetInstance(settingsUtils), ShellPage.SendDefaultIPCMessage, App.IsDarkTheme);
+                        DataContext = ViewModel = new PowerLauncherViewModel(powerLauncherSettings, SettingsRepository<GeneralSettings>.GetInstance(settingsUtils), ShellPage.SendDefaultIPCMessage, App.IsDarkTheme, App.IsElevated);
                         this.Bindings.Update();
                     });
                 }


### PR DESCRIPTION
## Summary of the Pull Request

This PR adds a new mode for PT Run that allows it to act more like a Windows Search replacement. It was implemented in a way to try to not interfere in any way with the current model, as some really like the way it is. 

This new mode DOES require elevated PT (Just like some of the other global shortcuts). That is why in this mode you don't need to pick any other options/settings, and that's nice.

This is the DEFAULT mode:

![image](https://user-images.githubusercontent.com/4396667/177006246-77792f4e-199f-4390-86aa-a44b31add93e.png)

Here it is "Power Search", mode:
![image](https://user-images.githubusercontent.com/4396667/177006255-0ad585af-89f7-45a5-ae59-c6e9e2a08f31.png)

Also, the message and view of the warning/info will change based on whether PT is currently elevated:
![image](https://user-images.githubusercontent.com/4396667/177006346-a204b051-78cf-49da-8aff-101b1c3c17d5.png)
 

Verbiage/naming needs work.

## PR Checklist

- [X] **Closes:** #17906
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Dev docs:** Added/updated

## Detailed Description of the Pull Request / Additional comments
I understand this is not a simple PR because some people might not want this functionality. 


1. Since (the great!) Windows Vista, Start Menu and Windows Search have been joined. This was a great thing, but it changed what "windows key" did fundamentally. Some people use it to bring up the menu, other use it to be the fastest way to search.
2. Using this new "Power Search" mode, does not prevent access to "Windows Search". It's still there with Win+S.
3. An essential goal was/is to make sure 100% previous Win modifiers still work. E.g. Win+E, Win+X, ...

 
