### PR TITLE
[PTRun]Asynchronously load image and thumbnails

### DIFF
--- a/src/modules/launcher/Wox.Infrastructure/Image/ImageLoader.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Image/ImageLoader.cs
@@ -64,12 +64,12 @@ namespace Wox.Infrastructure.Image
             UpdateIconPath(theme);
             Task.Run(() =>
             {
-                Stopwatch.Normal("ImageLoader.Initialize - Preload images cost", () =>
+                Stopwatch.Normal("ImageLoader.Initialize - Preload images cost", async () =>
                 {
-                    ImageCache.Usage.AsParallel().ForAll(x =>
+                    foreach (var (path, _) in ImageCache.Usage)
                     {
-                        Load(x.Key, true);
-                    });
+                        await LoadAsync(path, true);
+                    }
                 });
 
                 Log.Info($"Number of preload images is <{ImageCache.Usage.Count}>, Images Number: {ImageCache.CacheSize()}, Unique Items {ImageCache.UniqueImagesInCache()}", MethodBase.GetCurrentMethod().DeclaringType);
@@ -120,10 +120,9 @@ namespace Wox.Infrastructure.Image
             Cache,
         }
 
-        private static ImageResult LoadInternal(string path, bool generateThumbnailsFromFiles, bool loadFullImage = false)
+        private static async ValueTask<ImageResult> LoadInternalAsync(string path, bool generateThumbnailsFromFiles, bool loadFullImage = false)
         {
-            ImageSource image;
-            ImageType type = ImageType.Error;
+            ImageResult imageResult;
             try
             {
                 if (string.IsNullOrEmpty(path))
@@ -144,82 +143,84 @@ namespace Wox.Infrastructure.Image
                     return new ImageResult(imageSource, ImageType.Data);
                 }
 
-                if (!Path.IsPathRooted(path))
-                {
-                    path = Path.Combine(Constant.ProgramDirectory, "Images", Path.GetFileName(path));
-                }
-
-                if (Directory.Exists(path))
-                {
-                    /* Directories can also have thumbnails instead of shell icons.
-                     * Generating thumbnails for a bunch of folders while scrolling through
-                     * results from Everything makes a big impact on performance and
-                     * Wox responsibility.
-                     * - Solution: just load the icon
-                     */
-                    type = ImageType.Folder;
-                    image = WindowsThumbnailProvider.GetThumbnail(path, Constant.ThumbnailSize, Constant.ThumbnailSize, ThumbnailOptions.IconOnly);
-                }
-                else if (File.Exists(path))
-                {
-                    // Using InvariantCulture since this is internal
-                    var extension = Path.GetExtension(path).ToLower(CultureInfo.InvariantCulture);
-                    if (ImageExtensions.Contains(extension))
-                    {
-                        type = ImageType.ImageFile;
-                        if (loadFullImage)
-                        {
-                            image = LoadFullImage(path);
-                        }
-                        else
-                        {
-                            // PowerToys Run internal images are png, so we make this exception
-                            if (extension == ".png" || generateThumbnailsFromFiles)
-                            {
-                                /* Although the documentation for GetImage on MSDN indicates that
-                                * if a thumbnail is available it will return one, this has proved to not
-                                * be the case in many situations while testing.
-                                * - Solution: explicitly pass the ThumbnailOnly flag
-                                */
-                                image = WindowsThumbnailProvider.GetThumbnail(path, Constant.ThumbnailSize, Constant.ThumbnailSize, ThumbnailOptions.ThumbnailOnly);
-                            }
-                            else
-                            {
-                                image = WindowsThumbnailProvider.GetThumbnail(path, Constant.ThumbnailSize, Constant.ThumbnailSize, ThumbnailOptions.IconOnly);
-                            }
-                        }
-                    }
-                    else if (!generateThumbnailsFromFiles || (extension == ".pdf" && WindowsThumbnailProvider.DoesPdfUseAcrobatAsProvider()))
-                    {
-                        // The PDF thumbnail provider from Adobe Reader and Acrobat Pro lets crash PT Run with an Dispatcher exception. (https://github.com/microsoft/PowerToys/issues/18166)
-                        // To not run into the crash, we only request the icon of PDF files if the PDF thumbnail handler is set to Adobe Reader/Acrobat Pro.
-                        // Also don't get thumbnail if the GenerateThumbnailsFromFiles option is off.
-                        type = ImageType.File;
-                        image = WindowsThumbnailProvider.GetThumbnail(path, Constant.ThumbnailSize, Constant.ThumbnailSize, ThumbnailOptions.IconOnly);
-                    }
-                    else
-                    {
-                        type = ImageType.File;
-                        image = WindowsThumbnailProvider.GetThumbnail(path, Constant.ThumbnailSize, Constant.ThumbnailSize, ThumbnailOptions.RESIZETOFIT);
-                    }
-                }
-                else
-                {
-                    image = ImageCache[ErrorIconPath];
-                    path = ErrorIconPath;
-                }
-
-                if (type != ImageType.Error)
-                {
-                    image.Freeze();
-                }
+                imageResult = await Task.Run(() => GetThumbnailResult(ref path, generateThumbnailsFromFiles, loadFullImage));
             }
             catch (System.Exception e)
             {
                 Log.Exception($"Failed to get thumbnail for {path}", e, MethodBase.GetCurrentMethod().DeclaringType);
-                type = ImageType.Error;
-                image = ImageCache[ErrorIconPath];
+                ImageSource image = ImageCache[ErrorIconPath];
                 ImageCache[path] = image;
+                imageResult = new ImageResult(image, ImageType.Error);
+            }
+
+            return imageResult;
+        }
+
+        private static ImageResult GetThumbnailResult(ref string path, bool generateThumbnailsFromFiles, bool loadFullImage = false)
+        {
+            ImageSource image;
+            ImageType type = ImageType.Error;
+
+            if (!Path.IsPathRooted(path))
+            {
+                path = Path.Combine(Constant.ProgramDirectory, "Images", Path.GetFileName(path));
+            }
+
+            if (Directory.Exists(path))
+            {
+                /* Directories can also have thumbnails instead of shell icons.
+                 * Generating thumbnails for a bunch of folders while scrolling through
+                 * results from Everything makes a big impact on performance and
+                 * Wox responsibility.
+                 * - Solution: just load the icon
+                 */
+                type = ImageType.Folder;
+                image = WindowsThumbnailProvider.GetThumbnail(path, Constant.ThumbnailSize, Constant.ThumbnailSize, ThumbnailOptions.IconOnly);
+            }
+            else if (File.Exists(path))
+            {
+                // Using InvariantCulture since this is internal
+                var extension = Path.GetExtension(path).ToLower(CultureInfo.InvariantCulture);
+                if (ImageExtensions.Contains(extension))
+                {
+                    type = ImageType.ImageFile;
+                    if (loadFullImage)
+                    {
+                        image = LoadFullImage(path);
+                    }
+                    else
+                    {
+                        // PowerToys Run internal images are png, so we make this exception
+                        if (extension == ".png" || generateThumbnailsFromFiles)
+                        {
+                            /* Although the documentation for GetImage on MSDN indicates that
+                            * if a thumbnail is available it will return one, this has proved to not
+                            * be the case in many situations while testing.
+                            * - Solution: explicitly pass the ThumbnailOnly flag
+                            */
+                            image = WindowsThumbnailProvider.GetThumbnail(path, Constant.ThumbnailSize, Constant.ThumbnailSize, ThumbnailOptions.ThumbnailOnly);
+                        }
+                        else
+                        {
+                            image = WindowsThumbnailProvider.GetThumbnail(path, Constant.ThumbnailSize, Constant.ThumbnailSize, ThumbnailOptions.IconOnly);
+                        }
+                    }
+                }
+                else
+                {
+                    type = ImageType.File;
+                    image = WindowsThumbnailProvider.GetThumbnail(path, Constant.ThumbnailSize, Constant.ThumbnailSize, ThumbnailOptions.RESIZETOFIT);
+                }
+            }
+            else
+            {
+                image = ImageCache[ErrorIconPath];
+                path = ErrorIconPath;
+            }
+
+            if (type != ImageType.Error)
+            {
+                image.Freeze();
             }
 
             return new ImageResult(image, type);
@@ -227,9 +228,9 @@ namespace Wox.Infrastructure.Image
 
         private const bool _enableImageHash = true;
 
-        public static ImageSource Load(string path, bool generateThumbnailsFromFiles, bool loadFullImage = false)
+        public static async ValueTask<ImageSource> LoadAsync(string path, bool generateThumbnailsFromFiles, bool loadFullImage = false)
         {
-            var imageResult = LoadInternal(path, generateThumbnailsFromFiles, loadFullImage);
+            var imageResult = await LoadInternalAsync(path, generateThumbnailsFromFiles, loadFullImage);
 
             var img = imageResult.ImageSource;
             if (imageResult.ImageType != ImageType.Error && imageResult.ImageType != ImageType.Cache)

--- a/src/modules/launcher/Wox.Infrastructure/Image/ImageLoader.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Image/ImageLoader.cs
@@ -206,6 +206,14 @@ namespace Wox.Infrastructure.Image
                         }
                     }
                 }
