### PR TITLE
[PastePlain]Set default shortcut to Ctrl+Win+Alt+V

### DIFF
--- a/src/modules/pasteplain/PastePlainModuleInterface/dllmain.cpp
+++ b/src/modules/pasteplain/PastePlainModuleInterface/dllmain.cpp
@@ -97,7 +97,7 @@ private:
         {
             Logger::info("PastePlain is going to use default shortcut");
             m_hotkey.win = true;
-            m_hotkey.alt = false;
+            m_hotkey.alt = true;
             m_hotkey.shift = false;
             m_hotkey.ctrl = true;
             m_hotkey.key = 'V';

--- a/src/settings-ui/Settings.UI.Library/PastePlainProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/PastePlainProperties.cs
@@ -10,7 +10,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
     {
         public PastePlainProperties()
         {
-            ActivationShortcut = new HotkeySettings(true, true, false, false, 0x56); // Ctrl+Win+V
+            ActivationShortcut = new HotkeySettings(true, true, true, false, 0x56); // Ctrl+Win+Alt+V
         }
 
         public HotkeySettings ActivationShortcut { get; set; }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Change the default shortcut of Paste as Plain Text to Ctrl+Win+Alt+V.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #24491
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Cleaned up the settings on `%localappdata%\Microsoft\PowerToys`, started PowerToys and verified the shortcut was set to Ctrl+Win+Alt+V and that it worked.
