### PR TITLE
[FileLocksmith]Query system processes if elevated

### DIFF
--- a/src/modules/FileLocksmith/FileLocksmithLibInterop/FileLocksmith.cpp
+++ b/src/modules/FileLocksmith/FileLocksmithLibInterop/FileLocksmith.cpp
@@ -103,56 +103,13 @@ std::vector<ProcessResult> find_processes_recursive(const std::vector<std::wstri
                 {
                     process_info.name,
                     process_info.pid,
+                    process_info.user,
                     std::vector(it->second.begin(), it->second.end())
                 });
         }
     }
 
     return result;
-}
-
-std::wstring pid_to_user(DWORD pid)
-{
-    HANDLE process = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
-
-    if (process == NULL)
-    {
-        return {};
-    }
-
-    std::wstring user = L"";
-    std::wstring domain = L"";
-
-    HANDLE token = NULL;
-
-    if (OpenProcessToken(process, TOKEN_QUERY, &token))
-    {
-        DWORD token_size = 0;
-        GetTokenInformation(token, TokenUser, NULL, 0, &token_size);
-
-        if (token_size > 0)
-        {
-            std::vector<BYTE> token_buffer(token_size);
-            GetTokenInformation(token, TokenUser, token_buffer.data(), token_size, &token_size);
-            TOKEN_USER* user_ptr = (TOKEN_USER*)token_buffer.data();
-            PSID psid = user_ptr->User.Sid;
-            DWORD user_size = 0;
-            DWORD domain_size = 0;
-            SID_NAME_USE sid_name;
-            LookupAccountSidW(NULL, psid, NULL, &user_size, NULL, &domain_size, &sid_name);
-            user.resize(user_size + 1);
-            domain.resize(domain_size + 1);
-            LookupAccountSidW(NULL, psid, user.data(), &user_size, domain.data(), &domain_size, &sid_name);
-            user[user_size] = L'\0';
-            domain[domain_size] = L'\0';
-        }
-
-        CloseHandle(token);
-    }
-
-    CloseHandle(process);
-
-    return user;
 }
 
 constexpr size_t LongMaxPathSize = 65536;

--- a/src/modules/FileLocksmith/FileLocksmithLibInterop/FileLocksmith.h
+++ b/src/modules/FileLocksmith/FileLocksmithLibInterop/FileLocksmith.h
@@ -6,14 +6,12 @@ struct ProcessResult
 {
     std::wstring name;
     DWORD pid;
+    std::wstring user;
     std::vector<std::wstring> files;
 };
 
 // Second version, checks handles towards files and all subfiles and folders of given dirs, if any.
 std::vector<ProcessResult> find_processes_recursive(const std::vector<std::wstring>& paths);
-
-// Gives the user name of the account running this process
-std::wstring pid_to_user(DWORD pid);
 
 // Gives the full path of the executable, given the process id
 std::wstring pid_to_full_path(DWORD pid);

--- a/src/modules/FileLocksmith/FileLocksmithLibInterop/FileLocksmithLibInterop.vcxproj
+++ b/src/modules/FileLocksmith/FileLocksmithLibInterop/FileLocksmithLibInterop.vcxproj
@@ -128,46 +128,6 @@
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\modules\FileLocksmith\</OutDir>
     <TargetName>PowerToys.FileLocksmithLib.Interop</TargetName>
   </PropertyGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
-      <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;_DEBUG;FILELOCKSMITHLIBINTEROP_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <CompileAsManaged>NetCore</CompileAsManaged>
-      <LanguageStandard>stdcpp17</LanguageStandard>
-      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
-      <AdditionalOptions>/Zc:twoPhase-</AdditionalOptions>
-    </ClCompile>
-    <Link>
-      <SubSystem>Windows</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-      <EnableUAC>false</EnableUAC>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
-      <FunctionLevelLinking>true</FunctionLevelLinking>
-      <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;NDEBUG;FILELOCKSMITHLIBINTEROP_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
-      <PrecompiledHeader>Use</PrecompiledHeader>
-      <CompileAsManaged>NetCore</CompileAsManaged>
-      <LanguageStandard>stdcpp17</LanguageStandard>
-      <AdditionalOptions>/Zc:twoPhase-</AdditionalOptions>
-      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
-    </ClCompile>
-    <Link>
-      <SubSystem>Windows</SubSystem>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <OptimizeReferences>true</OptimizeReferences>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-      <EnableUAC>false</EnableUAC>
-    </Link>
-  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>

