### PR TITLE
Fixed singleton crash when launching a second PT runner process

### DIFF
--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -82,7 +82,7 @@ void open_menu_from_another_instance(std::optional<std::string> settings_window)
 {
     const HWND hwnd_main = FindWindowW(L"PToyTrayIconWindow", nullptr);
     LPARAM msg = static_cast<LPARAM>(ESettingsWindowNames::Overview);
-    if (settings_window.has_value())
+    if (settings_window.has_value() && settings_window.value() != "")
     {
         msg = static_cast<LPARAM>(ESettingsWindowNames_from_string(settings_window.value()));
     }


### PR DESCRIPTION
## Summary of the Pull Request

Fixes #8277 by adding an additional check to the singleton used in launching PT from another process.

## PR Checklist

- [x] **Closes:** #8277
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected

## Validation Steps Performed

Manual testing that crash no longer occurs when relaunching the PowerToys executable with an instance already running.