### PR TITLE
[ci]Enable tests that depend on WebView2

### DIFF
--- a/.pipelines/ci/templates/build-powertoys-steps.yml
+++ b/.pipelines/ci/templates/build-powertoys-steps.yml
@@ -197,13 +197,11 @@ steps:
       **\Microsoft.PowerToys.Run.Plugin.TimeZone.UnitTests.dll
       **\Microsoft.Plugin.WindowsTerminal.UnitTests.dll
       **\Microsoft.Plugin.WindowWalker.UnitTests.dll
+      **\PreviewPaneUnitTests.dll
+      **\UnitTests-SvgThumbnailProvider.dll
+      **\UnitTests-SvgPreviewHandler.dll
       !**\obj\**
       !**\ref\**
-
-# TODO: Enable these tests after figuring out what caused the tests that depend on WebView2 to start timing out in CI.
-#  **\PreviewPaneUnitTests.dll # It's UnitTests-MarkdownPreviewHandler
-#  **\UnitTests-SvgThumbnailProvider.dll
-#  **\UnitTests-SvgPreviewHandler.dll
 
 # Native dlls
 - task: VSTest@2


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Enabling the WebView2 tests again, to check if CI has been updated with the latest WebView2 fixes.

