### PR TITLE
Fix typo in keyboard manager

### DIFF
--- a/src/modules/keyboardmanager/KeyboardManagerEditor/Resources.resx
+++ b/src/modules/keyboardmanager/KeyboardManagerEditor/Resources.resx
@@ -169,7 +169,7 @@
     <value>Target App:</value>
   </data>
   <data name="EditKeyboard_OrphanedDialogTitle" xml:space="preserve">
-    <value>Warning: The follow keys do not have assignments:</value>
+    <value>Warning: The following keys do not have assignments:</value>
     <comment>Key on a keyboard</comment>
   </data>
   <data name="EditKeyboard_PartialConfirmationDialogTitle" xml:space="preserve">


### PR DESCRIPTION
A small PR to fix a grammatical error in one of the UI strings in the keyboard manager module.

Tests, documentation and everything should be irrelevant as this is just a small typo fix.