### PR TITLE
[Peek] Unsupported File Previewer - Setting Window Size

### DIFF
--- a/src/modules/peek/Peek.FilePreviewer/FilePreview.xaml.cs
+++ b/src/modules/peek/Peek.FilePreviewer/FilePreview.xaml.cs
@@ -102,7 +102,8 @@ namespace Peek.FilePreviewer
             if (Previewer != null)
             {
                 var size = await Previewer.GetPreviewSizeAsync();
-                PreviewSizeChanged?.Invoke(this, new PreviewSizeChangedArgs(size));
+                SizeFormat windowSizeFormat = UnsupportedFilePreviewer != null ? SizeFormat.Percentage : SizeFormat.Pixels;
+                PreviewSizeChanged?.Invoke(this, new PreviewSizeChangedArgs(size, windowSizeFormat));
                 await Previewer.LoadPreviewAsync();
             }
         }

--- a/src/modules/peek/Peek.FilePreviewer/Models/PreviewSizeChangedArgs.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Models/PreviewSizeChangedArgs.cs
@@ -6,13 +6,22 @@ namespace Peek.FilePreviewer.Models
 {
     using Windows.Foundation;
 
+    public enum SizeFormat
+    {
+        Pixels,
+        Percentage,
+    }
+
     public class PreviewSizeChangedArgs
     {
-        public PreviewSizeChangedArgs(Size windowSizeRequested)
+        public PreviewSizeChangedArgs(Size windowSizeRequested, SizeFormat sizeFormat = SizeFormat.Pixels)
         {
             WindowSizeRequested = windowSizeRequested;
+            WindowSizeFormat = sizeFormat;
         }
 
         public Size WindowSizeRequested { get; init; }
+
+        public SizeFormat WindowSizeFormat { get; init; }
     }
 }

--- a/src/modules/peek/Peek.FilePreviewer/Peek.FilePreviewer.csproj
+++ b/src/modules/peek/Peek.FilePreviewer/Peek.FilePreviewer.csproj
@@ -22,6 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\settings-ui\Settings.UI.Library\Settings.UI.Library.csproj" />
     <ProjectReference Include="..\Peek.Common\Peek.Common.csproj" />
     <ProjectReference Include="..\WIC\WIC.csproj" />
   </ItemGroup>

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/UnsupportedFilePreviewer/UnsupportedFilePreviewer.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/UnsupportedFilePreviewer/UnsupportedFilePreviewer.cs
@@ -10,6 +10,7 @@ namespace Peek.FilePreviewer.Previewers
     using System.Threading;
     using System.Threading.Tasks;
     using CommunityToolkit.Mvvm.ComponentModel;
+    using Microsoft.PowerToys.Settings.UI.Library;
     using Microsoft.UI.Dispatching;
     using Microsoft.UI.Xaml.Controls;
     using Microsoft.UI.Xaml.Media.Imaging;
@@ -18,6 +19,7 @@ namespace Peek.FilePreviewer.Previewers
     using Peek.Common.Helpers;
     using Peek.FilePreviewer.Previewers.Helpers;
     using Windows.Foundation;
+
     using File = Peek.Common.Models.File;
 
     public partial class UnsupportedFilePreviewer : ObservableObject, IUnsupportedFilePreviewer, IDisposable
@@ -46,9 +48,23 @@ namespace Peek.FilePreviewer.Previewers
             FileName = file.FileName;
             DateModified = file.DateModified.ToString();
             Dispatcher = DispatcherQueue.GetForCurrentThread();
-
             PropertyChanged += OnPropertyChanged;
+
+            var settingsUtils = new SettingsUtils();
+            var settings = settingsUtils.GetSettingsOrDefault<PeekSettings>(PeekSettings.ModuleName);
+
+            if (settings != null)
+            {
+                UnsupportedFileWidthPercent = settings.Properties.UnsupportedFileWidthPercent / 100.0;
+                UnsupportedFileHeightPercent = settings.Properties.UnsupportedFileHeightPercent / 100.0;
+            }
         }
+
+        private double UnsupportedFileWidthPercent { get; set; }
+
+        private double UnsupportedFileHeightPercent { get; set; }
+
+        public bool IsPreviewLoaded => iconPreview != null;
 
         private File File { get; }
 
