### PR TITLE
[PTRun] New implementation of fuzzy string matching

### DIFF
--- a/src/modules/launcher/Wox.Infrastructure/StringMatcher.cs
+++ b/src/modules/launcher/Wox.Infrastructure/StringMatcher.cs
@@ -66,6 +66,12 @@ namespace Wox.Infrastructure
                 stringToCompare = stringToCompare.ToUpper(CultureInfo.CurrentCulture);
             }
 
+            query = query.Replace(" ", string.Empty);
+            if (string.IsNullOrEmpty(query))
+            {
+                return new MatchResult(false, UserSettingSearchPrecision);
+            }
+
             int bestMatchScore = -1;
             var bestIndexList = new List<int>();
             for (int startIndex = 0; startIndex <= stringToCompare.Length - query.Length; startIndex++)

--- a/src/modules/launcher/Wox.Infrastructure/StringMatcher.cs
+++ b/src/modules/launcher/Wox.Infrastructure/StringMatcher.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Microsoft.Plugin.Program.UnitTests")]
@@ -46,14 +45,8 @@ namespace Wox.Infrastructure
 
         /// <summary>
         /// Current method:
-        /// Character matching + substring matching;
-        /// 1. Query search string is split into substrings, separator is whitespace.
-        /// 2. Check each query substring's characters against full compare string,
-        /// 3. if a character in the substring is matched, loop back to verify the previous character.
-        /// 4. If previous character also matches, and is the start of the substring, update list.
-        /// 5. Once the previous character is verified, move on to the next character in the query substring.
-        /// 6. Move onto the next substring's characters until all substrings are checked.
-        /// 7. Consider success and move onto scoring if every char or substring without whitespaces matched
+        /// Find <paramref name="query"/> as a subsequence of <paramref name="stringToCompare"/>
+        /// such that the score is maximized.
         /// </summary>
         public MatchResult FuzzyMatch(string query, string stringToCompare, MatchOption opt)
         {
@@ -67,179 +60,66 @@ namespace Wox.Infrastructure
                 throw new ArgumentNullException(nameof(opt));
             }
 
-            query = query.Trim();
-
-            // Using InvariantCulture since this is internal
-            var fullStringToCompareWithoutCase = opt.IgnoreCase ? stringToCompare.ToUpper(CultureInfo.InvariantCulture) : stringToCompare;
-            var queryWithoutCase = opt.IgnoreCase ? query.ToUpper(CultureInfo.InvariantCulture) : query;
-
-            var querySubstrings = queryWithoutCase.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
-            int currentQuerySubstringIndex = 0;
-            var currentQuerySubstring = querySubstrings[currentQuerySubstringIndex];
-            var currentQuerySubstringCharacterIndex = 0;
-
-            var firstMatchIndex = -1;
-            var firstMatchIndexInWord = -1;
-            var lastMatchIndex = 0;
-            bool allQuerySubstringsMatched = false;
-            bool matchFoundInPreviousLoop = false;
-            bool allSubstringsContainedInCompareString = true;
-
-            var indexList = new List<int>();
-            List<int> spaceIndices = new List<int>();
-
-            for (var compareStringIndex = 0; compareStringIndex < fullStringToCompareWithoutCase.Length; compareStringIndex++)
+            if (opt.IgnoreCase)
             {
-                // To maintain a list of indices which correspond to spaces in the string to compare
-                // To populate the list only for the first query substring
-                if (fullStringToCompareWithoutCase[compareStringIndex].Equals(' ') && currentQuerySubstringIndex == 0)
-                {
-                    spaceIndices.Add(compareStringIndex);
-                }
+                query = query.ToUpper(CultureInfo.CurrentCulture);
+                stringToCompare = stringToCompare.ToUpper(CultureInfo.CurrentCulture);
+            }
 