--- a/src/modules/FileLocksmith/FileLocksmithLibInterop/NtdllExtensions.h
+++ b/src/modules/FileLocksmith/FileLocksmithLibInterop/NtdllExtensions.h
@@ -29,6 +29,7 @@ public:
     {
         DWORD pid;
         std::wstring name;
+        std::wstring user;
         std::vector<std::wstring> modules;
     };
 
@@ -43,6 +44,9 @@ public:
     std::wstring file_handle_to_kernel_name(HANDLE file_handle);
 
     std::wstring path_to_kernel_name(LPCWSTR path);
+
+    // Gives the user name of the account running this process
+    std::wstring pid_to_user(DWORD pid);
 
     std::vector<HandleInfo> handles() noexcept;
 

--- a/src/modules/FileLocksmith/FileLocksmithLibInterop/interop.cpp
+++ b/src/modules/FileLocksmith/FileLocksmithLibInterop/interop.cpp
@@ -222,5 +222,26 @@ namespace FileLocksmith::Interop
             return false;
         }
 
+        // adapted from common/utils/elevation.h. No need to bring all dependencies to this project, though.
+        // TODO: Make elevation.h lighter so that this function can be used without bringing dependencies like spdlog in.
+        static System::Boolean IsProcessElevated()
+        {
+            HANDLE token = nullptr;
+            bool elevated = false;
+            if (OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &token))
+            {
+                TOKEN_ELEVATION elevation;
+                DWORD size;
+                if (GetTokenInformation(token, TokenElevation, &elevation, sizeof(elevation), &size))
+                {
+                    elevated = (elevation.TokenIsElevated != 0);
+                }
+            }
+            if (token)
+            {
+                CloseHandle(token);
+            }
+            return elevated;
+        }
     };
 }

--- a/src/modules/FileLocksmith/FileLocksmithLibInterop/interop.cpp
+++ b/src/modules/FileLocksmith/FileLocksmithLibInterop/interop.cpp
@@ -10,6 +10,7 @@ namespace FileLocksmith::Interop
     {
         System::String^ name;
         System::UInt32 pid;
+        System::String^ user;
         array<System::String^>^ files;
     };
 
@@ -69,6 +70,7 @@ namespace FileLocksmith::Interop
 
                 item->name = from_wstring_view(result_cpp[i].name);
                 item->pid = result_cpp[i].pid;
+                item->user = from_wstring_view(result_cpp[i].user);
 
                 const int n_files = static_cast<int>(result_cpp[i].files.size());
                 item->files = gcnew array<System::String ^>(n_files);
@@ -81,12 +83,6 @@ namespace FileLocksmith::Interop
             }
 
             return result;
-        }
-
-        static System::String^ PidToUser(System::UInt32 pid)
-        {
-            auto user_cpp = pid_to_user(pid);
-            return from_wstring_view(user_cpp);
         }
 
         static System::String^ PidToFullPath(System::UInt32 pid)

--- a/src/modules/FileLocksmith/FileLocksmithUI/App.xaml.cs
+++ b/src/modules/FileLocksmith/FileLocksmithUI/App.xaml.cs
@@ -40,7 +40,17 @@ namespace FileLocksmithUI
                 return;
             }
 
-            _window = new MainWindow(Environment.GetCommandLineArgs().Contains("--elevated"));
+            bool isElevated = Environment.GetCommandLineArgs().Contains("--elevated");
+
+            if (isElevated)
+            {
+                if (!FileLocksmith.Interop.NativeMethods.SetDebugPrivilege())
+                {
+                    Logger.LogWarning("Couldn't set debug privileges to see system processes.");
+                }
+            }
+
+            _window = new MainWindow(isElevated);
             _window.Activate();
         }
 