@@ -72,8 +88,7 @@ namespace Peek.FilePreviewer.Previewers
         {
             return Task.Run(() =>
             {
-                // TODO: This is the min size. Calculate a 20-25% of the screen.
-                return new Size(680, 500);
+                return new Size(UnsupportedFileWidthPercent, UnsupportedFileHeightPercent);
             });
         }
 

--- a/src/modules/peek/Peek.UI/MainWindow.xaml.cs
+++ b/src/modules/peek/Peek.UI/MainWindow.xaml.cs
@@ -101,7 +101,7 @@ namespace Peek.UI
                 maxContentSize = new Size(monitorSize.Width * requestedSize.Width, (monitorSize.Height - titleBarHeight) * requestedSize.Height);
                 minContentSize = new Size(MinWindowWidth, MinWindowHeight - titleBarHeight);
 
-                adjustedContentSize = monitorSize.Fit(maxContentSize, minContentSize);
+                adjustedContentSize = maxContentSize.Fit(maxContentSize, minContentSize);
             }
             else if (e.WindowSizeFormat == SizeFormat.Pixels)
             {

--- a/src/modules/peek/Peek.UI/MainWindow.xaml.cs
+++ b/src/modules/peek/Peek.UI/MainWindow.xaml.cs
@@ -4,6 +4,7 @@
 
 namespace Peek.UI
 {
+    using System.Diagnostics;
     using interop;
     using Microsoft.UI.Windowing;
     using Microsoft.UI.Xaml.Input;
@@ -11,8 +12,6 @@ namespace Peek.UI
     using Peek.UI.Extensions;
     using Peek.UI.Native;
     using Windows.Foundation;
-    using Windows.System;
-    using Windows.UI.Core;
     using WinUIEx;
 
     /// <summary>
@@ -86,15 +85,38 @@ namespace Peek.UI
         /// <param name="e">PreviewSizeChangedArgs</param>
         private void FilePreviewer_PreviewSizeChanged(object sender, PreviewSizeChangedArgs e)
         {
+            // TODO: Use design-defined rules for adjusted window size
             var requestedSize = e.WindowSizeRequested;
             var monitorSize = this.GetMonitorSize();
 
-            // TODO: Use design-defined rules for adjusted window size
             var titleBarHeight = TitleBarControl.ActualHeight;
-            var maxContentSize = new Size(monitorSize.Width * MaxWindowToMonitorRatio, (monitorSize.Height - titleBarHeight) * MaxWindowToMonitorRatio);
+
+            var maxContentSize = new Size(0, 0);
             var minContentSize = new Size(MinWindowWidth, MinWindowHeight - titleBarHeight);
 
-            var adjustedContentSize = requestedSize.Fit(maxContentSize, minContentSize);
+            var adjustedContentSize = new Size(0, 0);
+
+            if (e.WindowSizeFormat == SizeFormat.Percentage)
+            {
+                maxContentSize = new Size(monitorSize.Width * requestedSize.Width, (monitorSize.Height - titleBarHeight) * requestedSize.Height);
+                minContentSize = new Size(MinWindowWidth, MinWindowHeight - titleBarHeight);
+
+                adjustedContentSize = monitorSize.Fit(maxContentSize, minContentSize);
+            }
+            else if (e.WindowSizeFormat == SizeFormat.Pixels)
+            {
+                maxContentSize = new Size(monitorSize.Width * MaxWindowToMonitorRatio, (monitorSize.Height - titleBarHeight) * MaxWindowToMonitorRatio);
+                minContentSize = new Size(MinWindowWidth, MinWindowHeight - titleBarHeight);
+
+                adjustedContentSize = requestedSize.Fit(maxContentSize, minContentSize);
+            }
+            else
+            {
+                Debug.Assert(false, "Unknown SizeFormat set for resizing window.");
+                adjustedContentSize = minContentSize;
+
+                return;
+            }
 
             // TODO: Only re-center if window has not been resized by user (or use design-defined logic).
             // TODO: Investigate why portrait images do not perfectly fit edge-to-edge

--- a/src/settings-ui/Settings.UI.Library/PeekProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/PeekProperties.cs
@@ -10,12 +10,21 @@ namespace Microsoft.PowerToys.Settings.UI.Library
 {
     public class PeekProperties
     {
+        public const double DefaultUnsupportedFileWidthPercent = 40.0;
+        public const double DefaultUnsupportedFileHeightPercent = 40.0;
+
         public PeekProperties()
         {
             ActivationShortcut = new HotkeySettings(false, true, false, false, 0x20);
+            UnsupportedFileWidthPercent = DefaultUnsupportedFileWidthPercent;
+            UnsupportedFileHeightPercent = DefaultUnsupportedFileHeightPercent;
         }
 
         public HotkeySettings ActivationShortcut { get; set; }
+
+        public double UnsupportedFileWidthPercent { get; set; }
+
+        public double UnsupportedFileHeightPercent { get; set; }
 
         public override string ToString()
             => JsonSerializer.Serialize(this);

--- a/src/settings-ui/Settings.UI.Library/ViewModels/PeekViewModel.cs
+++ b/src/settings-ui/Settings.UI.Library/ViewModels/PeekViewModel.cs
@@ -79,6 +79,35 @@ namespace Microsoft.PowerToys.Settings.UI.Library.ViewModels
             }
         }
 
+        public double UnsupportedFileWidthPercent
+        {
+            get => _peekSettings.Properties.UnsupportedFileWidthPercent;
+            set
+            {
+                if (_peekSettings.Properties.UnsupportedFileWidthPercent != value)
+                {
+                    _peekSettings.Properties.UnsupportedFileWidthPercent = value;
+                    OnPropertyChanged(nameof(UnsupportedFileWidthPercent));
+                    NotifySettingsChanged();
+                }
+            }
+        }
+
+        public double UnsupportedFileHeightPercent
+        {
+            get => _peekSettings.Properties.UnsupportedFileHeightPercent;
+
+            set
+            {
+                if (_peekSettings.Properties.UnsupportedFileHeightPercent != value)
+                {
+                    _peekSettings.Properties.UnsupportedFileHeightPercent = value;
+                    OnPropertyChanged(nameof(UnsupportedFileHeightPercent));
+                    NotifySettingsChanged();
+                }
+            }
+        }
+
         private void NotifySettingsChanged()
         {
             // Using InvariantCulture as this is an IPC message

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -2426,6 +2426,14 @@ From there, simply click on one of the supported files in the File Explorer and 
     <value>Enable Peek</value>
     <comment>Peek is a product name, do not loc</comment>
   </data>
+  <data name="Peek_UnsupportedFileWindowWidth.Header" xml:space="preserve">
+    <value>Unsupported file window width (%)</value>
+    <comment>Setting for width percent for unsupported file window.</comment>
+  </data>
+  <data name="Peek_UnsupportedFileWindowHeight.Header" xml:space="preserve">
+    <value>Unsupported file window height (%)</value>
+    <comment>Setting for height percent for unsupported file window.</comment>
+  </data>
   <data name="FancyZones_DisableRoundCornersOnWindowSnap.Content" xml:space="preserve">
     <value>Disable round corners when window is snapped</value>
   </data>

--- a/src/settings-ui/Settings.UI/Views/PeekPage.xaml
+++ b/src/settings-ui/Settings.UI/Views/PeekPage.xaml
@@ -22,6 +22,24 @@
                     <controls:ShortcutControl MinWidth="{StaticResource SettingActionControlMinWidth}" HotkeySettings="{x:Bind Path=ViewModel.ActivationShortcut, Mode=TwoWay}" />
                 </labs:SettingsCard>
 
+                <!--  Temporary internal setting.  -->
+                <labs:SettingsCard x:Uid="Peek_UnsupportedFileWindowWidth">
+                    <Slider
+                        MinWidth="{StaticResource SettingActionControlMinWidth}"
+                        Maximum="100"
+                        Minimum="20"
+                        Value="{x:Bind Mode=TwoWay, Path=ViewModel.UnsupportedFileWidthPercent}" />
+                </labs:SettingsCard>
+
+                <!--  Temporary internal setting.  -->
+                <labs:SettingsCard x:Uid="Peek_UnsupportedFileWindowHeight">
+                    <Slider
+                        MinWidth="{StaticResource SettingActionControlMinWidth}"
+                        Maximum="100"
+                        Minimum="20"
+                        Value="{x:Bind Mode=TwoWay, Path=ViewModel.UnsupportedFileHeightPercent}" />
+                </labs:SettingsCard>
+
             </StackPanel>
         </controls:SettingsPageControl.ModuleContent>
     </controls:SettingsPageControl>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

- Defaulting unsupported file previewer window to 40%
- Added settings for unsupported file previewer window width and height (Percentage of monitor)
- Falls back to 680x500 if the custom percentage is too small.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

