### PR TITLE
[PTRun] Support for plural units and improve alternative spellings

### DIFF
--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter.UnitTest/InputInterpreterTests.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter.UnitTest/InputInterpreterTests.cs
@@ -44,6 +44,16 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter.UnitTest
         }
 
         [DataTestMethod]
+        [DataRow(new string[] { "1", "metre", "in", "metre" }, new object[] { new string[] { "1", "meter", "in", "meter" } })]
+        [DataRow(new string[] { "1", "centimetre", "in", "kilometre" }, new object[] { new string[] { "1", "centimeter", "in", "kilometer" } })]
+        [DataRow(new string[] { "1", "metres", "in", "kilometres" }, new object[] { new string[] { "1", "meters", "in", "kilometers" } })]
+        public void HandlesMetreVsMeterNotation(string[] input, string[] expectedResult)
+        {
+            InputInterpreter.MetreToMeter(ref input);
+            CollectionAssert.AreEqual(expectedResult, input);
+        }
+
+        [DataTestMethod]
         [DataRow(new string[] { "5", "CeLsIuS", "in", "faHrenheiT" }, new object[] { new string[] { "5", "DegreeCelsius", "in", "DegreeFahrenheit" } })]
         [DataRow(new string[] { "5", "f", "in", "celsius" }, new object[] { new string[] { "5", "°f", "in", "DegreeCelsius" } })]
         [DataRow(new string[] { "5", "c", "in", "f" }, new object[] { new string[] { "5", "°c", "in", "°f" } })]

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter.UnitTest/UnitHandlerTests.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter.UnitTest/UnitHandlerTests.cs
@@ -14,7 +14,7 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter.UnitTest
         public void HandleTemperature()
         {
             var convertModel = new ConvertModel(1, "DegreeCelsius", "DegreeFahrenheit");
-            double result = UnitHandler.ConvertInput(convertModel, UnitsNet.QuantityType.Temperature);
+            double result = UnitHandler.ConvertInput(convertModel, UnitsNet.Temperature.Info);
             Assert.AreEqual(33.79999999999999d, result);
         }
 
@@ -22,7 +22,7 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter.UnitTest
         public void HandleLength()
         {
             var convertModel = new ConvertModel(1, "meter", "centimeter");
-            double result = UnitHandler.ConvertInput(convertModel, UnitsNet.QuantityType.Length);
+            double result = UnitHandler.ConvertInput(convertModel, UnitsNet.Length.Info);
             Assert.AreEqual(100, result);
         }
 
@@ -30,15 +30,23 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter.UnitTest
         public void HandleNanometerToKilometer()
         {
             var convertModel = new ConvertModel(1, "nanometer", "kilometer");
-            double result = UnitHandler.ConvertInput(convertModel, UnitsNet.QuantityType.Length);
+            double result = UnitHandler.ConvertInput(convertModel, UnitsNet.Length.Info);
             Assert.AreEqual(1E-12, result);
+        }
+
+        [TestMethod]
+        public void HandlePlurals()
+        {
+            var convertModel = new ConvertModel(1, "meters", "centimeters");
+            double result = UnitHandler.ConvertInput(convertModel, UnitsNet.Length.Info);
+            Assert.AreEqual(100, result);
         }
 
         [TestMethod]
         public void HandlesByteCapitals()
         {
             var convertModel = new ConvertModel(1, "kB", "kb");
-            double result = UnitHandler.ConvertInput(convertModel, UnitsNet.QuantityType.Information);
+            double result = UnitHandler.ConvertInput(convertModel, UnitsNet.Information.Info);
             Assert.AreEqual(8, result);
         }
 

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/Community.PowerToys.Run.Plugin.UnitConverter.csproj
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/Community.PowerToys.Run.Plugin.UnitConverter.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="UnitsNet" Version="4.76.0" />
+    <PackageReference Include="UnitsNet" Version="4.144.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/InputInterpreter.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/InputInterpreter.cs
@@ -169,19 +169,12 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
         }
 
         /// <summary>
-        /// Converts spelling "metre" to "meter"
+        /// Converts spelling "metre" to "meter", also for centimetre and other variants
         /// </summary>
         public static void MetreToMeter(ref string[] split)
         {
-            if (split[1].ToLowerInvariant() == "metre")
-            {
-                split[1] = "meter";
-            }
-
-            if (split[3].ToLowerInvariant() == "metre")
-            {
-                split[3] = "meter";
-            }
+            split[1] = split[1].Replace("metre", "meter", System.StringComparison.CurrentCultureIgnoreCase);
+            split[3] = split[3].Replace("metre", "meter", System.StringComparison.CurrentCultureIgnoreCase);
         }
 
         /// <summary>

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/Main.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/Main.cs
@@ -65,7 +65,7 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
                 Title = result.ToString(),
                 IcoPath = _icon_path,
                 Score = 300,
