### PR TITLE
[PowerRename] Scale window size

### DIFF
--- a/src/modules/powerrename/PowerRenameUILib/MainWindow.xaml.cpp
+++ b/src/modules/powerrename/PowerRenameUILib/MainWindow.xaml.cpp
@@ -17,6 +17,7 @@
 #include <string>
 #include <sstream>
 #include <vector>
+#include <shellscalingapi.h>
 
 #include "microsoft.ui.xaml.window.h"
 #include <winrt/Microsoft.UI.Interop.h>
@@ -65,31 +66,37 @@ namespace winrt::PowerRenameUI::implementation
         Microsoft::UI::WindowId windowId =
             Microsoft::UI::GetWindowIdFromWindow(m_window);
 
+        Microsoft::UI::Windowing::AppWindow appWindow =
+            Microsoft::UI::Windowing::AppWindow::GetFromWindowId(windowId);
+        appWindow.SetIcon(PowerRenameUIIco);
+
         POINT cursorPosition{};
         if (GetCursorPos(&cursorPosition))
         {
+            ::Windows::Graphics::PointInt32 point{ cursorPosition.x, cursorPosition.y};
+            Microsoft::UI::Windowing::DisplayArea displayArea = Microsoft::UI::Windowing::DisplayArea::GetFromPoint(point, Microsoft::UI::Windowing::DisplayAreaFallback::Nearest);
+
             HMONITOR hMonitor = MonitorFromPoint(cursorPosition, MONITOR_DEFAULTTOPRIMARY);
             MONITORINFOEX monitorInfo;
             monitorInfo.cbSize = sizeof(MONITORINFOEX);
             GetMonitorInfo(hMonitor, &monitorInfo);
-            RECT rect;
-            if (GetWindowRect(m_window, &rect))
-            {
-                int width = rect.right - rect.left;
-                int height = rect.bottom - rect.top;
+            UINT x_dpi;
+            GetDpiForMonitor(hMonitor, MONITOR_DPI_TYPE::MDT_EFFECTIVE_DPI, &x_dpi, &x_dpi);
+            UINT window_dpi = GetDpiForWindow(m_window);
 
-                MoveWindow(m_window,
-                             monitorInfo.rcWork.left + (monitorInfo.rcWork.right - monitorInfo.rcWork.left - width) / 2,
-                             monitorInfo.rcWork.top + (monitorInfo.rcWork.bottom - monitorInfo.rcWork.top - height) / 2,
-                             width,
-                             height,
-                             true);
-            }
+            int width = 1400;
+            int height = 800;
+
+            winrt::Windows::Graphics::RectInt32 rect;
+            // Scale window size
+            rect.Width = (int32_t)(width * (float)window_dpi / x_dpi);
+            rect.Height = (int32_t)(height * (float)window_dpi / x_dpi);
+            // Center to screen
+            rect.X = displayArea.WorkArea().X + displayArea.WorkArea().Width / 2 - width / 2;
+            rect.Y = displayArea.WorkArea().Y + displayArea.WorkArea().Height / 2 - height / 2;
+
+            appWindow.MoveAndResize(rect);
         }
-
-        Microsoft::UI::Windowing::AppWindow appWindow =
-            Microsoft::UI::Windowing::AppWindow::GetFromWindowId(windowId);
-        appWindow.SetIcon(PowerRenameUIIco);
 
         Title(hstring{ L"PowerRename" });
         

--- a/src/modules/powerrename/PowerRenameUILib/PowerRenameUI.vcxproj
+++ b/src/modules/powerrename/PowerRenameUILib/PowerRenameUI.vcxproj
@@ -70,7 +70,7 @@
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>kernel32.lib;user32.lib;dwmapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;dwmapi.lib;Shcore.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
@@ -80,7 +80,7 @@
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>kernel32.lib;user32.lib;dwmapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;dwmapi.lib;Shcore.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
On bigger screens PowerRename window was taking almost 100% (or more in some cases) of the screen.
This PR scales window size depending on the dpi. On some edgy resolutions and dpis , window may be a bit smaller than it should, but with hardcoded size, can't do much there.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #19239 #18704
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Try running PowerRename on different screens/resolutions/dpis and confirm that size of the window is reasonable (e.g. not taking 100% of the screen)
