### PR TITLE
Change HSB color convert and add unit test

### DIFF
--- a/src/modules/colorPicker/ColorPickerUI/Helpers/ColorHelper.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/ColorHelper.cs
@@ -59,10 +59,8 @@ namespace ColorPicker.Helpers
         /// <returns>The hue [0°..360°], saturation [0..1] and brightness [0..1] of the converted color</returns>
         internal static (double hue, double saturation, double brightness) ConvertToHSBColor(Color color)
         {
-            var min = Math.Min(Math.Min(color.R, color.G), color.B) / 255d;
-            var max = Math.Max(Math.Max(color.R, color.G), color.B) / 255d;
-
-            return (color.GetHue(), max == 0d ? 0d : (max - min) / max, max);
+            // HSB and HSV represents the same color space
+            return ConvertToHSVColor(color);
         }
 
         /// <summary>

--- a/src/modules/colorPicker/ColorPickerUI/Helpers/ColorHelper.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/ColorHelper.cs
@@ -58,7 +58,12 @@ namespace ColorPicker.Helpers
         /// <param name="color">The <see cref="Color"/> to convert</param>
         /// <returns>The hue [0°..360°], saturation [0..1] and brightness [0..1] of the converted color</returns>
         internal static (double hue, double saturation, double brightness) ConvertToHSBColor(Color color)
-            => (color.GetHue(), color.GetSaturation(), color.GetBrightness());
+        {
+            var min = Math.Min(Math.Min(color.R, color.G), color.B) / 255d;
+            var max = Math.Max(Math.Max(color.R, color.G), color.B) / 255d;
+
+            return (color.GetHue(), max == 0d ? 0d : (max - min) / max, max);
+        }
 
         /// <summary>
         /// Convert a given <see cref="Color"/> to a HSI color (hue, saturation, intensity)

--- a/src/modules/colorPicker/UnitTest-ColorPickerUI/Helpers/ColorConverterTest.cs
+++ b/src/modules/colorPicker/UnitTest-ColorPickerUI/Helpers/ColorConverterTest.cs
@@ -114,6 +114,55 @@ namespace Microsoft.ColorPicker.UnitTests
             Assert.AreEqual(result.value * 100d, value, 0.2d);
         }
 
+        // test values taken from https://de.wikipedia.org/wiki/HSV-Farbraum
+        [TestMethod]
+        [DataRow(000, 000, 000, 000, 000, 000)] // Black
+        [DataRow(000, 000, 100, 100, 100, 100)] // White
+        [DataRow(000, 100, 100, 100, 000, 000)] // Red
+        [DataRow(015, 100, 100, 100, 025, 000)] // Vermilion/Cinnabar
+        [DataRow(020, 075, 036, 036, 018, 009)] // Brown
+        [DataRow(030, 100, 100, 100, 050, 000)] // Orange
+        [DataRow(045, 100, 100, 100, 075, 000)] // Saffron
+        [DataRow(060, 100, 100, 100, 100, 000)] // Yellow
+        [DataRow(075, 100, 100, 075, 100, 000)] // Light green-yellow
+        [DataRow(090, 100, 100, 050, 100, 000)] // Green-yellow
+        [DataRow(105, 100, 100, 025, 100, 000)] // Lime
+        [DataRow(120, 100, 050, 000, 050, 000)] // Dark green
+        [DataRow(120, 100, 100, 000, 100, 000)] // Green
+        [DataRow(135, 100, 100, 000, 100, 025)] // Light blue-green
+        [DataRow(150, 100, 100, 000, 100, 050)] // Blue-green
+        [DataRow(165, 100, 100, 000, 100, 075)] // Green-cyan
+        [DataRow(180, 100, 100, 000, 100, 100)] // Cyan
+        [DataRow(195, 100, 100, 000, 075, 100)] // Blue-cyan
+        [DataRow(210, 100, 100, 000, 050, 100)] // Green-blue
+        [DataRow(225, 100, 100, 000, 025, 100)] // Light green-blue
+        [DataRow(240, 100, 100, 000, 000, 100)] // Blue
+        [DataRow(255, 100, 100, 025, 000, 100)] // Indigo
+        [DataRow(270, 100, 100, 050, 000, 100)] // Purple
+        [DataRow(285, 100, 100, 075, 000, 100)] // Blue-magenta
+        [DataRow(300, 100, 100, 100, 000, 100)] // Magenta
+        [DataRow(315, 100, 100, 100, 000, 075)] // Red-magenta
+        [DataRow(330, 100, 100, 100, 000, 050)] // Blue-red
+        [DataRow(345, 100, 100, 100, 000, 025)] // Light blue-red
+        public void ColorRGBtoHSBTest(double hue, double saturation, double value, int red, int green, int blue)
+        {
+            red = Convert.ToInt32(Math.Round(255d / 100d * red));         // [0%..100%] to [0..255]
+            green = Convert.ToInt32(Math.Round(255d / 100d * green));       // [0%..100%] to [0..255]
+            blue = Convert.ToInt32(Math.Round(255d / 100d * blue));        // [0%..100%] to [0..255]
+
+            var color = Color.FromArgb(255, red, green, blue);
+            var result = ColorHelper.ConvertToHSBColor(color);
+
+            // hue [0°..360°]
+            Assert.AreEqual(result.hue, hue, 0.2d);
+
+            // saturation[0..1]
+            Assert.AreEqual(result.saturation * 100d, saturation, 0.2d);
+
+            // value[0..1]
+            Assert.AreEqual(result.brightness * 100d, value, 0.2d);
+        }
+
         [TestMethod]
         [DataRow(000, 000, 000, 100, 000, 000, 000)] // Black
         [DataRow(000, 000, 000, 000, 255, 255, 255)] // White


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
Fix HSB color conversion.

## Fix https://github.com/microsoft/PowerToys/issues/19163
HSV and HSB color space should be the same.
Fixed the code and added an unit test to prevent problems in the future.
Tested manually and with the created unit test.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** https://github.com/microsoft/PowerToys/issues/19163
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validated the result by trying the https://github.com/microsoft/PowerToys/issues/19163 steps to reproduce, and verifying that the output color for blue is now the same as HSV.
Using the same test inputs used for HSV, added a test for HSB.

