### PR TITLE
[Mouse Highlighter] Opacity 1-100

### DIFF
--- a/src/modules/MouseUtils/MouseHighlighter/MouseHighlighter.h
+++ b/src/modules/MouseUtils/MouseHighlighter/MouseHighlighter.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "pch.h"
 
-constexpr int MOUSE_HIGHLIGHTER_DEFAULT_OPACITY = 160;
+constexpr int MOUSE_HIGHLIGHTER_DEFAULT_OPACITY = 75;
 const winrt::Windows::UI::Color MOUSE_HIGHLIGHTER_DEFAULT_LEFT_BUTTON_COLOR = winrt::Windows::UI::ColorHelper::FromArgb(MOUSE_HIGHLIGHTER_DEFAULT_OPACITY, 255, 255, 0);
 const winrt::Windows::UI::Color MOUSE_HIGHLIGHTER_DEFAULT_RIGHT_BUTTON_COLOR = winrt::Windows::UI::ColorHelper::FromArgb(MOUSE_HIGHLIGHTER_DEFAULT_OPACITY, 0, 0, 255);
 constexpr int MOUSE_HIGHLIGHTER_DEFAULT_RADIUS = 20;

--- a/src/modules/MouseUtils/MouseHighlighter/MouseHighlighter.h
+++ b/src/modules/MouseUtils/MouseHighlighter/MouseHighlighter.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "pch.h"
 
-constexpr int MOUSE_HIGHLIGHTER_DEFAULT_OPACITY = 75;
+constexpr int MOUSE_HIGHLIGHTER_DEFAULT_OPACITY = 65;
 const winrt::Windows::UI::Color MOUSE_HIGHLIGHTER_DEFAULT_LEFT_BUTTON_COLOR = winrt::Windows::UI::ColorHelper::FromArgb(MOUSE_HIGHLIGHTER_DEFAULT_OPACITY, 255, 255, 0);
 const winrt::Windows::UI::Color MOUSE_HIGHLIGHTER_DEFAULT_RIGHT_BUTTON_COLOR = winrt::Windows::UI::ColorHelper::FromArgb(MOUSE_HIGHLIGHTER_DEFAULT_OPACITY, 0, 0, 255);
 constexpr int MOUSE_HIGHLIGHTER_DEFAULT_RADIUS = 20;

--- a/src/modules/MouseUtils/MouseHighlighter/dllmain.cpp
+++ b/src/modules/MouseUtils/MouseHighlighter/dllmain.cpp
@@ -215,6 +215,13 @@ public:
             {
                 Logger::warn("Failed to initialize Opacity from settings. Will use default value");
             }
+
+            // Convert % to uint8_t
+            if ((std::wstring)settingsObject.GetNamedString(L"version") != L"1.0")
+            {
+                opacity = opacity * 255 / 100;
+            }
+
             try
             {
                 // Parse left button click color

--- a/src/settings-ui/Settings.UI.Library/MouseHighlighterProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/MouseHighlighterProperties.cs
@@ -34,7 +34,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             ActivationShortcut = new HotkeySettings(true, false, false, true, 0x48);
             LeftButtonClickColor = new StringProperty("#FFFF00");
             RightButtonClickColor = new StringProperty("#0000FF");
-            HighlightOpacity = new IntProperty(75);
+            HighlightOpacity = new IntProperty(65);
             HighlightRadius = new IntProperty(20);
             HighlightFadeDelayMs = new IntProperty(500);
             HighlightFadeDurationMs = new IntProperty(250);

--- a/src/settings-ui/Settings.UI.Library/MouseHighlighterProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/MouseHighlighterProperties.cs
@@ -34,7 +34,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             ActivationShortcut = new HotkeySettings(true, false, false, true, 0x48);
             LeftButtonClickColor = new StringProperty("#FFFF00");
             RightButtonClickColor = new StringProperty("#0000FF");
-            HighlightOpacity = new IntProperty(160);
+            HighlightOpacity = new IntProperty(75);
             HighlightRadius = new IntProperty(20);
             HighlightFadeDelayMs = new IntProperty(500);
             HighlightFadeDurationMs = new IntProperty(250);

--- a/src/settings-ui/Settings.UI.Library/MouseHighlighterSettings.cs
+++ b/src/settings-ui/Settings.UI.Library/MouseHighlighterSettings.cs
@@ -18,7 +18,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         {
             Name = ModuleName;
             Properties = new MouseHighlighterProperties();
-            Version = "1.0";
+            Version = "1.1";
         }
 
         public string GetModuleName()
@@ -29,6 +29,14 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         // This can be utilized in the future if the settings.json file is to be modified/deleted.
         public bool UpgradeSettingsConfiguration()
         {
+            // Migrate settings from 1.0 to 1.1
+            if (Version == "1.0")
+            {
+                Version = "1.1";
+                Properties.HighlightOpacity = new IntProperty(Properties.HighlightOpacity.Value * 100 / 255);
+                return true;
+            }
+
             return false;
         }
     }

--- a/src/settings-ui/Settings.UI/Views/MouseUtilsPage.xaml
+++ b/src/settings-ui/Settings.UI/Views/MouseUtilsPage.xaml
@@ -178,8 +178,8 @@
                               
                                 <controls:Setting x:Uid="MouseUtils_MouseHighlighter_HighlightOpacity" IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsMouseHighlighterEnabled}" Style="{StaticResource ExpanderContentSettingStyle}">
                                     <controls:Setting.ActionContent>
-                                        <Slider Minimum="0"
-                                            Maximum="255"
+                                        <Slider Minimum="1"
+                                            Maximum="100"
                                             MinWidth="{StaticResource SettingActionControlMinWidth}"
                                             Value="{x:Bind Mode=TwoWay, Path=ViewModel.MouseHighlighterOpacity}"
                                             HorizontalAlignment="Right"/>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Consistent opacity setting across mouse mouse utils.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #15311
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
- Changed Mouse Highlighter opacity from 0-255 to 1-100
- Added code for migrate current value

Need to handle check settings version on ViewModel and utility since the JSON won't be updated until the settings page is opened.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Open stable PT build
- Enable Mouse Highlighter
- Set opacity approx 130
- Open this PT build
- Start Mouse Highlighter
- Validate that opacity is approx 50%
- Open Mouse Highlighter settings
- Check that `%LOCALAPPDATA%\Microsoft\PowerToys\MouseHighlighter\settings.json` is migrated to version 1.1 and opacity is converted to %.
- Delete `%LOCALAPPDATA%\Microsoft\PowerToys\MouseHighlighter\settings.json`
- Open PT
- Check default opacity and version in the newly created `%LOCALAPPDATA%\Microsoft\PowerToys\MouseHighlighter\settings.json`