### PR TITLE
[FileExplorer] StlThumbnailProvider customization

### DIFF
--- a/src/modules/previewpane/StlThumbnailProvider/StlThumbnailProvider.cs
+++ b/src/modules/previewpane/StlThumbnailProvider/StlThumbnailProvider.cs
@@ -11,6 +11,7 @@ using System.Windows.Media.Media3D;
 using Common.ComInterlop;
 using Common.Utilities;
 using HelixToolkit.Wpf;
+using Microsoft.PowerToys.Settings.UI.Library;
 using Bitmap = System.Drawing.Bitmap;
 
 namespace Microsoft.PowerToys.ThumbnailHandler.Stl
@@ -50,7 +51,7 @@ namespace Microsoft.PowerToys.ThumbnailHandler.Stl
 
             var stlReader = new StLReader
             {
-                DefaultMaterial = new DiffuseMaterial(new SolidColorBrush(Color.FromRgb(255, 201, 36))),
+                DefaultMaterial = new DiffuseMaterial(new SolidColorBrush(DefaultMaterialColor)),
             };
 
             var model = stlReader.Read(stream);
@@ -138,6 +139,30 @@ namespace Microsoft.PowerToys.ThumbnailHandler.Stl
                             pdwAlpha = WTS_ALPHATYPE.WTSAT_ARGB;
                         }
                     }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating what color to use.
+        /// </summary>
+        public static Color DefaultMaterialColor
+        {
+            get
+            {
+                try
+                {
+                    var moduleSettings = new SettingsUtils();
+
+                    var colorString = moduleSettings.GetSettings<PowerPreviewSettings>(PowerPreviewSettings.ModuleName).Properties.StlThumbnailColor.Value;
+
+                    return (Color)ColorConverter.ConvertFromString(colorString);
+                }
+                catch (FileNotFoundException)
+                {
+                    // Couldn't read the settings.
+                    // Assume default color value.
+                    return Color.FromRgb(255, 201, 36);
                 }
             }
         }

--- a/src/modules/previewpane/StlThumbnailProvider/StlThumbnailProvider.csproj
+++ b/src/modules/previewpane/StlThumbnailProvider/StlThumbnailProvider.csproj
@@ -26,5 +26,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\common\ManagedTelemetry\Telemetry\ManagedTelemetry.csproj" />
     <ProjectReference Include="..\Common\PreviewHandlerCommon.csproj" />
+    <ProjectReference Include="..\..\..\settings-ui\Settings.UI.Library\Settings.UI.Library.csproj" />
   </ItemGroup>
 </Project>

--- a/src/settings-ui/Settings.UI.Library/PowerPreviewProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/PowerPreviewProperties.cs
@@ -12,6 +12,8 @@ namespace Microsoft.PowerToys.Settings.UI.Library
 {
     public class PowerPreviewProperties
     {
+        public const string DefaultStlThumbnailColor = "#FFC924";
+
         private bool enableSvgPreview = true;
 
         [JsonPropertyName("svg-previewer-toggle-setting")]
@@ -182,8 +184,12 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             }
         }
 
+        [JsonPropertyName("stl-thumbnail-color-setting")]
+        public StringProperty StlThumbnailColor { get; set; }
+
         public PowerPreviewProperties()
         {
+            StlThumbnailColor = new StringProperty(DefaultStlThumbnailColor);
         }
 
         public override string ToString()

--- a/src/settings-ui/Settings.UI.Library/ViewModels/PowerPreviewViewModel.cs
+++ b/src/settings-ui/Settings.UI.Library/ViewModels/PowerPreviewViewModel.cs
@@ -56,6 +56,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             _pdfThumbnailIsEnabled = Settings.Properties.EnablePdfThumbnail;
             _gcodeThumbnailIsEnabled = Settings.Properties.EnableGcodeThumbnail;
             _stlThumbnailIsEnabled = Settings.Properties.EnableStlThumbnail;
