### PR TITLE
[OOBE]Fix not shortcut not updating

### DIFF
--- a/src/settings-ui/Settings.UI.Library/ViewModels/ColorPickerViewModel.cs
+++ b/src/settings-ui/Settings.UI.Library/ViewModels/ColorPickerViewModel.cs
@@ -34,7 +34,11 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
 
         private Func<string, int> SendConfigMSG { get; }
 
-        public ColorPickerViewModel(ISettingsUtils settingsUtils, ISettingsRepository<GeneralSettings> settingsRepository, Func<string, int> ipcMSGCallBackFunc)
+        public ColorPickerViewModel(
+            ISettingsUtils settingsUtils,
+            ISettingsRepository<GeneralSettings> settingsRepository,
+            ISettingsRepository<ColorPickerSettings> colorPickerSettingsRepository,
+            Func<string, int> ipcMSGCallBackFunc)
         {
             // Obtain the general PowerToy settings configurations
             if (settingsRepository == null)
@@ -62,14 +66,13 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             GeneralSettingsConfig = settingsRepository.SettingsConfig;
 
             _settingsUtils = settingsUtils ?? throw new ArgumentNullException(nameof(settingsUtils));
-            if (_settingsUtils.SettingsExists(ColorPickerSettings.ModuleName))
+
+            if (colorPickerSettingsRepository == null)
             {
-                _colorPickerSettings = _settingsUtils.GetSettingsOrDefault<ColorPickerSettings>(ColorPickerSettings.ModuleName);
+                throw new ArgumentNullException(nameof(colorPickerSettingsRepository));
             }
-            else
-            {
-                _colorPickerSettings = new ColorPickerSettings();
-            }
+
+            _colorPickerSettings = colorPickerSettingsRepository.SettingsConfig;
 
             _isEnabled = GeneralSettingsConfig.Enabled.ColorPicker;
 

--- a/src/settings-ui/Settings.UI.Library/ViewModels/MeasureToolViewModel.cs
+++ b/src/settings-ui/Settings.UI.Library/ViewModels/MeasureToolViewModel.cs
@@ -175,13 +175,15 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
                 if (Settings.Properties.ActivationShortcut != value)
                 {
                     Settings.Properties.ActivationShortcut = value;
+
                     NotifyPropertyChanged();
+
                     SendConfigMSG(
-                        string.Format(
-                            CultureInfo.InvariantCulture,
-                            "{{ \"powertoys\": {{ \"{0}\": {1} }} }}",
-                            MeasureToolSettings.ModuleName,
-                            JsonSerializer.Serialize(Settings)));
+                         string.Format(
+                         CultureInfo.InvariantCulture,
+                         "{{ \"powertoys\": {{ \"{0}\": {1} }} }}",
+                         MeasureToolSettings.ModuleName,
+                         JsonSerializer.Serialize(Settings)));
                 }
             }
         }
