### PR TITLE
[Runner] Improve metered network detection

### DIFF
--- a/src/runner/UpdateUtils.cpp
+++ b/src/runner/UpdateUtils.cpp
@@ -88,7 +88,26 @@ bool IsMeteredConnection()
 {
     using namespace winrt::Windows::Networking::Connectivity;
     ConnectionProfile internetConnectionProfile = NetworkInformation::GetInternetConnectionProfile();
-    return internetConnectionProfile && internetConnectionProfile.IsWwanConnectionProfile();
+    if (!internetConnectionProfile)
+    {
+        return false;
+    }
+
+    if (internetConnectionProfile.IsWwanConnectionProfile())
+    {
+        return true;
+    }
+
+    ConnectionCost connectionCost = internetConnectionProfile.GetConnectionCost();
+    if (connectionCost.Roaming()
+        || connectionCost.OverDataLimit()
+        || connectionCost.NetworkCostType() == NetworkCostType::Fixed
+        || connectionCost.NetworkCostType() == NetworkCostType::Variable)
+    {
+        return true;
+    }
+
+    return false;
 }
 
 void ProcessNewVersionInfo(const github_version_info& version_info,


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Improve how runner is detecting wheter network is metered during in order to downlod the update.
The code is used by the settings callback and the backgound worker.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #24010
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

Preserved the old logic that consider metered a WWAN connection.
References:
- https://devblogs.microsoft.com/oldnewthing/20221013-00/?p=107285
- https://learn.microsoft.com/en-us/previous-versions/windows/apps/hh750310(v=win.10)

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

- Build PT with a version different than 0.0.1
- Set network as not metered from Windows settings
  - Open PT settings
  - Check for updates
  - Update should be downloaded and PT should ask for install
- Set network as metered from Windows settings
  - Open PT settings
  - Check for updates
  - Update should't be downloaded and PT should ask for download and install