+            _stlThumbnailColor = Settings.Properties.StlThumbnailColor.Value;
         }
 
         private bool _svgRenderIsEnabled;
@@ -68,6 +69,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
         private bool _pdfThumbnailIsEnabled;
         private bool _gcodeThumbnailIsEnabled;
         private bool _stlThumbnailIsEnabled;
+        private string _stlThumbnailColor;
 
         public bool SVGRenderIsEnabled
         {
@@ -244,6 +246,24 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
                 {
                     _stlThumbnailIsEnabled = value;
                     Settings.Properties.EnableStlThumbnail = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        public string STLThumbnailColor
+        {
+            get
+            {
+                return _stlThumbnailColor;
+            }
+
+            set
+            {
+                if (value != _stlThumbnailColor)
+                {
+                    _stlThumbnailColor = value;
+                    Settings.Properties.StlThumbnailColor.Value = value;
                     RaisePropertyChanged();
                 }
             }

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -684,6 +684,9 @@
     <value>.stl</value>
     <comment>File extension, should not be altered</comment>
   </data>
+  <data name="FileExplorerPreview_Color_Thumbnail_STL.Header" xml:space="preserve">
+    <value>Color</value>
+  </data>
   <data name="FileExplorerPreview_ToggleSwitch_Thumbnail_PDF.Header" xml:space="preserve">
     <value>Portable Document Format</value>
     <comment>File type, do not translate</comment>

--- a/src/settings-ui/Settings.UI/Views/PowerPreviewPage.xaml
+++ b/src/settings-ui/Settings.UI/Views/PowerPreviewPage.xaml
@@ -110,14 +110,29 @@
                         </controls:Setting.ActionContent>
                     </controls:Setting>
 
-                  <controls:Setting x:Uid="FileExplorerPreview_ToggleSwitch_Thumbnail_STL" Icon="&#xE914;">
-                      <controls:Setting.ActionContent>
-                          <ToggleSwitch IsOn="{x:Bind Mode=TwoWay, Path=ViewModel.STLThumbnailIsEnabled}"
-                                        x:Uid="ToggleSwitch"/>
-                      </controls:Setting.ActionContent>
-                  </controls:Setting>
+                    <controls:SettingExpander IsExpanded="False">
+                        <controls:SettingExpander.Header>
+                            <controls:Setting x:Uid="FileExplorerPreview_ToggleSwitch_Thumbnail_STL" Icon="&#xE914;">
+                                <controls:Setting.ActionContent>
+                                    <ToggleSwitch IsOn="{x:Bind Mode=TwoWay, Path=ViewModel.STLThumbnailIsEnabled}"
+                                          x:Uid="ToggleSwitch"/>
+                                </controls:Setting.ActionContent>
+                            </controls:Setting>
+                        </controls:SettingExpander.Header>
+
+                        <controls:SettingExpander.Content>
+                            <StackPanel>
+                                <controls:Setting x:Uid="FileExplorerPreview_Color_Thumbnail_STL" Style="{StaticResource ExpanderContentSettingStyle}">
+                                    <controls:Setting.ActionContent>
+                                        <controls:ColorPickerButton SelectedColor="{x:Bind Path=ViewModel.STLThumbnailColor, Mode=TwoWay}"
+                                                                    IsEnabled="{x:Bind ViewModel.STLThumbnailIsEnabled, Mode=OneWay}"/>
+                                    </controls:Setting.ActionContent>
+                                </controls:Setting>
+                            </StackPanel>
+                        </controls:SettingExpander.Content>
+                    </controls:SettingExpander>
                 </controls:SettingsGroup>
-                
+
             </StackPanel>
         </controls:SettingsPageControl.ModuleContent>
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Adds the ability to customize the color of the rendered STL models.

There is no easy way to change the color of the G-Code thumbnails as these are not generated, but extracted from the file metadata (those thumbnails images are generated by the slicer software and included as part of the g-code metadata)

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [X] **Closes:** #15974
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [X] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

