### PR TITLE
[Registry Preview] Update value parsing for split hex values

### DIFF
--- a/src/modules/registrypreview/RegistryPreviewUI/MainWindow.Utilities.cs
+++ b/src/modules/registrypreview/RegistryPreviewUI/MainWindow.Utilities.cs
@@ -327,7 +327,7 @@ namespace RegistryPreview
                         value = value.Replace("hex(7):", string.Empty);
                     }
 
-                    // Parse for the case where a \ is added immediately after hex delare
+                    // Parse for the case where a \ is added immediately after hex is declared
                     switch (registryValue.Type)
                     {
                         case "REG_QWORD":

--- a/src/modules/registrypreview/RegistryPreviewUI/MainWindow.Utilities.cs
+++ b/src/modules/registrypreview/RegistryPreviewUI/MainWindow.Utilities.cs
@@ -318,7 +318,7 @@ namespace RegistryPreview
                     }
                     else if (value.StartsWith("hex(2):", StringComparison.InvariantCultureIgnoreCase))
                     {
-                        registryValue.Type = "REG_EXAND_SZ";
+                        registryValue.Type = "REG_EXPAND_SZ";
                         value = value.Replace("hex(2):", string.Empty);
                     }
                     else if (value.StartsWith("hex(7):", StringComparison.InvariantCultureIgnoreCase))
@@ -327,11 +327,34 @@ namespace RegistryPreview
                         value = value.Replace("hex(7):", string.Empty);
                     }
 
+                    // Parse for the case where a \ is added immediately after hex delare
+                    switch (registryValue.Type)
+                    {
+                        case "REG_QWORD":
+                        case "REG_BINARY":
+                        case "REG_EXPAND_SZ":
+                        case "REG_MULTI_SZ":
+                            if (value == @"\")
+                            {
+                                // pad the value, so the parsing below is triggered
+                                value = @",\";
+                            }
+
+                            break;
+                    }
+
                     // If the end of a decimal line ends in a \ then you have to keep
                     // reading the block as a single value!
                     while (value.EndsWith(@",\", StringComparison.InvariantCulture))
                     {
                         value = value.TrimEnd('\\');
+
+                        // checking for a "blank" hex value so we can skip t
+                        if (value == @",")
+                        {
+                            value = string.Empty;
+                        }
+
                         index++;
                         if (index >= registryLines.Length)
                         {


### PR DESCRIPTION
## Summary of the Pull Request
Adds handling for split-binary values that can occur after editing a REG file by hand.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [X] **Closes:** #25550
- [X] **Communication:** Discussed on the bug referenced above

## Detailed Description of the Pull Request / Additional comments
Added some special handling when a REG file tries to split up a binary value immediately after the data header.  Example being:
`"Value"=hex:\` instead of what the Editor exports `"Value"=hex:00,01,02,\`

Also fixed a spelling error on REG_EXPAND_SZ in the UX.

## Validation Steps Performed
Tested several versions of REG files, including various types of hex values; this included the originally reported version.