### PR TITLE
Remove WebView2

### DIFF
--- a/installer/PowerToysSetup/PowerToys.wxs
+++ b/installer/PowerToysSetup/PowerToys.wxs
@@ -93,19 +93,6 @@
                     Version="6.0.9.31620"
                     Hash="$(var.Dotnet6PayloadHash)" />
             </ExePackage>
-            <ExePackage
-                DisplayName="Installing Microsoft Edge WebView2"
-                Name="MicrosoftEdgeWebview2Setup.exe"
-                Compressed="yes"
-                Id="WebView2"
-                DetectCondition="HasWebView2PerMachine OR HasWebView2PerUser"
-                SourceFile="WebView2\MicrosoftEdgeWebview2Setup.exe"
-                InstallCommand="/silent /install"
-                RepairCommand="/repair /passive"
-                Permanent="yes"
-                PerMachine="yes"
-                UninstallCommand="/silent /uninstall">
-            </ExePackage>
             <MsiPackage
                 DisplayName="Installing PowerToys"
                 SourceFile="$(var.PowerToysPlatform)\Release\PowerToysSetup-$(var.Version)-$(var.PowerToysPlatform).msi"


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Exclude WebView2 from installer because Windows 10 WebView2 is more widely rolled out.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Install Windows 10.

Go through OOBE.

After a few minutes, go to settings.

WebView2 runtime shows up.
![image](https://user-images.githubusercontent.com/46290258/194783110-bf134d93-20a0-4c3d-a7f4-c95f4dc1b82d.png)
![Annotation 2022-10-09 185104](https://user-images.githubusercontent.com/46290258/194783158-3249acb5-d1dc-430b-b93a-af707c35eb14.png)
