### PR TITLE
[TextExtractor] Add space between CJK words and non-CJK

### DIFF
--- a/src/modules/PowerOCR/PowerOCR/Helpers/ImageMethods.cs
+++ b/src/modules/PowerOCR/PowerOCR/Helpers/ImageMethods.cs
@@ -10,6 +10,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
@@ -146,11 +147,27 @@ internal class ImageMethods
                 }
                 else
                 {
+                    var cjkRegex = new Regex(@"\p{IsCJKUnifiedIdeographs}");
+
                     foreach (OcrLine ocrLine in ocrResult.Lines)
                     {
+                        bool isBeginning = true;
+                        bool isCJKPrev = false;
                         foreach (OcrWord ocrWord in ocrLine.Words)
                         {
-                            _ = text.Append(ocrWord.Text);
+                            bool isCJK = cjkRegex.IsMatch(ocrWord.Text);
+
+                            if (isBeginning || (isCJK && isCJKPrev))
+                            {
+                                _ = text.Append(ocrWord.Text);
+                            }
+                            else
+                            {
+                                _ = text.Append(' ').Append(ocrWord.Text);
+                            }
+
+                            isCJKPrev = isCJK;
+                            isBeginning = false;
                         }
 
                         text.Append(Environment.NewLine);

--- a/src/modules/PowerOCR/PowerOCR/Helpers/ImageMethods.cs
+++ b/src/modules/PowerOCR/PowerOCR/Helpers/ImageMethods.cs
@@ -157,15 +157,13 @@ internal class ImageMethods
                         {
                             bool isCJK = cjkRegex.IsMatch(ocrWord.Text);
 
-                            if (isBeginning || (isCJK && isCJKPrev))
+                            // Use spaces to separate non-CJK words.
+                            if (!isBeginning && (!isCJK || !isCJKPrev))
                             {
-                                _ = text.Append(ocrWord.Text);
-                            }
-                            else
-                            {
-                                _ = text.Append(' ').Append(ocrWord.Text);
+                                _ = text.Append(' ');
                             }
 
+                            _ = text.Append(ocrWord.Text);
                             isCJKPrev = isCJK;
                             isBeginning = false;
                         }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #20319 
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

related PR: https://github.com/microsoft/PowerToys/pull/20415

CJK OCR can detect non-CJK character like English. So, we need to add space between
- non-CJK word and non-CJK word
- non-CJK word and CJK word

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

<img width="360" alt="image" src="https://user-images.githubusercontent.com/23057110/193000196-1c870709-a0b3-4f0e-934d-16eac45b8953.png">

