### PR TITLE
Added option to tab through results directly instead of context buttons

### DIFF
--- a/src/modules/launcher/PowerLauncher/SettingsReader.cs
+++ b/src/modules/launcher/PowerLauncher/SettingsReader.cs
@@ -150,6 +150,11 @@ namespace PowerLauncher
                         _settings.ClearInputOnLaunch = overloadSettings.Properties.ClearInputOnLaunch;
                     }
 
+                    if (_settings.TabSelectsContextButtons != overloadSettings.Properties.TabSelectsContextButtons)
+                    {
+                        _settings.TabSelectsContextButtons = overloadSettings.Properties.TabSelectsContextButtons;
+                    }
+
                     if (_settings.Theme != overloadSettings.Properties.Theme)
                     {
                         _settings.Theme = overloadSettings.Properties.Theme;

--- a/src/modules/launcher/PowerLauncher/ViewModel/ResultsViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/ResultsViewModel.cs
@@ -186,21 +186,45 @@ namespace PowerLauncher.ViewModel
 
         public void SelectNextTabItem()
         {
-            // Do nothing if there is no selected item or we've selected the next context button
-            if (!SelectedItem?.SelectNextContextButton() ?? true)
+            if (_settings.TabSelectsContextButtons)
             {
-                SelectNextResult();
+                // Do nothing if there is no selected item or we've selected the next context button
+                if (!SelectedItem?.SelectNextContextButton() ?? true)
+                {
+                    SelectNextResult();
+                }
+            }
+            else
+            {
+                // Do nothing if there is no selected item
+                if (SelectedItem != null)
+                {
+                    SelectNextResult();
+                }
             }
         }
 
         public void SelectPrevTabItem()
         {
-            // Do nothing if there is no selected item or we've selected the previous context button
-            if (!SelectedItem?.SelectPrevContextButton() ?? true)
+            if (_settings.TabSelectsContextButtons)
             {
-                // Tabbing backwards should highlight the last item of the previous row
-                SelectPrevResult();
-                SelectedItem?.SelectLastContextButton();
+                // Do nothing if there is no selected item or we've selected the previous context button
+                if (!SelectedItem?.SelectPrevContextButton() ?? true)
+                {
+                    // Tabbing backwards should highlight the last item of the previous row
+                    SelectPrevResult();
+                    SelectedItem?.SelectLastContextButton();
+                }
+            }
+            else
+            {
+                // Do nothing if there is no selected item
+                if (SelectedItem != null)
+                {
+                    // Tabbing backwards should highlight the last item of the previous row
+                    SelectPrevResult();
+                    SelectedItem?.SelectLastContextButton();
+                }
             }
         }
 

--- a/src/modules/launcher/Wox.Infrastructure/UserSettings/PowerToysRunSettings.cs
+++ b/src/modules/launcher/Wox.Infrastructure/UserSettings/PowerToysRunSettings.cs
@@ -315,6 +315,8 @@ namespace Wox.Infrastructure.UserSettings
 
         public bool ClearInputOnLaunch { get; set; }
 
+        public bool TabSelectsContextButtons { get; set; }
+
         public bool RememberLastLaunchLocation { get; set; }
 
         public bool IgnoreHotkeysOnFullscreen { get; set; }

--- a/src/settings-ui/Settings.UI.Library/PowerLauncherProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/PowerLauncherProperties.cs
@@ -42,6 +42,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         [JsonPropertyName("clear_input_on_launch")]
         public bool ClearInputOnLaunch { get; set; }
 
+        [JsonPropertyName("tab_selects_context_buttons")]
+        public bool TabSelectsContextButtons { get; set; }
+
         [JsonPropertyName("theme")]
         public Theme Theme { get; set; }
 
@@ -79,6 +82,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             SearchTypePreference = "application_name";
             IgnoreHotkeysInFullscreen = false;
             ClearInputOnLaunch = false;
+            TabSelectsContextButtons = true;
             MaximumNumberOfResults = 4;
             Theme = Theme.System;
             Position = StartupPosition.Cursor;

--- a/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/PowerLauncherViewModelTest.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/PowerLauncherViewModelTest.cs
@@ -71,6 +71,7 @@ namespace ViewModelTests
             // Verify that the old settings persisted
             Assert.AreEqual(originalGeneralSettings.Enabled.PowerLauncher, viewModel.EnablePowerLauncher);
             Assert.AreEqual(originalSettings.Properties.ClearInputOnLaunch, viewModel.ClearInputOnLaunch);
+            Assert.AreEqual(originalSettings.Properties.TabSelectsContextButtons, viewModel.TabSelectsContextButtons);
             Assert.AreEqual(originalSettings.Properties.CopyPathLocation.ToString(), viewModel.CopyPathLocation.ToString());
             Assert.AreEqual(originalSettings.Properties.IgnoreHotkeysInFullscreen, viewModel.IgnoreHotkeysInFullScreen);
             Assert.AreEqual(originalSettings.Properties.MaximumNumberOfResults, viewModel.MaximumNumberOfResults);

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -493,6 +493,12 @@
   <data name="PowerLauncher_ClearInputOnLaunch.Content" xml:space="preserve">
     <value>Clear the previous query on launch</value>
   </data>
+  <data name="PowerLauncher_TabSelectsContextButtons.Header" xml:space="preserve">
+    <value>Tab through context buttons</value>
+  </data>
+  <data name="PowerLauncher_TabSelectsContextButtons.Description" xml:space="preserve">
+    <value>Pressing tab will first select through the available context buttons of the current selection before moving onto the next result</value>
+  </data>
   <data name="PowerLauncher_SearchQueryResultsWithDelay.Header" xml:space="preserve">
     <value>Input Smoothing</value>
     <comment>This is about adding a delay to wait for more input before executing a search</comment>

--- a/src/settings-ui/Settings.UI/ViewModels/PowerLauncherViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/PowerLauncherViewModel.cs
@@ -533,6 +533,23 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             }
         }
 
