### PR TITLE
[FancyZones] Move windows to the app last zone fix

### DIFF
--- a/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
@@ -250,7 +250,7 @@ FancyZones::Run() noexcept
         }
     });
 
-    PostMessage(m_window, WM_PRIV_VD_INIT, 0, 0);
+    PostMessage(m_window, WM_PRIV_INIT, 0, 0);
 }
 
 // IFancyZones
@@ -601,7 +601,7 @@ LRESULT FancyZones::WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lpa
         {
             OnSnapHotkey(static_cast<DWORD>(lparam));
         }
-        else if (message == WM_PRIV_VD_INIT)
+        else if (message == WM_PRIV_INIT)
         {
             OnDisplayChange(DisplayChangeType::Initialization);
         }
@@ -1099,7 +1099,7 @@ void FancyZones::SettingsUpdate(SettingId id)
     case SettingId::SpanZonesAcrossMonitors:
     {
         m_workAreaHandler.Clear();
-        PostMessageW(m_window, WM_PRIV_VD_INIT, NULL, NULL);
+        PostMessageW(m_window, WM_PRIV_INIT, NULL, NULL);
     }
     break;
     default:

--- a/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
@@ -37,6 +37,22 @@ enum class DisplayChangeType
     Initialization
 };
 
+constexpr wchar_t* DisplayChangeTypeName (const DisplayChangeType type){
+    switch (type)
+    {
+    case DisplayChangeType::WorkArea:
+        return L"WorkArea";
+    case DisplayChangeType::DisplayChange:
+        return L"DisplayChange";
+    case DisplayChangeType::VirtualDesktop:
+        return L"VirtualDesktop";
+    case DisplayChangeType::Initialization:
+        return L"Initialization";
+    default:
+        return L"";
+    }
+}
+
 // Non-localizable strings
 namespace NonLocalizable
 {
@@ -688,7 +704,7 @@ LRESULT FancyZones::WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lpa
 
 void FancyZones::OnDisplayChange(DisplayChangeType changeType) noexcept
 {
-    Logger::info(L"Display changed, type: {}", changeType);
+    Logger::info(L"Display changed, type: {}", DisplayChangeTypeName(changeType));
 
     bool updateWindowsPositions = false;
 

--- a/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
@@ -353,11 +353,7 @@ bool FancyZones::MoveToAppLastZone(HWND window, HMONITOR monitor) noexcept
             workArea = workAreas.at(monitor).get();
             if (workArea)
             {
-                auto guidStr = FancyZonesUtils::GuidToString(workArea->GetLayoutId());
-                if (guidStr.has_value())
-                {
-                    indexes = AppZoneHistory::instance().GetAppLastZoneIndexSet(window, workArea->UniqueId(), guidStr.value());
-                }
+                indexes = workArea->GetWindowZoneIndexes(window);
             }
         }
         else

--- a/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
@@ -743,6 +743,7 @@ void FancyZones::AddWorkArea(HMONITOR monitor, const FancyZonesDataTypes::WorkAr
     auto workArea = WorkArea::Create(m_hinstance, id, m_workAreaHandler.GetParent(monitor), rect);
     if (workArea)
     {
+        workArea->InitSnappedWindows();
         if (updateWindowsPositions)
         {
             workArea->UpdateWindowPositions();

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesData/AppZoneHistory.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesData/AppZoneHistory.cpp
@@ -532,29 +532,6 @@ bool AppZoneHistory::IsAnotherWindowOfApplicationInstanceZoned(HWND window, cons
     return false;
 }
 
-void AppZoneHistory::UpdateProcessIdToHandleMap(HWND window, const FancyZonesDataTypes::WorkAreaId& workAreaId)
-{
-    auto processPath = get_process_path_waiting_uwp(window);
-    if (!processPath.empty())
-    {
-        auto history = m_history.find(processPath);
-        if (history != std::end(m_history))
-        {
-            auto& perDesktopData = history->second;
-            for (auto& data : perDesktopData)
-            {
-                if (data.workAreaId == workAreaId)
-                {
-                    DWORD processId = 0;
-                    GetWindowThreadProcessId(window, &processId);
-                    data.processIdToHandleMap[processId] = window;
-                    break;
-                }
-            }
-        }
-    }
-}
-
 ZoneIndexSet AppZoneHistory::GetAppLastZoneIndexSet(HWND window, const FancyZonesDataTypes::WorkAreaId& workAreaId, const std::wstring& zoneSetId) const
 {
     auto processPath = get_process_path_waiting_uwp(window);

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesData/AppZoneHistory.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesData/AppZoneHistory.cpp
@@ -394,7 +394,7 @@ bool AppZoneHistory::SetAppLastZones(HWND window, const FancyZonesDataTypes::Wor
 
 bool AppZoneHistory::RemoveAppLastZone(HWND window, const FancyZonesDataTypes::WorkAreaId& workAreaId, const std::wstring_view& zoneSetId)
 {
-    Logger::info(L"Add app zone history, device: {}, layout: {}", workAreaId.toString(), zoneSetId);
+    Logger::info(L"Remove app zone history, device: {}, layout: {}", workAreaId.toString(), zoneSetId);
 
     auto processPath = get_process_path_waiting_uwp(window);
     if (!processPath.empty())
@@ -541,7 +541,6 @@ ZoneIndexSet AppZoneHistory::GetAppLastZoneIndexSet(HWND window, const FancyZone
         return {};
     }
 
-    auto srcVirtualDesktopIDStr = FancyZonesUtils::GuidToString(workAreaId.virtualDesktopId);
     auto app = processPath;
     auto pos = processPath.find_last_of('\\');
     if (pos != std::string::npos && pos + 1 < processPath.length())
@@ -549,10 +548,7 @@ ZoneIndexSet AppZoneHistory::GetAppLastZoneIndexSet(HWND window, const FancyZone
         app = processPath.substr(pos + 1);
     }
 
-    if (srcVirtualDesktopIDStr)
-    {
-        Logger::debug(L"Get {} zone history on monitor: {}, virtual desktop: {}", app, workAreaId.toString(), srcVirtualDesktopIDStr.value());
-    }
+    Logger::info(L"Get {} zone history on work area: {}", app, workAreaId.toString());
 
     auto history = m_history.find(processPath);
     if (history == std::end(m_history))
@@ -565,14 +561,9 @@ ZoneIndexSet AppZoneHistory::GetAppLastZoneIndexSet(HWND window, const FancyZone
     {
         if (data.zoneSetUuid == zoneSetId && data.workAreaId == workAreaId)
         {
-            auto vdStr = FancyZonesUtils::GuidToString(data.workAreaId.virtualDesktopId);
-            if (vdStr)
-            {
-                Logger::debug(L"App zone history found on the device {} with virtual desktop {}", data.workAreaId.toString(), vdStr.value()); 
-            }
-
             if (data.workAreaId.virtualDesktopId == workAreaId.virtualDesktopId || data.workAreaId.virtualDesktopId == GUID_NULL)
             {
+                Logger::info(L"App zone history found on the work area {}", data.workAreaId.toString());
                 return data.zoneIndexSet;
             }
         }

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesData/AppZoneHistory.h
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesData/AppZoneHistory.h
@@ -54,7 +54,6 @@ public:
     std::optional<FancyZonesDataTypes::AppZoneHistoryData> GetZoneHistory(const std::wstring& appPath, const FancyZonesDataTypes::WorkAreaId& workAreaId) const noexcept;
 
     bool IsAnotherWindowOfApplicationInstanceZoned(HWND window, const FancyZonesDataTypes::WorkAreaId& workAreaId) const noexcept;
-    void UpdateProcessIdToHandleMap(HWND window, const FancyZonesDataTypes::WorkAreaId& workAreaId);
     ZoneIndexSet GetAppLastZoneIndexSet(HWND window, const FancyZonesDataTypes::WorkAreaId& workAreaId, const std::wstring& zoneSetId) const;
 
     void SyncVirtualDesktops();

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesWinHookEventIDs.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesWinHookEventIDs.cpp
@@ -9,7 +9,6 @@ UINT WM_PRIV_NAMECHANGE;
 UINT WM_PRIV_WINDOWCREATED;
 UINT WM_PRIV_VD_INIT;
 UINT WM_PRIV_VD_SWITCH;
-UINT WM_PRIV_VD_UPDATE;
 UINT WM_PRIV_EDITOR;
 UINT WM_PRIV_LAYOUT_HOTKEYS_FILE_UPDATE;
 UINT WM_PRIV_LAYOUT_TEMPLATES_FILE_UPDATE;
@@ -32,7 +31,6 @@ void InitializeWinhookEventIds()
         WM_PRIV_WINDOWCREATED = RegisterWindowMessage(L"{bdb10669-75da-480a-9ec4-eeebf09a02d7}");
         WM_PRIV_VD_INIT = RegisterWindowMessage(L"{469818a8-00fa-4069-b867-a1da484fcd9a}");
         WM_PRIV_VD_SWITCH = RegisterWindowMessage(L"{128c2cb0-6bdf-493e-abbe-f8705e04aa95}");
-        WM_PRIV_VD_UPDATE = RegisterWindowMessage(L"{b8b72b46-f42f-4c26-9e20-29336cf2f22e}");
         WM_PRIV_EDITOR = RegisterWindowMessage(L"{87543824-7080-4e91-9d9c-0404642fc7b6}");
         WM_PRIV_LAYOUT_HOTKEYS_FILE_UPDATE = RegisterWindowMessage(L"{07229b7e-4f22-4357-b136-33c289be2295}");
         WM_PRIV_LAYOUT_TEMPLATES_FILE_UPDATE = RegisterWindowMessage(L"{4686f019-5d3d-4c5c-9051-b7cbbccca77d}");

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesWinHookEventIDs.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesWinHookEventIDs.cpp
@@ -7,7 +7,7 @@ UINT WM_PRIV_MOVESIZEEND;
 UINT WM_PRIV_LOCATIONCHANGE;
 UINT WM_PRIV_NAMECHANGE;
 UINT WM_PRIV_WINDOWCREATED;
-UINT WM_PRIV_VD_INIT;
+UINT WM_PRIV_INIT;
 UINT WM_PRIV_VD_SWITCH;
 UINT WM_PRIV_EDITOR;
 UINT WM_PRIV_LAYOUT_HOTKEYS_FILE_UPDATE;
@@ -29,7 +29,7 @@ void InitializeWinhookEventIds()
         WM_PRIV_LOCATIONCHANGE = RegisterWindowMessage(L"{d56c5ee7-58e5-481c-8c4f-8844cf4d0347}");
         WM_PRIV_NAMECHANGE = RegisterWindowMessage(L"{b7b30c61-bfa0-4d95-bcde-fc4f2cbf6d76}");
         WM_PRIV_WINDOWCREATED = RegisterWindowMessage(L"{bdb10669-75da-480a-9ec4-eeebf09a02d7}");
-        WM_PRIV_VD_INIT = RegisterWindowMessage(L"{469818a8-00fa-4069-b867-a1da484fcd9a}");
+        WM_PRIV_INIT = RegisterWindowMessage(L"{469818a8-00fa-4069-b867-a1da484fcd9a}");
         WM_PRIV_VD_SWITCH = RegisterWindowMessage(L"{128c2cb0-6bdf-493e-abbe-f8705e04aa95}");
         WM_PRIV_EDITOR = RegisterWindowMessage(L"{87543824-7080-4e91-9d9c-0404642fc7b6}");
         WM_PRIV_LAYOUT_HOTKEYS_FILE_UPDATE = RegisterWindowMessage(L"{07229b7e-4f22-4357-b136-33c289be2295}");

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesWinHookEventIDs.h
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesWinHookEventIDs.h
@@ -5,7 +5,7 @@ extern UINT WM_PRIV_MOVESIZEEND;
 extern UINT WM_PRIV_LOCATIONCHANGE;
 extern UINT WM_PRIV_NAMECHANGE;
 extern UINT WM_PRIV_WINDOWCREATED;
-extern UINT WM_PRIV_VD_INIT; // Scheduled when FancyZones is initialized
+extern UINT WM_PRIV_INIT; // Scheduled when FancyZones is initialized
 extern UINT WM_PRIV_VD_SWITCH; // Scheduled when virtual desktop switch occurs
 extern UINT WM_PRIV_EDITOR; // Scheduled when the editor exits
 extern UINT WM_PRIV_LAYOUT_HOTKEYS_FILE_UPDATE; // Scheduled when the watched layout-hotkeys.json file is updated

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesWinHookEventIDs.h
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesWinHookEventIDs.h
@@ -7,7 +7,6 @@ extern UINT WM_PRIV_NAMECHANGE;
 extern UINT WM_PRIV_WINDOWCREATED;
 extern UINT WM_PRIV_VD_INIT; // Scheduled when FancyZones is initialized
 extern UINT WM_PRIV_VD_SWITCH; // Scheduled when virtual desktop switch occurs
-extern UINT WM_PRIV_VD_UPDATE; // Scheduled on virtual desktops update (creation/deletion)
 extern UINT WM_PRIV_EDITOR; // Scheduled when the editor exits
 extern UINT WM_PRIV_LAYOUT_HOTKEYS_FILE_UPDATE; // Scheduled when the watched layout-hotkeys.json file is updated
 extern UINT WM_PRIV_LAYOUT_TEMPLATES_FILE_UPDATE; // Scheduled when the watched layout-templates.json file is updated

--- a/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
@@ -141,7 +141,7 @@ void WorkArea::MoveWindowIntoZoneByIndexSet(HWND window, const ZoneIndexSet& ind
 
     FancyZonesWindowUtils::SaveWindowSizeAndOrigin(window);
 
-    if (updatePosition)
+    if (updatePosition && IsWindowVisible(window))
     {
         const auto rect = m_layout->GetCombinedZonesRect(indexSet);
         if (rect.bottom - rect.top > 0 && rect.right - rect.left > 0)
@@ -543,22 +543,22 @@ void WorkArea::InitSnappedWindows()
 
     for (const auto& window : VirtualDesktop::instance().GetWindowsFromCurrentDesktop())
     {
-        auto zoneIndexSet = FancyZonesWindowProperties::RetrieveZoneIndexProperty(window);
-        if (zoneIndexSet.size() == 0)
+        auto indexes = FancyZonesWindowProperties::RetrieveZoneIndexProperty(window);
+        if (indexes.size() == 0)
         {
             continue;
         }
 
         if (!m_uniqueId.monitorId.monitor) // one work area across monitors
         {
-            MoveWindowIntoZoneByIndexSet(window, zoneIndexSet, false);
+            MoveWindowIntoZoneByIndexSet(window, indexes, false);
         }
         else
         {
-            const auto monitor = MonitorFromWindow(window, MONITOR_DEFAULTTONULL);
-            if (monitor && m_uniqueId.monitorId.monitor == monitor)
+            auto savedIndexes = GetWindowZoneIndexes(window);
+            if (savedIndexes == indexes)
             {
-                MoveWindowIntoZoneByIndexSet(window, zoneIndexSet, false);
+                MoveWindowIntoZoneByIndexSet(window, indexes, false);
             }
         }
     }

--- a/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
@@ -555,10 +555,20 @@ void WorkArea::InitSnappedWindows()
         }
         else
         {
-            auto savedIndexes = GetWindowZoneIndexes(window);
-            if (savedIndexes == indexes)
+            const auto monitor = MonitorFromWindow(window, MONITOR_DEFAULTTONULL);
+            if (monitor && m_uniqueId.monitorId.monitor == monitor)
             {
+                // prioritize snapping on the current monitor if the window was snapped to several work areas
                 MoveWindowIntoZoneByIndexSet(window, indexes, false);
+            }
+            else
+            {
+                // if the window is not snapped on the current monitor, then check the others
+                auto savedIndexes = GetWindowZoneIndexes(window);
+                if (savedIndexes == indexes)
+                {
+                    MoveWindowIntoZoneByIndexSet(window, indexes, false);
+                }
             }
         }
     }

--- a/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
@@ -405,6 +405,16 @@ void WorkArea::UnsnapWindow(HWND window)
     FancyZonesWindowProperties::RemoveZoneIndexProperty(window);
 }
 
+const GUID WorkArea::GetLayoutId() const noexcept
+{
+    if (m_layout)
+    {
+        return m_layout->Id();
+    }
+
+    return GUID{};
+}
+
 ZoneIndexSet WorkArea::GetWindowZoneIndexes(HWND window) const
 {
     if (m_layout)

--- a/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
@@ -539,7 +539,7 @@ void WorkArea::InitLayout(const FancyZonesDataTypes::WorkAreaId& parentUniqueId)
 
 void WorkArea::InitSnappedWindows()
 {
-    Logger::info(L"Init work area windows");
+    Logger::info(L"Init work area windows: {}", m_uniqueId.toString());
 
     for (const auto& window : VirtualDesktop::instance().GetWindowsFromCurrentDesktop())
     {

--- a/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
@@ -141,7 +141,7 @@ void WorkArea::MoveWindowIntoZoneByIndexSet(HWND window, const ZoneIndexSet& ind
 
     FancyZonesWindowUtils::SaveWindowSizeAndOrigin(window);
 
-    if (updatePosition && IsWindowVisible(window))
+    if (updatePosition)
     {
         const auto rect = m_layout->GetCombinedZonesRect(indexSet);
         if (rect.bottom - rect.top > 0 && rect.right - rect.left > 0)

--- a/src/modules/fancyzones/FancyZonesLib/WorkArea.h
+++ b/src/modules/fancyzones/FancyZonesLib/WorkArea.h
@@ -42,6 +42,7 @@ public:
     const std::unique_ptr<Layout>& GetLayout() const noexcept { return m_layout; }
     const std::unique_ptr<LayoutAssignedWindows>& GetLayoutWindows() const noexcept { return m_layoutWindows; }
     const HWND GetWorkAreaWindow() const noexcept { return m_window; }
+    const GUID GetLayoutId() const noexcept;
     
     ZoneIndexSet GetWindowZoneIndexes(HWND window) const;
 

--- a/src/modules/fancyzones/FancyZonesLib/WorkArea.h
+++ b/src/modules/fancyzones/FancyZonesLib/WorkArea.h
@@ -33,8 +33,7 @@ public:
         }
 #endif
         InitLayout(parentUniqueId);
-        InitSnappedWindows();
-
+        
         return true;
     }
     
@@ -52,6 +51,7 @@ public:
     bool MoveWindowIntoZoneByDirectionAndPosition(HWND window, DWORD vkCode, bool cycle);
     bool ExtendWindowByDirectionAndPosition(HWND window, DWORD vkCode);
 
+    void InitSnappedWindows();
     void SnapWindow(HWND window, const ZoneIndexSet& zones, bool extend = false);
     void UnsnapWindow(HWND window);
 
@@ -70,8 +70,7 @@ protected:
 private:
     bool InitWindow(HINSTANCE hinstance);
     void InitLayout(const FancyZonesDataTypes::WorkAreaId& parentUniqueId);
-    void InitSnappedWindows();
-
+    
     void CalculateZoneSet();
     void SetWorkAreaWindowAsTopmost(HWND draggedWindow) noexcept;
 

--- a/src/modules/fancyzones/FancyZonesTests/UnitTests/WorkArea.Spec.cpp
+++ b/src/modules/fancyzones/FancyZonesTests/UnitTests/WorkArea.Spec.cpp
@@ -460,7 +460,7 @@ namespace FancyZonesUnitTests
             PrepareGridLayout();
             auto workArea = WorkArea::Create(m_hInst, m_workAreaId, m_parentUniqueId, m_workAreaRect);
             const auto window = Mocks::WindowCreate(m_hInst);
-            workArea->MoveWindowIntoZoneByDirectionAndIndex(window, VK_RIGHT, true); // apply to 1st zone
+            workArea->MoveWindowIntoZoneByIndexSet(window, { 0 }, true); // snap to the 1st zone
 
             // test
             workArea->MoveWindowIntoZoneByDirectionAndPosition(window, VK_RIGHT, true);
@@ -478,7 +478,7 @@ namespace FancyZonesUnitTests
             PrepareGridLayout();
             auto workArea = WorkArea::Create(m_hInst, m_workAreaId, m_parentUniqueId, m_workAreaRect);
             const auto window = Mocks::WindowCreate(m_hInst);
-            workArea->MoveWindowIntoZoneByDirectionAndIndex(window, VK_RIGHT, true); // apply to 1st zone
+            workArea->MoveWindowIntoZoneByIndexSet(window, { 0 }, true); // snap to the 1st zone
 
             // test
             workArea->MoveWindowIntoZoneByDirectionAndPosition(window, VK_DOWN, true);
@@ -496,7 +496,7 @@ namespace FancyZonesUnitTests
             PrepareGridLayout();
             auto workArea = WorkArea::Create(m_hInst, m_workAreaId, m_parentUniqueId, m_workAreaRect);
             const auto window = Mocks::WindowCreate(m_hInst);
-            workArea->MoveWindowIntoZoneByDirectionAndIndex(window, VK_RIGHT, true); // apply to 1st zone
+            workArea->MoveWindowIntoZoneByIndexSet(window, { 0 }, true); // snap to the 1st zone
 
             // test
             workArea->MoveWindowIntoZoneByDirectionAndPosition(window, VK_LEFT, true);
@@ -533,7 +533,7 @@ namespace FancyZonesUnitTests
             auto workArea = WorkArea::Create(m_hInst, m_workAreaId, m_parentUniqueId, m_workAreaRect);
             const auto window = Mocks::WindowCreate(m_hInst);
             const auto& layoutWindows = workArea->GetLayoutWindows();
-            workArea->MoveWindowIntoZoneByDirectionAndIndex(window, VK_RIGHT, true); // apply to 1st zone
+            workArea->MoveWindowIntoZoneByIndexSet(window, { 0 }, true); // snap to the 1st zone
             Assert::IsTrue(ZoneIndexSet{ 0 } == layoutWindows->GetZoneIndexSetFromWindow(window));
 
             // test
@@ -551,7 +551,7 @@ namespace FancyZonesUnitTests
             PrepareGridLayout();
             auto workArea = WorkArea::Create(m_hInst, m_workAreaId, m_parentUniqueId, m_workAreaRect);
             const auto window = Mocks::WindowCreate(m_hInst);
-            workArea->MoveWindowIntoZoneByDirectionAndIndex(window, VK_RIGHT, true); // apply to 1st zone
+            workArea->MoveWindowIntoZoneByIndexSet(window, { 0 }, true); // snap to the 1st zone
 
             // test
             workArea->MoveWindowIntoZoneByDirectionAndPosition(window, VK_UP, false);
@@ -569,7 +569,7 @@ namespace FancyZonesUnitTests
             PrepareGridLayout();
             auto workArea = WorkArea::Create(m_hInst, m_workAreaId, m_parentUniqueId, m_workAreaRect);
             const auto window = Mocks::WindowCreate(m_hInst);
-            workArea->MoveWindowIntoZoneByDirectionAndIndex(window, VK_RIGHT, true); // apply to 1st zone
+            workArea->MoveWindowIntoZoneByIndexSet(window, { 0 }, true); // snap to the 1st zone
 
             // test
             workArea->ExtendWindowByDirectionAndPosition(window, VK_RIGHT);
@@ -587,7 +587,7 @@ namespace FancyZonesUnitTests
             PrepareGridLayout();
             auto workArea = WorkArea::Create(m_hInst, m_workAreaId, m_parentUniqueId, m_workAreaRect);
             const auto window = Mocks::WindowCreate(m_hInst);
-            workArea->MoveWindowIntoZoneByDirectionAndIndex(window, VK_RIGHT, true); // apply to 1st zone
+            workArea->MoveWindowIntoZoneByIndexSet(window, { 0 }, true); // snap to the 1st zone
 
             // test
             workArea->ExtendWindowByDirectionAndPosition(window, VK_DOWN);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Fixes returning apps to their zones: 
* after sleep/wake 
* after disconnecting/connecting the external monitor 
* after opening the app on the secondary monitor

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #23892, https://github.com/microsoft/PowerToys/issues/22936, https://github.com/microsoft/PowerToys/issues/23363, https://github.com/microsoft/PowerToys/issues/19193, https://github.com/microsoft/PowerToys/issues/23892, https://github.com/microsoft/PowerToys/issues/23964, https://github.com/microsoft/PowerToys/issues/24155, https://github.com/microsoft/PowerToys/issues/24114,
https://github.com/microsoft/PowerToys/issues/22303, https://github.com/microsoft/PowerToys/issues/19089, https://github.com/microsoft/PowerToys/issues/20929
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

* Enable `Move newly created windows to their last known zone`
* Assign apps to the zones on the primary and secondary monitors
* Close and reopen apps, verify they're opened in the zones
* Turn off FZ, move snapped windows, turn on FZ, verify windows returned to their zones
* Disconnect and reconnect monitor, verify apps from the secondary monitor returned to their zones
* Enable `Allow zones to span across monitors`, verify the same behavior
* Disable `Move newly created windows to their last known zone`, verify it doesn't work.
