### PR TITLE
[PowerRename]Don't crash dllhost on right-click

### DIFF
--- a/src/modules/powerrename/PowerRenameContextMenu/PowerRenameContextMenu.rc
+++ b/src/modules/powerrename/PowerRenameContextMenu/PowerRenameContextMenu.rc
@@ -1,60 +1,40 @@
-// Microsoft Visual C++ generated resource script.
-//
-
+#include <windows.h>
 #include "resource.h"
+#include "../../../common/version/version.h"
 
 #define APSTUDIO_READONLY_SYMBOLS
-/////////////////////////////////////////////////////////////////////////////
-//
-// Generated from the TEXTINCLUDE 2 resource.
-//
 #include "winres.h"
-
-/////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS
 
-/////////////////////////////////////////////////////////////////////////////
-// English (United States) resources
-
-#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
-LANGUAGE 9, 1
-
-#ifdef APSTUDIO_INVOKED
-/////////////////////////////////////////////////////////////////////////////
-//
-// TEXTINCLUDE
-//
-
-1 TEXTINCLUDE
+1 VERSIONINFO
+FILEVERSION FILE_VERSION
+PRODUCTVERSION PRODUCT_VERSION
+FILEFLAGSMASK VS_FFI_FILEFLAGSMASK
+#ifdef _DEBUG
+FILEFLAGS VS_FF_DEBUG
+#else
+FILEFLAGS 0x0L
+#endif
+FILEOS VOS_NT_WINDOWS32
+FILETYPE VFT_DLL
+FILESUBTYPE VFT2_UNKNOWN
 BEGIN
-    "resource.h\0"
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0" // US English (0x0409), Unicode (0x04B0) charset
+        BEGIN
+            VALUE "CompanyName", COMPANY_NAME
+            VALUE "FileDescription", FILE_DESCRIPTION
+            VALUE "FileVersion", FILE_VERSION_STRING
+            VALUE "InternalName", INTERNAL_NAME
+            VALUE "LegalCopyright", COPYRIGHT_NOTE
+            VALUE "OriginalFilename", ORIGINAL_FILENAME
+            VALUE "ProductName", PRODUCT_NAME
+            VALUE "ProductVersion", PRODUCT_VERSION_STRING
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200 // US English (0x0409), Unicode (1200) charset
+    END
 END
-
-2 TEXTINCLUDE  
-BEGIN
-    "#include ""winres.h""\r\n"
-    "\0"
-END
-
-3 TEXTINCLUDE  
-BEGIN
-    "\r\n"
-    "\0"
-END
-
-#endif    // APSTUDIO_INVOKED
-
-#endif    // English (United States) resources
-/////////////////////////////////////////////////////////////////////////////
-
-
-
-#ifndef APSTUDIO_INVOKED
-/////////////////////////////////////////////////////////////////////////////
-//
-// Generated from the TEXTINCLUDE 3 resource.
-//
-
-
-/////////////////////////////////////////////////////////////////////////////
-#endif    // not APSTUDIO_INVOKED

--- a/src/modules/powerrename/PowerRenameContextMenu/dllmain.cpp
+++ b/src/modules/powerrename/PowerRenameContextMenu/dllmain.cpp
@@ -93,6 +93,12 @@ public:
     {
         *cmdState = ECS_ENABLED;
 
+        // We've observed that it's possible that a null gets passed instead of an empty array. Just don't show the context menu in this case.
+        if (nullptr == selection) {
+            *cmdState = ECS_HIDDEN;
+            return S_OK;
+        }
+
         if (!CSettingsInstance().GetEnabled())
         {
             *cmdState = ECS_HIDDEN;

--- a/src/modules/powerrename/PowerRenameContextMenu/resource.h
+++ b/src/modules/powerrename/PowerRenameContextMenu/resource.h
@@ -2,13 +2,12 @@
 // Microsoft Visual C++ generated include file.
 // Used by PowerRenameContextMenu.rc
 
-// Next default values for new objects
-// 
-#ifdef APSTUDIO_INVOKED
-#ifndef APSTUDIO_READONLY_SYMBOLS
-#define _APS_NEXT_RESOURCE_VALUE        101
-#define _APS_NEXT_COMMAND_VALUE         40001
-#define _APS_NEXT_CONTROL_VALUE         1001
-#define _APS_NEXT_SYMED_VALUE           101
-#endif
-#endif
+//////////////////////////////
+// Non-localizable
+
+#define FILE_DESCRIPTION "PowerToys Rename Context Menu"
+#define INTERNAL_NAME "PowerToys.PowerRenameContextMenu"
+#define ORIGINAL_FILENAME "PowerToys.PowerRenameContextMenu.dll"
+
+// Non-localizable
+//////////////////////////////


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Check if explorer is passing a null array instead of an empty array to the PowerRename windows 11 context menu dll. We were hitting a null pointer exception there and a crash report was getting generated.
Also adds version number to the "PowerToys.PowerRenameContextMenu.dll" since it was missing.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #19722
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
With PowerRename enabled on Windows 11, right clicking empty space inside a folder to get the context menu to show was creating an error event on event viewer.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Verified that after using the newly built dll with the fix crash reports no longer appeared on the event viewer.
