### PR TITLE
TextExtractor-20950: fix focus on overlay on the first TextExtractor activation

### DIFF
--- a/src/modules/PowerOCR/PowerOCR/Helpers/OSInterop.cs
+++ b/src/modules/PowerOCR/PowerOCR/Helpers/OSInterop.cs
@@ -69,8 +69,20 @@ public static class OSInterop
     internal static extern short GetAsyncKeyState(int vKey);
 
     public delegate IntPtr HookProc(int nCode, IntPtr wParam, IntPtr lParam);
-#pragma warning restore CA1401 // P/Invokes should not be visible
 
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern IntPtr SetForegroundWindow(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    public static extern IntPtr GetForegroundWindow();
+
+    [DllImport("user32.dll")]
+    public static extern uint GetWindowThreadProcessId(IntPtr hWnd, IntPtr processId);
+
+    [DllImport("user32.dll")]
+    public static extern bool AttachThreadInput(uint idAttach, uint idAttachTo, bool fAttach);
+
+#pragma warning restore CA1401 // P/Invokes should not be visible
     [StructLayout(LayoutKind.Sequential)]
     internal struct LowLevelKeyboardInputEvent
     {

--- a/src/modules/PowerOCR/PowerOCR/Helpers/WindowUtilities.cs
+++ b/src/modules/PowerOCR/PowerOCR/Helpers/WindowUtilities.cs
@@ -15,7 +15,7 @@ public static class WindowUtilities
     {
         if (IsOCROverlayCreated())
         {
-            Logger.LogWarning("Tired to launch the overlay, but it has been already created.");
+            Logger.LogWarning("Tried to launch the overlay, but it has been already created.");
             return;
         }
 

--- a/src/modules/PowerOCR/PowerOCR/Helpers/WindowUtilities.cs
+++ b/src/modules/PowerOCR/PowerOCR/Helpers/WindowUtilities.cs
@@ -2,7 +2,6 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Forms;
 using Microsoft.PowerToys.Telemetry;
@@ -16,36 +15,12 @@ public static class WindowUtilities
     {
         if (IsOCROverlayCreated())
         {
-            Logger.LogWarning("Tired to launch the overlay but it was already created.");
+            Logger.LogWarning("Tired to launch the overlay, but it has been already created.");
             return;
         }
 
-        Screen[] allScreens = Screen.AllScreens;
-        WindowCollection allWindows = System.Windows.Application.Current.Windows;
-
-        List<OCROverlay> allFullscreenGrab = new List<OCROverlay>();
-
-        foreach (Screen screen in allScreens)
+        foreach (Screen screen in Screen.AllScreens)
         {
-            bool screenHasWindow = true;
-
-            foreach (Window window in allWindows)
-            {
-                System.Drawing.Point windowCenter =
-                    new System.Drawing.Point(
-                        (int)(window.Left + (window.Width / 2)),
-                        (int)(window.Top + (window.Height / 2)));
-                screenHasWindow = screen.Bounds.Contains(windowCenter);
-
-                // if (window is EditTextWindow)
-                //     isEditWindowOpen = true;
-            }
-
-            if (allWindows.Count < 1)
-            {
-                screenHasWindow = false;
-            }
-
             OCROverlay overlay = new OCROverlay()
             {
                 WindowStartupLocation = WindowStartupLocation.Manual,
@@ -73,8 +48,7 @@ public static class WindowUtilities
             }
 
             overlay.Show();
-            overlay.Activate();
-            allFullscreenGrab.Add(overlay);
+            ActivateWindow(overlay);
         }
 
         PowerToysTelemetry.Log.WriteEvent(new PowerOCR.Telemetry.PowerOCRInvokedEvent());
@@ -109,5 +83,25 @@ public static class WindowUtilities
 
         // TODO: Decide when to close the process
         // System.Windows.Application.Current.Shutdown();
+    }
+
+    public static void ActivateWindow(Window window)
+    {
+        var handle = new System.Windows.Interop.WindowInteropHelper(window).Handle;
+        var fgHandle = OSInterop.GetForegroundWindow();
+
+        var threadId1 = OSInterop.GetWindowThreadProcessId(handle, System.IntPtr.Zero);
+        var threadId2 = OSInterop.GetWindowThreadProcessId(fgHandle, System.IntPtr.Zero);
+
+        if (threadId1 != threadId2)
+        {
+            OSInterop.AttachThreadInput(threadId1, threadId2, true);
+            OSInterop.SetForegroundWindow(handle);
+            OSInterop.AttachThreadInput(threadId1, threadId2, false);
+        }
+        else
+        {
+            OSInterop.SetForegroundWindow(handle);
+        }
     }
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Fix focus on overlay on the first TextExtractor activation in most of the test cases.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [X] **Closes:** #20950
- [X] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
<kbd>Esc</kbd> is not handled because, `overlay.Activate()` doesn't focus on the overlay window after the first run of TextExtractor.
In scope of this PR:
- added `WindowUtilities::ActivateWindow`
- removed unused code

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
1. Close PowerToys
2. Open PowerToys
3. Press TextExtractor hotkey (<kbd>Win</kbd>+<kbd>Shift</kbd>+<kbd>T</kbd> by default)
4. Press <kbd>Esc</kbd>
5. Overlay should be closed
