### PR TITLE
[PTRun]Add setting to disable thumbnails

### DIFF
--- a/src/modules/launcher/PowerLauncher/SettingsReader.cs
+++ b/src/modules/launcher/PowerLauncher/SettingsReader.cs
@@ -166,6 +166,11 @@ namespace PowerLauncher
                         _settings.StartupPosition = overloadSettings.Properties.Position;
                     }
 
+                    if (_settings.GenerateThumbnailsFromFiles != overloadSettings.Properties.GenerateThumbnailsFromFiles)
+                    {
+                        _settings.GenerateThumbnailsFromFiles = overloadSettings.Properties.GenerateThumbnailsFromFiles;
+                    }
+
                     retry = false;
                 }
 

--- a/src/modules/launcher/PowerLauncher/ViewModel/ResultViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/ResultViewModel.cs
@@ -10,6 +10,7 @@ using System.Windows.Media;
 using PowerLauncher.Helper;
 using PowerLauncher.Plugin;
 using Wox.Infrastructure.Image;
+using Wox.Infrastructure.UserSettings;
 using Wox.Plugin;
 using Wox.Plugin.Logger;
 
@@ -22,6 +23,8 @@ namespace PowerLauncher.ViewModel
             Selection,
             Hover,
         }
+
+        private readonly PowerToysRunSettings _settings;
 
         public ObservableCollection<ContextMenuItemViewModel> ContextMenuItems { get; } = new ObservableCollection<ContextMenuItemViewModel>();
 
@@ -65,12 +68,14 @@ namespace PowerLauncher.ViewModel
 
         public const int NoSelectionIndex = -1;
 
-        public ResultViewModel(Result result, IMainViewModel mainViewModel)
+        public ResultViewModel(Result result, IMainViewModel mainViewModel, PowerToysRunSettings settings)
         {
             if (result != null)
             {
                 Result = result;
             }
+
+            _settings = settings;
 
             ContextMenuSelectedIndex = NoSelectionIndex;
             LoadContextMenu();
@@ -201,7 +206,7 @@ namespace PowerLauncher.ViewModel
                 }
 
                 // will get here either when icoPath has value\icon delegate is null\when had exception in delegate
-                return ImageLoader.Load(imagePath);
+                return ImageLoader.Load(imagePath, _settings.GenerateThumbnailsFromFiles);
             }
         }
 

--- a/src/modules/launcher/PowerLauncher/ViewModel/ResultsViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/ResultsViewModel.cs
@@ -272,7 +272,7 @@ namespace PowerLauncher.ViewModel
             List<ResultViewModel> newResults = new List<ResultViewModel>(newRawResults.Count);
             foreach (Result r in newRawResults)
             {
-                newResults.Add(new ResultViewModel(r, _mainViewModel));
+                newResults.Add(new ResultViewModel(r, _mainViewModel, _settings));
                 ct.ThrowIfCancellationRequested();
             }
 

--- a/src/modules/launcher/Wox.Infrastructure/UserSettings/PowerToysRunSettings.cs
+++ b/src/modules/launcher/Wox.Infrastructure/UserSettings/PowerToysRunSettings.cs
@@ -323,6 +323,8 @@ namespace Wox.Infrastructure.UserSettings
 
         public bool StartedFromPowerToysRunner { get; set; }
 
+        public bool GenerateThumbnailsFromFiles { get; set; } = true;
+
         public HttpProxy Proxy { get; set; } = new HttpProxy();
 
         [JsonConverter(typeof(JsonStringEnumConverter))]

--- a/src/modules/launcher/Wox.Test/ResultViewModelTest.cs
+++ b/src/modules/launcher/Wox.Test/ResultViewModelTest.cs
@@ -26,7 +26,7 @@ namespace Wox.Test
             var result = new Result();
             contextMenuResult = new ContextMenuResult();
             mainViewModelMock = new Mock<IMainViewModel>();
-            resultViewModel = new ResultViewModel(result, mainViewModelMock.Object);
+            resultViewModel = new ResultViewModel(result, mainViewModelMock.Object, null);
 
             var pluginMock = new Mock<IPlugin>();
             pluginMock.As<IContextMenu>().Setup(x => x.LoadContextMenus(result)).Returns(new List<ContextMenuResult> { contextMenuResult });

--- a/src/modules/launcher/Wox.Test/ResultsViewModelTest.cs
+++ b/src/modules/launcher/Wox.Test/ResultsViewModelTest.cs
@@ -18,7 +18,7 @@ namespace Wox.Test
             // Arrange
             ResultsViewModel rvm = new ResultsViewModel();
             Result result = new Result();
