### PR TITLE
Fix Settings backup and restore, reports "no backup found" when they …

### DIFF
--- a/src/settings-ui/Settings.UI.Library/SettingsBackupAndRestoreUtils.cs
+++ b/src/settings-ui/Settings.UI.Library/SettingsBackupAndRestoreUtils.cs
@@ -432,9 +432,14 @@ namespace Microsoft.PowerToys.Settings.UI.Library
                 var tempPath = Path.GetTempPath();
 
                 var fullBackupDir = Path.Combine(tempPath, "PowerToys_settings_" + latestFile.ToString(CultureInfo.InvariantCulture));
-                if (!Directory.Exists(fullBackupDir))
+
+                lock (backupSettingsInternalLock)
                 {
-                    ZipFile.ExtractToDirectory(settingsBackupFiles[latestFile], fullBackupDir);
+                    if (!Directory.Exists(fullBackupDir) || !File.Exists(Path.Combine(fullBackupDir, "manifest.json")))
+                    {
+                        TryDeleteDirectory(fullBackupDir);
+                        ZipFile.ExtractToDirectory(settingsBackupFiles[latestFile], fullBackupDir);
+                    }
                 }
 
                 ThreadPool.QueueUserWorkItem((x) =>


### PR DESCRIPTION
…do exist. #21869

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
If you delete all the files in the temp backup locations (e.g. "C:\Users\XXX\AppData\Local\Temp\PowerToys_settings_133123828902788367"), but leave the folder there, empty, you will get this error. 



<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [X] **Closes:** #21869
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed


