### PR TITLE
[ScreenRuler]Fix aka.ms links with new name

### DIFF
--- a/src/settings-ui/Settings.UI/OOBE/Views/OobeMeasureTool.xaml
+++ b/src/settings-ui/Settings.UI/OOBE/Views/OobeMeasureTool.xaml
@@ -24,7 +24,7 @@
                     Orientation="Horizontal"
                     Spacing="12">
                     <Button x:Uid="OOBE_Settings" Click="SettingsLaunchButton_Click" />
-                    <HyperlinkButton NavigateUri="https://aka.ms/PowerToysOverview_MeasureTool" Style="{StaticResource TextButtonStyle}">
+                    <HyperlinkButton NavigateUri="https://aka.ms/PowerToysOverview_ScreenRuler" Style="{StaticResource TextButtonStyle}">
                         <TextBlock x:Uid="LearnMore_MeasureTool" TextWrapping="Wrap" />
                     </HyperlinkButton>
                 </StackPanel>

--- a/src/settings-ui/Settings.UI/Views/MeasureToolPage.xaml
+++ b/src/settings-ui/Settings.UI/Views/MeasureToolPage.xaml
@@ -82,7 +82,7 @@
             </StackPanel>
         </controls:SettingsPageControl.ModuleContent>
         <controls:SettingsPageControl.PrimaryLinks>
-            <controls:PageLink x:Uid="LearnMore_MeasureTool" Link="https://aka.ms/PowerToysOverview_MeasureTool"/>
+            <controls:PageLink x:Uid="LearnMore_MeasureTool" Link="https://aka.ms/PowerToysOverview_ScreenRuler"/>
         </controls:SettingsPageControl.PrimaryLinks>
         <controls:SettingsPageControl.SecondaryLinks>
             <controls:PageLink x:Uid="Attribution_Rooler" Link="https://github.com/peteblois/rooler"/>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Fixes the "Learn more about" links with a link that's updated with the utility new name ("Screen Ruler").
