### PR TITLE
[Dev file previewer] Add option to set costum max file size and fix styling issue

### DIFF
--- a/src/modules/previewpane/MonacoPreviewHandler/MonacoPreviewHandlerControl.cs
+++ b/src/modules/previewpane/MonacoPreviewHandler/MonacoPreviewHandlerControl.cs
@@ -212,6 +212,7 @@ namespace Microsoft.PowerToys.PreviewHandler.Monaco
                             downloadLink.Top = TextRenderer.MeasureText(Resources.WebView2_Not_Installed_Message, errorMessage.Font).Height + 10;
                             downloadLink.Width = TextRenderer.MeasureText(Resources.Download_WebView2, errorMessage.Font).Width + 10;
                             downloadLink.Height = TextRenderer.MeasureText(Resources.Download_WebView2, errorMessage.Font).Height;
+                            downloadLink.ForeColor = Settings.TextColor;
                             Controls.Add(downloadLink);
                         }
                     });
@@ -222,6 +223,7 @@ namespace Microsoft.PowerToys.PreviewHandler.Monaco
                     Controls.Remove(_loadingBar);
                     Controls.Remove(_loadingBackground);
                     Label text = new Label();
+                    text.ForeColor = Settings.TextColor;
                     text.Text = Resources.Exception_Occurred;
                     text.Text += e.Message;
                     text.Text += "\n" + e.Source;
@@ -244,6 +246,7 @@ namespace Microsoft.PowerToys.PreviewHandler.Monaco
                 Controls.Remove(_loadingBackground);
                 Label errorMessage = new Label();
                 errorMessage.Text = Resources.Max_File_Size_Error.Replace("%1", (_settings.MaxFileSize / 1000).ToString(CultureInfo.CurrentCulture), StringComparison.InvariantCulture);
+                errorMessage.ForeColor = Settings.TextColor;
                 errorMessage.Width = 500;
                 errorMessage.Height = 50;
                 Controls.Add(errorMessage);

