### PR TITLE
[Analyzers][CPP] Changes to fix warning 26493 on src/modules/ (A to F)

### DIFF
--- a/src/modules/FileLocksmith/FileLocksmithExt/ExplorerCommand.cpp
+++ b/src/modules/FileLocksmith/FileLocksmithExt/ExplorerCommand.cpp
@@ -247,7 +247,7 @@ inline std::wstring get_module_folderpath(HMODULE mod = nullptr, const bool remo
     {
         PathRemoveFileSpecW(buffer);
     }
-    return { buffer, (UINT)lstrlenW(buffer) };
+    return { buffer, static_cast<UINT>(lstrlenW(buffer)) };
 }
 
 HRESULT ExplorerCommand::LaunchUI(CMINVOKECOMMANDINFO* pici, ipc::Writer* writer)

--- a/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.cpp
+++ b/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.cpp
@@ -23,7 +23,7 @@ namespace NonLocalizable
 bool isExcluded(HWND window)
 {
     auto processPath = get_process_path(window);
-    CharUpperBuffW(processPath.data(), (DWORD)processPath.length());
+    CharUpperBuffW(processPath.data(), static_cast<DWORD>(processPath.length()));
     return find_app_name_in_path(processPath, AlwaysOnTopSettings::settings().excludedApps);
 }
 
@@ -381,7 +381,7 @@ bool AlwaysOnTop::IsPinned(HWND window) const noexcept
 
 bool AlwaysOnTop::PinTopmostWindow(HWND window) const noexcept
 {
-    if (!SetProp(window, NonLocalizable::WINDOW_IS_PINNED_PROP, (HANDLE)1))
+    if (!SetProp(window, NonLocalizable::WINDOW_IS_PINNED_PROP, reinterpret_cast<HANDLE>(1)))
     {
         Logger::error(L"SetProp failed, {}", get_last_error_or_default(GetLastError()));
     }

--- a/src/modules/alwaysontop/AlwaysOnTop/FrameDrawer.cpp
+++ b/src/modules/alwaysontop/AlwaysOnTop/FrameDrawer.cpp
@@ -188,10 +188,10 @@ D2D1_ROUNDED_RECT FrameDrawer::ConvertRect(RECT rect, int thickness, float radiu
     float halfThickness = thickness / 2.0f;
 
     // 1 is needed to eliminate the gap between border and window
-    auto d2d1Rect = D2D1::RectF((float)rect.left + halfThickness + 1, 
-        (float)rect.top + halfThickness + 1, 
-        (float)rect.right - halfThickness - 1, 
-        (float)rect.bottom - halfThickness - 1);
+    auto d2d1Rect = D2D1::RectF(static_cast<float>(rect.left) + halfThickness + 1, 
+        static_cast<float>(rect.top) + halfThickness + 1, 
+        static_cast<float>(rect.right) - halfThickness - 1, 
+        static_cast<float>(rect.bottom) - halfThickness - 1);
     return D2D1::RoundedRect(d2d1Rect, radius, radius);
 }
 
@@ -200,10 +200,10 @@ D2D1_RECT_F FrameDrawer::ConvertRect(RECT rect, int thickness)
     float halfThickness = thickness / 2.0f;
 
     // 1 is needed to eliminate the gap between border and window
-    return D2D1::RectF((float)rect.left + halfThickness + 1,
-        (float)rect.top + halfThickness + 1,
-        (float)rect.right - halfThickness - 1,
-        (float)rect.bottom - halfThickness - 1);
+    return D2D1::RectF(static_cast<float>(rect.left) + halfThickness + 1,
+        static_cast<float>(rect.top) + halfThickness + 1,
+        static_cast<float>(rect.right) - halfThickness - 1,
+        static_cast<float>(rect.bottom) - halfThickness - 1);
 }
 
 void FrameDrawer::Render()

--- a/src/modules/alwaysontop/AlwaysOnTop/Settings.cpp
+++ b/src/modules/alwaysontop/AlwaysOnTop/Settings.cpp
@@ -169,7 +169,7 @@ void AlwaysOnTopSettings::LoadSettings()
             std::wstring apps = std::move(*jsonVal);
             std::vector<std::wstring> excludedApps;
             auto excludedUppercase = apps;
