### PR TITLE
[TextExtractor]Properly initialize PreferredLanguage

### DIFF
--- a/src/settings-ui/Settings.UI.Library/PowerOcrProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/PowerOcrProperties.cs
@@ -11,6 +11,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         public PowerOcrProperties()
         {
             ActivationShortcut = new HotkeySettings(true, false, false, true, 0x54); // Win+Shift+T
+            PreferredLanguage = string.Empty;
         }
 
         public HotkeySettings ActivationShortcut { get; set; }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Properly initialize the PreferredLanguage property for Text Extractor, so that it's not a null value. Having a null value as a default value caused an error while reading settings, making it go into a retry loop.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
After deleting local settings, and restarting PowerToys, verified that there was no longer a delay activating Text Extractor.