### PR TITLE
[Flyout]Appear next to the tray icon position

### DIFF
--- a/src/runner/settings_window.h
+++ b/src/runner/settings_window.h
@@ -22,7 +22,7 @@ enum class ESettingsWindowNames
 std::string ESettingsWindowNames_to_string(ESettingsWindowNames value);
 ESettingsWindowNames ESettingsWindowNames_from_string(std::string value);
 
-void open_settings_window(std::optional<std::wstring> settings_window, bool show_flyout);
+void open_settings_window(std::optional<std::wstring> settings_window, bool show_flyout, const std::optional<POINT>& flyout_position);
 void close_settings_window();
 
 void open_oobe_window();

--- a/src/runner/tray_icon.cpp
+++ b/src/runner/tray_icon.cpp
@@ -32,6 +32,8 @@ namespace
     HMENU h_sub_menu = nullptr;
     bool double_click_timer_running = false;
     bool double_clicked = false;
+    POINT tray_icon_click_point;
+
 }
 
 // Struct to fill with callback and the data. The window_proc is responsible for cleaning it.
@@ -123,7 +125,7 @@ void click_timer_elapsed()
     double_click_timer_running = false;
     if (!double_clicked)
     {
-        open_settings_window(std::nullopt, true);
+        open_settings_window(std::nullopt, true, tray_icon_click_point);
     }
 }
 
