### PR TITLE
[KBM]Set extended flag for media keys

### DIFF
--- a/src/modules/keyboardmanager/common/Helpers.cpp
+++ b/src/modules/keyboardmanager/common/Helpers.cpp
@@ -83,6 +83,25 @@ namespace Helpers
         case VK_DOWN:
         case VK_RIGHT:
         case VK_UP:
+        case VK_SLEEP:
+        case VK_MEDIA_NEXT_TRACK:
+        case VK_MEDIA_PREV_TRACK:
+        case VK_MEDIA_STOP:
+        case VK_MEDIA_PLAY_PAUSE:
+        case VK_VOLUME_MUTE:
+        case VK_VOLUME_UP:
+        case VK_VOLUME_DOWN:
+        case VK_LAUNCH_MEDIA_SELECT:
+        case VK_LAUNCH_MAIL:
+        case VK_LAUNCH_APP1:
+        case VK_LAUNCH_APP2:
+        case VK_BROWSER_SEARCH:
+        case VK_BROWSER_HOME:
+        case VK_BROWSER_BACK:
+        case VK_BROWSER_FORWARD:
+        case VK_BROWSER_STOP:
+        case VK_BROWSER_REFRESH:
+        case VK_BROWSER_FAVORITES:
             return true;
         default:
             return false;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Keyboard manager is sending scancodes for media keys which are being interpreted in some applications as other keys, as is exemplified in the issue this PR closes ( https://github.com/microsoft/PowerToys/issues/25463 ).
This is caused by us sending the scancode without prefixing it with `e0` as expected for extended keys (which in key events means adding the KEYEVENTF_EXTENDEDKEY flag to the event).
This PR adds the Windows Multimedia keys to the list of keys we're sending the extended flag. Source used to select the keys is: https://tigerheli.mameworld.info/encoder/scancodesset2.htm

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #25463
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
As mentioned in the issue, used https://en.key-test.ru/ to verify that, without the fix, mapping a key to Volume Down was registering the key `C` as well.
With the fix, using a key mapped to volume down no longer registers `C`.