### PR TITLE
Uniforming language version to C# 10

### DIFF
--- a/src/modules/colorPicker/ColorPickerUI/ColorPickerUI.csproj
+++ b/src/modules/colorPicker/ColorPickerUI/ColorPickerUI.csproj
@@ -16,7 +16,6 @@
     <RootNamespace>ColorPicker</RootNamespace>
     <AssemblyName>PowerToys.ColorPickerUI</AssemblyName>
     <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
-    <LangVersion>8.0</LangVersion>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">

--- a/src/modules/colorPicker/UnitTest-ColorPickerUI/UnitTest-ColorPickerUI.csproj
+++ b/src/modules/colorPicker/UnitTest-ColorPickerUI/UnitTest-ColorPickerUI.csproj
@@ -7,7 +7,6 @@
     <RootNamespace>Microsoft.ColorPicker.UnitTests</RootNamespace>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
-    <LangVersion>8.0</LangVersion>
     <OutputType>Library</OutputType>
     <Version>$(Version).0</Version>
   </PropertyGroup>

--- a/src/modules/launcher/PowerLauncher/App.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/App.xaml.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -101,7 +102,7 @@ namespace PowerLauncher
             {
                 var textToLog = new StringBuilder();
                 textToLog.AppendLine("Begin PowerToys Run startup ----------------------------------------------------");
-                textToLog.AppendLine($"Runtime info:{ErrorReporting.RuntimeInfo()}");
+                textToLog.AppendLine(CultureInfo.InvariantCulture, $"Runtime info:{ErrorReporting.RuntimeInfo()}");
 
                 RegisterAppDomainExceptions();
                 RegisterDispatcherUnhandledException();

--- a/src/modules/launcher/PowerLauncher/PowerLauncher.csproj
+++ b/src/modules/launcher/PowerLauncher/PowerLauncher.csproj
@@ -25,7 +25,6 @@
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DebugType>full</DebugType>
-    <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Optimize>false</Optimize>
@@ -36,7 +35,6 @@
     <DefineConstants>TRACE;RELEASE</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
-    <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/src/modules/launcher/PowerLauncher/ReportWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/ReportWindow.xaml.cs
@@ -47,7 +47,7 @@ namespace PowerLauncher
             content.AppendLine(ErrorReporting.RuntimeInfo());
 
             // Using CurrentCulture since this is displayed to user in the report window
-            content.AppendLine($"Date: {DateTime.Now.ToString(CultureInfo.CurrentCulture)}");
+            content.AppendLine(CultureInfo.CurrentCulture, $"Date: {DateTime.Now.ToString(CultureInfo.CurrentCulture)}");
             content.AppendLine("Exception:");
             content.AppendLine(exception.ToString());
             var paragraph = new Paragraph();

--- a/src/modules/launcher/Wox.Infrastructure/Exception/ExceptionFormatter.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Exception/ExceptionFormatter.cs
@@ -69,16 +69,16 @@ namespace Wox.Infrastructure.Exception
             sb.AppendLine();
 
             sb.AppendLine("## Environment");
-            sb.AppendLine($"* Command Line: {Environment.CommandLine}");
+            sb.AppendLine(CultureInfo.InvariantCulture, $"* Command Line: {Environment.CommandLine}");
 
             // Using InvariantCulture since this is internal
-            sb.AppendLine($"* Timestamp: {DateTime.Now.ToString(CultureInfo.InvariantCulture)}");
-            sb.AppendLine($"* Wox version: {Constant.Version}");
-            sb.AppendLine($"* OS Version: {Environment.OSVersion.VersionString}");
-            sb.AppendLine($"* IntPtr Length: {IntPtr.Size}");
-            sb.AppendLine($"* x64: {Environment.Is64BitOperatingSystem}");
-            sb.AppendLine($"* CLR Version: {Environment.Version}");
-            sb.AppendLine($"* Installed .NET Framework: ");
+            sb.AppendLine(CultureInfo.InvariantCulture, $"* Timestamp: {DateTime.Now.ToString(CultureInfo.InvariantCulture)}");
+            sb.AppendLine(CultureInfo.InvariantCulture, $"* Wox version: {Constant.Version}");
+            sb.AppendLine(CultureInfo.InvariantCulture, $"* OS Version: {Environment.OSVersion.VersionString}");
+            sb.AppendLine(CultureInfo.InvariantCulture, $"* IntPtr Length: {IntPtr.Size}");
+            sb.AppendLine(CultureInfo.InvariantCulture, $"* x64: {Environment.Is64BitOperatingSystem}");
+            sb.AppendLine(CultureInfo.InvariantCulture, $"* CLR Version: {Environment.Version}");
+            sb.AppendLine(CultureInfo.InvariantCulture, $"* Installed .NET Framework: ");
             foreach (var result in GetFrameworkVersionFromRegistry())
             {
                 sb.Append("   * ");

--- a/src/modules/launcher/Wox.Infrastructure/Wox.Infrastructure.csproj
+++ b/src/modules/launcher/Wox.Infrastructure/Wox.Infrastructure.csproj
@@ -20,7 +20,6 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DebugType>full</DebugType>
-    <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Optimize>false</Optimize>
@@ -30,7 +29,6 @@
     <DefineConstants>TRACE</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
-    <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/src/modules/launcher/Wox.Plugin/Logger/Log.cs
+++ b/src/modules/launcher/Wox.Plugin/Logger/Log.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Globalization;
 using System.IO.Abstractions;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -53,7 +54,7 @@ namespace Wox.Plugin.Logger
             var formattedOutput = new StringBuilder();
 
             formattedOutput.AppendLine("-------------------------- Begin exception --------------------------");
-            formattedOutput.AppendLine($"Message: {message}");
+            formattedOutput.AppendLine(CultureInfo.InvariantCulture, $"Message: {message}");
 
             do
             {

--- a/src/modules/launcher/Wox.Plugin/Wox.Plugin.csproj
+++ b/src/modules/launcher/Wox.Plugin/Wox.Plugin.csproj
@@ -21,7 +21,6 @@
     <DebugSymbols>true</DebugSymbols>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DebugType>full</DebugType>
-    <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Optimize>false</Optimize>
@@ -31,7 +30,6 @@
     <DefineConstants>TRACE</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
-    <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/src/modules/launcher/Wox.Test/Wox.Test.csproj
+++ b/src/modules/launcher/Wox.Test/Wox.Test.csproj
@@ -18,7 +18,6 @@
     <DebugSymbols>true</DebugSymbols>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DebugType>full</DebugType>
-    <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Optimize>false</Optimize>
@@ -29,7 +28,6 @@
     <DefineConstants>TRACE</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
-    <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Uniformed language version to C# 10 across the solution.
No need to set a fixed version since C# 10 is used for .NET 6 and will be updated to C# 11 when .NET 7 will be adopted.
https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/configure-language-version

![image](https://user-images.githubusercontent.com/25966642/177858154-72010599-8be1-4c23-b48c-0842d92288b4.png)

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #19208
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Build should pass
