### PR TITLE
Added an option in ExecutionShell enum for WindowsTerminal

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,13 +1,12 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
+﻿<configuration>
 	<config>
 		<clear />
 	</config>
 	<packageSourceMapping>
-		<packageSource key="Nuget.Org">
+		<packageSource key="nuget.org">
 			<package pattern="*" />
 		</packageSource>
-		<packageSource key="CommunityToolkit">
+		<packageSource key="https://pkgs.dev.azure.com/dotnet/CommunityToolkit/_packaging/CommunityToolkit-Labs/nuget/v3/index.json">
 			<package pattern="CommunityToolkit.Labs.*" />
 		</packageSource>
 	</packageSourceMapping>

--- a/nuget.config
+++ b/nuget.config
@@ -1,4 +1,4 @@
-﻿<configuration>
+<configuration>
 	<config>
 		<clear />
 	</config>

--- a/nuget.config
+++ b/nuget.config
@@ -1,12 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
 	<config>
 		<clear />
 	</config>
 	<packageSourceMapping>
-		<packageSource key="nuget.org">
+		<packageSource key="Nuget.Org">
 			<package pattern="*" />
 		</packageSource>
-		<packageSource key="https://pkgs.dev.azure.com/dotnet/CommunityToolkit/_packaging/CommunityToolkit-Labs/nuget/v3/index.json">
+		<packageSource key="CommunityToolkit">
 			<package pattern="CommunityToolkit.Labs.*" />
 		</packageSource>
 	</packageSourceMapping>

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Shell/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Shell/Main.cs
@@ -190,6 +190,20 @@ namespace Microsoft.Plugin.Shell
 
                 info = ShellCommand.SetProcessStartInfo("powershell.exe", workingDirectory, arguments, runAsVerbArg);
             }
+            else if (_settings.Shell == ExecutionShell.WindowsTerminal)
+            {
+                string arguments;
+                if (_settings.LeaveShellOpen)
+                {
+                    arguments = $"powershell -NoExit \"{command}\"";
+                }
+                else
+                {
+                    arguments = $"powershell \"{command}\"";
+                }
+
+                info = ShellCommand.SetProcessStartInfo("wt.exe", workingDirectory, arguments, runAsVerbArg);
+            }
             else if (_settings.Shell == ExecutionShell.RunCommand)
             {
                 // Open explorer if the path is a file or directory

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Shell/ShellPluginSettings.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Shell/ShellPluginSettings.cs
@@ -38,5 +38,6 @@ namespace Microsoft.Plugin.Shell
         Cmd = 0,
         Powershell = 1,
         RunCommand = 2,
+        WindowsTerminal = 3,
     }
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This pull request is based on [issue 4283](https://github.com/microsoft/PowerToys/issues/4283), along with other related issues. It adds a WindowsTerminal configuration option for the ExecutionShell.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

Currently we do not have any UI for configuring which shell runner to use, but we do have a config option that we can change to switch between different ExecutionShell "modes". Then ones currently available are Cmd, PowerShell and RunCommand.

Even though in Windows 11, PowerToys opens WindowsTerminal by default when running terminal commands (by ">") as Non-Administrator, when running the command as an Administrator (Ctrl+Shift+Enter by default), it opens the old Powershell GUI as Administrator. In Windows 10, it is worse, since there is no way to open WindowsTerminal by using ">" commands.

The proposed solution alleviates this problem in Windows 11, by launching wt.exe specifically and also allows Windows 10 users to always use WindowsTerminal when executing commands.

What I am proposing is a change to the Shell plugin. I have added a fourth option to the ExecutionShell enum: WindowsTerminal with enum value 3.
When option 3 is selected in the config, the proposed code starts up WindowsTerminal by running 
``wt.exe powershell -NoExit "{command}"`` with or without ``-NoExit``, depending on the LeaveShellOpen setting.


Disclaimer: This is my first time submitting a pull request. I read through all the rules but I probably messed something up, so please be kind. :)   Also I made the change because I needed it, but realized there was an open issue, so no harm in submitting a PR.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

I have tested this change on two different machines, one running Windows 11, and one running Windows 10. I did it by only replacing the compiled Shell Plugin .dll file, into a latest version stable install. Then, in my normal installation of PowerToys, I was able to use the new feature, since it is a just a small change, localized to just that plugin.

I did the same on the other PC and have not encountered any issues with the code. 
