### PR TITLE
Added extra checks

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/CalculateEngine.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/CalculateEngine.cs
@@ -43,11 +43,23 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
                 return default;
             }
 
+            input = Regex.Replace(input, " ", string.Empty);
+
             // mages has quirky log representation
             // mage has log == ln vs log10
             input = input.
                         Replace("log(", "log10(", true, CultureInfo.CurrentCulture).
                         Replace("ln(", "log(", true, CultureInfo.CurrentCulture);
+
+            // mages does not hande cases such as =2(5+5) or (2+2)(3+3),
+            // therefore, manually inserting multplication operator
+            for (int i = 1; i < input.Length; i++)
+            {
+                if (input[i] == '(' && (int.TryParse(input[i - 1].ToString(), out int _) || input[i - 1] == ')'))
+                {
+                    input = input.Insert(i, "*");
+                }
+            }
 
             var result = _magesEngine.Interpret(input);
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
When using the calculator plugin, inputs such as `=2(5+3)` are not being interpreted. This is because the mages engine isnt able to handle this therefore a work around of manually inserting the multiplicaiton operator can solve the issue.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #20187
- [ ] **Communication:** The go ahead for a PR to been given on the issue.
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

