### PR TITLE
repress modification keys after plain paste

### DIFF
--- a/src/modules/pasteplain/PastePlainModuleInterface/dllmain.cpp
+++ b/src/modules/pasteplain/PastePlainModuleInterface/dllmain.cpp
@@ -165,6 +165,18 @@ private:
         }
     }
 
+    void try_inject_modifier_key_restore(std::vector<INPUT> &inputs, short modifier)
+    {
+        // Most significant bit is set if key is down
+        if ((GetAsyncKeyState(static_cast<int>(modifier)) & 0x8000) != 0)
+        {
+            INPUT input_event = {};
+            input_event.type = INPUT_KEYBOARD;
+            input_event.ki.wVk = modifier;
+            inputs.push_back(input_event);
+        }
+    }
+
     void try_to_paste_as_plain_text()
     {
         std::wstring clipboard_text;
@@ -329,6 +341,15 @@ private:
                 input_event.ki.dwFlags = KEYEVENTF_KEYUP;
                 inputs.push_back(input_event);
             }
+
+            try_inject_modifier_key_restore(inputs, VK_LCONTROL);
+            try_inject_modifier_key_restore(inputs, VK_RCONTROL);
+            try_inject_modifier_key_restore(inputs, VK_LWIN);
+            try_inject_modifier_key_restore(inputs, VK_RWIN);
+            try_inject_modifier_key_restore(inputs, VK_LSHIFT);
+            try_inject_modifier_key_restore(inputs, VK_RSHIFT);
+            try_inject_modifier_key_restore(inputs, VK_LMENU);
+            try_inject_modifier_key_restore(inputs, VK_RMENU);
 
             auto uSent = SendInput(static_cast<UINT>(inputs.size()), inputs.data(), sizeof(INPUT));
             if (uSent != inputs.size())


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
After a plain paste represses all modification keys, so that you can paste multiple times.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #24437 
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Kept holding down the Paste As Plain Text shortcut, it pasted multiple times
