### PR TITLE
[AOT] Fix CPU consumption

### DIFF
--- a/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.cpp
+++ b/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.cpp
@@ -54,12 +54,14 @@ AlwaysOnTop::AlwaysOnTop(bool useLLKH) :
 
 AlwaysOnTop::~AlwaysOnTop()
 {
+    m_running = false;
+
     if (m_hPinEvent)
     {
+        // Needed to unblock MsgWaitForMultipleObjects one last time
+        SetEvent(m_hPinEvent);
         CloseHandle(m_hPinEvent);
     }
-
-    m_running = false;
     m_thread.join();
 
     CleanUp();
@@ -280,7 +282,11 @@ void AlwaysOnTop::RegisterLLKH()
         MSG msg;
         while (m_running)
         {
-            DWORD dwEvt = MsgWaitForMultipleObjects(1, &m_hPinEvent, false, 0, QS_ALLINPUT);
+            DWORD dwEvt = MsgWaitForMultipleObjects(1, &m_hPinEvent, false, INFINITE, QS_ALLINPUT);
+            if (!m_running)
+            {
+                break;
+            }
             switch (dwEvt)
             {
             case WAIT_OBJECT_0:


### PR DESCRIPTION
AOT was taking 100% of CPU core when enabled.

Wait until the object is signaled and double-check m_running race condition

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #19447
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

 - Confirm that AOT doesn't take 100% of CPU core
 - Confirm that AOT is closed when PT is closed (closing PT from VS or Task Manager)
