### PR TITLE
[Hosts] Workaround for context menu not opening

### DIFF
--- a/src/modules/Hosts/Hosts/Views/MainPage.xaml.cs
+++ b/src/modules/Hosts/Hosts/Views/MainPage.xaml.cs
@@ -100,6 +100,7 @@ namespace Hosts.Views
                 flyoutBase.ShowAt(owner, new FlyoutShowOptions
                 {
                     Position = e.GetPosition(owner),
+                    ShowMode = FlyoutShowMode.Transient, // https://github.com/microsoft/PowerToys/issues/21263
                 });
             }
         }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Workaround for context menu not opening after selecting an entry.
Repro here: https://github.com/microsoft/PowerToys/issues/21263#issuecomment-1279979507

Side-effect of the workaround is that `FlyoutShowMode.Transient` doesn't focus the opened flyout.
Already addressed the issue: https://github.com/microsoft/microsoft-ui-xaml/issues/7838
Let's keep the issue opened.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #21263
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments


<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Context menu is opening as expected
