### PR TITLE
[ci][spellchecker]Ignore resx noisy file

### DIFF
--- a/.github/actions/spell-check/excludes.txt
+++ b/.github/actions/spell-check/excludes.txt
@@ -78,6 +78,7 @@
 ^\Q.github/workflows/spelling2.yml\E$
 ^\Q.pipelines/ESRPSigning_core.json\E$
 ^\Qsrc/modules/colorPicker/ColorPickerUI/Shaders/GridShader.cso\E$
+^\Qsrc/modules/MouseUtils/MouseJumpUI/MainForm.resx\E$
 ^\Qsrc/common/ManagedCommon/ColorFormatHelper.cs\E$
 ^\Qinstaller/PowerToysSetup/Settings.wxs\E$
 ^\Qsrc/settings-ui/Settings.UI.UnitTests/BackwardsCompatibility/TestFiles/CorruptJson/Microsoft/PowerToys/settings.json\E$


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Spell checker is adding this to every PR:
![image](https://user-images.githubusercontent.com/26118718/222701008-495e0937-f1db-47a1-9b7e-20923e72439d.png)

This PR excludes that file from spell checking.
