### PR TITLE
[TextExtractor] fix error blanks in japanese OCR

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -618,6 +618,7 @@ HACCEL
 handlekeyboardhookevent
 handlerroutine
 hangeul
+Hankaku
 hanselman
 Hanzi
 Hardlines

--- a/src/modules/PowerOCR/PowerOCR/Helpers/ImageMethods.cs
+++ b/src/modules/PowerOCR/PowerOCR/Helpers/ImageMethods.cs
@@ -147,7 +147,7 @@ internal class ImageMethods
                 }
                 else
                 {
-                    // Kanji ,Hiragana, Katakana, Hankaku-Katakana do not need blank.(not only the symble in CJKUnifiedIdeographs).
+                    // Kanji ,Hiragana, Katakana, Hankaku-Katakana do not need blank.(not only the symbol in CJKUnifiedIdeographs).
                     // Maybe there are more symbols that don't require spaces like \u3001 \u3002.
                     var cjkRegex = new Regex(@"\p{IsCJKUnifiedIdeographs}|\p{IsHiragana}|\p{IsKatakana}|[\uFF61-\uFF9F]");
 

--- a/src/modules/PowerOCR/PowerOCR/Helpers/ImageMethods.cs
+++ b/src/modules/PowerOCR/PowerOCR/Helpers/ImageMethods.cs
@@ -147,7 +147,9 @@ internal class ImageMethods
                 }
                 else
                 {
-                    var cjkRegex = new Regex(@"\p{IsCJKUnifiedIdeographs}");
+                    // Kanji ,Hiragana, Katakana, Hankaku-Katakana do not need blank.(not only the symble in CJKUnifiedIdeographs).
+                    // Maybe there are more symbols that don't require spaces like \u3001 \u3002.
+                    var cjkRegex = new Regex(@"\p{IsCJKUnifiedIdeographs}|\p{IsHiragana}|\p{IsKatakana}|[\uFF61-\uFF9F]");
 
                     foreach (OcrLine ocrLine in ocrResult.Lines)
                     {

--- a/src/modules/PowerOCR/PowerOCR/Helpers/ImageMethods.cs
+++ b/src/modules/PowerOCR/PowerOCR/Helpers/ImageMethods.cs
@@ -147,8 +147,9 @@ internal class ImageMethods
                 }
                 else
                 {
-                    // Kanji ,Hiragana, Katakana, Hankaku-Katakana do not need blank.(not only the symbol in CJKUnifiedIdeographs).
+                    // Kanji, Hiragana, Katakana, Hankaku-Katakana do not need blank.(not only the symbol in CJKUnifiedIdeographs).
                     // Maybe there are more symbols that don't require spaces like \u3001 \u3002.
+                    // var cjkRegex = new Regex(@"\p{IsCJKUnifiedIdeographs}|\p{IsHiragana}|\p{IsKatakana}|[\uFF61-\uFF9F]|[\u3000-\u3003]");
                     var cjkRegex = new Regex(@"\p{IsCJKUnifiedIdeographs}|\p{IsHiragana}|\p{IsKatakana}|[\uFF61-\uFF9F]");
 
                     foreach (OcrLine ocrLine in ocrResult.Lines)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #22208 
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

#### This PR is to point out the problem of the pr #20926 and give a patch.
> The following submissions are relevant.

#20415 #20926
#### In pr #20926, the code add a blank in all symbol which is not in the CJK Unified Ideographs, but CJK Unified Ideographs just contains a small part symbols which do not need blank.

Like Kanji ,Hiragana, Katakana, Hankaku-Katakana, they all do not need blanks. Korean OCR engine behavior and rules are different from ZH and JP. So I just add JP and ZH. (combie pr #20926 and #20415)
#### And there may be more symbol that do not need blanks but is frequently-used like \U+3001 \U+3002.  Maybe it's better to be solved by the OCR engine? OR consider to Rewrite related modules?

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Japanese
> origin pic

![image](https://user-images.githubusercontent.com/59056753/205484660-fbf1e4ee-15d9-4708-8cd1-abe2f5ac869f.png)

> original error result

```
そ の 後 、 2 人 の 住 む 関東 は 本格的 に 梅雨入 り し 、 雨 の 日 の 午前 た け の さ さ や か
な 交流 が は し ま る 。 タ カ オ は 心 に 秘 め て い た 靴職人 に な る 夢 を 語 り 、 あ る 理由
か ら 味覚障害 を 患 う ユ キ ノ は タ カ オ の 作 る 弁当 の 料理 に 味 を 感 し る よ う に な
る 。 ユ キ ノ は 弁当 の お 礼 に と タ カ オ に 「 靴作 り の 本 」 を プ レ セ ン ト し 、 タ カ オ
は ユ キ ノ の た め に 靴 を 作 る こ と に 決 め 、 お そ る お そ る 彼女 の 足 を 採寸 す る 。
```

> results now (fixed)

```
その後 、 2 人の住む関東は本格的に梅雨入りし 、 雨の日の午前たけのささやか
な交流がはじまる 。 タカオは心に秘めていた靴職人になる夢を語り 、 ある理由
から味覚障害を患うユキノはタカオの作る弁当の料理に味を感しるようにな
る 。 ユキノは弁当のお礼にとタカオに 「 靴作りの本 」 をプレセントし 、 タカオ
はユキノのために靴を作ることに決め 、 おそるおそる彼女の足を採寸する 。
```

Chinese 
> origin pic

![image](https://user-images.githubusercontent.com/59056753/205484465-0e001268-0bd0-46b3-b383-4fdd46200e5b.png)
> ans

```
故事发生的地点是在每干年回归一次的彗星造访过一个月之前 ， 日本飞驊市的乡下小
町糸守町 。 在这里女高中生三叶每天都过着忧郁的生活 ， 而她烦恼的不光有担任町长的父
亲所举行的选举运动 ， 还有家传神社的古老习俗 。 在这个小小的町 ， 周围都只是些爱瞎操
心的老人 。 为此三叶对于大都市充满了憧憬 。
```

English
> origin pic

![image](https://user-images.githubusercontent.com/59056753/205484787-e2cdd886-519a-4b72-b081-a87bc585aa0c.png)
> ans

```
FoIIowing summer break, Takao returns tO school and spots Yukari, discovering that she is a literature teacher and
had been the target Of gossip and bullying. TO avoid further confrontation, Yukari opted tO avoid work and retreat tO
the park, hoping she would learn tO overcome her fears. However, she quits her jOb and leaves the school. That
afternoon, Takao meets Yukari at the park and greets her by reciting the 2 ， 5 14th poem from the ManIyöshü
Japanese poetry collection, the correct response tO her tanka, which he found in a classic Japanese literature
textbook. Aft e r getting soaked by a sudden thunderstorm, bOth head tO YukariIs apartment and spend the afternoon
together. When Takao confesses his love, Yukari is moved, but reminds him that she is a teacher and that she is
moving back tO her hometown on Shikoku. After Ta kao excuses himself, Yukari realizes her mistake and runs after
him. StiII upset, Ta kao angrily takes back what he had said and criticizes her fO r being SO secretive and never
opening up tO him. Yukari embraces him and the tWO cry while she explains that their time together in the park had
saved her.
```

### For Unicode 3000 ~ 303F IsCJKSymbolsandPunctuation. In Chinese and Japanese, they are no blanks, but if we want to include all symbols, it will be pretty difficult to judge (eg. https://github.com/TheJoeFin/Text-Grab/issues/191 is still not perfect, and have some mistakes). So just add the most important Hiragana, Katakana, Hankaku-Katakana.

### In ZH and JP, symbol like "、", "，", “。”, still have two blanks, because the regex pattern string don't include them.

> also OK
``` C#
var cjkRegex = new Regex(@"\p{IsCJKUnifiedIdeographs}|\p{IsHiragana}|\p{IsKatakana}|[\uFF61-\uFF9F]|[\u3000-\u3003]");
```