-                SubTitle = string.Format(CultureInfo.CurrentCulture, Properties.Resources.copy_to_clipboard, result.QuantityType),
+                SubTitle = string.Format(CultureInfo.CurrentCulture, Properties.Resources.copy_to_clipboard, result.QuantityInfo.Name),
                 Action = c =>
                 {
                     var ret = false;

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/UnitConversionResult.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/UnitConversionResult.cs
@@ -14,13 +14,13 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
 
         public string UnitName { get; }
 
-        public QuantityType QuantityType { get; }
+        public QuantityInfo QuantityInfo { get; }
 
-        public UnitConversionResult(double convertedValue, string unitName, QuantityType quantityType)
+        public UnitConversionResult(double convertedValue, string unitName, QuantityInfo quantityInfo)
         {
             ConvertedValue = convertedValue;
             UnitName = unitName;
-            QuantityType = quantityType;
+            QuantityInfo = quantityInfo;
         }
 
         public string ToString(System.IFormatProvider provider = null)

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/UnitHandler.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/UnitHandler.cs
@@ -37,7 +37,9 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
         /// <returns>Corresponding enum or null.</returns>
         private static Enum GetUnitEnum(string unit, QuantityInfo unitInfo)
         {
-            UnitInfo first = Array.Find(unitInfo.UnitInfos, info => info.Name.ToLowerInvariant() == unit.ToLowerInvariant());
+            UnitInfo first = Array.Find(unitInfo.UnitInfos, info =>
+                unit.ToLowerInvariant() == info.Name.ToLowerInvariant() || unit.ToLowerInvariant() == info.PluralName.ToLowerInvariant());
+
             if (first != null)
             {
                 return first.Value;

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/UnitHandler.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/UnitHandler.cs
@@ -14,21 +14,21 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
     {
         private static readonly int _roundingFractionalDigits = 4;
 
-        private static readonly QuantityType[] _included = new QuantityType[]
+        private static readonly QuantityInfo[] _included = new QuantityInfo[]
         {
-            QuantityType.Acceleration,
-            QuantityType.Angle,
-            QuantityType.Area,
-            QuantityType.Duration,
-            QuantityType.Energy,
-            QuantityType.Information,
-            QuantityType.Length,
-            QuantityType.Mass,
-            QuantityType.Power,
-            QuantityType.Pressure,
-            QuantityType.Speed,
-            QuantityType.Temperature,
-            QuantityType.Volume,
+            Acceleration.Info,
+            Angle.Info,
+            Area.Info,
+            Duration.Info,
+            Energy.Info,
+            Information.Info,
+            Length.Info,
+            Mass.Info,
+            Power.Info,
+            Pressure.Info,
+            Speed.Info,
+            Temperature.Info,
+            Volume.Info,
         };
 
         /// <summary>
@@ -72,12 +72,10 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
         /// Given parsed ConvertModel, computes result. (E.g "1 foot in cm").
         /// </summary>
         /// <returns>The converted value as a double.</returns>
-        public static double ConvertInput(ConvertModel convertModel, QuantityType quantityType)
+        public static double ConvertInput(ConvertModel convertModel, QuantityInfo quantityInfo)
         {
-            QuantityInfo unitInfo = Quantity.GetInfo(quantityType);
-
-            var fromUnit = GetUnitEnum(convertModel.FromUnit, unitInfo);
-            var toUnit = GetUnitEnum(convertModel.ToUnit, unitInfo);
+            var fromUnit = GetUnitEnum(convertModel.FromUnit, quantityInfo);
+            var toUnit = GetUnitEnum(convertModel.ToUnit, quantityInfo);
 
             if (fromUnit != null && toUnit != null)
             {
@@ -94,13 +92,13 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
         public static IEnumerable<UnitConversionResult> Convert(ConvertModel convertModel)
         {
             var results = new List<UnitConversionResult>();
-            foreach (QuantityType quantityType in _included)
+            foreach (var quantityInfo in _included)
             {
-                double convertedValue = UnitHandler.ConvertInput(convertModel, quantityType);
+                double convertedValue = UnitHandler.ConvertInput(convertModel, quantityInfo);
 
                 if (!double.IsNaN(convertedValue))
                 {
-                    UnitConversionResult result = new UnitConversionResult(Round(convertedValue), convertModel.ToUnit, quantityType);
+                    UnitConversionResult result = new UnitConversionResult(Round(convertedValue), convertModel.ToUnit, quantityInfo);
                     results.Add(result);
                 }
             }

--- a/src/modules/launcher/PowerLauncher/PowerLauncher.csproj
+++ b/src/modules/launcher/PowerLauncher/PowerLauncher.csproj
@@ -90,7 +90,7 @@
     <PackageReference Include="Microsoft.VCRTForwarders.140" Version="1.0.7" />
     <PackageReference Include="System.Data.OleDb" Version="6.0.0" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="6.0.0" />
-    <PackageReference Include="UnitsNet" Version="4.76.0" />
+    <PackageReference Include="UnitsNet" Version="4.144.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary of the Pull Request
Upgrades UnitsNet package to newest version to have support for plural units, did some refactoring due to deprecations in the package, and extended support for the 'metre'->'meter' conversion to also work for 'metres' or 'centimetre'.

## PR Checklist

- [x] **Closes:** #19856 
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [x] **Dev docs:** Added/updated N/A
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments


## Validation Steps Performed
Added some unit tests for the new functionality