### PR TITLE
Powertoys run cuts off input or uses previous input (19157)

### DIFF
--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -475,6 +475,31 @@ namespace PowerLauncher
             {
                 SearchBox.AutoCompleteTextBlock.Text = string.Empty;
             }
+
+            // If there will be a delay before starting the search, hide the last results since they are now invalid.
+            var showResultsWithDelay = _viewModel.GetSearchQueryResultsWithDelaySetting();
+            if (!_isTextSetProgrammatically && showResultsWithDelay)
+            {
+                DeselectAllResults();
+            }
+        }
+
+        private void DeselectAllResults()
+        {
+            // There must be a better way, but I don't know it.
+            _viewModel.Results.SelectedItem = null;
+            var resultsItems = _viewModel.Results.Results.ToList();
+
+            System.Threading.Tasks.Task.Run(() =>
+            {
+                Application.Current.Dispatcher.BeginInvoke(System.Windows.Threading.DispatcherPriority.Normal, new Action(() =>
+                {
+                    _viewModel.Results.Clear();
+                    _viewModel.Results.Results.NotifyChanges();
+                    _viewModel.Results.Results.AddRange(resultsItems);
+                    _viewModel.Results.Results.NotifyChanges();
+                }));
+            });
         }
 
         private void PerformSearchQuery(TextBox textBox)

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -563,7 +563,13 @@ namespace PowerLauncher
             if (_isTextSetProgrammatically)
             {
                 textBox.SelectionStart = textBox.Text.Length;
-                _isTextSetProgrammatically = false;
+
+                // because IF this is delayedExecution = false (run fast queries) we know this will be called again with delayedExecution = true
+                // if we don't do this, the second (partner) call will not be called _isTextSetProgrammatically = true also, and we need it to.
+                if (delayedExecution.HasValue && delayedExecution.Value)
+                {
+                    _isTextSetProgrammatically = false;
+                }
             }
             else
             {

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -494,7 +494,8 @@ namespace PowerLauncher
 
             var showResultsWithDelay = _viewModel.GetSearchQueryResultsWithDelaySetting();
 
-            if (showResultsWithDelay)
+            // only if we are using throttled search and throttled 'fast' search, do we need to do anything different with the current results.
+            if (showResultsWithDelay && _settings.PTRSearchQueryFastResultsWithDelay)
             {
                 // Default means we don't do anything we did not do before... leave the results as is, they will be changed as needed when results are returned
                 var pTRunStartNewSearchAction = _settings.PTRunStartNewSearchAction ?? "Default";
@@ -502,7 +503,7 @@ namespace PowerLauncher
                 if (pTRunStartNewSearchAction == "DeSelect")
                 {
                     // leave the results, be deselect anything to it will not be activated by <enter> key, can still be arrow-key or clicked though
-                    if (!_isTextSetProgrammatically && showResultsWithDelay)
+                    if (!_isTextSetProgrammatically)
                     {
                         DeselectAllResults();
                     }
@@ -510,7 +511,7 @@ namespace PowerLauncher
                 else if (pTRunStartNewSearchAction == "Clear")
                 {
                     // remove all results to prepare for new results, this causes flashing usually and is not cool
-                    if (!_isTextSetProgrammatically && showResultsWithDelay)
+                    if (!_isTextSetProgrammatically)
                     {
                         ClearResults();
                     }
@@ -527,28 +528,16 @@ namespace PowerLauncher
                 {
                     _viewModel.Results.Clear();
                     _viewModel.Results.Results.NotifyChanges();
-
-                    // _viewModel.HideResultsListView();
                 }));
             });
         }
 
         private void DeselectAllResults()
         {
-            // There must be a better way, but I don't know it.
-            _viewModel.Results.SelectedItem = null;
-            var resultsItems = _viewModel.Results.Results.ToList();
-
-            System.Threading.Tasks.Task.Run(() =>
+            Application.Current.Dispatcher.BeginInvoke(System.Windows.Threading.DispatcherPriority.Normal, new Action(() =>
             {
-                Application.Current.Dispatcher.BeginInvoke(System.Windows.Threading.DispatcherPriority.Normal, new Action(() =>
-                {
-                    _viewModel.Results.Clear();
-                    _viewModel.Results.Results.NotifyChanges();
-                    _viewModel.Results.Results.AddRange(resultsItems);
-                    _viewModel.Results.Results.NotifyChanges();
-                }));
-            });
+                _viewModel.Results.SelectedIndex = -1;
+            }));
         }
 
         private void PerformSearchQuery(TextBox textBox)

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -205,7 +205,7 @@ namespace PowerLauncher
             {
                 if (_settings.PTRSearchQueryFastResultsWithDelay)
                 {
-                    // old mode, delay fast and deleyed execution
+                    // old mode, delay fast and delayed execution
                     _reactiveSubscription = Observable.FromEventPattern<TextChangedEventHandler, TextChangedEventArgs>(
                     add => SearchBox.QueryTextBox.TextChanged += add,
                     remove => SearchBox.QueryTextBox.TextChanged -= remove)
@@ -501,7 +501,7 @@ namespace PowerLauncher
 
                 if (pTRunStartNewSearchAction == "DeSelect")
                 {
-                    // leave the results, be deselect anththing to it will not be activated by <enter> key, can still be arrow-key or clicked though
+                    // leave the results, be deselect anything to it will not be activated by <enter> key, can still be arrow-key or clicked though
                     if (!_isTextSetProgrammatically && showResultsWithDelay)
                     {
                         DeselectAllResults();

--- a/src/modules/launcher/PowerLauncher/SettingsReader.cs
+++ b/src/modules/launcher/PowerLauncher/SettingsReader.cs
@@ -115,6 +115,11 @@ namespace PowerLauncher
                         _settings.SearchInputDelay = overloadSettings.Properties.SearchInputDelay;
                     }
 
+                    if (_settings.SearchInputDelayFast != overloadSettings.Properties.SearchInputDelayFast)
+                    {
+                        _settings.SearchInputDelayFast = overloadSettings.Properties.SearchInputDelayFast;
+                    }
+
                     if (_settings.SearchClickedItemWeight != overloadSettings.Properties.SearchClickedItemWeight)
                     {
                         _settings.SearchClickedItemWeight = overloadSettings.Properties.SearchClickedItemWeight;

--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -1189,6 +1189,11 @@ namespace PowerLauncher.ViewModel
             return _settings.SearchQueryResultsWithDelay;
         }
 
+        public int GetSearchInputDelayFastSetting()
+        {
+            return _settings.SearchInputDelayFast;
+        }
+
         public int GetSearchInputDelaySetting()
         {
             return _settings.SearchInputDelay;

--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -736,11 +736,6 @@ namespace PowerLauncher.ViewModel
             }
         }
 
-        public void HideResultsListView()
-        {
-            Results.Visibility = Visibility.Hidden;
-        }
-
         private void UpdateResultsListViewAfterQuery(string queryText, bool noInitialResults = false, bool isDelayedInvoke = false)
         {
             Application.Current.Dispatcher.BeginInvoke(new Action(() =>

--- a/src/modules/launcher/Wox.Infrastructure/UserSettings/PowerToysRunSettings.cs
+++ b/src/modules/launcher/Wox.Infrastructure/UserSettings/PowerToysRunSettings.cs
@@ -82,11 +82,30 @@ namespace Wox.Infrastructure.UserSettings
 
         private int _searchInputDelay = 150;
 
+        private int _searchInputDelayFast = 30;
+
         private int _searchClickedItemWeight = 5;
 
         private bool _searchQueryTuningEnabled;
 
         private bool _searchWaitForSlowResults;
+
+        public int SearchInputDelayFast
+        {
+            get
+            {
+                return _searchInputDelayFast;
+            }
+
+            set
+            {
+                if (_searchInputDelayFast != value)
+                {
+                    _searchInputDelayFast = value;
+                    OnPropertyChanged(nameof(SearchInputDelayFast));
+                }
+            }
+        }
 
         public int SearchInputDelay
         {
@@ -174,8 +193,7 @@ namespace Wox.Infrastructure.UserSettings
 
         public bool PTRSearchQueryFastResultsWithDelay { get; set; }
 
-        public bool PTRSearchQueryFastResultsWithPartialDelay { get; set; }
-
+        // public bool PTRSearchQueryFastResultsWithPartialDelay { get; set; }
         public string QueryBoxFontStretch { get; set; }
 
         public string ResultFont { get; set; } = FontFamily.GenericSansSerif.Name;

--- a/src/modules/launcher/Wox.Infrastructure/UserSettings/PowerToysRunSettings.cs
+++ b/src/modules/launcher/Wox.Infrastructure/UserSettings/PowerToysRunSettings.cs
@@ -168,6 +168,12 @@ namespace Wox.Infrastructure.UserSettings
 
         public string QueryBoxFontWeight { get; set; }
 
+        public bool PTRunNonDelayedSearchInParallel { get; set; } = true;
+
+        public string PTRunStartNewSearchAction { get; set; }
+
+        public bool PTRSearchQueryFastResultsWithDelay { get; set; }
+
         public string QueryBoxFontStretch { get; set; }
 
         public string ResultFont { get; set; } = FontFamily.GenericSansSerif.Name;

--- a/src/modules/launcher/Wox.Infrastructure/UserSettings/PowerToysRunSettings.cs
+++ b/src/modules/launcher/Wox.Infrastructure/UserSettings/PowerToysRunSettings.cs
@@ -174,6 +174,8 @@ namespace Wox.Infrastructure.UserSettings
 
         public bool PTRSearchQueryFastResultsWithDelay { get; set; }
 
+        public bool PTRSearchQueryFastResultsWithPartialDelay { get; set; }
+
         public string QueryBoxFontStretch { get; set; }
 
         public string ResultFont { get; set; } = FontFamily.GenericSansSerif.Name;

--- a/src/settings-ui/Settings.UI.Library/PowerLauncherProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/PowerLauncherProperties.cs
@@ -57,6 +57,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         [JsonPropertyName("search_input_delay")]
         public int SearchInputDelay { get; set; }
 
+        [JsonPropertyName("search_input_delay_fast")]
+        public int SearchInputDelayFast { get; set; }
+
         [JsonPropertyName("search_clicked_item_weight")]
         public int SearchClickedItemWeight { get; set; }
 

--- a/src/settings-ui/Settings.UI.Library/ViewModels/PowerLauncherViewModel.cs
+++ b/src/settings-ui/Settings.UI.Library/ViewModels/PowerLauncherViewModel.cs
@@ -313,6 +313,23 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             }
         }
 
+        public int SearchInputDelayFast
+        {
+            get
+            {
+                return settings.Properties.SearchInputDelayFast;
+            }
+
+            set
+            {
+                if (settings.Properties.SearchInputDelayFast != value)
+                {
+                    settings.Properties.SearchInputDelayFast = value;
+                    UpdateSettings();
+                }
+            }
+        }
+
         public int SearchInputDelay
         {
             get

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -415,16 +415,28 @@
     <value>Clear the previous query on launch</value>
   </data>
   <data name="PowerLauncher_SearchQueryResultsWithDelay.Header" xml:space="preserve">
-    <value>Delay search</value>
+    <value>Search Throttle</value>
     <comment>This is about adding a delay to wait for more input before executing a search</comment>
   </data>
   <data name="PowerLauncher_SearchQueryResultsWithDelay.Description" xml:space="preserve">
-    <value>Add a delay to wait for more input before executing a search</value>
+    <value>A throttle to reduce results display jumpiness and load on the system</value>
   </data>
-  <data name="PowerLauncher_SearchInputDelayMs.Header" xml:space="preserve">
-    <value>Search delay (ms)</value>
+  <data name="PowerLauncher_FastSearchInputDelayMs.Header" xml:space="preserve">
+    <value>Fast plugins</value>    
+  </data>
+	<data name="PowerLauncher_FastSearchInputDelayMs.Description" xml:space="preserve">
+    <value>Throttle the faster plugins by this amount. 30ms to 50ms is recommended.</value>    
+  </data>
+	<data name="PowerLauncher_SlowSearchInputDelayMs.Header" xml:space="preserve">
+    <value>Slow plugins</value>    
+  </data>
+	<data name="PowerLauncher_SlowSearchInputDelayMs.Description" xml:space="preserve">
+    <value>Throttle the slower plugins by this amount. 100ms to 150ms is recommended.</value>    
+  </data>
+	<data name="PowerLauncher_SearchInputDelayMs.Header" xml:space="preserve">
+    <value>Fast plugin throttle (ms)</value>
     <comment>ms = milliseconds</comment>
-  </data>
+  </data>	
   <data name="KeyboardManager_KeysMappingLayoutRightHeader.Text" xml:space="preserve">
     <value>To:</value>
     <comment>Keyboard Manager mapping keys view right header</comment>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -415,23 +415,23 @@
     <value>Clear the previous query on launch</value>
   </data>
   <data name="PowerLauncher_SearchQueryResultsWithDelay.Header" xml:space="preserve">
-    <value>Search Throttle</value>
+    <value>Input Smoothing</value>
     <comment>This is about adding a delay to wait for more input before executing a search</comment>
   </data>
   <data name="PowerLauncher_SearchQueryResultsWithDelay.Description" xml:space="preserve">
-    <value>A throttle to reduce results display jumpiness and load on the system</value>
+    <value>Wait for more input before searching. This reduces interface jumpiness and system load.</value>
   </data>
   <data name="PowerLauncher_FastSearchInputDelayMs.Header" xml:space="preserve">
-    <value>Fast plugins</value>    
+    <value>Immediate plugins</value>    
   </data>
 	<data name="PowerLauncher_FastSearchInputDelayMs.Description" xml:space="preserve">
-    <value>Throttle the faster plugins by this amount. 30ms to 50ms is recommended.</value>    
+    <value>Affects the plugins that make the UI wait for their results by this amount. Recommended: 30-50 ms.</value>    
   </data>
 	<data name="PowerLauncher_SlowSearchInputDelayMs.Header" xml:space="preserve">
-    <value>Slow plugins</value>    
+    <value>Background execution plugins</value>    
   </data>
 	<data name="PowerLauncher_SlowSearchInputDelayMs.Description" xml:space="preserve">
-    <value>Throttle the slower plugins by this amount. 100ms to 150ms is recommended.</value>    
+    <value>Affects the plugins that execute in the background by this amount. Recommended: 100-150 ms.</value>    
   </data>
 	<data name="PowerLauncher_SearchInputDelayMs.Header" xml:space="preserve">
     <value>Fast plugin throttle (ms)</value>

--- a/src/settings-ui/Settings.UI/Views/PowerLauncherPage.xaml
+++ b/src/settings-ui/Settings.UI/Views/PowerLauncherPage.xaml
@@ -103,9 +103,23 @@
                             </controls:Setting>
                         </controls:SettingExpander.Header>
                         <controls:SettingExpander.Content>
-                            <controls:Setting x:Uid="PowerLauncher_SearchInputDelayMs" IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.SearchQueryResultsWithDelay}" Style="{StaticResource ExpanderContentSettingStyle}">
-                                <controls:Setting.ActionContent>
-                                    <muxc:NumberBox Minimum="0"
+                            <StackPanel>
+                                <controls:Setting x:Uid="PowerLauncher_FastSearchInputDelayMs" IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.SearchQueryResultsWithDelay}" Style="{StaticResource ExpanderContentSettingStyle}">
+                                    <controls:Setting.ActionContent>
+                                        <muxc:NumberBox Minimum="0"
+                                        Maximum="500"
+                                        Value="{x:Bind Mode=TwoWay, Path=ViewModel.SearchInputDelayFast}"
+                                        MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                        SpinButtonPlacementMode="Compact"
+                                        HorizontalAlignment="Left"
+                                        SmallChange="10"
+                                        LargeChange="50"/>
+                                    </controls:Setting.ActionContent>
+                                </controls:Setting>
+                                
+                                <controls:Setting x:Uid="PowerLauncher_SlowSearchInputDelayMs" IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.SearchQueryResultsWithDelay}" Style="{StaticResource ExpanderContentSettingStyle}">
+                                    <controls:Setting.ActionContent>
+                                        <muxc:NumberBox Minimum="0"
                                         Maximum="1000"
                                         Value="{x:Bind Mode=TwoWay, Path=ViewModel.SearchInputDelay}"
                                         MinWidth="{StaticResource SettingActionControlMinWidth}"
@@ -113,8 +127,11 @@
                                         HorizontalAlignment="Left"
                                         SmallChange="10"
                                         LargeChange="50"/>
-                                </controls:Setting.ActionContent>
-                            </controls:Setting>
+                                    </controls:Setting.ActionContent>
+                                </controls:Setting>
+                            </StackPanel>
+                            
+                            
                         </controls:SettingExpander.Content>
                     </controls:SettingExpander>
                     <controls:SettingExpander IsExpanded="True">


### PR DESCRIPTION
## Summary of the Pull Request
Updated code to disable using the enter key to activate the selected item in the results if new PT run search has started. This prevents the enter key from activating stales results.


## PR Checklist

- [X] **Closes:** #19157
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments
IsTemporaryDisabled is set to true when new search starts. 

IsTemporaryDisabled is set to false (enable <enter> to acivate selected item) when the new results are added to the result list. 

## Validation Steps Performed
You can test this by exacerbating the issue, by increasing the "search delay" to a very high number. 

