### PR TITLE
Run settings elevated when PT is running elevated

### DIFF
--- a/src/runner/settings_window.cpp
+++ b/src/runner/settings_window.cpp
@@ -383,22 +383,22 @@ void run_settings_window(bool show_oobe_window, bool show_scoobe_window, std::op
 
     BOOL process_created = false;
 
-    if (is_process_elevated())
-    {
-        // Commented out to fix #22659
-        // Running settings non-elevated and modules elevated when PowerToys is running elevated results
-        // in settings making changes in one file (non-elevated user dir) and modules are reading settings
-        // from different (elevated user) dir
+    // Commented out to fix #22659
+    // Running settings non-elevated and modules elevated when PowerToys is running elevated results
+    // in settings making changes in one file (non-elevated user dir) and modules are reading settings
+    // from different (elevated user) dir
+    //if (is_process_elevated())
+    //{
 
-        //auto res = RunNonElevatedFailsafe(executable_path, executable_args, get_module_folderpath());
-        //process_created = res.has_value();
-        //if (process_created)
-        //{
-        //    process_info.dwProcessId = res->processID;
-        //    process_info.hProcess = res->processHandle.release();
-        //    g_isLaunchInProgress = false;
-        //}
-    }
+    //    auto res = RunNonElevatedFailsafe(executable_path, executable_args, get_module_folderpath());
+    //    process_created = res.has_value();
+    //    if (process_created)
+    //    {
+    //        process_info.dwProcessId = res->processID;
+    //        process_info.hProcess = res->processHandle.release();
+    //        g_isLaunchInProgress = false;
+    //    }
+    //}
 
     if (FALSE == process_created)
     {

--- a/src/runner/settings_window.cpp
+++ b/src/runner/settings_window.cpp
@@ -385,14 +385,19 @@ void run_settings_window(bool show_oobe_window, bool show_scoobe_window, std::op
 
     if (is_process_elevated())
     {
-        auto res = RunNonElevatedFailsafe(executable_path, executable_args, get_module_folderpath());
-        process_created = res.has_value();
-        if (process_created)
-        {
-            process_info.dwProcessId = res->processID;
-            process_info.hProcess = res->processHandle.release();
-            g_isLaunchInProgress = false;
-        }
+        // Commented out to fix #22659
+        // Running settings non-elevated and modules elevated when PowerToys is running elevated results
+        // in settings making changes in one file (non-elevated user dir) and modules are reading settings
+        // from different (elevated user) dir
+
+        //auto res = RunNonElevatedFailsafe(executable_path, executable_args, get_module_folderpath());
+        //process_created = res.has_value();
+        //if (process_created)
+        //{
+        //    process_info.dwProcessId = res->processID;
+        //    process_info.hProcess = res->processHandle.release();
+        //    g_isLaunchInProgress = false;
+        //}
     }
 
     if (FALSE == process_created)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
        
Running settings non-elevated and modules elevated when PowerToys is running elevated results
in settings making changes in one file (non-elevated user dir) and modules are reading settings
from different (elevated user) dir

I'd rather leave this commented out than removed, as we might want to bring this back if we encounter different issues caused by this change.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #22659 #21977 #21887 #19084
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

