### PR TITLE
[FancyZones] Monitor id comparison fix

### DIFF
--- a/src/modules/fancyzones/FancyZonesLib/EditorParameters.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/EditorParameters.cpp
@@ -25,6 +25,7 @@ namespace JsonUtils
         std::wstring monitorName;
         std::wstring monitorInstanceId;
         std::wstring monitorSerialNumber;
+        int monitorNumber;
         std::wstring virtualDesktop;
         int dpi;
         int top;
@@ -42,6 +43,7 @@ namespace JsonUtils
             result.SetNamedValue(NonLocalizable::EditorParametersIds::MonitorNameId, json::value(monitor.monitorName));
             result.SetNamedValue(NonLocalizable::EditorParametersIds::MonitorInstanceId, json::value(monitor.monitorInstanceId));
             result.SetNamedValue(NonLocalizable::EditorParametersIds::MonitorSerialNumberId, json::value(monitor.monitorSerialNumber));
+            result.SetNamedValue(NonLocalizable::EditorParametersIds::MonitorNumberId, json::value(monitor.monitorNumber));
             result.SetNamedValue(NonLocalizable::EditorParametersIds::VirtualDesktopId, json::value(monitor.virtualDesktop));
             result.SetNamedValue(NonLocalizable::EditorParametersIds::Dpi, json::value(monitor.dpi));
             result.SetNamedValue(NonLocalizable::EditorParametersIds::TopCoordinate, json::value(monitor.top));
@@ -116,6 +118,7 @@ bool EditorParameters::Save() noexcept
         JsonUtils::MonitorInfo monitorJson;
         monitorJson.monitorName = ZonedWindowProperties::MultiMonitorName;
         monitorJson.monitorInstanceId = ZonedWindowProperties::MultiMonitorInstance;
+        monitorJson.monitorNumber = 0;
         monitorJson.virtualDesktop = virtualDesktopIdStr.value();
         monitorJson.top = combinedWorkArea.top;
         monitorJson.left = combinedWorkArea.left;
@@ -172,6 +175,7 @@ bool EditorParameters::Save() noexcept
 
             monitorJson.monitorName = monitorData.deviceId.id;
             monitorJson.monitorInstanceId = monitorData.deviceId.instanceId;
+            monitorJson.monitorNumber = monitorData.deviceId.number;
             monitorJson.monitorSerialNumber = monitorData.serialNumber;
             monitorJson.virtualDesktop = virtualDesktopIdStr.value();
 

--- a/src/modules/fancyzones/FancyZonesLib/EditorParameters.h
+++ b/src/modules/fancyzones/FancyZonesLib/EditorParameters.h
@@ -8,6 +8,7 @@ namespace NonLocalizable
         const static wchar_t* MonitorNameId = L"monitor";
         const static wchar_t* MonitorInstanceId = L"monitor-instance-id";
         const static wchar_t* MonitorSerialNumberId = L"monitor-serial-number";
+        const static wchar_t* MonitorNumberId = L"monitor-number";
         const static wchar_t* VirtualDesktopId = L"virtual-desktop";
         const static wchar_t* TopCoordinate = L"top-coordinate";
         const static wchar_t* LeftCoordinate = L"left-coordinate";

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesData/AppZoneHistory.h
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesData/AppZoneHistory.h
@@ -19,6 +19,7 @@ namespace NonLocalizable
         const static wchar_t* MonitorID = L"monitor";
         const static wchar_t* MonitorInstanceID = L"monitor-instance";
         const static wchar_t* MonitorSerialNumberID = L"serial-number";
+        const static wchar_t* MonitorNumberID = L"monitor-number";
         const static wchar_t* VirtualDesktopID = L"virtual-desktop";
     }
 }

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesData/AppliedLayouts.h
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesData/AppliedLayouts.h
@@ -20,6 +20,7 @@ namespace NonLocalizable
         const static wchar_t* MonitorID = L"monitor";
         const static wchar_t* MonitorInstanceID = L"monitor-instance";
         const static wchar_t* MonitorSerialNumberID = L"serial-number";
