### PR TITLE
[Analyzers][CPP] Turn on warning 26410

### DIFF
--- a/CppRuleSet.ruleset
+++ b/CppRuleSet.ruleset
@@ -20,7 +20,7 @@
     <Rule Id="C26407" Action="Error" />
     <Rule Id="C26408" Action="Info" />
     <Rule Id="C26409" Action="Info" />
-    <Rule Id="C26410" Action="Info" />
+    <Rule Id="C26410" Action="Error" />
     <Rule Id="C26411" Action="Error" />
     <Rule Id="C26414" Action="Info" />
     <Rule Id="C26415" Action="Info" />

--- a/src/modules/fancyzones/FancyZonesTests/UnitTests/Layout.Spec.cpp
+++ b/src/modules/fancyzones/FancyZonesTests/UnitTests/Layout.Spec.cpp
@@ -212,7 +212,7 @@ namespace FancyZonesUnitTests
             RECT{ .left = 0, .top = 0, .right = 1920, .bottom = 1080 }
         };
 
-        void checkZones(const std::unique_ptr<Layout>& layout, ZoneSetLayoutType type, size_t expectedCount, RECT rect)
+        void checkZones(const Layout* layout, ZoneSetLayoutType type, size_t expectedCount, RECT rect)
         {
             const auto& zones = layout->Zones();
             Assert::AreEqual(expectedCount, zones.size());
@@ -259,7 +259,7 @@ namespace FancyZonesUnitTests
                     auto layout = std::make_unique<Layout>(data);
                     auto result = layout->Init(rect, Mocks::Monitor());
                     Assert::IsTrue(result);
-                    checkZones(layout, static_cast<ZoneSetLayoutType>(type), zoneCount, rect);
+                    checkZones(layout.get(), static_cast<ZoneSetLayoutType>(type), zoneCount, rect);
                 }
             }
         }
@@ -294,7 +294,7 @@ namespace FancyZonesUnitTests
                     auto layout = std::make_unique<Layout>(data);
                     auto result = layout->Init(rect, Mocks::Monitor());
                     Assert::IsTrue(result);
-                    checkZones(layout, static_cast<ZoneSetLayoutType>(type), data.zoneCount, rect);
+                    checkZones(layout.get(), static_cast<ZoneSetLayoutType>(type), data.zoneCount, rect);
                 }
             }
         }
@@ -413,7 +413,7 @@ namespace FancyZonesUnitTests
                     auto layout = std::make_unique<Layout>(data);
                     auto result = layout->Init(rect, Mocks::Monitor());
                     Assert::IsTrue(result);
-                    checkZones(layout, static_cast<ZoneSetLayoutType>(type), zoneCount, rect);
+                    checkZones(layout.get(), static_cast<ZoneSetLayoutType>(type), zoneCount, rect);
                 }
             }
         }

--- a/src/modules/videoconference/VideoConferenceProxyFilter/DirectShowUtils.cpp
+++ b/src/modules/videoconference/VideoConferenceProxyFilter/DirectShowUtils.cpp
@@ -36,11 +36,6 @@ wil::com_ptr_nothrow<IMemAllocator> GetPinAllocator(wil::com_ptr_nothrow<IPin>& 
     return nullptr;
 }
 
-unique_media_type_ptr CopyMediaType(const unique_media_type_ptr& source)
-{
-    return CopyMediaType(source.get());
-}
-
 void MyFreeMediaType(AM_MEDIA_TYPE& mt)
 {
     if (mt.cbFormat != 0)
@@ -79,7 +74,7 @@ HRESULT MediaTypeEnumerator::Next(ULONG cObjects, AM_MEDIA_TYPE** outObjects, UL
     ULONG toFetch = cObjects;
     while (toFetch-- && _pos < _objects.size())
     {
-        auto copy = CopyMediaType(_objects[_pos++]);
+        auto copy = CopyMediaType(_objects[_pos++].get());
         outObjects[fetched++] = copy.release();
     }
 
@@ -109,7 +104,7 @@ HRESULT MediaTypeEnumerator::Clone(IEnumMediaTypes** ppEnum)
     cloned->_objects.resize(_objects.size());
     for (size_t i = 0; i < _objects.size(); ++i)
     {
-        cloned->_objects[i] = CopyMediaType(_objects[i]);
+        cloned->_objects[i] = CopyMediaType(_objects[i].get());
     }
 
     cloned->_pos = _pos;

--- a/src/modules/videoconference/VideoConferenceProxyFilter/DirectShowUtils.h
+++ b/src/modules/videoconference/VideoConferenceProxyFilter/DirectShowUtils.h
@@ -17,7 +17,6 @@ void MyDeleteMediaType(AM_MEDIA_TYPE* pmt);
 using unique_media_type_ptr =
     wistd::unique_ptr<AM_MEDIA_TYPE, wil::function_deleter<decltype(&MyDeleteMediaType), MyDeleteMediaType>>;
 
-unique_media_type_ptr CopyMediaType(const unique_media_type_ptr& source);
 unique_media_type_ptr CopyMediaType(const AM_MEDIA_TYPE* source);
 
 template<typename ObjectInterface, typename EnumeratorInterface>

--- a/src/modules/videoconference/VideoConferenceProxyFilter/VideoCaptureDevice.cpp
+++ b/src/modules/videoconference/VideoConferenceProxyFilter/VideoCaptureDevice.cpp
@@ -187,7 +187,7 @@ struct VideoCaptureReceiverPin : winrt::implements<VideoCaptureReceiverPin, IPin
             return VFW_E_NOT_CONNECTED;
         }
 
-        *pmt = *CopyMediaType(_inputCaptureMediaType).release();
+        *pmt = *CopyMediaType(_inputCaptureMediaType.get()).release();
         return S_OK;
     }
 
