### PR TITLE
Catch std::exception by reference

### DIFF
--- a/installer/PowerToysSetupCustomActions/CustomAction.cpp
+++ b/installer/PowerToysSetupCustomActions/CustomAction.cpp
@@ -982,7 +982,7 @@ UINT __stdcall UnRegisterContextMenuPackagesCA(MSIHANDLE hInstall)
             }
         }
     }
-    catch (std::exception e)
+    catch (std::exception& e)
     {
         std::string errorMessage{ "Exception thrown while trying to unregister sparse packages: " };
         errorMessage += e.what();

--- a/src/common/utils/package.h
+++ b/src/common/utils/package.h
@@ -102,7 +102,7 @@ namespace package {
 
             return true;
         }
-        catch (std::exception e)
+        catch (std::exception& e)
         {
             Logger::error("Exception thrown while trying to register package: {}", e.what());
 

--- a/src/modules/MeasureTool/MeasureToolModuleInterface/dllmain.cpp
+++ b/src/modules/MeasureTool/MeasureToolModuleInterface/dllmain.cpp
@@ -128,7 +128,7 @@ private:
 
             parse_hotkey(settings);
         }
-        catch (std::exception ex)
+        catch (std::exception& ex)
         {
             Logger::warn(L"An exception occurred while loading the settings file");
             // Error while loading from the settings file. Let default values stay as they are.
@@ -208,7 +208,7 @@ public:
             // Otherwise call a custom function to process the settings before saving them to disk:
             // save_settings();
         }
-        catch (std::exception ex)
+        catch (std::exception& ex)
         {
             // Improper JSON.
         }

--- a/src/modules/MeasureTool/MeasureToolModuleInterface/dllmain.cpp
+++ b/src/modules/MeasureTool/MeasureToolModuleInterface/dllmain.cpp
@@ -128,7 +128,7 @@ private:
 
             parse_hotkey(settings);
         }
-        catch (std::exception& ex)
+        catch (std::exception&)
         {
             Logger::warn(L"An exception occurred while loading the settings file");
             // Error while loading from the settings file. Let default values stay as they are.
@@ -208,7 +208,7 @@ public:
             // Otherwise call a custom function to process the settings before saving them to disk:
             // save_settings();
         }
-        catch (std::exception& ex)
+        catch (std::exception&)
         {
             // Improper JSON.
         }

--- a/src/modules/PowerOCR/PowerOCRModuleInterface/dllmain.cpp
+++ b/src/modules/PowerOCR/PowerOCRModuleInterface/dllmain.cpp
@@ -144,7 +144,7 @@ private:
 
             parse_hotkey(settings);
         }
-        catch (std::exception ex)
+        catch (std::exception& ex)
         {
             Logger::warn(L"An exception occurred while loading the settings file");
             // Error while loading from the settings file. Let default values stay as they are.
@@ -220,7 +220,7 @@ public:
             // Otherwise call a custom function to process the settings before saving them to disk:
             // save_settings();
         }
-        catch (std::exception ex)
+        catch (std::exception& ex)
         {
             // Improper JSON.
         }

--- a/src/modules/PowerOCR/PowerOCRModuleInterface/dllmain.cpp
+++ b/src/modules/PowerOCR/PowerOCRModuleInterface/dllmain.cpp
@@ -144,7 +144,7 @@ private:
 
             parse_hotkey(settings);
         }
-        catch (std::exception& ex)
+        catch (std::exception&)
         {
             Logger::warn(L"An exception occurred while loading the settings file");
             // Error while loading from the settings file. Let default values stay as they are.
@@ -220,7 +220,7 @@ public:
             // Otherwise call a custom function to process the settings before saving them to disk:
             // save_settings();
         }
-        catch (std::exception& ex)
+        catch (std::exception&)
         {
             // Improper JSON.
         }

--- a/src/modules/ShortcutGuide/ShortcutGuideModuleInterface/dllmain.cpp
+++ b/src/modules/ShortcutGuide/ShortcutGuideModuleInterface/dllmain.cpp
@@ -66,7 +66,7 @@ public:
 
             ParseSettings(values);
         }
-        catch (std::exception ex)
+        catch (std::exception& ex)
         {
             Logger::error("Failed to parse settings. {}", ex.what());
         }
