### PR TITLE
[Registry Preview] Moving to a different API to call the File Picker

### DIFF
--- a/src/modules/registrypreview/RegistryPreviewUI/FileName.cs
+++ b/src/modules/registrypreview/RegistryPreviewUI/FileName.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace RegistryPreview
+{
+    // Workaround for File Pickers that don't work while running as admin, per:
+    // https://github.com/microsoft/WindowsAppSDK/issues/2504https://github.com/microsoft/WindowsAppSDK/issues/2504
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+    public struct FileName
+    {
+        public int StructSize;
+        public IntPtr HwndOwner;
+        public IntPtr Instance;
+        public string Filter;
+        public string CustomFilter;
+        public int MaxCustFilter;
+        public int FilterIndex;
+        public string File;
+        public int MaxFile;
+        public string FileTitle;
+        public int MaxFileTitle;
+        public string InitialDir;
+        public string Title;
+        public int Flags;
+        public short FileOffset;
+        public short FileExtension;
+        public string DefExt;
+        public IntPtr CustData;
+        public IntPtr Hook;
+        public string TemplateName;
+        public IntPtr PtrReserved;
+        public int Reserved;
+        public int FlagsEx;
+    }
+}

--- a/src/modules/registrypreview/RegistryPreviewUI/FileName.cs
+++ b/src/modules/registrypreview/RegistryPreviewUI/FileName.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 namespace RegistryPreview
 {
     // Workaround for File Pickers that don't work while running as admin, per:
-    // https://github.com/microsoft/WindowsAppSDK/issues/2504https://github.com/microsoft/WindowsAppSDK/issues/2504
+    // https://github.com/microsoft/WindowsAppSDK/issues/2504
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
     public struct FileName
     {

--- a/src/modules/registrypreview/RegistryPreviewUI/MainWindow.Events.cs
+++ b/src/modules/registrypreview/RegistryPreviewUI/MainWindow.Events.cs
@@ -134,18 +134,21 @@ namespace RegistryPreview
                 }
             }
 
-            // Pull in a new REG file
-            FileOpenPicker fileOpenPicker = new FileOpenPicker();
-            fileOpenPicker.ViewMode = PickerViewMode.List;
-            fileOpenPicker.CommitButtonText = resourceLoader.GetString("OpenButtonText");
-            fileOpenPicker.SuggestedStartLocation = PickerLocationId.DocumentsLibrary;
-            fileOpenPicker.FileTypeFilter.Add(".reg");
+            // Pull in a new REG file - we have to use the direct Win32 method because FileOpenPicker crashes when it's
+            // called while running as admin
+            string documentsPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+            string filename = FilePicker.ShowDialog(
+                documentsPath,
+                new string[] { "reg" },
+                resourceLoader.GetString("FilterRegistryName"),
+                resourceLoader.GetString("OpenDialogTitle"));
 
-            // Get the HWND so we an open the modal
-            IntPtr hWnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
-            InitializeWithWindow.Initialize(fileOpenPicker, hWnd);
+            if (filename == string.Empty || File.Exists(filename) == false)
+            {
+                return;
+            }
 
