### PR TITLE
[Shotcut Guide] Dismiss with mouse

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -174,6 +174,7 @@ buildtask
 buildtransitive
 Burkina
 Buryatia
+BUTTONUP
 BValue
 BYPOSITION
 bytearray

--- a/src/modules/ShortcutGuide/ShortcutGuide/shortcut_guide.h
+++ b/src/modules/ShortcutGuide/ShortcutGuide/shortcut_guide.h
@@ -18,7 +18,8 @@ enum class HideWindowType
     ESC_PRESSED,
     WIN_RELEASED,
     WIN_SHORTCUT_PRESSED,
-    THE_SHORTCUT_PRESSED
+    THE_SHORTCUT_PRESSED,
+    MOUSE_BUTTONUP
 };
 
 class OverlayWindow
@@ -34,6 +35,7 @@ public:
     void was_hidden();
 
     bool overlay_visible() const;
+    bool win_key_activation() const;
 
     bool is_disabled_app(wchar_t* exePath);
 
@@ -52,6 +54,7 @@ private:
     void update_disabled_apps();
     HWND activeWindow;
     HHOOK keyboardHook;
+    HHOOK mouseHook;
 
     struct OverlayOpacity
     {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Dismiss shortcut guide on mouse button up.
Same behavior of Windows TaskView.
Not dismissed with mouse when activation is window key pressed and the key is still pressed.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #15338
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Set win key as activation
- Mouse click should not dismiss SG when win key is still pressed
- Mouse click should dismiss SG when activated from the flyout menu
- Set shortcut as activation
- Mouse click should dismiss SG when activated from the shortcut
- Mouse click should dismiss SG when activated from the flyout menu