### PR TITLE
[MouseHighlighter]Fix crash on non initialized shapes

### DIFF
--- a/src/modules/MouseUtils/MouseHighlighter/MouseHighlighter.cpp
+++ b/src/modules/MouseUtils/MouseHighlighter/MouseHighlighter.cpp
@@ -204,6 +204,12 @@ void Highlighter::StartDrawingPointFading(MouseButton button)
 
 void Highlighter::ClearDrawing()
 {
+    if (nullptr == m_shape || nullptr == m_shape.Shapes())
+    {
+        // Guard against m_shape not being initialized.
+        return;
+    }
+
     m_shape.Shapes().Clear();
 }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
We're getting some hits in watson crashing in the ClearDrawing function.
I've been unable to replicate it, so added some null checks to see if hits improve.
