### PR TITLE
[FileLocksmith]Fix crash while opening process handlers

### DIFF
--- a/src/modules/FileLocksmith/FileLocksmithLibInterop/interop.cpp
+++ b/src/modules/FileLocksmith/FileLocksmithLibInterop/interop.cpp
@@ -11,7 +11,6 @@ namespace FileLocksmith::Interop
         System::String^ name;
         System::UInt32 pid;
         array<System::String^>^ files;
-        System::Boolean isExpanded; // For helping in the UI
     };
 
     System::String^ from_wstring_view(std::wstring_view str)
@@ -77,7 +76,6 @@ namespace FileLocksmith::Interop
                 {
                     item->files[j] = from_wstring_view(result_cpp[i].files[j]);
                 }
-                item->isExpanded = false;
 
                 result[i] = item;
             }

--- a/src/modules/FileLocksmith/FileLocksmithUI/Views/MainPage.xaml
+++ b/src/modules/FileLocksmith/FileLocksmithUI/Views/MainPage.xaml
@@ -103,7 +103,7 @@
                     SelectionMode="None">
                     <ListView.ItemTemplate>
                         <DataTemplate x:DataType="interop:ProcessResult">
-                                <labs:SettingsExpander IsExpanded="{Binding isExpanded}" Margin="0,3,0,0">
+                                <labs:SettingsExpander Margin="0,3,0,0">
                                     <labs:SettingsExpander.Header>
                                         <!--  We can't use the HeaderIcon because it only support a BitmapIcon, which only supports UriSource - not a direct BitmapImage  -->
                                         <StackPanel Orientation="Horizontal">


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Fix crashes that were occurring when a process exited after we recognized it but before we added a watcher to check when it exited.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #114
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

Actually handle exceptions when getting the process handles and log them.
Remove the DataBinding on IsExpanded. It's not working and is filling the logs with useless information.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Tested on PCs where the crash was easily reproducible.