@@ -261,7 +261,7 @@ private:
 
             ParseSettings(settings);
         }
-        catch (std::exception ex)
+        catch (std::exception& ex)
         {
             Logger::error("Failed to init settings. {}", ex.what());
         }

--- a/src/modules/alwaysontop/AlwaysOnTopModuleInterface/dllmain.cpp
+++ b/src/modules/alwaysontop/AlwaysOnTopModuleInterface/dllmain.cpp
@@ -94,7 +94,7 @@ public:
             // Otherwise call a custom function to process the settings before saving them to disk:
             // save_settings();
         }
-        catch (std::exception ex)
+        catch (std::exception& ex)
         {
             // Improper JSON.
         }
@@ -273,7 +273,7 @@ private:
 
             parse_hotkey(settings);
         }
-        catch (std::exception ex)
+        catch (std::exception& ex)
         {
             Logger::warn(L"An exception occurred while loading the settings file");
             // Error while loading from the settings file. Let default values stay as they are.

--- a/src/modules/alwaysontop/AlwaysOnTopModuleInterface/dllmain.cpp
+++ b/src/modules/alwaysontop/AlwaysOnTopModuleInterface/dllmain.cpp
@@ -94,7 +94,7 @@ public:
             // Otherwise call a custom function to process the settings before saving them to disk:
             // save_settings();
         }
-        catch (std::exception& ex)
+        catch (std::exception&)
         {
             // Improper JSON.
         }
@@ -273,7 +273,7 @@ private:
 
             parse_hotkey(settings);
         }
-        catch (std::exception& ex)
+        catch (std::exception&)
         {
             Logger::warn(L"An exception occurred while loading the settings file");
             // Error while loading from the settings file. Let default values stay as they are.

--- a/src/modules/colorPicker/ColorPicker/dllmain.cpp
+++ b/src/modules/colorPicker/ColorPicker/dllmain.cpp
@@ -144,7 +144,7 @@ private:
 
             parse_hotkey(settings);
         }
-        catch (std::exception& ex)
+        catch (std::exception&)
         {
             Logger::warn(L"An exception occurred while loading the settings file");
             // Error while loading from the settings file. Let default values stay as they are.
@@ -221,7 +221,7 @@ public:
             // Otherwise call a custom function to process the settings before saving them to disk:
             // save_settings();
         }
-        catch (std::exception& ex)
+        catch (std::exception&)
         {
             // Improper JSON.
         }

--- a/src/modules/colorPicker/ColorPicker/dllmain.cpp
+++ b/src/modules/colorPicker/ColorPicker/dllmain.cpp
@@ -144,7 +144,7 @@ private:
 
             parse_hotkey(settings);
         }
-        catch (std::exception ex)
+        catch (std::exception& ex)
         {
             Logger::warn(L"An exception occurred while loading the settings file");
             // Error while loading from the settings file. Let default values stay as they are.
@@ -221,7 +221,7 @@ public:
             // Otherwise call a custom function to process the settings before saving them to disk:
             // save_settings();
         }
-        catch (std::exception ex)
+        catch (std::exception& ex)
         {
             // Improper JSON.
         }

--- a/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
+++ b/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
@@ -176,7 +176,7 @@ public:
             PowerToysSettings::CustomActionObject action_object =
                 PowerToysSettings::CustomActionObject::from_json_string(action);
         }
-        catch (std::exception& ex)
+        catch (std::exception&)
         {
             // Improper JSON.
         }
@@ -198,7 +198,7 @@ public:
             // Otherwise call a custom function to process the settings before saving them to disk:
             // save_settings();
         }
-        catch (std::exception& ex)
+        catch (std::exception&)
         {
             // Improper JSON.
         }
@@ -366,7 +366,7 @@ void Microsoft_Launcher::init_settings()
 
         parse_hotkey(settings);
     }
-    catch (std::exception& ex)
+    catch (std::exception&)
     {
         // Error while loading from the settings file. Let default values stay as they are.
     }

--- a/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
+++ b/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
@@ -176,7 +176,7 @@ public:
             PowerToysSettings::CustomActionObject action_object =
                 PowerToysSettings::CustomActionObject::from_json_string(action);
         }