-            CharUpperBuffW(excludedUppercase.data(), (DWORD)excludedUppercase.length());
+            CharUpperBuffW(excludedUppercase.data(), static_cast<DWORD>(excludedUppercase.length()));
             std::wstring_view view(excludedUppercase);
             view = left_trim<wchar_t>(trim<wchar_t>(view));
 

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesData/CustomLayouts.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesData/CustomLayouts.cpp
@@ -242,7 +242,7 @@ std::optional<LayoutData> CustomLayouts::GetLayout(const GUID& id) const noexcep
     {
         auto layoutInfo = std::get<FancyZonesDataTypes::CanvasLayoutInfo>(customLayout.info);
         layout.sensitivityRadius = layoutInfo.sensitivityRadius;
-        layout.zoneCount = (int)layoutInfo.zones.size();
+        layout.zoneCount = static_cast<int>(layoutInfo.zones.size());
     }
 
     return layout;

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesWindowProperties.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesWindowProperties.cpp
@@ -85,7 +85,7 @@ ZoneIndexSet FancyZonesWindowProperties::RetrieveZoneIndexProperty(HWND window)
 
 void FancyZonesWindowProperties::StampMovedOnOpeningProperty(HWND window)
 {
-    ::SetPropW(window, ZonedWindowProperties::PropertyMovedOnOpening, (HANDLE)1);
+    ::SetPropW(window, ZonedWindowProperties::PropertyMovedOnOpening, reinterpret_cast<HANDLE>(1));
 }
 
 bool FancyZonesWindowProperties::RetrieveMovedOnOpeningProperty(HWND window)

