### PR TITLE
commenting out settings button in FZ Editor

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -326,7 +326,7 @@
                                  ItemsSource="{Binding MonitorInfoForViewModel}" />
                 </Grid>
             </ScrollViewer>
-            <Button Click="SettingsBtn_Click"
+            <!--<Button Click="SettingsBtn_Click"
                     x:Name="settingsBtn"
                     Margin="8"
                     Foreground="{DynamicResource SystemControlBackgroundAccentBrush}"
@@ -340,7 +340,7 @@
                                FontFamily="Segoe MDL2 Assets"
                                AutomationProperties.Name="{x:Static props:Resources.OpenSettings}" />
                 </Button.Content>
-            </Button>
+            </Button>-->
         </Grid>
 
         <ui:ContentDialog x:Name="EditLayoutDialog"

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -326,7 +326,12 @@
                                  ItemsSource="{Binding MonitorInfoForViewModel}" />
                 </Grid>
             </ScrollViewer>
-            <!--<Button Click="SettingsBtn_Click"
+            <!--
+                // Commented because of issue https://github.com/microsoft/PowerToys/issues/19828 
+                // Settings would launch under the overlay for FZ Editor
+                //Lots of permutations to validate, Win10/11. Settings not launched, already launched, ...
+
+            <Button Click="SettingsBtn_Click"
                     x:Name="settingsBtn"
                     Margin="8"
                     Foreground="{DynamicResource SystemControlBackgroundAccentBrush}"
@@ -340,7 +345,8 @@
                                FontFamily="Segoe MDL2 Assets"
                                AutomationProperties.Name="{x:Static props:Resources.OpenSettings}" />
                 </Button.Content>
-            </Button>-->
+            </Button>
+            -->
         </Grid>
 
         <ui:ContentDialog x:Name="EditLayoutDialog"


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

right now if you click the settings button from the editor, settings app will launch under the overlay.  This is to remove the setting button.

@marypcbuk was the person that found the issue.

**Why approach taken:**
we'd have to make the Settings window AoT to solve the edge cases.  If we didn't do this solution, a user could click the editor overlay and then still lose settings.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #19828
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

