### PR TITLE
[PTRun] Drag and drop files

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/ContextMenuLoader.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/ContextMenuLoader.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Plugin.Folder
                     {
                         try
                         {
-                            Clipboard.SetText(record.FullPath);
+                            Clipboard.SetText(record.Path);
                             return true;
                         }
                         catch (Exception e)
@@ -75,18 +75,18 @@ namespace Microsoft.Plugin.Folder
                         {
                             if (record.Type == ResultType.File)
                             {
-                                Helper.OpenInConsole(_fileSystem.Path.GetDirectoryName(record.FullPath));
+                                Helper.OpenInConsole(_fileSystem.Path.GetDirectoryName(record.Path));
                             }
                             else
                             {
-                                Helper.OpenInConsole(record.FullPath);
+                                Helper.OpenInConsole(record.Path);
                             }
 
                             return true;
                         }
                         catch (Exception e)
                         {
-                            Log.Exception($"Failed to open {record.FullPath} in console, {e.Message}", e, GetType());
+                            Log.Exception($"Failed to open {record.Path} in console, {e.Message}", e, GetType());
 
                             return false;
                         }
@@ -109,9 +109,9 @@ namespace Microsoft.Plugin.Folder
                 AcceleratorModifiers = ModifierKeys.Control | ModifierKeys.Shift,
                 Action = _ =>
                 {
-                    if (!Helper.OpenInShell("explorer.exe", $"/select,\"{record.FullPath}\""))
+                    if (!Helper.OpenInShell("explorer.exe", $"/select,\"{record.Path}\""))
                     {
-                        var message = $"{Properties.Resources.Microsoft_plugin_folder_file_open_failed} {record.FullPath}";
+                        var message = $"{Properties.Resources.Microsoft_plugin_folder_file_open_failed} {record.Path}";
                         _context.API.ShowMsg(message);
                         return false;
                     }

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/Result/CreateOpenCurrentFolderResult.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/Result/CreateOpenCurrentFolderResult.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Plugin.Folder.Sources.Result
                 IcoPath = Search,
                 Score = 500,
                 Action = c => _shellAction.ExecuteSanitized(Search, contextApi),
-                ContextData = new SearchResult { Type = ResultType.Folder, FullPath = Search },
+                ContextData = new SearchResult { Type = ResultType.Folder, Path = Search },
             };
         }
     }

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/Result/EnvironmentVariableResult.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/Result/EnvironmentVariableResult.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Plugin.Folder.Sources.Result
                 SubTitle = string.Format(CultureInfo.CurrentCulture, Properties.Resources.wox_plugin_folder_select_folder_result_subtitle, Path),
                 ToolTipData = new ToolTipData(Title, string.Format(CultureInfo.CurrentCulture, Properties.Resources.wox_plugin_folder_select_folder_result_subtitle, Path)),
                 QueryTextDisplay = Path,
-                ContextData = new SearchResult { Type = ResultType.Folder, FullPath = Path },
+                ContextData = new SearchResult { Type = ResultType.Folder, Path = Path },
                 Action = c => _shellAction.Execute(Path, contextApi),
             };
         }

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/Result/FileItemResult.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/Result/FileItemResult.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Plugin.Folder.Sources.Result
                 ToolTipData = new ToolTipData(Title, string.Format(CultureInfo.CurrentCulture, Properties.Resources.wox_plugin_folder_select_file_result_subtitle, FilePath)),
                 IcoPath = FilePath,
                 Action = c => ShellAction.Execute(FilePath, contextApi),
-                ContextData = new SearchResult { Type = ResultType.File, FullPath = FilePath },
+                ContextData = new SearchResult { Type = ResultType.File, Path = FilePath },
             };
             return result;
         }

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/Result/FolderItemResult.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/Result/FolderItemResult.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Plugin.Folder.Sources.Result
                 SubTitle = string.Format(CultureInfo.CurrentCulture, Properties.Resources.wox_plugin_folder_select_folder_result_subtitle, Subtitle),
                 ToolTipData = new ToolTipData(Title, string.Format(CultureInfo.CurrentCulture, Properties.Resources.wox_plugin_folder_select_folder_result_subtitle, Subtitle)),
                 QueryTextDisplay = Path,