+        public bool TabSelectsContextButtons
+        {
+            get
+            {
+                return settings.Properties.TabSelectsContextButtons;
+            }
+
+            set
+            {
+                if (settings.Properties.TabSelectsContextButtons != value)
+                {
+                    settings.Properties.TabSelectsContextButtons = value;
+                    UpdateSettings();
+                }
+            }
+        }
+
         private ObservableCollection<PowerLauncherPluginViewModel> _plugins;
 
         public ObservableCollection<PowerLauncherPluginViewModel> Plugins

--- a/src/settings-ui/Settings.UI/Views/PowerLauncherPage.xaml
+++ b/src/settings-ui/Settings.UI/Views/PowerLauncherPage.xaml
@@ -56,6 +56,11 @@
                                     x:Uid="PowerLauncher_IgnoreHotkeysInFullScreen"
                                     IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.IgnoreHotkeysInFullScreen}" />
                             </labs:SettingsCard>
+                            <labs:SettingsCard ContentAlignment="Left">
+                                <controls:CheckBoxWithDescriptionControl
+                                    x:Uid="PowerLauncher_TabSelectsContextButtons"
+                                    IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.TabSelectsContextButtons}" />
+                            </labs:SettingsCard>
                         </labs:SettingsExpander.Items>
                     </labs:SettingsExpander>
                 </controls:SettingsGroup>

--- a/src/settings-ui/Settings.UI/Views/PowerLauncherPage.xaml
+++ b/src/settings-ui/Settings.UI/Views/PowerLauncherPage.xaml
@@ -56,11 +56,6 @@
                                     x:Uid="PowerLauncher_IgnoreHotkeysInFullScreen"
                                     IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.IgnoreHotkeysInFullScreen}" />
                             </labs:SettingsCard>
-                            <labs:SettingsCard ContentAlignment="Left">
-                                <controls:CheckBoxWithDescriptionControl
-                                    x:Uid="PowerLauncher_TabSelectsContextButtons"
-                                    IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.TabSelectsContextButtons}" />
-                            </labs:SettingsCard>
                         </labs:SettingsExpander.Items>
                     </labs:SettingsExpander>
                 </controls:SettingsGroup>
@@ -181,6 +176,15 @@
                             </labs:SettingsCard>
                         </labs:SettingsExpander.Items>
                     </labs:SettingsExpander>
+
+                    <labs:SettingsCard
+                        x:Uid="PowerLauncher_TabSelectsContextButtons"
+                        HeaderIcon="{ui:FontIcon FontFamily={StaticResource SymbolThemeFontFamily}, Glyph=&#xE7FD;}">
+                        <ToggleSwitch
+                            x:Uid="ToggleSwitch"
+                            IsOn="{x:Bind ViewModel.TabSelectsContextButtons, Mode=TwoWay}" />
+                    </labs:SettingsCard>
+
                 </controls:SettingsGroup>
 
                 <!--<ComboBox x:Uid="PowerLauncher_SearchResultPreference"


### PR DESCRIPTION
With reference to #22964

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #22964
- [ ] **Communication:** Have not discussed this, please let me know your thoughts
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
I wanted to add an option to tab through available results similar to tab completion in a shell, rather than having to tab through each context item, or having to move my left hand to the arrow keys.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
For the added setting, added the corrosponding test for settings.json backward compatibility, and the app directly, seems to function correctly.