+        const static wchar_t* MonitorNumberID = L"monitor-number";
         const static wchar_t* VirtualDesktopID = L"virtual-desktop";
         const static wchar_t* AppliedLayoutID = L"applied-layout";
         const static wchar_t* UuidID = L"uuid";

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesDataTypes.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesDataTypes.cpp
@@ -131,7 +131,7 @@ namespace FancyZonesDataTypes
     
     std::wstring DeviceId::toString() const noexcept
     {
-        return id + L"_" + instanceId;
+        return id + L"_" + instanceId + L"_" + std::to_wstring(number);
     }
 
     bool DeviceId::isDefault() const noexcept

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesDataTypes.h
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesDataTypes.h
@@ -117,6 +117,7 @@ namespace FancyZonesDataTypes
     {
         std::wstring id;
         std::wstring instanceId;
+        int number;
 
         bool isDefault() const noexcept;
         std::wstring toString() const noexcept;
@@ -169,12 +170,17 @@ namespace FancyZonesDataTypes
 
     inline bool operator==(const DeviceId& lhs, const DeviceId& rhs)
     {
-        if (lhs.isDefault())
+        if (lhs.id != rhs.id)
         {
-            return lhs.instanceId == rhs.instanceId; 
+            return false;
         }
 
-        return lhs.id == rhs.id;
+        if (lhs.instanceId != rhs.instanceId)
+        {
+            return lhs.number == rhs.number;
+        }
+
+        return true;
     }
 
     inline bool operator<(const DeviceId& lhs, const DeviceId& rhs)

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesDataTypes.h
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesDataTypes.h
@@ -195,7 +195,7 @@ namespace FancyZonesDataTypes
             return lhs.monitor == rhs.monitor;
         }
         
-        if (!lhs.serialNumber.empty() || !rhs.serialNumber.empty())
+        if (!lhs.serialNumber.empty() && !rhs.serialNumber.empty())
         {
             bool serialNumbersEqual = lhs.serialNumber == rhs.serialNumber;
             if (!serialNumbersEqual)

--- a/src/modules/fancyzones/FancyZonesTests/UnitTests/WorkAreaIdTests.Spec.cpp
+++ b/src/modules/fancyzones/FancyZonesTests/UnitTests/WorkAreaIdTests.Spec.cpp
@@ -118,15 +118,30 @@ namespace FancyZonesUnitTests
             Assert::IsFalse(id1 == id2);
         }
 
-        TEST_METHOD (DefaultMonitorIdDifferentInstanceId)
+        TEST_METHOD (DefaultMonitorIdDifferentInstanceIdSameNumber)
         {
             FancyZonesDataTypes::WorkAreaId id1{
-                .monitorId = { .deviceId = { .id = L"Default_Monitor", .instanceId = L"instance-id" }, .serialNumber = L"" },
+                .monitorId = { .deviceId = { .id = L"Default_Monitor", .instanceId = L"instance-id", .number = 1 }, .serialNumber = L"" },
                 .virtualDesktopId = FancyZonesUtils::GuidFromString(L"{E21F6F29-76FD-4FC1-8970-17AB8AD64847}").value()
             };
 
             FancyZonesDataTypes::WorkAreaId id2{
-                .monitorId = { .deviceId = { .id = L"Default_Monitor", .instanceId = L"another-instance-id" }, .serialNumber = L"" },
+                .monitorId = { .deviceId = { .id = L"Default_Monitor", .instanceId = L"another-instance-id", .number = 1 }, .serialNumber = L"" },
+                .virtualDesktopId = FancyZonesUtils::GuidFromString(L"{E21F6F29-76FD-4FC1-8970-17AB8AD64847}").value()
+            };
+
+            Assert::IsTrue(id1 == id2);
+        }
+
+        TEST_METHOD (DefaultMonitorIdDifferentInstanceIdDifferentNumber)
+        {
+            FancyZonesDataTypes::WorkAreaId id1{
+                .monitorId = { .deviceId = { .id = L"Default_Monitor", .instanceId = L"instance-id", .number = 1 }, .serialNumber = L"" },
+                .virtualDesktopId = FancyZonesUtils::GuidFromString(L"{E21F6F29-76FD-4FC1-8970-17AB8AD64847}").value()
+            };
+
+            FancyZonesDataTypes::WorkAreaId id2{
+                .monitorId = { .deviceId = { .id = L"Default_Monitor", .instanceId = L"another-instance-id", .number = 2 }, .serialNumber = L"" },
                 .virtualDesktopId = FancyZonesUtils::GuidFromString(L"{E21F6F29-76FD-4FC1-8970-17AB8AD64847}").value()
             };
 
@@ -163,21 +178,6 @@ namespace FancyZonesUnitTests
             Assert::IsFalse(id1 == id2);
         }
 
