### PR TITLE
[Awake]Don't exit from tray icon unless standalone

### DIFF
--- a/src/modules/awake/Awake/Core/TrayHelper.cs
+++ b/src/modules/awake/Awake/Core/TrayHelper.cs
@@ -82,23 +82,29 @@ namespace Awake.Core
             }
         }
 
-        internal static void SetTray(string text, AwakeSettings settings)
+        internal static void SetTray(string text, AwakeSettings settings, bool startedFromPowerToys)
         {
             SetTray(
                 text,
                 settings.Properties.KeepDisplayOn,
                 settings.Properties.Mode,
-                settings.Properties.TrayTimeShortcuts);
+                settings.Properties.TrayTimeShortcuts,
+                startedFromPowerToys);
         }
 
-        public static void SetTray(string text, bool keepDisplayOn, AwakeMode mode, Dictionary<string, int> trayTimeShortcuts)
+        public static void SetTray(string text, bool keepDisplayOn, AwakeMode mode, Dictionary<string, int> trayTimeShortcuts, bool startedFromPowerToys)
         {
             TrayMenu = new DestroyMenuSafeHandle(PInvoke.CreatePopupMenu());
 
             if (!TrayMenu.IsInvalid)
             {
-                PInvoke.InsertMenu(TrayMenu, 0, MENU_ITEM_FLAGS.MF_BYPOSITION | MENU_ITEM_FLAGS.MF_STRING, (uint)TrayCommands.TC_EXIT, "Exit");
-                PInvoke.InsertMenu(TrayMenu, 0, MENU_ITEM_FLAGS.MF_BYPOSITION | MENU_ITEM_FLAGS.MF_SEPARATOR, 0, string.Empty);
+                if (!startedFromPowerToys)
+                {
+                    // If Awake is started from PowerToys, the correct way to exit it is disabling it from Settings.
+                    PInvoke.InsertMenu(TrayMenu, 0, MENU_ITEM_FLAGS.MF_BYPOSITION | MENU_ITEM_FLAGS.MF_STRING, (uint)TrayCommands.TC_EXIT, "Exit");
+                    PInvoke.InsertMenu(TrayMenu, 0, MENU_ITEM_FLAGS.MF_BYPOSITION | MENU_ITEM_FLAGS.MF_SEPARATOR, 0, string.Empty);
+                }
+
                 PInvoke.InsertMenu(TrayMenu, 0, MENU_ITEM_FLAGS.MF_BYPOSITION | MENU_ITEM_FLAGS.MF_STRING | (keepDisplayOn ? MENU_ITEM_FLAGS.MF_CHECKED : MENU_ITEM_FLAGS.MF_UNCHECKED), (uint)TrayCommands.TC_DISPLAY_SETTING, "Keep screen on");
             }
 

--- a/src/modules/awake/Awake/Program.cs
+++ b/src/modules/awake/Awake/Program.cs
@@ -44,6 +44,8 @@ namespace Awake
         private static FileSystemWatcher? _watcher;
         private static SettingsUtils? _settingsUtils;
 
+        private static bool _startedFromPowerToys;
+
         public static Mutex LockMutex { get => _mutex; set => _mutex = value; }
 
         private static Logger? _log;
@@ -188,6 +190,10 @@ namespace Awake
                 _log.Info("No PID specified. Allocating console...");
                 APIHelper.AllocateConsole();
             }
+            else
+            {
+                _startedFromPowerToys = true;
+            }
 
             _log.Info($"The value for --use-pt-config is: {usePtConfig}");
             _log.Info($"The value for --display-on is: {displayOn}");
@@ -238,7 +244,7 @@ namespace Awake
                         .Select(e => e.EventArgs)
                         .Subscribe(HandleAwakeConfigChange);
 
-                    TrayHelper.SetTray(InternalConstants.FullAppName, new AwakeSettings());
+                    TrayHelper.SetTray(InternalConstants.FullAppName, new AwakeSettings(), _startedFromPowerToys);
 
                     // Initially the file might not be updated, so we need to start processing
                     // settings right away.
@@ -330,7 +336,7 @@ namespace Awake
                             }
                     }
 
-                    TrayHelper.SetTray(InternalConstants.FullAppName, settings);
+                    TrayHelper.SetTray(InternalConstants.FullAppName, settings, _startedFromPowerToys);
                 }
                 else
                 {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Remove the exit entry from Awake's tray icon when started from PowerToys. The way to exit Awake should be by disabling in Settings.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #22120
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Test awake and verify the Exit entry is no longer there.