-                ContextData = new SearchResult { Type = ResultType.Folder, FullPath = Path },
+                ContextData = new SearchResult { Type = ResultType.Folder, Path = Path },
                 Action = c => ShellAction.Execute(Path, contextApi),
             };
         }

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/UserFolderResult.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/UserFolderResult.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Plugin.Folder
                 // Using CurrentCulture since this is user facing
                 SubTitle = string.Format(CultureInfo.CurrentCulture, Properties.Resources.wox_plugin_folder_select_folder_result_subtitle, Subtitle),
                 QueryTextDisplay = Path,
-                ContextData = new SearchResult { Type = ResultType.Folder, FullPath = Path },
+                ContextData = new SearchResult { Type = ResultType.Folder, Path = Path },
                 Action = c => _shellAction.Execute(Path, contextApi),
             };
         }

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/SearchHelper/SearchResult.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/SearchHelper/SearchResult.cs
@@ -4,7 +4,9 @@
 
 namespace Microsoft.Plugin.Indexer.SearchHelper
 {
-    public class SearchResult
+    using Wox.Plugin.Interfaces;
+
+    public class SearchResult : IFileDropResult
     {
         // Contains the Path of the file or folder
         public string Path { get; set; }

--- a/src/modules/launcher/PowerLauncher/Helper/DragDataObject.cs
+++ b/src/modules/launcher/PowerLauncher/Helper/DragDataObject.cs
@@ -6,9 +6,10 @@ namespace PowerLauncher.Helper
 {
     using System;
     using System.Drawing;
-    using System.Drawing.Imaging;
     using System.Runtime.InteropServices;
     using System.Runtime.InteropServices.ComTypes;
+    using DrawingImaging = System.Drawing.Imaging;
+    using MediaImaging = System.Windows.Media.Imaging;
 
     // based on: https://stackoverflow.com/questions/61041282/showing-image-thumbnail-with-mouse-cursor-while-dragging/61148788#61148788
     public static class DragDataObject
@@ -78,17 +79,16 @@ namespace PowerLauncher.Helper
             // more methods available, but we don't need them
         }
 
-        // https://weblog.west-wind.com/posts/2020/Sep/16/Retrieving-Images-from-the-Clipboard-and-WPF-Image-Control-Woes
-        public static Bitmap BitmapSourceToBitmap(System.Windows.Media.Imaging.BitmapSource source)
+        // https://stackoverflow.com/a/2897325
+        public static Bitmap BitmapSourceToBitmap(MediaImaging.BitmapSource source)
         {
             if (source == null)
             {
                 return null;
             }
 
-            PixelFormat pixelFormat = PixelFormat.Format32bppArgb; // Bgr32 equiv default
-            Bitmap bitmap = new Bitmap(source.PixelWidth, source.PixelHeight, pixelFormat);
-            BitmapData bitmapData = bitmap.LockBits(new Rectangle(Point.Empty, bitmap.Size), ImageLockMode.WriteOnly, pixelFormat);
+            Bitmap bitmap = new Bitmap(source.PixelWidth, source.PixelHeight, DrawingImaging.PixelFormat.Format32bppArgb);
+            DrawingImaging.BitmapData bitmapData = bitmap.LockBits(new Rectangle(Point.Empty, bitmap.Size), DrawingImaging.ImageLockMode.WriteOnly, DrawingImaging.PixelFormat.Format32bppArgb);
 
             source.CopyPixels(System.Windows.Int32Rect.Empty, bitmapData.Scan0, bitmapData.Height * bitmapData.Stride, bitmapData.Stride);
             bitmap.UnlockBits(bitmapData);

--- a/src/modules/launcher/PowerLauncher/Helper/DragDataObject.cs
+++ b/src/modules/launcher/PowerLauncher/Helper/DragDataObject.cs
@@ -72,7 +72,7 @@ namespace PowerLauncher.Helper
         private interface IDragSourceHelper
         {
             [PreserveSig]
-            int InitializeFromBitmap(ref ShDragImage pshdi, IDataObject pDataObject);
+            int InitializeFromBitmap(ref ShDragImage pShDrawImage, IDataObject pDataObject);
 
             // more methods available, but we don't need them
         }

--- a/src/modules/launcher/PowerLauncher/Helper/DragDataObject.cs
+++ b/src/modules/launcher/PowerLauncher/Helper/DragDataObject.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace PowerLauncher.Helper
+{
+    using System;
+    using System.Drawing;
+    using System.Runtime.InteropServices;
+    using System.Runtime.InteropServices.ComTypes;
+
+    // based on: https://stackoverflow.com/questions/61041282/showing-image-thumbnail-with-mouse-cursor-while-dragging/61148788#61148788
+    public static class DragDataObject
+    {
+        private static readonly Guid DataObject = new Guid("b8c0bd9f-ed24-455c-83e6-d5390c4fe8c4");
+
+        public static IDataObject FromFile(string filePath)
+        {
+            Marshal.ThrowExceptionForHR(SHCreateItemFromParsingName(filePath, null, typeof(IShellItem).GUID, out IShellItem item));
+            Marshal.ThrowExceptionForHR(item.BindToHandler(null, DataObject, typeof(IDataObject).GUID, out object dataObject));
+            return (IDataObject)dataObject;
+        }
+
+        public static void SetDragImage(this IDataObject dataObject, IntPtr hBitmap, int width, int height)
+        {
+            if (dataObject == null)
+            {
+                throw new ArgumentNullException(nameof(dataObject));
+            }
+
+            IDragSourceHelper dragDropHelper = (IDragSourceHelper)new DragDropHelper();
+            ShDragImage dragImage = new ShDragImage
+            {
+                HBmpDragImage = hBitmap,
+                SizeDragImage = new Size(width, height),
+            };
+            Marshal.ThrowExceptionForHR(dragDropHelper.InitializeFromBitmap(ref dragImage, dataObject));
+        }
+
+        [DllImport("shell32", CharSet = CharSet.Unicode)]
+        private static extern int SHCreateItemFromParsingName(string path, IBindCtx pbc, [MarshalAs(UnmanagedType.LPStruct)] Guid riid, out IShellItem ppv);
+
+        [Guid("43826d1e-e718-42ee-bc55-a1e261c37bfe")]
+        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        private interface IShellItem
+        {
+            [PreserveSig]
+            int BindToHandler(IBindCtx pbc, [MarshalAs(UnmanagedType.LPStruct)] Guid bhid, [MarshalAs(UnmanagedType.LPStruct)] Guid riid, [MarshalAs(UnmanagedType.IUnknown)] out object ppv);
+
+            // more methods available, but we don't need them
+        }
+
+        [ComImport]
+        [Guid("4657278a-411b-11d2-839a-00c04fd918d0")] // CLSID_DragDropHelper
+        private class DragDropHelper
+        {
+        }
+
+        // https://docs.microsoft.com/en-us/windows/win32/api/shobjidl_core/ns-shobjidl_core-shdragimage
+        [StructLayout(LayoutKind.Sequential)]
+        private struct ShDragImage
+        {
+            public Size SizeDragImage;
+            public Point PtOffset;
+            public IntPtr HBmpDragImage;
+            public int CrColorKey;
+        }
+
+        // https://docs.microsoft.com/en-us/windows/win32/api/shobjidl_core/nn-shobjidl_core-idragsourcehelper
+        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        [Guid("DE5BF786-477A-11D2-839D-00C04FD918D0")]
+        private interface IDragSourceHelper
+        {
+            [PreserveSig]
+            int InitializeFromBitmap(ref ShDragImage pshdi, IDataObject pDataObject);
+
+            // more methods available, but we don't need them
+        }
+    }
+}

--- a/src/modules/launcher/PowerLauncher/Helper/DragDataObject.cs
+++ b/src/modules/launcher/PowerLauncher/Helper/DragDataObject.cs
@@ -6,6 +6,7 @@ namespace PowerLauncher.Helper
 {
     using System;
     using System.Drawing;
+    using System.Drawing.Imaging;
     using System.Runtime.InteropServices;
     using System.Runtime.InteropServices.ComTypes;
 
@@ -75,6 +76,24 @@ namespace PowerLauncher.Helper
             int InitializeFromBitmap(ref ShDragImage pShDrawImage, IDataObject pDataObject);
 
             // more methods available, but we don't need them
+        }
+
+        // https://weblog.west-wind.com/posts/2020/Sep/16/Retrieving-Images-from-the-Clipboard-and-WPF-Image-Control-Woes
+        public static Bitmap BitmapSourceToBitmap(System.Windows.Media.Imaging.BitmapSource source)
+        {
+            if (source == null)
+            {
+                return null;
+            }
+
+            PixelFormat pixelFormat = PixelFormat.Format32bppArgb; // Bgr32 equiv default
+            Bitmap bitmap = new Bitmap(source.PixelWidth, source.PixelHeight, pixelFormat);
+            BitmapData bitmapData = bitmap.LockBits(new Rectangle(Point.Empty, bitmap.Size), ImageLockMode.WriteOnly, pixelFormat);
+
+            source.CopyPixels(System.Windows.Int32Rect.Empty, bitmapData.Scan0, bitmapData.Height * bitmapData.Stride, bitmapData.Stride);
+            bitmap.UnlockBits(bitmapData);
+
+            return bitmap;
         }
     }
 }

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -13,6 +13,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Interop;
+using System.Windows.Media.Imaging;
 using Common.UI;
 using interop;
 using Microsoft.PowerLauncher.Telemetry;
@@ -309,7 +310,9 @@ namespace PowerLauncher
                     {
                         // DoDragDrop with file thumbnail as drag image
                         var dataObject = DragDataObject.FromFile(fileDropResult.Path);
-                        IntPtr hBitmap = Image.WindowsThumbnailProvider.GetHBitmap(Path.GetFullPath(fileDropResult.Path), Constant.ThumbnailSize, Constant.ThumbnailSize, Image.ThumbnailOptions.None);
+                        using var bitmap = DragDataObject.BitmapSourceToBitmap((BitmapSource)_mouseDownResultViewModel?.Image);
+                        IntPtr hBitmap = bitmap.GetHbitmap();
+
                         try
                         {
                             dataObject.SetDragImage(hBitmap, Constant.ThumbnailSize, Constant.ThumbnailSize);

--- a/src/modules/launcher/Wox.Infrastructure/Image/WindowsThumbnailProvider.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Image/WindowsThumbnailProvider.cs
@@ -92,7 +92,7 @@ namespace Wox.Infrastructure.Image
             }
         }
 
-        public static IntPtr GetHBitmap(string fileName, int width, int height, ThumbnailOptions options)
+        private static IntPtr GetHBitmap(string fileName, int width, int height, ThumbnailOptions options)
         {
             Guid shellItem2Guid = new Guid(IShellItem2Guid);
             int retCode = NativeMethods.SHCreateItemFromParsingName(fileName, IntPtr.Zero, ref shellItem2Guid, out IShellItem nativeShellItem);

--- a/src/modules/launcher/Wox.Infrastructure/Image/WindowsThumbnailProvider.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Image/WindowsThumbnailProvider.cs
@@ -92,7 +92,7 @@ namespace Wox.Infrastructure.Image
             }
         }
 
