### PR TITLE
[TextExtractor] Check for CJK Language before combining OCR result to string

### DIFF
--- a/src/modules/PowerOCR/PowerOCR/Helpers/ImageMethods.cs
+++ b/src/modules/PowerOCR/PowerOCR/Helpers/ImageMethods.cs
@@ -137,9 +137,24 @@ internal class ImageMethods
 
             if (singlePoint == null)
             {
-                foreach (OcrLine line in ocrResult.Lines)
+                if (isCJKLang == false)
                 {
-                    text.AppendLine(line.Text);
+                    foreach (OcrLine line in ocrResult.Lines)
+                    {
+                        text.AppendLine(line.Text);
+                    }
+                }
+                else
+                {
+                    foreach (OcrLine ocrLine in ocrResult.Lines)
+                    {
+                        foreach (OcrWord ocrWord in ocrLine.Words)
+                        {
+                            _ = text.Append(ocrWord.Text);
+                        }
+
+                        text.Append(Environment.NewLine);
+                    }
                 }
             }
             else


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #20319 
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
The Windows OCR Engine does not respect CJK language space between characters when getting text from a line.

To fix this:
1. Check if language is a CJK language
2. Add each character from every word to the return string instead of the Text from each line

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Similar bug was in Text Grab and I fixed it there. Tested in Text Grab before contributing the fix to Text Extractor. Issue #20319 has good reference images to reproduce the bug and test the fix.