-        TEST_METHOD (SameIdDifferentInstance)
-        {
-            FancyZonesDataTypes::WorkAreaId id1{
-                .monitorId = { .deviceId = { .id = L"device", .instanceId = L"instance-id-1" }, .serialNumber = L"" },
-                .virtualDesktopId = FancyZonesUtils::GuidFromString(L"{E21F6F29-76FD-4FC1-8970-17AB8AD64847}").value()
-            };
-
-            FancyZonesDataTypes::WorkAreaId id2{
-                .monitorId = { .deviceId = { .id = L"device", .instanceId = L"instance-id-2" }, .serialNumber = L"" },
-                .virtualDesktopId = FancyZonesUtils::GuidFromString(L"{E21F6F29-76FD-4FC1-8970-17AB8AD64847}").value()
-            };
-
-            Assert::IsTrue(id1 == id2);
-        }
-
         TEST_METHOD (SameIdDifferentSerialNumbers)
         {
             FancyZonesDataTypes::WorkAreaId id1{
@@ -202,6 +202,42 @@ namespace FancyZonesUnitTests
 
             FancyZonesDataTypes::WorkAreaId id2{
                 .monitorId = { .deviceId = { .id = L"device-2", .instanceId = L"instance-id-2" }, .serialNumber = L"serial-number-1" },
+                .virtualDesktopId = FancyZonesUtils::GuidFromString(L"{E21F6F29-76FD-4FC1-8970-17AB8AD64847}").value()
+            };
+
+            Assert::IsFalse(id1 == id2);
+        }
+
+        TEST_METHOD (MonitorReconnect)
+        {
+            // same: id, serial number and monitor number
+            // different: instance id
+
+            FancyZonesDataTypes::WorkAreaId id1{
+                .monitorId = { .deviceId = { .id = L"device", .instanceId = L"4&125707d6&0&UID1", .number = 1 }, .serialNumber = L"serial-number" },
+                .virtualDesktopId = FancyZonesUtils::GuidFromString(L"{E21F6F29-76FD-4FC1-8970-17AB8AD64847}").value()
+            };
+
+            FancyZonesDataTypes::WorkAreaId id2{
+                .monitorId = { .deviceId = { .id = L"device", .instanceId = L"4&125707d6&0&UID2", .number = 1 }, .serialNumber = L"serial-number" },
+                .virtualDesktopId = FancyZonesUtils::GuidFromString(L"{E21F6F29-76FD-4FC1-8970-17AB8AD64847}").value()
+            };
+
+            Assert::IsTrue(id1 == id2);
+        }
+
+        TEST_METHOD (SameMonitorModels)
+        {
+            // same: id, serial number
+            // different: monitor number, instance id
+
+            FancyZonesDataTypes::WorkAreaId id1{
+                .monitorId = { .deviceId = { .id = L"device", .instanceId = L"4&125707d6&0&UID1", .number = 1 }, .serialNumber = L"serial-number" },
+                .virtualDesktopId = FancyZonesUtils::GuidFromString(L"{E21F6F29-76FD-4FC1-8970-17AB8AD64847}").value()
+            };
+
+            FancyZonesDataTypes::WorkAreaId id2{
+                .monitorId = { .deviceId = { .id = L"device", .instanceId = L"4&125707d6&0&UID2", .number = 2 }, .serialNumber = L"serial-number" },
                 .virtualDesktopId = FancyZonesUtils::GuidFromString(L"{E21F6F29-76FD-4FC1-8970-17AB8AD64847}").value()
             };
 

--- a/src/modules/fancyzones/FancyZonesTests/UnitTests/WorkAreaIdTests.Spec.cpp
+++ b/src/modules/fancyzones/FancyZonesTests/UnitTests/WorkAreaIdTests.Spec.cpp
@@ -73,36 +73,6 @@ namespace FancyZonesUnitTests
             Assert::IsFalse(id1 == id2);
         }
 
-        TEST_METHOD (NoSerialNumber)
-        {
-            FancyZonesDataTypes::WorkAreaId id1{
-                .monitorId = { .deviceId = { .id = L"device", .instanceId = L"instance-id" }, .serialNumber = L"serial-number" },
-                .virtualDesktopId = FancyZonesUtils::GuidFromString(L"{E21F6F29-76FD-4FC1-8970-17AB8AD64847}").value()
-            };
-
-            FancyZonesDataTypes::WorkAreaId id2{
-                .monitorId = { .deviceId = { .id = L"device", .instanceId = L"instance-id" }, .serialNumber = L"" },
-                .virtualDesktopId = FancyZonesUtils::GuidFromString(L"{E21F6F29-76FD-4FC1-8970-17AB8AD64847}").value()
-            };
-
-            Assert::IsFalse(id1 == id2);
-        }
-
-        TEST_METHOD (NoSerialNumber2)
-        {
-            FancyZonesDataTypes::WorkAreaId id1{
-                .monitorId = { .deviceId = { .id = L"device", .instanceId = L"instance-id" }, .serialNumber = L"" },
-                .virtualDesktopId = FancyZonesUtils::GuidFromString(L"{E21F6F29-76FD-4FC1-8970-17AB8AD64847}").value()
-            };
-
-            FancyZonesDataTypes::WorkAreaId id2{
-                .monitorId = { .deviceId = { .id = L"device", .instanceId = L"instance-id" }, .serialNumber = L"serial-number" },
-                .virtualDesktopId = FancyZonesUtils::GuidFromString(L"{E21F6F29-76FD-4FC1-8970-17AB8AD64847}").value()
-            };
-
-            Assert::IsFalse(id1 == id2);
-        }
-
         TEST_METHOD (DifferentSerialNumber)
         {
             FancyZonesDataTypes::WorkAreaId id1{
@@ -242,6 +212,23 @@ namespace FancyZonesUnitTests
             };
 
             Assert::IsFalse(id1 == id2);
+        }
+
+        TEST_METHOD(SerialNumberNotFoundError)
+        {
+            // serial number is empty, other values are the same
+
+            FancyZonesDataTypes::WorkAreaId id1{
+                .monitorId = { .deviceId = { .id = L"device", .instanceId = L"instance-id", .number = 1 }, .serialNumber = L"serial-number" },
+                .virtualDesktopId = FancyZonesUtils::GuidFromString(L"{E21F6F29-76FD-4FC1-8970-17AB8AD64847}").value()
+            };
+
+            FancyZonesDataTypes::WorkAreaId id2{
+                .monitorId = { .deviceId = { .id = L"device", .instanceId = L"instance-id", .number = 1 }, .serialNumber = L"" },
+                .virtualDesktopId = FancyZonesUtils::GuidFromString(L"{E21F6F29-76FD-4FC1-8970-17AB8AD64847}").value()
+            };
+
+            Assert::IsTrue(id1 == id2);
         }
     };
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/Device.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/Device.cs
@@ -17,6 +17,8 @@ namespace FancyZonesEditor.Utils
 
         public string MonitorSerialNumber { get; set; }
 