-        private static IntPtr GetHBitmap(string fileName, int width, int height, ThumbnailOptions options)
+        public static IntPtr GetHBitmap(string fileName, int width, int height, ThumbnailOptions options)
         {
             Guid shellItem2Guid = new Guid(IShellItem2Guid);
             int retCode = NativeMethods.SHCreateItemFromParsingName(fileName, IntPtr.Zero, ref shellItem2Guid, out IShellItem nativeShellItem);

--- a/src/modules/launcher/Wox.Plugin/Interfaces/IFileDropResult.cs
+++ b/src/modules/launcher/Wox.Plugin/Interfaces/IFileDropResult.cs
@@ -2,14 +2,13 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace Microsoft.Plugin.Folder
+namespace Wox.Plugin.Interfaces
 {
-    using Wox.Plugin.Interfaces;
-
-    public class SearchResult : IFileDropResult
+    /// <summary>
+    /// This interface is to indicate results that contain a file/folder that is available for drag & drop to other applications
+    /// </summary>
+    public interface IFileDropResult
     {
         public string Path { get; set; }
-
-        public ResultType Type { get; set; }
     }
 }

--- a/src/modules/launcher/Wox.Test/Plugins/FolderPluginTest.cs
+++ b/src/modules/launcher/Wox.Test/Plugins/FolderPluginTest.cs
@@ -20,7 +20,7 @@ namespace Wox.Test.Plugins
             var mock = new Mock<IPublicAPI>();
             var pluginInitContext = new PluginInitContext() { API = mock.Object };
             var contextMenuLoader = new ContextMenuLoader(pluginInitContext);
-            var searchResult = new SearchResult() { Type = ResultType.Folder, FullPath = "C:/DummyFolder" };
+            var searchResult = new SearchResult() { Type = ResultType.Folder, Path = "C:/DummyFolder" };
             var result = new Result() { ContextData = searchResult };
 
             // Act
@@ -39,7 +39,7 @@ namespace Wox.Test.Plugins
             var mock = new Mock<IPublicAPI>();
             var pluginInitContext = new PluginInitContext() { API = mock.Object };
             var contextMenuLoader = new ContextMenuLoader(pluginInitContext);
-            var searchResult = new SearchResult() { Type = ResultType.File, FullPath = "C:/DummyFile.cs" };
+            var searchResult = new SearchResult() { Type = ResultType.File, Path = "C:/DummyFile.cs" };
             var result = new Result() { ContextData = searchResult };
 
             // Act


### PR DESCRIPTION
## Summary of the Pull Request
Support drag&drop to other application for files in result list. 
![Recording 2022-12-01 at 20 03 27](https://user-images.githubusercontent.com/12428377/205138315-71d8f802-de20-4c6f-91d1-3b2c5e556b44.gif)

## PR Checklist

- [x] **Closes:** #4462
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Dev docs:** Added/updated

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
To implement this behaviour, I added the following things:
- detect dragging an item from the suggestions list
- check whether this item represents a file/folder (something path-related)
- perform a DragDrop with path as FileDrop
- make related plugins (that return files/folders) mark their results as draggable file/folder

### detect dragging an item from the suggestions list
extend _src/modules/launcher/PowerLauncher/MainWindow.xaml.cs_
Save mouse position on mouse down and check aggainst system drag distance
```cs
private void SuggestionsList_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
{
    _mouseDownPosition = e.GetPosition(null);
    _mouseDownResultViewModel = ((FrameworkElement)e.OriginalSource).DataContext as ResultViewModel;
}

private void SuggestionsList_MouseMove(object sender, MouseEventArgs e)
{
    if (e.LeftButton == MouseButtonState.Pressed && ...)
    {
        Vector dragDistance = _mouseDownPosition - e.GetPosition(null);
        if (Math.Abs(dragDistance.X) > SystemParameters.MinimumHorizontalDragDistance || Math.Abs(dragDistance.Y) > SystemParameters.MinimumVerticalDragDistance)
        {
            ...
       }
    }
}
```

### check whether this item represents a file/folder (something path-related)
Since all plugins that return files/folders put their data objects containing the path information into `Result.ContextData`, I decided to introduce an interface `IFileDropResult` to indicate that a result contains a file/folder to be draggable.
_src/modules/launcher/Wox.Plugin/Interfaces/IFileDropResult.cs_
```cs
public interface IFileDropResult
{
    public string Path { get; set; }
}
```
So we can check whether the result connected to the view model of the clicked result item implements this interface.

```cs
private void SuggestionsList_MouseMove(object sender, MouseEventArgs e)
{
    if (... && _mouseDownResultViewModel?.Result?.ContextData is IFileDropResult fileDropResult)
    {  ...  }
}
```

### perform a DragDrop with path as FileDrop

If so, the PTRun window will be hidden and the corresponding path of the dragged item will be made available for dragging as FileDrop:
```cs
_viewModel.Hide();
DataObject dataObject = new DataObject(DataFormats.FileDrop, new[] { fileDropResult.Path });
DragDrop.DoDragDrop(ListBox.SuggestionsList, dataObject, DragDropEffects.Copy);
```

### make related plugins (that return files/folders) mark their results as draggable file/folder

The search result types of the following plugins now implement `IFileDropResult`:
- **Folder**/SearchResult.cs
- **Indexer**/SearchHelper/SearchResult.cs
- ([**Everything**/SearchResult.cs](https://github.com/lin-ycv/EverythingPowerToys/blob/main/SearchHelper/SearchResult.cs))

For unification, I had to rename Folder/SearchResult's `FullPath` to `Path`.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

(See screen recording)

![Recording 2022-12-01 at 19 59 50](https://user-images.githubusercontent.com/12428377/205138356-6cafc2e6-1083-4f25-a209-b1372b081bc4.gif)

