### PR TITLE
[PT Run] Disallow drag if we don't remember the position

### DIFF
--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -135,6 +135,17 @@ namespace PowerLauncher
                 case WM.HOTKEY:
                     handled = _viewModel.ProcessHotKeyMessages(wparam, lparam);
                     break;
+                case WM.SYSCOMMAND:
+                    int command = wparam.ToInt32() & 0xfff0;
+                    if (command == Wox.Plugin.Common.Win32.Win32Constants.SC_MOVE)
+                    {
+                        if (!_settings.RememberLastLaunchLocation)
+                        {
+                            handled = true;
+                        }
+                    }
+
+                    break;
             }
 
             return IntPtr.Zero;

--- a/src/modules/launcher/Wox.Plugin/Common/Win32/NativeMethods.cs
+++ b/src/modules/launcher/Wox.Plugin/Common/Win32/NativeMethods.cs
@@ -140,6 +140,11 @@ namespace Wox.Plugin.Common.Win32
         /// Closes the window
         /// </summary>
         public const int SC_CLOSE = 0xF060;
+
+        /// <summary>
+        /// Moves the window
+        /// </summary>
+        public const int SC_MOVE = 0xF010;
     }
 
     public enum HRESULT : uint


### PR DESCRIPTION
## Summary of the Pull Request
There is a flag for "RememberLastLaunchLocation" but it's not in use. If we don't use the new window position, might as well ignore the new position. 

## PR Checklist

- [X] **Closes:** #19151
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments
Disable drag if when RememberLastLaunchLocation == false

## Validation Steps Performed
Tried to drag, cannot drag, seems OK.
