### PR TITLE
[CI] Fix for building with Visual Studio 17.6

### DIFF
--- a/Cpp.Build.props
+++ b/Cpp.Build.props
@@ -53,6 +53,7 @@
       <ConformanceMode>false</ConformanceMode>
       <TreatWarningAsError>true</TreatWarningAsError>
       <LanguageStandard>stdcpplatest</LanguageStandard>
+	<BuildStlModules>false</BuildStlModules>
       <AdditionalOptions>/await %(AdditionalOptions)</AdditionalOptions>
       <PreprocessorDefinitions>_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>

--- a/src/modules/MouseUtils/FindMyMouse/FindMyMouse.cpp
+++ b/src/modules/MouseUtils/FindMyMouse/FindMyMouse.cpp
@@ -54,7 +54,7 @@ protected:
     D* Shim() { return static_cast<D*>(this); }
     LRESULT BaseWndProc(UINT message, WPARAM wParam, LPARAM lParam) noexcept;
 
-    HWND m_hwnd;
+    HWND m_hwnd{};
     POINT m_sonarPos = ptNowhere;
 
     // Only consider double left control click if at least 100ms passed between the clicks, to avoid keyboards that might be sending rapid clicks.
@@ -118,7 +118,7 @@ private:
         ControlUp2,
     };
 
-    HWND m_hwndOwner;
+    HWND m_hwndOwner{};
     SonarState m_sonarState = SonarState::Idle;
     POINT m_lastKeyPos{};
     ULONGLONG m_lastKeyTime{};


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Resolves issues building with Visual Studio 17.6 by disabling the building of C++/23 Standard Library Modules. Fixes struct member object initialization issue that triggers C26495 with FindMyMouse. 
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [X] **Closes:** #25526 
- [X] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Built with both VS 17.5 and VS 17.6 Preview 5 to verify that both builds continue functioning properly. 
