### PR TITLE
[Analyzers][CPP] Turn on warning 4459

### DIFF
--- a/Cpp.Build.props
+++ b/Cpp.Build.props
@@ -42,7 +42,7 @@
     <ClCompile>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <WarningLevel>Level4</WarningLevel>
-      <DisableSpecificWarnings>26800;28251;6387;4458;4505;4459;4702;6031;6248;26451;28182;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <DisableSpecificWarnings>26800;28251;6387;4458;4505;4702;6031;6248;26451;28182;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <DisableAnalyzeExternal >true</DisableAnalyzeExternal>
       <ExternalWarningLevel>TurnOffAllWarnings</ExternalWarningLevel>
       <ConformanceMode>false</ConformanceMode>

--- a/src/modules/ShortcutGuide/ShortcutGuide/overlay_window.cpp
+++ b/src/modules/ShortcutGuide/ShortcutGuide/overlay_window.cpp
@@ -646,7 +646,7 @@ void D2DOverlayWindow::hide_thumbnail()
 
 void D2DOverlayWindow::render(ID2D1DeviceContext5* d2d_dc)
 {
-    if (!hidden && !instance->overlay_visible())
+    if (!hidden && !overlay_window_instance->overlay_visible())
     {
         hide();
         return;

--- a/src/modules/ShortcutGuide/ShortcutGuide/shortcut_guide.cpp
+++ b/src/modules/ShortcutGuide/ShortcutGuide/shortcut_guide.cpp
@@ -20,7 +20,7 @@
 #include <common/hooks/LowlevelKeyboardEvent.h>
 
 // TODO: refactor singleton
-OverlayWindow* instance = nullptr;
+OverlayWindow* overlay_window_instance = nullptr;
 
 namespace
 {
@@ -136,13 +136,13 @@ namespace
             if (event.lParam->vkCode == VK_ESCAPE)
             {
                 Logger::trace(L"ESC key was pressed");
-                instance->CloseWindow(HideWindowType::ESC_PRESSED);
+                overlay_window_instance->CloseWindow(HideWindowType::ESC_PRESSED);
             }
 
             if (wasWinPressed && !isKeyDown(event) && isWin(event.lParam->vkCode))
             {
                 Logger::trace(L"Win key was released");
-                instance->CloseWindow(HideWindowType::WIN_RELEASED);
+                overlay_window_instance->CloseWindow(HideWindowType::WIN_RELEASED);
             }
 
             if (isKeyDown(event) && isWin(event.lParam->vkCode))
@@ -153,7 +153,7 @@ namespace
             if (onlyWinPressed() && isKeyDown(event) && !isWin(event.lParam->vkCode))
             {
                 Logger::trace(L"Shortcut with win key was pressed");
-                instance->CloseWindow(HideWindowType::WIN_SHORTCUT_PRESSED);
+                overlay_window_instance->CloseWindow(HideWindowType::WIN_SHORTCUT_PRESSED);
             }
         }
 
@@ -180,8 +180,8 @@ namespace
 
 OverlayWindow::OverlayWindow(HWND activeWindow)
 {
-    instance = this;
-    this->activeWindow = activeWindow;
+    overlay_window_instance = this;
+    this -> activeWindow = activeWindow;
     app_name = GET_RESOURCE_STRING(IDS_SHORTCUT_GUIDE);
 
     Logger::info("Overlay Window is creating");
@@ -252,7 +252,7 @@ void OverlayWindow::CloseWindow(HideWindowType type, int mainThreadId)
 bool OverlayWindow::IsDisabled()
 {
     WCHAR exePath[MAX_PATH] = L"";
-    instance->get_exe_path(activeWindow, exePath);
+    overlay_window_instance->get_exe_path(activeWindow, exePath);
     if (wcslen(exePath) > 0)
     {
         return is_disabled_app(exePath);

--- a/src/modules/ShortcutGuide/ShortcutGuide/shortcut_guide.cpp
+++ b/src/modules/ShortcutGuide/ShortcutGuide/shortcut_guide.cpp
@@ -181,7 +181,7 @@ namespace
 OverlayWindow::OverlayWindow(HWND activeWindow)
 {
     overlay_window_instance = this;
-    this -> activeWindow = activeWindow;
+    this->activeWindow = activeWindow;
     app_name = GET_RESOURCE_STRING(IDS_SHORTCUT_GUIDE);
 
     Logger::info("Overlay Window is creating");

--- a/src/modules/ShortcutGuide/ShortcutGuide/shortcut_guide.h
+++ b/src/modules/ShortcutGuide/ShortcutGuide/shortcut_guide.h
@@ -9,7 +9,7 @@
 #include "Generated Files/resource.h"
 
 // We support only one instance of the overlay
-extern class OverlayWindow* instance;
+extern class OverlayWindow* overlay_window_instance;
 
 class TargetState;
 

--- a/src/modules/ShortcutGuide/ShortcutGuide/target_state.cpp
+++ b/src/modules/ShortcutGuide/ShortcutGuide/target_state.cpp
@@ -33,7 +33,7 @@ void TargetState::toggle_force_shown()
     if (state != ForceShown)
     {
         state = ForceShown;
-        instance->on_held();
+        overlay_window_instance->on_held();
     }
     else
     {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Turn on warning 4459
declaration of 'identifier' hides global declaration

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Continues towards:** #940
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Turn on warning 4459 - declaration of 'identifier' hides global declaration
Change the name of a global to avoid conflict with a winRT local variable.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
CI
