### PR TITLE
[PowerAccent] Fix toolbar positioning on first launch

### DIFF
--- a/src/modules/poweraccent/PowerAccent.UI/Selector.xaml.cs
+++ b/src/modules/poweraccent/PowerAccent.UI/Selector.xaml.cs
@@ -38,8 +38,8 @@ public partial class Selector : Window, IDisposable
         this.Visibility = isActive ? Visibility.Visible : Visibility.Collapsed;
         if (isActive)
         {
-            CenterWindow();
             characters.ItemsSource = chars;
+            CenterWindow();
             Microsoft.PowerToys.Telemetry.PowerToysTelemetry.Log.WriteEvent(new PowerAccent.Core.Telemetry.PowerAccentShowAccentMenuEvent());
         }
     }


### PR DESCRIPTION
As position is being set according to toolbar width&height (depends on num of
characters), on first toolbar-show size of the toolbar is wrong (list items are not set yet).
Therefore, first set characters and then position.

![image](https://user-images.githubusercontent.com/57057282/187143593-ecdd43a1-fcc1-44dc-acec-734e3105e2fb.png)


<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #2668
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

- set toolbar position to top right corner
- trigger poweraccent (a + space)
- observe that on first triggering toolbar is not fully visible