### PR TITLE
[runner] Don't save settings on Settings app start

### DIFF
--- a/src/runner/settings_window.cpp
+++ b/src/runner/settings_window.cpp
@@ -370,8 +370,6 @@ void run_settings_window(bool show_oobe_window, bool show_scoobe_window, std::op
         settings_theme = L"dark";
     }
 
-    GeneralSettings save_settings = get_general_settings();
-
     // Arg 6: elevated status
     bool isElevated{ get_general_settings().isElevated };
     std::wstring settings_elevatedStatus = isElevated ? L"true" : L"false";
@@ -396,10 +394,6 @@ void run_settings_window(bool show_oobe_window, bool show_scoobe_window, std::op
     std::wstring settings_containsFlyoutPosition = flyout_position.has_value() ? L"true" : L"false";
 
     // Args 13, .... : Optional arguments depending on the options presented before. All by the same value.
-
-    // create general settings file to initialize the settings file with installation configurations like :
-    // 1. Run on start up.
-    PTSettingsHelper::save_general_settings(save_settings.to_json());
 
     std::wstring executable_args = fmt::format(L"\"{}\" {} {} {} {} {} {} {} {} {} {} {}",
                                                    executable_path,


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This is my best guess of what is happening, so please question everything I wrote bellow. :)

Couldn't reproduce the issue on update, but managed to reproduce it in a different way (details bellow) and it looks like the same issue. Fixes modules being disabled after PowerToys update. More details bellow. I haven't seen any downside to removing this code, let me know if you can think of any.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #24606
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
There is a race condition while PowerToys is being started after the update because of the following logic https://github.com/microsoft/PowerToys/blob/main/src/Update/PowerToys.Update.cpp#L184 which ends up starting PowerToys right after the install (update) second time as installer is running it as well in the end: https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs#L200

When starting PowerToys twice one after another in very short time period, what can happen is that second instance of runner will send a message to tray window to [run settings app](https://github.com/microsoft/PowerToys/blob/main/src/runner/main.cpp#L81) 
where removed `get_general_settings` will get `is_enabled()` state of the modules before the modules are actually enabled by first instance of runner [here ](https://github.com/microsoft/PowerToys/blob/main/src/runner/main.cpp#L197) and overwrite the settings file with this new state where most of the modules are disabled because default value of m_enabled is false for most of the modules (except PowerRename, ImageResizer, File Locksmith). This state can be seen in logs coming out of nowhere by searching for `fancyzones:"false"`.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Building and running `main` branch test following:
 - Run PT from Visual Studio
 - Enable all PT modules (just to be sure modules are enabled)
 - Stop PT
 - Run PT from Visual Studio
 - As soon as PT icon appears in sys tray double-click it to open settings
 - Observe in settings that some modules are disabled

Do the same with this change and observe that modules stay enabled.
