### PR TITLE
Fix link to disk usage footprint document

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ In this release, we focused on releasing new features and improvements.
 
 ### Documentation
 
-- Added PowerToys [disk usage footprint document](doc\devdocs\disk-usage-footprint.md).
+- Added PowerToys [disk usage footprint document](/doc/devdocs/disk-usage-footprint.md).
 - Fixed some grammar issues on main readme / Wiki.  Thanks [@CanePlayz](https://github.com/CanePlayz)!
 
 ### Development


### PR DESCRIPTION
## Summary of the Pull Request

This PR fixes a broken link in the recent readme update

The link to the `disk-usage-footprint.md` document was relative and didn't point to the right location. This PR fixes that by referencing it as an absolute path.