### PR TITLE
disable trigger if letter is not longer pushed

### DIFF
--- a/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.cpp
+++ b/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.cpp
@@ -115,12 +115,20 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
         {
             Logger::info(L"Show toolbar. Letter: %d, Trigger: %d", letterPressed, triggerPressed);
 
+            if (!((GetAsyncKeyState((int)letterPressed) & 0x8000) != 0))
+            {
+                triggerPressed = 0;
+                Logger::info(L"Reset trigger key");
+                return false;
+            }
+
             // Keep track if it was triggered with space so that it can be typed on false starts.
             m_triggeredWithSpace = triggerPressed == VK_SPACE;
             m_toolbarVisible = true;
 
             m_showToolbarCb(letterPressed);
         }
+
 
         if (m_toolbarVisible && triggerPressed)
         {

--- a/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.cpp
+++ b/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.cpp
@@ -129,7 +129,6 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
             m_showToolbarCb(letterPressed);
         }
 
-
         if (m_toolbarVisible && triggerPressed)
         {
             if (triggerPressed == VK_LEFT)

--- a/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.cpp
+++ b/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.cpp
@@ -115,7 +115,7 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
         {
             Logger::info(L"Show toolbar. Letter: %d, Trigger: %d", letterPressed, triggerPressed);
 
-            if (!((GetAsyncKeyState((int)letterPressed) & 0x8000) != 0))
+            if (((GetAsyncKeyState((int)letterPressed) & 0x8000) == 0))
             {
                 triggerPressed = 0;
                 Logger::info(L"Reset trigger key");

--- a/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.cpp
+++ b/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.cpp
@@ -101,8 +101,10 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
             if (std::find(std::begin(triggers), end(triggers), static_cast<TriggerKey>(info.vkCode)) != end(triggers))
             {
                 triggerPressed = info.vkCode;
+                const bool isLetterReleased = (GetAsyncKeyState((int)letterPressed) & 0x8000) == 0;
 
-                if ((triggerPressed == VK_SPACE && m_settings.activationKey == PowerAccentActivationKey::LeftRightArrow) ||
+                if (isLetterReleased ||
+                    (triggerPressed == VK_SPACE && m_settings.activationKey == PowerAccentActivationKey::LeftRightArrow) ||
                     ((triggerPressed == VK_LEFT || triggerPressed == VK_RIGHT) && m_settings.activationKey == PowerAccentActivationKey::Space))
                 {
                     triggerPressed = 0;
@@ -114,13 +116,6 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
         if (!m_toolbarVisible && letterPressed != LetterKey::None && triggerPressed)
         {
             Logger::info(L"Show toolbar. Letter: %d, Trigger: %d", letterPressed, triggerPressed);
-
-            if (((GetAsyncKeyState((int)letterPressed) & 0x8000) == 0))
-            {
-                triggerPressed = 0;
-                Logger::info(L"Reset trigger key");
-                return false;
-            }
 
             // Keep track if it was triggered with space so that it can be typed on false starts.
             m_triggeredWithSpace = triggerPressed == VK_SPACE;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
An issue as been up about QuickAccent is been open after locking and unlocking the session on Windows 11 https://github.com/microsoft/PowerToys/issues/21036

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
A check has been added if the key still stroke when trigger is called (like space bar for example).

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

