### PR TITLE
[Installer]Revert ignore startmenu shortcut on update

### DIFF
--- a/installer/PowerToysSetup/Product.wxs
+++ b/installer/PowerToysSetup/Product.wxs
@@ -599,7 +599,6 @@
 
     <DirectoryRef Id="ApplicationProgramsFolder">
       <Component Id="PowerToysStartMenuShortcut" >
-        <Condition>NOT PREVIOUSVERSIONSINSTALLED</Condition>
         <Shortcut Id="ApplicationStartMenuShortcut"
         Name="PowerToys (Preview)"
         Description="PowerToys - Windows system utilities to maximize productivity"


### PR DESCRIPTION
## Summary of the Pull Request
Fix PowerToys updating removing the PowerToys shortcut in Start Menu.

## PR Checklist

- [x] **Closes:** #19708
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments

This reverts commit 7f6c91e166f692c5a456c370ec32a1797a8402ea. ( https://github.com/microsoft/PowerToys/pull/19618 )

## Validation Steps Performed

Built a 0.0.1 and 0.0.2 builds and verified that upgrading from 0.0.1 to 0.0.2 creates the PowerToys shortcut, even after deleting it between installs.