### PR TITLE
[PT Run] [Terminal Plugin] Use GetAppListEntires and add scoring

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsTerminal/Helpers/TerminalQuery.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsTerminal/Helpers/TerminalQuery.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Security.Principal;
@@ -14,16 +15,14 @@ namespace Microsoft.PowerToys.Run.Plugin.WindowsTerminal.Helpers
 {
     public class TerminalQuery : ITerminalQuery
     {
-        /// Static list of all Windows Terminal packages. As key we use the app name and in the value we save the AUMID of each package.
-        /// AUMID = ApplicationUserModelId: This is an identifier id for the app. The syntax is '<PackageFamilyName>!App'.
-        /// The AUMID of an AppX package will never change. (https://github.com/microsoft/PowerToys/pull/15836#issuecomment-1025204301)
-        private static readonly IReadOnlyDictionary<string, string> Packages = new Dictionary<string, string>()
-        {
-            { "Microsoft.WindowsTerminal", "Microsoft.WindowsTerminal_8wekyb3d8bbwe!App" },
-            { "Microsoft.WindowsTerminalPreview", "Microsoft.WindowsTerminalPreview_8wekyb3d8bbwe!App" },
-        };
-
         private readonly PackageManager _packageManager;
+
+        // Static list of all Windows Terminal packages.
+        private static ReadOnlyCollection<string> Packages => new List<string>
+        {
+            "Microsoft.WindowsTerminal",
+            "Microsoft.WindowsTerminalPreview",
+        }.AsReadOnly();
 
         private IEnumerable<TerminalPackage> Terminals => GetTerminals();
 
@@ -61,9 +60,11 @@ namespace Microsoft.PowerToys.Run.Plugin.WindowsTerminal.Helpers
             var user = WindowsIdentity.GetCurrent().User;
             var localAppDataPath = Environment.GetEnvironmentVariable("LOCALAPPDATA");
 
-            foreach (var p in _packageManager.FindPackagesForUser(user.Value).Where(p => Packages.Keys.Contains(p.Id.Name)))
+            foreach (var p in _packageManager.FindPackagesForUser(user.Value).Where(p => Packages.Contains(p.Id.Name)))
             {
-                var aumid = Packages[p.Id.Name];
+                var appListEntries = p.GetAppListEntries();
+
+                var aumid = appListEntries.Single().AppUserModelId;
                 var version = new Version(p.Id.Version.Major, p.Id.Version.Minor, p.Id.Version.Build, p.Id.Version.Revision);
                 var settingsPath = Path.Combine(localAppDataPath, "Packages", p.Id.FamilyName, "LocalState", "settings.json");
                 yield return new TerminalPackage(aumid, version, p.DisplayName, settingsPath, p.Logo.LocalPath);

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsTerminal/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsTerminal/Main.cs
@@ -69,13 +69,15 @@ namespace Microsoft.PowerToys.Run.Plugin.WindowsTerminal
                 }
 
                 // Action keyword only or search query match
-                if ((!string.IsNullOrWhiteSpace(query.ActionKeyword) && string.IsNullOrWhiteSpace(search)) || StringMatcher.FuzzySearch(search, profile.Name).Success)
+                int score = StringMatcher.FuzzySearch(search, profile.Name).Score;
+                if ((!string.IsNullOrWhiteSpace(query.ActionKeyword) && string.IsNullOrWhiteSpace(search)) || score > 0)
                 {
                     result.Add(new Result
                     {
                         Title = profile.Name,
                         SubTitle = profile.Terminal.DisplayName,
                         Icon = () => GetLogo(profile.Terminal),
+                        Score = score,
                         Action = _ =>
                         {
                             Launch(profile.Terminal.AppUserModelId, profile.Name);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

For speed up reasons we removed the call to GetAppListEntiresAsync in #15836.
Now that we have bumped min required os verison to 19041 we can go back to use api. But now we can use a non-async method. 

This PR implements the call to the method GetAppListEntries() and reverts some of the changes in #15836.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #19123
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

This PR adds scoring too for a better result order.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Local build and searching for terminal profiles.

