### PR TITLE
Updates to parsing for certain Value types and empty values

### DIFF
--- a/src/modules/registrypreview/RegistryPreviewUI/MainWindow.Utilities.cs
+++ b/src/modules/registrypreview/RegistryPreviewUI/MainWindow.Utilities.cs
@@ -431,6 +431,21 @@ namespace RegistryPreview
                             registryValue.Value = value;
 
                             break;
+                        case "REG_DWORD":
+                            if (value.Length <= 0)
+                            {
+                                registryValue.Type = "ERROR";
+                            }
+
+                            break;
+                        case "REG_QWORD":
+                            if (value.Length <= 0)
+                            {
+                                value = resourceLoader.GetString("InvalidQword");
+                            }
+
+                            registryValue.Value = value;
+                            break;
                         default:
                             registryValue.Value = value;
                             break;

--- a/src/modules/registrypreview/RegistryPreviewUI/Strings/en-US/Resources.resw
+++ b/src/modules/registrypreview/RegistryPreviewUI/Strings/en-US/Resources.resw
@@ -138,6 +138,9 @@
   <data name="FilterRegistryName" xml:space="preserve">
     <value>Registry files (*.reg)</value>
   </data>
+  <data name="InvalidQword" xml:space="preserve">
+    <value>(Invalid QWORD (64-bit) value)</value>
+  </data>
   <data name="InvalidRegistryFile" xml:space="preserve">
     <value> doesn't appear to be a valid registry file!</value>
   </data>


### PR DESCRIPTION
## Summary of the Pull Request
Adds special handling for DWORD and QWORD Value types with empty values.

## PR Checklist

- [X] **Closes:** #25663
- [X] **Communication:** I've discussed this in bugs, for specific cases/fixes
- [X] **Localization:** All end user facing strings can be localized

## Detailed Description of the Pull Request / Additional comments
Additional handling for these two specific Value types.

## Validation Steps Performed
Additional handling for these two specific Value types.