-            ResultViewModel selectedItem = new ResultViewModel(result, null);
+            ResultViewModel selectedItem = new ResultViewModel(result, null, null);
             selectedItem.ContextMenuItems.Add(new ContextMenuItemViewModel(null, null, null, null, Key.None, ModifierKeys.None, null));
             rvm.SelectedItem = selectedItem;
 
@@ -32,7 +32,7 @@ namespace Wox.Test
             // Arrange
             ResultsViewModel rvm = new ResultsViewModel();
             Result result = new Result();
-            ResultViewModel selectedItem = new ResultViewModel(result, null);
+            ResultViewModel selectedItem = new ResultViewModel(result, null, null);
             selectedItem.ContextMenuItems.Add(new ContextMenuItemViewModel(null, null, null, null, Key.None, ModifierKeys.None, null));
             rvm.SelectedItem = selectedItem;
 
@@ -49,7 +49,7 @@ namespace Wox.Test
             // Arrange
             ResultsViewModel rvm = new ResultsViewModel();
             Result result = new Result();
-            ResultViewModel selectedItem = new ResultViewModel(result, null);
+            ResultViewModel selectedItem = new ResultViewModel(result, null, null);
             selectedItem.ContextMenuItems.Add(new ContextMenuItemViewModel(null, null, null, null, Key.None, ModifierKeys.None, null));
             rvm.SelectedItem = selectedItem;
 
@@ -66,7 +66,7 @@ namespace Wox.Test
             // Arrange
             ResultsViewModel rvm = new ResultsViewModel();
             Result result = new Result();
-            ResultViewModel selectedItem = new ResultViewModel(result, null);
+            ResultViewModel selectedItem = new ResultViewModel(result, null, null);
             selectedItem.ContextMenuItems.Add(new ContextMenuItemViewModel(null, null, null, null, Key.None, ModifierKeys.None, null));
             selectedItem.ContextMenuItems.Add(new ContextMenuItemViewModel(null, null, null, null, Key.None, ModifierKeys.None, null));
             selectedItem.ContextMenuItems.Add(new ContextMenuItemViewModel(null, null, null, null, Key.None, ModifierKeys.None, null));
@@ -88,7 +88,7 @@ namespace Wox.Test
             // Arrange
             ResultsViewModel rvm = new ResultsViewModel();
             Result result = new Result();
-            ResultViewModel selectedItem = new ResultViewModel(result, null);
+            ResultViewModel selectedItem = new ResultViewModel(result, null, null);
             selectedItem.ContextMenuItems.Add(new ContextMenuItemViewModel(null, null, null, null, Key.None, ModifierKeys.None, null));
             rvm.SelectedItem = selectedItem;
 
@@ -106,7 +106,7 @@ namespace Wox.Test
             // Arrange
             ResultsViewModel rvm = new ResultsViewModel();
             Result result = new Result();
-            ResultViewModel selectedItem = new ResultViewModel(result, null);
+            ResultViewModel selectedItem = new ResultViewModel(result, null, null);
             selectedItem.ContextMenuItems.Add(new ContextMenuItemViewModel(null, null, null, null, Key.None, ModifierKeys.None, null));
             rvm.SelectedItem = selectedItem;
 
@@ -124,7 +124,7 @@ namespace Wox.Test
             // Arrange
             ResultsViewModel rvm = new ResultsViewModel();
             Result result = new Result();
-            ResultViewModel selectedItem = new ResultViewModel(result, null);
+            ResultViewModel selectedItem = new ResultViewModel(result, null, null);
             selectedItem.ContextMenuItems.Add(new ContextMenuItemViewModel(null, null, null, null, Key.None, ModifierKeys.None, null));
             rvm.SelectedItem = selectedItem;
 

--- a/src/settings-ui/Settings.UI.Library/PowerLauncherProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/PowerLauncherProperties.cs
@@ -72,6 +72,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         [JsonPropertyName("search_wait_for_slow_results")]
         public bool SearchWaitForSlowResults { get; set; }
 
+        [JsonPropertyName("generate_thumbnails_from_files")]
+        public bool GenerateThumbnailsFromFiles { get; set; }
+
         public PowerLauncherProperties()
         {
             OpenPowerLauncher = new HotkeySettings(false, false, true, false, 32);
@@ -92,6 +95,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             SearchClickedItemWeight = 5;
             SearchQueryTuningEnabled = false;
             SearchWaitForSlowResults = false;
+            GenerateThumbnailsFromFiles = true;
         }
     }
 }

