### PR TITLE
PT Run settings: show icons of user-installed plugins

### DIFF
--- a/src/modules/launcher/PowerLauncher/SettingsReader.cs
+++ b/src/modules/launcher/PowerLauncher/SettingsReader.cs
@@ -215,8 +215,7 @@ namespace PowerLauncher
 
         private static string GetIcon(PluginMetadata metadata, string iconPath)
         {
-            var pluginDirectory = Path.GetFileName(metadata.PluginDirectory);
-            return Path.Combine(pluginDirectory, iconPath);
+            return Path.Combine(metadata.PluginDirectory, iconPath);
         }
 
         private static IEnumerable<PowerLauncherPluginSettings> GetDefaultPluginsSettings()

--- a/src/settings-ui/Settings.UI/ViewModels/PowerLauncherPluginViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/PowerLauncherPluginViewModel.cs
@@ -160,12 +160,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
 
         public string IconPath
         {
-            get
-            {
-                var path = isDark() ? settings.IconPathDark : settings.IconPathLight;
-                path = Path.Combine(Directory.GetCurrentDirectory(), @"modules\launcher\Plugins", path);
-                return path;
-            }
+            get => isDark() ? settings.IconPathDark : settings.IconPathLight;
         }
 
         public event PropertyChangedEventHandler PropertyChanged;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Fix loading of plugin icons for plugins installed to the user directory (`%LOCALAPPDATA%\Microsoft\PowerToys\PowerToys Run\Plugins`) in the PT Run settings page.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #24202
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

Previously, the icon paths were passed as relative paths (WRT the plugin directory) to the settings page, which then hard-coded the plugin directory to the default plugin directory (_i.e._, in Program Files), causing icons for locally-installed plugins to appear blank. This was fixed by passing the absolute path to the icons instead.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Compiled & validated that all plugin icons are displayed correctly in the settings page.

