### PR TITLE
Devdocs: Fix dead link to settings spec

### DIFF
--- a/doc/devdocs/readme.md
+++ b/doc/devdocs/readme.md
@@ -137,7 +137,7 @@ To run and debug PowerToys from Visual Studio when the user is a member of the A
 ## How to create new PowerToys
 
 See the instructions on [how to install the PowerToys Module project template](/tools/project_template). <br />
-Specifications for the [PowerToys settings API](/doc/devdocs/settings.md).
+Specifications for the [PowerToys settings API](settingsv2/readme.md).
 
 ## Implementation details
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Fixes dead link to settings spec. `/doc/devdocs/settings.md` does no longer exist. I guess it was replaced with `settingsv2/`.


