### PR TITLE
[tools]Fix typo for CleanUp tool powershell script

### DIFF
--- a/tools/CleanUp_tool_powershell_script/CleanUp_tool.ps1
+++ b/tools/CleanUp_tool_powershell_script/CleanUp_tool.ps1
@@ -8,7 +8,7 @@
 
 if (Test-Path -Path $SettingsPath -PathType Any)
 {
-    Remove-Item –Path $SettingsPath –Recurse
+    Remove-Item -Path $SettingsPath -Recurse
 }
 
 #Deleting SuperFancyZones registry key
@@ -17,7 +17,7 @@ if (Test-Path -Path $SettingsPath -PathType Any)
 
 if (Test-Path -Path $SuperFancyZones -PathType Any)
 {
-    Remove-Item –Path $SuperFancyZones –Recurse
+    Remove-Item -Path $SuperFancyZones -Recurse
 }
 
 #Deleting PowerRename registry key
@@ -26,7 +26,7 @@ if (Test-Path -Path $SuperFancyZones -PathType Any)
 
 if (Test-Path -Path $PowerRename -PathType Any)
 {
-    Remove-Item –Path $PowerRename –Recurse
+    Remove-Item -Path $PowerRename -Recurse
 }
 
 #Deleting ImageResizer registry key
@@ -35,7 +35,7 @@ if (Test-Path -Path $PowerRename -PathType Any)
 
 if (Test-Path -Path $ImageResizer -PathType Any)
 {
-    Remove-Item –Path $ImageResizer –Recurse
+    Remove-Item -Path $ImageResizer -Recurse
 }
 
 #Deleting DontShowThisDialogAgain registry key
@@ -44,5 +44,5 @@ if (Test-Path -Path $ImageResizer -PathType Any)
 
 if (Test-Path -Path $DontShowThisDialogAgain -PathType Any)
 {
-    Remove-Item –Path $DontShowThisDialogAgain
+    Remove-Item -Path $DontShowThisDialogAgain
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Fixed typo in `CleanUp_tool.ps1`

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #25747
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Powershell script has `–` instead of `-` in some places. I changed it and tested in my system.

First time doing PR. Sorry if I missed some steps for PR.
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

