### PR TITLE
PowerToys Run - FolderHelper.Expand

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -735,6 +735,7 @@ hmonitor
 HOLDENTER
 HOLDESC
 homepage
+HOMEPATH
 homljgmgpmcbpjbnjpfijnhipfkiclkd
 HOOKPROC
 Hostbackdropbrush

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder.UnitTests/Sources/Path/FolderHelperTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder.UnitTests/Sources/Path/FolderHelperTests.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using Microsoft.Plugin.Folder.Sources;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Plugin.Folder.Sources.Tests
+{
+    [TestClass]
+    public class FolderHelperTests
+    {
+        [DataTestMethod]
+        [DataRow(@"%SYSTEMDRIVE%", true)]
+        [DataRow(@"%O%S", false)]
+        [DataRow(@"abcd", false)]
+        [DataRow(@"%ProgramData%", true)]
+        [DataRow(@"%USERPROFILE%", true)]
+        [DataRow(@"powertoys", false)]
+
+        // can't test %HOMEPATH% on CI, so using \User as ExpandEnvironmentVariables was moved up
+        [DataRow(@"\Users", true)]
+        [DataRow(@"Users", false)]
+        public void ExpandsToRootedPath(string query, bool expected)
+        {
+            var expandedQuery = FolderHelper.Expand(query);
+            var result = Path.IsPathRooted(expandedQuery);
+            Assert.AreEqual(expected, result);
+        }
+    }
+}

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/Path/FolderHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/Path/FolderHelper.cs
@@ -84,6 +84,8 @@ namespace Microsoft.Plugin.Folder.Sources
                 throw new ArgumentNullException(nameof(search));
             }
 
+            search = Environment.ExpandEnvironmentVariables(search);
+
             var validRoots = new char[] { '\\', '/' };
 
             if (validRoots.Contains(search[0]) && (search.Length == 1 || !validRoots.Contains(search[1])))
@@ -98,7 +100,7 @@ namespace Microsoft.Plugin.Folder.Sources
                 search = search.Length > 1 ? Path.Combine(home, search.Substring(2)) : home;
             }
 
-            return Environment.ExpandEnvironmentVariables(search);
+            return search;
         }
     }
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Expanding the environmental variables before path combine 

This allows %HOMEPATH% to be expanded to \Users\myuser before adding the system drive.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #19428
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Manual test and added unit test

