### PR TITLE
[Settings] bkp and restore - select folder crash when elevated

### DIFF
--- a/src/settings-ui/Settings.UI/Helpers/ShellGetFolder.cs
+++ b/src/settings-ui/Settings.UI/Helpers/ShellGetFolder.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+using static Microsoft.PowerToys.Settings.UI.Helpers.ShellGetFolder;
+
+namespace Microsoft.PowerToys.Settings.UI.Helpers
+{
+    public class ShellGetFolder
+    {
+        [DllImport("shell32.dll")]
+        private static extern IntPtr SHBrowseForFolderW(ref BrowseInformation browseInfo);
+
+        [DllImport("shell32.dll")]
+        private static extern int SHGetPathFromIDListW(IntPtr pidl, IntPtr pszPath);
+
+        public delegate int BrowseCallbackProc(IntPtr hwnd, int msg, IntPtr lp, IntPtr wp);
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct BrowseInformation
+        {
+            public IntPtr HwndOwner;
+            public IntPtr PidlRoot;
+            public string PszDisplayName;
+            public string LpszTitle;
+            public uint UlFlags;
+            public BrowseCallbackProc Lpfn;
+            public IntPtr LParam;
+            public int IImage;
+        }
+
+        public static string GetFolderDialog(IntPtr hwndOwner)
+        {
+            StringBuilder sb = new StringBuilder(256);
+            IntPtr bufferAddress = Marshal.AllocHGlobal(256);
+            IntPtr pidl = IntPtr.Zero;
+            BrowseInformation browseInfo;
+            browseInfo.HwndOwner = hwndOwner;
+            browseInfo.PidlRoot = IntPtr.Zero;
+            browseInfo.PszDisplayName = null;
+            browseInfo.LpszTitle = null;
+            browseInfo.UlFlags = 0;
+            browseInfo.Lpfn = null;
+            browseInfo.LParam = IntPtr.Zero;
+            browseInfo.IImage = 0;
+
+            try
+            {
+                pidl = SHBrowseForFolderW(ref browseInfo);
+                if (SHGetPathFromIDListW(pidl, bufferAddress) == 0)
+                {
+                    return null;
+                }
+
+                sb.Append(Marshal.PtrToStringUni(bufferAddress));
+                Marshal.FreeHGlobal(bufferAddress);
+            }
+            finally
+            {
+                // Need to free pidl
+                Marshal.FreeCoTaskMem(pidl);
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/src/settings-ui/Settings.UI/Helpers/ShellGetFolder.cs
+++ b/src/settings-ui/Settings.UI/Helpers/ShellGetFolder.cs
@@ -34,8 +34,10 @@ namespace Microsoft.PowerToys.Settings.UI.Helpers
 
         public static string GetFolderDialog(IntPtr hwndOwner)
         {
-            StringBuilder sb = new StringBuilder(256);
-            IntPtr bufferAddress = Marshal.AllocHGlobal(256);
+            // windows MAX_PATH with long path enable can be approximated 32k char long
+            // allocating more than double (unicode) to hold the path
+            StringBuilder sb = new StringBuilder(65000);
+            IntPtr bufferAddress = Marshal.AllocHGlobal(65000);
             IntPtr pidl = IntPtr.Zero;
             BrowseInformation browseInfo;
             browseInfo.HwndOwner = hwndOwner;

--- a/src/settings-ui/Settings.UI/Views/GeneralPage.xaml.cs
+++ b/src/settings-ui/Settings.UI/Views/GeneralPage.xaml.cs
@@ -6,6 +6,7 @@ using System;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.PowerToys.Settings.UI.Helpers;
 using Microsoft.PowerToys.Settings.UI.Library;
 using Microsoft.PowerToys.Settings.UI.Library.Utilities;
 using Microsoft.PowerToys.Settings.UI.ViewModels;
@@ -142,12 +143,12 @@ namespace Microsoft.PowerToys.Settings.UI.Views
 
         private async Task<string> PickSingleFolderDialog()
         {
-            var openPicker = new FolderPicker();
+            // This function was changed to use the shell32 API to open folder dialog
+            // as the old one (PickSingleFolderAsync) can't work when the process is elevated
+            // TODO: go back PickSingleFolderAsync when it's fixed
             var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(App.GetSettingsWindow());
-            WinRT.Interop.InitializeWithWindow.Initialize(openPicker, hwnd);
-            openPicker.FileTypeFilter.Add("*");
-            var folder = await openPicker.PickSingleFolderAsync();
-            return folder?.Path;
+            string r = await Task.FromResult<string>(ShellGetFolder.GetFolderDialog(hwnd));
+            return r;
         }
     }
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Used shell32 select folder dialog, as the WinUI3 version is not working while elevated.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #23379
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manual test
