### PR TITLE
[ColorPicker] Always set the zoom factor

### DIFF
--- a/src/modules/colorPicker/ColorPickerUI/Helpers/ZoomWindowHelper.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/ZoomWindowHelper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation
+// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -88,10 +88,8 @@ namespace ColorPicker.Helpers
 
                 _zoomViewModel.ZoomArea = BitmapToImageSource(_bmp);
             }
-            else
-            {
-                _zoomViewModel.ZoomFactor = Math.Pow(ZoomFactor, _currentZoomLevel - 1);
-            }
+
+            _zoomViewModel.ZoomFactor = Math.Pow(ZoomFactor, _currentZoomLevel - 1);
 
             ShowZoomWindow(point);
         }


### PR DESCRIPTION
## Summary of the Pull Request
This fixes an issue where the zoom level did not appear to be reset after closing and re-opening the zoom window of the Color Picker.

## PR Checklist

- [x] **Closes:** #19664 
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments
When showing the zoom window, the zoom factor (that determines the scale of the zoom) was only set when zooming beyond the first "step". When exiting the zoom menu by pressing <kbd>Esc</kbd> instead of zooming out, this zoom factor was not reset, so when the user would zoom in somewhere else again, the zoom would seem to be stuck at the previous value until the user would zoom a second step.

The fix is to always set this zoom factor, also on the first zoom step.

## Validation Steps Performed
Manual testing