-        catch (std::exception ex)
+        catch (std::exception& ex)
         {
             // Improper JSON.
         }
@@ -198,7 +198,7 @@ public:
             // Otherwise call a custom function to process the settings before saving them to disk:
             // save_settings();
         }
-        catch (std::exception ex)
+        catch (std::exception& ex)
         {
             // Improper JSON.
         }
@@ -366,7 +366,7 @@ void Microsoft_Launcher::init_settings()
 
         parse_hotkey(settings);
     }
-    catch (std::exception ex)
+    catch (std::exception& ex)
     {
         // Error while loading from the settings file. Let default values stay as they are.
     }

--- a/src/modules/powerrename/PowerRenameUILib/MainWindow.xaml.cpp
+++ b/src/modules/powerrename/PowerRenameUILib/MainWindow.xaml.cpp
@@ -187,7 +187,7 @@ namespace winrt::PowerRenameUI::implementation
             SetHandlers();
             ReadSettings();
         }
-        catch (std::exception e)
+        catch (std::exception& e)
         {
             Logger::error("Exception thrown during explorer items population: {}", std::string{ e.what() });
         }

--- a/src/modules/powerrename/dll/dllmain.cpp
+++ b/src/modules/powerrename/dll/dllmain.cpp
@@ -286,7 +286,7 @@ public:
 
             Trace::SettingsChanged();
         }
-        catch (std::exception e)
+        catch (std::exception& e)
         {
             Logger::error("Configuration parsing failed: {}", std::string{ e.what() });
         }

--- a/src/runner/centralized_hotkeys.cpp
+++ b/src/runner/centralized_hotkeys.cpp
@@ -103,7 +103,7 @@ namespace CentralizedHotkeys
             {
                 actions[shortcut].begin()->action(shortcut.modifiersMask, shortcut.vkCode);
             }
-            catch(std::exception ex)
+            catch(std::exception& ex)
             {
                 Logger::error("Failed to execute hotkey's action. {}", ex.what());
             }

--- a/tools/project_template/ModuleTemplate/dllmain.cpp
+++ b/tools/project_template/ModuleTemplate/dllmain.cpp
@@ -286,7 +286,7 @@ void $safeprojectname$::init_settings()
 //    // Save the PowerToyValues JSON to the power toy settings file.
 //    values.save_to_settings_file();
 //  }
-//  catch (std::exception ex) {
+//  catch (std::exception& ex) {
 //    // Couldn't save the settings.
 //  }
 //}

--- a/tools/project_template/README.md
+++ b/tools/project_template/README.md
@@ -147,7 +147,7 @@ Here's an example settings implementation:
       // Otherwise call a custom function to process the settings before saving them to disk:
       // save_settings();
     }
-    catch (std::exception ex) {
+    catch (std::exception& ex) {
       // Improper JSON.
     }
   }
@@ -325,7 +325,7 @@ When the custom action button is pressed, the PowerToy's `call_custom_action()` 
         MessageBox(NULL, msg.c_str(), L"Custom action call.", MB_OK | MB_TOPMOST);
       }
     }
-    catch (std::exception ex) {
+    catch (std::exception& ex) {
       // Improper JSON.
     }
   }
@@ -371,7 +371,7 @@ void ExamplePowertoy::init_settings() {
       g_settings.test_color_prop = settings.get_string_value(L"test_color_picker");
     }
   }
-  catch (std::exception ex) {
+  catch (std::exception& ex) {
     // Error while loading from the settings file. Let default values stay as they are.
   }
 }
@@ -392,7 +392,7 @@ virtual void set_config(const wchar_t* config) override {
 ...
     values.save_to_settings_file();
   }
-  catch (std::exception ex) {
+  catch (std::exception& ex) {
     // Improper JSON.
   }
 }
@@ -434,7 +434,7 @@ void ExamplePowertoy::save_settings() {
     // Save the PowerToyValues JSON to the power toy settings file.
     values.save_to_settings_file();
   }
-  catch (std::exception ex) {
+  catch (std::exception& ex) {
     // Couldn't save the settings.
   }
 }


### PR DESCRIPTION
C++ exceptions should be caught by reference to prevent unnecessary object copy and type slicing.