### PR TITLE
[Peek] Fix opening Peek when FE window is set to full name path

### DIFF
--- a/src/modules/peek/Peek.UI/Helpers/FileExplorerHelper.cs
+++ b/src/modules/peek/Peek.UI/Helpers/FileExplorerHelper.cs
@@ -2,8 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Runtime.InteropServices;
+using System.IO;
 using System.Text;
 using Peek.UI.Native;
 using Windows.Win32;
@@ -39,6 +38,8 @@ namespace Peek.UI.Helpers
             NativeMethods.GetWindowText(new HWND(foregroundWindowHandle), foregroundWindowTitleBuffer, foregroundWindowTitleBuffer.Capacity);
 
             string foregroundWindowTitle = foregroundWindowTitleBuffer.ToString();
+            var directoryInfo = new DirectoryInfo(foregroundWindowTitle);
+            string windowFolderName = directoryInfo.Name;
 
             var shell = new Shell32.Shell();
             foreach (SHDocVw.InternetExplorer window in shell.Windows())
@@ -46,7 +47,7 @@ namespace Peek.UI.Helpers
                 var shellFolderView = (Shell32.IShellFolderViewDual2)window.Document;
                 var folderTitle = shellFolderView.Folder.Title;
 
-                if (window.HWND == (int)foregroundWindowHandle && folderTitle == foregroundWindowTitle)
+                if (window.HWND == (int)foregroundWindowHandle && folderTitle == windowFolderName)
                 {
                     return shellFolderView;
                 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