-                bool compareResult;
-                if (opt.IgnoreCase)
+            int bestMatchScore = -1;
+            var bestIndexList = new List<int>();
+            for (int startIndex = 0; startIndex <= stringToCompare.Length - query.Length; startIndex++)
+            {
+                // Optimization: Only start if the first characters match
+                if (query[0] != stringToCompare[startIndex])
                 {
-                    var fullStringToCompare = fullStringToCompareWithoutCase[compareStringIndex].ToString();
-                    var querySubstring = currentQuerySubstring[currentQuerySubstringCharacterIndex].ToString();
-#pragma warning disable CA1309 // Use ordinal string comparison (We are looking for a fuzzy match here)
-                    compareResult = string.Compare(fullStringToCompare, querySubstring, CultureInfo.CurrentCulture, CompareOptions.IgnoreCase | CompareOptions.IgnoreNonSpace) != 0;
-#pragma warning restore CA1309 // Use ordinal string comparison
-                }
-                else
-                {
-                    compareResult = fullStringToCompareWithoutCase[compareStringIndex] != currentQuerySubstring[currentQuerySubstringCharacterIndex];
-                }
-
-                if (compareResult)
-                {
-                    matchFoundInPreviousLoop = false;
                     continue;
                 }
 
-                if (firstMatchIndex < 0)
-                {
-                    // first matched char will become the start of the compared string
-                    firstMatchIndex = compareStringIndex;
-                }
+                int stringIndex = startIndex;
+                int queryIndex = 0;
 
-                if (currentQuerySubstringCharacterIndex == 0)
+                var indexList = new List<int>();
+                while (queryIndex < query.Length && stringIndex < stringToCompare.Length)
                 {
-                    // first letter of current word
-                    matchFoundInPreviousLoop = true;
-                    firstMatchIndexInWord = compareStringIndex;
-                }
-                else if (!matchFoundInPreviousLoop)
-                {
-                    // we want to verify that there is not a better match if this is not a full word
-                    // in order to do so we need to verify all previous chars are part of the pattern
-                    var startIndexToVerify = compareStringIndex - currentQuerySubstringCharacterIndex;
-
-                    if (AllPreviousCharsMatched(startIndexToVerify, currentQuerySubstringCharacterIndex, fullStringToCompareWithoutCase, currentQuerySubstring))
+                    if (query[queryIndex] == stringToCompare[stringIndex])
                     {
-                        matchFoundInPreviousLoop = true;
-
-                        // if it's the beginning character of the first query substring that is matched then we need to update start index
-                        firstMatchIndex = currentQuerySubstringIndex == 0 ? startIndexToVerify : firstMatchIndex;
-
-                        indexList = GetUpdatedIndexList(startIndexToVerify, currentQuerySubstringCharacterIndex, firstMatchIndexInWord, indexList);
+                        indexList.Add(stringIndex);
+                        queryIndex++;
+                        stringIndex++;
+                    }
+                    else
+                    {
+                        stringIndex++;
                     }
                 }
 
-                lastMatchIndex = compareStringIndex + 1;
-                indexList.Add(compareStringIndex);
-
-                currentQuerySubstringCharacterIndex++;
-
-                // if finished looping through every character in the current substring
-                if (currentQuerySubstringCharacterIndex == currentQuerySubstring.Length)
+                if (queryIndex == query.Length)
                 {
-                    // if any of the substrings was not matched then consider as all are not matched
-                    allSubstringsContainedInCompareString = matchFoundInPreviousLoop && allSubstringsContainedInCompareString;
-
-                    currentQuerySubstringIndex++;
-
-                    allQuerySubstringsMatched = AllQuerySubstringsMatched(currentQuerySubstringIndex, querySubstrings.Length);
-                    if (allQuerySubstringsMatched)
+                    int matchLen = indexList[indexList.Count - 1] - indexList[0] + 1;
+                    int matchScore = CalculateSearchScore(query, stringToCompare, indexList[0], matchLen);
+                    if (matchScore > bestMatchScore)
                     {
-                        break;
+                        bestMatchScore = matchScore;
+                        bestIndexList = indexList;
                     }
-
-                    // otherwise move to the next query substring
-                    currentQuerySubstring = querySubstrings[currentQuerySubstringIndex];
-                    currentQuerySubstringCharacterIndex = 0;
                 }
             }
 
