### PR TITLE
[Runner]Fix concurrency crashes when accessing ipc

### DIFF
--- a/src/runner/settings_window.cpp
+++ b/src/runner/settings_window.cpp
@@ -28,6 +28,7 @@
 #define BUFSIZE 1024
 
 TwoWayPipeMessageIPC* current_settings_ipc = NULL;
+std::mutex ipc_mutex;
 std::atomic_bool g_isLaunchInProgress = false;
 
 json::JsonObject get_power_toys_settings()
@@ -165,11 +166,6 @@ void dispatch_received_json(const std::wstring& json_to_parse)
 
     for (const auto& base_element : j)
     {
-        if (!current_settings_ipc)
-        {
-            continue;
-        }
-
         const auto name = base_element.Key();
         const auto value = base_element.Value();
 
@@ -177,25 +173,41 @@ void dispatch_received_json(const std::wstring& json_to_parse)
         {
             apply_general_settings(value.GetObjectW());
             const std::wstring settings_string{ get_all_settings().Stringify().c_str() };
-            current_settings_ipc->send(settings_string);
+            {
+                std::unique_lock lock{ ipc_mutex };
+                if(current_settings_ipc)
+                    current_settings_ipc->send(settings_string);
+            }
         }
         else if (name == L"powertoys")
         {
             dispatch_json_config_to_modules(value.GetObjectW());
             const std::wstring settings_string{ get_all_settings().Stringify().c_str() };
-            current_settings_ipc->send(settings_string);
+            {
+                std::unique_lock lock{ ipc_mutex };
+                if(current_settings_ipc)
+                    current_settings_ipc->send(settings_string);
+            }
         }
         else if (name == L"refresh")
         {
             const std::wstring settings_string{ get_all_settings().Stringify().c_str() };
-            current_settings_ipc->send(settings_string);
+            {
+                std::unique_lock lock{ ipc_mutex };
+                if(current_settings_ipc)
+                    current_settings_ipc->send(settings_string);
+            }
         }
         else if (name == L"action")
         {
             auto result = dispatch_json_action_to_module(value.GetObjectW());
             if (result.has_value())
             {
-                current_settings_ipc->send(result.value());
+                {
+                    std::unique_lock lock{ ipc_mutex };
+                    if(current_settings_ipc)
+                        current_settings_ipc->send(result.value());
+                }
             }
         }
     }
@@ -414,8 +426,11 @@ void run_settings_window(bool show_oobe_window, bool show_scoobe_window, std::op
         goto LExit;
     }
 
-    current_settings_ipc = new TwoWayPipeMessageIPC(powertoys_pipe_name, settings_pipe_name, receive_json_send_to_main_thread);
-    current_settings_ipc->start(hToken);
+    {
+        std::unique_lock lock{ ipc_mutex };
+        current_settings_ipc = new TwoWayPipeMessageIPC(powertoys_pipe_name, settings_pipe_name, receive_json_send_to_main_thread);
+        current_settings_ipc->start(hToken);
+    }
     g_settings_process_id = process_info.dwProcessId;
 
     if (process_info.hProcess)
@@ -443,12 +458,14 @@ LExit:
     {
         CloseHandle(process_info.hThread);
     }
-
-    if (current_settings_ipc)
     {
-        current_settings_ipc->end();
-        delete current_settings_ipc;
-        current_settings_ipc = nullptr;
+        std::unique_lock lock{ ipc_mutex };
+        if (current_settings_ipc)
+        {
+            current_settings_ipc->end();
+            delete current_settings_ipc;
+            current_settings_ipc = nullptr;
+        }
     }
 
     if (hToken)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
When closing the settings window, we're deleting the IPC, but some other thread might still try to access it.
Add some synchronization to avoid it.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #22137
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

Add a mutex and some locks to make sure we're checking for the ipc existence, using it, or deleting it only in one thread at the same time.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Tried reproing the issue #22137, without success.
