### PR TITLE
[Awake]Fix crash on negative timezone offsets

### DIFF
--- a/src/settings-ui/Settings.UI.Library/AwakeProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/AwakeProperties.cs
@@ -16,7 +16,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             Mode = AwakeMode.PASSIVE;
             IntervalHours = 0;
             IntervalMinutes = 0;
-            ExpirationDateTime = DateTimeOffset.MinValue;
+            ExpirationDateTime = DateTimeOffset.Now;
             CustomTrayTimes = new Dictionary<string, int>();
         }
 

--- a/src/settings-ui/Settings.UI.Library/AwakeSettings.cs
+++ b/src/settings-ui/Settings.UI.Library/AwakeSettings.cs
@@ -37,7 +37,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library
                     KeepDisplayOn = Properties.KeepDisplayOn,
                     IntervalMinutes = Properties.IntervalMinutes,
                     IntervalHours = Properties.IntervalHours,
-                    ExpirationDateTime = Properties.ExpirationDateTime,
+
+                    // Fix old buggy default value that might be saved in Settings. Some components don't deal well with negative timezones and minimum time offsets-
+                    ExpirationDateTime = Properties.ExpirationDateTime.Year < 2 ? DateTimeOffset.Now : Properties.ExpirationDateTime,
                 },
             };
         }

--- a/src/settings-ui/Settings.UI.Library/AwakeSettings.cs
+++ b/src/settings-ui/Settings.UI.Library/AwakeSettings.cs
@@ -38,7 +38,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
                     IntervalMinutes = Properties.IntervalMinutes,
                     IntervalHours = Properties.IntervalHours,
 
-                    // Fix old buggy default value that might be saved in Settings. Some components don't deal well with negative timezones and minimum time offsets-
+                    // Fix old buggy default value that might be saved in Settings. Some components don't deal well with negative time zones and minimum time offsets.
                     ExpirationDateTime = Properties.ExpirationDateTime.Year < 2 ? DateTimeOffset.Now : Properties.ExpirationDateTime,
                 },
             };


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Current behavior of PowerToys Awake for the "Keep Away Until Expiration" option is to set the default value to the minimum time offset ( `0001-01-01T00:00:00+00:00` ).
This seems to crash the DatePicker control on negative timezone offsets. because it will essentially try to show the day before the minimum.
This PR changes the default offset to current date when initializing the properties. It also checks when loading data to show in settings if the year is < 2 and sets it to current date instead.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #25334
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Set the computer's timezone to Pacific time (-8 hours offset).
- Replace "%localappdata\Microsoft\PowerToys\Awake\settings.json" with the one from the original issue.
[settings.zip](https://github.com/microsoft/PowerToys/files/11199628/settings.zip)
- Start PowerToys, go to Awake Settings page and select the "Keep Away Until Expiration" mode. Verify Settings doesn't crash.