--- a/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/PowerLauncherViewModelTest.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/PowerLauncherViewModelTest.cs
@@ -80,6 +80,7 @@ namespace ViewModelTests
             Assert.AreEqual(originalSettings.Properties.OverrideWinkeyS, viewModel.OverrideWinSKey);
             Assert.AreEqual(originalSettings.Properties.SearchResultPreference, viewModel.SearchResultPreference);
             Assert.AreEqual(originalSettings.Properties.SearchTypePreference, viewModel.SearchTypePreference);
+            Assert.AreEqual(originalSettings.Properties.GenerateThumbnailsFromFiles, viewModel.GenerateThumbnailsFromFiles);
 
             // Verify that the stub file was used
             var expectedCallCount = 2;  // once via the view model, and once by the test (GetSettings<T>)

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -503,7 +503,7 @@
     <value>Generate thumbnails from files</value>
   </data>
   <data name="PowerLauncher_GenerateThumbnailsFromFiles.Description" xml:space="preserve">
-    <value>Results will try to generate thumbnails for files. Disabling this setting off may increase stability and speed</value>
+    <value>Results will try to generate thumbnails for files. Disabling this setting may increase stability and speed</value>
   </data>
   <data name="PowerLauncher_SearchQueryResultsWithDelay.Header" xml:space="preserve">
     <value>Input Smoothing</value>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -499,6 +499,12 @@
   <data name="PowerLauncher_TabSelectsContextButtons.Description" xml:space="preserve">
     <value>Pressing tab will first select through the available context buttons of the current selection before moving onto the next result</value>
   </data>
+  <data name="PowerLauncher_GenerateThumbnailsFromFiles.Header" xml:space="preserve">
+    <value>Generate thumbnails from files</value>
+  </data>
+  <data name="PowerLauncher_GenerateThumbnailsFromFiles.Description" xml:space="preserve">
+    <value>Results will try to generate thumbnails for files. Disabling this setting off may increase stability and speed</value>
+  </data>
   <data name="PowerLauncher_SearchQueryResultsWithDelay.Header" xml:space="preserve">
     <value>Input Smoothing</value>
     <comment>This is about adding a delay to wait for more input before executing a search</comment>

--- a/src/settings-ui/Settings.UI/ViewModels/PowerLauncherViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/PowerLauncherViewModel.cs
@@ -563,6 +563,23 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             }
         }
 
+        public bool GenerateThumbnailsFromFiles
+        {
+            get
+            {
+                return settings.Properties.GenerateThumbnailsFromFiles;
+            }
+
+            set
+            {
+                if (settings.Properties.GenerateThumbnailsFromFiles != value)
+                {
+                    settings.Properties.GenerateThumbnailsFromFiles = value;
+                    UpdateSettings();
+                }
+            }
+        }
+
         private ObservableCollection<PowerLauncherPluginViewModel> _plugins;
 
         public ObservableCollection<PowerLauncherPluginViewModel> Plugins

--- a/src/settings-ui/Settings.UI/Views/PowerLauncherPage.xaml
+++ b/src/settings-ui/Settings.UI/Views/PowerLauncherPage.xaml
@@ -185,6 +185,14 @@
                             IsOn="{x:Bind ViewModel.TabSelectsContextButtons, Mode=TwoWay}" />
                     </labs:SettingsCard>
 
+                    <labs:SettingsCard
+                        x:Uid="PowerLauncher_GenerateThumbnailsFromFiles"
+                        >
+                        <ToggleSwitch
+                            x:Uid="ToggleSwitch"
+                            IsOn="{x:Bind ViewModel.GenerateThumbnailsFromFiles, Mode=TwoWay}" />
+                    </labs:SettingsCard>
+
                 </controls:SettingsGroup>
 
                 <!--<ComboBox x:Uid="PowerLauncher_SearchResultPreference"


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Add a Setting to allow users to disable thumbnail generation in PowerToys Run. Idea is to check if this can make #18166 any better.

![image](https://user-images.githubusercontent.com/26118718/223208453-143aedf2-ea87-48ad-b4b2-44396ef6a814.png)


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Helps debug:** #18166
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

There's an exception for png files, which will always be generated, since PowerToys Run plugins depend on it for internal images.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Cleaned up the image cache, started PowerToys, disabled the setting and verified no thumbnails were being generated. Cleaned the cache again, started PowerToys and verified thumbnails were being generated with the Setting turned on.