@@ -261,7 +261,7 @@ struct VideoCaptureReceiverPin : winrt::implements<VideoCaptureReceiverPin, IPin
         }
 
         auto enumerator = winrt::make_self<MediaTypeEnumerator>();
-        enumerator->_objects.emplace_back(CopyMediaType(_expectedMediaType));
+        enumerator->_objects.emplace_back(CopyMediaType(_expectedMediaType.get()));
         *ppEnum = enumerator.detach();
 
         return S_OK;

--- a/src/modules/videoconference/VideoConferenceProxyFilter/VideoCaptureProxyFilter.cpp
+++ b/src/modules/videoconference/VideoConferenceProxyFilter/VideoCaptureProxyFilter.cpp
@@ -128,7 +128,7 @@ HRESULT VideoCaptureProxyPin::ConnectionMediaType(AM_MEDIA_TYPE* pmt)
         return VFW_E_NOT_CONNECTED;
     }
 
-    *pmt = *CopyMediaType(_mediaFormat).release();
+    *pmt = *CopyMediaType(_mediaFormat.get()).release();
     return S_OK;
 }
 
@@ -196,7 +196,7 @@ HRESULT VideoCaptureProxyPin::EnumMediaTypes(IEnumMediaTypes** ppEnum)
     *ppEnum = nullptr;
 
     auto enumerator = winrt::make_self<MediaTypeEnumerator>();
-    enumerator->_objects.emplace_back(CopyMediaType(_mediaFormat));
+    enumerator->_objects.emplace_back(CopyMediaType(_mediaFormat.get()));
     *ppEnum = enumerator.detach();
 
     return S_OK;
@@ -251,7 +251,7 @@ HRESULT VideoCaptureProxyPin::GetFormat(AM_MEDIA_TYPE** ppmt)
         LOG("VideoCaptureProxyPin::GetFormat FAILED ppmt");
         return E_POINTER;
     }
-    *ppmt = CopyMediaType(_mediaFormat).release();
+    *ppmt = CopyMediaType(_mediaFormat.get()).release();
     return S_OK;
 }
 
@@ -299,7 +299,7 @@ HRESULT VideoCaptureProxyPin::GetStreamCaps(int iIndex, AM_MEDIA_TYPE** ppmt, BY
     caps.MinBitsPerSecond = vih->dwBitRate;
     caps.MaxBitsPerSecond = caps.MinBitsPerSecond;
 
-    *ppmt = CopyMediaType(_mediaFormat).release();
+    *ppmt = CopyMediaType(_mediaFormat.get()).release();
 
     const auto caps_begin = reinterpret_cast<const char*>(&caps);
     std::copy(caps_begin, caps_begin + sizeof(caps), pSCC);
@@ -765,7 +765,7 @@ HRESULT VideoCaptureProxyFilter::EnumPins(IEnumPins** ppEnum)
 
         auto& webcam = webcams[*selectedCamIdx];
         auto pin = winrt::make_self<VideoCaptureProxyPin>();
-        pin->_mediaFormat = CopyMediaType(webcam.bestFormat.mediaType);
+        pin->_mediaFormat = CopyMediaType(webcam.bestFormat.mediaType.get());
         pin->_owningFilter = this;
         _outPin.attach(pin.detach());
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Turn on warning 26410
The parameter 'parameter' is a reference to const unique pointer, use const T* or const T& instead (r.32)

This is part of the core guidelines code analyzer
https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#r32-take-a-unique_ptrwidget-parameter-to-express-that-a-function-assumes-ownership-of-a-widget

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Continues towards:** #940
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

