### PR TITLE
Runner save before opening settings

### DIFF
--- a/src/runner/settings_window.cpp
+++ b/src/runner/settings_window.cpp
@@ -370,6 +370,8 @@ void run_settings_window(bool show_oobe_window, bool show_scoobe_window, std::op
         settings_theme = L"dark";
     }
 
+    GeneralSettings save_settings = get_general_settings();
+
     // Arg 6: elevated status
     bool isElevated{ get_general_settings().isElevated };
     std::wstring settings_elevatedStatus = isElevated ? L"true" : L"false";
@@ -394,6 +396,10 @@ void run_settings_window(bool show_oobe_window, bool show_scoobe_window, std::op
     std::wstring settings_containsFlyoutPosition = flyout_position.has_value() ? L"true" : L"false";
 
     // Args 13, .... : Optional arguments depending on the options presented before. All by the same value.
+
+    // create general settings file to initialize the settings file with installation configurations like :
+    // 1. Run on start up.
+    PTSettingsHelper::save_general_settings(save_settings.to_json());
 
     std::wstring executable_args = fmt::format(L"\"{}\" {} {} {} {} {} {} {} {} {} {} {}",
                                                    executable_path,

--- a/src/runner/settings_window.cpp
+++ b/src/runner/settings_window.cpp
@@ -362,22 +362,22 @@ void run_settings_window(bool show_oobe_window, bool show_scoobe_window, std::op
     // Arg 4: process pid.
     DWORD powertoys_pid = GetCurrentProcessId();
 
+    GeneralSettings save_settings = get_general_settings();
+
     // Arg 5: settings theme.
-    const std::wstring settings_theme_setting{ get_general_settings().theme };
+    const std::wstring settings_theme_setting{ save_settings.theme };
     std::wstring settings_theme = L"system";
     if (settings_theme_setting == L"dark" || (settings_theme_setting == L"system" && WindowsColors::is_dark_mode()))
     {
         settings_theme = L"dark";
     }
 
-    GeneralSettings save_settings = get_general_settings();
-
     // Arg 6: elevated status
-    bool isElevated{ get_general_settings().isElevated };
+    bool isElevated{ save_settings.isElevated };
     std::wstring settings_elevatedStatus = isElevated ? L"true" : L"false";
 
     // Arg 7: is user an admin
-    bool isAdmin{ get_general_settings().isAdmin };
+    bool isAdmin{ save_settings.isAdmin };
     std::wstring settings_isUserAnAdmin = isAdmin ? L"true" : L"false";
 
     // Arg 8: should oobe window be shown


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This PR reverts https://github.com/microsoft/PowerToys/pull/25647 , as it caused some issues regarding information passing to the Settings app.

For example, after a clean install without any local files saved:
- Awake gets turned off when Settings is opened.
- All mouse utilities are turned on (some are supposed to be off by default).
- When you restart as admin through Settings the new Settings window won't allow you to enable VCM. You need to close settings window and start it again to be able to do it.


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Related:** #25647
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

- Reverts https://github.com/microsoft/PowerToys/commit/4b1aadafc2a8db6ffeb954d57d7d12b4289d7e24
- Minimizes the number of calls to get_general_settings.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Delete "%localappdata%\Microsoft\PowerToys".
- Start PowerToys.
- Open Settings app.
- Verify Awake is still enabled.
- Verify Mouse Pointer Crosshairs and Mouse Jump are disabled by default, as expected.
- Restarting as admin allows accessing the UI to enable VCM right away.