--- a/src/modules/fancyzones/FancyZonesLib/GenericKeyHook.h
+++ b/src/modules/fancyzones/FancyZonesLib/GenericKeyHook.h
@@ -48,7 +48,7 @@ private:
         {
             if (wParam == WM_KEYDOWN || wParam == WM_KEYUP)
             {
-                PKBDLLHOOKSTRUCT kbdHookStruct = (PKBDLLHOOKSTRUCT)lParam;
+                PKBDLLHOOKSTRUCT kbdHookStruct = reinterpret_cast<PKBDLLHOOKSTRUCT>(lParam);
                 if (((kbdHookStruct->vkCode == keys) || ...))
                 {
                     callback(wParam == WM_KEYDOWN);

--- a/src/modules/fancyzones/FancyZonesLib/LayoutConfigurator.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/LayoutConfigurator.cpp
@@ -197,8 +197,8 @@ ZonesMap LayoutConfigurator::Focus(FancyZonesUtils::Rect workArea, int zoneCount
 
     long left{ 100 };
     long top{ 100 };
-    long right{ left + long(workArea.width() * 0.4) };
-    long bottom{ top + long(workArea.height() * 0.4) };
+    long right{ left + static_cast<long>(workArea.width() * 0.4) };
+    long bottom{ top + static_cast<long>(workArea.height() * 0.4) };
 
     RECT focusZoneRect{ left, top, right, bottom };
 

--- a/src/modules/fancyzones/FancyZonesLib/MonitorUtils.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/MonitorUtils.cpp
@@ -88,7 +88,7 @@ namespace MonitorUtils
             // on a particular host computer.
             IWbemLocator* pLocator = 0;
 
-            hres = CoCreateInstance(CLSID_WbemLocator, 0, CLSCTX_INPROC_SERVER, IID_IWbemLocator, (LPVOID*)&pLocator);
+            hres = CoCreateInstance(CLSID_WbemLocator, 0, CLSCTX_INPROC_SERVER, IID_IWbemLocator, reinterpret_cast<LPVOID*>(&pLocator));
             if (FAILED(hres))
             {
                 Logger::error(L"Failed to create IWbemLocator object. {}", get_last_error_or_default(hres));

--- a/src/modules/fancyzones/FancyZonesLib/Settings.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/Settings.cpp
@@ -212,7 +212,7 @@ void FancyZonesSettings::LoadSettings()
             std::wstring apps = std::move(*val);
             std::vector<std::wstring> excludedApps;
             auto excludedUppercase = apps;
-            CharUpperBuffW(excludedUppercase.data(), (DWORD)excludedUppercase.length());
+            CharUpperBuffW(excludedUppercase.data(), static_cast<DWORD>(excludedUppercase.length()));
             std::wstring_view view(excludedUppercase);
             view = left_trim<wchar_t>(trim<wchar_t>(view));
 
@@ -236,7 +236,7 @@ void FancyZonesSettings::LoadSettings()
         if (auto val = values.get_int_value(NonLocalizable::OverlappingZonesAlgorithmID))
         {
             // Avoid undefined behavior
-            if (*val >= 0 || *val < (int)OverlappingZonesAlgorithm::EnumElements)
+            if (*val >= 0 || *val < static_cast<int>(OverlappingZonesAlgorithm::EnumElements))
             {
                 auto algorithm = (OverlappingZonesAlgorithm)*val;
                 if (m_settings.overlappingZonesAlgorithm != algorithm)

--- a/src/modules/fancyzones/FancyZonesLib/WindowUtils.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WindowUtils.cpp
@@ -226,7 +226,7 @@ bool FancyZonesWindowUtils::IsCandidateForZoning(HWND window)
     }
 
     std::wstring processPath = get_process_path_waiting_uwp(window);
-    CharUpperBuffW(const_cast<std::wstring&>(processPath).data(), (DWORD)processPath.length());
+    CharUpperBuffW(const_cast<std::wstring&>(processPath).data(), static_cast<DWORD>(processPath.length()));
     if (IsExcludedByUser(processPath))
     {
         return false;

--- a/src/modules/fancyzones/FancyZonesLib/ZonesOverlay.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/ZonesOverlay.cpp
@@ -70,7 +70,7 @@ D2D1_COLOR_F ZonesOverlay::ConvertColor(COLORREF color)
 
 D2D1_RECT_F ZonesOverlay::ConvertRect(RECT rect)
 {
-    return D2D1::RectF((float)rect.left + 0.5f, (float)rect.top + 0.5f, (float)rect.right - 0.5f, (float)rect.bottom - 0.5f);
+    return D2D1::RectF(rect.left + 0.5f, rect.top + 0.5f, rect.right - 0.5f, rect.bottom - 0.5f);
 }
 
 ZonesOverlay::ZonesOverlay(HWND window)
@@ -174,7 +174,7 @@ ZonesOverlay::RenderResult ZonesOverlay::Render()
             {
                 textFormat->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER);
                 textFormat->SetParagraphAlignment(DWRITE_PARAGRAPH_ALIGNMENT_CENTER);
-                m_renderTarget->DrawTextW(idStr.c_str(), (UINT32)idStr.size(), textFormat, drawableRect.rect, textBrush);
+                m_renderTarget->DrawTextW(idStr.c_str(), static_cast<UINT32>(idStr.size()), textFormat, drawableRect.rect, textBrush);
             }
 
             if (textBrush)

--- a/src/modules/fancyzones/FancyZonesTests/UnitTests/AppZoneHistoryTests.Spec.cpp
+++ b/src/modules/fancyzones/FancyZonesTests/UnitTests/AppZoneHistoryTests.Spec.cpp
@@ -16,7 +16,7 @@ namespace FancyZonesUnitTests
 
         TEST_METHOD_INITIALIZE(Init)
         {
-            m_hInst = (HINSTANCE)GetModuleHandleW(nullptr);
+            m_hInst = static_cast<HINSTANCE>(GetModuleHandleW(nullptr));
             AppZoneHistory::instance().LoadData();
         }
 

--- a/src/modules/fancyzones/FancyZonesTests/UnitTests/Util.cpp
+++ b/src/modules/fancyzones/FancyZonesTests/UnitTests/Util.cpp
@@ -70,7 +70,7 @@ BOOL RegisterDLLWindowClass(LPCWSTR szClassName, Mocks::HwndCreator* creator)
     wc.lpszMenuName = NULL;
     wc.cbClsExtra = 0;
     wc.cbWndExtra = 0;
-    wc.hbrBackground = (HBRUSH)COLOR_BACKGROUND;
+    wc.hbrBackground = reinterpret_cast<HBRUSH>(COLOR_BACKGROUND);
 
     auto regRes = RegisterClassEx(&wc);
     return regRes;
@@ -83,9 +83,9 @@ DWORD WINAPI ThreadProc(LPVOID lpParam)
     if (!creator)
         return static_cast<DWORD>(-1);
 
-    if (RegisterDLLWindowClass((LPCWSTR)creator->getWindowClassName().c_str(), creator) != 0)
+    if (RegisterDLLWindowClass(creator->getWindowClassName().c_str(), creator) != 0)
     {
-        auto hWnd = CreateWindowEx(0, (LPCWSTR)creator->getWindowClassName().c_str(), (LPCWSTR)creator->getTitle().c_str(), WS_EX_APPWINDOW, CW_USEDEFAULT, CW_USEDEFAULT, 10, 10, nullptr, nullptr, creator->getHInstance(), NULL);
+        auto hWnd = CreateWindowEx(0, creator->getWindowClassName().c_str(), creator->getTitle().c_str(), WS_EX_APPWINDOW, CW_USEDEFAULT, CW_USEDEFAULT, 10, 10, nullptr, nullptr, creator->getHInstance(), NULL);
         SetWindowPos(hWnd, HWND_TOPMOST, 10, 10, 100, 100, SWP_SHOWWINDOW);
         creator->setHwnd(hWnd);
         creator->setCondition(true);
@@ -130,7 +130,7 @@ namespace Mocks
         m_conditionFlag = false;
         std::unique_lock<std::mutex> lock(m_mutex);
 
-        m_thread = CreateThread(0, NULL, ThreadProc, (LPVOID)this, NULL, NULL);
+        m_thread = CreateThread(0, NULL, ThreadProc, reinterpret_cast<LPVOID>(this), NULL, NULL);
         m_conditionVar.wait(lock, [this] { return m_conditionFlag; });
 
         return m_hWnd;

--- a/src/modules/fancyzones/FancyZonesTests/UnitTests/WorkArea.Spec.cpp
+++ b/src/modules/fancyzones/FancyZonesTests/UnitTests/WorkArea.Spec.cpp
@@ -597,7 +597,7 @@ namespace FancyZonesUnitTests
             Assert::AreEqual((size_t)1, actualAppZoneHistory.size());
 
             const auto& layoutWindows = workArea->GetLayoutWindows();
-            Assert::IsTrue(ZoneIndexSet{ static_cast<ZoneIndex>(workArea->GetLayout()->Zones().size()) - 1 } == layoutWindows->GetZoneIndexSetFromWindow(window));
+            Assert::IsTrue(ZoneIndexSet{ static_cast<ZoneIndex>(workArea->GetLayout()->Zones().size() - 1) } == layoutWindows->GetZoneIndexSetFromWindow(window));
         }
 
         TEST_METHOD (MoveAppliedWindowByIndexNoCycle)

--- a/src/modules/fancyzones/FancyZonesTests/UnitTests/Zone.Spec.cpp
+++ b/src/modules/fancyzones/FancyZonesTests/UnitTests/Zone.Spec.cpp
@@ -16,7 +16,7 @@ namespace FancyZonesUnitTests
 
         TEST_METHOD_INITIALIZE(Init)
         {
-            m_hInst = (HINSTANCE)GetModuleHandleW(nullptr);
+            m_hInst = static_cast<HINSTANCE>(GetModuleHandleW(nullptr));
         }
 
     public:


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Changes to fix warning 26493 (Don't use C-style casts) on source/modules (starting with A to F)
This change is split into several PRs. This does not turn on the rule only fixes the code under source/modules (starting with A to F).
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Continues towards:** #940
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Most of the changes are replacing the C-style cast with static_cast.
Some of the C-style needed to be changed to reinterpret_cast.
There is a rule to be turned on to avoid reinterpret_cast so this should be re-evaluated in the future.
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

