### PR TITLE
[FancyZones] Fix window cycling on multiple monitors

### DIFF
--- a/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
@@ -537,43 +537,6 @@ void WorkArea::InitLayout(const FancyZonesDataTypes::WorkAreaId& parentUniqueId)
     CalculateZoneSet();
 }
 
-void WorkArea::InitSnappedWindows()
-{
-    Logger::info(L"Init work area windows: {}", m_uniqueId.toString());
-
-    for (const auto& window : VirtualDesktop::instance().GetWindowsFromCurrentDesktop())
-    {
-        auto indexes = FancyZonesWindowProperties::RetrieveZoneIndexProperty(window);
-        if (indexes.size() == 0)
-        {
-            continue;
-        }
-
-        if (!m_uniqueId.monitorId.monitor) // one work area across monitors
-        {
-            MoveWindowIntoZoneByIndexSet(window, indexes, false);
-        }
-        else
-        {
-            const auto monitor = MonitorFromWindow(window, MONITOR_DEFAULTTONULL);
-            if (monitor && m_uniqueId.monitorId.monitor == monitor)
-            {
-                // prioritize snapping on the current monitor if the window was snapped to several work areas
-                MoveWindowIntoZoneByIndexSet(window, indexes, false);
-            }
-            else
-            {
-                // if the window is not snapped on the current monitor, then check the others
-                auto savedIndexes = GetWindowZoneIndexes(window);
-                if (savedIndexes == indexes)
-                {
-                    MoveWindowIntoZoneByIndexSet(window, indexes, false);
-                }
-            }
-        }
-    }
-}
-
 void WorkArea::CalculateZoneSet()
 {
     const auto appliedLayout = AppliedLayouts::instance().GetDeviceLayout(m_uniqueId);

--- a/src/modules/fancyzones/FancyZonesLib/WorkArea.h
+++ b/src/modules/fancyzones/FancyZonesLib/WorkArea.h
@@ -51,7 +51,6 @@ public:
     bool MoveWindowIntoZoneByDirectionAndPosition(HWND window, DWORD vkCode, bool cycle);
     bool ExtendWindowByDirectionAndPosition(HWND window, DWORD vkCode);
 
-    void InitSnappedWindows();
     void SnapWindow(HWND window, const ZoneIndexSet& zones, bool extend = false);
     void UnsnapWindow(HWND window);
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Moved snapped window initialization.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #24470 
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

* Enable `Switch between windows in the current zone`
* Assign 2 or more windows to the same zone number on the different monitors. (e.g. assign 2 windows to the zone 1 on the first and the second monitors)
* Cycle through the windows in the zone 
* Verify that windows are activated only in one zone