### PR TITLE
[updater] Do not start PowerToys from PowerToys.Update.exe

### DIFF
--- a/src/Update/PowerToys.Update.cpp
+++ b/src/Update/PowerToys.Update.cpp
@@ -110,7 +110,7 @@ bool InstallNewVersionStage1(fs::path installer)
     {
         // Detect if PT was running
         const auto pt_main_window = FindWindowW(pt_tray_icon_window_class, nullptr);
-        const bool launch_powertoys = pt_main_window != nullptr;
+
         if (pt_main_window != nullptr)
         {
             SendMessageW(pt_main_window, WM_CLOSE, 0, 0);
@@ -119,10 +119,7 @@ bool InstallNewVersionStage1(fs::path installer)
         std::wstring arguments{ UPDATE_NOW_LAUNCH_STAGE2 };
         arguments += L" \"";
         arguments += installer.c_str();
-        arguments += L"\" \"";
-        arguments += get_module_folderpath();
-        arguments += L"\" ";
-        arguments += launch_powertoys ? UPDATE_STAGE2_RESTART_PT : UPDATE_STAGE2_DONT_START_PT;
+        arguments += L"\"";
         SHELLEXECUTEINFOW sei{ sizeof(sei) };
         sei.fMask = { SEE_MASK_FLAG_NO_UI | SEE_MASK_NOASYNC };
         sei.lpFile = copy_in_temp->c_str();
@@ -137,7 +134,7 @@ bool InstallNewVersionStage1(fs::path installer)
     }
 }
 
-bool InstallNewVersionStage2(std::wstring installer_path, std::wstring_view install_path, bool launch_powertoys)
+bool InstallNewVersionStage2(std::wstring installer_path)
 {
     std::transform(begin(installer_path), end(installer_path), begin(installer_path), ::towlower);
 
@@ -181,18 +178,6 @@ bool InstallNewVersionStage2(std::wstring installer_path, std::wstring_view inst
         state.state = UpdateState::upToDate;
     });
 
-    if (launch_powertoys)
-    {
-        std::wstring new_pt_path{ install_path };
-        new_pt_path += L"\\PowerToys.exe";
-        SHELLEXECUTEINFOW sei{ sizeof(sei) };
-        sei.fMask = { SEE_MASK_FLAG_NO_UI | SEE_MASK_NOASYNC };
-        sei.lpFile = new_pt_path.c_str();
-        sei.nShow = SW_SHOWNORMAL;
-        sei.lpParameters = UPDATE_REPORT_SUCCESS;
-        return ShellExecuteExW(&sei) == TRUE;
-    }
-
     return true;
 }
 
@@ -230,7 +215,7 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int)
     else if (action == UPDATE_NOW_LAUNCH_STAGE2)
     {
         using namespace std::string_view_literals;
-        const bool failed = !InstallNewVersionStage2(args[2], args[3], args[4] == std::wstring_view{ UPDATE_STAGE2_RESTART_PT });
+        const bool failed = !InstallNewVersionStage2(args[2]);
         if (failed)
         {
             UpdateState::store([&](UpdateState& state) {

--- a/src/Version.props
+++ b/src/Version.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <Version>0.0.1</Version>
+    <Version>0.71.0</Version>
     <DevEnvironment>Local</DevEnvironment>
   </PropertyGroup>
 </Project>

--- a/src/Version.props
+++ b/src/Version.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <Version>0.71.0</Version>
+    <Version>0.0.1</Version>
     <DevEnvironment>Local</DevEnvironment>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
PowerToys is already being started from the installer which is run by the updater

Couldn't reproduce the issue. More details here https://github.com/microsoft/PowerToys/pull/25647.

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #16679
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Build the installer with 2 new versions e.g. 70 and 71.
Install v70 - observe that PT is running after installation
Update to v71 - observe that OOBE is shown after update