### PR TITLE
[PT Run] System plugin: Setting for separate "Empty Recycle Bin" result

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.System/Components/Commands.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.System/Components/Commands.cs
@@ -33,7 +33,7 @@ namespace Microsoft.PowerToys.Run.Plugin.System.Components
         /// Returns a list with all system command results
         /// </summary>
         /// <param name="isUefi">Value indicating if the system is booted in uefi mode</param>
-        /// <param name="splitRecycleBinResults">Value idicating if we should show two results for Recycle Bin.</param>
+        /// <param name="splitRecycleBinResults">Value indicating if we should show two results for Recycle Bin.</param>
         /// <param name="confirmCommands">A value indicating if the user should confirm the system commands</param>
         /// <param name="emptyRBSuccessMessage">Show a success message after empty Recycle Bin.</param>
         /// <param name="iconTheme">The current theme to use for the icons</param>
@@ -106,7 +106,7 @@ namespace Microsoft.PowerToys.Run.Plugin.System.Components
                 },
             });
 
-            // SHow Recycle Bin results based on setting.
+            // Show Recycle Bin results based on setting.
             if (splitRecycleBinResults)
             {
                 results.AddRange(new[]

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.System/Components/Commands.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.System/Components/Commands.cs
@@ -35,7 +35,7 @@ namespace Microsoft.PowerToys.Run.Plugin.System.Components
         /// <param name="isUefi">Value indicating if the system is booted in uefi mode</param>
         /// <param name="splitRecycleBinResults">Value idicating if we should show two results for Recycle Bin.</param>
         /// <param name="confirmCommands">A value indicating if the user should confirm the system commands</param>
-        /// <param name="emptyRBSuccessMsg">Show a success message after empty Recycle Bin.</param>
+        /// <param name="emptyRBSuccessMessage">Show a success message after empty Recycle Bin.</param>
         /// <param name="iconTheme">The current theme to use for the icons</param>
         /// <param name="culture">The culture to use for the result's title and sub title</param>
         /// <returns>A list of all results</returns>
@@ -132,7 +132,7 @@ namespace Microsoft.PowerToys.Run.Plugin.System.Components
                             return true;
                         },
                     },
-                })
+                });
             }
             else
             {

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.System/Components/Commands.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.System/Components/Commands.cs
@@ -5,14 +5,10 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Runtime;
-using System.Windows;
-using System.Windows.Interop;
 using Microsoft.PowerToys.Run.Plugin.System.Properties;
 using Wox.Infrastructure;
 using Wox.Plugin;
 using Wox.Plugin.Common.Win32;
-using Wox.Plugin.Logger;
 
 namespace Microsoft.PowerToys.Run.Plugin.System.Components
 {
@@ -37,11 +33,13 @@ namespace Microsoft.PowerToys.Run.Plugin.System.Components
         /// Returns a list with all system command results
         /// </summary>
         /// <param name="isUefi">Value indicating if the system is booted in uefi mode</param>
+        /// <param name="splitRecycleBinResults">Value idicating if we should show two results for Recycle Bin.</param>
+        /// <param name="confirmCommands">A value indicating if the user should confirm the system commands</param>
+        /// <param name="emptyRBSuccessMsg">Show a success message after empty Recycle Bin.</param>
         /// <param name="iconTheme">The current theme to use for the icons</param>
         /// <param name="culture">The culture to use for the result's title and sub title</param>
-        /// <param name="confirmCommands">A value indicating if the user should confirm the system commands</param>
         /// <returns>A list of all results</returns>
-        internal static List<Result> GetSystemCommands(bool isUefi, string iconTheme, CultureInfo culture, bool confirmCommands)
+        internal static List<Result> GetSystemCommands(bool isUefi, bool splitRecycleBinResults, bool confirmCommands, bool emptyRBSuccessMessage, string iconTheme, CultureInfo culture)
         {
             var results = new List<Result>();
             results.AddRange(new[]
@@ -106,7 +104,39 @@ namespace Microsoft.PowerToys.Run.Plugin.System.Components
                         return ResultHelper.ExecuteCommand(confirmCommands, Resources.Microsoft_plugin_sys_hibernate_confirmation, () => NativeMethods.SetSuspendState(true, true, true));
                     },
                 },
-                new Result
+            });
+
+            // SHow Recycle Bin results based on setting.
+            if (splitRecycleBinResults)
+            {
+                results.AddRange(new[]
+                {
+                    new Result
+                    {
+                        Title = Resources.ResourceManager.GetString("Microsoft_plugin_sys_RecycleBinOpen", culture),
+                        SubTitle = Resources.ResourceManager.GetString("Microsoft_plugin_sys_RecycleBin_description", culture),
+                        IcoPath = $"Images\\recyclebin.{iconTheme}.png",
+                        Action = c =>
+                        {
+                            return Helper.OpenInShell("explorer.exe", "shell:RecycleBinFolder");
+                        },
+                    },
+                    new Result
+                    {
+                        Title = Resources.ResourceManager.GetString("Microsoft_plugin_sys_RecycleBinEmptyResult", culture),
+                        SubTitle = Resources.ResourceManager.GetString("Microsoft_plugin_sys_RecycleBinEmpty_description", culture),
+                        IcoPath = $"Images\\recyclebin.{iconTheme}.png",
+                        Action = c =>
+                        {
+                            ResultHelper.EmptyRecycleBinAsync(emptyRBSuccessMessage);
+                            return true;
+                        },
+                    },
+                })
+            }
+            else
+            {
+                results.Add(new Result
                 {
                     Title = Resources.ResourceManager.GetString("Microsoft_plugin_sys_RecycleBin", culture),
                     SubTitle = Resources.ResourceManager.GetString("Microsoft_plugin_sys_RecycleBin_description", culture),
@@ -116,8 +146,8 @@ namespace Microsoft.PowerToys.Run.Plugin.System.Components
                     {
                         return Helper.OpenInShell("explorer.exe", "shell:RecycleBinFolder");
                     },
-                },
-            });
+                });
+            }
 
             // UEFI command/result. It is only available on systems booted in UEFI mode.
             if (isUefi)

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.System/Components/ResultHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.System/Components/ResultHelper.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
-using System.Windows.Navigation;
 using Microsoft.PowerToys.Run.Plugin.System.Properties;
 using Wox.Plugin;
 using Wox.Plugin.Common.Win32;

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.System/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.System/Main.cs
@@ -26,6 +26,7 @@ namespace Microsoft.PowerToys.Run.Plugin.System
         private bool _showSuccessOnEmptyRB;
         private bool _localizeSystemCommands;
         private bool _reduceNetworkResultScore;
