### PR TITLE
[Power Rename] Select all while filter is active

### DIFF
--- a/src/modules/powerrename/PowerRenameUILib/MainWindow.xaml.cpp
+++ b/src/modules/powerrename/PowerRenameUILib/MainWindow.xaml.cpp
@@ -273,8 +273,13 @@ namespace winrt::PowerRenameUI::implementation
         {
             ToggleAll();
             m_allSelected = !m_allSelected;
-            m_explorerItems.Clear();
-            PopulateExplorerItems();
+            if (button_showRenamed().IsChecked())
+            {
+                m_explorerItems.Clear();
+                m_explorerItemsMap.clear();
+                PopulateExplorerItems();
+                UpdateCounts();
+            }
         }
     }
 

--- a/src/modules/powerrename/PowerRenameUILib/MainWindow.xaml.cpp
+++ b/src/modules/powerrename/PowerRenameUILib/MainWindow.xaml.cpp
@@ -273,6 +273,8 @@ namespace winrt::PowerRenameUI::implementation
         {
             ToggleAll();
             m_allSelected = !m_allSelected;
+            m_explorerItems.Clear();
+            PopulateExplorerItems();
         }
     }
 
@@ -738,7 +740,8 @@ namespace winrt::PowerRenameUI::implementation
                 int id = 0;
                 spItem->GetId(&id);
                 auto item = FindById(id);
-                item.Checked(selected);
+                if (item)
+                    item.Checked(selected);
             }
         }
         UpdateCounts();


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Fix the crash that happens on PowerRename when clicking select all while filter is active (only show files that will be renamed)

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #23505
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manual Testing
