### PR TITLE
[AlwaysOnTop] Fix: Border stays after moving window to another desktop

### DIFF
--- a/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.cpp
+++ b/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.cpp
@@ -317,7 +317,7 @@ void AlwaysOnTop::SubscribeToEvents()
         EVENT_SYSTEM_MINIMIZESTART,
         EVENT_SYSTEM_MINIMIZEEND,
         EVENT_SYSTEM_MOVESIZEEND,
-        EVENT_OBJECT_NAMECHANGE,
+        EVENT_SYSTEM_FOREGROUND,
         EVENT_OBJECT_DESTROY
     };
 
@@ -479,14 +479,9 @@ void AlwaysOnTop::HandleWinHookEvent(WinHookEvent* data) noexcept
         }
     }
     break;
-    case EVENT_OBJECT_NAMECHANGE:
+    case EVENT_SYSTEM_FOREGROUND:
     {
-        // The accessibility name of the desktop window changes whenever the user
-        // switches virtual desktops.
-        if (data->hwnd == GetDesktopWindow())
-        {
-            VirtualDesktopSwitchedHandle();
-        }
+        RefreshBorders();
     }
     break;
     default:
@@ -494,17 +489,23 @@ void AlwaysOnTop::HandleWinHookEvent(WinHookEvent* data) noexcept
     }
 }
 
-void AlwaysOnTop::VirtualDesktopSwitchedHandle()
+void AlwaysOnTop::RefreshBorders()
 {
     for (const auto& [window, border] : m_topmostWindows)
     {
         if (m_virtualDesktopUtils.IsWindowOnCurrentDesktop(window))
         {
-            AssignBorder(window);
+            if (!border)
+            {
+                AssignBorder(window);
+            }
         }
         else
         {
-            m_topmostWindows[window] = nullptr;
+            if (border)
+            {
+                m_topmostWindows[window] = nullptr;
+            }
         }
     }
 }

--- a/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.h
+++ b/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.h
@@ -65,8 +65,6 @@ private:
     void UnpinAll();
     void CleanUp();
 
-    void VirtualDesktopSwitchedHandle();
-
     bool IsTracked(HWND window) const noexcept;
     bool IsTopmost(HWND window) const noexcept;
     bool IsPinned(HWND window) const noexcept;
@@ -74,6 +72,7 @@ private:
     bool PinTopmostWindow(HWND window) const noexcept;
     bool UnpinTopmostWindow(HWND window) const noexcept;
     bool AssignBorder(HWND window);
+    void RefreshBorders();
 
     virtual void SettingsUpdate(SettingId type) override;
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #18673 
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

* Pin window on top
* Open TaskView
* Move pinned window to another virtual desktop
* Return to the initial virtual desktop
* Verify border doesn't stay on the initial virtual desktop