+        private bool _separateEmptyRB;
 
         public string Name => Resources.Microsoft_plugin_sys_plugin_name;
 
@@ -53,6 +54,12 @@ namespace Microsoft.PowerToys.Run.Plugin.System
             {
                 Key = "LocalizeSystemCommands",
                 DisplayLabel = Resources.Use_localized_system_commands,
+                Value = true,
+            },
+            new PluginAdditionalOption()
+            {
+                Key = "SeparateResultEmptyRB",
+                DisplayLabel = Resources.Microsoft_plugin_sys_RecycleBin_ShowEmptySeparate,
                 Value = true,
             },
             new PluginAdditionalOption()
@@ -90,7 +97,7 @@ namespace Microsoft.PowerToys.Run.Plugin.System
             }
 
             // normal system commands are fast and can be returned immediately
-            var systemCommands = Commands.GetSystemCommands(IsBootedInUefiMode, IconTheme, culture, _confirmSystemCommands);
+            var systemCommands = Commands.GetSystemCommands(IsBootedInUefiMode, _separateEmptyRB, _confirmSystemCommands, _showSuccessOnEmptyRB, IconTheme, culture);
             foreach (var c in systemCommands)
             {
                 var resultMatch = StringMatcher.FuzzySearch(query.Search, c.Title);
@@ -209,6 +216,7 @@ namespace Microsoft.PowerToys.Run.Plugin.System
             var showSuccessOnEmptyRB = false;
             var localizeSystemCommands = true;
             var reduceNetworkResultScore = true;
+            var separateEmptyRB = false;
 
             if (settings != null && settings.AdditionalOptions != null)
             {
@@ -223,12 +231,16 @@ namespace Microsoft.PowerToys.Run.Plugin.System
 
                 var optionNetworkScore = settings.AdditionalOptions.FirstOrDefault(x => x.Key == "ReduceNetworkResultScore");
                 reduceNetworkResultScore = optionNetworkScore?.Value ?? reduceNetworkResultScore;
+
+                var optionSeparateEmptyRB = settings.AdditionalOptions.FirstOrDefault(x => x.Key == "SeparateResultEmptyRB");
+                separateEmptyRB = optionSeparateEmptyRB?.Value ?? separateEmptyRB;
             }
 
             _confirmSystemCommands = confirmSystemCommands;
             _showSuccessOnEmptyRB = showSuccessOnEmptyRB;
             _localizeSystemCommands = localizeSystemCommands;
             _reduceNetworkResultScore = reduceNetworkResultScore;
+            _separateEmptyRB = separateEmptyRB;
         }
     }
 }

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.System/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.System/Main.cs
@@ -60,7 +60,7 @@ namespace Microsoft.PowerToys.Run.Plugin.System
             {
                 Key = "SeparateResultEmptyRB",
                 DisplayLabel = Resources.Microsoft_plugin_sys_RecycleBin_ShowEmptySeparate,
-                Value = true,
+                Value = false,
             },
             new PluginAdditionalOption()
             {

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.System/Properties/Resources.Designer.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.System/Properties/Resources.Designer.cs
@@ -457,11 +457,47 @@ namespace Microsoft.PowerToys.Run.Plugin.System.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Show a success message after empty the Recycle Bin.
+        ///   Looks up a localized string similar to Show separate result for Empty Recycle Bin command.
+        /// </summary>
+        internal static string Microsoft_plugin_sys_RecycleBin_ShowEmptySeparate {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_sys_RecycleBin_ShowEmptySeparate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Show a success message after emptying the Recycle Bin.
         /// </summary>
         internal static string Microsoft_plugin_sys_RecycleBin_ShowEmptySuccessMessage {
             get {
                 return ResourceManager.GetString("Microsoft_plugin_sys_RecycleBin_ShowEmptySuccessMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Empty Recycle Bin.
+        /// </summary>
+        internal static string Microsoft_plugin_sys_RecycleBinEmpty_description {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_sys_RecycleBinEmpty_description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Empty Recycle Bin.
+        /// </summary>
+        internal static string Microsoft_plugin_sys_RecycleBinEmptyResult {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_sys_RecycleBinEmptyResult", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Open Recycle Bin.
+        /// </summary>
+        internal static string Microsoft_plugin_sys_RecycleBinOpen {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_sys_RecycleBinOpen", resourceCulture);
             }
         }
         

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.System/Properties/Resources.resx
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.System/Properties/Resources.resx
@@ -244,6 +244,18 @@
     <value>Recycle Bin</value>
     <comment>Means the recycle bin folder in Explorer.</comment>
   </data>
+  <data name="Microsoft_plugin_sys_RecycleBinEmptyResult" xml:space="preserve">
+    <value>Empty Recycle Bin</value>
+    <comment>This should align to the action in Windows of emptying the recycle bin on your computer.</comment>
+  </data>
+  <data name="Microsoft_plugin_sys_RecycleBinEmpty_description" xml:space="preserve">
+    <value>Empty Recycle Bin</value>
+    <comment>This should align to the action in Windows of emptying the recycle bin on your computer.</comment>
+  </data>
+  <data name="Microsoft_plugin_sys_RecycleBinOpen" xml:space="preserve">
+    <value>Open Recycle Bin</value>
+    <comment>Means the recycle bin folder in Explorer.</comment>
+  </data>
   <data name="Microsoft_plugin_sys_RecycleBin_contextMenu" xml:space="preserve">
     <value>Empty Recycle Bin (Shift+Delete)</value>
     <comment>This should align to the action in Windows of emptying the recycle bin on your computer.</comment>
@@ -270,6 +282,9 @@
   <data name="Microsoft_plugin_sys_RecycleBin_searchTag" xml:space="preserve">
     <value>Empty Recycle Bin</value>
     <comment>This should align to the action in Windows of emptying the recycle bin on your computer.</comment>
+  </data>
+  <data name="Microsoft_plugin_sys_RecycleBin_ShowEmptySeparate" xml:space="preserve">
+    <value>Show separate result for Empty Recycle Bin command</value>
   </data>
   <data name="Microsoft_plugin_sys_RecycleBin_ShowEmptySuccessMessage" xml:space="preserve">
     <value>Show a success message after emptying the Recycle Bin</value>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This PR adds a default off setting to show two separate results for recycle bin instead of one with a context menu.

**Setting off (default):**
- One result: Open Recycle Bin
   - Context menu: Empty Recycle Bin (Shift+Del)

**Setting on:**
- First result: Open Recycle Bin
- Second result: Empty Recycle Bin

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #23796 
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Local build and test of behavior.
