### PR TITLE
[Settings][Awake]Show display option on indefinite

### DIFF
--- a/src/settings-ui/Settings.UI/ViewModels/AwakeViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/AwakeViewModel.cs
@@ -76,6 +76,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                     GeneralSettingsConfig.Enabled.Awake = value;
                     OnPropertyChanged(nameof(IsEnabled));
                     OnPropertyChanged(nameof(IsTimeConfigurationEnabled));
+                    OnPropertyChanged(nameof(IsScreenConfigurationPossibleEnabled));
 
                     OutGoingGeneralSettings outgoing = new OutGoingGeneralSettings(GeneralSettingsConfig);
                     SendConfigMSG(outgoing.ToString());
@@ -94,6 +95,11 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             get => _mode == AwakeMode.TIMED && _isEnabled;
         }
 
+        public bool IsScreenConfigurationPossibleEnabled
+        {
+            get => _mode != AwakeMode.PASSIVE && _isEnabled;
+        }
+
         public AwakeMode Mode
         {
             get => _mode;
@@ -104,6 +110,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                     _mode = value;
                     OnPropertyChanged(nameof(Mode));
                     OnPropertyChanged(nameof(IsTimeConfigurationEnabled));
+                    OnPropertyChanged(nameof(IsScreenConfigurationPossibleEnabled));
 
                     Settings.Properties.Mode = value;
                     NotifyPropertyChanged();

--- a/src/settings-ui/Settings.UI/Views/AwakePage.xaml
+++ b/src/settings-ui/Settings.UI/Views/AwakePage.xaml
@@ -83,7 +83,7 @@
                     <labs:SettingsCard
                         x:Uid="Awake_EnableDisplayKeepAwake"
                         HeaderIcon="{ui:FontIcon FontFamily={StaticResource SymbolThemeFontFamily}, Glyph=&#xE7FB;}"
-                        Visibility="{x:Bind ViewModel.IsTimeConfigurationEnabled, Mode=OneWay}">
+                        Visibility="{x:Bind ViewModel.IsScreenConfigurationPossibleEnabled, Mode=OneWay}">
                         <ToggleSwitch
                             x:Uid="ToggleSwitch"
                             IsOn="{x:Bind ViewModel.KeepDisplayOn, Mode=TwoWay}" />


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

The option to keep the screen on is only shown when keeping the computer awake for some time.
It should show on keeping the computer awake indefinitely.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #22592
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Create a new property to set the visibility of the keep the screen on correctly.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Ran awake and verified the option now appears when setting to "Indefinite".
![image](https://user-images.githubusercontent.com/26118718/206281747-b8a8f598-be16-457b-b55e-fec127bd9a34.png)
