### PR TITLE
[runner] Fix issue on files cleanup when directory doesn't exist

### DIFF
--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -304,7 +304,7 @@ void cleanup_updates()
     if (std::filesystem::exists(update_dir))
     {
         // Msi and exe files
-        for (const auto& entry : std::filesystem::directory_iterator(updating::get_pending_updates_path()))
+        for (const auto& entry : std::filesystem::directory_iterator(update_dir))
         {
             auto entryPath = entry.path().wstring();
             std::transform(entryPath.begin(), entryPath.end(), entryPath.begin(), ::towlower);

--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -300,19 +300,23 @@ void cleanup_updates()
         return;
     }
 
-    // Msi and exe files
-    for (const auto& entry : std::filesystem::directory_iterator(updating::get_pending_updates_path()))
+    auto update_dir = updating::get_pending_updates_path();
+    if (std::filesystem::exists(update_dir))
     {
-        auto entryPath = entry.path().wstring();
-        std::transform(entryPath.begin(), entryPath.end(), entryPath.begin(), ::towlower);
-
-        if (entryPath.ends_with(L".msi") || entryPath.ends_with(L".exe"))
+        // Msi and exe files
+        for (const auto& entry : std::filesystem::directory_iterator(updating::get_pending_updates_path()))
         {
-            std::error_code err;
-            std::filesystem::remove(entry, err);
-            if (err.value())
+            auto entryPath = entry.path().wstring();
+            std::transform(entryPath.begin(), entryPath.end(), entryPath.begin(), ::towlower);
+
+            if (entryPath.ends_with(L".msi") || entryPath.ends_with(L".exe"))
             {
-                Logger::warn("Failed to delete installer file {}. {}", entry.path().string(), err.message());
+                std::error_code err;
+                std::filesystem::remove(entry, err);
+                if (err.value())
+                {
+                    Logger::warn("Failed to delete installer file {}. {}", entry.path().string(), err.message());
+                }
             }
         }
     }
@@ -320,17 +324,20 @@ void cleanup_updates()
     // Log files
     auto rootPath{ PTSettingsHelper::get_root_save_folder_location() };
     auto currentVersion = left_trim<wchar_t>(get_product_version(), L"v");
-    for (const auto& entry : std::filesystem::directory_iterator(rootPath))
+    if (std::filesystem::exists(rootPath))
     {
-        auto entryPath = entry.path().wstring();
-        std::transform(entryPath.begin(), entryPath.end(), entryPath.begin(), ::towlower);
-        if (entry.is_regular_file() && entryPath.ends_with(L".log") && entryPath.find(currentVersion) == std::string::npos)
+        for (const auto& entry : std::filesystem::directory_iterator(rootPath))
         {
-            std::error_code err;
-            std::filesystem::remove(entry, err);
-            if (err.value())
+            auto entryPath = entry.path().wstring();
+            std::transform(entryPath.begin(), entryPath.end(), entryPath.begin(), ::towlower);
+            if (entry.is_regular_file() && entryPath.ends_with(L".log") && entryPath.find(currentVersion) == std::string::npos)
             {
-                Logger::warn("Failed to delete log file {}. {}", entry.path().string(), err.message());
+                std::error_code err;
+                std::filesystem::remove(entry, err);
+                if (err.value())
+                {
+                    Logger::warn("Failed to delete log file {}. {}", entry.path().string(), err.message());
+                }
             }
         }
     }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

When there is no Updates dir, PowerToys breaks.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #19854
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

