### PR TITLE
[FancyZones] Fix applied layout reset in multi monitor mode 

### DIFF
--- a/src/modules/fancyzones/FancyZonesLib/EditorParameters.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/EditorParameters.cpp
@@ -114,7 +114,8 @@ bool EditorParameters::Save() noexcept
         RECT combinedMonitorArea = FancyZonesUtils::GetAllMonitorsCombinedRect<&MONITORINFOEX::rcMonitor>();
 
         JsonUtils::MonitorInfo monitorJson;
-        monitorJson.monitorName = ZonedWindowProperties::MultiMonitorDeviceID;
+        monitorJson.monitorName = ZonedWindowProperties::MultiMonitorName;
+        monitorJson.monitorInstanceId = ZonedWindowProperties::MultiMonitorInstance;
         monitorJson.virtualDesktop = virtualDesktopIdStr.value();
         monitorJson.top = combinedWorkArea.top;
         monitorJson.left = combinedWorkArea.left;

--- a/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
@@ -758,7 +758,7 @@ void FancyZones::UpdateWorkAreas() noexcept
     {
         FancyZonesDataTypes::WorkAreaId workAreaId;
         workAreaId.virtualDesktopId = VirtualDesktop::instance().GetCurrentVirtualDesktopId();
-        workAreaId.monitorId = { .deviceId = ZonedWindowProperties::MultiMonitorDeviceID };
+        workAreaId.monitorId = { .deviceId = { .id = ZonedWindowProperties::MultiMonitorName, .instanceId = ZonedWindowProperties::MultiMonitorInstance } };
 
         AddWorkArea(nullptr, workAreaId);
     }

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesWindowProperties.h
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesWindowProperties.h
@@ -11,7 +11,8 @@ namespace ZonedWindowProperties
     const wchar_t PropertyRestoreOriginID[] = L"FancyZones_RestoreOrigin";
     const wchar_t PropertyCornerPreference[] = L"FancyZones_CornerPreference";
 
-    const wchar_t MultiMonitorDeviceID[] = L"FancyZones#MultiMonitorDevice";
+    const wchar_t MultiMonitorName[] = L"FancyZones";
+    const wchar_t MultiMonitorInstance[] = L"MultiMonitorDevice";
 }
 
 namespace FancyZonesWindowProperties

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
@@ -369,6 +369,8 @@ namespace FancyZonesEditor.Utils
 
                         var monitor = new Monitor(workArea, monitorSize);
                         monitor.Device.MonitorName = nativeData.Monitor;
+                        monitor.Device.MonitorInstanceId = nativeData.MonitorInstanceId;
+                        monitor.Device.MonitorSerialNumber = nativeData.MonitorSerialNumber;
                         monitor.Device.VirtualDesktopId = nativeData.VirtualDesktop;
 
                         App.Overlay.AddMonitor(monitor);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Fix layout resetting in multi-monitor mode when installing 0.60 over the older version.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #16370 
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

* Enable multi-monitor mode (`Span zones across monitors`) and apply any layout using the older PT version
* Run FZ
* Verify layout wasn't reset 