### PR TITLE
[AOT] Properly handle thread when destroyed

### DIFF
--- a/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.cpp
+++ b/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.cpp
@@ -56,10 +56,11 @@ AlwaysOnTop::~AlwaysOnTop()
 {
     if (m_hPinEvent)
     {
-        SetEvent(m_hPinEvent);
-        m_thread.join();
         CloseHandle(m_hPinEvent);
     }
+
+    m_running = false;
+    m_thread.join();
 
     CleanUp();
 }
@@ -274,12 +275,12 @@ void AlwaysOnTop::RegisterLLKH()
         Logger::warn(L"Failed to create pinEvent. {}", get_last_error_or_default(GetLastError()));
         return;
     }
-	
+
     m_thread = std::thread([this]() {
         MSG msg;
-        while (1)
+        while (m_running)
         {
-            DWORD dwEvt = MsgWaitForMultipleObjects(1, &m_hPinEvent, false, INFINITE, QS_ALLINPUT);
+            DWORD dwEvt = MsgWaitForMultipleObjects(1, &m_hPinEvent, false, 0, QS_ALLINPUT);
             switch (dwEvt)
             {
             case WAIT_OBJECT_0:
@@ -296,7 +297,7 @@ void AlwaysOnTop::RegisterLLKH()
                 }
                 break;
             default:
-                return false;
+                break;
             }
         }
     });

--- a/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.h
+++ b/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.h
@@ -50,6 +50,7 @@ private:
     HANDLE m_hPinEvent;
     std::thread m_thread;
     const bool m_useCentralizedLLKH;
+    bool m_running = true;
 
     LRESULT WndProc(HWND, UINT, WPARAM, LPARAM) noexcept;
     void HandleWinHookEvent(WinHookEvent* data) noexcept;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

AOT isn't properly terminated when runner is killed https://github.com/microsoft/PowerToys/issues/19447#issuecomment-1186457316

I am not able to test an update but I think this will fix that bug.
And of course the thread need to be fixed.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #19447
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

- Pin/Unpin event is signaled in the AOT destructor.
- The thread used for listening the shortcut was hanging when the join method is called in the AOT destructor.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Pin a window
- Move the window (border should be redrawed as expected)
- Open task manager
- Kill `PowerToys.exe`
- Every PT process should be killed including `PowerToys.AlwaysOnTop.exe`