-            StorageFile storageFile = await fileOpenPicker.PickSingleFileAsync();
+            StorageFile storageFile = await StorageFile.GetFileFromPathAsync(filename);
 
             if (storageFile != null)
             {

--- a/src/modules/registrypreview/RegistryPreviewUI/MainWindow.Events.cs
+++ b/src/modules/registrypreview/RegistryPreviewUI/MainWindow.Events.cs
@@ -136,11 +136,8 @@ namespace RegistryPreview
 
             // Pull in a new REG file - we have to use the direct Win32 method because FileOpenPicker crashes when it's
             // called while running as admin
-            string documentsPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-            string filename = FilePicker.ShowDialog(
-                documentsPath,
-                new string[] { "reg" },
-                resourceLoader.GetString("FilterRegistryName"),
+            string filename = OpenFilePicker.ShowDialog(
+                resourceLoader.GetString("FilterRegistryName") + '\0' + "*.reg" + '\0' + resourceLoader.GetString("FilterAllFiles") + '\0' + "*.*" + '\0' + '\0',
                 resourceLoader.GetString("OpenDialogTitle"));
 
             if (filename == string.Empty || File.Exists(filename) == false)
@@ -177,27 +174,23 @@ namespace RegistryPreview
         /// <summary>
         /// Uses a picker to save out a copy of the current reg file
         /// </summary>
-        private async void SaveAsButton_Click(object sender, RoutedEventArgs e)
+        private void SaveAsButton_Click(object sender, RoutedEventArgs e)
         {
-            // Save out a new REG file and then open it
-            FileSavePicker fileSavePicker = new FileSavePicker();
-            fileSavePicker.CommitButtonText = resourceLoader.GetString("SaveButtonText");
-            fileSavePicker.SuggestedStartLocation = PickerLocationId.DocumentsLibrary;
-            fileSavePicker.FileTypeChoices.Add("Registry file", new List<string>() { ".reg" });
-            fileSavePicker.SuggestedFileName = resourceLoader.GetString("SuggestFileName");
+            // Save out a new REG file and then open it - we have to use the direct Win32 method because FileOpenPicker crashes when it's
+            // called while running as admin
+            string filename = SaveFilePicker.ShowDialog(
+                resourceLoader.GetString("SuggestFileName"),
+                resourceLoader.GetString("FilterRegistryName") + '\0' + "*.reg" + '\0' + resourceLoader.GetString("FilterAllFiles") + '\0' + "*.*" + '\0' + '\0',
+                resourceLoader.GetString("SaveDialogTitle"));
 
-            // Get the HWND so we an save the modal
-            IntPtr hWnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
-            InitializeWithWindow.Initialize(fileSavePicker, hWnd);
-
-            StorageFile storageFile = await fileSavePicker.PickSaveFileAsync();
-
-            if (storageFile != null)
+            if (filename == string.Empty)
             {
-                App.AppFilename = storageFile.Path;
-                SaveFile();
-                UpdateToolBarAndUI(OpenRegistryFile(App.AppFilename));
+                return;
             }
+
+            App.AppFilename = filename;
+            SaveFile();
+            UpdateToolBarAndUI(OpenRegistryFile(App.AppFilename));
         }
 
         /// <summary>

--- a/src/modules/registrypreview/RegistryPreviewUI/OpenFileName.cs
+++ b/src/modules/registrypreview/RegistryPreviewUI/OpenFileName.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 namespace RegistryPreview
 {
     // Workaround for File Pickers that don't work while running as admin, per:
-    // https://github.com/microsoft/WindowsAppSDK/issues/2504https://github.com/microsoft/WindowsAppSDK/issues/2504
+    // https://github.com/microsoft/WindowsAppSDK/issues/2504
     public static partial class OpenFilePicker
     {
         [DllImport("comdlg32.dll", SetLastError = true, CharSet = CharSet.Auto)]

--- a/src/modules/registrypreview/RegistryPreviewUI/OpenFileName.cs
+++ b/src/modules/registrypreview/RegistryPreviewUI/OpenFileName.cs
@@ -2,68 +2,32 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Runtime.InteropServices;
 
 namespace RegistryPreview
 {
-    // Workaround for broken FileOpenPicker while running as admin, per:
+    // Workaround for File Pickers that don't work while running as admin, per:
     // https://github.com/microsoft/WindowsAppSDK/issues/2504https://github.com/microsoft/WindowsAppSDK/issues/2504
-    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
-    public struct OpenFileName
-    {
-#pragma warning disable SA1307 // relax casing rule, for external APIs
-        public int lStructSize;
-        public IntPtr hwndOwner;
-        public IntPtr hInstance;
-        public string lpstrFilter;
-        public string lpstrCustomFilter;
-        public int nMaxCustFilter;
-        public int nFilterIndex;
-        public string lpstrFile;
-        public int nMaxFile;
-        public string lpstrFileTitle;
-        public int nMaxFileTitle;
-        public string lpstrInitialDir;
-        public string lpstrTitle;
-        public int Flags;
-        public short nFileOffset;
-        public short nFileExtension;
-        public string lpstrDefExt;
-        public IntPtr lCustData;
-        public IntPtr lpfnHook;
-        public string lpTemplateName;
-        public IntPtr pvReserved;
-        public int dwReserved;
-        public int flagsEx;
-#pragma warning restore SA1307 // relax casing rule, for external APIs
-    }
-
-    public static partial class FilePicker
+    public static partial class OpenFilePicker
     {
         [DllImport("comdlg32.dll", SetLastError = true, CharSet = CharSet.Auto)]
-        private static extern bool GetOpenFileName(ref OpenFileName ofn);
+        private static extern bool GetOpenFileName(ref FileName openFileName);
 
-        public static string ShowDialog(string startingDirectory, string[] filters, string filterName, string dialogTitle)
+        public static string ShowDialog(string filter, string dialogTitle)
         {
-            OpenFileName ofn = default(OpenFileName);
-            ofn.lStructSize = Marshal.SizeOf(ofn);
+            FileName openFileName = default(FileName);
+            openFileName.StructSize = Marshal.SizeOf(openFileName);
 
-            ofn.lpstrFilter = filterName;
-            foreach (string filter in filters)
+            openFileName.Filter = filter;
+            openFileName.File = new string(new char[256]);
+            openFileName.MaxFile = openFileName.File.Length;
+            openFileName.FileTitle = new string(new char[64]);
+            openFileName.MaxFileTitle = openFileName.FileTitle.Length;
+            openFileName.Title = dialogTitle;
+
+            if (GetOpenFileName(ref openFileName))
             {
-                ofn.lpstrFilter += $"\0*.{filter}";
-            }
-
-            ofn.lpstrFile = new string(new char[256]);
-            ofn.nMaxFile = ofn.lpstrFile.Length;
-            ofn.lpstrFileTitle = new string(new char[64]);
-            ofn.nMaxFileTitle = ofn.lpstrFileTitle.Length;
-            ofn.lpstrTitle = dialogTitle;
-
-            if (GetOpenFileName(ref ofn))
-            {
-                return ofn.lpstrFile;
+                return openFileName.File;
             }
 
             return string.Empty;

--- a/src/modules/registrypreview/RegistryPreviewUI/OpenFileName.cs
+++ b/src/modules/registrypreview/RegistryPreviewUI/OpenFileName.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace RegistryPreview
+{
+    // Workaround for broken FileOpenPicker while running as admin, per:
+    // https://github.com/microsoft/WindowsAppSDK/issues/2504https://github.com/microsoft/WindowsAppSDK/issues/2504
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+    public struct OpenFileName
+    {
+#pragma warning disable SA1307 // relax casing rule, for external APIs
+        public int lStructSize;
+        public IntPtr hwndOwner;
+        public IntPtr hInstance;
+        public string lpstrFilter;
+        public string lpstrCustomFilter;
+        public int nMaxCustFilter;
+        public int nFilterIndex;
+        public string lpstrFile;
+        public int nMaxFile;
+        public string lpstrFileTitle;
+        public int nMaxFileTitle;
+        public string lpstrInitialDir;
+        public string lpstrTitle;
+        public int Flags;
+        public short nFileOffset;
+        public short nFileExtension;
+        public string lpstrDefExt;
+        public IntPtr lCustData;
+        public IntPtr lpfnHook;
+        public string lpTemplateName;
+        public IntPtr pvReserved;
+        public int dwReserved;
+        public int flagsEx;
+#pragma warning restore SA1307 // relax casing rule, for external APIs
+    }
+
+    public static partial class FilePicker
+    {
+        [DllImport("comdlg32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+        private static extern bool GetOpenFileName(ref OpenFileName ofn);
+
+        public static string ShowDialog(string startingDirectory, string[] filters, string filterName, string dialogTitle)
+        {
+            OpenFileName ofn = default(OpenFileName);
+            ofn.lStructSize = Marshal.SizeOf(ofn);
+
+            ofn.lpstrFilter = filterName;
+            foreach (string filter in filters)
+            {
+                ofn.lpstrFilter += $"\0*.{filter}";
+            }
+
+            ofn.lpstrFile = new string(new char[256]);
+            ofn.nMaxFile = ofn.lpstrFile.Length;
+            ofn.lpstrFileTitle = new string(new char[64]);
+            ofn.nMaxFileTitle = ofn.lpstrFileTitle.Length;
+            ofn.lpstrTitle = dialogTitle;
+
+            if (GetOpenFileName(ref ofn))
+            {
+                return ofn.lpstrFile;
+            }
+
+            return string.Empty;
+        }
+    }
+}

--- a/src/modules/registrypreview/RegistryPreviewUI/RegistryPreviewUI.csproj
+++ b/src/modules/registrypreview/RegistryPreviewUI/RegistryPreviewUI.csproj
@@ -24,6 +24,7 @@
 		<AssemblyDescription>PowerToys RegistryPreview</AssemblyDescription>
 		<RootNamespace>RegistryPreview</RootNamespace>
 		<DisableWinExeOutputInference>true</DisableWinExeOutputInference>
+		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	</PropertyGroup>
 
 	<!-- SelfContained=true requires RuntimeIdentifier to be set -->

--- a/src/modules/registrypreview/RegistryPreviewUI/SaveFileName.cs
+++ b/src/modules/registrypreview/RegistryPreviewUI/SaveFileName.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 namespace RegistryPreview
 {
     // Workaround for File Pickers that don't work while running as admin, per:
-    // https://github.com/microsoft/WindowsAppSDK/issues/2504https://github.com/microsoft/WindowsAppSDK/issues/2504
+    // https://github.com/microsoft/WindowsAppSDK/issues/2504
     public static partial class SaveFilePicker
     {
         [DllImport("comdlg32.dll", SetLastError = true, CharSet = CharSet.Auto)]

--- a/src/modules/registrypreview/RegistryPreviewUI/SaveFileName.cs
+++ b/src/modules/registrypreview/RegistryPreviewUI/SaveFileName.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+namespace RegistryPreview
+{
+    // Workaround for File Pickers that don't work while running as admin, per:
+    // https://github.com/microsoft/WindowsAppSDK/issues/2504https://github.com/microsoft/WindowsAppSDK/issues/2504
+    public static partial class SaveFilePicker
+    {
+        [DllImport("comdlg32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+        private static extern bool GetSaveFileName(ref FileName saveFileName);
+
+        public static string ShowDialog(string suggestedFilename, string filter, string dialogTitle)
+        {
+            FileName saveFileName = default(FileName);
+            saveFileName.StructSize = Marshal.SizeOf(saveFileName);
+
+            saveFileName.Filter = filter;
+            saveFileName.File = new string(new char[256]);
+            saveFileName.MaxFile = saveFileName.File.Length;
+            saveFileName.File = string.Concat(suggestedFilename, saveFileName.File);
+            saveFileName.FileTitle = new string(new char[64]);
+            saveFileName.MaxFileTitle = saveFileName.FileTitle.Length;
+            saveFileName.Title = dialogTitle;
+            saveFileName.DefExt = "reg";
+
+            if (GetSaveFileName(ref saveFileName))
+            {
+                return saveFileName.File;
+            }
+
+            return string.Empty;
+        }
+    }
+}

--- a/src/modules/registrypreview/RegistryPreviewUI/Strings/en-US/Resources.resw
+++ b/src/modules/registrypreview/RegistryPreviewUI/Strings/en-US/Resources.resw
@@ -132,6 +132,9 @@
   <data name="FileSaveError" xml:space="preserve">
     <value>The REG file cannot be written to.</value>
   </data>
+  <data name="FilterRegistryName" xml:space="preserve">
+    <value>Registry Files</value>
+  </data>
   <data name="InvalidRegistryFile" xml:space="preserve">
     <value> doesn't appear to be a valid registry file!</value>
   </data>
@@ -150,11 +153,8 @@
   <data name="OkButtonText" xml:space="preserve">
     <value>OK</value>
   </data>
-  <data name="OpenButton.Label" xml:space="preserve">
+  <data name="OpenDialogTitle" xml:space="preserve">
     <value>Open file...</value>
-  </data>
-  <data name="OpenButtonText" xml:space="preserve">
-    <value>Open</value>
   </data>
   <data name="RefreshButton.Label" xml:space="preserve">
     <value>Reload from file</value>

--- a/src/modules/registrypreview/RegistryPreviewUI/Strings/en-US/Resources.resw
+++ b/src/modules/registrypreview/RegistryPreviewUI/Strings/en-US/Resources.resw
@@ -153,8 +153,11 @@
   <data name="OkButtonText" xml:space="preserve">
     <value>OK</value>
   </data>
-  <data name="OpenDialogTitle" xml:space="preserve">
+  <data name="OpenButton.Label" xml:space="preserve">
     <value>Open file...</value>
+  </data>
+  <data name="OpenDialogTitle" xml:space="preserve">
+    <value>Open Registry file...</value>
   </data>
   <data name="RefreshButton.Label" xml:space="preserve">
     <value>Reload from file</value>

--- a/src/modules/registrypreview/RegistryPreviewUI/Strings/en-US/Resources.resw
+++ b/src/modules/registrypreview/RegistryPreviewUI/Strings/en-US/Resources.resw
@@ -132,8 +132,11 @@
   <data name="FileSaveError" xml:space="preserve">
     <value>The REG file cannot be written to.</value>
   </data>
+  <data name="FilterAllFiles" xml:space="preserve">
+    <value>All files (*.*)</value>
+  </data>
   <data name="FilterRegistryName" xml:space="preserve">
-    <value>Registry Files</value>
+    <value>Registry files (*.reg)</value>
   </data>
   <data name="InvalidRegistryFile" xml:space="preserve">
     <value> doesn't appear to be a valid registry file!</value>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Calls a different API for the FilePicker UI, since the built in version fails, when called by an app with Admin rights.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #25250 
- [x] **Localization:** All end user facing strings can be localized

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Calling FileOpenPicker and FileSavePicker from within the app would cause a crash, if the app was launched as an Administrator. 
 It appears that this is a known issue for these APIs, so the code now calls the Win32/PInvoke versions, which does not have an issue with Admin rights.  All other changes support this shift to the "new" API.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Tested the Open file... button and Save as.... with different elevated and non-elevated states.