--- a/src/modules/FileLocksmith/FileLocksmithUI/App.xaml.cs
+++ b/src/modules/FileLocksmith/FileLocksmithUI/App.xaml.cs
@@ -40,7 +40,7 @@ namespace FileLocksmithUI
                 return;
             }
 
-            bool isElevated = Environment.GetCommandLineArgs().Contains("--elevated");
+            bool isElevated = FileLocksmith.Interop.NativeMethods.IsProcessElevated();
 
             if (isElevated)
             {

--- a/src/modules/FileLocksmith/FileLocksmithUI/Converters/UserToSystemWarningVisibilityConverter.cs
+++ b/src/modules/FileLocksmith/FileLocksmithUI/Converters/UserToSystemWarningVisibilityConverter.cs
@@ -5,19 +5,29 @@
 namespace PowerToys.FileLocksmithUI.Converters
 {
     using System;
+    using System.Globalization;
     using FileLocksmith.Interop;
+    using Microsoft.UI.Xaml;
     using Microsoft.UI.Xaml.Data;
 
-    public sealed class PidToUserConverter : IValueConverter
+    public sealed class UserToSystemWarningVisibilityConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, string language)
         {
-            return NativeMethods.PidToUser((uint)value);
+            string user = ((string)value).ToUpperInvariant().TrimEnd('\0').Trim();
+            if (user.Equals("SYSTEM", StringComparison.Ordinal) || user.Equals("LOCALSYSTEM", StringComparison.Ordinal))
+            {
+                return Visibility.Visible;
+            }
+            else
+            {
+                return Visibility.Collapsed;
+            }
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, string language)
         {
-            return value;
+            throw new NotSupportedException();
         }
     }
 }

