### PR TITLE
[Win11]Fix context menus on insider dev builds

### DIFF
--- a/src/modules/imageresizer/ImageResizerContextMenu/AppxManifest.xml
+++ b/src/modules/imageresizer/ImageResizerContextMenu/AppxManifest.xml
@@ -42,9 +42,9 @@
             </desktop5:ItemType>
           </desktop4:FileExplorerContextMenus>
         </desktop4:Extension>
-        <com:Extension Category="windows.comServer">
+        <com:Extension Category="windows.comServer" uap10:RuntimeBehavior="packagedClassicApp">
           <com:ComServer>
-            <com:SurrogateServer  DisplayName="Context menu verb handler">
+            <com:SurrogateServer DisplayName="Context menu verb handler">
               <com:Class Id="8F491918-259F-451A-950F-8C3EBF4864AF" Path="PowerToys.ImageResizerContextMenu.dll" ThreadingModel="STA"/>
             </com:SurrogateServer>
           </com:ComServer>

--- a/src/modules/powerrename/PowerRenameContextMenu/AppxManifest.xml
+++ b/src/modules/powerrename/PowerRenameContextMenu/AppxManifest.xml
@@ -48,9 +48,9 @@
             </desktop5:ItemType>
           </desktop4:FileExplorerContextMenus>
         </desktop4:Extension>
-        <com:Extension Category="windows.comServer">
+        <com:Extension Category="windows.comServer" uap10:RuntimeBehavior="packagedClassicApp">
           <com:ComServer>
-            <com:SurrogateServer  DisplayName="Context menu verb handler">
+            <com:SurrogateServer DisplayName="Context menu verb handler">
               <com:Class Id="1861E28B-A1F0-4EF4-A1FE-4C8CA88E2174" Path="PowerToys.PowerRenameContextMenu.dll" ThreadingModel="STA"/>
             </com:SurrogateServer>
           </com:ComServer>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Fixes tier 1 context menu entries for PowerRename and ImageResizer on Windows 11 dev channel insider builds.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #19233
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

Tier1 context menu entries are failing with the message:
"error 0x80080204: While preparing to process the request, the system failed to register the windows.comServer extension due to the following error: The Appx package's manifest is invalid."

The PR adds a tag to simulate classic behavior and make the manifest valid for those builds.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Tested on a Windows 11 build 25145 VM and it worked, tier 1 context menus are shown.