### PR TITLE
[ColorPicker] Store color history in a separated file

### DIFF
--- a/src/modules/colorPicker/ColorPickerUI/Settings/UserSettings.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Settings/UserSettings.cs
@@ -3,11 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel.Composition;
 using System.IO;
 using System.IO.Abstractions;
-using System.Linq;
+using System.Text.Json;
 using System.Threading;
 using ColorPicker.Common;
 using Microsoft.PowerToys.Settings.UI.Library;
@@ -22,6 +23,7 @@ namespace ColorPicker.Settings
     {
         private readonly ISettingsUtils _settingsUtils;
         private const string ColorPickerModuleName = "ColorPicker";
+        private const string ColorPickerHistoryFilename = "colorHistory.json";
         private const string DefaultActivationShortcut = "Ctrl + Break";
         private const int MaxNumberOfRetry = 5;
         private const int SettingsReadOnChangeDelayInMs = 300;
@@ -55,11 +57,7 @@ namespace ColorPicker.Settings
         {
             if (!_loadingColorsHistory)
             {
-                var settings = _settingsUtils.GetSettingsOrDefault<ColorPickerSettings, ColorPickerSettingsVersion1>(ColorPickerModuleName, settingsUpgrader: ColorPickerSettings.UpgradeSettings);
-                ColorHistory.CollectionChanged -= ColorHistory_CollectionChanged;
-                settings.Properties.ColorHistory = ColorHistory.ToList();
-                ColorHistory.CollectionChanged += ColorHistory_CollectionChanged;
-                settings.Save(_settingsUtils);
+                _settingsUtils.SaveSettings(JsonSerializer.Serialize(ColorHistory, new JsonSerializerOptions { WriteIndented = true }), ColorPickerModuleName, ColorPickerHistoryFilename);
             }
         }
 
@@ -119,14 +117,21 @@ namespace ColorPicker.Settings
                                 ColorHistoryLimit.Value = settings.Properties.ColorHistoryLimit;
                                 ShowColorName.Value = settings.Properties.ShowColorName;
 
-                                if (settings.Properties.ColorHistory == null)
+                                List<string> savedColorHistory = new List<string>();
+                                try
                                 {
-                                    settings.Properties.ColorHistory = new System.Collections.Generic.List<string>();
+                                    string filePath = _settingsUtils.GetSettingsFilePath(ColorPickerModuleName, ColorPickerHistoryFilename);
+                                    string jsonSettingsString = System.IO.File.ReadAllText(filePath).Trim('\0');
+                                    savedColorHistory = JsonSerializer.Deserialize<List<string>>(jsonSettingsString);
+                                }
+                                catch (Exception)
+                                {
+                                    Logger.LogInfo("ColorPicker colorHistory.json was missing or corrupt");
                                 }
 
                                 _loadingColorsHistory = true;
                                 ColorHistory.Clear();
-                                foreach (var item in settings.Properties.ColorHistory)
+                                foreach (var item in savedColorHistory)
                                 {
                                     ColorHistory.Add(item);
                                 }

--- a/src/modules/colorPicker/ColorPickerUI/Settings/UserSettings.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Settings/UserSettings.cs
@@ -121,8 +121,15 @@ namespace ColorPicker.Settings
                                 try
                                 {
                                     string filePath = _settingsUtils.GetSettingsFilePath(ColorPickerModuleName, ColorPickerHistoryFilename);
-                                    string jsonSettingsString = System.IO.File.ReadAllText(filePath).Trim('\0');
-                                    savedColorHistory = JsonSerializer.Deserialize<List<string>>(jsonSettingsString);
+                                    if (!File.Exists(filePath))
+                                    {
+                                        savedColorHistory = settings.Properties.ColorHistory;
+                                    }
+                                    else
+                                    {
+                                        string jsonSettingsString = System.IO.File.ReadAllText(filePath).Trim('\0');
+                                        savedColorHistory = JsonSerializer.Deserialize<List<string>>(jsonSettingsString);
+                                    }
                                 }
                                 catch (Exception)
                                 {

--- a/src/modules/colorPicker/ColorPickerUI/Settings/UserSettings.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Settings/UserSettings.cs
@@ -123,7 +123,10 @@ namespace ColorPicker.Settings
                                     string filePath = _settingsUtils.GetSettingsFilePath(ColorPickerModuleName, ColorPickerHistoryFilename);
                                     if (!File.Exists(filePath))
                                     {
-                                        savedColorHistory = settings.Properties.ColorHistory;
+                                        if (settings.Properties.ColorHistory != null)
+                                        {
+                                            savedColorHistory = settings.Properties.ColorHistory;
+                                        }
                                     }
                                     else
                                     {

--- a/src/settings-ui/Settings.UI.Library/ColorPickerProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/ColorPickerProperties.cs
@@ -16,7 +16,6 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         {
             ActivationShortcut = new HotkeySettings(true, false, false, true, 0x43);
             ChangeCursor = false;
-            ColorHistory = new List<string>();
             ColorHistoryLimit = 20;
             VisibleColorFormats = new Dictionary<string, KeyValuePair<bool, string>>();
             VisibleColorFormats.Add("HEX", new KeyValuePair<bool, string>(true, ColorFormatHelper.GetDefaultFormat("HEX")));
@@ -50,6 +49,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         [JsonPropertyName("activationaction")]
         public ColorPickerActivationAction ActivationAction { get; set; }
 
+        // Property ColorHistory is not used, the color history is saved separatedly in the colorHistory.json file
         [JsonPropertyName("colorhistory")]
         public List<string> ColorHistory { get; set; }
 

--- a/src/settings-ui/Settings.UI.Library/ColorPickerSettings.cs
+++ b/src/settings-ui/Settings.UI.Library/ColorPickerSettings.cs
@@ -56,7 +56,6 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             newSettings.Properties.ActivationShortcut = oldSettings.Properties.ActivationShortcut;
             newSettings.Properties.ChangeCursor = oldSettings.Properties.ChangeCursor;
             newSettings.Properties.ActivationAction = oldSettings.Properties.ActivationAction;
-            newSettings.Properties.ColorHistory = new List<string>(oldSettings.Properties.ColorHistory);
             newSettings.Properties.ColorHistoryLimit = oldSettings.Properties.ColorHistoryLimit;
             newSettings.Properties.ShowColorName = oldSettings.Properties.ShowColorName;
             newSettings.Properties.ActivationShortcut = oldSettings.Properties.ActivationShortcut;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Store color history in a separate file.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #23091 
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Not storing the color history in the settings file, as it is not a setting and it gets overwritten by the settings page (and occassionly history gets lost). The color history is stored in the colorHistory.json file instead
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
tested locally
