### PR TITLE
[QuickAccent] Shift + Space to navigate backwards

### DIFF
--- a/src/modules/poweraccent/PowerAccent.Core/PowerAccent.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/PowerAccent.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation
+// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -50,11 +50,11 @@ public class PowerAccent : IDisposable
             });
         }));
 
-        _keyboardListener.SetNextCharEvent(new PowerToys.PowerAccentKeyboardService.NextChar((TriggerKey triggerKey) =>
+        _keyboardListener.SetNextCharEvent(new PowerToys.PowerAccentKeyboardService.NextChar((TriggerKey triggerKey, bool shiftPressed) =>
         {
             System.Windows.Application.Current.Dispatcher.Invoke(() =>
             {
-                ProcessNextChar(triggerKey);
+                ProcessNextChar(triggerKey, shiftPressed);
             });
         }));
 
@@ -104,7 +104,7 @@ public class PowerAccent : IDisposable
         _visible = false;
     }
 
-    private void ProcessNextChar(TriggerKey triggerKey)
+    private void ProcessNextChar(TriggerKey triggerKey, bool shiftPressed)
     {
         if (_visible && _selectedIndex == -1)
         {
@@ -139,13 +139,27 @@ public class PowerAccent : IDisposable
 
         if (triggerKey == TriggerKey.Space)
         {
-            if (_selectedIndex < _characters.Length - 1)
+            if (shiftPressed)
             {
-                ++_selectedIndex;
+                if (_selectedIndex == 0)
+                {
+                    _selectedIndex = _characters.Length - 1;
+                }
+                else
+                {
+                    --_selectedIndex;
+                }
             }
             else
             {
-                _selectedIndex = 0;
+                if (_selectedIndex < _characters.Length - 1)
+                {
+                    ++_selectedIndex;
+                }
+                else
+                {
+                    _selectedIndex = 0;
+                }
             }
         }
 

--- a/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.cpp
+++ b/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.cpp
@@ -144,7 +144,8 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
     bool KeyboardListener::OnKeyDown(KBDLLHOOKSTRUCT info) noexcept
     {
         auto letterKey = static_cast<LetterKey>(info.vkCode);
-        if (!m_shiftPressed && (info.vkCode == VK_LSHIFT || info.vkCode == VK_RSHIFT))
+        // Shift key detected only if the toolbar is already visible to avoid conflicts with uppercase
+        if (!m_shiftPressed && m_toolbarVisible && (info.vkCode == VK_LSHIFT || info.vkCode == VK_RSHIFT))
         {
             m_shiftPressed = true;
         }

--- a/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.cpp
+++ b/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.cpp
@@ -192,17 +192,17 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
         {
             if (triggerPressed == VK_LEFT)
             {
-                Logger::info(L"Next toolbar position - left");
+                Logger::debug(L"Next toolbar position - left");
                 m_nextCharCb(TriggerKey::Left, m_leftShiftPressed || m_rightShiftPressed);
             }
             else if (triggerPressed == VK_RIGHT)
             {
-                Logger::info(L"Next toolbar position - right");
+                Logger::debug(L"Next toolbar position - right");
                 m_nextCharCb(TriggerKey::Right, m_leftShiftPressed || m_rightShiftPressed);
             }
             else if (triggerPressed == VK_SPACE)
             {
-                Logger::info(L"Next toolbar position - space");
+                Logger::debug(L"Next toolbar position - space");
                 m_nextCharCb(TriggerKey::Space, m_leftShiftPressed || m_rightShiftPressed);
             }
 
@@ -218,7 +218,8 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
         {
             m_leftShiftPressed = false;
         }
-        else if (m_rightShiftPressed && info.vkCode == VK_RSHIFT)
+
+        if (m_rightShiftPressed && info.vkCode == VK_RSHIFT)
         {
             m_rightShiftPressed = false;
         }

--- a/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.h
+++ b/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.h
@@ -52,10 +52,11 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
         PowerAccentSettings m_settings;
         std::function<void(LetterKey)> m_showToolbarCb;
         std::function<void(InputType)> m_hideToolbarCb;
-        std::function<void(TriggerKey)> m_nextCharCb;
+        std::function<void(TriggerKey, bool)> m_nextCharCb;
         std::function<bool(LetterKey)> m_isLanguageLetterCb;
         bool m_triggeredWithSpace;
         spdlog::stopwatch m_stopwatch;
+        bool m_shiftPressed;
 
         std::mutex m_mutex_excluded_apps;
         std::pair<HWND, bool> m_prevForegrndAppExcl{ NULL, false };

--- a/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.h
+++ b/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.h
@@ -56,7 +56,8 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
         std::function<bool(LetterKey)> m_isLanguageLetterCb;
         bool m_triggeredWithSpace;
         spdlog::stopwatch m_stopwatch;
-        bool m_shiftPressed;
+        bool m_leftShiftPressed;
+        bool m_rightShiftPressed;
 
         std::mutex m_mutex_excluded_apps;
         std::pair<HWND, bool> m_prevForegrndAppExcl{ NULL, false };

--- a/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.idl
+++ b/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.idl
@@ -60,7 +60,7 @@ namespace PowerToys
 
         [version(1.0), uuid(37197089-5438-4479-af57-30ab3f3c8be4)] delegate void ShowToolbar(LetterKey key);
         [version(1.0), uuid(8eb79d6b-1826-424f-9fbc-af21ae19725e)] delegate void HideToolbar(InputType inputType);
-        [version(1.0), uuid(db72d45c-a5a2-446f-bdc1-506e9121764a)] delegate void NextChar(TriggerKey inputSpace);
+        [version(1.0), uuid(db72d45c-a5a2-446f-bdc1-506e9121764a)] delegate void NextChar(TriggerKey inputSpace, boolean shiftPressed);
         [version(1.0), uuid(20be2919-2b91-4313-b6e0-4c3484fe91ef)] delegate void IsLanguageLetter(LetterKey key, [out] boolean* result);
 
         [default_interface] runtimeclass KeyboardListener {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Detect shift key to navigate characters backwards with activation key set to space.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #21548
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Set activation key to space (also test with left/right/space)
- Activate quick accent
- Validate that shift + space is navigating characters backwards (left/right shift)