### PR TITLE
[Logs]Don't create a thread for each logger

### DIFF
--- a/src/common/logger/logger.cpp
+++ b/src/common/logger/logger.cpp
@@ -91,8 +91,8 @@ void Logger::init(std::string loggerName, std::wstring logFilePath, std::wstring
 
     logger->set_level(logLevel);
     logger->set_pattern("[%Y-%m-%d %H:%M:%S.%f] [p-%P] [t-%t] [%l] %v");
+    logger->flush_on(logLevel); // Auto flush on every log message.
     spdlog::register_logger(logger);
-    spdlog::flush_every(std::chrono::seconds(3));
     logger->info("{} logger is initialized", loggerName);
 }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Our use of spdlog is creating a thread for logging for each utility. This is spending 100K-200K CPU cycles each 3s for each PowerToys that uses logging, according to https://github.com/microsoft/PowerToys/issues/22286
Logging is sparse enough that we can just flush after each message instead of having so many threads spinning.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Partially solves:** #22286
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Built and verified with sysinternals Process Explorer that threads for each disabled modules are no longer being created for logging. Logging still occurs.
I see there are still some threads that can be started for FancyZones and VCM. Those will be investigated and fixed on another PR.
