### PR TITLE
Color picker fix settings page

### DIFF
--- a/src/settings-ui/Settings.UI.Library/ColorFormatModel.cs
+++ b/src/settings-ui/Settings.UI.Library/ColorFormatModel.cs
@@ -86,8 +86,11 @@ namespace Microsoft.PowerToys.Settings.UI.Library
 
             set
             {
-                _canMoveUp = value;
-                OnPropertyChanged(nameof(CanMoveUp));
+                if (value != _canMoveUp)
+                {
+                    _canMoveUp = value;
+                    OnPropertyChanged(nameof(CanMoveUp));
+                }
             }
         }
 
@@ -100,8 +103,11 @@ namespace Microsoft.PowerToys.Settings.UI.Library
 
             set
             {
-                _canMoveDown = value;
-                OnPropertyChanged(nameof(CanMoveDown));
+                if (value != _canMoveDown)
+                {
+                    _canMoveDown = value;
+                    OnPropertyChanged(nameof(CanMoveDown));
+                }
             }
         }
 

--- a/src/settings-ui/Settings.UI/ViewModels/ColorPickerViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/ColorPickerViewModel.cs
@@ -336,7 +336,9 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 ColorFormats[0].CanMoveUp = true;
             }
 
-            ColorFormats.Insert(0, new ColorFormatModel(newColorName, newColorFormat, isShown));
+            ColorFormatModel newModel = new ColorFormatModel(newColorName, newColorFormat, isShown);
+            newModel.PropertyChanged += ColorFormat_PropertyChanged;
+            ColorFormats.Insert(0, newModel);
             SetPreviewSelectedIndex();
         }
 

--- a/src/settings-ui/Settings.UI/Views/ColorPickerPage.xaml
+++ b/src/settings-ui/Settings.UI/Views/ColorPickerPage.xaml
@@ -189,7 +189,7 @@
                                                     <MenuFlyoutItem
                                                         x:Uid="MoveUp"
                                                         Click="ReorderButtonUp_Click"
-                                                        IsEnabled="{x:Bind CanMoveUp}">
+                                                        IsEnabled="{x:Bind CanMoveUp, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
                                                         <MenuFlyoutItem.Icon>
                                                             <FontIcon Glyph="&#xE74A;" />
                                                         </MenuFlyoutItem.Icon>
@@ -197,7 +197,7 @@
                                                     <MenuFlyoutItem
                                                         x:Uid="MoveDown"
                                                         Click="ReorderButtonDown_Click"
-                                                        IsEnabled="{x:Bind CanMoveDown}">
+                                                        IsEnabled="{x:Bind CanMoveDown, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
                                                         <MenuFlyoutItem.Icon>
                                                             <FontIcon Glyph="&#xE74B;" />
                                                         </MenuFlyoutItem.Icon>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
[ColorPicker] Fix problems: settings not sent to CP module for newly created color formats. The move up button is disabled for 2nd element of the color formats list after adding a new color format
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
The propert changed event was missing for the newly created color format objects. Fixed. 
The moveUp property change was not bound correctly. Fixed.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Tested locally
