### PR TITLE
ColorPicker fixing 'old' formats still represented in the old pre-defined format in color picker module

### DIFF
--- a/src/modules/colorPicker/ColorPickerUI/Helpers/ColorRepresentationHelper.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/ColorRepresentationHelper.cs
@@ -34,26 +34,16 @@ namespace ColorPicker.Helpers
         /// <param name="colorRepresentationType">The type of the representation</param>
         /// <returns>A <see cref="string"/> representation of a color</returns>
         internal static string GetStringRepresentation(Color color, string colorRepresentationType, string colorFormat)
-            => colorRepresentationType switch
+        {
+            if (string.IsNullOrEmpty(colorFormat))
             {
-                "CMYK" => ColorToCMYK(color),
-                "HEX" => ColorToHex(color),
-                "HSB" => ColorToHSB(color),
-                "HSI" => ColorToHSI(color),
-                "HSL" => ColorToHSL(color),
-                "HSV" => ColorToHSV(color),
-                "HWB" => ColorToHWB(color),
-                "NCol" => ColorToNCol(color),
-                "RGB" => ColorToRGB(color),
-                "CIELAB" => ColorToCIELAB(color),
-                "CIEXYZ" => ColorToCIEXYZ(color),
-                "VEC4" => ColorToFloat(color),
-                "Decimal" => ColorToDecimal(color),
-                "HEX Int" => ColorToHexInteger(color),
-
-                // Fall-back value, when "_userSettings.CopiedColorRepresentation.Value" is incorrect
-                _ => string.IsNullOrEmpty(colorFormat) ? ColorToHex(color) : ColorFormatHelper.GetStringRepresentation(color, colorFormat),
-            };
+                return ColorToHex(color);
+            }
+            else
+            {
+                return ColorFormatHelper.GetStringRepresentation(color, colorFormat);
+            }
+        }
 
         /// <summary>
         /// Return a <see cref="string"/> representation of a CMYK color

--- a/src/modules/colorPicker/UnitTest-ColorPickerUI/Helpers/ColorRepresentationHelperTest.cs
+++ b/src/modules/colorPicker/UnitTest-ColorPickerUI/Helpers/ColorRepresentationHelperTest.cs
@@ -4,6 +4,7 @@
 
 using System.Drawing;
 using ColorPicker.Helpers;
+using ManagedCommon;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.ColorPicker.UnitTests
@@ -29,7 +30,7 @@ namespace Microsoft.ColorPicker.UnitTests
 
         public void GetStringRepresentationTest(string type, string expected)
         {
-            var result = ColorRepresentationHelper.GetStringRepresentation(Color.Black, type, string.Empty);
+            var result = ColorRepresentationHelper.GetStringRepresentation(Color.Black, type, ColorFormatHelper.GetDefaultFormat(type));
             Assert.AreEqual(result, expected);
         }
     }


### PR DESCRIPTION

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
ColorPicker fixing 'old' formats still represented in the old pre-defined format in color picker module
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [X] **Closes:** #22534 
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
The color picker module contained fixed, hard coded color formats for the predefined formats. I simply forgot to remove them when converting them to customisable formats. Fixed with this changes. 
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Tested locally