@@ -212,6 +214,9 @@ LRESULT __stdcall tray_icon_window_proc(HWND window, UINT message, WPARAM wparam
                 // ignore event if this is the second click of a double click
                 if (!double_click_timer_running)
                 {
+                    // save the cursor position for sending where to show the popup.
+                    GetCursorPos(&tray_icon_click_point);
+
                     // start timer for detecting single or double click
                     double_click_timer_running = true;
                     double_clicked = false;

--- a/src/runner/tray_icon.h
+++ b/src/runner/tray_icon.h
@@ -7,7 +7,7 @@ void start_tray_icon();
 // Stop the Tray Icon
 void stop_tray_icon();
 // Open the Settings Window
-void open_settings_window(std::optional<std::wstring> settings_window, bool show_flyout);
+void open_settings_window(std::optional<std::wstring> settings_window, bool show_flyout, const std::optional<POINT>& flyout_position = std::nullopt);
 // Callback type to be called by the tray icon loop
 typedef void (*main_loop_callback_function)(PVOID);
 // Calls a callback in _callback

--- a/src/settings-ui/Settings.UI/FlyoutWindow.xaml.cs
+++ b/src/settings-ui/Settings.UI/FlyoutWindow.xaml.cs
@@ -1,11 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+using Microsoft.PowerToys.Settings.UI.Helpers;
 using Microsoft.PowerToys.Settings.UI.Library.Telemetry.Events;
 using Microsoft.PowerToys.Settings.UI.ViewModels.Flyout;
 using Microsoft.PowerToys.Telemetry;
 using Microsoft.UI;
 using Microsoft.UI.Windowing;
+using Windows.Graphics;
 using WinUIEx;
 
 namespace Microsoft.PowerToys.Settings.UI
@@ -21,23 +23,65 @@ namespace Microsoft.PowerToys.Settings.UI
 
         public FlyoutViewModel ViewModel { get; set; }
 
-        public FlyoutWindow()
+        public POINT? FlyoutAppearPosition { get; set; }
+
+        public FlyoutWindow(POINT? initialPosition)
         {
             this.InitializeComponent();
             this.Activated += FlyoutWindow_Activated;
-            var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
-            WindowId windowId = Win32Interop.GetWindowIdFromWindow(hwnd);
-            DisplayArea displayArea = DisplayArea.GetFromWindowId(windowId, DisplayAreaFallback.Nearest);
-            double dpiScale = (float)this.GetDpiForWindow() / 96;
-            double x = displayArea.WorkArea.Width - (dpiScale * (WindowWidth + WindowMargin));
-            double y = displayArea.WorkArea.Height - (dpiScale * (WindowHeight + WindowMargin));
-            this.MoveAndResize(x, y, WindowWidth, WindowHeight);
+            FlyoutAppearPosition = initialPosition;
             ViewModel = new FlyoutViewModel();
         }
 
         private void FlyoutWindow_Activated(object sender, Microsoft.UI.Xaml.WindowActivatedEventArgs args)
         {
             PowerToysTelemetry.Log.WriteEvent(new TrayFlyoutActivatedEvent());
+            if (args.WindowActivationState == Microsoft.UI.Xaml.WindowActivationState.CodeActivated)
+            {
+                var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
+                WindowId windowId = Win32Interop.GetWindowIdFromWindow(hwnd);
+                if (!FlyoutAppearPosition.HasValue)
+                {
+                    DisplayArea displayArea = DisplayArea.GetFromWindowId(windowId, DisplayAreaFallback.Nearest);
+                    double dpiScale = (float)this.GetDpiForWindow() / 96;
+                    double x = displayArea.WorkArea.Width - (dpiScale * (WindowWidth + WindowMargin));
+                    double y = displayArea.WorkArea.Height - (dpiScale * (WindowHeight + WindowMargin));
+                    this.MoveAndResize(x, y, WindowWidth, WindowHeight);
+                }
+                else
+                {
+                    DisplayArea displayArea = DisplayArea.GetFromPoint(new PointInt32(FlyoutAppearPosition.Value.X, FlyoutAppearPosition.Value.Y), DisplayAreaFallback.Nearest);
+
+                    // Move the window to the correct screen as a little blob, so we can get the accurate dpi for the screen to calculate the best position to show it.
+                    this.MoveAndResize(FlyoutAppearPosition.Value.X, FlyoutAppearPosition.Value.Y, 1, 1);
+                    double dpiScale = (float)this.GetDpiForWindow() / 96;
+
+                    // Position the window so that it's inside the display are closest to the point.
+                    POINT newPosition = new POINT(FlyoutAppearPosition.Value.X - (int)(dpiScale * WindowWidth / 2), FlyoutAppearPosition.Value.Y - (int)(dpiScale * WindowHeight / 2));
+                    if (newPosition.X < displayArea.WorkArea.X)
+                    {
+                        newPosition.X = displayArea.WorkArea.X;
+                    }
+
+                    if (newPosition.Y < displayArea.WorkArea.Y)
+                    {
+                        newPosition.Y = displayArea.WorkArea.Y;
+                    }
+
+                    if (newPosition.X + (dpiScale * WindowWidth) > displayArea.WorkArea.X + displayArea.WorkArea.Width)
+                    {
+                        newPosition.X = (int)(displayArea.WorkArea.X + displayArea.WorkArea.Width - (dpiScale * WindowWidth));
+                    }
+
+                    if (newPosition.Y + (dpiScale * WindowHeight) > displayArea.WorkArea.Y + displayArea.WorkArea.Height)
+                    {
+                        newPosition.Y = (int)(displayArea.WorkArea.Y + displayArea.WorkArea.Height - (dpiScale * WindowHeight));
+                    }
+
+                    this.MoveAndResize(newPosition.X, newPosition.Y, WindowWidth, WindowHeight);
+                }
+            }
+
             if (args.WindowActivationState == Microsoft.UI.Xaml.WindowActivationState.Deactivated)
             {
                 if (ViewModel.CanHide)

--- a/src/settings-ui/Settings.UI/MainWindow.xaml.cs
+++ b/src/settings-ui/Settings.UI/MainWindow.xaml.cs
@@ -171,16 +171,17 @@ namespace Microsoft.PowerToys.Settings.UI
             });
 
             // open flyout
-            ShellPage.SetOpenFlyoutCallback(() =>
+            ShellPage.SetOpenFlyoutCallback((POINT? p) =>
             {
                 this.DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Normal, () =>
                 {
                     if (App.GetFlyoutWindow() == null)
                     {
-                        App.SetFlyoutWindow(new FlyoutWindow());
+                        App.SetFlyoutWindow(new FlyoutWindow(p));
                     }
 
                     FlyoutWindow flyout = App.GetFlyoutWindow();
+                    flyout.FlyoutAppearPosition = p;
                     flyout.Activate();
 
                     // https://github.com/microsoft/microsoft-ui-xaml/issues/7595 - Activate doesn't bring window to the foreground
@@ -196,7 +197,7 @@ namespace Microsoft.PowerToys.Settings.UI
                 {
                     if (App.GetFlyoutWindow() == null)
                     {
-                        App.SetFlyoutWindow(new FlyoutWindow());
+                        App.SetFlyoutWindow(new FlyoutWindow(null));
                     }
 
                     App.GetFlyoutWindow().ViewModel.DisableHiding();

--- a/src/settings-ui/Settings.UI/Views/ShellPage.xaml.cs
+++ b/src/settings-ui/Settings.UI/Views/ShellPage.xaml.cs
@@ -337,14 +337,14 @@ namespace Microsoft.PowerToys.Settings.UI.Views
                     {
                         POINT? p = null;
 
-                        IJsonValue flyoutPointXJson;
-                        IJsonValue flyoutPointYJson;
-                        if (json.TryGetValue("x_position", out flyoutPointXJson) && json.TryGetValue("y_position", out flyoutPointYJson))
+                        IJsonValue flyoutPointX;
+                        IJsonValue flyoutPointY;
+                        if (json.TryGetValue("x_position", out flyoutPointX) && json.TryGetValue("y_position", out flyoutPointY))
                         {
-                            if (flyoutPointXJson.ValueType == JsonValueType.Number && flyoutPointYJson.ValueType == JsonValueType.Number)
+                            if (flyoutPointX.ValueType == JsonValueType.Number && flyoutPointY.ValueType == JsonValueType.Number)
                             {
-                                int flyout_x = (int)flyoutPointXJson.GetNumber();
-                                int flyout_y = (int)flyoutPointYJson.GetNumber();
+                                int flyout_x = (int)flyoutPointX.GetNumber();
+                                int flyout_y = (int)flyoutPointY.GetNumber();
                                 p = new POINT(flyout_x, flyout_y);
                             }
                         }

--- a/src/settings-ui/Settings.UI/Views/ShellPage.xaml.cs
+++ b/src/settings-ui/Settings.UI/Views/ShellPage.xaml.cs
@@ -45,7 +45,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
         /// <summary>
         /// Declaration for the opening flyout window callback function.
         /// </summary>
-        public delegate void FlyoutOpeningCallback();
+        public delegate void FlyoutOpeningCallback(POINT? point);
 
         /// <summary>
         /// Declaration for the disabling hide of flyout window callback function.
@@ -330,13 +330,28 @@ namespace Microsoft.PowerToys.Settings.UI.Views
         {
             if (json != null)
             {
-                if (json.ToString().StartsWith("{\"ShowYourself\":"))
+                IJsonValue whatToShowJson;
+                if (json.TryGetValue("ShowYourself", out whatToShowJson))
                 {
-                    if (json.ToString().EndsWith("\"flyout\"}"))
+                    if (whatToShowJson.ValueType == JsonValueType.String && whatToShowJson.GetString().Equals("flyout"))
                     {
-                        OpenFlyoutCallback();
+                        POINT? p = null;
+
+                        IJsonValue flyoutPointXJson;
+                        IJsonValue flyoutPointYJson;
+                        if (json.TryGetValue("x_position", out flyoutPointXJson) && json.TryGetValue("y_position", out flyoutPointYJson))
+                        {
+                            if (flyoutPointXJson.ValueType == JsonValueType.Number && flyoutPointYJson.ValueType == JsonValueType.Number)
+                            {
+                                int flyout_x = (int)flyoutPointXJson.GetNumber();
+                                int flyout_y = (int)flyoutPointYJson.GetNumber();
+                                p = new POINT(flyout_x, flyout_y);
+                            }
+                        }
+
+                        OpenFlyoutCallback(p);
                     }
-                    else if (json.ToString().EndsWith("\"main_page\"}"))
+                    else if (whatToShowJson.ValueType == JsonValueType.String && whatToShowJson.GetString().Equals("main_page"))
                     {
                         OpenMainWindowCallback();
                     }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

The system tray quick launcher flyout assumes that the taskbar is always on the bottom of the primary screen.
This PR makes it so that the flyout tries to appear closer to the place where the tray icon was clicked.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #23737
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

- Send the coordinates of the click to settings to make the flyout appear on those coordinates.
- Adapt according to the screen dpis.
- Refactor argument passing to the settings app so that optional arguments are taken into account.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Tried opening settings normally and from a module like PowerRename to verify it still opened correctly (arguments refactoring)
Verified many taskbar positions / dpis on Windows 10.
Tried showing the flyout both as the first thing after we start PowerToys and also after opening Settings.