### PR TITLE
Workaround for ShortcutControl accessibility problem

### DIFF
--- a/src/settings-ui/Settings.UI/Controls/ShortcutControl/ShortcutControl.xaml.cs
+++ b/src/settings-ui/Settings.UI/Controls/ShortcutControl/ShortcutControl.xaml.cs
@@ -102,6 +102,7 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
             shortcutDialog.PrimaryButtonClick += ShortcutDialog_PrimaryButtonClick;
             shortcutDialog.Opened += ShortcutDialog_Opened;
             shortcutDialog.Closing += ShortcutDialog_Closing;
+            AutomationProperties.SetName(EditButton, resourceLoader.GetString("Activation_Shortcut_Title"));
         }
 
         private void ShortcutControl_Unloaded(object sender, RoutedEventArgs e)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Workaround for ShortcutControl accessibility problem
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [X] **Closes:** #21551 
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
There is possibly a problem in UWP. Our ShortcutConrol works perfectly when placed inside a SettingsExpander and has the accessibility problem described in the issue 21551 (name not set) when placed inside a SettingsCard. This PR implements a workaround for the issue, sets the missing property in the constructor. 
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Tested locally
