### PR TITLE
[installer]Terminate more PowerToys processes

### DIFF
--- a/installer/PowerToysSetupCustomActions/CustomAction.cpp
+++ b/installer/PowerToysSetupCustomActions/CustomAction.cpp
@@ -1364,7 +1364,7 @@ UINT __stdcall TerminateProcessesCA(MSIHANDLE hInstall)
     }
     processes.resize(bytes / sizeof(processes[0]));
 
-    std::array<std::wstring_view, 11> processesToTerminate = {
+    std::array<std::wstring_view, 23> processesToTerminate = {
         L"PowerToys.PowerLauncher.exe",
         L"PowerToys.Settings.exe",
         L"PowerToys.Awake.exe",
@@ -1376,6 +1376,18 @@ UINT __stdcall TerminateProcessesCA(MSIHANDLE hInstall)
         L"PowerToys.AlwaysOnTop.exe",
         L"PowerToys.exe",
         L"PowerToys.RegistryPreview.exe",
+        L"PowerToys.Hosts.exe",
+        L"PowerToys.PowerRename.exe",
+        L"PowerToys.ImageResizer.exe",
+        L"PowerToys.GcodeThumbnailProvider.exe",
+        L"PowerToys.PdfThumbnailProvider.exe",
+        L"PowerToys.MonacoPreviewHandler.exe",
+        L"PowerToys.MarkdownPreviewHandler.exe",
+        L"PowerToys.StlThumbnailProvider.exe",
+        L"PowerToys.SvgThumbnailProvider.exe",
+        L"PowerToys.GcodePreviewHandler.exe",
+        L"PowerToys.PdfPreviewHandler.exe",
+        L"PowerToys.SvgPreviewHandler.exe",
     };
 
     for (const auto procID : processes)

--- a/installer/PowerToysSetupCustomActions/CustomAction.cpp
+++ b/installer/PowerToysSetupCustomActions/CustomAction.cpp
@@ -1374,7 +1374,6 @@ UINT __stdcall TerminateProcessesCA(MSIHANDLE hInstall)
         L"PowerToys.MouseJumpUI.exe",
         L"PowerToys.ColorPickerUI.exe",
         L"PowerToys.AlwaysOnTop.exe",
-        L"PowerToys.exe",
         L"PowerToys.RegistryPreview.exe",
         L"PowerToys.Hosts.exe",
         L"PowerToys.PowerRename.exe",
@@ -1388,6 +1387,7 @@ UINT __stdcall TerminateProcessesCA(MSIHANDLE hInstall)
         L"PowerToys.GcodePreviewHandler.exe",
         L"PowerToys.PdfPreviewHandler.exe",
         L"PowerToys.SvgPreviewHandler.exe",
+        L"PowerToys.exe",
     };
 
     for (const auto procID : processes)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

We get quite some reports of upgrading PowerToys to leave some files from previous versions laying around.

I've been able to repro something similar by:
1 - Install PowerToys
2 - Open a file Explorer Window with a preview pane, selecting a file that uses monaco preview handler (any C++ file from PowerToys source code will do, for example.
3 - Uninstall PowerToys
4 - Verify that some dlls remain in "C:\Program Files\PowerToys".

This seems to be caused by "PowerToys.MonacoPreviewHandler.exe" keeping to use those dlls. This also affects every hard link to those dlls that is created by installer.

This PR adds some more executables to terminate when installing/uninstalling PowerToys. We expect this might make the problem better in the future. If not upgrading from 0.69 to 0.70, at least when upgrading from 0.70 to 0.71.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #25512 #25324
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
With an installer build with this fix:
1 - Uninstall any PowerToys installation and delete "C:\Program Files\PowerToys" to make sure we're starting from a clean slate.
2 - Install PowerToys
3 - Open a file Explorer Window with a preview pane, selecting a file that uses monaco preview handler (any C++ file from PowerToys source code will do, for example.
4 - Uninstall PowerToys
5 - Verify that "C:\Program Files\PowerToys" gets deleted with the uninstall process.
