### PR TITLE
[FancyZones]Fallback and fixes for GetDisplays

### DIFF
--- a/src/modules/fancyzones/FancyZonesLib/MonitorUtils.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/MonitorUtils.cpp
@@ -222,7 +222,6 @@ namespace MonitorUtils
         std::vector<FancyZonesDataTypes::MonitorId> GetDisplays()
         {
             auto allMonitors = FancyZonesUtils::GetAllMonitorInfo<&MONITORINFOEX::rcWork>();
-            std::unordered_map<std::wstring, DWORD> displayDeviceIdxMap;
             std::vector<FancyZonesDataTypes::MonitorId> result{};
 
             for (auto& monitorData : allMonitors)
@@ -237,7 +236,9 @@ namespace MonitorUtils
 
                 bool foundActiveMonitor = false;
 
-                while(EnumDisplayDevicesW(monitorInfo.szDevice, displayDeviceIdxMap[monitorInfo.szDevice], &displayDevice, EDD_GET_DEVICE_INTERFACE_NAME))
+                DWORD displayDeviceIndex = 0;
+
+                while (EnumDisplayDevicesW(monitorInfo.szDevice, displayDeviceIndex, &displayDevice, EDD_GET_DEVICE_INTERFACE_NAME))
                 {
                     Logger::info(L"Get display device for display {} : {}", monitorInfo.szDevice, displayDevice.DeviceID);
                     if (WI_IsFlagSet(displayDevice.StateFlags, DISPLAY_DEVICE_ACTIVE) &&
@@ -247,6 +248,7 @@ namespace MonitorUtils
                         foundActiveMonitor = true;
                         break;
                     }
+                    displayDeviceIndex++;
                 }
 
                 if (foundActiveMonitor)

--- a/src/modules/fancyzones/FancyZonesLib/MonitorUtils.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/MonitorUtils.cpp
@@ -230,32 +230,61 @@ namespace MonitorUtils
                 auto monitorInfo = monitorData.second;
 
                 DISPLAY_DEVICE displayDevice{ .cb = sizeof(displayDevice) };
-                std::wstring deviceId;
-                auto enumRes = EnumDisplayDevicesW(monitorInfo.szDevice, displayDeviceIdxMap[monitorInfo.szDevice], &displayDevice, EDD_GET_DEVICE_INTERFACE_NAME);
 
-                if (!enumRes)
-                {
-                    Logger::error(L"EnumDisplayDevicesW error: {}", get_last_error_or_default(GetLastError()));
-                    continue;
-                }
-                
-                Logger::info(L"Display: {}, number: {}", displayDevice.DeviceID);
-                FancyZonesDataTypes::MonitorId id{ .monitor = monitorData.first, .deviceId = SplitDisplayDeviceId(displayDevice.DeviceID) };
+                FancyZonesDataTypes::MonitorId monitorId {
+                    .monitor = monitorData.first
+                };
 
-                try
+                bool foundActiveMonitor = false;
+
+                while(EnumDisplayDevicesW(monitorInfo.szDevice, displayDeviceIdxMap[monitorInfo.szDevice], &displayDevice, EDD_GET_DEVICE_INTERFACE_NAME))
                 {
-                    std::wstring numberStr = displayDevice.DeviceName; // \\.\DISPLAY1\Monitor0
-                    numberStr = numberStr.substr(0, numberStr.find_last_of('\\')); // \\.\DISPLAY1
-                    numberStr = remove_non_digits(numberStr);
-                    id.deviceId.number = std::stoi(numberStr);
-                }
-                catch (...)
-                {
-                    Logger::error(L"Failed to get monitor number from {}", displayDevice.DeviceName);
+                    Logger::info(L"Get display device for display {} : {}", monitorInfo.szDevice, displayDevice.DeviceID);
+                    if (WI_IsFlagSet(displayDevice.StateFlags, DISPLAY_DEVICE_ACTIVE) &&
+                        WI_IsFlagClear(displayDevice.StateFlags, DISPLAY_DEVICE_MIRRORING_DRIVER))
+                    {
+                        // Find display devices associated with the display.
+                        foundActiveMonitor = true;
+                        break;
+                    }
                 }
 
-                result.push_back(std::move(id));
-                
+                if (foundActiveMonitor)
+                {
+                    monitorId.deviceId = SplitDisplayDeviceId(displayDevice.DeviceID);
+                    try
+                    {
+                        std::wstring numberStr = displayDevice.DeviceName; // \\.\DISPLAY1\Monitor0
+                        numberStr = numberStr.substr(0, numberStr.find_last_of('\\')); // \\.\DISPLAY1
+                        numberStr = remove_non_digits(numberStr);
+                        monitorId.deviceId.number = std::stoi(numberStr);
+                    }
+                    catch (...)
+                    {
+                        Logger::error(L"Failed to get monitor number from {}", displayDevice.DeviceName);
+                        monitorId.deviceId.number = 0;
+                    }
+                }
+                else
+                {
+                    // Use the display name when no proper device was found.
+                    monitorId.deviceId.id = monitorInfo.szDevice;
+                    monitorId.deviceId.instanceId = L"";
+                    Logger::info(L"No active monitor found for {} : {}", monitorInfo.szDevice, get_last_error_or_default(GetLastError()));
+                    try
+                    {
+                        std::wstring numberStr = monitorInfo.szDevice; // \\.\DISPLAY1
+                        numberStr = remove_non_digits(numberStr);
+                        monitorId.deviceId.number = std::stoi(numberStr);
+                    }
+                    catch (...)
+                    {
+                        Logger::error(L"Failed to get display number from {}", monitorInfo.szDevice);
+                        monitorId.deviceId.number = 0;
+                    }
+                }
+
+                result.push_back(std::move(monitorId));
             }
 
             return result;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Fixes issues with FancyZones Editor not opening after the monitor identification work.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #19223 and the remaining reported issues in #19203
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

With the new monitor identification code, FancyZones was failing in cases where `EnumDisplayDevicesW` didn't detect any monitors connected to a display device.
It also looks for the active monitor inside each display device since it's possible for a monitor to be inactive and the correct one for the display will be another monitor connected to the display device.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Asked the users from the issues to test it on their configurations, since I've got no physical or virtual machine capable of replicating the same conditions for the users.
