### PR TITLE
[ImageResizer]Fix call to AssocGetPerceivedType

### DIFF
--- a/src/modules/imageresizer/ImageResizerContextMenu/dllmain.cpp
+++ b/src/modules/imageresizer/ImageResizerContextMenu/dllmain.cpp
@@ -106,8 +106,20 @@ public:
         }
         LPTSTR pszPath;
         // Retrieves the entire file system path of the file from its shell item
-        shellItem->GetDisplayName(SIGDN_FILESYSPATH, &pszPath);
+        HRESULT getDisplayResult = shellItem->GetDisplayName(SIGDN_FILESYSPATH, &pszPath);
+        if (S_OK != getDisplayResult || nullptr == pszPath)
+        {
+            // Avoid crashes in the following code.
+            return E_FAIL;
+        }
+
         LPTSTR pszExt = PathFindExtension(pszPath);
+        if (nullptr == pszExt)
+        {
+            CoTaskMemFree(pszPath);
+            // Avoid crashes in the following code.
+            return E_FAIL;
+        }
 
         // TODO: Instead, detect whether there's a WIC codec installed that can handle this file
         AssocGetPerceivedType(pszExt, &type, &flag, NULL);

--- a/src/modules/imageresizer/dll/ContextMenuHandler.cpp
+++ b/src/modules/imageresizer/dll/ContextMenuHandler.cpp
@@ -82,7 +82,19 @@ HRESULT CContextMenuHandler::QueryContextMenu(_In_ HMENU hmenu, UINT indexMenu, 
     PERCEIVED type;
     PERCEIVEDFLAG flag;
     LPTSTR pszPath = i.CurrentItem();
+    if (nullptr == pszPath)
+    {
+        // Avoid crashes in the following code.
+        return E_FAIL;
+    }
+
     LPTSTR pszExt = PathFindExtension(pszPath);
+    if (nullptr == pszExt)
+    {
+        free(pszPath);
+        // Avoid crashes in the following code.
+        return E_FAIL;
+    }
 
     // TODO: Instead, detect whether there's a WIC codec installed that can handle this file
     AssocGetPerceivedType(pszExt, &type, &flag, NULL);
@@ -378,8 +390,20 @@ HRESULT __stdcall CContextMenuHandler::GetState(IShellItemArray* psiItemArray, B
     psiItemArray->GetItemAt(0, &shellItem);
     LPTSTR pszPath;
     // Retrieves the entire file system path of the file from its shell item
-    shellItem->GetDisplayName(SIGDN_FILESYSPATH, &pszPath);
+    HRESULT getDisplayResult = shellItem->GetDisplayName(SIGDN_FILESYSPATH, &pszPath);
+    if (S_OK != getDisplayResult || nullptr == pszPath)
+    {
+        // Avoid crashes in the following code.
+        return E_FAIL;
+    }
+
     LPTSTR pszExt = PathFindExtension(pszPath);
+    if (nullptr == pszExt)
+    {
+        CoTaskMemFree(pszPath);
+        // Avoid crashes in the following code.
+        return E_FAIL;
+    }
 
     // TODO: Instead, detect whether there's a WIC codec installed that can handle this file
     AssocGetPerceivedType(pszExt, &type, &flag, NULL);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Add some error checks before calling AssocGetPerceivedType, as we're getting null read errors for that function in Watson.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Built installer and verified the Image Resizer context menu still works.
