### PR TITLE
[Win11]Also show old context menus

### DIFF
--- a/src/modules/imageresizer/dll/ContextMenuHandler.cpp
+++ b/src/modules/imageresizer/dll/ContextMenuHandler.cpp
@@ -2,7 +2,6 @@
 
 #include "pch.h"
 #include "ContextMenuHandler.h"
-#include <ImageResizerConstants.h>
 
 #include <Settings.h>
 #include <trace.h>
@@ -68,9 +67,6 @@ HRESULT CContextMenuHandler::QueryContextMenu(_In_ HMENU hmenu, UINT indexMenu, 
         return S_OK;
 
     if (!CSettingsInstance().GetEnabled())
-        return E_FAIL;
-
-    if (package::IsWin11OrGreater() && package::IsPackageRegistered(ImageResizerConstants::ModulePackageDisplayName))
         return E_FAIL;
 
     // NB: We just check the first item. We could iterate through more if the first one doesn't meet the criteria

--- a/src/modules/powerrename/dll/PowerRenameExt.cpp
+++ b/src/modules/powerrename/dll/PowerRenameExt.cpp
@@ -1,6 +1,5 @@
 #include "pch.h"
 #include "PowerRenameExt.h"
-#include "PowerRenameConstants.h"
 #include <trace.h>
 #include <Helpers.h>
 #include <common/themes/icon_helpers.h>
@@ -67,9 +66,6 @@ HRESULT CPowerRenameMenu::QueryContextMenu(HMENU hMenu, UINT index, UINT uIDFirs
 
     // Check if at least one of the selected items is actually renamable.
     if (!DataObjectContainsRenamableItem(m_spdo))
-        return E_FAIL;
-
-    if (package::IsWin11OrGreater() && package::IsPackageRegistered(PowerRenameConstants::ModulePackageDisplayName))
         return E_FAIL;
 
     // Check if we should only be on the extended context menu


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Some users can use software that makes the windows 11 tier 1 menu entries not show.
Still show old context menus, even if it means showing duplicate entries.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #19219
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Some users can use software that makes the windows 11 tier 1 menu entries not show.
Still show old context menus, even if it means showing duplicate entries.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Right-clicking on Windows 11 still shows the old context menus, even if these will show duplicate entries in some configurations.