### PR TITLE
[PowerRename][ImageResizer]Fallback for tier 1 menus

### DIFF
--- a/src/modules/imageresizer/ImageResizerLib/ImageResizerConstants.h
+++ b/src/modules/imageresizer/ImageResizerLib/ImageResizerConstants.h
@@ -9,4 +9,5 @@ namespace ImageResizerConstants
     // Name of the ImageResizer save folder.
     inline const std::wstring ModuleOldSaveFolderKey = L"ImageResizer";
     inline const std::wstring ModuleSaveFolderKey = L"Image Resizer";
+    inline const std::wstring ModulePackageDisplayName = L"ImageResizerContextMenu";
 }

--- a/src/modules/imageresizer/dll/ContextMenuHandler.cpp
+++ b/src/modules/imageresizer/dll/ContextMenuHandler.cpp
@@ -64,22 +64,15 @@ HRESULT CContextMenuHandler::Initialize(_In_opt_ PCIDLIST_ABSOLUTE pidlFolder, _
 
 HRESULT CContextMenuHandler::QueryContextMenu(_In_ HMENU hmenu, UINT indexMenu, UINT idCmdFirst, UINT idCmdLast, UINT uFlags)
 {
-    if (package::IsWin11OrGreater())
-    {
-        if(package::IsPackageRegistered(ImageResizerConstants::ModulePackageDisplayName))
-        {
-            return E_FAIL;
-        }
-    }
-
     if (uFlags & CMF_DEFAULTONLY)
-    {
         return S_OK;
-    }
+
     if (!CSettingsInstance().GetEnabled())
-    {
         return E_FAIL;
-    }
+
+    if (package::IsWin11OrGreater() && package::IsPackageRegistered(ImageResizerConstants::ModulePackageDisplayName))
+        return E_FAIL;
+
     // NB: We just check the first item. We could iterate through more if the first one doesn't meet the criteria
     HDropIterator i(m_pdtobj);
     i.First();

--- a/src/modules/imageresizer/dll/ContextMenuHandler.cpp
+++ b/src/modules/imageresizer/dll/ContextMenuHandler.cpp
@@ -2,6 +2,7 @@
 
 #include "pch.h"
 #include "ContextMenuHandler.h"
+#include <ImageResizerConstants.h>
 
 #include <Settings.h>
 #include <trace.h>
@@ -64,7 +65,12 @@ HRESULT CContextMenuHandler::Initialize(_In_opt_ PCIDLIST_ABSOLUTE pidlFolder, _
 HRESULT CContextMenuHandler::QueryContextMenu(_In_ HMENU hmenu, UINT indexMenu, UINT idCmdFirst, UINT idCmdLast, UINT uFlags)
 {
     if (package::IsWin11OrGreater())
-        return E_FAIL;
+    {
+        if(package::IsPackageRegistered(ImageResizerConstants::ModulePackageDisplayName))
+        {
+            return E_FAIL;
+        }
+    }
 
     if (uFlags & CMF_DEFAULTONLY)
     {

--- a/src/modules/imageresizer/dll/dllmain.cpp
+++ b/src/modules/imageresizer/dll/dllmain.cpp
@@ -102,8 +102,7 @@ public:
             std::wstring path = get_module_folderpath(g_hInst_imageResizer);
             std::wstring packageUri = path + L"\\ImageResizerContextMenuPackage.msix";
 
-            std::wstring packageDisplayName{ L"ImageResizerContextMenu" };
-            if (!package::IsPackageRegistered(packageDisplayName))
+            if (!package::IsPackageRegistered(ImageResizerConstants::ModulePackageDisplayName))
             {
                 package::RegisterSparsePackage(path, packageUri);
             }

--- a/src/modules/powerrename/dll/PowerRenameConstants.h
+++ b/src/modules/powerrename/dll/PowerRenameConstants.h
@@ -5,4 +5,5 @@ namespace PowerRenameConstants
 {
     // Name of the powertoy module.
     inline const std::wstring ModuleKey = L"PowerRename";
+    inline const std::wstring ModulePackageDisplayName = L"PowerRenameContextMenu";
 }

--- a/src/modules/powerrename/dll/PowerRenameExt.cpp
+++ b/src/modules/powerrename/dll/PowerRenameExt.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include "PowerRenameExt.h"
+#include "PowerRenameConstants.h"
 #include <trace.h>
 #include <Helpers.h>
 #include <common/themes/icon_helpers.h>
@@ -71,7 +72,7 @@ HRESULT CPowerRenameMenu::QueryContextMenu(HMENU hMenu, UINT index, UINT uIDFirs
         {
             // continue
         }
-        else
+        else if (package::IsPackageRegistered(PowerRenameConstants::ModulePackageDisplayName))
         {
             return E_FAIL;
         }

--- a/src/modules/powerrename/dll/PowerRenameExt.cpp
+++ b/src/modules/powerrename/dll/PowerRenameExt.cpp
@@ -65,27 +65,15 @@ HRESULT CPowerRenameMenu::QueryContextMenu(HMENU hMenu, UINT index, UINT uIDFirs
     if (!CSettingsInstance().GetEnabled())
         return E_FAIL;
 
-    // Win11 context menu can't distinguish between extended and default menu, so use this one
-    if (package::IsWin11OrGreater())
-    {
-        if (CSettingsInstance().GetExtendedContextMenuOnly() && (uFlags & CMF_EXTENDEDVERBS))
-        {
-            // continue
-        }
-        else if (package::IsPackageRegistered(PowerRenameConstants::ModulePackageDisplayName))
-        {
-            return E_FAIL;
-        }
-    }
-    else
-    {
-        // Check if we should only be on the extended context menu
-        if (CSettingsInstance().GetExtendedContextMenuOnly() && (!(uFlags & CMF_EXTENDEDVERBS)))
-            return E_FAIL;
-    }
-
     // Check if at least one of the selected items is actually renamable.
     if (!DataObjectContainsRenamableItem(m_spdo))
+        return E_FAIL;
+
+    if (package::IsWin11OrGreater() && package::IsPackageRegistered(PowerRenameConstants::ModulePackageDisplayName))
+        return E_FAIL;
+
+    // Check if we should only be on the extended context menu
+    if (CSettingsInstance().GetExtendedContextMenuOnly() && (!(uFlags & CMF_EXTENDEDVERBS)))
         return E_FAIL;
 
     HRESULT hr = E_UNEXPECTED;

--- a/src/modules/powerrename/dll/dllmain.cpp
+++ b/src/modules/powerrename/dll/dllmain.cpp
@@ -193,8 +193,7 @@ public:
             std::wstring path = get_module_folderpath(g_hInst);
             std::wstring packageUri = path + L"\\PowerRenameContextMenuPackage.msix";
 
-            std::wstring packageDisplayName{ L"PowerRenameContextMenu" };
-            if (!package::IsPackageRegistered(packageDisplayName))
+            if (!package::IsPackageRegistered(PowerRenameConstants::ModulePackageDisplayName))
             {
                 package::RegisterSparsePackage(path, packageUri);
             }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
On some configurations, installing the sparse package for tier 1 menus in PowerRename and ImageResizer may fail. This means PowerRename and ImageResizer would not be accessible from the context menu.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #13168
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
On Windows 11, if the package for the Windows 11 context menu is not installed, still show the old context menu entries.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Used an invalid signature so that the machine I was testing in would refuse to install the context menu packages and verified the old context menu items were accessible.
