### PR TITLE
Power Launcher fix Firefox command path

### DIFF
--- a/src/modules/launcher/Wox.Plugin/Common/DefaultBrowserInfo.cs
+++ b/src/modules/launcher/Wox.Plugin/Common/DefaultBrowserInfo.cs
@@ -114,6 +114,18 @@ namespace Wox.Plugin.Common
                         commandPattern = GetIndirectString(commandPattern);
                     }
 
+                    // HACK: for firefox installed through Microsoft store
+                    // When installed through Microsoft Firefox the commandPattern does not have
+                    // quotes for the path. As the Program Files does have a space
+                    // the extracted path would be invalid, here we add the quotes to fix it
+                    const string FirefoxExecutableName = "firefox.exe";
+                    if (commandPattern.Contains(FirefoxExecutableName) && commandPattern.Contains(@"\WindowsApps\") && (!commandPattern.StartsWith('\"')))
+                    {
+                        var pathEndIndex = commandPattern.IndexOf(FirefoxExecutableName, StringComparison.Ordinal) + FirefoxExecutableName.Length;
+                        commandPattern = commandPattern.Insert(pathEndIndex, "\"");
+                        commandPattern = commandPattern.Insert(0, "\"");
+                    }
+
                     if (commandPattern.StartsWith('\"'))
                     {
                         var endQuoteIndex = commandPattern.IndexOf('\"', 1);


### PR DESCRIPTION
Workaround to fix command path for Firefox installed through Microsoft Store

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
When Firefox is installed through Microsoft Store its registry command path is not between quotes.
as discussed https://github.com/microsoft/PowerToys/issues/19260.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #19260
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
The change looks for the registry key that does not contain quotes and contains firefox.exe
Adds the quotes for the command and lets the rest of the code deals with it.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Tested it manually testing that power run web search works with Firefox installed through Microsoft Store.
And tested it works ok for other browsers and Firefox installed from the .exe
