### PR TITLE
[PastePlain]Support Ctrl+V as activation shortcut

### DIFF
--- a/src/modules/interface/powertoy_module_interface.h
+++ b/src/modules/interface/powertoy_module_interface.h
@@ -125,6 +125,10 @@ public:
         return powertoys_gpo::gpo_rule_configured_not_configured;
     }
 
+    // Some actions like PastePlain generate new inputs, which we don't want to catch again.
+    // The flag was purposefully chose to not collide with other keyboard manager flags.
+    const static inline ULONG_PTR CENTRALIZED_KEYBOARD_HOOK_DONT_TRIGGER_FLAG = 0x110;
+
 protected:
     HANDLE CreateDefaultEvent(const wchar_t* eventName)
     {

--- a/src/modules/pasteplain/PastePlainModuleInterface/dllmain.cpp
+++ b/src/modules/pasteplain/PastePlainModuleInterface/dllmain.cpp
@@ -311,6 +311,8 @@ private:
                 INPUT input_event = {};
                 input_event.type = INPUT_KEYBOARD;
                 input_event.ki.wVk = 0x56; // V
+                // Avoid triggering detection by the centralized keyboard hook. Allows using Control+V as activation.
+                input_event.ki.dwExtraInfo = CENTRALIZED_KEYBOARD_HOOK_DONT_TRIGGER_FLAG;
                 inputs.push_back(input_event);
             }
 
@@ -319,6 +321,8 @@ private:
                 input_event.type = INPUT_KEYBOARD;
                 input_event.ki.wVk = 0x56; // V
                 input_event.ki.dwFlags = KEYEVENTF_KEYUP;
+                // Avoid triggering detection by the centralized keyboard hook. Allows using Control+V as activation.
+                input_event.ki.dwExtraInfo = CENTRALIZED_KEYBOARD_HOOK_DONT_TRIGGER_FLAG;
                 inputs.push_back(input_event);
             }
 

--- a/src/runner/centralized_kb_hook.cpp
+++ b/src/runner/centralized_kb_hook.cpp
@@ -88,6 +88,12 @@ namespace CentralizedKeyboardHook
 
         const auto& keyPressInfo = *reinterpret_cast<KBDLLHOOKSTRUCT*>(lParam);
 
+        if (keyPressInfo.dwExtraInfo == PowertoyModuleIface::CENTRALIZED_KEYBOARD_HOOK_DONT_TRIGGER_FLAG)
+        {
+            // The new keystroke was generated from one of our actions. We should pass it along.
+            return CallNextHookEx(hHook, nCode, wParam, lParam);
+        }
+
         // Check if the keys are pressed.
         if (!pressedKeyDescriptors.empty())
         {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

When trying to use Ctrl+V as the activation shortcut for Paste as Plain Text, it wasn't working.
This PR adds a flag we can pass when a module's action simulates input so we can ignore it.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #24446
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Set Ctrl+V as the activation shortcut of Paste as Plain Text and verify it still works.
