### PR TITLE
[FileExplorer Add-ons][SVG thumbnail] Swap order of default and svg namespace if default comes first

### DIFF
--- a/src/modules/previewpane/SvgThumbnailProvider/SvgThumbnailProvider.cs
+++ b/src/modules/previewpane/SvgThumbnailProvider/SvgThumbnailProvider.cs
@@ -256,6 +256,10 @@ namespace Microsoft.PowerToys.ThumbnailHandler.Svg
                     svgData = reader.ReadToEnd();
                     try
                     {
+                        // Fixes #17527 - Inkscape v1.1 swapped order of default and svg namespaces in svg file (default first, svg after).
+                        // That resulted in parser being unable to parse it correctly and instead of svg, text was previewed.
+                        // MS Edge and Firefox also couldn't preview svg files with mentioned order of namespaces definitions.
+                        svgData = SvgPreviewHandlerHelper.SwapNamespaces(svgData);
                         svgData = SvgPreviewHandlerHelper.AddStyleSVG(svgData);
                     }
                     catch (Exception)


### PR DESCRIPTION
Same as https://github.com/microsoft/PowerToys/pull/18825, but for svg thumbnails

Inkscape v1.1 swapped order of default and svg namespaces in svg file (default first, svg after).
That resulted in parser being unable to parse it correctly and instead of svg, text was previewed.
MS Edge and Firefox also couldn't preview svg files with mentioned order of namespaces definitions.


<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #17527 
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Download examples.zip from issue description and confirm that for all 3 SVG files thumbnail and preview is ok. (for file #3, comment is affecting the fix logic, so deleting comment from that file makes it work. It's not expected that regular svg file will have namespace declarations in comment before actual declarations, so fix does not include check for comments)
