### PR TITLE
[Quick Accent] fix showing selector window

### DIFF
--- a/src/modules/poweraccent/PowerAccent.Core/Tools/Calculation.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/Tools/Calculation.cs
@@ -20,7 +20,7 @@ namespace PowerAccent.Core.Tools
 
         public static Point GetRawCoordinatesFromPosition(Position position, Rect screen, Size window)
         {
-            int offset = 10;
+            int offset = 20;
 
             double pointX = position switch
             {

--- a/src/modules/poweraccent/PowerAccent.Core/Tools/Calculation.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/Tools/Calculation.cs
@@ -20,7 +20,7 @@ namespace PowerAccent.Core.Tools
 
         public static Point GetRawCoordinatesFromPosition(Position position, Rect screen, Size window)
         {
-            int offset = 20;
+            int offset = 24;
 
             double pointX = position switch
             {

--- a/src/modules/poweraccent/PowerAccent.UI/Selector.xaml
+++ b/src/modules/poweraccent/PowerAccent.UI/Selector.xaml
@@ -38,7 +38,7 @@
 
 
     </Window.Resources>
-    <Grid Margin="24,24,24,24">
+    <Grid>
         <Border
             HorizontalAlignment="Center"
             VerticalAlignment="Center"

--- a/src/modules/poweraccent/PowerAccent.UI/Selector.xaml.cs
+++ b/src/modules/poweraccent/PowerAccent.UI/Selector.xaml.cs
@@ -66,6 +66,7 @@ public partial class Selector : Window, IDisposable, INotifyPropertyChanged
         if (isActive)
         {
             characters.ItemsSource = chars;
+            this.UpdateLayout(); // Required for filling the actual width/height before positioning.
             SetWindowPosition();
             Show();
             Microsoft.PowerToys.Telemetry.PowerToysTelemetry.Log.WriteEvent(new PowerAccent.Core.Telemetry.PowerAccentShowAccentMenuEvent());

--- a/src/modules/poweraccent/PowerAccent.UI/Selector.xaml.cs
+++ b/src/modules/poweraccent/PowerAccent.UI/Selector.xaml.cs
@@ -63,13 +63,16 @@ public partial class Selector : Window, IDisposable, INotifyPropertyChanged
     {
         CharacterNameVisibility = _powerAccent.ShowUnicodeDescription ? Visibility.Visible : Visibility.Collapsed;
 
-        this.Visibility = isActive ? Visibility.Visible : Visibility.Collapsed;
-
         if (isActive)
         {
             characters.ItemsSource = chars;
-            CenterWindow();
+            SetWindowPosition();
+            Show();
             Microsoft.PowerToys.Telemetry.PowerToysTelemetry.Log.WriteEvent(new PowerAccent.Core.Telemetry.PowerAccentShowAccentMenuEvent());
+        }
+        else
+        {
+            Hide();
         }
     }
 
@@ -78,11 +81,10 @@ public partial class Selector : Window, IDisposable, INotifyPropertyChanged
         Application.Current.Shutdown();
     }
 
-    private void CenterWindow()
+    private void SetWindowPosition()
     {
-        UpdateLayout();
-        Size window = new (((System.Windows.Controls.Panel)Application.Current.MainWindow.Content).ActualWidth, ((System.Windows.Controls.Panel)Application.Current.MainWindow.Content).ActualHeight);
-        Point position = _powerAccent.GetDisplayCoordinates(window);
+        Size windowSize = new (((System.Windows.Controls.Panel)Application.Current.MainWindow.Content).ActualWidth, ((System.Windows.Controls.Panel)Application.Current.MainWindow.Content).ActualHeight);
+        Point position = _powerAccent.GetDisplayCoordinates(windowSize);
         this.Left = position.X;
         this.Top = position.Y;
     }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Fix the displaying selector window after the user login.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #20807
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
### Scenario #1
1. Log-in using userA
2. Run QuickAccent and insert some letter
3. Log-in using userB
4. Log-in using userA
5. Run QuickAccent and insert some letter

### Scenario #2
1. Log-in via RDP
2. Run QuickAccent and insert some letter
3. Close RDP connection, keep session alive
4. Connect again
5. Run QuickAccent and insert some letter

In both these scenarios 0.64 version shows a blank rectangle.
The latest version from the main (with improved UI) is not showing a window at all.
