### PR TITLE
Analyzers cpp turn on 4127

### DIFF
--- a/Cpp.Build.props
+++ b/Cpp.Build.props
@@ -42,7 +42,7 @@
     <ClCompile>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <WarningLevel>Level4</WarningLevel>
-      <DisableSpecificWarnings>26800;28251;4127;4189;4239;4244;4245;4389;4456;4457;4701;6387;4458;4505;4515;4459;4702;6031;6248;26451;28182;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <DisableSpecificWarnings>26800;28251;4189;4239;4244;4245;4389;4456;4457;4701;6387;4458;4505;4515;4459;4702;6031;6248;26451;28182;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <DisableAnalyzeExternal >true</DisableAnalyzeExternal>
       <ExternalWarningLevel>TurnOffAllWarnings</ExternalWarningLevel>
       <ConformanceMode>false</ConformanceMode>

--- a/src/common/updating/updating.cpp
+++ b/src/common/updating/updating.cpp
@@ -13,7 +13,7 @@ namespace // Strings in this namespace should not be localized
 {
     const wchar_t LATEST_RELEASE_ENDPOINT[] = L"https://api.github.com/repos/microsoft/PowerToys/releases/latest";
     const wchar_t ALL_RELEASES_ENDPOINT[] = L"https://api.github.com/repos/microsoft/PowerToys/releases";
-    
+
     const wchar_t LOCAL_BUILD_ERROR[] = L"Local build cannot be updated";
     const wchar_t NETWORK_ERROR[] = L"Network error";
 
@@ -70,7 +70,7 @@ namespace updating
     std::future<nonstd::expected<github_version_info, std::wstring>> get_github_version_info_async(const bool prerelease)
     {
         // If the current version starts with 0.0.*, it means we're on a local build from a farm and shouldn't check for updates.
-        if (VERSION_MAJOR == 0 && VERSION_MINOR == 0)
+        if constexpr (VERSION_MAJOR == 0 && VERSION_MINOR == 0)
         {
             co_return nonstd::make_unexpected(LOCAL_BUILD_ERROR);
         }

--- a/src/runner/unhandled_exception_handler.cpp
+++ b/src/runner/unhandled_exception_handler.cpp
@@ -167,7 +167,7 @@ LONG WINAPI unhandled_exception_handler(PEXCEPTION_POINTERS info)
     return EXCEPTION_CONTINUE_SEARCH;
 }
 
-extern "C" void AbortHandler(int signal_number)
+extern "C" void AbortHandler(int /*signal_number*/)
 {
     init_symbols();
     std::wstring ex_description = L"SIGABRT was raised.";


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Turn on warning 4127, conditional expression is constant

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Continues towards:** #x940
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass - no new tests
- [x] **Localization:** All end user facing strings can be localized - no new strings
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Turn on warning 4127 and changing 1 if expression to if constexpr

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Unit Tests and CI
