### PR TITLE
[Peek] Fix loading thumbnail for dehydrated images

### DIFF
--- a/src/modules/peek/Peek.Common/Extensions/IFileSystemItemExtensions.cs
+++ b/src/modules/peek/Peek.Common/Extensions/IFileSystemItemExtensions.cs
@@ -12,13 +12,18 @@ namespace Peek.Common.Extensions
 {
     public static class IFileSystemItemExtensions
     {
-        public static Size GetImageSize(this IFileSystemItem item)
+        public static Size? GetImageSize(this IFileSystemItem item)
         {
-            var propertyStore = item.PropertyStore;
-            var width = propertyStore.TryGetUInt(PropertyKey.ImageHorizontalSize) ?? 0;
-            var height = propertyStore.TryGetUInt(PropertyKey.ImageVerticalSize) ?? 0;
+            Size? size = null;
 
-            var size = new Size((int)width, (int)height);
+            var propertyStore = item.PropertyStore;
+            var width = propertyStore.TryGetUInt(PropertyKey.ImageHorizontalSize);
+            var height = propertyStore.TryGetUInt(PropertyKey.ImageVerticalSize);
+
+            if (width != null && height != null)
+            {
+                size = new Size((int)width, (int)height);
+            }
 
             return size;
         }

--- a/src/modules/peek/Peek.FilePreviewer/FilePreview.xaml.cs
+++ b/src/modules/peek/Peek.FilePreviewer/FilePreview.xaml.cs
@@ -251,8 +251,8 @@ namespace Peek.FilePreviewer
             sb.Append(dateModifiedFormatted);
 
             cancellationToken.ThrowIfCancellationRequested();
-            Size dimensions = await Task.Run(Item.GetImageSize);
-            string dimensionsFormatted = dimensions.IsEmpty ? string.Empty : "\n" + ReadableStringHelper.FormatResourceString("PreviewTooltip_Dimensions", dimensions.Width, dimensions.Height);
+            Size? dimensions = await Task.Run(Item.GetImageSize);
+            string dimensionsFormatted = dimensions == null ? string.Empty : "\n" + ReadableStringHelper.FormatResourceString("PreviewTooltip_Dimensions", dimensions.Value.Width, dimensions.Value.Height);
             sb.Append(dimensionsFormatted);
 
             cancellationToken.ThrowIfCancellationRequested();


### PR DESCRIPTION
## Summary of the Pull Request
- Open file on background thread to free ui thread for thumbnail loading
- Make Size nullable to handle cases where the image file does not have width/height