### PR TITLE
Calculator - Human multiplication expressions

### DIFF
--- a/doc/devdocs/modules/launcher/plugins/calculator.md
+++ b/doc/devdocs/modules/launcher/plugins/calculator.md
@@ -21,7 +21,12 @@ The Calculator plugin as the name suggests is used to perform calculations on th
 
 ### [`CalculateHelper`](/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/CalculateHelper.cs)
 - The [`CalculateHelper.cs`](src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/CalculateHelper.cs) class checks to see if the user entered query is a valid input to the calculator and only if the input is valid does it perform the operation.
-- It does so by matching the user query to a valid regex.
+  - It does so by matching the user query to a valid regex.
+- This class also handles some human multiplication expression like `2(1+2)` and `(2+3)(3+4)` in order to be computed by `Mages` lib.
+  - It does so by matching some regex and inserting `'*'` where appropriate, e.g: `2(1+2) -> 2 * (1+2)`
+  - It takes into account the combination of numbers (`num`), constants (`const`), functions (`func`) and expressions in parentheses (`(exp)`).
+  - The blank spaces between them is also considered.
+  - Some combinations were not handled as they are not common such as `'const num'` or `'func const'`
 
 ### [`CalculateEngine`](src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/CalculateEngine.cs)
 - The main computation is done in the [`CalculateEngine.cs`](src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/CalculateEngine.cs) file using the `Mages` library.

--- a/doc/devdocs/modules/launcher/plugins/calculator.md
+++ b/doc/devdocs/modules/launcher/plugins/calculator.md
@@ -25,7 +25,7 @@ The Calculator plugin as the name suggests is used to perform calculations on th
 - This class also handles some human multiplication expression like `2(1+2)` and `(2+3)(3+4)` in order to be computed by `Mages` lib.
   - It does so by matching some regex and inserting `'*'` where appropriate, e.g: `2(1+2) -> 2 * (1+2)`
   - It takes into account the combination of numbers (`num`), constants (`const`), functions (`func`) and expressions in parentheses (`(exp)`).
-  - The blank spaces between them is also considered.
+  - The blank spaces between them are also considered.
   - Some combinations were not handled as they are not common such as `'const num'` or `'func const'`
 
 ### [`CalculateEngine`](src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/CalculateEngine.cs)

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator.UnitTest/ExtendedCalculatorParserTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator.UnitTest/ExtendedCalculatorParserTests.cs
@@ -37,8 +37,6 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.UnitTests
 
         [DataTestMethod]
         [DataRow("test")]
-        [DataRow("pi(2)")] // Incorrect input, constant is being treated as a function.
-        [DataRow("e(2)")]
         [DataRow("[10,10]")] // '[10,10]' is interpreted as array by mages engine
         public void Interpret_NoResult_WhenCalled(string input)
         {

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator.UnitTest/QueryTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator.UnitTest/QueryTests.cs
@@ -113,6 +113,16 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.UnitTests
         }
 
         [DataTestMethod]
+        [DataRow("pie", "pi * e")]
+        [DataRow("eln(100)", "e * ln(100)")]
+        [DataRow("pi(1+1)", "pi * (1+1)")]
+        [DataRow("2pi", "2 * pi")]
+        [DataRow("2log10(100)", "2 * log10(100)")]
+        [DataRow("2(3+4)", "2 * (3+4)")]
+        [DataRow("sin(pi)cos(pi)", "sin(pi) * cos(pi)")]
+        [DataRow("log10(100)(2+3)", "log10(100) * (2+3)")]
+        [DataRow("(1+1)cos(pi)", "(1+1) * cos(pi)")]
+        [DataRow("(1+1)(2+2)", "(1+1) * (2+2)")]
         [DataRow("2(1+1)", "2 * (1+1)")]
         [DataRow("pi(1+1)", "pi * (1+1)")]
         [DataRow("pilog(100)", "pi * log(100)")]