+                else if (!generateThumbnailsFromFiles || (extension == ".pdf" && WindowsThumbnailProvider.DoesPdfUseAcrobatAsProvider()))
+                {
+                    // The PDF thumbnail provider from Adobe Reader and Acrobat Pro lets crash PT Run with an Dispatcher exception. (https://github.com/microsoft/PowerToys/issues/18166)
+                    // To not run into the crash, we only request the icon of PDF files if the PDF thumbnail handler is set to Adobe Reader/Acrobat Pro.
+                    // Also don't get thumbnail if the GenerateThumbnailsFromFiles option is off.
+                    type = ImageType.File;
+                    image = WindowsThumbnailProvider.GetThumbnail(path, Constant.ThumbnailSize, Constant.ThumbnailSize, ThumbnailOptions.IconOnly);
+                }
                 else
                 {
                     type = ImageType.File;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Thumbnail image loading on PowerToys Run is now done asynchronously, similar to the improvement that FlowLauncher as adopted as well.
In my tests, this fixes the #18166 dispatcher error we've been seeing so frequently for a long time.
I'm distributing a non official build as well for affected users to be able to give it a test.
This PR also removes the special case we added for Adobe Reader and pdf files.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #18166
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
This error is quite hard to replicate. Best way here is just checking if PT Run still works OK and let's try to have the users give us some feedback on the issue.
