### PR TITLE
[GitHub]Add install method to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -18,6 +18,16 @@ body:
   validations:
     required: true
 
+- type: input
+  attributes:
+    label: Installation method
+    placeholder: |
+      "GitHub releases"
+    description: |
+      How was PowerToys installed? (Examples: Github releases, Microsoft Store, WinGet, Chocolatey, Scoop)
+  validations:
+    required: true
+
 - type: checkboxes
   attributes:
     label: Running as admin

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -26,10 +26,11 @@ body:
     options:
       - GitHub
       - Windows Store
+      - WinGet
       - PowerToys auto-update
-      - Choco
+      - Chocolatey
       - Scoop
-      - Other
+      - Other (please specify in "Steps to Reproduce")
   validations:
     required: true
 - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -30,6 +30,7 @@ body:
       - PowerToys auto-update
       - Chocolatey
       - Scoop
+      - Dev build in Visual Studio
       - Other (please specify in "Steps to Reproduce")
   validations:
     required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -18,16 +18,20 @@ body:
   validations:
     required: true
 
-- type: input
+- type: dropdown
   attributes:
     label: Installation method
-    placeholder: |
-      "GitHub releases"
-    description: |
-      How was PowerToys installed? (Examples: Github releases, Microsoft Store, WinGet, Chocolatey, Scoop)
+    description: How / Where was PowerToys installed from?
+    multiple: true
+    options:
+      - GitHub
+      - Windows Store
+      - PowerToys auto-update
+      - Choco
+      - Scoop
+      - Other
   validations:
     required: true
-
 - type: checkboxes
   attributes:
     label: Running as admin


### PR DESCRIPTION
## Summary of the Pull Request

Asks the user to include the install method in their Bug Report.
Some bugs seem to appear only when installing through certain methods, so this would make it easier to reproduce. This issue comes to mind, as an example: https://github.com/microsoft/PowerToys/issues/21108