--- a/src/modules/previewpane/MonacoPreviewHandler/Settings.cs
+++ b/src/modules/previewpane/MonacoPreviewHandler/Settings.cs
@@ -66,7 +66,7 @@ namespace Microsoft.PowerToys.PreviewHandler.Monaco
             {
                 try
                 {
-                    return moduleSettings.GetSettings<PowerPreviewSettings>(PowerPreviewSettings.ModuleName).Properties.MonacoPreviewMaxFileSize.Value;
+                    return moduleSettings.GetSettings<PowerPreviewSettings>(PowerPreviewSettings.ModuleName).Properties.MonacoPreviewMaxFileSize.Value * 1000;
                 }
                 catch (FileNotFoundException)
                 {

--- a/src/modules/previewpane/MonacoPreviewHandler/Settings.cs
+++ b/src/modules/previewpane/MonacoPreviewHandler/Settings.cs
@@ -58,11 +58,24 @@ namespace Microsoft.PowerToys.PreviewHandler.Monaco
         }
 
         /// <summary>
-        /// Max file size for displaying (in bytes).
+        /// Gets Max file size for displaying (in bytes).
         /// </summary>
-        private readonly long _maxFileSize = 50000;
-
-        public long MaxFileSize => _maxFileSize;
+        public double MaxFileSize
+        {
+            get
+            {
+                try
+                {
+                    return moduleSettings.GetSettings<PowerPreviewSettings>(PowerPreviewSettings.ModuleName).Properties.MonacoPreviewMaxFileSize.Value;
+                }
+                catch (FileNotFoundException)
+                {
+                    // Couldn't read the settings.
+                    // Assume default of 50000.
+                    return 50000;
+                }
+            }
+        }
 
         /// <summary>
         /// Gets the color of the window background.

--- a/src/settings-ui/Settings.UI.Library/PowerPreviewProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/PowerPreviewProperties.cs
@@ -13,7 +13,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
     public class PowerPreviewProperties
     {
         public const string DefaultStlThumbnailColor = "#FFC924";
-        public const int DefaultMonacoMaxFileSize = 50000;
+        public const int DefaultMonacoMaxFileSize = 50;
 
         private bool enableSvgPreview = true;
 

--- a/src/settings-ui/Settings.UI.Library/PowerPreviewProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/PowerPreviewProperties.cs
@@ -13,6 +13,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
     public class PowerPreviewProperties
     {
         public const string DefaultStlThumbnailColor = "#FFC924";
+        public const int DefaultMonacoMaxFileSize = 50000;
 
         private bool enableSvgPreview = true;
 
@@ -116,6 +117,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             }
         }
 
+        [JsonPropertyName("monaco-previewer-max-file-size")]
+        public IntProperty MonacoPreviewMaxFileSize { get; set; }
+
         private bool enablePdfPreview;
 
         [JsonPropertyName("pdf-previewer-toggle-setting")]
@@ -207,6 +211,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         public PowerPreviewProperties()
         {
             StlThumbnailColor = new StringProperty(DefaultStlThumbnailColor);
+            MonacoPreviewMaxFileSize = new IntProperty(DefaultMonacoMaxFileSize);
         }
 
         public override string ToString()

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -2931,4 +2931,12 @@ Activate by holding the key for the character you want to add an accent to, then
   <data name="UpdateAvailable.Title" xml:space="preserve">
     <value>Update available</value>
   </data>
+  <data name="FileExplorerPreview_Toggle_Monaco_Max_File_Size.Header" xml:space="preserve">
+    <value>Maximum file size to preview</value>
+    <comment>Size refers to the disk space used by a file</comment>
+  </data>
+  <data name="FileExplorerPreview_Toggle_Monaco_Max_File_Size.Description" xml:space="preserve">
+    <value>The maximum size a file can have to get displayed in bytes. This is a safety mechanism to prevent loading big files into RAM.</value>
+    <comment>"RAM" refers to random access memory; "size" refers to disk space; "bytes" refer to the measurement unit</comment>
+  </data>
 </root>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -2936,7 +2936,7 @@ Activate by holding the key for the character you want to add an accent to, then
     <comment>Size refers to the disk space used by a file</comment>
   </data>
   <data name="FileExplorerPreview_Toggle_Monaco_Max_File_Size.Description" xml:space="preserve">
-    <value>The maximum size, in bytes, for files to be displayed. This is a safety mechanism to prevent loading large files into RAM.</value>
+    <value>The maximum size, in kilobytes, for files to be displayed. This is a safety mechanism to prevent loading large files into RAM.</value>
     <comment>"RAM" refers to random access memory; "size" refers to disk space; "bytes" refer to the measurement unit</comment>
   </data>
 </root>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -2936,7 +2936,7 @@ Activate by holding the key for the character you want to add an accent to, then
     <comment>Size refers to the disk space used by a file</comment>
   </data>
   <data name="FileExplorerPreview_Toggle_Monaco_Max_File_Size.Description" xml:space="preserve">
-    <value>The maximum size a file can have to get displayed in bytes. This is a safety mechanism to prevent loading big files into RAM.</value>
+    <value>The maximum size, in bytes, for files to be displayed. This is a safety mechanism to prevent loading large files into RAM.</value>
     <comment>"RAM" refers to random access memory; "size" refers to disk space; "bytes" refer to the measurement unit</comment>
   </data>
 </root>

--- a/src/settings-ui/Settings.UI/ViewModels/PowerPreviewViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/PowerPreviewViewModel.cs
@@ -98,6 +98,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
 
             _monacoWrapText = Settings.Properties.EnableMonacoPreviewWordWrap;
             _monacoPreviewTryFormat = Settings.Properties.MonacoPreviewTryFormat;
+            _monacoMaxFileSize = Settings.Properties.MonacoPreviewMaxFileSize.Value;
 
             _pdfRenderEnabledGpoRuleConfiguration = GPOWrapper.GetConfiguredPdfPreviewEnabledValue();
             if (_pdfRenderEnabledGpoRuleConfiguration == GpoRuleConfigured.Disabled || _pdfRenderEnabledGpoRuleConfiguration == GpoRuleConfigured.Enabled)
@@ -175,6 +176,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
         private bool _monacoRenderIsEnabled;
         private bool _monacoWrapText;
         private bool _monacoPreviewTryFormat;
+        private int _monacoMaxFileSize;
 
         private GpoRuleConfigured _pdfRenderEnabledGpoRuleConfiguration;
         private bool _pdfRenderEnabledStateIsGPOConfigured;
@@ -348,6 +350,24 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 {
                     _monacoPreviewTryFormat = value;
                     Settings.Properties.MonacoPreviewTryFormat = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        public int MonacoPreviewMaxFileSize
+        {
+            get
+            {
+                return _monacoMaxFileSize;
+            }
+
+            set
+            {
+                if (_monacoMaxFileSize != value)
+                {
+                    _monacoMaxFileSize = value;
+                    Settings.Properties.MonacoPreviewMaxFileSize.Value = value;
                     RaisePropertyChanged();
                 }
             }

--- a/src/settings-ui/Settings.UI/Views/PowerPreviewPage.xaml
+++ b/src/settings-ui/Settings.UI/Views/PowerPreviewPage.xaml
@@ -78,6 +78,16 @@
                                     IsChecked="{x:Bind ViewModel.MonacoPreviewTryFormat, Mode=TwoWay}"
                                     IsEnabled="{x:Bind ViewModel.MonacoRenderIsEnabled, Mode=OneWay}" />
                             </labs:SettingsCard>
+                            <labs:SettingsCard
+                                x:Uid="FileExplorerPreview_Toggle_Monaco_Max_File_Size"
+                                IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.MonacoRenderIsEnabled}">
+                                <NumberBox
+                                    MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                    Maximum="100000"
+                                    Minimum="2000"
+                                    SpinButtonPlacementMode="Compact"
+                                    Value="{x:Bind Mode=TwoWay, Path=ViewModel.MonacoPreviewMaxFileSize}" />
+                            </labs:SettingsCard>
                         </labs:SettingsExpander.Items>
                     </labs:SettingsExpander>
 

--- a/src/settings-ui/Settings.UI/Views/PowerPreviewPage.xaml
+++ b/src/settings-ui/Settings.UI/Views/PowerPreviewPage.xaml
@@ -83,8 +83,8 @@
                                 IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.MonacoRenderIsEnabled}">
                                 <NumberBox
                                     MinWidth="{StaticResource SettingActionControlMinWidth}"
-                                    Maximum="100000"
-                                    Minimum="2000"
+                                    Maximum="100"
+                                    Minimum="2"
                                     SpinButtonPlacementMode="Compact"
                                     Value="{x:Bind Mode=TwoWay, Path=ViewModel.MonacoPreviewMaxFileSize}" />
                             </labs:SettingsCard>


### PR DESCRIPTION
## Summary of the Pull Request

- Add option to set costum max file size
- Fixed wrong foreground color for text (like File too big text) when in dark mode

## PR Checklist

- [x] **Closes:** #19578
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx


