### PR TITLE
[Installer]Add missing xaml noise png assets

### DIFF
--- a/installer/PowerToysSetup/FileLocksmith.wxs
+++ b/installer/PowerToysSetup/FileLocksmith.wxs
@@ -35,6 +35,15 @@
     <!--FileLocksmithAssetsFiles_Component_Def-->
     </DirectoryRef>
 
+    <DirectoryRef Id="FileLocksmithMicrosoftUIXamlAssetsInstallFolder" FileSource="$(var.BinDir)modules\$(var.FileLocksmithProjectName)\Microsoft.UI.Xaml\Assets">
+      <Component Id="FileLocksmithMicrosoftUIXamlAssets_NoiseAsset_256x256_PNG.png" Win64="yes" Guid="39889494-838A-4B9A-BD0A-105A1F0161BF">
+        <RegistryKey Root="$(var.RegistryScope)" Key="Software\Classes\powertoys\components">
+          <RegistryValue Type="string" Name="FileLocksmithMicrosoftUIXamlAssets_NoiseAsset_256x256_PNG" Value="" KeyPath="yes"/>
+        </RegistryKey>
+        <File Id="FileLocksmithMicrosoftUIXamlAssetsFile_NoiseAsset_256x256_PNG.png" Source="$(var.BinDir)modules\$(var.FileLocksmithProjectName)\Microsoft.UI.Xaml\Assets\NoiseAsset_256x256_PNG.png" />
+      </Component>
+    </DirectoryRef>
+
     <ComponentGroup Id="FileLocksmithComponentGroup">
       <Component Id="RemoveFileLocksmithFolder" Guid="1DAC9A3F-D89C-4730-BF57-1778E011709B" Directory="FileLocksmithInstallFolder" >
         <RegistryKey Root="$(var.RegistryScope)" Key="Software\Classes\powertoys\components">
@@ -42,8 +51,11 @@
         </RegistryKey>
         <RemoveFolder Id="RemoveFolderFileLocksmithFolder" Directory="FileLocksmithInstallFolder" On="uninstall"/>
         <RemoveFolder Id="RemoveFolderFileLocksmithAssetsFolder" Directory="FileLocksmithAssetsInstallFolder" On="uninstall"/>
+        <RemoveFolder Id="RemoveFolderFileLocksmithMicrosoftUIXamlInstallFolder" Directory="FileLocksmithMicrosoftUIXamlInstallFolder" On="uninstall"/>
+        <RemoveFolder Id="RemoveFolderFileLocksmithMicrosoftUIXamlAssetsInstallFolder" Directory="FileLocksmithMicrosoftUIXamlAssetsInstallFolder" On="uninstall"/>
       </Component>
       <ComponentRef Id="Module_FileLocksmith" />
+      <ComponentRef Id="FileLocksmithMicrosoftUIXamlAssets_NoiseAsset_256x256_PNG.png" />
     </ComponentGroup>
 
   </Fragment>

--- a/installer/PowerToysSetup/Product.wxs
+++ b/installer/PowerToysSetup/Product.wxs
@@ -452,6 +452,9 @@
             </Directory>
             <Directory Id="FileLocksmithInstallFolder" Name="$(var.FileLocksmithProjectName)">
               <Directory Id="FileLocksmithAssetsInstallFolder" Name="Assets" />
+              <Directory Id="FileLocksmithMicrosoftUIXamlInstallFolder" Name="Microsoft.UI.Xaml">
+                <Directory Id="FileLocksmithMicrosoftUIXamlAssetsInstallFolder" Name="Assets" />
+              </Directory>
             </Directory>
             <Directory Id="PowerRenameInstallFolder" Name="$(var.PowerRenameProjectName)">
               <Directory Id="PowerRenameAssetsFolder" Name="Assets" />
@@ -501,6 +504,9 @@
             <!-- RegistryPreview -->
             <Directory Id="RegistryPreviewInstallFolder" Name="$(var.RegistryPreviewProjectName)">
               <Directory Id="RegistryPreviewAssetsInstallFolder" Name="Assets" />
+              <Directory Id="RegistryPreviewMicrosoftUIXamlInstallFolder" Name="Microsoft.UI.Xaml">
+                <Directory Id="RegistryPreviewMicrosoftUIXamlAssetsInstallFolder" Name="Assets" />
+              </Directory>
             </Directory>
 
             <!-- AlwaysOnTop -->

--- a/installer/PowerToysSetup/RegistryPreview.wxs
+++ b/installer/PowerToysSetup/RegistryPreview.wxs
@@ -22,6 +22,15 @@
     <!--RegistryPreviewAssetsFiles_Component_Def-->
     </DirectoryRef>
 
+    <DirectoryRef Id="RegistryPreviewMicrosoftUIXamlAssetsInstallFolder" FileSource="$(var.BinDir)modules\$(var.RegistryPreviewProjectName)\Microsoft.UI.Xaml\Assets">
+      <Component Id="RegistryPreviewMicrosoftUIXamlAssets_NoiseAsset_256x256_PNG.png" Win64="yes" Guid="CBE56377-8E9F-4C4E-85B5-514916FCE818">
+        <RegistryKey Root="$(var.RegistryScope)" Key="Software\Classes\powertoys\components">
+          <RegistryValue Type="string" Name="RegistryPreviewMicrosoftUIXamlAssets_NoiseAsset_256x256_PNG" Value="" KeyPath="yes"/>
+        </RegistryKey>
+        <File Id="RegistryPreviewMicrosoftUIXamlAssetsFile_NoiseAsset_256x256_PNG.png" Source="$(var.BinDir)modules\$(var.RegistryPreviewProjectName)\Microsoft.UI.Xaml\Assets\NoiseAsset_256x256_PNG.png" />
+      </Component>
+    </DirectoryRef>
+
     <ComponentGroup Id="RegistryPreviewComponentGroup">
       <Component Id="RemoveRegistryPreviewFolder" Guid="D3DBC395-FAC5-44B1-BE44-3FE2B6E0F391" Directory="RegistryPreviewInstallFolder" >
         <RegistryKey Root="$(var.RegistryScope)" Key="Software\Classes\powertoys\components">
@@ -29,7 +38,10 @@
         </RegistryKey>
         <RemoveFolder Id="RemoveFolderRegistryPreviewFolder" Directory="RegistryPreviewInstallFolder" On="uninstall"/>
         <RemoveFolder Id="RemoveFolderRegistryPreviewAssetsFolder" Directory="RegistryPreviewAssetsInstallFolder" On="uninstall"/>
+        <RemoveFolder Id="RemoveFolderRegistryPreviewMicrosoftUIXamlInstallFolder" Directory="RegistryPreviewMicrosoftUIXamlInstallFolder" On="uninstall"/>
+        <RemoveFolder Id="RemoveFolderRegistryPreviewMicrosoftUIXamlAssetsInstallFolder" Directory="RegistryPreviewMicrosoftUIXamlAssetsInstallFolder" On="uninstall"/>
       </Component>
+      <ComponentRef Id="RegistryPreviewMicrosoftUIXamlAssets_NoiseAsset_256x256_PNG.png" />
     </ComponentGroup>
 
   </Fragment>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Installer is missing the "Microsoft.UI.Xaml\Assets\NoiseAsset_256x256_PNG.png" asset file for Registry Preview and File Locksmith, causing some UI elements, like tooltips, to appear with a transparent background when the Transparency effects option is turned on in Windows Colors settings.
This PR adds those files and fixes the issue.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #25253
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Build installer and verified installed File Locksmith and Registry Preview have opaque backgrounds.