### PR TITLE
[Analyzers][CPP] Turn on warning 4515

### DIFF
--- a/Cpp.Build.props
+++ b/Cpp.Build.props
@@ -42,7 +42,7 @@
     <ClCompile>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <WarningLevel>Level4</WarningLevel>
-      <DisableSpecificWarnings>26800;28251;4389;4456;4457;4701;6387;4458;4505;4515;4459;4702;6031;6248;26451;28182;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <DisableSpecificWarnings>26800;28251;4389;4456;4457;4701;6387;4458;4505;4459;4702;6031;6248;26451;28182;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <DisableAnalyzeExternal >true</DisableAnalyzeExternal>
       <ExternalWarningLevel>TurnOffAllWarnings</ExternalWarningLevel>
       <ConformanceMode>false</ConformanceMode>

--- a/src/modules/alwaysontop/AlwaysOnTopModuleInterface/pch.h
+++ b/src/modules/alwaysontop/AlwaysOnTopModuleInterface/pch.h
@@ -9,9 +9,3 @@
 #include <TraceLoggingActivity.h>
 #include <wil\common.h>
 #include <wil\result.h>
-
-
-namespace winrt
-{
-    using namespace ::winrt;
-}

--- a/src/modules/fancyzones/FancyZonesLib/pch.h
+++ b/src/modules/fancyzones/FancyZonesLib/pch.h
@@ -22,8 +22,3 @@
 #include <unordered_set>
 #include <ShObjIdl.h>
 #include <optional>
-
-namespace winrt
-{
-    using namespace ::winrt;
-}

--- a/src/modules/fancyzones/FancyZonesModuleInterface/pch.h
+++ b/src/modules/fancyzones/FancyZonesModuleInterface/pch.h
@@ -9,9 +9,3 @@
 #include <TraceLoggingActivity.h>
 #include <wil\common.h>
 #include <wil\result.h>
-
-
-namespace winrt
-{
-    using namespace ::winrt;
-}


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Turn on warning 4515
'namespace' : namespace uses itself

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Continues towards:** #940
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Turn on warning 4515- 'namespace' : namespace uses itself
removed all occurrences of recursive namespace use.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
CI