+        public int MonitorNumber { get; set; }
+
         public Size MonitorSize { get; set; }
 
         public string VirtualDesktopId { get; set; }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
@@ -81,6 +81,8 @@ namespace FancyZonesEditor.Utils
 
             public string MonitorSerialNumber { get; set; }
 
+            public int MonitorNumber { get; set; }
+
             public string VirtualDesktop { get; set; }
 
             public int Dpi { get; set; }
@@ -133,6 +135,8 @@ namespace FancyZonesEditor.Utils
                 public string Monitor { get; set; }
 
                 public string MonitorInstance { get; set; }
+
+                public int MonitorNumber { get; set; }
 
                 public string SerialNumber { get; set; }
 
@@ -319,6 +323,7 @@ namespace FancyZonesEditor.Utils
                         string targetMonitorId = string.Empty;
                         string targetMonitorSerialNumber = string.Empty;
                         string targetVirtualDesktop = string.Empty;
+                        int targetMonitorNumber = 0;
 
                         foreach (NativeMonitorData nativeData in editorParams.Monitors)
                         {
@@ -327,6 +332,7 @@ namespace FancyZonesEditor.Utils
                             {
                                 targetMonitorId = nativeData.Monitor;
                                 targetMonitorSerialNumber = nativeData.MonitorSerialNumber;
+                                targetMonitorNumber = nativeData.MonitorNumber;
                                 targetVirtualDesktop = nativeData.VirtualDesktop;
                             }
 
@@ -336,6 +342,7 @@ namespace FancyZonesEditor.Utils
                             monitor.Device.MonitorName = nativeData.Monitor;
                             monitor.Device.MonitorInstanceId = nativeData.MonitorInstanceId;
                             monitor.Device.MonitorSerialNumber = nativeData.MonitorSerialNumber;
+                            monitor.Device.MonitorNumber = nativeData.MonitorNumber;
                             monitor.Device.VirtualDesktopId = nativeData.VirtualDesktop;
                             monitor.Device.Dpi = nativeData.Dpi;
 
@@ -349,6 +356,7 @@ namespace FancyZonesEditor.Utils
                             var monitor = monitors[i];
                             if (monitor.Device.MonitorName == targetMonitorId &&
                                 monitor.Device.MonitorSerialNumber == targetMonitorSerialNumber &&
+                                monitor.Device.MonitorNumber == targetMonitorNumber &&
                                 monitor.Device.VirtualDesktopId == targetVirtualDesktop)
                             {
                                 App.Overlay.CurrentDesktop = i;
@@ -371,6 +379,7 @@ namespace FancyZonesEditor.Utils
                         monitor.Device.MonitorName = nativeData.Monitor;
                         monitor.Device.MonitorInstanceId = nativeData.MonitorInstanceId;
                         monitor.Device.MonitorSerialNumber = nativeData.MonitorSerialNumber;
+                        monitor.Device.MonitorNumber = nativeData.MonitorNumber;
                         monitor.Device.VirtualDesktopId = nativeData.VirtualDesktop;
 
                         App.Overlay.AddMonitor(monitor);
@@ -571,6 +580,7 @@ namespace FancyZonesEditor.Utils
                     {
                         Monitor = monitor.Device.MonitorName,
                         MonitorInstance = monitor.Device.MonitorInstanceId,
+                        MonitorNumber = monitor.Device.MonitorNumber,
                         SerialNumber = monitor.Device.MonitorSerialNumber,
                         VirtualDesktop = monitor.Device.VirtualDesktopId,
                     },
@@ -838,6 +848,7 @@ namespace FancyZonesEditor.Utils
                 {
                     if (monitor.Device.MonitorName == layout.Device.Monitor &&
                         monitor.Device.MonitorSerialNumber == layout.Device.SerialNumber &&
+                        monitor.Device.MonitorNumber == layout.Device.MonitorNumber &&
                         (monitor.Device.VirtualDesktopId == layout.Device.VirtualDesktop ||
                         layout.Device.VirtualDesktop == DefaultVirtualDesktopGuid))
                     {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Added monitor number as a fallback value in case of identical device ids and serial numbers on different monitors.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #19203 
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Added WorkAreaId comparison unit tests representing situations 
* Different monitors with identical serial numbers and device ids
* Same monitor reconnect