### PR TITLE
[Launcher][WindowWalker] Show all open windows with action keyword

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.WindowWalker/Components/SearchResult.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.WindowWalker/Components/SearchResult.cs
@@ -81,6 +81,18 @@ namespace Microsoft.Plugin.WindowWalker.Components
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="SearchResult"/> class.
+        /// </summary>
+        internal SearchResult(Window window)
+        {
+            Result = window;
+            SearchMatchesInTitle = new List<int>();
+            SearchMatchesInProcessName = new List<int>();
+            SearchResultMatchType = SearchType.Empty;
+            CalculateScore();
+        }
+
+        /// <summary>
         /// Calculates the score for how closely this window matches the search string
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Small improvement for WindowWalker plugin. Show all open windows when the plugin is called with action keyword only.
Adopting the same behavior of other plugins: Service, Settings, Terminal, ...

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #12010
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Build
- Open Launcher
- Press WindowWalker action keywork
- All open window should be displayed
