### PR TITLE
[Settings] Shortcut edit dialog: Fix bugs 

### DIFF
--- a/src/settings-ui/Settings.UI.Library/HotkeySettingsControlHook.cs
+++ b/src/settings-ui/Settings.UI.Library/HotkeySettingsControlHook.cs
@@ -79,6 +79,8 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             }
         }
 
+        public bool GetDisposedState() => disposedValue;
+
         public void Dispose()
         {
             Dispose(disposing: true);

--- a/src/settings-ui/Settings.UI/Controls/ShortcutControl/ShortcutControl.xaml.cs
+++ b/src/settings-ui/Settings.UI/Controls/ShortcutControl/ShortcutControl.xaml.cs
@@ -89,6 +89,8 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
             hook = new HotkeySettingsControlHook(Hotkey_KeyDown, Hotkey_KeyUp, Hotkey_IsActive, FilterAccessibleKeyboardEvents);
             ResourceLoader resourceLoader = ResourceLoader.GetForViewIndependentUse();
 
+            App.GetSettingsWindow().Activated += ShortcutDialog_SettingsWindow_Activated;
+
             // We create the Dialog in C# because doing it in XAML is giving WinUI/XAML Island bugs when using dark theme.
             shortcutDialog = new ContentDialog
             {
@@ -110,6 +112,8 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
             shortcutDialog.PrimaryButtonClick -= ShortcutDialog_PrimaryButtonClick;
             shortcutDialog.Opened -= ShortcutDialog_Opened;
             shortcutDialog.Closing -= ShortcutDialog_Closing;
+
+            App.GetSettingsWindow().Activated -= ShortcutDialog_SettingsWindow_Activated;
 
             // Dispose the HotkeySettingsControlHook object to terminate the hook threads when the textbox is unloaded
             hook.Dispose();
@@ -361,6 +365,19 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
             else
             {
                 return false;
+            }
+        }
+
+        private void ShortcutDialog_SettingsWindow_Activated(object sender, WindowActivatedEventArgs args)
+        {
+            args.Handled = true;
+            if (args.WindowActivationState != WindowActivationState.Deactivated && hook.GetDisposedState() == true)
+            {
+                hook = new HotkeySettingsControlHook(Hotkey_KeyDown, Hotkey_KeyUp, Hotkey_IsActive, FilterAccessibleKeyboardEvents);
+            }
+            else if (args.WindowActivationState == WindowActivationState.Deactivated && hook.GetDisposedState() == false)
+            {
+                hook.Dispose();
             }
         }
 

--- a/src/settings-ui/Settings.UI/Controls/ShortcutControl/ShortcutControl.xaml.cs
+++ b/src/settings-ui/Settings.UI/Controls/ShortcutControl/ShortcutControl.xaml.cs
@@ -336,6 +336,7 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
             c.Keys = HotkeySettings.GetKeysList();
 
             shortcutDialog.XamlRoot = this.XamlRoot;
+            shortcutDialog.RequestedTheme = this.ActualTheme;
             await shortcutDialog.ShowAsync();
         }
 

--- a/src/settings-ui/Settings.UI/Controls/ShortcutControl/ShortcutControl.xaml.cs
+++ b/src/settings-ui/Settings.UI/Controls/ShortcutControl/ShortcutControl.xaml.cs
@@ -373,10 +373,12 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
             args.Handled = true;
             if (args.WindowActivationState != WindowActivationState.Deactivated && hook.GetDisposedState() == true)
             {
+                // If the PT settings window gets focussed/activated again, we enable the keyboard hook to catch the keyboard input.
                 hook = new HotkeySettingsControlHook(Hotkey_KeyDown, Hotkey_KeyUp, Hotkey_IsActive, FilterAccessibleKeyboardEvents);
             }
             else if (args.WindowActivationState == WindowActivationState.Deactivated && hook.GetDisposedState() == false)
             {
+                // If the PT settings window lost focus/activation, we disable the keyboard hook to allow keyboard input on other windows.
                 hook.Dispose();
             }
         }

--- a/src/settings-ui/Settings.UI/Controls/ShortcutControl/ShortcutDialogContentControl.xaml
+++ b/src/settings-ui/Settings.UI/Controls/ShortcutControl/ShortcutDialogContentControl.xaml
@@ -79,6 +79,20 @@
                                         Style="{StaticResource CriticalIconInfoBadgeStyle}" />
                         -->
 
+                        <Grid Margin="2,0,12,0" AutomationProperties.AccessibilityView="Raw">
+                            <!--  Error badge  -->
+                            <FontIcon
+                                                    FontFamily="{StaticResource SymbolThemeFontFamily}"
+                                                    Foreground="{ThemeResource InfoBarErrorSeverityIconBackground}"
+                                                    Glyph="{StaticResource InfoBarIconBackgroundGlyph}"
+                                                    FontSize="16" />
+                            <FontIcon
+                                                    FontFamily="{StaticResource SymbolThemeFontFamily}"
+                                                    Foreground="{ThemeResource InfoBarErrorSeverityIconForeground}"
+                                                    Glyph="{StaticResource InfoBarErrorIconGlyph}" 
+                                                    FontSize="16" />
+                        </Grid>
+
                         <TextBlock
                             x:Name="InvalidShortcutWarningLabel"
                             x:Uid="InvalidShortcut"