@@ -189,7 +191,6 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
         public void NotifyPropertyChanged([CallerMemberName] string propertyName = null)
         {
             OnPropertyChanged(propertyName);
-
             if (propertyName == nameof(ShowContinuousCaptureWarning))
             {
                 // Don't trigger a settings update if the changed property is for visual notification.

--- a/src/settings-ui/Settings.UI.Library/ViewModels/PowerLauncherViewModel.cs
+++ b/src/settings-ui/Settings.UI.Library/ViewModels/PowerLauncherViewModel.cs
@@ -36,7 +36,11 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
 
         private Func<string, int> SendConfigMSG { get; }
 
-        public PowerLauncherViewModel(PowerLauncherSettings settings, ISettingsRepository<GeneralSettings> settingsRepository, Func<string, int> ipcMSGCallBackFunc, Func<bool> isDark)
+        public PowerLauncherViewModel(
+            PowerLauncherSettings settings,
+            ISettingsRepository<GeneralSettings> settingsRepository,
+            Func<string, int> ipcMSGCallBackFunc,
+            Func<bool> isDark)
         {
             if (settings == null)
             {

--- a/src/settings-ui/Settings.UI.Library/ViewModels/PowerOcrViewModel.cs
+++ b/src/settings-ui/Settings.UI.Library/ViewModels/PowerOcrViewModel.cs
@@ -33,6 +33,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
         public PowerOcrViewModel(
             ISettingsUtils settingsUtils,
             ISettingsRepository<GeneralSettings> settingsRepository,
+            ISettingsRepository<PowerOcrSettings> powerOcrsettingsRepository,
             Func<string, int> ipcMSGCallBackFunc)
         {
             // To obtain the general settings configurations of PowerToys Settings.
@@ -50,14 +51,13 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             }
 
             _settingsUtils = settingsUtils ?? throw new ArgumentNullException(nameof(settingsUtils));
-            if (_settingsUtils.SettingsExists(PowerOcrSettings.ModuleName))
+
+            if (powerOcrsettingsRepository == null)
             {
-                _powerOcrSettings = _settingsUtils.GetSettingsOrDefault<PowerOcrSettings>(PowerOcrSettings.ModuleName);
+                throw new ArgumentNullException(nameof(powerOcrsettingsRepository));
             }
-            else
-            {
-                _powerOcrSettings = new PowerOcrSettings();
-            }
+
+            _powerOcrSettings = powerOcrsettingsRepository.SettingsConfig;
 
             _isEnabled = GeneralSettingsConfig.Enabled.PowerOCR;
 
@@ -98,6 +98,8 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
                 {
                     _powerOcrSettings.Properties.ActivationShortcut = value;
                     OnPropertyChanged(nameof(ActivationShortcut));
+
+                    _settingsUtils.SaveSettings(_powerOcrSettings.ToJsonString(), PowerOcrSettings.ModuleName);
                     NotifySettingsChanged();
                 }
             }

--- a/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/ColorPicker.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/ColorPicker.cs
@@ -36,13 +36,14 @@ namespace ViewModelTests
             var mockGeneralSettingsUtils = new SettingsUtils(mockGeneralIOProvider.Object, settingPathMock.Object);
             GeneralSettings originalGeneralSettings = mockGeneralSettingsUtils.GetSettingsOrDefault<GeneralSettings>();
             var generalSettingsRepository = new BackCompatTestProperties.MockSettingsRepository<GeneralSettings>(mockGeneralSettingsUtils);
+            var colorPickerSettingsRepository = new BackCompatTestProperties.MockSettingsRepository<ColorPickerSettings>(mockSettingsUtils);
 
             // Act
             // Initialise View Model with test Config files
             using (var viewModel = new ColorPickerViewModel(
                 mockSettingsUtils,
                 generalSettingsRepository,
-                SettingsRepository<ColorPickerSettings>.GetInstance(new SettingsUtils()),
+                colorPickerSettingsRepository,
                 ColorPickerIsEnabledByDefaultIPC))
             {
                 // Assert

--- a/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/ColorPicker.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/ColorPicker.cs
@@ -39,7 +39,11 @@ namespace ViewModelTests
 
             // Act
             // Initialise View Model with test Config files
-            using (var viewModel = new ColorPickerViewModel(mockSettingsUtils, generalSettingsRepository, ColorPickerIsEnabledByDefaultIPC))
+            using (var viewModel = new ColorPickerViewModel(
+                mockSettingsUtils,
+                generalSettingsRepository,
+                SettingsRepository<ColorPickerSettings>.GetInstance(new SettingsUtils()),
+                ColorPickerIsEnabledByDefaultIPC))
             {
                 // Assert
                 // Verify that the old settings persisted
@@ -58,7 +62,11 @@ namespace ViewModelTests
         public void ColorPickerIsEnabledByDefault()
         {
             var mockSettingsUtils = ISettingsUtilsMocks.GetStubSettingsUtils<ColorPickerSettings>();
-            using (var viewModel = new ColorPickerViewModel(ISettingsUtilsMocks.GetStubSettingsUtils<ColorPickerSettings>().Object, SettingsRepository<GeneralSettings>.GetInstance(ISettingsUtilsMocks.GetStubSettingsUtils<GeneralSettings>().Object), ColorPickerIsEnabledByDefaultIPC))
+            using (var viewModel = new ColorPickerViewModel(
+                ISettingsUtilsMocks.GetStubSettingsUtils<ColorPickerSettings>().Object,
+                SettingsRepository<GeneralSettings>.GetInstance(ISettingsUtilsMocks.GetStubSettingsUtils<GeneralSettings>().Object),
+                SettingsRepository<ColorPickerSettings>.GetInstance(new SettingsUtils()),
+                ColorPickerIsEnabledByDefaultIPC))
             {
                 Assert.IsTrue(viewModel.IsEnabled);
             }

--- a/src/settings-ui/Settings.UI/Views/ColorPickerPage.xaml.cs
+++ b/src/settings-ui/Settings.UI/Views/ColorPickerPage.xaml.cs
@@ -15,7 +15,11 @@ namespace Microsoft.PowerToys.Settings.UI.Views
         public ColorPickerPage()
         {
             var settingsUtils = new SettingsUtils();
-            ViewModel = new ColorPickerViewModel(settingsUtils, SettingsRepository<GeneralSettings>.GetInstance(settingsUtils), ShellPage.SendDefaultIPCMessage);
+            ViewModel = new ColorPickerViewModel(
+                settingsUtils,
+                SettingsRepository<GeneralSettings>.GetInstance(settingsUtils),
+                SettingsRepository<ColorPickerSettings>.GetInstance(settingsUtils),
+                ShellPage.SendDefaultIPCMessage);
             DataContext = ViewModel;
             InitializeComponent();
         }

--- a/src/settings-ui/Settings.UI/Views/PowerLauncherPage.xaml.cs
+++ b/src/settings-ui/Settings.UI/Views/PowerLauncherPage.xaml.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.ObjectModel;
 using System.IO;
 using Microsoft.PowerToys.Settings.UI.Library;
+using Microsoft.PowerToys.Settings.UI.Library.Interfaces;
 using Microsoft.PowerToys.Settings.UI.Library.Utilities;
 using Microsoft.PowerToys.Settings.UI.Library.ViewModels;
 using Microsoft.UI.Xaml.Controls;
@@ -34,7 +35,8 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             InitializeComponent();
             var settingsUtils = new SettingsUtils();
             _lastIPCMessageSentTick = Environment.TickCount;
-            PowerLauncherSettings settings = settingsUtils.GetSettingsOrDefault<PowerLauncherSettings>(PowerLauncherSettings.ModuleName);
+
+            PowerLauncherSettings settings = SettingsRepository<PowerLauncherSettings>.GetInstance(settingsUtils)?.SettingsConfig;
             ViewModel = new PowerLauncherViewModel(settings, SettingsRepository<GeneralSettings>.GetInstance(settingsUtils), SendDefaultIPCMessageTimed, App.IsDarkTheme);
             DataContext = ViewModel;
             _ = Helper.GetFileWatcher(PowerLauncherSettings.ModuleName, "settings.json", () =>
@@ -48,7 +50,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
                 PowerLauncherSettings powerLauncherSettings = null;
                 try
                 {
-                    powerLauncherSettings = settingsUtils.GetSettingsOrDefault<PowerLauncherSettings>(PowerLauncherSettings.ModuleName);
+                    powerLauncherSettings = SettingsRepository<PowerLauncherSettings>.GetInstance(settingsUtils)?.SettingsConfig;
                 }
                 catch (IOException ex)
                 {

--- a/src/settings-ui/Settings.UI/Views/PowerOcrPage.xaml.cs
+++ b/src/settings-ui/Settings.UI/Views/PowerOcrPage.xaml.cs
@@ -18,6 +18,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             ViewModel = new PowerOcrViewModel(
                 settingsUtils,
                 SettingsRepository<GeneralSettings>.GetInstance(settingsUtils),
+                SettingsRepository<PowerOcrSettings>.GetInstance(settingsUtils),
                 ShellPage.SendDefaultIPCMessage);
             DataContext = ViewModel;
             InitializeComponent();

--- a/src/settings-ui/Settings.UI/Views/VideoConference.xaml.cs
+++ b/src/settings-ui/Settings.UI/Views/VideoConference.xaml.cs
@@ -34,7 +34,12 @@ namespace Microsoft.PowerToys.Settings.UI.Views
         public VideoConferencePage()
         {
             var settingsUtils = new SettingsUtils();
-            ViewModel = new VideoConferenceViewModel(settingsUtils, SettingsRepository<GeneralSettings>.GetInstance(settingsUtils), ShellPage.SendDefaultIPCMessage, PickFileDialog);
+            ViewModel = new VideoConferenceViewModel(
+                settingsUtils,
+                SettingsRepository<GeneralSettings>.GetInstance(settingsUtils),
+                SettingsRepository<VideoConferenceSettings>.GetInstance(settingsUtils),
+                ShellPage.SendDefaultIPCMessage,
+                PickFileDialog);
             DataContext = ViewModel;
             InitializeComponent();
         }


### PR DESCRIPTION
Fix for issue #20953.
Activation key update in the OOBE window when the user changes it in the settings window.


## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [X] **Closes:** #20953
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Added settings repository reference to the ViewModel constructor to use the repository settings object. Without the reference the OOBE window class created a second instance of the settings object. That caused the problem. 

Same problem detected also in the Color Picker, PowerToys Run and Video Conference Mute modules. All fixed.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
Tested manually.
