### PR TITLE
Fixed null ref issue when "clean previous query on launch" enabled.

### DIFF
--- a/src/modules/launcher/PowerLauncher/App.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/App.xaml.cs
@@ -212,7 +212,7 @@ namespace PowerLauncher
         private void OnThemeChanged(Theme oldTheme, Theme newTheme)
         {
             ImageLoader.UpdateIconPath(newTheme);
-            _mainVM.Query(new MainViewModel.QueryTuningOptions());
+            _mainVM.Query();
         }
 
         /// <summary>

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -488,15 +488,8 @@ namespace PowerLauncher
             }
             else
             {
-                var options = new MainViewModel.QueryTuningOptions
-                {
-                    SearchClickedItemWeight = _viewModel.GetSearchClickedItemWeight(),
-                    SearchQueryTuningEnabled = _viewModel.GetSearchQueryTuningEnabled(),
-                    SearchWaitForSlowResults = _viewModel.GetSearchWaitForSlowResults(),
-                };
-
                 _viewModel.QueryText = text;
-                _viewModel.Query(options);
+                _viewModel.Query();
             }
         }
 

--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -362,14 +362,14 @@ namespace PowerLauncher.ViewModel
         /// </summary>
         /// <param name="queryText">Text that is being queried from user</param>
         /// <param name="requery">Optional Parameter that if true, will automatically execute a query against the updated text</param>
-        public void ChangeQueryText(string queryText, bool requery = false, QueryTuningOptions tuningOptions = null)
+        public void ChangeQueryText(string queryText, bool requery = false)
         {
             SystemQueryText = queryText;
 
             if (requery)
             {
                 QueryText = queryText;
-                Query(tuningOptions);
+                Query();
             }
         }
 
@@ -472,11 +472,11 @@ namespace PowerLauncher.ViewModel
             public bool SearchWaitForSlowResults { get; set; }
         }
 
-        public void Query(QueryTuningOptions options)
+        public void Query()
         {
             if (SelectedIsFromQueryResults())
             {
-                QueryResults(options);
+                QueryResults();
             }
             else if (HistorySelected())
             {
@@ -527,8 +527,9 @@ namespace PowerLauncher.ViewModel
             }
         }
 
-        private void QueryResults(QueryTuningOptions queryTuning)
+        private void QueryResults()
         {
+            var queryTuning = GetQueryTuningOptions();
             var doFinalSort = queryTuning.SearchQueryTuningEnabled && queryTuning.SearchWaitForSlowResults;
 
             if (!string.IsNullOrEmpty(QueryText))
@@ -1155,6 +1156,16 @@ namespace PowerLauncher.ViewModel
         public int GetSearchInputDelaySetting()
         {
             return _settings.SearchInputDelay;
+        }
+
+        public QueryTuningOptions GetQueryTuningOptions()
+        {
+            return new MainViewModel.QueryTuningOptions
+            {
+                SearchClickedItemWeight = GetSearchClickedItemWeight(),
+                SearchQueryTuningEnabled = GetSearchQueryTuningEnabled(),
+                SearchWaitForSlowResults = GetSearchWaitForSlowResults(),
+            };
         }
 
         public int GetSearchClickedItemWeight()


### PR DESCRIPTION
## Summary of the Pull Request
Fixes bug from #19166


## PR Checklist

- [X] **Closes:** #19166
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx


## Detailed Description of the Pull Request / Additional comments
Change code around to prevent call path with null arg.

## Validation Steps Performed
Tested with new settings on/off, including 

