### PR TITLE
[AlwaysOnTop] Return topmost if it was lost

### DIFF
--- a/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.cpp
+++ b/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.cpp
@@ -424,7 +424,6 @@ void AlwaysOnTop::HandleWinHookEvent(WinHookEvent* data) noexcept
         {
             UnpinTopmostWindow(window);
             toErase.push_back(window);
-            continue;
         }
     }
 

--- a/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.cpp
+++ b/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.cpp
@@ -493,7 +493,7 @@ void AlwaysOnTop::HandleWinHookEvent(WinHookEvent* data) noexcept
             // fixes https://github.com/microsoft/PowerToys/issues/19168
             if (!IsTopmost(window))
             {
-                Logger::trace(L"Reset topmost");
+                Logger::trace(L"A window no longer has Topmost set and it should. Setting topmost again.");
                 PinTopmostWindow(window);
             }
         }

--- a/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.cpp
+++ b/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.cpp
@@ -413,16 +413,25 @@ void AlwaysOnTop::HandleWinHookEvent(WinHookEvent* data) noexcept
         return;
     }
 
-    // fix for the https://github.com/microsoft/PowerToys/issues/15300
-    // check if the window was closed, since for some EVENT_OBJECT_DESTROY doesn't work 
     std::vector<HWND> toErase{};
     for (const auto& [window, border] : m_topmostWindows)
     {
+        // check if the window was closed, since for some EVENT_OBJECT_DESTROY doesn't work
+        // fixes https://github.com/microsoft/PowerToys/issues/15300
         bool visible = IsWindowVisible(window);
         if (!visible)
         {
             UnpinTopmostWindow(window);
             toErase.push_back(window);
+            continue;
+        }
+
+        // check reset windows
+        // fixes https://github.com/microsoft/PowerToys/issues/19168
+        if (!IsTopmost(window))
+        {
+            Logger::trace("Reset topmost flag");
+            PinTopmostWindow(window);
         }
     }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Check WS_EX_TOPMOST on the focus event and set it again in case it was lost for some reason.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #19168
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

* Pin OneNote or StickyNotes window
* Alt-tab or click on another window 
* Return focus to the first window back, observe it's still topmost. 