### PR TITLE
SettingUtils fixing error reporting when reading settings in old format

### DIFF
--- a/src/settings-ui/Settings.UI.Library/SettingsUtils.cs
+++ b/src/settings-ui/Settings.UI.Library/SettingsUtils.cs
@@ -115,18 +115,20 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             // This is different from the case where we have trailing zeros following a valid json file, which we have handled by trimming the trailing zeros.
             catch (JsonException ex)
             {
-                Logger.LogError($"Exception encountered while loading {powertoy} settings.", ex);
+                Logger.LogInfo($"Settings file {fileName} for {powertoy} was unrecognized. Possibly containing an older version. Trying to read again.");
 
                 // try to deserialize to the old format, which is presented in T2
                 try
                 {
                     T2 oldSettings = GetSettings<T2>(powertoy, fileName);
                     T newSettings = (T)settingsUpgrader(oldSettings);
+                    Logger.LogInfo($"Settings file {fileName} for {powertoy} was read successfully in the old format.");
                     return newSettings;
                 }
                 catch (Exception)
                 {
                     // do nothing, the problem wasn't that the settings was stored in the previous format, continue with the default settings
+                    Logger.LogError($"Exception encountered while loading {powertoy} settings.", ex);
                 }
             }
             catch (FileNotFoundException)

--- a/src/settings-ui/Settings.UI.Library/SettingsUtils.cs
+++ b/src/settings-ui/Settings.UI.Library/SettingsUtils.cs
@@ -128,7 +128,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
                 catch (Exception)
                 {
                     // do nothing, the problem wasn't that the settings was stored in the previous format, continue with the default settings
-                    Logger.LogError($"Exception encountered while loading {powertoy} settings.", ex);
+                    Logger.LogError($"{powertoy} settings are corrupt or the format is not supported any longer. Using default settings instead.", ex);
                 }
             }
             catch (FileNotFoundException)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
SettingsUtils Fix exception logging when reading a settings file in the old format
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Caught exceptions should not be reported as errors if it happens in controlled way - as in this case. Fixed.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
tested locally
