### PR TITLE
[FancyZones] Fix window resize on layout change

### DIFF
--- a/src/modules/fancyzones/FancyZonesLib/LayoutAssignedWindows.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/LayoutAssignedWindows.cpp
@@ -69,6 +69,11 @@ void LayoutAssignedWindows::Dismiss(HWND window)
     FancyZonesWindowProperties::SetTabSortKeyWithinZone(window, std::nullopt);
 }
 
+std::map<HWND, ZoneIndexSet> LayoutAssignedWindows::SnappedWindows() const noexcept
+{
+    return m_windowIndexSet;
+}
+
 ZoneIndexSet LayoutAssignedWindows::GetZoneIndexSetFromWindow(HWND window) const noexcept
 {
     auto it = m_windowIndexSet.find(window);

--- a/src/modules/fancyzones/FancyZonesLib/LayoutAssignedWindows.h
+++ b/src/modules/fancyzones/FancyZonesLib/LayoutAssignedWindows.h
@@ -19,6 +19,7 @@ public :
     void Extend(HWND window, const ZoneIndexSet& zones);
     void Dismiss(HWND window);
 
+    std::map<HWND, ZoneIndexSet> SnappedWindows() const noexcept;
     ZoneIndexSet GetZoneIndexSetFromWindow(HWND window) const noexcept;
     bool IsZoneEmpty(ZoneIndex zoneIndex) const noexcept;
     

--- a/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
@@ -354,9 +354,7 @@ bool WorkArea::ExtendWindowByDirectionAndPosition(HWND window, DWORD vkCode)
         const auto adjustedRect = FancyZonesWindowUtils::AdjustRectForSizeWindowToRect(window, rect, m_window);
         FancyZonesWindowUtils::SizeWindowToRect(window, adjustedRect);
 
-        m_layoutWindows->Extend(window, resultIndexSet);
-
-        SnapWindow(window, resultIndexSet);
+        SnapWindow(window, resultIndexSet, true);
 
         return true;
     }
@@ -364,15 +362,22 @@ bool WorkArea::ExtendWindowByDirectionAndPosition(HWND window, DWORD vkCode)
     return false;
 }
 
-void WorkArea::SnapWindow(HWND window, const ZoneIndexSet& zones)
+void WorkArea::SnapWindow(HWND window, const ZoneIndexSet& zones, bool extend)
 {
     if (!m_layoutWindows || !m_layout)
     {
         return;
     }
 
-    m_layoutWindows->Assign(window, zones);
-
+    if (extend)
+    {
+        m_layoutWindows->Extend(window, zones);
+    }
+    else
+    {
+        m_layoutWindows->Assign(window, zones);
+    }
+    
     auto guidStr = FancyZonesUtils::GuidToString(m_layout->Id());
     if (guidStr.has_value())
     {

--- a/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
@@ -144,8 +144,11 @@ void WorkArea::MoveWindowIntoZoneByIndexSet(HWND window, const ZoneIndexSet& ind
     if (updatePosition)
     {
         const auto rect = m_layout->GetCombinedZonesRect(indexSet);
-        const auto adjustedRect = FancyZonesWindowUtils::AdjustRectForSizeWindowToRect(window, rect, m_window);
-        FancyZonesWindowUtils::SizeWindowToRect(window, adjustedRect);
+        if (rect.bottom - rect.top > 0 && rect.right - rect.left > 0)
+        {
+            const auto adjustedRect = FancyZonesWindowUtils::AdjustRectForSizeWindowToRect(window, rect, m_window);
+            FancyZonesWindowUtils::SizeWindowToRect(window, adjustedRect);
+        }
     }
 
     SnapWindow(window, indexSet);

--- a/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
@@ -465,6 +465,20 @@ void WorkArea::UpdateActiveZoneSet()
     }
 }
 
+void WorkArea::UpdateWindowPositions()
+{
+    if (!m_layoutWindows)
+    {
+        return;
+    }
+
+    const auto& snappedWindows = m_layoutWindows->SnappedWindows();
+    for (const auto& [window, zones] : snappedWindows)
+    {
+        MoveWindowIntoZoneByIndexSet(window, zones, true);
+    }
+}
+
 void WorkArea::CycleWindows(HWND window, bool reverse)
 {
     if (m_layoutWindows)
@@ -510,8 +524,7 @@ void WorkArea::InitLayout(const FancyZonesDataTypes::WorkAreaId& parentUniqueId)
 
 void WorkArea::InitSnappedWindows()
 {
-    static bool updatePositionOnceOnStartFlag = true;
-    Logger::info(L"Init work area windows, update positions = {}", updatePositionOnceOnStartFlag);
+    Logger::info(L"Init work area windows");
 
     for (const auto& window : VirtualDesktop::instance().GetWindowsFromCurrentDesktop())
     {
@@ -523,19 +536,17 @@ void WorkArea::InitSnappedWindows()
 
         if (!m_uniqueId.monitorId.monitor) // one work area across monitors
         {
-            MoveWindowIntoZoneByIndexSet(window, zoneIndexSet, updatePositionOnceOnStartFlag);
+            MoveWindowIntoZoneByIndexSet(window, zoneIndexSet, false);
         }
         else
         {
             const auto monitor = MonitorFromWindow(window, MONITOR_DEFAULTTONULL);
             if (monitor && m_uniqueId.monitorId.monitor == monitor)
             {
-                MoveWindowIntoZoneByIndexSet(window, zoneIndexSet, updatePositionOnceOnStartFlag);
+                MoveWindowIntoZoneByIndexSet(window, zoneIndexSet, false);
             }
         }
     }
-
-    updatePositionOnceOnStartFlag = false;
 }
 
 void WorkArea::CalculateZoneSet()

--- a/src/modules/fancyzones/FancyZonesLib/WorkArea.h
+++ b/src/modules/fancyzones/FancyZonesLib/WorkArea.h
@@ -55,6 +55,7 @@ public:
     void UnsnapWindow(HWND window);
 
     void UpdateActiveZoneSet();
+    void UpdateWindowPositions();
 
     void ShowZonesOverlay(const ZoneIndexSet& highlight, HWND draggedWindow = nullptr);
     void HideZonesOverlay();

--- a/src/modules/fancyzones/FancyZonesLib/WorkArea.h
+++ b/src/modules/fancyzones/FancyZonesLib/WorkArea.h
@@ -51,7 +51,7 @@ public:
     bool MoveWindowIntoZoneByDirectionAndPosition(HWND window, DWORD vkCode, bool cycle);
     bool ExtendWindowByDirectionAndPosition(HWND window, DWORD vkCode);
 
-    void SnapWindow(HWND window, const ZoneIndexSet& zones);
+    void SnapWindow(HWND window, const ZoneIndexSet& zones, bool extend = false);
     void UnsnapWindow(HWND window);
 
     void UpdateActiveZoneSet();


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #23820
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

* Enable `During zone layout changes, windows assigned to a zone will match new size/position`
* Set shortcuts to 2 custom layouts with different amount of zones
* Snap window to a zone whose number is present in both layouts
* Change the layout using a shortcut
* Verify window fits the zone 
* Snap window to a zone whose number is present in only one layout
* Change the layout using a shortcut
* Verify window didn't change its position 