### PR TITLE
[PowerLauncher] don't use Environment.Exit(0) and gracefully shutdown…

### DIFF
--- a/src/modules/launcher/PowerLauncher/Helper/NativeEventWaiter.cs
+++ b/src/modules/launcher/PowerLauncher/Helper/NativeEventWaiter.cs
@@ -12,17 +12,21 @@ namespace PowerLauncher.Helper
 {
     public static class NativeEventWaiter
     {
-        public static void WaitForEventLoop(string eventName, Action callback)
+        public static void WaitForEventLoop(string eventName, Action callback, CancellationToken cancel)
         {
             new Thread(() =>
             {
                 var eventHandle = new EventWaitHandle(false, EventResetMode.AutoReset, eventName);
                 while (true)
                 {
-                    if (eventHandle.WaitOne())
+                    if (WaitHandle.WaitAny(new WaitHandle[] { cancel.WaitHandle, eventHandle }) == 1)
                     {
                         Log.Info($"Successfully waited for {eventName}", MethodBase.GetCurrentMethod().DeclaringType);
                         Application.Current.Dispatcher.Invoke(callback);
+                    }
+                    else
+                    {
+                        return;
                     }
                 }
             }).Start();

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -20,6 +20,7 @@ using PowerLauncher.Plugin;
 using PowerLauncher.Telemetry.Events;
 using PowerLauncher.ViewModel;
 using Wox.Infrastructure.UserSettings;
+using CancellationToken = System.Threading.CancellationToken;
 using KeyEventArgs = System.Windows.Input.KeyEventArgs;
 using Log = Wox.Plugin.Logger.Log;
 using Screen = System.Windows.Forms.Screen;
@@ -30,6 +31,7 @@ namespace PowerLauncher
     {
         private readonly PowerToysRunSettings _settings;
         private readonly MainViewModel _viewModel;
+        private readonly CancellationToken _nativeWaiterCancelToken;
         private bool _isTextSetProgrammatically;
         private bool _deletePressed;
         private HwndSource _hwndSource;
@@ -38,18 +40,19 @@ namespace PowerLauncher
         private bool _disposedValue;
         private IDisposable _reactiveSubscription;
 
-        public MainWindow(PowerToysRunSettings settings, MainViewModel mainVM)
+        public MainWindow(PowerToysRunSettings settings, MainViewModel mainVM, CancellationToken nativeWaiterCancelToken)
             : this()
         {
             DataContext = mainVM;
             _viewModel = mainVM;
+            _nativeWaiterCancelToken = nativeWaiterCancelToken;
             _settings = settings;
 
             InitializeComponent();
 
             _firstDeleteTimer.Elapsed += CheckForFirstDelete;
             _firstDeleteTimer.Interval = 1000;
-            NativeEventWaiter.WaitForEventLoop(Constants.RunSendSettingsTelemetryEvent(), SendSettingsTelemetry);
+            NativeEventWaiter.WaitForEventLoop(Constants.RunSendSettingsTelemetryEvent(), SendSettingsTelemetry, _nativeWaiterCancelToken);
         }
 
         private void SendSettingsTelemetry()


### PR DESCRIPTION
… all threads

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
- use CancellationTokenSource for event waiter threads
- don't use Environment.Exit(0)

**Possible risks**:
- slower shutdown

If it fixes the issue, we need to do the same for other modules, e.g. ColorPicker, FZE, OCR.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** Watson crash
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- opens w/ hotkey
- opens from oobe
- exit PowerToys runner and verify Run closes
- try taskkill /f /im PowerToys.exe (would crash on exit before) and verify Run closes
