### PR TITLE
[FancyZones] Avoid unnecessary monitors re-identification

### DIFF
--- a/src/modules/fancyzones/FancyZonesLib/EditorParameters.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/EditorParameters.cpp
@@ -2,7 +2,7 @@
 #include "EditorParameters.h"
 
 #include <FancyZonesLib/FancyZonesWindowProperties.h>
-#include <FancyZonesLib/MonitorUtils.h>
+#include <FancyZonesLib/Monitors.h>
 #include <FancyZonesLib/on_thread_executor.h>
 #include <FancyZonesLib/Settings.h>
 #include <FancyZonesLib/VirtualDesktop.h>
@@ -133,7 +133,7 @@ bool EditorParameters::Save() noexcept
     }
     else
     {
-        auto monitors = MonitorUtils::IdentifyMonitors();
+        auto monitors = Monitors::instance().Get();
 
         HMONITOR targetMonitor{};
         if (FancyZonesSettings::settings().use_cursorpos_editor_startupscreen)

--- a/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
@@ -686,8 +686,7 @@ void FancyZones::OnDisplayChange(DisplayChangeType changeType) noexcept
     Logger::info(L"Display changed, type: {}", changeType);
 
     if (changeType == DisplayChangeType::Initialization ||
-        changeType == DisplayChangeType::DisplayChange ||
-        changeType == DisplayChangeType::WorkArea)
+        changeType == DisplayChangeType::DisplayChange)
     {
         Monitors::instance().Identify();
     }

--- a/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
@@ -21,6 +21,7 @@
 #include <FancyZonesLib/FancyZonesWindowProcessing.h>
 #include <FancyZonesLib/FancyZonesWindowProperties.h>
 #include <FancyZonesLib/FancyZonesWinHookEventIDs.h>
+#include <FancyZonesLib/Monitors.h>
 #include <FancyZonesLib/MonitorUtils.h>
 #include <FancyZonesLib/Settings.h>
 #include <FancyZonesLib/SettingsObserver.h>
@@ -684,6 +685,13 @@ void FancyZones::OnDisplayChange(DisplayChangeType changeType) noexcept
 {
     Logger::info(L"Display changed, type: {}", changeType);
 
+    if (changeType == DisplayChangeType::Initialization ||
+        changeType == DisplayChangeType::DisplayChange ||
+        changeType == DisplayChangeType::WorkArea)
+    {
+        Monitors::instance().Identify();
+    }
+
     if (changeType == DisplayChangeType::VirtualDesktop ||
         changeType == DisplayChangeType::Initialization)
     {
@@ -694,7 +702,7 @@ void FancyZones::OnDisplayChange(DisplayChangeType changeType) noexcept
             RegisterVirtualDesktopUpdates();
 
             // id format of applied-layouts and app-zone-history was changed in 0.60
-            auto monitors = MonitorUtils::IdentifyMonitors();
+            auto monitors = Monitors::instance().Get();
             AppliedLayouts::instance().AdjustWorkAreaIds(monitors);
             AppZoneHistory::instance().AdjustWorkAreaIds(monitors);
         }
@@ -764,7 +772,7 @@ void FancyZones::UpdateWorkAreas() noexcept
     }
     else
     {
-        auto monitors = MonitorUtils::IdentifyMonitors();
+        auto monitors = Monitors::instance().Get();
         for (const auto& monitor : monitors)
         {
             FancyZonesDataTypes::WorkAreaId workAreaId;

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesLib.vcxproj
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesLib.vcxproj
@@ -54,6 +54,7 @@
     <ClInclude Include="FancyZonesData\LayoutHotkeys.h" />
     <ClInclude Include="LayoutConfigurator.h" />
     <ClInclude Include="ModuleConstants.h" />
+    <ClInclude Include="Monitors.h" />
     <ClInclude Include="MonitorUtils.h" />
     <ClInclude Include="MonitorWorkAreaHandler.h" />
     <ClInclude Include="pch.h" />
@@ -101,6 +102,7 @@
       <PrecompiledHeaderFile>../pch.h</PrecompiledHeaderFile>
     </ClCompile>
     <ClCompile Include="LayoutConfigurator.cpp" />
+    <ClCompile Include="Monitors.cpp" />
     <ClCompile Include="MonitorUtils.cpp" />
     <ClCompile Include="MonitorWorkAreaHandler.cpp" />
     <ClCompile Include="OnThreadExecutor.cpp" />

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesLib.vcxproj.filters
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesLib.vcxproj.filters
@@ -135,6 +135,9 @@
     <ClInclude Include="EditorParameters.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Monitors.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp">
@@ -222,6 +225,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="EditorParameters.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Monitors.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/modules/fancyzones/FancyZonesLib/MonitorUtils.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/MonitorUtils.cpp
@@ -331,25 +331,4 @@ namespace MonitorUtils
             }
         }
     }