@@ -134,7 +144,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.UnitTests
         [DataRow("pipipie", "pi * pi * pi * e")]
         [DataRow("(1+1)(3+2)(1+1)(1+1)", "(1+1) * (3+2) * (1+1) * (1+1)")]
         [DataRow("(1+1) (3+2)  (1+1)(1+1)", "(1+1) * (3+2) * (1+1) * (1+1)")]
-        public void RightHumaMultiplicationExpressionTransformation(string typedString, string expectedQuery)
+        public void RightHumanMultiplicationExpressionTransformation(string typedString, string expectedQuery)
         {
             // Setup
 
@@ -167,7 +177,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.UnitTests
         [DataRow("pipipie")]
         [DataRow("(1+1)(3+2)(1+1)(1+1)")]
         [DataRow("(1+1) (3+2)  (1+1)(1+1)")]
-        public void NoErrorForHumaMultiplicationExpressions(string typedString)
+        public void NoErrorForHumanMultiplicationExpressions(string typedString)
         {
             // Setup
             Mock<Main> main = new();
@@ -192,7 +202,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.UnitTests
         [DataRow("(1+1)(3+2)", "10")]
         [DataRow("(1+1)cos(pi)", "-2")]
         [DataRow("log(100)cos(pi)", "-2")]
-        public void RightAnswerForHumaMultiplicationExpressions(string typedString, string answer)
+        public void RightAnswerForHumanMultiplicationExpressions(string typedString, string answer)
         {
             // Setup
             Mock<Main> main = new();

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator.UnitTest/QueryTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator.UnitTest/QueryTests.cs
@@ -14,7 +14,6 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.UnitTests
     {
         [DataTestMethod]
         [DataRow("=pi(9+)", "Expression wrong or incomplete (Did you forget some parentheses?)")]
-        [DataRow("=pi(9)", "Expression wrong or incomplete (Did you forget some parentheses?)")]
         [DataRow("=pi,", "Expression wrong or incomplete (Did you forget some parentheses?)")]
         [DataRow("=log()", "Expression wrong or incomplete (Did you forget some parentheses?)")]
         [DataRow("=0xf0x6", "Expression wrong or incomplete (Did you forget some parentheses?)")]
@@ -41,7 +40,6 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.UnitTests
 
         [DataTestMethod]
         [DataRow("pi(9+)")]
-        [DataRow("pi(9)")]
         [DataRow("pi,")]
         [DataRow("log()")]
         [DataRow("0xf0x6")]
@@ -112,6 +110,102 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.UnitTests
             // Assert
             Assert.AreEqual(result, "Copy this number to the clipboard");
             Assert.AreEqual(resultWithKeyword, "Copy this number to the clipboard");
+        }
+
+        [DataTestMethod]
+        [DataRow("2(1+1)", "2 * (1+1)")]
+        [DataRow("pi(1+1)", "pi * (1+1)")]
+        [DataRow("pilog(100)", "pi * log(100)")]
+        [DataRow("3log(100)", "3 * log(100)")]
+        [DataRow("2e", "2 * e")]
+        [DataRow("(1+1)(3+2)", "(1+1) * (3+2)")]
+        [DataRow("(1+1)cos(pi)", "(1+1) * cos(pi)")]
+        [DataRow("sin(pi)cos(pi)", "sin(pi) * cos(pi)")]
+        [DataRow("2 (1+1)", "2 * (1+1)")]
+        [DataRow("pi  (1+1)", "pi * (1+1)")]
+        [DataRow("pi  log(100)", "pi * log(100)")]
+        [DataRow("3   log(100)", "3 * log(100)")]
+        [DataRow("2 e", "2 * e")]
+        [DataRow("(1+1)  (3+2)", "(1+1) * (3+2)")]
+        [DataRow("(1+1)  cos(pi)", "(1+1) * cos(pi)")]
+        [DataRow("sin  (pi)  cos(pi)", "sin  (pi) * cos(pi)")]
+        [DataRow("2picos(pi)(1+1)", "2 * pi * cos(pi) * (1+1)")]
+        [DataRow("pilog(100)log(1000)", "pi * log(100) * log(1000)")]
+        [DataRow("pipipie", "pi * pi * pi * e")]
+        [DataRow("(1+1)(3+2)(1+1)(1+1)", "(1+1) * (3+2) * (1+1) * (1+1)")]
+        [DataRow("(1+1) (3+2)  (1+1)(1+1)", "(1+1) * (3+2) * (1+1) * (1+1)")]
+        public void RightHumaMultiplicationExpressionTransformation(string typedString, string expectedQuery)
+        {
+            // Setup
+
+            // Act
+            var result = CalculateHelper.FixHumanMultiplicationExpressions(typedString);
+
+            // Assert
+            Assert.AreEqual(expectedQuery, result);
+        }
+
+        [DataTestMethod]
+        [DataRow("2(1+1)")]
+        [DataRow("pi(1+1)")]
+        [DataRow("pilog(100)")]
+        [DataRow("3log(100)")]
+        [DataRow("2e")]
+        [DataRow("(1+1)(3+2)")]
+        [DataRow("(1+1)cos(pi)")]
+        [DataRow("sin(pi)cos(pi)")]
+        [DataRow("2 (1+1)")]
+        [DataRow("pi  (1+1)")]
+        [DataRow("pi  log(100)")]
+        [DataRow("3   log(100)")]
+        [DataRow("2 e")]
+        [DataRow("(1+1)  (3+2)")]
+        [DataRow("(1+1)  cos(pi)")]
+        [DataRow("sin  (pi)  cos(pi)")]
+        [DataRow("2picos(pi)(1+1)")]
+        [DataRow("pilog(100)log(1000)")]
+        [DataRow("pipipie")]
+        [DataRow("(1+1)(3+2)(1+1)(1+1)")]
+        [DataRow("(1+1) (3+2)  (1+1)(1+1)")]
+        public void NoErrorForHumaMultiplicationExpressions(string typedString)
+        {
+            // Setup
+            Mock<Main> main = new();
+            Query expectedQuery = new(typedString);
+            Query expectedQueryWithKeyword = new("=" + typedString, "=");
+
+            // Act
+            var result = main.Object.Query(expectedQuery).FirstOrDefault()?.SubTitle;
+            var resultWithKeyword = main.Object.Query(expectedQueryWithKeyword).FirstOrDefault()?.SubTitle;
+
+            // Assert
+            Assert.AreEqual("Copy this number to the clipboard", result);
+            Assert.AreEqual("Copy this number to the clipboard", resultWithKeyword);
+        }
+
+        [DataTestMethod]
+        [DataRow("2(1+1)", "4")]
+        [DataRow("pi(1+1)", "6.2831853072")]
+        [DataRow("pilog(100)", "6.2831853072")]
+        [DataRow("3log(100)", "6")]
+        [DataRow("2e", "5.4365636569")]
+        [DataRow("(1+1)(3+2)", "10")]
+        [DataRow("(1+1)cos(pi)", "-2")]
+        [DataRow("log(100)cos(pi)", "-2")]
+        public void RightAnswerForHumaMultiplicationExpressions(string typedString, string answer)
+        {
+            // Setup
+            Mock<Main> main = new();
+            Query expectedQuery = new(typedString);
+            Query expectedQueryWithKeyword = new("=" + typedString, "=");
+
+            // Act
+            var result = main.Object.Query(expectedQuery).FirstOrDefault()?.Title;
+            var resultWithKeyword = main.Object.Query(expectedQueryWithKeyword).FirstOrDefault()?.Title;
+
+            // Assert
+            Assert.AreEqual(answer, result);
+            Assert.AreEqual(answer, resultWithKeyword);
         }
     }
 }

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/CalculateEngine.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/CalculateEngine.cs
@@ -49,6 +49,8 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
                         Replace("log(", "log10(", true, CultureInfo.CurrentCulture).
                         Replace("ln(", "log(", true, CultureInfo.CurrentCulture);
 
+            input = CalculateHelper.FixHumanMultiplicationExpressions(input);
+
             var result = _magesEngine.Interpret(input);
 
             // This could happen for some incorrect queries, like pi(2)

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/CalculateHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/CalculateHelper.cs
@@ -51,16 +51,20 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
 
         public static string FixHumanMultiplicationExpressions(string input)
         {
-            var output = Check_NumberOrConstant_ParenthesisExpr(input);
-            output = Check_NumberOrConstant_Func(output);
-            output = Check_ParenthesisExpr_Func(output);
-            output = Check_ParenthesisExpr_ParenthesisExpr(output);
-            output = Check_Number_Constant(output);
-            output = Check_Constant_Constant(output);
+            var output = CheckNumberOrConstantThenParenthesisExpr(input);
+            output = CheckNumberOrConstantThenFunc(output);
+            output = CheckParenthesisExprThenFunc(output);
+            output = CheckParenthesisExprThenParenthesisExpr(output);
+            output = CheckNumberThenConstant(output);
+            output = CheckConstantThenConstant(output);
             return output;
         }
 
-        private static string Check_NumberOrConstant_ParenthesisExpr(string input)
+        /*
+         * num (exp)
+         * const (exp)
+         */
+        private static string CheckNumberOrConstantThenParenthesisExpr(string input)
         {
             var output = input;
             do
@@ -81,7 +85,11 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
             return output;
         }
 
-        private static string Check_NumberOrConstant_Func(string input)
+        /*
+         * num func
+         * const func
+         */
+        private static string CheckNumberOrConstantThenFunc(string input)
         {
             var output = input;
             do
@@ -107,21 +115,32 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
             return output;
         }
 
-        private static string Check_ParenthesisExpr_Func(string input)
+        /*
+         * (exp) func
+         * func func
+         */
+        private static string CheckParenthesisExprThenFunc(string input)
         {
             var p = @"(\))\s*([a-zA-Z]+[0-9]*\s*\()";
             var r = "$1 * $2";
             return Regex.Replace(input, p, r);
         }
 
-        private static string Check_ParenthesisExpr_ParenthesisExpr(string input)
+        /*
+         * (exp) (exp)
+         * func (exp)
+         */
+        private static string CheckParenthesisExprThenParenthesisExpr(string input)
         {
             var p = @"(\))\s*(\()";
             var r = "$1 * $2";
             return Regex.Replace(input, p, r);
         }
 
-        private static string Check_Number_Constant(string input)
+        /*
+         * num const
+         */
+        private static string CheckNumberThenConstant(string input)
         {
             var output = input;
             do
@@ -142,7 +161,10 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
             return output;
         }
 
-        private static string Check_Constant_Constant(string input)
+        /*
+         * const const
+         */
+        private static string CheckConstantThenConstant(string input)
         {
             var output = input;
             do

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/CalculateHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/CalculateHelper.cs
@@ -48,5 +48,119 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
 
             return true;
         }
+
+        public static string FixHumanMultiplicationExpressions(string input)
+        {
+            var output = Check_NumberOrConstant_ParenthesisExpr(input);
+            output = Check_NumberOrConstant_Func(output);
+            output = Check_ParenthesisExpr_Func(output);
+            output = Check_ParenthesisExpr_ParenthesisExpr(output);
+            output = Check_Number_Constant(output);
+            output = Check_Constant_Constant(output);
+            return output;
+        }
+
+        private static string Check_NumberOrConstant_ParenthesisExpr(string input)
+        {
+            var output = input;
+            do
+            {
+                input = output;
+                output = Regex.Replace(input, @"(\d+|pi|e)\s*(\()", m =>
+                {
+                    if (m.Index > 0 && char.IsLetter(input[m.Index - 1]))
+                    {
+                        return m.Value;
+                    }
+
+                    return $"{m.Groups[1].Value} * {m.Groups[2].Value}";
+                });
+            }
+            while (output != input);
+
+            return output;
+        }
+
+        private static string Check_NumberOrConstant_Func(string input)
+        {
+            var output = input;
+            do
+            {
+                input = output;
+                output = Regex.Replace(input, @"(\d+|pi|e)\s*([a-zA-Z]+[0-9]*\s*\()", m =>
+                {
+                    if (input[m.Index] == 'e' && input[m.Index + 1] == 'x' && input[m.Index + 2] == 'p')
+                    {
+                        return m.Value;
+                    }
+
+                    if (m.Index > 0 && char.IsLetter(input[m.Index - 1]))
+                    {
+                        return m.Value;
+                    }
+
+                    return $"{m.Groups[1].Value} * {m.Groups[2].Value}";
+                });
+            }
+            while (output != input);
+
+            return output;
+        }
+
+        private static string Check_ParenthesisExpr_Func(string input)
+        {
+            var p = @"(\))\s*([a-zA-Z]+[0-9]*\s*\()";
+            var r = "$1 * $2";
+            return Regex.Replace(input, p, r);
+        }
+
+        private static string Check_ParenthesisExpr_ParenthesisExpr(string input)
+        {
+            var p = @"(\))\s*(\()";
+            var r = "$1 * $2";
+            return Regex.Replace(input, p, r);
+        }
+
+        private static string Check_Number_Constant(string input)
+        {
+            var output = input;
+            do
+            {
+                input = output;
+                output = Regex.Replace(input, @"(\d+)\s*(pi|e)", m =>
+                {
+                    if (m.Index > 0 && char.IsLetter(input[m.Index - 1]))
+                    {
+                        return m.Value;
+                    }
+
+                    return $"{m.Groups[1].Value} * {m.Groups[2].Value}";
+                });
+            }
+            while (output != input);
+
+            return output;
+        }
+
+        private static string Check_Constant_Constant(string input)
+        {
+            var output = input;
+            do
+            {
+                input = output;
+                output = Regex.Replace(input, @"(pi|e)\s*(pi|e)", m =>
+                {
+                    if (m.Index > 0 && char.IsLetter(input[m.Index - 1]))
+                    {
+                        return m.Value;
+                    }
+
+                    return $"{m.Groups[1].Value} * {m.Groups[2].Value}";
+                });
+            }
+            while (output != input);
+
+            return output;
+        }
     }
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #20187
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [x] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [x] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: [#4328](https://github.com/MicrosoftDocs/windows-dev-docs/pull/4328)

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

I took into account the combination of numbers (`num`), constants (`const`), functions (`func`) and expressions in parentheses (`(exp)`). The blank spaces between them were also considered. The solution is based on `regex`es. Some combinations were not handled as they are not common (but some could be handled if necessary)
- [x] `const const`: `pie = pi * e`  
- [ ] `const num`: `pi3 = pi * 3` not handled because it is not common
- [x] `const func`: `eln(100) = e * ln(100)`
- [x] `const (exp)`: `pi(1+1) = pi * (1+1)`
- [x] `num const`: `2pi = 2 * pi` 
- [ ] `num num`: not handled
- [x] `num func`: `2log10(100) = 2 * log10(100)`
- [x] `num (exp)`: `2(3+4) = 2 * (3+4)`
- [ ] `func const`: `log10(100)pi = log10(100) * pi` not handled because it is not common
- [ ] `func num`: `log10(100)3 = log10(100) * 3` not handled because it is not common
- [x] `func func`: `sin(pi)cos(pi) = sin(pi) * cos(pi)`
- [x] `func (exp)`: `log10(100)(2+3) = log10(100) * (2+3)`
- [ ] `(exp) const`: `(1+2)pi = (1+2) * pi` not handled because it is not common
- [ ] `(exp) num`: `(1+2)4 = (1+2) * 4` not handled because it is not common
- [x] `(exp) func`: `(1+1)cos(pi) = (1+1) * cos(pi)`
- [x] `(exp) (exp)`: `(1+1)(2+2) = (1+1) * (2+2)`

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