--- a/src/settings-ui/Settings.UI/Controls/ShortcutControl/ShortcutDialogContentControl.xaml
+++ b/src/settings-ui/Settings.UI/Controls/ShortcutControl/ShortcutDialogContentControl.xaml
@@ -56,53 +56,14 @@
             VerticalAlignment="Top"
             Orientation="Vertical"
             Spacing="8">
-            <Grid Height="36">
+            <Grid Height="62">
 
-                <Border
-                    x:Name="WarningBanner"
-                    Margin="-2,0,0,0"
-                    Padding="8"
-                    Background="{ThemeResource InfoBarErrorSeverityBackgroundBrush}"
-                    BorderBrush="{ThemeResource InfoBarBorderBrush}"
-                    BorderThickness="{ThemeResource InfoBarBorderThickness}"
-                    CornerRadius="{ThemeResource ControlCornerRadius}"
-                    Visibility="{Binding ElementName=ShortcutContentControl, Path=IsError, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="*" />
-                        </Grid.ColumnDefinitions>
+                <InfoBar x:Uid="InvalidShortcut"
+                         IsClosable="False"
+                         IsOpen="{Binding ElementName=ShortcutContentControl, Path=IsError, Mode=OneWay}"
+                         IsTabStop="{Binding ElementName=ShortcutContentControl, Path=IsError, Mode=OneWay}"
+                         Severity="Error" />
 
-                        <!--TODO(stefan) InfoBadge not available
-                        <InfoBadge AutomationProperties.AccessibilityView="Raw"
-                                        Margin="2,0,12,0"
-                                        Style="{StaticResource CriticalIconInfoBadgeStyle}" />
-                        -->
-
-                        <Grid Margin="2,0,12,0" AutomationProperties.AccessibilityView="Raw">
-                            <!--  Error badge  -->
-                            <FontIcon
-                                                    FontFamily="{StaticResource SymbolThemeFontFamily}"
-                                                    Foreground="{ThemeResource InfoBarErrorSeverityIconBackground}"
-                                                    Glyph="{StaticResource InfoBarIconBackgroundGlyph}"
-                                                    FontSize="16" />
-                            <FontIcon
-                                                    FontFamily="{StaticResource SymbolThemeFontFamily}"
-                                                    Foreground="{ThemeResource InfoBarErrorSeverityIconForeground}"
-                                                    Glyph="{StaticResource InfoBarErrorIconGlyph}" 
-                                                    FontSize="16" />
-                        </Grid>
-
-                        <TextBlock
-                            x:Name="InvalidShortcutWarningLabel"
-                            x:Uid="InvalidShortcut"
-                            Grid.Column="1"
-                            Margin="0,-1,0,0"
-                            VerticalAlignment="Center"
-                            FontWeight="{ThemeResource InfoBarTitleFontWeight}"
-                            Foreground="{ThemeResource InfoBarTitleForeground}" />
-                    </Grid>
-                </Border>
             </Grid>
             <toolkitcontrols:MarkdownTextBlock
                 x:Uid="InvalidShortcutWarningLabel"

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -2124,6 +2124,7 @@ From there, simply click on one of the supported files in the File Explorer and 
   </data>
   <data name="InvalidShortcutWarningLabel.Text" xml:space="preserve">
     <value>Only shortcuts that start with **Windows key**, **Ctrl**, **Alt** or **Shift** are valid.</value>
+    <comment>The ** sequences are used for text formatting of the key names. Don't remove them on translation.</comment>
   </data>
   <data name="FancyZones_SpanZonesAcrossMonitors.Description" xml:space="preserve">
     <value>All monitors must have the same DPI scaling and will be treated as one large combined rectangle which contains all monitors</value>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -2119,7 +2119,7 @@ From there, simply click on one of the supported files in the File Explorer and 
   <data name="Activation_Shortcut_Title" xml:space="preserve">
     <value>Activation shortcut</value>
   </data>
-  <data name="InvalidShortcut.Text" xml:space="preserve">
+  <data name="InvalidShortcut.Title" xml:space="preserve">
     <value>Invalid shortcut</value>
   </data>
   <data name="InvalidShortcutWarningLabel.Text" xml:space="preserve">


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This PR fixes some bugs in our custom shortcut edit dialog:
   - Missing error badge in "invalid key" warning.
   - The dialog is not PT Settings theme aware.
   - Fixed a bug that when it is open but the window has no focus the key inputs are still catched.

Before:
![image](https://user-images.githubusercontent.com/61519853/228023416-865ae51b-2a3a-45ff-bd16-00239639516b.png)

After:
![image](https://user-images.githubusercontent.com/61519853/228023298-629a9063-1ed8-4e8b-b423-669f9f4bb371.png)



<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #25059 , #25048, #25051
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

   - Added a resw comment for the shortcut instruction text. Currently the format markers gets lost on translation.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Local build and tested functionality.
