### PR TITLE
ColorPicker fix format name duplicates

### DIFF
--- a/src/settings-ui/Settings.UI/ViewModels/ColorPickerViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/ColorPickerViewModel.cs
@@ -400,7 +400,8 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             }
             else
             {
-                colorFormatModel.IsValid = ColorFormats.Count(x => x.Name.ToUpperInvariant().Equals(colorFormatModel.Name.ToUpperInvariant(), StringComparison.Ordinal)) < 2;
+                colorFormatModel.IsValid = ColorFormats.Count(x => x.Name.ToUpperInvariant().Equals(colorFormatModel.Name.ToUpperInvariant(), StringComparison.Ordinal))
+                    < (colorFormatModel.IsNew ? 1 : 2);
             }
         }
 

--- a/src/settings-ui/Settings.UI/ViewModels/ColorPickerViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/ColorPickerViewModel.cs
@@ -234,13 +234,20 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
         {
             foreach (var storedColorFormat in _colorPickerSettings.Properties.VisibleColorFormats)
             {
+                // skip entries with empty name or duplicated name, it should never occure
+                string storedName = storedColorFormat.Key;
+                if (storedName == string.Empty || ColorFormats.Count(x => x.Name.ToUpperInvariant().Equals(storedName.ToUpperInvariant(), StringComparison.Ordinal)) > 0)
+                {
+                    continue;
+                }
+
                 string format = storedColorFormat.Value.Value;
                 if (format == string.Empty)
                 {
-                    format = ColorFormatHelper.GetDefaultFormat(storedColorFormat.Key);
+                    format = ColorFormatHelper.GetDefaultFormat(storedName);
                 }
 
-                ColorFormatModel customColorFormat = new ColorFormatModel(storedColorFormat.Key, format, storedColorFormat.Value.Key);
+                ColorFormatModel customColorFormat = new ColorFormatModel(storedName, format, storedColorFormat.Value.Key);
                 customColorFormat.PropertyChanged += ColorFormat_PropertyChanged;
                 ColorFormats.Add(customColorFormat);
             }

--- a/src/settings-ui/Settings.UI/ViewModels/ColorPickerViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/ColorPickerViewModel.cs
@@ -234,7 +234,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
         {
             foreach (var storedColorFormat in _colorPickerSettings.Properties.VisibleColorFormats)
             {
-                // skip entries with empty name or duplicated name, it should never occure
+                // skip entries with empty name or duplicated name, it should never occur
                 string storedName = storedColorFormat.Key;
                 if (storedName == string.Empty || ColorFormats.Count(x => x.Name.ToUpperInvariant().Equals(storedName.ToUpperInvariant(), StringComparison.Ordinal)) > 0)
                 {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
ColorPicker Ensure that there cannot be 2 color formats with the same name
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #22551 
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Fixing code, ensuring that there cannot be 2 color formats with the same name. Name should be unique, as they must identify the color format. (It was working when modifying an existing color format, now it has been fixed for color format creation too)
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
tested locally
