### PR TITLE
ColorPicker-17636: Fix warning "Failed to get ... mouse position-1,1"

### DIFF
--- a/src/modules/colorPicker/ColorPickerUI/Behaviors/AppearAnimationBehavior.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Behaviors/AppearAnimationBehavior.cs
@@ -19,7 +19,6 @@ namespace ColorPicker.Behaviors
 
         private void AssociatedObject_Loaded(object sender, RoutedEventArgs e)
         {
-            Appear();
             AssociatedObject.IsVisibleChanged += AssociatedObject_IsVisibleChanged;
         }
 

--- a/src/modules/colorPicker/ColorPickerUI/Mouse/IMouseInfoProvider.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Mouse/IMouseInfoProvider.cs
@@ -19,5 +19,7 @@ namespace ColorPicker.Mouse
         event MouseUpEventHandler OnMouseDown;
 
         System.Windows.Point CurrentPosition { get; }
+
+        Color CurrentColor { get; }
     }
 }

--- a/src/modules/colorPicker/ColorPickerUI/Mouse/MouseInfoProvider.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Mouse/MouseInfoProvider.cs
@@ -42,6 +42,8 @@ namespace ColorPicker.Mouse
             _mouseHook = new MouseHook();
             _userSettings = userSettings;
             _userSettings.CopiedColorRepresentation.PropertyChanged += CopiedColorRepresentation_PropertyChanged;
+            _previousMousePosition = GetCursorPosition();
+            _previousColor = GetPixelColor(_previousMousePosition);
         }
 
         public event EventHandler<Color> MouseColorChanged;
@@ -57,6 +59,14 @@ namespace ColorPicker.Mouse
             get
             {
                 return _previousMousePosition;
+            }
+        }
+
+        public Color CurrentColor
+        {
+            get
+            {
+                return _previousColor;
             }
         }
 

--- a/src/modules/colorPicker/ColorPickerUI/ViewModels/MainViewModel.cs
+++ b/src/modules/colorPicker/ColorPickerUI/ViewModels/MainViewModel.cs
@@ -67,6 +67,7 @@ namespace ColorPicker.ViewModels
 
             if (mouseInfoProvider != null)
             {
+                SetColorDetails(mouseInfoProvider.CurrentColor);
                 mouseInfoProvider.MouseColorChanged += Mouse_ColorChanged;
                 mouseInfoProvider.OnMouseDown += MouseInfoProvider_OnMouseDown;
                 mouseInfoProvider.OnMouseWheel += MouseInfoProvider_OnMouseWheel;
@@ -132,9 +133,7 @@ namespace ColorPicker.ViewModels
         /// <param name="color">The new <see cref="Color"/> under the mouse cursor</param>
         private void Mouse_ColorChanged(object sender, System.Drawing.Color color)
         {
-            ColorBrush = new SolidColorBrush(Color.FromArgb(color.A, color.R, color.G, color.B));
-            ColorText = ColorRepresentationHelper.GetStringRepresentation(color, _userSettings.CopiedColorRepresentation.Value);
-            ColorName = ColorNameHelper.GetColorName(color);
+            SetColorDetails(color);
         }
 
         /// <summary>
@@ -170,6 +169,13 @@ namespace ColorPicker.ViewModels
         {
             var color = ((SolidColorBrush)ColorBrush).Color;
             return color.A + "|" + color.R + "|" + color.G + "|" + color.B;
+        }
+
+        private void SetColorDetails(System.Drawing.Color color)
+        {
+            ColorBrush = new SolidColorBrush(Color.FromArgb(color.A, color.R, color.G, color.B));
+            ColorText = ColorRepresentationHelper.GetStringRepresentation(color, _userSettings.CopiedColorRepresentation.Value);
+            ColorName = ColorNameHelper.GetColorName(color);
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
The PR fixes issue described in https://github.com/microsoft/PowerToys/issues/17636#issuecomment-1095166440

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [X] **Closes:** #17636
- [X] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
**Root cause analysis**
According to conditions, the warning is printed if position cannot be found in any of available monitors.
However, the position in the warning is always `[-1,1]` and obviously it's invalid. 
It's taken directly from `MouseInfoProvider` right after `MouseInfoProvider` object creation. 
In `MouseInfoProvider` constructor, `_previousMousePosition`  is not getting initialized, therefore `-1,1` can be returned.

**Fix description**
Update mouse information in `MouseInfoProvider `constructor, therefore information provided by the object is valid right after it's creation.
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Check Color Picker logs for warnings

