### PR TITLE
Fail build when nugets aren't consolidated

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+    "version": 1,
+    "isRoot": true,
+    "tools": {
+        "dotnet-consolidate": {
+            "version": "2.0.0",
+            "commands": [
+                "dotnet-consolidate"
+            ]
+        }
+    }
+}

--- a/.pipelines/ci/templates/build-powertoys-steps.yml
+++ b/.pipelines/ci/templates/build-powertoys-steps.yml
@@ -8,6 +8,13 @@ steps:
   clean: true
 
 - task: PowerShell@2
+  displayName: Verifying Nuget packages for PowerToys.sln
+  inputs:
+    filePath: '$(build.sourcesdirectory)\.pipelines\verifyNugetPackages.ps1'
+    arguments: -solution '$(build.sourcesdirectory)\PowerToys.sln' -tempDir '$(agent.TempDirectory)'
+    pwsh: true
+
+- task: PowerShell@2
   displayName: Verify Arm64 configuration for PowerToys.sln
   inputs:
     filePath: '$(build.sourcesdirectory)\.pipelines\verifyArm64Configuration.ps1'

--- a/.pipelines/ci/templates/build-powertoys-steps.yml
+++ b/.pipelines/ci/templates/build-powertoys-steps.yml
@@ -11,7 +11,7 @@ steps:
   displayName: Verifying Nuget packages for PowerToys.sln
   inputs:
     filePath: '$(build.sourcesdirectory)\.pipelines\verifyNugetPackages.ps1'
-    arguments: -solution '$(build.sourcesdirectory)\PowerToys.sln' -tempDir '$(agent.TempDirectory)'
+    arguments: -solution '$(build.sourcesdirectory)\PowerToys.sln'
     pwsh: true
 
 - task: PowerShell@2

--- a/.pipelines/verifyNugetPackages.ps1
+++ b/.pipelines/verifyNugetPackages.ps1
@@ -1,0 +1,23 @@
+[CmdletBinding()]
+Param(
+    [Parameter(Mandatory=$True,Position=1)]
+    [string]$solution,
+
+    [Parameter(Mandatory=$True,Position=2)]
+    [string]$tempDir
+)
+
+Write-Host "Verifying Nuget packages for $solution"
+
+Set-Location $tempDir
+
+dotnet tool install dotnet-consolidate --tool-path $tempDir
+./dotnet-consolidate.exe -s $solution
+
+if (-not $?)
+{
+    Write-Host -ForegroundColor Red "Nuget packages needs to be consolidated"
+    exit 1
+}
+
+exit 0

--- a/.pipelines/verifyNugetPackages.ps1
+++ b/.pipelines/verifyNugetPackages.ps1
@@ -11,7 +11,7 @@ dotnet consolidate -s $solution
 
 if (-not $?)
 {
-    Write-Host -ForegroundColor Red "Nuget packages needs to be consolidated"
+    Write-Host -ForegroundColor Red "Nuget packages with the same name must all be the same version."
     exit 1
 }
 

--- a/.pipelines/verifyNugetPackages.ps1
+++ b/.pipelines/verifyNugetPackages.ps1
@@ -1,18 +1,13 @@
 [CmdletBinding()]
 Param(
     [Parameter(Mandatory=$True,Position=1)]
-    [string]$solution,
-
-    [Parameter(Mandatory=$True,Position=2)]
-    [string]$tempDir
+    [string]$solution
 )
 
 Write-Host "Verifying Nuget packages for $solution"
 
-Set-Location $tempDir
-
-dotnet tool install dotnet-consolidate --tool-path $tempDir
-./dotnet-consolidate.exe -s $solution
+dotnet tool restore
+dotnet consolidate -s $solution
 
 if (-not $?)
 {

--- a/src/modules/FileLocksmith/FileLocksmithUI/FileLocksmithUI.csproj
+++ b/src/modules/FileLocksmith/FileLocksmithUI/FileLocksmithUI.csproj
@@ -59,7 +59,7 @@
     <PackageReference Include="CommunityToolkit.WinUI.UI" Version="7.1.2" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.1.5" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.0.9" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22000.194" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.1" />
     <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
     <PackageReference Include="WinUIEx" Version="1.8.0" />
     <Manifest Include="$(ApplicationManifest)" />

--- a/src/modules/FileLocksmith/FileLocksmithUI/FileLocksmithUI.csproj
+++ b/src/modules/FileLocksmith/FileLocksmithUI/FileLocksmithUI.csproj
@@ -59,7 +59,7 @@
     <PackageReference Include="CommunityToolkit.WinUI.UI" Version="7.1.2" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.1.5" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.0.9" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.1" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22000.194" />
     <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
     <PackageReference Include="WinUIEx" Version="1.8.0" />
     <Manifest Include="$(ApplicationManifest)" />


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Validate consolidated Nuget packages in the build pipeline.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #22261
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

```
...
2022-11-23T19:28:44.2080069Z --------------------------------------------------------------------------------------
2022-11-23T19:29:00.9448407Z Tool 'dotnet-consolidate' (version '2.0.0') was restored. Available commands: dotnet-consolidate
2022-11-23T19:29:00.9449197Z 
2022-11-23T19:29:00.9449600Z Restore was successful.
2022-11-23T19:29:06.1290678Z Analyzing packages in C:\a\_work\1\s\PowerToys.sln
2022-11-23T19:29:06.1348482Z Found 1 non-consolidated packages
2022-11-23T19:29:06.1348905Z 
2022-11-23T19:29:06.1349276Z ----------------------------
2022-11-23T19:29:06.1349763Z Microsoft.Windows.SDK.BuildTools
2022-11-23T19:29:06.1350186Z ----------------------------
2022-11-23T19:29:06.1356405Z FileLocksmithUI - 10.0.22000.194
2022-11-23T19:29:06.1356987Z Hosts - 10.0.22621.1
2022-11-23T19:29:06.1357362Z MeasureToolUI - 10.0.22621.1
2022-11-23T19:29:06.1357781Z PowerRenameUI - 10.0.22621.1
2022-11-23T19:29:06.1358155Z PowerToys.MeasureToolCore - 10.0.22621.1
2022-11-23T19:29:06.1358504Z PowerToys.Settings - 10.0.22621.1
2022-11-23T19:29:06.1358696Z 
2022-11-23T19:29:06.1983520Z Nuget packages needs to be consolidated
2022-11-23T19:29:06.6029194Z ##[error]PowerShell exited with code '1'.
2022-11-23T19:29:06.6872997Z ##[section]Finishing: Verifying Nuget packages for PowerToys.sln
```

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

