### PR TITLE
[General]Fix dead keys being pressed by PowerToys

### DIFF
--- a/src/common/SettingsAPI/settings_objects.h
+++ b/src/common/SettingsAPI/settings_objects.h
@@ -217,7 +217,8 @@ namespace PowerToysSettings
             }
             std::array<BYTE, 256> key_states{}; // Zero-initialize
             std::array<wchar_t, 256> output;
-            auto output_bytes = ToUnicodeEx(key_code, scan_code, key_states.data(), output.data(), (int)output.size() - 1, 0, layout);
+            const UINT wFlags = 1 << 2; // If bit 2 is set, keyboard state is not changed (Windows 10, version 1607 and newer)
+            auto output_bytes = ToUnicodeEx(key_code, scan_code, key_states.data(), output.data(), (int)output.size() - 1, wFlags, layout);
             if (output_bytes <= 0)
             {
                 // If ToUnicodeEx fails (e.g. for F1-F12 keys) use GetKeyNameTextW

--- a/src/common/interop/keyboard_layout.cpp
+++ b/src/common/interop/keyboard_layout.cpp
@@ -55,7 +55,8 @@ bool mapKeycodeToUnicode(const int vCode, HKL layout, const BYTE* keyState, std:
     // Get the scan code from the virtual key code
     const UINT scanCode = MapVirtualKeyExW(vCode, MAPVK_VK_TO_VSC, layout);
     // Get the unicode representation from the virtual key code and scan code pair
-    const int result = ToUnicodeEx(vCode, scanCode, keyState, outBuffer.data(), (int)outBuffer.size(), 0, layout);
+    const UINT wFlags = 1 << 2; // If bit 2 is set, keyboard state is not changed (Windows 10, version 1607 and newer)
+    const int result = ToUnicodeEx(vCode, scanCode, keyState, outBuffer.data(), (int)outBuffer.size(), wFlags, layout);
     return result != 0;
 }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Fixes random backticks being sent on some keyboard layouts when Fancy Zones is enabled

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #8083
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

The use of `ToUnicodeEx` means that the keyboard state may change.
Ref https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-tounicodeex#remarks
> As ToUnicodeEx translates the virtual-key code, it also changes the state of the kernel-mode keyboard buffer. This state-change affects dead keys, ligatures, alt+numpad key entry, and so on. It might also cause undesired side-effects if used in conjunction with [TranslateMessage](https://docs.microsoft.com/en-us/windows/desktop/api/winuser/nf-winuser-translatemessage) (which also changes the state of the kernel-mode keyboard buffer).

Recently, it's been made possible to not change the keyboard state when calling this function, so I added code to use that flag.
> [in] wFlags
Type: UINT
The behavior of the function.
If bit 0 is set, a menu is active.
If bit 2 is set, keyboard state is not changed (Windows 10, version 1607 and newer)
All other bits (through 31) are reserved.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
As better described in https://github.com/microsoft/PowerToys/issues/19014#issuecomment-1165779901 , I've been able to replicate it with a US-International Keyboard layout. 
After the fix, I could no longer print a backtick into notepad with the space key after enabling FancyZones.
