### PR TITLE
[FancyZones] Opacity reset fix

### DIFF
--- a/src/modules/fancyzones/FancyZonesLib/WindowDrag.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WindowDrag.cpp
@@ -213,22 +213,30 @@ void WindowDrag::SetWindowTransparency()
         if (!SetLayeredWindowAttributes(m_window, 0, (255 * 50) / 100, LWA_ALPHA))
         {
             Logger::error(L"Window transparency: SetLayeredWindowAttributes failed, {}", get_last_error_or_default(GetLastError()));
+            return;
         }
+
+        m_windowProperties.transparencySet = true;
     }
 }
 
 void WindowDrag::ResetWindowTransparency()
 {
-    if (FancyZonesSettings::settings().makeDraggedWindowTransparent)
+    if (FancyZonesSettings::settings().makeDraggedWindowTransparent && m_windowProperties.transparencySet)
     {
+        bool reset = true;
         if (!SetLayeredWindowAttributes(m_window, m_windowProperties.crKey, m_windowProperties.alpha, m_windowProperties.dwFlags))
         {
-            Logger::error(L"Window transparency: SetLayeredWindowAttributes failed");
+            Logger::error(L"Window transparency: SetLayeredWindowAttributes failed, {}", get_last_error_or_default(GetLastError()));
+            reset = false;
         }
 
         if (SetWindowLong(m_window, GWL_EXSTYLE, m_windowProperties.exstyle) == 0)
         {
             Logger::error(L"Window transparency: SetWindowLong failed, {}", get_last_error_or_default(GetLastError()));
+            reset = false;
         }
+
+        m_windowProperties.transparencySet = !reset;
     }
 }

--- a/src/modules/fancyzones/FancyZonesLib/WindowDrag.h
+++ b/src/modules/fancyzones/FancyZonesLib/WindowDrag.h
@@ -33,6 +33,7 @@ private:
         COLORREF crKey = RGB(0, 0, 0);
         DWORD dwFlags = 0;
         BYTE alpha = 0;
+        bool transparencySet{false};
     };
 
     const HWND m_window;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** https://github.com/microsoft/PowerToys/issues/4451
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

* Turn on `Make dragged window transparent` option
* Open the Magic: The Gathering Online or Unity window
* Drag it without snapping 
* Make sure the opacity hasn't changed and window looks and works as before