### PR TITLE
Revert "[ci]Fix dead links for WiX 3 binaries"

### DIFF
--- a/.pipelines/installWiX.ps1
+++ b/.pipelines/installWiX.ps1
@@ -1,7 +1,7 @@
 $ProgressPreference = 'SilentlyContinue'
 
-$WixDownloadUrl = "https://github.com/JaneaSystems/wix3/releases/download/wix3-3.14.0.6526/wix314.exe"
-$WixBinariesDownloadUrl = "https://github.com/JaneaSystems/wix3/releases/download/wix3-3.14.0.6526/wix314-binaries.zip"
+$WixDownloadUrl = "https://wixtoolset.org/downloads/v3.14.0.6526/wix314.exe"
+$WixBinariesDownloadUrl = "https://wixtoolset.org/downloads/v3.14.0.6526/wix314-binaries.zip"
 
 # Download WiX binaries and verify their hash sums
 Invoke-WebRequest -Uri $WixDownloadUrl -OutFile "$($ENV:Temp)\wix314.exe"

--- a/doc/devdocs/readme.md
+++ b/doc/devdocs/readme.md
@@ -73,8 +73,8 @@ The installer can only be compiled in `Release` mode, step 1 and 2 must be done 
 ### Prerequisites for building the MSI installer
 
 1. Install the [WiX Toolset Visual Studio 2022 Extension](https://marketplace.visualstudio.com/items?itemName=WixToolset.WixToolsetVisualStudio2022Extension).
-1. Install the [WiX Toolset build tools](https://wixtoolset.org/releases/v3-14-0-6526/). The links to the binaries are not working, so we've created a [fork here](https://github.com/JaneaSystems/wix3/releases/tag/wix3-3.14.0.6526) where the WiX Toolset can be downloaded from.
-1. Download [WiX binaries](https://github.com/JaneaSystems/wix3/releases/download/wix3-3.14.0.6526/wix314-binaries.zip) and extract `wix.targets` to `C:\Program Files (x86)\WiX Toolset v3.14`.
+1. Install the [WiX Toolset build tools](https://wixtoolset.org/releases/v3-14-0-6526/).
+1. Download [WiX binaries](https://wixtoolset.org/downloads/v3.14.0.6526/wix314-binaries.zip) and extract `wix.targets` to `C:\Program Files (x86)\WiX Toolset v3.14`.
 
 ### Locally building the installer prerequisite projects all at once from the command-line
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
The WiX3 binaries were reinstated in the WiX website, so we can use official links again on our CI.
This reverts commit 07f3507f11abb2eb7aa5e1d80a6a6d0413dce655.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Currently checking if CIs still pass.