-            // proceed to calculate score if every char or substring without whitespaces matched
-            if (allQuerySubstringsMatched)
+            if (bestMatchScore != -1)
             {
-                var nearestSpaceIndex = CalculateClosestSpaceIndex(spaceIndices, firstMatchIndex);
-                var score = CalculateSearchScore(query, stringToCompare, firstMatchIndex - nearestSpaceIndex - 1, lastMatchIndex - firstMatchIndex, allSubstringsContainedInCompareString);
-
-                return new MatchResult(true, UserSettingSearchPrecision, indexList, score);
+                return new MatchResult(true, UserSettingSearchPrecision, bestIndexList, bestMatchScore);
             }
 
             return new MatchResult(false, UserSettingSearchPrecision);
         }
 
-        // To get the index of the closest space which precedes the first matching index
-        private static int CalculateClosestSpaceIndex(List<int> spaceIndices, int firstMatchIndex)
-        {
-            if (spaceIndices.Count == 0)
-            {
-                return -1;
-            }
-            else
-            {
-                int? ind = spaceIndices.OrderBy(item => (firstMatchIndex - item)).Where(item => firstMatchIndex > item).FirstOrDefault();
-                int closestSpaceIndex = ind ?? -1;
-                return closestSpaceIndex;
-            }
-        }
-
-        private static bool AllPreviousCharsMatched(int startIndexToVerify, int currentQuerySubstringCharacterIndex, string fullStringToCompareWithoutCase, string currentQuerySubstring)
-        {
-            var allMatch = true;
-            for (int indexToCheck = 0; indexToCheck < currentQuerySubstringCharacterIndex; indexToCheck++)
-            {
-                if (fullStringToCompareWithoutCase[startIndexToVerify + indexToCheck] !=
-                    currentQuerySubstring[indexToCheck])
-                {
-                    allMatch = false;
-                }
-            }
-
-            return allMatch;
-        }
-
-        private static List<int> GetUpdatedIndexList(int startIndexToVerify, int currentQuerySubstringCharacterIndex, int firstMatchIndexInWord, List<int> indexList)
-        {
-            var updatedList = new List<int>();
-
-            indexList.RemoveAll(x => x >= firstMatchIndexInWord);
-
-            updatedList.AddRange(indexList);
-
-            for (int indexToCheck = 0; indexToCheck < currentQuerySubstringCharacterIndex; indexToCheck++)
-            {
-                updatedList.Add(startIndexToVerify + indexToCheck);
-            }
-
-            return updatedList;
-        }
-
-        private static bool AllQuerySubstringsMatched(int currentQuerySubstringIndex, int querySubstringsLength)
-        {
-            return currentQuerySubstringIndex >= querySubstringsLength;
-        }
-
-        private static int CalculateSearchScore(string query, string stringToCompare, int firstIndex, int matchLen, bool allSubstringsContainedInCompareString)
+        private static int CalculateSearchScore(string query, string stringToCompare, int firstIndex, int matchLen)
         {
             // A match found near the beginning of a string is scored more than a match found near the end
             // A match is scored more if the characters in the patterns are closer to each other,
             // while the score is lower if they are more spread out
-            var score = 100 * (query.Length + 1) / ((1 + firstIndex) + (matchLen + 1));
+            var score = 100 * query.Length * 10 / (1 + firstIndex + (10 * matchLen));
 
             // A match with less characters assigning more weights
             if (stringToCompare.Length - query.Length < 5)
@@ -249,20 +129,6 @@ namespace Wox.Infrastructure
             else if (stringToCompare.Length - query.Length < 10)
             {
                 score += 10;
-            }
-
-            if (allSubstringsContainedInCompareString)
-            {
-                int count = query.Count(c => !char.IsWhiteSpace(c));
-                int threshold = 4;
-                if (count <= threshold)
-                {
-                    score += count * 10;
-                }
-                else
-                {
-                    score += (threshold * 10) + ((count - threshold) * 5);
-                }
             }
 
 #pragma warning disable CA1309 // Use ordinal string comparison (Using CurrentCultureIgnoreCase since this relates to queries input by user)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
**This is currently a draft, as the tests seem to be tuned to the old implementation, and I want to decide what to do about this.**

## Summary of the Pull Request


This PR reimplements fuzzy string matching and searching should return more intuitive results now.
I'm open to discussing more ideas on how this can be further improved.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #18599
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

For example, PowerShell ISE should now be the second result when searching for ISE, right after Publisher.
Ran PT Run unit tests.