### PR TITLE
[Run] String-type settings support for PowerToys Run plugins

### DIFF
--- a/src/settings-ui/Settings.UI.Library/PluginAdditionalStringOption.cs
+++ b/src/settings-ui/Settings.UI.Library/PluginAdditionalStringOption.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.PowerToys.Settings.UI.Library;
+
+namespace Settings.UI.Library
+{
+    public class PluginAdditionalStringOption : PluginAdditionalOption
+    {
+        public new string Value { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary of the Pull Request
Hi there! This is Simone. I've posted a few weeks ago a Tweet where I've shown ChatGPT integration into PowerToys Run, implemented as a custom plugin. Clint Rutkas reached out to me to ask if I wanted to make this plugin a reality and I agreed.

We've exchanged a few mails and had a brief call two weeks ago and we discovered a few points that need development before the plugin can become a reality for everyone:

- There is a need for String settings on PT Run plugins. Currently PT Run plugins can only have Boolean-types settings, and my plugin needs the user to enter a personal OpenAI API key to work. **(This is what this PR is about)**
- A custom result layout can be made to break out of the limits of the single text-line result that Run can display.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** None, apparently (should I open an issue for this?)
- [x] **Communication:** I've discussed this with core contributors already. Clint, as mentioned before!
- [ ] **Tests:** None yet
- [ ] **Localization:** None yet
- [ ] **Dev docs:** None yet

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
I've had to take some time and as I'm now ready to work on this, here's what I've planned for this PR:

- The string option class extends the original one to avoid breaking other plugins
- A new custom logic will be implemented in the view:

  - if the Value type is string, a new string setting control will be created, otherwise, the classic boolean checkbox will appear

I'm open to suggestions here, of course. Work has just started. Thanks!

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
None yet. PR is in development state