### PR TITLE
[Settings]Fix null exception on shortcut control

### DIFF
--- a/src/settings-ui/Settings.UI/Controls/ShortcutControl/ShortcutControl.xaml.cs
+++ b/src/settings-ui/Settings.UI/Controls/ShortcutControl/ShortcutControl.xaml.cs
@@ -89,7 +89,10 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
             hook = new HotkeySettingsControlHook(Hotkey_KeyDown, Hotkey_KeyUp, Hotkey_IsActive, FilterAccessibleKeyboardEvents);
             ResourceLoader resourceLoader = ResourceLoader.GetForViewIndependentUse();
 
-            App.GetSettingsWindow().Activated += ShortcutDialog_SettingsWindow_Activated;
+            if (App.GetSettingsWindow() != null)
+            {
+                App.GetSettingsWindow().Activated += ShortcutDialog_SettingsWindow_Activated;
+            }
 
             // We create the Dialog in C# because doing it in XAML is giving WinUI/XAML Island bugs when using dark theme.
             shortcutDialog = new ContentDialog
@@ -113,7 +116,10 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
             shortcutDialog.Opened -= ShortcutDialog_Opened;
             shortcutDialog.Closing -= ShortcutDialog_Closing;
 
-            App.GetSettingsWindow().Activated -= ShortcutDialog_SettingsWindow_Activated;
+            if (App.GetSettingsWindow() != null)
+            {
+                App.GetSettingsWindow().Activated -= ShortcutDialog_SettingsWindow_Activated;
+            }
 
             // Dispose the HotkeySettingsControlHook object to terminate the hook threads when the textbox is unloaded
             if (hook != null)

--- a/src/settings-ui/Settings.UI/Controls/ShortcutControl/ShortcutControl.xaml.cs
+++ b/src/settings-ui/Settings.UI/Controls/ShortcutControl/ShortcutControl.xaml.cs
@@ -116,7 +116,12 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
             App.GetSettingsWindow().Activated -= ShortcutDialog_SettingsWindow_Activated;
 
             // Dispose the HotkeySettingsControlHook object to terminate the hook threads when the textbox is unloaded
-            hook.Dispose();
+            if (hook != null)
+            {
+                hook.Dispose();
+            }
+
+            hook = null;
         }
 
         private void KeyEventHandler(int key, bool matchValue, int matchValueCode)
@@ -371,15 +376,16 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
         private void ShortcutDialog_SettingsWindow_Activated(object sender, WindowActivatedEventArgs args)
         {
             args.Handled = true;
-            if (args.WindowActivationState != WindowActivationState.Deactivated && hook.GetDisposedState() == true)
+            if (args.WindowActivationState != WindowActivationState.Deactivated && (hook == null || hook.GetDisposedState() == true))
             {
                 // If the PT settings window gets focussed/activated again, we enable the keyboard hook to catch the keyboard input.
                 hook = new HotkeySettingsControlHook(Hotkey_KeyDown, Hotkey_KeyUp, Hotkey_IsActive, FilterAccessibleKeyboardEvents);
             }
-            else if (args.WindowActivationState == WindowActivationState.Deactivated && hook.GetDisposedState() == false)
+            else if (args.WindowActivationState == WindowActivationState.Deactivated && hook != null && hook.GetDisposedState() == false)
             {
                 // If the PT settings window lost focus/activation, we disable the keyboard hook to allow keyboard input on other windows.
                 hook.Dispose();
+                hook = null;
             }
         }
 
@@ -394,7 +400,12 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
             {
                 if (disposing)
                 {
-                    hook.Dispose();
+                    if (hook != null)
+                    {
+                        hook.Dispose();
+                    }
+
+                    hook = null;
                 }
 
                 disposedValue = true;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
For 0.69, we've been receiving Watson crashes for Settings with a null reference exception on `ShortcutControl_Unloaded`.
This PR adds some null checks around the handling of hook and getting the settings window object.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** Watson reports
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Can't repro the reported crashes, just checked setting different shortcuts still work in general.