-   
-    std::vector<FancyZonesDataTypes::MonitorId> IdentifyMonitors() noexcept
-    {
-        Logger::info(L"Identifying monitors");
-
-        auto displays = Display::GetDisplays();
-        auto monitors = WMI::GetHardwareMonitorIds();
-        
-        for (const auto& monitor : monitors)
-        {
-            for (auto& display : displays)
-            {
-                if (monitor.deviceId.id == display.deviceId.id)
-                {
-                    display.serialNumber = monitor.serialNumber;    
-                }
-            }
-        }
-        
-        return displays;
-    }
 }

--- a/src/modules/fancyzones/FancyZonesLib/MonitorUtils.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/MonitorUtils.cpp
@@ -222,20 +222,20 @@ namespace MonitorUtils
         std::vector<FancyZonesDataTypes::MonitorId> GetDisplays()
         {
             auto allMonitors = FancyZonesUtils::GetAllMonitorInfo<&MONITORINFOEX::rcWork>();
-            std::unordered_map<std::wstring, DWORD> displayDeviceIdxMap;
             std::vector<FancyZonesDataTypes::MonitorId> result{};
-
+            DWORD displayDeviceIdx{ 0 };
+            
             for (auto& monitorData : allMonitors)
             {
                 auto monitorInfo = monitorData.second;
 
                 DISPLAY_DEVICE displayDevice{ .cb = sizeof(displayDevice) };
                 std::wstring deviceId;
-                auto enumRes = EnumDisplayDevicesW(monitorInfo.szDevice, displayDeviceIdxMap[monitorInfo.szDevice], &displayDevice, EDD_GET_DEVICE_INTERFACE_NAME);
+                auto enumRes = EnumDisplayDevicesW(monitorInfo.szDevice, displayDeviceIdx, &displayDevice, EDD_GET_DEVICE_INTERFACE_NAME);
 
                 if (!enumRes)
                 {
-                    Logger::error(L"EnumDisplayDevicesW error: {}", get_last_error_or_default(GetLastError()));
+                    Logger::error(L"EnumDisplayDevicesW error: {}", monitorInfo.szDevice);
                     continue;
                 }
                 

--- a/src/modules/fancyzones/FancyZonesLib/MonitorUtils.h
+++ b/src/modules/fancyzones/FancyZonesLib/MonitorUtils.h
@@ -17,6 +17,5 @@ namespace MonitorUtils
         FancyZonesDataTypes::DeviceId SplitWMIDeviceId(const std::wstring& str) noexcept;
     }
 
-    std::vector<FancyZonesDataTypes::MonitorId> IdentifyMonitors() noexcept;
     void OpenWindowOnActiveMonitor(HWND window, HMONITOR monitor) noexcept;
 };

--- a/src/modules/fancyzones/FancyZonesLib/Monitors.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/Monitors.cpp
@@ -1,0 +1,36 @@
+#include "pch.h"
+#include "Monitors.h"
+
+#include <FancyZonesLib/MonitorUtils.h>
+
+#include <common/logger/logger.h>
+
+Monitors& Monitors::instance()
+{
+    static Monitors self;
+    return self;
+}
+
+void Monitors::Identify()
+{
+    Logger::info(L"Identifying monitors");
+
+    m_monitors = MonitorUtils::Display::GetDisplays();
+    auto monitors = MonitorUtils::WMI::GetHardwareMonitorIds();
+
+    for (const auto& monitor : monitors)
+    {
+        for (auto& display : m_monitors)
+        {
+            if (monitor.deviceId.id == display.deviceId.id)
+            {
+                display.serialNumber = monitor.serialNumber;
+            }
+        }
+    }
+}
+
+const std::vector<FancyZonesDataTypes::MonitorId>& Monitors::Get() const noexcept
+{
+    return m_monitors;
+}

