### PR TITLE
[PT Run] Revert for QueryHistory and UserSelectedRecord saved on search

### DIFF
--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -197,26 +197,8 @@ namespace PowerLauncher.ViewModel
 
                         if (SelectedIsFromQueryResults())
                         {
-                            // todo: revert _userSelectedRecordStorage.Save() and _historyItemsStorage.Save() after https://github.com/microsoft/PowerToys/issues/9164 is done
                             _userSelectedRecord.Add(result);
-                            try
-                            {
-                                _userSelectedRecordStorage.Save();
-                            }
-                            catch (UnauthorizedAccessException ex)
-                            {
-                                Log.Warn($"Failed to save file. ${ex.Message}", this.GetType());
-                            }
-
                             _history.Add(result.OriginQuery.RawQuery);
-                            try
-                            {
-                                _historyItemsStorage.Save();
-                            }
-                            catch (UnauthorizedAccessException ex)
-                            {
-                                Log.Warn($"Failed to save file. ${ex.Message}", this.GetType());
-                            }
                         }
                         else
                         {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Small performance improvement: `UserSelectedRecord.json` and `QueryHistory.json` shoudn't be saved on every search.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #9164
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Gracefully terminate of PT Run is already implemented.
`UserSelectedRecord.json` and `QueryHistory.json` should be persisted only on close.

https://github.com/microsoft/PowerToys/blob/202abd351b3c1206c6daa4b43ccbcb70b0d5f9f2/src/modules/launcher/Microsoft.Launcher/dllmain.cpp#L95

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Launch PT Run from the runner
- Perform a few searches and open the result
- Close PT from the system tray
- `QueryHistory.json` and `UserSelectedRecord.json` in `%LOCALAPPDATA%\Microsoft\PowerToys\PowerToys Run\Settings` should be updated

Repeted disabling PT Run instead of close PT from the runner.