### PR TITLE
[QuickAccent]Upgrade Vanara.PInvoke dependencies to 3.4.11

### DIFF
--- a/src/modules/poweraccent/PowerAccent.Core/Models/Point.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/Models/Point.cs
@@ -24,7 +24,7 @@ public struct Point
         Y = y;
     }
 
-    public Point(System.Drawing.Point point)
+    public Point(Vanara.PInvoke.POINT point)
     {
         X = point.X;
         Y = point.Y;
@@ -34,7 +34,7 @@ public struct Point
 
     public double Y { get; init; }
 
-    public static implicit operator Point(System.Drawing.Point point) => new Point(point.X, point.Y);
+    public static implicit operator Point(Vanara.PInvoke.POINT point) => new Point(point.X, point.Y);
 
     public static Point operator /(Point point, double divider)
     {

--- a/src/modules/poweraccent/PowerAccent.Core/PowerAccent.Core.csproj
+++ b/src/modules/poweraccent/PowerAccent.Core/PowerAccent.Core.csproj
@@ -17,8 +17,8 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.0.0" />
-        <PackageReference Include="Vanara.PInvoke.User32" Version="3.3.15" />
-	<PackageReference Include="Vanara.PInvoke.Shell32" Version="3.3.15" />
+        <PackageReference Include="Vanara.PInvoke.User32" Version="3.4.11" />
+        <PackageReference Include="Vanara.PInvoke.Shell32" Version="3.4.11" />
 </ItemGroup>
 
     <ItemGroup>

--- a/src/modules/poweraccent/PowerAccent.Core/Tools/WindowsFunctions.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/Tools/WindowsFunctions.cs
@@ -44,12 +44,12 @@ internal static class WindowsFunctions
         User32.GUITHREADINFO guiInfo = new ();
         guiInfo.cbSize = (uint)Marshal.SizeOf(guiInfo);
         User32.GetGUIThreadInfo(0, ref guiInfo);
-        System.Drawing.Point caretPosition = new System.Drawing.Point(guiInfo.rcCaret.left, guiInfo.rcCaret.top);
+        POINT caretPosition = new POINT(guiInfo.rcCaret.left, guiInfo.rcCaret.top);
         User32.ClientToScreen(guiInfo.hwndCaret, ref caretPosition);
 
         if (caretPosition.X == 0)
         {
-            System.Drawing.Point testPoint;
+            POINT testPoint;
             User32.GetCaretPos(out testPoint);
             return testPoint;
         }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Upgrade the Vanara.PInvoke in QuickAccent's dependencies.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** chore
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Upgrades the Vanara.PInvoke dependencies to 3.4.11, for better .net 6 support and to avoid a System.Drawing.Common CVE.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Build the installer and everything still works as expected.
