### PR TITLE
[Registry Preview] Clamps for window size and position

### DIFF
--- a/src/modules/registrypreview/RegistryPreviewUI/MainWindow.xaml.cs
+++ b/src/modules/registrypreview/RegistryPreviewUI/MainWindow.xaml.cs
@@ -62,7 +62,12 @@ namespace RegistryPreview
                     SizeInt32 size;
                     size.Width = (int)jsonSettings.GetNamedNumber("appWindow.Size.Width");
                     size.Height = (int)jsonSettings.GetNamedNumber("appWindow.Size.Height");
-                    appWindow.Resize(size);
+
+                    // check to make sure the size values are reasonable before attempting to restore the last saved size
+                    if (size.Width >= 320 && size.Height >= 240)
+                    {
+                        appWindow.Resize(size);
+                    }
                 }
 
                 // reposition the window
@@ -71,7 +76,12 @@ namespace RegistryPreview
                     PointInt32 point;
                     point.X = (int)jsonSettings.GetNamedNumber("appWindow.Position.X");
                     point.Y = (int)jsonSettings.GetNamedNumber("appWindow.Position.Y");
-                    appWindow.Move(point);
+
+                    // check to make sure the move values are reasonable before attempting to restore the last saved location
+                    if (point.X >= 0 && point.Y >= 0)
+                    {
+                        appWindow.Move(point);
+                    }
                 }
             }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Adds a floor value for size (320x240) and position (0x0)

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #25254

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Makes sure that if a size or position is "too small" when the application loads that it uses the default size or position, so the window is always seen.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Tested at various small sizes and locations across the screen.

Note: this does not handle a position that is "too large" as I couldn't find a great way to get the max size a desktop in a multi-monitor world [yet].