### PR TITLE
[Registry Preview] Cleanup of the resizing/moving logic on start up

### DIFF
--- a/src/modules/registrypreview/RegistryPreviewUI/MainWindow.Utilities.cs
+++ b/src/modules/registrypreview/RegistryPreviewUI/MainWindow.Utilities.cs
@@ -9,9 +9,12 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Windows.Data.Json;
 using Windows.Foundation.Metadata;
 using Windows.Storage;
 
@@ -733,40 +736,23 @@ namespace RegistryPreview
             ChangeCursor(gridPreview, false);
         }
 
-        private async void OpenSettingsFile(string path, string filename)
+        private void OpenSettingsFile(string path, string filename)
         {
-            StorageFolder storageFolder = null;
-            StorageFile storageFile = null;
             string fileContents = string.Empty;
-
-            try
+            string storageFile = Path.Combine(path, filename);
+            if (File.Exists(storageFile))
             {
-                storageFolder = await StorageFolder.GetFolderFromPathAsync(path);
-            }
-            catch
-            {
-            }
-
-            try
-            {
-                if (storageFolder != null)
+                try
                 {
-                    storageFile = await storageFolder.GetFileAsync(filename);
+                    TextReader reader = new StreamReader(storageFile);
+                    fileContents = reader.ReadToEnd();
+                    reader.Close();
                 }
-            }
-            catch
-            {
-            }
-
-            try
-            {
-                if (storageFile != null)
+                catch
                 {
-                    fileContents = await Windows.Storage.FileIO.ReadTextAsync(storageFile);
+                    // set up default JSON blob
+                    fileContents = "{ }";
                 }
-            }
-            catch
-            {
             }
 
             try

--- a/src/modules/registrypreview/RegistryPreviewUI/MainWindow.Utilities.cs
+++ b/src/modules/registrypreview/RegistryPreviewUI/MainWindow.Utilities.cs
@@ -9,12 +9,9 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Reflection;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Windows.Data.Json;
 using Windows.Foundation.Metadata;
 using Windows.Storage;
 

--- a/src/modules/registrypreview/RegistryPreviewUI/MainWindow.xaml.cs
+++ b/src/modules/registrypreview/RegistryPreviewUI/MainWindow.xaml.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Threading.Tasks;
 using Microsoft.UI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -53,10 +52,6 @@ namespace RegistryPreview
             appWindow.SetIcon("app.ico");
             appWindow.Closing += AppWindow_Closing;
 
-            // TODO: figure out a way to only call this once after MainWindow is initialized but before it shows itself
-            // Calling it from here only successfully resizes/moves the window and it seems to be based off timing, which is horrible.
-            // Calling it from GridPreview_Loaded() works 100% of the time, but the initial state of the window flashes before sizing/moving it
-            //
             // if have settings, update the location of the window
             if (jsonSettings != null)
             {

--- a/src/modules/registrypreview/RegistryPreviewUI/MainWindow.xaml.cs
+++ b/src/modules/registrypreview/RegistryPreviewUI/MainWindow.xaml.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 using Microsoft.UI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -40,9 +41,10 @@ namespace RegistryPreview
             // Initialize the string table
             resourceLoader = ResourceLoader.GetForViewIndependentUse();
 
-            // Removed this on 2/15/23 as it doesn't seem to be doing anything any more
-            // Attempts to force the visual tree to load faster
-            // this.Activate();
+            // Open settings file; this moved to after the window tweak because it gives the window time to start up
+            settingsFolder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + @"\Microsoft\PowerToys\" + APPNAME;
+            settingsFile = APPNAME + "_settings.json";
+            OpenSettingsFile(settingsFolder, settingsFile);
 
             // Update the Win32 looking window with the correct icon (and grab the appWindow handle for later)
             IntPtr windowHandle = WinRT.Interop.WindowNative.GetWindowHandle(this);
@@ -51,36 +53,31 @@ namespace RegistryPreview
             appWindow.SetIcon("app.ico");
             appWindow.Closing += AppWindow_Closing;
 
-            // Open settings file; this moved to after the window tweak because it gives the window time to start up
-            settingsFolder = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + @"\Microsoft\PowerToys\" + APPNAME;
-            settingsFile = APPNAME + "_settings.json";
-            OpenSettingsFile(settingsFolder, settingsFile);
-
             // TODO: figure out a way to only call this once after MainWindow is initialized but before it shows itself
             // Calling it from here only successfully resizes/moves the window and it seems to be based off timing, which is horrible.
             // Calling it from GridPreview_Loaded() works 100% of the time, but the initial state of the window flashes before sizing/moving it
             //
-            // // if have settings, update the location of the window
-            // if (jsonSettings != null)
-            // {
-            //     // resize the window
-            //     if (jsonSettings.ContainsKey("appWindow.Size.Width") && jsonSettings.ContainsKey("appWindow.Size.Height"))
-            //     {
-            //         SizeInt32 size;
-            //         size.Width = (int)jsonSettings.GetNamedNumber("appWindow.Size.Width");
-            //         size.Height = (int)jsonSettings.GetNamedNumber("appWindow.Size.Height");
-            //         appWindow.Resize(size);
-            //     }
-            //
-            //     // reposition the window
-            //     if (jsonSettings.ContainsKey("appWindow.Position.X") && jsonSettings.ContainsKey("appWindow.Position.Y"))
-            //     {
-            //         PointInt32 point;
-            //         point.X = (int)jsonSettings.GetNamedNumber("appWindow.Position.X");
-            //         point.Y = (int)jsonSettings.GetNamedNumber("appWindow.Position.Y");
-            //         appWindow.Move(point);
-            //     }
-            // }
+            // if have settings, update the location of the window
+            if (jsonSettings != null)
+            {
+                // resize the window
+                if (jsonSettings.ContainsKey("appWindow.Size.Width") && jsonSettings.ContainsKey("appWindow.Size.Height"))
+                {
+                    SizeInt32 size;
+                    size.Width = (int)jsonSettings.GetNamedNumber("appWindow.Size.Width");
+                    size.Height = (int)jsonSettings.GetNamedNumber("appWindow.Size.Height");
+                    appWindow.Resize(size);
+                }
+
+                // reposition the window
+                if (jsonSettings.ContainsKey("appWindow.Position.X") && jsonSettings.ContainsKey("appWindow.Position.Y"))
+                {
+                    PointInt32 point;
+                    point.X = (int)jsonSettings.GetNamedNumber("appWindow.Position.X");
+                    point.Y = (int)jsonSettings.GetNamedNumber("appWindow.Position.Y");
+                    appWindow.Move(point);
+                }
+            }
 
             // Update Toolbar
             if ((App.AppFilename == null) || (File.Exists(App.AppFilename) != true))


### PR DESCRIPTION
## Cleanup of the resizing/moving logic on start up
Initial check-in disabled the functionality that restored the last position and size of the main window on launch.

## PR Checklist

- [x] **Closes:** restores commented out functionality from PR #23709 
- [ ] **Communication:** I'll be looking for input from @stefansjfw as he repro'd at will.
- [x] **Tests:** All local testing has passed.
- [x] **Localization:** No string changes.
- [x] **Dev docs:** No change required
- [x] **New binaries:** No new binaries; this is an in-place replacement,
- [x] **Documentation updated:** No change required.

## Detailed Description of the Pull Request / Additional comments
It appears that the "modern" async-based file reading calls I was making were sometimes working and sometimes not.  When I wrapped them into a Task, I found that the Task would sometimes be fine and other times, it would block and never return, in spite of the 2 second timeout I requested.  I've since moved to the more traditional and blocking APIs for confirming file existence and reading the JSON blob into place.

## Validation Steps Performed
I was not able to reproduce this issue while debugging, but I could sometimes reproduce it, if launched from desktop, and very often, if I put the file read early in the Main Window constructor.  With using the updated file handlers, I cannot reproduce the problem under any conditions.