--- a/src/modules/FileLocksmith/FileLocksmithUI/Converters/UserToSystemWarningVisibilityConverter.cs
+++ b/src/modules/FileLocksmith/FileLocksmithUI/Converters/UserToSystemWarningVisibilityConverter.cs
@@ -14,7 +14,7 @@ namespace PowerToys.FileLocksmithUI.Converters
     {
         public object Convert(object value, Type targetType, object parameter, string language)
         {
-            string user = ((string)value).ToUpperInvariant().TrimEnd('\0').Trim();
+            string user = ((string)value).ToUpperInvariant().Trim();
             if (user.Equals("SYSTEM", StringComparison.Ordinal) || user.Equals("LOCALSYSTEM", StringComparison.Ordinal))
             {
                 return Visibility.Visible;

--- a/src/modules/FileLocksmith/FileLocksmithUI/Strings/en-us/Resources.resw
+++ b/src/modules/FileLocksmith/FileLocksmithUI/Strings/en-us/Resources.resw
@@ -136,6 +136,9 @@
     <value>Click to see the entire list of paths.</value>
     <comment>Paths as in file paths that were selected for the utility to check.</comment>
   </data>
+  <data name="ProcessIsSystemUserWarning.Text" xml:space="preserve">
+    <value>The process belongs to a system user. Closing it may cause the system to malfunction.</value>
+  </data>
   <data name="SelectedFilesListDialog.Title" xml:space="preserve">
     <value>Selected file paths</value>
     <comment>Paths as in file paths that were selected for the utility to check.</comment>

--- a/src/modules/FileLocksmith/FileLocksmithUI/Views/MainPage.xaml
+++ b/src/modules/FileLocksmith/FileLocksmithUI/Views/MainPage.xaml
@@ -25,7 +25,7 @@
             TrueValue="Collapsed" />
         <converters:FileCountConverter x:Key="fileCountConverter" />
         <converters:PidToIconConverter x:Key="pidToIconConverter" />
-        <converters:PidToUserConverter x:Key="pidToUserConverter" />
+        <converters:UserToSystemWarningVisibilityConverter x:Key="userToSystemWarningVisibilityConverter" />
         <converters:FileListToDescriptionConverter x:Key="fileListToDescriptionConverter" />
     </Page.Resources>
 
@@ -116,6 +116,17 @@
                                         </StackPanel>
                                     </labs:SettingsExpander.Header>
                                     <labs:SettingsExpander.Content>
+                                    <StackPanel Orientation="Horizontal">
+                                        <FontIcon
+                                            Margin="0,0,8,0"
+                                            Glyph="&#xE7BA;"
+                                            Foreground="Yellow"
+                                            Visibility="{x:Bind user, Mode=OneTime, Converter={StaticResource userToSystemWarningVisibilityConverter}}"
+                                            >
+                                            <ToolTipService.ToolTip>
+                                                <TextBlock TextWrapping="Wrap" x:Uid="ProcessIsSystemUserWarning" />
+                                            </ToolTipService.ToolTip>
+                                        </FontIcon>
                                         <Button Command="{Binding Path=DataContext.EndTaskCommand, ElementName=ProcessesListView}" CommandParameter="{Binding}">
                                             <StackPanel Orientation="Horizontal" Spacing="6">
                                                 <FontIcon
@@ -125,6 +136,7 @@
                                                 <TextBlock x:Uid="EndTask" />
                                             </StackPanel>
                                         </Button>
+                                    </StackPanel>
                                     </labs:SettingsExpander.Content>
                                     <labs:SettingsExpander.Items>
                                         <labs:SettingsCard x:Uid="ProcessID">
@@ -137,7 +149,7 @@
                                             <TextBlock
                                                 Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                                 IsTextSelectionEnabled="True"
-                                                Text="{x:Bind pid, Converter={StaticResource pidToUserConverter}}" />
+                                                Text="{x:Bind user}" />
                                         </labs:SettingsCard>
                                         <labs:SettingsCard ContentAlignment="Vertical">
                                             <labs:SettingsCard.Header>

--- a/src/modules/FileLocksmith/FileLocksmithUI/Views/MainPage.xaml
+++ b/src/modules/FileLocksmith/FileLocksmithUI/Views/MainPage.xaml
@@ -120,7 +120,7 @@
                                         <FontIcon
                                             Margin="0,0,8,0"
                                             Glyph="&#xE7BA;"
-                                            Foreground="Yellow"
+                                            Foreground="{ThemeResource InfoBarWarningSeverityIconBackground}"
                                             Visibility="{x:Bind user, Mode=OneTime, Converter={StaticResource userToSystemWarningVisibilityConverter}}"
                                             >
                                             <ToolTipService.ToolTip>

--- a/src/modules/FileLocksmith/FileLocksmithUI/Views/MainPage.xaml
+++ b/src/modules/FileLocksmith/FileLocksmithUI/Views/MainPage.xaml
@@ -211,7 +211,7 @@
             x:Uid="SelectedFilesListDialog"
             >
             <ScrollViewer HorizontalScrollBarVisibility="Auto" HorizontalScrollMode="Auto" VerticalScrollBarVisibility="Auto" VerticalScrollMode="Auto">
-                <TextBlock Text="{x:Bind ViewModel.PathsToString, Mode=OneWay}"/>
+                <TextBlock IsTextSelectionEnabled="True" Text="{x:Bind ViewModel.PathsToString, Mode=OneWay}"/>
             </ScrollViewer>
         </ContentDialog>
     </Grid>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

File Locksmith can't see processes that belong to the system user.
This PR allows that when running elevated.

![image](https://user-images.githubusercontent.com/26118718/199785668-33eee5cb-a9aa-48f6-86e6-16e63c163ab8.png)

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #21661 
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

- When running elevated, ask for SeDebugPrivilege for the File Locksmith process in order to be able to view files used by system processes.
- The user of each process is now sent with the process results instead of queried from the UI, so moved this function accordingly and removed the interop function from the API.
- Add a warning in UI when listing a system process.
- Also make the list of files selected by the context menu selectable as a minor fix.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Tried it on the Windows folder running as elevated and verified the system processes are shown.
