### PR TITLE
[PT Run]Results behaviour for whitespace query

### DIFF
--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/Main.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/Main.cs
@@ -136,10 +136,7 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces
                 });
             }
 
-            if (query.ActionKeyword == string.Empty || (query.ActionKeyword != string.Empty && query.Search != string.Empty))
-            {
-                results = results.Where(a => a.Title.ToLowerInvariant().Contains(query.Search.ToLowerInvariant())).ToList();
-            }
+            results = results.Where(a => a.Title.ToLowerInvariant().Contains(query.Search.ToLowerInvariant())).ToList();
 
             results.ForEach(x =>
                     {

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.WebSearch/Main.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.WebSearch/Main.cs
@@ -60,8 +60,8 @@ namespace Community.PowerToys.Run.Plugin.WebSearch
 
             var results = new List<Result>();
 
-            // empty non-global query:
-            if (!AreResultsGlobal() && query.ActionKeyword == query.RawQuery)
+            // empty query
+            if (string.IsNullOrEmpty(query.Search))
             {
                 string arguments = "? ";
                 results.Add(new Result
@@ -84,8 +84,7 @@ namespace Community.PowerToys.Run.Plugin.WebSearch
                 });
                 return results;
             }
-
-            if (!string.IsNullOrEmpty(query.Search))
+            else
             {
                 string searchTerm = query.Search;
 

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Uri/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Uri/Main.cs
@@ -46,8 +46,7 @@ namespace Microsoft.Plugin.Uri
         {
             var results = new List<Result>();
 
-            if (IsActivationKeyword(query)
-                && BrowserInfo.IsDefaultBrowserSet)
+            if (string.IsNullOrWhiteSpace(query?.Search) && BrowserInfo.IsDefaultBrowserSet)
             {
                 results.Add(new Result
                 {
@@ -102,12 +101,6 @@ namespace Microsoft.Plugin.Uri
             }
 
             return results;
-        }
-
-        private static bool IsActivationKeyword(Query query)
-        {
-            return !string.IsNullOrEmpty(query?.ActionKeyword)
-                   && query?.ActionKeyword == query?.RawQuery;
         }
 
         public void Init(PluginInitContext context)

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests/QueryTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests/QueryTests.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Globalization;
 using System.Linq;
-using System.Threading;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Wox.Infrastructure;
@@ -37,7 +36,6 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests
         [DataRow("now", 3)]
         [DataRow("current", 3)]
         [DataRow("year", 0)]
-        [DataRow("", 0)]
         [DataRow("time::10:10:10", 0)]
         [DataRow("date::10/10/10", 0)]
         public void CountWithoutPluginKeyword(string typedString, int expectedResultCount)

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate/Components/SearchController.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate/Components/SearchController.cs
@@ -42,12 +42,6 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.Components
             bool isEmptySearchInput = string.IsNullOrEmpty(query.Search);
             string searchTerm = query.Search;
 
-            // Empty search without keyword => return no results
-            if (!isKeywordSearch && isEmptySearchInput)
-            {
-                return results;
-            }
-
             // Conjunction search without keyword => return no results
             // (This improves the results on global queries.)
             if (!isKeywordSearch && _conjunctionList.Any(x => x.Equals(searchTerm, StringComparison.CurrentCultureIgnoreCase)))

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsTerminal/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsTerminal/Main.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation
+// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -70,7 +70,7 @@ namespace Microsoft.PowerToys.Run.Plugin.WindowsTerminal
 
                 // Action keyword only or search query match
                 int score = StringMatcher.FuzzySearch(search, profile.Name).Score;
-                if ((!string.IsNullOrWhiteSpace(query.ActionKeyword) && string.IsNullOrWhiteSpace(search)) || score > 0)
+                if (string.IsNullOrWhiteSpace(search) || score > 0)
                 {
                     result.Add(new Result
                     {

--- a/src/modules/launcher/PowerLauncher/Plugin/PluginManager.cs
+++ b/src/modules/launcher/PowerLauncher/Plugin/PluginManager.cs
@@ -175,6 +175,11 @@ namespace PowerLauncher.Plugin
                 return new List<Result>();
             }
 
+            if (string.IsNullOrEmpty(query.ActionKeyword) && string.IsNullOrWhiteSpace(query.Search))
+            {
+                return new List<Result>();
+            }
+
             try
             {
                 List<Result> results = null;

--- a/src/modules/launcher/Wox.Plugin/Query.cs
+++ b/src/modules/launcher/Wox.Plugin/Query.cs
@@ -1,9 +1,8 @@
-﻿// Copyright (c) Microsoft Corporation
+// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using Mono.Collections.Generic;
 
@@ -58,7 +57,7 @@ namespace Wox.Plugin
             {
                 if (_search == null)
                 {
-                    _search = RawQuery.Substring(ActionKeyword.Length).Trim();
+                    _search = RawQuery.Substring(ActionKeyword?.Length ?? 0).Trim();
                 }
 
                 return _search;

--- a/src/modules/launcher/Wox.Test/PluginManagerTest.cs
+++ b/src/modules/launcher/Wox.Test/PluginManagerTest.cs
@@ -17,12 +17,6 @@ namespace Wox.Test
         [DataRow(">", "dummyQueryText", "dummyTitle", "> dummyQueryText")]
         [DataRow(">", null, "dummyTitle", "> dummyTitle")]
         [DataRow(">", "", "dummyTitle", "> dummyTitle")]
-        [DataRow("", "dummyQueryText", "dummyTitle", "dummyQueryText")]
-        [DataRow("", null, "dummyTitle", "dummyTitle")]
-        [DataRow("", "", "dummyTitle", "dummyTitle")]
-        [DataRow(null, "dummyQueryText", "dummyTitle", "dummyQueryText")]
-        [DataRow(null, null, "dummyTitle", "dummyTitle")]
-        [DataRow(null, "", "dummyTitle", "dummyTitle")]
         public void QueryForPluginSetsActionKeywordWhenQueryTextDisplayIsEmpty(string actionKeyword, string queryTextDisplay, string title, string expectedResult)
         {
             // Arrange
@@ -57,6 +51,45 @@ namespace Wox.Test
 
             // Assert
             Assert.AreEqual(expectedResult, queryOutput[0].QueryTextDisplay);
+        }
+
+        [DataTestMethod]
+        [DataRow("", true)]
+        [DataRow(null, true)]
+        [DataRow(">", false)]
+        public void QueryDefaultResultsForPlugin(string actionKeyword, bool emptyResults)
+        {
+            // Arrange
+            var query = new Query(string.Empty, actionKeyword);
+            var metadata = new PluginMetadata
+            {
+                ID = "dummyName",
+                IcoPathDark = "dummyIcoPath",
+                IcoPathLight = "dummyIcoPath",
+                ExecuteFileName = "dummyExecuteFileName",
+                PluginDirectory = "dummyPluginDirectory",
+                ActionKeyword = ">",
+                IsGlobal = true,
+            };
+            var result = new Result()
+            {
+                QueryTextDisplay = "dummyQueryText",
+                Title = "dummyTitle",
+            };
+            var results = new List<Result>() { result };
+            var pluginMock = new Mock<IPlugin>();
+            pluginMock.Setup(r => r.Query(query)).Returns(results);
+            var pluginPair = new PluginPair(metadata)
+            {
+                Plugin = pluginMock.Object,
+                IsPluginInitialized = true,
+            };
+
+            // Act
+            var queryOutput = PluginManager.QueryForPlugin(pluginPair, query);
+
+            // Assert
+            Assert.AreEqual(queryOutput.Count == 0, emptyResults);
         }
     }
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Centralized the behaviour for whitespace query:
- Without action keywords: no results showed
- With action keywords: default results for the called plugin are showed

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #13497
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
- Centralized the behaviour for whitespace query in the PluginManager
- Plugins cleanup
- Updated/Added tests

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Set Registry, Settings, VS Code, WebSearch, Uri, TimeDate and Terminal plugins as global
- Search for a whitespace query: no results should be displayed
- Call Registry, Settings, VS Code, WebSearch, Uri, TimeDate and Terminal with action keyword only: the default results should be displayed