### PR TITLE
[PTRun] Windows Terminal plugin: Add option to open profiles in quake window

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsTerminal.UnitTests/TerminalHelperTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsTerminal.UnitTests/TerminalHelperTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Plugin.WindowsTerminal.UnitTests
         [DataRow("Windows PowerShell", true, true, "--window _quake nt --profile \"Windows PowerShell\"")]
         [DataRow("Windows PowerShell", false, true, "--window _quake nt --profile \"Windows PowerShell\"")]
         [DataRow("Windows PowerShell", true, false, "--window 0 nt --profile \"Windows PowerShell\"")]
-        [DataRow("Windows PowerShell", false, false, "--profile \"Windows PowerShell\"")]
+        [DataRow("Windows PowerShell", false, false, " --profile \"Windows PowerShell\"")]
         public void ArgumentsTest(string profile, bool openNewTab, bool openQuake, string expectedArguments)
         {
             var arguments = TerminalHelper.GetArguments(profile, openNewTab, openQuake);

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsTerminal.UnitTests/TerminalHelperTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsTerminal.UnitTests/TerminalHelperTests.cs
@@ -15,8 +15,8 @@ namespace Microsoft.Plugin.WindowsTerminal.UnitTests
     public class TerminalHelperTests
     {
         [DataTestMethod]
-        [DataRow("Windows PowerShell", true, true, "--window _quake nt --profile \"Windows PowerShell\"")]
-        [DataRow("Windows PowerShell", false, true, "--window _quake nt --profile \"Windows PowerShell\"")]
+        [DataRow("Windows PowerShell", true, true, "--window _quake --profile \"Windows PowerShell\"")]
+        [DataRow("Windows PowerShell", false, true, "--window _quake --profile \"Windows PowerShell\"")]
         [DataRow("Windows PowerShell", true, false, "--window 0 nt --profile \"Windows PowerShell\"")]
         [DataRow("Windows PowerShell", false, false, " --profile \"Windows PowerShell\"")]
         public void ArgumentsTest(string profile, bool openNewTab, bool openQuake, string expectedArguments)

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsTerminal.UnitTests/TerminalHelperTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsTerminal.UnitTests/TerminalHelperTests.cs
@@ -15,11 +15,13 @@ namespace Microsoft.Plugin.WindowsTerminal.UnitTests
     public class TerminalHelperTests
     {
         [DataTestMethod]
-        [DataRow("Windows PowerShell", true, "--window 0 nt --profile \"Windows PowerShell\"")]
-        [DataRow("Windows PowerShell", false, "--profile \"Windows PowerShell\"")]
-        public void ArgumentsTest(string profile, bool openNewTab, string expectedArguments)
+        [DataRow("Windows PowerShell", true, true, "--window _quake nt --profile \"Windows PowerShell\"")]
+        [DataRow("Windows PowerShell", false, true, "--window _quake nt --profile \"Windows PowerShell\"")]
+        [DataRow("Windows PowerShell", true, false, "--window 0 nt --profile \"Windows PowerShell\"")]
+        [DataRow("Windows PowerShell", false, false, "--profile \"Windows PowerShell\"")]
+        public void ArgumentsTest(string profile, bool openNewTab, bool openQuake, string expectedArguments)
         {
-            var arguments = TerminalHelper.GetArguments(profile, openNewTab);
+            var arguments = TerminalHelper.GetArguments(profile, openNewTab, openQuake);
             Assert.AreEqual(arguments, expectedArguments);
         }
 

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsTerminal/Helpers/TerminalHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsTerminal/Helpers/TerminalHelper.cs
@@ -21,7 +21,10 @@ namespace Microsoft.PowerToys.Run.Plugin.WindowsTerminal.Helpers
             var argsPrefix = string.Empty;
             if (openQuake)
             {
-                argsPrefix = "--window _quake nt";
+                // It does not matter whether we add the "nt" argument here; when specifying the
+                // _quake window explicitly, Windows Terminal will always open a new tab when the
+                // window exists, or open a new window when it does not yet.
+                argsPrefix = "--window _quake";
             }
             else if (openNewTab)
             {

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsTerminal/Helpers/TerminalHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsTerminal/Helpers/TerminalHelper.cs
@@ -15,9 +15,20 @@ namespace Microsoft.PowerToys.Run.Plugin.WindowsTerminal.Helpers
         /// </summary>
         /// <param name="profileName">Name of the Terminal profile</param>
         /// <param name="openNewTab">Whether to launch the profile in a new tab</param>
-        public static string GetArguments(string profileName, bool openNewTab)
+        /// <param name="openQuake">Whether to launch the profile in the quake window</param>
+        public static string GetArguments(string profileName, bool openNewTab, bool openQuake)
         {
-            return openNewTab ? $"--window 0 nt --profile \"{profileName}\"" : $"--profile \"{profileName}\"";
+            var argsPrefix = string.Empty;
+            if (openQuake)
+            {
+                argsPrefix = "--window _quake nt";
+            }
+            else if (openNewTab)
+            {
+                argsPrefix = "--window 0 nt";
+            }
+
+            return $"{argsPrefix} --profile \"{profileName}\"";
         }
 
         /// <summary>

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsTerminal/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsTerminal/Main.cs
@@ -45,16 +45,16 @@ namespace Microsoft.PowerToys.Run.Plugin.WindowsTerminal
 
             new PluginAdditionalOption()
             {
-                Key = ShowHiddenProfiles,
-                DisplayLabel = Resources.show_hidden_profiles,
+                Key = OpenQuake,
+                DisplayLabel = Resources.open_quake,
+                DisplayDescription = Resources.open_quake_description,
                 Value = false,
             },
 
             new PluginAdditionalOption()
             {
-                Key = OpenQuake,
-                DisplayLabel = Resources.open_quake,
-                DisplayDescription = Resources.open_quake_description,
+                Key = ShowHiddenProfiles,
+                DisplayLabel = Resources.show_hidden_profiles,
                 Value = false,
             },
         };

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsTerminal/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsTerminal/Main.cs
@@ -21,10 +21,12 @@ namespace Microsoft.PowerToys.Run.Plugin.WindowsTerminal
     public class Main : IPlugin, IContextMenu, IPluginI18n, ISettingProvider
     {
         private const string OpenNewTab = nameof(OpenNewTab);
+        private const string OpenQuake = nameof(OpenQuake);
         private const string ShowHiddenProfiles = nameof(ShowHiddenProfiles);
         private readonly ITerminalQuery _terminalQuery = new TerminalQuery();
         private PluginInitContext _context;
         private bool _openNewTab;
+        private bool _openQuake;
         private bool _showHiddenProfiles;
         private Dictionary<string, BitmapImage> _logoCache = new Dictionary<string, BitmapImage>();
 
@@ -45,6 +47,14 @@ namespace Microsoft.PowerToys.Run.Plugin.WindowsTerminal
             {
                 Key = ShowHiddenProfiles,
                 DisplayLabel = Resources.show_hidden_profiles,
+                Value = false,
+            },
+
+            new PluginAdditionalOption()
+            {
+                Key = OpenQuake,
+                DisplayLabel = Resources.open_quake,
+                DisplayDescription = Resources.open_quake_description,
                 Value = false,
             },
         };
@@ -134,7 +144,7 @@ namespace Microsoft.PowerToys.Run.Plugin.WindowsTerminal
         {
             var appManager = new ApplicationActivationManager();
             const ActivateOptions noFlags = ActivateOptions.None;
-            var queryArguments = TerminalHelper.GetArguments(profile, _openNewTab);
+            var queryArguments = TerminalHelper.GetArguments(profile, _openNewTab, _openQuake);
             try
             {
                 appManager.ActivateApplication(id, queryArguments, noFlags, out var unusedPid);
@@ -153,7 +163,7 @@ namespace Microsoft.PowerToys.Run.Plugin.WindowsTerminal
             try
             {
                 string path = "shell:AppsFolder\\" + id;
-                Helper.OpenInShell(path, TerminalHelper.GetArguments(profile, _openNewTab), runAs: Helper.ShellRunAsType.Administrator);
+                Helper.OpenInShell(path, TerminalHelper.GetArguments(profile, _openNewTab, _openQuake), runAs: Helper.ShellRunAsType.Administrator);
             }
             catch (Exception ex)
             {
@@ -172,15 +182,18 @@ namespace Microsoft.PowerToys.Run.Plugin.WindowsTerminal
         public void UpdateSettings(PowerLauncherPluginSettings settings)
         {
             var openNewTab = false;
+            var openQuake = false;
             var showHiddenProfiles = false;
 
             if (settings != null && settings.AdditionalOptions != null)
             {
                 openNewTab = settings.AdditionalOptions.FirstOrDefault(x => x.Key == OpenNewTab)?.Value ?? false;
+                openQuake = settings.AdditionalOptions.FirstOrDefault(x => x.Key == OpenQuake)?.Value ?? false;
                 showHiddenProfiles = settings.AdditionalOptions.FirstOrDefault(x => x.Key == ShowHiddenProfiles)?.Value ?? false;
             }
 
             _openNewTab = openNewTab;
+            _openQuake = openQuake;
             _showHiddenProfiles = showHiddenProfiles;
         }
 

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsTerminal/Properties/Resources.Designer.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsTerminal/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.PowerToys.Run.Plugin.WindowsTerminal.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -66,6 +66,24 @@ namespace Microsoft.PowerToys.Run.Plugin.WindowsTerminal.Properties {
         internal static string open_new_tab {
             get {
                 return ResourceManager.GetString("open_new_tab", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Open profiles in the quake window.
+        /// </summary>
+        internal static string open_quake {
+            get {
+                return ResourceManager.GetString("open_quake", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Windows Terminal supports a &quot;quake&quot; feature where a terminal window is accessible using a global hotkey. Enable this option to open profiles in this window..
+        /// </summary>
+        internal static string open_quake_description {
+            get {
+                return ResourceManager.GetString("open_quake_description", resourceCulture);
             }
         }
         

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsTerminal/Properties/Resources.resx
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsTerminal/Properties/Resources.resx
@@ -122,9 +122,11 @@
   </data>
   <data name="open_quake" xml:space="preserve">
     <value>Open profiles in the quake window</value>
+    <comment>Quake is a well-known computer game. Don't localize. See https://en.wikipedia.org/wiki/Quake_(video_game)</comment>
   </data>
   <data name="open_quake_description" xml:space="preserve">
-    <value>Windows Terminal supports a "quake" feature where a terminal window is accessible using a global hotkey. Enable this option to open profiles in this window.</value>
+    <value>Windows Terminal supports a "quake" feature where a terminal window is accessible using a global hotkey. Enable this option to open profiles in a new tab in this window.</value>
+    <comment>Quake is a well-known computer game. Don't localize. See https://en.wikipedia.org/wiki/Quake_(video_game)</comment>
   </data>
   <data name="plugin_description" xml:space="preserve">
     <value>Open Windows Terminal profiles.</value>

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsTerminal/Properties/Resources.resx
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsTerminal/Properties/Resources.resx
@@ -120,6 +120,12 @@
   <data name="open_new_tab" xml:space="preserve">
     <value>Open profiles in a new tab</value>
   </data>
+  <data name="open_quake" xml:space="preserve">
+    <value>Open profiles in the quake window</value>
+  </data>
+  <data name="open_quake_description" xml:space="preserve">
+    <value>Windows Terminal supports a "quake" feature where a terminal window is accessible using a global hotkey. Enable this option to open profiles in this window.</value>
+  </data>
   <data name="plugin_description" xml:space="preserve">
     <value>Open Windows Terminal profiles.</value>
   </data>


### PR DESCRIPTION
## Summary of the Pull Request
Adds an option for the Windows Terminal PTRun Plugin to open the selected profiles in the quake window. WT has a "special" quake window that can be summoned with a hotkey, but that is not included in the standard behaviour of "open in new tab" (see https://github.com/microsoft/terminal/issues/10561). To allow PTRun to open profiles in this window, a new option was introduced.

## PR Checklist

- [ ] **Closes:** #19999
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [x] **Dev docs:** Added/updated (N/A)
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Semantically it would be best if this option would be "dependent" on the pre-existing "open in new tab" option; so this can only be checked if the other was checked; or they should be mutually exclusive. However, I don't believe that's possible with the current code setup, but it might be good to keep in mind.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manual checks and updated unit tests.
