### PR TITLE
[PowerOCR][Telemetry]Cancel and capture events

### DIFF
--- a/src/modules/PowerOCR/PowerOCR/Helpers/WindowUtilities.cs
+++ b/src/modules/PowerOCR/PowerOCR/Helpers/WindowUtilities.cs
@@ -77,7 +77,7 @@ public static class WindowUtilities
             allFullscreenGrab.Add(overlay);
         }
 
-        PowerToysTelemetry.Log.WriteEvent(new PowerOCR.Telemetry.PowerOCRLaunchOverlayEvent());
+        PowerToysTelemetry.Log.WriteEvent(new PowerOCR.Telemetry.PowerOCRInvokedEvent());
     }
 
     internal static bool IsOCROverlayCreated()

--- a/src/modules/PowerOCR/PowerOCR/OCROverlay.xaml.cs
+++ b/src/modules/PowerOCR/PowerOCR/OCROverlay.xaml.cs
@@ -8,6 +8,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
+using Microsoft.PowerToys.Telemetry;
 using PowerOCR.Helpers;
 using PowerOCR.Utilities;
 
@@ -102,6 +103,7 @@ public partial class OCROverlay : Window
         {
             case Key.Escape:
                 WindowUtilities.CloseAllOCROverlays();
+                PowerToysTelemetry.Log.WriteEvent(new PowerOCR.Telemetry.PowerOCRCancelledEvent());
                 break;
             default:
                 break;
@@ -274,11 +276,13 @@ public partial class OCROverlay : Window
         {
             Clipboard.SetText(grabbedText);
             WindowUtilities.CloseAllOCROverlays();
+            PowerToysTelemetry.Log.WriteEvent(new PowerOCR.Telemetry.PowerOCRCaptureEvent());
         }
     }
 
     private void CancelMenuItem_Click(object sender, RoutedEventArgs e)
     {
         WindowUtilities.CloseAllOCROverlays();
+        PowerToysTelemetry.Log.WriteEvent(new PowerOCR.Telemetry.PowerOCRCancelledEvent());
     }
 }

--- a/src/modules/PowerOCR/PowerOCR/Telemetry/PowerOCRCancelledEvent.cs
+++ b/src/modules/PowerOCR/PowerOCR/Telemetry/PowerOCRCancelledEvent.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics.Tracing;
+using Microsoft.PowerToys.Telemetry;
+using Microsoft.PowerToys.Telemetry.Events;
+
+namespace PowerOCR.Telemetry
+{
+    [EventData]
+    public class PowerOCRCancelledEvent : EventBase, IEvent
+    {
+        public PartA_PrivTags PartA_PrivTags => PartA_PrivTags.ProductAndServiceUsage;
+    }
+}

--- a/src/modules/PowerOCR/PowerOCR/Telemetry/PowerOCRCaptureEvent.cs
+++ b/src/modules/PowerOCR/PowerOCR/Telemetry/PowerOCRCaptureEvent.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics.Tracing;
+using Microsoft.PowerToys.Telemetry;
+using Microsoft.PowerToys.Telemetry.Events;
+
+namespace PowerOCR.Telemetry
+{
+    [EventData]
+    public class PowerOCRCaptureEvent : EventBase, IEvent
+    {
+        public PartA_PrivTags PartA_PrivTags => PartA_PrivTags.ProductAndServiceUsage;
+    }
+}

--- a/src/modules/PowerOCR/PowerOCR/Telemetry/PowerOCRInvokedEvent.cs
+++ b/src/modules/PowerOCR/PowerOCR/Telemetry/PowerOCRInvokedEvent.cs
@@ -9,7 +9,7 @@ using Microsoft.PowerToys.Telemetry.Events;
 namespace PowerOCR.Telemetry
 {
     [EventData]
-    public class PowerOCRLaunchOverlayEvent : EventBase, IEvent
+    public class PowerOCRInvokedEvent : EventBase, IEvent
     {
         public PartA_PrivTags PartA_PrivTags => PartA_PrivTags.ProductAndServiceUsage;
     }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Adds telemetry events for when the OCR session is cancelled and when a capture occurs.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #4371
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

Adds telemetry events for when the OCR session is cancelled and when a capture occurs.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
No validation for telemetry until we're out in the wild.