--- a/src/modules/fancyzones/FancyZonesLib/Monitors.h
+++ b/src/modules/fancyzones/FancyZonesLib/Monitors.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <FancyZonesLib/FancyZonesDataTypes.h>
+
+class Monitors
+{
+public:
+    static Monitors& instance();
+
+    void Identify();
+
+    const std::vector<FancyZonesDataTypes::MonitorId>& Get() const noexcept;
+
+private:
+    Monitors(){};
+    ~Monitors() = default;
+
+    std::vector<FancyZonesDataTypes::MonitorId> m_monitors;
+};

--- a/tools/MonitorReportTool/MonitorReportTool.cpp
+++ b/tools/MonitorReportTool/MonitorReportTool.cpp
@@ -40,27 +40,44 @@ void LogEnumDisplayMonitors()
     Logger::log(L" ---- EnumDisplayMonitors ---- ");
 
     auto allMonitors = FancyZonesUtils::GetAllMonitorInfo<&MONITORINFOEX::rcWork>();
-    std::unordered_map<std::wstring, DWORD> displayDeviceIdxMap;
+    
+    for (auto& monitorData : allMonitors)
+    {
+        auto monitorInfo = monitorData.second;
+
+        DISPLAY_DEVICE displayDevice{ .cb = sizeof(displayDevice) };
+        DWORD deviceIdx{0};
+        while (EnumDisplayDevicesW(monitorInfo.szDevice, deviceIdx, &displayDevice, EDD_GET_DEVICE_INTERFACE_NAME))
+        {
+            Logger::log(L"Device {}", deviceIdx);
+            Logger::log(L"DeviceId: {}", std::wstring(displayDevice.DeviceID));
+            Logger::log(L"DeviceKey: {}", std::wstring(displayDevice.DeviceKey));
+            Logger::log(L"DeviceName: {}", std::wstring(displayDevice.DeviceName));
+            Logger::log(L"DeviceString: {}", std::wstring(displayDevice.DeviceString));
+            Logger::log(L"");
+
+            deviceIdx++;
+        }
+    }
+
+    Logger::log(L" ---- EnumDisplayMonitors ---- ");
 
     for (auto& monitorData : allMonitors)
     {
         auto monitorInfo = monitorData.second;
 
         DISPLAY_DEVICE displayDevice{ .cb = sizeof(displayDevice) };
-        std::wstring deviceId;
-        auto enumRes = EnumDisplayDevicesW(monitorInfo.szDevice, displayDeviceIdxMap[monitorInfo.szDevice], &displayDevice, EDD_GET_DEVICE_INTERFACE_NAME);
-
-        if (enumRes == 0)
+        DWORD deviceIdx{ 0 };
+        while (EnumDisplayDevicesW(monitorInfo.szDevice, deviceIdx, &displayDevice, 0))
         {
-            Logger::log(get_last_error_or_default(GetLastError()));
-        }
-        else
-        {
+            Logger::log(L"Device {}", deviceIdx);
             Logger::log(L"DeviceId: {}", std::wstring(displayDevice.DeviceID));
             Logger::log(L"DeviceKey: {}", std::wstring(displayDevice.DeviceKey));
             Logger::log(L"DeviceName: {}", std::wstring(displayDevice.DeviceName));
             Logger::log(L"DeviceString: {}", std::wstring(displayDevice.DeviceString));
             Logger::log(L"");
+
+            deviceIdx++;
         }
     }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Identify monitors on start or when the configuration is changed and use this data on editor opening.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #19223 
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

* Verify `[info] Identifying monitors` appears in logs only after `[info] Display changed, type: ...` and doesn't appear on editor start.
* Verify monitors identified correctly on configuration change (on FZ start, after disconnect/connect monitor)
 