### PR TITLE
[VCM]Only use File Watchers if modules is enabled

### DIFF
--- a/src/modules/videoconference/VideoConferenceModule/VideoConferenceModule.cpp
+++ b/src/modules/videoconference/VideoConferenceModule/VideoConferenceModule.cpp
@@ -311,11 +311,7 @@ void VideoConferenceModule::onMicrophoneConfigurationChanged()
     }
 }
 
-VideoConferenceModule::VideoConferenceModule() :
-    _generalSettingsWatcher{ PTSettingsHelper::get_powertoys_general_save_file_location(), [this] {
-                                toolbar.scheduleGeneralSettingsUpdate();
-                            } },
-    _moduleSettingsWatcher{ PTSettingsHelper::get_module_save_file_location(get_key()), [this] { toolbar.scheduleModuleSettingsUpdate(); } }
+VideoConferenceModule::VideoConferenceModule()
 {
     init_settings();
     _settingsUpdateChannel =
@@ -524,6 +520,15 @@ void VideoConferenceModule::enable()
 {
     if (!_enabled)
     {
+        _generalSettingsWatcher = std::make_unique<FileWatcher> (
+            PTSettingsHelper::get_powertoys_general_save_file_location(), [this] {
+            toolbar.scheduleGeneralSettingsUpdate();
+            });
+        _moduleSettingsWatcher = std::make_unique<FileWatcher> (
+            PTSettingsHelper::get_module_save_file_location(get_key()), [this] {
+                toolbar.scheduleModuleSettingsUpdate();
+            });
+
         toggleProxyCamRegistration(true);
         toolbar.setMicrophoneMute(getMicrophoneMuteState());
         toolbar.setCameraMute(getVirtualCameraMuteState());
@@ -572,6 +577,8 @@ void VideoConferenceModule::disable()
 {
     if (_enabled)
     {
+        _generalSettingsWatcher.reset();
+        _moduleSettingsWatcher.reset();
         toggleProxyCamRegistration(false);
         if (hook_handle)
         {

--- a/src/modules/videoconference/VideoConferenceModule/VideoConferenceModule.h
+++ b/src/modules/videoconference/VideoConferenceModule/VideoConferenceModule.h
@@ -88,8 +88,8 @@ private:
     std::optional<SerializedSharedMemory> _imageOverlayChannel;
     std::optional<SerializedSharedMemory> _settingsUpdateChannel;
 
-    FileWatcher _generalSettingsWatcher;
-    FileWatcher _moduleSettingsWatcher;
+    std::unique_ptr<FileWatcher> _generalSettingsWatcher;
+    std::unique_ptr<FileWatcher> _moduleSettingsWatcher;
 
     static VideoConferenceSettings settings;
     static Toolbar toolbar;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
VCM currently uses File watchers for the settings, whether the module is enabled or disabled. That results in a lot of wasted cycles, as seen in https://github.com/microsoft/PowerToys/issues/22286

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Partially solves:** #22286
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Verified with sysinternal's Process Explorer that the threads for the File Watcher are only running when VCM is enabled.