### PR TITLE
[Analyzers][CPP] Turn on warning 26471

### DIFF
--- a/CppRuleSet.ruleset
+++ b/CppRuleSet.ruleset
@@ -64,7 +64,7 @@
     <Rule Id="C26464" Action="Error" />
     <Rule Id="C26465" Action="Hidden" />
     <Rule Id="C26466" Action="Error" />
-    <Rule Id="C26471" Action="Hidden" />
+    <Rule Id="C26471" Action="Error" />
     <Rule Id="C26472" Action="Hidden" />
     <Rule Id="C26473" Action="Hidden" />
     <Rule Id="C26474" Action="Hidden" />

--- a/src/ActionRunner/actionRunner.cpp
+++ b/src/ActionRunner/actionRunner.cpp
@@ -79,7 +79,7 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int)
             hMapFile = OpenFileMappingW(FILE_MAP_WRITE, FALSE, pidFile.data());
             if (hMapFile)
             {
-                pidBuffer = reinterpret_cast<PDWORD>(MapViewOfFile(hMapFile, FILE_MAP_ALL_ACCESS, 0, 0, sizeof(DWORD)));
+                pidBuffer = static_cast<PDWORD>(MapViewOfFile(hMapFile, FILE_MAP_ALL_ACCESS, 0, 0, sizeof(DWORD)));
                 if (pidBuffer)
                 {
                     *pidBuffer = 0;

--- a/src/common/utils/exec.h
+++ b/src/common/utils/exec.h
@@ -2,7 +2,12 @@
 
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
+
+// disable warning 26471 - Don't use reinterpret_cast. A cast from void* can use static_cast
+#pragma warning(push)
+#pragma warning(disable: 26471)
 #include <wil/resource.h>
+#pragma warning(pop)
 
 #include <optional>
 #include <string>

--- a/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.h
+++ b/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.h
@@ -24,7 +24,7 @@ protected:
         if (!thisRef && (message == WM_CREATE))
         {
             const auto createStruct = reinterpret_cast<LPCREATESTRUCT>(lparam);
-            thisRef = reinterpret_cast<AlwaysOnTop*>(createStruct->lpCreateParams);
+            thisRef = static_cast<AlwaysOnTop*>(createStruct->lpCreateParams);
             SetWindowLongPtr(window, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(thisRef));
         }
 

--- a/src/modules/alwaysontop/AlwaysOnTop/WindowBorder.h
+++ b/src/modules/alwaysontop/AlwaysOnTop/WindowBorder.h
@@ -23,7 +23,7 @@ protected:
         if ((thisRef == nullptr) && (message == WM_CREATE))
         {
             auto createStruct = reinterpret_cast<LPCREATESTRUCT>(lparam);
-            thisRef = reinterpret_cast<WindowBorder*>(createStruct->lpCreateParams);
+            thisRef = static_cast<WindowBorder*>(createStruct->lpCreateParams);
             SetWindowLongPtr(window, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(thisRef));
         }
 

--- a/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
@@ -748,7 +748,7 @@ LRESULT CALLBACK FancyZones::s_WndProc(HWND window, UINT message, WPARAM wparam,
     if (!thisRef && (message == WM_CREATE))
     {
         const auto createStruct = reinterpret_cast<LPCREATESTRUCT>(lparam);
-        thisRef = reinterpret_cast<FancyZones*>(createStruct->lpCreateParams);
+        thisRef = static_cast<FancyZones*>(createStruct->lpCreateParams);
         SetWindowLongPtr(window, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(thisRef));
     }
 

--- a/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
@@ -680,7 +680,7 @@ LRESULT CALLBACK WorkArea::s_WndProc(HWND window, UINT message, WPARAM wparam, L
     if ((thisRef == nullptr) && (message == WM_CREATE))
     {
         auto createStruct = reinterpret_cast<LPCREATESTRUCT>(lparam);
-        thisRef = reinterpret_cast<WorkArea*>(createStruct->lpCreateParams);
+        thisRef = static_cast<WorkArea*>(createStruct->lpCreateParams);
         SetWindowLongPtr(window, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(thisRef));
     }
 

--- a/src/modules/fancyzones/FancyZonesTests/UnitTests/Util.cpp
+++ b/src/modules/fancyzones/FancyZonesTests/UnitTests/Util.cpp
@@ -79,7 +79,7 @@ BOOL RegisterDLLWindowClass(LPCWSTR szClassName, Mocks::HwndCreator* creator)
 DWORD WINAPI ThreadProc(LPVOID lpParam)
 {
     MSG messages;
-    Mocks::HwndCreator* creator = reinterpret_cast<Mocks::HwndCreator*>(lpParam);
+    Mocks::HwndCreator* creator = static_cast<Mocks::HwndCreator*>(lpParam);
     if (!creator)
         return static_cast<DWORD>(-1);
 

--- a/src/modules/powerrename/lib/PowerRenameManager.cpp
+++ b/src/modules/powerrename/lib/PowerRenameManager.cpp
@@ -727,7 +727,7 @@ DWORD WINAPI CPowerRenameManager::s_fileOpWorkerThread(_In_ void* pv)
 {
     if (SUCCEEDED(CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE)))
     {
-        WorkerThreadData* pwtd = reinterpret_cast<WorkerThreadData*>(pv);
+        WorkerThreadData* pwtd = static_cast<WorkerThreadData*>(pv);
         if (pwtd)
         {
             bool closeUIWindowAfterRenaming = true;
@@ -914,7 +914,7 @@ DWORD WINAPI CPowerRenameManager::s_regexWorkerThread(_In_ void* pv)
     try
     {
         winrt::check_hresult(CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE));
-        WorkerThreadData* pwtd = reinterpret_cast<WorkerThreadData*>(pv);
+        WorkerThreadData* pwtd = static_cast<WorkerThreadData*>(pv);
         if (pwtd)
         {
             PostMessage(pwtd->hwndManager, SRM_REGEX_STARTED, GetCurrentThreadId(), 0);

--- a/tools/WebcamReportTool/DirectShowUtils.h
+++ b/tools/WebcamReportTool/DirectShowUtils.h
@@ -5,7 +5,12 @@
 #include <windows.h>
 #include <dshow.h>
 
+// disable warning 26471 - Don't use reinterpret_cast. A cast from void* can use static_cast
+#pragma warning(push)
+#pragma warning(disable: 26471)
 #include <wil/com.h>
+#pragma warning(push)
+
 #include <winrt/Windows.Foundation.h>
 
 #include <vector>

--- a/tools/WebcamReportTool/main.cpp
+++ b/tools/WebcamReportTool/main.cpp
@@ -5,7 +5,12 @@
 #include <dshow.h>
 #include <cguid.h>
 
+// disable warning 26471 - Don't use reinterpret_cast. A cast from void* can use static_cast
+#pragma warning(push)
+#pragma warning(disable: 26471)
 #include <wil/com.h>
+#pragma warning(push)
+
 #include <wil/resource.h>
 
 #include <iostream>


### PR DESCRIPTION

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Turn on warning 26471
Don't use reinterpret_cast. A cast from void* can use static_cast

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Continues towards:** #940
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Turn on warning 26471 - Don't use reinterpret_cast. A cast from void* can use static_cast
void* can be reinterpreted with static_cast
It was disable for winRT headers and changed to static_cast for PowerToys code

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

